### PR TITLE
Add MLite skills foundation

### DIFF
--- a/experimental/lite/README.md
+++ b/experimental/lite/README.md
@@ -30,6 +30,7 @@ This initial drop intentionally does not include:
 experimental/lite/
   README.md
   docs/                       Design and usage notes
+  skills/                     Agent-agnostic maintenance skills
   megatron/
     lite/
       runtime/                Runtime API, config, and mlite backend registry
@@ -73,6 +74,7 @@ Model names currently registered by default:
 - [Runtime](docs/runtime.md)
 - [Models](docs/models.md)
 - [Porting Notes](docs/porting.md)
+- [Skills](skills/README.md)
 
 ## Acknowledgements
 

--- a/experimental/lite/skills/README.md
+++ b/experimental/lite/skills/README.md
@@ -1,0 +1,167 @@
+# Megatron Lite Skills
+
+This directory defines agent-agnostic skills for maintaining Megatron Lite.
+A skill is an operational contract for agents: what context to load, what
+invariants to protect, how to make a change, and what evidence to leave behind.
+
+These files are not Codex, Claude, or tool-specific skills. Do not add
+agent-specific frontmatter, prompt wrappers, or runtime assumptions here.
+
+## Function Model
+
+Treat a skill as a function:
+
+- `Schema` is the signature and summary.
+- `imports` are skills that must be loaded before execution, like Python imports.
+- `calls` are every skill this function explicitly calls in the body.
+- the body is Python-like pseudocode with bounded exits.
+
+An agent should be able to route work from the `Schema` alone. It should read
+the body only when executing that skill.
+
+## File Layout
+
+Each skill file has three regions:
+
+1. Before `MLITE_SKILL_SCHEMA_BEGIN`: a short human-facing title or note. Agents
+   should not depend on this region for routing.
+2. Between `MLITE_SKILL_SCHEMA_BEGIN` and `MLITE_SKILL_SCHEMA_END`: the compact
+   schema used for retrieval, routing, imports, and call planning.
+3. After `MLITE_SKILL_SCHEMA_END`: the skill body. This must be Python-like
+   pseudocode, not free-form prose.
+
+The pseudocode is a contract, not executable Python. It should still be precise:
+clear inputs, explicit outputs, explicit skill calls, and finite exits.
+
+Skills are organized like Python modules. A skill is a single `.md` file;
+directories are namespaces, not skill bodies. Do not create `skill-name/README.md`
+for individual skills.
+Map schema names to paths by replacing `.` with `/` and `_` with `-`, then
+adding `.md`: `model_compose.config_mapping` lives at
+`model-compose/config-mapping.md`.
+
+## Loading Model
+
+Agents should load skills progressively:
+
+1. Read this file.
+2. Read exactly one leaf skill for the current work type.
+3. Read linked Megatron Lite docs or source files only when the leaf skill asks
+   for them.
+
+Keep the active context small. A skill should point to durable source files and
+validation commands instead of copying long design background.
+
+## Defined Skills
+
+`basic`:
+- `basic.constitution`
+- `basic.find_reference`
+- `basic.align_precision`
+- `basic.align_e2e_precision`
+- `basic.lint_skill`
+- `basic.construct_proxy_task`
+- `basic.review_threshold`
+
+`primitive`:
+- `primitive.contract`
+- `primitive.principle`
+- `primitive.select_for_compose`
+- `primitive.design`
+- `primitive.validate`
+- `primitive.fuse`
+- `primitive.process_group`
+- `primitive.parallel.tp`
+- `primitive.parallel.ep`
+- `primitive.parallel.pp`
+- `primitive.parallel.cp`
+- `primitive.optimizer.fsdp`
+- `primitive.optimizer.distopt`
+- `primitive.module.moe`
+- `primitive.module.gqa`
+- `primitive.module.thd`
+
+Primitive work has two reusable meta layers: `primitive.principle` defines what
+must be true, and `primitive.select_for_compose` decides when a primitive belongs
+in a model composition.
+
+`model_compose`:
+- `model_compose.config_mapping`
+- `model_compose.weight_mapping`
+- `model_compose.build_model`
+- `model_compose.qwen`
+
+`application`:
+- `application.runtime`
+- `application.verl`
+- `application.bench`
+
+`perf`:
+- `perf.measure`
+- `perf.memory`
+- `perf.fusion`
+- `perf.optimize`
+
+`insight`:
+- `insight.progressive_model_support`
+- `insight.progressive_primitive_design`
+- `insight.scope_control`
+
+## Skill Contract
+
+Each skill file contains a delimited schema block near the top. Agents may read
+only this block for routing, then read the body only when executing the skill.
+
+````text
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "basic.align_precision", kind="state_machine", purpose="align precision",
+    imports=["basic.constitution"], calls=["basic.constitution", "basic.find_reference"],
+    inputs=["task", "files", "reference", "budget"],
+    outputs=["patch", "evidence", "risks"], exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+````
+
+Use the markers instead of fixed line counts. Keep the schema short enough to
+scan without reading the body; prefer compact lists and short field names over
+prose.
+
+After the schema, each skill body is Python-like pseudocode. The top-level
+function should match the schema inputs and return one of the declared exits.
+Use prose only inside short comments.
+
+Required sections:
+
+- one top-level function matching the schema name;
+- explicit `return done(...)`, `return blocked(...)`, or
+  `return out_of_scope(...)`;
+- explicit calls to skills as `namespace.skill(...)`.
+
+`imports` and `calls` are separate. `imports` says what an agent should preload.
+`calls` says what the body invokes. If a loaded skill is directly invoked, list
+it in `calls` too.
+
+Every loop must have a progress measure, a maximum attempt count, or a blocking
+condition. A skill that can spin forever is invalid.
+
+## Skill Lint
+
+Every new or changed skill should pass `basic.lint_skill` before review. Lint is
+structural: it checks that schema can be extracted, imports and calls resolve,
+the file path matches the schema name, body calls match declared calls, exits
+are explicit, and loops are bounded. Scenario dry-runs are optional but
+preferred for complex skills; they use mocked inputs to verify the pseudocode
+can reach a declared exit.
+
+## Boundaries
+
+- Skills describe how agents work; `docs/` describes Megatron Lite for users and
+  reviewers.
+- Skills must not replace tests. They should name the right validation surface.
+- Skills must not store task history, temporary job logs, or one-off debugging
+  transcripts.
+- Skills should stay stable across agents. If a rule depends on one agent tool,
+  keep it outside this directory.

--- a/experimental/lite/skills/application/bench.md
+++ b/experimental/lite/skills/application/bench.md
@@ -1,0 +1,31 @@
+# Bench Skill
+
+Run benchmark-style checks without weakening precision evidence.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "application.bench", kind="state_machine", purpose="benchmark with controlled variables and evidence",
+    imports=["basic.constitution"], calls=["perf.measure"],
+    inputs=["task", "bench_config", "target", "budget"],
+    outputs=["bench", "evidence", "risks"], exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def bench(task, bench_config, target, budget):
+    controlled = bench_config.variables.freeze_all_except(bench_config.axis)
+    if controlled.has_unknown_unfrozen_axes():
+        return blocked("bench has uncontrolled variables", risks=controlled.unknown_axes)
+
+    measurement = perf.measure(task, target=target, workload=bench_config.workload, budget=budget.measure)
+    if not measurement.done:
+        return blocked("bench measurement failed", evidence=measurement)
+
+    evidence = record_evidence(task, run=measurement.run, comparison=measurement.metrics, environment=budget.env)
+    risks = ["benchmarks are not correctness proof", "uncontrolled variables can dominate"]
+    return done(bench=measurement.metrics, evidence=evidence, risks=risks)
+```

--- a/experimental/lite/skills/application/runtime.md
+++ b/experimental/lite/skills/application/runtime.md
@@ -1,0 +1,30 @@
+# Runtime Skill
+
+Validate the MLite runtime path end to end.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "application.runtime", kind="state_machine", purpose="validate MLite runtime build/train/save/load",
+    imports=["basic.constitution"], calls=["basic.align_precision"],
+    inputs=["task", "runtime_config", "model", "budget"],
+    outputs=["runtime", "evidence", "risks"], exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def runtime(task, runtime_config, model, budget):
+    if runtime_config.backend != "mlite":
+        return out_of_scope("not MLite runtime")
+
+    run = execute_runtime_steps(["init", "build_model", "train_step", "save", "load"], runtime_config, model)
+    if not run.return_code == 0:
+        return blocked("runtime path failed", evidence=run)
+
+    precision = basic.align_precision(task, target=model, variables=runtime_config.variables, budget=budget.precision)
+    evidence = record_evidence(task, run=run, comparison=precision, environment=budget.env)
+    return done(runtime=run, evidence=evidence, risks=["runtime success can hide model-local mismatch"])
+```

--- a/experimental/lite/skills/application/verl.md
+++ b/experimental/lite/skills/application/verl.md
@@ -1,0 +1,35 @@
+# VERL Skill
+
+Validate MLite through VERL SFT, RL, or GRPO workflows.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "application.verl", kind="state_machine", purpose="validate VERL workflows with MLite",
+    imports=["basic.constitution"], calls=["basic.align_e2e_precision"],
+    inputs=["task", "verl_config", "model", "budget"],
+    outputs=["workflow", "evidence", "risks"], exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def verl(task, verl_config, model, budget):
+    if verl_config.algorithm not in ["SFT", "RL", "GRPO"]:
+        return out_of_scope("not a VERL SFT/RL/GRPO workflow")
+
+    modes = {"SFT": ["SFT"], "RL": ["RL"], "GRPO": ["RL"]}[verl_config.algorithm]
+    e2e = basic.align_e2e_precision(task, target=model, modes=modes, budget=budget.e2e)
+    if not e2e.done:
+        return blocked("VERL e2e precision failed", evidence=e2e)
+
+    evidence = record_evidence(task, run=e2e.evidence.run, comparison=e2e.evidence, environment=budget.env)
+    risks = [
+        "SFT loss curve can pass while a lower-level bug remains shared",
+        "RL reward variance can hide precision drift",
+        "rollout backend can become the reference accidentally",
+    ]
+    return done(workflow=verl_config.algorithm, evidence=evidence, risks=risks)
+```

--- a/experimental/lite/skills/basic/align-e2e-precision.md
+++ b/experimental/lite/skills/basic/align-e2e-precision.md
@@ -1,0 +1,59 @@
+# Align E2E Precision Skill
+
+Use pretrain, SFT, or RL as the strongest but highest-cost precision evidence.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "basic.align_e2e_precision", kind="state_machine", purpose="validate precision through pretrain/SFT/RL",
+    imports=["basic.constitution"], calls=["basic.constitution", "basic.find_reference", "basic.review_threshold"],
+    inputs=["task", "target", "modes", "budget"],
+    outputs=["alignment", "evidence", "override", "risks"], exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def align_e2e_precision(task, target, modes, budget):
+    if task.scope not in ["precision", "model", "runtime", "application"]:
+        return out_of_scope("not an end-to-end precision task")
+    if not budget.high_cost_approved:
+        return blocked("e2e precision requires high-cost approval")
+
+    mode = choose_first_available(modes, order=["pretrain", "SFT", "RL"])
+    if mode is None:
+        return blocked("no e2e mode selected")
+
+    ref = basic.find_reference(task, layer=target.layer, candidates=task.references, budget=budget.reference)
+    if not ref.done:
+        return blocked("no usable e2e reference", evidence=ref)
+
+    policy = basic.constitution(task, layer=target.layer, reference=ref.reference)
+    if not policy.done:
+        return blocked("e2e precision policy failed", evidence=policy)
+
+    run = construct_e2e_run(
+        mode,
+        target,
+        reference=ref.reference,
+        freeze=["dataset", "tokenizer", "checkpoint", "schedule", "seed", "variables"],
+        compare=["loss_curve", "grad_norm", "reward_or_metric", "checkpoint_delta"],
+    )
+    if run is None:
+        return blocked("cannot construct comparable e2e run")
+
+    threshold = basic.review_threshold(task, ref.contract, requested_threshold=task.tolerance)
+    if not threshold.done:
+        return blocked("e2e precision threshold review failed", evidence=threshold)
+    compare_mode = threshold.compare_mode
+
+    evidence = run_reference_and_target(run, compare_mode=compare_mode)
+    risks = ["high cost", "may preserve a shared bug", "can mask local mismatches"]
+
+    if evidence.pass_:
+        return done(alignment="e2e_aligned", evidence=evidence, override=True, risks=risks)
+
+    return done(alignment="e2e_mismatch", evidence=evidence, override=False, risks=risks)
+```

--- a/experimental/lite/skills/basic/align-precision.md
+++ b/experimental/lite/skills/basic/align-precision.md
@@ -1,0 +1,99 @@
+# Align Precision Skill
+
+Align Megatron Lite behavior against a reference, or localize the first precision
+break with controlled variables.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "basic.align_precision", kind="state_machine", purpose="recursively align precision to reference",
+    imports=["basic.constitution"],
+    calls=[
+        "basic.constitution", "basic.find_reference", "basic.construct_proxy_task",
+        "basic.review_threshold", "basic.align_precision", "basic.align_e2e_precision",
+    ],
+    inputs=["task", "target", "variables", "budget"],
+    outputs=["alignment", "evidence", "next"], exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def align_precision(task, target, variables, budget):
+    if task.scope not in ["precision", "primitive", "model"]:
+        return out_of_scope("not a precision-alignment task")
+    if budget.depth > budget.max_depth or budget.attempts > budget.max_attempts:
+        return blocked("precision recursion budget exhausted")
+
+    ref = basic.find_reference(task, layer=target.layer, candidates=task.references, budget=budget.reference)
+    if not ref.done:
+        return blocked("no usable reference", evidence=ref)
+
+    policy = basic.constitution(task, layer=target.layer, reference=ref.reference)
+    if not policy.done:
+        return blocked("precision policy failed", evidence=policy)
+
+    proxy_result = basic.construct_proxy_task(
+        task,
+        target=target,
+        reference=ref.reference,
+        variables=variables,
+        budget=budget.proxy,
+    )
+    if not proxy_result.done:
+        return blocked("cannot construct minimal proxy task")
+    proxy_task = proxy_result.proxy
+
+    controlled = variables.freeze_all_except(task.variable_under_test)
+    if controlled.has_unknown_unfrozen_axes():
+        return blocked("unknown variables remain uncontrolled", risks=controlled.unknown_axes)
+    axes = controlled.axes(one_at_a_time=True)
+
+    deterministic = run_same_setting(proxy_task, runs=3)
+    if not deterministic.bitwise_equal():
+        proxy_task = remove_known_nondeterminism(proxy_task)
+        deterministic = run_same_setting(proxy_task, runs=3)
+        if not deterministic.bitwise_equal() and policy.validation.requires_bitwise:
+            return blocked("reference or target is not deterministic", evidence=deterministic)
+
+    threshold = basic.review_threshold(task, ref.contract, requested_threshold=task.tolerance)
+    if not threshold.done:
+        return blocked("precision threshold review failed", evidence=threshold)
+    mode = threshold.compare_mode
+
+    full = compare(proxy_task, target, ref.reference, mode=mode)
+    if full.pass_:
+        return done(alignment="aligned", evidence=[deterministic, full], next=[])
+
+    evidence = [deterministic, full]
+    for axis in axes:
+        experiment = vary_one_axis(proxy_task, axis=axis)
+        evidence.append(compare(experiment, target, ref.reference, mode=mode))
+        if evidence[-1].first_failure:
+            break
+
+    for unit in decompose(target, order=["layer", "submodule", "primitive"]):
+        child = basic.align_precision(
+            task.narrow_to(unit),
+            target=unit,
+            variables=variables.freeze_except(unit.related_axes),
+            budget=budget.child(increment=["depth", "attempts"]),
+        )
+        evidence.append(child)
+        if child.alignment in ["aligned", "localized_mismatch"] or child.blocked:
+            break
+
+    if budget.e2e.high_cost_approved:
+        e2e = basic.align_e2e_precision(task, target=target, modes=task.e2e_modes, budget=budget.e2e)
+        evidence.append(e2e)
+        if e2e.alignment == "e2e_aligned":
+            return done(
+                alignment="e2e_aligned_override",
+                evidence=evidence,
+                next=["local mismatch overridden by high-cost e2e evidence", *e2e.risks],
+            )
+
+    return done(alignment="localized_mismatch", evidence=evidence, next=owner_of_first_failure(evidence))
+```

--- a/experimental/lite/skills/basic/constitution.md
+++ b/experimental/lite/skills/basic/constitution.md
@@ -1,0 +1,45 @@
+# Basic Constitution Skill
+
+Global constraints for all Megatron Lite skills.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "basic.constitution", kind="constitution", purpose="set global MLite constraints",
+    imports=[], calls=[],
+    inputs=["task", "layer", "reference"],
+    outputs=["constraints", "validation", "stop"], exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def constitution(task, layer, reference):
+    if reference is None:
+        return blocked("no validation reference")
+    if task.requires_undefined_skill:
+        return out_of_scope("required procedural skill is undefined")
+
+    constraints = [
+        occam_razor("choose the smallest correct and reviewable design"),
+        modularity("primitives are replaceable unless explicitly fused"),
+        bounded_state_machine("every procedural skill has finite exits"),
+    ]
+
+    validation = [
+        reference_order(["Megatron", "HuggingFace", "Torch", "first principles"]),
+        require_bitwise_when_possible(reference),
+        minimal_primitive_check(scope=["single_gpu", "single_node"], reduce=["layers", "experts"]),
+        require_end_to_end_before_delivery(),
+    ]
+
+    stop = [
+        "missing reference",
+        "missing validation path",
+        "required procedural skill is undefined",
+    ]
+
+    return done(constraints=constraints, validation=validation, stop=stop)
+```

--- a/experimental/lite/skills/basic/construct-proxy-task.md
+++ b/experimental/lite/skills/basic/construct-proxy-task.md
@@ -1,0 +1,38 @@
+# Construct Proxy Task Skill
+
+Build the smallest task that can falsify a claim.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "basic.construct_proxy_task", kind="state_machine", purpose="minimize validation while preserving claim",
+    imports=["basic.constitution"], calls=[],
+    inputs=["task", "target", "reference", "variables", "budget"],
+    outputs=["proxy", "controlled", "risks"], exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def construct_proxy_task(task, target, reference, variables, budget):
+    if reference is None:
+        return blocked("proxy task needs a reference")
+
+    proxy = minimize(
+        target,
+        start=["single_gpu", "single_node"],
+        reduce=["layers", "experts", "sequence", "hidden", "batch"],
+        preserve=["operation", "shape_rules", "dtype_rules", task.variable_under_test],
+    )
+    if proxy is None or not proxy.still_tests(task.claim):
+        return blocked("cannot build minimal proxy that preserves claim")
+
+    controlled = variables.freeze_all_except(task.variable_under_test)
+    if controlled.has_unknown_unfrozen_axes():
+        return blocked("proxy has uncontrolled variables", risks=controlled.unknown_axes)
+
+    risks = ["proxy may miss bugs that require full scale"]
+    return done(proxy=proxy, controlled=controlled, risks=risks)
+```

--- a/experimental/lite/skills/basic/find-reference.md
+++ b/experimental/lite/skills/basic/find-reference.md
@@ -1,0 +1,51 @@
+# Find Reference Skill
+
+Find the strongest checkable reference for a Megatron Lite task.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "basic.find_reference", kind="state_machine", purpose="select a checkable validation reference",
+    imports=[], calls=[],
+    inputs=["task", "layer", "candidates", "budget"],
+    outputs=["reference", "contract", "risks"], exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def find_reference(task, layer, candidates, budget):
+    if task.scope not in ["primitive", "model", "runtime", "application", "precision"]:
+        return out_of_scope("unknown validation surface")
+
+    ordered = [
+        megatron_reference(task, layer),
+        huggingface_reference(task, layer),
+        torch_reference(task, layer),
+        first_principles_formula_or_distributed_invariant(task, layer),
+        *candidates,
+    ]
+
+    risks = []
+    for ref in ordered[:budget.max_candidates]:
+        if ref is None or not ref.exists():
+            continue
+
+        contract = extract_contract(
+            ref,
+            fields=["inputs", "outputs", "shape", "dtype", "seed", "variables", "tolerance"],
+        )
+        if not contract.is_checkable():
+            risks.append((ref, "reference exists but contract is incomplete"))
+            continue
+        if ref.requires_unavailable_assets():
+            risks.append((ref, "reference requires unavailable assets"))
+            continue
+
+        variables = freeze_variables(contract.variables, except_=task.variable_under_test)
+        return done(reference=ref, contract=contract.with_variables(variables), risks=risks)
+
+    return blocked("no checkable reference", risks=risks)
+```

--- a/experimental/lite/skills/basic/lint-skill.md
+++ b/experimental/lite/skills/basic/lint-skill.md
@@ -1,0 +1,58 @@
+# Lint Skill
+
+Validate a Megatron Lite skill file before review.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "basic.lint_skill", kind="state_machine", purpose="validate skill structure and dry-runs",
+    imports=[], calls=[],
+    inputs=["skill_file", "registry", "scenarios", "budget"],
+    outputs=["lint", "dry_runs", "risks"], exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def lint_skill(skill_file, registry, scenarios, budget):
+    if not skill_file.path.startswith("experimental/lite/skills/"):
+        return out_of_scope("not an MLite skill")
+
+    schema = extract_schema_block(skill_file)
+    if schema is None:
+        return blocked("missing schema markers")
+
+    spec = parse_skill_schema(schema)
+    expected_path = module_name_to_path(spec.name)
+    if skill_file.path != expected_path:
+        return blocked("schema name does not match file path", evidence=[spec.name, skill_file.path])
+
+    lint = [
+        require_single_md_file(skill_file),
+        reject_readme_skill_body(skill_file),
+        require_python_like_body(skill_file),
+        require_top_level_function(skill_file, name=spec.name.split(".")[-1], inputs=spec.inputs),
+        require_declared_exits(skill_file, exits=spec.exits),
+        require_bounded_loops(skill_file),
+        require_resolved_imports(spec.imports, registry),
+        require_resolved_calls(spec.calls, registry),
+    ]
+    body_calls = extract_skill_calls(skill_file.body, registry=registry)
+    lint.extend([
+        require_body_calls_declared(body_calls, declared=spec.calls),
+        require_declared_calls_used(spec.calls, body_calls, allow_recursive=True),
+    ])
+    if any(check.fail for check in lint):
+        return blocked("skill lint failed", lint=lint)
+
+    dry_runs = []
+    for scenario in scenarios[:budget.max_scenarios]:
+        dry_runs.append(trace_pseudocode(skill_file, scenario, max_steps=budget.max_steps))
+        if dry_runs[-1].exit not in spec.exits:
+            return blocked("scenario reached undeclared exit", dry_runs=dry_runs)
+
+    risks = ["dry-runs are contract checks, not executable unit tests"]
+    return done(lint=lint, dry_runs=dry_runs, risks=risks)
+```

--- a/experimental/lite/skills/basic/review-threshold.md
+++ b/experimental/lite/skills/basic/review-threshold.md
@@ -1,0 +1,33 @@
+# Review Threshold Skill
+
+Choose the comparison mode and require human review for non-bitwise thresholds.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "basic.review_threshold", kind="state_machine", purpose="select bitwise or reviewed tolerance",
+    imports=["basic.constitution"], calls=[],
+    inputs=["task", "reference_contract", "requested_threshold"],
+    outputs=["compare_mode", "review", "risks"], exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def review_threshold(task, reference_contract, requested_threshold):
+    if reference_contract is None:
+        return blocked("missing reference contract for threshold review")
+
+    if reference_contract.bitwise_possible:
+        return done(compare_mode=bitwise(), review=False, risks=[])
+
+    threshold = requested_threshold or relative(0.01)
+    review = human_review_required(
+        reason="non-bitwise precision threshold; 1% relative is only a default",
+        threshold=threshold,
+    )
+    risks = ["accepted threshold can hide real precision bugs"]
+    return done(compare_mode=threshold, review=review, risks=risks)
+```

--- a/experimental/lite/skills/insight/progressive-model-support.md
+++ b/experimental/lite/skills/insight/progressive-model-support.md
@@ -1,0 +1,201 @@
+# Progressive Model Support Skill
+
+Plan model support through either an HF-first path or a nearest-reference diff path.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "insight.progressive_model_support", kind="state_machine", purpose="stage model support with HF and bridge/reference paths",
+    imports=["basic.constitution"],
+    calls=[
+        "basic.find_reference", "basic.align_precision", "basic.align_e2e_precision",
+        "primitive.select_for_compose",
+        "model_compose.config_mapping", "model_compose.weight_mapping", "model_compose.build_model",
+    ],
+    inputs=["task", "model", "budget"],
+    outputs=["path", "stages", "evidence", "risks"], exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def progressive_model_support(task, model, budget):
+    if model.is_pure_new or not model.has_bridge_or_nearest_reference():
+        result = support_pure_new_model_from_hf(task, model, budget)
+    else:
+        result = support_model_from_bridge_reference(task, model, budget)
+
+    if not result.done:
+        return blocked("progressive model support failed", evidence=result)
+    return done(path=result.path, stages=result.stages, evidence=result.evidence, risks=result.risks)
+
+
+def support_pure_new_model_from_hf(task, model, budget):
+    stages = ["hf_config", "hf_weights", "PP", "EP", "CP_if_needed", "TP_if_needed", "e2e"]
+    evidence = []
+
+    config = model_compose.config_mapping(task, model.hf.config, model.lite_config, budget.config)
+    evidence.append(config)
+    if not config.done:
+        return blocked("pure-new HF path stopped at config mapping", evidence=evidence)
+
+    weights = model_compose.weight_mapping(task, model.hf.checkpoint, model.lite_model, budget.weights)
+    evidence.append(weights)
+    if not weights.done:
+        return blocked("pure-new HF path stopped at weight mapping", evidence=evidence)
+
+    primitive_steps = [
+        step("PP", required=True, features=["pipeline_parallel"]),
+        step("EP", required=model.has_moe, features=["expert_parallel", "moe", "deepep"]),
+        step("CP", required=model.needs_long_context or model.uses_thd, features=["context_parallel", "thd"]),
+        step("TP", required=model.needs_tensor_parallel_for_memory_or_perf, features=["tensor_parallel"]),
+    ]
+    partial = model.empty_lite_model(config=config.mapping, weights=weights.mapping)
+
+    for primitive_step in primitive_steps:
+        if not primitive_step.required:
+            continue
+        selection = primitive.select_for_compose(
+            task.narrow_to(primitive_step.name),
+            model_spec=model.spec.require(primitive_step.features),
+            candidates=model.primitive_candidates(primitive_step.features),
+            budget=budget.primitive_step(primitive_step.name),
+        )
+        evidence.append(selection)
+        if not selection.done:
+            return blocked("pure-new primitive selection failed", evidence=evidence)
+
+        partial = model_compose.build_model(
+            task.narrow_to(primitive_step.name),
+            model_spec=partial.spec.with_primitives(selection.selection),
+            primitives=partial.primitives + selection.selection,
+            budget=budget.build_step(primitive_step.name),
+        )
+        evidence.append(partial)
+        if not partial.done:
+            return blocked("pure-new incremental model build failed", evidence=evidence)
+
+        precision = compare_model_precision_ladder(
+            task.narrow_to(primitive_step.name),
+            target=partial.model,
+            reference=model.hf,
+            variables=model.variables.freeze_all_except(primitive_step.features),
+            budget=budget.precision_step(primitive_step.name),
+        )
+        evidence.append(precision)
+        if not precision.done:
+            return blocked("pure-new precision ladder failed", evidence=evidence)
+
+    e2e = basic.align_e2e_precision(task, target=partial.model, modes=task.e2e_modes, budget=budget.e2e)
+    evidence.append(e2e)
+    if not e2e.done:
+        return blocked("pure-new model stopped at e2e", evidence=evidence)
+
+    risks = ["HF-first path can miss bugs shared by HF conversion and Lite compose"]
+    return done(path="hf_first_pure_new", stages=stages, evidence=evidence, risks=risks)
+
+
+def support_model_from_bridge_reference(task, model, budget):
+    stages = ["nearest_reference", "diff_primitives", "bridge_precision", "hf_cross_check", "e2e"]
+    evidence = []
+
+    reference = basic.find_reference(
+        task,
+        layer="model",
+        candidates=[model.bridge_reference, *model.nearest_existing_models, "mbridge", "megatron-bridge"],
+        budget=budget.reference,
+    )
+    evidence.append(reference)
+    if not reference.done:
+        return blocked("no nearest model reference for diff path", evidence=evidence)
+
+    diff = model.diff_against(reference.reference)
+    selection = primitive.select_for_compose(
+        task.narrow_to(diff),
+        model_spec=diff.model_spec,
+        candidates=diff.primitive_candidates,
+        budget=budget.diff_primitives,
+    )
+    evidence.append(selection)
+    if not selection.done:
+        return blocked("diff primitive selection failed", evidence=evidence)
+
+    config = model_compose.config_mapping(task, model.hf.config, model.lite_config, budget.config)
+    weights = model_compose.weight_mapping(task, model.hf.checkpoint, model.lite_model, budget.weights)
+    evidence.extend([config, weights])
+    if not config.done or not weights.done:
+        return blocked("HF config or weight mapping failed in reference path", evidence=evidence)
+
+    candidate = model_compose.build_model(
+        task,
+        model_spec=model.spec.apply_diff(diff, config.mapping),
+        primitives=reference.reference.primitives + selection.selection,
+        budget=budget.build,
+    )
+    evidence.append(candidate)
+    if not candidate.done:
+        return blocked("reference-diff model build failed", evidence=evidence)
+
+    bridge_precision = compare_model_precision_ladder(
+        task.narrow_to("bridge_reference"),
+        target=candidate.model,
+        reference=reference.reference,
+        variables=model.variables.freeze_all_except(diff.changed_features),
+        budget=budget.bridge_precision,
+    )
+    evidence.append(bridge_precision)
+    if not bridge_precision.done:
+        return blocked("reference-diff precision failed", evidence=evidence)
+
+    hf_precision = compare_model_precision_ladder(
+        task.narrow_to("hf_cross_check"),
+        target=candidate.model,
+        reference=model.hf,
+        variables=model.variables.freeze_all_except(diff.changed_features),
+        budget=budget.hf_precision,
+    )
+    evidence.append(hf_precision)
+    if not hf_precision.done:
+        return blocked("HF cross-check precision failed", evidence=evidence)
+
+    e2e = basic.align_e2e_precision(task, target=candidate.model, modes=task.e2e_modes, budget=budget.e2e)
+    evidence.append(e2e)
+    if not e2e.done:
+        return blocked("reference-diff model stopped at e2e", evidence=evidence)
+
+    risks = ["nearest-reference path can inherit reference bugs", "HF cross-check is still required"]
+    return done(path="nearest_reference_diff", stages=stages, evidence=evidence, risks=risks)
+
+
+def compare_model_precision_ladder(task, target, reference, variables, budget):
+    forward = basic.align_precision(
+        task.with_phase("forward").with_reference(reference).with_metrics(["bitwise_when_possible", "cos_sim"]),
+        target=target.forward_proxy(),
+        variables=variables.freeze_all_except("forward_math"),
+        budget=budget.forward,
+    )
+    if not forward.done:
+        return blocked("forward precision failed", evidence=forward)
+
+    backward = basic.align_precision(
+        task.with_phase("backward_grad").with_reference(reference).with_metrics(["bitwise_when_possible", "grad_cos_sim"]),
+        target=target.backward_proxy(),
+        variables=variables.freeze_all_except("backward_grad"),
+        budget=budget.backward,
+    )
+    if not backward.done:
+        return blocked("backward gradient precision failed", evidence=[forward, backward])
+
+    grad_norm = compare_grad_norm(
+        target,
+        reference,
+        mode=["bitwise_when_possible", "relative_threshold", "cos_sim_supporting_signal"],
+        tolerance=budget.grad_norm_tolerance,
+    )
+    if not grad_norm.pass_:
+        return blocked("grad norm precision failed", evidence=[forward, backward, grad_norm])
+
+    return done(alignment="forward_backward_grad_norm_aligned", evidence=[forward, backward, grad_norm], risks=[])
+```

--- a/experimental/lite/skills/insight/progressive-primitive-design.md
+++ b/experimental/lite/skills/insight/progressive-primitive-design.md
@@ -1,0 +1,39 @@
+# Progressive Primitive Design Skill
+
+Plan a new primitive from first principles to performance.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "insight.progressive_primitive_design", kind="state_machine", purpose="stage new primitive design",
+    imports=["basic.constitution"], calls=["primitive.design", "primitive.validate", "perf.optimize"],
+    inputs=["task", "primitive", "budget"],
+    outputs=["stages", "evidence", "risks"], exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def progressive_primitive_design(task, primitive, budget):
+    stages = ["principle", "single_device", "single_node", "distributed", "model_compose", "perf"]
+    evidence = []
+
+    design = primitive.design(task, primitive, primitive.requirements, budget.design)
+    evidence.append(design)
+    if not design.done:
+        return blocked("primitive design stopped at contract design", evidence=evidence)
+
+    validation = primitive.validate(task, primitive=primitive, implementation=primitive.implementation, budget=budget.validation)
+    evidence.append(validation)
+    if not validation.done:
+        return blocked("primitive design stopped at validation", evidence=evidence)
+
+    optimization = perf.optimize(task, target=primitive.implementation, constraints=primitive.perf_constraints, budget=budget.perf)
+    evidence.append(optimization)
+    if not optimization.done:
+        return blocked("primitive design stopped at performance", evidence=evidence)
+
+    return done(stages=stages, evidence=evidence, risks=["performance stage must not rewrite correctness contract"])
+```

--- a/experimental/lite/skills/insight/scope-control.md
+++ b/experimental/lite/skills/insight/scope-control.md
@@ -1,0 +1,29 @@
+# Scope Control Skill
+
+Decide when to split work instead of expanding a skill or task.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "insight.scope_control", kind="state_machine", purpose="prevent skill and task scope creep",
+    imports=["basic.constitution"], calls=["basic.lint_skill"],
+    inputs=["task", "change", "budget"],
+    outputs=["decision", "split", "risks"], exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def scope_control(task, change, budget):
+    if change.touches_multiple_namespaces() or change.exceeds(budget.max_files):
+        return done(decision="split", split=propose_child_tasks(change), risks=["large review surface"])
+    if change.adds_new_procedure_without_schema():
+        return blocked("new procedure needs a skill schema")
+
+    lint = basic.lint_skill(change.skill_file, registry=budget.registry, scenarios=[], budget=budget.lint)
+    if not lint.done:
+        return blocked("scope-control lint failed", evidence=lint)
+    return done(decision="continue", split=[], risks=[])
+```

--- a/experimental/lite/skills/model-compose/build-model.md
+++ b/experimental/lite/skills/model-compose/build-model.md
@@ -1,0 +1,35 @@
+# Build Model Skill
+
+Compose a Megatron Lite model from validated primitives.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "model_compose.build_model", kind="state_machine", purpose="compose MLite model from primitives",
+    imports=["basic.constitution"], calls=["primitive.select_for_compose", "primitive.validate", "basic.align_precision"],
+    inputs=["task", "model_spec", "primitives", "budget"],
+    outputs=["model", "validation", "risks"], exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def build_model(task, model_spec, primitives, budget):
+    selected = primitive.select_for_compose(task, model_spec=model_spec, candidates=primitives, budget=budget.selection)
+    if not selected.done:
+        return blocked("primitive selection failed before model compose", evidence=selected)
+
+    for selected_primitive in selected.selection:
+        result = primitive.validate(task, primitive=selected_primitive, implementation=selected_primitive.impl, budget=budget.primitive)
+        if not result.done:
+            return blocked("primitive not validated before model compose", evidence=result)
+
+    model = compose_layers(model_spec, selected.selection, boundary=["runtime", "model", "primitive"])
+    precision = basic.align_precision(task, target=model, variables=model.variables, budget=budget.precision)
+    if not precision.done:
+        return blocked("model precision failed", evidence=precision)
+
+    return done(model=model, validation=precision, risks=["composition can hide primitive boundary bugs"])
+```

--- a/experimental/lite/skills/model-compose/config-mapping.md
+++ b/experimental/lite/skills/model-compose/config-mapping.md
@@ -1,0 +1,34 @@
+# Config Mapping Skill
+
+Map external model configs into Megatron Lite configs.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "model_compose.config_mapping", kind="state_machine", purpose="map model configs into MLite",
+    imports=["basic.constitution"], calls=["basic.find_reference"],
+    inputs=["task", "source_config", "target_config", "budget"],
+    outputs=["mapping", "evidence", "risks"], exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def config_mapping(task, source_config, target_config, budget):
+    reference = basic.find_reference(task, layer="config", candidates=[source_config], budget=budget.reference)
+    if not reference.done:
+        return blocked("config reference not found", evidence=reference)
+
+    mapping = map_fields(
+        source_config,
+        target_config,
+        required=["hidden_size", "num_layers", "num_heads", "dtype", "moe", "rope"],
+    )
+    if mapping.has_missing_required_fields():
+        return blocked("config mapping incomplete", evidence=mapping.missing)
+
+    evidence = record_evidence(task, run=mapping.check, comparison=mapping.comparison, environment=budget.env)
+    return done(mapping=mapping, evidence=evidence, risks=["default mismatch", "alias mismatch"])
+```

--- a/experimental/lite/skills/model-compose/qwen.md
+++ b/experimental/lite/skills/model-compose/qwen.md
@@ -1,0 +1,37 @@
+# Qwen Compose Skill
+
+Compose Qwen3 and Qwen3.5 Megatron Lite models.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "model_compose.qwen", kind="state_machine", purpose="compose Qwen3/Qwen3.5 MLite models",
+    imports=["basic.constitution"], calls=["model_compose.config_mapping", "model_compose.weight_mapping", "model_compose.build_model"],
+    inputs=["task", "hf_model", "lite_model", "budget"],
+    outputs=["model", "mapping", "evidence", "risks"], exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def qwen(task, hf_model, lite_model, budget):
+    if hf_model.family not in ["qwen3", "qwen3_5"]:
+        return out_of_scope("not a Qwen3/Qwen3.5 model")
+
+    config = model_compose.config_mapping(task, hf_model.config, lite_model.config, budget.config)
+    if not config.done:
+        return blocked("Qwen config mapping failed", evidence=config)
+
+    weights = model_compose.weight_mapping(task, hf_model.checkpoint, lite_model, budget.weights)
+    if not weights.done:
+        return blocked("Qwen weight mapping failed", evidence=weights)
+
+    model = model_compose.build_model(task, lite_model.spec, lite_model.primitives, budget.build)
+    if not model.done:
+        return blocked("Qwen model build failed", evidence=model)
+
+    risks = ["Qwen alias mismatch", "MoE router drift", "GQA head mapping drift"]
+    return done(model=model.model, mapping=[config.mapping, weights.mapping], evidence=[weights.evidence, model.validation], risks=risks)
+```

--- a/experimental/lite/skills/model-compose/weight-mapping.md
+++ b/experimental/lite/skills/model-compose/weight-mapping.md
@@ -1,0 +1,40 @@
+# Weight Mapping Skill
+
+Map checkpoint weights into Megatron Lite model state.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "model_compose.weight_mapping", kind="state_machine", purpose="map checkpoint weights into MLite",
+    imports=["basic.constitution"], calls=["basic.find_reference", "basic.align_precision"],
+    inputs=["task", "source_checkpoint", "target_model", "budget"],
+    outputs=["mapping", "coverage", "evidence"], exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def weight_mapping(task, source_checkpoint, target_model, budget):
+    candidates = [
+        source_checkpoint,
+        "mbridge",
+        "megatron-bridge",
+        *budget.reference.extra_checkpoint_tools,
+    ]
+    reference = basic.find_reference(task, layer="checkpoint", candidates=candidates, budget=budget.reference)
+    if not reference.done:
+        return blocked("checkpoint reference not found", evidence=reference)
+
+    mapping = map_weight_names_shapes_dtypes(source_checkpoint, target_model, reference_tools=["mbridge", "megatron-bridge"])
+    coverage = mapping.coverage()
+    if not coverage.complete:
+        return blocked("weight mapping incomplete", evidence=coverage.missing)
+
+    precision = basic.align_precision(task, target=target_model, variables=mapping.variables, budget=budget.precision)
+    if not precision.done:
+        return blocked("mapped model precision failed", evidence=precision)
+
+    return done(mapping=mapping, coverage=coverage, evidence=precision)
+```

--- a/experimental/lite/skills/perf/fusion.md
+++ b/experimental/lite/skills/perf/fusion.md
@@ -1,0 +1,31 @@
+# Fusion Skill
+
+Evaluate fusion opportunities without breaking primitive boundaries.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "perf.fusion", kind="state_machine", purpose="evaluate safe fusion opportunities",
+    imports=["basic.constitution"], calls=["primitive.fuse", "perf.measure"],
+    inputs=["task", "candidates", "target", "budget"],
+    outputs=["fusion", "evidence", "risks"], exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def fusion(task, candidates, target, budget):
+    fused = propose_fusion(candidates, target)
+    decision = primitive.fuse(task, primitives=candidates, fused_design=fused, budget=budget.fuse)
+    if not decision.done:
+        return blocked("fusion decision failed", evidence=decision)
+
+    measurement = perf.measure(task, target=fused, workload=budget.workload, budget=budget.measure)
+    if not measurement.done:
+        return blocked("fused target measurement failed", evidence=measurement)
+
+    risks = [*decision.risks, "fusion must not replace precision validation"]
+    return done(fusion=fused, evidence=[decision, measurement], risks=risks)
+```

--- a/experimental/lite/skills/perf/measure.md
+++ b/experimental/lite/skills/perf/measure.md
@@ -1,0 +1,30 @@
+# Measure Skill
+
+Measure runtime, memory, and quality metrics with a stable protocol.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "perf.measure", kind="state_machine", purpose="measure performance without losing precision context",
+    imports=["basic.constitution"], calls=[],
+    inputs=["task", "target", "workload", "budget"],
+    outputs=["metrics", "run", "risks"], exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def measure(task, target, workload, budget):
+    if workload is None:
+        return blocked("missing workload")
+
+    run = execute_with_protocol(target, workload, warmup=budget.warmup, repeats=budget.repeats)
+    metrics = collect_metrics(run, fields=["tokens_per_sec", "step_time", "memory", "loss_or_reward"])
+    if metrics.has_missing_fields():
+        return blocked("performance evidence incomplete", evidence=metrics)
+
+    risks = ["performance numbers without precision evidence are not sufficient"]
+    return done(metrics=metrics, run=run, risks=risks)
+```

--- a/experimental/lite/skills/perf/memory.md
+++ b/experimental/lite/skills/perf/memory.md
@@ -1,0 +1,40 @@
+# Memory Skill
+
+Analyze memory across parameters, optimizer state, activations, and offload.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "perf.memory", kind="state_machine", purpose="analyze MLite memory behavior",
+    imports=["basic.constitution"], calls=["perf.measure"],
+    inputs=["task", "target", "memory_config", "budget"],
+    outputs=["memory", "evidence", "risks"], exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def memory(task, target, memory_config, budget):
+    measurement = perf.measure(task, target=target, workload=memory_config.workload, budget=budget.measure)
+    if not measurement.done:
+        return blocked("memory measurement failed", evidence=measurement)
+
+    memory = split_memory(measurement.metrics.memory, buckets=["params", "grads", "optimizer", "activations", "offload"])
+    model = estimate_memory(
+        target,
+        reference="https://developer.nvidia.cn/blog/explore-using-the-megatron-core-training-framework-to-improve-gpu-memory-efficiency-in-large-model-training/",
+        static_axes=["EP*PP changes expert/layer ownership", "FSDP changes param/grad/optimizer ownership"],
+        dynamic_axes=["TP*CP changes activation and attention working-set shape", "THD changes packed-token activation shape"],
+    )
+    comparison = compare_estimate_to_measurement(model, measurement.metrics.memory)
+    if not comparison.within(memory_config.tolerance):
+        return blocked("memory estimate and measurement disagree", evidence=[model, measurement, comparison])
+
+    risks = [
+        "offload can improve capacity while hiding transfer bottlenecks",
+        "static memory and dynamic peak must be inspected separately",
+    ]
+    return done(memory=memory, evidence=[measurement, model, comparison], risks=risks)
+```

--- a/experimental/lite/skills/perf/optimize.md
+++ b/experimental/lite/skills/perf/optimize.md
@@ -1,0 +1,61 @@
+# Optimize Skill
+
+Iterate on performance while preserving precision evidence.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "perf.optimize", kind="state_machine", purpose="optimize performance under precision guardrails",
+    imports=["basic.constitution"], calls=["basic.align_precision", "perf.measure", "perf.fusion", "primitive.design"],
+    inputs=["task", "target", "candidates", "budget"],
+    outputs=["best", "evidence", "risks"], exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def optimize(task, target, candidates, budget):
+    best = None
+    evidence = []
+    queue = candidates[:budget.max_candidates]
+
+    for attempt in range(budget.max_attempts):
+        if not queue:
+            break
+        candidate = queue.pop(0)
+
+        experiment = run_experiment(candidate, workload=budget.workload, knobs=budget.tunable_knobs)
+        profile = perf.measure(task, target=candidate, workload=experiment.workload, budget=budget.measure)
+        evidence.append((candidate, experiment, profile))
+        if not profile.done:
+            continue
+
+        opportunities = analyze_profile(
+            profile.metrics,
+            spaces=["compute_communication_overlap", "kernel_fusion", "schedule_tuning", "new_or_split_primitive"],
+        )
+        if opportunities.require_fusion:
+            fusion = perf.fusion(task, candidates=opportunities.fusion_candidates, target=candidate, budget=budget.fusion)
+            evidence.append(fusion)
+            if fusion.done:
+                queue.append(fusion.fusion)
+        if opportunities.require_primitive_design:
+            design = primitive.design(task, opportunities.primitive, opportunities.requirements, budget.primitive_design)
+            evidence.append(design)
+            if design.done:
+                queue.append(design.design)
+
+        tuned = tune_parameters(candidate, opportunities.knobs)
+        precision = basic.align_precision(task, target=tuned, variables=tuned.variables, budget=budget.precision)
+        if not precision.done:
+            continue
+        measurement = perf.measure(task, target=tuned, workload=budget.workload, budget=budget.measure)
+        evidence.append((tuned, precision, measurement))
+        best = choose_better(best, tuned, measurement.metrics)
+
+    if best is None:
+        return blocked("no optimized candidate preserved precision", evidence=evidence)
+    return done(best=best, evidence=evidence, risks=["optimization search can overfit benchmark", "profiling must be repeated after every primitive change"])
+```

--- a/experimental/lite/skills/primitive/contract.md
+++ b/experimental/lite/skills/primitive/contract.md
@@ -1,0 +1,61 @@
+# Primitive Contract Skill
+
+Define the required outputs for every MLite primitive skill.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "primitive.contract", kind="constitution", purpose="define primitive skill outputs",
+    imports=["basic.constitution"], calls=[],
+    inputs=["primitive", "scope", "reference"],
+    outputs=["principle", "implementation_contract", "usage_contract", "validation", "risks"],
+    exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def contract(primitive, scope, reference):
+    if reference is None:
+        return blocked("primitive needs a reference or first-principles invariant")
+
+    principle = require([
+        "math_or_parallel_semantics",
+        "invariants",
+        "shape_dtype_rank_rules",
+        "what_must_match_reference",
+    ])
+    implementation_contract = require([
+        "owned_files_or_modules",
+        "public_api",
+        "state_and_config",
+        "process_groups_or_device_placement",
+        "forward_backward_update_details",
+        "failure_modes",
+    ])
+    usage_contract = require([
+        "config_keys",
+        "minimal_example",
+        "valid_combinations",
+        "selection_rules",
+        "unsupported_combinations",
+    ])
+    validation = require([
+        "single_gpu_or_single_node_proxy",
+        "controlled_variables",
+        "precision_reference",
+        "composition_test",
+        "e2e_path_if_applicable",
+    ])
+    risks = ["silent mismatch", "dtype drift", "hidden coupling", "wrong selection rule"]
+
+    return done(
+        principle=principle,
+        implementation_contract=implementation_contract,
+        usage_contract=usage_contract,
+        validation=validation,
+        risks=risks,
+    )
+```

--- a/experimental/lite/skills/primitive/design.md
+++ b/experimental/lite/skills/primitive/design.md
@@ -1,0 +1,41 @@
+# Primitive Design Skill
+
+Design a replaceable MLite primitive before implementation.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "primitive.design", kind="state_machine", purpose="design a modular primitive",
+    imports=["basic.constitution"], calls=["primitive.principle", "primitive.contract", "basic.find_reference"],
+    inputs=["task", "primitive", "requirements", "budget"],
+    outputs=["design", "reference", "risks"], exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def design(task, primitive, requirements, budget):
+    ref = basic.find_reference(task, layer=primitive.layer, candidates=requirements.references, budget=budget.reference)
+    if not ref.done:
+        return blocked("no primitive reference", evidence=ref)
+
+    principle = primitive.principle(primitive, reference=ref.reference, constraints=requirements.constraints)
+    if not principle.done:
+        return blocked("primitive principle failed", evidence=principle)
+
+    contract = primitive.contract(primitive, scope=requirements.scope, reference=ref.reference)
+    if not contract.done:
+        return blocked("primitive contract failed", evidence=contract)
+
+    design = {
+        "principle": principle.principle,
+        "implementation_details": define_owned_modules_and_dataflow(primitive),
+        "api": define_inputs_outputs_config_keys(primitive),
+        "composition": declare_valid_and_invalid_combinations(primitive),
+        "selection": decide_when_to_use_or_not_use(primitive),
+        "replaceability": require_no_hidden_dependency(primitive),
+    }
+    return done(design=design, reference=ref, risks=contract.risks)
+```

--- a/experimental/lite/skills/primitive/fuse.md
+++ b/experimental/lite/skills/primitive/fuse.md
@@ -1,0 +1,40 @@
+# Primitive Fuse Skill
+
+Decide whether primitive coupling is allowed as an explicit fused primitive.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "primitive.fuse", kind="state_machine", purpose="approve or reject primitive fusion",
+    imports=["basic.constitution"], calls=["primitive.validate", "basic.align_precision"],
+    inputs=["task", "primitives", "fused_design", "budget"],
+    outputs=["decision", "validation", "risks"], exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def fuse(task, primitives, fused_design, budget):
+    if not fused_design.names_all_coupled_primitives(primitives):
+        return blocked("fusion hides primitive coupling")
+    if not fused_design.has_independent_fallback_or_reference():
+        return blocked("fusion needs an unfused reference")
+
+    structure = primitive.validate(
+        task,
+        primitive=fused_design.primitive,
+        implementation=fused_design.implementation,
+        budget=budget.validate,
+    )
+    if not structure.done:
+        return blocked("fused primitive structure not validated", evidence=structure)
+
+    precision = basic.align_precision(task, target=fused_design, variables=fused_design.variables, budget=budget.precision)
+    if not precision.done:
+        return blocked("fused primitive precision not validated", evidence=precision)
+
+    risks = ["fusion can mask individual primitive bugs", "fusion reduces replaceability"]
+    return done(decision="approved_fused_primitive", validation=[structure, precision], risks=risks)
+```

--- a/experimental/lite/skills/primitive/module/gqa.md
+++ b/experimental/lite/skills/primitive/module/gqa.md
@@ -1,0 +1,46 @@
+# GQA Primitive Skill
+
+Define, implement, use, and validate grouped-query attention primitives.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "primitive.module.gqa", kind="primitive", purpose="define and validate GQA module primitive",
+    imports=["basic.constitution"], calls=["primitive.contract", "primitive.validate"],
+    inputs=["task", "implementation", "config", "reference", "budget"],
+    outputs=["principle", "implementation_contract", "usage_contract", "validation", "risks"],
+    exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def gqa(task, implementation, config, reference, budget):
+    contract = primitive.contract(implementation.gqa, scope=task.scope, reference=reference)
+    if not contract.done:
+        return blocked("GQA contract not satisfied", evidence=contract)
+
+    principle = {
+        "semantics": "many query heads share fewer key/value heads",
+        "invariants": ["KV repeat mapping matches reference", "attention mask and rotary positions are unchanged"],
+        "reference": reference or "HuggingFace attention implementation",
+    }
+    implementation_contract = {
+        "details": ["qkv projection layout", "head mapping", "kv repeat", "attention call"],
+        "state": ["num_attention_heads", "num_key_value_heads", "head_dim"],
+        "boundaries": ["GQA owns head mapping; TP owns sharding of projection weights; THD owns packed sequence boundaries"],
+    }
+    usage_contract = {
+        "config": require_config_keys(config, ["num_attention_heads", "num_key_value_heads"]),
+        "choose_when": ["architecture declares grouped KV heads"],
+        "avoid_when": ["num_attention_heads not divisible by num_key_value_heads"],
+        "compose_with": ["TP projection sharding", "CP context sharding with explicit head/context mapping", "THD packed attention when use_thd=True"],
+    }
+    validation = primitive.validate(task, primitive=implementation.gqa, implementation=implementation, budget=budget)
+    risks = ["head repeat mismatch", "qkv layout bug", "attention mask drift"]
+    if not validation.done:
+        return blocked("GQA validation failed", evidence=validation)
+    return done(principle=principle, implementation_contract=implementation_contract, usage_contract=usage_contract, validation=validation, risks=risks)
+```

--- a/experimental/lite/skills/primitive/module/moe.md
+++ b/experimental/lite/skills/primitive/module/moe.md
@@ -1,0 +1,58 @@
+# MoE Primitive Skill
+
+Define, implement, use, and validate mixture-of-experts primitives.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "primitive.module.moe", kind="primitive", purpose="define and validate MoE module primitive",
+    imports=["basic.constitution"], calls=["primitive.contract", "primitive.validate", "primitive.parallel.ep"],
+    inputs=["task", "implementation", "config", "reference", "budget"],
+    outputs=["principle", "implementation_contract", "usage_contract", "validation", "risks"],
+    exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def moe(task, implementation, config, reference, budget):
+    contract = primitive.contract(implementation.moe, scope=task.scope, reference=reference)
+    if not contract.done:
+        return blocked("MoE contract not satisfied", evidence=contract)
+
+    principle = {
+        "semantics": "router selects experts and combines weighted expert outputs",
+        "invariants": ["router logits/topk match reference", "dispatch/combine preserves token order"],
+        "reference": reference or "HuggingFace/Megatron MoE layer or first-principles weighted sum",
+    }
+    implementation_contract = {
+        "details": ["router", "topk", "token dispatcher", "DeepEP dispatcher", "expert MLP", "combine weights"],
+        "state": ["expert params", "router dtype", "capacity/drop policy", "DeepEP dispatch metadata"],
+        "boundaries": ["module owns routing math; EP owns distributed expert placement; DeepEP owns dispatch/combine transport"],
+    }
+    usage_contract = {
+        "config": require_config_keys(config, ["num_experts", "top_k", "expert_parallel_size", "use_deepep"]),
+        "choose_when": ["model architecture has sparse experts", "expert count justifies EP or grouped GEMM"],
+        "avoid_when": ["router tie behavior cannot be stabilized", "DeepEP metadata cannot be validated against all-to-all"],
+        "compose_with": ["primitive.parallel.ep", "DeepEP dispatcher when EP>1", "primitive.parallel.tp for expert MLP if explicit"],
+    }
+    ep_validation = None
+    if config.expert_parallel_size > 1:
+        ep_validation = primitive.parallel.ep(task, implementation=implementation, config=config, reference=reference, budget=budget.ep)
+        if not ep_validation.done:
+            return blocked("MoE EP composition failed", evidence=ep_validation)
+
+    validation = primitive.validate(task, primitive=implementation.moe, implementation=implementation, budget=budget)
+    risks = ["router tie sensitivity", "expert capacity mismatch", "DeepEP metadata mismatch", "hidden state flattening bug"]
+    if not validation.done:
+        return blocked("MoE validation failed", evidence=validation)
+    return done(
+        principle=principle,
+        implementation_contract=implementation_contract,
+        usage_contract=usage_contract,
+        validation=[ep_validation, validation],
+        risks=risks,
+    )
+```

--- a/experimental/lite/skills/primitive/module/thd.md
+++ b/experimental/lite/skills/primitive/module/thd.md
@@ -1,0 +1,59 @@
+# THD Primitive Skill
+
+Define, implement, use, and validate packed THD variable-length attention.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "primitive.module.thd", kind="primitive", purpose="define and validate THD packed-sequence primitive",
+    imports=["basic.constitution"], calls=["primitive.contract", "primitive.validate", "primitive.parallel.cp"],
+    inputs=["task", "implementation", "config", "reference", "budget"],
+    outputs=["principle", "implementation_contract", "usage_contract", "validation", "risks"],
+    exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def thd(task, implementation, config, reference, budget):
+    contract = primitive.contract(implementation.thd, scope=task.scope, reference=reference)
+    if not contract.done:
+        return blocked("THD contract not satisfied", evidence=contract)
+
+    principle = {
+        "semantics": "pack variable-length sequences as total_tokens x heads x dim for attention",
+        "invariants": ["cu_seqlens define sequence boundaries", "pack/unpack never crosses sequence boundaries"],
+        "reference": reference or "Megatron/Core TE THD packed-sequence attention contract",
+    }
+    implementation_contract = {
+        "details": ["PackedSeqParams", "PackedTHDBatch", "pack_nested_thd", "unpack_packed_thd_to_nested"],
+        "state": ["cu_seqlens", "cu_seqlens_padded", "max_seqlen", "qkv_format=thd"],
+        "boundaries": ["THD owns packing; CP owns zigzag rank partition when cp_size > 1"],
+    }
+    usage_contract = {
+        "config": require_config_keys(config, ["use_thd", "sequence_length", "context_parallel_size"]),
+        "choose_when": ["variable-length SFT/RL data", "padding waste dominates", "attention supports packed THD"],
+        "avoid_when": ["reference cannot expose cu_seqlens", "operator path lacks packed-sequence support"],
+        "compose_with": ["primitive.parallel.cp via zigzag THD slicing", "primitive.module.gqa attention path"],
+    }
+
+    cp_validation = None
+    if config.context_parallel_size > 1 and not task.stack.contains("primitive.parallel.cp"):
+        cp_validation = primitive.parallel.cp(task.push("primitive.module.thd"), implementation=implementation, config=config, reference=reference, budget=budget.cp)
+        if not cp_validation.done:
+            return blocked("THD CP composition failed", evidence=cp_validation)
+
+    validation = primitive.validate(task, primitive=implementation.thd, implementation=implementation, budget=budget)
+    risks = ["cu_seqlens mismatch", "padding alignment drift", "CP zigzag pack/unpack bug"]
+    if not validation.done:
+        return blocked("THD validation failed", evidence=validation)
+    return done(
+        principle=principle,
+        implementation_contract=implementation_contract,
+        usage_contract=usage_contract,
+        validation=[cp_validation, validation],
+        risks=risks,
+    )
+```

--- a/experimental/lite/skills/primitive/optimizer/distopt.md
+++ b/experimental/lite/skills/primitive/optimizer/distopt.md
@@ -1,0 +1,46 @@
+# Distributed Optimizer Skill
+
+Define, implement, use, and validate distributed optimizer sharding.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "primitive.optimizer.distopt", kind="primitive", purpose="define and validate distributed optimizer primitive",
+    imports=["basic.constitution"], calls=["primitive.contract", "primitive.validate"],
+    inputs=["task", "implementation", "config", "reference", "budget"],
+    outputs=["principle", "implementation_contract", "usage_contract", "validation", "risks"],
+    exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def distopt(task, implementation, config, reference, budget):
+    contract = primitive.contract(implementation.distopt, scope=task.scope, reference=reference)
+    if not contract.done:
+        return blocked("DistOpt contract not satisfied", evidence=contract)
+
+    principle = {
+        "semantics": "shard optimizer state and updates across data-parallel ranks",
+        "invariants": ["global update equals unsharded optimizer", "state partition is deterministic"],
+        "reference": reference or "single-rank optimizer with same grads",
+    }
+    implementation_contract = {
+        "details": ["state partition", "grad shard ownership", "update and param sync"],
+        "state": ["momentum/variance shard", "master param ownership", "offload policy"],
+        "boundaries": ["optimizer primitive owns update state; data-parallel grad sync is a separate runtime contract"],
+    }
+    usage_contract = {
+        "config": require_config_keys(config, ["use_distributed_optimizer", "data_parallel_size"]),
+        "choose_when": ["optimizer state memory dominates", "replicated optimizer state is too expensive"],
+        "avoid_when": ["single-rank proxy debugging", "FSDP already owns optimizer sharding"],
+        "compose_with": ["data-parallel gradient path", "TP/EP/PP with clear DP group"],
+    }
+    validation = primitive.validate(task, primitive=implementation.distopt, implementation=implementation, budget=budget)
+    risks = ["state shard drift", "param sync mismatch", "offload update device mismatch"]
+    if not validation.done:
+        return blocked("DistOpt validation failed", evidence=validation)
+    return done(principle=principle, implementation_contract=implementation_contract, usage_contract=usage_contract, validation=validation, risks=risks)
+```

--- a/experimental/lite/skills/primitive/optimizer/fsdp.md
+++ b/experimental/lite/skills/primitive/optimizer/fsdp.md
@@ -1,0 +1,46 @@
+# FSDP Skill
+
+Define, implement, use, and validate fully sharded data parallelism.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "primitive.optimizer.fsdp", kind="primitive", purpose="define and validate FSDP optimizer primitive",
+    imports=["basic.constitution"], calls=["primitive.contract", "primitive.validate"],
+    inputs=["task", "implementation", "config", "reference", "budget"],
+    outputs=["principle", "implementation_contract", "usage_contract", "validation", "risks"],
+    exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def fsdp(task, implementation, config, reference, budget):
+    contract = primitive.contract(implementation.fsdp, scope=task.scope, reference=reference)
+    if not contract.done:
+        return blocked("FSDP contract not satisfied", evidence=contract)
+
+    principle = {
+        "semantics": "shard parameters, gradients, and optimizer state while materialized computation matches reference",
+        "invariants": ["materialized params equal reference", "optimizer update equals unsharded update"],
+        "reference": reference or "single-rank optimizer update with same params/grads",
+    }
+    implementation_contract = {
+        "details": ["wrap policy", "param shard", "all_gather before compute", "reduce_scatter grads"],
+        "state": ["optimizer state shard", "param offload", "optimizer offload", "update-state device"],
+        "boundaries": ["model modules expose params; optimizer primitive owns sharding/offload"],
+    }
+    usage_contract = {
+        "config": require_config_keys(config, ["fsdp_size", "param_offload", "optimizer_offload"]),
+        "choose_when": ["optimizer memory dominates", "param/optimizer offload is needed"],
+        "avoid_when": ["debugging model math; use unsharded optimizer first"],
+        "compose_with": ["TP/EP/PP through explicit param ownership", "DistOpt only with clear owner split"],
+    }
+    validation = primitive.validate(task, primitive=implementation.fsdp, implementation=implementation, budget=budget)
+    risks = ["offload device mismatch", "optimizer state drift", "materialization timing bug"]
+    if not validation.done:
+        return blocked("FSDP validation failed", evidence=validation)
+    return done(principle=principle, implementation_contract=implementation_contract, usage_contract=usage_contract, validation=validation, risks=risks)
+```

--- a/experimental/lite/skills/primitive/parallel/cp.md
+++ b/experimental/lite/skills/primitive/parallel/cp.md
@@ -1,0 +1,52 @@
+# Context Parallel Skill
+
+Define, implement, use, and validate context parallelism.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "primitive.parallel.cp", kind="primitive", purpose="define and validate CP primitive",
+    imports=["basic.constitution"], calls=["primitive.contract", "primitive.validate", "primitive.module.thd"],
+    inputs=["task", "implementation", "config", "reference", "budget"],
+    outputs=["principle", "implementation_contract", "usage_contract", "validation", "risks"],
+    exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def cp(task, implementation, config, reference, budget):
+    contract = primitive.contract(implementation.cp, scope=task.scope, reference=reference)
+    if not contract.done:
+        return blocked("CP contract not satisfied", evidence=contract)
+
+    principle = {
+        "semantics": "partition sequence context while preserving attention result",
+        "invariants": ["CP=1 equals unsharded attention", "position and mask mapping are identical"],
+        "reference": reference or "unsharded attention formula",
+    }
+    implementation_contract = {
+        "details": ["cp_group", "zigzag_split_for_cp", "zigzag_reconstruct_from_cp_parts", "position ids", "mask partition"],
+        "collectives": ["context gather/scatter or ring attention path"],
+        "autograd": ["no non-differentiable fallback collectives"],
+    }
+    usage_contract = {
+        "config": require_config_keys(config, ["context_parallel_size", "sequence_length"]),
+        "choose_when": ["long context exceeds local memory", "attention implementation supports CP"],
+        "avoid_when": ["reference cannot validate positions/masks", "model attention variant lacks CP support"],
+        "compose_with": ["TP only with explicit head/context ownership", "PP by stage-local context policy", "THD packed sequences via zigzag THD slicing"],
+    }
+    thd_validation = None
+    if config.use_thd and not task.stack.contains("primitive.module.thd"):
+        thd_validation = primitive.module.thd(task.push("primitive.parallel.cp"), implementation=implementation, config=config, reference=reference, budget=budget.thd)
+        if not thd_validation.done:
+            return blocked("CP THD composition failed", evidence=thd_validation)
+
+    validation = primitive.validate(task, primitive=implementation.cp, implementation=implementation, budget=budget)
+    risks = ["zigzag reconstruction mismatch", "position mismatch", "mask mismatch", "non-differentiable gather fallback"]
+    if not validation.done:
+        return blocked("CP validation failed", evidence=validation)
+    return done(principle=principle, implementation_contract=implementation_contract, usage_contract=usage_contract, validation=[thd_validation, validation], risks=risks)
+```

--- a/experimental/lite/skills/primitive/parallel/ep.md
+++ b/experimental/lite/skills/primitive/parallel/ep.md
@@ -1,0 +1,46 @@
+# Expert Parallel Skill
+
+Define, implement, use, and validate expert parallelism.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "primitive.parallel.ep", kind="primitive", purpose="define and validate EP primitive",
+    imports=["basic.constitution"], calls=["primitive.contract", "primitive.validate"],
+    inputs=["task", "implementation", "config", "reference", "budget"],
+    outputs=["principle", "implementation_contract", "usage_contract", "validation", "risks"],
+    exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def ep(task, implementation, config, reference, budget):
+    contract = primitive.contract(implementation.ep, scope=task.scope, reference=reference)
+    if not contract.done:
+        return blocked("EP contract not satisfied", evidence=contract)
+
+    principle = {
+        "semantics": "partition experts across ranks while router semantics stay global",
+        "invariants": ["EP=1 equals local MoE", "dispatch/combine preserve token order and weights"],
+        "reference": reference or "Megatron MoE expert parallel path",
+    }
+    implementation_contract = {
+        "details": ["ep_group", "expert placement", "token dispatcher", "combine weights"],
+        "collectives": ["all_to_all token exchange", "optional grouped GEMM locality"],
+        "state": ["expert ownership", "capacity/drop policy", "router dtype"],
+    }
+    usage_contract = {
+        "config": require_config_keys(config, ["expert_model_parallel_size", "num_experts"]),
+        "choose_when": ["num_experts exceeds local capacity", "MoE communication is acceptable"],
+        "avoid_when": ["router nondeterminism is unresolved", "expert count cannot map cleanly"],
+        "compose_with": ["TP only with explicit expert and tensor group nesting", "FSDP/DistOpt through optimizer owner"],
+    }
+    validation = primitive.validate(task, primitive=implementation.ep, implementation=implementation, budget=budget)
+    risks = ["router tie instability", "token drop mismatch", "all-to-all participant mismatch"]
+    if not validation.done:
+        return blocked("EP validation failed", evidence=validation)
+    return done(principle=principle, implementation_contract=implementation_contract, usage_contract=usage_contract, validation=validation, risks=risks)
+```

--- a/experimental/lite/skills/primitive/parallel/pp.md
+++ b/experimental/lite/skills/primitive/parallel/pp.md
@@ -1,0 +1,46 @@
+# Pipeline Parallel Skill
+
+Define, implement, use, and validate pipeline parallelism.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "primitive.parallel.pp", kind="primitive", purpose="define and validate PP primitive",
+    imports=["basic.constitution"], calls=["primitive.contract", "primitive.validate"],
+    inputs=["task", "implementation", "config", "reference", "budget"],
+    outputs=["principle", "implementation_contract", "usage_contract", "validation", "risks"],
+    exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def pp(task, implementation, config, reference, budget):
+    contract = primitive.contract(implementation.pp, scope=task.scope, reference=reference)
+    if not contract.done:
+        return blocked("PP contract not satisfied", evidence=contract)
+
+    principle = {
+        "semantics": "partition ordered layers into pipeline stages",
+        "invariants": ["stage concatenation equals full layer order", "microbatch schedule preserves gradients"],
+        "reference": reference or "Megatron pipeline schedule",
+    }
+    implementation_contract = {
+        "details": ["stage assignment", "send/recv activation tensors", "microbatch schedule"],
+        "state": ["layer ownership", "activation shape", "loss stage"],
+        "boundaries": ["first/last stage embeddings and heads", "MTP or auxiliary heads if present"],
+    }
+    usage_contract = {
+        "config": require_config_keys(config, ["pipeline_model_parallel_size", "num_layers"]),
+        "choose_when": ["model depth exceeds single-rank memory", "stageable layer stack"],
+        "avoid_when": ["tiny proxy unless testing PP itself", "uneven stage ownership without explicit plan"],
+        "compose_with": ["TP/EP inside each stage", "FSDP/DistOpt outside stage groups"],
+    }
+    validation = primitive.validate(task, primitive=implementation.pp, implementation=implementation, budget=budget)
+    risks = ["stage boundary off by one", "activation shape mismatch", "schedule deadlock"]
+    if not validation.done:
+        return blocked("PP validation failed", evidence=validation)
+    return done(principle=principle, implementation_contract=implementation_contract, usage_contract=usage_contract, validation=validation, risks=risks)
+```

--- a/experimental/lite/skills/primitive/parallel/tp.md
+++ b/experimental/lite/skills/primitive/parallel/tp.md
@@ -1,0 +1,46 @@
+# Tensor Parallel Skill
+
+Define, implement, use, and validate tensor parallelism.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "primitive.parallel.tp", kind="primitive", purpose="define and validate TP primitive",
+    imports=["basic.constitution"], calls=["primitive.contract", "primitive.validate"],
+    inputs=["task", "implementation", "config", "reference", "budget"],
+    outputs=["principle", "implementation_contract", "usage_contract", "validation", "risks"],
+    exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def tp(task, implementation, config, reference, budget):
+    contract = primitive.contract(implementation.tp, scope=task.scope, reference=reference)
+    if not contract.done:
+        return blocked("TP contract not satisfied", evidence=contract)
+
+    principle = {
+        "semantics": "split linear/vocab dimensions across tensor-parallel ranks",
+        "invariants": ["TP=1 equals unsharded reference", "row/column shard axes are explicit"],
+        "reference": reference or "Megatron tensor-parallel layers",
+    }
+    implementation_contract = {
+        "details": ["tp_group", "ColumnParallelLinear", "RowParallelLinear", "VocabParallelEmbedding"],
+        "collectives": ["all_gather output when needed", "reduce_scatter or all_reduce gradients"],
+        "state": ["sharded weight layout", "bias ownership", "vocab padding"],
+    }
+    usage_contract = {
+        "config": require_config_keys(config, ["tensor_model_parallel_size"]),
+        "choose_when": ["large matmul or vocab projection", "model has TP-compatible dimensions"],
+        "avoid_when": ["dimension not divisible and no padding contract", "debugging non-TP primitive"],
+        "compose_with": ["FSDP/DistOpt through optimizer owner", "PP", "EP with explicit group nesting", "CP/THD with explicit head/context ownership"],
+    }
+    validation = primitive.validate(task, primitive=implementation.tp, implementation=implementation, budget=budget)
+    risks = ["wrong shard axis", "missing collective", "dtype drift across shards"]
+    if not validation.done:
+        return blocked("TP validation failed", evidence=validation)
+    return done(principle=principle, implementation_contract=implementation_contract, usage_contract=usage_contract, validation=validation, risks=risks)
+```

--- a/experimental/lite/skills/primitive/principle.md
+++ b/experimental/lite/skills/primitive/principle.md
@@ -1,0 +1,32 @@
+# Primitive Principle Skill
+
+State the principle and invariants of a primitive before implementation choices.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "primitive.principle", kind="primitive", purpose="define primitive principle and invariants",
+    imports=["basic.constitution"], calls=[],
+    inputs=["primitive", "reference", "constraints"],
+    outputs=["principle", "invariants", "reference", "risks"], exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def principle(primitive, reference, constraints):
+    if reference is None and not constraints.has_first_principles:
+        return blocked("primitive principle needs a reference or first-principles invariant")
+
+    principle = state_math_or_parallel_semantics(primitive, reference=reference)
+    invariants = [
+        define_shape_dtype_rank_rules(primitive),
+        define_forward_backward_update_equivalence(primitive),
+        define_bitwise_or_threshold_contract(primitive, reference),
+        define_single_gpu_or_single_node_proxy(primitive),
+    ]
+    risks = ["weak principle leads to implementation-specific tests", "missing invariant hides shared bugs"]
+    return done(principle=principle, invariants=invariants, reference=reference, risks=risks)
+```

--- a/experimental/lite/skills/primitive/process-group.md
+++ b/experimental/lite/skills/primitive/process-group.md
@@ -1,0 +1,32 @@
+# Process Group Skill
+
+Validate process-group ownership and collective participation.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "primitive.process_group", kind="state_machine", purpose="validate process groups and collectives",
+    imports=["basic.constitution"], calls=[],
+    inputs=["task", "groups", "collectives", "budget"],
+    outputs=["mapping", "validation", "risks"], exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def process_group(task, groups, collectives, budget):
+    mapping = derive_rank_mapping(groups)
+    if mapping.has_overlap_without_owner():
+        return blocked("rank belongs to overlapping groups without explicit owner")
+    if not collectives.have_same_participants(mapping):
+        return blocked("collective participants diverge", evidence=collectives.diff(mapping))
+
+    validation = [
+        smoke_collective(groups, collectives, shape="tiny"),
+        vary_group_size_one_axis_at_a_time(groups, budget=budget),
+    ]
+    risks = ["NCCL hang from participant mismatch", "rank-order mismatch"]
+    return done(mapping=mapping, validation=validation, risks=risks)
+```

--- a/experimental/lite/skills/primitive/select-for-compose.md
+++ b/experimental/lite/skills/primitive/select-for-compose.md
@@ -1,0 +1,44 @@
+# Primitive Select For Compose Skill
+
+Choose primitives for model composition without coupling their implementations.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "primitive.select_for_compose", kind="state_machine", purpose="choose primitives for model compose",
+    imports=["basic.constitution"], calls=["primitive.principle"],
+    inputs=["task", "model_spec", "candidates", "budget"],
+    outputs=["selection", "rejected", "evidence", "risks"], exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def select_for_compose(task, model_spec, candidates, budget):
+    selection = []
+    rejected = []
+    evidence = []
+
+    for candidate in candidates[:budget.max_candidates]:
+        principle = primitive.principle(candidate, reference=candidate.reference, constraints=model_spec.constraints)
+        evidence.append(principle)
+        if not principle.done:
+            rejected.append((candidate, "principle missing"))
+            continue
+        if not candidate.supports(model_spec.required_features):
+            rejected.append((candidate, "missing required model feature"))
+            continue
+        if candidate.creates_hidden_coupling(selection):
+            rejected.append((candidate, "hidden primitive coupling"))
+            continue
+        selection.append(candidate)
+
+    selection = minimize_complexity(selection, prefer=["single_gpu_proxy", "single_node_proxy", "existing_reference"])
+    if not covers_required_features(selection, model_spec.required_features):
+        return blocked("primitive selection does not cover model spec", evidence=[evidence, rejected])
+
+    risks = ["selection can overfit one model family", "unsupported combinations must stay explicit"]
+    return done(selection=selection, rejected=rejected, evidence=evidence, risks=risks)
+```

--- a/experimental/lite/skills/primitive/validate.md
+++ b/experimental/lite/skills/primitive/validate.md
@@ -1,0 +1,38 @@
+# Primitive Validate Skill
+
+Validate one primitive before using it in a model.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "primitive.validate", kind="state_machine", purpose="validate primitive correctness and precision",
+    imports=["basic.constitution"], calls=["basic.construct_proxy_task", "basic.align_precision"],
+    inputs=["task", "primitive", "implementation", "budget"],
+    outputs=["validation", "evidence", "risks"], exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def validate(task, primitive, implementation, budget):
+    proxy = basic.construct_proxy_task(
+        task, target=primitive, reference=implementation.reference, variables=implementation.variables, budget=budget.proxy
+    )
+    if not proxy.done:
+        return blocked("primitive proxy task not constructed", evidence=proxy)
+
+    precision = basic.align_precision(task, target=primitive, variables=implementation.variables, budget=budget.precision)
+    if not precision.done:
+        return blocked("primitive precision not validated", evidence=precision)
+
+    validation = [
+        "static_contract",
+        "single_gpu_or_node_proxy",
+        "controlled_variable_precision",
+        "composition_with_adjacent_primitives",
+        "usage_example_runs",
+    ]
+    return done(validation=validation, evidence=[proxy, precision], risks=precision.next)
+```


### PR DESCRIPTION
## Summary

Adds an agent-agnostic MLite skills foundation under experimental/lite/skills. Skills are organized like Python modules, use a delimited schema block for retrieval, and use Python-like pseudocode bodies with explicit inputs, outputs, calls, and exits.

## Contents

- Defines the skills file layout, schema contract, module naming rules, and lint expectations.
- Adds foundational skills for reference selection, precision alignment, end-to-end precision evidence, proxy task construction, threshold review, and skill linting.
- Adds primitive skills for parallel, module, and optimizer primitives, including TP, EP, PP, CP, DDP, FSDP, DistOpt, MoE, and GQA.
- Adds model composition, application, performance, and insight skills.

## Validation

- git diff --check HEAD -- experimental/lite/skills
- Verified each skill has exactly one schema marker pair.
- Verified schema names map to file paths.
- Verified the root skills index covers every schema name.

## Notes

This change adds documentation-style operational contracts only. It does not modify runtime, model, primitive, or training code.
