### PR TITLE
Expand MLite validation test coverage

### DIFF
--- a/experimental/lite/tests/README.md
+++ b/experimental/lite/tests/README.md
@@ -34,7 +34,7 @@ Current matrix:
 | Checkpoint restore vs direct training | xfail sentinels only in this validation PR | FSDP2 and distopt checkpoint smokes are xfail until the follow-up bugfix PR |
 | Runtime backend registry/config | `unit/primitive/test_runtime_config_unit.py`, `unit/runtime/test_runtime_backend_unit.py` | covered through checkpoint/model handles |
 | Runtime env/offload controls | `unit/runtime/test_runtime_backend_unit.py` | `smoke/primitive/test_fsdp2_offload_checkpoint_smoke.py` |
-| Optimizer update-state offload fraction | `unit/primitive/test_runtime_config_unit.py` | `smoke/primitive/test_fsdp2_offload_checkpoint_smoke.py` |
+| Optimizer update-state offload fraction | `unit/primitive/test_runtime_config_unit.py` and single-process CUDA coverage in `unit/primitive/test_fsdp2_offload_gpu.py` | multi-rank FSDP2 grad clipping is xfail until the follow-up bugfix PR |
 | Qwen3 lite config/build/forward | `unit/model/test_qwen_config_unit.py` | `smoke/model/test_qwen_lite_forward_smoke.py` |
 | Qwen3.5 lite config/build/forward | `unit/model/test_qwen_config_unit.py` | `smoke/model/test_qwen_lite_forward_smoke.py` |
 

--- a/experimental/lite/tests/README.md
+++ b/experimental/lite/tests/README.md
@@ -1,0 +1,41 @@
+# Megatron Lite Validation
+
+`experimental/lite/tests` separates MLite validation into two layers:
+
+- Unit tests: CPU/single-process contract tests for primitive, model, runtime, checkpoint sentinels, config, and helper behavior. Tests that need optional packages such as Transformer Engine explicitly skip when unavailable.
+- Smoke tests: real `torch.distributed` tests for TP/EP/PP/CP/FSDP2/offload/checkpoint/distopt and tiny Qwen lite forward/backward behavior. Smoke runs are capped at one node and at most 8 GPUs.
+
+Run unit coverage:
+
+```bash
+PYTHONPATH="$(pwd):$(pwd)/experimental/lite" pytest experimental/lite/tests/unit
+```
+
+Run smoke coverage on one node:
+
+```bash
+PYTHONPATH="$(pwd):$(pwd)/experimental/lite" MLITE_RUN_SMOKE=1 MLITE_SMOKE_NPROC=8 \
+  experimental/lite/tests/run_primitive_validation.sh
+```
+
+The smoke suite is skipped by default in regular `pytest` runs. Enable it with `--mlite-smoke` or `MLITE_RUN_SMOKE=1`.
+
+Current matrix:
+
+| Surface | Unit | Smoke |
+| --- | --- | --- |
+| TP/EP/PP/CP topology | `unit/primitive/test_parallel_unit.py` | `smoke/primitive/test_parallel_topologies_smoke.py` |
+| THD packing helpers | `unit/primitive/test_parallel_unit.py` | CP topology smoke exercises distributed CP groups |
+| GQA/attention split contract | `unit/primitive/test_attention_moe_unit.py` | Qwen model smoke exercises attention forward/backward |
+| MoE router/aux-loss contract | `unit/primitive/test_attention_moe_unit.py` | Qwen model smoke exercises router, dispatcher, and experts |
+| DDP + distributed optimizer | `unit/primitive/test_checkpoint_unit.py` has xfail checkpoint contract sentinels | `smoke/primitive/test_distopt_checkpoint_smoke.py` is xfail until the follow-up bugfix PR |
+| FSDP2 config/wrap/offload | `unit/primitive/test_fsdp2_unit.py` | `smoke/primitive/test_fsdp2_offload_checkpoint_smoke.py` |
+| FSDP2 save/load resume | `unit/primitive/test_checkpoint_unit.py` has xfail checkpoint contract sentinels | FSDP2 checkpoint smoke is xfail until the follow-up bugfix PR |
+| Checkpoint restore vs direct training | xfail sentinels only in this validation PR | FSDP2 and distopt checkpoint smokes are xfail until the follow-up bugfix PR |
+| Runtime backend registry/config | `unit/primitive/test_runtime_config_unit.py`, `unit/runtime/test_runtime_backend_unit.py` | covered through checkpoint/model handles |
+| Runtime env/offload controls | `unit/runtime/test_runtime_backend_unit.py` | `smoke/primitive/test_fsdp2_offload_checkpoint_smoke.py` |
+| Optimizer update-state offload fraction | `unit/primitive/test_runtime_config_unit.py` | `smoke/primitive/test_fsdp2_offload_checkpoint_smoke.py` |
+| Qwen3 lite config/build/forward | `unit/model/test_qwen_config_unit.py` | `smoke/model/test_qwen_lite_forward_smoke.py` |
+| Qwen3.5 lite config/build/forward | `unit/model/test_qwen_config_unit.py` | `smoke/model/test_qwen_lite_forward_smoke.py` |
+
+Classic FSDP is not a separate MLite primitive in the current source tree; MLite's native sharded optimizer coverage is FSDP2 plus Megatron DDP/distopt.

--- a/experimental/lite/tests/conftest.py
+++ b/experimental/lite/tests/conftest.py
@@ -14,6 +14,16 @@ for root in (REPO_ROOT, LITE_ROOT):
         sys.path.insert(0, str(root))
 
 
+def pytest_configure(config):
+    config.addinivalue_line("markers", "mlite: mark a test as Megatron Lite validation coverage")
+    config.addinivalue_line(
+        "markers",
+        "smoke: mark a Megatron Lite smoke test; skipped unless --mlite-smoke or MLITE_RUN_SMOKE=1 is set",
+    )
+    config.addinivalue_line("markers", "gpu: mark a test as requiring CUDA")
+    config.addinivalue_line("markers", "distributed: mark a test as requiring torch.distributed")
+
+
 def pytest_addoption(parser):
     parser.addoption(
         "--mlite-smoke",

--- a/experimental/lite/tests/conftest.py
+++ b/experimental/lite/tests/conftest.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+LITE_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[3]
+for root in (REPO_ROOT, LITE_ROOT):
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--mlite-smoke",
+        action="store_true",
+        default=False,
+        help="run Megatron Lite smoke tests",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    run_smoke = config.getoption("--mlite-smoke") or os.getenv("MLITE_RUN_SMOKE") == "1"
+    if run_smoke:
+        return
+    skip_smoke = pytest.mark.skip(reason="set --mlite-smoke or MLITE_RUN_SMOKE=1 to run")
+    for item in items:
+        if "smoke" in item.keywords:
+            item.add_marker(skip_smoke)

--- a/experimental/lite/tests/run_primitive_validation.sh
+++ b/experimental/lite/tests/run_primitive_validation.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "${ROOT}"
+
+export PYTHONPATH="${ROOT}:${ROOT}/experimental/lite:${PYTHONPATH:-}"
+
+pytest experimental/lite/tests/unit "$@"
+
+if [[ "${MLITE_RUN_SMOKE:-0}" == "1" ]]; then
+  NPROC="${MLITE_SMOKE_NPROC:-${WORLD_SIZE:-1}}"
+  if (( NPROC < 1 || NPROC > 8 )); then
+    echo "MLITE smoke tests require 1 <= MLITE_SMOKE_NPROC <= 8, got ${NPROC}" >&2
+    exit 2
+  fi
+  torchrun --standalone --nproc_per_node="${NPROC}" \
+    -m pytest --mlite-smoke experimental/lite/tests/smoke "$@"
+fi

--- a/experimental/lite/tests/smoke/model/test_qwen_lite_forward_smoke.py
+++ b/experimental/lite/tests/smoke/model/test_qwen_lite_forward_smoke.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.distributed as dist
+
+
+pytestmark = [
+    pytest.mark.mlite,
+    pytest.mark.smoke,
+    pytest.mark.gpu,
+    pytest.mark.distributed,
+]
+
+
+def _qwen3_symbols():
+    pytest.importorskip("transformer_engine.pytorch")
+    from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
+    from megatron.lite.model.qwen3_moe.lite.model import Qwen3MoEModel
+
+    return Qwen3MoEConfig, Qwen3MoEModel
+
+
+def _qwen35_symbols():
+    pytest.importorskip("transformer_engine.pytorch")
+    from megatron.lite.model.qwen3_5.config import Qwen35Config
+    from megatron.lite.model.qwen3_5.lite.model import Qwen35Model
+
+    return Qwen35Config, Qwen35Model
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _single_node_cuda_dist():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for Qwen lite model smoke tests.")
+    if int(os.environ.get("WORLD_SIZE", "1")) > 8:
+        pytest.skip("Megatron Lite smoke tests are capped at single-node 8 GPUs.")
+
+    os.environ.setdefault("RANK", "0")
+    os.environ.setdefault("WORLD_SIZE", "1")
+    os.environ.setdefault("LOCAL_RANK", "0")
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29531")
+
+    torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
+    created_pg = False
+    if not dist.is_initialized():
+        dist.init_process_group(backend="nccl", init_method="env://")
+        created_pg = True
+    yield
+    if created_pg and dist.is_initialized():
+        dist.destroy_process_group()
+
+
+def _tiny_qwen3_config():
+    Qwen3MoEConfig, _Qwen3MoEModel = _qwen3_symbols()
+    return Qwen3MoEConfig(
+        num_hidden_layers=1,
+        hidden_size=16,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=4,
+        vocab_size=64,
+        num_experts=2,
+        num_experts_per_tok=1,
+        moe_intermediate_size=8,
+        max_position_embeddings=16,
+        layer_types=["full_attention"],
+    )
+
+
+def _tiny_qwen35_config():
+    Qwen35Config, _Qwen35Model = _qwen35_symbols()
+    return Qwen35Config(
+        num_hidden_layers=1,
+        hidden_size=16,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=4,
+        vocab_size=64,
+        num_experts=2,
+        num_experts_per_tok=1,
+        moe_intermediate_size=8,
+        shared_expert_intermediate_size=8,
+        linear_num_key_heads=2,
+        linear_key_head_dim=4,
+        linear_num_value_heads=2,
+        linear_value_head_dim=4,
+        linear_conv_kernel_dim=2,
+        max_position_embeddings=16,
+        partial_rotary_factor=1.0,
+        mrope_section=[1, 1, 0],
+        layer_types=["full_attention"],
+    )
+
+
+def _parallel_state():
+    from megatron.lite.primitive.parallel import init_parallel
+    from megatron.lite.runtime.contracts.config import ParallelConfig
+
+    return init_parallel(ParallelConfig(tp=1, etp=1, ep=1, pp=1, cp=1))
+
+
+def _token_batch(vocab_size: int):
+    torch.manual_seed(9876 + dist.get_rank())
+    input_ids = torch.randint(0, vocab_size, (2, 4), device="cuda")
+    labels = torch.randint(0, vocab_size, (2, 4), device="cuda")
+    return input_ids, labels
+
+
+def _assert_loss_and_backward(output: dict, model: torch.nn.Module):
+    loss = output["loss"]
+    assert loss.ndim == 0
+    assert torch.isfinite(loss)
+    loss.backward()
+    grad_params = [
+        param
+        for param in model.parameters()
+        if param.requires_grad and param.grad is not None
+    ]
+    assert grad_params
+    assert all(torch.isfinite(param.grad.detach().float()).all() for param in grad_params)
+
+
+def test_qwen3_moe_lite_tiny_forward_backward_smoke():
+    _Qwen3MoEConfig, Qwen3MoEModel = _qwen3_symbols()
+    config = _tiny_qwen3_config()
+    model = Qwen3MoEModel(config, _parallel_state(), use_deepep=False).cuda().to(torch.bfloat16)
+    input_ids, labels = _token_batch(config.vocab_size)
+
+    output = model(input_ids=input_ids, labels=labels, return_log_probs=True)
+
+    assert output["hidden_states"].shape[-1] == config.hidden_size
+    assert output["log_probs"].shape == labels.shape
+    _assert_loss_and_backward(output, model)
+
+
+def test_qwen35_lite_tiny_forward_backward_smoke():
+    _Qwen35Config, Qwen35Model = _qwen35_symbols()
+    config = _tiny_qwen35_config()
+    train_config = SimpleNamespace(
+        tp=1,
+        ep=1,
+        etp=1,
+        pp=1,
+        cp=1,
+        vpp=None,
+        use_deepep=False,
+        fp8=False,
+        recompute_modules=[],
+        deterministic=True,
+    )
+    model = Qwen35Model(config, train_config, _parallel_state()).cuda().to(torch.bfloat16)
+    input_ids, labels = _token_batch(config.vocab_size)
+
+    output = model(input_ids=input_ids, labels=labels)
+
+    assert output["hidden_states"].shape[-1] == config.hidden_size
+    assert output["log_probs"].shape == labels.shape
+    _assert_loss_and_backward(output, model)

--- a/experimental/lite/tests/smoke/primitive/test_distopt_checkpoint_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_distopt_checkpoint_smoke.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+import torch
+import torch.nn as nn
+
+from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig
+from megatron.core.optimizer import OptimizerConfig, get_megatron_optimizer
+from megatron.core.transformer import TransformerConfig
+from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
+from megatron.lite.runtime.contracts.handle import ModelHandle
+from tests.unit_tests.test_utilities import Utils
+
+
+pytestmark = [
+    pytest.mark.mlite,
+    pytest.mark.smoke,
+    pytest.mark.gpu,
+    pytest.mark.distributed,
+    pytest.mark.xfail(
+        reason="MLite distopt checkpoint continuity is covered by a follow-up bugfix PR.",
+        strict=True,
+    ),
+]
+
+
+class TinyDense(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc1 = nn.Linear(8, 8, bias=False)
+        self.fc2 = nn.Linear(8, 4, bias=False)
+
+    def forward(self, x):
+        return self.fc2(torch.relu(self.fc1(x)))
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _single_node_cuda_distopt():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for distopt smoke tests.")
+    if int(os.environ.get("WORLD_SIZE", "1")) > 8:
+        pytest.skip("Megatron Lite smoke tests are capped at single-node 8 GPUs.")
+
+    Utils.set_world_size(
+        int(os.environ.get("WORLD_SIZE", "1")),
+        int(os.environ.get("LOCAL_RANK", "0")),
+    )
+    Utils.initialize_model_parallel()
+    yield
+    Utils.destroy_model_parallel()
+
+
+def _build_model_and_distopt():
+    torch.manual_seed(2468)
+    model = TinyDense().bfloat16().cuda()
+    ddp_config = DistributedDataParallelConfig(use_distributed_optimizer=True)
+    wrapped = DistributedDataParallel(
+        TransformerConfig(num_attention_heads=1, num_layers=1),
+        ddp_config,
+        model,
+    )
+    optimizer = get_megatron_optimizer(
+        OptimizerConfig(optimizer="adam", lr=1.0e-3, bf16=True, use_distributed_optimizer=True),
+        [wrapped],
+    )
+    return wrapped, optimizer
+
+
+def _train_step(model, optimizer, x: torch.Tensor):
+    output = model(x)
+    loss = output.float().square().mean()
+    loss.backward()
+    optimizer.step()
+    optimizer.zero_grad()
+    if hasattr(model, "zero_grad_buffer"):
+        model.zero_grad_buffer()
+    return loss.detach()
+
+
+def _local_named_params(model) -> dict[str, torch.Tensor]:
+    return {name: param.detach().cpu().float().clone() for name, param in model.named_parameters()}
+
+
+def _assert_model_close(lhs, rhs):
+    lhs_params = _local_named_params(lhs)
+    rhs_params = _local_named_params(rhs)
+    assert lhs_params.keys() == rhs_params.keys()
+    for name in lhs_params:
+        torch.testing.assert_close(lhs_params[name], rhs_params[name], atol=0.0, rtol=0.0)
+
+
+def test_distopt_checkpoint_load_matches_uninterrupted_training_single_node(tmp_path):
+    model_for_ckpt, optimizer_for_ckpt = _build_model_and_distopt()
+    direct_model, direct_optimizer = _build_model_and_distopt()
+    loaded_model, loaded_optimizer = _build_model_and_distopt()
+    runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
+
+    torch.manual_seed(1357)
+    x0 = torch.randn(4, 8, device="cuda", dtype=torch.bfloat16)
+    x1 = torch.randn(4, 8, device="cuda", dtype=torch.bfloat16)
+
+    _train_step(model_for_ckpt, optimizer_for_ckpt, x0)
+    _train_step(direct_model, direct_optimizer, x0)
+
+    runtime.save_checkpoint(
+        ModelHandle(
+            model=model_for_ckpt,
+            optimizer=optimizer_for_ckpt,
+            _extras={"model_chunks": [model_for_ckpt]},
+        ),
+        str(tmp_path),
+        step=1,
+    )
+    assert runtime.load_checkpoint(
+        ModelHandle(
+            model=loaded_model,
+            optimizer=loaded_optimizer,
+            _extras={"model_chunks": [loaded_model]},
+        ),
+        str(tmp_path),
+    ) == 1
+
+    _train_step(direct_model, direct_optimizer, x1)
+    _train_step(loaded_model, loaded_optimizer, x1)
+    _assert_model_close(direct_model, loaded_model)

--- a/experimental/lite/tests/smoke/primitive/test_fsdp2_offload_checkpoint_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_fsdp2_offload_checkpoint_smoke.py
@@ -179,6 +179,11 @@ def test_fsdp2_runtime_model_and_optimizer_offload_roundtrip_single_node():
     assert _optimizer_state_devices(optimizer) == {"cuda"}
 
 
+@pytest.mark.xfail(
+    int(os.environ.get("WORLD_SIZE", "1")) > 1,
+    reason="MLite FSDP2 offload_fraction multi-rank grad clipping is covered by a follow-up bugfix PR.",
+    strict=True,
+)
 def test_fsdp2_offload_fraction_keeps_optimizer_update_state_on_cpu_single_node():
     model, ps = _build_fsdp2_model()
     optimizer = _build_optimizer(model, ps, offload_fraction=1.0)

--- a/experimental/lite/tests/smoke/primitive/test_fsdp2_offload_checkpoint_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_fsdp2_offload_checkpoint_smoke.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+
+from megatron.lite.primitive.optimizers.fsdp2 import (
+    FSDP2Config,
+    build_fsdp2_adamw,
+    build_fsdp2_device_mesh,
+    fsdp2_available,
+    wrap_fsdp2,
+)
+from megatron.lite.primitive.optimizers.fsdp2.adamw import iter_torch_optimizers, to_local_tensor
+from megatron.lite.primitive.parallel.state import ParallelState
+from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
+from megatron.lite.runtime.contracts.handle import ModelHandle
+
+
+pytestmark = [
+    pytest.mark.mlite,
+    pytest.mark.smoke,
+    pytest.mark.gpu,
+    pytest.mark.distributed,
+]
+
+
+class TinyUnit(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(8, 8)
+        self.act = nn.GELU()
+
+    def forward(self, x):
+        return self.act(self.linear(x))
+
+
+class TinyModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.unit0 = TinyUnit()
+        self.unit1 = TinyUnit()
+        self.out = nn.Linear(8, 4)
+
+    def forward(self, x):
+        return self.out(self.unit1(self.unit0(x)))
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _single_node_cuda_dist():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for FSDP2 smoke tests.")
+    if not fsdp2_available():
+        pytest.skip("Installed PyTorch does not expose FSDP2 fully_shard.")
+    if int(os.environ.get("WORLD_SIZE", "1")) > 8:
+        pytest.skip("Megatron Lite smoke tests are capped at single-node 8 GPUs.")
+
+    os.environ.setdefault("RANK", "0")
+    os.environ.setdefault("WORLD_SIZE", "1")
+    os.environ.setdefault("LOCAL_RANK", "0")
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29521")
+
+    torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
+    created_pg = False
+    if not dist.is_initialized():
+        dist.init_process_group(backend="nccl", init_method="env://")
+        created_pg = True
+    yield
+    if created_pg and dist.is_initialized():
+        dist.destroy_process_group()
+
+
+def _parallel_state() -> ParallelState:
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    return ParallelState(
+        dp_group=dist.group.WORLD,
+        dp_cp_group=dist.group.WORLD,
+        dp_size=world_size,
+        dp_cp_size=world_size,
+        dp_rank=rank,
+        dp_cp_rank=rank,
+    )
+
+
+def _build_fsdp2_model(dtype: torch.dtype = torch.bfloat16) -> tuple[nn.Module, ParallelState]:
+    torch.manual_seed(1234)
+    model = TinyModel().cuda().to(dtype=dtype)
+    ps = _parallel_state()
+    config = FSDP2Config(unit_modules=(TinyUnit,), reshard_after_forward=True)
+    mesh = build_fsdp2_device_mesh(ps, config)
+    return wrap_fsdp2(model, ps, config, mesh=mesh), ps
+
+
+def _build_optimizer(model: nn.Module, ps: ParallelState, *, offload_fraction: float):
+    return build_fsdp2_adamw(
+        [model],
+        SimpleNamespace(
+            optimizer="adam",
+            lr=1.0e-3,
+            weight_decay=0.0,
+            adam_beta1=0.9,
+            adam_beta2=0.95,
+            adam_eps=1.0e-8,
+            clip_grad=1.0,
+            offload_fraction=offload_fraction,
+        ),
+        ps,
+        use_fp32_master=True,
+    )
+
+
+def _local_param_devices(model: nn.Module) -> set[str]:
+    return {to_local_tensor(param.detach()).device.type for param in model.parameters()}
+
+
+def _optimizer_state_devices(optimizer) -> set[str]:
+    devices: set[str] = set()
+    for child in iter_torch_optimizers(optimizer.optimizer):
+        for param_state in getattr(child, "state", {}).values():
+            if not isinstance(param_state, dict):
+                continue
+            for value in param_state.values():
+                if isinstance(value, torch.Tensor):
+                    devices.add(to_local_tensor(value).device.type)
+    return devices
+
+
+def _local_named_params(model: nn.Module) -> dict[str, torch.Tensor]:
+    return {
+        name: to_local_tensor(param.detach()).cpu().float().clone()
+        for name, param in model.named_parameters()
+    }
+
+
+def _train_step(model: nn.Module, optimizer, x: torch.Tensor, target: torch.Tensor):
+    optimizer.zero_grad()
+    loss = torch.nn.functional.mse_loss(model(x).float(), target.float())
+    loss.backward()
+    success, grad_norm, _ = optimizer.step()
+    assert success
+    assert torch.isfinite(torch.tensor(grad_norm))
+    return loss.detach()
+
+
+def _assert_local_params_close(lhs: nn.Module, rhs: nn.Module):
+    lhs_params = _local_named_params(lhs)
+    rhs_params = _local_named_params(rhs)
+    assert lhs_params.keys() == rhs_params.keys()
+    for name in lhs_params:
+        torch.testing.assert_close(lhs_params[name], rhs_params[name], atol=0.0, rtol=0.0)
+
+
+def test_fsdp2_runtime_model_and_optimizer_offload_roundtrip_single_node():
+    model, ps = _build_fsdp2_model()
+    optimizer = _build_optimizer(model, ps, offload_fraction=0.0)
+    handle = ModelHandle(
+        model=model,
+        optimizer=optimizer,
+        parallel_state=ps,
+        _extras={"model_chunks": [model]},
+    )
+    runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
+
+    assert _local_param_devices(model) == {"cuda"}
+    assert _optimizer_state_devices(optimizer) == {"cuda"}
+
+    runtime.to(handle, "cpu", model=True, optimizer=True, grad=True)
+    assert _local_param_devices(model) == {"cpu"}
+    assert _optimizer_state_devices(optimizer) == {"cpu"}
+
+    runtime.to(handle, "cuda", model=True, optimizer=True, grad=True)
+    assert _local_param_devices(model) == {"cuda"}
+    assert _optimizer_state_devices(optimizer) == {"cuda"}
+
+
+def test_fsdp2_offload_fraction_keeps_optimizer_update_state_on_cpu_single_node():
+    model, ps = _build_fsdp2_model()
+    optimizer = _build_optimizer(model, ps, offload_fraction=1.0)
+
+    assert _optimizer_state_devices(optimizer) == {"cpu"}
+
+    x = torch.randn(4, 8, device="cuda", dtype=torch.bfloat16)
+    target = torch.randn(4, 4, device="cuda", dtype=torch.bfloat16)
+    _train_step(model, optimizer, x, target)
+
+    assert _local_param_devices(model) == {"cuda"}
+    assert _optimizer_state_devices(optimizer) == {"cpu"}
+
+
+@pytest.mark.xfail(
+    reason="MLite FSDP2 checkpoint continuity is covered by a follow-up bugfix PR.",
+    strict=True,
+)
+def test_fsdp2_checkpoint_load_matches_uninterrupted_training_single_node(tmp_path):
+    model_for_ckpt, ps = _build_fsdp2_model()
+    optimizer_for_ckpt = _build_optimizer(model_for_ckpt, ps, offload_fraction=0.0)
+    direct_model, direct_ps = _build_fsdp2_model()
+    direct_optimizer = _build_optimizer(direct_model, direct_ps, offload_fraction=0.0)
+    loaded_model, loaded_ps = _build_fsdp2_model()
+    loaded_optimizer = _build_optimizer(loaded_model, loaded_ps, offload_fraction=0.0)
+    runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
+
+    torch.manual_seed(4321)
+    x0 = torch.randn(4, 8, device="cuda", dtype=torch.bfloat16)
+    y0 = torch.randn(4, 4, device="cuda", dtype=torch.bfloat16)
+    x1 = torch.randn(4, 8, device="cuda", dtype=torch.bfloat16)
+    y1 = torch.randn(4, 4, device="cuda", dtype=torch.bfloat16)
+
+    _train_step(model_for_ckpt, optimizer_for_ckpt, x0, y0)
+    _train_step(direct_model, direct_optimizer, x0, y0)
+
+    runtime.save_checkpoint(
+        ModelHandle(
+            model=model_for_ckpt,
+            optimizer=optimizer_for_ckpt,
+            parallel_state=ps,
+            _extras={"model_chunks": [model_for_ckpt]},
+        ),
+        str(tmp_path),
+        step=1,
+    )
+    assert runtime.load_checkpoint(
+        ModelHandle(
+            model=loaded_model,
+            optimizer=loaded_optimizer,
+            parallel_state=loaded_ps,
+            _extras={"model_chunks": [loaded_model]},
+        ),
+        str(tmp_path),
+    ) == 1
+
+    _train_step(direct_model, direct_optimizer, x1, y1)
+    _train_step(loaded_model, loaded_optimizer, x1, y1)
+    _assert_local_params_close(direct_model, loaded_model)

--- a/experimental/lite/tests/smoke/primitive/test_parallel_topologies_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_parallel_topologies_smoke.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from megatron.lite.primitive.parallel import init_parallel
+
+
+pytestmark = [
+    pytest.mark.mlite,
+    pytest.mark.smoke,
+    pytest.mark.gpu,
+    pytest.mark.distributed,
+]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _single_node_cuda_dist():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for distributed primitive smoke tests.")
+    if int(os.environ.get("WORLD_SIZE", "1")) > 8:
+        pytest.skip("Megatron Lite smoke tests are capped at single-node 8 GPUs.")
+
+    os.environ.setdefault("RANK", "0")
+    os.environ.setdefault("WORLD_SIZE", "1")
+    os.environ.setdefault("LOCAL_RANK", "0")
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29511")
+
+    torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
+    created_pg = False
+    if not dist.is_initialized():
+        dist.init_process_group(backend="nccl", init_method="env://")
+        created_pg = True
+    yield
+    if created_pg and dist.is_initialized():
+        dist.destroy_process_group()
+
+
+def _assert_group_size(group, expected: int):
+    if expected == 1:
+        return
+    assert group is not None
+    assert dist.get_world_size(group) == expected
+
+
+def _topologies(world_size: int):
+    yield "dp_only", SimpleNamespace(tp=1, ep=1, etp=1, cp=1, pp=1)
+    if world_size >= 2:
+        yield "tp2", SimpleNamespace(tp=2, ep=1, etp=1, cp=1, pp=1)
+        yield "cp2", SimpleNamespace(tp=1, ep=1, etp=1, cp=2, pp=1)
+        yield "pp2", SimpleNamespace(tp=1, ep=1, etp=1, cp=1, pp=2)
+        yield "ep2", SimpleNamespace(tp=1, ep=2, etp=1, cp=1, pp=1)
+    if world_size >= 4:
+        yield "tp2_ep2_pp2", SimpleNamespace(tp=2, ep=2, etp=1, cp=1, pp=2)
+    if world_size >= 8:
+        yield "tp2_ep2_cp2_pp2", SimpleNamespace(tp=2, ep=2, etp=1, cp=2, pp=2)
+
+
+def test_parallel_state_builds_expected_primitive_groups():
+    world_size = dist.get_world_size()
+    for name, cfg in _topologies(world_size):
+        if world_size % (cfg.tp * cfg.cp * cfg.pp) != 0:
+            continue
+        if world_size % (cfg.etp * cfg.ep * cfg.pp) != 0:
+            continue
+
+        ps = init_parallel(cfg)
+        dense_dp = world_size // (cfg.tp * cfg.cp * cfg.pp)
+        expert_dp = world_size // (cfg.etp * cfg.ep * cfg.pp)
+
+        assert ps.tp_size == cfg.tp
+        assert ps.cp_size == cfg.cp
+        assert ps.pp_size == cfg.pp
+        assert ps.ep_size == cfg.ep
+        assert ps.dp_size == dense_dp
+        assert ps.expert_dp_size == expert_dp
+        assert 0 <= ps.tp_rank < cfg.tp
+        assert 0 <= ps.cp_rank < cfg.cp
+        assert 0 <= ps.pp_rank < cfg.pp
+        assert 0 <= ps.ep_rank < cfg.ep
+        _assert_group_size(ps.tp_group, cfg.tp)
+        _assert_group_size(ps.cp_group, cfg.cp)
+        _assert_group_size(ps.pp_group, cfg.pp)
+        _assert_group_size(ps.ep_group, cfg.ep)
+        _assert_group_size(ps.dp_group, dense_dp)
+        _assert_group_size(ps.dp_cp_group, dense_dp * cfg.cp)
+        _assert_group_size(ps.ep_dp_group, expert_dp)
+        # tp_ep follows Megatron Core's expert tensor + expert model group,
+        # not the dense-layer TP group. MLite currently keeps ETP at 1.
+        _assert_group_size(ps.tp_ep_group, cfg.etp * cfg.ep)
+        if cfg.pp > 1:
+            assert ps.pp_next_rank in ps.pp_global_ranks
+            assert ps.pp_prev_rank in ps.pp_global_ranks

--- a/experimental/lite/tests/unit/model/test_qwen_config_unit.py
+++ b/experimental/lite/tests/unit/model/test_qwen_config_unit.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import pytest
+
+from megatron.lite.model.qwen3_5.config import Qwen35Config
+from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
+from megatron.lite.model.registry import (
+    resolve_model_type_from_hf,
+    resolve_runtime_model_name,
+)
+
+
+pytestmark = pytest.mark.mlite
+
+
+def _tiny_qwen3_hf_dict() -> dict:
+    return {
+        "model_type": "qwen3_moe",
+        "hidden_size": 16,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "num_hidden_layers": 1,
+        "vocab_size": 64,
+        "num_experts": 2,
+        "num_experts_per_tok": 1,
+        "moe_intermediate_size": 8,
+        "rope_parameters": {"rope_theta": 12345.0},
+    }
+
+
+def _tiny_qwen35_text_config() -> dict:
+    return {
+        "hidden_size": 16,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "head_dim": 4,
+        "num_hidden_layers": 2,
+        "vocab_size": 64,
+        "num_experts": 2,
+        "num_experts_per_tok": 1,
+        "moe_intermediate_size": 8,
+        "shared_expert_intermediate_size": 8,
+        "linear_num_key_heads": 2,
+        "linear_key_head_dim": 4,
+        "linear_num_value_heads": 2,
+        "linear_value_head_dim": 4,
+        "linear_conv_kernel_dim": 2,
+        "num_nextn_predict_layers": 1,
+        "layer_types": ["linear_attention", "full_attention", "full_attention"],
+        "rope_parameters": {
+            "partial_rotary_factor": 1.0,
+            "mrope_section": [1, 1, 0],
+        },
+    }
+
+
+def test_registry_resolves_qwen_lite_model_names():
+    assert resolve_model_type_from_hf({"model_type": "qwen3_moe"}) == "qwen3"
+    assert resolve_model_type_from_hf({"model_type": "qwen3_5_moe"}) == "qwen3_5"
+    assert resolve_runtime_model_name("qwen3", "lite") == "qwen3"
+    assert resolve_runtime_model_name("qwen3_moe", "lite") == "qwen3_moe"
+    assert resolve_runtime_model_name("qwen3_5", "lite") == "qwen3_5"
+
+
+def test_qwen3_config_from_hf_dict_derives_head_dim_and_rope_theta():
+    cfg = Qwen3MoEConfig._from_hf_dict(_tiny_qwen3_hf_dict())
+
+    assert cfg.hidden_size == 16
+    assert cfg.head_dim == 4
+    assert cfg.layer_types == ["full_attention"]
+    assert cfg.rope_theta == 12345.0
+
+
+def test_qwen3_config_rejects_invalid_expert_topk():
+    hf = _tiny_qwen3_hf_dict()
+    hf["num_experts_per_tok"] = 3
+
+    with pytest.raises(ValueError, match="num_experts_per_tok"):
+        Qwen3MoEConfig._from_hf_dict(hf)
+
+
+def test_qwen35_config_from_text_config_splits_mtp_layer_types():
+    cfg = Qwen35Config._from_hf_dict(
+        {
+            "model_type": "qwen3_5_moe",
+            "text_config": _tiny_qwen35_text_config(),
+        }
+    )
+
+    assert cfg.layer_types == ["linear_attention", "full_attention"]
+    assert cfg.mtp_layer_types == ["full_attention"]
+    assert cfg.rotary_dim == 4
+    assert cfg.mrope_section == [1, 1, 0]
+
+
+def test_qwen_lite_protocols_build_configs_from_hf_dicts():
+    pytest.importorskip("transformer_engine.pytorch")
+
+    from megatron.lite.model.qwen3_5.lite import protocol as qwen35_protocol
+    from megatron.lite.model.qwen3_moe.lite import protocol as qwen3_protocol
+
+    qwen3_cfg = qwen3_protocol.build_model_config(_tiny_qwen3_hf_dict(), vocab_size=128)
+    qwen35_cfg = qwen35_protocol.build_model_config(
+        {"model_type": "qwen3_5_moe", "text_config": _tiny_qwen35_text_config()},
+        vocab_size=128,
+    )
+
+    assert qwen3_cfg.vocab_size == 128
+    assert qwen35_cfg.vocab_size == 128
+    assert qwen35_cfg.layer_type_at(0) == "linear_attention"
+    assert qwen35_cfg.layer_type_at(1) == "full_attention"

--- a/experimental/lite/tests/unit/primitive/test_attention_moe_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_attention_moe_unit.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+
+pytestmark = pytest.mark.mlite
+
+
+def _split_grouped_qkvg():
+    pytest.importorskip("transformer_engine.pytorch")
+    from megatron.lite.primitive.modules.gqa import split_grouped_qkvg
+
+    return split_grouped_qkvg
+
+
+def _moe_aux_scaler():
+    pytest.importorskip("transformer_engine.pytorch")
+    from megatron.lite.primitive.modules.moe import MoEAuxLossAutoScaler
+
+    return MoEAuxLossAutoScaler
+
+
+def _router_and_parallel_state():
+    pytest.importorskip("transformer_engine.pytorch")
+    from megatron.lite.primitive.modules.router import TopKRouter
+    from megatron.lite.primitive.parallel import ParallelState
+
+    return TopKRouter, ParallelState
+
+
+def _router_config():
+    return SimpleNamespace(
+        hidden_size=4,
+        num_experts=4,
+        num_experts_per_tok=2,
+        router_aux_loss_coef=0.1,
+    )
+
+
+def _walk_grad_fn_names(tensor: torch.Tensor) -> set[str]:
+    names: set[str] = set()
+    stack = [tensor.grad_fn]
+    while stack:
+        fn = stack.pop()
+        if fn is None:
+            continue
+        names.add(type(fn).__name__)
+        stack.extend(parent for parent, _idx in fn.next_functions)
+    return names
+
+
+def test_gqa_split_grouped_qkvg_preserves_q_gate_kv_order():
+    split_grouped_qkvg = _split_grouped_qkvg()
+    qkv = torch.arange(24).reshape(1, 24)
+
+    query, gate, key, value = split_grouped_qkvg(
+        qkv,
+        num_heads=4,
+        num_kv_heads=2,
+        head_dim=2,
+    )
+
+    assert query.shape == (1, 4, 2)
+    assert gate.shape == (1, 4, 2)
+    assert key.shape == (1, 2, 2)
+    assert value.shape == (1, 2, 2)
+    assert torch.equal(
+        query,
+        torch.tensor([[[0, 1], [2, 3], [12, 13], [14, 15]]]),
+    )
+    assert torch.equal(
+        gate,
+        torch.tensor([[[4, 5], [6, 7], [16, 17], [18, 19]]]),
+    )
+    assert torch.equal(key, torch.tensor([[[8, 9], [20, 21]]]))
+    assert torch.equal(value, torch.tensor([[[10, 11], [22, 23]]]))
+
+
+def test_moe_aux_loss_auto_scaler_threads_scaled_aux_gradient():
+    MoEAuxLossAutoScaler = _moe_aux_scaler()
+    MoEAuxLossAutoScaler.set_loss_scale(torch.tensor([0.25]))
+    output = torch.randn(3, requires_grad=True)
+    aux_loss = torch.tensor(2.0, requires_grad=True)
+
+    scaled_output = MoEAuxLossAutoScaler.apply(output * 2.0, aux_loss)
+    scaled_output.sum().backward()
+
+    torch.testing.assert_close(output.grad, torch.full_like(output, 2.0))
+    torch.testing.assert_close(aux_loss.grad, torch.tensor(0.25))
+    MoEAuxLossAutoScaler.main_loss_backward_scale = None
+
+
+def test_topk_router_returns_finite_scores_and_valid_expert_indices():
+    TopKRouter, ParallelState = _router_and_parallel_state()
+    config = _router_config()
+    router = TopKRouter(config, ParallelState(), compute_aux_loss=False)
+    hidden = torch.randn(5, 4)
+
+    scores, indices = router(hidden)
+
+    assert scores.shape == (5, 2)
+    assert indices.shape == (5, 2)
+    assert scores.dtype == hidden.dtype
+    assert torch.isfinite(scores).all()
+    assert indices.min().item() >= 0
+    assert indices.max().item() < config.num_experts
+
+
+def test_topk_router_scores_are_normalized_and_deterministic_in_eval():
+    TopKRouter, ParallelState = _router_and_parallel_state()
+    config = _router_config()
+    router = TopKRouter(config, ParallelState(), compute_aux_loss=False)
+    hidden = torch.randn(5, config.hidden_size)
+
+    router.eval()
+    scores_1, indices_1 = router(hidden)
+    scores_2, indices_2 = router(hidden)
+
+    torch.testing.assert_close(scores_1.sum(dim=-1), torch.ones(hidden.size(0)))
+    torch.testing.assert_close(scores_1, scores_2, atol=0, rtol=0)
+    assert torch.equal(indices_1, indices_2)
+
+
+def test_topk_router_does_not_attach_aux_scaler_in_eval():
+    TopKRouter, ParallelState = _router_and_parallel_state()
+    config = _router_config()
+    router = TopKRouter(config, ParallelState(), compute_aux_loss=True)
+    hidden = torch.randn(5, config.hidden_size)
+
+    router.eval()
+    scores, _indices = router(hidden)
+
+    assert not any("MoEAuxLoss" in name for name in _walk_grad_fn_names(scores))
+
+
+def test_topk_router_aux_loss_contributes_gate_gradient():
+    TopKRouter, ParallelState = _router_and_parallel_state()
+    config = _router_config()
+    router = TopKRouter(config, ParallelState(), compute_aux_loss=True)
+    hidden = torch.randn(8, config.hidden_size)
+
+    router.train()
+    scores, _indices = router(hidden)
+    scores.sum().backward()
+    grad_with_aux = router.gate.weight.grad.detach().clone()
+
+    router.zero_grad()
+    saved_coeff = router.aux_loss_coeff
+    router.aux_loss_coeff = 0.0
+    scores_no_aux, _indices = router(hidden)
+    scores_no_aux.sum().backward()
+    grad_no_aux = router.gate.weight.grad.detach().clone()
+    router.aux_loss_coeff = saved_coeff
+
+    assert torch.isfinite(grad_with_aux).all()
+    assert torch.isfinite(grad_no_aux).all()
+    assert (grad_with_aux - grad_no_aux).abs().sum().item() > 0.0

--- a/experimental/lite/tests/unit/primitive/test_checkpoint_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_checkpoint_unit.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+import torch
+import torch.nn as nn
+
+from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
+from megatron.lite.runtime.contracts.handle import ModelHandle
+
+
+pytestmark = [
+    pytest.mark.mlite,
+    pytest.mark.xfail(
+        reason="MLite runtime checkpoint API/DCP continuity is covered by a follow-up bugfix PR.",
+        strict=True,
+    ),
+]
+
+
+class TinyMLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layers = nn.Sequential(
+            nn.Linear(4, 8),
+            nn.GELU(),
+            nn.Linear(8, 2),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.layers(x)
+
+
+def _step(model: nn.Module, optimizer: torch.optim.Optimizer, x: torch.Tensor, y: torch.Tensor):
+    optimizer.zero_grad(set_to_none=True)
+    loss = torch.nn.functional.mse_loss(model(x), y)
+    loss.backward()
+    optimizer.step()
+    return loss.detach()
+
+
+def _clone_model_and_optimizer(model: nn.Module):
+    clone = copy.deepcopy(model)
+    optimizer = torch.optim.AdamW(clone.parameters(), lr=1.0e-3, weight_decay=0.0)
+    return clone, optimizer
+
+
+def _assert_model_close(lhs: nn.Module, rhs: nn.Module):
+    for (lhs_name, lhs_param), (rhs_name, rhs_param) in zip(
+        lhs.named_parameters(),
+        rhs.named_parameters(),
+        strict=True,
+    ):
+        assert lhs_name == rhs_name
+        torch.testing.assert_close(lhs_param, rhs_param, atol=0.0, rtol=0.0)
+
+
+def test_runtime_checkpoint_load_matches_uninterrupted_training(tmp_path):
+    torch.manual_seed(2029)
+    base = TinyMLP()
+    ckpt_model, ckpt_optimizer = _clone_model_and_optimizer(base)
+    direct_model, direct_optimizer = _clone_model_and_optimizer(base)
+    loaded_model, loaded_optimizer = _clone_model_and_optimizer(base)
+    x0, y0 = torch.randn(3, 4), torch.randn(3, 2)
+    x1, y1 = torch.randn(3, 4), torch.randn(3, 2)
+
+    _step(ckpt_model, ckpt_optimizer, x0, y0)
+    _step(direct_model, direct_optimizer, x0, y0)
+
+    runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
+    ckpt_handle = ModelHandle(
+        model=ckpt_model,
+        optimizer=ckpt_optimizer,
+        _extras={"model_chunks": [ckpt_model]},
+    )
+    runtime.save_checkpoint(ckpt_handle, str(tmp_path), step=1)
+
+    loaded_handle = ModelHandle(
+        model=loaded_model,
+        optimizer=loaded_optimizer,
+        _extras={"model_chunks": [loaded_model]},
+    )
+    assert runtime.load_checkpoint(loaded_handle, str(tmp_path)) == 1
+
+    _step(direct_model, direct_optimizer, x1, y1)
+    _step(loaded_model, loaded_optimizer, x1, y1)
+
+    _assert_model_close(direct_model, loaded_model)
+
+
+class DistOptLike:
+    """Small optimizer wrapper with the same checkpoint contract as distopt."""
+
+    def __init__(self, optimizer: torch.optim.Optimizer):
+        self.optimizer = optimizer
+        self.load_calls = 0
+        self.parameter_save_calls = 0
+        self.parameter_load_calls = 0
+
+    def zero_grad(self):
+        self.optimizer.zero_grad(set_to_none=True)
+
+    def step(self):
+        self.optimizer.step()
+        return True, 0.0, 0
+
+    def state_dict(self):
+        state = self.optimizer.state_dict()
+        state["distopt_like_marker"] = {"load_calls": self.load_calls}
+        return state
+
+    def load_state_dict(self, state):
+        marker = state.pop("distopt_like_marker")
+        self.load_calls = int(marker["load_calls"]) + 1
+        self.optimizer.load_state_dict(state)
+
+    def save_parameter_state(self, filename: str):
+        self.parameter_save_calls += 1
+        torch.save({"parameter_save_calls": self.parameter_save_calls}, filename)
+
+    def load_parameter_state(self, filename: str, *, update_legacy_format: bool = False):
+        state = torch.load(filename)
+        self.parameter_load_calls = int(state["parameter_save_calls"])
+
+
+def test_runtime_checkpoint_uses_optimizer_state_dict_contract(tmp_path):
+    torch.manual_seed(2030)
+    model = TinyMLP()
+    optimizer = DistOptLike(torch.optim.AdamW(model.parameters(), lr=1.0e-3))
+    x, y = torch.randn(3, 4), torch.randn(3, 2)
+    optimizer.zero_grad()
+    torch.nn.functional.mse_loss(model(x), y).backward()
+    optimizer.step()
+
+    runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
+    runtime.save_checkpoint(
+        ModelHandle(model=model, optimizer=optimizer, _extras={"model_chunks": [model]}),
+        str(tmp_path),
+        step=7,
+    )
+
+    loaded_model = TinyMLP()
+    loaded_optimizer = DistOptLike(torch.optim.AdamW(loaded_model.parameters(), lr=1.0e-3))
+    loaded_handle = ModelHandle(
+        model=loaded_model,
+        optimizer=loaded_optimizer,
+        _extras={"model_chunks": [loaded_model]},
+    )
+
+    assert runtime.load_checkpoint(loaded_handle, str(tmp_path)) == 7
+    assert loaded_optimizer.load_calls == 1
+    assert loaded_optimizer.parameter_load_calls == 1
+    assert (tmp_path / "training_state.optimizer_parameter_state.pt").exists()
+    _assert_model_close(model, loaded_model)

--- a/experimental/lite/tests/unit/primitive/test_fsdp2_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_fsdp2_unit.py
@@ -1,0 +1,333 @@
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+from megatron.lite.primitive.optimizers.fsdp2 import (
+    FSDP2Config,
+    clip_grads_with_sharded_norm_,
+    fsdp2_available,
+)
+from megatron.lite.primitive.optimizers.fsdp2.adamw import build_adamw_optimizer
+from megatron.lite.primitive.optimizers.fsdp2.wrap import build_fsdp2_shard_placement_fn
+from megatron.lite.primitive.parallel.state import ParallelState
+
+
+pytestmark = pytest.mark.mlite
+
+fsdp2_wrap = importlib.import_module("megatron.lite.primitive.optimizers.fsdp2.wrap")
+
+
+class ToyBlock(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = nn.Linear(4, 4)
+
+    def forward(self, x):
+        return self.proj(x)
+
+
+class ToyModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.block = ToyBlock()
+        self.out = nn.Linear(4, 2)
+
+    def forward(self, x):
+        return self.out(self.block(x))
+
+
+class TwoBlockModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.block0 = ToyBlock()
+        self.block1 = ToyBlock()
+        self.out = nn.Linear(4, 2)
+
+    def forward(self, x):
+        return self.out(self.block1(self.block0(x)))
+
+
+class NestedToyBlock(ToyBlock):
+    def __init__(self):
+        super().__init__()
+        self.inner = ToyBlock()
+
+
+def test_fsdp2_config_validates_empty_wrap_surface():
+    with pytest.raises(ValueError, match="wrap_root=True"):
+        FSDP2Config(wrap_root=False)
+
+
+@pytest.mark.parametrize("field", ["mesh_dim_name", "device_type"])
+def test_fsdp2_config_rejects_empty_names(field: str):
+    with pytest.raises(ValueError, match=field):
+        FSDP2Config(**{field: ""})
+
+
+def test_fsdp2_config_normalizes_unit_and_leaf_modules():
+    cfg = FSDP2Config(unit_modules=[nn.Linear], leaf_module_names=["embed"])
+
+    assert cfg.unit_modules == (nn.Linear,)
+    assert cfg.leaf_module_names == ("embed",)
+    assert isinstance(fsdp2_available(), bool)
+
+
+def test_fsdp2_shard_placement_prefers_first_divisible_dimension():
+    placement_for_two = build_fsdp2_shard_placement_fn(2)
+    placement_for_three = build_fsdp2_shard_placement_fn(3)
+
+    assert placement_for_two(nn.Parameter(torch.empty(3, 4))).dim == 1
+    assert placement_for_three(nn.Parameter(torch.empty(3, 4))).dim == 0
+
+
+def test_fsdp2_shard_placement_rejects_invalid_group_size():
+    with pytest.raises(ValueError, match="positive"):
+        build_fsdp2_shard_placement_fn(0)
+
+
+def test_fsdp2_rejects_invalid_unit_path():
+    with pytest.raises(ValueError, match="Invalid FSDP2 unit module path"):
+        fsdp2_wrap._resolve_unit_module_types(("Linear",))
+
+
+def test_fsdp2_rejects_non_module_unit_path():
+    with pytest.raises(TypeError, match="does not resolve"):
+        fsdp2_wrap._resolve_unit_module_types(("math.sqrt",))
+
+
+def test_wrap_fsdp2_requires_distributed_when_mesh_is_not_provided(monkeypatch):
+    monkeypatch.setattr(
+        fsdp2_wrap,
+        "_load_fully_shard",
+        lambda: lambda module, **kwargs: module,
+    )
+
+    with pytest.raises(RuntimeError, match="torch.distributed"):
+        fsdp2_wrap.wrap_fsdp2(ToyModel(), ParallelState(), FSDP2Config())
+
+
+def test_wrap_fsdp2_wraps_units_then_root_and_preserves_param_attrs(monkeypatch):
+    model = ToyModel()
+    model.block.proj.weight.tensor_model_parallel = True
+    calls: list[nn.Module] = []
+
+    def fake_fully_shard(module, **kwargs):
+        calls.append(module)
+        for param in module.parameters():
+            vars(param).clear()
+        module._fake_fsdp2_kwargs = kwargs
+        return module
+
+    monkeypatch.setattr(fsdp2_wrap, "_load_fully_shard", lambda: fake_fully_shard)
+
+    result = fsdp2_wrap.wrap_fsdp2(
+        model,
+        ParallelState(),
+        FSDP2Config(unit_modules=(ToyBlock,), reshard_after_forward=False),
+        mesh=SimpleNamespace(name="mesh"),
+    )
+
+    assert result is model
+    assert calls == [model.block, model]
+    assert model.block.proj.weight.tensor_model_parallel is True
+    assert model._fake_fsdp2_kwargs["reshard_after_forward"] is False
+    assert model._fake_fsdp2_kwargs["mesh"].name == "mesh"
+
+
+def test_wrap_fsdp2_accepts_unit_module_import_paths(monkeypatch):
+    model = ToyModel()
+    calls: list[nn.Module] = []
+
+    def fake_fully_shard(module, **kwargs):
+        calls.append(module)
+        return module
+
+    monkeypatch.setattr(fsdp2_wrap, "_load_fully_shard", lambda: fake_fully_shard)
+
+    fsdp2_wrap.wrap_fsdp2(
+        model,
+        ParallelState(),
+        FSDP2Config(
+            unit_modules=("torch.nn.modules.linear.Linear",),
+            wrap_root=False,
+        ),
+        mesh=SimpleNamespace(name="mesh"),
+    )
+
+    assert calls == [model.block.proj, model.out]
+
+
+def test_wrap_fsdp2_uses_container_order_without_nested_unit_duplicates(monkeypatch):
+    model = nn.Module()
+    model.layers = nn.ModuleDict(
+        {
+            "10": NestedToyBlock(),
+            "2": ToyBlock(),
+            "11": ToyBlock(),
+        }
+    )
+    calls: list[nn.Module] = []
+
+    def fake_fully_shard(module, **kwargs):
+        calls.append(module)
+        module._fake_fsdp2_kwargs = kwargs
+        return module
+
+    monkeypatch.setattr(fsdp2_wrap, "_load_fully_shard", lambda: fake_fully_shard)
+
+    fsdp2_wrap.wrap_fsdp2(
+        model,
+        ParallelState(),
+        FSDP2Config(unit_modules=(ToyBlock,), reshard_after_forward=True),
+        mesh=SimpleNamespace(name="mesh"),
+    )
+
+    assert calls == [
+        model.layers["10"],
+        model.layers["2"],
+        model.layers["11"],
+        model,
+    ]
+    assert model.layers["10"]._fake_fsdp2_kwargs["reshard_after_forward"] is True
+    assert not hasattr(model.layers["10"].inner, "_fake_fsdp2_kwargs")
+    assert model.layers["11"]._fake_fsdp2_kwargs["reshard_after_forward"] is False
+
+
+def test_wrap_fsdp2_configures_default_forward_prefetch(monkeypatch):
+    model = TwoBlockModel()
+    calls: list[nn.Module] = []
+
+    def fake_fully_shard(module, **kwargs):
+        calls.append(module)
+        module._forward_prefetch = None
+        module._backward_prefetch = None
+        module._fake_fsdp2_kwargs = kwargs
+
+        def set_forward_prefetch(modules, *, _module=module):
+            _module._forward_prefetch = list(modules)
+
+        def set_backward_prefetch(modules, *, _module=module):
+            _module._backward_prefetch = list(modules)
+
+        module.set_modules_to_forward_prefetch = set_forward_prefetch
+        module.set_modules_to_backward_prefetch = set_backward_prefetch
+        return module
+
+    monkeypatch.setattr(fsdp2_wrap, "_load_fully_shard", lambda: fake_fully_shard)
+
+    fsdp2_wrap.wrap_fsdp2(
+        model,
+        ParallelState(),
+        FSDP2Config(
+            unit_modules=(ToyBlock,),
+            reshard_after_forward=True,
+        ),
+        mesh=SimpleNamespace(name="mesh"),
+    )
+
+    assert calls == [model.block0, model.block1, model]
+    assert model.block0._fake_fsdp2_kwargs["reshard_after_forward"] is True
+    assert model.block1._fake_fsdp2_kwargs["reshard_after_forward"] is False
+    assert model._fake_fsdp2_kwargs["reshard_after_forward"] is False
+    assert model._forward_prefetch == [model.block0]
+    assert model.block0._forward_prefetch == [model.block1]
+    assert model.block1._backward_prefetch is None
+
+
+def test_wrap_fsdp2_prefetch_depths(monkeypatch):
+    model = nn.Sequential(ToyBlock(), ToyBlock(), ToyBlock())
+
+    def fake_fully_shard(module, **kwargs):
+        module._forward_prefetch = None
+        module._backward_prefetch = None
+
+        def set_forward_prefetch(modules, *, _module=module):
+            _module._forward_prefetch = list(modules)
+
+        def set_backward_prefetch(modules, *, _module=module):
+            _module._backward_prefetch = list(modules)
+
+        module.set_modules_to_forward_prefetch = set_forward_prefetch
+        module.set_modules_to_backward_prefetch = set_backward_prefetch
+        return module
+
+    monkeypatch.setattr(fsdp2_wrap, "_load_fully_shard", lambda: fake_fully_shard)
+
+    fsdp2_wrap.wrap_fsdp2(
+        model,
+        ParallelState(),
+        FSDP2Config(
+            unit_modules=(ToyBlock,),
+            wrap_root=False,
+            forward_prefetch_depth=2,
+            backward_prefetch_depth=2,
+        ),
+        mesh=SimpleNamespace(name="mesh"),
+    )
+
+    assert model[0]._forward_prefetch == [model[1], model[2]]
+    assert model[1]._forward_prefetch == [model[2]]
+    assert model[2]._backward_prefetch == [model[1], model[0]]
+
+
+def test_clip_grads_with_sharded_norm_scales_cpu_grads_once():
+    p0 = nn.Parameter(torch.ones(2))
+    p1 = nn.Parameter(torch.ones(2))
+    p0.grad = torch.tensor([3.0, 4.0])
+    p1.grad = torch.tensor([0.0, 12.0])
+
+    clip_grads_with_sharded_norm_([p0, p1], max_norm=6.5, total_norm=torch.tensor(13.0))
+
+    scale = 6.5 / (13.0 + 1.0e-6)
+    torch.testing.assert_close(p0.grad, torch.tensor([3.0, 4.0]) * scale)
+    torch.testing.assert_close(p1.grad, torch.tensor([0.0, 12.0]) * scale)
+
+
+def test_fp32_adamw_state_dict_roundtrip_cpu():
+    param = nn.Parameter(torch.tensor([1.0, -2.0], dtype=torch.bfloat16))
+    optimizer = build_adamw_optimizer(
+        [{"params": [param], "weight_decay": 0.0}],
+        all_params=[param],
+        lr=0.1,
+        weight_decay=0.0,
+        betas=(0.9, 0.99),
+        eps=1.0e-8,
+        foreach=False,
+        use_fp32_master=True,
+        cpu_update=False,
+        model_param_dtypes={id(param): torch.bfloat16},
+        opt=SimpleNamespace(),
+    )
+    param.grad = torch.tensor([0.5, -0.25], dtype=torch.bfloat16)
+    optimizer.step()
+    state = optimizer.state_dict()
+
+    loaded_param = nn.Parameter(torch.tensor([9.0, 9.0], dtype=torch.bfloat16))
+    loaded_optimizer = build_adamw_optimizer(
+        [{"params": [loaded_param], "weight_decay": 0.0}],
+        all_params=[loaded_param],
+        lr=0.1,
+        weight_decay=0.0,
+        betas=(0.9, 0.99),
+        eps=1.0e-8,
+        foreach=False,
+        use_fp32_master=True,
+        cpu_update=False,
+        model_param_dtypes={id(loaded_param): torch.bfloat16},
+        opt=SimpleNamespace(),
+    )
+    loaded_optimizer.load_state_dict(state)
+    loaded_state = loaded_optimizer.state_dict()
+
+    assert loaded_state["step_count"] == state["step_count"]
+    for key in ("master_params", "exp_avgs", "exp_avg_sqs", "steps"):
+        assert len(loaded_state[key]) == len(state[key])
+    torch.testing.assert_close(loaded_state["master_params"][0], state["master_params"][0])
+    torch.testing.assert_close(loaded_state["exp_avgs"][0], state["exp_avgs"][0])
+    torch.testing.assert_close(loaded_state["exp_avg_sqs"][0], state["exp_avg_sqs"][0])
+    assert loaded_state["steps"] == state["steps"]

--- a/experimental/lite/tests/unit/primitive/test_parallel_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_parallel_unit.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from megatron.lite.primitive.parallel import (
+    ParallelState,
+    build_pipeline_chunk_layout,
+    reconstruct_packed_from_cp_parts,
+    roll_packed_thd_left,
+    split_packed_to_cp_local,
+    zigzag_position_ids_for_cp,
+    zigzag_reconstruct_from_cp_parts,
+    zigzag_slice_for_cp,
+    zigzag_split_for_cp,
+)
+
+
+pytestmark = pytest.mark.mlite
+
+
+def test_cp_zigzag_split_slice_and_reconstruct_match():
+    tensor = torch.arange(16).reshape(1, 8, 2)
+    parts = [zigzag_split_for_cp(tensor, rank, cp_size=2, seq_dim=1) for rank in range(2)]
+
+    assert torch.equal(parts[0], tensor[:, [0, 1, 6, 7], :])
+    assert torch.equal(parts[1], tensor[:, [2, 3, 4, 5], :])
+    assert torch.equal(zigzag_slice_for_cp(tensor, 0, cp_size=2, seq_dim=1), parts[0])
+    assert torch.equal(zigzag_slice_for_cp(tensor, 1, cp_size=2, seq_dim=1), parts[1])
+    assert torch.equal(zigzag_reconstruct_from_cp_parts(parts, seq_dim=1), tensor)
+
+
+def test_cp_position_ids_follow_zigzag_order():
+    assert torch.equal(
+        zigzag_position_ids_for_cp(8, cp_rank=0, cp_size=2, device=torch.device("cpu")),
+        torch.tensor([[0, 1, 6, 7]]),
+    )
+    assert torch.equal(
+        zigzag_position_ids_for_cp(8, cp_rank=1, cp_size=2, device=torch.device("cpu")),
+        torch.tensor([[2, 3, 4, 5]]),
+    )
+
+
+def test_pp_layout_marks_stage_boundaries_and_vpp_chunks():
+    rank0 = ParallelState(pp_size=2, pp_rank=0, pp_is_first=True, pp_is_last=False)
+    rank1 = ParallelState(pp_size=2, pp_rank=1, pp_is_first=False, pp_is_last=True)
+
+    assert build_pipeline_chunk_layout(8, rank0).layer_indices == [0, 1, 2, 3]
+    assert build_pipeline_chunk_layout(8, rank0).has_embed is True
+    assert build_pipeline_chunk_layout(8, rank0).has_head is False
+    assert build_pipeline_chunk_layout(8, rank1).layer_indices == [4, 5, 6, 7]
+    assert build_pipeline_chunk_layout(8, rank1).has_embed is False
+    assert build_pipeline_chunk_layout(8, rank1).has_head is True
+
+    vpp_rank0_chunk1 = build_pipeline_chunk_layout(8, rank0, vpp=2, vpp_chunk_id=1)
+    vpp_rank1_chunk1 = build_pipeline_chunk_layout(8, rank1, vpp=2, vpp_chunk_id=1)
+    assert vpp_rank0_chunk1.layer_indices == [4, 5]
+    assert vpp_rank0_chunk1.has_head is False
+    assert vpp_rank1_chunk1.layer_indices == [6, 7]
+    assert vpp_rank1_chunk1.has_head is True
+
+
+def test_thd_roll_keeps_sequence_boundaries():
+    cu_seqlens = torch.tensor([0, 4, 8], dtype=torch.int32)
+    rolled, token_sum = roll_packed_thd_left(
+        torch.arange(8),
+        cu_seqlens_padded=cu_seqlens,
+        dims=0,
+    )
+
+    assert torch.equal(rolled, torch.tensor([1, 2, 3, 0, 5, 6, 7, 0]))
+    assert token_sum.item() == 24
+
+
+def test_thd_cp_split_and_reconstruct_roundtrip():
+    cu_seqlens = torch.tensor([0, 8], dtype=torch.int32)
+    tensor = torch.arange(8)
+    parts = [
+        split_packed_to_cp_local(
+            tensor,
+            cu_seqlens_padded=cu_seqlens,
+            cp_size=2,
+            cp_rank=rank,
+            dim=0,
+        )
+        for rank in range(2)
+    ]
+
+    assert torch.equal(parts[0], torch.tensor([0, 1, 6, 7]))
+    assert torch.equal(parts[1], torch.tensor([2, 3, 4, 5]))
+    assert torch.equal(
+        reconstruct_packed_from_cp_parts(parts, cu_seqlens_padded=cu_seqlens, cp_size=2, dim=0),
+        tensor,
+    )

--- a/experimental/lite/tests/unit/primitive/test_runtime_config_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_runtime_config_unit.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import pytest
+
+from megatron.lite.runtime import RuntimeConfig, create_runtime
+from megatron.lite.runtime.backends.mlite.config import DebugConfig, MegatronLiteConfig
+from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
+
+
+pytestmark = pytest.mark.mlite
+
+
+def test_mlite_config_defaults_are_stable():
+    cfg = MegatronLiteConfig(model_name="qwen3_moe")
+
+    assert cfg.model_name == "qwen3_moe"
+    assert cfg.impl == "lite"
+    assert cfg.parallel.tp == 1
+    assert cfg.parallel.ep == 1
+    assert cfg.parallel.pp == 1
+    assert cfg.parallel.cp == 1
+    assert isinstance(cfg.optimizer, OptimizerConfig)
+    assert isinstance(cfg.debug, DebugConfig)
+
+
+def test_mlite_config_from_dict_preserves_parallel_optimizer_and_impl_cfg():
+    cfg = MegatronLiteConfig.from_dict(
+        "/models/qwen",
+        {
+            "model_name": "qwen3_moe",
+            "impl": "lite",
+            "tp": 2,
+            "ep": 4,
+            "pp": 2,
+            "cp": 2,
+            "optimizer": {
+                "lr": 1.0e-4,
+                "weight_decay": 0.1,
+                "adam_beta1": 0.9,
+                "offload_fraction": 1.0,
+            },
+            "impl_cfg": {"attn_impl": "mcore", "moe_impl": "ml"},
+            "use_thd": True,
+            "precision_aware_opt": True,
+        },
+    )
+
+    assert cfg.hf_path == "/models/qwen"
+    assert cfg.parallel == ParallelConfig(tp=2, etp=None, ep=4, pp=2, vpp=1, cp=2)
+    assert cfg.optimizer.lr == 1.0e-4
+    assert cfg.optimizer.weight_decay == 0.1
+    assert cfg.optimizer.adam_beta1 == 0.9
+    assert cfg.optimizer.offload_fraction == 1.0
+    assert cfg.impl_cfg["attn_impl"] == "mcore"
+    assert cfg.impl_cfg["moe_impl"] == "ml"
+    assert cfg.impl_cfg["use_thd"] is True
+    assert cfg.impl_cfg["precision_aware_opt"] is True
+
+
+def test_mlite_config_rejects_num_microbatches_in_backend_config():
+    with pytest.raises(ValueError, match="num_microbatches"):
+        MegatronLiteConfig.from_dict(
+            "/models/qwen",
+            {"model_name": "qwen3_moe", "num_microbatches": 2},
+        )
+
+
+def test_create_runtime_uses_mlite_backend_registry():
+    runtime = create_runtime(
+        RuntimeConfig(
+            backend="mlite",
+            hf_path="/models/qwen",
+            backend_cfg={"model_name": "qwen3_moe", "load_hf_weights": False},
+        )
+    )
+
+    assert type(runtime).__name__ == "MegatronLiteRuntime"
+    assert runtime.tier == "rl_best"

--- a/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
+++ b/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
@@ -1,0 +1,333 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch.nn as nn
+
+from megatron.lite.runtime import create_runtime
+from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig
+from megatron.lite.runtime.backends.mlite.runtime import (
+    MegatronLiteRuntime,
+    _apply_attention_backend_env,
+    _build_impl_cfg,
+)
+from megatron.lite.runtime.contracts.config import (
+    OptimizerConfig,
+    ParallelConfig,
+    RuntimeConfig,
+)
+from megatron.lite.runtime.contracts.handle import ModelHandle
+
+
+pytestmark = pytest.mark.mlite
+
+
+def test_runtime_config_defaults_to_mlite_backend():
+    cfg = RuntimeConfig()
+
+    assert cfg.backend == "mlite"
+    assert cfg.hf_path == ""
+    assert isinstance(cfg.backend_cfg, dict)
+
+
+def test_runtime_config_accepts_mlite_backend_cfg():
+    cfg = RuntimeConfig(
+        backend="mlite",
+        hf_path="/models/Qwen3",
+        backend_cfg={
+            "model_name": "qwen3",
+            "impl": "lite",
+            "tp": 2,
+            "ep": 4,
+        },
+    )
+
+    assert cfg.backend == "mlite"
+    assert cfg.backend_cfg["model_name"] == "qwen3"
+    assert cfg.backend_cfg["tp"] == 2
+
+
+def test_mlite_config_defaults_and_parallel_fields():
+    cfg = MegatronLiteConfig(
+        model_name="qwen3_moe",
+        parallel=ParallelConfig(tp=4, etp=1, ep=8, pp=2, vpp=2, cp=2),
+    )
+
+    assert cfg.model_name == "qwen3_moe"
+    assert cfg.impl == "lite"
+    assert cfg.parallel.tp == 4
+    assert cfg.parallel.ep == 8
+    assert cfg.parallel.pp == 2
+    assert cfg.parallel.cp == 2
+
+
+def test_mlite_config_impl_cfg_optimizer_and_load_gate():
+    hook = lambda cfg: cfg  # noqa: E731
+    cfg = MegatronLiteConfig(
+        model_name="qwen3_moe",
+        impl_cfg={"recompute": "full", "use_deepep": True},
+        optimizer=OptimizerConfig(lr=1e-4, weight_decay=0.1, adam_beta1=0.9),
+        load_hf_weights=False,
+        model_config_hook=hook,
+    )
+
+    assert cfg.impl_cfg["recompute"] == "full"
+    assert cfg.impl_cfg["use_deepep"] is True
+    assert cfg.optimizer.lr == 1e-4
+    assert cfg.optimizer.adam_beta1 == 0.9
+    assert cfg.load_hf_weights is False
+    assert cfg.model_config_hook is hook
+
+
+def test_mlite_config_from_dict_accepts_optimizer_override_config():
+    cfg = MegatronLiteConfig.from_dict(
+        "/models/Qwen3",
+        {
+            "optimizer": {
+                "override_optimizer_config": {
+                    "fsdp2_use_fp32_master": False,
+                    "offload_fraction": 1.0,
+                },
+            },
+        },
+    )
+
+    assert cfg.optimizer.override_optimizer_config == {
+        "fsdp2_use_fp32_master": False,
+        "offload_fraction": 1.0,
+    }
+
+
+def test_mlite_config_from_dict_rejects_num_microbatches():
+    with pytest.raises(ValueError, match="num_microbatches"):
+        MegatronLiteConfig.from_dict(
+            "/models/Qwen3",
+            {
+                "model_name": "qwen3",
+                "tp": 4,
+                "num_microbatches": 2,
+            },
+        )
+
+
+@dataclass
+class _FakeImplConfig:
+    parallel: object
+    hf_path: str = ""
+    optimizer_config: object = None
+    attention_backend_override: str | None = None
+
+
+def test_build_impl_cfg_backfills_top_level_hf_path_and_runtime_fields():
+    proto = type("Proto", (), {"ImplConfig": _FakeImplConfig})
+    cfg = MegatronLiteConfig(
+        model_name="qwen3",
+        hf_path="/models/top",
+        attention_backend_override="local",
+    )
+
+    impl_cfg = _build_impl_cfg(proto, cfg)
+
+    assert impl_cfg.parallel is cfg.parallel
+    assert impl_cfg.hf_path == "/models/top"
+    assert impl_cfg.optimizer_config is cfg.optimizer
+    assert impl_cfg.attention_backend_override == "local"
+
+
+def test_build_impl_cfg_preserves_explicit_impl_hf_path():
+    proto = type("Proto", (), {"ImplConfig": _FakeImplConfig})
+    cfg = MegatronLiteConfig(
+        model_name="qwen3",
+        hf_path="/models/top",
+        impl_cfg={"hf_path": "/models/impl"},
+    )
+
+    impl_cfg = _build_impl_cfg(proto, cfg)
+
+    assert impl_cfg.hf_path == "/models/impl"
+
+
+@pytest.mark.parametrize(
+    ("backend", "expected"),
+    [
+        ("auto", ("1", "1", "1")),
+        ("flash", ("1", "0", "0")),
+        ("fused", ("0", "1", "0")),
+        ("unfused", ("0", "0", "1")),
+        ("local", ("0", "0", "0")),
+    ],
+)
+def test_attention_backend_override_sets_expected_env(monkeypatch, backend, expected):
+    for name in ("NVTE_FLASH_ATTN", "NVTE_FUSED_ATTN", "NVTE_UNFUSED_ATTN"):
+        monkeypatch.delenv(name, raising=False)
+
+    _apply_attention_backend_env(backend, tag="unit")
+
+    assert (
+        os.environ["NVTE_FLASH_ATTN"],
+        os.environ["NVTE_FUSED_ATTN"],
+        os.environ["NVTE_UNFUSED_ATTN"],
+    ) == expected
+
+
+def test_attention_backend_override_rejects_unknown_backend():
+    with pytest.raises(ValueError, match="attention_backend_override"):
+        _apply_attention_backend_env("invalid", tag="unit")
+
+
+class HookedOptimizer:
+    def __init__(self):
+        self.calls: list[str] = []
+
+    def offload_state_to_cpu(self):
+        self.calls.append("offload")
+
+    def load_state_to_device(self):
+        self.calls.append("load")
+
+
+def test_runtime_to_prefers_optimizer_specific_offload_hooks():
+    optimizer = HookedOptimizer()
+    handle = ModelHandle(
+        model=nn.Linear(2, 2),
+        optimizer=optimizer,
+        _extras={"model_chunks": []},
+    )
+    runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
+
+    runtime.to(handle, "cpu", model=False, optimizer=True, grad=False)
+    runtime.to(handle, "cuda", model=False, optimizer=True, grad=False)
+
+    assert optimizer.calls == ["offload", "load"]
+
+
+def test_model_handle_dp_defaults():
+    handle = ModelHandle(model=MagicMock())
+
+    assert handle.dp_rank == 0
+    assert handle.dp_size == 1
+    assert handle.dp_group is None
+
+
+def test_model_handle_dp_from_parallel_state():
+    ps = MagicMock()
+    ps.dp_rank = 3
+    ps.dp_size = 8
+    ps.dp_group = "fake_group"
+
+    handle = ModelHandle(model=MagicMock(), parallel_state=ps)
+
+    assert handle.dp_rank == 3
+    assert handle.dp_size == 8
+    assert handle.dp_group == "fake_group"
+
+
+def test_model_handle_cp_range_and_config_properties():
+    cfg = {"tp": 8, "ep": 4}
+    default_handle = ModelHandle(model=MagicMock())
+    configured_handle = ModelHandle(
+        model=MagicMock(),
+        config=cfg,
+        _extras={"cp_range": (1, 8)},
+    )
+
+    assert default_handle.cp_range == (1, 1)
+    assert configured_handle.cp_range == (1, 8)
+    assert configured_handle.config is cfg
+
+
+def test_runtime_dispatch_creates_mlite_backend():
+    with patch("megatron.lite.runtime.backends.mlite.create") as mock_create:
+        backend = MagicMock()
+        mock_create.return_value = backend
+
+        runtime = create_runtime(
+            RuntimeConfig(
+                backend="mlite",
+                hf_path="/models/test",
+                backend_cfg={"model_name": "qwen3"},
+            )
+        )
+
+    assert runtime is backend
+    mock_create.assert_called_once_with("/models/test", {"model_name": "qwen3"})
+
+
+def test_runtime_dispatch_unknown_backend_raises():
+    with pytest.raises(KeyError):
+        create_runtime(RuntimeConfig(backend="nonexistent"))
+
+
+def _run_verl_sft_dry_run(script: Path, tmp_path: Path, **env_overrides: str) -> str:
+    env = {
+        **os.environ,
+        "MODEL_PATH": "/tmp/mlite-model",
+        "TRAIN_FILES": "/tmp/mlite-train.parquet",
+        "OUTPUT_ROOT": str(tmp_path),
+        "DRY_RUN": "1",
+        "NUM_GPUS": "1",
+        "NPROC_PER_NODE": "1",
+        "TP_SIZE": "1",
+        "PP_SIZE": "1",
+        "CP_SIZE": "1",
+        "EP_SIZE": "1",
+        "ETP_SIZE": "1",
+        **env_overrides,
+    }
+    completed = subprocess.run(
+        [str(script)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return completed.stdout
+
+
+def test_verl_sft_script_maps_offload_env_to_backend_args(tmp_path):
+    script = (
+        Path(__file__).resolve().parents[3]
+        / "examples"
+        / "verl"
+        / "scripts"
+        / "run_qwen3moe_sft.sh"
+    )
+
+    command = _run_verl_sft_dry_run(
+        script,
+        tmp_path,
+        PARAM_OFFLOAD="True",
+        OPTIMIZER_OFFLOAD="True",
+        OPTIMIZER_STATE_OFFLOAD_FRACTION="0.75",
+    )
+
+    assert "engine.param_offload=True" in command
+    assert "engine.optimizer_offload=True" in command
+    assert "+optim.override_optimizer_config.offload_fraction=0.75" in command
+    assert "+optim.override_optimizer_config.use_precision_aware_optimizer=True" in command
+
+
+def test_verl_sft_script_does_not_emit_optimizer_state_offload_when_disabled(tmp_path):
+    script = (
+        Path(__file__).resolve().parents[3]
+        / "examples"
+        / "verl"
+        / "scripts"
+        / "run_qwen3moe_sft.sh"
+    )
+
+    command = _run_verl_sft_dry_run(
+        script,
+        tmp_path,
+        PARAM_OFFLOAD="False",
+        OPTIMIZER_OFFLOAD="False",
+    )
+
+    assert "engine.param_offload=False" in command
+    assert "engine.optimizer_offload=False" in command
+    assert "override_optimizer_config.offload_fraction" not in command

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,16 +211,12 @@ exclude = '''
 
 [tool.pytest.ini_options]
 addopts = "--durations=15 -s -rA -x"
-testpaths = ["tests", "experimental/lite/tests"]
+testpaths = ["tests"]
 python_files = "test_*.py"
 markers = [
     "internal: mark a test as a test to private/internal functions.",
     "flaky: mark flaky tests for LTS environment",
     "flaky_in_dev: mark flaky tests for DEV environment",
-    "mlite: mark a test as Megatron Lite validation coverage",
-    "smoke: mark a Megatron Lite smoke test; skipped unless --mlite-smoke or MLITE_RUN_SMOKE=1 is set",
-    "gpu: mark a test as requiring CUDA",
-    "distributed: mark a test as requiring torch.distributed",
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,12 +211,16 @@ exclude = '''
 
 [tool.pytest.ini_options]
 addopts = "--durations=15 -s -rA -x"
-testpaths = ["tests"]
+testpaths = ["tests", "experimental/lite/tests"]
 python_files = "test_*.py"
 markers = [
     "internal: mark a test as a test to private/internal functions.",
     "flaky: mark flaky tests for LTS environment",
     "flaky_in_dev: mark flaky tests for DEV environment",
+    "mlite: mark a test as Megatron Lite validation coverage",
+    "smoke: mark a Megatron Lite smoke test; skipped unless --mlite-smoke or MLITE_RUN_SMOKE=1 is set",
+    "gpu: mark a test as requiring CUDA",
+    "distributed: mark a test as requiring torch.distributed",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
Summary:
- Split the MLite validation PR down to test coverage only. This branch adds the `experimental/lite/tests` matrix, pytest markers/configuration, the validation runner, and README coverage notes.
- Cover primitive, model, and runtime surfaces across unit tests and single-node smoke tests: TP/EP/PP/CP topology, THD helpers, GQA, MoE router/aux-loss, FSDP2 wrapping/offload, runtime config/env/offload contracts, distopt checkpoint sentinels, and Qwen3/Qwen3.5 lite config plus tiny forward/backward smoke.
- Keep follow-up runtime/FSDP2/distopt fixes out of this PR. Known failing continuity paths are represented as strict xfail sentinels so the tests will flip to failures if the follow-up fixes make them unexpectedly pass before the xfail is removed.

Expected xfail coverage:
- Runtime checkpoint API/DCP continuity unit sentinels.
- Distopt checkpoint continuity smoke sentinel.
- FSDP2 checkpoint continuity smoke sentinel.
- FSDP2 `offload_fraction=1.0` multi-rank grad clipping smoke sentinel; single-process CUDA offload-fraction coverage still passes in the unit layer.

Validation:
- `git diff --check`
- `bash -n experimental/lite/tests/run_primitive_validation.sh`
- `python -m py_compile` on the added/updated MLite test files
- 8-GPU single-node Slurm validation on PR head `27766714a`, job `12628881`, rc=0:
  - Unit stage: 63 passed, 2 xfailed, 0 failed.
  - Smoke stage under `MLITE_RUN_SMOKE=1 MLITE_SMOKE_NPROC=8`: 4 passed, 3 xfailed, 0 failed per rank.
  - Passing smoke coverage includes Qwen3/Qwen3.5 tiny forward/backward, parallel topology construction, and FSDP2 runtime model/optimizer offload roundtrip.
  - Expected xfails are the distopt checkpoint continuity, FSDP2 multi-rank offload-fraction grad clipping, and FSDP2 checkpoint continuity sentinels.