### PR TITLE
Add native DeepSeek-V4 lite support

### DIFF
--- a/experimental/lite/megatron/lite/model/deepseek_v4/__init__.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/__init__.py
@@ -1,0 +1,5 @@
+"""DeepSeek V4 native model package."""
+
+from .config import DeepseekV4Config
+
+__all__ = ["DeepseekV4Config"]

--- a/experimental/lite/megatron/lite/model/deepseek_v4/config.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/config.py
@@ -1,0 +1,151 @@
+"""DeepSeek V4 model configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from megatron.lite.primitive.config import load_hf_config_dict
+
+_HF_FIELDS = frozenset({
+    "attention_dropout",
+    "compress_ratios",
+    "compress_rope_theta",
+    "hc_eps",
+    "hc_mult",
+    "hc_sinkhorn_iters",
+    "head_dim",
+    "hidden_act",
+    "hidden_size",
+    "index_head_dim",
+    "index_n_heads",
+    "index_topk",
+    "initializer_range",
+    "max_position_embeddings",
+    "moe_intermediate_size",
+    "n_routed_experts",
+    "n_shared_experts",
+    "norm_topk_prob",
+    "num_attention_heads",
+    "num_experts_per_tok",
+    "num_hash_layers",
+    "num_hidden_layers",
+    "num_key_value_heads",
+    "num_nextn_predict_layers",
+    "o_groups",
+    "o_lora_rank",
+    "q_lora_rank",
+    "qk_rope_head_dim",
+    "rms_norm_eps",
+    "rope_theta",
+    "routed_scaling_factor",
+    "scoring_func",
+    "sliding_window",
+    "swiglu_limit",
+    "topk_method",
+    "vocab_size",
+})
+
+
+@dataclass
+class DeepseekV4Config:
+    """Pure DeepSeek V4 architecture parameters used by the native lite path."""
+
+    vocab_size: int = 129280
+    hidden_size: int = 4096
+    moe_intermediate_size: int = 2048
+    num_hidden_layers: int = 43
+    num_attention_heads: int = 64
+    num_key_value_heads: int = 1
+    head_dim: int = 128
+    qk_rope_head_dim: int = 64
+    q_lora_rank: int = 1024
+    o_lora_rank: int = 1024
+    o_groups: int = 8
+    n_routed_experts: int = 256
+    n_shared_experts: int = 1
+    num_experts_per_tok: int = 6
+    routed_scaling_factor: float = 1.5
+    norm_topk_prob: bool = True
+    scoring_func: str = "sqrtsoftplus"
+    topk_method: str = "noaux_tc"
+    hidden_act: str = "silu"
+    swiglu_limit: float = 10.0
+    max_position_embeddings: int = 1_048_576
+    rope_theta: float = 10_000.0
+    compress_rope_theta: float = 160_000.0
+    compress_ratios: list[int] = field(default_factory=list)
+    sliding_window: int = 128
+    num_hash_layers: int = 3
+    hc_eps: float = 1e-6
+    hc_mult: int = 4
+    hc_sinkhorn_iters: int = 20
+    index_head_dim: int = 128
+    index_n_heads: int = 64
+    index_topk: int = 512
+    num_nextn_predict_layers: int = 1
+    rms_norm_eps: float = 1e-6
+    attention_dropout: float = 0.0
+    initializer_range: float = 0.02
+
+    def __post_init__(self) -> None:
+        errors: list[str] = []
+
+        def check(cond: bool, message: str) -> None:
+            if not cond:
+                errors.append(message)
+
+        check(self.num_hidden_layers >= 1, "num_hidden_layers must be >= 1")
+        check(self.hidden_size > 0, "hidden_size must be > 0")
+        check(self.num_attention_heads >= 1, "num_attention_heads must be >= 1")
+        check(self.num_key_value_heads == 1, "stage-1 native DeepSeek V4 expects num_key_value_heads == 1")
+        check(self.num_attention_heads % self.o_groups == 0, "num_attention_heads must be divisible by o_groups")
+        check(self.head_dim > 0, "head_dim must be > 0")
+        check(0 < self.qk_rope_head_dim <= self.head_dim, "qk_rope_head_dim must be in (0, head_dim]")
+        check(self.q_lora_rank > 0, "q_lora_rank must be > 0")
+        check(self.o_lora_rank > 0, "o_lora_rank must be > 0")
+        check(self.n_routed_experts >= 1, "n_routed_experts must be >= 1")
+        check(
+            1 <= self.num_experts_per_tok <= self.n_routed_experts,
+            "num_experts_per_tok must be in [1, n_routed_experts]",
+        )
+        check(self.moe_intermediate_size > 0, "moe_intermediate_size must be > 0")
+        check(self.hc_mult >= 1, "hc_mult must be >= 1")
+        check(self.vocab_size > 0, "vocab_size must be > 0")
+        check(self.scoring_func in {"sqrtsoftplus", "sigmoid", "softmax"}, "unsupported scoring_func")
+        check(self.topk_method in {"noaux_tc", "greedy"}, "unsupported topk_method")
+        if self.compress_ratios:
+            expected_ratio_lengths = {
+                self.num_hidden_layers,
+                self.num_hidden_layers + self.num_nextn_predict_layers,
+            }
+            check(
+                len(self.compress_ratios) in expected_ratio_lengths,
+                "len(compress_ratios) must equal num_hidden_layers or "
+                "num_hidden_layers + num_nextn_predict_layers",
+            )
+
+        if errors:
+            raise ValueError(
+                f"Invalid DeepseekV4Config ({len(errors)} error"
+                f"{'s' if len(errors) != 1 else ''}):\n  " + "\n  ".join(errors)
+            )
+
+    @classmethod
+    def from_hf(cls, path: str, **overrides) -> DeepseekV4Config:
+        return cls._from_hf_dict(load_hf_config_dict(path), **overrides)
+
+    @classmethod
+    def from_hf_config(cls, hf_config, **overrides) -> DeepseekV4Config:
+        data = hf_config.to_dict() if hasattr(hf_config, "to_dict") else vars(hf_config)
+        return cls._from_hf_dict(data, **overrides)
+
+    @classmethod
+    def _from_hf_dict(cls, hf: dict[str, Any], **overrides) -> DeepseekV4Config:
+        kwargs = {key: value for key, value in hf.items() if key in _HF_FIELDS and value is not None}
+        rope_parameters = hf.get("rope_parameters")
+        if isinstance(rope_parameters, dict):
+            if "rope_theta" not in kwargs:
+                kwargs["rope_theta"] = float(rope_parameters.get("rope_theta", cls.rope_theta))
+        kwargs.update(overrides)
+        return cls(**kwargs)

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/__init__.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/__init__.py
@@ -1,0 +1,2 @@
+"""DeepSeek V4 native lite implementation."""
+

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
@@ -1,0 +1,298 @@
+"""Direct HF safetensor loading for native DeepSeek V4 lite."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+import math
+import re
+
+import torch
+import torch.nn as nn
+
+from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
+from megatron.lite.primitive.ckpt.hf_weights import SafeTensorReader, unwrap_model
+from megatron.lite.primitive.parallel import ParallelState
+from megatron.lite.primitive.utils import log_rank0
+
+
+def EXPERT_CLASSIFIER(name: str) -> bool:
+    return ".experts." in name and ".shared_experts." not in name
+
+
+_LAYER_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"^model\.layers\.(\d+)\.input_layernorm\.weight$"), r"layers.\1.attn_norm.weight"),
+    (re.compile(r"^model\.layers\.(\d+)\.post_attention_layernorm\.weight$"), r"layers.\1.ffn_norm.weight"),
+    (re.compile(r"^model\.layers\.(\d+)\.self_attn\.wq_a\.weight$"), r"layers.\1.attn.wq_a.weight"),
+    (re.compile(r"^model\.layers\.(\d+)\.self_attn\.q_norm\.weight$"), r"layers.\1.attn.q_norm.weight"),
+    (re.compile(r"^model\.layers\.(\d+)\.self_attn\.wq_b\.weight$"), r"layers.\1.attn.wq_b.weight"),
+    (re.compile(r"^model\.layers\.(\d+)\.self_attn\.wkv\.weight$"), r"layers.\1.attn.wkv.weight"),
+    (re.compile(r"^model\.layers\.(\d+)\.self_attn\.kv_norm\.weight$"), r"layers.\1.attn.kv_norm.weight"),
+    (re.compile(r"^model\.layers\.(\d+)\.self_attn\.wo_a\.weight$"), r"layers.\1.attn.wo_a.weight"),
+    (re.compile(r"^model\.layers\.(\d+)\.self_attn\.wo_b\.weight$"), r"layers.\1.attn.wo_b.weight"),
+    (re.compile(r"^model\.layers\.(\d+)\.self_attn\.sinks$"), r"layers.\1.attn.attn_sink"),
+    (re.compile(r"^model\.layers\.(\d+)\.self_attn\.compressor\.(.+)$"), r"layers.\1.attn.compressor.\2"),
+    (re.compile(r"^model\.layers\.(\d+)\.self_attn\.indexer\.(.+)$"), r"layers.\1.attn.indexer.\2"),
+    (re.compile(r"^model\.layers\.(\d+)\.mlp\.gate\.weight$"), r"layers.\1.ffn.gate.weight"),
+    (re.compile(r"^model\.layers\.(\d+)\.mlp\.gate\.e_score_correction_bias$"), r"layers.\1.ffn.gate.bias"),
+    (re.compile(r"^model\.layers\.(\d+)\.mlp\.gate\.tid2eid$"), r"layers.\1.ffn.gate.tid2eid"),
+    (re.compile(r"^model\.layers\.(\d+)\.mlp\.shared_experts\.gate_proj\.weight$"), r"layers.\1.ffn.shared_experts.w1.weight"),
+    (re.compile(r"^model\.layers\.(\d+)\.mlp\.shared_experts\.up_proj\.weight$"), r"layers.\1.ffn.shared_experts.w3.weight"),
+    (re.compile(r"^model\.layers\.(\d+)\.mlp\.shared_experts\.down_proj\.weight$"), r"layers.\1.ffn.shared_experts.w2.weight"),
+    (re.compile(r"^model\.layers\.(\d+)\.attn_hc\.fn$"), r"layers.\1.hc_attn_fn"),
+    (re.compile(r"^model\.layers\.(\d+)\.attn_hc\.base$"), r"layers.\1.hc_attn_base"),
+    (re.compile(r"^model\.layers\.(\d+)\.attn_hc\.scale$"), r"layers.\1.hc_attn_scale"),
+    (re.compile(r"^model\.layers\.(\d+)\.ffn_hc\.fn$"), r"layers.\1.hc_ffn_fn"),
+    (re.compile(r"^model\.layers\.(\d+)\.ffn_hc\.base$"), r"layers.\1.hc_ffn_base"),
+    (re.compile(r"^model\.layers\.(\d+)\.ffn_hc\.scale$"), r"layers.\1.hc_ffn_scale"),
+    (re.compile(r"^model\.layers\.(\d+)\.mlp\.experts\.(\d+)\.gate_proj\.weight$"), r"layers.\1.ffn.experts.\2.w1.weight"),
+    (re.compile(r"^model\.layers\.(\d+)\.mlp\.experts\.(\d+)\.up_proj\.weight$"), r"layers.\1.ffn.experts.\2.w3.weight"),
+    (re.compile(r"^model\.layers\.(\d+)\.mlp\.experts\.(\d+)\.down_proj\.weight$"), r"layers.\1.ffn.experts.\2.w2.weight"),
+]
+
+_MTP_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"^model\.mtp\.(\d+)\.input_layernorm\.weight$"), r"mtp.\1.attn_norm.weight"),
+    (re.compile(r"^model\.mtp\.(\d+)\.post_attention_layernorm\.weight$"), r"mtp.\1.ffn_norm.weight"),
+    (re.compile(r"^model\.mtp\.(\d+)\.self_attn\.wq_a\.weight$"), r"mtp.\1.attn.wq_a.weight"),
+    (re.compile(r"^model\.mtp\.(\d+)\.self_attn\.q_norm\.weight$"), r"mtp.\1.attn.q_norm.weight"),
+    (re.compile(r"^model\.mtp\.(\d+)\.self_attn\.wq_b\.weight$"), r"mtp.\1.attn.wq_b.weight"),
+    (re.compile(r"^model\.mtp\.(\d+)\.self_attn\.wkv\.weight$"), r"mtp.\1.attn.wkv.weight"),
+    (re.compile(r"^model\.mtp\.(\d+)\.self_attn\.kv_norm\.weight$"), r"mtp.\1.attn.kv_norm.weight"),
+    (re.compile(r"^model\.mtp\.(\d+)\.self_attn\.wo_a\.weight$"), r"mtp.\1.attn.wo_a.weight"),
+    (re.compile(r"^model\.mtp\.(\d+)\.self_attn\.wo_b\.weight$"), r"mtp.\1.attn.wo_b.weight"),
+    (re.compile(r"^model\.mtp\.(\d+)\.self_attn\.sinks$"), r"mtp.\1.attn.attn_sink"),
+    (re.compile(r"^model\.mtp\.(\d+)\.self_attn\.compressor\.(.+)$"), r"mtp.\1.attn.compressor.\2"),
+    (re.compile(r"^model\.mtp\.(\d+)\.self_attn\.indexer\.(.+)$"), r"mtp.\1.attn.indexer.\2"),
+    (re.compile(r"^model\.mtp\.(\d+)\.mlp\.gate\.weight$"), r"mtp.\1.ffn.gate.weight"),
+    (re.compile(r"^model\.mtp\.(\d+)\.mlp\.gate\.e_score_correction_bias$"), r"mtp.\1.ffn.gate.bias"),
+    (re.compile(r"^model\.mtp\.(\d+)\.mlp\.gate\.tid2eid$"), r"mtp.\1.ffn.gate.tid2eid"),
+    (re.compile(r"^model\.mtp\.(\d+)\.mlp\.shared_experts\.gate_proj\.weight$"), r"mtp.\1.ffn.shared_experts.w1.weight"),
+    (re.compile(r"^model\.mtp\.(\d+)\.mlp\.shared_experts\.up_proj\.weight$"), r"mtp.\1.ffn.shared_experts.w3.weight"),
+    (re.compile(r"^model\.mtp\.(\d+)\.mlp\.shared_experts\.down_proj\.weight$"), r"mtp.\1.ffn.shared_experts.w2.weight"),
+    (re.compile(r"^model\.mtp\.(\d+)\.attn_hc\.fn$"), r"mtp.\1.hc_attn_fn"),
+    (re.compile(r"^model\.mtp\.(\d+)\.attn_hc\.base$"), r"mtp.\1.hc_attn_base"),
+    (re.compile(r"^model\.mtp\.(\d+)\.attn_hc\.scale$"), r"mtp.\1.hc_attn_scale"),
+    (re.compile(r"^model\.mtp\.(\d+)\.ffn_hc\.fn$"), r"mtp.\1.hc_ffn_fn"),
+    (re.compile(r"^model\.mtp\.(\d+)\.ffn_hc\.base$"), r"mtp.\1.hc_ffn_base"),
+    (re.compile(r"^model\.mtp\.(\d+)\.ffn_hc\.scale$"), r"mtp.\1.hc_ffn_scale"),
+    (re.compile(r"^model\.mtp\.(\d+)\.mlp\.experts\.(\d+)\.gate_proj\.weight$"), r"mtp.\1.ffn.experts.\2.w1.weight"),
+    (re.compile(r"^model\.mtp\.(\d+)\.mlp\.experts\.(\d+)\.up_proj\.weight$"), r"mtp.\1.ffn.experts.\2.w3.weight"),
+    (re.compile(r"^model\.mtp\.(\d+)\.mlp\.experts\.(\d+)\.down_proj\.weight$"), r"mtp.\1.ffn.experts.\2.w2.weight"),
+    (re.compile(r"^model\.mtp\.(\d+)\.e_proj\.weight$"), r"mtp.\1.e_proj.weight"),
+    (re.compile(r"^model\.mtp\.(\d+)\.h_proj\.weight$"), r"mtp.\1.h_proj.weight"),
+    (re.compile(r"^model\.mtp\.(\d+)\.enorm\.weight$"), r"mtp.\1.enorm.weight"),
+    (re.compile(r"^model\.mtp\.(\d+)\.hnorm\.weight$"), r"mtp.\1.hnorm.weight"),
+    (re.compile(r"^model\.mtp\.(\d+)\.norm\.weight$"), r"mtp.\1.norm.weight"),
+    (re.compile(r"^model\.mtp\.(\d+)\.hc_head\.hc_fn$"), r"mtp.\1.hc_head_fn"),
+    (re.compile(r"^model\.mtp\.(\d+)\.hc_head\.hc_base$"), r"mtp.\1.hc_head_base"),
+    (re.compile(r"^model\.mtp\.(\d+)\.hc_head\.hc_scale$"), r"mtp.\1.hc_head_scale"),
+]
+
+_TOP_LEVEL = {
+    "model.embed_tokens.weight": "embed.weight",
+    "model.norm.weight": "norm.weight",
+    "model.hc_head.hc_fn": "hc_head_fn",
+    "model.hc_head.hc_base": "hc_head_base",
+    "model.hc_head.hc_scale": "hc_head_scale",
+    "lm_head.weight": "head.weight",
+}
+
+
+def _has(reader: SafeTensorReader, name: str) -> bool:
+    if reader.index:
+        return name in reader.index
+    try:
+        reader.get_tensor(name)
+    except Exception:
+        return False
+    return True
+
+
+def _scale_name_for_hf_name(name: str) -> str:
+    if name.endswith(".weight"):
+        return f"{name[:-7]}.scale"
+    return f"{name}.scale"
+
+
+def _scale_to_float(scale: torch.Tensor) -> torch.Tensor:
+    if scale.dtype.is_floating_point:
+        return scale.float()
+    if scale.dtype == torch.uint8:
+        return torch.pow(torch.tensor(2.0, dtype=torch.float32), scale.float() - 127.0)
+    return scale.float()
+
+
+def _expand_block_scale(scale: torch.Tensor, target_shape: torch.Size | tuple[int, ...]) -> torch.Tensor:
+    target = tuple(int(dim) for dim in target_shape)
+    while scale.ndim > len(target) and scale.shape[0] == 1:
+        scale = scale.squeeze(0)
+    while scale.ndim < len(target):
+        scale = scale.unsqueeze(-1)
+    if tuple(scale.shape) == target:
+        return scale
+    out = scale
+    for dim, size in enumerate(target):
+        if out.shape[dim] == size:
+            continue
+        repeat = math.ceil(size / out.shape[dim])
+        out = out.repeat_interleave(repeat, dim=dim)
+    slices = tuple(slice(0, size) for size in target)
+    return out[slices]
+
+
+def _dequantize_scaled_tensor(tensor: torch.Tensor, scale: torch.Tensor, shape: torch.Size) -> torch.Tensor:
+    scale_f = _expand_block_scale(_scale_to_float(scale), shape)
+    return tensor.float() * scale_f
+
+
+def _copy_param(
+    param: nn.Parameter | torch.Tensor,
+    tensor: torch.Tensor,
+    *,
+    scale: torch.Tensor | None = None,
+) -> None:
+    if scale is not None:
+        tensor = _dequantize_scaled_tensor(tensor, scale, param.shape)
+    elif param.dtype.is_floating_point and not tensor.dtype.is_floating_point:
+        raise RuntimeError(
+            f"Refusing to copy quantized tensor with dtype {tensor.dtype} into {tuple(param.shape)} "
+            "without a matching .scale tensor."
+        )
+    param.data.copy_(tensor.to(device=param.device, dtype=param.dtype))
+
+
+def _hf_name_for_state_key(name: str) -> str | None:
+    mapped = _TOP_LEVEL.get(name)
+    if mapped is not None:
+        return mapped
+    for pattern, replacement in (*_LAYER_PATTERNS, *_MTP_PATTERNS):
+        new_key, count = pattern.subn(replacement, name)
+        if count:
+            return new_key
+    return None
+
+
+def _layer_base_hf_names(prefix: str, config: DeepseekV4Config, *, layer_idx: int) -> list[str]:
+    names = [
+        f"{prefix}.attn_norm.weight",
+        f"{prefix}.ffn_norm.weight",
+        f"{prefix}.hc_attn_fn",
+        f"{prefix}.hc_attn_base",
+        f"{prefix}.hc_attn_scale",
+        f"{prefix}.hc_ffn_fn",
+        f"{prefix}.hc_ffn_base",
+        f"{prefix}.hc_ffn_scale",
+        f"{prefix}.attn.attn_sink",
+        f"{prefix}.attn.wq_a.weight",
+        f"{prefix}.attn.q_norm.weight",
+        f"{prefix}.attn.wq_b.weight",
+        f"{prefix}.attn.wkv.weight",
+        f"{prefix}.attn.kv_norm.weight",
+        f"{prefix}.attn.wo_a.weight",
+        f"{prefix}.attn.wo_b.weight",
+        f"{prefix}.ffn.gate.weight",
+    ]
+    if layer_idx < config.num_hash_layers:
+        names.append(f"{prefix}.ffn.gate.tid2eid")
+    else:
+        names.append(f"{prefix}.ffn.gate.bias")
+    for proj in ("w1", "w3", "w2"):
+        names.append(f"{prefix}.ffn.shared_experts.{proj}.weight")
+    for expert_id in range(config.n_routed_experts):
+        for proj in ("w1", "w3", "w2"):
+            names.append(f"{prefix}.ffn.experts.{expert_id}.{proj}.weight")
+    if config.compress_ratios and config.compress_ratios[layer_idx] > 1:
+        names.extend(
+            [
+                f"{prefix}.attn.compressor.ape",
+                f"{prefix}.attn.compressor.wkv.weight",
+                f"{prefix}.attn.compressor.wgate.weight",
+                f"{prefix}.attn.compressor.norm.weight",
+            ]
+        )
+    if config.compress_ratios and config.compress_ratios[layer_idx] == 4:
+        names.extend(
+            [
+                f"{prefix}.attn.indexer.wq_b.weight",
+                f"{prefix}.attn.indexer.compressor.ape",
+                f"{prefix}.attn.indexer.compressor.wkv.weight",
+                f"{prefix}.attn.indexer.compressor.wgate.weight",
+                f"{prefix}.attn.indexer.compressor.norm.weight",
+                f"{prefix}.attn.indexer.weights_proj.weight",
+            ]
+        )
+    return names
+
+
+def expected_hf_names(
+    config: DeepseekV4Config,
+    *,
+    available_hf_names: Iterable[str] | None = None,
+) -> set[str]:
+    names = {
+        "embed.weight",
+        "norm.weight",
+        "head.weight",
+        "hc_head_fn",
+        "hc_head_base",
+        "hc_head_scale",
+    }
+    for layer_idx in range(config.num_hidden_layers):
+        names.update(_layer_base_hf_names(f"layers.{layer_idx}", config, layer_idx=layer_idx))
+    for mtp_idx in range(config.num_nextn_predict_layers):
+        layer_idx = config.num_hidden_layers + mtp_idx
+        prefix = f"mtp.{mtp_idx}"
+        names.update(_layer_base_hf_names(prefix, config, layer_idx=layer_idx))
+        names.update(
+            {
+                f"{prefix}.e_proj.weight",
+                f"{prefix}.h_proj.weight",
+                f"{prefix}.enorm.weight",
+                f"{prefix}.hnorm.weight",
+                f"{prefix}.norm.weight",
+                f"{prefix}.hc_head_fn",
+                f"{prefix}.hc_head_base",
+                f"{prefix}.hc_head_scale",
+            }
+        )
+    if available_hf_names is not None:
+        available = set(available_hf_names)
+        for name in tuple(names):
+            scale_name = _scale_name_for_hf_name(name)
+            if scale_name in available:
+                names.add(scale_name)
+    return names
+
+
+def load_hf_weights(model: nn.Module, path: str, config: DeepseekV4Config, ps: ParallelState) -> None:
+    if (ps.tp_size, ps.ep_size, ps.etp_size, ps.cp_size, ps.pp_size) != (1, 1, 1, 1, 1):
+        raise NotImplementedError("DeepSeek V4 direct HF load currently supports only TP=EP=ETP=CP=PP=1.")
+
+    del config
+    reader = SafeTensorReader(path)
+    base_model = unwrap_model(model)
+    state = base_model.state_dict()
+    loaded = 0
+    missing: list[str] = []
+    for name, target in state.items():
+        hf_name = _hf_name_for_state_key(name)
+        if hf_name is None or not _has(reader, hf_name):
+            missing.append(name)
+            continue
+        scale_name = _scale_name_for_hf_name(hf_name)
+        scale = reader.get_tensor(scale_name) if _has(reader, scale_name) else None
+        _copy_param(target, reader.get_tensor(hf_name), scale=scale)
+        loaded += 1
+
+    log_rank0(f"DeepSeek V4 native loaded {loaded} tensors from {path}")
+    for name in missing:
+        log_rank0(f"WARNING: DeepSeek V4 checkpoint tensor missing: {name}")
+
+
+__all__ = [
+    "EXPERT_CLASSIFIER",
+    "_dequantize_scaled_tensor",
+    "_hf_name_for_state_key",
+    "_scale_name_for_hf_name",
+    "expected_hf_names",
+    "load_hf_weights",
+]

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/model.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/model.py
@@ -1,0 +1,644 @@
+"""Native DeepSeek V4 lite model with CPU-smoke-friendly torch modules."""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+import math
+from types import SimpleNamespace
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
+from megatron.lite.primitive.parallel.state import ParallelState
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, hidden_size: int, eps: float = 1e-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.eps = eps
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        norm = torch.rsqrt(x.float().pow(2).mean(dim=-1, keepdim=True) + self.eps)
+        return x * norm.to(dtype=x.dtype) * self.weight.to(device=x.device, dtype=x.dtype)
+
+
+class DeepseekV4GroupedLinear(nn.Module):
+    def __init__(self, in_features_per_group: int, out_features: int, n_groups: int):
+        super().__init__()
+        self.in_features_per_group = in_features_per_group
+        self.out_features = out_features
+        self.n_groups = n_groups
+        self.weight = nn.Parameter(torch.empty(out_features, in_features_per_group))
+        nn.init.kaiming_uniform_(self.weight, a=math.sqrt(5))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        out_per_group = self.out_features // self.n_groups
+        weight = self.weight.view(self.n_groups, out_per_group, self.in_features_per_group)
+        return torch.einsum("...gd,god->...go", x, weight)
+
+
+def _hc_split_sinkhorn(
+    mixes: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    hc_mult: int,
+    iters: int,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    split_sizes = [hc_mult, hc_mult, hc_mult * hc_mult]
+    pre_mix, post_mix, comb_mix = mixes.split(split_sizes, dim=-1)
+    base_pre, base_post, base_comb = hc_base.float().split(split_sizes, dim=-1)
+    scale = hc_scale.float()
+    pre = torch.sigmoid(pre_mix * scale[0] + base_pre) + eps
+    post = torch.sigmoid(post_mix * scale[1] + base_post) + eps
+    log_comb = (comb_mix * scale[2] + base_comb).view(*comb_mix.shape[:-1], hc_mult, hc_mult)
+    for _ in range(iters):
+        log_comb = log_comb - log_comb.logsumexp(-1, keepdim=True)
+        log_comb = log_comb - log_comb.logsumexp(-2, keepdim=True)
+    return pre, post, log_comb.exp() + eps
+
+
+class DeepseekV4HyperConnection(nn.Module):
+    def __init__(self, hidden_size: int, hc_mult: int, sinkhorn_iters: int, eps: float):
+        super().__init__()
+        mix = (2 + hc_mult) * hc_mult
+        self.hidden_size = hidden_size
+        self.hc_mult = hc_mult
+        self.sinkhorn_iters = sinkhorn_iters
+        self.eps = eps
+        self.fn = nn.Parameter(torch.empty(mix, hc_mult * hidden_size, dtype=torch.float32))
+        self.base = nn.Parameter(torch.zeros(mix, dtype=torch.float32))
+        self.scale = nn.Parameter(torch.ones(3, dtype=torch.float32))
+        nn.init.xavier_uniform_(self.fn)
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        if x.dim() == 3:
+            x = x.unsqueeze(2).expand(*x.shape[:2], self.hc_mult, x.size(-1))
+        shape, dtype = x.shape, x.dtype
+        xf = x.flatten(2).float()
+        rsqrt = torch.rsqrt(xf.square().mean(-1, keepdim=True) + self.eps)
+        mixes = F.linear(xf, self.fn.float()) * rsqrt
+        pre, post, comb = _hc_split_sinkhorn(
+            mixes, self.scale, self.base, self.hc_mult, self.sinkhorn_iters, self.eps
+        )
+        y = torch.sum(pre.unsqueeze(-1) * xf.view(shape), dim=2)
+        return y.to(dtype), post, comb
+
+    @staticmethod
+    def post(
+        x: torch.Tensor,
+        residual: torch.Tensor,
+        post: torch.Tensor,
+        comb: torch.Tensor,
+    ) -> torch.Tensor:
+        y = post.unsqueeze(-1) * x.unsqueeze(-2).float()
+        y = y + torch.sum(comb.unsqueeze(-1) * residual.float().unsqueeze(-2), dim=2)
+        return y.to(dtype=x.dtype)
+
+
+class DeepseekV4HyperHead(nn.Module):
+    def __init__(self, hidden_size: int, hc_mult: int, eps: float):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.hc_mult = hc_mult
+        self.eps = eps
+        self.hc_fn = nn.Parameter(torch.empty(hc_mult, hc_mult * hidden_size, dtype=torch.float32))
+        self.hc_base = nn.Parameter(torch.zeros(hc_mult, dtype=torch.float32))
+        self.hc_scale = nn.Parameter(torch.ones(1, dtype=torch.float32))
+        nn.init.xavier_uniform_(self.hc_fn)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if x.dim() == 3:
+            return x
+        shape, dtype = x.shape, x.dtype
+        xf = x.flatten(2).float()
+        rsqrt = torch.rsqrt(xf.square().mean(-1, keepdim=True) + self.eps)
+        mixes = F.linear(xf, self.hc_fn.float()) * rsqrt
+        pre = torch.sigmoid(mixes * self.hc_scale.float() + self.hc_base.float()) + self.eps
+        y = torch.sum(pre.unsqueeze(-1) * xf.view(shape), dim=2)
+        return y.to(dtype)
+
+
+def _build_cos_sin(
+    position_ids: torch.Tensor,
+    rope_head_dim: int,
+    rope_theta: float,
+    *,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    inv_freq = 1.0 / (
+        rope_theta ** (torch.arange(0, rope_head_dim, 2, device=device, dtype=torch.float32) / rope_head_dim)
+    )
+    freqs = torch.einsum("bs,d->bsd", position_ids.to(torch.float32), inv_freq)
+    emb = torch.cat([freqs, freqs], dim=-1)
+    return emb.cos().to(dtype=dtype), emb.sin().to(dtype=dtype)
+
+
+def _apply_partial_rope(
+    x: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    rope_head_dim: int,
+) -> torch.Tensor:
+    if rope_head_dim == 0:
+        return x
+    rope = x[..., -rope_head_dim:]
+    tail = x[..., :-rope_head_dim]
+    rope_pairs = rope.unflatten(-1, (-1, 2))
+    a, b = rope_pairs[..., 0], rope_pairs[..., 1]
+    c = cos[..., : rope_head_dim // 2]
+    s = sin[..., : rope_head_dim // 2]
+    while c.ndim < a.ndim:
+        c = c.unsqueeze(1)
+        s = s.unsqueeze(1)
+    out_a = a * c - b * s
+    out_b = a * s + b * c
+    rope_out = torch.stack([out_a, out_b], dim=-1).flatten(-2)
+    return torch.cat([tail, rope_out], dim=-1)
+
+
+def _clamped_swiglu(gate: torch.Tensor, up: torch.Tensor, limit: float) -> torch.Tensor:
+    gate = gate.float()
+    up = up.float()
+    if limit > 0:
+        up = torch.clamp(up, min=-limit, max=limit)
+        gate = torch.clamp(gate, max=limit)
+    return F.silu(gate) * up
+
+
+class DeepseekV4Compressor(nn.Module):
+    def __init__(self, config: DeepseekV4Config, compress_ratio: int, head_dim: int):
+        super().__init__()
+        self.compress_ratio = compress_ratio
+        self.head_dim = head_dim
+        self.rope_head_dim = min(config.qk_rope_head_dim, head_dim)
+        self.overlap = compress_ratio == 4
+        self.coff = 2 if self.overlap else 1
+        self.wkv = nn.Linear(config.hidden_size, self.coff * head_dim, bias=False)
+        self.wgate = nn.Linear(config.hidden_size, self.coff * head_dim, bias=False)
+        self.ape = nn.Parameter(torch.empty(compress_ratio, self.coff * head_dim, dtype=torch.float32))
+        self.norm = RMSNorm(head_dim, eps=config.rms_norm_eps)
+        nn.init.normal_(self.ape, mean=0.0, std=config.initializer_range)
+
+    def _overlap_transform(self, tensor: torch.Tensor, fill_value: float) -> torch.Tensor:
+        bsz, n_blocks, ratio, _, head_dim = tensor.shape
+        out = tensor.new_full((bsz, n_blocks, 2 * ratio, head_dim), fill_value)
+        out[:, :, ratio:] = tensor[:, :, :, 1]
+        out[:, 1:, :ratio] = tensor[:, :-1, :, 0]
+        return out
+
+    def forward(self, x: torch.Tensor, *, position_ids: torch.Tensor, rope_theta: float) -> torch.Tensor | None:
+        bsz, seq_len, _ = x.shape
+        ratio = self.compress_ratio
+        n_blocks = seq_len // ratio
+        if n_blocks == 0:
+            return None
+        cutoff = n_blocks * ratio
+        content = self.wkv(x[:, :cutoff])
+        gate = self.wgate(x[:, :cutoff])
+        content = content.view(bsz, n_blocks, ratio, self.coff, self.head_dim)
+        gate = gate.view_as(content)
+        gate = gate + self.ape.view(1, 1, ratio, self.coff, self.head_dim).to(gate.device)
+        if self.overlap:
+            content = self._overlap_transform(content, 0.0)
+            gate = self._overlap_transform(gate, float("-inf"))
+        else:
+            content = content.squeeze(3)
+            gate = gate.squeeze(3)
+        weights = torch.softmax(gate.float(), dim=2).to(dtype=content.dtype)
+        compressed = self.norm((content * weights).sum(dim=2))
+        compressed = compressed.unsqueeze(1)
+        compressed_positions = position_ids[:, :cutoff:ratio]
+        cos, sin = _build_cos_sin(
+            compressed_positions,
+            self.rope_head_dim,
+            rope_theta,
+            device=x.device,
+            dtype=compressed.dtype,
+        )
+        return _apply_partial_rope(compressed, cos, sin, self.rope_head_dim)
+
+
+class DeepseekV4DSAIndexer(nn.Module):
+    def __init__(self, config: DeepseekV4Config, compress_ratio: int):
+        super().__init__()
+        self.index_n_heads = config.index_n_heads
+        self.index_head_dim = config.index_head_dim
+        self.index_topk = config.index_topk
+        self.rope_head_dim = min(config.qk_rope_head_dim, config.index_head_dim)
+        self.softmax_scale = self.index_head_dim ** -0.5
+        self.wq_b = nn.Linear(config.q_lora_rank, config.index_n_heads * config.index_head_dim, bias=False)
+        self.weights_proj = nn.Linear(config.hidden_size, config.index_n_heads, bias=False)
+        self.compressor = DeepseekV4Compressor(config, compress_ratio, config.index_head_dim)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        q_low: torch.Tensor,
+        *,
+        position_ids: torch.Tensor,
+        rope_theta: float,
+    ) -> tuple[torch.Tensor, torch.Tensor] | None:
+        compressed = self.compressor(x, position_ids=position_ids, rope_theta=rope_theta)
+        if compressed is None:
+            return None
+        bsz, seq_len, _ = x.shape
+        n_compressed = compressed.size(2)
+        cos, sin = _build_cos_sin(
+            position_ids,
+            self.rope_head_dim,
+            rope_theta,
+            device=x.device,
+            dtype=x.dtype,
+        )
+        q = self.wq_b(q_low).view(bsz, seq_len, self.index_n_heads, self.index_head_dim).transpose(1, 2)
+        q = _apply_partial_rope(q, cos, sin, self.rope_head_dim)
+        k = compressed.squeeze(1)
+        weights = self.weights_proj(x).float() * (self.index_n_heads ** -0.5) * self.softmax_scale
+        scores = torch.einsum("bhsd,btd->bsht", q.float(), k.float()).relu()
+        scores = (scores * weights.unsqueeze(-1)).sum(dim=2)
+        visible = (torch.arange(seq_len, device=x.device) + 1) // self.compressor.compress_ratio
+        c_pos = torch.arange(n_compressed, device=x.device).view(1, 1, n_compressed)
+        valid = c_pos < visible.view(1, seq_len, 1)
+        scores = scores.masked_fill(~valid, -float("inf"))
+        topk = min(self.index_topk, n_compressed)
+        indices = scores.topk(topk, dim=-1).indices
+        return scores, indices
+
+
+class DeepseekV4Attention(nn.Module):
+    def __init__(self, config: DeepseekV4Config, *, layer_idx: int):
+        super().__init__()
+        self.config = config
+        self.num_heads = config.num_attention_heads
+        self.head_dim = config.head_dim
+        self.rope_head_dim = config.qk_rope_head_dim
+        self.num_heads_per_group = config.num_attention_heads // config.o_groups
+        self.compress_ratio = config.compress_ratios[layer_idx] if config.compress_ratios else 0
+        self.wq_a = nn.Linear(config.hidden_size, config.q_lora_rank, bias=False)
+        self.q_norm = RMSNorm(config.q_lora_rank, eps=config.rms_norm_eps)
+        self.wq_b = nn.Linear(config.q_lora_rank, self.num_heads * self.head_dim, bias=False)
+        self.wkv = nn.Linear(config.hidden_size, self.head_dim, bias=False)
+        self.kv_norm = RMSNorm(config.head_dim, eps=config.rms_norm_eps)
+        self.wo_a = DeepseekV4GroupedLinear(
+            self.num_heads_per_group * self.head_dim,
+            config.o_groups * config.o_lora_rank,
+            config.o_groups,
+        )
+        self.wo_b = nn.Linear(config.o_groups * config.o_lora_rank, config.hidden_size, bias=False)
+        self.sinks = nn.Parameter(torch.zeros(self.num_heads))
+        self.compressor = (
+            DeepseekV4Compressor(config, self.compress_ratio, self.head_dim)
+            if self.compress_ratio > 1
+            else None
+        )
+        self.indexer = (
+            DeepseekV4DSAIndexer(config, self.compress_ratio)
+            if self.compress_ratio == 4
+            else None
+        )
+
+    def _local_mask(self, seq_len: int, device: torch.device) -> torch.Tensor:
+        q_pos = torch.arange(seq_len, device=device).unsqueeze(1)
+        k_pos = torch.arange(seq_len, device=device).unsqueeze(0)
+        return (k_pos <= q_pos) & (k_pos >= q_pos - self.config.sliding_window + 1)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        position_ids: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        batch, seq_len, _ = x.shape
+        cos, sin = _build_cos_sin(
+            position_ids,
+            self.rope_head_dim,
+            self.config.rope_theta,
+            device=x.device,
+            dtype=x.dtype,
+        )
+        q_low = self.q_norm(self.wq_a(x))
+        q = self.wq_b(q_low).view(batch, seq_len, self.num_heads, self.head_dim).transpose(1, 2)
+        q = q * torch.rsqrt(q.float().pow(2).mean(dim=-1, keepdim=True) + self.config.rms_norm_eps).to(dtype=q.dtype)
+        kv = self.kv_norm(self.wkv(x)).view(batch, seq_len, 1, self.head_dim).transpose(1, 2)
+        q = _apply_partial_rope(q, cos, sin, self.rope_head_dim)
+        kv = _apply_partial_rope(kv, cos, sin, self.rope_head_dim)
+        k = kv.expand(-1, self.num_heads, -1, -1)
+        v = kv.expand(-1, self.num_heads, -1, -1)
+
+        local_scores = torch.matmul(q, k.transpose(-1, -2)) / (self.head_dim ** 0.5)
+        local_mask = self._local_mask(seq_len, x.device).view(1, 1, seq_len, seq_len)
+        local_scores = local_scores.masked_fill(~local_mask, -float("inf"))
+        if attention_mask is not None:
+            local_scores = local_scores + attention_mask.to(dtype=local_scores.dtype)
+
+        score_parts = [local_scores]
+        value_parts = [v]
+        compressed = None
+        if self.compressor is not None:
+            compressed = self.compressor(
+                x, position_ids=position_ids, rope_theta=self.config.compress_rope_theta
+            )
+        if compressed is not None:
+            compressed_heads = compressed.expand(-1, self.num_heads, -1, -1)
+            compressed_scores = torch.matmul(q, compressed_heads.transpose(-1, -2)) / (self.head_dim ** 0.5)
+            n_compressed = compressed.size(2)
+            visible = (torch.arange(seq_len, device=x.device) + 1) // self.compress_ratio
+            c_pos = torch.arange(n_compressed, device=x.device).view(1, 1, 1, n_compressed)
+            compressed_valid = c_pos < visible.view(1, 1, seq_len, 1)
+            compressed_scores = compressed_scores.masked_fill(~compressed_valid, -float("inf"))
+            if self.indexer is not None:
+                indexer_out = self.indexer(
+                    x, q_low, position_ids=position_ids, rope_theta=self.config.compress_rope_theta
+                )
+                if indexer_out is not None:
+                    index_scores, topk_indices = indexer_out
+                    topk_mask = torch.zeros_like(index_scores, dtype=torch.bool)
+                    topk_mask.scatter_(-1, topk_indices, True)
+                    compressed_scores = compressed_scores + index_scores.unsqueeze(1)
+                    compressed_scores = compressed_scores.masked_fill(~topk_mask.unsqueeze(1), -float("inf"))
+            score_parts.append(compressed_scores)
+            value_parts.append(compressed_heads)
+
+        scores = torch.cat(score_parts, dim=-1)
+        sink = self.sinks.view(1, self.num_heads, 1, 1).expand(batch, -1, seq_len, -1).to(dtype=scores.dtype)
+        probs = torch.softmax(torch.cat([scores, sink], dim=-1), dim=-1).to(dtype=q.dtype)
+
+        context = q.new_zeros(batch, self.num_heads, seq_len, self.head_dim)
+        offset = 0
+        for part_idx, values in enumerate(value_parts):
+            next_offset = offset + values.size(2)
+            partial = torch.matmul(probs[..., offset:next_offset], values)
+            if part_idx > 0:
+                partial = _apply_partial_rope(partial, cos, -sin, self.rope_head_dim)
+            context = context + partial
+            offset = next_offset
+
+        context = context.transpose(1, 2)
+        grouped = context.reshape(batch, seq_len, self.config.o_groups, self.num_heads_per_group * self.head_dim)
+        return self.wo_b(self.wo_a(grouped).flatten(2))
+
+
+class DeepseekV4Router(nn.Module):
+    def __init__(self, config: DeepseekV4Config, *, is_hash_layer: bool):
+        super().__init__()
+        self.is_hash_layer = is_hash_layer
+        self.topk = config.num_experts_per_tok
+        self.route_scale = config.routed_scaling_factor
+        self.norm_topk_prob = config.norm_topk_prob
+        self.scoring_func = config.scoring_func
+        self.weight = nn.Parameter(torch.empty(config.n_routed_experts, config.hidden_size))
+        nn.init.kaiming_uniform_(self.weight, a=math.sqrt(5))
+        if self.is_hash_layer:
+            self.register_buffer(
+                "tid2eid",
+                torch.zeros(config.vocab_size, self.topk, dtype=torch.int64),
+                persistent=True,
+            )
+        else:
+            self.register_buffer(
+                "e_score_correction_bias",
+                torch.zeros(config.n_routed_experts, dtype=torch.float32),
+            )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        input_ids: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        logits = F.linear(x.float(), self.weight.float())
+        if self.scoring_func == "sqrtsoftplus":
+            scores = F.softplus(logits).sqrt()
+        elif self.scoring_func == "sigmoid":
+            scores = logits.sigmoid()
+        else:
+            scores = logits.softmax(dim=-1)
+
+        if self.is_hash_layer and input_ids is not None:
+            indices = self.tid2eid[input_ids.reshape(-1).to(torch.int64)]
+        else:
+            bias = getattr(self, "e_score_correction_bias", None)
+            scores_for_choice = scores if bias is None else scores + bias.to(dtype=scores.dtype)
+            indices = scores_for_choice.topk(self.topk, dim=-1, sorted=False).indices
+
+        weights = scores.gather(1, indices)
+        if self.norm_topk_prob and self.topk > 1:
+            weights = weights / (weights.sum(dim=-1, keepdim=True) + 1e-20)
+        return (weights * self.route_scale).to(dtype=x.dtype), indices
+
+
+class DeepseekV4MLP(nn.Module):
+    def __init__(self, hidden_size: int, intermediate_size: int, swiglu_limit: float):
+        super().__init__()
+        self.gate_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.up_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.down_proj = nn.Linear(intermediate_size, hidden_size, bias=False)
+        self.swiglu_limit = swiglu_limit
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        y = _clamped_swiglu(self.gate_proj(x), self.up_proj(x), self.swiglu_limit)
+        return self.down_proj(y.to(dtype=x.dtype))
+
+
+class DeepseekV4MoE(nn.Module):
+    def __init__(self, config: DeepseekV4Config, *, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.gate = DeepseekV4Router(config, is_hash_layer=layer_idx < config.num_hash_layers)
+        self.experts = nn.ModuleList(
+            [
+                DeepseekV4MLP(config.hidden_size, config.moe_intermediate_size, config.swiglu_limit)
+                for _ in range(config.n_routed_experts)
+            ]
+        )
+        shared_intermediate = config.n_shared_experts * config.moe_intermediate_size
+        self.shared_experts = (
+            DeepseekV4MLP(config.hidden_size, shared_intermediate, config.swiglu_limit)
+            if config.n_shared_experts > 0
+            else None
+        )
+
+    def forward(self, x: torch.Tensor, *, input_ids: torch.Tensor | None = None) -> torch.Tensor:
+        shape = x.shape
+        x_flat = x.reshape(-1, self.hidden_size)
+        weights, indices = self.gate(x_flat, input_ids=input_ids)
+        out = torch.zeros_like(x_flat)
+        for expert_id, expert in enumerate(self.experts):
+            token_pos, slot = torch.where(indices == expert_id)
+            if token_pos.numel() == 0:
+                continue
+            expert_out = expert(x_flat.index_select(0, token_pos))
+            out.index_add_(0, token_pos, expert_out * weights[token_pos, slot].unsqueeze(-1))
+        if self.shared_experts is not None:
+            out = out + self.shared_experts(x_flat)
+        return out.view(shape)
+
+
+class DeepseekV4Layer(nn.Module):
+    def __init__(self, config: DeepseekV4Config, layer_idx: int):
+        super().__init__()
+        self.self_attn = DeepseekV4Attention(config, layer_idx=layer_idx)
+        self.mlp = DeepseekV4MoE(config, layer_idx=layer_idx)
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.attn_hc = DeepseekV4HyperConnection(
+            config.hidden_size, config.hc_mult, config.hc_sinkhorn_iters, config.hc_eps
+        )
+        self.ffn_hc = DeepseekV4HyperConnection(
+            config.hidden_size, config.hc_mult, config.hc_sinkhorn_iters, config.hc_eps
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        position_ids: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        input_ids: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        residual = x
+        attn_in, post, comb = self.attn_hc(x)
+        attn_out = self.self_attn(
+            self.input_layernorm(attn_in),
+            position_ids=position_ids,
+            attention_mask=attention_mask,
+        )
+        x = DeepseekV4HyperConnection.post(attn_out, residual, post, comb)
+
+        residual = x
+        ffn_in, post, comb = self.ffn_hc(x)
+        ffn_out = self.mlp(self.post_attention_layernorm(ffn_in), input_ids=input_ids)
+        return DeepseekV4HyperConnection.post(ffn_out, residual, post, comb)
+
+
+class DeepseekV4MTPBlock(DeepseekV4Layer):
+    def __init__(self, config: DeepseekV4Config, layer_idx: int):
+        super().__init__(config, layer_idx=layer_idx)
+        self.e_proj = nn.Linear(config.hidden_size, config.hidden_size, bias=False)
+        self.h_proj = nn.Linear(config.hidden_size, config.hidden_size, bias=False)
+        self.enorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.hnorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.hc_head = DeepseekV4HyperHead(config.hidden_size, config.hc_mult, config.hc_eps)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        input_ids: torch.Tensor,
+        embed_tokens: nn.Embedding,
+        position_ids: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        embedded = self.enorm(embed_tokens(input_ids))
+        projected = self.e_proj(embedded).unsqueeze(2) + self.h_proj(self.hnorm(x))
+        return super().forward(
+            projected,
+            position_ids=position_ids,
+            attention_mask=attention_mask,
+            input_ids=input_ids,
+        )
+
+    def contract(self, x: torch.Tensor) -> torch.Tensor:
+        return self.norm(self.hc_head(x))
+
+
+class DeepseekV4Model(nn.Module):
+    def __init__(self, config: DeepseekV4Config):
+        super().__init__()
+        self.config = config
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.layers = nn.ModuleList(
+            [DeepseekV4Layer(config, layer_idx=i) for i in range(config.num_hidden_layers)]
+        )
+        self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.hc_head = DeepseekV4HyperHead(config.hidden_size, config.hc_mult, config.hc_eps)
+        self.mtp = nn.ModuleList(
+            [
+                DeepseekV4MTPBlock(config, layer_idx=config.num_hidden_layers + i)
+                for i in range(config.num_nextn_predict_layers)
+            ]
+        )
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        *,
+        position_ids: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if input_ids.dim() == 1:
+            input_ids = input_ids.unsqueeze(0)
+        hidden = self.embed_tokens(input_ids)
+        hidden = hidden.unsqueeze(2).expand(-1, -1, self.config.hc_mult, -1).contiguous()
+        batch, seq_len = input_ids.shape
+        if position_ids is None:
+            position_ids = torch.arange(seq_len, device=input_ids.device).unsqueeze(0).expand(batch, -1)
+        elif position_ids.dim() == 1:
+            position_ids = position_ids.unsqueeze(0).expand(batch, -1)
+        for layer in self.layers:
+            hidden = layer(
+                hidden,
+                position_ids=position_ids,
+                attention_mask=attention_mask,
+                input_ids=input_ids,
+            )
+        return self.norm(self.hc_head(hidden))
+
+
+class DeepseekV4ForCausalLM(nn.Module):
+    def __init__(
+        self,
+        config: DeepseekV4Config,
+        train_cfg: SimpleNamespace | None = None,
+        ps: ParallelState | None = None,
+    ):
+        super().__init__()
+        self.config = config
+        self.train_cfg = train_cfg or SimpleNamespace(fp8=False)
+        self.ps = ps or ParallelState()
+        self.model = DeepseekV4Model(config)
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self._input_tensor: torch.Tensor | None = None
+
+    def set_input_tensor(self, input_tensor):
+        if isinstance(input_tensor, list):
+            input_tensor = input_tensor[0] if input_tensor else None
+        self._input_tensor = input_tensor
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None = None,
+        *,
+        hidden_states: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        labels: torch.Tensor | None = None,
+    ) -> dict[str, torch.Tensor]:
+        if hidden_states is not None:
+            raise NotImplementedError("DeepSeek V4 lite does not support pipeline hidden-state injection yet.")
+        if input_ids is None:
+            raise ValueError("input_ids is required")
+        fp8_ctx = nullcontext()
+        with fp8_ctx:
+            hidden = self.model(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                attention_mask=attention_mask,
+            )
+            logits = self.lm_head(hidden)
+        output = {"hidden_states": hidden, "logits": logits}
+        if labels is not None:
+            loss = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                labels.reshape(-1),
+                ignore_index=-100,
+            )
+            output["loss"] = loss
+        return output

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
@@ -1,0 +1,96 @@
+"""DeepSeek V4 native lite protocol for Megatron Lite runtime."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
+from megatron.lite.model.deepseek_v4.lite.checkpoint import (
+    EXPERT_CLASSIFIER,
+)
+from megatron.lite.model.deepseek_v4.lite.checkpoint import (
+    load_hf_weights as _load_hf_weights_impl,
+)
+from megatron.lite.primitive.bundle import ModelBundle
+from megatron.lite.primitive.parallel import ParallelState, init_parallel
+from megatron.lite.runtime.contracts import ParallelConfig
+
+
+def is_expert_param(name: str) -> bool:
+    return EXPERT_CLASSIFIER(name)
+
+
+@dataclass(frozen=True)
+class ImplConfig:
+    parallel: ParallelConfig = field(default_factory=ParallelConfig)
+    optimizer: str | None = None
+    hf_path: str = ""
+    deterministic: bool = True
+
+
+def build_model_config(source: str | Path | dict, **overrides) -> DeepseekV4Config:
+    if isinstance(source, dict):
+        cfg = DeepseekV4Config._from_hf_dict(source)
+    else:
+        cfg = DeepseekV4Config.from_hf(str(source))
+    for key, value in overrides.items():
+        if hasattr(cfg, key):
+            setattr(cfg, key, value)
+    return cfg
+
+
+def _forward_step(model: nn.Module, batch: dict) -> dict:
+    kwargs: dict[str, Any] = {
+        "input_ids": batch["input_ids"],
+        "labels": batch.get("labels"),
+    }
+    for key in ("position_ids", "attention_mask"):
+        if key in batch:
+            kwargs[key] = batch[key]
+    if kwargs["input_ids"].dim() == 1:
+        kwargs["input_ids"] = kwargs["input_ids"].unsqueeze(0)
+    return model(**kwargs)
+
+
+def _validate_parallel_scope(p: ParallelConfig) -> None:
+    etp = 1 if p.etp is None else p.etp
+    if (p.tp, etp, p.ep, p.cp, p.pp, p.vpp) != (1, 1, 1, 1, 1, 1):
+        raise NotImplementedError(
+            "DeepSeek V4 native lite stage-1 currently supports only TP=EP=ETP=CP=PP=VPP=1."
+        )
+
+
+def build_model(model_cfg: DeepseekV4Config, *, impl_cfg: ImplConfig) -> ModelBundle:
+    from megatron.lite.model.deepseek_v4.lite.model import DeepseekV4ForCausalLM
+
+    _validate_parallel_scope(impl_cfg.parallel)
+    ps = init_parallel(impl_cfg.parallel)
+    train_cfg = SimpleNamespace(fp8=False)
+    chunk = DeepseekV4ForCausalLM(model_cfg, train_cfg=train_cfg, ps=ps).to(torch.bfloat16).cuda()
+
+    if impl_cfg.optimizer is not None:
+        raise NotImplementedError("DeepSeek V4 native lite stage-1 does not build an optimizer yet.")
+
+    return ModelBundle(
+        chunks=[chunk],
+        parallel_state=ps,
+        optimizer=None,
+        forward_step=_forward_step,
+        extras={"model_cfg": model_cfg, "optimizer_backend": "none"},
+    )
+
+
+def load_hf_weights(chunk: nn.Module, hf_path: str, model_cfg: DeepseekV4Config, ps: ParallelState) -> None:
+    if not hf_path:
+        return
+    _load_hf_weights_impl(chunk, hf_path, model_cfg, ps)
+
+
+def vocab_size(model_cfg: DeepseekV4Config) -> int | None:
+    return model_cfg.vocab_size

--- a/experimental/lite/megatron/lite/model/registry.py
+++ b/experimental/lite/megatron/lite/model/registry.py
@@ -93,6 +93,13 @@ register_model(
     impls={"lite": "megatron.lite.model.qwen3_5.lite.protocol"},
 )
 
+register_model(
+    "deepseek_v4",
+    package="megatron.lite.model.deepseek_v4",
+    hf_model_types=["deepseek_v4"],
+    impls={"lite": "megatron.lite.model.deepseek_v4.lite.protocol"},
+)
+
 
 # ---------------------------------------------------------------------------
 # Lookup functions

--- a/experimental/lite/tests/unit/model/test_deepseek_v4_lite_static.py
+++ b/experimental/lite/tests/unit/model/test_deepseek_v4_lite_static.py
@@ -1,0 +1,598 @@
+"""Static and CPU smoke tests for native DeepSeek V4 lite."""
+
+from __future__ import annotations
+
+import math
+import re
+from pathlib import Path
+
+
+def _tiny_config_kwargs():
+    return dict(
+        vocab_size=64,
+        hidden_size=24,
+        moe_intermediate_size=12,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=1,
+        head_dim=6,
+        qk_rope_head_dim=4,
+        q_lora_rank=8,
+        o_lora_rank=6,
+        o_groups=2,
+        n_routed_experts=3,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        num_hash_layers=1,
+        hc_mult=2,
+        compress_ratios=[4, 8, 4],
+        index_n_heads=2,
+        index_head_dim=4,
+        index_topk=2,
+        num_nextn_predict_layers=1,
+    )
+
+
+def _proxy_hf_tensors_from_native_state(state, config):
+    import torch
+
+    from megatron.lite.model.deepseek_v4.lite.checkpoint import _hf_name_for_state_key
+
+    hf_tensors = {}
+    native_state = {}
+    for index, (name, target) in enumerate(state.items()):
+        hf_name = _hf_name_for_state_key(name)
+        assert hf_name is not None
+        if target.dtype.is_floating_point:
+            values = torch.arange(target.numel(), dtype=torch.float32).reshape(target.shape)
+            values = ((values % 19) - 9) / 512.0 + ((index % 7) + 1) / 1024.0
+            if name.endswith(".norm.weight"):
+                values = values + 1.0
+            tensor = values.to(dtype=target.dtype)
+        else:
+            tensor = (
+                torch.arange(target.numel(), dtype=torch.int64).reshape(target.shape)
+                % config.n_routed_experts
+            ).to(dtype=target.dtype)
+        native_state[name] = tensor.contiguous()
+        hf_tensors[hf_name] = tensor.contiguous()
+    return hf_tensors, native_state
+
+
+def test_deepseek_v4_registry_resolves_lite():
+    from megatron.lite.model.registry import (
+        get_train_runtime_module,
+        resolve_model_type_from_hf,
+        resolve_runtime_model_name,
+    )
+
+    runtime_name = resolve_runtime_model_name("deepseek_v4", "lite")
+    assert runtime_name == "deepseek_v4"
+    module = get_train_runtime_module(runtime_name)
+    assert module.__name__ == "megatron.lite.model.deepseek_v4.lite.protocol"
+    assert resolve_model_type_from_hf({"model_type": "deepseek_v4"}) == "deepseek_v4"
+
+
+def test_deepseek_v4_config_reads_hf_fields():
+    from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
+
+    cfg = DeepseekV4Config._from_hf_dict(
+        {
+            "model_type": "deepseek_v4",
+            "hidden_size": 6144,
+            "num_hidden_layers": 61,
+            "num_attention_heads": 128,
+            "num_key_value_heads": 1,
+            "head_dim": 128,
+            "qk_rope_head_dim": 64,
+            "q_lora_rank": 1536,
+            "o_lora_rank": 1024,
+            "o_groups": 8,
+            "n_routed_experts": 256,
+            "n_shared_experts": 1,
+            "num_experts_per_tok": 6,
+            "compress_ratios": [0] * 62,
+            "num_nextn_predict_layers": 1,
+            "vocab_size": 129280,
+            "rope_parameters": {"rope_theta": 10000.0},
+        }
+    )
+
+    assert cfg.q_lora_rank == 1536
+    assert cfg.o_lora_rank == 1024
+    assert cfg.compress_ratios == [0] * 62
+    assert cfg.rope_theta == 10000.0
+
+
+def test_deepseek_v4_lite_does_not_import_wrappers_or_sibling_models():
+    root = (
+        Path(__file__).resolve().parents[3]
+        / "megatron"
+        / "lite"
+        / "model"
+        / "deepseek_v4"
+        / "lite"
+    )
+    for path in root.glob("*.py"):
+        text = path.read_text()
+        assert "mbridge" not in text
+        assert "megatron.core" not in text
+        assert "megatron.lite.model.qwen" not in text
+        assert "Automodel" not in text
+
+
+def test_deepseek_v4_lite_implementation_files_stay_small():
+    root = (
+        Path(__file__).resolve().parents[3]
+        / "megatron"
+        / "lite"
+        / "model"
+        / "deepseek_v4"
+        / "lite"
+    )
+    for name in ("model.py", "protocol.py", "checkpoint.py"):
+        line_count = len((root / name).read_text().splitlines())
+        assert line_count < 1000, f"{name} has {line_count} lines"
+
+
+def test_deepseek_v4_model_exports_hf_style_state_names():
+    from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
+    from megatron.lite.model.deepseek_v4.lite.model import DeepseekV4ForCausalLM
+
+    model = DeepseekV4ForCausalLM(DeepseekV4Config(**_tiny_config_kwargs()))
+    keys = set(model.state_dict())
+
+    assert "model.embed_tokens.weight" in keys
+    assert "model.layers.0.self_attn.wq_a.weight" in keys
+    assert "model.layers.0.self_attn.q_norm.weight" in keys
+    assert "model.layers.0.self_attn.wq_b.weight" in keys
+    assert "model.layers.0.self_attn.wkv.weight" in keys
+    assert "model.layers.0.self_attn.compressor.wkv.weight" in keys
+    assert "model.layers.0.self_attn.indexer.wq_b.weight" in keys
+    assert "model.layers.1.self_attn.compressor.wgate.weight" in keys
+    assert "model.layers.0.self_attn.wo_a.weight" in keys
+    assert "model.layers.0.self_attn.sinks" in keys
+    assert "model.layers.0.mlp.gate.weight" in keys
+    assert "model.layers.0.mlp.gate.tid2eid" in keys
+    assert "model.layers.1.mlp.gate.e_score_correction_bias" in keys
+    assert "model.layers.0.mlp.gate.e_score_correction_bias" not in keys
+    assert "model.layers.1.mlp.gate.tid2eid" not in keys
+    assert "model.layers.0.mlp.experts.0.gate_proj.weight" in keys
+    assert "model.layers.0.mlp.shared_experts.gate_proj.weight" in keys
+    assert "model.layers.0.attn_hc.fn" in keys
+    assert "model.hc_head.hc_fn" in keys
+    assert "model.mtp.0.e_proj.weight" in keys
+    assert "model.mtp.0.self_attn.wq_a.weight" in keys
+    assert "model.mtp.0.hc_head.hc_fn" in keys
+    assert "lm_head.weight" in keys
+
+
+def test_deepseek_v4_hf_name_mapping_covers_native_keys():
+    from megatron.lite.model.deepseek_v4.lite.checkpoint import _hf_name_for_state_key
+
+    assert _hf_name_for_state_key("model.embed_tokens.weight") == "embed.weight"
+    assert _hf_name_for_state_key("model.layers.2.self_attn.sinks") == "layers.2.attn.attn_sink"
+    assert _hf_name_for_state_key("model.layers.2.self_attn.compressor.wkv.weight") == "layers.2.attn.compressor.wkv.weight"
+    assert _hf_name_for_state_key("model.layers.2.self_attn.indexer.wq_b.weight") == "layers.2.attn.indexer.wq_b.weight"
+    assert _hf_name_for_state_key("model.layers.2.mlp.gate.e_score_correction_bias") == "layers.2.ffn.gate.bias"
+    assert _hf_name_for_state_key("model.layers.2.mlp.gate.tid2eid") == "layers.2.ffn.gate.tid2eid"
+    assert _hf_name_for_state_key("model.layers.2.mlp.shared_experts.up_proj.weight") == "layers.2.ffn.shared_experts.w3.weight"
+    assert _hf_name_for_state_key("model.layers.2.mlp.experts.7.down_proj.weight") == "layers.2.ffn.experts.7.w2.weight"
+    assert _hf_name_for_state_key("model.layers.2.attn_hc.scale") == "layers.2.hc_attn_scale"
+    assert _hf_name_for_state_key("model.hc_head.hc_scale") == "hc_head_scale"
+    assert _hf_name_for_state_key("model.mtp.0.self_attn.wq_a.weight") == "mtp.0.attn.wq_a.weight"
+    assert _hf_name_for_state_key("model.mtp.0.e_proj.weight") == "mtp.0.e_proj.weight"
+    assert _hf_name_for_state_key("model.mtp.0.hc_head.hc_scale") == "mtp.0.hc_head_scale"
+
+
+def test_deepseek_v4_hf_name_mapping_covers_every_native_state_key():
+    from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
+    from megatron.lite.model.deepseek_v4.lite.checkpoint import _hf_name_for_state_key
+    from megatron.lite.model.deepseek_v4.lite.model import DeepseekV4ForCausalLM
+
+    model = DeepseekV4ForCausalLM(DeepseekV4Config(**_tiny_config_kwargs()))
+    mapped = {name: _hf_name_for_state_key(name) for name in model.state_dict()}
+
+    assert [name for name, hf_name in mapped.items() if hf_name is None] == []
+    hf_names = list(mapped.values())
+    assert len(hf_names) == len(set(hf_names))
+
+
+def test_deepseek_v4_load_hf_weights_from_synthetic_safetensors(tmp_path):
+    import torch
+    from safetensors.torch import save_file
+
+    from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
+    from megatron.lite.model.deepseek_v4.lite.checkpoint import (
+        _dequantize_scaled_tensor,
+        _hf_name_for_state_key,
+        _scale_name_for_hf_name,
+        load_hf_weights,
+    )
+    from megatron.lite.model.deepseek_v4.lite.model import DeepseekV4ForCausalLM
+    from megatron.lite.primitive.parallel import ParallelState
+
+    cfg = DeepseekV4Config(**_tiny_config_kwargs())
+    model = DeepseekV4ForCausalLM(cfg)
+    state = model.state_dict()
+    hf_tensors = {}
+    expected = {}
+    for index, (name, target) in enumerate(state.items()):
+        hf_name = _hf_name_for_state_key(name)
+        assert hf_name is not None
+        if target.dtype.is_floating_point:
+            if name.endswith(".weight") and target.ndim >= 2:
+                raw = (
+                    torch.arange(target.numel(), dtype=torch.int16).reshape(target.shape)
+                    % 15
+                ).to(torch.int8)
+                scale_shape = tuple(max(1, (dim + 1) // 2) for dim in target.shape)
+                scale = torch.full(scale_shape, 127, dtype=torch.uint8)
+                if scale.numel():
+                    scale.flatten()[::2] = 128
+                tensor = raw
+                hf_tensors[_scale_name_for_hf_name(hf_name)] = scale
+                expected[name] = _dequantize_scaled_tensor(raw, scale, target.shape).to(dtype=target.dtype)
+            else:
+                tensor = (
+                    torch.arange(target.numel(), dtype=torch.float32).reshape(target.shape)
+                    + float(index)
+                )
+                if target.numel():
+                    tensor = tensor / max(target.numel(), 1)
+                expected[name] = tensor.to(dtype=target.dtype)
+        else:
+            tensor = (
+                torch.arange(target.numel(), dtype=torch.int64).reshape(target.shape)
+                % cfg.n_routed_experts
+            )
+            expected[name] = tensor.to(dtype=target.dtype)
+        hf_tensors[hf_name] = tensor.contiguous()
+
+    save_file(hf_tensors, tmp_path / "model.safetensors")
+    load_hf_weights(model, str(tmp_path), cfg, ParallelState())
+
+    loaded = model.state_dict()
+    for name, tensor in expected.items():
+        if tensor.dtype.is_floating_point:
+            torch.testing.assert_close(loaded[name], tensor)
+        else:
+            assert torch.equal(loaded[name], tensor)
+
+
+def test_deepseek_v4_proxy_hf_loaded_forward_matches_native_bitwise(tmp_path):
+    import torch
+    from safetensors.torch import save_file
+
+    from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
+    from megatron.lite.model.deepseek_v4.lite.checkpoint import load_hf_weights
+    from megatron.lite.model.deepseek_v4.lite.model import DeepseekV4ForCausalLM
+    from megatron.lite.primitive.parallel import ParallelState
+
+    cfg = DeepseekV4Config(**_tiny_config_kwargs())
+    native_ref = DeepseekV4ForCausalLM(cfg)
+    bb_model = DeepseekV4ForCausalLM(cfg)
+    hf_tensors, native_state = _proxy_hf_tensors_from_native_state(native_ref.state_dict(), cfg)
+
+    save_file(hf_tensors, tmp_path / "model.safetensors")
+    native_ref.load_state_dict(native_state, strict=True)
+    load_hf_weights(bb_model, str(tmp_path), cfg, ParallelState())
+    native_ref.eval()
+    bb_model.eval()
+
+    input_ids = (torch.arange(8, dtype=torch.long).unsqueeze(0) * 7) % cfg.vocab_size
+    position_ids = torch.arange(input_ids.size(1), dtype=torch.long).unsqueeze(0)
+    with torch.no_grad():
+        native_out = native_ref(input_ids=input_ids, position_ids=position_ids)
+        bb_out = bb_model(input_ids=input_ids, position_ids=position_ids)
+
+    assert torch.equal(bb_out["hidden_states"], native_out["hidden_states"])
+    assert torch.equal(bb_out["logits"], native_out["logits"])
+
+    mtp_hidden = torch.arange(
+        input_ids.size(0) * input_ids.size(1) * cfg.hc_mult * cfg.hidden_size,
+        dtype=torch.float32,
+    ).reshape(input_ids.size(0), input_ids.size(1), cfg.hc_mult, cfg.hidden_size)
+    mtp_hidden = (mtp_hidden % 23) / 128.0
+    with torch.no_grad():
+        native_mtp = native_ref.model.mtp[0](
+            mtp_hidden,
+            input_ids=input_ids,
+            embed_tokens=native_ref.model.embed_tokens,
+            position_ids=position_ids,
+        )
+        bb_mtp = bb_model.model.mtp[0](
+            mtp_hidden,
+            input_ids=input_ids,
+            embed_tokens=bb_model.model.embed_tokens,
+            position_ids=position_ids,
+        )
+        native_mtp_contract = native_ref.model.mtp[0].contract(native_mtp)
+        bb_mtp_contract = bb_model.model.mtp[0].contract(bb_mtp)
+
+    assert torch.equal(bb_mtp, native_mtp)
+    assert torch.equal(bb_mtp_contract, native_mtp_contract)
+
+
+def test_deepseek_v4_real_hf_index_coverage():
+    import json
+    import os
+
+    import pytest
+
+    from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
+    from megatron.lite.model.deepseek_v4.lite.checkpoint import expected_hf_names
+
+    snapshot = Path(
+        os.environ.get(
+            "DSV4_HF_SNAPSHOT",
+            "/lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_mcore/checkpoints/hf/DeepSeek-V4-Flash",
+        )
+    )
+    index_path = snapshot / "model.safetensors.index.json"
+    config_path = snapshot / "config.json"
+    if not index_path.exists() or not config_path.exists():
+        pytest.skip("DeepSeek-V4-Flash HF index/config not present in local cache")
+
+    hf_weight_map = json.loads(index_path.read_text())["weight_map"]
+    cfg = DeepseekV4Config._from_hf_dict(json.loads(config_path.read_text()))
+    expected = expected_hf_names(cfg, available_hf_names=hf_weight_map)
+
+    assert len(hf_weight_map) == 69187
+    assert sorted(set(hf_weight_map) - expected) == []
+    assert sorted(expected - set(hf_weight_map)) == []
+
+
+def _deepseek_v4_hf_snapshot() -> Path:
+    import os
+
+    return Path(
+        os.environ.get(
+            "DSV4_HF_SNAPSHOT",
+            "/lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_mcore/checkpoints/hf/DeepSeek-V4-Flash",
+        )
+    )
+
+
+def _state_key_for_real_proxy_hf_name(name: str) -> str | None:
+    if name in {
+        "embed.weight",
+        "head.weight",
+        "norm.weight",
+        "hc_head_fn",
+        "hc_head_base",
+        "hc_head_scale",
+    }:
+        return {
+            "embed.weight": "model.embed_tokens.weight",
+            "head.weight": "lm_head.weight",
+            "norm.weight": "model.norm.weight",
+            "hc_head_fn": "model.hc_head.hc_fn",
+            "hc_head_base": "model.hc_head.hc_base",
+            "hc_head_scale": "model.hc_head.hc_scale",
+        }[name]
+    if name.endswith(".scale"):
+        return None
+
+    matched = re.match(r"^(layers\.(\d+)|mtp\.(\d+))\.(.+)$", name)
+    if matched is None:
+        return None
+    native = f"model.layers.{matched.group(2)}" if matched.group(2) is not None else f"model.mtp.{matched.group(3)}"
+    suffix = matched.group(4)
+
+    direct = {
+        "attn_norm.weight": "input_layernorm.weight",
+        "ffn_norm.weight": "post_attention_layernorm.weight",
+        "attn.attn_sink": "self_attn.sinks",
+        "attn.wq_a.weight": "self_attn.wq_a.weight",
+        "attn.q_norm.weight": "self_attn.q_norm.weight",
+        "attn.wq_b.weight": "self_attn.wq_b.weight",
+        "attn.wkv.weight": "self_attn.wkv.weight",
+        "attn.kv_norm.weight": "self_attn.kv_norm.weight",
+        "attn.wo_a.weight": "self_attn.wo_a.weight",
+        "attn.wo_b.weight": "self_attn.wo_b.weight",
+        "attn.compressor.ape": "self_attn.compressor.ape",
+        "attn.compressor.wkv.weight": "self_attn.compressor.wkv.weight",
+        "attn.compressor.wgate.weight": "self_attn.compressor.wgate.weight",
+        "attn.compressor.norm.weight": "self_attn.compressor.norm.weight",
+        "attn.indexer.wq_b.weight": "self_attn.indexer.wq_b.weight",
+        "attn.indexer.compressor.ape": "self_attn.indexer.compressor.ape",
+        "attn.indexer.compressor.wkv.weight": "self_attn.indexer.compressor.wkv.weight",
+        "attn.indexer.compressor.wgate.weight": "self_attn.indexer.compressor.wgate.weight",
+        "attn.indexer.compressor.norm.weight": "self_attn.indexer.compressor.norm.weight",
+        "attn.indexer.weights_proj.weight": "self_attn.indexer.weights_proj.weight",
+        "ffn.gate.weight": "mlp.gate.weight",
+        "ffn.gate.bias": "mlp.gate.e_score_correction_bias",
+        "ffn.gate.tid2eid": "mlp.gate.tid2eid",
+        "ffn.shared_experts.w1.weight": "mlp.shared_experts.gate_proj.weight",
+        "ffn.shared_experts.w3.weight": "mlp.shared_experts.up_proj.weight",
+        "ffn.shared_experts.w2.weight": "mlp.shared_experts.down_proj.weight",
+        "hc_attn_fn": "attn_hc.fn",
+        "hc_attn_base": "attn_hc.base",
+        "hc_attn_scale": "attn_hc.scale",
+        "hc_ffn_fn": "ffn_hc.fn",
+        "hc_ffn_base": "ffn_hc.base",
+        "hc_ffn_scale": "ffn_hc.scale",
+        "e_proj.weight": "e_proj.weight",
+        "h_proj.weight": "h_proj.weight",
+        "enorm.weight": "enorm.weight",
+        "hnorm.weight": "hnorm.weight",
+        "norm.weight": "norm.weight",
+        "hc_head_fn": "hc_head.hc_fn",
+        "hc_head_base": "hc_head.hc_base",
+        "hc_head_scale": "hc_head.hc_scale",
+    }
+    if suffix in direct:
+        return f"{native}.{direct[suffix]}"
+
+    expert = re.match(r"^ffn\.experts\.(\d+)\.(w1|w3|w2)\.weight$", suffix)
+    if expert is not None:
+        proj = {"w1": "gate_proj", "w3": "up_proj", "w2": "down_proj"}[expert.group(2)]
+        return f"{native}.mlp.experts.{expert.group(1)}.{proj}.weight"
+    return None
+
+
+def _mbridge_ref_dequant(tensor, scale, shape):
+    """mbridge#147 DeepSeek weight_dequant reference: y = x.float() * block_scale."""
+    scale_f = scale.float()
+    target = tuple(int(dim) for dim in shape)
+    while scale_f.ndim > len(target) and scale_f.shape[0] == 1:
+        scale_f = scale_f.squeeze(0)
+    while scale_f.ndim < len(target):
+        scale_f = scale_f.unsqueeze(-1)
+    expanded = scale_f
+    for dim, size in enumerate(target):
+        if expanded.shape[dim] == size:
+            continue
+        expanded = expanded.repeat_interleave(math.ceil(size / expanded.shape[dim]), dim=dim)
+    return tensor.float() * expanded[tuple(slice(0, size) for size in target)]
+
+
+def test_deepseek_v4_real_checkpoint_proxy_loader_bitwise():
+    import json
+    import os
+
+    import pytest
+    import torch
+    from safetensors import safe_open
+
+    from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
+    from megatron.lite.model.deepseek_v4.lite.checkpoint import (
+        _copy_param,
+        _hf_name_for_state_key,
+        _scale_name_for_hf_name,
+    )
+
+    if os.environ.get("DSV4_REAL_PROXY_PARITY") != "1":
+        pytest.skip("set DSV4_REAL_PROXY_PARITY=1 to run real DeepSeek-V4-Flash proxy parity")
+
+    snapshot = _deepseek_v4_hf_snapshot()
+    index_path = snapshot / "model.safetensors.index.json"
+    config_path = snapshot / "config.json"
+    if not index_path.exists() or not config_path.exists():
+        pytest.skip(f"DeepSeek-V4-Flash config/index not present: {snapshot}")
+
+    hf_index = json.loads(index_path.read_text())["weight_map"]
+    first_shard = snapshot / hf_index["layers.0.attn.wq_a.weight"]
+    if not first_shard.exists():
+        pytest.skip(f"DeepSeek-V4-Flash full safetensor shards not present: {snapshot}")
+
+    cfg = DeepseekV4Config._from_hf_dict(json.loads(config_path.read_text()))
+    proxy_layers = (0, cfg.num_hidden_layers - 1)
+    prefixes = {f"layers.{idx}." for idx in proxy_layers}
+    include_mtp = os.environ.get("DSV4_REAL_PROXY_INCLUDE_MTP") == "1"
+    if include_mtp and cfg.num_nextn_predict_layers:
+        prefixes.update(f"mtp.{idx}." for idx in range(cfg.num_nextn_predict_layers))
+
+    state_to_hf: dict[str, str] = {}
+    for hf_name in hf_index:
+        if not any(hf_name.startswith(prefix) for prefix in prefixes):
+            continue
+        state_key = _state_key_for_real_proxy_hf_name(hf_name)
+        if state_key is None:
+            if not hf_name.endswith(".scale"):
+                raise AssertionError(f"real proxy HF name is not mapped to native state: {hf_name}")
+            continue
+        assert _hf_name_for_state_key(state_key) == hf_name
+        state_to_hf[state_key] = hf_name
+    for hf_name in ("norm.weight", "hc_head_fn", "hc_head_base", "hc_head_scale"):
+        state_key = _state_key_for_real_proxy_hf_name(hf_name)
+        assert state_key is not None
+        assert _hf_name_for_state_key(state_key) == hf_name
+        state_to_hf[state_key] = hf_name
+
+    contexts = []
+    handles = {}
+    tensor_device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    def read_tensor(name: str) -> torch.Tensor:
+        filename = hf_index[name]
+        handle = handles.get(filename)
+        if handle is None:
+            context = safe_open(str(snapshot / filename), framework="pt", device=tensor_device)
+            handle = context.__enter__()
+            contexts.append(context)
+            handles[filename] = handle
+        return handle.get_tensor(name)
+
+    checked = 0
+    quantized = 0
+    global_max = 0.0
+    worst = ""
+    try:
+        for state_key, hf_name in sorted(state_to_hf.items()):
+            raw = read_tensor(hf_name)
+            scale_name = _scale_name_for_hf_name(hf_name)
+            scale = read_tensor(scale_name) if scale_name in hf_index else None
+            if scale is not None:
+                quantized += 1
+                expected = _mbridge_ref_dequant(raw, scale, raw.shape).to(torch.float32)
+                target = torch.empty(raw.shape, dtype=torch.float32, device=raw.device)
+            elif raw.dtype.is_floating_point:
+                expected = raw.to(torch.float32)
+                target = torch.empty(raw.shape, dtype=torch.float32, device=raw.device)
+            else:
+                expected = raw.to(torch.int64)
+                target = torch.empty(raw.shape, dtype=torch.int64, device=raw.device)
+
+            _copy_param(target, raw, scale=scale)
+            if target.dtype.is_floating_point:
+                diff = (target - expected).abs()
+                max_abs = float(diff.max().item()) if diff.numel() else 0.0
+            else:
+                max_abs = 0.0 if torch.equal(target, expected) else float("inf")
+            if max_abs > global_max:
+                global_max = max_abs
+                worst = state_key
+            assert torch.equal(target, expected), f"{state_key} ({hf_name}) max_abs={max_abs}"
+            checked += 1
+    finally:
+        while contexts:
+            contexts.pop().__exit__(None, None, None)
+
+    print(
+        "[DSV4_REAL_PROXY] "
+        f"snapshot={snapshot} device={tensor_device} proxy_layers={proxy_layers} include_mtp={include_mtp} "
+        f"checked={checked} quantized={quantized} max_abs={global_max} worst={worst}"
+    )
+    assert checked > 0
+    assert quantized > 0
+    assert global_max == 0.0
+
+
+def test_deepseek_v4_protocol_rejects_cp_and_other_parallel_scope():
+    import pytest
+
+    from megatron.lite.model.deepseek_v4.lite.protocol import _validate_parallel_scope
+    from megatron.lite.runtime.contracts import ParallelConfig
+
+    _validate_parallel_scope(ParallelConfig(tp=1, ep=1, etp=1, cp=1, pp=1, vpp=1))
+    with pytest.raises(NotImplementedError):
+        _validate_parallel_scope(ParallelConfig(tp=1, ep=1, etp=1, cp=2, pp=1, vpp=1))
+    with pytest.raises(NotImplementedError):
+        _validate_parallel_scope(ParallelConfig(tp=2, ep=1, etp=1, cp=1, pp=1, vpp=1))
+
+
+def test_deepseek_v4_lite_tiny_cpu_forward_backward():
+    import torch
+
+    from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
+    from megatron.lite.model.deepseek_v4.lite.model import DeepseekV4ForCausalLM
+
+    torch.manual_seed(1234)
+    model = DeepseekV4ForCausalLM(DeepseekV4Config(**_tiny_config_kwargs()))
+    input_ids = torch.randint(0, model.config.vocab_size, (2, 5))
+    labels = torch.randint(0, model.config.vocab_size, (2, 5))
+
+    output = model(input_ids=input_ids, labels=labels)
+
+    assert output["hidden_states"].shape == (2, 5, model.config.hidden_size)
+    assert output["logits"].shape == (2, 5, model.config.vocab_size)
+    assert output["loss"].ndim == 0
+    output["loss"].backward()
+    grad_norm = sum(
+        param.grad.detach().float().norm()
+        for param in model.parameters()
+        if param.grad is not None
+    )
+    assert torch.isfinite(grad_norm)


### PR DESCRIPTION
## Summary
- Add native DeepSeek-V4 support under megatron.lite, including config parsing, protocol wiring, model construction, and HF checkpoint loading.
- Register the DeepSeek-V4 lite implementation in the model registry.
- Add focused unit coverage for registry/config behavior, native implementation boundaries, HF state-name mapping/loading, proxy parity, protocol validation, and a tiny CPU forward/backward smoke test.

## Validation
- Static and CPU smoke coverage added for the DeepSeek-V4 lite implementation.
- Real DeepSeek-V4-Flash checkpoint proxy parity was validated with bitwise max_abs=0.0.
- Native implementation and validation gates were reviewed before opening this PR.