### PR TITLE
Add GLM5 native lite model support

### DIFF
--- a/experimental/lite/megatron/lite/model/glm5/__init__.py
+++ b/experimental/lite/megatron/lite/model/glm5/__init__.py
@@ -1,0 +1,5 @@
+"""GLM-5 model family."""
+
+from megatron.lite.model.glm5.config import Glm5Config
+
+__all__ = ["Glm5Config"]

--- a/experimental/lite/megatron/lite/model/glm5/config.py
+++ b/experimental/lite/megatron/lite/model/glm5/config.py
@@ -1,0 +1,177 @@
+"""GLM-5 architecture config."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import fields as dc_fields
+from typing import Any
+
+from megatron.lite.primitive.config import load_hf_config_dict
+
+_HF_FIELDS = frozenset({
+    "attention_dropout",
+    "first_k_dense_replace",
+    "head_dim",
+    "hidden_size",
+    "index_head_dim",
+    "index_n_heads",
+    "index_topk",
+    "indexer_layer_norm_eps",
+    "indexer_rope_interleave",
+    "indexer_rope_first",
+    "indexer_use_hadamard",
+    "initializer_range",
+    "intermediate_size",
+    "kv_lora_rank",
+    "max_position_embeddings",
+    "mlp_layer_types",
+    "moe_intermediate_size",
+    "n_group",
+    "n_routed_experts",
+    "n_shared_experts",
+    "norm_topk_prob",
+    "num_attention_heads",
+    "num_experts_per_tok",
+    "num_hidden_layers",
+    "num_key_value_heads",
+    "num_nextn_predict_layers",
+    "q_lora_rank",
+    "qk_head_dim",
+    "qk_nope_head_dim",
+    "qk_rope_head_dim",
+    "latent_rms_norm_eps",
+    "rms_norm_eps",
+    "rope_interleave",
+    "rope_theta",
+    "routed_scaling_factor",
+    "topk_group",
+    "v_head_dim",
+    "vocab_size",
+})
+
+
+@dataclass
+class Glm5Config:
+    """Pure GLM-5 MoE + MLA + DSA architecture parameters."""
+
+    num_hidden_layers: int = 78
+    hidden_size: int = 6144
+    num_attention_heads: int = 64
+    num_key_value_heads: int = 64
+    head_dim: int = 64
+    vocab_size: int = 154880
+    max_position_embeddings: int = 202752
+    rms_norm_eps: float = 1e-5
+    attention_dropout: float = 0.0
+    initializer_range: float = 0.02
+
+    q_lora_rank: int = 2048
+    kv_lora_rank: int = 512
+    qk_head_dim: int = 256
+    qk_nope_head_dim: int = 192
+    qk_rope_head_dim: int = 64
+    v_head_dim: int = 256
+
+    index_head_dim: int = 128
+    index_n_heads: int = 32
+    index_topk: int = 2048
+    indexer_layer_norm_eps: float = 1e-6
+    indexer_rope_interleave: bool = False
+    indexer_rope_first: bool = True
+    indexer_use_hadamard: bool = False
+    rope_interleave: bool = False
+    rope_theta: float = 1_000_000.0
+    latent_rms_norm_eps: float = 1e-6
+
+    intermediate_size: int = 12288
+    moe_intermediate_size: int = 2048
+    first_k_dense_replace: int = 3
+    n_routed_experts: int = 256
+    n_shared_experts: int = 1
+    num_experts_per_tok: int = 8
+    n_group: int = 1
+    topk_group: int = 1
+    routed_scaling_factor: float = 2.5
+    norm_topk_prob: bool = True
+    num_nextn_predict_layers: int = 1
+    mlp_layer_types: list[str] | None = None
+
+    def __post_init__(self):
+        self._validate()
+
+    @property
+    def num_experts(self) -> int:
+        return self.n_routed_experts
+
+    def is_moe_layer(self, layer_idx: int) -> bool:
+        if self.mlp_layer_types is not None:
+            return self.mlp_layer_types[layer_idx] == "sparse"
+        return layer_idx >= self.first_k_dense_replace
+
+    def _validate(self) -> None:
+        errors: list[str] = []
+
+        def check(cond: bool, message: str) -> None:
+            if not cond:
+                errors.append(message)
+
+        check(self.num_hidden_layers >= 1, "num_hidden_layers must be >= 1")
+        check(self.hidden_size > 0, "hidden_size must be > 0")
+        check(self.q_lora_rank > 0, "q_lora_rank must be > 0")
+        check(self.kv_lora_rank > 0, "kv_lora_rank must be > 0")
+        check(
+            self.qk_head_dim == self.qk_nope_head_dim + self.qk_rope_head_dim,
+            "qk_head_dim must equal qk_nope_head_dim + qk_rope_head_dim",
+        )
+        check(
+            self.index_head_dim >= self.qk_rope_head_dim,
+            "index_head_dim must be >= qk_rope_head_dim",
+        )
+        check(
+            self.num_key_value_heads == self.num_attention_heads,
+            "initial GLM5 native path expects MLA heads to be ungrouped",
+        )
+        check(self.vocab_size > 0, "vocab_size must be > 0")
+        check(self.n_routed_experts >= 1, "n_routed_experts must be >= 1")
+        check(
+            1 <= self.num_experts_per_tok <= self.n_routed_experts,
+            "num_experts_per_tok must be in [1, n_routed_experts]",
+        )
+        check(1 <= self.topk_group <= self.n_group, "topk_group must be in [1, n_group]")
+        if self.mlp_layer_types is not None:
+            check(
+                len(self.mlp_layer_types) == self.num_hidden_layers,
+                "len(mlp_layer_types) must equal num_hidden_layers",
+            )
+            for idx, layer_type in enumerate(self.mlp_layer_types):
+                check(
+                    layer_type in {"dense", "sparse"},
+                    f"mlp_layer_types[{idx}] must be 'dense' or 'sparse'",
+                )
+
+        if errors:
+            raise ValueError(
+                f"Invalid Glm5Config ({len(errors)} error"
+                f"{'s' if len(errors) != 1 else ''}):\n  " + "\n  ".join(errors)
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {f.name: getattr(self, f.name) for f in dc_fields(self)}
+
+    @classmethod
+    def from_hf(cls, path_or_name: str, **overrides) -> Glm5Config:
+        return cls._from_hf_dict(load_hf_config_dict(path_or_name), **overrides)
+
+    @classmethod
+    def from_hf_config(cls, hf_config, **overrides) -> Glm5Config:
+        hf = hf_config.to_dict() if hasattr(hf_config, "to_dict") else vars(hf_config)
+        return cls._from_hf_dict(hf, **overrides)
+
+    @classmethod
+    def _from_hf_dict(cls, hf: dict[str, Any], **overrides) -> Glm5Config:
+        kwargs = {key: value for key, value in hf.items() if key in _HF_FIELDS and value is not None}
+        rope_parameters = hf.get("rope_parameters")
+        if isinstance(rope_parameters, dict) and "rope_theta" not in kwargs:
+            kwargs["rope_theta"] = float(rope_parameters.get("rope_theta", cls.rope_theta))
+        kwargs.update(overrides)
+        return cls(**kwargs)

--- a/experimental/lite/megatron/lite/model/glm5/lite/__init__.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/__init__.py
@@ -1,0 +1,5 @@
+"""Native GLM-5 lite implementation."""
+
+from megatron.lite.model.glm5.lite.model import Glm5ForCausalLM, Glm5Model
+
+__all__ = ["Glm5ForCausalLM", "Glm5Model"]

--- a/experimental/lite/megatron/lite/model/glm5/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/checkpoint.py
@@ -1,0 +1,237 @@
+"""Direct HF safetensor loading for native GLM-5."""
+
+from __future__ import annotations
+
+import re
+
+import torch
+import torch.nn as nn
+
+from megatron.lite.model.glm5.config import Glm5Config
+from megatron.lite.primitive.ckpt.hf_weights import SafeTensorReader, unwrap_model
+from megatron.lite.primitive.parallel import ParallelState
+from megatron.lite.primitive.utils import ensure_divisible
+from megatron.lite.primitive.utils import log_rank0
+
+
+def EXPERT_CLASSIFIER(name: str) -> bool:
+    return ".experts." in name
+
+
+def _has(reader: SafeTensorReader, name: str) -> bool:
+    if reader.index:
+        return name in reader.index
+    try:
+        reader.get_tensor(name)
+    except Exception:
+        return False
+    return True
+
+
+def _slice_to_target_shape(
+    tensor: torch.Tensor,
+    target: nn.Parameter | torch.Tensor,
+) -> torch.Tensor:
+    if tensor.shape == target.shape:
+        return tensor
+    if tensor.ndim != target.ndim:
+        raise RuntimeError(
+            f"Cannot load tensor with ndim {tensor.ndim} into target ndim {target.ndim}: "
+            f"{tuple(tensor.shape)} -> {tuple(target.shape)}"
+        )
+    if any(dst > src for src, dst in zip(tensor.shape, target.shape, strict=True)):
+        raise RuntimeError(
+            f"Cannot shrink source tensor {tuple(tensor.shape)} to target {tuple(target.shape)}"
+        )
+    slices = tuple(slice(0, dim) for dim in target.shape)
+    return tensor[slices].contiguous()
+
+
+def _copy_param(param: nn.Parameter | torch.Tensor, tensor: torch.Tensor) -> None:
+    local_tensor = getattr(param, "_local_tensor", None)
+    fsdp_slice = getattr(param, "megatron_fsdp_slice", None)
+    if local_tensor is not None and fsdp_slice is not None:
+        reference = getattr(param, "orig_param", param)
+        fitted = _slice_to_target_shape(tensor, reference)
+        local_fitted = fitted.flatten()[fsdp_slice]
+        if local_fitted.numel() != local_tensor.numel():
+            raise RuntimeError(
+                "Cannot load MegatronFSDP shard: "
+                f"source slice has {local_fitted.numel()} values but target local tensor "
+                f"has {local_tensor.numel()} values"
+            )
+        local_fitted = local_fitted.view(local_tensor.shape).contiguous()
+        local_tensor.copy_(local_fitted.to(device=local_tensor.device, dtype=local_tensor.dtype))
+        return
+
+    if local_tensor is not None and hasattr(param, "_spec"):
+        from torch.distributed.tensor._utils import compute_local_shape_and_global_offset
+
+        fitted = _slice_to_target_shape(tensor, param)
+        spec = param._spec
+        local_shape, global_offset = compute_local_shape_and_global_offset(
+            tuple(fitted.shape),
+            spec.mesh,
+            spec.placements,
+        )
+        shard_slices = tuple(
+            slice(offset, offset + size)
+            for offset, size in zip(global_offset, local_shape, strict=True)
+        )
+        local_fitted = fitted[shard_slices].contiguous()
+        if local_fitted.shape != local_tensor.shape:
+            local_fitted = _slice_to_target_shape(local_fitted, local_tensor)
+        local_tensor.copy_(local_fitted.to(device=local_tensor.device, dtype=local_tensor.dtype))
+        return
+
+    fitted = _slice_to_target_shape(tensor, param)
+    param.data.copy_(fitted.to(device=param.device, dtype=param.dtype))
+
+
+_SPLIT_EXPERT_RE = re.compile(
+    r"^(model\.layers\.\d+\.mlp\.experts)\.(\d+)\."
+    r"(gate_proj|up_proj|down_proj)\.weight$"
+)
+_LAYER_RE = re.compile(r"^(model\.layers\.)(\d+)(\..*)$")
+_LOCAL_EXPERT_RE = re.compile(r"^(model\.layers\.\d+\.mlp\.experts\.)(\d+)(\..*)$")
+_PACKED_EXPERT_RE = re.compile(
+    r"^(model\.layers\.\d+\.mlp\.experts)\.(gate_up_proj|down_proj)$"
+)
+
+
+def _resolve_hf_tensor(
+    reader: SafeTensorReader,
+    name: str,
+    target: nn.Parameter | torch.Tensor,
+) -> torch.Tensor | None:
+    if _has(reader, name):
+        return reader.get_tensor(name)
+
+    match = _SPLIT_EXPERT_RE.match(name)
+    if match is None:
+        return None
+
+    prefix, expert_idx_text, projection = match.groups()
+    expert_idx = int(expert_idx_text)
+    if projection in {"gate_proj", "up_proj"}:
+        gate_up_name = f"{prefix}.gate_up_proj"
+        if _has(reader, gate_up_name):
+            gate_up = reader.get_tensor(gate_up_name)
+            split = target.shape[0]
+            offset = 0 if projection == "gate_proj" else split
+            return gate_up[expert_idx, offset:offset + split, :]
+
+        gate_and_up_name = f"{prefix}.gate_and_up_projs"
+        if _has(reader, gate_and_up_name):
+            gate_and_up = reader.get_tensor(gate_and_up_name)
+            split = target.shape[0]
+            offset = 0 if projection == "gate_proj" else split
+            return gate_and_up[expert_idx, :, offset:offset + split].T.contiguous()
+
+    if projection == "down_proj":
+        down_name = f"{prefix}.down_proj"
+        if _has(reader, down_name):
+            return reader.get_tensor(down_name)[expert_idx]
+
+        down_projs_name = f"{prefix}.down_projs"
+        if _has(reader, down_projs_name):
+            return reader.get_tensor(down_projs_name)[expert_idx].T.contiguous()
+
+    return None
+
+
+def _local_layer_indices(model: nn.Module) -> list[int]:
+    if hasattr(model, "layer_indices"):
+        return list(model.layer_indices)
+    nested = getattr(model, "model", None)
+    if nested is not None and hasattr(nested, "layer_indices"):
+        return list(nested.layer_indices)
+    return []
+
+
+def _to_hf_state_name(
+    name: str,
+    *,
+    config: Glm5Config,
+    model: nn.Module,
+    ps: ParallelState,
+) -> str | None:
+    layer_indices = _local_layer_indices(model)
+    match = _LAYER_RE.match(name)
+    if match is not None and layer_indices:
+        prefix, local_idx_text, suffix = match.groups()
+        local_idx = int(local_idx_text)
+        if local_idx >= len(layer_indices):
+            return None
+        name = f"{prefix}{layer_indices[local_idx]}{suffix}"
+
+    match = _LOCAL_EXPERT_RE.match(name)
+    if match is None:
+        return name
+
+    prefix, local_expert_text, suffix = match.groups()
+    experts_per_rank = ensure_divisible(config.n_routed_experts, ps.ep_size)
+    global_expert = ps.ep_rank * experts_per_rank + int(local_expert_text)
+    return f"{prefix}{global_expert}{suffix}"
+
+
+def _resolve_named_parameter_tensor(
+    reader: SafeTensorReader,
+    name: str,
+    target: nn.Parameter | torch.Tensor,
+    *,
+    config: Glm5Config,
+    ps: ParallelState,
+) -> torch.Tensor | None:
+    match = _PACKED_EXPERT_RE.match(name)
+    if match is None:
+        return _resolve_hf_tensor(reader, name, target)
+
+    prefix, projection = match.groups()
+    experts_per_rank = ensure_divisible(config.n_routed_experts, ps.ep_size)
+    expert_start = ps.ep_rank * experts_per_rank
+    local_experts = target.shape[0]
+    tensors: list[torch.Tensor] = []
+    for local_expert in range(local_experts):
+        global_expert = expert_start + local_expert
+        expert_prefix = f"{prefix}.{global_expert}"
+        if projection == "gate_up_proj":
+            gate = reader.get_tensor(f"{expert_prefix}.gate_proj.weight")
+            up = reader.get_tensor(f"{expert_prefix}.up_proj.weight")
+            tensors.append(torch.cat([gate, up], dim=0).contiguous())
+        else:
+            tensors.append(reader.get_tensor(f"{expert_prefix}.down_proj.weight"))
+    return torch.stack(tensors, dim=0).contiguous()
+
+
+def load_hf_weights(model: nn.Module, path: str, config: Glm5Config, ps: ParallelState) -> None:
+    if ps.tp_size != 1 or ps.etp_size != 1:
+        raise NotImplementedError("GLM5 direct HF load currently supports TP=ETP=1.")
+
+    reader = SafeTensorReader(path)
+    base_model = unwrap_model(model)
+    loaded = 0
+    missing: list[str] = []
+    for name, target in base_model.named_parameters():
+        hf_name = _to_hf_state_name(name, config=config, model=base_model, ps=ps)
+        if hf_name is None:
+            continue
+        tensor = _resolve_named_parameter_tensor(
+            reader,
+            hf_name,
+            target,
+            config=config,
+            ps=ps,
+        )
+        if tensor is None:
+            missing.append(hf_name)
+            continue
+        _copy_param(target, tensor)
+        loaded += 1
+
+    log_rank0(f"GLM5 native loaded {loaded} tensors from {path}")
+    for name in missing:
+        log_rank0(f"WARNING: GLM5 checkpoint tensor missing: {name}")
+
+
+__all__ = ["EXPERT_CLASSIFIER", "load_hf_weights"]

--- a/experimental/lite/megatron/lite/model/glm5/lite/model.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/model.py
@@ -1,0 +1,522 @@
+"""Native GLM-5 model assembled from Megatron Lite primitives."""
+
+from __future__ import annotations
+
+import math
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from megatron.lite.model.glm5.config import Glm5Config
+from megatron.lite.primitive.modules.mla_dsa import MLADSA, RMSNorm, build_rotary_embeddings
+from megatron.lite.primitive.parallel import ParallelState
+from megatron.lite.primitive.utils import ensure_divisible
+
+
+class Glm5MLP(nn.Module):
+    def __init__(self, hidden_size: int, intermediate_size: int):
+        super().__init__()
+        self.gate_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.up_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.down_proj = nn.Linear(intermediate_size, hidden_size, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.down_proj(F.silu(self.gate_proj(x)) * self.up_proj(x))
+
+
+class Glm5RoutedExperts(nn.Module):
+    def __init__(
+        self,
+        num_experts: int,
+        hidden_size: int,
+        intermediate_size: int,
+        ps: ParallelState | None = None,
+    ):
+        super().__init__()
+        ps = ps or ParallelState()
+        self.num_global_experts = num_experts
+        self.num_experts = ensure_divisible(num_experts, ps.ep_size)
+        self.local_start = ps.ep_rank * self.num_experts
+        self.intermediate_size = intermediate_size
+        self.hidden_size = hidden_size
+        self.gate_up_proj = nn.Parameter(torch.empty(self.num_experts, 2 * intermediate_size, hidden_size))
+        self.down_proj = nn.Parameter(torch.empty(self.num_experts, hidden_size, intermediate_size))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        nn.init.kaiming_uniform_(self.gate_up_proj, a=math.sqrt(5))
+        nn.init.kaiming_uniform_(self.down_proj, a=math.sqrt(5))
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        tokens_per_expert: torch.Tensor,
+        permuted_probs: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if hidden_states.size(0) == 0:
+            output = hidden_states.reshape(0, self.hidden_size)
+            if permuted_probs is not None:
+                output = output + permuted_probs.sum().to(output.dtype) * 0.0
+            return output
+
+        output = hidden_states.new_empty(hidden_states.size(0), self.hidden_size)
+        offset = 0
+        for expert_idx, count in enumerate(tokens_per_expert.tolist()):
+            if count == 0:
+                continue
+            end = offset + count
+            expert_input = hidden_states[offset:end]
+            gate_up = F.linear(expert_input, self.gate_up_proj[expert_idx])
+            gate_proj, up_proj = gate_up.chunk(2, dim=-1)
+            expert_hidden = F.silu(gate_proj) * up_proj
+            expert_out = F.linear(expert_hidden, self.down_proj[expert_idx])
+            if permuted_probs is not None:
+                expert_out = expert_out * permuted_probs[offset:end].unsqueeze(-1)
+            output[offset:end] = expert_out.to(hidden_states.dtype)
+            offset = end
+        return output
+
+    def forward_topk(
+        self,
+        hidden_states: torch.Tensor,
+        topk_indices: torch.Tensor,
+        topk_weights: torch.Tensor,
+    ) -> torch.Tensor:
+        num_topk = topk_indices.size(-1)
+        num_tokens = hidden_states.size(0)
+        hidden_dim = hidden_states.size(-1)
+
+        token_idx = (
+            torch.arange(num_tokens, device=hidden_states.device)
+            .unsqueeze(1)
+            .expand(-1, num_topk)
+            .reshape(-1)
+        )
+        sample_weights = topk_weights.reshape(-1)
+        expert_ids = topk_indices.reshape(-1)
+        invalid_mask = expert_ids >= self.num_experts
+        expert_ids = expert_ids.clamp(0, self.num_experts - 1)
+        selected_hidden = hidden_states[token_idx]
+
+        selected_gate_up = self.gate_up_proj[expert_ids]
+        gate_up = torch.bmm(
+            selected_gate_up,
+            selected_hidden.unsqueeze(-1),
+        ).squeeze(-1)
+        gate_proj, up_proj = gate_up.chunk(2, dim=-1)
+        expert_hidden = F.silu(gate_proj) * up_proj
+
+        selected_down = self.down_proj[expert_ids]
+        expert_out = torch.bmm(
+            selected_down,
+            expert_hidden.unsqueeze(-1),
+        ).squeeze(-1)
+        weighted = expert_out * sample_weights.unsqueeze(-1)
+        weighted.masked_fill_(invalid_mask.unsqueeze(-1), 0.0)
+        return weighted.view(num_tokens, num_topk, hidden_dim).sum(dim=1).to(hidden_states.dtype)
+
+    def _save_to_state_dict(self, destination, prefix, keep_vars):
+        for expert_idx in range(self.num_experts):
+            gate_proj = self.gate_up_proj[expert_idx, : self.intermediate_size]
+            up_proj = self.gate_up_proj[expert_idx, self.intermediate_size :]
+            down_proj = self.down_proj[expert_idx]
+            if not keep_vars:
+                gate_proj = gate_proj.detach()
+                up_proj = up_proj.detach()
+                down_proj = down_proj.detach()
+            expert_prefix = f"{prefix}{expert_idx}."
+            destination[expert_prefix + "gate_proj.weight"] = gate_proj
+            destination[expert_prefix + "up_proj.weight"] = up_proj
+            destination[expert_prefix + "down_proj.weight"] = down_proj
+
+    def _load_from_state_dict(
+        self,
+        state_dict,
+        prefix,
+        local_metadata,
+        strict,
+        missing_keys,
+        unexpected_keys,
+        error_msgs,
+    ) -> None:
+        del local_metadata
+
+        def _copy(key: str, target: torch.Tensor) -> bool:
+            tensor = state_dict.get(key)
+            if tensor is None:
+                if strict:
+                    missing_keys.append(key)
+                return False
+            if tensor.shape != target.shape:
+                error_msgs.append(
+                    f"size mismatch for {key}: copying a param with shape {tuple(tensor.shape)} "
+                    f"from checkpoint, the shape in current model is {tuple(target.shape)}."
+                )
+                return False
+            with torch.no_grad():
+                target.copy_(tensor)
+            return True
+
+        gate_up_key = prefix + "gate_up_proj"
+        if gate_up_key in state_dict:
+            _copy(gate_up_key, self.gate_up_proj)
+        else:
+            for expert_idx in range(self.num_experts):
+                expert_prefix = f"{prefix}{expert_idx}."
+                _copy(
+                    expert_prefix + "gate_proj.weight",
+                    self.gate_up_proj[expert_idx, : self.intermediate_size],
+                )
+                _copy(
+                    expert_prefix + "up_proj.weight",
+                    self.gate_up_proj[expert_idx, self.intermediate_size :],
+                )
+        down_key = prefix + "down_proj"
+        if down_key in state_dict:
+            _copy(down_key, self.down_proj)
+        else:
+            for expert_idx in range(self.num_experts):
+                _copy(f"{prefix}{expert_idx}.down_proj.weight", self.down_proj[expert_idx])
+
+
+class Glm5Router(nn.Module):
+    def __init__(self, config: Glm5Config):
+        super().__init__()
+        self.weight = nn.Parameter(torch.empty(config.n_routed_experts, config.hidden_size))
+        self.register_buffer(
+            "e_score_correction_bias",
+            torch.zeros(config.n_routed_experts, dtype=torch.float32),
+        )
+        self.topk = config.num_experts_per_tok
+        self.n_group = config.n_group
+        self.topk_group = config.topk_group
+        self.route_scale = config.routed_scaling_factor
+        self.norm_topk_prob = config.norm_topk_prob
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        scores = F.linear(x.float(), self.weight.float()).sigmoid()
+        original_scores = scores
+        scores_for_choice = scores + self.e_score_correction_bias.to(scores.dtype)
+
+        if self.n_group > 1:
+            grouped = scores_for_choice.view(x.size(0), self.n_group, -1)
+            group_scores = grouped.topk(2, dim=-1, sorted=False).values.sum(dim=-1)
+            group_idx = group_scores.topk(self.topk_group, dim=-1, sorted=False).indices
+            group_mask = torch.zeros_like(group_scores, dtype=torch.bool).scatter_(1, group_idx, True)
+            scores_for_choice = scores_for_choice.masked_fill(
+                ~group_mask.unsqueeze(-1).expand_as(grouped).flatten(1),
+                0.0,
+            )
+
+        indices = scores_for_choice.topk(self.topk, dim=-1, sorted=False).indices
+        weights = original_scores.gather(1, indices)
+        if self.norm_topk_prob and self.topk > 1:
+            weights = weights / (weights.sum(dim=-1, keepdim=True) + 1e-20)
+        return weights * self.route_scale, indices
+
+
+def _build_glm5_pipeline_layers(num_hidden_layers: int, ps: ParallelState) -> list[int]:
+    if ps.pp_size > 2 and num_hidden_layers % ps.pp_size:
+        middle_layers = -(-num_hidden_layers // ps.pp_size)
+        edge_layers = num_hidden_layers - middle_layers * (ps.pp_size - 2)
+        first_layers = edge_layers // 2
+        last_layers = edge_layers - first_layers
+        counts = [first_layers, *([middle_layers] * (ps.pp_size - 2)), last_layers]
+        start = sum(counts[: ps.pp_rank])
+        return list(range(start, start + counts[ps.pp_rank]))
+
+    layers_per_stage = num_hidden_layers // ps.pp_size
+    remainder = num_hidden_layers % ps.pp_size
+    local_count = layers_per_stage + (1 if ps.pp_rank < remainder else 0)
+    start = ps.pp_rank * layers_per_stage + min(ps.pp_rank, remainder)
+    return list(range(start, start + local_count))
+
+
+class Glm5MoE(nn.Module):
+    def __init__(
+        self,
+        config: Glm5Config,
+        ps: ParallelState | None = None,
+        *,
+        use_deepep: bool = False,
+    ):
+        super().__init__()
+        ps = ps or ParallelState()
+        self.hidden_size = config.hidden_size
+        self.gate = Glm5Router(config)
+        self.dispatcher = None
+        if ps.ep_size > 1:
+            from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
+
+            self.dispatcher = TokenDispatcher(
+                config.n_routed_experts,
+                config.hidden_size,
+                ps,
+                use_deepep=use_deepep,
+                fuse_score_alltoall=True,
+            )
+        self.experts = Glm5RoutedExperts(
+            config.n_routed_experts,
+            config.hidden_size,
+            config.moe_intermediate_size,
+            ps,
+        )
+        shared_intermediate = config.n_shared_experts * config.moe_intermediate_size
+        self.shared_experts = (
+            Glm5MLP(config.hidden_size, shared_intermediate)
+            if config.n_shared_experts > 0
+            else None
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        shape = x.shape
+        residual = x
+        x_flat = x.reshape(-1, self.hidden_size)
+        weights, indices = self.gate(x_flat)
+        if self.dispatcher is None:
+            y = self.experts.forward_topk(x_flat, indices, weights).view(shape)
+        else:
+            dispatched, tpe, permuted_probs = self.dispatcher.dispatch(x_flat, weights, indices)
+            self.dispatcher.wait_dispatch_event()
+            expert_out = self.experts(dispatched, tpe, permuted_probs)
+            y = self.dispatcher.combine(expert_out).view(shape)
+        if self.shared_experts is not None:
+            y = y + self.shared_experts(residual)
+        return y
+
+
+class Glm5Layer(nn.Module):
+    def __init__(
+        self,
+        config: Glm5Config,
+        layer_idx: int,
+        ps: ParallelState | None = None,
+        *,
+        use_deepep: bool = False,
+    ):
+        super().__init__()
+        ps = ps or ParallelState()
+        self.self_attn = MLADSA(
+            hidden_size=config.hidden_size,
+            num_attention_heads=config.num_attention_heads,
+            q_lora_rank=config.q_lora_rank,
+            kv_lora_rank=config.kv_lora_rank,
+            qk_nope_head_dim=config.qk_nope_head_dim,
+            qk_rope_head_dim=config.qk_rope_head_dim,
+            v_head_dim=config.v_head_dim,
+            index_n_heads=config.index_n_heads,
+            index_head_dim=config.index_head_dim,
+            index_topk=config.index_topk,
+            rms_norm_eps=config.rms_norm_eps,
+            rope_interleaved=config.rope_interleave,
+            latent_rms_norm_eps=config.latent_rms_norm_eps,
+            indexer_layer_norm_eps=config.indexer_layer_norm_eps,
+            indexer_rope_interleaved=config.indexer_rope_interleave,
+            indexer_rope_first=config.indexer_rope_first,
+            indexer_use_hadamard=config.indexer_use_hadamard,
+            cp_size=ps.cp_size,
+            cp_rank=ps.cp_rank,
+            cp_group=ps.cp_group,
+        )
+        self.mlp = (
+            Glm5MoE(config, ps, use_deepep=use_deepep)
+            if config.is_moe_layer(layer_idx)
+            else Glm5MLP(config.hidden_size, config.intermediate_size)
+        )
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        position_ids: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        attn_out = self.self_attn(
+            self.input_layernorm(x),
+            cos=cos,
+            sin=sin,
+            position_ids=position_ids,
+            attention_mask=attention_mask,
+        )
+        x = x + attn_out
+        x = x + self.mlp(self.post_attention_layernorm(x))
+        return x
+
+
+class Glm5Model(nn.Module):
+    def __init__(
+        self,
+        config: Glm5Config,
+        ps: ParallelState | None = None,
+        *,
+        use_deepep: bool = False,
+    ):
+        super().__init__()
+        self.config = config
+        self.ps = ps or ParallelState()
+        self.layer_indices = _build_glm5_pipeline_layers(config.num_hidden_layers, self.ps)
+        self.embed_tokens = (
+            nn.Embedding(config.vocab_size, config.hidden_size)
+            if self.ps.pp_is_first
+            else None
+        )
+        self.layers = nn.ModuleList(
+            [
+                Glm5Layer(config, i, self.ps, use_deepep=use_deepep)
+                for i in self.layer_indices
+            ]
+        )
+        self.norm = (
+            RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+            if self.ps.pp_is_last
+            else None
+        )
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None = None,
+        *,
+        hidden_states: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if hidden_states is None:
+            if input_ids is None:
+                raise ValueError("input_ids or hidden_states is required")
+            if self.embed_tokens is None:
+                raise ValueError("input_ids are only accepted on the first pipeline stage")
+            hidden_states = self.embed_tokens(input_ids)
+        batch, seq_len, _ = hidden_states.shape
+        if position_ids is None:
+            if self.ps.cp_size > 1:
+                full_seq_len = seq_len * self.ps.cp_size
+                position_ids = (
+                    torch.arange(full_seq_len, device=hidden_states.device)
+                    .unsqueeze(0)
+                    .expand(batch, -1)
+                )
+            else:
+                position_ids = torch.arange(seq_len, device=hidden_states.device).unsqueeze(0).expand(batch, -1)
+        elif position_ids.dim() == 1:
+            position_ids = position_ids.unsqueeze(0).expand(batch, -1)
+
+        cos, sin = build_rotary_embeddings(
+            position_ids=position_ids.to(device=hidden_states.device, dtype=torch.long),
+            dim=self.config.qk_rope_head_dim,
+            rope_theta=self.config.rope_theta,
+            dtype=hidden_states.dtype,
+        )
+
+        h = hidden_states
+        for layer in self.layers:
+            h = layer(
+                h,
+                cos=cos,
+                sin=sin,
+                position_ids=position_ids,
+                attention_mask=attention_mask,
+            )
+        return self.norm(h) if self.norm is not None else h
+
+
+class Glm5ForCausalLM(nn.Module):
+    def __init__(
+        self,
+        config: Glm5Config,
+        train_cfg: SimpleNamespace | None = None,
+        ps: ParallelState | None = None,
+    ):
+        super().__init__()
+        self.config = config
+        self.train_cfg = train_cfg or SimpleNamespace(fp8=False)
+        self.ps = ps or ParallelState()
+        self.model = Glm5Model(
+            config,
+            self.ps,
+            use_deepep=bool(getattr(self.train_cfg, "use_deepep", False)),
+        )
+        self.layer_indices = self.model.layer_indices
+        self.lm_head = (
+            nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+            if self.ps.pp_is_last
+            else None
+        )
+        self._input_tensor: torch.Tensor | None = None
+
+    def set_input_tensor(self, input_tensor):
+        if isinstance(input_tensor, list):
+            input_tensor = input_tensor[0] if input_tensor else None
+        self._input_tensor = input_tensor
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None = None,
+        *,
+        hidden_states: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        labels: torch.Tensor | None = None,
+    ) -> dict[str, torch.Tensor]:
+        if input_ids is not None and input_ids.dim() == 1:
+            input_ids = input_ids.unsqueeze(0)
+        if hidden_states is None:
+            hidden_states = self._input_tensor
+
+        fp8_ctx = nullcontext()
+        with fp8_ctx:
+            hidden = self.model(
+                input_ids,
+                hidden_states=hidden_states,
+                position_ids=position_ids,
+                attention_mask=attention_mask,
+            )
+            logits = self.lm_head(hidden) if self.lm_head is not None else None
+
+        output = {"hidden_states": hidden}
+        if logits is None:
+            return output
+        if labels is not None:
+            loss = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                labels.reshape(-1),
+                ignore_index=-100,
+            )
+            output["loss"] = loss
+        else:
+            output["logits"] = logits
+        return output
+
+    @torch.no_grad()
+    def initialize_weights(self) -> None:
+        for module in self.modules():
+            if isinstance(module, nn.Linear):
+                nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+            elif isinstance(module, nn.Embedding):
+                nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+            elif isinstance(module, RMSNorm | nn.LayerNorm):
+                module.reset_parameters() if hasattr(module, "reset_parameters") else module.weight.fill_(1.0)
+            elif isinstance(module, Glm5RoutedExperts):
+                nn.init.normal_(module.gate_up_proj, mean=0.0, std=self.config.initializer_range)
+                nn.init.normal_(module.down_proj, mean=0.0, std=self.config.initializer_range)
+        for layer in self.model.layers:
+            if isinstance(layer.mlp, Glm5MoE):
+                layer.mlp.gate.e_score_correction_bias.zero_()
+
+
+__all__ = [
+    "Glm5ForCausalLM",
+    "Glm5Layer",
+    "Glm5MLP",
+    "Glm5MoE",
+    "Glm5Model",
+    "Glm5Router",
+    "Glm5RoutedExperts",
+    "MLADSA",
+]

--- a/experimental/lite/megatron/lite/model/glm5/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/protocol.py
@@ -1,0 +1,194 @@
+"""GLM-5 native lite protocol for Megatron Lite runtime."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+from types import SimpleNamespace
+
+import torch
+import torch.nn as nn
+
+from megatron.lite.model.glm5.config import Glm5Config
+from megatron.lite.model.glm5.lite.checkpoint import (
+    EXPERT_CLASSIFIER,
+)
+from megatron.lite.model.glm5.lite.checkpoint import (
+    load_hf_weights as _load_hf_weights_impl,
+)
+from megatron.lite.primitive.bundle import ModelBundle
+from megatron.lite.primitive.parallel import ParallelState, init_parallel
+from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec, wrap_checkpoint
+from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
+
+
+MODULE_MAP = {
+    "self_attn": lambda layer: layer.self_attn,
+    "mlp": lambda layer: layer.mlp,
+    "moe": lambda layer: layer.mlp if hasattr(layer.mlp, "dispatcher") else None,
+    "experts": lambda layer: getattr(getattr(layer, "mlp", None), "experts", None),
+    "shared_experts": lambda layer: getattr(getattr(layer, "mlp", None), "shared_experts", None),
+}
+
+
+def is_expert_param(name: str) -> bool:
+    return EXPERT_CLASSIFIER(name)
+
+
+@dataclass(frozen=True)
+class ImplConfig:
+    parallel: ParallelConfig = field(default_factory=ParallelConfig)
+    optimizer: str | None = "mc"
+    hf_path: str = ""
+    deterministic: bool = True
+    recompute: str | list[str] | None = None
+    offload: list[str] = field(default_factory=list)
+    use_deepep: bool = False
+    optimizer_config: OptimizerConfig | None = None
+
+
+def build_model_config(source: str | Path | dict, **overrides) -> Glm5Config:
+    if isinstance(source, dict):
+        cfg = Glm5Config._from_hf_dict(source)
+    else:
+        cfg = Glm5Config.from_hf(str(source))
+    for key, value in overrides.items():
+        if hasattr(cfg, key):
+            setattr(cfg, key, value)
+    return cfg
+
+
+def _forward_step(model: nn.Module, batch: dict) -> dict:
+    kwargs: dict[str, Any] = {
+        "input_ids": batch["input_ids"],
+        "labels": batch.get("labels"),
+    }
+    if kwargs["input_ids"].dim() == 1:
+        kwargs["input_ids"] = kwargs["input_ids"].unsqueeze(0)
+    for key in ("position_ids", "attention_mask"):
+        if key in batch:
+            kwargs[key] = batch[key]
+    return model(**kwargs)
+
+
+def _apply_glm5_recompute(layers: nn.ModuleList, recompute_spec: list[str], ps: ParallelState) -> None:
+    if not recompute_spec:
+        return
+    if "full" not in recompute_spec or ps.ep_size <= 1:
+        apply_recompute(layers, recompute_spec, MODULE_MAP)
+        return
+
+    for layer in layers:
+        wrap_checkpoint(layer, preserve_rng_state=True)
+
+    remaining = [name for name in recompute_spec if name != "full"]
+    if remaining:
+        apply_recompute(layers, remaining, MODULE_MAP)
+
+
+def _validate_parallel_scope(p: ParallelConfig) -> None:
+    etp = 1 if p.etp is None else p.etp
+    if (p.tp, etp, p.vpp) != (1, 1, 1):
+        raise NotImplementedError(
+            "GLM5 native lite currently supports TP=ETP=VPP=1. "
+            "EP/PP/CP are wired through existing Megatron Lite primitives."
+        )
+    if p.ep < 1 or p.pp < 1 or p.cp < 1:
+        raise ValueError(
+            "ParallelConfig ep/pp/cp must be >= 1, "
+            f"got ep={p.ep}, pp={p.pp}, cp={p.cp}."
+        )
+
+
+def build_model(model_cfg: Glm5Config, *, impl_cfg: ImplConfig) -> ModelBundle:
+    from megatron.lite.model.glm5.lite.model import Glm5ForCausalLM
+
+    _validate_parallel_scope(impl_cfg.parallel)
+    ps = init_parallel(impl_cfg.parallel)
+    recompute_spec = parse_recompute_spec(impl_cfg.recompute)
+    train_cfg = SimpleNamespace(use_deepep=impl_cfg.use_deepep)
+    chunk = Glm5ForCausalLM(model_cfg, train_cfg=train_cfg, ps=ps).to(torch.bfloat16).cuda()
+    chunks = [chunk]
+
+    _apply_glm5_recompute(chunk.model.layers, recompute_spec, ps)
+
+    if impl_cfg.offload:
+        from megatron.lite.primitive.recompute import apply_offload
+
+        apply_offload(chunk.model.layers, impl_cfg.offload, MODULE_MAP)
+
+    optimizer = None
+    optimizer_backend = "none"
+    finalize_grads = None
+    post_model_load_hook = None
+    if impl_cfg.optimizer in {"mc", "mc_full"}:
+        optimizer, finalize_grads = _build_mc_optimizer(chunks, model_cfg, impl_cfg, ps)
+        from megatron.lite.runtime.megatron_utils import register_training_hooks
+
+        register_training_hooks(chunks, optimizer)
+        optimizer_backend = "mc_full"
+    elif impl_cfg.optimizer == "fsdp2":
+        optimizer_backend = "fsdp2"
+
+        def _post_model_load_hook():
+            from megatron.lite.model.glm5.lite.model import Glm5Layer
+            from megatron.lite.primitive.optimizers.fsdp2 import (
+                build_fsdp2_training_optimizer,
+            )
+
+            return {
+                "optimizer": build_fsdp2_training_optimizer(
+                    chunks,
+                    impl_cfg.optimizer_config,
+                    ps,
+                    unit_modules=(Glm5Layer,),
+                    expert_classifier=is_expert_param,
+                    deterministic=impl_cfg.deterministic,
+                    vpp=1,
+                    leaf_module_names=(),
+                ),
+            }
+
+        post_model_load_hook = _post_model_load_hook
+    elif impl_cfg.optimizer is not None:
+        raise ValueError(f"Unsupported GLM5 optimizer: {impl_cfg.optimizer!r}")
+
+    return ModelBundle(
+        chunks=chunks,
+        parallel_state=ps,
+        optimizer=optimizer,
+        finalize_grads=finalize_grads,
+        forward_step=_forward_step,
+        extras={
+            "model_cfg": model_cfg,
+            "optimizer_backend": optimizer_backend,
+            "post_model_load_hook": post_model_load_hook,
+        },
+    )
+
+
+def _build_mc_optimizer(chunks, model_cfg, impl_cfg, ps):
+    from megatron.lite.primitive.optimizers.megatron_wrap import (
+        build_mc_training_optimizer,
+    )
+
+    return build_mc_training_optimizer(
+        chunks,
+        model_cfg=model_cfg,
+        impl_cfg=impl_cfg,
+        model_name="glm5",
+        ps=ps,
+        is_expert=is_expert_param,
+        deterministic=impl_cfg.deterministic,
+    )
+
+
+def load_hf_weights(chunk: nn.Module, hf_path: str, model_cfg: Glm5Config, ps: ParallelState) -> None:
+    if not hf_path:
+        return
+    _load_hf_weights_impl(chunk, hf_path, model_cfg, ps)
+
+
+def vocab_size(model_cfg: Glm5Config) -> int | None:
+    return model_cfg.vocab_size

--- a/experimental/lite/megatron/lite/model/registry.py
+++ b/experimental/lite/megatron/lite/model/registry.py
@@ -93,6 +93,13 @@ register_model(
     impls={"lite": "megatron.lite.model.qwen3_5.lite.protocol"},
 )
 
+register_model(
+    "glm5",
+    package="megatron.lite.model.glm5",
+    hf_model_types=["glm_moe_dsa"],
+    impls={"lite": "megatron.lite.model.glm5.lite.protocol"},
+)
+
 
 # ---------------------------------------------------------------------------
 # Lookup functions

--- a/experimental/lite/megatron/lite/primitive/modules/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/modules/__init__.py
@@ -1,26 +1,74 @@
-"""Shared model modules owned by Megatron Lite."""
+"""Shared model modules owned by Megatron Lite.
 
-from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
-from megatron.lite.primitive.modules.experts import Experts
-from megatron.lite.primitive.modules.gated_delta_net import GatedDeltaNet
-from megatron.lite.primitive.modules.gqa import GQAttention, split_grouped_qkvg
-from megatron.lite.primitive.modules.moe import MoEAuxLossAutoScaler, _AllToAll
-from megatron.lite.primitive.modules.mrope import MultimodalRotaryEmbedding
-from megatron.lite.primitive.modules.mtp import MTPBlock, MTPDecoderLayer, MTPLossAutoScaler
-from megatron.lite.primitive.modules.router import SigmoidTopKRouter, TopKRouter
+Exports stay lazy so importing one lightweight primitive does not eagerly import
+optional heavyweight dependencies used by another primitive.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
+    from megatron.lite.primitive.modules.experts import Experts
+    from megatron.lite.primitive.modules.gated_delta_net import GatedDeltaNet
+    from megatron.lite.primitive.modules.gqa import GQAttention, split_grouped_qkvg
+    from megatron.lite.primitive.modules.mla_dsa import (
+        DSAIndexer,
+        MLADSA,
+        RMSNorm,
+        build_rotary_embeddings,
+    )
+    from megatron.lite.primitive.modules.moe import MoEAuxLossAutoScaler, _AllToAll
+    from megatron.lite.primitive.modules.mrope import MultimodalRotaryEmbedding
+    from megatron.lite.primitive.modules.mtp import MTPBlock, MTPDecoderLayer, MTPLossAutoScaler
+    from megatron.lite.primitive.modules.router import SigmoidTopKRouter, TopKRouter
+
+_LAZY_EXPORTS = {
+    "DSAIndexer": "megatron.lite.primitive.modules.mla_dsa",
+    "Experts": "megatron.lite.primitive.modules.experts",
+    "GatedDeltaNet": "megatron.lite.primitive.modules.gated_delta_net",
+    "GQAttention": "megatron.lite.primitive.modules.gqa",
+    "MLADSA": "megatron.lite.primitive.modules.mla_dsa",
+    "MTPBlock": "megatron.lite.primitive.modules.mtp",
+    "MTPDecoderLayer": "megatron.lite.primitive.modules.mtp",
+    "MTPLossAutoScaler": "megatron.lite.primitive.modules.mtp",
+    "MoEAuxLossAutoScaler": "megatron.lite.primitive.modules.moe",
+    "MultimodalRotaryEmbedding": "megatron.lite.primitive.modules.mrope",
+    "RMSNorm": "megatron.lite.primitive.modules.mla_dsa",
+    "SigmoidTopKRouter": "megatron.lite.primitive.modules.router",
+    "TokenDispatcher": "megatron.lite.primitive.modules.dispatcher",
+    "TopKRouter": "megatron.lite.primitive.modules.router",
+    "_AllToAll": "megatron.lite.primitive.modules.moe",
+    "build_rotary_embeddings": "megatron.lite.primitive.modules.mla_dsa",
+    "split_grouped_qkvg": "megatron.lite.primitive.modules.gqa",
+}
+
+
+def __getattr__(name: str):
+    if name in _LAZY_EXPORTS:
+        mod = importlib.import_module(_LAZY_EXPORTS[name])
+        return getattr(mod, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
+    "DSAIndexer",
     "Experts",
     "GatedDeltaNet",
     "GQAttention",
+    "MLADSA",
     "MTPBlock",
     "MTPDecoderLayer",
     "MTPLossAutoScaler",
     "MoEAuxLossAutoScaler",
     "MultimodalRotaryEmbedding",
+    "RMSNorm",
     "SigmoidTopKRouter",
-    "split_grouped_qkvg",
     "TokenDispatcher",
     "TopKRouter",
     "_AllToAll",
+    "build_rotary_embeddings",
+    "split_grouped_qkvg",
 ]

--- a/experimental/lite/megatron/lite/primitive/modules/mla_dsa.py
+++ b/experimental/lite/megatron/lite/primitive/modules/mla_dsa.py
@@ -1,0 +1,516 @@
+"""Multi-head Latent Attention with Dynamic Sparse Attention.
+
+The module is model-agnostic: callers pass architecture dimensions directly and
+keep model config classes out of the primitive layer.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+from megatron.lite.primitive.parallel.cp import zigzag_reconstruct_from_cp_parts, zigzag_slice_for_cp
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, hidden_size: int, eps: float = 1e-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.eps = eps
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        input_dtype = x.dtype
+        y = x.float()
+        y = y * torch.rsqrt(y.pow(2).mean(dim=-1, keepdim=True) + self.eps)
+        return self.weight.to(input_dtype) * y.to(input_dtype)
+
+
+def _hadamard_transform_torch(x: torch.Tensor, scale: float) -> torch.Tensor:
+    n = x.shape[-1]
+    if n <= 0 or n & (n - 1):
+        raise ValueError(f"Hadamard rotation requires power-of-two dim, got {n}")
+    original_shape = x.shape
+    y = x.reshape(-1, n)
+    h = 1
+    while h < n:
+        y = y.reshape(-1, n // (h * 2), h * 2)
+        left = y[..., :h]
+        right = y[..., h:]
+        y = torch.cat([left + right, left - right], dim=-1)
+        h *= 2
+    return y.reshape(original_shape) * scale
+
+
+try:
+    from fast_hadamard_transform import hadamard_transform as _fast_hadamard_transform
+except Exception:  # pragma: no cover - optional CUDA extension
+    _fast_hadamard_transform = None
+
+
+def rotate_activation(x: torch.Tensor) -> torch.Tensor:
+    x = x.to(torch.bfloat16) if x.dtype != torch.bfloat16 else x
+    scale = x.shape[-1] ** -0.5
+    if _fast_hadamard_transform is not None and x.is_cuda:
+        return _fast_hadamard_transform(x, scale=scale)
+    return _hadamard_transform_torch(x, scale=scale)
+
+
+def build_rope_cache(
+    *,
+    dim: int,
+    max_position_embeddings: int,
+    rope_theta: float,
+    device: torch.device | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    inv_freq = 1.0 / (
+        rope_theta ** (torch.arange(0, dim, 2, dtype=torch.float32, device=device) / dim)
+    )
+    positions = torch.arange(max_position_embeddings, dtype=torch.float32, device=device)
+    freqs = torch.outer(positions, inv_freq)
+    return freqs.cos(), freqs.sin()
+
+
+def build_rotary_embeddings(
+    *,
+    position_ids: torch.Tensor,
+    dim: int,
+    rope_theta: float,
+    dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    device = position_ids.device
+    inv_freq = 1.0 / (
+        rope_theta
+        ** (torch.arange(0, dim, 2, dtype=torch.int64, device=device).to(torch.float32) / dim)
+    )
+    inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1)
+    position_ids_expanded = position_ids[:, None, :].float()
+    device_type = device.type if isinstance(device.type, str) and device.type != "mps" else "cpu"
+    with torch.autocast(device_type=device_type, enabled=False):
+        freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
+        emb = torch.cat((freqs, freqs), dim=-1)
+        cos = emb.cos()
+        sin = emb.sin()
+    return cos.to(dtype=dtype), sin.to(dtype=dtype)
+
+
+def rotate_half(x: torch.Tensor) -> torch.Tensor:
+    half = x.shape[-1] // 2
+    x1 = x[..., :half]
+    x2 = x[..., half:]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def apply_rotary_pos_emb(
+    x: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    *,
+    unsqueeze_dim: int,
+) -> torch.Tensor:
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+    return (x * cos) + (rotate_half(x) * sin)
+
+
+def apply_rotary_emb(
+    x: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    position_ids: torch.Tensor,
+    *,
+    interleaved: bool = True,
+) -> torch.Tensor:
+    if position_ids.dim() == 3:
+        position_ids = position_ids[0]
+    if position_ids.dim() == 1:
+        position_ids = position_ids.unsqueeze(0)
+
+    input_dtype = x.dtype
+    x = x.float()
+    cos = cos.to(device=x.device)[position_ids].float().unsqueeze(2)
+    sin = sin.to(device=x.device)[position_ids].float().unsqueeze(2)
+    if interleaved:
+        x_even = x[..., 0::2]
+        x_odd = x[..., 1::2]
+        out = torch.empty_like(x)
+        out[..., 0::2] = x_even * cos - x_odd * sin
+        out[..., 1::2] = x_even * sin + x_odd * cos
+        return out.to(input_dtype)
+
+    half = x.shape[-1] // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat([x1 * cos - x2 * sin, x1 * sin + x2 * cos], dim=-1).to(input_dtype)
+
+
+def _rotary_embeddings_from_cache(
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    position_ids: torch.Tensor,
+    *,
+    device: torch.device,
+    dtype: torch.dtype,
+    dim: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if cos.dim() == 3 and sin.dim() == 3:
+        return cos.to(device=device, dtype=dtype), sin.to(device=device, dtype=dtype)
+
+    if position_ids.dim() == 3:
+        position_ids = position_ids[0]
+    if position_ids.dim() == 1:
+        position_ids = position_ids.unsqueeze(0)
+    cos = cos.to(device=device)[position_ids].float()
+    sin = sin.to(device=device)[position_ids].float()
+    if cos.shape[-1] * 2 == dim:
+        cos = torch.cat((cos, cos), dim=-1)
+        sin = torch.cat((sin, sin), dim=-1)
+    return cos.to(dtype=dtype), sin.to(dtype=dtype)
+
+
+def _all_gather_cp(tensor: torch.Tensor, *, cp_size: int, cp_group) -> list[torch.Tensor]:
+    if cp_size <= 1:
+        return [tensor]
+    if cp_group is None:
+        raise RuntimeError("CP>1 requires a context-parallel process group.")
+    from torch.distributed.nn.functional import all_gather
+
+    return list(all_gather(tensor.contiguous(), group=cp_group))
+
+
+class DSAIndexer(nn.Module):
+    """Compute per-token top-k key indices for Dynamic Sparse Attention."""
+
+    def __init__(
+        self,
+        *,
+        hidden_size: int,
+        q_lora_rank: int,
+        qk_rope_head_dim: int,
+        index_n_heads: int,
+        index_head_dim: int,
+        index_topk: int,
+        rope_interleaved: bool = True,
+        layer_norm_eps: float = 1e-5,
+        rope_first: bool = False,
+        use_hadamard: bool = True,
+    ):
+        super().__init__()
+        if index_head_dim < qk_rope_head_dim:
+            raise ValueError("index_head_dim must be >= qk_rope_head_dim")
+        self.num_heads = index_n_heads
+        self.head_dim = index_head_dim
+        self.qk_rope_head_dim = qk_rope_head_dim
+        self.qk_nope_head_dim = index_head_dim - qk_rope_head_dim
+        self.index_topk = index_topk
+        self.rope_interleaved = rope_interleaved
+        self.rope_first = rope_first
+        self.use_hadamard = use_hadamard
+
+        self.wq_b = nn.Linear(q_lora_rank, index_n_heads * index_head_dim, bias=False)
+        self.wk = nn.Linear(hidden_size, index_head_dim, bias=False)
+        self.k_norm = nn.LayerNorm(index_head_dim, eps=layer_norm_eps)
+        self.weights_proj = nn.Linear(hidden_size, index_n_heads, bias=False)
+        self.softmax_scale = index_head_dim**-0.5
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        q_resid: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        position_ids: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        batch, seq_len, _ = x.shape
+        cos, sin = _rotary_embeddings_from_cache(
+            cos,
+            sin,
+            position_ids,
+            device=x.device,
+            dtype=x.dtype,
+            dim=self.qk_rope_head_dim,
+        )
+
+        q = self.wq_b(q_resid).view(batch, seq_len, self.num_heads, self.head_dim)
+
+        k = self.k_norm(self.wk(x))
+        if self.rope_first:
+            q_pe, q_nope = torch.split(
+                q,
+                [self.qk_rope_head_dim, self.qk_nope_head_dim],
+                dim=-1,
+            )
+            k_pe, k_nope = torch.split(
+                k,
+                [self.qk_rope_head_dim, self.qk_nope_head_dim],
+                dim=-1,
+            )
+        else:
+            q_nope, q_pe = torch.split(
+                q,
+                [self.qk_nope_head_dim, self.qk_rope_head_dim],
+                dim=-1,
+            )
+            k_nope, k_pe = torch.split(
+                k,
+                [self.qk_nope_head_dim, self.qk_rope_head_dim],
+                dim=-1,
+            )
+        q_pe = apply_rotary_pos_emb(q_pe, cos, sin, unsqueeze_dim=2)
+        k_pe = apply_rotary_pos_emb(k_pe.unsqueeze(2), cos, sin, unsqueeze_dim=2)
+        k_pe = k_pe.squeeze(2)
+
+        if self.rope_first:
+            q = torch.cat([q_pe, q_nope], dim=-1)
+            k = torch.cat([k_pe, k_nope], dim=-1)
+        else:
+            q = torch.cat([q_nope, q_pe], dim=-1)
+            k = torch.cat([k_nope, k_pe], dim=-1)
+        if self.use_hadamard:
+            q = rotate_activation(q)
+            k = rotate_activation(k)
+        k = k.unsqueeze(2).expand(batch, seq_len, self.num_heads, self.head_dim)
+
+        scores = torch.einsum("bqhd,bkhd->bhqk", q.float(), k.float()) * self.softmax_scale
+        scores = torch.relu(scores)
+        weights = self.weights_proj(x).float() * (self.num_heads**-0.5)
+        scores = torch.einsum("bhqk,bqh->bqk", scores, weights)
+
+        causal = torch.ones(seq_len, seq_len, dtype=torch.bool, device=x.device).tril()
+        if attention_mask is not None:
+            scores = scores + attention_mask.to(scores.dtype).view(batch, seq_len, seq_len)
+        else:
+            mask_value = torch.finfo(scores.dtype).min
+            scores = scores.masked_fill(~causal.view(1, seq_len, seq_len), mask_value)
+        topk = min(self.index_topk, seq_len)
+        return torch.topk(scores, k=topk, dim=-1).indices
+
+
+class MLADSA(nn.Module):
+    """Correctness-first MLA + DSA attention path."""
+
+    def __init__(
+        self,
+        *,
+        hidden_size: int,
+        num_attention_heads: int,
+        q_lora_rank: int,
+        kv_lora_rank: int,
+        qk_nope_head_dim: int,
+        qk_rope_head_dim: int,
+        v_head_dim: int,
+        index_n_heads: int,
+        index_head_dim: int,
+        index_topk: int,
+        rms_norm_eps: float,
+        rope_interleaved: bool = True,
+        latent_rms_norm_eps: float | None = None,
+        indexer_layer_norm_eps: float = 1e-5,
+        indexer_rope_interleaved: bool | None = None,
+        indexer_rope_first: bool = False,
+        indexer_use_hadamard: bool = True,
+        cp_size: int = 1,
+        cp_rank: int = 0,
+        cp_group=None,
+    ):
+        super().__init__()
+        if cp_size < 1:
+            raise ValueError(f"cp_size must be >= 1, got {cp_size}")
+        if not 0 <= cp_rank < cp_size:
+            raise ValueError(f"cp_rank must be in [0, {cp_size}), got {cp_rank}")
+        self.num_heads = num_attention_heads
+        self.q_lora_rank = q_lora_rank
+        self.kv_lora_rank = kv_lora_rank
+        self.qk_nope_head_dim = qk_nope_head_dim
+        self.qk_rope_head_dim = qk_rope_head_dim
+        self.qk_head_dim = qk_nope_head_dim + qk_rope_head_dim
+        self.v_head_dim = v_head_dim
+        self.rope_interleaved = rope_interleaved
+        self.softmax_scale = self.qk_head_dim**-0.5
+        self.cp_size = cp_size
+        self.cp_rank = cp_rank
+        self.cp_group = cp_group
+        latent_rms_norm_eps = rms_norm_eps if latent_rms_norm_eps is None else latent_rms_norm_eps
+        indexer_rope_interleaved = (
+            rope_interleaved if indexer_rope_interleaved is None else indexer_rope_interleaved
+        )
+
+        self.q_a_proj = nn.Linear(hidden_size, q_lora_rank, bias=False)
+        self.q_a_layernorm = RMSNorm(q_lora_rank, eps=latent_rms_norm_eps)
+        self.q_b_proj = nn.Linear(q_lora_rank, num_attention_heads * self.qk_head_dim, bias=False)
+        self.kv_a_proj_with_mqa = nn.Linear(hidden_size, kv_lora_rank + qk_rope_head_dim, bias=False)
+        self.kv_a_layernorm = RMSNorm(kv_lora_rank, eps=latent_rms_norm_eps)
+        self.kv_b_proj = nn.Linear(kv_lora_rank, num_attention_heads * (qk_nope_head_dim + v_head_dim), bias=False)
+        self.o_proj = nn.Linear(num_attention_heads * v_head_dim, hidden_size, bias=False)
+        self.indexer = DSAIndexer(
+            hidden_size=hidden_size,
+            q_lora_rank=q_lora_rank,
+            qk_rope_head_dim=qk_rope_head_dim,
+            index_n_heads=index_n_heads,
+            index_head_dim=index_head_dim,
+            index_topk=index_topk,
+            rope_interleaved=indexer_rope_interleaved,
+            layer_norm_eps=indexer_layer_norm_eps,
+            rope_first=indexer_rope_first,
+            use_hadamard=indexer_use_hadamard,
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        position_ids: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        cp_restore = False
+        if self.cp_size > 1:
+            x, position_ids, attention_mask = self._gather_cp_inputs(
+                x,
+                position_ids,
+                attention_mask,
+            )
+            cp_restore = True
+
+        batch, seq_len, _ = x.shape
+        q_resid = self.q_a_layernorm(self.q_a_proj(x))
+        topk_indices = self.indexer(x, q_resid, cos, sin, position_ids, attention_mask)
+
+        q = self.q_b_proj(q_resid).view(batch, seq_len, self.num_heads, self.qk_head_dim)
+        q_nope, q_pe = torch.split(q, [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
+        cos, sin = _rotary_embeddings_from_cache(
+            cos,
+            sin,
+            position_ids,
+            device=x.device,
+            dtype=x.dtype,
+            dim=self.qk_rope_head_dim,
+        )
+
+        q_pe = apply_rotary_pos_emb(q_pe, cos, sin, unsqueeze_dim=2)
+        query_states = torch.cat(
+            [q_nope.transpose(1, 2), q_pe.transpose(1, 2)],
+            dim=-1,
+        )
+
+        kv, k_pe = torch.split(
+            self.kv_a_proj_with_mqa(x),
+            [self.kv_lora_rank, self.qk_rope_head_dim],
+            dim=-1,
+        )
+        kv = self.kv_a_layernorm(kv)
+        k_pe = apply_rotary_pos_emb(
+            k_pe.unsqueeze(2),
+            cos,
+            sin,
+            unsqueeze_dim=2,
+        ).squeeze(2)
+
+        kv = self.kv_b_proj(kv).view(
+            batch,
+            seq_len,
+            self.num_heads,
+            self.qk_nope_head_dim + self.v_head_dim,
+        )
+        k_nope, v = torch.split(kv, [self.qk_nope_head_dim, self.v_head_dim], dim=-1)
+        k_pe = k_pe.view(batch, 1, seq_len, self.qk_rope_head_dim)
+        k_pe = k_pe.expand(-1, self.num_heads, -1, -1)
+        key_states = torch.cat([k_nope.transpose(1, 2), k_pe], dim=-1)
+        value_states = v.transpose(1, 2)
+
+        scores = torch.matmul(query_states, key_states.transpose(2, 3)) * self.softmax_scale
+        index_mask = torch.full(
+            (batch, seq_len, seq_len),
+            float("-inf"),
+            device=x.device,
+            dtype=query_states.dtype,
+        )
+        index_mask.scatter_(-1, topk_indices, 0.0)
+        index_mask = index_mask.unsqueeze(1)
+        if attention_mask is not None:
+            scores = scores + index_mask + attention_mask.to(scores.dtype).view(batch, 1, seq_len, seq_len)
+        else:
+            causal = torch.full(
+                (seq_len, seq_len),
+                torch.finfo(query_states.dtype).min,
+                device=x.device,
+                dtype=query_states.dtype,
+            )
+            causal = torch.triu(causal, diagonal=1).view(1, 1, seq_len, seq_len)
+            scores = scores + index_mask + causal
+
+        probs = torch.softmax(scores, dim=-1, dtype=torch.float32).to(query_states.dtype)
+        out = torch.matmul(probs, value_states)
+        out = out.transpose(1, 2).contiguous()
+        out = out.reshape(batch, seq_len, self.num_heads * self.v_head_dim)
+        if cp_restore:
+            out = zigzag_slice_for_cp(out, self.cp_rank, self.cp_size, seq_dim=1)
+        return self.o_proj(out)
+
+    def _gather_cp_inputs(
+        self,
+        x: torch.Tensor,
+        position_ids: torch.Tensor,
+        attention_mask: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        local_batch, local_seq = x.shape[:2]
+        x_parts = _all_gather_cp(x, cp_size=self.cp_size, cp_group=self.cp_group)
+        full_x = zigzag_reconstruct_from_cp_parts(x_parts, seq_dim=1)
+        full_seq = full_x.shape[1]
+
+        full_position_ids = self._full_cp_position_ids(
+            position_ids,
+            batch=local_batch,
+            local_seq=local_seq,
+            full_seq=full_seq,
+            device=x.device,
+        )
+        if attention_mask is not None:
+            expected = (full_seq, full_seq)
+            if tuple(attention_mask.shape[-2:]) != expected:
+                raise NotImplementedError(
+                    "GLM5 MLADSA CP attention_mask must already cover the reconstructed "
+                    f"full sequence {expected}, got {tuple(attention_mask.shape)}."
+                )
+        return full_x, full_position_ids, attention_mask
+
+    def _full_cp_position_ids(
+        self,
+        position_ids: torch.Tensor,
+        *,
+        batch: int,
+        local_seq: int,
+        full_seq: int,
+        device: torch.device,
+    ) -> torch.Tensor:
+        if position_ids.dim() == 3:
+            position_ids = position_ids[0]
+        if position_ids.dim() == 1:
+            position_ids = position_ids.unsqueeze(0).expand(batch, -1)
+        if position_ids.shape[-1] == full_seq:
+            return position_ids.to(device=device, dtype=torch.long)
+        if position_ids.shape[-1] != local_seq:
+            raise ValueError(
+                "GLM5 MLADSA CP position_ids must be either local or full sequence length, "
+                f"got {tuple(position_ids.shape)} for local_seq={local_seq}, full_seq={full_seq}."
+            )
+
+        pos_parts = _all_gather_cp(
+            position_ids.to(device=device, dtype=torch.long),
+            cp_size=self.cp_size,
+            cp_group=self.cp_group,
+        )
+        return zigzag_reconstruct_from_cp_parts(pos_parts, seq_dim=1)
+
+
+__all__ = [
+    "DSAIndexer",
+    "MLADSA",
+    "RMSNorm",
+    "apply_rotary_emb",
+    "apply_rotary_pos_emb",
+    "build_rope_cache",
+    "build_rotary_embeddings",
+    "rotate_activation",
+    "rotate_half",
+]

--- a/experimental/lite/tests/unit/model/test_glm5_lite_cp_smoke.py
+++ b/experimental/lite/tests/unit/model/test_glm5_lite_cp_smoke.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import pytest
+
+
+def _init_dist_or_skip():
+    import os
+
+    import torch
+    import torch.distributed as dist
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for GLM5 CP smoke.")
+    if "RANK" not in os.environ or "WORLD_SIZE" not in os.environ:
+        pytest.skip("Run with torchrun so CP ranks are available.")
+
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    torch.cuda.set_device(local_rank)
+    if not dist.is_initialized():
+        dist.init_process_group("nccl")
+    if dist.get_world_size() < 2:
+        pytest.skip("GLM5 CP smoke requires at least 2 ranks.")
+    return torch.device("cuda", local_rank)
+
+
+def _tiny_config_kwargs():
+    return dict(
+        num_hidden_layers=2,
+        hidden_size=16,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        head_dim=4,
+        vocab_size=32,
+        max_position_embeddings=32,
+        q_lora_rank=8,
+        kv_lora_rank=4,
+        qk_head_dim=8,
+        qk_nope_head_dim=4,
+        qk_rope_head_dim=4,
+        v_head_dim=4,
+        index_head_dim=8,
+        index_n_heads=2,
+        index_topk=2,
+        intermediate_size=20,
+        moe_intermediate_size=6,
+        first_k_dense_replace=1,
+        n_routed_experts=3,
+        n_shared_experts=1,
+        num_experts_per_tok=3,
+    )
+
+
+def _make_mla_dsa(*, cp_size: int = 1, cp_rank: int = 0, cp_group=None):
+    from megatron.lite.primitive.modules.mla_dsa import MLADSA
+
+    return MLADSA(
+        hidden_size=16,
+        num_attention_heads=2,
+        q_lora_rank=8,
+        kv_lora_rank=4,
+        qk_nope_head_dim=4,
+        qk_rope_head_dim=4,
+        v_head_dim=4,
+        index_n_heads=2,
+        index_head_dim=8,
+        index_topk=2,
+        rms_norm_eps=1e-5,
+        cp_size=cp_size,
+        cp_rank=cp_rank,
+        cp_group=cp_group,
+    )
+
+
+@pytest.mark.gpu
+def test_glm5_mla_dsa_cp2_matches_full_sequence_reference_forward_and_grad():
+    import torch
+    import torch.distributed as dist
+
+    from megatron.lite.primitive.modules.mla_dsa import build_rope_cache
+    from megatron.lite.primitive.parallel.cp import (
+        zigzag_position_ids_for_cp,
+        zigzag_slice_for_cp,
+    )
+    from megatron.lite.primitive.parallel.state import ParallelState
+
+    device = _init_dist_or_skip()
+    world = dist.get_world_size()
+    rank = dist.get_rank()
+    ps = ParallelState(cp_group=dist.group.WORLD, cp_size=world, cp_rank=rank)
+
+    torch.manual_seed(2026)
+    cp_attn = _make_mla_dsa(cp_size=world, cp_rank=rank, cp_group=ps.cp_group).to(
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    torch.manual_seed(2026)
+    ref_attn = _make_mla_dsa().to(device=device, dtype=torch.bfloat16)
+
+    batch, seq = 1, 8 * world
+    torch.manual_seed(99)
+    full_x = torch.randn(batch, seq, 16, device=device, dtype=torch.bfloat16)
+    local_x = zigzag_slice_for_cp(full_x, rank, world, seq_dim=1).detach().requires_grad_(True)
+    ref_x = full_x.detach().clone().requires_grad_(True)
+
+    cos, sin = build_rope_cache(
+        dim=4,
+        max_position_embeddings=seq,
+        rope_theta=1_000_000.0,
+        device=device,
+    )
+    local_pos = zigzag_position_ids_for_cp(seq, rank, world, device).expand(batch, -1)
+    full_pos = torch.arange(seq, device=device, dtype=torch.long).unsqueeze(0).expand(batch, -1)
+
+    cp_out = cp_attn(local_x, cos=cos, sin=sin, position_ids=local_pos)
+    ref_out = ref_attn(ref_x, cos=cos, sin=sin, position_ids=full_pos)
+    expected = zigzag_slice_for_cp(ref_out, rank, world, seq_dim=1)
+    torch.testing.assert_close(cp_out, expected, atol=3e-2, rtol=3e-2)
+
+    cp_out.float().sum().backward()
+    ref_out.float().sum().backward()
+    expected_grad = zigzag_slice_for_cp(ref_x.grad, rank, world, seq_dim=1)
+    assert local_x.grad is not None
+    torch.testing.assert_close(local_x.grad, expected_grad, atol=8e-2, rtol=8e-2)
+
+
+@pytest.mark.gpu
+def test_glm5_tiny_model_cp2_matches_full_sequence_reference_forward():
+    import torch
+    import torch.distributed as dist
+
+    from megatron.lite.model.glm5.config import Glm5Config
+    from megatron.lite.model.glm5.lite.model import Glm5ForCausalLM
+    from megatron.lite.primitive.parallel.cp import zigzag_slice_for_cp
+    from megatron.lite.primitive.parallel.state import ParallelState
+
+    device = _init_dist_or_skip()
+    world = dist.get_world_size()
+    rank = dist.get_rank()
+    cfg = Glm5Config(**_tiny_config_kwargs())
+    cfg.mlp_layer_types = ["dense", "dense"]
+    ps = ParallelState(cp_group=dist.group.WORLD, cp_size=world, cp_rank=rank)
+
+    torch.manual_seed(777)
+    cp_model = Glm5ForCausalLM(cfg, ps=ps).to(device=device, dtype=torch.bfloat16)
+    torch.manual_seed(777)
+    ref_model = Glm5ForCausalLM(cfg, ps=ParallelState()).to(device=device, dtype=torch.bfloat16)
+    cp_model.eval()
+    ref_model.eval()
+
+    batch, seq = 1, 8 * world
+    torch.manual_seed(100)
+    full_hidden = torch.randn(batch, seq, cfg.hidden_size, device=device, dtype=torch.bfloat16)
+    local_hidden = zigzag_slice_for_cp(full_hidden, rank, world, seq_dim=1).contiguous()
+
+    with torch.no_grad():
+        cp_hidden = cp_model(hidden_states=local_hidden)["hidden_states"]
+        ref_hidden = ref_model(hidden_states=full_hidden)["hidden_states"]
+    expected = zigzag_slice_for_cp(ref_hidden, rank, world, seq_dim=1)
+
+    torch.testing.assert_close(cp_hidden, expected, atol=1e-1, rtol=1e-1)
+
+
+@pytest.mark.gpu
+def test_glm5_tiny_model_cp2_forward_backward_smoke():
+    import torch
+    import torch.distributed as dist
+
+    from megatron.lite.model.glm5.config import Glm5Config
+    from megatron.lite.model.glm5.lite.model import Glm5ForCausalLM
+    from megatron.lite.primitive.parallel.cp import zigzag_slice_for_cp
+    from megatron.lite.primitive.parallel.state import ParallelState
+
+    device = _init_dist_or_skip()
+    world = dist.get_world_size()
+    rank = dist.get_rank()
+    cfg = Glm5Config(**_tiny_config_kwargs())
+    ps = ParallelState(cp_group=dist.group.WORLD, cp_size=world, cp_rank=rank)
+
+    torch.manual_seed(1234)
+    model = Glm5ForCausalLM(cfg, ps=ps).to(device=device, dtype=torch.bfloat16)
+
+    batch, seq = 1, 8 * world
+    torch.manual_seed(55)
+    full_ids = torch.randint(0, cfg.vocab_size, (batch, seq), device=device)
+    full_labels = torch.randint(0, cfg.vocab_size, (batch, seq), device=device)
+    input_ids = zigzag_slice_for_cp(full_ids, rank, world, seq_dim=1).contiguous()
+    labels = zigzag_slice_for_cp(full_labels, rank, world, seq_dim=1).contiguous()
+
+    output = model(input_ids=input_ids, labels=labels)
+    assert output["hidden_states"].shape == (batch, seq // world, cfg.hidden_size)
+    assert output["loss"].ndim == 0
+    output["loss"].backward()
+
+    grad_norm = torch.zeros((), device=device)
+    for param in model.parameters():
+        if param.grad is not None:
+            grad_norm = grad_norm + param.grad.detach().float().norm()
+    assert torch.isfinite(grad_norm)

--- a/experimental/lite/tests/unit/model/test_glm5_lite_static.py
+++ b/experimental/lite/tests/unit/model/test_glm5_lite_static.py
@@ -1,0 +1,286 @@
+"""Static and CPU smoke tests for native GLM-5 lite."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _tiny_config_kwargs():
+    return dict(
+        num_hidden_layers=2,
+        hidden_size=16,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        head_dim=4,
+        vocab_size=32,
+        max_position_embeddings=16,
+        q_lora_rank=8,
+        kv_lora_rank=4,
+        qk_head_dim=8,
+        qk_nope_head_dim=4,
+        qk_rope_head_dim=4,
+        v_head_dim=4,
+        index_head_dim=8,
+        index_n_heads=2,
+        index_topk=2,
+        intermediate_size=20,
+        moe_intermediate_size=6,
+        first_k_dense_replace=1,
+        n_routed_experts=3,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+    )
+
+
+def test_glm5_registry_resolves_lite():
+    from megatron.lite.model.registry import (
+        get_train_runtime_module,
+        resolve_model_type_from_hf,
+        resolve_runtime_model_name,
+    )
+
+    runtime_name = resolve_runtime_model_name("glm5", "lite")
+    assert runtime_name == "glm5"
+    module = get_train_runtime_module(runtime_name)
+    assert module.__name__ == "megatron.lite.model.glm5.lite.protocol"
+    assert resolve_model_type_from_hf({"model_type": "glm_moe_dsa"}) == "glm5"
+
+
+def test_glm5_config_reads_hf_architecture_fields():
+    from megatron.lite.model.glm5.config import Glm5Config
+
+    cfg = Glm5Config._from_hf_dict(
+        {
+            "model_type": "glm_moe_dsa",
+            "hidden_size": 6144,
+            "num_hidden_layers": 78,
+            "num_attention_heads": 64,
+            "num_key_value_heads": 64,
+            "q_lora_rank": 2048,
+            "kv_lora_rank": 512,
+            "qk_head_dim": 256,
+            "qk_nope_head_dim": 192,
+            "qk_rope_head_dim": 64,
+            "v_head_dim": 256,
+            "index_head_dim": 128,
+            "index_n_heads": 32,
+            "index_topk": 2048,
+            "first_k_dense_replace": 3,
+            "n_routed_experts": 256,
+            "n_shared_experts": 1,
+            "num_experts_per_tok": 8,
+            "vocab_size": 154880,
+            "rope_parameters": {"rope_theta": 1000000, "rope_type": "default"},
+        }
+    )
+
+    assert cfg.q_lora_rank == 2048
+    assert cfg.kv_lora_rank == 512
+    assert cfg.index_topk == 2048
+    assert cfg.rope_theta == 1_000_000.0
+    assert cfg.is_moe_layer(2) is False
+    assert cfg.is_moe_layer(3) is True
+
+
+def test_glm5_config_ignores_null_hf_optional_fields():
+    from megatron.lite.model.glm5.config import Glm5Config
+
+    cfg = Glm5Config._from_hf_dict(
+        {
+            "model_type": "glm_moe_dsa",
+            "indexer_rope_first": None,
+            "indexer_use_hadamard": None,
+            "mlp_layer_types": None,
+        }
+    )
+
+    assert cfg.indexer_rope_first is True
+    assert cfg.indexer_use_hadamard is False
+    assert cfg.mlp_layer_types is None
+
+
+def test_glm5_lite_does_not_import_wrappers_or_sibling_models():
+    root = Path(__file__).resolve().parents[3] / "megatron" / "lite" / "model" / "glm5" / "lite"
+    for path in root.glob("*.py"):
+        text = path.read_text()
+        assert "megatron.lite.model.qwen" not in text
+        assert "mbridge" not in text
+        assert "MCore" not in text
+        assert "megatron.core" not in text
+
+
+def test_glm5_lite_uses_primitive_mla_dsa():
+    root = Path(__file__).resolve().parents[3] / "megatron" / "lite"
+    model_text = (root / "model" / "glm5" / "lite" / "model.py").read_text()
+    primitive_text = (root / "primitive" / "modules" / "mla_dsa.py").read_text()
+
+    assert "from megatron.lite.primitive.modules.mla_dsa import MLADSA" in model_text
+    assert "class MLADSA" in primitive_text
+    assert "class DSAIndexer" in primitive_text
+
+
+def test_glm5_lite_model_exports_hf_style_state_names():
+    from megatron.lite.model.glm5.config import Glm5Config
+    from megatron.lite.model.glm5.lite.model import Glm5ForCausalLM
+
+    model = Glm5ForCausalLM(Glm5Config(**_tiny_config_kwargs()))
+    keys = set(model.state_dict())
+
+    assert "model.embed_tokens.weight" in keys
+    assert "model.layers.0.self_attn.q_a_proj.weight" in keys
+    assert "model.layers.0.mlp.gate_proj.weight" in keys
+    assert "model.layers.1.mlp.gate.weight" in keys
+    assert "model.layers.1.mlp.experts.0.gate_proj.weight" in keys
+    assert "model.layers.1.mlp.shared_experts.gate_proj.weight" in keys
+    assert "lm_head.weight" in keys
+
+
+def test_glm5_hf_loader_resolves_grouped_expert_tensors():
+    import torch
+
+    from megatron.lite.model.glm5.lite.checkpoint import _resolve_hf_tensor
+
+    class FakeReader:
+        def __init__(self, tensors):
+            self.tensors = tensors
+            self.index = {name: "model.safetensors" for name in tensors}
+
+        def get_tensor(self, name):
+            return self.tensors[name]
+
+    hf_gate_up = torch.arange(3 * 12 * 16, dtype=torch.float32).reshape(3, 12, 16)
+    hf_down = torch.arange(3 * 16 * 6, dtype=torch.float32).reshape(3, 16, 6)
+    hf_reader = FakeReader(
+        {
+            "model.layers.1.mlp.experts.gate_up_proj": hf_gate_up,
+            "model.layers.1.mlp.experts.down_proj": hf_down,
+        }
+    )
+
+    gate_target = torch.empty(6, 16)
+    down_target = torch.empty(16, 6)
+    assert torch.equal(
+        _resolve_hf_tensor(
+            hf_reader,
+            "model.layers.1.mlp.experts.2.gate_proj.weight",
+            gate_target,
+        ),
+        hf_gate_up[2, :6, :],
+    )
+    assert torch.equal(
+        _resolve_hf_tensor(
+            hf_reader,
+            "model.layers.1.mlp.experts.2.up_proj.weight",
+            gate_target,
+        ),
+        hf_gate_up[2, 6:, :],
+    )
+    assert torch.equal(
+        _resolve_hf_tensor(
+            hf_reader,
+            "model.layers.1.mlp.experts.2.down_proj.weight",
+            down_target,
+        ),
+        hf_down[2],
+    )
+
+    automodel_gate_up = torch.arange(3 * 16 * 12, dtype=torch.float32).reshape(3, 16, 12)
+    automodel_down = torch.arange(3 * 6 * 16, dtype=torch.float32).reshape(3, 6, 16)
+    automodel_reader = FakeReader(
+        {
+            "model.layers.1.mlp.experts.gate_and_up_projs": automodel_gate_up,
+            "model.layers.1.mlp.experts.down_projs": automodel_down,
+        }
+    )
+    assert torch.equal(
+        _resolve_hf_tensor(
+            automodel_reader,
+            "model.layers.1.mlp.experts.1.gate_proj.weight",
+            gate_target,
+        ),
+        automodel_gate_up[1, :, :6].T,
+    )
+    assert torch.equal(
+        _resolve_hf_tensor(
+            automodel_reader,
+            "model.layers.1.mlp.experts.1.up_proj.weight",
+            gate_target,
+        ),
+        automodel_gate_up[1, :, 6:].T,
+    )
+    assert torch.equal(
+        _resolve_hf_tensor(
+            automodel_reader,
+            "model.layers.1.mlp.experts.1.down_proj.weight",
+            down_target,
+        ),
+        automodel_down[1].T,
+    )
+
+
+def test_glm5_hf_loader_slices_full_expert_tensors_for_proxy_targets():
+    import torch
+
+    from megatron.lite.model.glm5.lite.checkpoint import _slice_to_target_shape
+
+    source = torch.arange(256 * 8, dtype=torch.float32).reshape(256, 8)
+    target = torch.empty(4, 8)
+    assert torch.equal(_slice_to_target_shape(source, target), source[:4])
+
+    source3d = torch.arange(256 * 6 * 8, dtype=torch.float32).reshape(256, 6, 8)
+    target3d = torch.empty(4, 6, 8)
+    assert torch.equal(_slice_to_target_shape(source3d, target3d), source3d[:4])
+
+
+def test_glm5_protocol_allows_cp_only_parallel_scope():
+    import pytest
+
+    from megatron.lite.model.glm5.lite.protocol import _validate_parallel_scope
+    from megatron.lite.runtime.contracts import ParallelConfig
+
+    _validate_parallel_scope(ParallelConfig(tp=1, ep=1, etp=1, cp=2, pp=1, vpp=1))
+    with pytest.raises(NotImplementedError):
+        _validate_parallel_scope(ParallelConfig(tp=2, ep=1, etp=1, cp=1, pp=1, vpp=1))
+
+
+def test_glm5_protocol_uses_mlite_optimizer_api():
+    from megatron.lite.model.glm5.lite.protocol import ImplConfig
+
+    protocol_path = (
+        Path(__file__).resolve().parents[3]
+        / "megatron"
+        / "lite"
+        / "model"
+        / "glm5"
+        / "lite"
+        / "protocol.py"
+    )
+    protocol_text = protocol_path.read_text()
+
+    assert ImplConfig().optimizer == "mc"
+    assert "build_mc_training_optimizer" in protocol_text
+    assert "build_mc_full_stack" not in protocol_text
+
+
+def test_glm5_lite_tiny_cpu_forward_backward():
+    import torch
+
+    from megatron.lite.model.glm5.config import Glm5Config
+    from megatron.lite.model.glm5.lite.model import Glm5ForCausalLM
+
+    torch.manual_seed(1234)
+    model = Glm5ForCausalLM(Glm5Config(**_tiny_config_kwargs()))
+    input_ids = torch.randint(0, model.config.vocab_size, (2, 5))
+    labels = torch.randint(0, model.config.vocab_size, (2, 5))
+
+    output = model(input_ids=input_ids, labels=labels)
+
+    assert output["hidden_states"].shape == (2, 5, model.config.hidden_size)
+    assert output["loss"].ndim == 0
+    output["loss"].backward()
+    grad_norm = sum(
+        param.grad.detach().float().norm()
+        for param in model.parameters()
+        if param.grad is not None
+    )
+    assert torch.isfinite(grad_norm)

--- a/experimental/lite/tests/unit/primitive/test_cp_zigzag.py
+++ b/experimental/lite/tests/unit/primitive/test_cp_zigzag.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import torch
+
+from megatron.lite.primitive.parallel.cp import (
+    zigzag_reconstruct_from_cp_parts,
+    zigzag_slice_for_cp,
+    zigzag_split_for_cp,
+)
+
+
+def test_dense_zigzag_split_reconstruct_roundtrip_with_grad():
+    cp_size = 4
+    full = torch.arange(2 * 32 * 3, dtype=torch.float32).reshape(2, 32, 3)
+    full.requires_grad_()
+
+    parts = [zigzag_slice_for_cp(full, rank, cp_size, seq_dim=1) for rank in range(cp_size)]
+    split_parts = [zigzag_split_for_cp(full, rank, cp_size, seq_dim=1) for rank in range(cp_size)]
+
+    for got, expected in zip(parts, split_parts, strict=True):
+        assert torch.equal(got, expected)
+
+    reconstructed = zigzag_reconstruct_from_cp_parts(parts, seq_dim=1)
+    assert torch.equal(reconstructed, full)
+
+    reconstructed.square().sum().backward()
+    assert torch.equal(full.grad, 2 * full.detach())


### PR DESCRIPTION
Adds GLM5 as a native lite model in experimental/lite/megatron/lite: config, model, checkpoint (HF weight mapping), protocol, and the MLA/DSA primitive; registered in the lite model registry. Unit tests: static construction + weight mapping + CP zigzag/smoke. CPU/static smoke passes locally.