### PR TITLE
Add Kimi K2 native lite model support

### DIFF
--- a/experimental/lite/megatron/lite/model/kimi_k2/__init__.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/__init__.py
@@ -1,0 +1,1 @@
+"""Kimi K2 model package."""

--- a/experimental/lite/megatron/lite/model/kimi_k2/config.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/config.py
@@ -1,0 +1,169 @@
+"""Kimi K2 / DeepSeekV3-style model configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from megatron.lite.primitive.config import load_hf_config_dict
+
+_HF_FIELDS = frozenset(
+    {
+        "num_hidden_layers",
+        "hidden_size",
+        "num_attention_heads",
+        "num_key_value_heads",
+        "vocab_size",
+        "rms_norm_eps",
+        "max_position_embeddings",
+        "intermediate_size",
+        "moe_intermediate_size",
+        "n_routed_experts",
+        "n_shared_experts",
+        "num_experts_per_tok",
+        "n_group",
+        "topk_group",
+        "topk_method",
+        "norm_topk_prob",
+        "scoring_func",
+        "seq_aux",
+        "first_k_dense_replace",
+        "moe_layer_freq",
+        "aux_loss_alpha",
+        "routed_scaling_factor",
+        "q_lora_rank",
+        "kv_lora_rank",
+        "qk_nope_head_dim",
+        "qk_rope_head_dim",
+        "v_head_dim",
+        "rope_theta",
+        "rope_scaling",
+        "tie_word_embeddings",
+        "num_nextn_predict_layers",
+    }
+)
+
+
+@dataclass
+class KimiK2Config:
+    """Pure architecture parameters for Kimi K2 Instruct."""
+
+    num_hidden_layers: int = 61
+    hidden_size: int = 7168
+    num_attention_heads: int = 64
+    num_key_value_heads: int = 64
+    vocab_size: int = 163840
+    rms_norm_eps: float = 1e-6
+    max_position_embeddings: int = 131072
+    intermediate_size: int = 18432
+    moe_intermediate_size: int = 2048
+    n_routed_experts: int = 384
+    n_shared_experts: int = 1
+    num_experts_per_tok: int = 8
+    n_group: int | None = 1
+    topk_group: int | None = 1
+    topk_method: str = "noaux_tc"
+    norm_topk_prob: bool = True
+    scoring_func: str = "sigmoid"
+    seq_aux: bool = True
+    first_k_dense_replace: int = 1
+    moe_layer_freq: int = 1
+    aux_loss_alpha: float = 0.001
+    routed_scaling_factor: float = 2.827
+    q_lora_rank: int = 1536
+    kv_lora_rank: int = 512
+    qk_nope_head_dim: int = 128
+    qk_rope_head_dim: int = 64
+    v_head_dim: int = 128
+    rope_theta: float = 50_000.0
+    rope_scaling: dict = field(
+        default_factory=lambda: {
+            "type": "yarn",
+            "factor": 32.0,
+            "original_max_position_embeddings": 4096,
+            "beta_fast": 1.0,
+            "beta_slow": 1.0,
+            "mscale": 1.0,
+            "mscale_all_dim": 1.0,
+        }
+    )
+    tie_word_embeddings: bool = False
+    num_nextn_predict_layers: int = 0
+
+    @property
+    def num_experts(self) -> int:
+        return self.n_routed_experts
+
+    @property
+    def shared_expert_intermediate_size(self) -> int:
+        return self.moe_intermediate_size * self.n_shared_experts
+
+    @property
+    def q_head_dim(self) -> int:
+        return self.qk_nope_head_dim + self.qk_rope_head_dim
+
+    def __post_init__(self) -> None:
+        errors: list[str] = []
+
+        def _check(cond: bool, msg: str) -> None:
+            if not cond:
+                errors.append(msg)
+
+        _check(self.num_hidden_layers >= 1, "num_hidden_layers must be >= 1")
+        _check(self.hidden_size > 0, "hidden_size must be > 0")
+        _check(self.num_attention_heads >= 1, "num_attention_heads must be >= 1")
+        _check(
+            self.num_attention_heads % self.num_key_value_heads == 0,
+            "num_attention_heads must be divisible by num_key_value_heads",
+        )
+        _check(self.q_lora_rank > 0, "q_lora_rank must be > 0")
+        _check(self.kv_lora_rank > 0, "kv_lora_rank must be > 0")
+        _check(self.qk_nope_head_dim > 0, "qk_nope_head_dim must be > 0")
+        _check(self.qk_rope_head_dim > 0, "qk_rope_head_dim must be > 0")
+        _check(self.v_head_dim > 0, "v_head_dim must be > 0")
+        _check(self.n_routed_experts >= 1, "n_routed_experts must be >= 1")
+        _check(
+            1 <= self.num_experts_per_tok <= self.n_routed_experts,
+            "num_experts_per_tok must be in [1, n_routed_experts]",
+        )
+        if self.n_group is not None or self.topk_group is not None:
+            _check(
+                self.n_group is not None and self.topk_group is not None,
+                "n_group and topk_group must be set together",
+            )
+            if self.n_group is not None and self.topk_group is not None:
+                _check(self.n_group >= 1, "n_group must be >= 1")
+                _check(1 <= self.topk_group <= self.n_group, "topk_group must be in [1, n_group]")
+                _check(
+                    self.n_routed_experts % self.n_group == 0,
+                    "n_routed_experts must be divisible by n_group",
+                )
+        _check(0 <= self.first_k_dense_replace <= self.num_hidden_layers, "bad dense prefix")
+        if errors:
+            raise ValueError("Invalid KimiK2Config:\n  " + "\n  ".join(errors))
+
+    @classmethod
+    def from_hf(cls, path: str, **overrides) -> KimiK2Config:
+        return cls._from_hf_dict(load_hf_config_dict(path), **overrides)
+
+    @classmethod
+    def from_hf_config(cls, hf_config, **overrides) -> KimiK2Config:
+        return cls._from_hf_dict(hf_config.to_dict(), **overrides)
+
+    @classmethod
+    def _from_hf_dict(cls, hf: dict, **overrides) -> KimiK2Config:
+        if "text_config" in hf and isinstance(hf["text_config"], dict):
+            hf = hf["text_config"]
+        kwargs = {k: v for k, v in hf.items() if k in _HF_FIELDS}
+        if "rope_scaling" in kwargs and kwargs["rope_scaling"] is None:
+            kwargs.pop("rope_scaling")
+        kwargs.update(overrides)
+        return cls(**kwargs)
+
+    def is_moe_layer(self, layer_idx: int) -> bool:
+        if layer_idx < self.first_k_dense_replace:
+            return False
+        freq = int(self.moe_layer_freq or 1)
+        return (layer_idx - self.first_k_dense_replace) % freq == 0
+
+
+__all__ = ["KimiK2Config"]

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/__init__.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/__init__.py
@@ -1,0 +1,1 @@
+"""Kimi K2 lite native sub-package."""

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/checkpoint.py
@@ -1,0 +1,375 @@
+"""Kimi K2 lite native checkpoint mapping."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+from torch.distributed.tensor import Replicate, Shard
+
+from megatron.lite.model.kimi_k2.config import KimiK2Config
+from megatron.lite.primitive.ckpt.hf_weights import SafeTensorReader, unwrap_model
+from megatron.lite.primitive.parallel import ParallelState
+from megatron.lite.primitive.utils import ensure_divisible, log_rank0
+
+
+def EXPERT_CLASSIFIER(name: str) -> bool:
+    return "experts" in name and "router" not in name and "shared" not in name
+
+
+def PLACEMENT_FN(param_name: str) -> list:
+    if "experts" in param_name and "router" not in param_name and "shared" not in param_name:
+        if "fc1" in param_name:
+            return [Replicate(), Replicate(), Shard(0), Shard(0)]
+        if "fc2" in param_name:
+            return [Replicate(), Replicate(), Shard(0), Shard(1)]
+        return [Replicate(), Replicate(), Replicate(), Replicate()]
+    if "linear_q_up_proj.linear.weight" in param_name:
+        return [Replicate(), Replicate(), Replicate(), Shard(0)]
+    if "linear_kv_up_proj.linear.weight" in param_name:
+        return [Replicate(), Replicate(), Replicate(), Shard(0)]
+    if "linear_proj.linear.weight" in param_name:
+        return [Replicate(), Replicate(), Replicate(), Shard(1)]
+    if "gate_up" in param_name:
+        return [Replicate(), Replicate(), Replicate(), Shard(0)]
+    if "down" in param_name:
+        return [Replicate(), Replicate(), Replicate(), Shard(1)]
+    if "embed" in param_name or "head" in param_name:
+        return [Replicate(), Replicate(), Replicate(), Shard(0)]
+    return [Replicate(), Replicate(), Replicate(), Replicate()]
+
+
+def _tp(tensor: torch.Tensor, rank: int, size: int, dim: int = 0) -> torch.Tensor:
+    return tensor if size <= 1 else tensor.chunk(size, dim=dim)[rank].contiguous()
+
+
+def _split_gate_up(tensor: torch.Tensor, rank: int, size: int) -> torch.Tensor:
+    if size <= 1:
+        return tensor
+    ffn = tensor.shape[0] // 2
+    gate = tensor[:ffn].chunk(size, dim=0)[rank]
+    up = tensor[ffn:].chunk(size, dim=0)[rank]
+    return torch.cat([gate, up], dim=0).contiguous()
+
+
+def _has(reader: SafeTensorReader, name: str) -> bool:
+    if reader.index:
+        return name in reader.index
+    try:
+        reader.get_tensor(name)
+    except Exception:
+        return False
+    return True
+
+
+def _dequant_fp8_weight(reader: SafeTensorReader, name: str, weight: torch.Tensor) -> torch.Tensor:
+    scale_name = f"{name}_scale_inv"
+    if weight.dim() != 2 or weight.element_size() != 1 or not _has(reader, scale_name):
+        return weight
+    scale = reader.get_tensor(scale_name).float()
+    rows, cols = weight.shape
+    expanded = scale.repeat_interleave(128, dim=0).repeat_interleave(128, dim=1)
+    expanded = expanded[:rows, :cols]
+    return weight.float() * expanded
+
+
+def _unpack_int4_from_int32(packed: torch.Tensor, shape: torch.Size) -> torch.Tensor:
+    if packed.dtype != torch.int32:
+        raise ValueError(f"Expected packed int4 tensor to be int32, got {packed.dtype}.")
+    pack_factor = 8
+    mask = 0xF
+    rows, cols = int(shape[0]), int(shape[1])
+    unpacked = torch.empty((packed.shape[0], packed.shape[1] * pack_factor), dtype=torch.int32)
+    for offset in range(pack_factor):
+        unpacked[:, offset::pack_factor] = (packed >> (4 * offset)) & mask
+    return (unpacked[:rows, :cols] - 8).to(torch.int8)
+
+
+def _dequant_int4_weight(reader: SafeTensorReader, name: str) -> torch.Tensor:
+    packed = reader.get_tensor(f"{name}_packed")
+    scale = reader.get_tensor(f"{name}_scale")
+    shape_tensor = reader.get_tensor(f"{name}_shape")
+    shape = torch.Size(int(x) for x in shape_tensor.tolist())
+
+    unpacked = _unpack_int4_from_int32(packed, shape).to(scale.dtype)
+    if scale.dim() != 2 or unpacked.dim() != 2:
+        raise ValueError(
+            f"Expected groupwise int4 tensors for {name}, got "
+            f"weight={tuple(unpacked.shape)} scale={tuple(scale.shape)}."
+        )
+    if scale.shape[0] not in (1, unpacked.shape[0]):
+        raise ValueError(
+            f"Unsupported int4 scale rows for {name}: "
+            f"weight={tuple(unpacked.shape)} scale={tuple(scale.shape)}."
+        )
+    if unpacked.shape[1] % scale.shape[1] != 0:
+        raise ValueError(
+            f"Unsupported int4 group layout for {name}: "
+            f"weight={tuple(unpacked.shape)} scale={tuple(scale.shape)}."
+        )
+
+    group_size = unpacked.shape[1] // scale.shape[1]
+    return (unpacked.unflatten(-1, (scale.shape[1], group_size)) * scale.unsqueeze(-1)).flatten(
+        start_dim=-2
+    )
+
+
+def _get(reader: SafeTensorReader, name: str) -> torch.Tensor:
+    if not _has(reader, name) and _has(reader, f"{name}_packed"):
+        return _dequant_int4_weight(reader, name)
+    tensor = reader.get_tensor(name)
+    return _dequant_fp8_weight(reader, name, tensor)
+
+
+def _text_prefix(reader: SafeTensorReader) -> str:
+    for prefix in ("model", "language_model.model", "model.language_model"):
+        if _has(reader, f"{prefix}.embed_tokens.weight"):
+            return prefix
+    raise KeyError("Could not find Kimi K2 text model prefix in HF checkpoint.")
+
+
+def _lm_head_name(reader: SafeTensorReader, text_prefix: str) -> str:
+    candidates = [
+        "lm_head.weight",
+        "language_model.lm_head.weight",
+        f"{text_prefix}.lm_head.weight",
+    ]
+    for name in candidates:
+        if _has(reader, name):
+            return name
+    raise KeyError("Could not find Kimi K2 lm_head.weight in HF checkpoint.")
+
+
+def _load_vocab(reader: SafeTensorReader, name: str, cfg: KimiK2Config, ps: ParallelState) -> torch.Tensor:
+    from megatron.lite.primitive.parallel import pad_vocab_for_tp
+
+    tensor = _get(reader, name)
+    padded = pad_vocab_for_tp(cfg.vocab_size, ps.tp_size)
+    if tensor.size(0) < padded:
+        pad = torch.zeros(padded - tensor.size(0), tensor.size(1), dtype=tensor.dtype)
+        tensor = torch.cat([tensor, pad], dim=0)
+    return _tp(tensor, ps.tp_rank, ps.tp_size)
+
+
+def _load_attention(
+    out: dict[str, torch.Tensor],
+    *,
+    local_prefix: str,
+    hf_prefix: str,
+    reader: SafeTensorReader,
+    ps: ParallelState,
+) -> None:
+    out[f"{local_prefix}.self_attention.linear_q_down_proj.weight"] = _get(
+        reader,
+        f"{hf_prefix}.q_a_proj.weight",
+    )
+    out[f"{local_prefix}.self_attention.linear_q_up_proj.linear.layer_norm_weight"] = _get(
+        reader,
+        f"{hf_prefix}.q_a_layernorm.weight",
+    )
+    out[f"{local_prefix}.self_attention.linear_q_up_proj.linear.weight"] = _tp(
+        _get(reader, f"{hf_prefix}.q_b_proj.weight"),
+        ps.tp_rank,
+        ps.tp_size,
+    )
+    out[f"{local_prefix}.self_attention.linear_kv_down_proj.weight"] = _get(
+        reader,
+        f"{hf_prefix}.kv_a_proj_with_mqa.weight",
+    )
+    out[f"{local_prefix}.self_attention.linear_kv_up_proj.linear.layer_norm_weight"] = _get(
+        reader,
+        f"{hf_prefix}.kv_a_layernorm.weight",
+    )
+    out[f"{local_prefix}.self_attention.linear_kv_up_proj.linear.weight"] = _tp(
+        _get(reader, f"{hf_prefix}.kv_b_proj.weight"),
+        ps.tp_rank,
+        ps.tp_size,
+    )
+    out[f"{local_prefix}.self_attention.linear_proj.linear.weight"] = _tp(
+        _get(reader, f"{hf_prefix}.o_proj.weight"),
+        ps.tp_rank,
+        ps.tp_size,
+        dim=1,
+    )
+
+
+def _load_dense_mlp(
+    out: dict[str, torch.Tensor],
+    *,
+    local_prefix: str,
+    hf_mlp_prefix: str,
+    hf_layer_prefix: str,
+    reader: SafeTensorReader,
+    ps: ParallelState,
+) -> None:
+    out[f"{local_prefix}.mlp.gate_up.linear.layer_norm_weight"] = _get(
+        reader,
+        f"{hf_layer_prefix}.post_attention_layernorm.weight",
+    )
+    gate_up = torch.cat(
+        [
+            _get(reader, f"{hf_mlp_prefix}.gate_proj.weight"),
+            _get(reader, f"{hf_mlp_prefix}.up_proj.weight"),
+        ],
+        dim=0,
+    )
+    out[f"{local_prefix}.mlp.gate_up.linear.weight"] = _split_gate_up(
+        gate_up,
+        ps.tp_rank,
+        ps.tp_size,
+    )
+    out[f"{local_prefix}.mlp.down.linear.weight"] = _tp(
+        _get(reader, f"{hf_mlp_prefix}.down_proj.weight"),
+        ps.tp_rank,
+        ps.tp_size,
+        dim=1,
+    )
+
+
+def _load_shared_expert(
+    out: dict[str, torch.Tensor],
+    *,
+    local_prefix: str,
+    hf_mlp_prefix: str,
+    reader: SafeTensorReader,
+    ps: ParallelState,
+) -> None:
+    prefixes = [f"{hf_mlp_prefix}.shared_experts", f"{hf_mlp_prefix}.shared_expert"]
+    shared = next(prefix for prefix in prefixes if _has(reader, f"{prefix}.down_proj.weight"))
+    gate_up = torch.cat(
+        [
+            _get(reader, f"{shared}.gate_proj.weight"),
+            _get(reader, f"{shared}.up_proj.weight"),
+        ],
+        dim=0,
+    )
+    out[f"{local_prefix}.moe.shared_expert.gate_up.linear.weight"] = _split_gate_up(
+        gate_up,
+        ps.tp_rank,
+        ps.tp_size,
+    )
+    out[f"{local_prefix}.moe.shared_expert.down.linear.weight"] = _tp(
+        _get(reader, f"{shared}.down_proj.weight"),
+        ps.tp_rank,
+        ps.tp_size,
+        dim=1,
+    )
+
+
+def _load_experts(
+    out: dict[str, torch.Tensor],
+    *,
+    local_prefix: str,
+    hf_mlp_prefix: str,
+    cfg: KimiK2Config,
+    ps: ParallelState,
+    reader: SafeTensorReader,
+) -> None:
+    num_local = ensure_divisible(cfg.num_experts, ps.ep_size)
+    local_start = ps.ep_rank * num_local
+    for local_idx in range(num_local):
+        global_idx = local_start + local_idx
+        ep = f"{hf_mlp_prefix}.experts.{global_idx}"
+        fc1 = torch.cat(
+            [
+                _get(reader, f"{ep}.gate_proj.weight"),
+                _get(reader, f"{ep}.up_proj.weight"),
+            ],
+            dim=0,
+        )
+        fc2 = _get(reader, f"{ep}.down_proj.weight")
+        if ps.etp_size > 1:
+            fc1 = _split_gate_up(fc1, ps.etp_rank, ps.etp_size)
+            fc2 = _tp(fc2, ps.etp_rank, ps.etp_size, dim=1)
+        out[f"{local_prefix}.moe.experts.fc1.weight{local_idx}"] = fc1
+        out[f"{local_prefix}.moe.experts.fc2.weight{local_idx}"] = fc2
+
+
+def _copy_loaded_state(model: nn.Module, loaded: dict[str, torch.Tensor]) -> None:
+    state = model.state_dict()
+    resolved: dict[str, torch.Tensor] = {}
+    for name, tensor in loaded.items():
+        actual = name if name in state else None
+        if actual is None:
+            for key in state:
+                if name in key:
+                    actual = key
+                    break
+        if actual is not None:
+            resolved[actual] = tensor
+        else:
+            log_rank0(f"WARNING: kimi_k2 checkpoint tensor has no target param: {name}")
+
+    for name, target in model.named_parameters():
+        if name not in resolved:
+            log_rank0(f"WARNING: {name} not loaded from checkpoint")
+            continue
+        tensor = resolved[name].to(device=target.device)
+        target.data.copy_(tensor.to(dtype=target.dtype))
+
+    for name, target in model.named_buffers():
+        if name not in resolved:
+            continue
+        tensor = resolved[name].to(device=target.device)
+        target.data.copy_(tensor.to(dtype=target.dtype) if target.is_floating_point() else tensor)
+
+
+def load_hf_weights(model: nn.Module, path: str, config: KimiK2Config, ps: ParallelState) -> None:
+    base_model = unwrap_model(model)
+    reader = SafeTensorReader(path)
+    out: dict[str, torch.Tensor] = {}
+
+    prefix = _text_prefix(reader)
+
+    if getattr(base_model, "embed", None) is not None:
+        out["embed.embedding.weight"] = _load_vocab(reader, f"{prefix}.embed_tokens.weight", config, ps)
+    if getattr(base_model, "norm", None) is not None:
+        out["norm.weight"] = _get(reader, f"{prefix}.norm.weight")
+    if getattr(base_model, "head", None) is not None:
+        out["head.col.linear.weight"] = _load_vocab(reader, _lm_head_name(reader, prefix), config, ps)
+
+    for local_idx, global_idx in enumerate(base_model.layer_indices):
+        lp = f"layers.{local_idx}"
+        hp = f"{prefix}.layers.{global_idx}"
+        out[f"{lp}.input_layernorm.weight"] = _get(reader, f"{hp}.input_layernorm.weight")
+        _load_attention(
+            out,
+            local_prefix=lp,
+            hf_prefix=f"{hp}.self_attn",
+            reader=reader,
+            ps=ps,
+        )
+        if config.is_moe_layer(global_idx):
+            out[f"{lp}.mlp_norm.weight"] = _get(reader, f"{hp}.post_attention_layernorm.weight")
+            out[f"{lp}.moe.router.gate.weight"] = _get(reader, f"{hp}.mlp.gate.weight")
+            bias_name = f"{hp}.mlp.gate.e_score_correction_bias"
+            if _has(reader, bias_name):
+                out[f"{lp}.moe.router.expert_bias"] = _get(reader, bias_name).float()
+            _load_shared_expert(out, local_prefix=lp, hf_mlp_prefix=f"{hp}.mlp", reader=reader, ps=ps)
+            _load_experts(
+                out,
+                local_prefix=lp,
+                hf_mlp_prefix=f"{hp}.mlp",
+                cfg=config,
+                ps=ps,
+                reader=reader,
+            )
+        else:
+            _load_dense_mlp(
+                out,
+                local_prefix=lp,
+                hf_mlp_prefix=f"{hp}.mlp",
+                hf_layer_prefix=hp,
+                reader=reader,
+                ps=ps,
+            )
+
+    _copy_loaded_state(base_model, out)
+
+
+__all__ = [
+    "EXPERT_CLASSIFIER",
+    "PLACEMENT_FN",
+    "_dequant_int4_weight",
+    "_dequant_fp8_weight",
+    "load_hf_weights",
+]

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/model.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/model.py
@@ -1,0 +1,405 @@
+"""Kimi K2 lite native model."""
+
+from __future__ import annotations
+
+import os
+from contextlib import nullcontext
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import transformer_engine.pytorch as te
+
+from megatron.lite.model.kimi_k2.config import KimiK2Config
+from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
+from megatron.lite.primitive.modules.experts import Experts
+from megatron.lite.primitive.modules.mla import MultiLatentAttention
+from megatron.lite.primitive.modules.router import SigmoidTopKRouter
+from megatron.lite.primitive.ops.cross_entropy import vocab_parallel_cross_entropy
+from megatron.lite.primitive.ops.linear_cross_entropy import linear_cross_entropy
+from megatron.lite.primitive.ops.logprob import vocab_parallel_entropy
+from megatron.lite.primitive.parallel import (
+    ColumnParallelLinear,
+    ParallelState,
+    RowParallelLinear,
+    VocabParallelEmbedding,
+    VocabParallelOutput,
+    build_pipeline_chunk_layout,
+    gather_from_sequence_parallel,
+    reduce_scatter_to_sequence_parallel,
+    scatter_to_sequence_parallel,
+)
+from megatron.lite.primitive.utils import build_fp8_recipe
+
+try:
+    from megatron.core.fusions.fused_bias_swiglu import bias_swiglu_impl as _mcore_swiglu
+except Exception:  # pragma: no cover - local static envs may not have Megatron-Core.
+    _mcore_swiglu = None
+
+_SP_GRAD_SUFFIXES: tuple[str, ...] = (
+    ".input_layernorm.weight",
+    ".self_attention.linear_q_down_proj.weight",
+    ".self_attention.linear_q_up_proj.linear.layer_norm_weight",
+    ".self_attention.linear_kv_down_proj.weight",
+    ".self_attention.linear_kv_up_proj.linear.layer_norm_weight",
+    ".mlp_norm.weight",
+    ".mlp.gate_up.linear.layer_norm_weight",
+    ".moe.router.gate.weight",
+    ".norm.weight",
+)
+
+
+def _collect_sp_grad_params(model: nn.Module) -> list[nn.Parameter]:
+    return [
+        param
+        for name, param in model.named_parameters()
+        if any(name.endswith(suffix) for suffix in _SP_GRAD_SUFFIXES) or name == "norm.weight"
+    ]
+
+
+def _swiglu(x: torch.Tensor) -> torch.Tensor:
+    if _mcore_swiglu is not None and x.is_cuda:
+        return _mcore_swiglu(x, None, False, False)
+    x1, x2 = torch.chunk(x, 2, dim=-1)
+    return F.silu(x1) * x2
+
+
+class DenseMLP(nn.Module):
+    def __init__(self, config: KimiK2Config, ps: ParallelState):
+        super().__init__()
+        self.gate_up = ColumnParallelLinear(
+            config.hidden_size,
+            config.intermediate_size * 2,
+            ps,
+            bias=False,
+            normalization="RMSNorm",
+            eps=config.rms_norm_eps,
+        )
+        self.down = RowParallelLinear(config.intermediate_size, config.hidden_size, ps, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.down(_swiglu(self.gate_up(x)))
+
+
+class SharedExpert(nn.Module):
+    def __init__(self, config: KimiK2Config, ps: ParallelState):
+        super().__init__()
+        self.ps = ps
+        ffn = config.shared_expert_intermediate_size
+        self.gate_up = _LocalLinear(config.hidden_size, ffn * 2 // ps.tp_size)
+        self.down = _LocalLinear(ffn // ps.tp_size, config.hidden_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        squeeze_batch = x.dim() == 2
+        if squeeze_batch:
+            x = x.unsqueeze(1)
+        full_x = gather_from_sequence_parallel(x, self.ps)
+        partial_out = self.down(_swiglu(self.gate_up(full_x)))
+        out = reduce_scatter_to_sequence_parallel(partial_out, self.ps)
+        return out.squeeze(1) if squeeze_batch else out
+
+
+class _LocalLinear(nn.Module):
+    """TE linear without built-in TP collectives; weight remains TP-local."""
+
+    def __init__(self, in_features: int, out_features: int):
+        super().__init__()
+        self.linear = te.Linear(
+            in_features,
+            out_features,
+            bias=False,
+            params_dtype=torch.bfloat16,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.linear(x)
+
+
+class MoELayer(nn.Module):
+    def __init__(
+        self,
+        config: KimiK2Config,
+        ps: ParallelState,
+        *,
+        use_deepep: bool,
+        router_bias_rate: float,
+        fp8: bool,
+        moe_act_recompute: bool,
+    ):
+        super().__init__()
+        if fp8:
+            raise NotImplementedError("Kimi K2 lite MoE fp8 training is not implemented yet.")
+        self.router = SigmoidTopKRouter(
+            config,
+            ps,
+            router_bias_rate=router_bias_rate,
+            compute_aux_loss=True,
+            use_pre_softmax=True,
+            persistent_expert_bias=True,
+        )
+        self.experts = Experts(
+            config,
+            ps,
+            fp8=fp8,
+            moe_act_recompute=moe_act_recompute,
+            use_mcore_grouped_gemm=True,
+        )
+        self.dispatcher = TokenDispatcher(
+            config.num_experts,
+            config.hidden_size,
+            ps,
+            use_deepep=use_deepep,
+        )
+        self.shared_expert = SharedExpert(config, ps)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        input_shape = x.shape
+
+        scores, indices = self.router(x)
+        dispatched, tpe, permuted_probs = self.dispatcher.dispatch(x, scores, indices)
+        del scores, indices
+        self.dispatcher.wait_dispatch_event()
+        expert_out = self.experts(
+            dispatched,
+            tpe,
+            permuted_probs,
+            tokens_per_expert_list=getattr(self.dispatcher, "_local_tpe_list", None),
+        )
+        routed_out = self.dispatcher.combine(expert_out)
+        shared_out = self.shared_expert(x)
+        output = routed_out.view(input_shape)
+        output += shared_out
+        return output.to(x.dtype)
+
+
+class KimiK2Layer(nn.Module):
+    def __init__(
+        self,
+        config: KimiK2Config,
+        ps: ParallelState,
+        layer_idx: int,
+        *,
+        use_deepep: bool = False,
+        router_bias_rate: float = 0.0,
+        fp8: bool = False,
+        moe_act_recompute: bool = False,
+        use_thd: bool = False,
+    ):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.input_layernorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.self_attention = MultiLatentAttention(
+            hidden_size=config.hidden_size,
+            num_attention_heads=config.num_attention_heads,
+            q_lora_rank=config.q_lora_rank,
+            kv_lora_rank=config.kv_lora_rank,
+            qk_nope_head_dim=config.qk_nope_head_dim,
+            qk_rope_head_dim=config.qk_rope_head_dim,
+            v_head_dim=config.v_head_dim,
+            ps=ps,
+            rms_norm_eps=config.rms_norm_eps,
+            rope_theta=config.rope_theta,
+            rope_scaling=config.rope_scaling,
+            use_thd=use_thd,
+        )
+        if config.is_moe_layer(layer_idx):
+            self.mlp_norm: nn.Module | None = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+            self.moe: MoELayer | None = MoELayer(
+                config,
+                ps,
+                use_deepep=use_deepep,
+                router_bias_rate=router_bias_rate,
+                fp8=fp8,
+                moe_act_recompute=moe_act_recompute,
+            )
+            self.mlp: DenseMLP | None = None
+        else:
+            self.mlp_norm = None
+            self.moe = None
+            self.mlp = DenseMLP(config, ps)
+
+    def forward(self, x: torch.Tensor, packed_seq_params=None) -> torch.Tensor:
+        x = x + self.self_attention(self.input_layernorm(x), packed_seq_params=packed_seq_params)
+        if self.moe is not None:
+            assert self.mlp_norm is not None
+            mlp_input = self.mlp_norm(x)
+            return x + self.moe(mlp_input)
+        assert self.mlp is not None
+        return x + self.mlp(x)
+
+
+def _temperature_to_float(temperature: float | torch.Tensor) -> float:
+    if isinstance(temperature, torch.Tensor):
+        if temperature.numel() != 1:
+            raise ValueError("KimiK2Model supports scalar temperature only.")
+        return float(temperature.detach().float().item())
+    return float(temperature)
+
+
+def _apply_attention_backend_override(backend: str | None) -> None:
+    if backend in (None, "flash"):
+        backend = "fused"
+    env = {
+        "auto": ("1", "1", "1"),
+        "flash": ("1", "0", "0"),
+        "fused": ("0", "1", "0"),
+        "unfused": ("0", "0", "1"),
+        "local": ("0", "0", "1"),
+    }.get(backend)
+    if env is None:
+        raise ValueError(
+            "attention_backend_override must be one of "
+            "{'auto', 'flash', 'fused', 'unfused', 'local'}"
+        )
+    os.environ["NVTE_FLASH_ATTN"], os.environ["NVTE_FUSED_ATTN"], os.environ["NVTE_UNFUSED_ATTN"] = env
+
+
+class KimiK2Model(nn.Module):
+    def __init__(
+        self,
+        config: KimiK2Config,
+        train_config,
+        ps: ParallelState,
+        *,
+        vpp_chunk_id: int | None = None,
+        router_bias_rate: float = 0.0,
+        use_thd: bool = False,
+        hf_path: str = "",
+        attention_backend_override: str | None = None,
+    ):
+        super().__init__()
+        del hf_path
+        _apply_attention_backend_override(attention_backend_override)
+        self.config = config
+        self.train_config = train_config
+        self.ps = ps
+        self._input_tensor: torch.Tensor | None = None
+
+        layout = build_pipeline_chunk_layout(config.num_hidden_layers, ps, train_config.vpp, vpp_chunk_id)
+        self.layer_indices = layout.layer_indices
+        self.pre_process = layout.has_embed
+        self.post_process = layout.has_head
+        self.share_embeddings_and_output_weights = bool(config.tie_word_embeddings)
+        self.vision_model: nn.Module | None = None
+
+        self.embed: VocabParallelEmbedding | None = None
+        if layout.has_embed:
+            self.embed = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
+
+        recompute_modules = getattr(train_config, "recompute_modules", [])
+        moe_act_recompute = "moe_act" in recompute_modules and "moe" not in recompute_modules
+        self.layers = nn.ModuleList(
+            [
+                KimiK2Layer(
+                    config,
+                    ps,
+                    idx,
+                    use_deepep=train_config.use_deepep,
+                    router_bias_rate=router_bias_rate,
+                    fp8=train_config.fp8,
+                    moe_act_recompute=moe_act_recompute,
+                    use_thd=use_thd,
+                )
+                for idx in self.layer_indices
+            ]
+        )
+
+        self.norm: nn.Module | None = None
+        self.head: VocabParallelOutput | None = None
+        if layout.has_head:
+            self.norm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+            self.head = VocabParallelOutput(config.vocab_size, config.hidden_size, ps)
+
+        self.sp_params: list[nn.Parameter] = []
+        if ps.tp_size > 1:
+            self.sp_params = _collect_sp_grad_params(self)
+
+    def set_input_tensor(self, input_tensor):
+        if isinstance(input_tensor, list):
+            if len(input_tensor) > 1:
+                raise ValueError("KimiK2Model expects a single pipeline input tensor.")
+            input_tensor = input_tensor[0] if input_tensor else None
+        self._input_tensor = input_tensor
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None = None,
+        hidden_states: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        packed_seq_params=None,
+        labels: torch.Tensor | None = None,
+        loss_mask: torch.Tensor | None = None,
+        temperature: float | torch.Tensor = 1.0,
+        use_fused_kernels: bool = False,
+        calculate_entropy: bool = False,
+    ) -> dict:
+        del position_ids, loss_mask
+        if self.embed is not None:
+            assert input_ids is not None
+            h = self.embed(input_ids)
+        else:
+            if hidden_states is None:
+                hidden_states = self._input_tensor
+            assert hidden_states is not None
+            h = hidden_states
+
+        fp8_ctx = (
+            te.fp8_autocast(enabled=True, fp8_recipe=build_fp8_recipe(self.train_config))
+            if self.train_config.fp8
+            else nullcontext()
+        )
+        with fp8_ctx:
+            if self.embed is not None:
+                h = scatter_to_sequence_parallel(h, self.ps)
+            for layer in self.layers:
+                h = layer(h, packed_seq_params=packed_seq_params)
+
+        output = {"hidden_states": h}
+        if self.head is not None:
+            assert self.norm is not None
+            hidden_for_head = self.norm(h)
+            if labels is not None:
+                temperature_value = _temperature_to_float(temperature)
+                labels_sb = labels.transpose(0, 1).contiguous()
+                if use_fused_kernels:
+                    hidden_full = gather_from_sequence_parallel(hidden_for_head, self.ps)
+                    log_probs, entropy = linear_cross_entropy(
+                        hidden_full,
+                        self._head_weight_for_fused_ce(hidden_full),
+                        labels_sb,
+                        temperature_value,
+                        self.ps.tp_group,
+                    )
+                    output["loss"] = (-log_probs).mean()
+                    output["log_probs"] = log_probs.transpose(0, 1).contiguous()
+                    if calculate_entropy:
+                        output["entropy"] = entropy.transpose(0, 1).contiguous()
+                else:
+                    logits = self.head(hidden_for_head)
+                    if temperature_value != 1.0:
+                        logits = logits / temperature_value
+                    loss = vocab_parallel_cross_entropy(logits, labels_sb, self.ps.tp_group)
+                    output["loss"] = loss.mean()
+                    output["log_probs"] = (-loss).transpose(0, 1).contiguous()
+                    if calculate_entropy:
+                        entropy = vocab_parallel_entropy(logits, self.ps.tp_group)
+                        output["entropy"] = entropy.transpose(0, 1).contiguous()
+            else:
+                logits = self.head(hidden_for_head)
+                output["logits"] = self.head.gather(logits).transpose(0, 1).contiguous()
+        return output
+
+    def _head_weight_for_fused_ce(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        assert self.head is not None
+        weight = self.head.col.linear.weight
+        return weight if weight.dtype == hidden_states.dtype else weight.to(dtype=hidden_states.dtype)
+
+
+__all__ = [
+    "DenseMLP",
+    "KimiK2Layer",
+    "KimiK2Model",
+    "MoELayer",
+    "MultiLatentAttention",
+    "SharedExpert",
+]

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/protocol.py
@@ -1,0 +1,251 @@
+"""Kimi K2 lite impl — native model protocol for Megatron Lite runtime."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from megatron.lite.model.kimi_k2.config import KimiK2Config
+from megatron.lite.model.kimi_k2.lite.checkpoint import (
+    load_hf_weights as _load_hf_weights_impl,
+)
+from megatron.lite.primitive.bundle import ModelBundle
+from megatron.lite.primitive.parallel import ParallelState, init_parallel
+from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec
+from megatron.lite.runtime.contracts import OptimizerConfig, ParallelConfig
+
+
+def is_expert_param(name: str) -> bool:
+    return "experts" in name and "router" not in name and "shared" not in name
+
+
+def _maybe(module_name: str):
+    def getter(layer):
+        module = getattr(layer, module_name, None)
+        return module
+
+    return getter
+
+
+def _moe_module(name: str):
+    def getter(layer):
+        moe = getattr(layer, "moe", None)
+        return getattr(moe, name, None) if moe is not None else None
+
+    return getter
+
+
+MODULE_MAP = {
+    "core_attn": lambda layer: layer.self_attention.core_attn,
+    "experts": _moe_module("experts"),
+    "moe": _maybe("moe"),
+    "router": _moe_module("router"),
+    "mlp": _maybe("mlp"),
+    "mlp_norm": lambda layer: layer.mlp_norm,
+    "attn_proj": lambda layer: layer.self_attention.linear_proj,
+    "mla": lambda layer: layer.self_attention,
+}
+
+
+@dataclass(frozen=True)
+class ImplConfig:
+    parallel: ParallelConfig = field(default_factory=ParallelConfig)
+    optimizer: str | None = "mc_full"
+    recompute: list[str] = field(default_factory=list)
+    offload: list[str] = field(default_factory=list)
+    use_deepep: bool = False
+    use_thd: bool = False
+    hf_path: str = ""
+    attention_backend_override: str | None = None
+    router_aux_loss_coef: float | None = None
+    router_bias_rate: float = 0.0
+    deterministic: bool = True
+    optimizer_config: OptimizerConfig | None = None
+
+
+def build_model_config(source: str | Path | dict, **overrides) -> KimiK2Config:
+    if isinstance(source, dict):
+        cfg = KimiK2Config._from_hf_dict(source)
+    else:
+        cfg = KimiK2Config.from_hf(str(source))
+    for key, value in overrides.items():
+        if hasattr(cfg, key):
+            setattr(cfg, key, value)
+    return cfg
+
+
+def _forward_step(model: nn.Module, batch: dict) -> dict:
+    kwargs: dict[str, Any] = {
+        "input_ids": batch["input_ids"],
+        "labels": batch["labels"],
+    }
+    if "packed_seq_params" in batch:
+        kwargs["packed_seq_params"] = batch["packed_seq_params"]
+    for key in ("loss_mask", "temperature", "use_fused_kernels", "calculate_entropy"):
+        if key in batch:
+            kwargs[key] = batch[key]
+    if kwargs["input_ids"].dim() == 1:
+        kwargs["input_ids"] = kwargs["input_ids"].unsqueeze(0)
+    return model(**kwargs)
+
+
+def _make_aux_loss_hook():
+    from megatron.lite.primitive.modules.moe import MoEAuxLossAutoScaler
+
+    def hook(scale: torch.Tensor) -> None:
+        MoEAuxLossAutoScaler.set_loss_scale(scale)
+
+    return hook
+
+
+def _build_mc_optimizer(chunks, model_cfg: KimiK2Config, impl_cfg: ImplConfig, ps: ParallelState):
+    from megatron.lite.primitive.optimizers.megatron_wrap import (
+        build_mc_full_stack,
+        finalize_mc_full_grads,
+    )
+
+    opt_cfg = impl_cfg.optimizer_config
+    if opt_cfg is None:
+        opt_cfg = SimpleNamespace(
+            optimizer="adam",
+            lr=1e-4,
+            weight_decay=0.01,
+            clip_grad=1.0,
+            offload_fraction=None,
+            adam_beta1=None,
+            adam_beta2=None,
+            adam_eps=None,
+        )
+
+    engine_cfg = SimpleNamespace(
+        model_name="kimi_k2",
+        parallel=impl_cfg.parallel,
+        optimizer=opt_cfg,
+    )
+    chunks[:], optimizer = build_mc_full_stack(
+        chunks,
+        model_cfg=model_cfg,
+        engine_cfg=engine_cfg,
+        ps=ps,
+        is_expert=is_expert_param,
+    )
+
+    def finalize() -> None:
+        finalize_mc_full_grads(chunks, optimizer)
+
+    return optimizer, finalize
+
+
+def build_model(model_cfg: KimiK2Config, *, impl_cfg: ImplConfig) -> ModelBundle:
+    from megatron.lite.model.kimi_k2.lite.model import KimiK2Model
+
+    p = impl_cfg.parallel
+    if impl_cfg.use_deepep and (p.etp is not None and p.etp > 1):
+        raise ValueError("use_deepep and etp>1 are mutually exclusive")
+    if impl_cfg.router_aux_loss_coef is not None:
+        model_cfg.aux_loss_alpha = impl_cfg.router_aux_loss_coef
+
+    ps = init_parallel(p)
+    recompute_spec = parse_recompute_spec(impl_cfg.recompute)
+    vpp = None if p.vpp == 1 else p.vpp
+    train_cfg = SimpleNamespace(
+        tp=ps.tp_size,
+        ep=ps.ep_size,
+        etp=ps.etp_size,
+        pp=ps.pp_size,
+        cp=ps.cp_size,
+        vpp=vpp,
+        use_deepep=impl_cfg.use_deepep,
+        fp8=False,
+        recompute_modules=recompute_spec,
+        deterministic=impl_cfg.deterministic,
+    )
+    model_kwargs: dict[str, Any] = dict(
+        router_bias_rate=impl_cfg.router_bias_rate,
+        use_thd=impl_cfg.use_thd,
+        hf_path=impl_cfg.hf_path,
+        attention_backend_override=impl_cfg.attention_backend_override,
+    )
+
+    if vpp is None:
+        chunks = [
+            KimiK2Model(model_cfg, train_cfg, ps, **model_kwargs)
+            .to(torch.bfloat16)
+            .cuda()
+        ]
+    else:
+        chunks = [
+            KimiK2Model(
+                model_cfg,
+                train_cfg,
+                ps,
+                vpp_chunk_id=i,
+                **model_kwargs,
+            )
+            .to(torch.bfloat16)
+            .cuda()
+            for i in range(vpp)
+        ]
+
+    if recompute_spec:
+        for chunk in chunks:
+            apply_recompute(chunk.layers, recompute_spec, MODULE_MAP)
+
+    if impl_cfg.offload:
+        from megatron.lite.primitive.recompute import apply_offload
+
+        for chunk in chunks:
+            apply_offload(chunk.layers, impl_cfg.offload, MODULE_MAP)
+
+    optimizer = None
+    finalize_grads = None
+    optimizer_backend = "none"
+    if impl_cfg.optimizer == "mc_full":
+        optimizer, finalize_grads = _build_mc_optimizer(chunks, model_cfg, impl_cfg, ps)
+        from megatron.lite.runtime.megatron_utils import register_training_hooks
+
+        register_training_hooks(chunks, optimizer)
+        optimizer_backend = "mc_full"
+    elif impl_cfg.optimizer is not None:
+        raise ValueError(f"Unknown kimi_k2 lite optimizer: {impl_cfg.optimizer!r}.")
+
+    return ModelBundle(
+        chunks=chunks,
+        parallel_state=ps,
+        optimizer=optimizer,
+        finalize_grads=finalize_grads,
+        forward_step=_forward_step,
+        extras={
+            "model_cfg": model_cfg,
+            "optimizer_backend": optimizer_backend,
+            "pre_forward_hook": _make_aux_loss_hook(),
+        },
+    )
+
+
+def load_hf_weights(
+    chunk: nn.Module, hf_path: str, model_cfg: KimiK2Config, ps: ParallelState
+) -> None:
+    if not hf_path:
+        return
+    _load_hf_weights_impl(chunk, hf_path, model_cfg, ps)
+
+
+def vocab_size(model_cfg) -> int | None:
+    cfg = getattr(model_cfg, "text_config", model_cfg)
+    return getattr(cfg, "vocab_size", None)
+
+
+__all__ = [
+    "ImplConfig",
+    "build_model",
+    "build_model_config",
+    "is_expert_param",
+    "load_hf_weights",
+    "vocab_size",
+]

--- a/experimental/lite/megatron/lite/model/registry.py
+++ b/experimental/lite/megatron/lite/model/registry.py
@@ -93,6 +93,13 @@ register_model(
     impls={"lite": "megatron.lite.model.qwen3_5.lite.protocol"},
 )
 
+register_model(
+    "kimi_k2",
+    package="megatron.lite.model.kimi_k2",
+    hf_model_types=["kimi_k2", "deepseek_v3"],
+    impls={"lite": "megatron.lite.model.kimi_k2.lite.protocol"},
+)
+
 
 # ---------------------------------------------------------------------------
 # Lookup functions

--- a/experimental/lite/megatron/lite/primitive/modules/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/modules/__init__.py
@@ -4,6 +4,7 @@ from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
 from megatron.lite.primitive.modules.experts import Experts
 from megatron.lite.primitive.modules.gated_delta_net import GatedDeltaNet
 from megatron.lite.primitive.modules.gqa import GQAttention, split_grouped_qkvg
+from megatron.lite.primitive.modules.mla import MultiLatentAttention
 from megatron.lite.primitive.modules.moe import MoEAuxLossAutoScaler, _AllToAll
 from megatron.lite.primitive.modules.mrope import MultimodalRotaryEmbedding
 from megatron.lite.primitive.modules.mtp import MTPBlock, MTPDecoderLayer, MTPLossAutoScaler
@@ -16,6 +17,7 @@ __all__ = [
     "MTPBlock",
     "MTPDecoderLayer",
     "MTPLossAutoScaler",
+    "MultiLatentAttention",
     "MoEAuxLossAutoScaler",
     "MultimodalRotaryEmbedding",
     "SigmoidTopKRouter",

--- a/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
+++ b/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
@@ -248,6 +248,7 @@ class TokenDispatcher:
         topk_scores: torch.Tensor,
         topk_indices: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        hidden_states = hidden_states.view(-1, hidden_states.size(-1))
         if self.ep_size <= 1:
             return self._dispatch_local(hidden_states, topk_scores, topk_indices)
         if self.use_deepep:

--- a/experimental/lite/megatron/lite/primitive/modules/experts.py
+++ b/experimental/lite/megatron/lite/primitive/modules/experts.py
@@ -23,6 +23,19 @@ from megatron.lite.primitive.utils import ensure_divisible
 
 __all__ = ["Experts", "_AllReduceETP"]
 
+try:
+    from megatron.core.fusions.fused_bias_swiglu import (
+        bias_swiglu_impl as _mcore_bias_swiglu,
+    )
+    from megatron.core.fusions.fused_bias_swiglu import (
+        weighted_bias_swiglu_impl as _mcore_weighted_swiglu,
+    )
+    from megatron.core.transformer.moe import grouped_gemm_util as _mcore_gg
+except Exception:  # pragma: no cover - local static envs may not have grouped_gemm.
+    _mcore_bias_swiglu = None
+    _mcore_weighted_swiglu = None
+    _mcore_gg = None
+
 
 @contextmanager
 def _expert_nvtx_range(name: str):
@@ -104,7 +117,11 @@ def weighted_bias_swiglu_impl(input, bias, weights, fp8_input_store=False):
 def swiglu_with_probs(y: torch.Tensor, probs: torch.Tensor | None) -> torch.Tensor:
     """SwiGLU with optional expert probability scaling."""
     if probs is not None:
+        if _mcore_weighted_swiglu is not None and y.is_cuda:
+            return _mcore_weighted_swiglu(y, bias=None, weights=probs)
         return weighted_bias_swiglu_impl(y, bias=None, weights=probs)
+    if _mcore_bias_swiglu is not None and y.is_cuda:
+        return _mcore_bias_swiglu(y, bias=None)
     y1, y2 = torch.chunk(y, 2, -1)
     return F.silu(y1) * y2
 
@@ -133,11 +150,13 @@ class Experts(nn.Module):
         fp8: bool = False,
         moe_act_recompute: bool = False,
         lora_config: LoraConfig | dict | None = None,
+        use_mcore_grouped_gemm: bool = False,
     ):
         super().__init__()
         self.num_local_experts = ensure_divisible(config.num_experts, ps.ep_size)
         self.fp8 = fp8
         self.moe_act_recompute = moe_act_recompute
+        self.use_mcore_grouped_gemm = use_mcore_grouped_gemm
         self.etp_group = ps.etp_group if ps.etp_size > 1 else None
 
         self.fc1 = te.GroupedLinear(
@@ -239,7 +258,16 @@ class Experts(nn.Module):
 
         probs = permuted_probs.unsqueeze(-1) if permuted_probs is not None else None
         with _expert_nvtx_range("ep_experts.forward"):
-            if self.moe_act_recompute and probs is not None:
+            if (
+                self.use_mcore_grouped_gemm
+                and self.fc1_lora is None
+                and self.fc2_lora is None
+                and _mcore_gg is not None
+                and _mcore_gg.ops is not None
+                and x.is_cuda
+            ):
+                out = self._mcore_grouped_gemm_forward(x, m_splits, probs)
+            elif self.moe_act_recompute and probs is not None:
                 act_ckpt = CheckpointWithoutOutput(preserve_rng_state=True)
                 fc1_out = self.fc1(x, m_splits)
                 if self.fc1_lora is not None:
@@ -265,6 +293,25 @@ class Experts(nn.Module):
         if pad_mask is not None:
             out = out[pad_mask]
         return out
+
+    def _mcore_grouped_gemm_forward(
+        self,
+        x: torch.Tensor,
+        m_splits: list[int],
+        probs: torch.Tensor | None,
+    ) -> torch.Tensor:
+        tokens_per_expert = torch.tensor(m_splits, device=x.device, dtype=torch.int64)
+        w1 = torch.stack(
+            [getattr(self.fc1, f"weight{i}").t() for i in range(self.num_local_experts)],
+            dim=0,
+        ).contiguous()
+        w2 = torch.stack(
+            [getattr(self.fc2, f"weight{i}").t() for i in range(self.num_local_experts)],
+            dim=0,
+        ).contiguous()
+        fc1_output = _mcore_gg.ops.gmm(x, w1, tokens_per_expert, trans_b=False)
+        hidden = swiglu_with_probs(fc1_output, probs)
+        return _mcore_gg.ops.gmm(hidden, w2, tokens_per_expert, trans_b=False)
 
     @staticmethod
     def _fp8_pad(x, permuted_probs, m_splits):

--- a/experimental/lite/megatron/lite/primitive/modules/mla.py
+++ b/experimental/lite/megatron/lite/primitive/modules/mla.py
@@ -1,0 +1,363 @@
+"""Multi-Latent Attention primitive for DeepSeek/Kimi-style models."""
+
+from __future__ import annotations
+
+import inspect
+import math
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import transformer_engine.pytorch as te
+from megatron.core.models.common.embeddings.rope_utils import (
+    _apply_rotary_pos_emb_bshd,
+    _apply_rotary_pos_emb_thd,
+)
+from megatron.core.models.common.embeddings.rotary_pos_embedding import (
+    RotaryEmbedding as MCoreRotaryEmbedding,
+)
+from megatron.core.models.common.embeddings.yarn_rotary_pos_embedding import (
+    YarnRotaryEmbedding,
+    _yarn_get_mscale,
+)
+
+from megatron.lite.primitive.parallel import (
+    ColumnParallelLinear,
+    ParallelState,
+    RowParallelLinear,
+    gather_from_sequence_parallel,
+)
+from megatron.lite.primitive.parallel.cp import (
+    zigzag_reconstruct_from_cp_parts,
+    zigzag_slice_for_cp,
+)
+
+_KEPT_PSP_FIELDS = (
+    "qkv_format",
+    "cu_seqlens_q",
+    "cu_seqlens_kv",
+    "cu_seqlens_q_padded",
+    "cu_seqlens_kv_padded",
+    "max_seqlen_q",
+    "max_seqlen_kv",
+)
+
+
+def _accepts_kwarg(fn, name: str) -> bool:
+    try:
+        params = inspect.signature(fn).parameters
+    except (TypeError, ValueError):
+        return False
+    return name in params or any(
+        param.kind == inspect.Parameter.VAR_KEYWORD for param in params.values()
+    )
+
+
+_ROPE_BSHD_ACCEPTS_MLA = _accepts_kwarg(_apply_rotary_pos_emb_bshd, "mla_rotary_interleaved")
+_ROPE_THD_ACCEPTS_MLA = _accepts_kwarg(_apply_rotary_pos_emb_thd, "mla_rotary_interleaved")
+_TE_DPA_ACCEPTS_SOFTMAX_SCALE = _accepts_kwarg(te.DotProductAttention, "softmax_scale")
+
+
+def _apply_mla_rope_bshd(t: torch.Tensor, freqs: torch.Tensor, *, mscale: float) -> torch.Tensor:
+    kwargs = dict(rotary_interleaved=False, mscale=mscale)
+    if _ROPE_BSHD_ACCEPTS_MLA:
+        kwargs["mla_rotary_interleaved"] = True
+    else:
+        kwargs["multi_latent_attention"] = True
+    return _apply_rotary_pos_emb_bshd(t, freqs, **kwargs)
+
+
+def _apply_mla_rope_thd(
+    t: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    freqs: torch.Tensor,
+    *,
+    mscale: float,
+    cp_group,
+) -> torch.Tensor:
+    kwargs = dict(
+        rotary_interleaved=False,
+        mscale=mscale,
+        cp_group=cp_group,
+    )
+    if _ROPE_THD_ACCEPTS_MLA:
+        kwargs["mla_rotary_interleaved"] = True
+    else:
+        kwargs["multi_latent_attention"] = True
+    return _apply_rotary_pos_emb_thd(t, cu_seqlens, freqs, **kwargs)
+
+
+class MultiLatentAttention(nn.Module):
+    """Native MLA composition using lite parallel linears and TE core attention."""
+
+    _cp_stream: torch.cuda.Stream | None = None
+
+    def __init__(
+        self,
+        *,
+        hidden_size: int,
+        num_attention_heads: int,
+        q_lora_rank: int,
+        kv_lora_rank: int,
+        qk_nope_head_dim: int,
+        qk_rope_head_dim: int,
+        v_head_dim: int,
+        ps: ParallelState,
+        rms_norm_eps: float = 1e-6,
+        rope_theta: float = 10_000.0,
+        rope_scaling: dict | None = None,
+        use_thd: bool = False,
+    ):
+        super().__init__()
+        if num_attention_heads % ps.tp_size != 0:
+            raise ValueError("num_attention_heads must be divisible by tensor parallel size")
+        self.ps = ps
+        self.num_heads_local = num_attention_heads // ps.tp_size
+        self.q_lora_rank = q_lora_rank
+        self.kv_lora_rank = kv_lora_rank
+        self.qk_nope_head_dim = qk_nope_head_dim
+        self.qk_rope_head_dim = qk_rope_head_dim
+        self.v_head_dim = v_head_dim
+        self.q_head_dim = qk_nope_head_dim + qk_rope_head_dim
+
+        self.linear_proj = RowParallelLinear(
+            num_attention_heads * v_head_dim,
+            hidden_size,
+            ps,
+            bias=False,
+        )
+        self.linear_q_down_proj = nn.Linear(hidden_size, q_lora_rank, bias=False)
+        self.linear_q_up_proj = ColumnParallelLinear(
+            q_lora_rank,
+            num_attention_heads * self.q_head_dim,
+            ps,
+            bias=False,
+            normalization="RMSNorm",
+            eps=rms_norm_eps,
+        )
+        self.linear_kv_down_proj = nn.Linear(
+            hidden_size,
+            kv_lora_rank + qk_rope_head_dim,
+            bias=False,
+        )
+        self.linear_kv_up_proj = ColumnParallelLinear(
+            kv_lora_rank,
+            num_attention_heads * (qk_nope_head_dim + v_head_dim),
+            ps,
+            bias=False,
+            normalization="RMSNorm",
+            eps=rms_norm_eps,
+        )
+
+        rope_scaling = dict(rope_scaling or {})
+        rope_type = rope_scaling.get("type", "rope")
+        if rope_type == "yarn":
+            factor = float(rope_scaling.get("factor", 1.0))
+            self.rotary = YarnRotaryEmbedding(
+                qk_rope_head_dim,
+                rotary_base=rope_theta,
+                scaling_factor=factor,
+                original_max_position_embeddings=int(
+                    rope_scaling.get("original_max_position_embeddings", 4096)
+                ),
+                beta_fast=float(rope_scaling.get("beta_fast", 32.0)),
+                beta_slow=float(rope_scaling.get("beta_slow", 1.0)),
+                mscale=float(rope_scaling.get("mscale", 1.0)),
+                mscale_all_dim=float(rope_scaling.get("mscale_all_dim", 1.0)),
+                cp_group=ps.cp_group if ps.cp_size > 1 else None,
+            )
+            attn_mscale = _yarn_get_mscale(factor, float(rope_scaling.get("mscale_all_dim", 1.0)))
+        elif rope_type == "rope":
+            self.rotary = MCoreRotaryEmbedding(
+                kv_channels=qk_rope_head_dim,
+                rotary_base=rope_theta,
+                use_cpu_initialization=False,
+                cp_group=ps.cp_group if ps.cp_size > 1 else None,
+            )
+            attn_mscale = 1.0
+        else:
+            raise ValueError(f"Unsupported MLA rope type: {rope_type!r}")
+        self._softmax_scale = attn_mscale * attn_mscale / math.sqrt(self.q_head_dim)
+        self._query_scale = 1.0 if _TE_DPA_ACCEPTS_SOFTMAX_SCALE else attn_mscale * attn_mscale
+
+        cp_kwargs = {}
+        if ps.cp_size > 1:
+            if MultiLatentAttention._cp_stream is None:
+                MultiLatentAttention._cp_stream = torch.cuda.Stream()
+            cp_kwargs = dict(
+                cp_group=ps.cp_group,
+                cp_global_ranks=ps.cp_global_ranks,
+                cp_stream=MultiLatentAttention._cp_stream,
+            )
+        self._use_torch_core = ps.cp_size > 1 and v_head_dim != self.q_head_dim
+        self.core_attn = None
+        if not self._use_torch_core:
+            dpa_kwargs = dict(cp_kwargs)
+            if _TE_DPA_ACCEPTS_SOFTMAX_SCALE:
+                dpa_kwargs["softmax_scale"] = self._softmax_scale
+            kv_channels = (
+                (self.q_head_dim, v_head_dim)
+                if v_head_dim != self.q_head_dim
+                else self.q_head_dim
+            )
+            self.core_attn = te.DotProductAttention(
+                num_attention_heads=self.num_heads_local,
+                kv_channels=kv_channels,
+                attention_dropout=0.0,
+                attn_mask_type="causal",
+                qkv_format="thd" if use_thd else "sbhd",
+                **dpa_kwargs,
+            )
+
+    def forward(self, x: torch.Tensor, packed_seq_params=None) -> torch.Tensor:
+        q_compressed = self.linear_q_down_proj(x)
+        kv_combined = self.linear_kv_down_proj(x)
+        kv_compressed, k_pos_emb = kv_combined.split(
+            [self.kv_lora_rank, self.qk_rope_head_dim],
+            dim=-1,
+        )
+        if self.ps.tp_size > 1:
+            k_pos_emb = gather_from_sequence_parallel(k_pos_emb, self.ps)
+
+        q_proj = self.linear_q_up_proj(q_compressed)
+        q = q_proj.view(
+            *q_proj.shape[:-1],
+            self.num_heads_local,
+            self.q_head_dim,
+        )
+        kv_proj = self.linear_kv_up_proj(kv_compressed)
+        kv = kv_proj.view(
+            *kv_proj.shape[:-1],
+            self.num_heads_local,
+            self.qk_nope_head_dim + self.v_head_dim,
+        )
+        q_nope, q_pos = q.split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
+        k_nope, value = kv.split([self.qk_nope_head_dim, self.v_head_dim], dim=-1)
+        k_pos = k_pos_emb.unsqueeze(-2)
+
+        is_thd = packed_seq_params is not None
+        if is_thd:
+            q_nope = q_nope.squeeze(1)
+            q_pos = q_pos.squeeze(1)
+            k_nope = k_nope.squeeze(1)
+            value = value.squeeze(1)
+            k_pos = k_pos.squeeze(1)
+
+        q_pos, k_pos = self._apply_rope(q_pos, k_pos, packed_seq_params)
+        if k_pos.dim() == q_nope.dim():
+            k_pos = k_pos.expand(*q_nope.shape[:-1], self.qk_rope_head_dim)
+        else:
+            k_pos = k_pos.expand(-1, -1, self.num_heads_local, -1)
+        query = torch.cat([q_nope, q_pos], dim=-1).contiguous()
+        key = torch.cat([k_nope, k_pos], dim=-1).contiguous()
+        value = value.contiguous()
+        if self._query_scale != 1.0:
+            query = query * self._query_scale
+
+        if is_thd:
+            if self._use_torch_core:
+                raise NotImplementedError("Packed THD MLA with v_head_dim != q_head_dim is not implemented yet.")
+            psp_kwargs = {
+                k: getattr(packed_seq_params, k)
+                for k in _KEPT_PSP_FIELDS
+                if getattr(packed_seq_params, k, None) is not None
+            }
+            assert self.core_attn is not None
+            out = self.core_attn(
+                query,
+                key,
+                value,
+                core_attention_bias_type="no_bias",
+                attn_mask_type="padding_causal",
+                **psp_kwargs,
+            ).reshape(query.size(0), 1, -1)
+        else:
+            if self._use_torch_core:
+                out = self._torch_core_attention(query, key, value)
+            else:
+                assert self.core_attn is not None
+                out = self.core_attn(query, key, value, core_attention_bias_type="no_bias")
+            if out.dim() > x.dim():
+                out = out.reshape(*out.shape[:-2], self.num_heads_local * self.v_head_dim)
+        return self.linear_proj(out)
+
+    def _torch_core_attention(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+    ) -> torch.Tensor:
+        local_seq = query.size(0)
+        if self.ps.cp_size > 1:
+            from torch.distributed.nn.functional import all_gather
+
+            query_parts = all_gather(query.contiguous(), group=self.ps.cp_group)
+            key_parts = all_gather(key.contiguous(), group=self.ps.cp_group)
+            value_parts = all_gather(value.contiguous(), group=self.ps.cp_group)
+            query = zigzag_reconstruct_from_cp_parts(query_parts, seq_dim=0)
+            key = zigzag_reconstruct_from_cp_parts(key_parts, seq_dim=0)
+            value = zigzag_reconstruct_from_cp_parts(value_parts, seq_dim=0)
+
+        q = query.permute(1, 2, 0, 3)
+        k = key.permute(1, 2, 0, 3)
+        v = value.permute(1, 2, 0, 3)
+        scale = self._softmax_scale if self._query_scale == 1.0 else None
+        out = F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            dropout_p=0.0,
+            is_causal=True,
+            scale=scale,
+        )
+        out = out.permute(2, 0, 1, 3).contiguous()
+        if self.ps.cp_size > 1:
+            out = zigzag_slice_for_cp(out, self.ps.cp_rank, self.ps.cp_size, seq_dim=0)
+            if out.size(0) != local_seq:
+                raise RuntimeError("CP MLA output shard has unexpected sequence length.")
+        return out
+
+    def _apply_rope(self, q_pos: torch.Tensor, k_pos: torch.Tensor, packed_seq_params):
+        is_thd = packed_seq_params is not None
+        if is_thd:
+            max_q = getattr(packed_seq_params, "max_seqlen_q", None)
+            max_kv = getattr(packed_seq_params, "max_seqlen_kv", None)
+            seq_len = (
+                int(max(max_q, max_kv))
+                if max_q is not None and max_kv is not None
+                else int(packed_seq_params.cu_seqlens_q[-1])
+            )
+            freqs = self.rotary(seq_len, packed_seq=True)
+            if isinstance(freqs, tuple):
+                freqs, mscale = freqs
+            else:
+                mscale = 1.0
+            q_pos = _apply_mla_rope_thd(
+                q_pos,
+                packed_seq_params.cu_seqlens_q,
+                freqs,
+                mscale=mscale,
+                cp_group=self.ps.cp_group,
+            )
+            k_pos = _apply_mla_rope_thd(
+                k_pos,
+                packed_seq_params.cu_seqlens_kv,
+                freqs,
+                mscale=mscale,
+                cp_group=self.ps.cp_group,
+            )
+            return q_pos, k_pos
+
+        seq_len = q_pos.size(0) * self.ps.cp_size
+        freqs = self.rotary(seq_len)
+        if isinstance(freqs, tuple):
+            freqs, mscale = freqs
+        else:
+            mscale = 1.0
+        return (
+            _apply_mla_rope_bshd(q_pos, freqs, mscale=mscale),
+            _apply_mla_rope_bshd(k_pos, freqs, mscale=mscale),
+        )
+
+
+__all__ = ["MultiLatentAttention"]

--- a/experimental/lite/megatron/lite/primitive/modules/router.py
+++ b/experimental/lite/megatron/lite/primitive/modules/router.py
@@ -42,6 +42,10 @@ _TOPK_ROUTING_SUPPORTS_DENSE_OUTPUT = _accepts_kwarg(
     topk_routing_with_score_function,
     "dense_output",
 )
+_TOPK_ROUTING_SUPPORTS_GROUPS = _accepts_kwarg(
+    topk_routing_with_score_function,
+    "num_groups",
+) and _accepts_kwarg(topk_routing_with_score_function, "group_topk")
 
 
 class TopKRouter(nn.Module):
@@ -56,6 +60,7 @@ class TopKRouter(nn.Module):
         compute_aux_loss: bool = True,
         use_pre_softmax: bool = False,
         moe_router_fusion: bool = False,
+        persistent_expert_bias: bool = False,
     ):
         super().__init__()
         if router_bias_rate > 0:
@@ -75,7 +80,7 @@ class TopKRouter(nn.Module):
         self.register_buffer(
             "expert_bias",
             torch.zeros(config.num_experts, dtype=torch.float32),
-            persistent=False,
+            persistent=persistent_expert_bias,
         )
 
         self._aux_loss_group = ps.tp_group if ps.tp_size > 1 else None
@@ -153,6 +158,7 @@ class SigmoidTopKRouter(nn.Module):
         compute_aux_loss: bool = True,
         use_pre_softmax: bool = False,
         moe_router_fusion: bool = False,
+        persistent_expert_bias: bool = False,
     ):
         super().__init__()
         if router_bias_rate > 0:
@@ -164,6 +170,8 @@ class SigmoidTopKRouter(nn.Module):
         self.num_experts = config.n_routed_experts
         self.aux_loss_coeff = config.aux_loss_alpha
         self.scaling_factor = config.routed_scaling_factor
+        self.num_groups = getattr(config, "n_group", None)
+        self.group_topk = getattr(config, "topk_group", None)
         self.router_bias_rate = router_bias_rate
         self.compute_aux_loss = compute_aux_loss
         self.use_pre_softmax = use_pre_softmax
@@ -173,14 +181,34 @@ class SigmoidTopKRouter(nn.Module):
         self.register_buffer(
             "expert_bias",
             torch.zeros(config.n_routed_experts, dtype=torch.float32),
+            persistent=persistent_expert_bias,
+        )
+        self.register_buffer(
+            "local_tokens_per_expert",
+            torch.zeros(config.n_routed_experts, dtype=torch.float32),
             persistent=False,
         )
 
         self._aux_loss_group = ps.tp_group if ps.tp_size > 1 else None
 
+    def _apply(self, fn):
+        super()._apply(fn)
+        self.expert_bias.data = self.expert_bias.data.float()
+        self.local_tokens_per_expert.data = self.local_tokens_per_expert.data.float()
+        return self
+
     def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-        logits = self.gate(x)
+        logits = router_gating_linear(x, self.gate.weight, None, torch.float32)
+        logits = logits.view(-1, self.num_experts)
         num_tokens = logits.size(0)
+        routing_kwargs = {}
+        if self.num_groups is not None and self.group_topk is not None:
+            if not _TOPK_ROUTING_SUPPORTS_GROUPS:
+                raise NotImplementedError(
+                    "This Megatron-Core topk_routing_with_score_function does not support "
+                    "group-limited routing."
+                )
+            routing_kwargs = dict(num_groups=self.num_groups, group_topk=self.group_topk)
         probs_dense, routing_map = topk_routing_with_score_function(
             logits,
             self.topk,
@@ -188,7 +216,11 @@ class SigmoidTopKRouter(nn.Module):
             expert_bias=self.expert_bias.to(logits.dtype),
             scaling_factor=(self.scaling_factor or None),
             fused=self.moe_router_fusion,
+            **routing_kwargs,
         )
+        if torch.is_grad_enabled():
+            with torch.no_grad():
+                self.local_tokens_per_expert += routing_map.sum(dim=0)
         # Recover topk from dense probs (see TopKRouter for rationale).
         topk_scores, topk_indices = torch.topk(probs_dense, k=self.topk, dim=-1)
         topk_scores = topk_scores.to(logits.dtype)

--- a/experimental/lite/megatron/lite/primitive/parallel/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/__init__.py
@@ -14,6 +14,7 @@ from megatron.lite.primitive.parallel.pp import PipelineChunkLayout, build_pipel
 from megatron.lite.primitive.parallel.sp import (
     gather_for_non_sp_head,
     gather_from_sequence_parallel,
+    reduce_scatter_to_sequence_parallel,
     scatter_to_sequence_parallel,
 )
 from megatron.lite.primitive.parallel.state import ParallelState, init_parallel
@@ -63,6 +64,7 @@ __all__ = [
     "pad_vocab_for_tp",
     "pack_nested_thd",
     "reconstruct_packed_from_cp_parts",
+    "reduce_scatter_to_sequence_parallel",
     "roll_packed_thd_left",
     "scatter_to_sequence_parallel",
     "split_packed_to_cp_local",

--- a/experimental/lite/megatron/lite/primitive/parallel/sp.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/sp.py
@@ -6,7 +6,12 @@ from typing import TYPE_CHECKING
 
 import torch  # pyright: ignore[reportMissingImports]
 
-from megatron.lite.primitive.ops.sp_ops import AllGatherDim0, AllGatherDim0ForNonSPConsumer, ScatterToSP
+from megatron.lite.primitive.ops.sp_ops import (
+    AllGatherDim0,
+    AllGatherDim0ForNonSPConsumer,
+    ReduceScatterDim0,
+    ScatterToSP,
+)
 
 if TYPE_CHECKING:
     from megatron.lite.primitive.parallel.state import ParallelState
@@ -26,6 +31,13 @@ def gather_from_sequence_parallel(x: torch.Tensor, ps: ParallelState) -> torch.T
     return AllGatherDim0.apply(x, ps.tp_size, ps.tp_rank, ps.tp_group)
 
 
+def reduce_scatter_to_sequence_parallel(x: torch.Tensor, ps: ParallelState) -> torch.Tensor:
+    """ReduceScatter [S, B, H] → [S/tp, B, H] for sequence parallel."""
+    if ps.tp_size == 1:
+        return x
+    return ReduceScatterDim0.apply(x, ps.tp_size, ps.tp_rank, ps.tp_group)
+
+
 def gather_for_non_sp_head(x: torch.Tensor, ps: ParallelState) -> torch.Tensor:
     """AllGather for non-SP consumer (e.g. vocab parallel head)."""
     if ps.tp_size == 1:
@@ -36,5 +48,6 @@ def gather_for_non_sp_head(x: torch.Tensor, ps: ParallelState) -> torch.Tensor:
 __all__ = [
     "gather_for_non_sp_head",
     "gather_from_sequence_parallel",
+    "reduce_scatter_to_sequence_parallel",
     "scatter_to_sequence_parallel",
 ]

--- a/experimental/lite/tests/unit/model/test_kimi_k2_lite_cp_smoke.py
+++ b/experimental/lite/tests/unit/model/test_kimi_k2_lite_cp_smoke.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+def _init_dist_or_skip():
+    import os
+
+    import torch
+    import torch.distributed as dist
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for Kimi K2 CP smoke.")
+    if "RANK" not in os.environ or "WORLD_SIZE" not in os.environ:
+        pytest.skip("Run with torchrun so CP ranks are available.")
+
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    torch.cuda.set_device(local_rank)
+    if not dist.is_initialized():
+        dist.init_process_group("nccl")
+    if dist.get_world_size() < 2:
+        pytest.skip("Kimi K2 CP smoke requires at least 2 ranks.")
+    return torch.device("cuda", local_rank)
+
+
+def _tiny_config():
+    from megatron.lite.model.kimi_k2.config import KimiK2Config
+
+    return KimiK2Config(
+        num_hidden_layers=2,
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        vocab_size=128,
+        intermediate_size=96,
+        moe_intermediate_size=16,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        n_group=2,
+        topk_group=1,
+        first_k_dense_replace=1,
+        q_lora_rank=16,
+        kv_lora_rank=12,
+        qk_nope_head_dim=8,
+        qk_rope_head_dim=8,
+        v_head_dim=8,
+        max_position_embeddings=128,
+        rope_theta=10000.0,
+        rope_scaling={
+            "type": "yarn",
+            "factor": 1.0,
+            "original_max_position_embeddings": 128,
+            "beta_fast": 1.0,
+            "beta_slow": 1.0,
+            "mscale": 1.0,
+            "mscale_all_dim": 1.0,
+        },
+    )
+
+
+def _train_cfg(cp: int):
+    return SimpleNamespace(
+        tp=1,
+        ep=1,
+        etp=1,
+        pp=1,
+        cp=cp,
+        vpp=None,
+        use_deepep=False,
+        fp8=False,
+        recompute_modules={},
+        deterministic=False,
+    )
+
+
+def test_kimi_k2_mla_cp2_matches_full_sequence_reference_forward_and_grad():
+    import torch
+    import torch.distributed as dist
+
+    device = _init_dist_or_skip()
+    from megatron.lite.primitive.modules.mla import MultiLatentAttention
+    from megatron.lite.primitive.parallel import ParallelState
+    from megatron.lite.primitive.parallel.cp import zigzag_slice_for_cp
+    from megatron.lite.primitive.parallel.state import init_parallel
+    from megatron.lite.runtime.contracts import ParallelConfig
+
+    world = dist.get_world_size()
+    rank = dist.get_rank()
+    cfg = _tiny_config()
+    ps = init_parallel(ParallelConfig(tp=1, ep=1, etp=1, cp=world, pp=1))
+
+    kwargs = dict(
+        hidden_size=cfg.hidden_size,
+        num_attention_heads=cfg.num_attention_heads,
+        q_lora_rank=cfg.q_lora_rank,
+        kv_lora_rank=cfg.kv_lora_rank,
+        qk_nope_head_dim=cfg.qk_nope_head_dim,
+        qk_rope_head_dim=cfg.qk_rope_head_dim,
+        v_head_dim=cfg.v_head_dim,
+        rms_norm_eps=cfg.rms_norm_eps,
+        rope_theta=cfg.rope_theta,
+        rope_scaling=cfg.rope_scaling,
+        use_thd=False,
+    )
+    torch.manual_seed(20260531)
+    cp_layer = MultiLatentAttention(ps=ps, **kwargs).to(device=device, dtype=torch.bfloat16)
+    torch.manual_seed(20260531)
+    ref_layer = MultiLatentAttention(ps=ParallelState(), **kwargs).to(
+        device=device,
+        dtype=torch.bfloat16,
+    )
+
+    seq, batch = 8 * world, 1
+    torch.manual_seed(123)
+    full_x = torch.randn(seq, batch, cfg.hidden_size, device=device, dtype=torch.bfloat16)
+    local_x = zigzag_slice_for_cp(full_x, rank, world, seq_dim=0).detach().requires_grad_(True)
+    ref_x = full_x.detach().clone().requires_grad_(True)
+
+    cp_out = cp_layer(local_x)
+    ref_out = ref_layer(ref_x)
+    expected = zigzag_slice_for_cp(ref_out, rank, world, seq_dim=0)
+    torch.testing.assert_close(cp_out, expected, atol=5e-2, rtol=5e-2)
+
+    cp_out.float().sum().backward()
+    expected.float().sum().backward()
+    expected_grad = zigzag_slice_for_cp(ref_x.grad, rank, world, seq_dim=0)
+    assert local_x.grad is not None
+    torch.testing.assert_close(local_x.grad, expected_grad, atol=1e-1, rtol=1e-1)
+
+
+def test_kimi_k2_tiny_model_cp2_matches_full_sequence_reference_forward():
+    import torch
+    import torch.distributed as dist
+
+    device = _init_dist_or_skip()
+    from megatron.lite.model.kimi_k2.lite.model import KimiK2Model
+    from megatron.lite.primitive.parallel import ParallelState
+    from megatron.lite.primitive.parallel.cp import zigzag_slice_for_cp
+    from megatron.lite.primitive.parallel.state import init_parallel
+    from megatron.lite.runtime.contracts import ParallelConfig
+
+    world = dist.get_world_size()
+    rank = dist.get_rank()
+    cfg = _tiny_config()
+    ps = init_parallel(ParallelConfig(tp=1, ep=1, etp=1, cp=world, pp=1))
+
+    torch.manual_seed(777)
+    cp_model = KimiK2Model(cfg, _train_cfg(world), ps, use_thd=False).to(
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    torch.manual_seed(777)
+    ref_model = KimiK2Model(cfg, _train_cfg(1), ParallelState(), use_thd=False).to(
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    cp_model.eval()
+    ref_model.eval()
+
+    batch, seq = 1, 8 * world
+    torch.manual_seed(100)
+    full_ids = torch.randint(0, cfg.vocab_size, (batch, seq), device=device)
+    full_labels = torch.randint(0, cfg.vocab_size, (batch, seq), device=device)
+    input_ids = zigzag_slice_for_cp(full_ids, rank, world, seq_dim=1).contiguous()
+    labels = zigzag_slice_for_cp(full_labels, rank, world, seq_dim=1).contiguous()
+
+    with torch.no_grad():
+        cp_out = cp_model(input_ids=input_ids, labels=labels)
+        ref_out = ref_model(input_ids=full_ids, labels=full_labels)
+
+    expected_hidden = zigzag_slice_for_cp(ref_out["hidden_states"], rank, world, seq_dim=0)
+    expected_log_probs = zigzag_slice_for_cp(ref_out["log_probs"], rank, world, seq_dim=1)
+    torch.testing.assert_close(cp_out["hidden_states"], expected_hidden, atol=1e-1, rtol=1e-1)
+    torch.testing.assert_close(cp_out["log_probs"], expected_log_probs, atol=1e-1, rtol=1e-1)

--- a/experimental/lite/tests/unit/model/test_kimi_k2_lite_static.py
+++ b/experimental/lite/tests/unit/model/test_kimi_k2_lite_static.py
@@ -1,0 +1,189 @@
+"""Static smoke coverage for Kimi K2 lite native implementation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def test_kimi_k2_lite_registry_resolves():
+    from megatron.lite.model.registry import (
+        get_train_runtime_module,
+        resolve_model_type_from_hf,
+        resolve_runtime_model_name,
+    )
+
+    runtime_name = resolve_runtime_model_name("kimi_k2", "lite")
+    assert runtime_name == "kimi_k2"
+    assert resolve_model_type_from_hf({"model_type": "kimi_k2"}) == "kimi_k2"
+    assert resolve_model_type_from_hf({"model_type": "deepseek_v3"}) == "kimi_k2"
+    module = get_train_runtime_module(runtime_name)
+    assert module.__name__ == "megatron.lite.model.kimi_k2.lite.protocol"
+
+
+def test_kimi_k2_config_reads_hf_fields():
+    from megatron.lite.model.kimi_k2.config import KimiK2Config
+
+    cfg = KimiK2Config._from_hf_dict(
+        {
+            "model_type": "kimi_k2",
+            "num_hidden_layers": 3,
+            "hidden_size": 32,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 4,
+            "vocab_size": 128,
+            "intermediate_size": 64,
+            "moe_intermediate_size": 16,
+            "n_routed_experts": 8,
+            "n_shared_experts": 2,
+            "num_experts_per_tok": 2,
+            "n_group": 4,
+            "topk_group": 2,
+            "topk_method": "noaux_tc",
+            "norm_topk_prob": True,
+            "scoring_func": "sigmoid",
+            "seq_aux": True,
+            "first_k_dense_replace": 1,
+            "q_lora_rank": 12,
+            "kv_lora_rank": 10,
+            "qk_nope_head_dim": 6,
+            "qk_rope_head_dim": 2,
+            "v_head_dim": 8,
+            "rope_scaling": {"type": "yarn", "factor": 32.0},
+        }
+    )
+
+    assert cfg.num_experts == 8
+    assert cfg.n_group == 4
+    assert cfg.topk_group == 2
+    assert cfg.shared_expert_intermediate_size == 32
+    assert cfg.q_head_dim == 8
+    assert not cfg.is_moe_layer(0)
+    assert cfg.is_moe_layer(1)
+
+
+def test_kimi_k2_lite_does_not_import_wrappers_or_sibling_models():
+    root = (
+        Path(__file__).resolve().parents[3]
+        / "megatron"
+        / "lite"
+        / "model"
+        / "kimi_k2"
+        / "lite"
+    )
+    forbidden = (
+        "megatron.lite.model.qwen3_5",
+        "megatron.lite.model.qwen3_moe",
+        "bridge_model",
+        "hybrid",
+        "build_mcore_context",
+        "from mbridge",
+        "import mbridge",
+    )
+    for path in root.glob("*.py"):
+        text = path.read_text()
+        for token in forbidden:
+            assert token not in text
+
+
+def test_kimi_k2_lite_implementation_files_stay_small():
+    root = (
+        Path(__file__).resolve().parents[3]
+        / "megatron"
+        / "lite"
+        / "model"
+        / "kimi_k2"
+        / "lite"
+    )
+    for name in ("model.py", "protocol.py", "checkpoint.py"):
+        line_count = len((root / name).read_text().splitlines())
+        assert line_count < 1000, f"{name} has {line_count} lines"
+
+
+def test_kimi_k2_lite_uses_mla_primitive():
+    root = (
+        Path(__file__).resolve().parents[3]
+        / "megatron"
+        / "lite"
+        / "model"
+        / "kimi_k2"
+        / "lite"
+    )
+    model_text = (root / "model.py").read_text()
+
+    assert "from megatron.lite.primitive.modules.mla import MultiLatentAttention" in model_text
+    assert "class MultiLatentAttention" not in model_text
+    assert "SigmoidTopKRouter" in model_text
+
+
+def test_kimi_k2_fp8_checkpoint_dequant_cpu_path():
+    torch = pytest.importorskip("torch")
+    if not hasattr(torch, "float8_e4m3fn"):
+        pytest.skip("torch float8_e4m3fn is required for this smoke.")
+
+    from megatron.lite.model.kimi_k2.lite.checkpoint import _dequant_fp8_weight
+
+    class Reader:
+        index = {"w_scale_inv": "fake.safetensors"}
+
+        @staticmethod
+        def get_tensor(name):
+            assert name == "w_scale_inv"
+            return torch.full((1, 1), 2.0, dtype=torch.float32)
+
+    weight = torch.tensor([[1.0, -2.0], [3.0, -4.0]], dtype=torch.float32).to(
+        torch.float8_e4m3fn
+    )
+    out = _dequant_fp8_weight(Reader(), "w", weight)
+
+    torch.testing.assert_close(out, weight.float() * 2.0)
+
+
+def test_kimi_k2_int4_checkpoint_dequant_cpu_path():
+    torch = pytest.importorskip("torch")
+
+    from megatron.lite.model.kimi_k2.lite.checkpoint import _get
+
+    values = torch.tensor([[-8, -7, -1, 0, 1, 2, 6, 7, -8, 7]], dtype=torch.int8)
+    unsigned = (values + 8).to(torch.int32)
+    packed = torch.zeros((1, 2), dtype=torch.int32)
+    for offset in range(8):
+        packed[:, 0] |= unsigned[:, offset] << (4 * offset)
+    for offset in range(2):
+        packed[:, 1] |= unsigned[:, 8 + offset] << (4 * offset)
+
+    class Reader:
+        index = {
+            "w_packed": "fake.safetensors",
+            "w_scale": "fake.safetensors",
+            "w_shape": "fake.safetensors",
+        }
+
+        @staticmethod
+        def get_tensor(name):
+            return {
+                "w_packed": packed,
+                "w_scale": torch.tensor([[0.5, 2.0]], dtype=torch.float32),
+                "w_shape": torch.tensor([1, 10], dtype=torch.int64),
+            }[name]
+
+    out = _get(Reader(), "w")
+    expected = torch.cat([values[:, :5].float() * 0.5, values[:, 5:].float() * 2.0], dim=1)
+
+    torch.testing.assert_close(out, expected)
+
+
+def test_kimi_k2_real_checkpoint_prefix_helpers():
+    from megatron.lite.model.kimi_k2.lite.checkpoint import _lm_head_name, _text_prefix
+
+    class Reader:
+        index = {
+            "language_model.model.embed_tokens.weight": "fake.safetensors",
+            "language_model.lm_head.weight": "fake.safetensors",
+        }
+
+    prefix = _text_prefix(Reader())
+
+    assert prefix == "language_model.model"
+    assert _lm_head_name(Reader(), prefix) == "language_model.lm_head.weight"


### PR DESCRIPTION
Ports Kimi K2 as a native lite model (config/model/checkpoint/protocol) with full HF weight mapping (MLA q/kv-lora, dense/shared/routed experts with EP/ETP, fp8/int4 dequant, vocab pad) and the MLA primitive. Registered in the lite model registry. Kept minimal and back-compatible (no wrapper or sibling-model imports; guarded by a dedicated test).