### PR TITLE
Add Megatron-FSDP (mfsdp) optimizer backend

### DIFF
--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
@@ -229,6 +229,28 @@ def build_model(model_cfg: Qwen35Config, *, impl_cfg: ImplConfig) -> ModelBundle
 
         register_training_hooks(chunks, optimizer)
         optimizer_backend = "mc_full"
+    elif impl_cfg.optimizer == "mfsdp":
+        optimizer_backend = "mfsdp"
+
+        def _post_model_load_hook():
+            from megatron.lite.model.qwen3_5.lite.model import Qwen35Layer
+            from megatron.lite.primitive.optimizers.mfsdp import (
+                build_mfsdp_training_optimizer,
+            )
+
+            optimizer, finalize = build_mfsdp_training_optimizer(
+                chunks,
+                model_cfg=model_cfg,
+                impl_cfg=impl_cfg,
+                ps=ps,
+                model_name="qwen3_5",
+                is_expert=is_expert_param,
+                fsdp_unit_modules=(Qwen35Layer,),
+                deterministic=deterministic,
+            )
+            return {"optimizer": optimizer, "finalize_grads": finalize}
+
+        post_model_load_hook = _post_model_load_hook
     elif impl_cfg.optimizer == "fsdp2":
         optimizer_backend = "fsdp2"
 

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
@@ -221,6 +221,28 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
             deterministic=deterministic,
         )
         optimizer_backend = "mc"
+    elif impl_cfg.optimizer == "mfsdp":
+        optimizer_backend = "mfsdp"
+
+        def _post_model_load_hook():
+            from megatron.lite.model.qwen3_moe.lite.model import TransformerLayer
+            from megatron.lite.primitive.optimizers.mfsdp import (
+                build_mfsdp_training_optimizer,
+            )
+
+            optimizer, finalize = build_mfsdp_training_optimizer(
+                chunks,
+                model_cfg=model_cfg,
+                impl_cfg=impl_cfg,
+                ps=ps,
+                model_name="qwen3_moe",
+                is_expert=is_expert_param,
+                fsdp_unit_modules=(TransformerLayer,),
+                deterministic=deterministic,
+            )
+            return {"optimizer": optimizer, "finalize_grads": finalize}
+
+        post_model_load_hook = _post_model_load_hook
     elif impl_cfg.optimizer == "fsdp2":
         optimizer_backend = "fsdp2"
 

--- a/experimental/lite/megatron/lite/primitive/optimizers/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/__init__.py
@@ -7,6 +7,7 @@ import importlib
 BACKENDS = {
     "mc": "megatron.lite.primitive.optimizers.megatron_wrap",
     "fsdp2": "megatron.lite.primitive.optimizers.fsdp2",
+    "mfsdp": "megatron.lite.primitive.optimizers.mfsdp",
 }
 
 

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/__init__.py
@@ -1,0 +1,23 @@
+"""Megatron-FSDP optimizer primitive package."""
+
+from __future__ import annotations
+
+from megatron.lite.primitive.optimizers.mfsdp.backend import (
+    BACKEND,
+    MegatronFSDPBackend,
+)
+from megatron.lite.primitive.optimizers.mfsdp.config import validate_mfsdp_config
+from megatron.lite.primitive.optimizers.mfsdp.optimizer import (
+    build_mfsdp_stack,
+    build_mfsdp_training_optimizer,
+    finalize_mfsdp_grads,
+)
+
+__all__ = [
+    "BACKEND",
+    "MegatronFSDPBackend",
+    "build_mfsdp_stack",
+    "build_mfsdp_training_optimizer",
+    "finalize_mfsdp_grads",
+    "validate_mfsdp_config",
+]

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/backend.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/backend.py
@@ -1,0 +1,2102 @@
+"""Runtime-facing Megatron-FSDP backend contract."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.distributed as dist
+from torch.distributed.tensor import DTensor  # pyright: ignore[reportMissingImports]
+
+try:
+    from megatron.core.distributed.fsdp.src.megatron_fsdp.uneven_dtensor import (
+        preprocess_state_dict_for_uneven_dtensor,
+    )
+except Exception:  # pragma: no cover - optional Megatron-Core integration.
+    preprocess_state_dict_for_uneven_dtensor = None
+
+from megatron.lite.primitive.optimizers.mfsdp.checkpoint_keys import (
+    canonicalize_expert_checkpoint_key,
+    expert_local_counts,
+    normalize_mcore_fsdp_param_name,
+    optimizer_checkpoint_expert_classifier,
+    optimizer_checkpoint_parallel_state,
+)
+from megatron.lite.primitive.optimizers.mfsdp.patches import PARAM_NAME_ATTR
+
+_MCORE_NON_PARAMETER_STATE_KEY = "mcore_non_parameter_state"
+_INNER_OPTIMIZER_STATE_KEY = "inner_optimizer_state"
+_PARAMETER_STATE_KEY = "parameter_state"
+_STATE_FORMAT_VERSION_KEY = "mfsdp_state_format_version"
+_PARAMETER_STATE_FORMAT_KEY = "parameter_state_format"
+_LIVE_PARAMETER_STATE_FORMAT = "live_param_groups"
+_FSDP_DTENSOR_PARAMETER_STATE_FORMAT = "fsdp_dtensor"
+_LOCAL_RANK_PARAMETER_STATE_FORMAT = "fsdp_dtensor_local_rank"
+_MAIN_PARAM_STATE_KEY = "param"
+_LOCAL_RANK_STATE_KEY = "rank_state"
+_STATE_FORMAT_VERSION = 2
+
+
+@dataclass(frozen=True, slots=True)
+class MegatronFSDPBackend:
+    name: str = "megatron_fsdp"
+    runtime_backend: str = "megatron_fsdp"
+
+    def zero_grad(self, optimizer: Any) -> None:
+        optimizer.zero_grad()
+
+    def finish_grad_sync(self, optimizer: Any) -> None:
+        if hasattr(optimizer, "finish_grad_sync"):
+            optimizer.finish_grad_sync()
+
+    def clip_grad_norm(self, optimizer: Any):
+        if hasattr(optimizer, "clip_grad_norm"):
+            return optimizer.clip_grad_norm()
+        return None
+
+    def step(self, optimizer: Any):
+        return optimizer.step()
+
+    def state_dict(self, optimizer: Any) -> dict:
+        mcore_optimizer = _unwrap_mcore_optimizer(optimizer)
+        if _is_mcore_mfsdp_optimizer(mcore_optimizer):
+            non_parameter_state = mcore_optimizer.state_dict()
+            parameter_state = _with_mcore_optimizer_group_meta(
+                _get_fsdp_dtensor_parameter_state(
+                    mcore_optimizer,
+                    clone_main_params=True,
+                ),
+                non_parameter_state,
+            )
+            return {
+                _STATE_FORMAT_VERSION_KEY: _STATE_FORMAT_VERSION,
+                _MCORE_NON_PARAMETER_STATE_KEY: non_parameter_state,
+                _PARAMETER_STATE_KEY: parameter_state,
+                _PARAMETER_STATE_FORMAT_KEY: _FSDP_DTENSOR_PARAMETER_STATE_FORMAT,
+            }
+        return optimizer.state_dict()
+
+    def dcp_state_dict(
+        self,
+        optimizer: Any,
+        *,
+        is_loading: bool,
+        include_main_params: bool = False,
+    ) -> dict:
+        """Build an M-FSDP optimizer state for DCP without MCore load-time dummy step.
+
+        MCore's fsdp_dtensor checkpoint loader initializes optimizer state by
+        manufacturing zero gradients and doing an optimizer step. For 30B-class
+        jobs that transient grad allocation is enough to OOM. DCP only needs a
+        correctly shaped destination tree, so loading uses empty per-parameter
+        state tensors keyed the same way as MCore's fsdp_dtensor save format.
+        """
+        mcore_optimizer = _unwrap_mcore_optimizer(optimizer)
+        if not _is_mcore_mfsdp_optimizer(mcore_optimizer):
+            return optimizer.state_dict()
+
+        if is_loading:
+            non_parameter_state = _mcore_non_parameter_state_template(mcore_optimizer)
+            _debug_template_cuda_sync("after-non-parameter-template")
+        else:
+            non_parameter_state = mcore_optimizer.state_dict()
+        if is_loading:
+            _debug_template_cuda_sync("before-parameter-state-template")
+            parameter_state = _get_fsdp_dtensor_parameter_state_template(
+                mcore_optimizer,
+                include_main_params=include_main_params,
+            )
+            _debug_template_cuda_sync("after-parameter-state-template")
+        else:
+            parameter_state = _get_fsdp_dtensor_parameter_state(
+                mcore_optimizer,
+                include_main_params=include_main_params,
+                clone_main_params=False,
+            )
+        parameter_state = _with_mcore_optimizer_group_meta(
+            parameter_state,
+            non_parameter_state,
+        )
+        parameter_state_format = _FSDP_DTENSOR_PARAMETER_STATE_FORMAT
+        if _use_local_rank_dcp_optimizer_state():
+            parameter_state = _local_rank_fsdp_dtensor_parameter_state_for_dcp(
+                parameter_state
+            )
+            parameter_state_format = _LOCAL_RANK_PARAMETER_STATE_FORMAT
+        else:
+            _preprocess_fsdp_dtensor_parameter_state_for_dcp(parameter_state)
+        return {
+            _STATE_FORMAT_VERSION_KEY: _STATE_FORMAT_VERSION,
+            _MCORE_NON_PARAMETER_STATE_KEY: non_parameter_state,
+            _PARAMETER_STATE_KEY: parameter_state,
+            _PARAMETER_STATE_FORMAT_KEY: parameter_state_format,
+        }
+
+    def load_state_dict(self, optimizer: Any, state_dict: dict) -> None:
+        mcore_optimizer = _unwrap_mcore_optimizer(optimizer)
+        if _is_mcore_mfsdp_optimizer(mcore_optimizer):
+            loaded_main_params = False
+            parameter_state = state_dict.get(_PARAMETER_STATE_KEY)
+            if parameter_state is not None:
+                parameter_state_format = state_dict.get(_PARAMETER_STATE_FORMAT_KEY)
+                if parameter_state_format in (None, _LIVE_PARAMETER_STATE_FORMAT):
+                    _load_live_parameter_state(mcore_optimizer, parameter_state)
+                    loaded_main_params = True
+                elif parameter_state_format == _FSDP_DTENSOR_PARAMETER_STATE_FORMAT:
+                    parameter_state = _with_mcore_optimizer_group_meta(
+                        parameter_state,
+                        state_dict.get(_MCORE_NON_PARAMETER_STATE_KEY),
+                    )
+                    loaded_main_params = _load_fsdp_dtensor_parameter_state(
+                        mcore_optimizer,
+                        parameter_state,
+                    )
+                elif parameter_state_format == _LOCAL_RANK_PARAMETER_STATE_FORMAT:
+                    parameter_state = _current_local_rank_parameter_state(parameter_state)
+                    parameter_state = _with_mcore_optimizer_group_meta(
+                        parameter_state,
+                        state_dict.get(_MCORE_NON_PARAMETER_STATE_KEY),
+                    )
+                    loaded_main_params = _load_fsdp_dtensor_parameter_state(
+                        mcore_optimizer,
+                        parameter_state,
+                    )
+                else:
+                    raise ValueError(
+                        f"Unsupported Megatron-FSDP parameter state format: "
+                        f"{parameter_state_format!r}."
+                    )
+            elif _INNER_OPTIMIZER_STATE_KEY in state_dict:
+                _load_inner_optimizer_state(
+                    mcore_optimizer,
+                    state_dict[_INNER_OPTIMIZER_STATE_KEY],
+                )
+                loaded_main_params = True
+            _restore_mcore_non_parameter_state(
+                mcore_optimizer,
+                state_dict.get(_MCORE_NON_PARAMETER_STATE_KEY),
+            )
+            if loaded_main_params:
+                _sync_main_weights_to_model_weights(mcore_optimizer)
+            return
+        optimizer.load_state_dict(state_dict)
+
+    def state_dict_has_main_params(self, state_dict: Any) -> bool:
+        return _state_dict_has_main_params(state_dict)
+
+    def sync_model_weights_to_main_weights(self, optimizer: Any) -> bool:
+        mcore_optimizer = _unwrap_mcore_optimizer(optimizer)
+        if not _is_mcore_mfsdp_optimizer(mcore_optimizer):
+            return False
+        return _sync_model_weights_to_main_weights(mcore_optimizer)
+
+    def finalize_grads(self, finalize_fn, model_chunks: list[Any], optimizer: Any) -> None:
+        finalize_fn(model_chunks, optimizer)
+
+
+BACKEND = MegatronFSDPBackend()
+
+
+def is_megatron_fsdp_optimizer(optimizer: Any) -> bool:
+    return _is_mcore_mfsdp_optimizer(_unwrap_mcore_optimizer(optimizer))
+
+
+def _is_mcore_mfsdp_optimizer(optimizer: Any) -> bool:
+    return any(
+        bool(getattr(getattr(leaf, "ddp_config", None), "use_megatron_fsdp", False))
+        for leaf in _iter_chained_optimizers(_unwrap_mcore_optimizer(optimizer))
+    )
+
+
+def _unwrap_mcore_optimizer(optimizer: Any) -> Any:
+    return getattr(optimizer, "_inner_optimizer", optimizer)
+
+
+def _inner_torch_optimizer(optimizer: Any) -> Any:
+    return getattr(_unwrap_mcore_optimizer(optimizer), "optimizer", None)
+
+
+def _restore_mcore_non_parameter_state(optimizer: Any, state_dict: Any) -> None:
+    if not isinstance(state_dict, dict):
+        if isinstance(state_dict, list):
+            for leaf_optimizer, leaf_state in zip(
+                _iter_chained_optimizers(optimizer),
+                state_dict,
+                strict=True,
+            ):
+                _restore_mcore_non_parameter_state(leaf_optimizer, leaf_state)
+        return
+    if "optimizer" not in state_dict and "grad_scaler" not in state_dict:
+        return
+    grad_scaler = getattr(optimizer, "grad_scaler", None)
+    grad_scaler_state = state_dict.get("grad_scaler")
+    if grad_scaler is not None and grad_scaler_state is not None:
+        grad_scaler.load_state_dict(grad_scaler_state)
+
+
+def _iter_chained_optimizers(optimizer: Any) -> list[Any]:
+    chained = getattr(optimizer, "chained_optimizers", None)
+    if chained is None:
+        return [optimizer]
+    return list(chained)
+
+
+@torch.no_grad()
+def _get_live_parameter_state(optimizer: Any) -> Any:
+    states = []
+    for chained_optimizer in _iter_chained_optimizers(optimizer):
+        inner_optimizer = _inner_torch_optimizer(chained_optimizer)
+        if inner_optimizer is None or not hasattr(inner_optimizer, "param_groups"):
+            raise TypeError("Megatron-FSDP optimizer is missing live param_groups.")
+        groups = []
+        optimizer_state = getattr(inner_optimizer, "state", {})
+        for group in inner_optimizer.param_groups:
+            params = list(group.get("params", ()))
+            groups.append(
+                {
+                    "group": {
+                        key: _clone_state_value(value)
+                        for key, value in group.items()
+                        if key != "params"
+                    },
+                    "params": [_clone_state_value(param) for param in params],
+                    "state": [
+                        {
+                            key: _clone_state_value(value)
+                            for key, value in optimizer_state.get(param, {}).items()
+                        }
+                        for param in params
+                    ],
+                }
+            )
+        states.append({"param_groups": groups})
+    return states[0] if len(states) == 1 else states
+
+
+@torch.no_grad()
+def _load_live_parameter_state(optimizer: Any, state: Any) -> None:
+    chained_optimizers = _iter_chained_optimizers(optimizer)
+    states = state if isinstance(state, list) else [state]
+    if len(states) != len(chained_optimizers):
+        raise ValueError(
+            "Megatron-FSDP live parameter state count does not match chained optimizers: "
+            f"{len(states)} != {len(chained_optimizers)}."
+        )
+    for chained_optimizer, chained_state in zip(chained_optimizers, states):
+        inner_optimizer = _inner_torch_optimizer(chained_optimizer)
+        if inner_optimizer is None or not hasattr(inner_optimizer, "param_groups"):
+            raise TypeError("Megatron-FSDP optimizer is missing live param_groups.")
+        saved_groups = chained_state.get("param_groups", [])
+        if len(saved_groups) != len(inner_optimizer.param_groups):
+            raise ValueError(
+                "Megatron-FSDP live parameter group count mismatch: "
+                f"{len(saved_groups)} != {len(inner_optimizer.param_groups)}."
+            )
+        optimizer_state = getattr(inner_optimizer, "state", None)
+        for group, saved_group in zip(inner_optimizer.param_groups, saved_groups):
+            for key, value in saved_group.get("group", {}).items():
+                group[key] = _clone_state_value(value)
+            params = list(group.get("params", ()))
+            saved_params = saved_group.get("params", [])
+            saved_states = saved_group.get("state", [])
+            if len(saved_params) != len(params) or len(saved_states) != len(params):
+                raise ValueError("Megatron-FSDP live parameter state has invalid group shape.")
+            for param, saved_param, saved_param_state in zip(
+                params,
+                saved_params,
+                saved_states,
+            ):
+                _copy_state_value_(param, saved_param)
+                if optimizer_state is not None:
+                    optimizer_state[param] = {
+                        key: _clone_state_value(value)
+                        for key, value in saved_param_state.items()
+                    }
+
+
+def _load_inner_optimizer_state(optimizer: Any, state: Any) -> None:
+    chained_optimizers = _iter_chained_optimizers(optimizer)
+    states = state if isinstance(state, list) else [state]
+    if len(states) != len(chained_optimizers):
+        raise ValueError(
+            "Megatron-FSDP inner optimizer state count does not match chained optimizers: "
+            f"{len(states)} != {len(chained_optimizers)}."
+        )
+    for chained_optimizer, chained_state in zip(chained_optimizers, states):
+        inner_optimizer = _inner_torch_optimizer(chained_optimizer)
+        if inner_optimizer is None or not hasattr(inner_optimizer, "load_state_dict"):
+            raise TypeError(
+                "Megatron-FSDP optimizer is missing an inner optimizer load_state_dict."
+            )
+        inner_optimizer.load_state_dict(chained_state)
+
+
+def _sync_main_weights_to_model_weights(optimizer: Any) -> None:
+    sync = getattr(optimizer, "_copy_main_params_to_model_params", None)
+    if callable(sync):
+        sync()
+        return
+    for chained_optimizer in _iter_chained_optimizers(optimizer):
+        sync = getattr(chained_optimizer, "_copy_main_params_to_model_params", None)
+        if callable(sync):
+            sync()
+
+
+@torch.no_grad()
+def _sync_model_weights_to_main_weights(optimizer: Any) -> bool:
+    synced_any = False
+    for chained_optimizer in _iter_chained_optimizers(optimizer):
+        if _sync_single_model_weights_to_main_weights(chained_optimizer):
+            synced_any = True
+    if synced_any:
+        print(
+            "[MFSDP_DCP_RESTORE] "
+            f"rank={_debug_rank()} model_to_main_params_synced=True",
+            flush=True,
+        )
+    return synced_any
+
+
+def _sync_single_model_weights_to_main_weights(optimizer: Any) -> bool:
+    ddp_config = getattr(optimizer, "ddp_config", None)
+    if not bool(getattr(ddp_config, "use_megatron_fsdp", False)):
+        sync = getattr(optimizer, "_copy_model_params_to_main_params", None)
+        if callable(sync):
+            sync()
+            return True
+        return False
+
+    buffer_synced_any = False
+    for model_chunk in getattr(optimizer, "model_chunks", ()):
+        buffer = getattr(model_chunk, "param_and_grad_buffer", None)
+        if buffer is not None:
+            buffer_synced_any = (
+                _sync_mfsdp_param_buffer_model_weights_to_main_weights(buffer)
+                or buffer_synced_any
+            )
+    if buffer_synced_any:
+        return True
+
+    copied_any = False
+    copied_any = (
+        _copy_model_group_weights_to_main_group(
+            optimizer,
+            getattr(optimizer, "model_float16_groups", ()),
+            getattr(optimizer, "shard_fp32_from_float16_groups", ()),
+        )
+        or copied_any
+    )
+    copied_any = (
+        _copy_model_group_weights_to_main_group(
+            optimizer,
+            getattr(optimizer, "model_fp32_groups", ()),
+            getattr(optimizer, "shard_fp32_groups", ()),
+        )
+        or copied_any
+    )
+    return copied_any
+
+
+def _sync_mfsdp_param_buffer_model_weights_to_main_weights(buffer: Any) -> bool:
+    copied_any = False
+    optimizer_named_parameters = getattr(buffer, "optimizer_named_parameters", None)
+    if optimizer_named_parameters:
+        dist_param_by_orig = {
+            getattr(dist_param, "orig_param", None): dist_param
+            for _name, dist_param in optimizer_named_parameters
+        }
+    else:
+        dist_param_by_orig = {}
+    for group in getattr(buffer, "parameter_groups", ()):
+        main_weight_buffer = getattr(group, "main_weight_buffer", None)
+        if main_weight_buffer is None:
+            continue
+        model_weight_buffer = getattr(group, "model_weight_buffer", None)
+        main_param_idx = getattr(main_weight_buffer, "param_idx", None)
+        if not isinstance(main_param_idx, dict):
+            raise TypeError("Megatron-FSDP main weight buffer is missing param_idx.")
+        for orig_param in getattr(group, "params", ()):
+            item_id = main_param_idx[orig_param]
+            model_weight, main_weight = _mfsdp_param_buffer_model_and_main_weight(
+                orig_param,
+                item_id,
+                model_weight_buffer,
+                main_weight_buffer,
+            )
+            if model_weight.numel() == 0:
+                continue
+            if model_weight.numel() != main_weight.numel():
+                name = getattr(buffer, "param_to_name", {}).get(orig_param)
+                raise ValueError(
+                    "Megatron-FSDP model-to-main buffer restore shape mismatch "
+                    f"for {name or '<unnamed>'}: model={tuple(model_weight.shape)} "
+                    f"main={tuple(main_weight.shape)}."
+                )
+            restored_main_weight = model_weight.view_as(main_weight).float()
+            main_weight.copy_(restored_main_weight)
+            dist_param = dist_param_by_orig.get(orig_param)
+            if dist_param is not None:
+                _copy_tensor_value_reshaped_(
+                    _tensor_local_data(dist_param),
+                    restored_main_weight,
+                )
+            copied_any = True
+    if copied_any:
+        copy_main_to_model = getattr(buffer, "copy_main_weights_to_model_weights", None)
+        if callable(copy_main_to_model):
+            copy_main_to_model()
+    return copied_any
+
+
+def _mfsdp_param_buffer_model_and_main_weight(
+    orig_param: Any,
+    item_id: int,
+    model_weight_buffer: Any,
+    main_weight_buffer: Any,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if model_weight_buffer is not None:
+        if bool(getattr(model_weight_buffer, "is_data_distributed", False)) or bool(
+            getattr(main_weight_buffer, "is_data_distributed", False)
+        ):
+            return (
+                model_weight_buffer.get_item(item_id, only_shard=True),
+                main_weight_buffer.get_item(item_id, only_shard=True),
+            )
+        return model_weight_buffer.get_item(item_id), main_weight_buffer.get_item(item_id)
+    if bool(getattr(main_weight_buffer, "is_data_distributed", False)):
+        raise TypeError(
+            "Megatron-FSDP cannot rebuild a sharded main weight buffer without a model weight buffer."
+        )
+    return _tensor_local_data(orig_param).view(-1), main_weight_buffer.get_item(item_id)
+
+
+def _copy_model_group_weights_to_main_group(
+    optimizer: Any,
+    model_groups: Any,
+    shard_main_groups: Any,
+) -> bool:
+    copied_any = False
+    for model_group, shard_main_group in zip(model_groups, shard_main_groups, strict=True):
+        for model_param, shard_main_param in zip(model_group, shard_main_group, strict=True):
+            if _is_distopt_quantized_param(optimizer, model_param):
+                continue
+            shard_model_param = _mfsdp_model_param_shard(optimizer, model_param)
+            if shard_model_param.numel() != shard_main_param.numel():
+                name = _optimizer_param_name(optimizer, model_param)
+                raise ValueError(
+                    "Megatron-FSDP model-to-main checkpoint restore shape mismatch "
+                    f"for {name or '<unnamed>'}: model_shard={tuple(shard_model_param.shape)} "
+                    f"main_shard={tuple(shard_main_param.shape)}."
+                )
+            shard_main_param.copy_(shard_model_param.view_as(shard_main_param))
+            copied_any = True
+    return copied_any
+
+
+def _mfsdp_model_param_shard(optimizer: Any, model_param: Any) -> torch.Tensor:
+    get_range_map = getattr(optimizer, "_get_model_param_range_map", None)
+    if not callable(get_range_map):
+        raise TypeError("Megatron-FSDP optimizer is missing _get_model_param_range_map.")
+    range_map = get_range_map(model_param)
+    if not isinstance(range_map, dict) or "gbuf_world_in_bucket" not in range_map:
+        raise TypeError("Megatron-FSDP optimizer range map is missing gbuf_world_in_bucket.")
+    world_range = range_map["gbuf_world_in_bucket"]
+    gbuf_map = getattr(optimizer, "model_param_gbuf_map", None)
+    if not isinstance(gbuf_map, dict) or model_param not in gbuf_map:
+        raise TypeError("Megatron-FSDP optimizer is missing model_param_gbuf_map entry.")
+    gbuf_index, _dtype, bucket_id = gbuf_map[model_param]
+    buffers = getattr(optimizer, "buffers", None)
+    try:
+        bucket = buffers[gbuf_index].buckets[bucket_id]
+        param_data = bucket.param_data
+    except (TypeError, AttributeError, IndexError, KeyError) as exc:
+        raise TypeError("Megatron-FSDP optimizer buffer metadata is invalid.") from exc
+    return param_data.view(-1)[world_range.start:world_range.end]
+
+
+def _is_distopt_quantized_param(optimizer: Any, model_param: Any) -> bool:
+    is_quantized = getattr(optimizer, "_is_distopt_quantized_param", None)
+    return bool(callable(is_quantized) and is_quantized(model_param))
+
+
+def _tensor_local_data(value: Any) -> torch.Tensor:
+    data = getattr(value, "data", value)
+    if isinstance(data, DTensor):
+        return _dtensor_local_tensor(data)
+    if isinstance(data, torch.Tensor):
+        return data
+    raise TypeError(f"Expected Tensor or DTensor, got {type(value).__name__}.")
+
+
+def _clone_state_value(value: Any) -> Any:
+    if torch.is_tensor(value):
+        return value.detach().clone()
+    if isinstance(value, dict):
+        return {key: _clone_state_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_clone_state_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_clone_state_value(item) for item in value)
+    return value
+
+
+def _copy_state_value_(target: Any, source: Any) -> None:
+    if isinstance(target, DTensor) or isinstance(source, DTensor):
+        _copy_tensor_value_reshaped_(
+            _tensor_local_data(target),
+            _tensor_local_data(source),
+        )
+        return
+    if torch.is_tensor(target) and torch.is_tensor(source):
+        with torch.no_grad():
+            target.copy_(source)
+
+
+def _copy_tensor_value_reshaped_(target: torch.Tensor, source: torch.Tensor) -> None:
+    if target.numel() != source.numel():
+        raise ValueError(
+            "Cannot copy optimizer tensor state with different element counts: "
+            f"target={tuple(target.shape)} source={tuple(source.shape)}."
+        )
+    with torch.no_grad():
+        target.copy_(source.view_as(target))
+
+
+def _get_fsdp_dtensor_parameter_state(
+    optimizer: Any,
+    *,
+    include_main_params: bool = True,
+    clone_main_params: bool = False,
+) -> Any:
+    states = []
+    for chained_optimizer in _iter_chained_optimizers(optimizer):
+        _ensure_fsdp_dtensor_optimizer_param_names(chained_optimizer)
+        sharded_state_dict = getattr(chained_optimizer, "sharded_state_dict", None)
+        if not callable(sharded_state_dict):
+            raise TypeError(
+                "Megatron-FSDP optimizer is missing sharded_state_dict for fsdp_dtensor state."
+            )
+        parameter_state = sharded_state_dict(
+            is_loading=False,
+            metadata={
+                "distrib_optim_sharding_type": _FSDP_DTENSOR_PARAMETER_STATE_FORMAT
+            },
+        )
+        parameter_state = _canonicalize_fsdp_dtensor_parameter_state(
+            chained_optimizer,
+            parameter_state,
+        )
+        if include_main_params:
+            parameter_state = _with_fsdp_dtensor_main_params(
+                parameter_state,
+                chained_optimizer,
+                clone_main_params=clone_main_params,
+            )
+            parameter_state = _canonicalize_fsdp_dtensor_parameter_state(
+                chained_optimizer,
+                parameter_state,
+            )
+        else:
+            parameter_state = _without_fsdp_dtensor_main_params(parameter_state)
+        states.append(parameter_state)
+    return states[0] if len(states) == 1 else states
+
+
+def _get_fsdp_dtensor_parameter_state_template(
+    optimizer: Any,
+    *,
+    include_main_params: bool,
+) -> Any:
+    states = []
+    for chained_optimizer in _iter_chained_optimizers(optimizer):
+        _debug_template_cuda_sync("before-name-map", log_success=True)
+        _ensure_fsdp_dtensor_optimizer_param_names(chained_optimizer)
+        _debug_template_cuda_sync("after-name-map", log_success=True)
+        state = {}
+        for param in _iter_inner_optimizer_params(chained_optimizer):
+            name = _optimizer_param_name(chained_optimizer, param)
+            if name is None:
+                continue
+            _debug_template_cuda_sync(
+                f"before-param-template:{name}",
+                log_success=_debug_dcp_template_key_enabled(name),
+            )
+            state[name] = _optimizer_param_state_template(
+                chained_optimizer,
+                param,
+                debug_name=name,
+                include_main_params=include_main_params,
+            )
+        parameter_state = {
+            "state": state,
+            "param_to_group_meta": _param_groups_to_param2group_meta(
+                chained_optimizer
+            ),
+        }
+        states.append(
+            _canonicalize_fsdp_dtensor_parameter_state(
+                chained_optimizer,
+                parameter_state,
+            )
+        )
+    return states[0] if len(states) == 1 else states
+
+
+def _optimizer_param_state_template(
+    optimizer: Any,
+    param: Any,
+    *,
+    debug_name: str | None = None,
+    include_main_params: bool,
+) -> dict[str, Any]:
+    inner_optimizer = _inner_torch_optimizer(optimizer)
+    live_state = {}
+    if inner_optimizer is not None:
+        optimizer_state = getattr(inner_optimizer, "state", {})
+        live_state = (
+            optimizer_state.get(param, {})
+            if isinstance(optimizer_state, dict)
+            else {}
+        )
+
+    if live_state:
+        state = {
+            key: _empty_state_value_like(
+                value,
+                debug_key=_debug_state_key(debug_name, str(key)),
+            )
+            for key, value in live_state.items()
+        }
+    else:
+        state = {
+            "exp_avg": _empty_state_value_like(
+                param,
+                debug_key=_debug_state_key(debug_name, "exp_avg"),
+            ),
+            "exp_avg_sq": _empty_state_value_like(
+                param,
+                debug_key=_debug_state_key(debug_name, "exp_avg_sq"),
+            ),
+        }
+    if include_main_params:
+        state[_MAIN_PARAM_STATE_KEY] = _checkpoint_tensor_view(param)
+    return state
+
+
+def _param_groups_to_param2group_meta(optimizer: Any) -> dict[str, Any]:
+    inner_optimizer = _inner_torch_optimizer(optimizer)
+    param_groups = getattr(inner_optimizer, "param_groups", None)
+    if param_groups is None:
+        return {}
+    mcore_converter = getattr(optimizer, "_param_groups_to_param2group_meta", None)
+    if callable(mcore_converter):
+        return mcore_converter(param_groups)
+
+    param_to_group_meta = {}
+    for group in param_groups:
+        group_meta = {key: value for key, value in group.items() if key != "params"}
+        for param in group.get("params", ()):
+            name = _optimizer_param_name(optimizer, param)
+            if name is not None:
+                param_to_group_meta[name] = dict(group_meta)
+    return param_to_group_meta
+
+
+def _with_optimizer_group_step_placeholders(state_dict: Any) -> Any:
+    if isinstance(state_dict, list):
+        return [_with_optimizer_group_step_placeholders(item) for item in state_dict]
+    if not isinstance(state_dict, dict):
+        return state_dict
+    optimizer_state = state_dict.get("optimizer")
+    if not isinstance(optimizer_state, dict):
+        return state_dict
+    param_groups = optimizer_state.get("param_groups")
+    if not isinstance(param_groups, list):
+        return state_dict
+
+    updated_optimizer_state = dict(optimizer_state)
+    updated_optimizer_state["param_groups"] = [
+        _with_group_step_placeholder(group) for group in param_groups
+    ]
+    updated_state_dict = dict(state_dict)
+    updated_state_dict["optimizer"] = updated_optimizer_state
+    return updated_state_dict
+
+
+def _with_group_step_placeholder(group: Any) -> Any:
+    if not isinstance(group, dict) or "step" in group:
+        return group
+    updated_group = dict(group)
+    updated_group["step"] = 0
+    return updated_group
+
+
+def _canonicalize_fsdp_dtensor_parameter_state(optimizer: Any, parameter_state: Any) -> Any:
+    if not isinstance(parameter_state, dict):
+        return parameter_state
+    canonicalize = _optimizer_param_name_canonicalizer(optimizer)
+    if canonicalize is None:
+        return parameter_state
+
+    updated = dict(parameter_state)
+    changed = False
+
+    state = parameter_state.get("state")
+    if isinstance(state, dict):
+        updated_state = {}
+        state_sources = {}
+        for name, value in state.items():
+            canonical_name = canonicalize(name) if isinstance(name, str) else name
+            _check_canonical_name_collision(state_sources, canonical_name, name)
+            updated_state[canonical_name] = value
+            state_sources[canonical_name] = name
+            changed = changed or canonical_name != name
+        updated["state"] = updated_state
+
+    param_to_group_meta = parameter_state.get("param_to_group_meta")
+    if isinstance(param_to_group_meta, dict):
+        updated_meta = {}
+        meta_sources = {}
+        for name, value in param_to_group_meta.items():
+            canonical_name = canonicalize(name) if isinstance(name, str) else name
+            _check_canonical_name_collision(meta_sources, canonical_name, name)
+            updated_meta[canonical_name] = value
+            meta_sources[canonical_name] = name
+            changed = changed or canonical_name != name
+        updated["param_to_group_meta"] = updated_meta
+
+    return updated if changed else parameter_state
+
+
+def _check_canonical_name_collision(
+    sources: dict[Any, Any],
+    canonical_name: Any,
+    source_name: Any,
+) -> None:
+    existing_source = sources.get(canonical_name)
+    if existing_source is None or existing_source == source_name:
+        return
+    raise ValueError(
+        "Megatron-FSDP optimizer checkpoint key canonicalization collision: "
+        f"{source_name!r} and {existing_source!r} map to {canonical_name!r}."
+    )
+
+
+def _optimizer_param_name_canonicalizer(optimizer: Any):
+    ps = optimizer_checkpoint_parallel_state(optimizer)
+    is_expert = optimizer_checkpoint_expert_classifier(optimizer)
+    if ps is None or is_expert is None:
+        return None
+
+    names = [
+        name
+        for name in _model_chunk_param_names(optimizer).values()
+        if isinstance(name, str)
+    ]
+    if not names:
+        mapping = getattr(optimizer, "param_to_name", None)
+        if isinstance(mapping, dict):
+            names.extend(name for name in mapping.values() if isinstance(name, str))
+    local_counts = expert_local_counts(
+        (normalize_mcore_fsdp_param_name(name) for name in names),
+        is_expert,
+    )
+
+    def canonicalize(name: str) -> str:
+        normalized = normalize_mcore_fsdp_param_name(name)
+        _, canonical_normalized = canonicalize_expert_checkpoint_key(
+            normalized,
+            normalized,
+            ps=ps,
+            is_expert=is_expert(normalized),
+            local_counts=local_counts,
+        )
+        if name.startswith("module.module."):
+            return f"module.module.{canonical_normalized}"
+        return canonical_normalized
+
+    return canonicalize
+
+
+def _mcore_non_parameter_state_template(optimizer: Any) -> Any:
+    """Build load-time MCore optimizer metadata without calling MCore state_dict.
+
+    MCore's Megatron-FSDP optimizer state_dict path is not a pure metadata
+    query before optimizer moments exist. For DCP load we only need a
+    correctly shaped tree for param-group metadata such as ``step``; parameter
+    tensors are represented separately by the fsdp_dtensor parameter state.
+    """
+    states = [
+        _single_mcore_non_parameter_state_template(chained_optimizer)
+        for chained_optimizer in _iter_chained_optimizers(optimizer)
+    ]
+    return states[0] if len(states) == 1 else states
+
+
+def _single_mcore_non_parameter_state_template(optimizer: Any) -> dict[str, Any]:
+    inner_optimizer = _inner_torch_optimizer(optimizer)
+    if inner_optimizer is None:
+        return {}
+    param_groups = getattr(inner_optimizer, "param_groups", None)
+    if not isinstance(param_groups, list):
+        return {}
+    return {
+        "optimizer": {
+            "state": {},
+            "param_groups": [
+                _with_group_step_placeholder(
+                    {key: value for key, value in group.items() if key != "params"}
+                )
+                for group in param_groups
+                if isinstance(group, dict)
+            ],
+        },
+    }
+
+
+def _empty_state_value_like(value: Any, *, debug_key: str | None = None) -> Any:
+    if isinstance(value, DTensor):
+        return _empty_dtensor_like(value, debug_key=debug_key)
+    data = getattr(value, "data", None)
+    if isinstance(data, DTensor):
+        return _empty_dtensor_like(data, debug_key=debug_key)
+    if torch.is_tensor(value):
+        return _empty_tensor_like(value)
+    if isinstance(value, dict):
+        return {
+            key: _empty_state_value_like(
+                item,
+                debug_key=_debug_state_key(debug_key, str(key)),
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [
+            _empty_state_value_like(
+                item,
+                debug_key=_debug_state_key(debug_key, str(index)),
+            )
+            for index, item in enumerate(value)
+        ]
+    if isinstance(value, tuple):
+        return tuple(
+            _empty_state_value_like(
+                item,
+                debug_key=_debug_state_key(debug_key, str(index)),
+            )
+            for index, item in enumerate(value)
+        )
+    return value
+
+
+def _empty_dtensor_like(
+    value: DTensor,
+    *,
+    debug_key: str | None = None,
+) -> DTensor:
+    local = _dtensor_local_tensor(value)
+    if _debug_dcp_template_key_enabled(debug_key):
+        _log_dtensor_template("before-empty", value, local, debug_key)
+        _cuda_synchronize_for_debug(local, debug_key)
+    local_empty = torch.empty_strided(
+        tuple(local.shape),
+        tuple(local.stride()),
+        dtype=local.dtype,
+        device=local.device,
+    )
+    _initialize_optimizer_template_tensor_(local_empty)
+    if _debug_dcp_template_key_enabled(debug_key):
+        _log_tensor_template("after-empty", local_empty, debug_key)
+        _cuda_synchronize_for_debug(local_empty, debug_key)
+    return DTensor.from_local(
+        local_empty,
+        value.device_mesh,
+        value.placements,
+        shape=value.shape,
+        stride=value.stride(),
+    )
+
+
+def _empty_tensor_like(value: torch.Tensor) -> torch.Tensor:
+    tensor = torch.empty_like(value)
+    _initialize_optimizer_template_tensor_(tensor)
+    return tensor
+
+
+def _initialize_optimizer_template_tensor_(tensor: torch.Tensor) -> None:
+    fill = os.environ.get("MLITE_MFSDP_DCP_TEMPLATE_FILL", "").lower()
+    if fill in {"nan", "sentinel"} and torch.is_floating_point(tensor):
+        tensor.fill_(float("nan"))
+    elif fill == "zero":
+        tensor.zero_()
+
+
+def _dtensor_local_tensor(value: DTensor) -> torch.Tensor:
+    local = getattr(value, "_local_tensor", None)
+    if isinstance(local, torch.Tensor):
+        return local
+    return value.to_local()
+
+
+def _debug_state_key(base: str | None, suffix: str | None) -> str | None:
+    if base is None:
+        return suffix
+    if not suffix:
+        return base
+    return f"{base}.{suffix}"
+
+
+def _debug_dcp_template_enabled() -> bool:
+    return os.environ.get("MLITE_MFSDP_DCP_DEBUG_TEMPLATE", "").lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _debug_dcp_template_key_enabled(debug_key: str | None) -> bool:
+    if not _debug_dcp_template_enabled():
+        return False
+    key_filter = os.environ.get("MLITE_MFSDP_DCP_DEBUG_TEMPLATE_FILTER", "")
+    return not key_filter or (debug_key is not None and key_filter in debug_key)
+
+
+def _debug_template_cuda_sync(phase: str, *, log_success: bool = False) -> None:
+    if not _debug_dcp_template_enabled() or not torch.cuda.is_available():
+        return
+    try:
+        torch.cuda.synchronize()
+    except Exception as exc:
+        print(
+            "[MFSDP_DCP_TEMPLATE] "
+            f"rank={_debug_rank()} phase={phase}-cuda-sync-error "
+            f"error={type(exc).__name__}: {exc}",
+            flush=True,
+        )
+        raise
+    if log_success:
+        print(
+            "[MFSDP_DCP_TEMPLATE] "
+            f"rank={_debug_rank()} phase={phase}-cuda-sync-ok",
+            flush=True,
+        )
+
+
+def _debug_rank() -> int:
+    if dist.is_available() and dist.is_initialized():
+        return dist.get_rank()
+    return -1
+
+
+def _log_dtensor_template(
+    phase: str,
+    value: DTensor,
+    local: torch.Tensor,
+    debug_key: str | None,
+) -> None:
+    print(
+        "[MFSDP_DCP_TEMPLATE] "
+        f"rank={_debug_rank()} phase={phase} key={debug_key} "
+        f"global_shape={_safe_debug_value(lambda: tuple(value.shape))} "
+        f"global_stride={_safe_debug_value(lambda: tuple(value.stride()))} "
+        f"placements={_safe_debug_value(lambda: value.placements)} "
+        f"mesh={_safe_debug_value(lambda: value.device_mesh)} "
+        f"local_shape={_safe_debug_value(lambda: tuple(local.shape))} "
+        f"local_stride={_safe_debug_value(lambda: tuple(local.stride()))} "
+        f"dtype={_safe_debug_value(lambda: local.dtype)} "
+        f"device={_safe_debug_value(lambda: local.device)} "
+        f"storage_bytes={_safe_storage_bytes(local)}",
+        flush=True,
+    )
+
+
+def _log_tensor_template(
+    phase: str,
+    tensor: torch.Tensor,
+    debug_key: str | None,
+) -> None:
+    print(
+        "[MFSDP_DCP_TEMPLATE] "
+        f"rank={_debug_rank()} phase={phase} key={debug_key} "
+        f"shape={_safe_debug_value(lambda: tuple(tensor.shape))} "
+        f"stride={_safe_debug_value(lambda: tuple(tensor.stride()))} "
+        f"dtype={_safe_debug_value(lambda: tensor.dtype)} "
+        f"device={_safe_debug_value(lambda: tensor.device)} "
+        f"storage_bytes={_safe_storage_bytes(tensor)}",
+        flush=True,
+    )
+
+
+def _cuda_synchronize_for_debug(tensor: torch.Tensor, debug_key: str | None) -> None:
+    device = getattr(tensor, "device", None)
+    if device is None or device.type != "cuda":
+        return
+    try:
+        torch.cuda.synchronize(device)
+    except Exception as exc:
+        print(
+            "[MFSDP_DCP_TEMPLATE] "
+            f"rank={_debug_rank()} phase=cuda-sync-error key={debug_key} "
+            f"error={type(exc).__name__}: {exc}",
+            flush=True,
+        )
+        raise
+
+
+def _safe_storage_bytes(tensor: torch.Tensor) -> Any:
+    return _safe_debug_value(lambda: tensor.untyped_storage().nbytes())
+
+
+def _safe_debug_value(fn: Any) -> Any:
+    try:
+        return fn()
+    except Exception as exc:
+        return f"<{type(exc).__name__}: {exc}>"
+
+
+def _load_fsdp_dtensor_parameter_state(optimizer: Any, state: Any) -> bool:
+    chained_optimizers = _iter_chained_optimizers(optimizer)
+    states = state if isinstance(state, list) else [state]
+    if len(states) != len(chained_optimizers):
+        raise ValueError(
+            "Megatron-FSDP fsdp_dtensor parameter state count does not match chained optimizers: "
+            f"{len(states)} != {len(chained_optimizers)}."
+        )
+    loaded_main_params = False
+    for chained_optimizer, chained_state in zip(chained_optimizers, states):
+        if chained_state is not None:
+            _ensure_fsdp_dtensor_optimizer_param_names(chained_optimizer)
+            chained_state = _canonicalize_fsdp_dtensor_parameter_state(
+                chained_optimizer,
+                chained_state,
+            )
+            _install_fsdp_dtensor_optimizer_state(chained_optimizer, chained_state)
+            loaded_main_params = (
+                _restore_fsdp_dtensor_main_params(chained_optimizer, chained_state)
+                or loaded_main_params
+            )
+    return loaded_main_params
+
+
+@torch.no_grad()
+def _install_fsdp_dtensor_optimizer_state(optimizer: Any, parameter_state: Any) -> None:
+    inner_optimizer = _inner_torch_optimizer(optimizer)
+    if inner_optimizer is None:
+        raise TypeError("Megatron-FSDP optimizer is missing an inner optimizer.")
+    state_by_name = (
+        parameter_state.get("state")
+        if isinstance(parameter_state, dict)
+        else None
+    )
+    if not isinstance(state_by_name, dict):
+        return
+    param_to_group_meta = parameter_state.get("param_to_group_meta")
+    if not isinstance(param_to_group_meta, dict):
+        raise TypeError("Megatron-FSDP optimizer state is missing param_to_group_meta.")
+
+    installed_names: set[str] = set()
+    optimizer_state = getattr(inner_optimizer, "state", None)
+    if optimizer_state is None:
+        optimizer_state = {}
+        inner_optimizer.state = optimizer_state
+    if not isinstance(optimizer_state, dict):
+        raise TypeError("Megatron-FSDP inner optimizer state is not a dict.")
+    precision_aware = _use_precision_aware_optimizer(optimizer)
+    sanitize_stats = {"tensors": 0, "elements": 0}
+    live_params = _iter_inner_optimizer_params(optimizer)
+    for param in live_params:
+        name = _optimizer_param_name(optimizer, param)
+        if name is None:
+            continue
+        saved_state = state_by_name.get(name)
+        if not isinstance(saved_state, dict):
+            continue
+        _install_fsdp_dtensor_param_state(
+            inner_optimizer,
+            optimizer_state,
+            param,
+            name,
+            saved_state,
+            precision_aware=precision_aware,
+            sanitize_stats=sanitize_stats,
+        )
+        installed_names.add(name)
+    _ensure_all_named_optimizer_states_installed(state_by_name, installed_names)
+    _restore_mfsdp_inner_optimizer_param_groups(
+        optimizer,
+        inner_optimizer,
+        param_to_group_meta,
+    )
+    _debug_optimizer_restore_summary(
+        state_by_name=state_by_name,
+        live_param_count=len(live_params),
+        installed_count=len(installed_names),
+        inner_state_count=len(optimizer_state),
+        param_groups=getattr(inner_optimizer, "param_groups", None),
+        precision_aware=precision_aware,
+        sanitize_stats=sanitize_stats,
+    )
+
+
+def _install_fsdp_dtensor_param_state(
+    inner_optimizer: Any,
+    optimizer_state: dict[Any, Any],
+    param: Any,
+    name: str,
+    saved_state: dict[str, Any],
+    *,
+    precision_aware: bool,
+    sanitize_stats: dict[str, int],
+) -> None:
+    set_scaled_state = getattr(inner_optimizer, "set_scaled_state", None)
+    param_state: dict[str, Any] = {}
+    optimizer_state[param] = param_state
+    for key, value in saved_state.items():
+        if key == _MAIN_PARAM_STATE_KEY:
+            continue
+        _validate_optimizer_state_value(param, name, key, value)
+        if torch.is_tensor(value):
+            stored_value = _optimizer_state_tensor_for_inner_optimizer(
+                value,
+                param_name=name,
+                state_key=str(key),
+                sanitize_stats=sanitize_stats,
+            )
+            param_state[key] = stored_value
+            if callable(set_scaled_state):
+                set_scaled_state(param, key, _optimizer_state_value_for_te(stored_value))
+        else:
+            param_state[key] = _clone_state_value(value)
+    _debug_optimizer_restore_param(name, param, param_state)
+
+
+def _optimizer_state_tensor_for_inner_optimizer(
+    value: torch.Tensor,
+    *,
+    param_name: str,
+    state_key: str,
+    sanitize_stats: dict[str, int],
+) -> torch.Tensor:
+    if isinstance(value, DTensor):
+        local = _dtensor_local_tensor(value)
+    else:
+        local = value
+    if state_key != "step" and torch.is_floating_point(local):
+        _sanitize_optimizer_state_tensor_(
+            local,
+            sanitize_stats,
+            param_name=param_name,
+            state_key=state_key,
+            source_value=value,
+        )
+    return local
+
+
+def _sanitize_optimizer_state_tensor_(
+    tensor: torch.Tensor,
+    sanitize_stats: dict[str, int],
+    *,
+    param_name: str,
+    state_key: str,
+    source_value: Any,
+) -> None:
+    flat = tensor.detach().view(-1)
+    chunk_size = _optimizer_state_sanitize_chunk_size()
+    sanitized_tensor = False
+    total_nonfinite = 0
+    first_bad_index: int | None = None
+    first_bad_count = 0
+    for start in range(0, flat.numel(), chunk_size):
+        chunk = flat[start : start + chunk_size]
+        # Avoid materializing a full-param finite mask; Qwen3MoE restore runs near
+        # the memory ceiling before optimizer state install.
+        if bool(torch.isfinite(chunk).all().item()):
+            continue
+        if _debug_optimizer_sanitize_enabled():
+            bad_mask = ~torch.isfinite(chunk)
+            bad_count = int(bad_mask.sum().item())
+            if first_bad_index is None:
+                local_bad = torch.nonzero(bad_mask, as_tuple=False)
+                first_bad_index = start + int(local_bad[0].item()) if local_bad.numel() else start
+                first_bad_count = bad_count
+        else:
+            bad_count = chunk.numel()
+        chunk.nan_to_num_(nan=0.0, posinf=0.0, neginf=0.0)
+        total_nonfinite += int(bad_count)
+        sanitized_tensor = True
+    if sanitized_tensor:
+        sanitize_stats["tensors"] = int(sanitize_stats.get("tensors", 0)) + 1
+        sanitize_stats["elements"] = int(sanitize_stats.get("elements", 0)) + total_nonfinite
+        _debug_optimizer_sanitize_report(
+            tensor,
+            source_value,
+            sanitize_stats,
+            param_name=param_name,
+            state_key=state_key,
+            bad_elements=total_nonfinite,
+            first_bad_index=first_bad_index,
+            first_bad_chunk_count=first_bad_count,
+        )
+
+
+def _optimizer_state_sanitize_chunk_size() -> int:
+    raw = os.environ.get("MLITE_MFSDP_DCP_SANITIZE_CHUNK_SIZE", "1048576")
+    try:
+        return max(int(raw), 1)
+    except ValueError:
+        return 1048576
+
+
+def _debug_optimizer_sanitize_enabled() -> bool:
+    return os.environ.get("MLITE_MFSDP_DCP_DEBUG_SANITIZE", "").lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _debug_optimizer_sanitize_report(
+    tensor: torch.Tensor,
+    source_value: Any,
+    sanitize_stats: dict[str, int],
+    *,
+    param_name: str,
+    state_key: str,
+    bad_elements: int,
+    first_bad_index: int | None,
+    first_bad_chunk_count: int,
+) -> None:
+    if not _debug_optimizer_sanitize_enabled():
+        return
+    max_reports = _debug_optimizer_sanitize_max_reports()
+    reports = int(sanitize_stats.get("reports", 0))
+    if reports >= max_reports:
+        return
+    sanitize_stats["reports"] = reports + 1
+    source_shape = tuple(source_value.shape) if torch.is_tensor(source_value) else None
+    source_local_shape = None
+    source_placements = None
+    if isinstance(source_value, DTensor):
+        source_local_shape = tuple(_dtensor_local_tensor(source_value).shape)
+        source_placements = tuple(str(placement) for placement in source_value.placements)
+    print(
+        "[MFSDP_DCP_RESTORE_SANITIZE] "
+        f"rank={_debug_rank()} name={param_name} key={state_key} "
+        f"shape={tuple(tensor.shape)} dtype={tensor.dtype} device={tensor.device} "
+        f"source_shape={source_shape} source_local_shape={source_local_shape} "
+        f"source_placements={source_placements} bad_elements={bad_elements} "
+        f"first_bad_index={first_bad_index} "
+        f"first_bad_chunk_count={first_bad_chunk_count}",
+        flush=True,
+    )
+
+
+def _debug_optimizer_sanitize_max_reports() -> int:
+    raw = os.environ.get("MLITE_MFSDP_DCP_DEBUG_SANITIZE_MAX_REPORTS", "16")
+    try:
+        return max(int(raw), 0)
+    except ValueError:
+        return 16
+
+
+def _use_precision_aware_optimizer(optimizer: Any) -> bool:
+    config = getattr(optimizer, "config", None)
+    return bool(getattr(config, "use_precision_aware_optimizer_no_fp8_or_ds_fp8", False))
+
+
+def _optimizer_state_value_for_te(value: torch.Tensor) -> torch.Tensor:
+    if value.dtype == torch.float32:
+        return value
+    return value.float()
+
+
+def _restore_mfsdp_inner_optimizer_param_groups(
+    optimizer: Any,
+    inner_optimizer: Any,
+    param_to_group_meta: dict[str, Any],
+) -> None:
+    param_groups = getattr(inner_optimizer, "param_groups", None)
+    if not isinstance(param_groups, list):
+        return
+    for group in param_groups:
+        if not isinstance(group, dict):
+            continue
+        group_meta = _group_meta_for_inner_optimizer_group(
+            optimizer,
+            group,
+            param_to_group_meta,
+        )
+        if group_meta is None:
+            continue
+        for key, value in group_meta.items():
+            if key != "params":
+                group[key] = value
+
+
+def _group_meta_for_inner_optimizer_group(
+    optimizer: Any,
+    group: dict[str, Any],
+    param_to_group_meta: dict[str, Any],
+) -> dict[str, Any] | None:
+    matched_meta = None
+    for param in group.get("params", ()):
+        name = _optimizer_param_name(optimizer, param)
+        if name is None:
+            continue
+        group_meta = param_to_group_meta.get(name)
+        if not isinstance(group_meta, dict):
+            continue
+        if matched_meta is None:
+            matched_meta = group_meta
+            continue
+        if matched_meta != group_meta:
+            raise ValueError(
+                "Megatron-FSDP optimizer checkpoint has inconsistent group metadata "
+                f"within one live optimizer group: {name}."
+            )
+    return matched_meta
+
+
+def _validate_optimizer_state_value(
+    param: Any,
+    name: str,
+    state_key: str,
+    value: Any,
+) -> None:
+    if not torch.is_tensor(value):
+        return
+    if state_key == "step":
+        return
+    expected_shape = _optimizer_state_expected_shape(param, value)
+    if tuple(value.shape) != expected_shape:
+        raise ValueError(
+            "Megatron-FSDP optimizer checkpoint state shape mismatch for "
+            f"{name}.{state_key}: checkpoint={tuple(value.shape)} expected={expected_shape}."
+        )
+
+
+def _optimizer_state_expected_shape(param: Any, value: Any) -> tuple[int, ...]:
+    if isinstance(value, DTensor):
+        return tuple(param.shape)
+    if isinstance(param, DTensor):
+        return tuple(_dtensor_local_tensor(param).shape)
+    data = getattr(param, "data", None)
+    if isinstance(data, DTensor):
+        return tuple(_dtensor_local_tensor(data).shape)
+    return tuple(param.shape)
+
+
+def _ensure_all_named_optimizer_states_installed(
+    state_by_name: dict[str, Any],
+    installed_names: set[str],
+) -> None:
+    missing_names = sorted(
+        name
+        for name, saved_state in state_by_name.items()
+        if isinstance(saved_state, dict)
+        and any(key != _MAIN_PARAM_STATE_KEY for key in saved_state)
+        and name not in installed_names
+    )
+    if missing_names:
+        preview = ", ".join(missing_names[:5])
+        if len(missing_names) > 5:
+            preview = f"{preview}, ..."
+        raise ValueError(
+            "Megatron-FSDP optimizer checkpoint contains states that were not "
+            f"matched to live optimizer parameters: {preview}"
+        )
+
+
+def _debug_optimizer_restore_enabled() -> bool:
+    return os.environ.get("MLITE_MFSDP_DCP_DEBUG_RESTORE", "").lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _debug_optimizer_restore_key_enabled(name: str | None) -> bool:
+    if not _debug_optimizer_restore_enabled():
+        return False
+    key_filter = os.environ.get("MLITE_MFSDP_DCP_DEBUG_RESTORE_FILTER", "")
+    return not key_filter or (name is not None and key_filter in name)
+
+
+def _debug_optimizer_restore_param(
+    name: str,
+    param: Any,
+    param_state: dict[str, Any],
+) -> None:
+    if not _debug_optimizer_restore_key_enabled(name):
+        return
+    state_parts = []
+    for key, value in param_state.items():
+        if torch.is_tensor(value):
+            state_parts.append(
+                f"{key}:shape={tuple(value.shape)},dtype={value.dtype},device={value.device}"
+            )
+        else:
+            state_parts.append(f"{key}:type={type(value).__name__}")
+    print(
+        "[MFSDP_DCP_RESTORE] "
+        f"rank={_debug_rank()} name={name} param_shape={_debug_shape(param)} "
+        f"param_dtype={getattr(param, 'dtype', None)} states={';'.join(state_parts)}",
+        flush=True,
+    )
+
+
+def _debug_shape(value: Any) -> Any:
+    shape = getattr(value, "shape", None)
+    if shape is None:
+        return None
+    return tuple(shape)
+
+
+def _debug_optimizer_restore_summary(
+    *,
+    state_by_name: dict[str, Any],
+    live_param_count: int,
+    installed_count: int,
+    inner_state_count: int,
+    param_groups: Any,
+    precision_aware: bool,
+    sanitize_stats: dict[str, int],
+) -> None:
+    if _debug_rank() != 0:
+        return
+    saved_param_states = sum(
+        1 for saved_state in state_by_name.values() if isinstance(saved_state, dict)
+    )
+    group_steps = _debug_param_group_steps(param_groups)
+    print(
+        "[MFSDP_DCP_RESTORE] "
+        f"rank=0 summary saved_param_states={saved_param_states} "
+        f"live_params={live_param_count} installed={installed_count} "
+        f"inner_optimizer_state={inner_state_count} "
+        f"precision_aware={precision_aware} group_steps={group_steps} "
+        f"sanitized_tensors={int(sanitize_stats.get('tensors', 0))} "
+        f"sanitized_elements={int(sanitize_stats.get('elements', 0))}",
+        flush=True,
+    )
+
+
+def _debug_param_group_steps(param_groups: Any) -> Any:
+    if not isinstance(param_groups, list):
+        return None
+    steps = []
+    for group in param_groups:
+        if not isinstance(group, dict):
+            continue
+        step = group.get("step")
+        if torch.is_tensor(step):
+            step = step.item()
+        if step not in steps:
+            steps.append(step)
+    return steps
+
+
+def _with_fsdp_dtensor_main_params(
+    parameter_state: Any,
+    optimizer: Any,
+    *,
+    clone_main_params: bool,
+) -> Any:
+    if not isinstance(parameter_state, dict):
+        return parameter_state
+    state = parameter_state.get("state")
+    if not isinstance(state, dict):
+        return parameter_state
+
+    updated_state = dict(state)
+    changed = False
+    for param in _iter_inner_optimizer_params(optimizer):
+        name = _optimizer_param_name(optimizer, param)
+        if name is None:
+            continue
+        param_state = updated_state.get(name)
+        if not isinstance(param_state, dict):
+            continue
+        param_state = dict(param_state)
+        param_state[_MAIN_PARAM_STATE_KEY] = (
+            _clone_state_value(param)
+            if clone_main_params
+            else _checkpoint_tensor_view(param)
+        )
+        updated_state[name] = param_state
+        changed = True
+
+    if not changed:
+        return parameter_state
+    updated_parameter_state = dict(parameter_state)
+    updated_parameter_state["state"] = updated_state
+    return updated_parameter_state
+
+
+def _checkpoint_tensor_view(value: Any) -> Any:
+    """Return a non-owning tensor view suitable for immediate DCP save.
+
+    Qwen3MoE M-FSDP runs too close to the memory ceiling to clone fp32 master
+    params while building the optimizer state tree. DCP only needs a stable
+    read-only view during ``dcp.save``.
+    """
+    if isinstance(value, DTensor):
+        local = _dtensor_local_tensor(value).detach()
+        return DTensor.from_local(
+            local,
+            value.device_mesh,
+            value.placements,
+            shape=value.shape,
+            stride=value.stride(),
+        )
+    if torch.is_tensor(value):
+        return value.detach()
+    if isinstance(value, dict):
+        return {key: _checkpoint_tensor_view(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_checkpoint_tensor_view(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_checkpoint_tensor_view(item) for item in value)
+    return value
+
+
+def _without_fsdp_dtensor_main_params(parameter_state: Any) -> Any:
+    if not isinstance(parameter_state, dict):
+        return parameter_state
+    state = parameter_state.get("state")
+    if not isinstance(state, dict):
+        return parameter_state
+
+    changed = False
+    updated_state = {}
+    for name, param_state in state.items():
+        if not isinstance(param_state, dict) or _MAIN_PARAM_STATE_KEY not in param_state:
+            updated_state[name] = param_state
+            continue
+        updated_param_state = dict(param_state)
+        del updated_param_state[_MAIN_PARAM_STATE_KEY]
+        updated_state[name] = updated_param_state
+        changed = True
+
+    if not changed:
+        return parameter_state
+    updated_parameter_state = dict(parameter_state)
+    updated_parameter_state["state"] = updated_state
+    return updated_parameter_state
+
+
+def _use_local_rank_dcp_optimizer_state() -> bool:
+    return os.environ.get(
+        "MLITE_MFSDP_DCP_OPTIMIZER_LOCAL_SHARDS",
+        "1",
+    ).lower() not in {"0", "false", "no", "off", ""}
+
+
+def _local_rank_fsdp_dtensor_parameter_state_for_dcp(parameter_state: Any) -> dict[str, Any]:
+    """Store M-FSDP optimizer shards as rank-local tensors for DCP.
+
+    Megatron-FSDP optimizer params are slices of flattened FSDP buffers. Their
+    local tensor shapes do not necessarily form a legal Shard(dim) partition of
+    the original parameter shape, so representing them as normal DTensors lets
+    DCP restore only the regular shard prefix. Rank-local keys preserve the
+    exact production resume semantics for the current topology, matching the
+    model local-shard DCP path.
+    """
+    rank = dist.get_rank() if dist.is_available() and dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_available() and dist.is_initialized() else 1
+    return {
+        "rank": rank,
+        "world_size": world_size,
+        _LOCAL_RANK_STATE_KEY: {
+            f"rank{rank}": _local_rank_checkpoint_tensor_view(parameter_state)
+        },
+    }
+
+
+def _current_local_rank_parameter_state(parameter_state: Any) -> Any:
+    if not isinstance(parameter_state, dict):
+        return parameter_state
+    rank = dist.get_rank() if dist.is_available() and dist.is_initialized() else 0
+    rank_state = parameter_state.get(_LOCAL_RANK_STATE_KEY)
+    if not isinstance(rank_state, dict):
+        raise TypeError("Megatron-FSDP local-rank optimizer checkpoint is missing rank_state.")
+    key = f"rank{rank}"
+    if key not in rank_state:
+        available = ", ".join(sorted(str(item) for item in rank_state)[:8])
+        raise KeyError(
+            "Megatron-FSDP local-rank optimizer checkpoint does not contain "
+            f"{key}; available keys: {available}"
+        )
+    saved_world_size = parameter_state.get("world_size")
+    if (
+        saved_world_size is not None
+        and dist.is_available()
+        and dist.is_initialized()
+        and int(saved_world_size) != dist.get_world_size()
+    ):
+        raise ValueError(
+            "Megatron-FSDP local-rank optimizer checkpoint requires the same world size: "
+            f"checkpoint={saved_world_size} current={dist.get_world_size()}."
+        )
+    return rank_state[key]
+
+
+def _local_rank_checkpoint_tensor_view(value: Any) -> Any:
+    if isinstance(value, DTensor):
+        return _dtensor_local_tensor(value).detach()
+    data = getattr(value, "data", None)
+    if isinstance(data, DTensor):
+        return _dtensor_local_tensor(data).detach()
+    if torch.is_tensor(value):
+        return value.detach()
+    if isinstance(value, dict):
+        return {key: _local_rank_checkpoint_tensor_view(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_local_rank_checkpoint_tensor_view(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_local_rank_checkpoint_tensor_view(item) for item in value)
+    return value
+
+
+def _preprocess_fsdp_dtensor_parameter_state_for_dcp(parameter_state: Any) -> None:
+    if preprocess_state_dict_for_uneven_dtensor is None:
+        _debug_uneven_dtensor_preprocess("missing", parameter_state)
+        return
+    if isinstance(parameter_state, list):
+        for item in parameter_state:
+            _preprocess_fsdp_dtensor_parameter_state_for_dcp(item)
+        return
+    if not isinstance(parameter_state, dict):
+        return
+    try:
+        _debug_uneven_dtensor_preprocess("before", parameter_state)
+        preprocess_state_dict_for_uneven_dtensor(parameter_state)
+        _debug_uneven_dtensor_preprocess("after", parameter_state)
+    except Exception as exc:
+        print(
+            "[MFSDP_DCP_RESTORE] "
+            f"rank={_debug_rank()} uneven_dtensor_preprocess_error="
+            f"{type(exc).__name__}: {exc}",
+            flush=True,
+        )
+        raise
+
+
+def _debug_uneven_dtensor_preprocess(stage: str, parameter_state: Any) -> None:
+    if not _debug_uneven_dtensor_preprocess_enabled() or _debug_rank() != 0:
+        return
+    print(
+        "[MFSDP_DCP_PREPROCESS] "
+        f"rank=0 stage={stage} dtensors={_count_dtensors(parameter_state)}",
+        flush=True,
+    )
+
+
+def _debug_uneven_dtensor_preprocess_enabled() -> bool:
+    return os.environ.get("MLITE_MFSDP_DCP_DEBUG_PREPROCESS", "").lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _count_dtensors(value: Any) -> int:
+    if isinstance(value, DTensor):
+        return 1
+    if isinstance(value, dict):
+        return sum(_count_dtensors(item) for item in value.values())
+    if isinstance(value, (list, tuple)):
+        return sum(_count_dtensors(item) for item in value)
+    return 0
+
+
+def _state_dict_has_main_params(state_dict: Any) -> bool:
+    if not isinstance(state_dict, dict):
+        return False
+    if _INNER_OPTIMIZER_STATE_KEY in state_dict:
+        return True
+    parameter_state = state_dict.get(_PARAMETER_STATE_KEY)
+    if parameter_state is None:
+        return False
+    parameter_states = parameter_state if isinstance(parameter_state, list) else [parameter_state]
+    for item in parameter_states:
+        if _parameter_state_has_main_params(item):
+            return True
+    return False
+
+
+def _parameter_state_has_main_params(parameter_state: Any) -> bool:
+    if isinstance(parameter_state, list):
+        return any(_parameter_state_has_main_params(item) for item in parameter_state)
+    if not isinstance(parameter_state, dict):
+        return False
+    rank_state = parameter_state.get(_LOCAL_RANK_STATE_KEY)
+    if isinstance(rank_state, dict):
+        return any(_parameter_state_has_main_params(item) for item in rank_state.values())
+    state = parameter_state.get("state")
+    if not isinstance(state, dict):
+        return False
+    return any(
+        isinstance(param_state, dict) and _MAIN_PARAM_STATE_KEY in param_state
+        for param_state in state.values()
+    )
+
+
+def _restore_fsdp_dtensor_main_params(optimizer: Any, parameter_state: Any) -> bool:
+    if not isinstance(parameter_state, dict):
+        return False
+    state = parameter_state.get("state")
+    if not isinstance(state, dict):
+        return False
+
+    restored_any = False
+    restored_params = 0
+    restored_buffers = 0
+    for param in _iter_inner_optimizer_params(optimizer):
+        name = _optimizer_param_name(optimizer, param)
+        if name is None:
+            continue
+        param_state = state.get(name)
+        if not isinstance(param_state, dict):
+            continue
+        saved_param = param_state.get(_MAIN_PARAM_STATE_KEY)
+        if saved_param is None:
+            continue
+        _copy_state_value_(param, saved_param)
+        restored_params += 1
+        if _restore_mfsdp_buffer_main_weight_from_param(optimizer, param, saved_param):
+            restored_buffers += 1
+        restored_any = True
+    _debug_main_param_restore_summary(restored_params, restored_buffers)
+    return restored_any
+
+
+def _restore_mfsdp_buffer_main_weight_from_param(
+    optimizer: Any,
+    param: Any,
+    saved_param: Any,
+) -> bool:
+    orig_param = getattr(param, "orig_param", None)
+    if orig_param is None:
+        return False
+    source = _tensor_local_data(saved_param)
+    for buffer in _iter_mfsdp_param_and_grad_buffers(optimizer):
+        if _restore_mfsdp_buffer_main_weight(buffer, orig_param, source):
+            return True
+    return False
+
+
+def _restore_mfsdp_buffer_main_weight(
+    buffer: Any,
+    orig_param: Any,
+    source: torch.Tensor,
+) -> bool:
+    param_to_group = getattr(buffer, "param_to_param_group", None)
+    if not isinstance(param_to_group, dict) or orig_param not in param_to_group:
+        return False
+    parameter_groups = getattr(buffer, "parameter_groups", None)
+    try:
+        group = parameter_groups[param_to_group[orig_param]]
+        main_weight_buffer = group.main_weight_buffer
+    except (TypeError, AttributeError, IndexError, KeyError):
+        return False
+    if main_weight_buffer is None:
+        return False
+    main_param_idx = getattr(main_weight_buffer, "param_idx", None)
+    if not isinstance(main_param_idx, dict) or orig_param not in main_param_idx:
+        return False
+    item_id = main_param_idx[orig_param]
+    model_weight_buffer = getattr(group, "model_weight_buffer", None)
+    use_shard = bool(
+        (model_weight_buffer is not None and getattr(model_weight_buffer, "is_data_distributed", False))
+        or getattr(main_weight_buffer, "is_data_distributed", False)
+    )
+    main_weight = main_weight_buffer.get_item(item_id, only_shard=use_shard)
+    _copy_tensor_value_reshaped_(main_weight, source)
+    return True
+
+
+def _iter_mfsdp_param_and_grad_buffers(optimizer: Any) -> list[Any]:
+    buffers = []
+    seen: set[int] = set()
+    for model_chunk in getattr(optimizer, "model_chunks", ()) or ():
+        for owner in (model_chunk, getattr(model_chunk, "module", None)):
+            if owner is None:
+                continue
+            buffer = getattr(owner, "param_and_grad_buffer", None)
+            if buffer is None or id(buffer) in seen:
+                continue
+            seen.add(id(buffer))
+            buffers.append(buffer)
+    return buffers
+
+
+def _debug_main_param_restore_summary(restored_params: int, restored_buffers: int) -> None:
+    if _debug_rank() != 0:
+        return
+    if restored_params == 0:
+        return
+    print(
+        "[MFSDP_DCP_RESTORE] "
+        f"rank=0 main_params_restored={restored_params} "
+        f"main_weight_buffers_restored={restored_buffers}",
+        flush=True,
+    )
+
+
+def _with_mcore_optimizer_group_meta(parameter_state: Any, non_parameter_state: Any) -> Any:
+    if isinstance(parameter_state, list):
+        non_parameter_states = non_parameter_state if isinstance(non_parameter_state, list) else []
+        if len(non_parameter_states) != len(parameter_state):
+            return parameter_state
+        return [
+            _with_single_mcore_optimizer_group_meta(param_state, non_param_state)
+            for param_state, non_param_state in zip(
+                parameter_state,
+                non_parameter_states,
+                strict=True,
+            )
+        ]
+    return _with_single_mcore_optimizer_group_meta(parameter_state, non_parameter_state)
+
+
+def _with_single_mcore_optimizer_group_meta(parameter_state: Any, non_parameter_state: Any) -> Any:
+    if not isinstance(parameter_state, dict):
+        return parameter_state
+    param_to_group_meta = parameter_state.get("param_to_group_meta")
+    if not isinstance(param_to_group_meta, dict):
+        return parameter_state
+
+    optimizer_group_metas = _mcore_optimizer_group_metas(non_parameter_state)
+    if not optimizer_group_metas:
+        return parameter_state
+
+    updated_param_to_group_meta = {}
+    changed = False
+    for param_name, group_meta in param_to_group_meta.items():
+        if not isinstance(group_meta, dict):
+            updated_param_to_group_meta[param_name] = group_meta
+            continue
+        optimizer_group_meta = _match_optimizer_group_meta(group_meta, optimizer_group_metas)
+        if optimizer_group_meta is None:
+            updated_param_to_group_meta[param_name] = group_meta
+            continue
+        merged_group_meta = dict(group_meta)
+        for key, value in optimizer_group_meta.items():
+            if key == "params":
+                continue
+            if key not in merged_group_meta or not _metadata_values_equal(
+                merged_group_meta[key],
+                value,
+            ):
+                merged_group_meta[key] = value
+                changed = True
+        updated_param_to_group_meta[param_name] = merged_group_meta
+
+    if not changed:
+        return parameter_state
+    updated_parameter_state = dict(parameter_state)
+    updated_parameter_state["param_to_group_meta"] = updated_param_to_group_meta
+    return updated_parameter_state
+
+
+def _mcore_optimizer_group_metas(non_parameter_state: Any) -> list[dict[str, Any]]:
+    if not isinstance(non_parameter_state, dict):
+        return []
+    optimizer_state = non_parameter_state.get("optimizer")
+    if not isinstance(optimizer_state, dict):
+        return []
+    param_groups = optimizer_state.get("param_groups")
+    if not isinstance(param_groups, list):
+        return []
+    return [group for group in param_groups if isinstance(group, dict)]
+
+
+def _match_optimizer_group_meta(
+    parameter_group_meta: dict[str, Any],
+    optimizer_group_metas: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    if len(optimizer_group_metas) == 1:
+        return optimizer_group_metas[0]
+    for optimizer_group_meta in optimizer_group_metas:
+        common_keys = (
+            set(parameter_group_meta)
+            & set(optimizer_group_meta)
+            - {"params"}
+        )
+        if common_keys and all(
+            _metadata_values_equal(parameter_group_meta[key], optimizer_group_meta[key])
+            for key in common_keys
+        ):
+            return optimizer_group_meta
+    return None
+
+
+def _metadata_values_equal(left: Any, right: Any) -> bool:
+    if torch.is_tensor(left) or torch.is_tensor(right):
+        return torch.is_tensor(left) and torch.is_tensor(right) and torch.equal(left, right)
+    if isinstance(left, dict) and isinstance(right, dict):
+        return set(left) == set(right) and all(
+            _metadata_values_equal(left[key], right[key]) for key in left
+        )
+    if isinstance(left, (list, tuple)) and isinstance(right, (list, tuple)):
+        return len(left) == len(right) and all(
+            _metadata_values_equal(left_item, right_item)
+            for left_item, right_item in zip(left, right, strict=True)
+        )
+    return left == right
+
+
+def _ensure_fsdp_dtensor_optimizer_param_names(optimizer: Any) -> None:
+    """Teach MCore's fsdp_dtensor state path about optimizer DTensor params.
+
+    Megatron-FSDP builds torch optimizer param groups from DTensor-wrapped
+    optimizer parameters. MCore's ``_param_name`` lazily maps original model
+    parameters to names, so its fsdp_dtensor state path can miss the optimizer
+    parameters unless the wrapper mirrors each ``orig_param`` name onto the
+    DTensor parameter.
+    """
+    inner_optimizer = _inner_torch_optimizer(optimizer)
+    if inner_optimizer is None or not hasattr(inner_optimizer, "param_groups"):
+        return
+    mapping = getattr(optimizer, "param_to_name", None)
+    if not isinstance(mapping, dict):
+        mapping = {}
+        setattr(optimizer, "param_to_name", mapping)
+    model_chunk_names = _model_chunk_param_names(optimizer)
+    canonicalize = _optimizer_param_name_canonicalizer(optimizer)
+    for group in inner_optimizer.param_groups:
+        for param in group.get("params", ()):
+            orig_param = getattr(param, "orig_param", None)
+            name = _optimizer_param_name_candidate(
+                optimizer,
+                param,
+                orig_param=orig_param,
+                mapping=mapping,
+                model_chunk_names=model_chunk_names,
+            )
+            if name is None:
+                continue
+            if canonicalize is not None:
+                name = canonicalize(name)
+            mapping[param] = name
+            if orig_param is not None:
+                mapping[orig_param] = name
+
+
+def _model_chunk_param_names(optimizer: Any) -> dict[int, str]:
+    param_names: dict[int, str] = {}
+    model_chunks = getattr(optimizer, "model_chunks", ()) or ()
+    for chunk in model_chunks:
+        for owner in (chunk, getattr(chunk, "module", None)):
+            if owner is None:
+                continue
+            buffer = getattr(owner, "param_and_grad_buffer", None)
+            named_parameters = getattr(buffer, "optimizer_named_parameters", None)
+            if named_parameters is None:
+                continue
+            for name, param in named_parameters:
+                state_name = _mcore_fsdp_state_name(name)
+                param_names.setdefault(id(param), state_name)
+                orig_param = getattr(param, "orig_param", None)
+                if orig_param is not None:
+                    param_names.setdefault(id(orig_param), state_name)
+                data = getattr(param, "data", None)
+                if data is not None:
+                    param_names.setdefault(id(data), state_name)
+    if param_names:
+        return param_names
+
+    for chunk in model_chunks:
+        named_parameters = getattr(chunk, "named_parameters", None)
+        if callable(named_parameters):
+            for name, param in named_parameters():
+                param_names.setdefault(id(param), name)
+                data = getattr(param, "data", None)
+                if data is not None:
+                    param_names.setdefault(id(data), name)
+    return param_names
+
+
+def _mcore_fsdp_state_name(name: str) -> str:
+    if name.startswith("module.module."):
+        return name
+    return f"module.module.{name}"
+
+
+def _optimizer_param_name_candidate(
+    optimizer: Any,
+    param: Any,
+    *,
+    orig_param: Any,
+    mapping: dict[Any, str],
+    model_chunk_names: dict[int, str],
+) -> str | None:
+    for candidate in (
+        model_chunk_names.get(id(param)),
+        model_chunk_names.get(id(orig_param)) if orig_param is not None else None,
+        mapping.get(param),
+        mapping.get(orig_param) if orig_param is not None else None,
+        _attr_param_name(param),
+        _attr_param_name(orig_param),
+    ):
+        if candidate:
+            return candidate
+    if _mcore_param_name_fallback_enabled():
+        for candidate in (
+            _safe_mcore_param_name(optimizer, param),
+            _safe_mcore_param_name(optimizer, orig_param),
+        ):
+            if candidate:
+                return candidate
+    return None
+
+
+def _mcore_param_name_fallback_enabled() -> bool:
+    return os.environ.get(
+        "MLITE_MFSDP_ALLOW_MCORE_PARAM_NAME_FALLBACK", ""
+    ).lower() in {"1", "true", "yes", "on"}
+
+
+def _attr_param_name(param: Any) -> str | None:
+    name = getattr(param, PARAM_NAME_ATTR, None)
+    return name if isinstance(name, str) and name else None
+
+
+def _safe_mcore_param_name(optimizer: Any, param: Any) -> str | None:
+    if param is None:
+        return None
+    param_name = getattr(optimizer, "_param_name", None)
+    if not callable(param_name):
+        return None
+    try:
+        return param_name(param)
+    except (AssertionError, RuntimeError):
+        return None
+
+
+def _iter_inner_optimizer_params(optimizer: Any) -> list[Any]:
+    inner_optimizer = _inner_torch_optimizer(optimizer)
+    if inner_optimizer is None or not hasattr(inner_optimizer, "param_groups"):
+        return []
+    return [
+        param
+        for group in inner_optimizer.param_groups
+        for param in group.get("params", ())
+    ]
+
+
+def _optimizer_param_name(optimizer: Any, param: Any) -> str | None:
+    mapping = getattr(optimizer, "param_to_name", None)
+    name = mapping.get(param) if isinstance(mapping, dict) else None
+    if name is not None:
+        return name
+    return _safe_mcore_param_name(optimizer, param)
+
+
+__all__ = ["BACKEND", "MegatronFSDPBackend", "is_megatron_fsdp_optimizer"]

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/checkpoint_keys.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/checkpoint_keys.py
@@ -1,0 +1,127 @@
+"""M-FSDP checkpoint key canonicalization helpers."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Iterable
+from typing import Any
+
+MFSDP_CHECKPOINT_PS_ATTR = "_mlite_mfsdp_checkpoint_parallel_state"
+MFSDP_CHECKPOINT_EXPERT_CLASSIFIER_ATTR = "_mlite_mfsdp_checkpoint_expert_classifier"
+
+
+def attach_mfsdp_checkpoint_metadata(
+    optimizer: Any,
+    *,
+    ps: Any,
+    is_expert: Callable[[str], bool],
+) -> None:
+    """Attach Megatron Lite checkpoint metadata to an MCore optimizer and its leaves."""
+    for target in _optimizer_and_leaves(optimizer):
+        setattr(target, MFSDP_CHECKPOINT_PS_ATTR, ps)
+        setattr(target, MFSDP_CHECKPOINT_EXPERT_CLASSIFIER_ATTR, is_expert)
+
+
+def optimizer_checkpoint_parallel_state(optimizer: Any) -> Any | None:
+    for target in _optimizer_and_leaves(optimizer):
+        ps = getattr(target, MFSDP_CHECKPOINT_PS_ATTR, None)
+        if ps is not None:
+            return ps
+        ps = getattr(target, "ps", None)
+        if ps is not None:
+            return ps
+    return None
+
+
+def optimizer_checkpoint_expert_classifier(
+    optimizer: Any,
+) -> Callable[[str], bool] | None:
+    for target in _optimizer_and_leaves(optimizer):
+        classifier = getattr(target, MFSDP_CHECKPOINT_EXPERT_CLASSIFIER_ATTR, None)
+        if callable(classifier):
+            return classifier
+    return None
+
+
+def expert_local_counts(
+    names: Iterable[str],
+    is_expert: Callable[[str], bool],
+) -> dict[str, int]:
+    local_indices: dict[str, set[int]] = {}
+    for name in names:
+        if not is_expert(name):
+            continue
+        match = re.search(r"weight(\d+)$", name)
+        if match is None:
+            continue
+        prefix = expert_name_prefix(name)
+        local_idx = int(match.group(1))
+        local_indices.setdefault(prefix, set()).add(local_idx)
+    return {
+        prefix: len(indices)
+        for prefix, indices in local_indices.items()
+        if indices == set(range(len(indices)))
+    }
+
+
+def canonicalize_expert_checkpoint_key(
+    key: str,
+    name: str,
+    *,
+    ps: Any,
+    is_expert: bool,
+    local_counts: dict[str, int],
+) -> tuple[str, str]:
+    """Map M-FSDP local expert ids to global checkpoint ids.
+
+    M-FSDP exposes expert weights with local EP ids, e.g. every EP rank has
+    ``...fc1.weight0`` for a different global expert. DCP keys must identify
+    the global expert, otherwise EP ranks write/read different experts under
+    the same key.
+    """
+    if not is_expert or int(getattr(ps, "ep_size", 1) or 1) <= 1:
+        return key, name
+    local_match = re.search(r"weight(\d+)$", name)
+    if local_match is None:
+        return key, name
+    local_idx = int(local_match.group(1))
+    num_local = local_counts.get(expert_name_prefix(name))
+    if num_local is None:
+        return key, name
+    if local_idx >= num_local:
+        return key, name
+    global_idx = int(getattr(ps, "ep_rank", 0)) * num_local + local_idx
+    return (
+        replace_trailing_expert_idx(key, global_idx),
+        replace_trailing_expert_idx(name, global_idx),
+    )
+
+
+def expert_name_prefix(name: str) -> str:
+    return re.sub(r"weight\d+$", "weight", name)
+
+
+def replace_trailing_expert_idx(name: str, idx: int) -> str:
+    return re.sub(r"weight\d+$", f"weight{idx}", name)
+
+
+def normalize_mcore_fsdp_param_name(name: str) -> str:
+    prefix = "module.module."
+    return name[len(prefix) :] if name.startswith(prefix) else name
+
+
+def _optimizer_and_leaves(optimizer: Any) -> tuple[Any, ...]:
+    leaves = getattr(optimizer, "chained_optimizers", None)
+    if leaves is None:
+        return (optimizer,)
+    return (optimizer, *tuple(leaves))
+
+
+__all__ = [
+    "attach_mfsdp_checkpoint_metadata",
+    "canonicalize_expert_checkpoint_key",
+    "expert_local_counts",
+    "normalize_mcore_fsdp_param_name",
+    "optimizer_checkpoint_expert_classifier",
+    "optimizer_checkpoint_parallel_state",
+]

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/config.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/config.py
@@ -1,0 +1,376 @@
+"""Megatron-FSDP config lowering and validation.
+
+This module is the isolation boundary for MCore-specific optimizer/DDP config
+shape. The runtime-facing primitive should stay close to FSDP2, while this
+module owns Megatron-FSDP's supported surface and fail-fast checks.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import fields, is_dataclass
+from typing import Any
+
+import torch  # pyright: ignore[reportMissingImports]
+
+_SUPPORTED_MODELS = {
+    "qwen3_moe",
+    "qwen3_moe_mcore_hybrid",
+    "qwen3_5",
+    "qwen3_5_mcore_hybrid",
+}
+_SUPPORTED_OPTIMIZERS = {"adam", "sgd"}
+_SUPPORTED_SHARDING_STRATEGIES = {"no_shard", "optim", "optim_grads", "optim_grads_params"}
+_REQUIRED_DDP_KNOB_VALUES = {
+    "use_distributed_optimizer": True,
+    "use_megatron_fsdp": True,
+}
+_UNSUPPORTED_OPTIMIZATION_KNOBS = {
+    "use_hsdp",
+    "hsdp",
+}
+_DDP_ALIAS_KEYS = {
+    "mfsdp_sharding_strategy": "data_parallel_sharding_strategy",
+    "megatron_fsdp_sharding_strategy": "data_parallel_sharding_strategy",
+}
+_DDP_DEFAULT_KEYS = {
+    "use_distributed_optimizer",
+    "use_megatron_fsdp",
+    "data_parallel_sharding_strategy",
+    "overlap_grad_reduce",
+    "overlap_param_gather",
+    "grad_reduce_in_fp32",
+    "nccl_ub",
+    "fsdp_double_buffer",
+    "num_distributed_optimizer_instances",
+}
+_DTYPE_DDP_KEYS = {
+    "megatron_fsdp_main_params_dtype",
+    "megatron_fsdp_main_grads_dtype",
+    "megatron_fsdp_grad_comm_dtype",
+}
+_OPTIMIZER_BASE_KEYS = {
+    "optimizer",
+    "lr",
+    "min_lr",
+    "clip_grad",
+    "weight_decay",
+    "lr_warmup_steps_ratio",
+    "total_training_steps",
+    "lr_warmup_steps",
+    "lr_warmup_init",
+    "lr_decay_steps",
+    "lr_decay_style",
+    "weight_decay_incr_style",
+    "lr_wsd_decay_style",
+    "lr_wsd_decay_steps",
+    "use_checkpoint_opt_param_scheduler",
+    "adam_beta1",
+    "adam_beta2",
+    "adam_eps",
+    "offload_fraction",
+    "use_precision_aware_optimizer",
+    "decoupled_weight_decay",
+    "override_optimizer_config",
+}
+
+
+def validate_mfsdp_config(engine_cfg) -> None:
+    """Validate the supported surface for optimizer='megatron_fsdp'."""
+    if engine_cfg.model_name not in _SUPPORTED_MODELS:
+        raise ValueError(
+            "optimizer_impl='megatron_fsdp' currently supports only qwen3_moe "
+            "and qwen3_5 variants."
+        )
+    validate_mfsdp_topology(engine_cfg.parallel, model_name=engine_cfg.model_name)
+    opt = engine_cfg.optimizer
+    validate_optimizer_name(getattr(opt, "optimizer", "adam"))
+    validate_precision_aware_disabled(opt)
+    validate_optimization_knobs(opt)
+    validate_mfsdp_topology_optimizer_combo(engine_cfg.parallel, opt)
+    if os.environ.get("CUDA_DEVICE_MAX_CONNECTIONS") == "1":
+        raise ValueError("Megatron-FSDP requires CUDA_DEVICE_MAX_CONNECTIONS > 1 or unset.")
+
+
+def validate_mfsdp_topology(parallel_cfg, *, model_name: str | None = None) -> None:
+    """Validate supported topology surfaces for Megatron-FSDP."""
+    pp = int(getattr(parallel_cfg, "pp", 1) or 1)
+    vpp = int(getattr(parallel_cfg, "vpp", 1) or 1)
+
+    if vpp > 1 and pp <= 1:
+        raise ValueError(
+            "optimizer_impl='megatron_fsdp' requires pp>1 when vpp>1."
+        )
+
+
+def validate_mfsdp_topology_optimizer_combo(parallel_cfg, opt) -> None:
+    pp = int(getattr(parallel_cfg, "pp", 1) or 1)
+    vpp = int(getattr(parallel_cfg, "vpp", 1) or 1)
+    values = dict(getattr(opt, "override_optimizer_config", None) or {})
+    instances = values.get(
+        "num_distributed_optimizer_instances",
+        getattr(opt, "num_distributed_optimizer_instances", None),
+    )
+    if _invalid_distributed_optimizer_instances(instances):
+        return
+    normalized_instances = _distributed_optimizer_instance_override(instances)
+    if normalized_instances is not None and normalized_instances > 1 and (pp > 1 or vpp > 1):
+        raise ValueError(
+            "optimizer_impl='megatron_fsdp' does not support "
+            "num_distributed_optimizer_instances>1 with pp/vpp yet."
+        )
+
+
+def split_mfsdp_overrides(
+    opt,
+    ddp_config_cls,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Split generic optimizer overrides into OptimizerConfig vs DDPConfig keys."""
+    ddp_fields = {field.name for field in fields(ddp_config_cls)}
+    raw_overrides = _collect_mfsdp_overrides(opt, ddp_fields)
+    ddp_overrides: dict[str, Any] = {}
+    opt_overrides: dict[str, Any] = {}
+
+    for key, value in raw_overrides.items():
+        ddp_key = _DDP_ALIAS_KEYS.get(key, key)
+        if ddp_key == "num_distributed_optimizer_instances":
+            if _invalid_distributed_optimizer_instances(value):
+                raise ValueError(
+                    "optimizer_impl='megatron_fsdp' requires "
+                    "num_distributed_optimizer_instances to be a positive integer."
+                )
+            normalized = _distributed_optimizer_instance_override(value)
+            if normalized is not None:
+                if ddp_key not in ddp_fields:
+                    raise ValueError(
+                        "Megatron-Core DistributedDataParallelConfig does not support "
+                        f"{ddp_key!r} in this environment."
+                )
+                ddp_overrides[ddp_key] = normalized
+        elif ddp_key in ddp_fields:
+            _validate_ddp_knob_value(ddp_key, value)
+            ddp_overrides[ddp_key] = value
+        elif ddp_key in _UNSUPPORTED_OPTIMIZATION_KNOBS:
+            if _truthy_feature_value(value):
+                raise ValueError(
+                    "optimizer_impl='megatron_fsdp' does not accept hsdp/use_hsdp aliases; "
+                    "set num_distributed_optimizer_instances explicitly."
+                )
+        elif ddp_key in _DDP_DEFAULT_KEYS or ddp_key in _DTYPE_DDP_KEYS:
+            raise ValueError(
+                f"Megatron-Core DistributedDataParallelConfig does not support "
+                f"{ddp_key!r} in this environment."
+            )
+        else:
+            opt_overrides[key] = value
+    validate_optimization_knobs(opt, opt_overrides)
+    return opt_overrides, ddp_overrides
+
+
+def validate_optimizer_name(optimizer_name: str) -> None:
+    if optimizer_name not in _SUPPORTED_OPTIMIZERS:
+        raise ValueError(
+            "optimizer_impl='megatron_fsdp' supports only adam/sgd through "
+            f"Megatron-Core DistributedOptimizer, got {optimizer_name!r}."
+        )
+
+
+def _collect_mfsdp_overrides(opt, ddp_fields: set[str]) -> dict[str, Any]:
+    """Collect explicit overrides from dict-style and benchmark attribute-style inputs."""
+    raw_overrides = dict(getattr(opt, "override_optimizer_config", None) or {})
+    optimizer_base_keys = set(_OPTIMIZER_BASE_KEYS)
+    if is_dataclass(opt):
+        optimizer_base_keys.update(field.name for field in fields(opt))
+
+    for key, value in vars(opt).items():
+        if key.startswith("_") or key in optimizer_base_keys:
+            continue
+        raw_overrides.setdefault(key, value)
+    return raw_overrides
+
+
+def validate_precision_aware_disabled(opt, opt_overrides: dict[str, Any] | None = None) -> None:
+    precision_aware = getattr(opt, "use_precision_aware_optimizer", None)
+    raw_overrides = dict(getattr(opt, "override_optimizer_config", None) or {})
+    if "use_precision_aware_optimizer" in raw_overrides:
+        precision_aware = raw_overrides["use_precision_aware_optimizer"]
+    if opt_overrides and "use_precision_aware_optimizer" in opt_overrides:
+        precision_aware = opt_overrides["use_precision_aware_optimizer"]
+    if precision_aware not in {None, True, False}:
+        raise ValueError("use_precision_aware_optimizer must be a boolean when set.")
+    if precision_aware is True:
+        raise ValueError(
+            "optimizer_impl='megatron_fsdp' does not support "
+            "use_precision_aware_optimizer=True in this image; Slurm smoke hit "
+            "transformer_engine::multi_tensor_scale_cuda segfault."
+        )
+
+
+def validate_optimization_knobs(opt, opt_overrides: dict[str, Any] | None = None) -> None:
+    """Validate Phase 3.4 optimization knobs before lowering into MCore config."""
+    values = dict(getattr(opt, "override_optimizer_config", None) or {})
+    if opt_overrides:
+        values.update(opt_overrides)
+    for key in _UNSUPPORTED_OPTIMIZATION_KNOBS:
+        value = values.get(key, getattr(opt, key, None))
+        if _truthy_feature_value(value):
+            raise ValueError(
+                "optimizer_impl='megatron_fsdp' does not accept hsdp/use_hsdp aliases; "
+                "set num_distributed_optimizer_instances explicitly."
+            )
+    instances = values.get(
+        "num_distributed_optimizer_instances",
+        getattr(opt, "num_distributed_optimizer_instances", None),
+    )
+    if _invalid_distributed_optimizer_instances(instances):
+        raise ValueError(
+            "optimizer_impl='megatron_fsdp' requires "
+            "num_distributed_optimizer_instances to be a positive integer."
+        )
+    nccl_ub = values.get("nccl_ub", getattr(opt, "nccl_ub", None))
+    if _truthy_feature_value(nccl_ub) and _cuda_alloc_conf_expands_segments():
+        raise ValueError(
+            "optimizer_impl='megatron_fsdp' requires PYTORCH_CUDA_ALLOC_CONF without "
+            "expandable_segments:True when nccl_ub=True; unset it before enabling UBR."
+        )
+    for key, required_value in _REQUIRED_DDP_KNOB_VALUES.items():
+        value = values.get(key, getattr(opt, key, required_value))
+        if value != required_value:
+            raise ValueError(
+                f"optimizer_impl='megatron_fsdp' requires {key}={required_value!r}."
+            )
+    validate_precision_aware_disabled(opt, opt_overrides)
+
+
+def build_mfsdp_ddp_config(ddp_config_cls, overrides: dict[str, Any]):
+    ddp_fields = {field.name for field in fields(ddp_config_cls)}
+    required_fields = {
+        "use_distributed_optimizer",
+        "use_megatron_fsdp",
+        "data_parallel_sharding_strategy",
+    }
+    missing = sorted(required_fields - ddp_fields)
+    if missing:
+        raise ValueError(
+            "Installed Megatron-Core DistributedDataParallelConfig is missing "
+            f"required Megatron-FSDP fields: {missing}."
+        )
+    kwargs: dict[str, Any] = {
+        "use_distributed_optimizer": True,
+        "use_megatron_fsdp": True,
+        "data_parallel_sharding_strategy": "optim_grads_params",
+        "overlap_grad_reduce": False,
+        "overlap_param_gather": False,
+        "grad_reduce_in_fp32": True,
+        "megatron_fsdp_main_params_dtype": torch.float32,
+        "megatron_fsdp_main_grads_dtype": None,
+        "megatron_fsdp_grad_comm_dtype": None,
+    }
+    kwargs.update(overrides)
+    strategy = kwargs["data_parallel_sharding_strategy"]
+    if strategy not in _SUPPORTED_SHARDING_STRATEGIES:
+        raise ValueError(
+            "Megatron-FSDP data_parallel_sharding_strategy must be one of "
+            f"{sorted(_SUPPORTED_SHARDING_STRATEGIES)}, got {strategy!r}."
+        )
+    for key, required_value in _REQUIRED_DDP_KNOB_VALUES.items():
+        if kwargs.get(key) != required_value:
+            raise ValueError(
+                f"optimizer_impl='megatron_fsdp' requires {key}={required_value!r}."
+            )
+    for key in _DTYPE_DDP_KEYS:
+        if key in kwargs:
+            kwargs[key] = coerce_dtype(kwargs.get(key), key=key)
+    supported_kwargs = {key: value for key, value in kwargs.items() if key in ddp_fields}
+    return ddp_config_cls(**supported_kwargs)
+
+
+def coerce_dtype(value: Any, *, key: str) -> torch.dtype | None:
+    if value is None or isinstance(value, torch.dtype):
+        return value
+    if isinstance(value, str):
+        dtype_name = value.lower().removeprefix("torch.")
+        if dtype_name in {"none", "null"}:
+            return None
+        mapping = {
+            "fp32": torch.float32,
+            "float32": torch.float32,
+            "float": torch.float32,
+            "bf16": torch.bfloat16,
+            "bfloat16": torch.bfloat16,
+            "fp16": torch.float16,
+            "float16": torch.float16,
+            "half": torch.float16,
+        }
+        if dtype_name in mapping:
+            return mapping[dtype_name]
+    raise ValueError(f"{key} must be a torch.dtype, None, or dtype string, got {value!r}.")
+
+
+def _validate_ddp_knob_value(key: str, value: Any) -> None:
+    if key in _REQUIRED_DDP_KNOB_VALUES and value != _REQUIRED_DDP_KNOB_VALUES[key]:
+        raise ValueError(
+            f"optimizer_impl='megatron_fsdp' requires "
+            f"{key}={_REQUIRED_DDP_KNOB_VALUES[key]!r}."
+        )
+
+
+def _truthy_feature_value(value: Any) -> bool:
+    if value is None or value is False:
+        return False
+    if isinstance(value, int | float) and value == 0:
+        return False
+    if isinstance(value, str) and value.lower() in {"", "0", "false", "none", "null", "off"}:
+        return False
+    return True
+
+
+def _cuda_alloc_conf_expands_segments() -> bool:
+    value = os.environ.get("PYTORCH_CUDA_ALLOC_CONF", "")
+    for item in value.split(","):
+        key, _, raw = item.strip().partition(":")
+        if key.lower() == "expandable_segments" and raw.lower() in {"1", "true", "yes", "on"}:
+            return True
+    return False
+
+
+def _invalid_distributed_optimizer_instances(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, int | float):
+        return int(value) != value or value < 1
+    if isinstance(value, str):
+        normalized = value.lower()
+        if normalized in {"", "none", "null"}:
+            return False
+        try:
+            return int(normalized) < 1
+        except ValueError:
+            return True
+    return True
+
+
+def _distributed_optimizer_instance_override(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, int | float):
+        return int(value)
+    if isinstance(value, str):
+        normalized = value.lower()
+        if normalized in {"", "none", "null"}:
+            return None
+        return int(normalized)
+    return None
+
+
+__all__ = [
+    "build_mfsdp_ddp_config",
+    "coerce_dtype",
+    "split_mfsdp_overrides",
+    "validate_mfsdp_config",
+    "validate_mfsdp_topology",
+    "validate_mfsdp_topology_optimizer_combo",
+    "validate_optimization_knobs",
+    "validate_optimizer_name",
+    "validate_precision_aware_disabled",
+]

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/dtensor_grad.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/dtensor_grad.py
@@ -1,0 +1,206 @@
+"""DTensor gradient helpers local to the Megatron-FSDP primitive."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Callable, Iterable
+from typing import Any
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+
+try:  # pragma: no cover - import availability is PyTorch-version dependent.
+    from torch.distributed.tensor import DTensor, Replicate
+except ImportError:  # pragma: no cover
+    DTensor = Replicate = None  # type: ignore[assignment]
+
+
+def sharded_grad_sq_sum(
+    params: Iterable[nn.Parameter],
+    *,
+    accum_dtype: str | torch.dtype = torch.float32,
+    default_device: torch.device | None = None,
+    chunk_size_numel: int = 0,
+    include_param: Callable[[nn.Parameter], bool] | None = None,
+    scalar_all_reduce: Callable[[torch.Tensor, dist.ProcessGroup, dist.ReduceOp], None]
+    | None = None,
+) -> torch.Tensor:
+    """Return global L2 grad squared-sum for M-FSDP Tensor/DTensor params.
+
+    This intentionally mirrors FSDP2's helper semantics, but stays inside the
+    M-FSDP package so the primitive does not depend on FSDP2 implementation
+    modules. Reductions that are model-layout policy, such as PP or EP, remain
+    in ``grad_norm.py``.
+    """
+
+    dtype = _resolve_torch_dtype(accum_dtype)
+    groups = _group_grads(params)
+    total: torch.Tensor | None = None
+    for group in groups.values():
+        local_sq = _group_local_sq_sum(
+            group,
+            dtype=dtype,
+            chunk_size_numel=chunk_size_numel,
+            include_param=include_param,
+        )
+        meta = group[0][2]
+        if meta is not None and not _has_partial_placement(meta) and dist.is_initialized():
+            _reduce_dtensor_scalar_(
+                local_sq,
+                meta,
+                op=dist.ReduceOp.SUM,
+                scalar_all_reduce=scalar_all_reduce,
+            )
+        total = local_sq if total is None else total.to(local_sq.device) + local_sq
+
+    if total is None:
+        return torch.zeros((), device=default_device or torch.device("cpu"), dtype=dtype)
+    return total
+
+
+def _resolve_torch_dtype(dtype: str | torch.dtype) -> torch.dtype:
+    if isinstance(dtype, torch.dtype):
+        resolved = dtype
+    else:
+        name = dtype.removeprefix("torch.")
+        resolved = getattr(torch, name, None)
+    if not isinstance(resolved, torch.dtype):
+        raise ValueError(f"Unsupported torch dtype for grad norm accumulation: {dtype!r}")
+    if not torch.empty((), dtype=resolved).is_floating_point():
+        raise ValueError(f"Grad norm accumulation dtype must be floating point: {dtype!r}")
+    return resolved
+
+
+def _group_grads(
+    params: Iterable[nn.Parameter],
+) -> dict[tuple[Any, ...], list[tuple[nn.Parameter, torch.Tensor, Any | None]]]:
+    groups: dict[tuple[Any, ...], list[tuple[nn.Parameter, torch.Tensor, Any | None]]] = defaultdict(
+        list
+    )
+    for param in params:
+        grad = param.grad
+        if grad is None:
+            continue
+        meta = _dtensor_meta(param, grad)
+        if meta is None:
+            key = ("tensor", _local_grad(grad, meta).device)
+        else:
+            key = (
+                "dtensor",
+                id(meta.device_mesh),
+                tuple(
+                    (type(placement).__name__, repr(placement))
+                    for placement in meta.placements
+                ),
+            )
+        groups[key].append((param, grad, meta))
+    return groups
+
+
+def _group_local_sq_sum(
+    group: list[tuple[nn.Parameter, torch.Tensor, Any | None]],
+    *,
+    dtype: torch.dtype,
+    chunk_size_numel: int = 0,
+    include_param: Callable[[nn.Parameter], bool] | None = None,
+) -> torch.Tensor:
+    device = _local_grad(group[0][1], group[0][2]).device
+    total = torch.zeros((), device=device, dtype=dtype)
+    for param, grad, meta in group:
+        if include_param is not None and not include_param(param):
+            continue
+        local_grad = _local_grad(grad, meta)
+        total += _tensor_sq_sum(
+            local_grad.detach(),
+            dtype=dtype,
+            chunk_size_numel=chunk_size_numel,
+        )
+    return total
+
+
+def _tensor_sq_sum(
+    tensor: torch.Tensor,
+    *,
+    dtype: torch.dtype,
+    chunk_size_numel: int = 0,
+) -> torch.Tensor:
+    if chunk_size_numel <= 0 or tensor.numel() <= chunk_size_numel:
+        return tensor.to(dtype).pow(2).sum()
+    try:
+        flat = tensor.view(-1)
+    except RuntimeError:
+        flat = tensor.reshape(-1)
+    total = torch.zeros((), device=tensor.device, dtype=dtype)
+    for start in range(0, flat.numel(), chunk_size_numel):
+        chunk = flat.narrow(0, start, min(chunk_size_numel, flat.numel() - start))
+        total += chunk.to(dtype).pow(2).sum()
+    return total
+
+
+def _local_grad(grad: torch.Tensor, meta: Any | None) -> torch.Tensor:
+    if meta is not None and _has_partial_placement(meta):
+        full_tensor = getattr(grad, "full_tensor", None)
+        if callable(full_tensor):
+            return full_tensor()
+    local_tensor = getattr(grad, "_local_tensor", None)
+    if isinstance(local_tensor, torch.Tensor):
+        return local_tensor
+    to_local = getattr(grad, "to_local", None)
+    if callable(to_local):
+        return to_local()
+    return grad
+
+
+def _dtensor_meta(param: nn.Parameter, grad: torch.Tensor) -> Any | None:
+    if _is_dtensor_like(grad):
+        return grad
+    if _is_dtensor_like(param):
+        return param
+    return None
+
+
+def _is_dtensor_like(tensor: Any) -> bool:
+    if DTensor is not None and isinstance(tensor, DTensor):
+        return True
+    return (
+        callable(getattr(tensor, "to_local", None))
+        and hasattr(tensor, "device_mesh")
+        and hasattr(tensor, "placements")
+    )
+
+
+def _has_partial_placement(dtensor: Any) -> bool:
+    return any(_placement_name(placement) == "Partial" for placement in dtensor.placements)
+
+
+def _is_replicate_placement(placement: Any) -> bool:
+    if Replicate is not None and isinstance(placement, Replicate):
+        return True
+    return _placement_name(placement) == "Replicate"
+
+
+def _placement_name(placement: Any) -> str:
+    return type(placement).__name__
+
+
+def _reduce_dtensor_scalar_(
+    value: torch.Tensor,
+    dtensor: Any,
+    *,
+    op: dist.ReduceOp,
+    scalar_all_reduce: Callable[[torch.Tensor, dist.ProcessGroup, dist.ReduceOp], None]
+    | None = None,
+) -> None:
+    for mesh_dim, placement in enumerate(dtensor.placements):
+        if _is_replicate_placement(placement):
+            continue
+        group = dtensor.device_mesh.get_group(mesh_dim)
+        if dist.get_world_size(group) > 1:
+            if scalar_all_reduce is None:
+                dist.all_reduce(value, op=op, group=group)
+            else:
+                scalar_all_reduce(value, group, op)
+
+
+__all__ = ["sharded_grad_sq_sum"]

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/grad_norm.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/grad_norm.py
@@ -1,0 +1,1849 @@
+"""Canonical grad-norm handling for the Megatron-FSDP primitive.
+
+Megatron-Core's FSDP optimizer currently flattens FSDP DTensor gradients to
+local tensors before it computes the norm. That makes the final answer depend
+on the optimizer's single grad-stats group. Megatron Lite needs the same semantics
+as the fsdp2 primitive: compute dense and expert shards in their own parallel
+domains, then combine through pipeline parallelism.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import re
+import time
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+import torch
+import torch.distributed as dist
+
+from megatron.lite.primitive.optimizers.mfsdp.dtensor_grad import sharded_grad_sq_sum
+from megatron.lite.primitive.optimizers.mfsdp.patches import (
+    PARAM_NAME_ATTR,
+    should_skip_tp_duplicate_sync,
+)
+from megatron.lite.primitive.parallel.state import ParallelState
+
+
+def _phase_debug(phase: str) -> None:
+    if os.environ.get("MLITE_BENCH_PHASE_DEBUG", "0") != "1":
+        return
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    print(f"[MFSDP_STEP_PHASE] rank={rank} phase={phase} t={time.time():.6f}", flush=True)
+
+
+@dataclass(frozen=True, slots=True)
+class GradNormBreakdown:
+    dense_sq: float
+    dense_tp_sharded_sq: float
+    dense_tp_replicated_sq: float
+    expert_sq: float
+    global_dense_sq: float
+    global_dense_tp_sharded_sq: float
+    global_dense_tp_replicated_sq: float
+    global_expert_sq: float
+    total_sq: float
+    grad_norm: float
+    dense_params: int
+    dense_tp_replicated_params: int
+    expert_params: int
+    dense_names: tuple[str, ...] = ()
+    dense_tp_replicated_names: tuple[str, ...] = ()
+    expert_names: tuple[str, ...] = ()
+
+
+class CanonicalGradNormMegatronFSDPOptimizer:
+    """Wrap a Megatron-Core optimizer with Megatron Lite's M-FSDP grad norm.
+
+    The wrapper delegates everything except ``step``. ``step`` follows
+    Megatron-Core's optimizer sequence, but replaces the norm/clip section with
+    ``compute_mfsdp_grad_norm``.
+    """
+
+    name = "megatron_fsdp"
+
+    def __init__(
+        self,
+        optimizer: Any,
+        ps: ParallelState,
+        *,
+        model_chunks: list[Any] | None = None,
+        param_is_expert: dict[int, bool] | None = None,
+        param_names: dict[int, str] | None = None,
+    ):
+        self._inner_optimizer = optimizer
+        self.ps = ps
+        self._model_chunks = list(model_chunks or ())
+        self._param_is_expert = dict(param_is_expert or {})
+        self._param_names = dict(param_names or {})
+        self._debug_update_step = 0
+        if _debug_param_names():
+            _print_param_name_debug(self._param_is_expert, self._param_names)
+        if _debug_updates():
+            _install_update_debug_hooks(self._inner_optimizer)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner_optimizer, name)
+
+    @property
+    def optimizer(self) -> Any:
+        return getattr(self._inner_optimizer, "optimizer", None)
+
+    @property
+    def param_groups(self) -> Any:
+        return getattr(self._inner_optimizer, "param_groups", [])
+
+    def zero_grad(self, *args, **kwargs):
+        return self._inner_optimizer.zero_grad(*args, **kwargs)
+
+    def state_dict(self):
+        return self._inner_optimizer.state_dict()
+
+    def load_state_dict(self, state_dict):
+        return self._inner_optimizer.load_state_dict(state_dict)
+
+    def reload_model_params(self) -> None:
+        """M-FSDP is built after model load, so main params are already current."""
+        return None
+
+    @torch.no_grad()
+    def step(self):
+        if not _use_canonical_grad_norm():
+            _phase_debug("inner_step:start")
+            result = self._inner_optimizer.step()
+            _phase_debug("inner_step:end")
+            return result
+
+        _phase_debug("prepare_grads:start")
+        found_inf_flag = self._inner_optimizer.prepare_grads()
+        _phase_debug("prepare_grads:end")
+        if found_inf_flag:
+            return False, None, None
+
+        _phase_debug("sync_main_grads:start")
+        _sync_mfsdp_model_chunk_main_grads(
+            self._inner_optimizer,
+            model_chunks=self._model_chunks,
+        )
+        _phase_debug("sync_main_grads:end")
+
+        mcore_norm_before_scale = None
+        if _debug_grad_norm():
+            _phase_debug("mcore_get_grad_norm:start")
+            mcore_norm_before_scale = self._inner_optimizer.get_grad_norm()
+            _phase_debug("mcore_get_grad_norm:end")
+        expert_scale = _expert_grad_scale(self.ps)
+        _phase_debug("expert_grad_scale:start")
+        _scale_mfsdp_expert_grads(
+            self._inner_optimizer,
+            param_is_expert=self._param_is_expert,
+            scale=expert_scale,
+        )
+        _phase_debug("expert_grad_scale:end")
+        _phase_debug("canonical_grad_norm:start")
+        breakdown = compute_mfsdp_grad_norm(
+            self._inner_optimizer,
+            self.ps,
+            param_is_expert=self._param_is_expert,
+            param_names=self._param_names,
+        )
+        _phase_debug("canonical_grad_norm:end")
+        grad_norm = breakdown.grad_norm
+
+        if _debug_grad_norm():
+            assert mcore_norm_before_scale is not None
+            _print_grad_norm_debug(
+                mcore_norm_before_scale,
+                breakdown,
+                expert_scale=expert_scale,
+            )
+
+        if not math.isfinite(grad_norm):
+            return False, grad_norm, None
+
+        _phase_debug("clip_grads:start")
+        _clip_mfsdp_grads_by_total_norm(
+            self._inner_optimizer,
+            grad_norm,
+            model_chunks=self._model_chunks,
+            ps=self.ps,
+            param_is_expert=self._param_is_expert,
+            param_names=self._param_names,
+        )
+        _phase_debug("clip_grads:end")
+        if _debug_grad_norm():
+            _phase_debug("postclip_grad_norm:start")
+            postclip_mcore_norm = self._inner_optimizer.get_grad_norm()
+            postclip_breakdown = compute_mfsdp_grad_norm(
+                self._inner_optimizer,
+                self.ps,
+                param_is_expert=self._param_is_expert,
+                param_names=self._param_names,
+            )
+            _phase_debug("postclip_grad_norm:end")
+            _print_postclip_grad_norm_debug(postclip_mcore_norm, postclip_breakdown)
+
+        config = getattr(self._inner_optimizer, "config", None)
+        log_num_zeros = bool(getattr(config, "log_num_zeros_in_grad", False))
+        _phase_debug("count_zeros:start")
+        num_zeros_in_grad = self._inner_optimizer.count_zeros() if log_num_zeros else None
+        _phase_debug("count_zeros:end")
+        if _debug_updates():
+            _set_update_debug_step(self._inner_optimizer, self._debug_update_step)
+            _print_update_debug(self._inner_optimizer, self._debug_update_step, "pre_step")
+        _phase_debug("step_with_ready_grads:start")
+        if _skip_post_step_param_sync():
+            if os.environ.get("MLITE_MFSDP_DEBUG_PARAM_SYNC", "0") == "1":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                print(
+                    f"[MFSDP_PARAM_SYNC] phase=skip_post_step_sync_active rank={rank}",
+                    flush=True,
+                )
+            old_active = os.environ.get("MLITE_MFSDP_SKIP_START_PARAM_SYNC_ACTIVE")
+            os.environ["MLITE_MFSDP_SKIP_START_PARAM_SYNC_ACTIVE"] = "1"
+            originals = _disable_chunk_param_sync(self._model_chunks)
+            try:
+                update_successful = self._inner_optimizer.step_with_ready_grads()
+            finally:
+                _restore_chunk_param_sync(originals)
+                if old_active is None:
+                    os.environ.pop("MLITE_MFSDP_SKIP_START_PARAM_SYNC_ACTIVE", None)
+                else:
+                    os.environ["MLITE_MFSDP_SKIP_START_PARAM_SYNC_ACTIVE"] = old_active
+        else:
+            update_successful = self._inner_optimizer.step_with_ready_grads()
+        _phase_debug("step_with_ready_grads:end")
+        if _debug_updates():
+            _print_update_debug(self._inner_optimizer, self._debug_update_step, "post_step")
+            self._debug_update_step += 1
+        if _debug_finite_scan():
+            _print_finite_scan(
+                self._inner_optimizer,
+                "post_step",
+                param_names=self._param_names,
+            )
+
+        return update_successful, grad_norm, num_zeros_in_grad
+
+
+def _skip_post_step_param_sync() -> bool:
+    return os.environ.get(
+        "MLITE_MFSDP_SKIP_POST_STEP_PARAM_SYNC", "0"
+    ).lower() in ("1", "true", "yes", "on")
+
+
+def _disable_chunk_param_sync(model_chunks: Iterable[Any]) -> list[tuple[Any, Any]]:
+    originals: list[tuple[Any, Any]] = []
+
+    def _noop_start_param_sync(*_args: Any, **_kwargs: Any) -> None:
+        if os.environ.get("MLITE_MFSDP_DEBUG_PARAM_SYNC", "0") == "1":
+            rank = dist.get_rank() if dist.is_initialized() else 0
+            print(
+                f"[MFSDP_PARAM_SYNC] phase=post_step_noop rank={rank}",
+                flush=True,
+            )
+
+    for chunk in model_chunks:
+        if not hasattr(chunk, "start_param_sync"):
+            continue
+        originals.append((chunk, chunk.start_param_sync))
+        chunk.start_param_sync = _noop_start_param_sync
+    return originals
+
+
+def _restore_chunk_param_sync(originals: Iterable[tuple[Any, Any]]) -> None:
+    for chunk, original in originals:
+        chunk.start_param_sync = original
+
+
+@torch.no_grad()
+def compute_mfsdp_grad_norm(
+    optimizer: Any,
+    ps: ParallelState,
+    *,
+    param_is_expert: dict[int, bool] | None = None,
+    param_names: dict[int, str] | None = None,
+) -> GradNormBreakdown:
+    device = _first_grad_device(optimizer)
+    dense_dtensor_sharded_params: list[torch.nn.Parameter] = []
+    dense_dtensor_sharded_sq = _new_accumulator(device)
+    dense_dtensor_tp_sharded_sq = _new_accumulator(device)
+    dense_tp_replicated_sq = _new_accumulator(device)
+    dense_plain_sharded_sq = _new_accumulator(device)
+    dense_replicated_sq = _new_accumulator(device)
+    expert_dtensor_sharded_sq = _new_accumulator(device)
+    expert_plain_sharded_sq = _new_accumulator(device)
+    dense_params = 0
+    dense_tp_replicated_param_count = 0
+    expert_params = 0
+    dense_names: list[str] = []
+    dense_tp_replicated_names: list[str] = []
+    expert_names: list[str] = []
+
+    for leaf_optimizer in _iter_leaf_optimizers(optimizer):
+        for param_group in _iter_param_groups(leaf_optimizer):
+            group_is_expert = bool(param_group.get("is_expert_parallel", False))
+            for param in param_group.get("params", ()):
+                is_expert = _param_is_expert(param, group_is_expert, param_is_expert)
+                tp_group = ps.etp_group if is_expert else ps.tp_group
+                grad = _grad_for_norm(param, leaf_optimizer)
+                if grad is None:
+                    continue
+                include_in_norm = _include_param_in_norm(param, tp_group)
+                has_dtensor = _has_dtensor_grad_or_param(param, grad)
+                is_tp_replicated = _is_tp_replicated_grad_param(param, is_expert)
+                if not include_in_norm and not has_dtensor and not is_tp_replicated:
+                    continue
+                if is_expert:
+                    if has_dtensor:
+                        if include_in_norm:
+                            expert_dtensor_sharded_sq = (
+                                expert_dtensor_sharded_sq
+                                + _grad_sq_sum(grad).to(expert_dtensor_sharded_sq.device)
+                            )
+                    elif include_in_norm:
+                        expert_plain_sharded_sq = expert_plain_sharded_sq + _grad_sq_sum(
+                            grad
+                        ).to(expert_plain_sharded_sq.device)
+                    if include_in_norm:
+                        expert_params += 1
+                    if include_in_norm and _debug_param_names():
+                        expert_names.append(_param_name(param, param_names))
+                else:
+                    if is_tp_replicated:
+                        if _include_shared_param_in_norm(param):
+                            dense_tp_replicated_sq = dense_tp_replicated_sq + _grad_sq_sum(
+                                grad
+                            ).to(dense_tp_replicated_sq.device)
+                        dense_tp_replicated_param_count += 1
+                        if _debug_param_names():
+                            dense_tp_replicated_names.append(_param_name(param, param_names))
+                    elif has_dtensor:
+                        dense_dtensor_sharded_params.append(param)
+                        if include_in_norm:
+                            if _is_tp_sharded_grad_param(param, False):
+                                dense_dtensor_tp_sharded_sq = (
+                                    dense_dtensor_tp_sharded_sq
+                                    + _grad_sq_sum(grad).to(
+                                        dense_dtensor_tp_sharded_sq.device
+                                    )
+                                )
+                            else:
+                                dense_dtensor_sharded_sq = (
+                                    dense_dtensor_sharded_sq
+                                    + _grad_sq_sum(grad).to(dense_dtensor_sharded_sq.device)
+                                )
+                    elif include_in_norm and _is_sharded_param_grad(param, grad):
+                        dense_plain_sharded_sq = dense_plain_sharded_sq + _grad_sq_sum(
+                            grad
+                        ).to(dense_plain_sharded_sq.device)
+                    elif include_in_norm:
+                        grad_sq = _grad_sq_sum(grad)
+                        dense_replicated_sq = dense_replicated_sq + grad_sq.to(
+                            dense_replicated_sq.device
+                        )
+                    if include_in_norm:
+                        dense_params += 1
+                    if include_in_norm and _debug_param_names():
+                        dense_names.append(_param_name(param, param_names))
+
+    _phase_debug("canonical_grad_norm:dense_dtensor_non_tp_sq:start")
+    _sum_in_group(
+        dense_dtensor_sharded_sq,
+        ps.dp_cp_group or ps.dp_group,
+        tag="dense_dtensor_non_tp_dp",
+    )
+    _phase_debug("canonical_grad_norm:dense_dtensor_non_tp_sq:end")
+    _phase_debug("canonical_grad_norm:dense_dtensor_tp_sharded_sq:start")
+    _sum_in_group(
+        dense_dtensor_tp_sharded_sq,
+        ps.dp_cp_group or ps.dp_group,
+        tag="dense_dtensor_tp_sharded_dp",
+    )
+    _sum_in_group(
+        dense_dtensor_tp_sharded_sq,
+        ps.tp_group,
+        tag="dense_dtensor_tp_group",
+    )
+    _phase_debug("canonical_grad_norm:dense_dtensor_tp_sharded_sq:end")
+    _phase_debug("canonical_grad_norm:dense_tp_replicated_sq:start")
+    _sum_in_group(
+        dense_tp_replicated_sq,
+        ps.dp_cp_group or ps.dp_group,
+        tag="dense_tp_replicated_dp",
+    )
+    _phase_debug("canonical_grad_norm:dense_tp_replicated_sq:end")
+    _phase_debug("canonical_grad_norm:dense_plain_reduce:start")
+    _sum_in_group(
+        dense_plain_sharded_sq,
+        ps.dp_cp_group or ps.dp_group,
+        tag="dense_plain_dp",
+    )
+    _sum_in_group(dense_plain_sharded_sq, ps.tp_group, tag="dense_plain_tp")
+    _sum_in_group(dense_replicated_sq, ps.tp_group, tag="dense_replicated_tp")
+    _phase_debug("canonical_grad_norm:dense_plain_reduce:end")
+    dense_sq = (
+        dense_dtensor_sharded_sq
+        + dense_dtensor_tp_sharded_sq.to(dense_dtensor_sharded_sq.device)
+        + dense_tp_replicated_sq.to(dense_dtensor_sharded_sq.device)
+        + dense_plain_sharded_sq.to(dense_dtensor_sharded_sq.device)
+        + dense_replicated_sq.to(dense_dtensor_sharded_sq.device)
+    )
+    if _debug_grad_norm_candidates():
+        _print_dense_dtensor_candidate_debug(
+            dense_dtensor_sharded_params,
+            ps,
+            default_device=device,
+            param_names=param_names,
+        )
+
+    _phase_debug("canonical_grad_norm:expert_dtensor_sq:start")
+    _sum_in_group(
+        expert_dtensor_sharded_sq,
+        ps.ep_dp_group,
+        tag="expert_dtensor_ep_dp",
+    )
+    _phase_debug("canonical_grad_norm:expert_dtensor_sq:end")
+    _phase_debug("canonical_grad_norm:expert_reduce:start")
+    _sum_in_group(expert_plain_sharded_sq, ps.ep_dp_group, tag="expert_plain_ep_dp")
+    _sum_in_group(expert_plain_sharded_sq, ps.etp_group, tag="expert_plain_etp")
+    expert_sq = expert_dtensor_sharded_sq + expert_plain_sharded_sq.to(
+        expert_dtensor_sharded_sq.device
+    )
+    _sum_in_group(expert_sq, ps.ep_group, tag="expert_ep")
+    _phase_debug("canonical_grad_norm:expert_reduce:end")
+
+    if _debug_grad_norm():
+        global_dense_sq = dense_sq.clone()
+        global_dense_tp_sharded_sq = dense_dtensor_tp_sharded_sq.clone()
+        global_dense_tp_replicated_sq = dense_tp_replicated_sq.clone()
+        global_expert_sq = expert_sq.clone()
+        _phase_debug("canonical_grad_norm:debug_global_dense_pp_reduce:start")
+        _sum_in_group(global_dense_sq, ps.pp_group, tag="debug_global_dense_pp")
+        _phase_debug("canonical_grad_norm:debug_global_dense_pp_reduce:end")
+        _phase_debug("canonical_grad_norm:debug_global_dense_tp_pp_reduce:start")
+        _sum_in_group(
+            global_dense_tp_sharded_sq,
+            ps.pp_group,
+            tag="debug_global_dense_tp_pp",
+        )
+        _phase_debug("canonical_grad_norm:debug_global_dense_tp_pp_reduce:end")
+        _phase_debug("canonical_grad_norm:debug_global_dense_tp_repl_pp_reduce:start")
+        _sum_in_group(
+            global_dense_tp_replicated_sq,
+            ps.pp_group,
+            tag="debug_global_dense_tp_repl_pp",
+        )
+        _phase_debug("canonical_grad_norm:debug_global_dense_tp_repl_pp_reduce:end")
+        _phase_debug("canonical_grad_norm:debug_global_expert_pp_reduce:start")
+        _sum_in_group(global_expert_sq, ps.pp_group, tag="debug_global_expert_pp")
+        _phase_debug("canonical_grad_norm:debug_global_expert_pp_reduce:end")
+        total_sq = global_dense_sq + global_expert_sq.to(global_dense_sq.device)
+    else:
+        global_dense_sq = dense_sq
+        global_dense_tp_sharded_sq = dense_dtensor_tp_sharded_sq
+        global_dense_tp_replicated_sq = dense_tp_replicated_sq
+        global_expert_sq = expert_sq
+        total_sq = dense_sq + expert_sq.to(dense_sq.device)
+        _phase_debug("canonical_grad_norm:total_pp_reduce:start")
+        _sum_in_group(total_sq, ps.pp_group, tag="total_pp")
+        _phase_debug("canonical_grad_norm:total_pp_reduce:end")
+    grad_norm = total_sq.sqrt()
+    _phase_debug("canonical_grad_norm:grad_norm_item:start")
+    grad_norm_value = float(grad_norm.float().item())
+    _phase_debug("canonical_grad_norm:grad_norm_item:end")
+    collect_component_stats = _debug_grad_norm()
+    if collect_component_stats:
+        _phase_debug("canonical_grad_norm:component_items:start")
+        dense_sq_value = float(dense_sq.float().item())
+        dense_tp_sharded_sq_value = float(dense_dtensor_tp_sharded_sq.float().item())
+        dense_tp_replicated_sq_value = float(dense_tp_replicated_sq.float().item())
+        expert_sq_value = float(expert_sq.float().item())
+        global_dense_sq_value = float(global_dense_sq.float().item())
+        global_dense_tp_sharded_sq_value = float(
+            global_dense_tp_sharded_sq.float().item()
+        )
+        global_dense_tp_replicated_sq_value = float(
+            global_dense_tp_replicated_sq.float().item()
+        )
+        global_expert_sq_value = float(global_expert_sq.float().item())
+        total_sq_value = float(total_sq.float().item())
+        _phase_debug("canonical_grad_norm:component_items:end")
+    else:
+        dense_sq_value = float("nan")
+        dense_tp_sharded_sq_value = float("nan")
+        dense_tp_replicated_sq_value = float("nan")
+        expert_sq_value = float("nan")
+        global_dense_sq_value = float("nan")
+        global_dense_tp_sharded_sq_value = float("nan")
+        global_dense_tp_replicated_sq_value = float("nan")
+        global_expert_sq_value = float("nan")
+        total_sq_value = grad_norm_value * grad_norm_value
+    return GradNormBreakdown(
+        dense_sq=dense_sq_value,
+        dense_tp_sharded_sq=dense_tp_sharded_sq_value,
+        dense_tp_replicated_sq=dense_tp_replicated_sq_value,
+        expert_sq=expert_sq_value,
+        global_dense_sq=global_dense_sq_value,
+        global_dense_tp_sharded_sq=global_dense_tp_sharded_sq_value,
+        global_dense_tp_replicated_sq=global_dense_tp_replicated_sq_value,
+        global_expert_sq=global_expert_sq_value,
+        total_sq=total_sq_value,
+        grad_norm=grad_norm_value,
+        dense_params=dense_params,
+        dense_tp_replicated_params=dense_tp_replicated_param_count,
+        expert_params=expert_params,
+        dense_names=tuple(dense_names[:20]),
+        dense_tp_replicated_names=tuple(dense_tp_replicated_names[:20]),
+        expert_names=tuple(expert_names[:20]),
+    )
+
+
+def _clip_mfsdp_grads_by_total_norm(
+    optimizer: Any,
+    grad_norm: float,
+    *,
+    model_chunks: list[Any] | None = None,
+    ps: ParallelState | None = None,
+    param_is_expert: dict[int, bool] | None = None,
+    param_names: dict[int, str] | None = None,
+) -> None:
+    if not math.isfinite(float(grad_norm)):
+        return
+    clip_coeff = _mfsdp_clip_coeff(optimizer, grad_norm)
+    if clip_coeff is None or clip_coeff >= 1.0:
+        return
+    if _debug_clip_rank_stats():
+        _print_clip_rank_stats(
+            grad_norm=float(grad_norm),
+            clip_coeff=clip_coeff,
+            scaled_params=0,
+            local_sq_before=0.0,
+            local_sq_after=0.0,
+            stage="pre",
+        )
+    debug_clip = _debug_clip()
+    seen_param_ids: set[int] = set()
+    scaled_params = 0
+    debug_local_sq_before = 0.0
+    debug_local_sq_after = 0.0
+    debug_dtensor_local = 0
+    debug_dtensor_to_local = 0
+    for leaf_optimizer in _iter_leaf_optimizers(optimizer):
+        if bool(getattr(leaf_optimizer, "is_stub_optimizer", False)):
+            continue
+        config = getattr(leaf_optimizer, "config", None)
+        clip_grad = float(getattr(config, "clip_grad", 0.0))
+        if clip_grad <= 0.0:
+            continue
+        use_decoupled_grad = bool(
+            getattr(config, "use_precision_aware_optimizer_no_fp8_or_ds_fp8", False)
+        )
+        for param_group in _iter_param_groups(leaf_optimizer):
+            for param in param_group.get("params", ()):
+                param_id = id(param)
+                if param_id in seen_param_ids:
+                    continue
+                seen_param_ids.add(param_id)
+                grad = (
+                    getattr(param, "decoupled_grad", None)
+                    if use_decoupled_grad
+                    else getattr(param, "grad", None)
+                )
+                if grad is not None:
+                    if debug_clip:
+                        local_grad = _to_local_grad(grad)
+                        if local_grad is not None:
+                            debug_local_sq_before += float(
+                                _grad_sq_sum(local_grad).float().item()
+                            )
+                        if getattr(grad, "_local_tensor", None) is not None:
+                            debug_dtensor_local += 1
+                        elif callable(getattr(grad, "to_local", None)):
+                            debug_dtensor_to_local += 1
+                    _scale_grad_in_place(grad, clip_coeff)
+                    if debug_clip:
+                        local_grad = _to_local_grad(grad)
+                        if local_grad is not None:
+                            debug_local_sq_after += float(
+                                _grad_sq_sum(local_grad).float().item()
+                            )
+                    scaled_params += 1
+    if debug_clip:
+        _print_clip_debug(
+            float(grad_norm),
+            clip_coeff,
+            scaled_params,
+            mode="param_grads",
+            local_sq_before=debug_local_sq_before,
+            local_sq_after=debug_local_sq_after,
+            dtensor_local=debug_dtensor_local,
+            dtensor_to_local=debug_dtensor_to_local,
+        )
+    if _debug_clip_rank_stats():
+        _print_clip_rank_stats(
+            grad_norm=float(grad_norm),
+            clip_coeff=clip_coeff,
+            scaled_params=scaled_params,
+            local_sq_before=debug_local_sq_before,
+            local_sq_after=debug_local_sq_after,
+            stage="post_scale",
+        )
+
+
+def _mfsdp_clip_coeff(optimizer: Any, grad_norm: float) -> float | None:
+    clip_grad = _mfsdp_clip_grad(optimizer)
+    if clip_grad is None:
+        return None
+    return clip_grad / (float(grad_norm) + 1.0e-6)
+
+
+def _mfsdp_clip_grad(optimizer: Any) -> float | None:
+    for leaf_optimizer in _iter_leaf_optimizers(optimizer):
+        if bool(getattr(leaf_optimizer, "is_stub_optimizer", False)):
+            continue
+        config = getattr(leaf_optimizer, "config", None)
+        clip_grad = float(getattr(config, "clip_grad", 0.0))
+        if clip_grad > 0.0:
+            return clip_grad
+    return None
+
+
+def _mfsdp_model_chunks_for_clip(
+    optimizer: Any,
+    model_chunks: list[Any] | None,
+) -> list[Any]:
+    chunks: list[Any] = []
+    seen_ids: set[int] = set()
+
+    def add_chunk(chunk: Any) -> None:
+        chunk_id = id(chunk)
+        if chunk_id in seen_ids:
+            return
+        seen_ids.add(chunk_id)
+        chunks.append(chunk)
+
+    for chunk in model_chunks or ():
+        add_chunk(chunk)
+    for chunk in getattr(optimizer, "model_chunks", ()) or ():
+        add_chunk(chunk)
+    for leaf_optimizer in _iter_leaf_optimizers(optimizer):
+        for chunk in getattr(leaf_optimizer, "model_chunks", ()) or ():
+            add_chunk(chunk)
+    return chunks
+
+
+def _sync_mfsdp_model_chunk_main_grads(
+    optimizer: Any,
+    *,
+    model_chunks: list[Any] | None = None,
+) -> bool:
+    synced_any = False
+    for chunk in _mfsdp_model_chunks_for_clip(optimizer, model_chunks):
+        buffer = getattr(chunk, "param_and_grad_buffer", None)
+        update_main_grads = getattr(buffer, "update_main_grads", None)
+        if callable(update_main_grads):
+            update_main_grads()
+            synced_any = True
+            continue
+        scale_gradients = getattr(chunk, "scale_gradients", None)
+        if callable(scale_gradients):
+            scale_gradients(1.0)
+            synced_any = True
+    return synced_any
+
+
+def _scale_mfsdp_expert_grads(
+    optimizer: Any,
+    *,
+    param_is_expert: dict[int, bool],
+    scale: float,
+) -> None:
+    if scale == 1.0:
+        return
+    seen_param_ids: set[int] = set()
+    for leaf_optimizer in _iter_leaf_optimizers(optimizer):
+        for param_group in _iter_param_groups(leaf_optimizer):
+            group_is_expert = bool(param_group.get("is_expert_parallel", False))
+            for param in param_group.get("params", ()):
+                param_id = id(param)
+                if param_id in seen_param_ids:
+                    continue
+                seen_param_ids.add(param_id)
+                if not _param_is_expert(param, group_is_expert, param_is_expert):
+                    continue
+                grad = getattr(param, "grad", None)
+                if grad is not None:
+                    _scale_grad_in_place(grad, scale)
+
+
+def _expert_grad_scale(ps: ParallelState) -> float:
+    override = os.environ.get("MLITE_MFSDP_EXPERT_GRAD_SCALE")
+    if override is not None:
+        return float(override)
+    return 1.0
+
+
+def _iter_leaf_optimizers(optimizer: Any) -> list[Any]:
+    chained = getattr(optimizer, "chained_optimizers", None)
+    if chained is None:
+        return [optimizer]
+    return list(chained)
+
+
+def _iter_param_groups(optimizer: Any) -> Iterable[dict[str, Any]]:
+    param_groups = getattr(optimizer, "param_groups", None)
+    if param_groups is None:
+        inner_optimizer = getattr(optimizer, "optimizer", None)
+        param_groups = getattr(inner_optimizer, "param_groups", None)
+    return param_groups or ()
+
+
+def _param_is_expert(
+    param: torch.Tensor,
+    group_is_expert: bool,
+    param_is_expert: dict[int, bool] | None,
+) -> bool:
+    if param_is_expert is not None and id(param) in param_is_expert:
+        return bool(param_is_expert[id(param)])
+    if not getattr(param, "allreduce", True):
+        return True
+    return group_is_expert
+
+
+def _param_name(param: torch.Tensor, param_names: dict[int, str] | None) -> str:
+    if param_names is None:
+        return "<unknown>"
+    return param_names.get(id(param), "<unknown>")
+
+
+def _is_sharded_param_grad(param: torch.Tensor, grad: torch.Tensor) -> bool:
+    if getattr(param, "__fsdp_param__", False):
+        return True
+    if getattr(getattr(param, "grad", None), "_local_tensor", None) is not None:
+        return True
+    return getattr(grad, "_spec", None) is not None
+
+
+def _has_dtensor_grad_or_param(param: torch.Tensor, grad: torch.Tensor) -> bool:
+    raw_grad = getattr(param, "grad", None)
+    return _is_dtensor_like(grad) or _is_dtensor_like(raw_grad) or _is_dtensor_like(param)
+
+
+def _is_dtensor_like(tensor: Any) -> bool:
+    return (
+        callable(getattr(tensor, "to_local", None))
+        and hasattr(tensor, "device_mesh")
+        and hasattr(tensor, "placements")
+    )
+
+
+def _scale_grad_in_place(grad: Any, scale: float) -> None:
+    local_tensor = getattr(grad, "_local_tensor", None)
+    if isinstance(local_tensor, torch.Tensor):
+        local_tensor.mul_(scale)
+        return
+    to_local = getattr(grad, "to_local", None)
+    if callable(to_local):
+        local_grad = to_local()
+        local_grad.mul_(scale)
+        return
+    grad.mul_(scale)
+
+
+def _grad_for_norm(param: torch.Tensor, optimizer: Any) -> torch.Tensor | None:
+    if getattr(param, "__fsdp_param__", False):
+        return _to_local_grad(getattr(param, "grad", None))
+
+    config = getattr(optimizer, "config", None)
+    use_decoupled_grad = bool(
+        getattr(config, "use_precision_aware_optimizer_no_fp8_or_ds_fp8", False)
+    )
+    if use_decoupled_grad:
+        grad = getattr(param, "decoupled_grad", None)
+    else:
+        grad = getattr(param, "grad", None)
+    return _to_local_grad(grad)
+
+
+def _include_param_in_norm(param: torch.Tensor, tp_group: Any) -> bool:
+    from megatron.core.tensor_parallel import (  # pyright: ignore[reportMissingImports]
+        param_is_not_tensor_parallel_duplicate,
+    )
+    from megatron.core.transformer.module import (  # pyright: ignore[reportMissingImports]
+        param_is_not_shared,
+    )
+
+    return bool(param_is_not_shared(param)) and bool(
+        param_is_not_tensor_parallel_duplicate(param, tp_group=tp_group)
+    )
+
+
+def _include_shared_param_in_norm(param: torch.Tensor) -> bool:
+    from megatron.core.transformer.module import (  # pyright: ignore[reportMissingImports]
+        param_is_not_shared,
+    )
+
+    return bool(param_is_not_shared(param))
+
+
+def _is_tp_replicated_grad_param(param: torch.Tensor, is_expert: bool) -> bool:
+    if is_expert:
+        return False
+    return bool(getattr(param, "sequence_parallel", False))
+
+
+def _is_tp_sharded_grad_param(param: torch.Tensor, is_expert: bool) -> bool:
+    if is_expert:
+        return False
+    if _is_tp_replicated_grad_param(param, is_expert):
+        return False
+    if not bool(getattr(param, "tensor_model_parallel", False)):
+        return False
+    partition_dim = getattr(param, "partition_dim", None)
+    if partition_dim == 1:
+        return True
+    return partition_dim == 0 and _is_vocab_tp_sharded_param(param)
+
+
+def _is_vocab_tp_sharded_param(param: torch.Tensor) -> bool:
+    name = _param_policy_name(param)
+    return (
+        name.endswith("embed.embedding.weight")
+        or name.endswith("mtp_embed.embedding.weight")
+        or name.endswith("head.col.linear.weight")
+    )
+
+
+def _param_policy_name(param: torch.Tensor) -> str:
+    name = str(getattr(param, PARAM_NAME_ATTR, ""))
+    if name:
+        return name
+    orig_param = getattr(param, "orig_param", None)
+    if orig_param is not None:
+        return str(getattr(orig_param, PARAM_NAME_ATTR, ""))
+    return ""
+
+
+def _dense_dtensor_candidate_sq(
+    params: list[torch.nn.Parameter],
+    ps: ParallelState,
+    *,
+    default_device: torch.device,
+    include_param,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    local_sq = sharded_grad_sq_sum(
+        params,
+        accum_dtype=torch.float32,
+        default_device=default_device,
+        include_param=include_param,
+    )
+    tp_sq = local_sq.clone()
+    _sum_in_group(tp_sq, ps.tp_group)
+    return local_sq, tp_sq
+
+
+def _print_dense_dtensor_candidate_debug(
+    params: list[torch.nn.Parameter],
+    ps: ParallelState,
+    *,
+    default_device: torch.device,
+    param_names: dict[int, str] | None,
+) -> None:
+    include_base = lambda param: (
+        not _is_tp_replicated_grad_param(param, False)
+        and _include_param_in_norm(param, ps.tp_group)
+    )
+    row_sq, row_tp_sq = _dense_dtensor_candidate_sq(
+        params,
+        ps,
+        default_device=default_device,
+        include_param=lambda param: (
+            include_base(param) and getattr(param, "partition_dim", None) == 1
+        ),
+    )
+    column_sq, column_tp_sq = _dense_dtensor_candidate_sq(
+        params,
+        ps,
+        default_device=default_device,
+        include_param=lambda param: (
+            include_base(param) and getattr(param, "partition_dim", None) == 0
+        ),
+    )
+    local_tp_column_sq, local_tp_column_tp_sq = _dense_dtensor_candidate_sq(
+        params,
+        ps,
+        default_device=default_device,
+        include_param=lambda param: (
+            include_base(param)
+            and getattr(param, "partition_dim", None) == 0
+            and should_skip_tp_duplicate_sync(param)
+        ),
+    )
+    mcore_tp_column_sq, mcore_tp_column_tp_sq = _dense_dtensor_candidate_sq(
+        params,
+        ps,
+        default_device=default_device,
+        include_param=lambda param: (
+            include_base(param)
+            and getattr(param, "partition_dim", None) == 0
+            and not should_skip_tp_duplicate_sync(param)
+        ),
+    )
+    no_partition_sq, no_partition_tp_sq = _dense_dtensor_candidate_sq(
+        params,
+        ps,
+        default_device=default_device,
+        include_param=lambda param: (
+            include_base(param) and getattr(param, "partition_dim", None) not in (0, 1)
+        ),
+    )
+    shared_excluded_sq, shared_excluded_tp_sq = _dense_dtensor_candidate_sq(
+        params,
+        ps,
+        default_device=default_device,
+        include_param=lambda param: (
+            not _is_tp_replicated_grad_param(param, False)
+            and not _include_shared_param_in_norm(param)
+        ),
+    )
+    tp_duplicate_excluded_sq, tp_duplicate_excluded_tp_sq = _dense_dtensor_candidate_sq(
+        params,
+        ps,
+        default_device=default_device,
+        include_param=lambda param: (
+            not _is_tp_replicated_grad_param(param, False)
+            and _include_shared_param_in_norm(param)
+            and not _include_param_in_norm(param, ps.tp_group)
+        ),
+    )
+    vocab_column_sq, vocab_column_tp_sq = _dense_dtensor_candidate_sq(
+        params,
+        ps,
+        default_device=default_device,
+        include_param=lambda param: include_base(param)
+        and _is_column_category(param, "vocab", param_names),
+    )
+    attn_qkv_column_sq, attn_qkv_column_tp_sq = _dense_dtensor_candidate_sq(
+        params,
+        ps,
+        default_device=default_device,
+        include_param=lambda param: include_base(param)
+        and _is_column_category(param, "attn_qkv", param_names),
+    )
+    attn_aux_column_sq, attn_aux_column_tp_sq = _dense_dtensor_candidate_sq(
+        params,
+        ps,
+        default_device=default_device,
+        include_param=lambda param: include_base(param)
+        and _is_column_category(param, "attn_aux", param_names),
+    )
+    fc1_column_sq, fc1_column_tp_sq = _dense_dtensor_candidate_sq(
+        params,
+        ps,
+        default_device=default_device,
+        include_param=lambda param: include_base(param)
+        and _is_column_category(param, "fc1", param_names),
+    )
+    other_column_sq, other_column_tp_sq = _dense_dtensor_candidate_sq(
+        params,
+        ps,
+        default_device=default_device,
+        include_param=lambda param: include_base(param)
+        and _is_column_category(param, "other", param_names),
+    )
+    if dist.is_initialized() and dist.get_rank() != 0:
+        return
+    shared_names = _candidate_names(
+        params,
+        include_param=lambda param: (
+            not _is_tp_replicated_grad_param(param, False)
+            and not _include_shared_param_in_norm(param)
+        ),
+        param_names=param_names,
+    )
+    tp_duplicate_names = _candidate_names(
+        params,
+        include_param=lambda param: (
+            not _is_tp_replicated_grad_param(param, False)
+            and _include_shared_param_in_norm(param)
+            and not _include_param_in_norm(param, ps.tp_group)
+        ),
+        param_names=param_names,
+    )
+    print(
+        "[MFSDP_GN_CANDIDATES] "
+        f"row_sq={float(row_sq.float().item()):.9e} "
+        f"row_tp_sq={float(row_tp_sq.float().item()):.9e} "
+        f"column_sq={float(column_sq.float().item()):.9e} "
+        f"column_tp_sq={float(column_tp_sq.float().item()):.9e} "
+        f"local_tp_column_sq={float(local_tp_column_sq.float().item()):.9e} "
+        f"local_tp_column_tp_sq={float(local_tp_column_tp_sq.float().item()):.9e} "
+        f"mcore_tp_column_sq={float(mcore_tp_column_sq.float().item()):.9e} "
+        f"mcore_tp_column_tp_sq={float(mcore_tp_column_tp_sq.float().item()):.9e} "
+        f"no_partition_sq={float(no_partition_sq.float().item()):.9e} "
+        f"no_partition_tp_sq={float(no_partition_tp_sq.float().item()):.9e} "
+        f"shared_excluded_sq={float(shared_excluded_sq.float().item()):.9e} "
+        f"shared_excluded_tp_sq={float(shared_excluded_tp_sq.float().item()):.9e} "
+        f"tp_duplicate_excluded_sq={float(tp_duplicate_excluded_sq.float().item()):.9e} "
+        f"tp_duplicate_excluded_tp_sq={float(tp_duplicate_excluded_tp_sq.float().item()):.9e} "
+        f"vocab_column_sq={float(vocab_column_sq.float().item()):.9e} "
+        f"vocab_column_tp_sq={float(vocab_column_tp_sq.float().item()):.9e} "
+        f"attn_qkv_column_sq={float(attn_qkv_column_sq.float().item()):.9e} "
+        f"attn_qkv_column_tp_sq={float(attn_qkv_column_tp_sq.float().item()):.9e} "
+        f"attn_aux_column_sq={float(attn_aux_column_sq.float().item()):.9e} "
+        f"attn_aux_column_tp_sq={float(attn_aux_column_tp_sq.float().item()):.9e} "
+        f"fc1_column_sq={float(fc1_column_sq.float().item()):.9e} "
+        f"fc1_column_tp_sq={float(fc1_column_tp_sq.float().item()):.9e} "
+        f"other_column_sq={float(other_column_sq.float().item()):.9e} "
+        f"other_column_tp_sq={float(other_column_tp_sq.float().item()):.9e} "
+        f"shared_names={shared_names} "
+        f"tp_duplicate_names={tp_duplicate_names}",
+        flush=True,
+    )
+
+
+def _candidate_names(
+    params: list[torch.nn.Parameter],
+    *,
+    include_param,
+    param_names: dict[int, str] | None,
+    limit: int = 8,
+) -> list[str]:
+    names: list[str] = []
+    for param in params:
+        if not include_param(param):
+            continue
+        names.append(_param_debug_name(param, param_names))
+        if len(names) >= limit:
+            break
+    return names
+
+
+def _param_debug_name(
+    param: torch.nn.Parameter,
+    param_names: dict[int, str] | None,
+) -> str:
+    if param_names is not None and id(param) in param_names:
+        return param_names[id(param)]
+    return str(getattr(param, PARAM_NAME_ATTR, ""))
+
+
+def _is_column_category(
+    param: torch.nn.Parameter,
+    category: str,
+    param_names: dict[int, str] | None,
+) -> bool:
+    if getattr(param, "partition_dim", None) != 0:
+        return False
+    name = _param_debug_name(param, param_names)
+    is_vocab = (
+        name.endswith("embed.embedding.weight")
+        or name.endswith("mtp_embed.embedding.weight")
+        or name.endswith("head.col.linear.weight")
+    )
+    is_attn_qkv = (
+        ".attn.qkv." in name
+        or ".attn.linear_qkv." in name
+        or ".self_attention.linear_qkv." in name
+        or ".self_attention.in_proj." in name
+        or ".self_attention.gdn.in_proj." in name
+    )
+    is_attn_aux = ".eh_proj." in name
+    is_fc1 = (
+        ".shared_experts." in name
+        or ".linear_fc1." in name
+        or ".experts.fc1." in name
+        or ".experts.linear_fc1." in name
+    )
+    if category == "vocab":
+        return is_vocab
+    if category == "attn_qkv":
+        return is_attn_qkv
+    if category == "attn_aux":
+        return is_attn_aux
+    if category == "fc1":
+        return is_fc1
+    if category == "other":
+        return not (is_vocab or is_attn_qkv or is_attn_aux or is_fc1)
+    return False
+
+
+def _to_local_grad(grad: Any) -> torch.Tensor | None:
+    if grad is None:
+        return None
+    local_tensor = getattr(grad, "_local_tensor", None)
+    if local_tensor is not None:
+        return local_tensor
+    try:
+        from megatron.core.utils import to_local_if_dtensor  # pyright: ignore[reportMissingImports]
+
+        return to_local_if_dtensor(grad)
+    except Exception:
+        return grad
+
+
+def _grad_sq_sum(grad: torch.Tensor) -> torch.Tensor:
+    local = grad.detach()
+    if local.dtype != torch.float32:
+        local = local.float()
+    return local.pow(2).sum(dtype=torch.float32)
+
+
+def _first_grad_device(optimizer: Any) -> torch.device:
+    for leaf_optimizer in _iter_leaf_optimizers(optimizer):
+        for param_group in _iter_param_groups(leaf_optimizer):
+            for param in param_group.get("params", ()):
+                grad = _to_local_grad(getattr(param, "grad", None))
+                if grad is not None:
+                    return grad.device
+    return torch.device("cuda", torch.cuda.current_device())
+
+
+def _new_accumulator(device: torch.device) -> torch.Tensor:
+    return torch.zeros((), dtype=torch.float32, device=device)
+
+
+def _sum_in_group(value: torch.Tensor, group: Any, *, tag: str = "sum") -> None:
+    if group is None or not dist.is_initialized():
+        return
+    if dist.get_world_size(group) <= 1:
+        return
+    dist.all_reduce(value, op=dist.ReduceOp.SUM, group=group)
+    _sync_scalar_reduce_if_needed(value, tag)
+
+
+def _scalar_all_reduce(
+    value: torch.Tensor,
+    group: dist.ProcessGroup,
+    op: dist.ReduceOp,
+    tag: str,
+) -> None:
+    dist.all_reduce(value, op=op, group=group)
+    _sync_scalar_reduce_if_needed(value, tag)
+
+
+def _sync_scalar_reduce_if_needed(value: torch.Tensor, tag: str) -> None:
+    if not _sync_scalar_reductions():
+        return
+    if value.device.type != "cuda":
+        return
+    _phase_debug(f"canonical_grad_norm:{tag}:cuda_sync:start")
+    torch.cuda.synchronize(value.device)
+    _phase_debug(f"canonical_grad_norm:{tag}:cuda_sync:end")
+
+
+def _use_canonical_grad_norm() -> bool:
+    raw = os.environ.get("MLITE_MFSDP_USE_CANONICAL_GRAD_NORM", "1")
+    return raw.strip().lower() not in {"0", "false", "no", "off"}
+
+
+def _sync_scalar_reductions() -> bool:
+    raw = os.environ.get("MLITE_MFSDP_SYNC_SCALAR_REDUCTIONS", "0")
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _debug_grad_norm() -> bool:
+    raw = os.environ.get("MLITE_MFSDP_DEBUG_GRAD_NORM", "0")
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _debug_grad_norm_candidates() -> bool:
+    raw = os.environ.get("MLITE_MFSDP_DEBUG_GRAD_NORM_CANDIDATES", "0")
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _debug_param_names() -> bool:
+    raw = os.environ.get("MLITE_MFSDP_DEBUG_PARAM_NAMES", "0")
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _debug_clip() -> bool:
+    raw = os.environ.get("MLITE_MFSDP_DEBUG_CLIP", "0")
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _debug_clip_rank_stats() -> bool:
+    raw = os.environ.get("MLITE_MFSDP_DEBUG_CLIP_RANKS", "0")
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _debug_updates() -> bool:
+    raw = os.environ.get("MLITE_MFSDP_DEBUG_UPDATES", "0")
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _debug_finite_scan() -> bool:
+    raw = os.environ.get("MLITE_MFSDP_DEBUG_FINITE_SCAN", "0")
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _debug_finite_scan_max_reports() -> int:
+    raw = os.environ.get("MLITE_MFSDP_DEBUG_FINITE_MAX_REPORTS", "3")
+    try:
+        return max(int(raw), 1)
+    except ValueError:
+        return 3
+
+
+def _debug_finite_scan_ranks() -> set[int] | None:
+    raw = os.environ.get("MLITE_MFSDP_DEBUG_FINITE_RANKS", "all").strip()
+    if raw.lower() in {"", "all", "*"}:
+        return None
+    ranks: set[int] = set()
+    for item in raw.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        try:
+            ranks.add(int(item))
+        except ValueError:
+            continue
+    return ranks or {0}
+
+
+def _debug_update_max_steps() -> int:
+    raw = os.environ.get("MLITE_MFSDP_DEBUG_UPDATE_MAX_STEPS", "1")
+    try:
+        return max(int(raw), 0)
+    except ValueError:
+        return 1
+
+
+def _debug_update_ranks() -> set[int]:
+    raw = os.environ.get("MLITE_MFSDP_DEBUG_UPDATE_RANKS", "0,1")
+    ranks: set[int] = set()
+    for item in raw.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        try:
+            ranks.add(int(item))
+        except ValueError:
+            continue
+    return ranks or {0}
+
+
+def _debug_update_name_pattern() -> re.Pattern[str]:
+    raw = os.environ.get(
+        "MLITE_MFSDP_DEBUG_UPDATE_NAMES",
+        "|".join(
+            (
+                r"embed\.embedding\.weight$",
+                r"head\.col\.linear\.weight$",
+                r"layers\.0\..*(qkv|linear_qkv|proj|linear_proj).*weight$",
+                r"layers\.0\..*(experts|linear_fc|linear_fc1|linear_fc2).*weight$",
+            )
+        ),
+    )
+    return re.compile(raw)
+
+
+def _install_update_debug_hooks(optimizer: Any) -> None:
+    for buffer in _iter_mfsdp_param_and_grad_buffers(optimizer):
+        if getattr(buffer, "_mlite_mfsdp_update_debug_wrapped", False):
+            continue
+        original = buffer.copy_main_weights_to_model_weights
+
+        def wrapped_copy_main_weights_to_model_weights(
+            original=original,
+            buffer=buffer,
+        ):
+            step = int(getattr(buffer, "_mlite_mfsdp_update_debug_step", 0))
+            _print_update_debug_for_buffer(buffer, step, "pre_copy")
+            result = original()
+            _print_update_debug_for_buffer(buffer, step, "post_copy")
+            return result
+
+        buffer._mlite_mfsdp_original_copy_main_weights_to_model_weights = original
+        buffer.copy_main_weights_to_model_weights = wrapped_copy_main_weights_to_model_weights
+        buffer._mlite_mfsdp_update_debug_wrapped = True
+
+
+def _set_update_debug_step(optimizer: Any, step: int) -> None:
+    for buffer in _iter_mfsdp_param_and_grad_buffers(optimizer):
+        buffer._mlite_mfsdp_update_debug_step = int(step)
+
+
+def _print_update_debug(optimizer: Any, step: int, stage: str) -> None:
+    if step >= _debug_update_max_steps():
+        return
+    for buffer in _iter_mfsdp_param_and_grad_buffers(optimizer):
+        _print_update_debug_for_buffer(buffer, step, stage)
+
+
+def _print_update_debug_for_buffer(buffer: Any, step: int, stage: str) -> None:
+    if step >= _debug_update_max_steps():
+        return
+    if dist.is_initialized():
+        rank = dist.get_rank()
+        if rank not in _debug_update_ranks():
+            return
+    else:
+        rank = 0
+    pattern = _debug_update_name_pattern()
+    printed = 0
+    for name, param in getattr(buffer, "optimizer_named_parameters", ()):
+        if not pattern.search(name):
+            continue
+        orig_param = getattr(param, "orig_param", None)
+        skip_param = orig_param if orig_param is not None else param
+        model_tensor, main_tensor = _mfsdp_buffer_tensors_for_debug(buffer, orig_param)
+        model_sig = _tensor_debug_signature(model_tensor)
+        main_sig = _tensor_debug_signature(main_tensor)
+        param_sig = _tensor_debug_signature(param)
+        grad_sig = _tensor_debug_signature(getattr(param, "grad", None))
+        diff_norm = _tensor_debug_diff_norm(model_tensor, main_tensor)
+        param_main_diff_norm = _tensor_debug_diff_norm(param, main_tensor)
+        buffer_meta = _mfsdp_buffer_metadata_for_debug(buffer, orig_param)
+        print(
+            "[MFSDP_UPDATE] "
+            f"rank={rank} "
+            f"step={step} "
+            f"stage={stage} "
+            f"name={name} "
+            f"tp={int(bool(getattr(param, 'tensor_model_parallel', False)))} "
+            f"partition_dim={getattr(param, 'partition_dim', None)} "
+            f"tp_mode={getattr(param, '_tensor_parallel_mode', None)} "
+            f"skip_sync={int(should_skip_tp_duplicate_sync(skip_param))} "
+            f"{buffer_meta} "
+            f"model={model_sig} "
+            f"main={main_sig} "
+            f"param={param_sig} "
+            f"grad={grad_sig} "
+            f"model_main_diff_norm={diff_norm} "
+            f"param_main_diff_norm={param_main_diff_norm}",
+            flush=True,
+        )
+        printed += 1
+        if printed >= 12:
+            break
+
+
+def _print_finite_scan(
+    optimizer: Any,
+    stage: str,
+    *,
+    param_names: dict[int, str] | None,
+) -> None:
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    ranks = _debug_finite_scan_ranks()
+    should_print_details = ranks is None or rank in ranks
+    max_reports = _debug_finite_scan_max_reports()
+    total_tensors = 0
+    bad_tensors = 0
+    bad_elements = 0
+    reports: list[str] = []
+    category_counts: dict[str, list[int]] = {}
+    category_reports: dict[str, list[str]] = {}
+
+    def check_tensor(label: str, tensor: Any) -> None:
+        nonlocal total_tensors, bad_tensors, bad_elements
+        local = _debug_local_tensor(tensor)
+        if local is None or not isinstance(local, torch.Tensor):
+            return
+        category = _finite_scan_category(label)
+        counts = category_counts.setdefault(category, [0, 0, 0])
+        counts[0] += 1
+        total_tensors += 1
+        detached = local.detach()
+        if detached.numel() == 0:
+            return
+        finite = torch.isfinite(detached)
+        if bool(finite.all().item()):
+            return
+        bad_tensors += 1
+        nonfinite = int((~finite).sum().item())
+        bad_elements += nonfinite
+        counts[1] += 1
+        counts[2] += nonfinite
+        if len(reports) >= max_reports:
+            global_reports_full = True
+        else:
+            global_reports_full = False
+        stats = detached.float()
+        finite_stats = stats[finite]
+        if finite_stats.numel() > 0:
+            finite_min = float(finite_stats.min().item())
+            finite_max = float(finite_stats.max().item())
+        else:
+            finite_min = float("nan")
+            finite_max = float("nan")
+        first_bad = int((~finite).reshape(-1).nonzero()[0].item())
+        bad_value = float(stats.reshape(-1)[first_bad].item())
+        report = (
+            f"{label}:shape={tuple(detached.shape)} "
+            f"dtype={detached.dtype} nonfinite={nonfinite} "
+            f"first_bad={first_bad} first_bad_value={bad_value:.9e} "
+            f"finite_min={finite_min:.9e} finite_max={finite_max:.9e}"
+        )
+        if not global_reports_full:
+            reports.append(report)
+        category_list = category_reports.setdefault(category, [])
+        if len(category_list) < max_reports:
+            category_list.append(report)
+
+    for leaf_optimizer in _iter_leaf_optimizers(optimizer):
+        leaf_name = type(leaf_optimizer).__name__
+        for param_group_index, param_group in enumerate(_iter_param_groups(leaf_optimizer)):
+            for param_index, param in enumerate(param_group.get("params", ())):
+                name = _param_debug_name(param, param_names)
+                if not name:
+                    name = f"group{param_group_index}.param{param_index}"
+                check_tensor(f"{leaf_name}.param.{name}", param)
+                check_tensor(f"{leaf_name}.grad.{name}", getattr(param, "grad", None))
+                check_tensor(
+                    f"{leaf_name}.decoupled_grad.{name}",
+                    getattr(param, "decoupled_grad", None),
+                )
+        inner_optimizer = getattr(leaf_optimizer, "optimizer", None)
+        state = getattr(inner_optimizer, "state", None)
+        if isinstance(state, dict):
+            for state_param, state_dict in state.items():
+                state_name = _param_debug_name(state_param, param_names)
+                if not state_name:
+                    state_name = f"state_param_{id(state_param)}"
+                if not isinstance(state_dict, dict):
+                    continue
+                for key, value in state_dict.items():
+                    if torch.is_tensor(value) or _is_dtensor_like(value):
+                        check_tensor(f"{leaf_name}.optimizer_state.{state_name}.{key}", value)
+
+    for buffer_index, buffer in enumerate(_iter_mfsdp_param_and_grad_buffers(optimizer)):
+        prefix = f"buffer{buffer_index}"
+        for name, param in getattr(buffer, "optimizer_named_parameters", ()):
+            orig_param = getattr(param, "orig_param", None)
+            model_tensor, main_tensor = _mfsdp_buffer_tensors_for_debug(buffer, orig_param)
+            check_tensor(f"{prefix}.model.{name}", model_tensor)
+            check_tensor(f"{prefix}.main.{name}", main_tensor)
+
+    if dist.is_initialized() and torch.cuda.is_available():
+        device = torch.device("cuda", torch.cuda.current_device())
+        counts = torch.tensor(
+            [total_tensors, bad_tensors, bad_elements],
+            dtype=torch.long,
+            device=device,
+        )
+        dist.all_reduce(counts, op=dist.ReduceOp.SUM)
+        world_total_tensors = int(counts[0].item())
+        world_bad_tensors = int(counts[1].item())
+        world_bad_elements = int(counts[2].item())
+    else:
+        world_total_tensors = total_tensors
+        world_bad_tensors = bad_tensors
+        world_bad_elements = bad_elements
+
+    if should_print_details:
+        print(
+            "[MFSDP_FINITE_SCAN] "
+            f"rank={rank} "
+            f"stage={stage} "
+            f"local_tensors={total_tensors} "
+            f"local_bad_tensors={bad_tensors} "
+            f"local_bad_elements={bad_elements} "
+            f"world_tensors={world_total_tensors} "
+            f"world_bad_tensors={world_bad_tensors} "
+            f"world_bad_elements={world_bad_elements} "
+            f"categories={_finite_scan_category_summary(category_counts)} "
+            f"category_reports={category_reports} "
+            f"reports={reports}",
+            flush=True,
+        )
+
+
+def _finite_scan_category(label: str) -> str:
+    if ".optimizer_state." in label:
+        return "optimizer_state"
+    if ".decoupled_grad." in label:
+        return "decoupled_grad"
+    if ".grad." in label:
+        return "grad"
+    if ".param." in label:
+        return "optimizer_param"
+    if ".model." in label:
+        return "buffer_model"
+    if ".main." in label:
+        return "buffer_main"
+    return "other"
+
+
+def _finite_scan_category_summary(category_counts: dict[str, list[int]]) -> dict[str, str]:
+    return {
+        category: f"total={counts[0]},bad={counts[1]},bad_elements={counts[2]}"
+        for category, counts in sorted(category_counts.items())
+    }
+
+
+def _mfsdp_buffer_tensors_for_debug(buffer: Any, orig_param: Any) -> tuple[Any, Any]:
+    if orig_param is None:
+        return None, None
+    try:
+        group = buffer.parameter_groups[buffer.param_to_param_group[orig_param]]
+        mbuf = group.main_weight_buffer
+        wbuf = group.model_weight_buffer
+        if mbuf is None:
+            return None, None
+        item_id = mbuf.param_idx[orig_param]
+        use_shard = bool(
+            (wbuf is not None and getattr(wbuf, "is_data_distributed", False))
+            or getattr(mbuf, "is_data_distributed", False)
+        )
+        main_tensor = mbuf.get_item(item_id, only_shard=use_shard)
+        if wbuf is None:
+            model_tensor = None
+        else:
+            model_tensor = wbuf.get_item(item_id, only_shard=use_shard)
+        return model_tensor, main_tensor
+    except Exception as exc:
+        return f"error:{type(exc).__name__}:{exc}", None
+
+
+def _mfsdp_buffer_metadata_for_debug(buffer: Any, orig_param: Any) -> str:
+    if orig_param is None:
+        return "buffer=none"
+    try:
+        group = buffer.parameter_groups[buffer.param_to_param_group[orig_param]]
+        mbuf = group.main_weight_buffer
+        wbuf = group.model_weight_buffer
+        if mbuf is None:
+            return "buffer=main_none"
+        item_id = mbuf.param_idx[orig_param]
+        use_shard = bool(
+            (wbuf is not None and getattr(wbuf, "is_data_distributed", False))
+            or getattr(mbuf, "is_data_distributed", False)
+        )
+        return (
+            f"item_id={item_id} "
+            f"use_shard={int(use_shard)} "
+            f"wbuf_dist={int(bool(wbuf is not None and getattr(wbuf, 'is_data_distributed', False)))} "
+            f"mbuf_dist={int(bool(getattr(mbuf, 'is_data_distributed', False)))} "
+            f"wbuf_dp={_buffer_dp_debug(wbuf)} "
+            f"mbuf_dp={_buffer_dp_debug(mbuf)} "
+            f"wbuf_item={_buffer_item_debug(wbuf, item_id)} "
+            f"mbuf_item={_buffer_item_debug(mbuf, item_id)}"
+        )
+    except Exception as exc:
+        return f"buffer_error={type(exc).__name__}:{exc}"
+
+
+def _buffer_dp_debug(buf: Any) -> str:
+    if buf is None:
+        return "none"
+    return f"{getattr(buf, 'dp_rank', None)}/{getattr(buf, 'dp_world_size', None)}"
+
+
+def _buffer_item_debug(buf: Any, item_id: int) -> str:
+    if buf is None:
+        return "none"
+    try:
+        local = buf._get_item_local_index(item_id)
+        shard = buf._get_item_local_shard_index(item_id)
+        global_item = buf.locate_item_in_global_item(item_id)
+        return f"local={local},shard={shard},global={global_item}"
+    except Exception as exc:
+        return f"error:{type(exc).__name__}:{exc}"
+
+
+def _iter_mfsdp_param_and_grad_buffers(optimizer: Any) -> Iterable[Any]:
+    for leaf_optimizer in _iter_leaf_optimizers(optimizer):
+        for model_chunk in getattr(leaf_optimizer, "model_chunks", ()):
+            buffer = getattr(model_chunk, "param_and_grad_buffer", None)
+            if buffer is not None:
+                yield buffer
+
+
+def _tensor_debug_signature(tensor: Any) -> str:
+    if isinstance(tensor, str):
+        return tensor
+    local = _debug_local_tensor(tensor)
+    if local is None:
+        return "none"
+    detached = local.detach()
+    if detached.numel() == 0:
+        return f"shape={tuple(detached.shape)} numel=0"
+    stats = detached.float()
+    flat = stats.reshape(-1)
+    sample = flat.narrow(0, 0, min(flat.numel(), 4096))
+    return (
+        f"shape={tuple(detached.shape)} "
+        f"numel={detached.numel()} "
+        f"sample_sum={float(sample.sum().item()):.9e} "
+        f"sample_norm={float(sample.norm().item()):.9e} "
+        f"first={float(flat[0].item()):.9e}"
+    )
+
+
+def _tensor_debug_diff_norm(left: Any, right: Any) -> str:
+    left_local = _debug_local_tensor(left)
+    right_local = _debug_local_tensor(right)
+    if left_local is None or right_local is None:
+        return "nan"
+    if tuple(left_local.shape) != tuple(right_local.shape):
+        return "shape_mismatch"
+    left_flat = left_local.detach().float().reshape(-1)
+    right_flat = right_local.detach().float().reshape(-1)
+    sample_numel = min(left_flat.numel(), 4096)
+    diff = left_flat.narrow(0, 0, sample_numel) - right_flat.narrow(0, 0, sample_numel)
+    return f"{float(diff.norm().item()):.9e}"
+
+
+def _debug_local_tensor(tensor: Any) -> torch.Tensor | None:
+    if tensor is None:
+        return None
+    data = getattr(tensor, "data", tensor)
+    local_tensor = getattr(data, "_local_tensor", None)
+    if isinstance(local_tensor, torch.Tensor):
+        return local_tensor
+    to_local = getattr(data, "to_local", None)
+    if callable(to_local):
+        local = to_local()
+        if isinstance(local, torch.Tensor):
+            return local
+    if isinstance(data, torch.Tensor):
+        return data
+    return None
+
+
+def _print_clip_debug(
+    grad_norm: float,
+    clip_coeff: float | None,
+    scaled_params: int,
+    *,
+    mode: str,
+    local_sq_before: float = 0.0,
+    local_sq_after: float = 0.0,
+    dtensor_local: int = 0,
+    dtensor_to_local: int = 0,
+) -> None:
+    if dist.is_initialized() and dist.get_rank() != 0:
+        return
+    expected_after = (
+        local_sq_before * float(clip_coeff) * float(clip_coeff)
+        if clip_coeff is not None and clip_coeff < 1.0
+        else local_sq_before
+    )
+    local_ratio = local_sq_after / expected_after if expected_after else float("nan")
+    print(
+        "[MFSDP_CLIP] "
+        f"mode={mode} "
+        f"grad_norm={grad_norm:.9f} "
+        f"clip_coeff={float(clip_coeff) if clip_coeff is not None else float('nan'):.9f} "
+        f"scaled_params={scaled_params} "
+        f"local_sq_before={local_sq_before:.9e} "
+        f"local_sq_after={local_sq_after:.9e} "
+        f"expected_after={expected_after:.9e} "
+        f"local_ratio={local_ratio:.9f} "
+        f"dtensor_local={dtensor_local} "
+        f"dtensor_to_local={dtensor_to_local}",
+        flush=True,
+    )
+
+
+def _print_clip_rank_stats(
+    *,
+    grad_norm: float,
+    clip_coeff: float,
+    scaled_params: int,
+    local_sq_before: float,
+    local_sq_after: float,
+    stage: str,
+) -> None:
+    if not dist.is_initialized():
+        return
+    device = torch.device("cuda", torch.cuda.current_device()) if torch.cuda.is_available() else None
+    if device is None:
+        return
+    values = torch.tensor(
+        [
+            float(grad_norm),
+            float(clip_coeff),
+            float(scaled_params),
+            float(local_sq_before),
+            float(local_sq_after),
+        ],
+        dtype=torch.float64,
+        device=device,
+    )
+    mins = values.clone()
+    maxs = values.clone()
+    dist.all_reduce(mins, op=dist.ReduceOp.MIN)
+    dist.all_reduce(maxs, op=dist.ReduceOp.MAX)
+    if dist.get_rank() != 0:
+        return
+    print(
+        "[MFSDP_CLIP_RANKS] "
+        f"stage={stage} "
+        f"world={dist.get_world_size()} "
+        f"grad_norm_min={float(mins[0].item()):.9f} "
+        f"grad_norm_max={float(maxs[0].item()):.9f} "
+        f"clip_coeff_min={float(mins[1].item()):.9f} "
+        f"clip_coeff_max={float(maxs[1].item()):.9f} "
+        f"scaled_params_min={int(mins[2].item())} "
+        f"scaled_params_max={int(maxs[2].item())} "
+        f"local_sq_before_min={float(mins[3].item()):.9e} "
+        f"local_sq_before_max={float(maxs[3].item()):.9e} "
+        f"local_sq_after_min={float(mins[4].item()):.9e} "
+        f"local_sq_after_max={float(maxs[4].item()):.9e}",
+        flush=True,
+    )
+
+
+def _print_param_name_debug(
+    param_is_expert: dict[int, bool],
+    param_names: dict[int, str],
+) -> None:
+    if dist.is_initialized() and dist.get_rank() != 0:
+        return
+    dense_names = [
+        name for param_id, name in param_names.items() if not param_is_expert.get(param_id, False)
+    ]
+    expert_names = [
+        name for param_id, name in param_names.items() if param_is_expert.get(param_id, False)
+    ]
+    print(
+        "[MFSDP_PARAM_NAMES] "
+        f"dense_count={len(dense_names)} "
+        f"expert_count={len(expert_names)} "
+        f"dense_sample={dense_names[:20]} "
+        f"expert_sample={expert_names[:20]}",
+        flush=True,
+    )
+
+
+def _print_grad_norm_debug(
+    mcore_norm: float,
+    breakdown: GradNormBreakdown,
+    *,
+    expert_scale: float,
+) -> None:
+    if _debug_clip_rank_stats():
+        _print_norm_rank_stats("MFSDP_GN_RANKS", breakdown.grad_norm)
+        _print_breakdown_rank_stats("MFSDP_GN_COMPONENT_RANKS", breakdown)
+    if dist.is_initialized() and dist.get_rank() != 0:
+        return
+    ratio = float(mcore_norm) / breakdown.grad_norm if breakdown.grad_norm else float("nan")
+    print(
+        "[MFSDP_GN] "
+        f"mcore={float(mcore_norm):.9f} "
+        f"canonical={breakdown.grad_norm:.9f} "
+        f"ratio={ratio:.9f} "
+        f"dense_sq={breakdown.dense_sq:.9e} "
+        f"dense_tp_sharded_sq={breakdown.dense_tp_sharded_sq:.9e} "
+        f"dense_tp_replicated_sq={breakdown.dense_tp_replicated_sq:.9e} "
+        f"expert_sq={breakdown.expert_sq:.9e} "
+        f"global_dense_sq={breakdown.global_dense_sq:.9e} "
+        f"global_dense_tp_sharded_sq={breakdown.global_dense_tp_sharded_sq:.9e} "
+        f"global_dense_tp_replicated_sq={breakdown.global_dense_tp_replicated_sq:.9e} "
+        f"global_expert_sq={breakdown.global_expert_sq:.9e} "
+        f"dense_params={breakdown.dense_params} "
+        f"dense_tp_replicated_params={breakdown.dense_tp_replicated_params} "
+        f"expert_params={breakdown.expert_params} "
+        f"expert_scale={expert_scale:.9f} "
+        f"dense_names={list(breakdown.dense_names)} "
+        f"dense_tp_replicated_names={list(breakdown.dense_tp_replicated_names)} "
+        f"expert_names={list(breakdown.expert_names)}",
+        flush=True,
+    )
+
+
+def _print_postclip_grad_norm_debug(
+    mcore_norm: float,
+    breakdown: GradNormBreakdown,
+) -> None:
+    if _debug_clip_rank_stats():
+        _print_norm_rank_stats("MFSDP_GN_POSTCLIP_RANKS", breakdown.grad_norm)
+        _print_breakdown_rank_stats("MFSDP_GN_POSTCLIP_COMPONENT_RANKS", breakdown)
+    if dist.is_initialized() and dist.get_rank() != 0:
+        return
+    print(
+        "[MFSDP_GN_POSTCLIP] "
+        f"mcore={float(mcore_norm):.9f} "
+        f"canonical={breakdown.grad_norm:.9f} "
+        f"dense_sq={breakdown.dense_sq:.9e} "
+        f"dense_tp_sharded_sq={breakdown.dense_tp_sharded_sq:.9e} "
+        f"dense_tp_replicated_sq={breakdown.dense_tp_replicated_sq:.9e} "
+        f"expert_sq={breakdown.expert_sq:.9e}",
+        flush=True,
+    )
+
+
+def _print_norm_rank_stats(tag: str, value: float) -> None:
+    if not dist.is_initialized():
+        return
+    if not torch.cuda.is_available():
+        return
+    device = torch.device("cuda", torch.cuda.current_device())
+    min_value = torch.tensor(float(value), dtype=torch.float64, device=device)
+    max_value = min_value.clone()
+    dist.all_reduce(min_value, op=dist.ReduceOp.MIN)
+    dist.all_reduce(max_value, op=dist.ReduceOp.MAX)
+    if dist.get_rank() != 0:
+        return
+    print(
+        f"[{tag}] "
+        f"world={dist.get_world_size()} "
+        f"min={float(min_value.item()):.9f} "
+        f"max={float(max_value.item()):.9f}",
+        flush=True,
+    )
+
+
+def _print_breakdown_rank_stats(tag: str, breakdown: GradNormBreakdown) -> None:
+    if not dist.is_initialized():
+        return
+    if not torch.cuda.is_available():
+        return
+    device = torch.device("cuda", torch.cuda.current_device())
+    values = torch.tensor(
+        [
+            breakdown.dense_sq,
+            breakdown.dense_tp_sharded_sq,
+            breakdown.dense_tp_replicated_sq,
+            breakdown.expert_sq,
+            breakdown.global_dense_sq,
+            breakdown.global_dense_tp_sharded_sq,
+            breakdown.global_dense_tp_replicated_sq,
+            breakdown.global_expert_sq,
+            breakdown.total_sq,
+        ],
+        dtype=torch.float64,
+        device=device,
+    )
+    mins = values.clone()
+    maxs = values.clone()
+    dist.all_reduce(mins, op=dist.ReduceOp.MIN)
+    dist.all_reduce(maxs, op=dist.ReduceOp.MAX)
+    if dist.get_rank() != 0:
+        return
+    print(
+        f"[{tag}] "
+        f"world={dist.get_world_size()} "
+        f"dense_sq_min={float(mins[0].item()):.9e} "
+        f"dense_sq_max={float(maxs[0].item()):.9e} "
+        f"dense_tp_sharded_sq_min={float(mins[1].item()):.9e} "
+        f"dense_tp_sharded_sq_max={float(maxs[1].item()):.9e} "
+        f"dense_tp_replicated_sq_min={float(mins[2].item()):.9e} "
+        f"dense_tp_replicated_sq_max={float(maxs[2].item()):.9e} "
+        f"expert_sq_min={float(mins[3].item()):.9e} "
+        f"expert_sq_max={float(maxs[3].item()):.9e} "
+        f"global_dense_sq_min={float(mins[4].item()):.9e} "
+        f"global_dense_sq_max={float(maxs[4].item()):.9e} "
+        f"global_dense_tp_sharded_sq_min={float(mins[5].item()):.9e} "
+        f"global_dense_tp_sharded_sq_max={float(maxs[5].item()):.9e} "
+        f"global_dense_tp_replicated_sq_min={float(mins[6].item()):.9e} "
+        f"global_dense_tp_replicated_sq_max={float(maxs[6].item()):.9e} "
+        f"global_expert_sq_min={float(mins[7].item()):.9e} "
+        f"global_expert_sq_max={float(maxs[7].item()):.9e} "
+        f"total_sq_min={float(mins[8].item()):.9e} "
+        f"total_sq_max={float(maxs[8].item()):.9e}",
+        flush=True,
+    )
+
+
+__all__ = [
+    "CanonicalGradNormMegatronFSDPOptimizer",
+    "GradNormBreakdown",
+    "compute_mfsdp_grad_norm",
+]

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/metadata.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/metadata.py
@@ -1,0 +1,206 @@
+"""MCore-FSDP metadata adapters for Megatron Lite-owned module implementations."""
+
+from __future__ import annotations
+
+import torch.nn as nn  # pyright: ignore[reportMissingImports]
+
+from megatron.lite.primitive.optimizers.mfsdp.patches import (
+    clear_skip_tp_duplicate_sync,
+    mark_skip_tp_duplicate_sync,
+    set_mfsdp_param_name,
+)
+from megatron.lite.primitive.protocols import ExpertClassifierFn
+
+
+_COLUMN_PARALLEL_WEIGHT_SUFFIXES: tuple[str, ...] = (
+    "embed.embedding.weight",
+    "mtp_embed.embedding.weight",
+    "head.col.linear.weight",
+    ".attn.qkv.linear.weight",
+    ".attn.linear_qkv.weight",
+    ".self_attention.linear_qkv.weight",
+    ".self_attention.in_proj.weight",
+    ".self_attention.gdn.in_proj.weight",
+    ".eh_proj.linear.weight",
+    ".experts.fc1.weight",
+    ".experts.linear_fc1.weight",
+    ".shared_experts.linear_fc1.weight",
+    ".linear_fc1.weight",
+)
+
+_ROW_PARALLEL_WEIGHT_SUFFIXES: tuple[str, ...] = (
+    ".attn.proj.linear.weight",
+    ".attn.linear_proj.weight",
+    ".self_attention.linear_proj.weight",
+    ".self_attention.out_proj.weight",
+    ".self_attention.gdn.out_proj.weight",
+    ".linear_proj.weight",
+    ".experts.fc2.weight",
+    ".experts.linear_fc2.weight",
+    ".shared_experts.linear_fc2.weight",
+    ".linear_fc2.weight",
+    ".down_proj.weight",
+    ".o_proj.weight",
+)
+
+_MANUAL_MCORE_TP_MODE_WEIGHT_SUFFIXES: tuple[str, ...] = (
+    "embed.embedding.weight",
+    "mtp_embed.embedding.weight",
+    "head.col.linear.weight",
+)
+
+
+def _matches_weight_suffix(name: str, suffix: str) -> bool:
+    if suffix.startswith(".") and name == suffix[1:]:
+        return True
+    if name.endswith(suffix):
+        return True
+    idx = name.rfind(suffix)
+    if idx < 0:
+        return False
+    return name[idx + len(suffix) :].isdigit()
+
+
+def _infer_tp_partition_dim(name: str) -> int | None:
+    """Infer Megatron Lite-owned TP weight partition dim for MCore-FSDP metadata."""
+    if any(
+        _matches_weight_suffix(name, suffix)
+        for suffix in _COLUMN_PARALLEL_WEIGHT_SUFFIXES
+    ):
+        return 0
+    if any(
+        _matches_weight_suffix(name, suffix)
+        for suffix in _ROW_PARALLEL_WEIGHT_SUFFIXES
+    ):
+        return 1
+    return None
+
+
+def _requires_manual_mcore_tp_mode(name: str) -> bool:
+    return any(
+        _matches_weight_suffix(name, suffix)
+        for suffix in _MANUAL_MCORE_TP_MODE_WEIGHT_SUFFIXES
+    )
+
+
+def normalize_mfsdp_expert_tensor_parallel_attrs(
+    model: nn.Module,
+    is_expert_param: ExpertClassifierFn,
+    *,
+    etp_size: int,
+) -> None:
+    """Normalize expert TP metadata to expert-tensor-parallel, not dense TP.
+
+    ``_mark_mc_parallel_attrs`` only knows dense TP size and conservatively marks
+    every unmarked 2D param as tensor-parallel. Megatron Lite's routed experts are sharded by
+    EP and optionally ETP; when ETP=1 they must not carry dense TP metadata or
+    MCore-FSDP may scatter/gather optimizer main weights with the wrong mesh.
+    """
+    etp_size = max(int(etp_size), 1)
+    for name, param in model.named_parameters():
+        if not is_expert_param(name):
+            continue
+        if etp_size <= 1:
+            param.tensor_model_parallel = False
+            _clear_tp_attrs(param)
+            continue
+        if param.ndim <= 1:
+            param.tensor_model_parallel = False
+            _clear_tp_attrs(param)
+            continue
+        if getattr(param, "average_gradients_across_tp_domain", False):
+            continue
+        if getattr(param, "sequence_parallel", False):
+            continue
+        partition_dim = getattr(param, "partition_dim", None)
+        if partition_dim not in (0, 1):
+            partition_dim = _infer_tp_partition_dim(name)
+        if partition_dim is None:
+            param.tensor_model_parallel = False
+            _clear_tp_attrs(param)
+            continue
+        _set_tp_attrs(param, partition_dim, set_mcore_mode=True)
+
+
+def _clear_attr(obj, attr: str) -> None:
+    if hasattr(obj, attr):
+        delattr(obj, attr)
+
+
+def _clear_tp_attrs(param) -> None:
+    _clear_attr(param, "partition_dim")
+    _clear_attr(param, "partition_stride")
+    _clear_attr(param, "_tensor_parallel_mode")
+    clear_skip_tp_duplicate_sync(param)
+
+
+def _set_tp_attrs(param, partition_dim: int, *, set_mcore_mode: bool) -> None:
+    param.tensor_model_parallel = True
+    param.partition_dim = int(partition_dim)
+    param.partition_stride = getattr(param, "partition_stride", 1)
+    mark_skip_tp_duplicate_sync(param)
+    if set_mcore_mode:
+        param._tensor_parallel_mode = "column" if int(partition_dim) == 0 else "row"
+    else:
+        _clear_attr(param, "_tensor_parallel_mode")
+
+
+def ensure_mfsdp_tp_partition_attrs(model: nn.Module) -> None:
+    """Fill MCore-FSDP TP metadata for Megatron Lite-owned tensor-parallel params.
+
+    MCore-native TP layers already set a precise partition dimension. Megatron Lite's
+    custom column/vocab layers are output/vocab sharded (dim 0), while Megatron Lite's
+    row-parallel projection weights are input sharded (dim 1). The partition
+    attrs are enough for current MCore-FSDP to build TP-sharded DTensors, while
+    the local patch below only guards duplicate-TP sync paths for marked Megatron Lite
+    local shards.
+
+    This pass is deliberately conservative with ``_tensor_parallel_mode``.
+    Setting the mode on every Megatron Lite/TE dense TP weight changes Megatron-FSDP's
+    model-buffer initialization path and has to be enabled only after a
+    topology-specific precision gate proves it safe. Attention row-projection
+    weights are intentionally kept on the local-shard path: assigning MCore
+    ``_tensor_parallel_mode="row"`` currently hangs Qwen3MoE 4n32g before the
+    first optimizer step. For the remaining local TP
+    shards, the M-FSDP primitive marks them so its MCore patch skips only the
+    incorrect duplicate-TP broadcast.
+    """
+    _ensure_mfsdp_tp_partition_attrs(model, set_mcore_mode_for_all=False)
+
+
+def _ensure_mfsdp_tp_partition_attrs(
+    model: nn.Module,
+    *,
+    set_mcore_mode_for_all: bool,
+) -> None:
+    for name, param in model.named_parameters():
+        set_mfsdp_param_name(param, name)
+        if param.ndim <= 1:
+            if getattr(param, "tensor_model_parallel", False):
+                param.tensor_model_parallel = False
+                _clear_tp_attrs(param)
+            continue
+        if not getattr(param, "tensor_model_parallel", False):
+            _clear_attr(param, "_tensor_parallel_mode")
+            clear_skip_tp_duplicate_sync(param)
+            continue
+        partition_dim = getattr(param, "partition_dim", None)
+        if partition_dim not in (0, 1):
+            partition_dim = _infer_tp_partition_dim(name)
+        if partition_dim is None:
+            param.tensor_model_parallel = False
+            _clear_tp_attrs(param)
+            continue
+        _set_tp_attrs(
+            param,
+            partition_dim,
+            set_mcore_mode=(
+                set_mcore_mode_for_all or _requires_manual_mcore_tp_mode(name)
+            ),
+        )
+
+
+__all__ = [
+    "ensure_mfsdp_tp_partition_attrs",
+    "normalize_mfsdp_expert_tensor_parallel_attrs",
+]

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/native.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/native.py
@@ -1,0 +1,49 @@
+"""Boundary scaffold for a future Megatron Lite-native Megatron-FSDP adapter.
+
+This module is intentionally not registered as an optimizer backend. It records
+the Phase 3 boundary: keep the wrap primitive as the oracle, and only move
+small, proven interface pieces into Megatron Lite-native code when the wrapper exposes a
+specific blocker.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class NativeMFSDPBoundary:
+    """Ownership boundary for any future native work."""
+
+    bb_owned: tuple[str, ...] = (
+        "config_lowering",
+        "parallel_state_to_process_groups",
+        "hf_load_and_checkpoint_adapter",
+        "runtime_hook_scheduling",
+        "debug_and_measurement",
+    )
+    mcore_owned: tuple[str, ...] = (
+        "param_and_grad_buffer",
+        "fsdp_flatten_shard_unshard",
+        "communication_scheduling",
+        "optimizer_state_sharding",
+        "dtensor_checkpoint_semantics",
+        "te_fp8_hooks",
+    )
+
+
+NATIVE_BOUNDARY = NativeMFSDPBoundary()
+
+
+def build_native_mfsdp_stack(*_args, **_kwargs):
+    raise NotImplementedError(
+        "Megatron Lite-native Megatron-FSDP is a Phase 3 boundary only. Use "
+        "optimizer='megatron_fsdp' as the registered wrapper primitive."
+    )
+
+
+__all__ = [
+    "NATIVE_BOUNDARY",
+    "NativeMFSDPBoundary",
+    "build_native_mfsdp_stack",
+]

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/optimizer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/optimizer.py
@@ -1,0 +1,235 @@
+"""Megatron-FSDP wrap backend for Megatron Lite.
+
+This primitive intentionally stays thin: Megatron Lite owns model construction,
+HF loading, and the runtime loop; Megatron-Core owns the FSDP wrapper,
+ParamAndGradBuffer, and DistributedOptimizer integration.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch.nn as nn  # pyright: ignore[reportMissingImports]
+
+from megatron.lite.primitive.optimizers.megatron_wrap import (
+    _build_transformer_config,
+    _ensure_mc_mpu_parallel_state,
+    _mark_mc_parallel_attrs,
+    build_mc_optimizer_config,
+)
+from megatron.lite.primitive.optimizers.mfsdp.config import (
+    build_mfsdp_ddp_config,
+    split_mfsdp_overrides,
+    validate_mfsdp_config,
+    validate_optimizer_name,
+)
+from megatron.lite.primitive.optimizers.mfsdp.checkpoint_keys import (
+    attach_mfsdp_checkpoint_metadata,
+)
+from megatron.lite.primitive.optimizers.mfsdp.grad_norm import (
+    CanonicalGradNormMegatronFSDPOptimizer,
+)
+from megatron.lite.primitive.optimizers.mfsdp.metadata import (
+    ensure_mfsdp_tp_partition_attrs,
+    normalize_mfsdp_expert_tensor_parallel_attrs,
+)
+from megatron.lite.primitive.optimizers.mfsdp.patches import (
+    install_mfsdp_tp_duplicate_sync_patch,
+)
+from megatron.lite.primitive.optimizers.mfsdp.process_groups import (
+    build_mfsdp_pg_collection,
+    install_mfsdp_mesh_patch,
+)
+from megatron.lite.primitive.protocols import ExpertClassifierFn, default_expert_classifier
+
+
+def build_mfsdp_stack(
+    model_chunks: list[nn.Module],
+    *,
+    model_cfg,
+    engine_cfg,
+    ps,
+    is_expert: ExpertClassifierFn | None = None,
+    proto=None,
+    fsdp_unit_modules: tuple[type[nn.Module] | str, ...] | None = None,
+    skip_fsdp_wrap: bool = False,
+):
+    """Wrap model chunks with Megatron-FSDP and build the matching optimizer."""
+    from megatron.core.distributed import (  # pyright: ignore[reportMissingImports]
+        DistributedDataParallelConfig,
+        FullyShardedDataParallel,
+    )
+    from megatron.core.distributed.finalize_model_grads import (  # pyright: ignore[reportMissingImports]
+        finalize_model_grads,
+    )
+    from megatron.core.optimizer import (
+        get_megatron_optimizer,  # pyright: ignore[reportMissingImports]
+    )
+    from megatron.core.transformer.enums import ModelType  # pyright: ignore[reportMissingImports]
+
+    validate_mfsdp_config(engine_cfg)
+    install_mfsdp_mesh_patch()
+    install_mfsdp_tp_duplicate_sync_patch()
+
+    p = engine_cfg.parallel
+    opt = engine_cfg.optimizer
+    opt_overrides, ddp_overrides = split_mfsdp_overrides(
+        opt,
+        DistributedDataParallelConfig,
+    )
+
+    mc_transformer_cfg = _build_transformer_config(model_cfg, engine_cfg)
+    mc_transformer_cfg.finalize_model_grads_func = finalize_model_grads
+    if is_expert is not None:
+        is_expert_param = is_expert
+    elif proto is not None and hasattr(proto, "EXPERT_CLASSIFIER"):
+        is_expert_param = proto.EXPERT_CLASSIFIER
+    else:
+        is_expert_param = default_expert_classifier
+
+    _ensure_mc_mpu_parallel_state(engine_cfg)
+    use_mpu_groups = bool(getattr(engine_cfg, "deterministic", False))
+    pg_collection = None if use_mpu_groups else build_mfsdp_pg_collection(ps, engine_cfg)
+
+    if skip_fsdp_wrap:
+        wrapped_chunks = list(model_chunks)
+    else:
+        ddp_config = build_mfsdp_ddp_config(DistributedDataParallelConfig, ddp_overrides)
+        wrapped_chunks = []
+        unit_modules = list(fsdp_unit_modules) if fsdp_unit_modules is not None else None
+        for chunk_idx, chunk in enumerate(model_chunks):
+            chunk.model_type = ModelType.encoder_or_decoder
+            _mark_mc_parallel_attrs(chunk, is_expert_param, tp_size=p.tp)
+            normalize_mfsdp_expert_tensor_parallel_attrs(
+                chunk,
+                is_expert_param,
+                etp_size=int(p.etp or 1),
+            )
+            ensure_mfsdp_tp_partition_attrs(chunk)
+            wrapped_chunks.append(
+                FullyShardedDataParallel(
+                    mc_transformer_cfg,
+                    ddp_config,
+                    chunk,
+                    fsdp_unit_modules=unit_modules,
+                    disable_bucketing=(chunk_idx > 0),
+                    pg_collection=pg_collection,
+                )
+            )
+
+    opt_config = build_mc_optimizer_config(
+        opt,
+        override_optimizer_config=opt_overrides or None,
+    )
+    validate_optimizer_name(opt_config.optimizer)
+    opt_config.use_distributed_optimizer = True
+    if skip_fsdp_wrap or use_mpu_groups:
+        optimizer = get_megatron_optimizer(config=opt_config, model_chunks=wrapped_chunks)
+        optimizer._mc_pg_collection = None  # pyright: ignore[reportAttributeAccessIssue]
+    else:
+        optimizer = get_megatron_optimizer(
+            config=opt_config,
+            model_chunks=wrapped_chunks,
+            use_gloo_process_groups=False,
+            pg_collection=pg_collection,
+        )
+        optimizer._mc_pg_collection = pg_collection  # pyright: ignore[reportAttributeAccessIssue]
+    optimizer_leaves = getattr(optimizer, "chained_optimizers", None)
+    for optimizer_owner in (optimizer, *tuple(optimizer_leaves or ())):
+        if not hasattr(optimizer_owner, "model_chunks"):
+            optimizer_owner.model_chunks = wrapped_chunks  # pyright: ignore[reportAttributeAccessIssue]
+    attach_mfsdp_checkpoint_metadata(optimizer, ps=ps, is_expert=is_expert_param)
+    param_is_expert, param_names = _build_wrapped_param_metadata(wrapped_chunks, is_expert_param)
+    optimizer = CanonicalGradNormMegatronFSDPOptimizer(
+        optimizer,
+        ps,
+        model_chunks=wrapped_chunks,
+        param_is_expert=param_is_expert,
+        param_names=param_names,
+    )
+    attach_mfsdp_checkpoint_metadata(optimizer, ps=ps, is_expert=is_expert_param)
+    return wrapped_chunks, optimizer
+
+
+def build_mfsdp_training_optimizer(
+    model_chunks: list[nn.Module],
+    *,
+    model_cfg,
+    impl_cfg,
+    ps,
+    model_name: str,
+    is_expert: ExpertClassifierFn | None = None,
+    fsdp_unit_modules: tuple[type[nn.Module] | str, ...] | None = None,
+    deterministic: bool | None = None,
+):
+    """Build the Megatron-FSDP stack from a Megatron Lite ImplConfig."""
+    opt = impl_cfg.optimizer_config
+    if opt is None:
+        opt = SimpleNamespace(
+            optimizer="adam",
+            lr=1e-4,
+            min_lr=0.0,
+            weight_decay=0.01,
+            clip_grad=1.0,
+            offload_fraction=None,
+            adam_beta1=None,
+            adam_beta2=None,
+            adam_eps=None,
+        )
+    if deterministic is None:
+        from megatron.lite.primitive.deterministic import deterministic_requested
+
+        deterministic = deterministic_requested()
+
+    engine_cfg = SimpleNamespace(
+        model_name=model_name,
+        parallel=impl_cfg.parallel,
+        optimizer=opt,
+        deterministic=bool(deterministic),
+    )
+    model_chunks[:], optimizer = build_mfsdp_stack(
+        model_chunks,
+        model_cfg=model_cfg,
+        engine_cfg=engine_cfg,
+        ps=ps,
+        is_expert=is_expert,
+        fsdp_unit_modules=fsdp_unit_modules,
+    )
+
+    def finalize_grads() -> None:
+        finalize_mfsdp_grads(model_chunks, optimizer)
+
+    return optimizer, finalize_grads
+
+
+def finalize_mfsdp_grads(model_chunks: list[nn.Module], optimizer) -> None:
+    """Run Megatron-Core gradient finalization for Megatron-FSDP chunks."""
+    from megatron.core.distributed.finalize_model_grads import (  # pyright: ignore[reportMissingImports]
+        finalize_model_grads,
+    )
+
+    finalize_model_grads(model_chunks, pg_collection=optimizer._mc_pg_collection)
+
+
+def _build_wrapped_param_metadata(
+    model_chunks: list[nn.Module],
+    is_expert_param: ExpertClassifierFn,
+) -> tuple[dict[int, bool], dict[int, str]]:
+    param_is_expert: dict[int, bool] = {}
+    param_names: dict[int, str] = {}
+    for chunk in model_chunks:
+        for name, param in chunk.named_parameters():
+            param_is_expert[id(param)] = bool(is_expert_param(name)) or not getattr(
+                param,
+                "allreduce",
+                True,
+            )
+            param_names[id(param)] = name
+    return param_is_expert, param_names
+
+
+__all__ = [
+    "build_mfsdp_stack",
+    "build_mfsdp_training_optimizer",
+    "finalize_mfsdp_grads",
+]

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/patches.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/patches.py
@@ -1,0 +1,344 @@
+"""Small Megatron-FSDP patches owned by the M-FSDP primitive."""
+
+from __future__ import annotations
+
+import os
+import re
+from functools import wraps
+from typing import Any, Callable
+
+
+SKIP_TP_DUPLICATE_SYNC_ATTR = "_mlite_mfsdp_skip_tp_duplicate_sync"
+PARAM_NAME_ATTR = "_mlite_mfsdp_param_name"
+_PATCHED_ATTR = "_mlite_mfsdp_skip_tp_duplicate_sync_patch"
+_ORIGINAL_ATTR = "_mlite_mfsdp_original_make_fsdp_dtensor"
+_PARAM_SYNC_PATCHED_ATTR = "_mlite_mfsdp_param_sync_debug_patch"
+_START_PARAM_SYNC_PATCHED_ATTR = "_mlite_mfsdp_start_param_sync_patch"
+
+
+def mark_skip_tp_duplicate_sync(param: Any) -> None:
+    setattr(param, SKIP_TP_DUPLICATE_SYNC_ATTR, True)
+
+
+def clear_skip_tp_duplicate_sync(param: Any) -> None:
+    if hasattr(param, SKIP_TP_DUPLICATE_SYNC_ATTR):
+        delattr(param, SKIP_TP_DUPLICATE_SYNC_ATTR)
+
+
+def set_mfsdp_param_name(param: Any, name: str) -> None:
+    setattr(param, PARAM_NAME_ATTR, name)
+
+
+def should_skip_tp_duplicate_sync(param: Any) -> bool:
+    """Return whether MCore must not TP-broadcast this Megatron Lite-owned local shard."""
+    if not bool(getattr(param, SKIP_TP_DUPLICATE_SYNC_ATTR, False)):
+        return False
+    return getattr(param, "_tensor_parallel_mode", None) not in ("column", "row")
+
+
+def _wrap_make_fsdp_dtensor(make_fsdp_dtensor: Callable[..., Any]) -> Callable[..., Any]:
+    @wraps(make_fsdp_dtensor)
+    def wrapped_make_fsdp_dtensor(*args, **kwargs):
+        local_tensor = kwargs.get("local_tensor")
+        if local_tensor is None and len(args) >= 1:
+            local_tensor = args[0]
+        param = kwargs.get("param")
+        if param is None and len(args) >= 2:
+            param = args[1]
+        force_in = kwargs.get("force_sync_tp_duplicated_param")
+        if param is not None and should_skip_tp_duplicate_sync(param):
+            kwargs["force_sync_tp_duplicated_param"] = False
+            kwargs["run_check"] = False
+        if param is not None:
+            _print_dtensor_debug(
+                param,
+                local_tensor,
+                None,
+                phase="begin",
+                force_in=force_in,
+                force_out=kwargs.get("force_sync_tp_duplicated_param"),
+                is_sharded_param=kwargs.get("is_sharded_param"),
+                is_expert_param=kwargs.get("is_expert_param"),
+            )
+        result = make_fsdp_dtensor(*args, **kwargs)
+        if param is not None:
+            _print_dtensor_debug(
+                param,
+                local_tensor,
+                result,
+                phase="end",
+                force_in=force_in,
+                force_out=kwargs.get("force_sync_tp_duplicated_param"),
+                is_sharded_param=kwargs.get("is_sharded_param"),
+                is_expert_param=kwargs.get("is_expert_param"),
+            )
+        return result
+
+    setattr(wrapped_make_fsdp_dtensor, _PATCHED_ATTR, True)
+    setattr(wrapped_make_fsdp_dtensor, _ORIGINAL_ATTR, make_fsdp_dtensor)
+    return wrapped_make_fsdp_dtensor
+
+
+def install_mfsdp_tp_duplicate_sync_patch() -> None:
+    """Guard MCore duplicate-TP sync for marked Megatron Lite local TP shards.
+
+    Megatron Lite modules keep their local TP shards as normal tensors. Current
+    MCore-FSDP uses ``tensor_model_parallel`` plus ``partition_dim`` to choose
+    TP-sharded DTensor placement, but some duplicate-TP sync paths can still be
+    forced for params marked as duplicated. The patch is intentionally narrow:
+    it only changes that sync decision for params marked by this primitive and
+    leaves MCore DTensor placement untouched.
+    """
+    from megatron.core.distributed.fsdp.src.megatron_fsdp import (  # pyright: ignore[reportMissingImports]
+        param_and_grad_buffer,
+    )
+
+    make_fsdp_dtensor = param_and_grad_buffer.make_fsdp_dtensor
+    install_mfsdp_start_param_sync_patch()
+    if bool(getattr(make_fsdp_dtensor, _PATCHED_ATTR, False)):
+        install_mfsdp_param_sync_debug_patch(param_and_grad_buffer)
+        return
+    param_and_grad_buffer.make_fsdp_dtensor = _wrap_make_fsdp_dtensor(make_fsdp_dtensor)
+    install_mfsdp_param_sync_debug_patch(param_and_grad_buffer)
+
+
+def install_mfsdp_start_param_sync_patch() -> None:
+    from megatron.core.distributed.fsdp.src.megatron_fsdp import (  # pyright: ignore[reportMissingImports]
+        megatron_fsdp,
+    )
+
+    fsdp_cls = megatron_fsdp.MegatronFSDP
+    start_param_sync = fsdp_cls.start_param_sync
+    if bool(getattr(start_param_sync, _START_PARAM_SYNC_PATCHED_ATTR, False)):
+        return
+
+    @wraps(start_param_sync)
+    def wrapped_start_param_sync(self, *args, **kwargs):
+        if os.environ.get("MLITE_MFSDP_SKIP_START_PARAM_SYNC_ACTIVE", "0") == "1":
+            if _debug_param_sync():
+                try:
+                    import torch.distributed as dist  # pyright: ignore[reportMissingImports]
+
+                    rank = dist.get_rank() if dist.is_initialized() else 0
+                except Exception:
+                    rank = 0
+                print(
+                    f"[MFSDP_PARAM_SYNC] phase=start_param_sync_noop rank={rank}",
+                    flush=True,
+                )
+            return None
+        return start_param_sync(self, *args, **kwargs)
+
+    setattr(wrapped_start_param_sync, _START_PARAM_SYNC_PATCHED_ATTR, True)
+    fsdp_cls.start_param_sync = wrapped_start_param_sync
+
+
+def install_mfsdp_param_sync_debug_patch(param_and_grad_buffer: Any) -> None:
+    """Print MCore FSDP param all-gather bucket state when explicitly requested."""
+    pipeline_cls = getattr(param_and_grad_buffer, "AllGatherPipeline", None)
+    if pipeline_cls is None or bool(getattr(pipeline_cls, _PARAM_SYNC_PATCHED_ATTR, False)):
+        return
+
+    original_async = pipeline_cls.async_bucket_gather
+    original_wait = pipeline_cls.wait_bucket_ready
+
+    @wraps(original_async)
+    def wrapped_async(self, bucket_id, bwd, *args, **kwargs):
+        _print_param_sync_debug(self, "async_begin", bucket_id, bwd)
+        result = original_async(self, bucket_id, bwd, *args, **kwargs)
+        _print_param_sync_debug(self, "async_end", bucket_id, bwd)
+        return result
+
+    @wraps(original_wait)
+    def wrapped_wait(self, bucket_id, bwd, *args, **kwargs):
+        _print_param_sync_debug(self, "wait_begin", bucket_id, bwd)
+        result = original_wait(self, bucket_id, bwd, *args, **kwargs)
+        _print_param_sync_debug(self, "wait_end", bucket_id, bwd)
+        return result
+
+    pipeline_cls.async_bucket_gather = wrapped_async
+    pipeline_cls.wait_bucket_ready = wrapped_wait
+    setattr(pipeline_cls, _PARAM_SYNC_PATCHED_ATTR, True)
+
+
+def _debug_dtensor() -> bool:
+    return os.environ.get("MLITE_MFSDP_DEBUG_DTENSOR", "0").lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+def _debug_param_sync() -> bool:
+    return os.environ.get("MLITE_MFSDP_DEBUG_PARAM_SYNC", "0").lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+def _debug_dtensor_ranks() -> set[int]:
+    raw = os.environ.get("MLITE_MFSDP_DEBUG_DTENSOR_RANKS", "0,1")
+    ranks: set[int] = set()
+    for item in raw.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        try:
+            ranks.add(int(item))
+        except ValueError:
+            continue
+    return ranks or {0}
+
+
+def _debug_param_sync_ranks() -> set[int]:
+    raw = os.environ.get("MLITE_MFSDP_DEBUG_PARAM_SYNC_RANKS", "0,1")
+    ranks: set[int] = set()
+    for item in raw.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        try:
+            ranks.add(int(item))
+        except ValueError:
+            continue
+    return ranks or {0}
+
+
+def _debug_dtensor_name_pattern() -> re.Pattern[str]:
+    raw = os.environ.get(
+        "MLITE_MFSDP_DEBUG_DTENSOR_NAMES",
+        r"layers\.0\..*(qkv|linear_qkv|proj|linear_proj).*weight$",
+    )
+    return re.compile(raw)
+
+
+def _print_dtensor_debug(
+    param: Any,
+    local_tensor: Any,
+    result: Any,
+    *,
+    phase: str,
+    force_in: Any,
+    force_out: Any,
+    is_sharded_param: Any,
+    is_expert_param: Any,
+) -> None:
+    if not _debug_dtensor():
+        return
+    try:
+        import torch.distributed as dist  # pyright: ignore[reportMissingImports]
+
+        rank = dist.get_rank() if dist.is_initialized() else 0
+    except Exception:
+        rank = 0
+    if rank not in _debug_dtensor_ranks():
+        return
+    name = str(getattr(param, PARAM_NAME_ATTR, ""))
+    if not _debug_dtensor_name_pattern().search(name):
+        return
+    print(
+        "[MFSDP_DTENSOR] "
+        f"phase={phase} "
+        f"rank={rank} "
+        f"name={name or '<unknown>'} "
+        f"tp={int(bool(getattr(param, 'tensor_model_parallel', False)))} "
+        f"partition_dim={getattr(param, 'partition_dim', None)} "
+        f"tp_mode={getattr(param, '_tensor_parallel_mode', None)} "
+        f"skip_sync={int(should_skip_tp_duplicate_sync(param))} "
+        f"force_in={force_in} "
+        f"force_out={force_out} "
+        f"is_sharded_param={is_sharded_param} "
+        f"is_expert_param={is_expert_param} "
+        f"param_shape={_shape_tuple(param)} "
+        f"local_shape={_shape_tuple(local_tensor)} "
+        f"result_shape={_shape_tuple(result)} "
+        f"result_placements={getattr(result, 'placements', None)}",
+        flush=True,
+    )
+
+
+def _print_param_sync_debug(pipeline: Any, phase: str, bucket_id: Any, bwd: Any) -> None:
+    if not _debug_param_sync():
+        return
+    try:
+        import torch.distributed as dist  # pyright: ignore[reportMissingImports]
+
+        rank = dist.get_rank() if dist.is_initialized() else 0
+    except Exception:
+        dist = None
+        rank = 0
+    if rank not in _debug_param_sync_ranks():
+        return
+
+    wbuf = None
+    group = None
+    try:
+        wbuf = pipeline.get_fsdp_buffer(bucket_id, bwd)
+        group = getattr(wbuf, "data_parallel_group", None)
+    except Exception:
+        pass
+    try:
+        ranks = dist.get_process_group_ranks(group) if dist is not None and group is not None else None
+    except Exception:
+        ranks = None
+    try:
+        shard = wbuf.get_shard_from_local_buffer() if wbuf is not None else None
+    except Exception:
+        shard = None
+    try:
+        bucket_key = pipeline.get_bucket_key(bucket_id, bwd)
+        status = pipeline.bucket_status.get(bucket_key)
+    except Exception:
+        bucket_key = None
+        status = None
+
+    print(
+        "[MFSDP_PARAM_SYNC] "
+        f"phase={phase} "
+        f"rank={rank} "
+        f"bucket_id={bucket_id} "
+        f"bwd={bwd} "
+        f"bucket_key={bucket_key} "
+        f"status={status} "
+        f"group_ranks={ranks} "
+        f"buffer_numel={_numel(getattr(wbuf, 'data', None))} "
+        f"shard_numel={_numel(shard)} "
+        f"bucket_status={getattr(pipeline, 'bucket_status', None)}",
+        flush=True,
+    )
+
+
+def _numel(value: Any) -> int | None:
+    if value is None:
+        return None
+    numel = getattr(value, "numel", None)
+    if numel is None:
+        return None
+    try:
+        return int(numel())
+    except TypeError:
+        return None
+
+
+def _shape_tuple(value: Any) -> tuple[int, ...] | None:
+    shape = getattr(value, "shape", None)
+    if shape is None:
+        return None
+    try:
+        return tuple(int(dim) for dim in shape)
+    except TypeError:
+        return None
+
+
+__all__ = [
+    "PARAM_NAME_ATTR",
+    "SKIP_TP_DUPLICATE_SYNC_ATTR",
+    "clear_skip_tp_duplicate_sync",
+    "install_mfsdp_tp_duplicate_sync_patch",
+    "mark_skip_tp_duplicate_sync",
+    "set_mfsdp_param_name",
+    "should_skip_tp_duplicate_sync",
+]

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/process_groups.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/process_groups.py
@@ -1,0 +1,293 @@
+"""Megatron-FSDP process-group adapter.
+
+This module is intentionally M-FSDP-local.  It translates Megatron Lite's
+``ParallelState`` rank layout into the process groups and mesh shape expected
+by the installed Megatron-Core FSDP wrapper.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch  # pyright: ignore[reportMissingImports]
+import torch.distributed as dist  # pyright: ignore[reportMissingImports]
+
+
+def install_mfsdp_mesh_patch() -> None:
+    """Make Megatron-Core FSDP mesh helpers pipeline-stage aware.
+
+    The Megatron-Core build in the runbook image creates FSDP meshes from the
+    global world size, which assumes ``world = dp_cp * ep * tp``. Megatron Lite's
+    PP layout is ``world = pp * dp_cp * tp`` for dense params and
+    ``world = pp * expert_dp * ep * etp`` for expert params.  Build the mesh
+    from the rank block containing the current pipeline stage instead.
+    """
+
+    from megatron.core.distributed.fsdp import (  # pyright: ignore[reportMissingImports]
+        mcore_fsdp_adapter,
+    )
+
+    if getattr(mcore_fsdp_adapter, "_mlite_mfsdp_pp_mesh_patch", False):
+        return
+
+    mcore_fsdp_adapter._mlite_original_get_dp_tp_mesh = mcore_fsdp_adapter._get_dp_tp_mesh
+    mcore_fsdp_adapter._mlite_original_get_hsdp_tp_mesh = (
+        mcore_fsdp_adapter._get_hsdp_tp_mesh
+    )
+    mcore_fsdp_adapter._get_dp_tp_mesh = _get_pp_local_dp_tp_mesh
+    mcore_fsdp_adapter._get_hsdp_tp_mesh = _get_pp_local_hsdp_tp_mesh
+    mcore_fsdp_adapter._mlite_mfsdp_pp_mesh_patch = True
+
+
+def build_mfsdp_pg_collection(ps, engine_cfg):
+    """Build MCore ``ProcessGroupCollection`` for the Megatron-FSDP primitive."""
+
+    from megatron.core.process_groups_config import (  # pyright: ignore[reportMissingImports]
+        ProcessGroupCollection,
+    )
+
+    if ps.pp_group is None:
+        raise ValueError("optimizer_impl='megatron_fsdp' requires a local pp_group.")
+
+    rank = dist.get_rank()
+    world = dist.get_world_size()
+    num_dist_opt_instances = _distributed_optimizer_instances(engine_cfg)
+    if num_dist_opt_instances < 1:
+        raise ValueError("num_distributed_optimizer_instances must be a positive integer.")
+    if num_dist_opt_instances > 1:
+        if ps.pp_size > 1:
+            raise ValueError(
+                "optimizer_impl='megatron_fsdp' has not closed HSDP with PP/VPP yet."
+            )
+        if ps.dp_cp_size % num_dist_opt_instances != 0:
+            raise ValueError(
+                "optimizer_impl='megatron_fsdp' requires dp_cp_size to be divisible by "
+                "num_distributed_optimizer_instances."
+            )
+        if ps.expert_dp_size % num_dist_opt_instances != 0:
+            raise ValueError(
+                "optimizer_impl='megatron_fsdp' requires expert_dp_size to be divisible by "
+                "num_distributed_optimizer_instances."
+            )
+
+    singleton_group = None
+    for singleton_rank in range(world):
+        group = dist.new_group([singleton_rank])
+        if rank == singleton_rank:
+            singleton_group = group
+    if singleton_group is None:
+        raise RuntimeError("Failed to construct singleton process group for optional reductions.")
+
+    if ps.pp_size == 1:
+        mp_group = ps.tp_group
+        tp_ep_pp_group = ps.tp_ep_group
+    else:
+        mp_group = None
+        for dp_idx in range(ps.dp_size):
+            for cp_idx in range(ps.cp_size):
+                ranks = [
+                    _dense_rank(ps, tp_idx, cp_idx, dp_idx, pp_idx)
+                    for pp_idx in range(ps.pp_size)
+                    for tp_idx in range(ps.tp_size)
+                ]
+                group = dist.new_group(ranks)
+                if rank in ranks:
+                    mp_group = group
+
+        tp_ep_pp_group = None
+        for expert_dp_idx in range(ps.expert_dp_size):
+            ranks = [
+                _expert_rank(ps, etp_idx, ep_idx, expert_dp_idx, pp_idx)
+                for pp_idx in range(ps.pp_size)
+                for ep_idx in range(ps.ep_size)
+                for etp_idx in range(ps.etp_size)
+            ]
+            group = dist.new_group(ranks)
+            if rank in ranks:
+                tp_ep_pp_group = group
+
+        if mp_group is None or tp_ep_pp_group is None:
+            raise RuntimeError("Failed to construct M-FSDP pipeline-aware process groups.")
+
+    intra_dp_cp_group = ps.dp_cp_group
+    intra_expt_dp_group = ps.ep_dp_group
+    inter_dist_opt_group = None
+    intra_dist_opt_group = dist.group.WORLD
+    if num_dist_opt_instances > 1:
+        (
+            intra_dp_cp_group,
+            intra_expt_dp_group,
+            inter_dist_opt_group,
+            intra_dist_opt_group,
+        ) = _build_hsdp_groups(ps, num_dist_opt_instances, rank)
+
+    return ProcessGroupCollection(
+        tp=ps.tp_group,
+        cp=ps.cp_group,
+        pp=ps.pp_group,
+        ep=ps.ep_group,
+        mp=mp_group,
+        dp=ps.dp_group,
+        dp_cp=ps.dp_cp_group,
+        expt_dp=ps.ep_dp_group,
+        intra_dp_cp=intra_dp_cp_group,
+        intra_expt_dp=intra_expt_dp_group,
+        inter_dist_opt=inter_dist_opt_group,
+        expt_tp=ps.etp_group,
+        tp_ep=ps.tp_ep_group,
+        tp_ep_pp=tp_ep_pp_group,
+        intra_dist_opt=intra_dist_opt_group,
+        embd=singleton_group,
+        pos_embd=singleton_group,
+    )
+
+
+def _build_hsdp_groups(ps, num_dist_opt_instances: int, rank: int):
+    inner_dp_cp = ps.dp_cp_size // num_dist_opt_instances
+    inner_expert_dp = ps.expert_dp_size // num_dist_opt_instances
+    intra_dp_cp_group = None
+    intra_expt_dp_group = None
+    inter_dist_opt_group = None
+    intra_dist_opt_group = None
+
+    for pp_idx in range(ps.pp_size):
+        for tp_idx in range(ps.tp_size):
+            for outer_idx in range(num_dist_opt_instances):
+                start = outer_idx * inner_dp_cp
+                ranks = []
+                for local_dp_cp_idx in range(inner_dp_cp):
+                    dp_cp_idx = start + local_dp_cp_idx
+                    dp_idx = dp_cp_idx // ps.cp_size
+                    cp_idx = dp_cp_idx % ps.cp_size
+                    ranks.append(_dense_rank(ps, tp_idx, cp_idx, dp_idx, pp_idx))
+                group = dist.new_group(ranks)
+                if rank in ranks:
+                    intra_dp_cp_group = group
+
+    for pp_idx in range(ps.pp_size):
+        for etp_idx in range(ps.etp_size):
+            for ep_idx in range(ps.ep_size):
+                for outer_idx in range(num_dist_opt_instances):
+                    start = outer_idx * inner_expert_dp
+                    ranks = [
+                        _expert_rank(ps, etp_idx, ep_idx, expert_dp_idx, pp_idx)
+                        for expert_dp_idx in range(start, start + inner_expert_dp)
+                    ]
+                    group = dist.new_group(ranks)
+                    if rank in ranks:
+                        intra_expt_dp_group = group
+
+    for pp_idx in range(ps.pp_size):
+        for tp_idx in range(ps.tp_size):
+            for local_dp_cp_idx in range(inner_dp_cp):
+                ranks = []
+                for outer_idx in range(num_dist_opt_instances):
+                    dp_cp_idx = outer_idx * inner_dp_cp + local_dp_cp_idx
+                    dp_idx = dp_cp_idx // ps.cp_size
+                    cp_idx = dp_cp_idx % ps.cp_size
+                    ranks.append(_dense_rank(ps, tp_idx, cp_idx, dp_idx, pp_idx))
+                group = dist.new_group(ranks)
+                if rank in ranks:
+                    inter_dist_opt_group = group
+
+    for pp_idx in range(ps.pp_size):
+        for outer_idx in range(num_dist_opt_instances):
+            ranks = []
+            start = outer_idx * inner_dp_cp
+            for local_dp_cp_idx in range(inner_dp_cp):
+                dp_cp_idx = start + local_dp_cp_idx
+                dp_idx = dp_cp_idx // ps.cp_size
+                cp_idx = dp_cp_idx % ps.cp_size
+                for tp_idx in range(ps.tp_size):
+                    ranks.append(_dense_rank(ps, tp_idx, cp_idx, dp_idx, pp_idx))
+            group = dist.new_group(ranks)
+            if rank in ranks:
+                intra_dist_opt_group = group
+
+    if (
+        intra_dp_cp_group is None
+        or intra_expt_dp_group is None
+        or inter_dist_opt_group is None
+        or intra_dist_opt_group is None
+    ):
+        raise RuntimeError("Failed to construct Megatron-FSDP HSDP process groups.")
+
+    return (
+        intra_dp_cp_group,
+        intra_expt_dp_group,
+        inter_dist_opt_group,
+        intra_dist_opt_group,
+    )
+
+
+def _get_pp_local_dp_tp_mesh(dp_cp_group, tp_group, ep_size=1):
+    rank = dist.get_rank()
+    dp_cp_size = dp_cp_group.size()
+    tp_size = dist.get_world_size(tp_group) if tp_group is not None else 1
+    tp_idx = _group_index(tp_group, rank) if tp_group is not None else 0
+    dp_cp_idx = _group_index(dp_cp_group, rank)
+    ep_idx = ((rank - tp_idx) // tp_size) % int(ep_size)
+    base_rank = rank - ((dp_cp_idx * int(ep_size) + ep_idx) * tp_size + tp_idx)
+    mesh = torch.arange(
+        base_rank,
+        base_rank + dp_cp_size * int(ep_size) * tp_size,
+    ).reshape(dp_cp_size, int(ep_size), tp_size)
+    return mesh.permute(1, 0, 2)[ep_idx].contiguous()
+
+
+def _get_pp_local_hsdp_tp_mesh(outer_fsdp_dp_group, dp_cp_group, tp_group):
+    rank = dist.get_rank()
+    outer_size = outer_fsdp_dp_group.size()
+    fsdp_size = dp_cp_group.size()
+    tp_size = dist.get_world_size(tp_group) if tp_group is not None else 1
+    outer_idx = _group_index(outer_fsdp_dp_group, rank)
+    fsdp_idx = _group_index(dp_cp_group, rank)
+    tp_idx = _group_index(tp_group, rank) if tp_group is not None else 0
+    base_rank = rank - ((outer_idx * fsdp_size + fsdp_idx) * tp_size + tp_idx)
+    return torch.arange(
+        base_rank,
+        base_rank + outer_size * fsdp_size * tp_size,
+    ).reshape(outer_size, fsdp_size, tp_size)
+
+
+def _group_index(group, rank: int) -> int:
+    ranks = dist.get_process_group_ranks(group)
+    try:
+        return ranks.index(rank)
+    except ValueError as exc:
+        raise RuntimeError(f"Rank {rank} is not in process group ranks {ranks}.") from exc
+
+
+def _dense_rank(ps, tp_i: int, cp_i: int, dp_i: int, pp_i: int) -> int:
+    return ((pp_i * ps.dp_size + dp_i) * ps.cp_size + cp_i) * ps.tp_size + tp_i
+
+
+def _expert_rank(ps, etp_i: int, ep_i: int, edp_i: int, pp_i: int) -> int:
+    return ((pp_i * ps.expert_dp_size + edp_i) * ps.ep_size + ep_i) * ps.etp_size + etp_i
+
+
+def _distributed_optimizer_instances(engine_cfg: Any) -> int:
+    opt = getattr(engine_cfg, "optimizer", None)
+    if opt is None:
+        return 1
+    values = dict(getattr(opt, "override_optimizer_config", None) or {})
+    raw = values.get(
+        "num_distributed_optimizer_instances",
+        getattr(opt, "num_distributed_optimizer_instances", None),
+    )
+    if raw is None or raw is False or raw is True:
+        return 1
+    if isinstance(raw, int | float):
+        return int(raw)
+    if isinstance(raw, str):
+        normalized = raw.lower()
+        if normalized in {"", "none", "null"}:
+            return 1
+        return int(normalized)
+    return 1
+
+
+__all__ = [
+    "build_mfsdp_pg_collection",
+    "install_mfsdp_mesh_patch",
+]

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from megatron.lite.primitive.optimizers import get_optimizer_backend
+from megatron.lite.primitive.optimizers.mfsdp import config as mfsdp_config
+from megatron.lite.primitive.optimizers.mfsdp import grad_norm as mfsdp_grad_norm
+from megatron.lite.primitive.optimizers.mfsdp import optimizer as mfsdp_optimizer
+from megatron.lite.primitive.optimizers.mfsdp.patches import should_skip_tp_duplicate_sync
+from megatron.lite.runtime.contracts.config import ParallelConfig
+
+
+@dataclass
+class _FakeDDPConfig:
+    use_distributed_optimizer: bool = False
+    use_megatron_fsdp: bool = False
+    data_parallel_sharding_strategy: str = "no_shard"
+    bucket_size: int | None = None
+    overlap_grad_reduce: bool = False
+    overlap_param_gather: bool = False
+    num_distributed_optimizer_instances: int = 1
+    nccl_ub: bool = False
+    fsdp_double_buffer: bool = False
+    megatron_fsdp_main_params_dtype: torch.dtype | None = None
+    megatron_fsdp_main_grads_dtype: torch.dtype | None = None
+    megatron_fsdp_grad_comm_dtype: torch.dtype | None = None
+
+
+def _engine_cfg(**overrides):
+    cfg = SimpleNamespace(
+        model_name="qwen3_5",
+        parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1),
+        optimizer=SimpleNamespace(optimizer="adam", override_optimizer_config={}),
+    )
+    for key, value in overrides.items():
+        setattr(cfg, key, value)
+    return cfg
+
+
+def test_mfsdp_backend_registry_resolves_backend():
+    backend = get_optimizer_backend("mfsdp")
+
+    assert backend.name == "megatron_fsdp"
+    assert backend.runtime_backend == "megatron_fsdp"
+
+
+def test_mfsdp_config_lowers_aliases_and_preserves_optimizer_keys():
+    opt = SimpleNamespace(
+        override_optimizer_config={
+            "mfsdp_sharding_strategy": "optim_grads",
+            "bucket_size": 1234,
+            "adam_beta1": 0.8,
+        }
+    )
+
+    opt_overrides, ddp_overrides = mfsdp_config.split_mfsdp_overrides(
+        opt,
+        _FakeDDPConfig,
+    )
+
+    assert opt_overrides == {"adam_beta1": 0.8}
+    assert ddp_overrides["data_parallel_sharding_strategy"] == "optim_grads"
+    assert ddp_overrides["bucket_size"] == 1234
+
+    cfg = mfsdp_config.build_mfsdp_ddp_config(
+        _FakeDDPConfig,
+        {
+            "megatron_fsdp_main_params_dtype": "bf16",
+            "megatron_fsdp_grad_comm_dtype": "torch.float16",
+        },
+    )
+
+    assert cfg.use_distributed_optimizer is True
+    assert cfg.use_megatron_fsdp is True
+    assert cfg.data_parallel_sharding_strategy == "optim_grads_params"
+    assert cfg.megatron_fsdp_main_params_dtype is torch.bfloat16
+    assert cfg.megatron_fsdp_main_grads_dtype is None
+    assert cfg.megatron_fsdp_grad_comm_dtype is torch.float16
+
+
+def test_mfsdp_config_rejects_unsupported_optimizer():
+    engine_cfg = _engine_cfg(
+        optimizer=SimpleNamespace(optimizer="adamw", override_optimizer_config={})
+    )
+    with pytest.raises(ValueError, match="adam/sgd"):
+        mfsdp_config.validate_mfsdp_config(engine_cfg)
+
+
+def test_mfsdp_grad_clip_scales_unique_grads_and_decoupled_grads():
+    shared = torch.nn.Parameter(torch.ones(2))
+    shared.grad = torch.ones(2)
+    other = torch.nn.Parameter(torch.ones(2))
+    other.grad = torch.ones(2)
+    decoupled = torch.nn.Parameter(torch.ones(2))
+    decoupled.grad = torch.ones(2)
+    decoupled.decoupled_grad = torch.ones(2)
+
+    class _Leaf:
+        def __init__(self, params, *, use_decoupled_grad=False):
+            self.is_stub_optimizer = False
+            self.config = SimpleNamespace(
+                clip_grad=1.0,
+                use_precision_aware_optimizer_no_fp8_or_ds_fp8=use_decoupled_grad,
+            )
+            self.param_groups = [{"params": params}]
+
+        def get_parameters(self):
+            return []
+
+    optimizer = SimpleNamespace(
+        chained_optimizers=[
+            _Leaf([shared, other]),
+            _Leaf([shared]),
+            _Leaf([decoupled], use_decoupled_grad=True),
+        ],
+    )
+
+    mfsdp_grad_norm._clip_mfsdp_grads_by_total_norm(optimizer, grad_norm=4.0)
+
+    assert torch.allclose(shared.grad, torch.full_like(shared.grad, 0.25))
+    assert torch.allclose(other.grad, torch.full_like(other.grad, 0.25))
+    assert torch.equal(decoupled.grad, torch.ones(2))
+    assert torch.allclose(decoupled.decoupled_grad, torch.full_like(decoupled.grad, 0.25))
+
+
+def test_mfsdp_metadata_infers_tp_partition_attrs_for_known_weights():
+    class _Leaf(torch.nn.Module):
+        def __init__(self, *, param_name: str = "weight"):
+            super().__init__()
+            param = torch.nn.Parameter(torch.randn(4, 3))
+            param.tensor_model_parallel = True
+            setattr(self, param_name, param)
+
+    class _Layer(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.attn = torch.nn.Module()
+            self.attn.qkv = torch.nn.Module()
+            self.attn.qkv.linear = _Leaf()
+            self.attn.proj = torch.nn.Module()
+            self.attn.proj.linear = _Leaf()
+            self.moe = torch.nn.Module()
+            self.moe.experts = torch.nn.Module()
+            self.moe.experts.fc1 = _Leaf(param_name="weight0")
+            self.moe.experts.fc2 = _Leaf(param_name="weight0")
+
+    model = torch.nn.Module()
+    model.layers = torch.nn.ModuleList([_Layer()])
+
+    mfsdp_optimizer.ensure_mfsdp_tp_partition_attrs(model)
+
+    layer = model.layers[0]
+    assert layer.attn.qkv.linear.weight.partition_dim == 0
+    assert layer.attn.proj.linear.weight.partition_dim == 1
+    assert layer.moe.experts.fc1.weight0.partition_dim == 0
+    assert layer.moe.experts.fc2.weight0.partition_dim == 1
+    assert should_skip_tp_duplicate_sync(layer.attn.qkv.linear.weight)


### PR DESCRIPTION
Ports the validated Megatron-FSDP delivery into megatron.lite as an optimizer backend (registered as BACKENDS['mfsdp']): backend, grad_norm, config, process groups, checkpoint keys, dtensor grad, optimizer, patches. Qwen3-MoE / Qwen3.5 protocols gain an optimizer='mfsdp' post-load path. Unit tests included; GPU smoke to follow.