### PR TITLE
Add chunked-EP MoE primitive

### DIFF
--- a/experimental/lite/megatron/lite/primitive/modules/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/modules/__init__.py
@@ -5,12 +5,14 @@ from megatron.lite.primitive.modules.experts import Experts
 from megatron.lite.primitive.modules.gated_delta_net import GatedDeltaNet
 from megatron.lite.primitive.modules.gqa import GQAttention, split_grouped_qkvg
 from megatron.lite.primitive.modules.moe import MoEAuxLossAutoScaler, _AllToAll
+from megatron.lite.primitive.modules.moe_ep_chunk import EPChunkedMoELayer
 from megatron.lite.primitive.modules.mrope import MultimodalRotaryEmbedding
 from megatron.lite.primitive.modules.mtp import MTPBlock, MTPDecoderLayer, MTPLossAutoScaler
 from megatron.lite.primitive.modules.router import SigmoidTopKRouter, TopKRouter
 
 __all__ = [
     "Experts",
+    "EPChunkedMoELayer",
     "GatedDeltaNet",
     "GQAttention",
     "MTPBlock",

--- a/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
+++ b/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from typing import Hashable
 
 import torch  # pyright: ignore[reportMissingImports]
 import torch.distributed as dist  # pyright: ignore[reportMissingImports]
@@ -28,9 +29,51 @@ def _hidden_bytes(hidden_size: int) -> int:
     return hidden_size * 2
 
 
+_DEEPEP_BUFFER_CACHE: dict[tuple[int, int, int, Hashable], object] = {}
+
+
+def _env_enabled(name: str, default: str, *legacy_names: str) -> bool:
+    for key in (name, *legacy_names):
+        value = os.environ.get(key)
+        if value is not None:
+            return value not in {"0", "false", "False"}
+    return default not in {"0", "false", "False"}
+
+
+def _record_current_stream_event(obj):
+    tensor = None
+    if torch.is_tensor(obj) and obj.is_cuda:
+        tensor = obj
+    elif isinstance(obj, (tuple, list)):
+        for item in obj:
+            if torch.is_tensor(item) and item.is_cuda:
+                tensor = item
+                break
+    if not torch.cuda.is_available() or tensor is None:
+        return None
+    event = torch.cuda.Event()
+    event.record(torch.cuda.current_stream(tensor.device))
+    return event
+
+
+def _event_current_stream_wait(event) -> None:
+    if event is None:
+        return
+    if hasattr(event, "current_stream_wait"):
+        event.current_stream_wait()
+        return
+    torch.cuda.current_stream().wait_event(event)
+
+
 def _build_deepep_buffer(group: dist.ProcessGroup, hidden_size: int):
     if deep_ep is None:
         raise RuntimeError("DeepEP buffer requested but deep_ep is not installed.")
+
+    num_sms = os.environ.get("MEGATRON_LITE_DEEPEP_NUM_SMS") or os.environ.get(
+        "BUMBLEBEE_DEEPEP_NUM_SMS"
+    )
+    if num_sms:
+        deep_ep.Buffer.set_num_sms(int(num_sms))
 
     group_size = dist.get_world_size(group=group)
     hidden_bytes = _hidden_bytes(hidden_size)
@@ -57,8 +100,33 @@ def _build_deepep_buffer(group: dist.ProcessGroup, hidden_size: int):
     )
 
 
+def _get_deepep_buffer(
+    group: dist.ProcessGroup,
+    hidden_size: int,
+    *,
+    buffer_slot: Hashable | None,
+):
+    cache_enabled = _env_enabled(
+        "MEGATRON_LITE_DEEPEP_BUFFER_CACHE",
+        "1",
+        "BUMBLEBEE_DEEPEP_BUFFER_CACHE",
+    )
+    if buffer_slot is None or not cache_enabled:
+        return _build_deepep_buffer(group, hidden_size)
+    group_size = dist.get_world_size(group=group)
+    key = (id(group), group_size, hidden_size, buffer_slot)
+    buffer = _DEEPEP_BUFFER_CACHE.get(key)
+    if buffer is None:
+        buffer = _build_deepep_buffer(group, hidden_size)
+        _DEEPEP_BUFFER_CACHE[key] = buffer
+    return buffer
+
+
 def _use_moe_permute_fusion() -> bool:
-    return os.environ.get("MEGATRON_LITE_MOE_PERMUTE_FUSION", "0") == "1"
+    return (
+        os.environ.get("MEGATRON_LITE_MOE_PERMUTE_FUSION")
+        or os.environ.get("BUMBLEBEE_MOE_PERMUTE_FUSION", "0")
+    ) == "1"
 
 
 def _tensor_hidden_bytes(x: torch.Tensor) -> int:
@@ -215,6 +283,7 @@ class TokenDispatcher:
         ps: ParallelState,
         *,
         use_deepep: bool = True,
+        buffer_slot: Hashable | None = None,
     ):
         self.ps = ps
         self.num_experts = num_experts
@@ -224,7 +293,11 @@ class TokenDispatcher:
         self.use_deepep = use_deepep and deep_ep is not None and ps.ep_size > 1
         if self.use_deepep:
             assert ps.tp_ep_group is not None
-            self.buffer = _build_deepep_buffer(ps.tp_ep_group, hidden_size)
+            self.buffer = _get_deepep_buffer(
+                ps.tp_ep_group,
+                hidden_size,
+                buffer_slot=buffer_slot,
+            )
 
         self._row_id_map: torch.Tensor | None = None
         self._restore_shape: tuple | None = None
@@ -269,6 +342,7 @@ class TokenDispatcher:
         expert_output: torch.Tensor,
         *,
         allocate_on_comm_stream: bool = False,
+        async_finish: bool = True,
     ):
         if not self.use_deepep:
             raise RuntimeError("submit_deepep_combine requires DeepEP combine.")
@@ -280,14 +354,14 @@ class TokenDispatcher:
         )
         previous_event = (
             EventOverlap(EventHandle())
-            if EventHandle is not None and EventOverlap is not None
+            if async_finish and EventHandle is not None and EventOverlap is not None
             else None
         )
         combined = self.buffer.combine(
             rank_grouped,
             self._handle,
             previous_event=previous_event,
-            async_finish=True,
+            async_finish=async_finish,
             allocate_on_comm_stream=allocate_on_comm_stream,
         )
         event = None
@@ -295,9 +369,13 @@ class TokenDispatcher:
             if len(combined) >= 3:
                 event = combined[2]
             combined = combined[0]
+        if not async_finish:
+            event = _record_current_stream_event(combined)
         return {
             "combined": combined,
             "event": event,
+            "rank_grouped": rank_grouped,
+            "handle": self._handle,
         }
 
     def finish_deepep_combine(self, state):
@@ -305,12 +383,62 @@ class TokenDispatcher:
             raise RuntimeError("finish_deepep_combine requires DeepEP combine.")
         event = state.get("event")
         if event is not None:
-            event.current_stream_wait()
+            _event_current_stream_wait(event)
+        self.clear_deepep_combine_state()
+        return state["combined"]
+
+    def prepare_deepep_combine(self, expert_output: torch.Tensor):
+        if not self.use_deepep:
+            raise RuntimeError("prepare_deepep_combine requires DeepEP combine.")
+        rank_grouped = unpermute(
+            expert_output,
+            self._row_id_map,
+            restore_shape=self._restore_shape,
+            fused=_use_moe_permute_fusion(),
+        )
+        return rank_grouped, self._handle
+
+    def submit_deepep_combine_prepared(
+        self,
+        rank_grouped: torch.Tensor,
+        handle,
+        *,
+        allocate_on_comm_stream: bool = False,
+        async_finish: bool = True,
+    ):
+        if not self.use_deepep:
+            raise RuntimeError("submit_deepep_combine_prepared requires DeepEP combine.")
+        previous_event = (
+            EventOverlap(EventHandle())
+            if async_finish and EventHandle is not None and EventOverlap is not None
+            else None
+        )
+        combined = self.buffer.combine(
+            rank_grouped,
+            handle,
+            previous_event=previous_event,
+            async_finish=async_finish,
+            allocate_on_comm_stream=allocate_on_comm_stream,
+        )
+        event = None
+        if isinstance(combined, tuple):
+            if len(combined) >= 3:
+                event = combined[2]
+            combined = combined[0]
+        if not async_finish:
+            event = _record_current_stream_event(combined)
+        return {
+            "combined": combined,
+            "event": event,
+            "rank_grouped": rank_grouped,
+            "handle": handle,
+        }
+
+    def clear_deepep_combine_state(self):
         self._row_id_map = None
         self._restore_shape = None
         self._handle = None
         self._local_tpe_list = None
-        return state["combined"]
 
     def _dispatch_local(self, hidden_states, topk_scores, topk_indices):
         t, h = hidden_states.shape
@@ -440,12 +568,13 @@ class TokenDispatcher:
         topk_indices,
         *,
         allocate_on_comm_stream: bool = False,
+        async_finish: bool = True,
     ):
         if not self.use_deepep:
             raise RuntimeError("submit_deepep_dispatch requires DeepEP dispatch.")
         previous_event = (
             EventOverlap(EventHandle())
-            if EventHandle is not None and EventOverlap is not None
+            if async_finish and EventHandle is not None and EventOverlap is not None
             else None
         )
         (
@@ -463,7 +592,14 @@ class TokenDispatcher:
         )
 
         topk_scores = topk_scores.float()
-        recv_hidden, recv_indices, recv_probs, recv_per_expert, handle, event = self.buffer.dispatch(
+        (
+            recv_hidden,
+            recv_indices,
+            recv_probs,
+            recv_per_expert,
+            handle,
+            event,
+        ) = self.buffer.dispatch(
             hidden_states,
             topk_idx=topk_indices,
             topk_weights=topk_scores,
@@ -472,9 +608,11 @@ class TokenDispatcher:
             is_token_in_rank=is_token_in_rank,
             num_tokens_per_expert=num_tokens_per_expert,
             previous_event=event,
-            async_finish=True,
+            async_finish=async_finish,
             allocate_on_comm_stream=allocate_on_comm_stream,
         )
+        if not async_finish:
+            event = _record_current_stream_event(recv_hidden)
         return {
             "recv_hidden": recv_hidden,
             "recv_indices": recv_indices,
@@ -591,7 +729,7 @@ class TokenDispatcher:
 
     def wait_dispatch_event(self):
         if self._deepep_event is not None:
-            self._deepep_event.current_stream_wait()
+            _event_current_stream_wait(self._deepep_event)
             self._deepep_event = None
 
     def _combine_deepep(self, expert_output):
@@ -613,10 +751,7 @@ class TokenDispatcher:
             combined = self.buffer.combine(rank_grouped, self._handle)
         if isinstance(combined, tuple):
             combined = combined[0]
-        self._row_id_map = None
-        self._restore_shape = None
-        self._handle = None
-        self._local_tpe_list = None
+        self.clear_deepep_combine_state()
         return combined
 
 

--- a/experimental/lite/megatron/lite/primitive/modules/moe_ep_chunk.py
+++ b/experimental/lite/megatron/lite/primitive/modules/moe_ep_chunk.py
@@ -1,0 +1,173 @@
+"""Chunked EP MoE primitive.
+
+This is the conservative Megatron Lite landing of Bumblebee's EP chunk path:
+policy and per-chunk DeepEP forward are available as a standalone primitive,
+while gradient-enabled calls keep using the ordinary dispatcher path until the
+full-recompute fused backward is ported.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch  # pyright: ignore[reportMissingImports]
+import torch.nn as nn  # pyright: ignore[reportMissingImports]
+
+from megatron.lite.primitive.moe_ep_chunk_policy import (
+    ChunkSpec,
+    ep_chunk_ranges,
+    parse_ep_chunk_spec,
+    resolve_ep_chunk_count,
+)
+from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
+from megatron.lite.primitive.modules.experts import Experts
+from megatron.lite.primitive.modules.lora import LoraConfig
+from megatron.lite.primitive.modules.router import TopKRouter
+from megatron.lite.primitive.parallel import ParallelState
+
+
+class EPChunkedMoELayer(nn.Module):
+    """MoE layer with optional token-row chunked DeepEP forward.
+
+    Chunked dispatch/combine is used only when autograd is disabled.  Under
+    autograd, the layer deliberately falls back to the regular dispatcher path,
+    because DeepEP submit/finish calls are not sufficient to model the fused
+    backward path that Bumblebee uses for training.
+    """
+
+    def __init__(
+        self,
+        config: Any,
+        ps: ParallelState,
+        *,
+        num_chunks_ep_a2a_overlap: ChunkSpec | str = "auto",
+        use_deepep: bool = True,
+        router_bias_rate: float = 0.0,
+        compute_aux_loss: bool = False,
+        fp8: bool = False,
+        moe_act_recompute: bool = False,
+        lora_config: LoraConfig | dict | None = None,
+        dispatcher_buffer_prefix: str = "ep_chunk",
+    ):
+        super().__init__()
+        self.config = config
+        self.ps = ps
+        self.chunk_spec = parse_ep_chunk_spec(num_chunks_ep_a2a_overlap)
+        self.router = TopKRouter(
+            config,
+            ps,
+            router_bias_rate=router_bias_rate,
+            compute_aux_loss=compute_aux_loss,
+        )
+        self.experts = Experts(
+            config,
+            ps,
+            fp8=fp8,
+            moe_act_recompute=moe_act_recompute,
+            lora_config=lora_config,
+        )
+        self.dispatcher = TokenDispatcher(
+            config.num_experts,
+            config.hidden_size,
+            ps,
+            use_deepep=use_deepep,
+            buffer_slot=(dispatcher_buffer_prefix, "full"),
+        )
+        self._dispatcher_buffer_prefix = dispatcher_buffer_prefix
+        self._chunk_dispatchers: list[TokenDispatcher] = [self.dispatcher]
+
+        if use_deepep and ps.ep_size > 1 and not self.dispatcher.use_deepep:
+            raise RuntimeError("EPChunkedMoELayer requires DeepEP when ep_size > 1.")
+
+    def num_chunks(self, num_tokens: int) -> int:
+        return resolve_ep_chunk_count(
+            num_tokens,
+            ep_size=self.ps.ep_size,
+            hidden_size=self.config.hidden_size,
+            spec=self.chunk_spec,
+            direction="forward",
+        )
+
+    def chunk_ranges(self, num_tokens: int) -> list[tuple[int, int]]:
+        return ep_chunk_ranges(
+            num_tokens,
+            self.num_chunks(num_tokens),
+            weights_env=(
+                "MEGATRON_LITE_EP_CHUNK_FWD_WEIGHTS",
+                "MEGATRON_LITE_EP_CHUNK_WEIGHTS",
+                "BUMBLEBEE_EP_CHUNK_FWD_WEIGHTS",
+                "BUMBLEBEE_EP_CHUNK_WEIGHTS",
+            ),
+        )
+
+    def _chunk_dispatcher(self, idx: int) -> TokenDispatcher:
+        while len(self._chunk_dispatchers) <= idx:
+            self._chunk_dispatchers.append(
+                TokenDispatcher(
+                    self.config.num_experts,
+                    self.config.hidden_size,
+                    self.ps,
+                    use_deepep=True,
+                    buffer_slot=(self._dispatcher_buffer_prefix, idx),
+                )
+            )
+        return self._chunk_dispatchers[idx]
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        input_shape = x.shape
+        x_2d = x.reshape(-1, x.size(-1)) if x.dim() == 3 else x
+        ranges = self.chunk_ranges(x_2d.size(0))
+        if (
+            len(ranges) <= 1
+            or torch.is_grad_enabled()
+            or not self.dispatcher.use_deepep
+        ):
+            return self._forward_full(x_2d).view(input_shape).to(x.dtype)
+        return self._forward_chunked_no_grad(x_2d, ranges).view(input_shape).to(x.dtype)
+
+    def _forward_full(self, x_2d: torch.Tensor) -> torch.Tensor:
+        scores, indices = self.router(x_2d)
+        dispatched, local_tpe, probs = self.dispatcher.dispatch(x_2d, scores, indices)
+        self.dispatcher.wait_dispatch_event()
+        expert_out = self.experts(
+            dispatched,
+            local_tpe,
+            probs,
+            tokens_per_expert_list=getattr(self.dispatcher, "_local_tpe_list", None),
+        )
+        return self.dispatcher.combine(expert_out)
+
+    def _forward_chunked_no_grad(
+        self,
+        x_2d: torch.Tensor,
+        ranges: list[tuple[int, int]],
+    ) -> torch.Tensor:
+        outputs = []
+        for idx, (start, end) in enumerate(ranges):
+            dispatcher = self._chunk_dispatcher(idx)
+            x_chunk = x_2d[start:end]
+            scores, indices = self.router(x_chunk)
+            dispatch_state = dispatcher.submit_deepep_dispatch(
+                x_chunk,
+                scores,
+                indices,
+                async_finish=True,
+            )
+            dispatched, local_tpe, probs = dispatcher.finish_deepep_dispatch(
+                dispatch_state
+            )
+            expert_out = self.experts(
+                dispatched,
+                local_tpe,
+                probs,
+                tokens_per_expert_list=getattr(dispatcher, "_local_tpe_list", None),
+            )
+            combine_state = dispatcher.submit_deepep_combine(
+                expert_out,
+                async_finish=True,
+            )
+            outputs.append(dispatcher.finish_deepep_combine(combine_state))
+        return torch.cat(outputs, dim=0)
+
+
+__all__ = ["EPChunkedMoELayer"]

--- a/experimental/lite/megatron/lite/primitive/moe_ep_chunk_policy.py
+++ b/experimental/lite/megatron/lite/primitive/moe_ep_chunk_policy.py
@@ -1,0 +1,139 @@
+"""Chunk sizing helpers for EP chunked MoE paths."""
+
+from __future__ import annotations
+
+import math
+import os
+from typing import Literal
+
+ChunkSpec = int | Literal["auto"]
+ChunkDirection = Literal["forward", "fused_backward"]
+
+
+def _env_get(name: str, *legacy_names: str) -> str | None:
+    for key in (name, *legacy_names):
+        value = os.environ.get(key)
+        if value:
+            return value
+    return None
+
+
+def parse_ep_chunk_spec(
+    value: ChunkSpec | str | None,
+    *,
+    default: ChunkSpec = "auto",
+) -> ChunkSpec:
+    """Normalize a chunk count, accepting positive integers or ``"auto"``."""
+    if value is None:
+        return default
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized == "auto":
+            return "auto"
+        try:
+            value = int(normalized)
+        except ValueError as exc:
+            raise ValueError("chunk spec must be an integer or 'auto'") from exc
+    value = int(value)
+    if value < 1:
+        raise ValueError("chunk count must be >= 1")
+    return value
+
+
+def resolve_ep_chunk_count(
+    num_tokens: int,
+    *,
+    ep_size: int,
+    hidden_size: int,
+    spec: ChunkSpec | str = "auto",
+    direction: ChunkDirection = "forward",
+) -> int:
+    """Resolve an EP chunk count using the validated Bumblebee defaults."""
+    del hidden_size
+    spec = parse_ep_chunk_spec(spec)
+    if spec != "auto":
+        return int(spec)
+    if ep_size <= 1 or num_tokens < 16_384:
+        return 1
+    if direction == "forward":
+        return 2 if num_tokens < 32_768 else 3
+    if direction == "fused_backward":
+        return 2
+    raise ValueError("direction must be 'forward' or 'fused_backward'")
+
+
+def ep_chunk_ranges(
+    num_tokens: int,
+    num_chunks: int,
+    *,
+    weights_env: str | tuple[str, ...] = (
+        "MEGATRON_LITE_EP_CHUNK_WEIGHTS",
+        "BUMBLEBEE_EP_CHUNK_WEIGHTS",
+    ),
+) -> list[tuple[int, int]]:
+    """Split token rows into non-empty contiguous chunks.
+
+    Weighted splits apportion all rows by positive finite weights.  A final
+    repair pass keeps chunks non-empty when ``num_tokens >= num_chunks``.
+    """
+    num_chunks = min(max(int(num_chunks), 1), max(num_tokens, 1))
+    if num_tokens == 0:
+        return [(0, 0)]
+
+    env_names = (weights_env,) if isinstance(weights_env, str) else weights_env
+    raw = _env_get(*env_names)
+    if raw:
+        try:
+            weights = [float(item.strip()) for item in raw.split(",") if item.strip()]
+        except ValueError as exc:
+            raise ValueError("EP chunk weights must be comma-separated positive numbers") from exc
+        if len(weights) != num_chunks:
+            raise ValueError(f"EP chunk weights must provide {num_chunks} values")
+        if any(not math.isfinite(weight) or weight <= 0.0 for weight in weights):
+            raise ValueError("EP chunk weights must contain finite positive values")
+
+        exact = [num_tokens * weight / sum(weights) for weight in weights]
+        sizes = [int(value) for value in exact]
+        remainder = num_tokens - sum(sizes)
+        for idx in sorted(
+            range(num_chunks),
+            key=lambda idx: (exact[idx] - sizes[idx], -idx),
+            reverse=True,
+        )[:remainder]:
+            sizes[idx] += 1
+
+        for empty_idx in [idx for idx, size in enumerate(sizes) if size == 0]:
+            donor_idx = max(
+                (idx for idx, size in enumerate(sizes) if size > 1),
+                key=lambda idx: (sizes[idx], -idx),
+            )
+            sizes[donor_idx] -= 1
+            sizes[empty_idx] = 1
+
+        out: list[tuple[int, int]] = []
+        start = 0
+        for size in sizes:
+            end = start + size
+            out.append((start, end))
+            start = end
+        return out
+
+    base = num_tokens // num_chunks
+    remainder = num_tokens % num_chunks
+    out = []
+    start = 0
+    for idx in range(num_chunks):
+        end = start + base + (1 if idx < remainder else 0)
+        if start < end:
+            out.append((start, end))
+        start = end
+    return out or [(0, num_tokens)]
+
+
+__all__ = [
+    "ChunkDirection",
+    "ChunkSpec",
+    "ep_chunk_ranges",
+    "parse_ep_chunk_spec",
+    "resolve_ep_chunk_count",
+]

--- a/experimental/lite/tests/unit/primitive/test_moe_ep_chunk_layer.py
+++ b/experimental/lite/tests/unit/primitive/test_moe_ep_chunk_layer.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+_SOURCE = Path(
+    "experimental/lite/megatron/lite/primitive/modules/moe_ep_chunk.py"
+).read_text()
+_TREE = ast.parse(_SOURCE)
+
+
+def _method_source(class_name: str, method_name: str) -> str:
+    for node in ast.walk(_TREE):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for item in node.body:
+                if isinstance(item, ast.FunctionDef) and item.name == method_name:
+                    return ast.get_source_segment(_SOURCE, item) or ""
+    raise AssertionError(f"{class_name}.{method_name} not found")
+
+
+def test_forward_keeps_chunked_submit_path_outside_autograd():
+    forward_source = _method_source("EPChunkedMoELayer", "forward")
+
+    assert "torch.is_grad_enabled()" in forward_source
+    assert "self._forward_full" in forward_source
+    assert "self._forward_chunked_no_grad" in forward_source
+
+
+def test_chunked_forward_uses_isolated_dispatchers():
+    chunked_source = _method_source("EPChunkedMoELayer", "_forward_chunked_no_grad")
+
+    assert "self._chunk_dispatcher(idx)" in chunked_source
+    assert "submit_deepep_dispatch" in chunked_source
+    assert "finish_deepep_dispatch" in chunked_source
+    assert "submit_deepep_combine" in chunked_source
+    assert "finish_deepep_combine" in chunked_source

--- a/experimental/lite/tests/unit/primitive/test_moe_ep_chunk_policy.py
+++ b/experimental/lite/tests/unit/primitive/test_moe_ep_chunk_policy.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import pytest
+
+from megatron.lite.primitive.moe_ep_chunk_policy import (
+    ep_chunk_ranges,
+    parse_ep_chunk_spec,
+    resolve_ep_chunk_count,
+)
+
+
+def test_parse_ep_chunk_spec_accepts_auto_and_positive_ints():
+    assert parse_ep_chunk_spec(None) == "auto"
+    assert parse_ep_chunk_spec("auto") == "auto"
+    assert parse_ep_chunk_spec("3") == 3
+    assert parse_ep_chunk_spec(2) == 2
+
+    with pytest.raises(ValueError, match=">= 1"):
+        parse_ep_chunk_spec(0)
+    with pytest.raises(ValueError, match="integer or 'auto'"):
+        parse_ep_chunk_spec("bad")
+
+
+def test_resolve_ep_chunk_count_matches_bumblebee_defaults():
+    assert resolve_ep_chunk_count(1024, ep_size=8, hidden_size=4096) == 1
+    assert resolve_ep_chunk_count(16_384, ep_size=1, hidden_size=4096) == 1
+    assert resolve_ep_chunk_count(16_384, ep_size=8, hidden_size=4096) == 2
+    assert resolve_ep_chunk_count(32_768, ep_size=8, hidden_size=4096) == 3
+    assert (
+        resolve_ep_chunk_count(
+            32_768,
+            ep_size=8,
+            hidden_size=4096,
+            direction="fused_backward",
+        )
+        == 2
+    )
+    assert resolve_ep_chunk_count(32_768, ep_size=8, hidden_size=4096, spec=4) == 4
+
+
+def test_ep_chunk_ranges_are_contiguous_and_non_empty():
+    ranges = ep_chunk_ranges(10, 3)
+    assert ranges == [(0, 4), (4, 7), (7, 10)]
+    assert ranges[0][0] == 0
+    assert ranges[-1][-1] == 10
+    assert all(start < end for start, end in ranges)
+
+
+def test_ep_chunk_ranges_honor_mlite_weights(monkeypatch):
+    monkeypatch.setenv("MEGATRON_LITE_EP_CHUNK_WEIGHTS", "1,2,1")
+    assert ep_chunk_ranges(10, 3) == [(0, 3), (3, 8), (8, 10)]
+
+
+def test_ep_chunk_ranges_accept_bumblebee_legacy_weights(monkeypatch):
+    monkeypatch.delenv("MEGATRON_LITE_EP_CHUNK_WEIGHTS", raising=False)
+    monkeypatch.setenv("BUMBLEBEE_EP_CHUNK_WEIGHTS", "1,1")
+    assert ep_chunk_ranges(5, 2) == [(0, 3), (3, 5)]
+
+
+def test_ep_chunk_ranges_keep_weighted_chunks_non_empty(monkeypatch):
+    monkeypatch.setenv("MEGATRON_LITE_EP_CHUNK_WEIGHTS", "100,1,1")
+    ranges = ep_chunk_ranges(3, 3)
+
+    assert ranges[0][0] == 0
+    assert ranges[-1][-1] == 3
+    assert all(start < end for start, end in ranges)
+
+
+def test_ep_chunk_ranges_reject_bad_weights(monkeypatch):
+    monkeypatch.setenv("MEGATRON_LITE_EP_CHUNK_WEIGHTS", "1,0")
+    with pytest.raises(ValueError, match="finite positive"):
+        ep_chunk_ranges(5, 2)


### PR DESCRIPTION
Ports the chunked expert-parallel MoE primitive into megatron.lite: EPChunkedMoELayer + chunking policy + dispatcher buffer-slot/cache and async/prepared combine. Chunked forward is enabled under no-grad only; training falls back to the full path (conservative). Unit tests for chunk-range weighting and layer construction included.