### PR TITLE
Add independent MLite primitive unit coverage

### DIFF
--- a/experimental/lite/megatron/lite/primitive/modules/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/modules/__init__.py
@@ -1,13 +1,38 @@
 """Shared model modules owned by Megatron Lite."""
 
-from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
-from megatron.lite.primitive.modules.experts import Experts
-from megatron.lite.primitive.modules.gated_delta_net import GatedDeltaNet
-from megatron.lite.primitive.modules.gqa import GQAttention, split_grouped_qkvg
-from megatron.lite.primitive.modules.moe import MoEAuxLossAutoScaler, _AllToAll
-from megatron.lite.primitive.modules.mrope import MultimodalRotaryEmbedding
-from megatron.lite.primitive.modules.mtp import MTPBlock, MTPDecoderLayer, MTPLossAutoScaler
-from megatron.lite.primitive.modules.router import SigmoidTopKRouter, TopKRouter
+from __future__ import annotations
+
+_EXPORTS = {
+    "Experts": ("megatron.lite.primitive.modules.experts", "Experts"),
+    "GatedDeltaNet": ("megatron.lite.primitive.modules.gated_delta_net", "GatedDeltaNet"),
+    "GQAttention": ("megatron.lite.primitive.modules.gqa", "GQAttention"),
+    "MTPBlock": ("megatron.lite.primitive.modules.mtp", "MTPBlock"),
+    "MTPDecoderLayer": ("megatron.lite.primitive.modules.mtp", "MTPDecoderLayer"),
+    "MTPLossAutoScaler": ("megatron.lite.primitive.modules.mtp", "MTPLossAutoScaler"),
+    "MoEAuxLossAutoScaler": ("megatron.lite.primitive.modules.moe", "MoEAuxLossAutoScaler"),
+    "MultimodalRotaryEmbedding": (
+        "megatron.lite.primitive.modules.mrope",
+        "MultimodalRotaryEmbedding",
+    ),
+    "SigmoidTopKRouter": ("megatron.lite.primitive.modules.router", "SigmoidTopKRouter"),
+    "TokenDispatcher": ("megatron.lite.primitive.modules.dispatcher", "TokenDispatcher"),
+    "TopKRouter": ("megatron.lite.primitive.modules.router", "TopKRouter"),
+    "_AllToAll": ("megatron.lite.primitive.modules.moe", "_AllToAll"),
+    "split_grouped_qkvg": ("megatron.lite.primitive.modules.gqa", "split_grouped_qkvg"),
+}
+
+
+def __getattr__(name: str):
+    if name not in _EXPORTS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    import importlib
+
+    module_name, attr_name = _EXPORTS[name]
+    module = importlib.import_module(module_name)
+    value = getattr(module, attr_name)
+    globals()[name] = value
+    return value
 
 __all__ = [
     "Experts",

--- a/experimental/lite/megatron/lite/primitive/modules/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/modules/__init__.py
@@ -18,7 +18,10 @@ _EXPORTS = {
     "TokenDispatcher": ("megatron.lite.primitive.modules.dispatcher", "TokenDispatcher"),
     "TopKRouter": ("megatron.lite.primitive.modules.router", "TopKRouter"),
     "_AllToAll": ("megatron.lite.primitive.modules.moe", "_AllToAll"),
-    "split_grouped_qkvg": ("megatron.lite.primitive.modules.gqa", "split_grouped_qkvg"),
+    "split_grouped_qkvg": (
+        "megatron.lite.primitive.modules.gqa_utils",
+        "split_grouped_qkvg",
+    ),
 }
 
 

--- a/experimental/lite/megatron/lite/primitive/modules/gqa.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gqa.py
@@ -26,6 +26,7 @@ from megatron.core.models.common.embeddings.rotary_pos_embedding import (  # pyr
     RotaryEmbedding as MCoreRotaryEmbedding,
 )
 
+from megatron.lite.primitive.modules.gqa_utils import split_grouped_qkvg
 from megatron.lite.primitive.modules.lora import LinearLoRA, LoraConfig, normalize_lora_config
 from megatron.lite.primitive.modules.mrope import MultimodalRotaryEmbedding
 from megatron.lite.primitive.parallel import ColumnParallelLinear, ParallelState, RowParallelLinear
@@ -51,34 +52,6 @@ def _callable_accepts_kwarg(fn, kwarg: str) -> bool:
     return any(
         param.kind is inspect.Parameter.VAR_KEYWORD or param.name == kwarg
         for param in parameters
-    )
-
-
-def split_grouped_qkvg(
-    qkv: torch.Tensor,
-    *,
-    num_heads: int,
-    num_kv_heads: int,
-    head_dim: int,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    lead = qkv.shape[:-1]
-    q_heads_per_group = ensure_divisible(num_heads, num_kv_heads)
-    group_width = (2 * q_heads_per_group + 2) * head_dim
-    grouped = qkv.reshape(*lead, num_kv_heads, group_width)
-    query, gate, key, value = grouped.split(
-        [
-            q_heads_per_group * head_dim,
-            q_heads_per_group * head_dim,
-            head_dim,
-            head_dim,
-        ],
-        dim=-1,
-    )
-    return (
-        query.reshape(*lead, num_heads, head_dim),
-        gate.reshape(*lead, num_heads, head_dim),
-        key.reshape(*lead, num_kv_heads, head_dim),
-        value.reshape(*lead, num_kv_heads, head_dim),
     )
 
 

--- a/experimental/lite/megatron/lite/primitive/modules/gqa_utils.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gqa_utils.py
@@ -1,0 +1,38 @@
+"""Pure grouped-query attention helpers."""
+
+from __future__ import annotations
+
+import torch
+
+from megatron.lite.primitive.utils import ensure_divisible
+
+
+def split_grouped_qkvg(
+    qkv: torch.Tensor,
+    *,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    lead = qkv.shape[:-1]
+    q_heads_per_group = ensure_divisible(num_heads, num_kv_heads)
+    group_width = (2 * q_heads_per_group + 2) * head_dim
+    grouped = qkv.reshape(*lead, num_kv_heads, group_width)
+    query, gate, key, value = grouped.split(
+        [
+            q_heads_per_group * head_dim,
+            q_heads_per_group * head_dim,
+            head_dim,
+            head_dim,
+        ],
+        dim=-1,
+    )
+    return (
+        query.reshape(*lead, num_heads, head_dim),
+        gate.reshape(*lead, num_heads, head_dim),
+        key.reshape(*lead, num_kv_heads, head_dim),
+        value.reshape(*lead, num_kv_heads, head_dim),
+    )
+
+
+__all__ = ["split_grouped_qkvg"]

--- a/experimental/lite/megatron/lite/primitive/ops/linear_cross_entropy.py
+++ b/experimental/lite/megatron/lite/primitive/ops/linear_cross_entropy.py
@@ -61,7 +61,7 @@ def linear_cross_entropy(
     logits = torch.matmul(hidden, weight.t())
     if temperature != 1.0:
         logits = logits / float(temperature)
-    loss = vocab_parallel_cross_entropy(logits, labels, tp_group)
+    loss = vocab_parallel_cross_entropy(logits.clone(), labels, tp_group)
     entropy = _vocab_parallel_entropy(logits, tp_group)
     return _reshape_like_labels(-loss, labels), _reshape_like_labels(entropy, labels)
 

--- a/experimental/lite/tests/README.md
+++ b/experimental/lite/tests/README.md
@@ -24,14 +24,20 @@ Current matrix:
 
 | Surface | Unit | Smoke |
 | --- | --- | --- |
-| TP/EP/PP/CP topology | `unit/primitive/test_parallel_unit.py` | `smoke/primitive/test_parallel_topologies_smoke.py` |
+| TP/EP/PP/CP/SP topology | `unit/primitive/test_parallel_unit.py`, `unit/primitive/test_parallel_dimensions_independent_unit.py` | `smoke/primitive/test_parallel_topologies_smoke.py` |
+| TP linear/vocab primitives | `unit/primitive/test_parallel_dimensions_independent_unit.py` | Qwen model smoke exercises TP linear surfaces |
+| EP token dispatch | `unit/primitive/test_parallel_dimensions_independent_unit.py` | Qwen model smoke exercises router, dispatcher, and experts |
 | THD packing helpers | `unit/primitive/test_parallel_unit.py` | CP topology smoke exercises distributed CP groups |
 | GQA/attention split contract | `unit/primitive/test_attention_moe_unit.py` | Qwen model smoke exercises attention forward/backward |
 | MoE router/aux-loss contract | `unit/primitive/test_attention_moe_unit.py` | Qwen model smoke exercises router, dispatcher, and experts |
-| DDP + distributed optimizer | `unit/primitive/test_checkpoint_unit.py` has xfail checkpoint contract sentinels | `smoke/primitive/test_distopt_checkpoint_smoke.py` is xfail until the follow-up bugfix PR |
+| LoRA adapter primitives | `unit/primitive/test_module_primitives_independent_unit.py` | Qwen model smoke can enable adapters in follow-up coverage |
+| MTP/MRoPE/Gated Delta helper contracts | `unit/primitive/test_module_primitives_independent_unit.py`, `unit/primitive/test_ops_data_trainstep_unit.py` | Qwen3.5 model smoke exercises MRoPE/Gated DeltaNet paths |
+| Loss/logprob/math ops | `unit/primitive/test_ops_data_trainstep_unit.py` | Qwen model smoke exercises loss plumbing |
+| Data/recompute/train-step primitives | `unit/primitive/test_ops_data_trainstep_unit.py` | model/runtime smoke exercises training loop integration |
+| DDP + distributed optimizer | `unit/primitive/test_checkpoint_unit.py`, `unit/primitive/test_checkpoint_runtime.py` | `smoke/primitive/test_distopt_checkpoint_smoke.py` |
 | FSDP2 config/wrap/offload | `unit/primitive/test_fsdp2_unit.py` | `smoke/primitive/test_fsdp2_offload_checkpoint_smoke.py` |
-| FSDP2 save/load resume | `unit/primitive/test_checkpoint_unit.py` has xfail checkpoint contract sentinels | FSDP2 checkpoint smoke is xfail until the follow-up bugfix PR |
-| Checkpoint restore vs direct training | xfail sentinels only in this validation PR | FSDP2 and distopt checkpoint smokes are xfail until the follow-up bugfix PR |
+| FSDP2 save/load resume | `unit/primitive/test_checkpoint_unit.py`, `unit/primitive/test_checkpoint_runtime.py` | `smoke/primitive/test_fsdp2_offload_checkpoint_smoke.py` |
+| Checkpoint restore vs direct training | `unit/primitive/test_checkpoint_unit.py`, `unit/primitive/test_checkpoint_runtime.py` | FSDP2 and distopt checkpoint smokes cover distributed restore paths |
 | Runtime backend registry/config | `unit/primitive/test_runtime_config_unit.py`, `unit/runtime/test_runtime_backend_unit.py` | covered through checkpoint/model handles |
 | Runtime env/offload controls | `unit/runtime/test_runtime_backend_unit.py` | `smoke/primitive/test_fsdp2_offload_checkpoint_smoke.py` |
 | Optimizer update-state offload fraction | `unit/primitive/test_runtime_config_unit.py` and single-process CUDA coverage in `unit/primitive/test_fsdp2_offload_gpu.py` | multi-rank FSDP2 grad clipping is xfail until the follow-up bugfix PR |

--- a/experimental/lite/tests/README.md
+++ b/experimental/lite/tests/README.md
@@ -2,7 +2,7 @@
 
 `experimental/lite/tests` separates MLite validation into two layers:
 
-- Unit tests: CPU/single-process contract tests for primitive, model, runtime, checkpoint sentinels, config, and helper behavior. Tests that need optional packages such as Transformer Engine explicitly skip when unavailable.
+- Unit tests: CPU/single-process contract tests for primitive, model, runtime, checkpoint sentinels, config, and helper behavior. Pure helper tests stub optional imports when no Transformer Engine runtime path is exercised; tests that need the real package explicitly skip when unavailable.
 - Smoke tests: real `torch.distributed` tests for TP/EP/PP/CP/FSDP2/offload/checkpoint/distopt and tiny Qwen lite forward/backward behavior. Smoke runs are capped at one node and at most 8 GPUs.
 
 Run unit coverage:

--- a/experimental/lite/tests/conftest.py
+++ b/experimental/lite/tests/conftest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -41,3 +42,34 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if "smoke" in item.keywords:
             item.add_marker(skip_smoke)
+
+
+@pytest.fixture
+def transformer_engine_import_stub(monkeypatch):
+    def install() -> None:
+        try:
+            import transformer_engine.pytorch  # noqa: F401
+
+            return
+        except ModuleNotFoundError as exc:
+            if exc.name not in {"transformer_engine", "transformer_engine.pytorch"}:
+                raise
+
+        class _UnavailableTE:
+            def __init__(self, *args, **kwargs):
+                raise RuntimeError(
+                    "Transformer Engine is not installed in this test environment."
+                )
+
+        root = types.ModuleType("transformer_engine")
+        root.__version__ = "0.0.0"
+        pytorch = types.ModuleType("transformer_engine.pytorch")
+        pytorch.DotProductAttention = _UnavailableTE
+        pytorch.LayerNormLinear = _UnavailableTE
+        pytorch.Linear = _UnavailableTE
+        pytorch.RMSNorm = _UnavailableTE
+        root.pytorch = pytorch
+        monkeypatch.setitem(sys.modules, "transformer_engine", root)
+        monkeypatch.setitem(sys.modules, "transformer_engine.pytorch", pytorch)
+
+    return install

--- a/experimental/lite/tests/smoke/primitive/test_distopt_checkpoint_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_distopt_checkpoint_smoke.py
@@ -19,10 +19,6 @@ pytestmark = [
     pytest.mark.smoke,
     pytest.mark.gpu,
     pytest.mark.distributed,
-    pytest.mark.xfail(
-        reason="MLite distopt checkpoint continuity is covered by a follow-up bugfix PR.",
-        strict=True,
-    ),
 ]
 
 

--- a/experimental/lite/tests/smoke/primitive/test_fsdp2_offload_checkpoint_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_fsdp2_offload_checkpoint_smoke.py
@@ -198,10 +198,6 @@ def test_fsdp2_offload_fraction_keeps_optimizer_update_state_on_cpu_single_node(
     assert _optimizer_state_devices(optimizer) == {"cpu"}
 
 
-@pytest.mark.xfail(
-    reason="MLite FSDP2 checkpoint continuity is covered by a follow-up bugfix PR.",
-    strict=True,
-)
 def test_fsdp2_checkpoint_load_matches_uninterrupted_training_single_node(tmp_path):
     model_for_ckpt, ps = _build_fsdp2_model()
     optimizer_for_ckpt = _build_optimizer(model_for_ckpt, ps, offload_fraction=0.0)

--- a/experimental/lite/tests/unit/primitive/test_attention_moe_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_attention_moe_unit.py
@@ -10,21 +10,23 @@ pytestmark = pytest.mark.mlite
 
 
 def _split_grouped_qkvg():
-    pytest.importorskip("transformer_engine.pytorch")
-    from megatron.lite.primitive.modules.gqa import split_grouped_qkvg
+    from megatron.lite.primitive.modules import split_grouped_qkvg
 
     return split_grouped_qkvg
 
 
 def _moe_aux_scaler():
-    pytest.importorskip("transformer_engine.pytorch")
     from megatron.lite.primitive.modules.moe import MoEAuxLossAutoScaler
 
     return MoEAuxLossAutoScaler
 
 
-def _router_and_parallel_state():
-    pytest.importorskip("transformer_engine.pytorch")
+def _router_and_parallel_state(monkeypatch):
+    from megatron.core.transformer.moe import moe_utils
+
+    if not hasattr(moe_utils, "te_general_gemm"):
+        monkeypatch.setattr(moe_utils, "te_general_gemm", None, raising=False)
+
     from megatron.lite.primitive.modules.router import TopKRouter
     from megatron.lite.primitive.parallel import ParallelState
 
@@ -93,8 +95,8 @@ def test_moe_aux_loss_auto_scaler_threads_scaled_aux_gradient():
     MoEAuxLossAutoScaler.main_loss_backward_scale = None
 
 
-def test_topk_router_returns_finite_scores_and_valid_expert_indices():
-    TopKRouter, ParallelState = _router_and_parallel_state()
+def test_topk_router_returns_finite_scores_and_valid_expert_indices(monkeypatch):
+    TopKRouter, ParallelState = _router_and_parallel_state(monkeypatch)
     config = _router_config()
     router = TopKRouter(config, ParallelState(), compute_aux_loss=False)
     hidden = torch.randn(5, 4)
@@ -109,8 +111,8 @@ def test_topk_router_returns_finite_scores_and_valid_expert_indices():
     assert indices.max().item() < config.num_experts
 
 
-def test_topk_router_scores_are_normalized_and_deterministic_in_eval():
-    TopKRouter, ParallelState = _router_and_parallel_state()
+def test_topk_router_scores_are_normalized_and_deterministic_in_eval(monkeypatch):
+    TopKRouter, ParallelState = _router_and_parallel_state(monkeypatch)
     config = _router_config()
     router = TopKRouter(config, ParallelState(), compute_aux_loss=False)
     hidden = torch.randn(5, config.hidden_size)
@@ -124,8 +126,8 @@ def test_topk_router_scores_are_normalized_and_deterministic_in_eval():
     assert torch.equal(indices_1, indices_2)
 
 
-def test_topk_router_does_not_attach_aux_scaler_in_eval():
-    TopKRouter, ParallelState = _router_and_parallel_state()
+def test_topk_router_does_not_attach_aux_scaler_in_eval(monkeypatch):
+    TopKRouter, ParallelState = _router_and_parallel_state(monkeypatch)
     config = _router_config()
     router = TopKRouter(config, ParallelState(), compute_aux_loss=True)
     hidden = torch.randn(5, config.hidden_size)
@@ -136,8 +138,8 @@ def test_topk_router_does_not_attach_aux_scaler_in_eval():
     assert not any("MoEAuxLoss" in name for name in _walk_grad_fn_names(scores))
 
 
-def test_topk_router_aux_loss_contributes_gate_gradient():
-    TopKRouter, ParallelState = _router_and_parallel_state()
+def test_topk_router_aux_loss_contributes_gate_gradient(monkeypatch):
+    TopKRouter, ParallelState = _router_and_parallel_state(monkeypatch)
     config = _router_config()
     router = TopKRouter(config, ParallelState(), compute_aux_loss=True)
     hidden = torch.randn(8, config.hidden_size)

--- a/experimental/lite/tests/unit/primitive/test_checkpoint_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_checkpoint_unit.py
@@ -10,13 +10,7 @@ from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
 from megatron.lite.runtime.contracts.handle import ModelHandle
 
 
-pytestmark = [
-    pytest.mark.mlite,
-    pytest.mark.xfail(
-        reason="MLite runtime checkpoint API/DCP continuity is covered by a follow-up bugfix PR.",
-        strict=True,
-    ),
-]
+pytestmark = pytest.mark.mlite
 
 
 class TinyMLP(nn.Module):

--- a/experimental/lite/tests/unit/primitive/test_module_primitives_independent_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_module_primitives_independent_unit.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+
+from megatron.lite.primitive.modules.lora import (
+    GroupedLinearLoRA,
+    LinearLoRA,
+    SharedGroupedLinearLoRA,
+    freeze_non_lora_params,
+    normalize_lora_config,
+    trainable_param_stats,
+)
+
+
+pytestmark = pytest.mark.mlite
+
+
+def test_lora_config_aliases_and_trainable_param_accounting():
+    cfg = normalize_lora_config(
+        {
+            "enabled": True,
+            "rank": 2,
+            "alpha": 6,
+            "targets": ["qkv", "fc2"],
+        }
+    )
+
+    assert cfg.enabled
+    assert cfg.scale == 3.0
+    assert cfg.targets() == {"linear_qkv", "linear_fc2"}
+    assert cfg.targets_module("qkv")
+    assert cfg.targets_module("linear_fc2")
+    assert not normalize_lora_config({"enabled": False, "rank": 8}).enabled
+    with pytest.raises(TypeError, match="LoRA config"):
+        normalize_lora_config(object())
+
+    class TinyAdapterModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.base = nn.Linear(3, 2)
+            self.lora_adapter = nn.Linear(3, 2)
+
+    model = TinyAdapterModel()
+    stats = freeze_non_lora_params(model)
+
+    assert stats["lora_tensors"] == 2
+    assert stats["frozen_tensors"] == 2
+    assert not model.base.weight.requires_grad
+    assert model.lora_adapter.weight.requires_grad
+    assert trainable_param_stats(model) == {
+        "trainable_tensors": 2,
+        "trainable_numel": model.lora_adapter.weight.numel() + model.lora_adapter.bias.numel(),
+    }
+
+
+def test_linear_lora_forward_backward_matches_low_rank_delta():
+    layer = LinearLoRA(3, 2, rank=2, alpha=4, dropout=0.0)
+    with torch.no_grad():
+        layer.lora_a.copy_(torch.tensor([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]))
+        layer.lora_b.copy_(torch.tensor([[1.0, 2.0], [3.0, 4.0]]))
+
+    x = torch.tensor([[1.0, 2.0, 3.0]], requires_grad=True)
+    output = layer(x)
+
+    torch.testing.assert_close(output, torch.tensor([[10.0, 22.0]]))
+    output.sum().backward()
+    torch.testing.assert_close(x.grad, torch.tensor([[8.0, 12.0, 0.0]]))
+
+
+def test_grouped_lora_respects_per_expert_splits():
+    layer = GroupedLinearLoRA(2, 2, 2, rank=1, alpha=1, dropout=0.0)
+    with torch.no_grad():
+        layer.lora_a.copy_(torch.tensor([[[1.0, 0.0]], [[0.0, 1.0]]]))
+        layer.lora_b.copy_(torch.tensor([[[2.0], [3.0]], [[5.0], [7.0]]]))
+
+    x = torch.tensor([[2.0, 9.0], [4.0, 1.0], [6.0, 3.0]])
+    output = layer(x, [1, 2])
+
+    torch.testing.assert_close(
+        output,
+        torch.tensor([[4.0, 6.0], [5.0, 7.0], [15.0, 21.0]]),
+    )
+    with pytest.raises(ValueError, match="expected 2 splits"):
+        layer(x, [3])
+
+
+def test_shared_grouped_lora_uses_one_adapter_for_all_experts():
+    layer = SharedGroupedLinearLoRA(2, 2, 2, rank=1, alpha=2, dropout=0.0)
+    with torch.no_grad():
+        layer.lora_a.copy_(torch.tensor([[1.0, -1.0]]))
+        layer.lora_b.copy_(torch.tensor([[2.0], [3.0]]))
+
+    output = layer(torch.tensor([[3.0, 1.0], [4.0, 7.0]]), [1, 1])
+
+    torch.testing.assert_close(output, torch.tensor([[8.0, 12.0], [-12.0, -18.0]]))
+
+
+def test_mrope_interleaves_text_height_and_width_sections():
+    from megatron.lite.primitive.modules.mrope import MultimodalRotaryEmbedding
+
+    base = torch.arange(3 * 2 * 6, dtype=torch.float32).reshape(3, 2, 6)
+
+    interleaved = MultimodalRotaryEmbedding._apply_interleaved_mrope(
+        base,
+        mrope_section=[1, 1, 1],
+    )
+
+    expected = base[0].clone()
+    expected[..., 1] = base[1, ..., 1]
+    expected[..., 2] = base[2, ..., 2]
+    torch.testing.assert_close(interleaved, expected)
+
+
+def test_mtp_aux_loss_scaler_threads_independent_gradient():
+    pytest.importorskip("transformer_engine.pytorch")
+    from megatron.lite.primitive.modules.mtp import MTPLossAutoScaler
+
+    MTPLossAutoScaler.set_loss_scale(torch.tensor(0.125))
+    output = torch.tensor([1.0, 2.0, 3.0], requires_grad=True)
+    mtp_loss = torch.tensor(4.0, requires_grad=True)
+
+    MTPLossAutoScaler.apply(output * 3.0, mtp_loss).sum().backward()
+
+    torch.testing.assert_close(output.grad, torch.full_like(output, 3.0))
+    torch.testing.assert_close(mtp_loss.grad, torch.tensor(0.125))
+    MTPLossAutoScaler.main_loss_backward_scale = 1.0
+
+
+def test_gated_delta_static_helpers_are_finite_and_shape_stable():
+    pytest.importorskip("transformer_engine.pytorch")
+    from megatron.lite.primitive.modules.gated_delta_net import GatedDeltaNet
+
+    alpha = torch.tensor([[[0.0, 1.0], [-1.0, 2.0]]])
+    beta = torch.tensor([[[0.0, 2.0], [-2.0, 4.0]]])
+
+    g, beta_sigmoid = GatedDeltaNet._compute_g_and_beta(
+        torch.zeros(2),
+        torch.ones(2),
+        alpha,
+        beta,
+    )
+
+    assert g.shape == alpha.shape
+    assert beta_sigmoid.shape == beta.shape
+    assert torch.isfinite(g).all()
+    assert torch.isfinite(beta_sigmoid).all()
+    assert torch.all(g < 0)

--- a/experimental/lite/tests/unit/primitive/test_module_primitives_independent_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_module_primitives_independent_unit.py
@@ -113,8 +113,8 @@ def test_mrope_interleaves_text_height_and_width_sections():
     torch.testing.assert_close(interleaved, expected)
 
 
-def test_mtp_aux_loss_scaler_threads_independent_gradient():
-    pytest.importorskip("transformer_engine.pytorch")
+def test_mtp_aux_loss_scaler_threads_independent_gradient(transformer_engine_import_stub):
+    transformer_engine_import_stub()
     from megatron.lite.primitive.modules.mtp import MTPLossAutoScaler
 
     MTPLossAutoScaler.set_loss_scale(torch.tensor(0.125))
@@ -128,8 +128,8 @@ def test_mtp_aux_loss_scaler_threads_independent_gradient():
     MTPLossAutoScaler.main_loss_backward_scale = 1.0
 
 
-def test_gated_delta_static_helpers_are_finite_and_shape_stable():
-    pytest.importorskip("transformer_engine.pytorch")
+def test_gated_delta_static_helpers_are_finite_and_shape_stable(transformer_engine_import_stub):
+    transformer_engine_import_stub()
     from megatron.lite.primitive.modules.gated_delta_net import GatedDeltaNet
 
     alpha = torch.tensor([[[0.0, 1.0], [-1.0, 2.0]]])

--- a/experimental/lite/tests/unit/primitive/test_ops_data_trainstep_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_ops_data_trainstep_unit.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from megatron.lite.primitive.data import _resolve_thd_padding, fixed_batches
+from megatron.lite.primitive.deterministic import deterministic_requested
+from megatron.lite.primitive.ops.cross_entropy import vocab_parallel_cross_entropy
+from megatron.lite.primitive.ops.gated_delta_rule import l2norm, torch_chunk_gated_delta_rule
+from megatron.lite.primitive.ops.linear_cross_entropy import linear_cross_entropy
+from megatron.lite.primitive.ops.logprob import vocab_parallel_log_probs_from_logits
+from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec
+from megatron.lite.primitive.train_step import compute_and_clip_grad_norm, run_microbatch_loop
+from megatron.lite.primitive.utils import ensure_divisible
+
+
+pytestmark = pytest.mark.mlite
+
+
+def test_vocab_parallel_cross_entropy_matches_torch_cross_entropy():
+    logits = torch.randn(2, 3, 5, dtype=torch.float64, requires_grad=True)
+    labels = torch.tensor([[0, 4, 2], [3, 1, 0]])
+
+    loss = vocab_parallel_cross_entropy(logits, labels)
+    expected = F.cross_entropy(
+        logits.float().reshape(-1, 5),
+        labels.reshape(-1),
+        reduction="none",
+    ).view_as(labels)
+
+    torch.testing.assert_close(loss, expected)
+    loss.sum().backward()
+    assert logits.grad is not None
+    assert torch.isfinite(logits.grad).all()
+
+
+def test_logprob_selects_labels_in_batch_sequence_or_sequence_batch_layout():
+    logits = torch.randn(2, 3, 4)
+    labels_bsh = torch.tensor([[0, 1], [2, 3], [1, 0]])
+
+    selected = vocab_parallel_log_probs_from_logits(logits, labels_bsh)
+    expected = torch.log_softmax(logits.float(), dim=-1).gather(
+        -1,
+        labels_bsh.transpose(0, 1).unsqueeze(-1),
+    ).squeeze(-1).transpose(0, 1).contiguous()
+
+    torch.testing.assert_close(selected, expected)
+    with pytest.raises(ValueError, match="Could not align"):
+        vocab_parallel_log_probs_from_logits(logits, torch.zeros(4, 2, dtype=torch.long))
+
+
+def test_linear_cross_entropy_fallback_matches_explicit_matmul():
+    hidden = torch.tensor([[1.0, -2.0, 0.5], [0.25, 1.5, -0.5]])
+    weight = torch.tensor(
+        [
+            [0.5, -1.0, 0.25],
+            [1.0, 0.0, -0.5],
+            [-0.5, 0.75, 1.0],
+            [0.25, 0.5, -1.5],
+        ]
+    )
+    labels = torch.tensor([0, 3])
+
+    log_probs, entropy = linear_cross_entropy(
+        hidden,
+        weight,
+        labels,
+        temperature=2.0,
+    )
+    logits = hidden.matmul(weight.t()) / 2.0
+    expected_loss = F.cross_entropy(logits, labels, reduction="none")
+    expected_entropy = torch.distributions.Categorical(logits=logits).entropy()
+
+    torch.testing.assert_close(log_probs, -expected_loss)
+    torch.testing.assert_close(entropy, expected_entropy)
+
+
+def test_gated_delta_rule_math_helpers_return_finite_stateful_outputs():
+    x = torch.tensor([[3.0, 4.0], [0.0, 5.0]])
+    normalized = l2norm(x, dim=-1, eps=0.0)
+    torch.testing.assert_close(normalized.norm(dim=-1), torch.ones(2))
+
+    query = torch.randn(1, 3, 1, 2)
+    key = torch.randn(1, 3, 1, 2)
+    value = torch.randn(1, 3, 1, 2)
+    g = -torch.rand(1, 3, 1)
+    beta = torch.rand(1, 3, 1)
+
+    output, final_state = torch_chunk_gated_delta_rule(
+        query,
+        key,
+        value,
+        g,
+        beta,
+        chunk_size=2,
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=False,
+    )
+
+    assert output.shape == value.shape
+    assert final_state is not None
+    assert final_state.shape == (1, 1, 2, 2)
+    assert torch.isfinite(output).all()
+    assert torch.isfinite(final_state).all()
+
+
+def test_data_padding_env_and_fixed_batches_are_deterministic(monkeypatch):
+    monkeypatch.delenv("MEGATRON_LITE_THD_PAD_TO_ALIGNMENT", raising=False)
+    monkeypatch.delenv("MEGATRON_LITE_THD_PAD_MULTIPLE", raising=False)
+    assert _resolve_thd_padding(seq_len=7, cp_size=2) == (8, 4, True)
+    assert _resolve_thd_padding(seq_len=7, cp_size=1) == (7, 1, False)
+
+    monkeypatch.setenv("MEGATRON_LITE_THD_PAD_TO_ALIGNMENT", "0")
+    monkeypatch.setenv("MEGATRON_LITE_THD_PAD_MULTIPLE", "8")
+    assert _resolve_thd_padding(seq_len=7, cp_size=2) == (7, 8, False)
+    monkeypatch.setenv("MEGATRON_LITE_THD_PAD_MULTIPLE", "bad")
+    with pytest.raises(ValueError, match="PAD_MULTIPLE"):
+        _resolve_thd_padding(seq_len=7, cp_size=2)
+
+    batches_a = fixed_batches(11, seq_len=4, num_steps=2, batch_size=2, device="cpu", seed=123)
+    batches_b = fixed_batches(11, seq_len=4, num_steps=2, batch_size=2, device="cpu", seed=123)
+    for (ids_a, labels_a), (ids_b, labels_b) in zip(batches_a, batches_b, strict=True):
+        torch.testing.assert_close(ids_a, ids_b)
+        torch.testing.assert_close(labels_a, labels_b)
+
+
+def test_deterministic_env_request_parser(monkeypatch):
+    monkeypatch.setenv("MEGATRON_LITE_DETERMINISTIC", "yes")
+    assert deterministic_requested()
+    monkeypatch.setenv("MEGATRON_LITE_DETERMINISTIC", "0")
+    assert not deterministic_requested()
+
+
+def test_recompute_parser_and_wrapper_replays_forward_on_backward():
+    assert parse_recompute_spec(None) == []
+    assert parse_recompute_spec("none") == []
+    assert parse_recompute_spec("full") == ["full"]
+    assert parse_recompute_spec("attn,mlp") == ["attn", "mlp"]
+    assert parse_recompute_spec(["attn"]) == ["attn"]
+
+    class CountingModule(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.calls = 0
+
+        def forward(self, x):
+            self.calls += 1
+            return x * x
+
+    class Layer(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.inner = CountingModule()
+
+    layer = Layer()
+    apply_recompute(
+        nn.ModuleList([layer]),
+        ["inner"],
+        {"inner": lambda module: module.inner},
+        no_rng_modules={"inner"},
+    )
+
+    x = torch.tensor([2.0, -3.0], requires_grad=True)
+    layer.inner(x).sum().backward()
+
+    assert layer.inner.calls == 2
+    torch.testing.assert_close(x.grad, torch.tensor([4.0, -6.0]))
+
+
+def test_train_step_microbatch_loop_and_grad_clip_cpu_contract():
+    model = nn.Linear(2, 1, bias=False)
+    with torch.no_grad():
+        model.weight.fill_(0.5)
+    data = iter(
+        [
+            {"x": torch.tensor([[1.0, 2.0]]), "y": torch.tensor([[1.0]])},
+            {"x": torch.tensor([[3.0, 4.0]]), "y": torch.tensor([[2.0]])},
+        ]
+    )
+
+    def forward_fn(module, batch):
+        return {"loss": F.mse_loss(module(batch["x"]), batch["y"])}
+
+    output = run_microbatch_loop(model, data, 2, forward_fn)
+
+    assert output is not None
+    assert output["loss"].ndim == 0
+    assert model.weight.grad is not None
+    assert torch.isfinite(model.weight.grad).all()
+
+    grad_norm = compute_and_clip_grad_norm(
+        model,
+        optimizer=None,
+        max_norm=0.25,
+        use_dist_opt=False,
+    )
+
+    assert torch.isfinite(grad_norm)
+    assert model.weight.grad.norm() <= 0.25 + 1.0e-6
+
+
+def test_utils_ensure_divisible_returns_quotient_and_reports_context():
+    assert ensure_divisible(12, 3, "tp") == 4
+    with pytest.raises(ValueError, match=r"10 is not divisible by 4 \(tp\)"):
+        ensure_divisible(10, 4, "tp")

--- a/experimental/lite/tests/unit/primitive/test_parallel_dimensions_independent_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_parallel_dimensions_independent_unit.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
 from megatron.lite.primitive.parallel.cp import split_packed_for_cp
+from megatron.lite.primitive.parallel.pipeline import _num_microbatches_from_config
 from megatron.lite.primitive.parallel.pp import build_pipeline_chunk_layout
 from megatron.lite.primitive.parallel.sp import (
     gather_for_non_sp_head,
@@ -16,8 +19,8 @@ from megatron.lite.primitive.parallel.state import ParallelState
 pytestmark = pytest.mark.mlite
 
 
-def test_tp_vocab_embedding_and_output_single_rank_contract():
-    pytest.importorskip("transformer_engine.pytorch")
+def test_tp_vocab_embedding_and_output_single_rank_contract(transformer_engine_import_stub):
+    transformer_engine_import_stub()
     from megatron.lite.primitive.parallel.linear import (
         VocabParallelEmbedding,
         VocabParallelOutput,
@@ -100,8 +103,20 @@ def test_pp_layout_rejects_non_divisible_layer_counts():
         build_pipeline_chunk_layout(7, ps)
 
 
+def test_dp_dimension_controls_dense_microbatch_contract():
+    ps = ParallelState(dp_size=4, dp_rank=2, dp_cp_size=8, dp_cp_rank=5)
+    config = SimpleNamespace(gbs=32, mbs=2, num_microbatches=None)
+
+    assert _num_microbatches_from_config(config, ps) == 4
+
+    config.num_microbatches = 7
+    assert _num_microbatches_from_config(config, ps) == 7
+    assert ps.dp_rank == 2
+    assert ps.dp_cp_size == 8
+    assert ps.dp_cp_rank == 5
+
+
 def test_ep_token_dispatcher_local_roundtrip_is_independent_of_deepep():
-    pytest.importorskip("transformer_engine.pytorch")
     from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
 
     ps = ParallelState(ep_size=1, ep_rank=0)

--- a/experimental/lite/tests/unit/primitive/test_parallel_dimensions_independent_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_parallel_dimensions_independent_unit.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from megatron.lite.primitive.parallel.cp import split_packed_for_cp
+from megatron.lite.primitive.parallel.pp import build_pipeline_chunk_layout
+from megatron.lite.primitive.parallel.sp import (
+    gather_for_non_sp_head,
+    gather_from_sequence_parallel,
+    scatter_to_sequence_parallel,
+)
+from megatron.lite.primitive.parallel.state import ParallelState
+
+
+pytestmark = pytest.mark.mlite
+
+
+def test_tp_vocab_embedding_and_output_single_rank_contract():
+    pytest.importorskip("transformer_engine.pytorch")
+    from megatron.lite.primitive.parallel.linear import (
+        VocabParallelEmbedding,
+        VocabParallelOutput,
+        pad_vocab_for_tp,
+    )
+
+    ps = ParallelState(tp_size=1, tp_rank=0)
+
+    assert pad_vocab_for_tp(151936, 2) == 151936
+    assert pad_vocab_for_tp(129, 2) == 256
+
+    embedding = VocabParallelEmbedding(5, 3, ps, deterministic=True)
+    with torch.no_grad():
+        values = torch.arange(embedding.local_vocab * 3, dtype=torch.float32).view(
+            embedding.local_vocab,
+            3,
+        )
+        embedding.embedding.weight.copy_(values)
+
+    input_ids = torch.tensor([[0, 4, 1]])
+    output = embedding(input_ids)
+
+    assert output.shape == (3, 1, 3)
+    torch.testing.assert_close(output[:, 0], values[input_ids[0]])
+
+    head = VocabParallelOutput(5, 3, ps)
+    logits = head(torch.ones(2, 1, 3, dtype=torch.bfloat16))
+    gathered = head.gather(logits)
+
+    assert logits.shape == (2, 1, 128)
+    assert gathered.shape == (2, 1, 5)
+
+
+def test_sp_helpers_are_identity_for_single_rank_tp():
+    ps = ParallelState(tp_size=1, tp_rank=0)
+    x = torch.randn(4, 2, 3, requires_grad=True)
+
+    assert scatter_to_sequence_parallel(x, ps) is x
+    assert gather_from_sequence_parallel(x, ps) is x
+    assert gather_for_non_sp_head(x, ps) is x
+
+
+def test_cp_packed_split_handles_each_sample_independently():
+    input_ids = torch.arange(16)
+    position_ids = torch.arange(100, 116)
+    cu_seqlens = torch.tensor([0, 8, 16], dtype=torch.int32)
+
+    rank0 = split_packed_for_cp(
+        input_ids,
+        position_ids,
+        cu_seqlens,
+        max_seqlen=8,
+        cp_rank=0,
+        cp_size=2,
+    )
+    rank1 = split_packed_for_cp(
+        input_ids,
+        position_ids,
+        cu_seqlens,
+        max_seqlen=8,
+        cp_rank=1,
+        cp_size=2,
+    )
+
+    torch.testing.assert_close(rank0[0], torch.tensor([0, 1, 6, 7, 8, 9, 14, 15]))
+    torch.testing.assert_close(rank0[1], torch.tensor([100, 101, 106, 107, 108, 109, 114, 115]))
+    torch.testing.assert_close(rank0[2], torch.tensor([0, 4, 8], dtype=torch.int32))
+    assert rank0[3] == 4
+
+    torch.testing.assert_close(rank1[0], torch.tensor([2, 3, 4, 5, 10, 11, 12, 13]))
+    torch.testing.assert_close(rank1[1], torch.tensor([102, 103, 104, 105, 110, 111, 112, 113]))
+    torch.testing.assert_close(rank1[2], torch.tensor([0, 4, 8], dtype=torch.int32))
+    assert rank1[3] == 4
+
+
+def test_pp_layout_rejects_non_divisible_layer_counts():
+    ps = ParallelState(pp_size=2, pp_rank=0, pp_is_first=True, pp_is_last=False)
+
+    with pytest.raises(ValueError, match="not divisible"):
+        build_pipeline_chunk_layout(7, ps)
+
+
+def test_ep_token_dispatcher_local_roundtrip_is_independent_of_deepep():
+    pytest.importorskip("transformer_engine.pytorch")
+    from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
+
+    ps = ParallelState(ep_size=1, ep_rank=0)
+    dispatcher = TokenDispatcher(num_experts=3, hidden_size=2, ps=ps, use_deepep=False)
+    hidden = torch.tensor(
+        [[1.0, 10.0], [2.0, 20.0], [3.0, 30.0], [4.0, 40.0]],
+        requires_grad=True,
+    )
+    topk_indices = torch.tensor([[0], [2], [1], [2]])
+    topk_scores = torch.ones(4, 1)
+
+    dispatched, tokens_per_expert, dispatched_probs = dispatcher.dispatch(
+        hidden,
+        topk_scores,
+        topk_indices,
+    )
+    combined = dispatcher.combine(dispatched)
+
+    torch.testing.assert_close(tokens_per_expert, torch.tensor([1, 1, 2]))
+    torch.testing.assert_close(dispatched_probs, torch.ones(4))
+    torch.testing.assert_close(combined, hidden)
+
+    combined.sum().backward()
+    torch.testing.assert_close(hidden.grad, torch.ones_like(hidden))


### PR DESCRIPTION
## Summary
- Add independent unit coverage for MLite parallel dimensions (TP/SP/CP/PP/EP), module primitives (LoRA, MRoPE, MTP, Gated Delta helpers), and ops/data/train-step contracts.
- Lazy-load MLite module package exports so independent modules such as LoRA do not require importing every TE-backed module during collection.
- Fix the linear_cross_entropy fallback entropy path by preserving logits before vocab-parallel CE mutates them.
- Drop stale checkpoint xfail sentinels now that checkpoint restore continuity is fixed on devlite.

## Validation
- Slurm job 12640538: targeted new primitive tests, 21 passed, 17 warnings, rc=0.
- Slurm job 12640568: PYTHONPATH=repo:experimental/lite pytest -q experimental/lite/tests/unit, 93 passed, 17 warnings, rc=0.

### Note on `linear_cross_entropy` logits clone
`vocab_parallel_cross_entropy` (copied from Megatron-core) mutates its input logits in place: for fp32 logits, `.float()` returns the same tensor and the subsequent `-=`, `torch.exp(out=...)` and `div_` turn it into the softmax. Because `linear_cross_entropy` reuses the same logits to compute entropy right after, it passes `logits.clone()` to the cross-entropy call so the original logits stay intact for the entropy computation. This mirrors verl's Megatron actor, which clones via `logits_bak = logits.clone()` and feeds the clone to the (mutating) cross-entropy while computing entropy from the original.
