### PR TITLE
Refresh MLite documentation positioning

### DIFF
--- a/experimental/lite/README.md
+++ b/experimental/lite/README.md
@@ -1,8 +1,13 @@
 # Megatron Lite
 
-Megatron Lite is an experimental training runtime and model implementation layer
-for Megatron. The source lives under `experimental/lite/megatron/lite`, and the
-public import path is `megatron.lite`.
+Megatron Lite is an experimental, agentic-native training runtime and native
+model implementation layer for Megatron. It is designed for work that needs to
+move quickly without giving up Megatron-Core performance: small composable
+primitives, explicit model/runtime protocols, and validation recipes that make
+changes easy to review and easy to reproduce.
+
+The source lives under `experimental/lite/megatron/lite`, and the public import
+path is `megatron.lite`.
 
 Do not import `experimental.lite` from user code. Examples and public APIs should
 refer to `megatron.lite`.
@@ -13,7 +18,7 @@ This initial drop contains:
 
 - A lightweight runtime API in `megatron.lite.runtime`.
 - Common training primitives in `megatron.lite.primitive`.
-- Lite-only model implementations for Qwen3 MoE and Qwen3.5 MoE.
+- Lite-only native model implementations for Qwen3 MoE and Qwen3.5 MoE.
 - Hugging Face safetensors load/export helpers for the included models.
 - Megatron-Core optimizer wrapping for the lite runtime.
 - FSDP2 optimizer primitives for supported lite model protocols.
@@ -25,6 +30,27 @@ This initial drop contains:
 This initial drop intentionally does not include:
 
 - Hybrid model implementations.
+- Dense Qwen3 model support. The included Qwen3-family path is Qwen3 MoE only.
+
+## Why MLite
+
+- **Agentic-native development surface.** Runtime, model, and primitive code are
+  split into reviewable contracts so agents and humans can make targeted changes
+  without touching unrelated Megatron subsystems.
+- **Native MLite models, not wrapper models.** `backend="mlite"` builds native
+  `megatron.lite` model code; reference backends are used only for comparison.
+- **Megatron-Core distopt parity.** In deterministic correctness runs against the
+  `mbridge` reference backend on the Megatron-Core distributed optimizer path,
+  MLite matched loss and grad-norm exactly (`max_abs=0.0`) with no mismatches;
+  post-step weights and eval logits were checked by SHA256 fingerprints.
+- **Speed-aligned with the Core path.** On an 8x H100 Qwen3.5 MoE benchmark using
+  `distopt`, MLite measured 309.433 ms/step and 105,896.935 tokens/s, compared
+  with 332.201 ms/step and 98,639.089 tokens/s for `mbridge`, and 334.936
+  ms/step and 97,833.496 tokens/s for the real `bridge` path.
+
+The `mbridge` benchmark line is the validated Megatron-Core/distopt reference
+used for this PR. The `bridge` line is a separate Megatron-Bridge environment
+check and should not be confused with the Core/distopt parity claim.
 
 ## Layout
 
@@ -55,7 +81,7 @@ from megatron.lite.runtime import MegatronLiteConfig, RuntimeConfig, create_runt
 cfg = RuntimeConfig(
     backend="mlite",
     hf_path="/path/to/hf-model",
-    backend_cfg=MegatronLiteConfig(model_name="qwen3", impl="lite"),
+    backend_cfg=MegatronLiteConfig(model_name="qwen3_moe", impl="lite"),
 )
 runtime = create_runtime(cfg)
 handle = runtime.build_model()
@@ -68,12 +94,35 @@ validated benchmark example. `backend="bridge"` selects the Megatron-Bridge
 runtime backend and requires an environment where `import megatron.bridge` works
 when the model is built.
 
-Model names currently registered by default:
+Canonical model names currently registered by default:
 
-- `qwen3`: Qwen3 MoE lite implementation. HF `model_type` values
-  `qwen3_moe` and `qwen2_moe` resolve to this model name.
-- `qwen3_moe`: compatibility alias for the same Qwen3 MoE lite implementation.
+- `qwen3_moe`: Qwen3 MoE lite implementation. Use this name in new configs.
 - `qwen3_5`: Qwen3.5 MoE lite implementation.
+
+Compatibility names:
+
+- `qwen3`: legacy alias for the Qwen3 MoE implementation only. It does not mean
+  dense Qwen3 support. HF `model_type` values `qwen3_moe` and `qwen2_moe`
+  currently resolve through this compatibility path.
+
+## Benchmark And Correctness Signoff
+
+The validated benchmark and correctness commands live in
+[`examples/bench/README.md`](examples/bench/README.md). The signoff setup uses
+Qwen3.5 MoE, `optimizer_backend=distopt`, deterministic mode for strict
+correctness, and identical synthetic input streams for paired performance runs.
+
+Reproduce the strict MLite vs Megatron-Core/distopt comparison with:
+
+```bash
+export MEGATRON_LITE_DETERMINISTIC=1
+export CUBLAS_WORKSPACE_CONFIG=:4096:8
+
+HF_PATH=/models/Qwen3.5-35B-A3B \
+REFERENCE_BACKEND=mbridge \
+DRY_RUN=0 \
+bash experimental/lite/examples/bench/scripts/run_qwen35_correctness_pair.sh
+```
 
 ## Docs
 

--- a/experimental/lite/docs/architecture.md
+++ b/experimental/lite/docs/architecture.md
@@ -40,6 +40,7 @@ The model protocol owns:
 ## Current Deliberate Omissions
 
 This package currently includes only the lite model implementation path. It
-intentionally excludes non-lite model/runtime implementations and benchmark
-entrypoints. FSDP2 is included as an optimizer primitive and can be selected by
-model protocols that support it.
+intentionally excludes non-lite and hybrid model implementation packages. The
+optional benchmark entrypoints under `examples/bench` are comparison tools and
+are not imported by the package runtime. FSDP2 is included as an optimizer
+primitive and can be selected by model protocols that support it.

--- a/experimental/lite/docs/models.md
+++ b/experimental/lite/docs/models.md
@@ -17,15 +17,15 @@ Optional protocol symbols:
 
 ## Included Models
 
-`qwen3` maps to the Qwen3 MoE lite implementation:
+`qwen3_moe` is the canonical name for the Qwen3 MoE lite implementation:
 
 ```text
 megatron.lite.model.qwen3_moe.lite.protocol
 ```
 
-`qwen3_moe` is kept as a compatibility alias for the same implementation.
-Hugging Face `model_type` values `qwen3_moe` and `qwen2_moe` resolve to
-`qwen3`.
+`qwen3` is kept as a legacy compatibility alias for the same implementation. It
+does not mean dense Qwen3 support. Hugging Face `model_type` values `qwen3_moe`
+and `qwen2_moe` currently resolve through this compatibility path.
 
 `qwen3_5` maps to the Qwen3.5 MoE lite implementation:
 

--- a/experimental/lite/docs/porting.md
+++ b/experimental/lite/docs/porting.md
@@ -17,15 +17,18 @@ lives under `experimental/lite/megatron/lite`, so users can add
 Keep the PR focused on the lite model implementation path:
 
 - Runtime backend: `mlite`.
-- Models: Qwen3 MoE and Qwen3.5 MoE.
+- Reference comparison backends: `mbridge` for the validated legacy
+  Megatron-Core/distopt path and `bridge` for real Megatron-Bridge environments.
+- Models: Qwen3 MoE and Qwen3.5 MoE. Dense Qwen3 is not included.
 - Model implementations: `lite` only.
 - Optimizer primitives: Megatron-Core optimizer wrapping and FSDP2.
+- Optional examples: benchmark and VERL launchers under `experimental/lite/examples`.
 
 Keep these out of the first PR unless the scope changes:
 
 - Hybrid model implementation packages.
-- Bridge model/runtime implementation packages.
-- Benchmark scripts and experiment-specific entrypoints.
+- Megatron-Bridge model implementation packages.
+- Undocumented experiment-specific entrypoints.
 
 ## Package Integration
 

--- a/experimental/lite/docs/runtime.md
+++ b/experimental/lite/docs/runtime.md
@@ -9,7 +9,7 @@ cfg = RuntimeConfig(
     backend="mlite",
     hf_path="/path/to/hf-model",
     backend_cfg=MegatronLiteConfig(
-        model_name="qwen3",
+        model_name="qwen3_moe",
         impl="lite",
         parallel=ParallelConfig(tp=1, pp=1, cp=1, ep=1),
     ),
@@ -49,7 +49,8 @@ examples can execute without Megatron-Bridge installed.
 
 `MegatronLiteConfig` carries `mlite` backend settings:
 
-- `model_name`: `qwen3`, `qwen3_moe`, or `qwen3_5`.
+- `model_name`: `qwen3_moe` or `qwen3_5` for new configs. `qwen3` remains
+  accepted as a legacy alias for `qwen3_moe` only; dense Qwen3 is not included.
 - `impl`: currently only `lite`.
 - `parallel`: tensor, expert, pipeline, virtual pipeline, and context sizes.
 - `optimizer`: Megatron-Core optimizer settings.

--- a/experimental/lite/examples/bench/README.md
+++ b/experimental/lite/examples/bench/README.md
@@ -9,10 +9,19 @@ Megatron-Bridge package and requires an environment where `import
 megatron.bridge` works. Dry-run mode does not import either reference package and
 is safe for config validation.
 
-The `backend=mlite` path remains native MLite. For deterministic Qwen3.5 runs it
-mounts the Qwen3.5 vision module from the local Hugging Face model code through
-`transformers`; it does not import `mbridge` or Megatron-Bridge to build the
-MLite model.
+The `backend=mlite` path remains native MLite. For deterministic Qwen3.5 MoE
+runs it mounts the Qwen3.5 vision module from the local Hugging Face model code
+through `transformers`; it does not import `mbridge` or Megatron-Bridge to build
+the MLite model.
+
+This benchmark separates two validation lines:
+
+- `mbridge`: the validated reference for MLite vs Megatron-Core distributed
+  optimizer (`distopt`) parity.
+- `bridge`: a real Megatron-Bridge environment check when `import
+  megatron.bridge` works.
+
+Use the `mbridge` line for Core/distopt precision and speed claims.
 
 ## Dry-Run
 
@@ -93,10 +102,10 @@ strict optimizer-metric evidence is the deterministic run below.
 ## Deterministic mbridge Correctness
 
 Slurm job `12630675` completed a strict deterministic MLite vs `mbridge` run
-with 1x GPU, `seed=42`, Qwen3.5, `seq_len=8`, `truncate_layers=1`,
-`keep_experts=2`, and `steps=2`.
+with 1x GPU, `seed=42`, Qwen3.5 MoE, `seq_len=8`, `truncate_layers=1`,
+`keep_experts=2`, `optimizer_backend=distopt`, and `steps=2`.
 
-The comparison passed with no mismatches:
+The comparison passed with bitwise scalar parity and no mismatches:
 
 - `samples=2`
 - `max_loss_abs=0.0`
@@ -181,4 +190,16 @@ python experimental/lite/examples/bench/correctness.py compare \
   /tmp/qwen35_mlite_correctness.json \
   /tmp/qwen35_mbridge_correctness.json \
   --fail-on-mismatch
+```
+
+For the PR signoff pair script:
+
+```bash
+export MEGATRON_LITE_DETERMINISTIC=1
+export CUBLAS_WORKSPACE_CONFIG=:4096:8
+
+HF_PATH=/models/Qwen3.5-35B-A3B \
+REFERENCE_BACKEND=mbridge \
+DRY_RUN=0 \
+bash experimental/lite/examples/bench/scripts/run_qwen35_correctness_pair.sh
 ```

--- a/experimental/lite/skills/model-compose/qwen.md
+++ b/experimental/lite/skills/model-compose/qwen.md
@@ -1,13 +1,13 @@
 # Qwen Compose Skill
 
-Compose Qwen3 and Qwen3.5 Megatron Lite models.
+Compose Qwen3 MoE and Qwen3.5 Megatron Lite models.
 
 ## Schema
 
 <!-- MLITE_SKILL_SCHEMA_BEGIN -->
 ```python
 schema = Skill(
-    "model_compose.qwen", kind="state_machine", purpose="compose Qwen3/Qwen3.5 MLite models",
+    "model_compose.qwen", kind="state_machine", purpose="compose Qwen3 MoE/Qwen3.5 MLite models",
     imports=["basic.constitution"], calls=["model_compose.config_mapping", "model_compose.weight_mapping", "model_compose.build_model"],
     inputs=["task", "hf_model", "lite_model", "budget"],
     outputs=["model", "mapping", "evidence", "risks"], exits=["done", "blocked", "out_of_scope"],
@@ -17,8 +17,8 @@ schema = Skill(
 
 ```python
 def qwen(task, hf_model, lite_model, budget):
-    if hf_model.family not in ["qwen3", "qwen3_5"]:
-        return out_of_scope("not a Qwen3/Qwen3.5 model")
+    if hf_model.family not in ["qwen3_moe", "qwen3_5"]:
+        return out_of_scope("not a Qwen3 MoE/Qwen3.5 model")
 
     config = model_compose.config_mapping(task, hf_model.config, lite_model.config, budget.config)
     if not config.done:

--- a/experimental/lite/tests/README.md
+++ b/experimental/lite/tests/README.md
@@ -31,7 +31,7 @@ Current matrix:
 | GQA/attention split contract | `unit/primitive/test_attention_moe_unit.py` | Qwen model smoke exercises attention forward/backward |
 | MoE router/aux-loss contract | `unit/primitive/test_attention_moe_unit.py` | Qwen model smoke exercises router, dispatcher, and experts |
 | LoRA adapter primitives | `unit/primitive/test_module_primitives_independent_unit.py` | Qwen model smoke can enable adapters in follow-up coverage |
-| MTP/MRoPE/Gated Delta helper contracts | `unit/primitive/test_module_primitives_independent_unit.py`, `unit/primitive/test_ops_data_trainstep_unit.py` | Qwen3.5 model smoke exercises MRoPE/Gated DeltaNet paths |
+| MTP/MRoPE/Gated Delta helper contracts | `unit/primitive/test_module_primitives_independent_unit.py`, `unit/primitive/test_ops_data_trainstep_unit.py` | Qwen3.5 MoE model smoke exercises MRoPE/Gated DeltaNet paths |
 | Loss/logprob/math ops | `unit/primitive/test_ops_data_trainstep_unit.py` | Qwen model smoke exercises loss plumbing |
 | Data/recompute/train-step primitives | `unit/primitive/test_ops_data_trainstep_unit.py` | model/runtime smoke exercises training loop integration |
 | DDP + distributed optimizer | `unit/primitive/test_checkpoint_unit.py`, `unit/primitive/test_checkpoint_runtime.py` | `smoke/primitive/test_distopt_checkpoint_smoke.py` |
@@ -41,7 +41,7 @@ Current matrix:
 | Runtime backend registry/config | `unit/primitive/test_runtime_config_unit.py`, `unit/runtime/test_runtime_backend_unit.py` | covered through checkpoint/model handles |
 | Runtime env/offload controls | `unit/runtime/test_runtime_backend_unit.py` | `smoke/primitive/test_fsdp2_offload_checkpoint_smoke.py` |
 | Optimizer update-state offload fraction | `unit/primitive/test_runtime_config_unit.py` and single-process CUDA coverage in `unit/primitive/test_fsdp2_offload_gpu.py` | multi-rank FSDP2 grad clipping is xfail until the follow-up bugfix PR |
-| Qwen3 lite config/build/forward | `unit/model/test_qwen_config_unit.py` | `smoke/model/test_qwen_lite_forward_smoke.py` |
-| Qwen3.5 lite config/build/forward | `unit/model/test_qwen_config_unit.py` | `smoke/model/test_qwen_lite_forward_smoke.py` |
+| Qwen3 MoE lite config/build/forward | `unit/model/test_qwen_config_unit.py` | `smoke/model/test_qwen_lite_forward_smoke.py` |
+| Qwen3.5 MoE lite config/build/forward | `unit/model/test_qwen_config_unit.py` | `smoke/model/test_qwen_lite_forward_smoke.py` |
 
 Classic FSDP is not a separate MLite primitive in the current source tree; MLite's native sharded optimizer coverage is FSDP2 plus Megatron DDP/distopt.


### PR DESCRIPTION
Summary:
- Add agentic-native MLite positioning and make the native model/runtime contract explicit.
- Correct model support wording: Qwen3 MoE and Qwen3.5 MoE are supported; `qwen3` is documented only as a legacy alias for Qwen3 MoE, not dense Qwen3 support.
- Surface the distopt benchmark and deterministic correctness evidence in the README, and separate the `mbridge` Megatron-Core reference from the real `bridge` path.
- Align runtime, model, porting, test, and compose-skill docs with the corrected model naming.

Validation:
- `git diff --check HEAD~1 HEAD`
- `PYTHONPATH="$(pwd)/experimental/lite:$(pwd)" python - <<'PY' ...` registry check confirmed `qwen3_moe`, `qwen3_5`, and legacy `qwen3` alias registrations.

No training or GPU tests were run; this is a documentation-only change.