### PR TITLE
Harden MLite distopt MoE checkpoint continuity

### DIFF
--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
@@ -390,6 +390,9 @@ class Qwen3MoEModel(nn.Module):
         self.layer_indices = layout.layer_indices
         has_embed = layout.has_embed
         has_head = layout.has_head
+        self.pre_process = has_embed
+        self.post_process = has_head
+        self.share_embeddings_and_output_weights = False
 
         self.embed: VocabParallelEmbedding | None = None
         if has_embed:

--- a/experimental/lite/megatron/lite/primitive/ckpt/distckpt.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/distckpt.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import Callable, Iterable, MutableMapping
+from dataclasses import replace
 from types import MethodType
 from typing import Any
 
@@ -43,6 +44,7 @@ def attach_model_sharded_state_dict(
             chunk,
         )
         chunk._mlite_distopt_sharded_state_dict = True  # type: ignore[attr-defined]
+        chunk._mlite_distopt_parallel_state = ps  # type: ignore[attr-defined]
 
 
 def supports_distopt_distckpt(model: nn.Module | Iterable[nn.Module], optimizer: Any) -> bool:
@@ -143,14 +145,8 @@ def _synchronize_native_optimizer_steps(optimizer: Any) -> None:
             return
         seen.add(obj_id)
 
-        chained = getattr(obj, "chained_optimizers", None)
-        if isinstance(chained, Iterable):
-            for child in chained:
-                visit(child)
-
-        inner = getattr(obj, "optimizer", None)
-        if inner is not None and inner is not obj:
-            visit(inner)
+        for child in _iter_optimizer_children(obj):
+            visit(child)
 
         state = getattr(obj, "state", None)
         if isinstance(state, MutableMapping):
@@ -248,29 +244,42 @@ def _iter_distributed_optimizers(optimizer: Any) -> Iterable[Any]:
             return
         seen.add(obj_id)
 
+        inner = _safe_inner_optimizer(obj)
         if (
             callable(getattr(obj, "sharded_state_dict", None))
             and hasattr(obj, "gbuf_ranges")
             and hasattr(obj, "buffers")
-            and hasattr(obj, "optimizer")
+            and inner is not None
         ):
             yield obj
 
-        chained = getattr(obj, "chained_optimizers", None)
-        if isinstance(chained, Iterable):
-            for child in chained:
-                yield from visit(child)
-
-        sub_optimizers = getattr(obj, "sub_optimizers", None)
-        if isinstance(sub_optimizers, Iterable):
-            for child in sub_optimizers:
-                yield from visit(child)
-
-        inner = getattr(obj, "optimizer", None)
-        if inner is not None and inner is not obj:
-            yield from visit(inner)
+        for child in _iter_optimizer_children(obj, known_inner=inner):
+            yield from visit(child)
 
     yield from visit(optimizer)
+
+
+def _iter_optimizer_children(obj: Any, *, known_inner: Any | None = None) -> Iterable[Any]:
+    chained = getattr(obj, "chained_optimizers", None)
+    if isinstance(chained, Iterable):
+        yield from chained
+
+    sub_optimizers = getattr(obj, "sub_optimizers", None)
+    if isinstance(sub_optimizers, Iterable):
+        yield from sub_optimizers
+
+    inner = _safe_inner_optimizer(obj) if known_inner is None else known_inner
+    if inner is not None and inner is not obj:
+        yield inner
+
+
+def _safe_inner_optimizer(obj: Any) -> Any | None:
+    if isinstance(getattr(obj, "chained_optimizers", None), Iterable):
+        # Megatron-Core ChainedOptimizer exposes `.optimizer` only for the
+        # single-optimizer compatibility case; multi-optimizer PP/EP chains
+        # assert on access. The children above are the real traversal targets.
+        return None
+    return getattr(obj, "optimizer", None)
 
 
 def _empty_native_optimizer_state_dict(distopt: Any, fallback_step: int) -> dict[str, Any]:
@@ -394,7 +403,7 @@ def _rank_offsets_and_replica_id(
     ps: ParallelState,
     *,
     expert: bool,
-) -> tuple[tuple[tuple[int, int, int], ...], tuple[int, int, int]]:
+) -> tuple[tuple[tuple[int, int, int], ...], tuple[int, ...]]:
     ranks, sizes = _mesh_ranks_and_sizes(ps, expert=expert)
     axis_fragments: dict[int, tuple[int, int]] = {}
     for placement, rank, size in zip(placements, ranks, sizes, strict=True):
@@ -409,9 +418,11 @@ def _rank_offsets_and_replica_id(
 
 
 def _replica_id(placements: list, ps: ParallelState, *, expert: bool) -> tuple[int, int, int]:
+    # PP stages own different parameters. They are not replicas of one
+    # another, so PP rank must not make a shard non-main.
     if expert:
         return (
-            _replica_axis_rank(placements, 0, ps.pp_rank),
+            0,
             _replica_axis_rank(placements, 2, ps.ep_rank),
             _replica_axis_rank(placements, 1, ps.expert_dp_rank),
         )
@@ -421,7 +432,7 @@ def _replica_id(placements: list, ps: ParallelState, *, expert: bool) -> tuple[i
         else ps.dp_cp_rank
     )
     return (
-        _replica_axis_rank(placements, 0, ps.pp_rank),
+        0,
         _replica_axis_rank(placements, 3, ps.tp_rank),
         int(dp_cp_rank),
     )
@@ -460,11 +471,46 @@ def _shard_dim(placement: Any) -> int | None:
 
 def _model_sharded_state_dict(model: nn.Module | Iterable[nn.Module]) -> dict[str, Any]:
     chunks = _model_chunks(model)
-    if len(chunks) == 1:
-        return {"model": chunks[0].sharded_state_dict()}  # type: ignore[attr-defined]
+    ps = _chunk_parallel_state(chunks[0]) if chunks else None
     return {
-        f"model{idx}": chunk.sharded_state_dict()  # type: ignore[attr-defined]
+        _model_chunk_key(ps, idx, len(chunks)): _chunk_sharded_state_dict(
+            chunk,
+            _model_chunk_sharded_key_prefix(ps, idx, len(chunks)),
+        )
         for idx, chunk in enumerate(chunks)
+    }
+
+
+def _model_chunk_key(ps: ParallelState | None, idx: int, num_chunks: int) -> str:
+    if ps is not None and ps.pp_size > 1:
+        key = f"model_pp{ps.pp_rank}"
+        if num_chunks > 1:
+            key = f"{key}_vpp{idx}"
+        return key
+    if num_chunks == 1:
+        return "model"
+    return f"model{idx}"
+
+
+def _model_chunk_sharded_key_prefix(ps: ParallelState | None, idx: int, num_chunks: int) -> str:
+    if ps is None and num_chunks == 1:
+        return ""
+    if ps is not None and ps.pp_size <= 1 and num_chunks == 1:
+        return ""
+    return f"{_model_chunk_key(ps, idx, num_chunks)}."
+
+
+def _chunk_sharded_state_dict(chunk: nn.Module, sharded_key_prefix: str) -> dict[str, Any]:
+    chunk_sd = chunk.sharded_state_dict()  # type: ignore[attr-defined]
+    if not sharded_key_prefix:
+        return chunk_sd
+    return {
+        key: (
+            replace(value, key=f"{sharded_key_prefix}{value.key}")
+            if isinstance(value, ShardedTensor)
+            else value
+        )
+        for key, value in chunk_sd.items()
     }
 
 
@@ -479,10 +525,24 @@ def _load_model_state_dict(model: nn.Module | Iterable[nn.Module], state_dict: d
     if len(chunks) == 1 and "model" in state_dict:
         _wrapped_module(chunks[0]).load_state_dict(state_dict["model"], strict=False)
         return
+    ps = _chunk_parallel_state(chunks[0]) if chunks else None
+    if len(chunks) == 1 and ps is not None and ps.pp_size > 1:
+        key = _model_chunk_key(ps, 0, 1)
+        if key in state_dict:
+            _wrapped_module(chunks[0]).load_state_dict(state_dict[key], strict=False)
+        return
     for idx, chunk in enumerate(chunks):
-        key = f"model{idx}"
+        key = _model_chunk_key(ps, idx, len(chunks))
         if key in state_dict:
             _wrapped_module(chunk).load_state_dict(state_dict[key], strict=False)
+
+
+def _chunk_parallel_state(chunk: nn.Module) -> ParallelState | None:
+    ps = getattr(chunk, "_mlite_distopt_parallel_state", None)
+    if ps is not None:
+        return ps
+    wrapped = _wrapped_module(chunk)
+    return getattr(wrapped, "_mlite_distopt_parallel_state", None)
 
 
 def _model_chunks(model: nn.Module | Iterable[nn.Module]) -> list[nn.Module]:

--- a/experimental/lite/tests/unit/primitive/test_training_checkpoint.py
+++ b/experimental/lite/tests/unit/primitive/test_training_checkpoint.py
@@ -6,9 +6,15 @@ from types import SimpleNamespace
 import torch
 from torch.distributed.tensor import Replicate, Shard
 
+from megatron.core.dist_checkpointing.strategies.torch import (
+    _replace_state_dict_keys_with_sharded_keys,
+)
 from megatron.lite.primitive.ckpt import dcp
 from megatron.lite.primitive.ckpt.distckpt import (
+    _model_sharded_state_dict,
     _rank_offsets_and_replica_id,
+    _single_or_all_model_state,
+    _synchronize_native_optimizer_steps,
     attach_model_sharded_state_dict,
 )
 from megatron.lite.primitive.parallel import ParallelState
@@ -114,7 +120,7 @@ def test_distopt_checkpoint_dispatches_to_mcore_distckpt(monkeypatch, tmp_path) 
 
     model_sd = saved["state_dict"]["model"]
     assert set(model_sd) == {"weight", "bias"}
-    assert model_sd["weight"].replica_id == (1, 2, 3)
+    assert model_sd["weight"].replica_id == (0, 2, 3)
     assert optimizer.save_model_sd is model_sd
     assert saved["state_dict"]["optimizer"] == {"is_loading": False}
     assert saved["state_dict"]["step"] == 5
@@ -155,9 +161,94 @@ def test_distopt_checkpoint_offsets_cover_tp_pp_ep_etp_topology() -> None:
     )
 
     assert dense_offsets == ((0, 1, 2),)
-    assert dense_replica == (1, 0, 0)
+    assert dense_replica == (0, 0, 0)
     assert expert_offsets == ((0, 3, 4),)
-    assert expert_replica == (1, 0, 0)
+    assert expert_replica == (0, 0, 0)
+
+
+def test_distopt_replica_id_groups_sharded_axes_by_placement() -> None:
+    placements = [Replicate(), Replicate(), Replicate(), Shard(0)]
+    rank_offsets0, replica_id0 = _rank_offsets_and_replica_id(
+        placements,
+        ParallelState(tp_size=2, tp_rank=0),
+        expert=False,
+    )
+    rank_offsets1, replica_id1 = _rank_offsets_and_replica_id(
+        placements,
+        ParallelState(tp_size=2, tp_rank=1),
+        expert=False,
+    )
+
+    assert rank_offsets0 == ((0, 0, 2),)
+    assert rank_offsets1 == ((0, 1, 2),)
+    assert replica_id0 == replica_id1 == (0, 0, 0)
+
+    expert_offsets, expert_replica_id = _rank_offsets_and_replica_id(
+        [Replicate(), Replicate(), Shard(0), Shard(1)],
+        ParallelState(ep_size=2, ep_rank=1, etp_size=2, etp_rank=1),
+        expert=True,
+    )
+
+    assert expert_offsets == ((0, 1, 2), (1, 1, 2))
+    assert expert_replica_id == (0, 0, 0)
+
+
+def test_distopt_replica_id_does_not_treat_pp_as_a_replica_axis() -> None:
+    rank_offsets, replica_id = _rank_offsets_and_replica_id(
+        [Replicate(), Replicate(), Replicate(), Shard(0)],
+        ParallelState(pp_size=2, pp_rank=1, tp_size=2, tp_rank=1),
+        expert=False,
+    )
+
+    assert rank_offsets == ((0, 1, 2),)
+    assert replica_id == (0, 0, 0)
+
+    _rank_offsets, replica_id = _rank_offsets_and_replica_id(
+        [Replicate(), Replicate(), Replicate(), Replicate()],
+        ParallelState(pp_size=2, pp_rank=1, tp_size=2, tp_rank=0),
+        expert=False,
+    )
+
+    assert replica_id == (0, 0, 0)
+
+
+def test_distopt_pp_rank_one_model_keys_survive_torch_dist_main_replica_filter() -> None:
+    ps = ParallelState(pp_size=2, pp_rank=1, pp_is_first=False, pp_is_last=True)
+    model = torch.nn.Linear(4, 2)
+    attach_model_sharded_state_dict([model], ps)
+
+    model_sd = _model_sharded_state_dict(model)
+    filtered_sd, _flat_mapping, _rename_mapping = _replace_state_dict_keys_with_sharded_keys(
+        model_sd,
+        keep_only_main_replica=True,
+    )
+
+    assert set(filtered_sd) == {"model_pp1.weight", "model_pp1.bias"}
+
+
+def test_distopt_model_state_keys_are_pp_and_vpp_aware() -> None:
+    ps = ParallelState(pp_size=2, pp_rank=1, pp_is_first=False, pp_is_last=True)
+    single_chunk = torch.nn.Linear(4, 2)
+    attach_model_sharded_state_dict([single_chunk], ps)
+
+    single_sd = _model_sharded_state_dict(single_chunk)
+
+    assert set(single_sd) == {"model_pp1"}
+    assert set(single_sd["model_pp1"]) == {"weight", "bias"}
+    assert single_sd["model_pp1"]["weight"].key == "model_pp1.weight"
+    assert _single_or_all_model_state(single_sd) is single_sd
+
+    chunks = [torch.nn.Linear(4, 2), torch.nn.Linear(4, 2)]
+    attach_model_sharded_state_dict(chunks, ps)
+
+    vpp_sd = _model_sharded_state_dict(chunks)
+
+    assert set(vpp_sd) == {"model_pp1_vpp0", "model_pp1_vpp1"}
+    assert set(vpp_sd["model_pp1_vpp0"]) == {"weight", "bias"}
+    assert set(vpp_sd["model_pp1_vpp1"]) == {"weight", "bias"}
+    assert vpp_sd["model_pp1_vpp0"]["weight"].key == "model_pp1_vpp0.weight"
+    assert vpp_sd["model_pp1_vpp1"]["weight"].key == "model_pp1_vpp1.weight"
+    assert _single_or_all_model_state(vpp_sd) is vpp_sd
 
 
 def test_distopt_checkpoint_loads_from_mcore_distckpt(monkeypatch, tmp_path) -> None:
@@ -192,6 +283,37 @@ def test_distopt_checkpoint_loads_from_mcore_distckpt(monkeypatch, tmp_path) -> 
     torch.testing.assert_close(wrapped_module.weight, expected_weight)
     torch.testing.assert_close(wrapped_module.bias, expected_bias)
     assert optimizer.loaded_state == {"loaded": True}
+
+
+def test_distopt_step_sync_traverses_multi_optimizer_chain_without_optimizer_property() -> None:
+    class FakeTorchOptimizer:
+        def __init__(self, steps):
+            self.state = {
+                object(): {"step": torch.tensor(step, dtype=torch.int64)}
+                for step in steps
+            }
+
+    class FakeDistOpt:
+        def __init__(self, steps):
+            self.optimizer = FakeTorchOptimizer(steps)
+
+    class FakeChainedOptimizer:
+        def __init__(self):
+            self.chained_optimizers = [FakeDistOpt([1, 3]), FakeDistOpt([2, 4])]
+
+        @property
+        def optimizer(self):
+            raise AssertionError(
+                "ChainedOptimizer has more than one optimizer when accessing self.optimizer"
+            )
+
+    chained = FakeChainedOptimizer()
+
+    _synchronize_native_optimizer_steps(chained)
+
+    for child in chained.chained_optimizers:
+        steps = [int(state["step"].item()) for state in child.optimizer.state.values()]
+        assert steps == [max(steps)] * len(steps)
 
 
 def test_runtime_checkpoint_api_passes_current_training_checkpoint_signature(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## Summary
- Add pipeline-stage ownership flags to the Qwen3MoE Lite model so Megatron-Core gradient finalization can inspect `pre_process` and `post_process`.
- Make MLite distopt checkpoint model keys PP/VPP-aware while keeping PP stages out of checkpoint replica IDs, so all pipeline stages survive torch-dist main-replica filtering.
- Traverse multi-child `ChainedOptimizer` instances without touching the asserting `.optimizer` property.
- Add focused unit coverage for PP/VPP model keys, PP rank filtering, placement-aware replica IDs, optimizer chain traversal, and tp2/pp2/ep2/ETP offset metadata.

## Validation
- Slurm 12676874: `experimental/lite/tests/unit/primitive/test_training_checkpoint.py` -> 10 passed, 19 warnings.
- Slurm 12676906: targeted TE + 8 GPU Qwen3MoE continuity smoke `test_qwen3_moe_distopt_checkpoint_restores_rng_and_continues_bitwise_tp2_pp2_ep2` -> 1 passed, non-skip; bitwise assertions use `atol=rtol=0`.
- Slurm 12676955: full TE + 8 GPU validation on commit 886f4a1d3 -> unit 152 passed, smoke 8 passed / 1 xfailed, Slurm exit 0.