### PR TITLE
Clean up and format Megatron Lite

### DIFF
--- a/experimental/lite/.pre-commit-config.yaml
+++ b/experimental/lite/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+- repo: local
+  hooks:
+  - id: isort
+    name: isort
+    entry: isort
+    language: python
+    additional_dependencies: ["isort==5.13.2"]
+    files: ^experimental/lite/.*\.py$
+  - id: black
+    name: black
+    entry: black
+    language: python
+    additional_dependencies: ["black==24.4.2"]
+    files: ^experimental/lite/.*\.py$
+    args: ["--skip-magic-trailing-comma", "--skip-string-normalization"]

--- a/experimental/lite/examples/__init__.py
+++ b/experimental/lite/examples/__init__.py
@@ -1,2 +1,1 @@
 """Megatron Lite examples package."""
-

--- a/experimental/lite/examples/bench/bench.py
+++ b/experimental/lite/examples/bench/bench.py
@@ -22,13 +22,12 @@ if str(_EXPERIMENTAL_LITE_ROOT) not in sys.path:
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(1, str(_REPO_ROOT))
 
+from examples.bench.results import StepTrace
+from examples.bench.session import PretrainSessionConfig, run_pretrain_session
 from megatron.lite.runtime import RuntimeConfig, create_runtime
 from megatron.lite.runtime.backends.bridge.config import BridgeConfig
 from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig
 from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
-
-from examples.bench.results import StepTrace
-from examples.bench.session import PretrainSessionConfig, run_pretrain_session
 
 
 @dataclass
@@ -146,9 +145,7 @@ def _make_mlite_model_config_hook(cfg: BenchCliConfig):
             if keep_experts <= 0 or keep_experts > old_num:
                 raise ValueError(f"keep_experts must be in [1, {old_num}], got {keep_experts}.")
             return replace(
-                model_cfg,
-                num_experts=keep_experts,
-                num_experts_per_tok=min(old_topk, keep_experts),
+                model_cfg, num_experts=keep_experts, num_experts_per_tok=min(old_topk, keep_experts)
             )
 
         hooks.append(keep_experts_hook)
@@ -162,7 +159,9 @@ def _make_mlite_model_config_hook(cfg: BenchCliConfig):
             if old_layers is None or layer_types is None:
                 raise ValueError("truncate_layers requires num_hidden_layers and layer_types.")
             if keep_layers <= 0 or keep_layers > old_layers:
-                raise ValueError(f"truncate_layers must be in [1, {old_layers}], got {keep_layers}.")
+                raise ValueError(
+                    f"truncate_layers must be in [1, {old_layers}], got {keep_layers}."
+                )
             return replace(
                 model_cfg,
                 num_hidden_layers=keep_layers,
@@ -223,7 +222,9 @@ def _make_bridge_post_init_hook(cfg: BenchCliConfig):
             if old_layers is None:
                 raise ValueError("truncate_layers requires HF config with num_hidden_layers.")
             if keep_layers <= 0 or keep_layers > old_layers:
-                raise ValueError(f"truncate_layers must be in [1, {old_layers}], got {keep_layers}.")
+                raise ValueError(
+                    f"truncate_layers must be in [1, {old_layers}], got {keep_layers}."
+                )
             hf_cfg.num_hidden_layers = keep_layers
             if hasattr(hf_cfg, "layer_types"):
                 hf_cfg.layer_types = list(hf_cfg.layer_types[:keep_layers])
@@ -291,8 +292,7 @@ def build_runtime_config(cfg: BenchCliConfig) -> RuntimeConfig:
             build_optimizer=not cfg.skip_optimizer_build,
             override_ddp_config=_json_mapping(cfg.override_ddp_json, name="override_ddp_json"),
             override_transformer_config=_json_mapping(
-                cfg.override_transformer_json,
-                name="override_transformer_json",
+                cfg.override_transformer_json, name="override_transformer_json"
             ),
             override_optimizer_config=optimizer_overrides,
             bridge_post_init=_make_bridge_post_init_hook(cfg),
@@ -377,10 +377,7 @@ def run(cfg: BenchCliConfig) -> dict[str, Any]:
     rt = create_runtime(rt_cfg)
     handle = rt.build_model()
     result = run_pretrain_session(
-        rt,
-        handle,
-        build_session_config(cfg),
-        step_reporter=_step_reporter,
+        rt, handle, build_session_config(cfg), step_reporter=_step_reporter
     )
     return result.to_dict()
 

--- a/experimental/lite/examples/bench/correctness.py
+++ b/experimental/lite/examples/bench/correctness.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import argparse
-from contextlib import contextmanager
 import hashlib
 import json
 import os
 import struct
 import sys
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -71,7 +71,9 @@ def _hash_tensor(tensor: torch.Tensor | None) -> dict[str, Any] | None:
         "sha256": hashlib.sha256(raw).hexdigest(),
     }
     if as_bf16 is not None:
-        result["sha256_as_bf16"] = hashlib.sha256(as_bf16.view(torch.uint8).numpy().tobytes()).hexdigest()
+        result["sha256_as_bf16"] = hashlib.sha256(
+            as_bf16.view(torch.uint8).numpy().tobytes()
+        ).hexdigest()
     if summary is not None:
         flat = summary.reshape(-1)
         result["summary"] = {
@@ -109,11 +111,7 @@ def _record_activation_probe(
     tensor_hooks: list[Any] | None = None,
 ) -> None:
     tensor = _first_tensor(output)
-    record = {
-        "name": name,
-        "found": True,
-        "tensor": _hash_tensor(tensor),
-    }
+    record = {"name": name, "found": True, "tensor": _hash_tensor(tensor)}
     if record_grad:
         record["grad"] = None
         record["grad_found"] = isinstance(tensor, torch.Tensor) and tensor.requires_grad
@@ -132,7 +130,11 @@ def _resolve_probe_module(modules: dict[str, Any], name: str) -> tuple[str, Any]
     module = modules.get(name)
     if module is not None:
         return name, module
-    matches = [(candidate_name, candidate) for candidate_name, candidate in modules.items() if candidate_name.endswith(f".{name}")]
+    matches = [
+        (candidate_name, candidate)
+        for candidate_name, candidate in modules.items()
+        if candidate_name.endswith(f".{name}")
+    ]
     if len(matches) == 1:
         return matches[0]
     return None
@@ -181,11 +183,7 @@ def _activation_probe_context(handle, probe_names: list[str], *, record_grad: bo
                     return _original(*args, **kwargs)
                 output = _original(*args, **kwargs)
                 _record_activation_probe(
-                    records,
-                    _probe_name,
-                    output,
-                    record_grad=record_grad,
-                    tensor_hooks=tensor_hooks,
+                    records, _probe_name, output, record_grad=record_grad, tensor_hooks=tensor_hooks
                 )
                 records[-1]["resolved_name"] = f"{_resolved_name}::{_method_name}"
                 records[-1]["module_type"] = _module_type
@@ -205,25 +203,19 @@ def _activation_probe_context(handle, probe_names: list[str], *, record_grad: bo
 
             def _pre_hook(_module, args, probe_name=name, resolved_probe_name=resolved_name):
                 _record_activation_probe(
-                    records,
-                    probe_name,
-                    args,
-                    record_grad=record_grad,
-                    tensor_hooks=tensor_hooks,
+                    records, probe_name, args, record_grad=record_grad, tensor_hooks=tensor_hooks
                 )
                 records[-1]["resolved_name"] = f"{resolved_probe_name}:input"
-                records[-1]["module_type"] = type(_module).__module__ + "." + type(_module).__qualname__
+                records[-1]["module_type"] = (
+                    type(_module).__module__ + "." + type(_module).__qualname__
+                )
 
             hooks.append(module.register_forward_pre_hook(_pre_hook))
             continue
 
         def _hook(_module, _args, output, probe_name=name, resolved_probe_name=resolved_name):
             _record_activation_probe(
-                records,
-                probe_name,
-                output,
-                record_grad=record_grad,
-                tensor_hooks=tensor_hooks,
+                records, probe_name, output, record_grad=record_grad, tensor_hooks=tensor_hooks
             )
             records[-1]["resolved_name"] = resolved_probe_name
             records[-1]["module_type"] = type(_module).__module__ + "." + type(_module).__qualname__
@@ -381,10 +373,7 @@ def run_backend(
                 rt.zero_grad(handle)
                 _sync(session_cfg.device)
                 result = rt.forward_backward(
-                    handle,
-                    data_iter,
-                    loss_fn=None,
-                    num_microbatches=session_cfg.num_microbatches,
+                    handle, data_iter, loss_fn=None, num_microbatches=session_cfg.num_microbatches
                 )
                 _sync(session_cfg.device)
                 logits = _hash_tensor(result.model_output.vocab_parallel_logits)
@@ -497,8 +486,7 @@ def main(argv: list[str] | None = None) -> dict[str, Any]:
     ns = _parser().parse_args(argv)
     if ns.command == "compare":
         result = compare_correctness_artifacts(
-            load_result_artifact(ns.baseline),
-            load_result_artifact(ns.candidate),
+            load_result_artifact(ns.baseline), load_result_artifact(ns.candidate)
         )
         text = json.dumps(result, indent=2, sort_keys=True)
         print(text, flush=True)
@@ -508,7 +496,9 @@ def main(argv: list[str] | None = None) -> dict[str, Any]:
             raise SystemExit(1)
         return result
 
-    cfg = BenchCliConfig(**{k: v for k, v in vars(ns).items() if k in BenchCliConfig.__dataclass_fields__})
+    cfg = BenchCliConfig(
+        **{k: v for k, v in vars(ns).items() if k in BenchCliConfig.__dataclass_fields__}
+    )
     artifact = run_backend(
         cfg,
         hash_weights=not ns.skip_weight_hash,

--- a/experimental/lite/examples/bench/results.py
+++ b/experimental/lite/examples/bench/results.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-import math
 import json
+import math
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -127,11 +127,7 @@ def result_summary(artifact: dict[str, Any]) -> dict[str, Any]:
 
 
 def compare_step_traces(
-    baseline: dict[str, Any],
-    candidate: dict[str, Any],
-    *,
-    atol: float = 1e-4,
-    rtol: float = 1e-4,
+    baseline: dict[str, Any], candidate: dict[str, Any], *, atol: float = 1e-4, rtol: float = 1e-4
 ) -> dict[str, Any]:
     """Compare loss and grad-norm traces from two benchmark artifacts."""
     base_steps = baseline.get("result", {}).get("step_traces", [])
@@ -144,8 +140,7 @@ def compare_step_traces(
         cand = cand_steps[idx]
         max_loss_abs = max(max_loss_abs, abs(float(base["loss"]) - float(cand["loss"])))
         max_grad_norm_abs = max(
-            max_grad_norm_abs,
-            abs(float(base["grad_norm"]) - float(cand["grad_norm"])),
+            max_grad_norm_abs, abs(float(base["grad_norm"]) - float(cand["grad_norm"]))
         )
 
     lengths_match = sample_count == len(base_steps) == len(cand_steps)
@@ -154,9 +149,7 @@ def compare_step_traces(
         [abs(float(step["grad_norm"])) for step in base_steps[:sample_count]] + [0.0]
     )
     loss_passed = lengths_match and max_loss_abs <= atol + rtol * loss_ref_max
-    grad_norm_passed = (
-        lengths_match and max_grad_norm_abs <= atol + rtol * grad_norm_ref_max
-    )
+    grad_norm_passed = lengths_match and max_grad_norm_abs <= atol + rtol * grad_norm_ref_max
 
     return {
         "samples": sample_count,
@@ -171,8 +164,7 @@ def compare_step_traces(
 
 
 def compare_correctness_artifacts(
-    baseline: dict[str, Any],
-    candidate: dict[str, Any],
+    baseline: dict[str, Any], candidate: dict[str, Any]
 ) -> dict[str, Any]:
     """Strict bitwise comparison for deterministic correctness artifacts."""
     base_steps = baseline.get("steps", [])
@@ -211,13 +203,7 @@ def compare_correctness_artifacts(
         if math.isfinite(grad_abs):
             max_grad_norm_abs = max(max_grad_norm_abs, grad_abs)
 
-        for field in (
-            "loss",
-            "grad_norm",
-            "post_step_weights",
-            "update_successful",
-            "num_zeros",
-        ):
+        for field in ("loss", "grad_norm", "post_step_weights", "update_successful", "num_zeros"):
             if base.get(field) != cand.get(field):
                 mismatches.append({"step": idx, "field": field})
         if not _tensor_fingerprint_matches(base.get("logits"), cand.get("logits")):

--- a/experimental/lite/examples/bench/session.py
+++ b/experimental/lite/examples/bench/session.py
@@ -116,7 +116,9 @@ def _resolve_model_stats(config: Any, proto: Any) -> Any | None:
     return proto
 
 
-def _resolve_step_flops(handle: ModelHandle, cfg: PretrainSessionConfig) -> tuple[int | None, int | None]:
+def _resolve_step_flops(
+    handle: ModelHandle, cfg: PretrainSessionConfig
+) -> tuple[int | None, int | None]:
     config = handle.config
     proto = handle._extras.get("protocol")
     model_stats = _resolve_model_stats(config, proto)
@@ -178,10 +180,7 @@ def run_pretrain_session(
             _sync(cfg.device)
             t0 = time.perf_counter()
             result = rt.forward_backward(
-                handle,
-                data_iter,
-                loss_fn=None,
-                num_microbatches=cfg.num_microbatches,
+                handle, data_iter, loss_fn=None, num_microbatches=cfg.num_microbatches
             )
             if cfg.no_optimizer:
                 grad_norm = 0.0

--- a/experimental/lite/examples/verl/verl_mlite/compat.py
+++ b/experimental/lite/examples/verl/verl_mlite/compat.py
@@ -33,7 +33,9 @@ def _patch_transformers_rope_ignore_keys() -> None:
                 if isinstance(ignore_keys, list):
                     kwargs["ignore_keys"] = set(ignore_keys)
                 elif ignore_keys is not None and not isinstance(ignore_keys, set):
-                    if isinstance(ignore_keys, Iterable) and not isinstance(ignore_keys, (str, bytes)):
+                    if isinstance(ignore_keys, Iterable) and not isinstance(
+                        ignore_keys, (str, bytes)
+                    ):
                         kwargs["ignore_keys"] = set(ignore_keys)
                 return check_received_keys(*args, **kwargs)
 

--- a/experimental/lite/examples/verl/verl_mlite/engine/config.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/config.py
@@ -33,6 +33,8 @@ class MegatronLiteEngineConfig(EngineConfig):
     def __post_init__(self) -> None:
         super().__post_init__()
         if self.strategy != "mlite":
-            raise ValueError(f"MegatronLiteEngineConfig expects strategy='mlite', got {self.strategy!r}")
+            raise ValueError(
+                f"MegatronLiteEngineConfig expects strategy='mlite', got {self.strategy!r}"
+            )
         if self.custom_backend_module:
             importlib.import_module(self.custom_backend_module)

--- a/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
@@ -7,21 +7,7 @@ from typing import Any
 
 import torch
 import torch.distributed as dist
-from megatron.lite.model import resolve_model_type_from_hf
-from megatron.lite.primitive.ckpt import load_training_checkpoint, save_training_checkpoint
-from megatron.lite.primitive.parallel import pack_nested_thd, unpack_packed_thd_to_nested
-from megatron.lite.primitive.protocols import default_expert_classifier, default_placement_fn
-from megatron.lite.runtime import create_runtime
-from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig
-from megatron.lite.runtime.contracts.config import (
-    OptimizerConfig as MegatronLiteOptimizerConfig,
-)
-from megatron.lite.runtime.contracts.config import (
-    ParallelConfig,
-    RuntimeConfig,
-)
 from tensordict import TensorDict
-
 from verl.trainer.config import CheckpointConfig
 from verl.utils import tensordict_utils as tu
 from verl.utils.dataset.dataset_utils import DatasetPadMode
@@ -29,6 +15,15 @@ from verl.utils.device import get_device_id, get_device_name
 from verl.workers.config import HFModelConfig, OptimizerConfig
 from verl.workers.engine.base import BaseEngine, BaseEngineCtx, EngineRegistry
 from verl.workers.engine.utils import postprocess_batch_func, prepare_micro_batches
+
+from megatron.lite.model import resolve_model_type_from_hf
+from megatron.lite.primitive.ckpt import load_training_checkpoint, save_training_checkpoint
+from megatron.lite.primitive.parallel import pack_nested_thd, unpack_packed_thd_to_nested
+from megatron.lite.primitive.protocols import default_expert_classifier, default_placement_fn
+from megatron.lite.runtime import create_runtime
+from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig
+from megatron.lite.runtime.contracts.config import OptimizerConfig as MegatronLiteOptimizerConfig
+from megatron.lite.runtime.contracts.config import ParallelConfig, RuntimeConfig
 
 from .config import MegatronLiteEngineConfig
 
@@ -165,7 +160,9 @@ class MegatronLiteEngine(BaseEngine):
         self.module = self._extract_primary_module()
 
         if self.handle._optimizer is not None and self.handle._lr_scheduler is None:
-            self.handle._lr_scheduler = _build_lr_scheduler(self.handle._optimizer, self._mlite_config.optimizer)
+            self.handle._lr_scheduler = _build_lr_scheduler(
+                self.handle._optimizer, self._mlite_config.optimizer
+            )
 
         self.to(
             device="cpu",
@@ -198,11 +195,17 @@ class MegatronLiteEngine(BaseEngine):
             return self.handle._optimizer.param_groups[0]["lr"]
         return 0.0
 
-    def forward_backward_batch(self, data: TensorDict, loss_function, forward_only: bool = False) -> dict[str, Any]:
+    def forward_backward_batch(
+        self, data: TensorDict, loss_function, forward_only: bool = False
+    ) -> dict[str, Any]:
         self._require_initialized()
-        pad_mode = tu.get_non_tensor_data(data=data, key="pad_mode", default=DatasetPadMode.NO_PADDING)
+        pad_mode = tu.get_non_tensor_data(
+            data=data, key="pad_mode", default=DatasetPadMode.NO_PADDING
+        )
         if pad_mode != DatasetPadMode.NO_PADDING:
-            raise NotImplementedError("MegatronLiteEngine only supports pad_mode=no_padding for now.")
+            raise NotImplementedError(
+                "MegatronLiteEngine only supports pad_mode=no_padding for now."
+            )
 
         tu.assign_non_tensor(data, sp_size=self.engine_config.cp)
 
@@ -217,9 +220,7 @@ class MegatronLiteEngine(BaseEngine):
         tu.assign_non_tensor(data, dp_size=self.get_data_parallel_size())
 
         micro_batches, indices = prepare_micro_batches(
-            data=data,
-            dp_group=self.get_data_parallel_group(),
-            same_micro_num_in_dp=True,
+            data=data, dp_group=self.get_data_parallel_group(), same_micro_num_in_dp=True
         )
 
         if self._use_runtime_forward_backward():
@@ -255,9 +256,7 @@ class MegatronLiteEngine(BaseEngine):
                 )
 
                 model_output = self._build_verl_model_output(
-                    raw_output=raw_output,
-                    micro_batch=micro_batch,
-                    inputs=model_inputs,
+                    raw_output=raw_output, micro_batch=micro_batch, inputs=model_inputs
                 )
 
                 if loss_function is not None:
@@ -280,11 +279,7 @@ class MegatronLiteEngine(BaseEngine):
                 loss.backward()
 
             outputs.append(
-                {
-                    "model_output": model_output,
-                    "loss": loss.detach().item(),
-                    "metrics": metrics,
-                }
+                {"model_output": model_output, "loss": loss.detach().item(), "metrics": metrics}
             )
 
         if not forward_only:
@@ -313,7 +308,9 @@ class MegatronLiteEngine(BaseEngine):
     def get_data_parallel_size(self):
         if self.handle is None:
             world_size = dist.get_world_size() if dist.is_initialized() else 1
-            return world_size // (self.engine_config.tp * self.engine_config.cp * self.engine_config.pp)
+            return world_size // (
+                self.engine_config.tp * self.engine_config.cp * self.engine_config.pp
+            )
         return self.handle.dp_size
 
     def get_data_parallel_rank(self):
@@ -357,7 +354,9 @@ class MegatronLiteEngine(BaseEngine):
         save_optimizer = save_contents is None or "optimizer" in save_contents
         if not save_model and not save_optimizer:
             if self._rank == 0:
-                print(f"Skipping Megatron Lite checkpoint save at step {global_step}: save_contents={save_contents}")
+                print(
+                    f"Skipping Megatron Lite checkpoint save at step {global_step}: save_contents={save_contents}"
+                )
             if dist.is_initialized():
                 dist.barrier()
             return
@@ -382,7 +381,10 @@ class MegatronLiteEngine(BaseEngine):
                 save_optimizer=save_optimizer,
             )
             if self.handle._lr_scheduler is not None and self._rank == 0:
-                torch.save(self.handle._lr_scheduler.state_dict(), os.path.join(local_path, _LR_SCHEDULER_STATE))
+                torch.save(
+                    self.handle._lr_scheduler.state_dict(),
+                    os.path.join(local_path, _LR_SCHEDULER_STATE),
+                )
             if dist.is_initialized():
                 dist.barrier()
         finally:
@@ -467,7 +469,9 @@ class MegatronLiteEngine(BaseEngine):
     def _build_impl_cfg(self) -> dict[str, Any]:
         impl_cfg = dict(self.engine_config.impl_cfg)
         if impl_cfg.get("use_thd", True) is not True:
-            raise ValueError("MegatronLiteEngine supports only THD/no-padding SFT; set engine.impl_cfg.use_thd=True.")
+            raise ValueError(
+                "MegatronLiteEngine supports only THD/no-padding SFT; set engine.impl_cfg.use_thd=True."
+            )
         impl_cfg["use_thd"] = True
         mtp_cfg = getattr(self.model_config, "mtp", None)
         if mtp_cfg is not None:
@@ -476,7 +480,9 @@ class MegatronLiteEngine(BaseEngine):
             impl_cfg["mtp_enable"] = mtp_enable
             impl_cfg["mtp_enable_train"] = mtp_enable_train
             impl_cfg["mtp_detach_encoder"] = bool(getattr(mtp_cfg, "detach_encoder", False))
-            impl_cfg["mtp_loss_scaling_factor"] = float(getattr(mtp_cfg, "mtp_loss_scaling_factor", 0.1))
+            impl_cfg["mtp_loss_scaling_factor"] = float(
+                getattr(mtp_cfg, "mtp_loss_scaling_factor", 0.1)
+            )
         if self.engine_config.full_determinism:
             impl_cfg.setdefault("deterministic", True)
         if self.engine_config.forward_only:
@@ -487,7 +493,9 @@ class MegatronLiteEngine(BaseEngine):
         optimizer_name = self._normalize_optimizer_name(self.optimizer_config)
         betas = tuple(getattr(self.optimizer_config, "betas", (0.9, 0.999)))
         override = getattr(self.optimizer_config, "override_optimizer_config", {}) or {}
-        offload_fraction = override.get("offload_fraction", override.get("optimizer_offload_fraction"))
+        offload_fraction = override.get(
+            "offload_fraction", override.get("optimizer_offload_fraction")
+        )
         if offload_fraction is None and override.get("optimizer_cpu_offload"):
             offload_fraction = 1.0
         if offload_fraction is None and self.is_optimizer_offload_enabled:
@@ -514,13 +522,13 @@ class MegatronLiteEngine(BaseEngine):
             lr_warmup_init=getattr(self.optimizer_config, "lr_warmup_init", 0.0),
             lr_decay_steps=getattr(self.optimizer_config, "lr_decay_steps", None),
             lr_decay_style=lr_decay_style,
-            weight_decay_incr_style=getattr(self.optimizer_config, "weight_decay_incr_style", "constant"),
+            weight_decay_incr_style=getattr(
+                self.optimizer_config, "weight_decay_incr_style", "constant"
+            ),
             lr_wsd_decay_style=getattr(self.optimizer_config, "lr_wsd_decay_style", "exponential"),
             lr_wsd_decay_steps=getattr(self.optimizer_config, "lr_wsd_decay_steps", None),
             use_checkpoint_opt_param_scheduler=getattr(
-                self.optimizer_config,
-                "use_checkpoint_opt_param_scheduler",
-                False,
+                self.optimizer_config, "use_checkpoint_opt_param_scheduler", False
             ),
             adam_beta1=betas[0],
             adam_beta2=betas[1],
@@ -536,7 +544,9 @@ class MegatronLiteEngine(BaseEngine):
         lower = str(optimizer_name).lower()
         if "adam" in lower:
             return "adam"
-        raise ValueError(f"MegatronLiteEngine only supports Adam-style optimizers today, got {optimizer_name!r}")
+        raise ValueError(
+            f"MegatronLiteEngine only supports Adam-style optimizers today, got {optimizer_name!r}"
+        )
 
     def _extract_primary_module(self):
         model = self.handle._model
@@ -565,7 +575,9 @@ class MegatronLiteEngine(BaseEngine):
         num_micro_batches = len(micro_batches)
         batch_num_tokens = tu.get_non_tensor_data(data=data, key="batch_num_tokens", default=None)
         if batch_num_tokens is None:
-            raise ValueError("MegatronLiteEngine PP/CP SFT requires batch_num_tokens for VERL-compatible loss scaling.")
+            raise ValueError(
+                "MegatronLiteEngine PP/CP SFT requires batch_num_tokens for VERL-compatible loss scaling."
+            )
         if batch_num_tokens <= 0:
             raise ValueError(f"batch_num_tokens must be positive, got {batch_num_tokens}.")
         loss_scale = self.get_data_parallel_size() * num_micro_batches / float(batch_num_tokens)
@@ -614,7 +626,9 @@ class MegatronLiteEngine(BaseEngine):
     def _make_model_inputs(self, micro_batch: TensorDict) -> dict[str, torch.Tensor]:
         input_ids = micro_batch["input_ids"]
         if not getattr(input_ids, "is_nested", False):
-            raise NotImplementedError("MegatronLiteEngine supports only nested no-padding THD batches.")
+            raise NotImplementedError(
+                "MegatronLiteEngine supports only nested no-padding THD batches."
+            )
 
         ps = self.handle._parallel_state
         loss_mask = self._loss_mask_for_packing(micro_batch, input_ids)
@@ -630,9 +644,7 @@ class MegatronLiteEngine(BaseEngine):
             roll_loss_mask=True,
         )
         use_fused_kernels = tu.get_non_tensor_data(
-            data=micro_batch,
-            key="use_fused_kernels",
-            default=self.engine_config.use_fused_kernels,
+            data=micro_batch, key="use_fused_kernels", default=self.engine_config.use_fused_kernels
         )
 
         return {
@@ -644,11 +656,15 @@ class MegatronLiteEngine(BaseEngine):
             "packed_batch": packed_batch,
             "temperature": self._scalar_temperature(micro_batch),
             "use_fused_kernels": use_fused_kernels,
-            "calculate_entropy": tu.get_non_tensor_data(data=micro_batch, key="calculate_entropy", default=False),
+            "calculate_entropy": tu.get_non_tensor_data(
+                data=micro_batch, key="calculate_entropy", default=False
+            ),
         }
 
     @staticmethod
-    def _loss_mask_for_packing(micro_batch: TensorDict, input_ids: torch.Tensor) -> torch.Tensor | None:
+    def _loss_mask_for_packing(
+        micro_batch: TensorDict, input_ids: torch.Tensor
+    ) -> torch.Tensor | None:
         if "loss_mask" not in micro_batch.keys():
             return None
 
@@ -693,9 +709,7 @@ class MegatronLiteEngine(BaseEngine):
             micro_batch = runtime_batch["_verl_micro_batch"]
             inputs = runtime_batch["_verl_inputs"]
             model_output = self._build_verl_model_output(
-                raw_output=raw_output,
-                micro_batch=micro_batch,
-                inputs=inputs,
+                raw_output=raw_output, micro_batch=micro_batch, inputs=inputs
             )
             raw_output["_verl_model_output"] = model_output
             if loss_function is not None:
@@ -742,12 +756,18 @@ class MegatronLiteEngine(BaseEngine):
         temperature = micro_batch["temperature"]
         if not isinstance(temperature, torch.Tensor):
             return float(temperature)
-        values = temperature.values() if getattr(temperature, "is_nested", False) else temperature.reshape(-1)
+        values = (
+            temperature.values()
+            if getattr(temperature, "is_nested", False)
+            else temperature.reshape(-1)
+        )
         if values.numel() == 0:
             return 1.0
         first = values[0].detach()
         if not torch.all(values.detach() == first).item():
-            raise NotImplementedError("MegatronLiteEngine currently supports scalar temperature only.")
+            raise NotImplementedError(
+                "MegatronLiteEngine currently supports scalar temperature only."
+            )
         return float(first.float().item())
 
     def _checkpoint_hooks(self):

--- a/experimental/lite/megatron/lite/model/qwen3_5/config.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/config.py
@@ -1,39 +1,42 @@
 """Qwen3.5 model configuration."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 
 from megatron.lite.primitive.config import load_hf_config_dict
 
-_HF_FIELDS = frozenset({
-    "num_hidden_layers",
-    "hidden_size",
-    "num_attention_heads",
-    "num_key_value_heads",
-    "head_dim",
-    "vocab_size",
-    "rms_norm_eps",
-    "max_position_embeddings",
-    "router_aux_loss_coef",
-    "num_experts",
-    "num_experts_per_tok",
-    "moe_intermediate_size",
-    "shared_expert_intermediate_size",
-    "linear_num_key_heads",
-    "linear_key_head_dim",
-    "linear_num_value_heads",
-    "linear_value_head_dim",
-    "linear_conv_kernel_dim",
-    "layer_types",
-    "partial_rotary_factor",
-    "mrope_section",
-    "mtp_num_hidden_layers",
-    "mtp_use_dedicated_embeddings",
-    "num_nextn_predict_layers",
-    "mtp_loss_scaling_factor",
-    "mtp_use_repeated_layer",
-    "mtp_layer_types",
-})
+_HF_FIELDS = frozenset(
+    {
+        "num_hidden_layers",
+        "hidden_size",
+        "num_attention_heads",
+        "num_key_value_heads",
+        "head_dim",
+        "vocab_size",
+        "rms_norm_eps",
+        "max_position_embeddings",
+        "router_aux_loss_coef",
+        "num_experts",
+        "num_experts_per_tok",
+        "moe_intermediate_size",
+        "shared_expert_intermediate_size",
+        "linear_num_key_heads",
+        "linear_key_head_dim",
+        "linear_num_value_heads",
+        "linear_value_head_dim",
+        "linear_conv_kernel_dim",
+        "layer_types",
+        "partial_rotary_factor",
+        "mrope_section",
+        "mtp_num_hidden_layers",
+        "mtp_use_dedicated_embeddings",
+        "num_nextn_predict_layers",
+        "mtp_loss_scaling_factor",
+        "mtp_use_repeated_layer",
+        "mtp_layer_types",
+    }
+)
 
 
 @dataclass
@@ -98,8 +101,8 @@ class Qwen35Config:
             and not self.mtp_layer_types
             and len(self.layer_types) == self.num_hidden_layers + self.num_nextn_predict_layers
         ):
-            self.mtp_layer_types = self.layer_types[self.num_hidden_layers:]
-            self.layer_types = self.layer_types[:self.num_hidden_layers]
+            self.mtp_layer_types = self.layer_types[self.num_hidden_layers :]
+            self.layer_types = self.layer_types[: self.num_hidden_layers]
         if self.num_nextn_predict_layers > 0 and not self.mtp_layer_types:
             self.mtp_layer_types = ["full_attention"] * self.num_nextn_predict_layers
         if len(self.layer_types) != self.num_hidden_layers:
@@ -107,7 +110,10 @@ class Qwen35Config:
                 f"len(layer_types)={len(self.layer_types)} != "
                 f"num_hidden_layers={self.num_hidden_layers}"
             )
-        if self.num_nextn_predict_layers > 0 and len(self.mtp_layer_types) != self.num_nextn_predict_layers:
+        if (
+            self.num_nextn_predict_layers > 0
+            and len(self.mtp_layer_types) != self.num_nextn_predict_layers
+        ):
             raise ValueError(
                 f"len(mtp_layer_types)={len(self.mtp_layer_types)} != "
                 f"num_nextn_predict_layers={self.num_nextn_predict_layers}"
@@ -121,7 +127,10 @@ class Qwen35Config:
             if not cond:
                 errors.append(msg)
 
-        _check(self.num_hidden_layers >= 1, f"num_hidden_layers must be >= 1, got {self.num_hidden_layers}")
+        _check(
+            self.num_hidden_layers >= 1,
+            f"num_hidden_layers must be >= 1, got {self.num_hidden_layers}",
+        )
         _check(
             self.num_nextn_predict_layers >= 0,
             f"num_nextn_predict_layers must be >= 0, got {self.num_nextn_predict_layers}",
@@ -134,7 +143,10 @@ class Qwen35Config:
         _check(self.hidden_size > 0, f"hidden_size must be > 0, got {self.hidden_size}")
         _check(self.head_dim > 0, f"head_dim must be > 0, got {self.head_dim}")
         _check(self.vocab_size > 0, f"vocab_size must be > 0, got {self.vocab_size}")
-        _check(self.num_attention_heads >= 1, f"num_attention_heads must be >= 1, got {self.num_attention_heads}")
+        _check(
+            self.num_attention_heads >= 1,
+            f"num_attention_heads must be >= 1, got {self.num_attention_heads}",
+        )
         _check(
             self.num_attention_heads % self.num_key_value_heads == 0,
             f"num_attention_heads({self.num_attention_heads}) must be divisible by "
@@ -146,15 +158,30 @@ class Qwen35Config:
             f"num_experts_per_tok({self.num_experts_per_tok}) must be in "
             f"[1, num_experts({self.num_experts})]",
         )
-        _check(self.moe_intermediate_size > 0, f"moe_intermediate_size must be > 0, got {self.moe_intermediate_size}")
+        _check(
+            self.moe_intermediate_size > 0,
+            f"moe_intermediate_size must be > 0, got {self.moe_intermediate_size}",
+        )
         _check(
             self.shared_expert_intermediate_size > 0,
             f"shared_expert_intermediate_size must be > 0, got {self.shared_expert_intermediate_size}",
         )
-        _check(self.linear_num_key_heads >= 1, f"linear_num_key_heads must be >= 1, got {self.linear_num_key_heads}")
-        _check(self.linear_key_head_dim > 0, f"linear_key_head_dim must be > 0, got {self.linear_key_head_dim}")
-        _check(self.linear_num_value_heads >= 1, f"linear_num_value_heads must be >= 1, got {self.linear_num_value_heads}")
-        _check(self.linear_value_head_dim > 0, f"linear_value_head_dim must be > 0, got {self.linear_value_head_dim}")
+        _check(
+            self.linear_num_key_heads >= 1,
+            f"linear_num_key_heads must be >= 1, got {self.linear_num_key_heads}",
+        )
+        _check(
+            self.linear_key_head_dim > 0,
+            f"linear_key_head_dim must be > 0, got {self.linear_key_head_dim}",
+        )
+        _check(
+            self.linear_num_value_heads >= 1,
+            f"linear_num_value_heads must be >= 1, got {self.linear_num_value_heads}",
+        )
+        _check(
+            self.linear_value_head_dim > 0,
+            f"linear_value_head_dim must be > 0, got {self.linear_value_head_dim}",
+        )
         _check(
             0.0 < self.partial_rotary_factor <= 1.0,
             f"partial_rotary_factor must be in (0, 1], got {self.partial_rotary_factor}",
@@ -177,7 +204,9 @@ class Qwen35Config:
         for i, lt in enumerate(self.layer_types):
             _check(lt in valid_types, f"layer_types[{i}] must be one of {valid_types}, got '{lt}'")
         for i, lt in enumerate(self.mtp_layer_types):
-            _check(lt in valid_types, f"mtp_layer_types[{i}] must be one of {valid_types}, got '{lt}'")
+            _check(
+                lt in valid_types, f"mtp_layer_types[{i}] must be one of {valid_types}, got '{lt}'"
+            )
 
         if errors:
             raise ValueError(
@@ -215,7 +244,9 @@ class Qwen35Config:
             if "mrope_section" not in kwargs and "mrope_section" in rp:
                 kwargs["mrope_section"] = list(rp["mrope_section"])
         if "head_dim" not in kwargs or kwargs.get("head_dim") is None:
-            kwargs["head_dim"] = kwargs.get("hidden_size", 2048) // kwargs.get("num_attention_heads", 16)
+            kwargs["head_dim"] = kwargs.get("hidden_size", 2048) // kwargs.get(
+                "num_attention_heads", 16
+            )
         if kwargs.get("num_nextn_predict_layers") is None:
             kwargs["num_nextn_predict_layers"] = 0
         kwargs.update(overrides)

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/checkpoint.py
@@ -87,10 +87,7 @@ def _tp_linear_attn_in_proj(
 
 
 def _tp_linear_attn_conv1d(
-    tensor: torch.Tensor,
-    *,
-    cfg: Qwen35Config,
-    ps: ParallelState,
+    tensor: torch.Tensor, *, cfg: Qwen35Config, ps: ParallelState
 ) -> torch.Tensor:
     qk_dim = cfg.linear_num_key_heads * cfg.linear_key_head_dim
     v_dim = cfg.linear_num_value_heads * cfg.linear_value_head_dim
@@ -123,7 +120,9 @@ def _has(reader: SafeTensorReader, name: str) -> bool:
     return True
 
 
-def _load_vocab(reader: SafeTensorReader, name: str, cfg: Qwen35Config, ps: ParallelState) -> torch.Tensor:
+def _load_vocab(
+    reader: SafeTensorReader, name: str, cfg: Qwen35Config, ps: ParallelState
+) -> torch.Tensor:
     from megatron.lite.primitive.parallel import pad_vocab_for_tp
 
     tensor = _get(reader, name)
@@ -149,26 +148,17 @@ def _load_full_attn(
     k = _get(reader, f"{hf_prefix}.k_proj.weight")
     v = _get(reader, f"{hf_prefix}.v_proj.weight")
     out[f"{local_prefix}.full_attn.qkv.linear.weight"] = _tp(
-        _merge_full_attn_qkvg(q, k, v, cfg=cfg),
-        ps.tp_rank,
-        ps.tp_size,
+        _merge_full_attn_qkvg(q, k, v, cfg=cfg), ps.tp_rank, ps.tp_size
     )
     out[f"{local_prefix}.full_attn.q_norm.weight"] = _get(reader, f"{hf_prefix}.q_norm.weight")
     out[f"{local_prefix}.full_attn.k_norm.weight"] = _get(reader, f"{hf_prefix}.k_norm.weight")
     out[f"{local_prefix}.full_attn.proj.linear.weight"] = _tp(
-        _get(reader, f"{hf_prefix}.o_proj.weight"),
-        ps.tp_rank,
-        ps.tp_size,
-        dim=1,
+        _get(reader, f"{hf_prefix}.o_proj.weight"), ps.tp_rank, ps.tp_size, dim=1
     )
 
 
 def _merge_full_attn_qkvg(
-    q_gate: torch.Tensor,
-    key: torch.Tensor,
-    value: torch.Tensor,
-    *,
-    cfg: Qwen35Config,
+    q_gate: torch.Tensor, key: torch.Tensor, value: torch.Tensor, *, cfg: Qwen35Config
 ) -> torch.Tensor:
     kv_heads = cfg.num_key_value_heads
     head_dim = cfg.head_dim
@@ -186,9 +176,7 @@ def _merge_full_attn_qkvg(
 
 
 def _unmerge_full_attn_qkvg(
-    tensor: torch.Tensor,
-    *,
-    cfg: Qwen35Config,
+    tensor: torch.Tensor, *, cfg: Qwen35Config
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Invert Qwen35 lite's full-attention q/g/k/v packing."""
     q_heads_per_group = ensure_divisible(cfg.num_attention_heads, cfg.num_key_value_heads)
@@ -207,8 +195,7 @@ def _unmerge_full_attn_qkvg(
     query = query.reshape(cfg.num_attention_heads, cfg.head_dim, hidden)
     gate = gate.reshape(cfg.num_attention_heads, cfg.head_dim, hidden)
     q_gate = torch.cat([query, gate], dim=1).reshape(
-        cfg.num_attention_heads * 2 * cfg.head_dim,
-        hidden,
+        cfg.num_attention_heads * 2 * cfg.head_dim, hidden
     )
     key = key.reshape(cfg.num_key_value_heads * cfg.head_dim, hidden)
     value = value.reshape(cfg.num_key_value_heads * cfg.head_dim, hidden)
@@ -216,36 +203,18 @@ def _unmerge_full_attn_qkvg(
 
 
 def _split_linear_attn_in_proj(
-    tensor: torch.Tensor,
-    *,
-    cfg: Qwen35Config,
-) -> tuple[
-    torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
-]:
+    tensor: torch.Tensor, *, cfg: Qwen35Config
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     qk_dim = cfg.linear_num_key_heads * cfg.linear_key_head_dim
     v_dim = cfg.linear_num_value_heads * cfg.linear_value_head_dim
     return tensor.split(
-        [
-            qk_dim,
-            qk_dim,
-            v_dim,
-            v_dim,
-            cfg.linear_num_value_heads,
-            cfg.linear_num_value_heads,
-        ],
+        [qk_dim, qk_dim, v_dim, v_dim, cfg.linear_num_value_heads, cfg.linear_num_value_heads],
         dim=0,
     )
 
 
 def _merge_linear_attn_in_proj_tp_shards(
-    shards: list[torch.Tensor],
-    *,
-    cfg: Qwen35Config,
+    shards: list[torch.Tensor], *, cfg: Qwen35Config
 ) -> torch.Tensor:
     world_size = len(shards)
     qk_dim = ensure_divisible(cfg.linear_num_key_heads * cfg.linear_key_head_dim, world_size)
@@ -265,9 +234,7 @@ def _merge_linear_attn_in_proj_tp_shards(
 
 
 def _merge_linear_attn_conv1d_tp_shards(
-    shards: list[torch.Tensor],
-    *,
-    cfg: Qwen35Config,
+    shards: list[torch.Tensor], *, cfg: Qwen35Config
 ) -> torch.Tensor:
     world_size = len(shards)
     qk_dim = ensure_divisible(cfg.linear_num_key_heads * cfg.linear_key_head_dim, world_size)
@@ -318,18 +285,18 @@ class Qwen35WeightSpec:
         del native_name
         return hf_tensors[0]
 
-    def gather_dense(self, native_name: str, tensor: torch.Tensor, ps: ParallelState) -> torch.Tensor | None:
+    def gather_dense(
+        self, native_name: str, tensor: torch.Tensor, ps: ParallelState
+    ) -> torch.Tensor | None:
         if ps.tp_size <= 1:
             return None
         if native_name.endswith(".linear_attn.in_proj.linear.weight"):
             return _merge_linear_attn_in_proj_tp_shards(
-                _allgather_tp_shards(tensor, ps),
-                cfg=self.config,
+                _allgather_tp_shards(tensor, ps), cfg=self.config
             )
         if native_name.endswith(".linear_attn.conv1d.weight"):
             return _merge_linear_attn_conv1d_tp_shards(
-                _allgather_tp_shards(tensor, ps),
-                cfg=self.config,
+                _allgather_tp_shards(tensor, ps), cfg=self.config
             )
         if native_name.endswith(".moe.shared_expert.gate_up.linear.weight"):
             return _merge_gate_up_tp_shards(_allgather_tp_shards(tensor, ps))
@@ -340,7 +307,9 @@ class Qwen35WeightSpec:
             return None
         return re.sub(r"\.weight\d+$", ".packed", native_name)
 
-    def native_to_hf(self, native_name: str, tensor: torch.Tensor) -> list[tuple[str, torch.Tensor]]:
+    def native_to_hf(
+        self, native_name: str, tensor: torch.Tensor
+    ) -> list[tuple[str, torch.Tensor]]:
         if self.target == "vllm":
             return self._native_to_vllm(native_name, tensor)
 
@@ -424,7 +393,9 @@ class Qwen35WeightSpec:
             buffer[int(expert_idx)] = tensor.contiguous()
             if len(buffer) < self.config.num_experts:
                 return []
-            packed = torch.stack([buffer[i] for i in range(self.config.num_experts)], dim=0).contiguous()
+            packed = torch.stack(
+                [buffer[i] for i in range(self.config.num_experts)], dim=0
+            ).contiguous()
             del self._expert_export_buffers[buffer_key]
             if kind == "1":
                 return [(f"{prefix}.mlp.experts.gate_up_proj", packed)]
@@ -439,7 +410,9 @@ class Qwen35WeightSpec:
 
         return []
 
-    def _native_to_vllm(self, native_name: str, tensor: torch.Tensor) -> list[tuple[str, torch.Tensor]]:
+    def _native_to_vllm(
+        self, native_name: str, tensor: torch.Tensor
+    ) -> list[tuple[str, torch.Tensor]]:
         if native_name == "embed.embedding.weight":
             return [("language_model.model.embed_tokens.weight", tensor)]
         if native_name == "norm.weight":
@@ -520,7 +493,9 @@ class Qwen35WeightSpec:
             buffer[int(expert_idx)] = tensor.contiguous()
             if len(buffer) < self.config.num_experts:
                 return []
-            packed = torch.stack([buffer[i] for i in range(self.config.num_experts)], dim=0).contiguous()
+            packed = torch.stack(
+                [buffer[i] for i in range(self.config.num_experts)], dim=0
+            ).contiguous()
             del self._expert_export_buffers[buffer_key]
             if kind == "1":
                 return [(f"{prefix}.mlp.experts.gate_up_proj", packed)]
@@ -606,30 +581,23 @@ def _load_linear_attn(
     a = _get(reader, f"{hf_prefix}.in_proj_a.weight")
 
     out[f"{local_prefix}.linear_attn.in_proj.linear.weight"] = _tp_linear_attn_in_proj(
-        q,
-        k,
-        v,
-        z,
-        b,
-        a,
-        ps=ps,
+        q, k, v, z, b, a, ps=ps
     )
     out[f"{local_prefix}.linear_attn.in_proj.linear.layer_norm_weight"] = input_ln
     out[f"{local_prefix}.linear_attn.conv1d.weight"] = _tp_linear_attn_conv1d(
-        _get(reader, f"{hf_prefix}.conv1d.weight"),
-        cfg=cfg,
-        ps=ps,
+        _get(reader, f"{hf_prefix}.conv1d.weight"), cfg=cfg, ps=ps
     )
-    out[f"{local_prefix}.linear_attn.dt_bias"] = _tp(_get(reader, f"{hf_prefix}.dt_bias"), ps.tp_rank, ps.tp_size)
-    out[f"{local_prefix}.linear_attn.A_log"] = _tp(_get(reader, f"{hf_prefix}.A_log"), ps.tp_rank, ps.tp_size)
+    out[f"{local_prefix}.linear_attn.dt_bias"] = _tp(
+        _get(reader, f"{hf_prefix}.dt_bias"), ps.tp_rank, ps.tp_size
+    )
+    out[f"{local_prefix}.linear_attn.A_log"] = _tp(
+        _get(reader, f"{hf_prefix}.A_log"), ps.tp_rank, ps.tp_size
+    )
     out[f"{local_prefix}.linear_attn.norm.weight"] = _zero_centered_gamma_from_hf(
         _get(reader, f"{hf_prefix}.norm.weight")
     )
     out[f"{local_prefix}.linear_attn.o_proj.linear.weight"] = _tp(
-        _get(reader, f"{hf_prefix}.out_proj.weight"),
-        ps.tp_rank,
-        ps.tp_size,
-        dim=1,
+        _get(reader, f"{hf_prefix}.out_proj.weight"), ps.tp_rank, ps.tp_size, dim=1
     )
 
 
@@ -643,26 +611,17 @@ def _load_shared_expert(
 ) -> None:
     shared = f"{hf_mlp_prefix}.shared_expert"
     gate_up = torch.cat(
-        [
-            _get(reader, f"{shared}.gate_proj.weight"),
-            _get(reader, f"{shared}.up_proj.weight"),
-        ],
+        [_get(reader, f"{shared}.gate_proj.weight"), _get(reader, f"{shared}.up_proj.weight")],
         dim=0,
     )
     out[f"{local_prefix}.moe.shared_expert.gate_up.linear.weight"] = _split_gate_up(
-        gate_up,
-        ps.tp_rank,
-        ps.tp_size,
+        gate_up, ps.tp_rank, ps.tp_size
     )
     out[f"{local_prefix}.moe.shared_expert.down.linear.weight"] = _tp(
-        _get(reader, f"{shared}.down_proj.weight"),
-        ps.tp_rank,
-        ps.tp_size,
-        dim=1,
+        _get(reader, f"{shared}.down_proj.weight"), ps.tp_rank, ps.tp_size, dim=1
     )
     out[f"{local_prefix}.moe.shared_expert.shared_gate.weight"] = _get(
-        reader,
-        f"{hf_mlp_prefix}.shared_expert_gate.weight",
+        reader, f"{hf_mlp_prefix}.shared_expert_gate.weight"
     )
 
 
@@ -697,11 +656,7 @@ def _load_experts(
         global_idx = local_start + local_idx
         ep = f"{hf_mlp_prefix}.experts.{global_idx}"
         fc1 = torch.cat(
-            [
-                _get(reader, f"{ep}.gate_proj.weight"),
-                _get(reader, f"{ep}.up_proj.weight"),
-            ],
-            dim=0,
+            [_get(reader, f"{ep}.gate_proj.weight"), _get(reader, f"{ep}.up_proj.weight")], dim=0
         )
         fc2 = _get(reader, f"{ep}.down_proj.weight")
         if ps.etp_size > 1:
@@ -745,7 +700,9 @@ def load_hf_weights(model: nn.Module, path: str, config: Qwen35Config, ps: Paral
 
     prefix = "model.language_model"
     if getattr(base_model, "embed", None) is not None:
-        out["embed.embedding.weight"] = _load_vocab(reader, f"{prefix}.embed_tokens.weight", config, ps)
+        out["embed.embedding.weight"] = _load_vocab(
+            reader, f"{prefix}.embed_tokens.weight", config, ps
+        )
     if getattr(base_model, "norm", None) is not None:
         out["norm.weight"] = _get(reader, f"{prefix}.norm.weight")
     if getattr(base_model, "head", None) is not None:
@@ -776,18 +733,19 @@ def load_hf_weights(model: nn.Module, path: str, config: Qwen35Config, ps: Paral
                 reader=reader,
             )
         out[f"{lp}.mlp_norm.weight"] = _get(reader, f"{hp}.post_attention_layernorm.weight")
-        out[f"{lp}.moe.router.gate.weight"] = _get(reader, f"{hp}.mlp.gate.weight")[: config.num_experts]
+        out[f"{lp}.moe.router.gate.weight"] = _get(reader, f"{hp}.mlp.gate.weight")[
+            : config.num_experts
+        ]
         _load_shared_expert(out, local_prefix=lp, hf_mlp_prefix=f"{hp}.mlp", ps=ps, reader=reader)
-        _load_experts(out, local_prefix=lp, hf_mlp_prefix=f"{hp}.mlp", cfg=config, ps=ps, reader=reader)
+        _load_experts(
+            out, local_prefix=lp, hf_mlp_prefix=f"{hp}.mlp", cfg=config, ps=ps, reader=reader
+        )
 
     _copy_loaded_state(base_model, out)
 
 
 def export_hf_weights(
-    model: nn.Module | list[nn.Module],
-    config: Qwen35Config,
-    ps: ParallelState,
-    **kwargs,
+    model: nn.Module | list[nn.Module], config: Qwen35Config, ps: ParallelState, **kwargs
 ):
     from megatron.lite.primitive.ckpt.hf_weights import export_hf_weights as _export
 
@@ -796,7 +754,9 @@ def export_hf_weights(
     target = kwargs.pop("target", "hf")
     if include_mtp_only:
         return
-    yield from _export(model, Qwen35WeightSpec(config, target=target), ps, vocab_size=config.vocab_size, **kwargs)
+    yield from _export(
+        model, Qwen35WeightSpec(config, target=target), ps, vocab_size=config.vocab_size, **kwargs
+    )
 
 
 __all__ = [

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
@@ -14,8 +14,8 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 import transformer_engine.pytorch as te
-from megatron.core.fusions.fused_bias_swiglu import bias_swiglu_impl
 
+from megatron.core.fusions.fused_bias_swiglu import bias_swiglu_impl
 from megatron.lite.model.qwen3_5.config import Qwen35Config
 from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
 from megatron.lite.primitive.modules.experts import Experts
@@ -111,11 +111,7 @@ class SharedExpert(nn.Module):
             return self.linear(x)
 
     def __init__(
-        self,
-        config: Qwen35Config,
-        ps: ParallelState,
-        *,
-        use_plain_te_linear: bool = False,
+        self, config: Qwen35Config, ps: ParallelState, *, use_plain_te_linear: bool = False
     ):
         super().__init__()
         ffn = config.shared_expert_intermediate_size
@@ -179,16 +175,9 @@ class MoELayer(nn.Module):
         )
         self.experts = Experts(config, ps, fp8=fp8, moe_act_recompute=moe_act_recompute)
         self.dispatcher = TokenDispatcher(
-            config.num_experts,
-            config.hidden_size,
-            ps,
-            use_deepep=use_deepep,
+            config.num_experts, config.hidden_size, ps, use_deepep=use_deepep
         )
-        self.shared_expert = SharedExpert(
-            config,
-            ps,
-            use_plain_te_linear=shared_expert_plain_te,
-        )
+        self.shared_expert = SharedExpert(config, ps, use_plain_te_linear=shared_expert_plain_te)
         self.preserve_3d_graph = bool(preserve_3d_graph)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -276,9 +265,7 @@ class Qwen35Layer(nn.Module):
                 deterministic=deterministic,
             )
         self.mlp_norm = te.RMSNorm(
-            config.hidden_size,
-            eps=config.rms_norm_eps,
-            zero_centered_gamma=True,
+            config.hidden_size, eps=config.rms_norm_eps, zero_centered_gamma=True
         )
         self.moe = MoELayer(
             config,
@@ -293,10 +280,7 @@ class Qwen35Layer(nn.Module):
         )
 
     def forward(
-        self,
-        x: torch.Tensor,
-        position_ids: torch.Tensor | None = None,
-        packed_seq_params=None,
+        self, x: torch.Tensor, position_ids: torch.Tensor | None = None, packed_seq_params=None
     ) -> torch.Tensor:
         residual = x
         if self.full_attn is not None:
@@ -357,7 +341,9 @@ class Qwen35Model(nn.Module):
         self.mtp_loss_scaling_factor = config.mtp_loss_scaling_factor
         self._input_tensor: torch.Tensor | None = None
 
-        layout = build_pipeline_chunk_layout(config.num_hidden_layers, ps, train_config.vpp, vpp_chunk_id)
+        layout = build_pipeline_chunk_layout(
+            config.num_hidden_layers, ps, train_config.vpp, vpp_chunk_id
+        )
         self.layer_indices = layout.layer_indices
         has_embed = layout.has_embed
         has_head = layout.has_head
@@ -394,7 +380,9 @@ class Qwen35Model(nn.Module):
         self.norm: nn.Module | None = None
         self.head: VocabParallelOutput | None = None
         if has_head:
-            self.norm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps, zero_centered_gamma=True)
+            self.norm = te.RMSNorm(
+                config.hidden_size, eps=config.rms_norm_eps, zero_centered_gamma=True
+            )
             self.head = VocabParallelOutput(config.vocab_size, config.hidden_size, ps)
 
         self.mtp_embed: VocabParallelEmbedding | None = None
@@ -563,11 +551,11 @@ class Qwen35Model(nn.Module):
         mtp_loss_mask = loss_mask.clone()
         mtp_loss_values = []
         for mtp_hidden in mtp_hidden_states:
-            mtp_labels, _ = roll_packed_thd_left(mtp_labels, packed_seq_params=packed_seq_params, dims=-1)
+            mtp_labels, _ = roll_packed_thd_left(
+                mtp_labels, packed_seq_params=packed_seq_params, dims=-1
+            )
             mtp_loss_mask, num_tokens = roll_packed_thd_left(
-                mtp_loss_mask,
-                packed_seq_params=packed_seq_params,
-                dims=-1,
+                mtp_loss_mask, packed_seq_params=packed_seq_params, dims=-1
             )
             labels_sb = mtp_labels.transpose(0, 1).contiguous()
             mask_sb = mtp_loss_mask.transpose(0, 1).contiguous()
@@ -591,16 +579,23 @@ class Qwen35Model(nn.Module):
             num_tokens = num_tokens.to(dtype=token_loss.dtype).clamp_min(1.0)
             mtp_loss_values.append(token_loss.sum() / num_tokens)
             mtp_loss_scale = self.mtp_loss_scaling_factor / max(len(mtp_hidden_states), 1)
-            hidden_states = MTPLossAutoScaler.apply(hidden_states, mtp_loss_scale * token_loss / num_tokens)
+            hidden_states = MTPLossAutoScaler.apply(
+                hidden_states, mtp_loss_scale * token_loss / num_tokens
+            )
 
         if not mtp_loss_values:
             return None
-        return hidden_states, torch.stack([loss.detach().float() for loss in mtp_loss_values]).mean()
+        return (
+            hidden_states,
+            torch.stack([loss.detach().float() for loss in mtp_loss_values]).mean(),
+        )
 
     def _head_weight_for_fused_ce(self, hidden_states: torch.Tensor) -> torch.Tensor:
         assert self.head is not None
         weight = self.head.col.linear.weight
-        return weight if weight.dtype == hidden_states.dtype else weight.to(dtype=hidden_states.dtype)
+        return (
+            weight if weight.dtype == hidden_states.dtype else weight.to(dtype=hidden_states.dtype)
+        )
 
 
 def _iter_auto_model_class_refs(hf_config) -> list[str]:
@@ -632,11 +627,7 @@ def _resolve_hf_vision_cls(hf_config, hf_path: str) -> type:
     errors: list[str] = []
     for class_ref in _iter_auto_model_class_refs(hf_config):
         try:
-            model_cls = get_class_from_dynamic_module(
-                class_ref,
-                hf_path,
-                trust_remote_code=True,
-            )
+            model_cls = get_class_from_dynamic_module(class_ref, hf_path, trust_remote_code=True)
         except Exception as exc:
             errors.append(f"{class_ref}: {exc}")
             continue

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
@@ -1,4 +1,5 @@
 """Qwen3.5 lite impl — native model protocol for Megatron Lite runtime."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -10,15 +11,24 @@ import torch
 import torch.nn as nn
 
 from megatron.lite.model.qwen3_5.config import Qwen35Config
-from megatron.lite.model.qwen3_5.lite.checkpoint import (
-    PLACEMENT_FN,
-    export_hf_weights as _export_hf_weights_impl,
-    load_hf_weights as _load_hf_weights_impl,
-)
+from megatron.lite.model.qwen3_5.lite.checkpoint import EXPERT_CLASSIFIER, PLACEMENT_FN
+from megatron.lite.model.qwen3_5.lite.checkpoint import export_hf_weights as _export_hf_weights_impl
+from megatron.lite.model.qwen3_5.lite.checkpoint import load_hf_weights as _load_hf_weights_impl
 from megatron.lite.primitive.bundle import ModelBundle
 from megatron.lite.primitive.parallel import ParallelState, init_parallel
 from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec
 from megatron.lite.runtime.contracts import OptimizerConfig, ParallelConfig
+
+__all__ = [
+    "EXPERT_CLASSIFIER",
+    "ImplConfig",
+    "PLACEMENT_FN",
+    "build_model",
+    "build_model_config",
+    "export_hf_weights",
+    "load_hf_weights",
+    "vocab_size",
+]
 
 
 def is_expert_param(name: str) -> bool:
@@ -54,10 +64,10 @@ def _full_attn_module(layer, name: str):
 
 MODULE_MAP = {
     "core_attn": lambda layer: _full_attn_module(layer, "core_attn"),
-    "experts":   lambda layer: layer.moe.experts,
-    "moe":       lambda layer: layer.moe,
-    "router":    lambda layer: layer.moe.router,
-    "mlp_norm":  lambda layer: layer.mlp_norm,
+    "experts": lambda layer: layer.moe.experts,
+    "moe": lambda layer: layer.moe,
+    "router": lambda layer: layer.moe.router,
+    "mlp_norm": lambda layer: layer.mlp_norm,
     "attn_proj": lambda layer: _full_attn_module(layer, "proj"),
     "linear_attn": lambda layer: layer.linear_attn,
 }
@@ -76,10 +86,7 @@ def build_model_config(source: str | Path | dict, **overrides) -> Qwen35Config:
 
 
 def _forward_step(model: nn.Module, batch: dict) -> dict:
-    kwargs: dict[str, Any] = {
-        "input_ids": batch["input_ids"],
-        "labels": batch["labels"],
-    }
+    kwargs: dict[str, Any] = {"input_ids": batch["input_ids"], "labels": batch["labels"]}
     if "position_ids" in batch:
         kwargs["position_ids"] = batch["position_ids"]
     if "packed_seq_params" in batch:
@@ -93,9 +100,7 @@ def _forward_step(model: nn.Module, batch: dict) -> dict:
 
 
 def _make_aux_loss_hook():
-    from megatron.lite.primitive.modules.moe import (
-        MoEAuxLossAutoScaler,
-    )
+    from megatron.lite.primitive.modules.moe import MoEAuxLossAutoScaler
     from megatron.lite.primitive.modules.mtp import MTPLossAutoScaler
 
     def hook(scale: torch.Tensor) -> None:
@@ -106,9 +111,7 @@ def _make_aux_loss_hook():
 
 
 def _build_mc_optimizer(chunks, model_cfg: Qwen35Config, impl_cfg: ImplConfig, ps: ParallelState):
-    from megatron.lite.primitive.optimizers.megatron_wrap import (
-        build_mc_training_optimizer,
-    )
+    from megatron.lite.primitive.optimizers.megatron_wrap import build_mc_training_optimizer
 
     return build_mc_training_optimizer(
         chunks,
@@ -172,20 +175,10 @@ def build_model(model_cfg: Qwen35Config, *, impl_cfg: ImplConfig) -> ModelBundle
     )
 
     if vpp is None:
-        chunks = [
-            Qwen35Model(model_cfg, train_cfg, ps, **model_kwargs)
-            .to(torch.bfloat16)
-            .cuda()
-        ]
+        chunks = [Qwen35Model(model_cfg, train_cfg, ps, **model_kwargs).to(torch.bfloat16).cuda()]
     else:
         chunks = [
-            Qwen35Model(
-                model_cfg,
-                train_cfg,
-                ps,
-                vpp_chunk_id=i,
-                **model_kwargs,
-            )
+            Qwen35Model(model_cfg, train_cfg, ps, vpp_chunk_id=i, **model_kwargs)
             .to(torch.bfloat16)
             .cuda()
             for i in range(vpp)
@@ -211,10 +204,7 @@ def build_model(model_cfg: Qwen35Config, *, impl_cfg: ImplConfig) -> ModelBundle
         from megatron.lite.runtime.megatron_utils import register_training_hooks
 
         attach_model_sharded_state_dict(
-            chunks,
-            ps,
-            get_placements=PLACEMENT_FN,
-            is_expert=is_expert_param,
+            chunks, ps, get_placements=PLACEMENT_FN, is_expert=is_expert_param
         )
         register_training_hooks(chunks, optimizer)
         optimizer_backend = "distopt"
@@ -223,9 +213,7 @@ def build_model(model_cfg: Qwen35Config, *, impl_cfg: ImplConfig) -> ModelBundle
 
         def _post_model_load_hook():
             from megatron.lite.model.qwen3_5.lite.model import Qwen35Layer
-            from megatron.lite.primitive.optimizers.fsdp2 import (
-                build_fsdp2_training_optimizer,
-            )
+            from megatron.lite.primitive.optimizers.fsdp2 import build_fsdp2_training_optimizer
 
             return {
                 "optimizer": build_fsdp2_training_optimizer(
@@ -237,7 +225,7 @@ def build_model(model_cfg: Qwen35Config, *, impl_cfg: ImplConfig) -> ModelBundle
                     deterministic=deterministic,
                     vpp=impl_cfg.parallel.vpp,
                     leaf_module_names=(),
-                ),
+                )
             }
 
         post_model_load_hook = _post_model_load_hook
@@ -268,10 +256,7 @@ def load_hf_weights(
 
 
 def export_hf_weights(
-    chunks: list[nn.Module],
-    model_cfg: Qwen35Config,
-    ps: ParallelState,
-    **kwargs,
+    chunks: list[nn.Module], model_cfg: Qwen35Config, ps: ParallelState, **kwargs
 ):
     yield from _export_hf_weights_impl(chunks, model_cfg, ps, **kwargs)
 

--- a/experimental/lite/megatron/lite/model/qwen3_5/stats.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/stats.py
@@ -6,11 +6,7 @@ from megatron.lite.model.qwen3_5.config import Qwen35Config
 
 
 def num_floating_point_operations(
-    model_cfg: Qwen35Config,
-    *,
-    seq_len: int,
-    global_batch_size: int,
-    tp_size: int = 1,
+    model_cfg: Qwen35Config, *, seq_len: int, global_batch_size: int, tp_size: int = 1
 ) -> int | None:
     """Megatron-aligned FLOPs estimate for one training step."""
 
@@ -45,8 +41,12 @@ def num_floating_point_operations(
                 for i in range(num_hidden_layers)
             ]
 
-        num_full_attention_layers = sum(layer_type == "full_attention" for layer_type in layer_types)
-        num_linear_attention_layers = sum(layer_type == "linear_attention" for layer_type in layer_types)
+        num_full_attention_layers = sum(
+            layer_type == "full_attention" for layer_type in layer_types
+        )
+        num_linear_attention_layers = sum(
+            layer_type == "linear_attention" for layer_type in layer_types
+        )
         if num_full_attention_layers + num_linear_attention_layers != num_hidden_layers:
             return None
 
@@ -80,11 +80,15 @@ def num_floating_point_operations(
         linear_conv_kernel_dim = int(_get("linear_conv_kernel_dim"))
         qk_dim = linear_key_head_dim * linear_num_key_heads
         v_dim = linear_value_head_dim * linear_num_value_heads
-        linear_attention_flops = 6 * total_tokens * (
-            hidden_size * (2 * qk_dim + 2 * v_dim + 2 * linear_num_value_heads)
-            + linear_conv_kernel_dim * (2 * qk_dim + v_dim)
-            + linear_num_value_heads * (linear_value_head_dim**2) * 4
-            + hidden_size * v_dim
+        linear_attention_flops = (
+            6
+            * total_tokens
+            * (
+                hidden_size * (2 * qk_dim + 2 * v_dim + 2 * linear_num_value_heads)
+                + linear_conv_kernel_dim * (2 * qk_dim + v_dim)
+                + linear_num_value_heads * (linear_value_head_dim**2) * 4
+                + hidden_size * v_dim
+            )
         )
 
         moe_intermediate_size = int(_get("moe_intermediate_size"))
@@ -94,10 +98,7 @@ def num_floating_point_operations(
             18
             * total_tokens
             * hidden_size
-            * (
-                moe_intermediate_size * num_experts_per_tok
-                + shared_expert_intermediate_size
-            )
+            * (moe_intermediate_size * num_experts_per_tok + shared_expert_intermediate_size)
             * num_hidden_layers
         )
 
@@ -168,8 +169,7 @@ def activated_params(model_cfg: Qwen35Config) -> int | None:
         shared_expert_intermediate_size = int(_get("shared_expert_intermediate_size"))
         router = hidden_size * num_experts
         routed_expert = (
-            hidden_size * (2 * moe_intermediate_size)
-            + moe_intermediate_size * hidden_size
+            hidden_size * (2 * moe_intermediate_size) + moe_intermediate_size * hidden_size
         )
         shared_expert = (
             hidden_size * (2 * shared_expert_intermediate_size)

--- a/experimental/lite/megatron/lite/model/qwen3_moe/config.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/config.py
@@ -33,9 +33,7 @@ class Qwen3MoEConfig:
     num_nextn_predict_layers: int = 0
     mtp_loss_scaling_factor: float = 0.1
     mtp_use_repeated_layer: bool = False
-    layer_types: list[str] = field(
-        default_factory=lambda: ["full_attention"] * 48
-    )
+    layer_types: list[str] = field(default_factory=lambda: ["full_attention"] * 48)
 
     def __post_init__(self):
         self._validate()
@@ -72,10 +70,7 @@ class Qwen3MoEConfig:
         )
         valid_types = {"full_attention"}
         for i, lt in enumerate(self.layer_types):
-            _check(
-                lt in valid_types,
-                f"layer_types[{i}] must be one of {valid_types}, got '{lt}'",
-            )
+            _check(lt in valid_types, f"layer_types[{i}] must be one of {valid_types}, got '{lt}'")
 
         if errors:
             raise ValueError(
@@ -116,8 +111,6 @@ class Qwen3MoEConfig:
             kwargs["num_nextn_predict_layers"] = 0
 
         if "layer_types" not in kwargs:
-            kwargs["layer_types"] = ["full_attention"] * kwargs.get(
-                "num_hidden_layers", 48
-            )
+            kwargs["layer_types"] = ["full_attention"] * kwargs.get("num_hidden_layers", 48)
         kwargs.update(overrides)
         return cls(**kwargs)

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/checkpoint.py
@@ -20,7 +20,9 @@ from megatron.lite.primitive.ckpt.dcp import (  # noqa: F401 — re-export
 from megatron.lite.primitive.ckpt.hf_weights import extract_layer_idx, parse_expert_idx
 
 
-def _pack_mcore_qkv(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, config: Qwen3MoEConfig) -> torch.Tensor:
+def _pack_mcore_qkv(
+    q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, config: Qwen3MoEConfig
+) -> torch.Tensor:
     q_per_group = config.num_attention_heads // config.num_key_value_heads
     q = q.view(config.num_key_value_heads, q_per_group * config.head_dim, -1)
     k = k.view(config.num_key_value_heads, config.head_dim, -1)
@@ -28,7 +30,9 @@ def _pack_mcore_qkv(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, config: Q
     return torch.cat([q, k, v], dim=1).reshape(-1, q.shape[-1]).contiguous()
 
 
-def _unpack_mcore_qkv(tensor: torch.Tensor, config: Qwen3MoEConfig) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+def _unpack_mcore_qkv(
+    tensor: torch.Tensor, config: Qwen3MoEConfig
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     q_per_group = config.num_attention_heads // config.num_key_value_heads
     group_width = (q_per_group + 2) * config.head_dim
     packed = tensor.view(config.num_key_value_heads, group_width, -1)
@@ -62,23 +66,29 @@ class Qwen3MoEWeightSpec:
             ap = f"model.layers.{li}.self_attn"
             mp = f"model.layers.{li}.mlp"
             lp = f"layers.{li}"
-            wm.update({
-                f"{lp}.attn.qkv.linear.layer_norm_weight": [f"model.layers.{li}.input_layernorm.weight"],
-                f"{lp}.attn.qkv.linear.weight": [f"{ap}.q_proj.weight", f"{ap}.k_proj.weight", f"{ap}.v_proj.weight"],
-                f"{lp}.attn.q_norm.weight": [f"{ap}.q_norm.weight"],
-                f"{lp}.attn.k_norm.weight": [f"{ap}.k_norm.weight"],
-                f"{lp}.attn.proj.linear.weight": [f"{ap}.o_proj.weight"],
-                f"{lp}.mlp_norm.weight": [f"model.layers.{li}.post_attention_layernorm.weight"],
-                f"{lp}.moe.router.gate.weight": [f"{mp}.gate.weight"],
-            })
+            wm.update(
+                {
+                    f"{lp}.attn.qkv.linear.layer_norm_weight": [
+                        f"model.layers.{li}.input_layernorm.weight"
+                    ],
+                    f"{lp}.attn.qkv.linear.weight": [
+                        f"{ap}.q_proj.weight",
+                        f"{ap}.k_proj.weight",
+                        f"{ap}.v_proj.weight",
+                    ],
+                    f"{lp}.attn.q_norm.weight": [f"{ap}.q_norm.weight"],
+                    f"{lp}.attn.k_norm.weight": [f"{ap}.k_norm.weight"],
+                    f"{lp}.attn.proj.linear.weight": [f"{ap}.o_proj.weight"],
+                    f"{lp}.mlp_norm.weight": [f"model.layers.{li}.post_attention_layernorm.weight"],
+                    f"{lp}.moe.router.gate.weight": [f"{mp}.gate.weight"],
+                }
+            )
             for e in range(c.num_experts):
                 wm[f"{lp}.moe.experts._fc1_weight_{e}"] = [
                     f"{mp}.experts.{e}.gate_proj.weight",
                     f"{mp}.experts.{e}.up_proj.weight",
                 ]
-                wm[f"{lp}.moe.experts._fc2_weight_{e}"] = [
-                    f"{mp}.experts.{e}.down_proj.weight",
-                ]
+                wm[f"{lp}.moe.experts._fc2_weight_{e}"] = [f"{mp}.experts.{e}.down_proj.weight"]
         for mi in range(c.num_nextn_predict_layers):
             hf_li = c.num_hidden_layers + mi
             hp = f"model.layers.{hf_li}"
@@ -86,27 +96,31 @@ class Qwen3MoEWeightSpec:
             mp = f"{hp}.mlp"
             lp = f"mtp.layers.{mi}"
             tlp = f"{lp}.transformer_layer"
-            wm.update({
-                f"{lp}.enorm.weight": [f"{hp}.enorm.weight"],
-                f"{lp}.hnorm.weight": [f"{hp}.hnorm.weight"],
-                f"{lp}.eh_proj.linear.weight": [f"{hp}.eh_proj.weight"],
-                f"{lp}.final_layernorm.weight": [f"{hp}.shared_head.norm.weight"],
-                f"{tlp}.attn.qkv.linear.layer_norm_weight": [f"{hp}.input_layernorm.weight"],
-                f"{tlp}.attn.qkv.linear.weight": [f"{ap}.q_proj.weight", f"{ap}.k_proj.weight", f"{ap}.v_proj.weight"],
-                f"{tlp}.attn.q_norm.weight": [f"{ap}.q_norm.weight"],
-                f"{tlp}.attn.k_norm.weight": [f"{ap}.k_norm.weight"],
-                f"{tlp}.attn.proj.linear.weight": [f"{ap}.o_proj.weight"],
-                f"{tlp}.mlp_norm.weight": [f"{hp}.post_attention_layernorm.weight"],
-                f"{tlp}.moe.router.gate.weight": [f"{mp}.gate.weight"],
-            })
+            wm.update(
+                {
+                    f"{lp}.enorm.weight": [f"{hp}.enorm.weight"],
+                    f"{lp}.hnorm.weight": [f"{hp}.hnorm.weight"],
+                    f"{lp}.eh_proj.linear.weight": [f"{hp}.eh_proj.weight"],
+                    f"{lp}.final_layernorm.weight": [f"{hp}.shared_head.norm.weight"],
+                    f"{tlp}.attn.qkv.linear.layer_norm_weight": [f"{hp}.input_layernorm.weight"],
+                    f"{tlp}.attn.qkv.linear.weight": [
+                        f"{ap}.q_proj.weight",
+                        f"{ap}.k_proj.weight",
+                        f"{ap}.v_proj.weight",
+                    ],
+                    f"{tlp}.attn.q_norm.weight": [f"{ap}.q_norm.weight"],
+                    f"{tlp}.attn.k_norm.weight": [f"{ap}.k_norm.weight"],
+                    f"{tlp}.attn.proj.linear.weight": [f"{ap}.o_proj.weight"],
+                    f"{tlp}.mlp_norm.weight": [f"{hp}.post_attention_layernorm.weight"],
+                    f"{tlp}.moe.router.gate.weight": [f"{mp}.gate.weight"],
+                }
+            )
             for e in range(c.num_experts):
                 wm[f"{tlp}.moe.experts._fc1_weight_{e}"] = [
                     f"{mp}.experts.{e}.gate_proj.weight",
                     f"{mp}.experts.{e}.up_proj.weight",
                 ]
-                wm[f"{tlp}.moe.experts._fc2_weight_{e}"] = [
-                    f"{mp}.experts.{e}.down_proj.weight",
-                ]
+                wm[f"{tlp}.moe.experts._fc2_weight_{e}"] = [f"{mp}.experts.{e}.down_proj.weight"]
         return wm
 
     def hf_to_native(self, native_name: str, hf_tensors: list[torch.Tensor]) -> torch.Tensor:
@@ -122,7 +136,9 @@ class Qwen3MoEWeightSpec:
             return t[: self.config.num_experts]
         return t
 
-    def native_to_hf(self, native_name: str, tensor: torch.Tensor) -> list[tuple[str, torch.Tensor]]:
+    def native_to_hf(
+        self, native_name: str, tensor: torch.Tensor
+    ) -> list[tuple[str, torch.Tensor]]:
         c = self.config
         if native_name == "mtp_embed.embedding.weight":
             return []
@@ -139,11 +155,18 @@ class Qwen3MoEWeightSpec:
                 return [(f"{hp}.eh_proj.weight", tensor)]
             if native_name.endswith(".final_layernorm.weight"):
                 return [(f"{hp}.shared_head.norm.weight", tensor)]
-            proxy = native_name.replace(f"mtp.layers.{mtp_idx}.transformer_layer", f"layers.{hf_li}")
+            proxy = native_name.replace(
+                f"mtp.layers.{mtp_idx}.transformer_layer", f"layers.{hf_li}"
+            )
             return self.native_to_hf(proxy, tensor)
         if "embed" in native_name and "embedding" in native_name:
             return [("model.embed_tokens.weight", tensor)]
-        if native_name.endswith("norm.weight") and "layers" not in native_name and "attn" not in native_name and "mlp" not in native_name:
+        if (
+            native_name.endswith("norm.weight")
+            and "layers" not in native_name
+            and "attn" not in native_name
+            and "mlp" not in native_name
+        ):
             return [("model.norm.weight", tensor)]
         if "head" in native_name:
             return [("lm_head.weight", tensor)]
@@ -179,7 +202,10 @@ class Qwen3MoEWeightSpec:
             ei = parse_expert_idx(native_name)
             mp = f"model.layers.{li}.mlp"
             gate, up = tensor.chunk(2, dim=0)
-            return [(f"{mp}.experts.{ei}.gate_proj.weight", gate), (f"{mp}.experts.{ei}.up_proj.weight", up)]
+            return [
+                (f"{mp}.experts.{ei}.gate_proj.weight", gate),
+                (f"{mp}.experts.{ei}.up_proj.weight", up),
+            ]
         if "experts" in native_name and "fc2" in native_name:
             li = extract_layer_idx(native_name)
             ei = parse_expert_idx(native_name)
@@ -234,7 +260,9 @@ def load_hf_weights(model, path: str, config: Qwen3MoEConfig, ps) -> None:
 def export_hf_weights(model, config: Qwen3MoEConfig, ps, **kwargs):
     from megatron.lite.primitive.ckpt.hf_weights import export_hf_weights as _export
 
-    yield from _export(model, Qwen3MoEWeightSpec(config), ps, vocab_size=config.vocab_size, **kwargs)
+    yield from _export(
+        model, Qwen3MoEWeightSpec(config), ps, vocab_size=config.vocab_size, **kwargs
+    )
 
 
 def save_hf_weights(model, path: str, config: Qwen3MoEConfig, ps) -> None:

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/lora_adapter.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/lora_adapter.py
@@ -14,7 +14,6 @@ from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
 from megatron.lite.primitive.modules.lora import LoraConfig, normalize_lora_config
 from megatron.lite.primitive.parallel import ParallelState
 
-
 _PEFT_PREFIX = "base_model.model.model"
 
 
@@ -95,7 +94,9 @@ def _expert_lora_is_shared(lora: Any) -> bool:
     return bool(getattr(lora, "shared_across_experts", False)) or lora.lora_a.dim() == 2
 
 
-def _expand_shared_expert_lora(lora: Any, num_local_experts: int) -> tuple[torch.Tensor, torch.Tensor]:
+def _expand_shared_expert_lora(
+    lora: Any, num_local_experts: int
+) -> tuple[torch.Tensor, torch.Tensor]:
     if _expert_lora_is_shared(lora):
         return (
             lora.lora_a.detach().unsqueeze(0).expand(num_local_experts, -1, -1).contiguous(),
@@ -105,11 +106,7 @@ def _expand_shared_expert_lora(lora: Any, num_local_experts: int) -> tuple[torch
 
 
 def _split_local_mcore_qkv_b(
-    qkv_b: torch.Tensor,
-    *,
-    num_heads_local: int,
-    num_kv_heads_local: int,
-    head_dim: int,
+    qkv_b: torch.Tensor, *, num_heads_local: int, num_kv_heads_local: int, head_dim: int
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     q_per_group = num_heads_local // num_kv_heads_local
     group_width = (q_per_group + 2) * head_dim
@@ -235,7 +232,9 @@ def _infer_native_alpha(chunks: list[nn.Module] | tuple[nn.Module, ...]) -> int 
     if not alphas:
         return None
     if len(alphas) != 1:
-        raise ValueError(f"Native LoRA modules have inconsistent effective alpha values: {sorted(alphas)}.")
+        raise ValueError(
+            f"Native LoRA modules have inconsistent effective alpha values: {sorted(alphas)}."
+        )
     return next(iter(alphas))
 
 
@@ -253,7 +252,9 @@ def _validate_adapter_config(
     state_rank = _infer_state_rank(state)
     config_rank = adapter_config.get("r")
     if config_rank is not None and state_rank is not None and int(config_rank) != state_rank:
-        raise ValueError(f"Adapter config rank r={config_rank} does not match tensor rank {state_rank}.")
+        raise ValueError(
+            f"Adapter config rank r={config_rank} does not match tensor rank {state_rank}."
+        )
 
     config_targets = _peft_target_set(adapter_config.get("target_modules"))
     state_targets = _state_target_modules(state)
@@ -274,7 +275,9 @@ def _validate_adapter_config(
         expected = normalize_lora_config(lora_config)
         expected_targets = set(_target_modules_from_lora_config(expected))
         if config_rank is not None and int(config_rank) != expected.rank:
-            raise ValueError(f"Adapter config rank r={config_rank} does not match expected rank {expected.rank}.")
+            raise ValueError(
+                f"Adapter config rank r={config_rank} does not match expected rank {expected.rank}."
+            )
         if config_alpha is not None and int(config_alpha) != _effective_lora_alpha(expected):
             raise ValueError(
                 "Adapter config lora_alpha="
@@ -336,8 +339,6 @@ def export_lora_adapter_state(
     state: dict[str, torch.Tensor] = {}
     q_heads_local = model_cfg.num_attention_heads // ps.tp_size
     kv_heads_local = model_cfg.num_key_value_heads // ps.tp_size
-    local_attn_width = q_heads_local * model_cfg.head_dim
-    local_kv_width = kv_heads_local * model_cfg.head_dim
 
     for chunk in _iter_qwen_chunks(list(chunks)):
         for layer in chunk.layers:
@@ -386,10 +387,18 @@ def export_lora_adapter_state(
                 gate_b, up_b = fc1_b.chunk(2, dim=1)
                 if _rank() == 0:
                     for expert_idx in range(model_cfg.num_experts):
-                        state[_expert_key(layer_idx, expert_idx, "gate_proj", "lora_A")] = fc1_a[expert_idx]
-                        state[_expert_key(layer_idx, expert_idx, "gate_proj", "lora_B")] = gate_b[expert_idx]
-                        state[_expert_key(layer_idx, expert_idx, "up_proj", "lora_A")] = fc1_a[expert_idx].clone()
-                        state[_expert_key(layer_idx, expert_idx, "up_proj", "lora_B")] = up_b[expert_idx]
+                        state[_expert_key(layer_idx, expert_idx, "gate_proj", "lora_A")] = fc1_a[
+                            expert_idx
+                        ]
+                        state[_expert_key(layer_idx, expert_idx, "gate_proj", "lora_B")] = gate_b[
+                            expert_idx
+                        ]
+                        state[_expert_key(layer_idx, expert_idx, "up_proj", "lora_A")] = fc1_a[
+                            expert_idx
+                        ].clone()
+                        state[_expert_key(layer_idx, expert_idx, "up_proj", "lora_B")] = up_b[
+                            expert_idx
+                        ]
 
             if experts.fc2_lora is not None:
                 fc2_a_local, fc2_b_local = _expand_shared_expert_lora(
@@ -399,8 +408,12 @@ def export_lora_adapter_state(
                 fc2_b = _all_gather_cat(fc2_b_local, ps.ep_group, dim=0)
                 if _rank() == 0:
                     for expert_idx in range(model_cfg.num_experts):
-                        state[_expert_key(layer_idx, expert_idx, "down_proj", "lora_A")] = fc2_a[expert_idx]
-                        state[_expert_key(layer_idx, expert_idx, "down_proj", "lora_B")] = fc2_b[expert_idx]
+                        state[_expert_key(layer_idx, expert_idx, "down_proj", "lora_A")] = fc2_a[
+                            expert_idx
+                        ]
+                        state[_expert_key(layer_idx, expert_idx, "down_proj", "lora_B")] = fc2_b[
+                            expert_idx
+                        ]
 
     if _rank() != 0:
         return {}
@@ -463,12 +476,7 @@ def save_lora_adapter(
             ),
             "num_tensors": len(state),
             "num_parameters": int(sum(t.numel() for t in state.values())),
-            "parallel": {
-                "tp": ps.tp_size,
-                "ep": ps.ep_size,
-                "etp": ps.etp_size,
-                "pp": ps.pp_size,
-            },
+            "parallel": {"tp": ps.tp_size, "ep": ps.ep_size, "etp": ps.etp_size, "pp": ps.pp_size},
             "model": {
                 "num_hidden_layers": model_cfg.num_hidden_layers,
                 "hidden_size": model_cfg.hidden_size,
@@ -540,13 +548,14 @@ def load_lora_adapter_state(
             attn = layer.attn
             if attn.qkv_lora is not None:
                 q_a = _require_tensor(state, _attn_key(layer_idx, "q_proj", "lora_A")).to(
-                    device=attn.qkv_lora.lora_a.device,
-                    dtype=attn.qkv_lora.lora_a.dtype,
+                    device=attn.qkv_lora.lora_a.device, dtype=attn.qkv_lora.lora_a.dtype
                 )
                 k_a = _require_tensor(state, _attn_key(layer_idx, "k_proj", "lora_A")).to(q_a)
                 v_a = _require_tensor(state, _attn_key(layer_idx, "v_proj", "lora_A")).to(q_a)
                 if strict and (not torch.equal(q_a, k_a) or not torch.equal(q_a, v_a)):
-                    raise ValueError("Megatron Lite fused qkv_lora requires q/k/v lora_A tensors to match.")
+                    raise ValueError(
+                        "Megatron Lite fused qkv_lora requires q/k/v lora_A tensors to match."
+                    )
                 q_a_local = (
                     _slice_lora_rank_partition(q_a, ps)
                     if _is_rank_partitioned_lora_a(attn.qkv_lora, ps)
@@ -554,24 +563,21 @@ def load_lora_adapter_state(
                 )
                 q_b = _slice_tp_output(
                     _require_tensor(state, _attn_key(layer_idx, "q_proj", "lora_B")).to(
-                        device=attn.qkv_lora.lora_b.device,
-                        dtype=attn.qkv_lora.lora_b.dtype,
+                        device=attn.qkv_lora.lora_b.device, dtype=attn.qkv_lora.lora_b.dtype
                     ),
                     q_width_local,
                     ps,
                 )
                 k_b = _slice_tp_output(
                     _require_tensor(state, _attn_key(layer_idx, "k_proj", "lora_B")).to(
-                        device=attn.qkv_lora.lora_b.device,
-                        dtype=attn.qkv_lora.lora_b.dtype,
+                        device=attn.qkv_lora.lora_b.device, dtype=attn.qkv_lora.lora_b.dtype
                     ),
                     kv_width_local,
                     ps,
                 )
                 v_b = _slice_tp_output(
                     _require_tensor(state, _attn_key(layer_idx, "v_proj", "lora_B")).to(
-                        device=attn.qkv_lora.lora_b.device,
-                        dtype=attn.qkv_lora.lora_b.dtype,
+                        device=attn.qkv_lora.lora_b.device, dtype=attn.qkv_lora.lora_b.dtype
                     ),
                     kv_width_local,
                     ps,
@@ -592,15 +598,13 @@ def load_lora_adapter_state(
             if attn.proj_lora is not None:
                 proj_a = _slice_tp_input(
                     _require_tensor(state, _attn_key(layer_idx, "o_proj", "lora_A")).to(
-                        device=attn.proj_lora.lora_a.device,
-                        dtype=attn.proj_lora.lora_a.dtype,
+                        device=attn.proj_lora.lora_a.device, dtype=attn.proj_lora.lora_a.dtype
                     ),
                     attn_in_width_local,
                     ps,
                 )
                 proj_b = _require_tensor(state, _attn_key(layer_idx, "o_proj", "lora_B")).to(
-                    device=attn.proj_lora.lora_b.device,
-                    dtype=attn.proj_lora.lora_b.dtype,
+                    device=attn.proj_lora.lora_b.device, dtype=attn.proj_lora.lora_b.dtype
                 )
                 if _is_output_partitioned_lora_b(attn.proj_lora, ps):
                     proj_b = _slice_tp_output(proj_b, attn.proj_lora.lora_b.shape[0], ps)
@@ -627,7 +631,9 @@ def load_lora_adapter_state(
                             state, _expert_key(layer_idx, expert_idx, "up_proj", "lora_A")
                         ).to(gate_a)
                         if strict and not torch.equal(gate_a, up_a):
-                            raise ValueError("Megatron Lite fused fc1_lora requires gate/up lora_A tensors to match.")
+                            raise ValueError(
+                                "Megatron Lite fused fc1_lora requires gate/up lora_A tensors to match."
+                            )
                         local_gate_a.append(gate_a)
                         local_gate_b.append(
                             _require_tensor(
@@ -646,12 +652,16 @@ def load_lora_adapter_state(
                             )
                         )
                     if strict:
-                        if any(not torch.equal(local_gate_a[0], value) for value in local_gate_a[1:]):
+                        if any(
+                            not torch.equal(local_gate_a[0], value) for value in local_gate_a[1:]
+                        ):
                             raise ValueError(
                                 "Megatron Lite shared expert fc1_lora can only import PEFT adapters "
                                 "whose local expert gate lora_A tensors are identical."
                             )
-                        if any(not torch.equal(local_gate_b[0], value) for value in local_gate_b[1:]):
+                        if any(
+                            not torch.equal(local_gate_b[0], value) for value in local_gate_b[1:]
+                        ):
                             raise ValueError(
                                 "Megatron Lite shared expert fc1_lora can only import PEFT adapters "
                                 "whose local expert gate lora_B tensors are identical."
@@ -662,27 +672,41 @@ def load_lora_adapter_state(
                                 "whose local expert up lora_B tensors are identical."
                             )
                     experts.fc1_lora.lora_a.data.copy_(local_gate_a[0])
-                    experts.fc1_lora.lora_b.data.copy_(torch.cat([local_gate_b[0], local_up_b[0]], dim=0))
+                    experts.fc1_lora.lora_b.data.copy_(
+                        torch.cat([local_gate_b[0], local_up_b[0]], dim=0)
+                    )
                     loaded += 2
                 else:
                     for local_idx, expert_idx in enumerate(range(expert_start, expert_stop)):
-                        gate_a = _require_tensor(state, _expert_key(layer_idx, expert_idx, "gate_proj", "lora_A")).to(
+                        gate_a = _require_tensor(
+                            state, _expert_key(layer_idx, expert_idx, "gate_proj", "lora_A")
+                        ).to(
                             device=experts.fc1_lora.lora_a.device,
                             dtype=experts.fc1_lora.lora_a.dtype,
                         )
-                        up_a = _require_tensor(state, _expert_key(layer_idx, expert_idx, "up_proj", "lora_A")).to(gate_a)
+                        up_a = _require_tensor(
+                            state, _expert_key(layer_idx, expert_idx, "up_proj", "lora_A")
+                        ).to(gate_a)
                         if strict and not torch.equal(gate_a, up_a):
-                            raise ValueError("Megatron Lite fused fc1_lora requires gate/up lora_A tensors to match.")
-                        gate_b = _require_tensor(state, _expert_key(layer_idx, expert_idx, "gate_proj", "lora_B")).to(
+                            raise ValueError(
+                                "Megatron Lite fused fc1_lora requires gate/up lora_A tensors to match."
+                            )
+                        gate_b = _require_tensor(
+                            state, _expert_key(layer_idx, expert_idx, "gate_proj", "lora_B")
+                        ).to(
                             device=experts.fc1_lora.lora_b.device,
                             dtype=experts.fc1_lora.lora_b.dtype,
                         )
-                        up_b = _require_tensor(state, _expert_key(layer_idx, expert_idx, "up_proj", "lora_B")).to(
+                        up_b = _require_tensor(
+                            state, _expert_key(layer_idx, expert_idx, "up_proj", "lora_B")
+                        ).to(
                             device=experts.fc1_lora.lora_b.device,
                             dtype=experts.fc1_lora.lora_b.dtype,
                         )
                         experts.fc1_lora.lora_a.data[local_idx].copy_(gate_a)
-                        experts.fc1_lora.lora_b.data[local_idx].copy_(torch.cat([gate_b, up_b], dim=0))
+                        experts.fc1_lora.lora_b.data[local_idx].copy_(
+                            torch.cat([gate_b, up_b], dim=0)
+                        )
                         loaded += 2
 
             if experts.fc2_lora is not None:
@@ -691,13 +715,17 @@ def load_lora_adapter_state(
                     local_b = []
                     for expert_idx in range(expert_start, expert_stop):
                         local_a.append(
-                            _require_tensor(state, _expert_key(layer_idx, expert_idx, "down_proj", "lora_A")).to(
+                            _require_tensor(
+                                state, _expert_key(layer_idx, expert_idx, "down_proj", "lora_A")
+                            ).to(
                                 device=experts.fc2_lora.lora_a.device,
                                 dtype=experts.fc2_lora.lora_a.dtype,
                             )
                         )
                         local_b.append(
-                            _require_tensor(state, _expert_key(layer_idx, expert_idx, "down_proj", "lora_B")).to(
+                            _require_tensor(
+                                state, _expert_key(layer_idx, expert_idx, "down_proj", "lora_B")
+                            ).to(
                                 device=experts.fc2_lora.lora_b.device,
                                 dtype=experts.fc2_lora.lora_b.dtype,
                             )
@@ -719,13 +747,17 @@ def load_lora_adapter_state(
                 else:
                     for local_idx, expert_idx in enumerate(range(expert_start, expert_stop)):
                         experts.fc2_lora.lora_a.data[local_idx].copy_(
-                            _require_tensor(state, _expert_key(layer_idx, expert_idx, "down_proj", "lora_A")).to(
+                            _require_tensor(
+                                state, _expert_key(layer_idx, expert_idx, "down_proj", "lora_A")
+                            ).to(
                                 device=experts.fc2_lora.lora_a.device,
                                 dtype=experts.fc2_lora.lora_a.dtype,
                             )
                         )
                         experts.fc2_lora.lora_b.data[local_idx].copy_(
-                            _require_tensor(state, _expert_key(layer_idx, expert_idx, "down_proj", "lora_B")).to(
+                            _require_tensor(
+                                state, _expert_key(layer_idx, expert_idx, "down_proj", "lora_B")
+                            ).to(
                                 device=experts.fc2_lora.lora_b.device,
                                 dtype=experts.fc2_lora.lora_b.dtype,
                             )
@@ -756,7 +788,9 @@ def load_lora_adapter(
         expected = normalize_lora_config(lora_config)
         state_rank = _infer_state_rank(state)
         if state_rank is not None and state_rank != expected.rank:
-            raise ValueError(f"Adapter tensor rank {state_rank} does not match expected rank {expected.rank}.")
+            raise ValueError(
+                f"Adapter tensor rank {state_rank} does not match expected rank {expected.rank}."
+            )
     return load_lora_adapter_state(chunks, state, model_cfg, ps, strict=strict)
 
 

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
@@ -54,19 +54,13 @@ class MoELayer(nn.Module):
         super().__init__()
         # Match Qwen3-MoE's `load_balancing_type="none"` setting: no aux loss.
         self.router = TopKRouter(
-            config, ps,
-            router_bias_rate=router_bias_rate,
-            compute_aux_loss=False,
+            config, ps, router_bias_rate=router_bias_rate, compute_aux_loss=False
         )
         self.experts = Experts(
-            config,
-            ps,
-            fp8=fp8,
-            moe_act_recompute=moe_act_recompute,
-            lora_config=lora_config,
+            config, ps, fp8=fp8, moe_act_recompute=moe_act_recompute, lora_config=lora_config
         )
         self.dispatcher = TokenDispatcher(
-            config.num_experts, config.hidden_size, ps, use_deepep=use_deepep,
+            config.num_experts, config.hidden_size, ps, use_deepep=use_deepep
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -154,7 +148,8 @@ class TransformerLayer(nn.Module):
         )
         self.mlp_norm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.moe = MoELayer(
-            config, ps,
+            config,
+            ps,
             use_deepep=use_deepep,
             router_bias_rate=router_bias_rate,
             fp8=fp8,
@@ -163,10 +158,7 @@ class TransformerLayer(nn.Module):
         )
 
     def forward(
-        self,
-        x: torch.Tensor,
-        position_ids: torch.Tensor | None = None,
-        packed_seq_params=None,
+        self, x: torch.Tensor, position_ids: torch.Tensor | None = None, packed_seq_params=None
     ) -> torch.Tensor:
         residual = x
         h = self.attn(x, position_ids=position_ids, packed_seq_params=packed_seq_params)
@@ -228,11 +220,7 @@ class MultiTokenPredictionLayer(nn.Module):
         self.enorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.hnorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.eh_proj = VanillaColumnParallelLinear(
-            config.hidden_size * 2,
-            config.hidden_size,
-            ps,
-            sp=ps.tp_size > 1,
-            gather_output=True,
+            config.hidden_size * 2, config.hidden_size, ps, sp=ps.tp_size > 1, gather_output=True
         )
         self.transformer_layer = TransformerLayer(
             config,
@@ -256,17 +244,13 @@ class MultiTokenPredictionLayer(nn.Module):
         rotary_position_ids: torch.Tensor | None = None,
         packed_seq_params=None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
-        attention_position_ids = rotary_position_ids if rotary_position_ids is not None else position_ids
-        input_ids, _ = roll_packed_thd_left(
-            input_ids,
-            packed_seq_params=packed_seq_params,
-            dims=-1,
+        attention_position_ids = (
+            rotary_position_ids if rotary_position_ids is not None else position_ids
         )
+        input_ids, _ = roll_packed_thd_left(input_ids, packed_seq_params=packed_seq_params, dims=-1)
         if position_ids is not None:
             position_ids, _ = roll_packed_thd_left(
-                position_ids,
-                packed_seq_params=packed_seq_params,
-                dims=-1,
+                position_ids, packed_seq_params=packed_seq_params, dims=-1
             )
         decoder_input = self.embedding(input_ids)
         decoder_input = scatter_to_sequence_parallel(decoder_input, self.ps)
@@ -281,9 +265,7 @@ class MultiTokenPredictionLayer(nn.Module):
         hidden_states = self.eh_proj(hidden_states)
         hidden_states = scatter_to_sequence_parallel(hidden_states, self.ps)
         hidden_states = self.transformer_layer(
-            hidden_states,
-            position_ids=attention_position_ids,
-            packed_seq_params=packed_seq_params,
+            hidden_states, position_ids=attention_position_ids, packed_seq_params=packed_seq_params
         )
         hidden_states = self.final_layernorm(hidden_states)
         return hidden_states, input_ids, position_ids
@@ -354,7 +336,9 @@ class MultiTokenPredictionBlock(nn.Module):
 def _temperature_to_float(temperature: float | torch.Tensor) -> float:
     if isinstance(temperature, torch.Tensor):
         if temperature.numel() != 1:
-            raise ValueError("Megatron Lite fused/MTP SFT currently supports scalar temperature only.")
+            raise ValueError(
+                "Megatron Lite fused/MTP SFT currently supports scalar temperature only."
+            )
         return float(temperature.detach().float().item())
     return float(temperature)
 
@@ -384,9 +368,7 @@ class Qwen3MoEModel(nn.Module):
         self.mtp_enable_train = bool(mtp_enable and mtp_enable_train)
         self.mtp_loss_scaling_factor = config.mtp_loss_scaling_factor
         self._input_tensor: torch.Tensor | None = None
-        layout = build_pipeline_chunk_layout(
-            config.num_hidden_layers, ps, vpp, vpp_chunk_id,
-        )
+        layout = build_pipeline_chunk_layout(config.num_hidden_layers, ps, vpp, vpp_chunk_id)
         self.layer_indices = layout.layer_indices
         has_embed = layout.has_embed
         has_head = layout.has_head
@@ -403,7 +385,9 @@ class Qwen3MoEModel(nn.Module):
         self.layers = nn.ModuleList(
             [
                 TransformerLayer(
-                    config, ps, idx,
+                    config,
+                    ps,
+                    idx,
                     use_deepep=use_deepep,
                     router_bias_rate=router_bias_rate,
                     fp8=fp8,
@@ -579,14 +563,10 @@ class Qwen3MoEModel(nn.Module):
         mtp_loss_values = []
         for mtp_hidden in mtp_hidden_states:
             mtp_labels, _ = roll_packed_thd_left(
-                mtp_labels,
-                packed_seq_params=packed_seq_params,
-                dims=-1,
+                mtp_labels, packed_seq_params=packed_seq_params, dims=-1
             )
             mtp_loss_mask, num_tokens = roll_packed_thd_left(
-                mtp_loss_mask,
-                packed_seq_params=packed_seq_params,
-                dims=-1,
+                mtp_loss_mask, packed_seq_params=packed_seq_params, dims=-1
             )
             labels_sb = mtp_labels.transpose(0, 1).contiguous()
             mask_sb = mtp_loss_mask.transpose(0, 1).contiguous()
@@ -611,11 +591,16 @@ class Qwen3MoEModel(nn.Module):
             mtp_loss_values.append(token_loss.sum() / num_tokens)
 
             mtp_loss_scale = self.mtp_loss_scaling_factor / max(len(mtp_hidden_states), 1)
-            hidden_states = MTPLossAutoScaler.apply(hidden_states, mtp_loss_scale * token_loss / num_tokens)
+            hidden_states = MTPLossAutoScaler.apply(
+                hidden_states, mtp_loss_scale * token_loss / num_tokens
+            )
 
         if not mtp_loss_values:
             return None
-        return hidden_states, torch.stack([loss.detach().float() for loss in mtp_loss_values]).mean()
+        return (
+            hidden_states,
+            torch.stack([loss.detach().float() for loss in mtp_loss_values]).mean(),
+        )
 
     def _head_weight_for_fused_ce(self, hidden_states: torch.Tensor) -> torch.Tensor:
         assert self.head is not None

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
@@ -25,13 +25,10 @@ from typing import Any
 import torch
 import torch.nn as nn
 
-from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
 from megatron.lite.model.qwen3_moe.common import is_expert_param
-from megatron.lite.model.qwen3_moe.lite.checkpoint import (
-    EXPERT_CLASSIFIER,
-    PLACEMENT_FN,
-    load_hf_weights as _load_hf_weights_impl,
-)
+from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
+from megatron.lite.model.qwen3_moe.lite.checkpoint import EXPERT_CLASSIFIER, PLACEMENT_FN
+from megatron.lite.model.qwen3_moe.lite.checkpoint import load_hf_weights as _load_hf_weights_impl
 from megatron.lite.model.qwen3_moe.lite.model import MTPLossAutoScaler, Qwen3MoEModel
 from megatron.lite.primitive.bundle import ModelBundle
 from megatron.lite.primitive.modules.lora import (
@@ -44,6 +41,16 @@ from megatron.lite.primitive.parallel import ParallelState, init_parallel
 from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec
 from megatron.lite.runtime.contracts import OptimizerConfig, ParallelConfig
 
+__all__ = [
+    "EXPERT_CLASSIFIER",
+    "ImplConfig",
+    "PLACEMENT_FN",
+    "build_model",
+    "build_model_config",
+    "export_hf_weights",
+    "load_hf_weights",
+    "vocab_size",
+]
 
 # ---------------------------------------------------------------------------
 # ImplConfig
@@ -181,7 +188,8 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
         for i in range(vpp):
             chunks.append(
                 Qwen3MoEModel(model_cfg, ps, vpp=vpp, vpp_chunk_id=i, **model_kwargs)
-                .to(torch.bfloat16).cuda()
+                .to(torch.bfloat16)
+                .cuda()
             )
 
     # ── recompute ──
@@ -209,9 +217,7 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
     finalize_grads = None
     post_model_load_hook = None
     if impl_cfg.optimizer == "mc":
-        from megatron.lite.primitive.optimizers.megatron_wrap import (
-            build_mc_training_optimizer,
-        )
+        from megatron.lite.primitive.optimizers.megatron_wrap import build_mc_training_optimizer
 
         optimizer, finalize_grads = build_mc_training_optimizer(
             chunks,
@@ -225,10 +231,7 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
         from megatron.lite.primitive.ckpt import attach_model_sharded_state_dict
 
         attach_model_sharded_state_dict(
-            chunks,
-            ps,
-            get_placements=PLACEMENT_FN,
-            is_expert=is_expert_param,
+            chunks, ps, get_placements=PLACEMENT_FN, is_expert=is_expert_param
         )
         optimizer_backend = "distopt"
     elif impl_cfg.optimizer == "fsdp2":
@@ -236,9 +239,7 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
 
         def _post_model_load_hook():
             from megatron.lite.model.qwen3_moe.lite.model import TransformerLayer
-            from megatron.lite.primitive.optimizers.fsdp2 import (
-                build_fsdp2_training_optimizer,
-            )
+            from megatron.lite.primitive.optimizers.fsdp2 import build_fsdp2_training_optimizer
 
             return {
                 "optimizer": build_fsdp2_training_optimizer(
@@ -253,7 +254,7 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
                     # CE path reads head.col.linear.weight directly, and the
                     # embedding path is also driven from model.forward().
                     leaf_module_names=(),
-                ),
+                )
             }
 
         post_model_load_hook = _post_model_load_hook
@@ -293,10 +294,7 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
 
 
 def load_hf_weights(
-    chunk: nn.Module,
-    hf_path: str,
-    model_cfg: Qwen3MoEConfig,
-    ps: ParallelState,
+    chunk: nn.Module, hf_path: str, model_cfg: Qwen3MoEConfig, ps: ParallelState
 ) -> None:
     """Load HF pretrained weights into model chunk."""
     if not hf_path:
@@ -305,10 +303,7 @@ def load_hf_weights(
 
 
 def export_hf_weights(
-    chunks: list[nn.Module],
-    model_cfg: Qwen3MoEConfig,
-    ps: ParallelState,
-    **kwargs,
+    chunks: list[nn.Module], model_cfg: Qwen3MoEConfig, ps: ParallelState, **kwargs
 ):
     """Export HF weights from model chunks."""
     from megatron.lite.model.qwen3_moe.lite.checkpoint import export_hf_weights as _export

--- a/experimental/lite/megatron/lite/model/registry.py
+++ b/experimental/lite/megatron/lite/model/registry.py
@@ -81,9 +81,7 @@ register_model(
 )
 
 register_model(
-    "qwen3_moe",
-    package="megatron.lite.model.qwen3_moe",
-    impls={"lite": _QWEN3_MOE_LITE},
+    "qwen3_moe", package="megatron.lite.model.qwen3_moe", impls={"lite": _QWEN3_MOE_LITE}
 )
 
 register_model(
@@ -101,9 +99,7 @@ register_model(
 
 def get_model_package(model_name: str):
     if model_name not in MODEL_PACKAGES:
-        raise ValueError(
-            f"Unknown model: {model_name!r}. Available: {list(MODEL_PACKAGES)}"
-        )
+        raise ValueError(f"Unknown model: {model_name!r}. Available: {list(MODEL_PACKAGES)}")
     return importlib.import_module(MODEL_PACKAGES[model_name])
 
 
@@ -117,8 +113,7 @@ def resolve_runtime_model_name(model_name: str, impl: str) -> str:
     key = (model_name, impl)
     if key not in _IMPL_TO_RUNTIME_MODEL:
         raise ValueError(
-            f"No runtime for ({model_name!r}, {impl!r}). "
-            f"Known: {list(_IMPL_TO_RUNTIME_MODEL)}"
+            f"No runtime for ({model_name!r}, {impl!r}). " f"Known: {list(_IMPL_TO_RUNTIME_MODEL)}"
         )
     return _IMPL_TO_RUNTIME_MODEL[key]
 

--- a/experimental/lite/megatron/lite/primitive/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/__init__.py
@@ -1,2 +1,1 @@
 """Public primitive-layer entrypoints."""
-

--- a/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
@@ -61,12 +61,7 @@ def save_training_checkpoint(
         ckpt_path = os.path.join(path, f"step_{step}")
         os.makedirs(ckpt_path, exist_ok=True)
         _save_distopt_checkpoint(
-            model,
-            optimizer,
-            step,
-            ckpt_path,
-            save_model=save_model,
-            save_optimizer=save_optimizer,
+            model, optimizer, step, ckpt_path, save_model=save_model, save_optimizer=save_optimizer
         )
         if save_rng:
             _save_rng_sidecar(ckpt_path)
@@ -83,11 +78,7 @@ def save_training_checkpoint(
         for name, param in model.named_parameters():
             placements = get_placements(name)
             mesh = expert_mesh if is_expert(name) else dense_mesh
-            state_dict[f"model.{name}"] = _dcp_tensor_from_param(
-                param,
-                mesh,
-                placements,
-            )
+            state_dict[f"model.{name}"] = _dcp_tensor_from_param(param, mesh, placements)
 
     ckpt_path = os.path.join(path, f"step_{step}")
     os.makedirs(ckpt_path, exist_ok=True)
@@ -128,11 +119,7 @@ def load_training_checkpoint(
     ckpt_path = _resolve_step_checkpoint_path(path)
     if _supports_distopt_distckpt(model, optimizer):
         step = _load_distopt_checkpoint(
-            model,
-            optimizer,
-            ckpt_path,
-            load_model=load_model,
-            load_optimizer=load_optimizer,
+            model, optimizer, ckpt_path, load_model=load_model, load_optimizer=load_optimizer
         )
         if load_rng:
             _load_rng_sidecar(ckpt_path)
@@ -150,11 +137,7 @@ def load_training_checkpoint(
         for name, param in model.named_parameters():
             placements = get_placements(name)
             mesh = expert_mesh if is_expert(name) else dense_mesh
-            state_dict[f"model.{name}"] = _empty_dcp_tensor_like_param(
-                param,
-                mesh,
-                placements,
-            )
+            state_dict[f"model.{name}"] = _empty_dcp_tensor_like_param(param, mesh, placements)
 
     dcp.load(state_dict, checkpoint_id=ckpt_path)
 
@@ -181,8 +164,7 @@ def _resolve_step_checkpoint_path(path: str) -> str:
         return path
 
     step_dirs = sorted(
-        [d for d in os.listdir(path) if d.startswith("step_")],
-        key=lambda d: int(d.split("_")[1]),
+        [d for d in os.listdir(path) if d.startswith("step_")], key=lambda d: int(d.split("_")[1])
     )
     if step_dirs:
         return os.path.join(path, step_dirs[-1])
@@ -207,12 +189,7 @@ def _save_distopt_checkpoint(
     from megatron.lite.primitive.ckpt.distckpt import save_distopt_checkpoint
 
     save_distopt_checkpoint(
-        model,
-        optimizer,
-        step,
-        path,
-        save_model=save_model,
-        save_optimizer=save_optimizer,
+        model, optimizer, step, path, save_model=save_model, save_optimizer=save_optimizer
     )
 
 
@@ -227,11 +204,7 @@ def _load_distopt_checkpoint(
     from megatron.lite.primitive.ckpt.distckpt import load_distopt_checkpoint
 
     return load_distopt_checkpoint(
-        model,
-        optimizer,
-        path,
-        load_model=load_model,
-        load_optimizer=load_optimizer,
+        model, optimizer, path, load_model=load_model, load_optimizer=load_optimizer
     )
 
 
@@ -299,9 +272,7 @@ def _dcp_tensor_from_param(param: torch.Tensor, mesh: DeviceMesh, placements: li
 
 
 def _empty_dcp_tensor_like_param(
-    param: torch.Tensor,
-    mesh: DeviceMesh,
-    placements: list,
+    param: torch.Tensor, mesh: DeviceMesh, placements: list
 ) -> DTensor:
     if _is_dtensor_like(param):
         return _dtensor_from_dtensor_like_param(param, torch.empty_like(_to_local_tensor(param)))
@@ -320,10 +291,7 @@ def _dtensor_from_dtensor_like_param(param: torch.Tensor, local_tensor: torch.Te
 
 def _copy_tensor_(target: torch.Tensor, src: torch.Tensor) -> None:
     local_target = _to_local_tensor(target)
-    local_src = _to_local_tensor(src).to(
-        device=local_target.device,
-        dtype=local_target.dtype,
-    )
+    local_src = _to_local_tensor(src).to(device=local_target.device, dtype=local_target.dtype)
     if isinstance(local_target, torch.Tensor) and local_target is not target:
         local_target.copy_(local_src)
     else:
@@ -559,6 +527,7 @@ def _build_meshes(config):
 def log_rank0(msg: str) -> None:
     if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
         print(f"[megatron.lite] {msg}", flush=True)
+
 
 # ======================================================================
 # QKV / FC1 canonicalize for DCP (interleaved-TP ↔ canonical layout)

--- a/experimental/lite/megatron/lite/primitive/ckpt/distckpt.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/distckpt.py
@@ -21,7 +21,6 @@ from megatron.lite.primitive.protocols import (
     default_placement_fn,
 )
 
-
 _DISTOPT_METADATA = {
     "distrib_optim_sharding_type": "fully_reshardable",
     "distrib_optim_fully_reshardable_mem_efficient": False,
@@ -40,8 +39,7 @@ def attach_model_sharded_state_dict(
 
     for chunk in model_chunks:
         chunk.sharded_state_dict = MethodType(  # type: ignore[method-assign]
-            _build_bound_sharded_state_dict(ps, get_placements, is_expert),
-            chunk,
+            _build_bound_sharded_state_dict(ps, get_placements, is_expert), chunk
         )
         chunk._mlite_distopt_sharded_state_dict = True  # type: ignore[attr-defined]
         chunk._mlite_distopt_parallel_state = ps  # type: ignore[attr-defined]
@@ -80,8 +78,7 @@ def save_distopt_checkpoint(
         patches = _patch_empty_native_optimizer_state_dicts(optimizer, fallback_step=step)
         try:
             state_dict["optimizer"] = optimizer.sharded_state_dict(
-                _single_or_all_model_state(model_sd),
-                metadata=_DISTOPT_METADATA,
+                _single_or_all_model_state(model_sd), metadata=_DISTOPT_METADATA
             )
         finally:
             _restore_state_dict_patches(patches)
@@ -111,9 +108,7 @@ def load_distopt_checkpoint(
         patches = _patch_empty_native_optimizer_state_dicts(optimizer, fallback_step=0)
         try:
             load_sd["optimizer"] = optimizer.sharded_state_dict(
-                _single_or_all_model_state(model_sd),
-                is_loading=True,
-                metadata=_DISTOPT_METADATA,
+                _single_or_all_model_state(model_sd), is_loading=True, metadata=_DISTOPT_METADATA
             )
         finally:
             _restore_state_dict_patches(patches)
@@ -156,9 +151,7 @@ def _synchronize_native_optimizer_steps(optimizer: Any) -> None:
 
 
 def _patch_empty_native_optimizer_state_dicts(
-    optimizer: Any,
-    *,
-    fallback_step: int,
+    optimizer: Any, *, fallback_step: int
 ) -> list[tuple[Any, Any]]:
     patches: list[tuple[Any, Any]] = []
     for distopt in _iter_distributed_optimizers(optimizer):
@@ -169,9 +162,7 @@ def _patch_empty_native_optimizer_state_dicts(
         original_state_dict = distopt.state_dict
 
         def patched_state_dict(
-            original_state_dict=original_state_dict,
-            distopt=distopt,
-            fallback_step=fallback_step,
+            original_state_dict=original_state_dict, distopt=distopt, fallback_step=fallback_step
         ):
             try:
                 return original_state_dict()
@@ -194,10 +185,7 @@ def _patch_native_optimizer_step_load(optimizer: Any) -> list[tuple[Any, Any]]:
         original_set_state = distopt._set_main_param_and_optimizer_states
 
         def patched_set_state(
-            model_param,
-            tensors,
-            distopt=distopt,
-            original_set_state=original_set_state,
+            model_param, tensors, distopt=distopt, original_set_state=original_set_state
         ):
             removed_step = _pop_optimizer_step_for_model_param(distopt, model_param, tensors)
             try:
@@ -218,9 +206,7 @@ def _restore_set_state_patches(patches: list[tuple[Any, Any]]) -> None:
 
 
 def _pop_optimizer_step_for_model_param(
-    distopt: Any,
-    model_param,
-    tensors: dict[str, Any],
+    distopt: Any, model_param, tensors: dict[str, Any]
 ) -> tuple[MutableMapping, Any] | None:
     if "step" in tensors:
         return None
@@ -325,9 +311,7 @@ def _step_like(reference: Any, value: int) -> Any:
 
 
 def _build_bound_sharded_state_dict(
-    ps: ParallelState,
-    get_placements: PlacementFn,
-    is_expert: ExpertClassifierFn,
+    ps: ParallelState, get_placements: PlacementFn, is_expert: ExpertClassifierFn
 ) -> Callable:
     def sharded_state_dict(
         self,
@@ -390,19 +374,12 @@ def _make_sharded_tensor(
 ) -> ShardedTensor:
     rank_offsets, replica_id = _rank_offsets_and_replica_id(placements, ps, expert=expert)
     return ShardedTensor.from_rank_offsets(
-        key,
-        tensor,
-        *sharded_offsets,
-        *rank_offsets,
-        replica_id=replica_id,
+        key, tensor, *sharded_offsets, *rank_offsets, replica_id=replica_id
     )
 
 
 def _rank_offsets_and_replica_id(
-    placements: list,
-    ps: ParallelState,
-    *,
-    expert: bool,
+    placements: list, ps: ParallelState, *, expert: bool
 ) -> tuple[tuple[tuple[int, int, int], ...], tuple[int, ...]]:
     ranks, sizes = _mesh_ranks_and_sizes(ps, expert=expert)
     axis_fragments: dict[int, tuple[int, int]] = {}
@@ -431,11 +408,7 @@ def _replica_id(placements: list, ps: ParallelState, *, expert: bool) -> tuple[i
         if _placement_is_sharded(placements, 1) or _placement_is_sharded(placements, 2)
         else ps.dp_cp_rank
     )
-    return (
-        0,
-        _replica_axis_rank(placements, 3, ps.tp_rank),
-        int(dp_cp_rank),
-    )
+    return (0, _replica_axis_rank(placements, 3, ps.tp_rank), int(dp_cp_rank))
 
 
 def _replica_axis_rank(placements: list, axis: int, rank: int) -> int:
@@ -474,8 +447,7 @@ def _model_sharded_state_dict(model: nn.Module | Iterable[nn.Module]) -> dict[st
     ps = _chunk_parallel_state(chunks[0]) if chunks else None
     return {
         _model_chunk_key(ps, idx, len(chunks)): _chunk_sharded_state_dict(
-            chunk,
-            _model_chunk_sharded_key_prefix(ps, idx, len(chunks)),
+            chunk, _model_chunk_sharded_key_prefix(ps, idx, len(chunks))
         )
         for idx, chunk in enumerate(chunks)
     }
@@ -520,7 +492,9 @@ def _single_or_all_model_state(model_sd: dict[str, Any]) -> dict[str, Any]:
     return model_sd
 
 
-def _load_model_state_dict(model: nn.Module | Iterable[nn.Module], state_dict: dict[str, Any]) -> None:
+def _load_model_state_dict(
+    model: nn.Module | Iterable[nn.Module], state_dict: dict[str, Any]
+) -> None:
     chunks = _model_chunks(model)
     if len(chunks) == 1 and "model" in state_dict:
         _wrapped_module(chunks[0]).load_state_dict(state_dict["model"], strict=False)

--- a/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
@@ -22,6 +22,7 @@ import torch.nn as nn
 from safetensors import safe_open
 from safetensors.torch import save_file as _safe_save
 
+
 @runtime_checkable
 class HFWeights(Protocol):
     """Protocol for HF ↔ Megatron Lite weight conversion.
@@ -37,7 +38,9 @@ class HFWeights(Protocol):
         """Convert HF tensors → single Megatron Lite tensor (e.g. merge QKV)."""
         ...
 
-    def native_to_hf(self, native_name: str, tensor: torch.Tensor) -> list[tuple[str, torch.Tensor]]:
+    def native_to_hf(
+        self, native_name: str, tensor: torch.Tensor
+    ) -> list[tuple[str, torch.Tensor]]:
         """Convert Megatron Lite tensor → [(hf_name, hf_tensor)] (e.g. split QKV back)."""
         ...
 
@@ -116,9 +119,7 @@ def unwrap_model(model: nn.Module) -> nn.Module:
 
 
 def save_safetensors(
-    tensors: dict[str, torch.Tensor],
-    path: str,
-    filename: str = "model.safetensors",
+    tensors: dict[str, torch.Tensor], path: str, filename: str = "model.safetensors"
 ) -> None:
     os.makedirs(path, exist_ok=True)
     _safe_save(tensors, os.path.join(path, filename))
@@ -163,12 +164,7 @@ def split_dim(tensor: torch.Tensor, rank: int, world: int, dim: int = 0) -> torc
 
 
 def split_qkv(
-    tensor: torch.Tensor,
-    rank: int,
-    world: int,
-    num_q_heads: int,
-    num_kv_heads: int,
-    head_dim: int,
+    tensor: torch.Tensor, rank: int, world: int, num_q_heads: int, num_kv_heads: int, head_dim: int
 ) -> torch.Tensor:
     """TP-shard a fused [Q, K, V] weight, splitting Q/K/V heads independently.
 
@@ -180,8 +176,8 @@ def split_qkv(
     q_size = num_q_heads * head_dim
     kv_size = num_kv_heads * head_dim
     q = tensor[:q_size]
-    k = tensor[q_size:q_size + kv_size]
-    v = tensor[q_size + kv_size:]
+    k = tensor[q_size : q_size + kv_size]
+    v = tensor[q_size + kv_size :]
     q_shard = q.chunk(world, dim=0)[rank]
     k_shard = k.chunk(world, dim=0)[rank]
     v_shard = v.chunk(world, dim=0)[rank]
@@ -198,7 +194,7 @@ def split_gate_up(tensor: torch.Tensor, rank: int, world: int) -> torch.Tensor:
 
 
 def allgather_concat(
-    tensor: torch.Tensor, world_size: int, group: dist.ProcessGroup | None, dim: int,
+    tensor: torch.Tensor, world_size: int, group: dist.ProcessGroup | None, dim: int
 ) -> torch.Tensor:
     gathered = [torch.empty_like(tensor) for _ in range(world_size)]
     dist.all_gather(gathered, tensor.contiguous(), group=group)
@@ -241,9 +237,7 @@ def to_global_layer_name(name: str, layer_map: dict[int, int]) -> str:
     return re.sub(r"layers\.(\d+)\.", _replace, name)
 
 
-def gather_gate_up(
-    tensor: torch.Tensor, world_size: int, group: dist.ProcessGroup,
-) -> torch.Tensor:
+def gather_gate_up(tensor: torch.Tensor, world_size: int, group: dist.ProcessGroup) -> torch.Tensor:
     ffn_local = tensor.shape[0] // 2
     gate_full = allgather_concat(tensor[:ffn_local], world_size, group, dim=0)
     up_full = allgather_concat(tensor[ffn_local:], world_size, group, dim=0)
@@ -256,12 +250,7 @@ def gather_gate_up(
 
 
 def load_hf_weights(
-    model: nn.Module,
-    hf_path: str,
-    spec: HFWeights,
-    ps,
-    *,
-    vocab_size: int | None = None,
+    model: nn.Module, hf_path: str, spec: HFWeights, ps, *, vocab_size: int | None = None
 ) -> None:
     """Load HF safetensors into a Megatron Lite model using HFWeights.
 
@@ -305,14 +294,7 @@ def load_hf_weights(
         expert_gid = spec.expert_global_id(mapped)
         if expert_gid is not None:
             _load_expert_weight(
-                mapped,
-                hf_names,
-                reader,
-                spec,
-                ps,
-                loaded,
-                expert_gid,
-                expert_shard,
+                mapped, hf_names, reader, spec, ps, loaded, expert_gid, expert_shard
             )
             continue
 
@@ -326,7 +308,9 @@ def load_hf_weights(
                 if vocab_size is not None and ("embed" in mapped or "head" in mapped):
                     padded = pad_vocab_for_tp(vocab_size, ps.tp_size)
                     if tensor.size(0) < padded:
-                        pad = torch.zeros(padded - tensor.size(0), *tensor.shape[1:], dtype=tensor.dtype)
+                        pad = torch.zeros(
+                            padded - tensor.size(0), *tensor.shape[1:], dtype=tensor.dtype
+                        )
                         tensor = torch.cat([tensor, pad], dim=0)
                 qkv = spec.qkv_spec(mapped) if hasattr(spec, "qkv_spec") else None
                 if qkv is not None:
@@ -368,7 +352,9 @@ def _load_expert_weight(native_name, hf_names, reader, spec, ps, loaded, expert_
             else:
                 tensor = split_dim(tensor, ps.etp_rank, ps.etp_size, dim=split_d)
 
-    loaded[spec.expert_local_name(native_name, expert_gid - local_start)] = tensor.to(dtype=torch.bfloat16)
+    loaded[spec.expert_local_name(native_name, expert_gid - local_start)] = tensor.to(
+        dtype=torch.bfloat16
+    )
 
 
 def _resolve_param_name(name: str, state_dict: dict) -> str | None:
@@ -436,7 +422,9 @@ def export_hf_weights(
                 exported_params += 1
                 if not rank0_only or rank == 0:
                     for native_name, gathered_tensor in gathered_one.items():
-                        if vocab_size is not None and ("embed" in native_name or "head" in native_name):
+                        if vocab_size is not None and (
+                            "embed" in native_name or "head" in native_name
+                        ):
                             gathered_tensor = gathered_tensor[:vocab_size]
                         for hf_name, hf_tensor in spec.native_to_hf(native_name, gathered_tensor):
                             yield hf_name, _cast_export_tensor(hf_tensor, resolved_export_dtype)
@@ -514,7 +502,7 @@ def _gather_dense(name: str, tensor: torch.Tensor, spec: HFWeights, ps) -> torch
 
 
 def _gather_expert(
-    name: str, tensor: torch.Tensor, spec: HFWeights, ps, out: dict[str, torch.Tensor],
+    name: str, tensor: torch.Tensor, spec: HFWeights, ps, out: dict[str, torch.Tensor]
 ) -> None:
     """Gather an expert param across ETP + EP."""
     tensor = _gather_expert_etp(name, tensor, spec, ps)
@@ -549,10 +537,7 @@ def _expert_group_key(name: str) -> str:
 
 
 def _gather_expert_group(
-    entries: list[tuple[int, str, torch.Tensor]],
-    spec: HFWeights,
-    ps,
-    out: dict[str, torch.Tensor],
+    entries: list[tuple[int, str, torch.Tensor]], spec: HFWeights, ps, out: dict[str, torch.Tensor]
 ) -> None:
     """Gather local experts in one EP collective per layer/kind."""
     prepared = [
@@ -565,8 +550,7 @@ def _gather_expert_group(
         if packed_name is not None:
             if ps.ep_size <= 1 or ps.ep_group is None:
                 out[packed_name] = torch.stack(
-                    [tensor.contiguous() for _, _, tensor in prepared],
-                    dim=0,
+                    [tensor.contiguous() for _, _, tensor in prepared], dim=0
                 ).cpu()
                 return
 

--- a/experimental/lite/megatron/lite/primitive/config.py
+++ b/experimental/lite/megatron/lite/primitive/config.py
@@ -50,7 +50,4 @@ def load_hf_config_dict(path_or_name: str) -> dict[str, Any]:
         raise ValueError(f"Failed to load config from '{path_or_name}': {e}") from e
 
 
-__all__ = [
-    "load_hf_config_dict",
-    "to_dataclass",
-]
+__all__ = ["load_hf_config_dict", "to_dataclass"]

--- a/experimental/lite/megatron/lite/primitive/data.py
+++ b/experimental/lite/megatron/lite/primitive/data.py
@@ -76,29 +76,17 @@ def fixed_batches(
 
 
 def infinite_batches(
-    vocab_size: int,
-    seq_len: int,
-    batch_size: int = 1,
-    device: str = "cuda",
-    seed: int = 42,
+    vocab_size: int, seq_len: int, batch_size: int = 1, device: str = "cuda", seed: int = 42
 ):
     """Infinite deterministic batch generator (for throughput benchmarks)."""
     g = torch.Generator(device=device).manual_seed(seed)
     while True:
         yield {
             "input_ids": torch.randint(
-                0,
-                vocab_size,
-                (batch_size, seq_len),
-                device=device,
-                generator=g,
+                0, vocab_size, (batch_size, seq_len), device=device, generator=g
             ),
             "labels": torch.randint(
-                0,
-                vocab_size,
-                (batch_size, seq_len),
-                device=device,
-                generator=g,
+                0, vocab_size, (batch_size, seq_len), device=device, generator=g
             ),
         }
 
@@ -125,7 +113,9 @@ def infinite_batches_thd(
     split via zigzag striping. position_ids stay FULL because lite's RoPE
     (is_thd_format=False) auto-slices emb internally, same as BSH path.
     """
-    from megatron.core.packed_seq_params import PackedSeqParams  # pyright: ignore[reportMissingImports]  # noqa: I001
+    from megatron.core.packed_seq_params import (  # pyright: ignore[reportMissingImports]  # noqa: I001
+        PackedSeqParams,
+    )
 
     if cp_size < 1:
         raise ValueError(f"cp_size must be >= 1, got {cp_size}")
@@ -172,9 +162,9 @@ def infinite_batches_thd(
             ids_cp = zigzag_split_for_cp(ids_padded, cp_rank, cp_size, seq_dim=0)
             lbl_cp = zigzag_split_for_cp(lbl_padded, cp_rank, cp_size, seq_dim=0)
             yield {
-                "input_ids": ids_cp.unsqueeze(0),   # (1, T/cp)
-                "labels": lbl_cp.unsqueeze(0),       # (1, T/cp)
-                "position_ids": position_ids,         # FULL (3, 1, T)
+                "input_ids": ids_cp.unsqueeze(0),  # (1, T/cp)
+                "labels": lbl_cp.unsqueeze(0),  # (1, T/cp)
+                "position_ids": position_ids,  # FULL (3, 1, T)
                 "packed_seq_params": packed_seq_params,
             }
     else:
@@ -204,8 +194,4 @@ def infinite_batches_thd(
             }
 
 
-__all__ = [
-    "fixed_batches",
-    "infinite_batches",
-    "infinite_batches_thd",
-]
+__all__ = ["fixed_batches", "infinite_batches", "infinite_batches_thd"]

--- a/experimental/lite/megatron/lite/primitive/deterministic.py
+++ b/experimental/lite/megatron/lite/primitive/deterministic.py
@@ -1,4 +1,5 @@
 """Deterministic computation utilities for bitwise reproducible experiments."""
+
 from __future__ import annotations
 
 import os

--- a/experimental/lite/megatron/lite/primitive/modules/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/modules/__init__.py
@@ -18,10 +18,7 @@ _EXPORTS = {
     "TokenDispatcher": ("megatron.lite.primitive.modules.dispatcher", "TokenDispatcher"),
     "TopKRouter": ("megatron.lite.primitive.modules.router", "TopKRouter"),
     "_AllToAll": ("megatron.lite.primitive.modules.moe", "_AllToAll"),
-    "split_grouped_qkvg": (
-        "megatron.lite.primitive.modules.gqa_utils",
-        "split_grouped_qkvg",
-    ),
+    "split_grouped_qkvg": ("megatron.lite.primitive.modules.gqa_utils", "split_grouped_qkvg"),
 }
 
 
@@ -36,6 +33,7 @@ def __getattr__(name: str):
     value = getattr(module, attr_name)
     globals()[name] = value
     return value
+
 
 __all__ = [
     "Experts",

--- a/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
+++ b/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
@@ -6,11 +6,11 @@ import os
 
 import torch  # pyright: ignore[reportMissingImports]
 import torch.distributed as dist  # pyright: ignore[reportMissingImports]
+
 from megatron.core.transformer.moe.moe_utils import (  # pyright: ignore[reportMissingImports]
     permute,
     unpermute,
 )
-
 from megatron.lite.primitive.modules.moe import _AllToAll
 from megatron.lite.primitive.parallel import ParallelState
 from megatron.lite.primitive.utils import ensure_divisible
@@ -42,19 +42,13 @@ def _build_deepep_buffer(group: dist.ProcessGroup, hidden_size: int):
         deep_ep.Buffer.get_combine_config(group_size),
     ):
         num_nvl_bytes = max(
-            config.get_nvl_buffer_size_hint(hidden_bytes, group_size),
-            num_nvl_bytes,
+            config.get_nvl_buffer_size_hint(hidden_bytes, group_size), num_nvl_bytes
         )
         num_rdma_bytes = max(
-            config.get_rdma_buffer_size_hint(hidden_bytes, group_size),
-            num_rdma_bytes,
+            config.get_rdma_buffer_size_hint(hidden_bytes, group_size), num_rdma_bytes
         )
 
-    return deep_ep.Buffer(
-        group=group,
-        num_nvl_bytes=num_nvl_bytes,
-        num_rdma_bytes=num_rdma_bytes,
-    )
+    return deep_ep.Buffer(group=group, num_nvl_bytes=num_nvl_bytes, num_rdma_bytes=num_rdma_bytes)
 
 
 def _use_moe_permute_fusion() -> bool:
@@ -95,24 +89,19 @@ class _DeepEPDispatch(torch.autograd.Function):
             async_finish=async_finish,
             allocate_on_comm_stream=allocate_on_comm_stream,
         )
-        (
-            recv_hidden,
-            recv_indices,
-            recv_probs,
-            recv_per_expert,
-            handle,
-            after_event,
-        ) = buffer.dispatch(
-            hidden_states.contiguous(),
-            topk_idx=topk_indices,
-            topk_weights=topk_scores.float(),
-            num_tokens_per_rank=num_tokens_per_rank,
-            num_tokens_per_rdma_rank=num_tokens_per_rdma_rank,
-            is_token_in_rank=is_token_in_rank,
-            num_tokens_per_expert=num_tokens_per_expert,
-            previous_event=event,
-            async_finish=async_finish,
-            allocate_on_comm_stream=allocate_on_comm_stream,
+        (recv_hidden, recv_indices, recv_probs, recv_per_expert, handle, after_event) = (
+            buffer.dispatch(
+                hidden_states.contiguous(),
+                topk_idx=topk_indices,
+                topk_weights=topk_scores.float(),
+                num_tokens_per_rank=num_tokens_per_rank,
+                num_tokens_per_rdma_rank=num_tokens_per_rdma_rank,
+                is_token_in_rank=is_token_in_rank,
+                num_tokens_per_expert=num_tokens_per_expert,
+                previous_event=event,
+                async_finish=async_finish,
+                allocate_on_comm_stream=allocate_on_comm_stream,
+            )
         )
         if async_finish:
             after_event.current_stream_wait()
@@ -122,20 +111,13 @@ class _DeepEPDispatch(torch.autograd.Function):
         ctx.async_finish = async_finish
         ctx.allocate_on_comm_stream = allocate_on_comm_stream
         recv_per_expert_tensor = torch.tensor(
-            recv_per_expert,
-            dtype=torch.int64,
-            device=recv_hidden.device,
+            recv_per_expert, dtype=torch.int64, device=recv_hidden.device
         )
         return recv_hidden, recv_indices, recv_probs, recv_per_expert_tensor, handle
 
     @staticmethod
     def backward(
-        ctx,
-        grad_recv_hidden,
-        grad_recv_indices,
-        grad_recv_probs,
-        grad_recv_per_expert,
-        grad_handle,
+        ctx, grad_recv_hidden, grad_recv_indices, grad_recv_probs, grad_recv_per_expert, grad_handle
     ):
         del grad_recv_indices, grad_recv_per_expert, grad_handle
         previous_event = (
@@ -209,12 +191,7 @@ class _DeepEPCombine(torch.autograd.Function):
 class TokenDispatcher:
 
     def __init__(
-        self,
-        num_experts: int,
-        hidden_size: int,
-        ps: ParallelState,
-        *,
-        use_deepep: bool = True,
+        self, num_experts: int, hidden_size: int, ps: ParallelState, *, use_deepep: bool = True
     ):
         self.ps = ps
         self.num_experts = num_experts
@@ -235,25 +212,22 @@ class TokenDispatcher:
 
         if self.ep_size > 1 and self.num_local_experts > 1:
             chunk_idxs = torch.arange(self.ep_size * self.num_local_experts)
-            self._sort_by_experts = chunk_idxs.reshape(
-                self.ep_size, self.num_local_experts,
-            ).T.ravel().tolist()
-            self._restore_by_ranks = chunk_idxs.reshape(
-                self.num_local_experts, self.ep_size,
-            ).T.ravel().tolist()
+            self._sort_by_experts = (
+                chunk_idxs.reshape(self.ep_size, self.num_local_experts).T.ravel().tolist()
+            )
+            self._restore_by_ranks = (
+                chunk_idxs.reshape(self.num_local_experts, self.ep_size).T.ravel().tolist()
+            )
 
     def dispatch(
-        self,
-        hidden_states: torch.Tensor,
-        topk_scores: torch.Tensor,
-        topk_indices: torch.Tensor,
+        self, hidden_states: torch.Tensor, topk_scores: torch.Tensor, topk_indices: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
         if self.ep_size <= 1:
             return self._dispatch_local(hidden_states, topk_scores, topk_indices)
         if self.use_deepep:
             return self._dispatch_deepep(hidden_states, topk_scores, topk_indices)
         dispatched, tpe, sorted_scores = self._dispatch_alltoall(
-            hidden_states, topk_scores, topk_indices,
+            hidden_states, topk_scores, topk_indices
         )
         return dispatched, tpe, sorted_scores
 
@@ -265,10 +239,7 @@ class TokenDispatcher:
         return self._combine_alltoall(expert_output)
 
     def submit_deepep_combine(
-        self,
-        expert_output: torch.Tensor,
-        *,
-        allocate_on_comm_stream: bool = False,
+        self, expert_output: torch.Tensor, *, allocate_on_comm_stream: bool = False
     ):
         if not self.use_deepep:
             raise RuntimeError("submit_deepep_combine requires DeepEP combine.")
@@ -295,10 +266,7 @@ class TokenDispatcher:
             if len(combined) >= 3:
                 event = combined[2]
             combined = combined[0]
-        return {
-            "combined": combined,
-            "event": event,
-        }
+        return {"combined": combined, "event": event}
 
     def finish_deepep_combine(self, state):
         if not self.use_deepep:
@@ -324,8 +292,11 @@ class TokenDispatcher:
         probs_2d.scatter_(1, topk_indices, topk_scores)
 
         permuted, permuted_probs, sorted_indices = permute(
-            hidden_states, routing_map,
-            probs=probs_2d, num_out_tokens=num_out, fused=_use_moe_permute_fusion(),
+            hidden_states,
+            routing_map,
+            probs=probs_2d,
+            num_out_tokens=num_out,
+            fused=_use_moe_permute_fusion(),
         )[:3]
 
         self._row_id_map = sorted_indices
@@ -336,7 +307,8 @@ class TokenDispatcher:
 
     def _combine_local(self, expert_output):
         result = unpermute(
-            expert_output, self._row_id_map,
+            expert_output,
+            self._row_id_map,
             restore_shape=self._restore_shape,
             fused=_use_moe_permute_fusion(),
         )
@@ -352,14 +324,15 @@ class TokenDispatcher:
         routing_map.scatter_(1, topk_indices, True)
         num_out = t * topk_indices.size(1)
 
-        probs_2d = torch.zeros(
-            t, e, dtype=topk_scores.dtype, device=hidden_states.device,
-        )
+        probs_2d = torch.zeros(t, e, dtype=topk_scores.dtype, device=hidden_states.device)
         probs_2d.scatter_(1, topk_indices, topk_scores)
 
         permuted, permuted_probs, sorted_indices = permute(
-            hidden_states, routing_map,
-            probs=probs_2d, num_out_tokens=num_out, fused=_use_moe_permute_fusion(),
+            hidden_states,
+            routing_map,
+            probs=probs_2d,
+            num_out_tokens=num_out,
+            fused=_use_moe_permute_fusion(),
         )[:3]
         self._row_id_map = sorted_indices
         self._restore_shape = hidden_states.shape
@@ -377,11 +350,10 @@ class TokenDispatcher:
         self._output_splits = recv_tpe_2d.sum(dim=1).tolist()
 
         recv_flat = _AllToAll.apply(
-            permuted, self._input_splits, self._output_splits, self.ps.ep_group,
+            permuted, self._input_splits, self._output_splits, self.ps.ep_group
         )
         recv_scores = _AllToAll.apply(
-            permuted_probs.unsqueeze(-1),
-            self._input_splits, self._output_splits, self.ps.ep_group,
+            permuted_probs.unsqueeze(-1), self._input_splits, self._output_splits, self.ps.ep_group
         )
 
         if self.num_local_experts > 1:
@@ -416,7 +388,7 @@ class TokenDispatcher:
             rank_grouped = expert_output
 
         combined = _AllToAll.apply(
-            rank_grouped, self._output_splits, self._input_splits, self.ps.ep_group,
+            rank_grouped, self._output_splits, self._input_splits, self.ps.ep_group
         )
         result = unpermute(
             combined,
@@ -434,12 +406,7 @@ class TokenDispatcher:
         return result
 
     def submit_deepep_dispatch(
-        self,
-        hidden_states,
-        topk_scores,
-        topk_indices,
-        *,
-        allocate_on_comm_stream: bool = False,
+        self, hidden_states, topk_scores, topk_indices, *, allocate_on_comm_stream: bool = False
     ):
         if not self.use_deepep:
             raise RuntimeError("submit_deepep_dispatch requires DeepEP dispatch.")
@@ -463,17 +430,19 @@ class TokenDispatcher:
         )
 
         topk_scores = topk_scores.float()
-        recv_hidden, recv_indices, recv_probs, recv_per_expert, handle, event = self.buffer.dispatch(
-            hidden_states,
-            topk_idx=topk_indices,
-            topk_weights=topk_scores,
-            num_tokens_per_rank=num_tokens_per_rank,
-            num_tokens_per_rdma_rank=num_tokens_per_rdma_rank,
-            is_token_in_rank=is_token_in_rank,
-            num_tokens_per_expert=num_tokens_per_expert,
-            previous_event=event,
-            async_finish=True,
-            allocate_on_comm_stream=allocate_on_comm_stream,
+        recv_hidden, recv_indices, recv_probs, recv_per_expert, handle, event = (
+            self.buffer.dispatch(
+                hidden_states,
+                topk_idx=topk_indices,
+                topk_weights=topk_scores,
+                num_tokens_per_rank=num_tokens_per_rank,
+                num_tokens_per_rdma_rank=num_tokens_per_rdma_rank,
+                is_token_in_rank=is_token_in_rank,
+                num_tokens_per_expert=num_tokens_per_expert,
+                previous_event=event,
+                async_finish=True,
+                allocate_on_comm_stream=allocate_on_comm_stream,
+            )
         )
         return {
             "recv_hidden": recv_hidden,
@@ -507,17 +476,16 @@ class TokenDispatcher:
         if isinstance(recv_per_expert, torch.Tensor):
             recv_per_expert = [int(x) for x in recv_per_expert.detach().cpu().tolist()]
         local_tpe = torch.tensor(
-            recv_per_expert[: self.num_local_experts],
-            dtype=torch.int64, device=recv_hidden.device,
+            recv_per_expert[: self.num_local_experts], dtype=torch.int64, device=recv_hidden.device
         )
         self._local_tpe_list = [int(x) for x in recv_per_expert[: self.num_local_experts]]
         rows = recv_hidden.size(0)
         recv_indices = recv_indices.to(torch.long)
         routing_map = torch.zeros(
-            rows, self.num_local_experts, dtype=torch.bool, device=recv_hidden.device,
+            rows, self.num_local_experts, dtype=torch.bool, device=recv_hidden.device
         )
         probs_2d = torch.zeros(
-            rows, self.num_local_experts, dtype=recv_probs.dtype, device=recv_hidden.device,
+            rows, self.num_local_experts, dtype=recv_probs.dtype, device=recv_hidden.device
         )
         valid = recv_indices >= 0
         row_ids = torch.arange(rows, device=recv_hidden.device).unsqueeze(1)
@@ -548,10 +516,9 @@ class TokenDispatcher:
                 f"local_tpe_sum={int(local_tpe.sum().item())}",
                 flush=True,
             )
-        if (
-            os.environ.get("MEGATRON_LITE_DEEPEP_SKIP_DISPATCH_METADATA_CHECK") != "1"
-            and int(local_tpe.sum().item()) != int(dispatched.shape[0])
-        ):
+        if os.environ.get("MEGATRON_LITE_DEEPEP_SKIP_DISPATCH_METADATA_CHECK") != "1" and int(
+            local_tpe.sum().item()
+        ) != int(dispatched.shape[0]):
             ep_rank = dist.get_rank(group=self.ps.ep_group)
             raise RuntimeError(
                 "DeepEP dispatch metadata mismatch: "
@@ -562,30 +529,22 @@ class TokenDispatcher:
 
     def _dispatch_deepep(self, hidden_states, topk_scores, topk_indices):
         if torch.is_grad_enabled():
-            recv_hidden, recv_indices, recv_probs, recv_per_expert, handle = (
-                _DeepEPDispatch.apply(
-                    self.buffer,
-                    hidden_states,
-                    topk_indices,
-                    topk_scores.float(),
-                    self.num_experts,
-                    False,
-                    False,
-                )
+            recv_hidden, recv_indices, recv_probs, recv_per_expert, handle = _DeepEPDispatch.apply(
+                self.buffer,
+                hidden_states,
+                topk_indices,
+                topk_scores.float(),
+                self.num_experts,
+                False,
+                False,
             )
             self._handle = handle
             self._deepep_event = None
             return self._finish_deepep_dispatch(
-                recv_hidden,
-                recv_indices,
-                recv_probs,
-                recv_per_expert,
+                recv_hidden, recv_indices, recv_probs, recv_per_expert
             )
         state = self.submit_deepep_dispatch(
-            hidden_states,
-            topk_scores,
-            topk_indices,
-            allocate_on_comm_stream=False,
+            hidden_states, topk_scores, topk_indices, allocate_on_comm_stream=False
         )
         return self.finish_deepep_dispatch(state)
 
@@ -602,13 +561,7 @@ class TokenDispatcher:
             fused=_use_moe_permute_fusion(),
         )
         if torch.is_grad_enabled():
-            combined = _DeepEPCombine.apply(
-                self.buffer,
-                rank_grouped,
-                self._handle,
-                False,
-                False,
-            )
+            combined = _DeepEPCombine.apply(self.buffer, rank_grouped, self._handle, False, False)
         else:
             combined = self.buffer.combine(rank_grouped, self._handle)
         if isinstance(combined, tuple):

--- a/experimental/lite/megatron/lite/primitive/modules/experts.py
+++ b/experimental/lite/megatron/lite/primitive/modules/experts.py
@@ -53,11 +53,7 @@ def _weighted_swiglu(y, weights):
 def _swiglu_back(g, y):
     y_1, y_2 = torch.chunk(y, 2, -1)
     return torch.cat(
-        (
-            g * torch.sigmoid(y_1) * (1 + y_1 * (1 - torch.sigmoid(y_1))) * y_2,
-            g * F.silu(y_1),
-        ),
-        -1,
+        (g * torch.sigmoid(y_1) * (1 + y_1 * (1 - torch.sigmoid(y_1))) * y_2, g * F.silu(y_1)), -1
     )
 
 
@@ -96,9 +92,7 @@ def weighted_bias_swiglu_impl(input, bias, weights, fp8_input_store=False):
     if bias is not None:
         raise NotImplementedError("Bias is not supported for weighted swiglu fusion")
     output = _WeightedSwiGLUFunction.apply(input, weights, fp8_input_store)
-    return output if len(ori_shape) == 2 else output.view(
-        ori_shape[0], ori_shape[1], -1,
-    )
+    return output if len(ori_shape) == 2 else output.view(ori_shape[0], ori_shape[1], -1)
 
 
 def swiglu_with_probs(y: torch.Tensor, probs: torch.Tensor | None) -> torch.Tensor:
@@ -214,10 +208,7 @@ class Experts(nn.Module):
                     [
                         x,
                         torch.zeros(
-                            max_len - etp_real_len,
-                            x.shape[1],
-                            dtype=x.dtype,
-                            device=x.device,
+                            max_len - etp_real_len, x.shape[1], dtype=x.dtype, device=x.device
                         ),
                     ],
                     dim=0,
@@ -227,9 +218,7 @@ class Experts(nn.Module):
                         [
                             permuted_probs,
                             torch.zeros(
-                                max_len - etp_real_len,
-                                dtype=permuted_probs.dtype,
-                                device=x.device,
+                                max_len - etp_real_len, dtype=permuted_probs.dtype, device=x.device
                             ),
                         ],
                         dim=0,
@@ -280,10 +269,10 @@ class Experts(nn.Module):
             probs_pad = torch.zeros(total_padded, device=device, dtype=permuted_probs.dtype)
         src_off, dst_off = 0, 0
         for real, pad in zip(m_splits, padded, strict=True):
-            x_pad[dst_off:dst_off + real] = x[src_off:src_off + real]
-            mask[dst_off:dst_off + real] = True
+            x_pad[dst_off : dst_off + real] = x[src_off : src_off + real]
+            mask[dst_off : dst_off + real] = True
             if probs_pad is not None:
-                probs_pad[dst_off:dst_off + real] = permuted_probs[src_off:src_off + real]
+                probs_pad[dst_off : dst_off + real] = permuted_probs[src_off : src_off + real]
             src_off += real
             dst_off += pad
         return x_pad, probs_pad, padded, mask

--- a/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
@@ -7,11 +7,14 @@ import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 import transformer_engine.pytorch as te
-from megatron.core.jit import jit_fuser
 
+from megatron.core.jit import jit_fuser
 from megatron.lite.primitive.ops.gated_delta_rule import l2norm, torch_chunk_gated_delta_rule
 from megatron.lite.primitive.parallel import ColumnParallelLinear, ParallelState, RowParallelLinear
-from megatron.lite.primitive.parallel.cp import zigzag_reconstruct_from_cp_parts, zigzag_slice_for_cp
+from megatron.lite.primitive.parallel.cp import (
+    zigzag_reconstruct_from_cp_parts,
+    zigzag_slice_for_cp,
+)
 from megatron.lite.primitive.parallel.thd import (
     reconstruct_packed_from_cp_parts,
     split_packed_to_cp_local,
@@ -22,8 +25,8 @@ try:
     from fla.modules.convolution import (
         causal_conv1d as _fla_causal_conv1d,  # pyright: ignore[reportMissingImports]
     )
-    from fla.ops.gated_delta_rule import (  # pyright: ignore[reportMissingImports]
-        chunk_gated_delta_rule as _fla_chunk_gated_delta_rule,
+    from fla.ops.gated_delta_rule import (
+        chunk_gated_delta_rule as _fla_chunk_gated_delta_rule,  # pyright: ignore[reportMissingImports]
     )
 
     _HAS_FLA = True
@@ -87,10 +90,7 @@ class GatedDeltaNet(nn.Module):
         self.o_proj = RowParallelLinear(self.v_dim, hidden_size, ps, bias=False)
 
     def forward(
-        self,
-        x: torch.Tensor,
-        position_ids: torch.Tensor | None = None,
-        packed_seq_params=None,
+        self, x: torch.Tensor, position_ids: torch.Tensor | None = None, packed_seq_params=None
     ) -> torch.Tensor:
         del position_ids
         qkvzba = self.in_proj(x).transpose(0, 1).contiguous()
@@ -120,12 +120,7 @@ class GatedDeltaNet(nn.Module):
 
         qkv = self._causal_conv1d(qkv, seq_len, cu_seqlens=cu_seqlens)
         query, key, value, gate, beta, alpha = self._prepare_qkv(
-            qkv,
-            gate,
-            beta,
-            alpha,
-            batch,
-            seq_len,
+            qkv, gate, beta, alpha, batch, seq_len
         )
         g, beta = self._compute_g_and_beta(self.A_log, self.dt_bias, alpha, beta)
         out, _ = self._gated_delta_rule(
@@ -164,10 +159,7 @@ class GatedDeltaNet(nn.Module):
         if packed_seq_params is not None:
             cu_seqlens = self._packed_cu_seqlens(packed_seq_params)
             full = reconstruct_packed_from_cp_parts(
-                parts,
-                cu_seqlens_padded=cu_seqlens,
-                cp_size=self.ps.cp_size,
-                dim=1,
+                parts, cu_seqlens_padded=cu_seqlens, cp_size=self.ps.cp_size, dim=1
             )
             return full, ("packed", cu_seqlens)
         full = zigzag_reconstruct_from_cp_parts(parts, seq_dim=1)
@@ -188,11 +180,7 @@ class GatedDeltaNet(nn.Module):
         raise RuntimeError(f"Unknown CP restore kind: {kind!r}")
 
     def _causal_conv1d(
-        self,
-        qkv: torch.Tensor,
-        seq_len: int,
-        *,
-        cu_seqlens: torch.Tensor | None,
+        self, qkv: torch.Tensor, seq_len: int, *, cu_seqlens: torch.Tensor | None
     ) -> torch.Tensor:
         if cu_seqlens is None:
             qkv_t = qkv.transpose(1, 2).contiguous()

--- a/experimental/lite/megatron/lite/primitive/modules/gqa.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gqa.py
@@ -18,14 +18,14 @@ import inspect
 import torch
 import torch.nn as nn
 import transformer_engine.pytorch as te
+
 from megatron.core.models.common.embeddings.rope_utils import (  # pyright: ignore[reportMissingImports]
     _apply_rotary_pos_emb_bshd,
     _apply_rotary_pos_emb_thd,
 )
-from megatron.core.models.common.embeddings.rotary_pos_embedding import (  # pyright: ignore[reportMissingImports]
-    RotaryEmbedding as MCoreRotaryEmbedding,
+from megatron.core.models.common.embeddings.rotary_pos_embedding import (
+    RotaryEmbedding as MCoreRotaryEmbedding,  # pyright: ignore[reportMissingImports]
 )
-
 from megatron.lite.primitive.modules.gqa_utils import split_grouped_qkvg
 from megatron.lite.primitive.modules.lora import LinearLoRA, LoraConfig, normalize_lora_config
 from megatron.lite.primitive.modules.mrope import MultimodalRotaryEmbedding
@@ -38,9 +38,12 @@ from megatron.lite.primitive.utils import ensure_divisible
 # (Megatron-LM/megatron/core/extensions/transformer_engine.py:1501-1593).
 _KEPT_PSP_FIELDS = (
     "qkv_format",
-    "cu_seqlens_q", "cu_seqlens_kv",
-    "cu_seqlens_q_padded", "cu_seqlens_kv_padded",
-    "max_seqlen_q", "max_seqlen_kv",
+    "cu_seqlens_q",
+    "cu_seqlens_kv",
+    "cu_seqlens_q_padded",
+    "cu_seqlens_kv_padded",
+    "max_seqlen_q",
+    "max_seqlen_kv",
 )
 
 
@@ -50,8 +53,7 @@ def _callable_accepts_kwarg(fn, kwarg: str) -> bool:
     except (TypeError, ValueError):
         return False
     return any(
-        param.kind is inspect.Parameter.VAR_KEYWORD or param.name == kwarg
-        for param in parameters
+        param.kind is inspect.Parameter.VAR_KEYWORD or param.name == kwarg for param in parameters
     )
 
 
@@ -103,18 +105,24 @@ class GQAttention(nn.Module):
         # Mismatched order would put bucket boundaries in different places,
         # producing different per-rank fp32 master shard layouts and
         # non-bitwise step-1 divergence.
-        self.proj = RowParallelLinear(
-            num_attention_heads * head_dim, hidden_size, ps, bias=False,
-        )
+        self.proj = RowParallelLinear(num_attention_heads * head_dim, hidden_size, ps, bias=False)
         q_cols = num_attention_heads * (2 if output_gate else 1)
         qkv_size = (q_cols + 2 * num_key_value_heads) * head_dim
         self.qkv = ColumnParallelLinear(
-            hidden_size, qkv_size, ps,
-            bias=False, normalization="RMSNorm", eps=rms_norm_eps,
+            hidden_size,
+            qkv_size,
+            ps,
+            bias=False,
+            normalization="RMSNorm",
+            eps=rms_norm_eps,
             zero_centered_gamma=zero_centered_gamma,
         )
-        self.q_norm = te.RMSNorm(head_dim, eps=rms_norm_eps, zero_centered_gamma=zero_centered_gamma)
-        self.k_norm = te.RMSNorm(head_dim, eps=rms_norm_eps, zero_centered_gamma=zero_centered_gamma)
+        self.q_norm = te.RMSNorm(
+            head_dim, eps=rms_norm_eps, zero_centered_gamma=zero_centered_gamma
+        )
+        self.k_norm = te.RMSNorm(
+            head_dim, eps=rms_norm_eps, zero_centered_gamma=zero_centered_gamma
+        )
 
         lora = normalize_lora_config(lora_config)
         self.qkv_lora: LinearLoRA | None = None
@@ -169,9 +177,8 @@ class GQAttention(nn.Module):
                 rotary_base=rope_theta,
                 cp_group=ps.cp_group if ps.cp_size > 1 else None,
             )
-        self._rotary_accepts_packed_seq = (
-            self._mrope_section is None
-            and _callable_accepts_kwarg(self.rotary.forward, "packed_seq")
+        self._rotary_accepts_packed_seq = self._mrope_section is None and _callable_accepts_kwarg(
+            self.rotary.forward, "packed_seq"
         )
 
         cp_kwargs = {}
@@ -195,10 +202,7 @@ class GQAttention(nn.Module):
         )
 
     def forward(
-        self,
-        x: torch.Tensor,
-        position_ids: torch.Tensor | None = None,
-        packed_seq_params=None,
+        self, x: torch.Tensor, position_ids: torch.Tensor | None = None, packed_seq_params=None
     ) -> torch.Tensor:
         qkv = self.qkv(x)
         if self.qkv_lora is not None:
@@ -254,13 +258,19 @@ class GQAttention(nn.Module):
             else:
                 freqs = self.rotary(seq_len_for_rope)
             q = _apply_rotary_pos_emb_thd(
-                q, packed_seq_params.cu_seqlens_q, freqs,
-                rotary_interleaved=False, mscale=1.0,
+                q,
+                packed_seq_params.cu_seqlens_q,
+                freqs,
+                rotary_interleaved=False,
+                mscale=1.0,
                 cp_group=self.ps.cp_group,
             )
             k = _apply_rotary_pos_emb_thd(
-                k, packed_seq_params.cu_seqlens_kv, freqs,
-                rotary_interleaved=False, mscale=1.0,
+                k,
+                packed_seq_params.cu_seqlens_kv,
+                freqs,
+                rotary_interleaved=False,
+                mscale=1.0,
                 cp_group=self.ps.cp_group,
             )
         else:
@@ -281,7 +291,9 @@ class GQAttention(nn.Module):
                 if getattr(packed_seq_params, k, None) is not None
             }
             attn_out = self.core_attn(
-                q, k, v,
+                q,
+                k,
+                v,
                 core_attention_bias_type="no_bias",
                 attn_mask_type="padding_causal",
                 **psp_kwargs,

--- a/experimental/lite/megatron/lite/primitive/modules/gqa_utils.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gqa_utils.py
@@ -8,24 +8,14 @@ from megatron.lite.primitive.utils import ensure_divisible
 
 
 def split_grouped_qkvg(
-    qkv: torch.Tensor,
-    *,
-    num_heads: int,
-    num_kv_heads: int,
-    head_dim: int,
+    qkv: torch.Tensor, *, num_heads: int, num_kv_heads: int, head_dim: int
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     lead = qkv.shape[:-1]
     q_heads_per_group = ensure_divisible(num_heads, num_kv_heads)
     group_width = (2 * q_heads_per_group + 2) * head_dim
     grouped = qkv.reshape(*lead, num_kv_heads, group_width)
     query, gate, key, value = grouped.split(
-        [
-            q_heads_per_group * head_dim,
-            q_heads_per_group * head_dim,
-            head_dim,
-            head_dim,
-        ],
-        dim=-1,
+        [q_heads_per_group * head_dim, q_heads_per_group * head_dim, head_dim, head_dim], dim=-1
     )
     return (
         query.reshape(*lead, num_heads, head_dim),

--- a/experimental/lite/megatron/lite/primitive/modules/lora.py
+++ b/experimental/lite/megatron/lite/primitive/modules/lora.py
@@ -14,7 +14,6 @@ import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 
-
 _DEFAULT_TARGET_MODULES = ("linear_qkv", "linear_proj", "linear_fc1", "linear_fc2")
 _TARGET_ALIASES = {
     "qkv": "linear_qkv",
@@ -134,21 +133,13 @@ class _AllGatherSequence(torch.autograd.Function):
         world_size = dist.get_world_size(group)
         ctx.group = group
         ctx.local_seq = x.shape[0]
-        out = torch.empty(
-            (x.shape[0] * world_size, *x.shape[1:]),
-            dtype=x.dtype,
-            device=x.device,
-        )
+        out = torch.empty((x.shape[0] * world_size, *x.shape[1:]), dtype=x.dtype, device=x.device)
         dist.all_gather_into_tensor(out, x.contiguous(), group=group)
         return out
 
     @staticmethod
     def backward(ctx, grad: torch.Tensor):
-        out = torch.empty(
-            (ctx.local_seq, *grad.shape[1:]),
-            dtype=grad.dtype,
-            device=grad.device,
-        )
+        out = torch.empty((ctx.local_seq, *grad.shape[1:]), dtype=grad.dtype, device=grad.device)
         dist.reduce_scatter_tensor(out, grad.contiguous(), group=ctx.group)
         return out, None
 
@@ -158,23 +149,19 @@ class _ReduceScatterSequence(torch.autograd.Function):
     def forward(ctx, x: torch.Tensor, group) -> torch.Tensor:
         world_size = dist.get_world_size(group)
         if x.shape[0] % world_size != 0:
-            raise ValueError(f"Cannot reduce-scatter sequence dim {x.shape[0]} over TP={world_size}.")
+            raise ValueError(
+                f"Cannot reduce-scatter sequence dim {x.shape[0]} over TP={world_size}."
+            )
         ctx.group = group
         ctx.world_size = world_size
-        out = torch.empty(
-            (x.shape[0] // world_size, *x.shape[1:]),
-            dtype=x.dtype,
-            device=x.device,
-        )
+        out = torch.empty((x.shape[0] // world_size, *x.shape[1:]), dtype=x.dtype, device=x.device)
         dist.reduce_scatter_tensor(out, x.contiguous(), group=group)
         return out
 
     @staticmethod
     def backward(ctx, grad: torch.Tensor):
         out = torch.empty(
-            (grad.shape[0] * ctx.world_size, *grad.shape[1:]),
-            dtype=grad.dtype,
-            device=grad.device,
+            (grad.shape[0] * ctx.world_size, *grad.shape[1:]), dtype=grad.dtype, device=grad.device
         )
         dist.all_gather_into_tensor(out, grad.contiguous(), group=ctx.group)
         return out, None
@@ -195,9 +182,7 @@ class _ScatterSequence(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad: torch.Tensor):
         out = torch.empty(
-            (grad.shape[0] * ctx.world_size, *grad.shape[1:]),
-            dtype=grad.dtype,
-            device=grad.device,
+            (grad.shape[0] * ctx.world_size, *grad.shape[1:]), dtype=grad.dtype, device=grad.device
         )
         dist.all_gather_into_tensor(out, grad.contiguous(), group=ctx.group)
         return out, None, None
@@ -236,12 +221,12 @@ class _AllGatherLastDim(torch.autograd.Function):
         ctx.reduce_backward = bool(reduce_backward)
         flat = x.movedim(-1, 0).contiguous().view(ctx.local_width, -1)
         gathered = torch.empty(
-            (ctx.local_width * world_size, flat.shape[1]),
-            dtype=x.dtype,
-            device=x.device,
+            (ctx.local_width * world_size, flat.shape[1]), dtype=x.dtype, device=x.device
         )
         dist.all_gather_into_tensor(gathered, flat, group=group)
-        return gathered.view(ctx.local_width * world_size, *x.shape[:-1]).movedim(0, -1).contiguous()
+        return (
+            gathered.view(ctx.local_width * world_size, *x.shape[:-1]).movedim(0, -1).contiguous()
+        )
 
     @staticmethod
     def backward(ctx, grad: torch.Tensor):
@@ -264,7 +249,9 @@ class _SequenceParallelRankPartitionedLoRA(torch.autograd.Function):
     """
 
     @staticmethod
-    def forward(ctx, x: torch.Tensor, lora_a: torch.Tensor, lora_b: torch.Tensor, scale: float, group):
+    def forward(
+        ctx, x: torch.Tensor, lora_a: torch.Tensor, lora_b: torch.Tensor, scale: float, group
+    ):
         world_size = dist.get_world_size(group) if group is not None else 1
         if world_size > 1:
             gathered = _all_gather_sequence_forward(x, group, world_size)
@@ -294,17 +281,23 @@ class _SequenceParallelRankPartitionedLoRA(torch.autograd.Function):
         hidden = _all_gather_last_dim_forward(hidden_local, group, world_size)
 
         grad_out_scaled = grad_out * ctx.scale
-        grad_b = grad_out_scaled.reshape(-1, grad_out_scaled.shape[-1]).t().matmul(
-            hidden.reshape(-1, hidden.shape[-1])
+        grad_b = (
+            grad_out_scaled.reshape(-1, grad_out_scaled.shape[-1])
+            .t()
+            .matmul(hidden.reshape(-1, hidden.shape[-1]))
         )
         grad_hidden = grad_out_scaled.matmul(lora_b)
         if world_size > 1:
-            grad_hidden_local = _split_last_dim(grad_hidden, dist.get_rank(group), ctx.local_rank_width)
+            grad_hidden_local = _split_last_dim(
+                grad_hidden, dist.get_rank(group), ctx.local_rank_width
+            )
             dist.all_reduce(grad_hidden_local, op=dist.ReduceOp.SUM, group=group)
         else:
             grad_hidden_local = grad_hidden
-        grad_a = grad_hidden_local.reshape(-1, grad_hidden_local.shape[-1]).t().matmul(
-            gathered.reshape(-1, gathered.shape[-1])
+        grad_a = (
+            grad_hidden_local.reshape(-1, grad_hidden_local.shape[-1])
+            .t()
+            .matmul(gathered.reshape(-1, gathered.shape[-1]))
         )
         grad_gathered = grad_hidden_local.matmul(lora_a)
         if world_size > 1:
@@ -315,21 +308,13 @@ class _SequenceParallelRankPartitionedLoRA(torch.autograd.Function):
 
 
 def _all_gather_sequence_forward(x: torch.Tensor, group, world_size: int) -> torch.Tensor:
-    out = torch.empty(
-        (x.shape[0] * world_size, *x.shape[1:]),
-        dtype=x.dtype,
-        device=x.device,
-    )
+    out = torch.empty((x.shape[0] * world_size, *x.shape[1:]), dtype=x.dtype, device=x.device)
     dist.all_gather_into_tensor(out, x.contiguous(), group=group)
     return out
 
 
 def _reduce_scatter_sequence_forward(x: torch.Tensor, group, local_seq: int) -> torch.Tensor:
-    out = torch.empty(
-        (local_seq, *x.shape[1:]),
-        dtype=x.dtype,
-        device=x.device,
-    )
+    out = torch.empty((local_seq, *x.shape[1:]), dtype=x.dtype, device=x.device)
     dist.reduce_scatter_tensor(out, x.contiguous(), group=group)
     return out
 
@@ -340,9 +325,7 @@ def _all_gather_last_dim_forward(x: torch.Tensor, group, world_size: int) -> tor
     local_width = x.shape[-1]
     flat = x.movedim(-1, 0).contiguous().view(local_width, -1)
     gathered = torch.empty(
-        (local_width * world_size, flat.shape[1]),
-        dtype=x.dtype,
-        device=x.device,
+        (local_width * world_size, flat.shape[1]), dtype=x.dtype, device=x.device
     )
     dist.all_gather_into_tensor(gathered, flat, group=group)
     return gathered.view(local_width * world_size, *x.shape[:-1]).movedim(0, -1).contiguous()
@@ -410,7 +393,9 @@ class LinearLoRA(nn.Module):
         self.row_parallel_output = bool(row_parallel_output)
         self.sequence_parallel_scatter_output = bool(sequence_parallel_scatter_output)
         if self.row_parallel_output and self.sequence_parallel_scatter_output:
-            raise ValueError("Use either row_parallel_output or sequence_parallel_scatter_output, not both.")
+            raise ValueError(
+                "Use either row_parallel_output or sequence_parallel_scatter_output, not both."
+            )
         self.tp_group = tp_group
         self.tp_rank = int(tp_rank)
         self.input_parallel_reduce = bool(input_parallel_reduce)
@@ -440,11 +425,7 @@ class LinearLoRA(nn.Module):
         nn.init.zeros_(self.lora_b)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        if (
-            self.sequence_parallel_input
-            and self.rank_partitioned_a
-            and not self.training
-        ):
+        if self.sequence_parallel_input and self.rank_partitioned_a and not self.training:
             # Keep eval/inference on the simple path; the memory optimization
             # matters only when autograd needs to retain forward activations.
             pass
@@ -458,11 +439,7 @@ class LinearLoRA(nn.Module):
             and self.dropout_p == 0.0
         ):
             return _SequenceParallelRankPartitionedLoRA.apply(
-                x,
-                self.lora_a,
-                self.lora_b,
-                self.scale,
-                self.tp_group,
+                x, self.lora_a, self.lora_b, self.scale, self.tp_group
             )
         if self.sequence_parallel_input:
             x = _gather_sequence_parallel(x, self.tp_group)

--- a/experimental/lite/megatron/lite/primitive/modules/moe.py
+++ b/experimental/lite/megatron/lite/primitive/modules/moe.py
@@ -54,9 +54,7 @@ class _AllToAll(torch.autograd.Function):
         ctx.output_splits = output_splits
         ctx.group = group
         input_tensor = input_tensor.contiguous()
-        output = input_tensor.new_empty(
-            [sum(output_splits)] + list(input_tensor.shape[1:])
-        )
+        output = input_tensor.new_empty([sum(output_splits)] + list(input_tensor.shape[1:]))
         dist.all_to_all_single(
             output,
             input_tensor,
@@ -69,9 +67,7 @@ class _AllToAll(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad_output):
         grad_output = grad_output.contiguous()
-        grad_input = grad_output.new_empty(
-            [sum(ctx.input_splits)] + list(grad_output.shape[1:])
-        )
+        grad_input = grad_output.new_empty([sum(ctx.input_splits)] + list(grad_output.shape[1:]))
         dist.all_to_all_single(
             grad_input,
             grad_output,
@@ -80,4 +76,3 @@ class _AllToAll(torch.autograd.Function):
             group=ctx.group,
         )
         return grad_input, None, None, None
-

--- a/experimental/lite/megatron/lite/primitive/modules/mrope.py
+++ b/experimental/lite/megatron/lite/primitive/modules/mrope.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import torch
 import torch.distributed as dist
 import torch.nn as nn
+
 from megatron.core.models.common.embeddings.rope_utils import (  # pyright: ignore[reportMissingImports]
     get_pos_emb_on_this_cp_rank,
 )
@@ -25,9 +26,7 @@ class MultimodalRotaryEmbedding(nn.Module):
     ):
         super().__init__()
         dim = int(kv_channels * rotary_percent)
-        inv_freq = 1.0 / (
-            rotary_base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim)
-        )
+        inv_freq = 1.0 / (rotary_base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
         self.register_buffer("inv_freq", inv_freq, persistent=False)
         self.cp_group = cp_group
 
@@ -40,11 +39,7 @@ class MultimodalRotaryEmbedding(nn.Module):
         return freqs_t
 
     def forward(
-        self,
-        position_ids: torch.Tensor,
-        mrope_section: list[int],
-        *,
-        packed_seq: bool = False,
+        self, position_ids: torch.Tensor, mrope_section: list[int], *, packed_seq: bool = False
     ) -> torch.Tensor:
         seq = position_ids.to(device=self.inv_freq.device)
         inv_freq = self.inv_freq.float()
@@ -54,10 +49,6 @@ class MultimodalRotaryEmbedding(nn.Module):
         freqs = self._apply_interleaved_mrope(freqs, mrope_section)
         emb = torch.cat((freqs, freqs), dim=-1)
         emb = emb[..., None, :].transpose(0, 1).contiguous()
-        if (
-            not packed_seq
-            and self.cp_group is not None
-            and dist.get_world_size(self.cp_group) > 1
-        ):
+        if not packed_seq and self.cp_group is not None and dist.get_world_size(self.cp_group) > 1:
             emb = get_pos_emb_on_this_cp_rank(emb, 0, self.cp_group)
         return emb

--- a/experimental/lite/megatron/lite/primitive/modules/mtp.py
+++ b/experimental/lite/megatron/lite/primitive/modules/mtp.py
@@ -58,18 +58,10 @@ class MTPDecoderLayer(nn.Module):
         self.enorm = te.RMSNorm(hidden_size, eps=rms_norm_eps, zero_centered_gamma=True)
         self.hnorm = te.RMSNorm(hidden_size, eps=rms_norm_eps, zero_centered_gamma=True)
         self.eh_proj = VanillaColumnParallelLinear(
-            hidden_size * 2,
-            hidden_size,
-            ps,
-            sp=ps.tp_size > 1,
-            gather_output=True,
+            hidden_size * 2, hidden_size, ps, sp=ps.tp_size > 1, gather_output=True
         )
         self.transformer_layer = transformer_layer
-        self.final_layernorm = te.RMSNorm(
-            hidden_size,
-            eps=rms_norm_eps,
-            zero_centered_gamma=True,
-        )
+        self.final_layernorm = te.RMSNorm(hidden_size, eps=rms_norm_eps, zero_centered_gamma=True)
 
     def forward(
         self,
@@ -80,10 +72,14 @@ class MTPDecoderLayer(nn.Module):
         rotary_position_ids: torch.Tensor | None = None,
         packed_seq_params=None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
-        attention_position_ids = rotary_position_ids if rotary_position_ids is not None else position_ids
+        attention_position_ids = (
+            rotary_position_ids if rotary_position_ids is not None else position_ids
+        )
         input_ids, _ = roll_packed_thd_left(input_ids, packed_seq_params=packed_seq_params, dims=-1)
         if position_ids is not None:
-            position_ids, _ = roll_packed_thd_left(position_ids, packed_seq_params=packed_seq_params, dims=-1)
+            position_ids, _ = roll_packed_thd_left(
+                position_ids, packed_seq_params=packed_seq_params, dims=-1
+            )
         decoder_input = scatter_to_sequence_parallel(self.embedding(input_ids), self.ps)
         if self.detach_encoder:
             decoder_input = decoder_input.detach()
@@ -93,9 +89,7 @@ class MTPDecoderLayer(nn.Module):
         hidden_states = torch.cat((decoder_input, hidden_states), dim=-1)
         hidden_states = scatter_to_sequence_parallel(self.eh_proj(hidden_states), self.ps)
         hidden_states = self.transformer_layer(
-            hidden_states,
-            position_ids=attention_position_ids,
-            packed_seq_params=packed_seq_params,
+            hidden_states, position_ids=attention_position_ids, packed_seq_params=packed_seq_params
         )
         hidden_states = self.final_layernorm(hidden_states)
         return hidden_states, input_ids, position_ids

--- a/experimental/lite/megatron/lite/primitive/modules/router.py
+++ b/experimental/lite/megatron/lite/primitive/modules/router.py
@@ -13,13 +13,13 @@ from typing import TYPE_CHECKING
 import torch  # pyright: ignore[reportMissingImports]
 import torch.distributed as dist  # pyright: ignore[reportMissingImports]
 import torch.nn as nn  # pyright: ignore[reportMissingImports]
+
 from megatron.core.transformer.moe.moe_utils import (  # pyright: ignore[reportMissingImports]
     compute_routing_scores_for_aux_loss,
     router_gating_linear,
     switch_load_balancing_loss_func,
     topk_routing_with_score_function,
 )
-
 from megatron.lite.primitive.modules.moe import MoEAuxLossAutoScaler
 
 if TYPE_CHECKING:
@@ -27,19 +27,13 @@ if TYPE_CHECKING:
 
 
 def _ordered_topk_from_routing_map(
-    probs_dense: torch.Tensor,
-    routing_map: torch.Tensor,
-    topk: int,
+    probs_dense: torch.Tensor, routing_map: torch.Tensor, topk: int
 ) -> tuple[torch.Tensor, torch.Tensor]:
     expert_ids = torch.arange(
-        probs_dense.size(-1),
-        device=probs_dense.device,
-        dtype=torch.long,
+        probs_dense.size(-1), device=probs_dense.device, dtype=torch.long
     ).expand_as(routing_map)
     masked_ids = torch.where(
-        routing_map,
-        expert_ids,
-        torch.full_like(expert_ids, probs_dense.size(-1)),
+        routing_map, expert_ids, torch.full_like(expert_ids, probs_dense.size(-1))
     )
     topk_indices = torch.sort(masked_ids, dim=-1).values[:, :topk]
     topk_scores = torch.gather(probs_dense, dim=-1, index=topk_indices)
@@ -77,9 +71,7 @@ class TopKRouter(nn.Module):
 
         self.gate = nn.Linear(config.hidden_size, config.num_experts, bias=False)
         self.register_buffer(
-            "expert_bias",
-            torch.zeros(config.num_experts, dtype=torch.float32),
-            persistent=False,
+            "expert_bias", torch.zeros(config.num_experts, dtype=torch.float32), persistent=False
         )
 
         self._aux_loss_group = ps.tp_group if ps.tp_size > 1 else None
@@ -107,27 +99,20 @@ class TopKRouter(nn.Module):
                 fused=False,
             )
             topk_scores, topk_indices = _ordered_topk_from_routing_map(
-                probs_dense,
-                routing_map,
-                self.topk,
+                probs_dense, routing_map, self.topk
             )
         if self.router_dtype is None:
             topk_scores = topk_scores.to(x.dtype)
 
         if self.compute_aux_loss and self.training and torch.is_grad_enabled():
             routing_map, aux_scores = compute_routing_scores_for_aux_loss(
-                logits,
-                self.topk,
-                score_function="softmax",
-                fused=self.moe_router_fusion,
+                logits, self.topk, score_function="softmax", fused=self.moe_router_fusion
             )
             tokens_per_expert = routing_map.sum(dim=0).to(torch.int64)
             total_num_tokens = num_tokens
             if self._aux_loss_group is not None:
                 dist.all_reduce(tokens_per_expert, group=self._aux_loss_group)
-                total_num_tokens = num_tokens * dist.get_world_size(
-                    group=self._aux_loss_group
-                )
+                total_num_tokens = num_tokens * dist.get_world_size(group=self._aux_loss_group)
             aux_loss = switch_load_balancing_loss_func(
                 aux_scores,
                 tokens_per_expert,
@@ -192,26 +177,19 @@ class SigmoidTopKRouter(nn.Module):
             fused=self.moe_router_fusion,
         )
         topk_scores, topk_indices = _ordered_topk_from_routing_map(
-            probs_dense,
-            routing_map,
-            self.topk,
+            probs_dense, routing_map, self.topk
         )
         topk_scores = topk_scores.to(logits.dtype)
 
         if self.compute_aux_loss and self.training and torch.is_grad_enabled():
             _, aux_scores = compute_routing_scores_for_aux_loss(
-                logits,
-                self.topk,
-                score_function="sigmoid",
-                fused=self.moe_router_fusion,
+                logits, self.topk, score_function="sigmoid", fused=self.moe_router_fusion
             )
             tokens_per_expert = routing_map.sum(dim=0).to(torch.int64)
             total_num_tokens = num_tokens
             if self._aux_loss_group is not None:
                 dist.all_reduce(tokens_per_expert, group=self._aux_loss_group)
-                total_num_tokens = num_tokens * dist.get_world_size(
-                    group=self._aux_loss_group
-                )
+                total_num_tokens = num_tokens * dist.get_world_size(group=self._aux_loss_group)
             aux_loss = switch_load_balancing_loss_func(
                 aux_scores,
                 tokens_per_expert,

--- a/experimental/lite/megatron/lite/primitive/ops/cross_entropy.py
+++ b/experimental/lite/megatron/lite/primitive/ops/cross_entropy.py
@@ -38,9 +38,7 @@ class _VocabParallelCrossEntropy(torch.autograd.Function):
         else:
             rank = 0
             world_size = 1
-        vocab_start_index, vocab_end_index = _vocab_range(
-            partition_vocab_size, rank, world_size,
-        )
+        vocab_start_index, vocab_end_index = _vocab_range(partition_vocab_size, rank, world_size)
 
         # Mask targets outside this partition's vocab range.
         target_mask = (target < vocab_start_index) | (target >= vocab_end_index)

--- a/experimental/lite/megatron/lite/primitive/ops/gated_delta_rule.py
+++ b/experimental/lite/megatron/lite/primitive/ops/gated_delta_rule.py
@@ -62,8 +62,7 @@ def torch_chunk_gated_delta_rule(
     g = g.reshape(g.shape[0], g.shape[1], -1, chunk_size)
 
     mask = torch.triu(
-        torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=query.device),
-        diagonal=0,
+        torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=query.device), diagonal=0
     )
     g = g.cumsum(dim=-1)
     decay_mask = ((g.unsqueeze(-1) - g.unsqueeze(-2)).tril().exp().float()).tril()
@@ -83,8 +82,7 @@ def torch_chunk_gated_delta_rule(
     )
     core_attn_out = torch.zeros_like(value)
     mask = torch.triu(
-        torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=query.device),
-        diagonal=1,
+        torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=query.device), diagonal=1
     )
 
     for i in range(0, total_sequence_length // chunk_size):
@@ -96,17 +94,13 @@ def torch_chunk_gated_delta_rule(
         core_attn_out[:, :, i] = attn_inter + attn @ v_new
         last_recurrent_state = (
             last_recurrent_state * g[:, :, i, -1, None, None].exp()
-            + (k_i * (g[:, :, i, -1, None] - g[:, :, i]).exp()[..., None]).transpose(-1, -2)
-            @ v_new
+            + (k_i * (g[:, :, i, -1, None] - g[:, :, i]).exp()[..., None]).transpose(-1, -2) @ v_new
         )
 
     if not output_final_state:
         last_recurrent_state = None
     core_attn_out = core_attn_out.reshape(
-        core_attn_out.shape[0],
-        core_attn_out.shape[1],
-        -1,
-        core_attn_out.shape[-1],
+        core_attn_out.shape[0], core_attn_out.shape[1], -1, core_attn_out.shape[-1]
     )
     core_attn_out = core_attn_out[:, :, :sequence_length]
     core_attn_out = core_attn_out.transpose(1, 2).contiguous().to(initial_dtype)

--- a/experimental/lite/megatron/lite/primitive/ops/logprob.py
+++ b/experimental/lite/megatron/lite/primitive/ops/logprob.py
@@ -7,7 +7,7 @@ import torch.distributed as dist
 
 
 def vocab_parallel_log_probs_from_logits(
-    logits: torch.Tensor, labels: torch.Tensor | None = None,
+    logits: torch.Tensor, labels: torch.Tensor | None = None
 ) -> torch.Tensor:
     """Compute log-probabilities from already materialized logits.
 
@@ -51,7 +51,7 @@ def vocab_parallel_entropy(logits: torch.Tensor, tp_group=None) -> torch.Tensor:
 
 
 def _align_labels_to_logits(
-    logits: torch.Tensor, labels: torch.Tensor,
+    logits: torch.Tensor, labels: torch.Tensor
 ) -> tuple[torch.Tensor, bool]:
     if logits.ndim != labels.ndim + 1:
         raise ValueError(
@@ -69,6 +69,4 @@ def _align_labels_to_logits(
     ):
         return labels.transpose(0, 1).contiguous(), True
 
-    raise ValueError(
-        f"Could not align labels {labels.shape} with logits {logits.shape}."
-    )
+    raise ValueError(f"Could not align labels {labels.shape} with logits {logits.shape}.")

--- a/experimental/lite/megatron/lite/primitive/ops/sp_ops.py
+++ b/experimental/lite/megatron/lite/primitive/ops/sp_ops.py
@@ -13,20 +13,14 @@ import torch.distributed as dist  # pyright: ignore[reportMissingImports]
 
 def _ag_dim0(x: torch.Tensor, tp_size: int, group: dist.ProcessGroup) -> torch.Tensor:
     """AllGather on dim 0: [S/tp, B, H] → [S, B, H]."""
-    out = torch.empty(
-        tp_size * x.shape[0], x.shape[1], x.shape[2],
-        dtype=x.dtype, device=x.device,
-    )
+    out = torch.empty(tp_size * x.shape[0], x.shape[1], x.shape[2], dtype=x.dtype, device=x.device)
     dist.all_gather_into_tensor(out, x.contiguous(), group=group)
     return out
 
 
 def _rs_dim0(x: torch.Tensor, local_seq: int, group: dist.ProcessGroup) -> torch.Tensor:
     """ReduceScatter on dim 0: [S, B, H] → [S/tp, B, H]."""
-    out = torch.empty(
-        local_seq, x.shape[1], x.shape[2],
-        dtype=x.dtype, device=x.device,
-    )
+    out = torch.empty(local_seq, x.shape[1], x.shape[2], dtype=x.dtype, device=x.device)
     dist.reduce_scatter_tensor(out, x.contiguous(), group=group)
     return out
 
@@ -73,7 +67,7 @@ class AllGatherDim0ForNonSPConsumer(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad):
         start = ctx.tp_rank * ctx.local_seq
-        return grad[start:start + ctx.local_seq].contiguous(), None, None, None
+        return grad[start : start + ctx.local_seq].contiguous(), None, None, None
 
 
 class ScatterToSP(torch.autograd.Function):
@@ -85,16 +79,11 @@ class ScatterToSP(torch.autograd.Function):
         ctx.group = group
         local_seq = x.shape[0] // tp_size
         start = tp_rank * local_seq
-        return x[start:start + local_seq, :, :].contiguous()
+        return x[start : start + local_seq, :, :].contiguous()
 
     @staticmethod
     def backward(ctx, grad):
         return _ag_dim0(grad, ctx.tp_size, ctx.group), None, None, None
 
 
-__all__ = [
-    "AllGatherDim0",
-    "AllGatherDim0ForNonSPConsumer",
-    "ReduceScatterDim0",
-    "ScatterToSP",
-]
+__all__ = ["AllGatherDim0", "AllGatherDim0ForNonSPConsumer", "ReduceScatterDim0", "ScatterToSP"]

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/adamw.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/adamw.py
@@ -27,11 +27,7 @@ def local_grad_sq_sum(
             total = torch.zeros((), device=grad.device, dtype=dtype)
         total += grad.detach().to(dtype).pow(2).sum()
     if total is None:
-        return torch.zeros(
-            (),
-            device=default_device or torch.device("cpu"),
-            dtype=dtype,
-        )
+        return torch.zeros((), device=default_device or torch.device("cpu"), dtype=dtype)
     return total
 
 
@@ -219,11 +215,7 @@ class FP32AdamW:
                 exp_avg.mul_(beta1).add_(grad, alpha=1.0 - beta1)
                 exp_avg_sq.mul_(beta2).addcmul_(grad, grad, value=1.0 - beta2)
                 denom = exp_avg_sq.sqrt().div_(bias_correction2_sqrt).add_(self.eps)
-                master.addcdiv_(
-                    exp_avg.to(dtype=torch.float32),
-                    denom,
-                    value=-group_step_size,
-                )
+                master.addcdiv_(exp_avg.to(dtype=torch.float32), denom, value=-group_step_size)
                 self._copy_master_to_param(param, master)
 
     def _prepare_grad(self, grad: torch.Tensor, master: torch.Tensor) -> torch.Tensor:
@@ -334,27 +326,16 @@ def build_adamw_optimizer(
         raise ValueError(f"adamw_foreach must be True, False, or 'auto', got {foreach!r}.")
     if foreach is False:
         return torch.optim.AdamW(
-            param_groups,
-            lr=lr,
-            weight_decay=weight_decay,
-            betas=betas,
-            eps=eps,
-            foreach=False,
+            param_groups, lr=lr, weight_decay=weight_decay, betas=betas, eps=eps, foreach=False
         )
 
     dtensor_param_groups, tensor_param_groups = split_dtensor_and_tensor_param_groups(
-        param_groups,
-        default_weight_decay=weight_decay,
+        param_groups, default_weight_decay=weight_decay
     )
     split_param_groups = [group for group in (dtensor_param_groups, tensor_param_groups) if group]
     if foreach == "auto" and not dtensor_param_groups:
         return torch.optim.AdamW(
-            param_groups,
-            lr=lr,
-            weight_decay=weight_decay,
-            betas=betas,
-            eps=eps,
-            foreach=False,
+            param_groups, lr=lr, weight_decay=weight_decay, betas=betas, eps=eps, foreach=False
         )
     if len(split_param_groups) <= 1:
         return torch.optim.AdamW(
@@ -367,12 +348,7 @@ def build_adamw_optimizer(
         )
     return ChainedOptimizer(
         torch.optim.AdamW(
-            group,
-            lr=lr,
-            weight_decay=weight_decay,
-            betas=betas,
-            eps=eps,
-            foreach=True,
+            group, lr=lr, weight_decay=weight_decay, betas=betas, eps=eps, foreach=True
         )
         for group in split_param_groups
     )
@@ -389,11 +365,7 @@ def maybe_build_te_fused_adam_optimizer(
     opt,
     use_fp32_master: bool,
 ) -> Any | None:
-    if not get_bool_opt(
-        opt,
-        "fsdp2_use_te_fused_adam",
-        default=False,
-    ):
+    if not get_bool_opt(opt, "fsdp2_use_te_fused_adam", default=False):
         return None
     try:
         from transformer_engine.pytorch.optimizers.fused_adam import FusedAdam
@@ -402,9 +374,7 @@ def maybe_build_te_fused_adam_optimizer(
 
     all_param_list = list(all_params)
     master_weights = get_bool_opt(
-        opt,
-        "master_weights",
-        default=use_fp32_master and should_use_master_weights(all_param_list),
+        opt, "master_weights", default=use_fp32_master and should_use_master_weights(all_param_list)
     )
     kwargs = dict(
         lr=lr,
@@ -413,26 +383,10 @@ def maybe_build_te_fused_adam_optimizer(
         eps=eps,
         adam_w_mode=True,
         master_weights=master_weights,
-        master_weight_dtype=get_dtype_opt(
-            opt,
-            "master_weight_dtype",
-            default=torch.float32,
-        ),
-        store_param_remainders=get_bool_opt(
-            opt,
-            "store_param_remainders",
-            default=master_weights,
-        ),
-        exp_avg_dtype=get_dtype_opt(
-            opt,
-            "exp_avg_dtype",
-            default=torch.float32,
-        ),
-        exp_avg_sq_dtype=get_dtype_opt(
-            opt,
-            "exp_avg_sq_dtype",
-            default=torch.float32,
-        ),
+        master_weight_dtype=get_dtype_opt(opt, "master_weight_dtype", default=torch.float32),
+        store_param_remainders=get_bool_opt(opt, "store_param_remainders", default=master_weights),
+        exp_avg_dtype=get_dtype_opt(opt, "exp_avg_dtype", default=torch.float32),
+        exp_avg_sq_dtype=get_dtype_opt(opt, "exp_avg_sq_dtype", default=torch.float32),
     )
     return FusedAdam(param_groups, **filter_supported_kwargs(FusedAdam.__init__, kwargs))
 
@@ -462,12 +416,7 @@ def get_bool_opt(opt, attr: str, *, default: bool) -> bool:
     return str(value).strip().lower() in {"1", "true", "yes", "on"}
 
 
-def get_dtype_opt(
-    opt,
-    attr: str,
-    *,
-    default: torch.dtype,
-) -> torch.dtype:
+def get_dtype_opt(opt, attr: str, *, default: torch.dtype) -> torch.dtype:
     value = get_opt_value(opt, attr)
     if value is None:
         return default
@@ -497,9 +446,7 @@ def get_opt_value(opt, attr: str):
 
 
 def normalize_param_groups(
-    params: Iterable[nn.Parameter] | Iterable[dict[str, Any]],
-    *,
-    default_weight_decay: float,
+    params: Iterable[nn.Parameter] | Iterable[dict[str, Any]], *, default_weight_decay: float
 ) -> list[dict[str, Any]]:
     items = list(params)
     if not items:
@@ -519,9 +466,7 @@ def normalize_param_groups(
 
 
 def split_dtensor_and_tensor_param_groups(
-    param_groups: Iterable[dict[str, Any]],
-    *,
-    default_weight_decay: float,
+    param_groups: Iterable[dict[str, Any]], *, default_weight_decay: float
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     dtensor_groups: list[dict[str, Any]] = []
     tensor_groups: list[dict[str, Any]] = []
@@ -557,9 +502,7 @@ def iter_torch_optimizers(optimizer: Any) -> Iterable[torch.optim.Optimizer]:
 
 
 def dtensor_from_local(
-    local_tensor: torch.Tensor,
-    device_mesh: Any,
-    placements: Any,
+    local_tensor: torch.Tensor, device_mesh: Any, placements: Any
 ) -> torch.Tensor:
     from torch.distributed.tensor import DTensor
 

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/grad_clip.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/grad_clip.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import math
-from numbers import Number
 from collections import defaultdict
 from collections.abc import Callable, Iterable
+from numbers import Number
 from typing import Any
 
 import torch
@@ -24,8 +24,9 @@ def sharded_grad_sq_sum(
     accum_dtype: str | torch.dtype = torch.float32,
     default_device: torch.device | None = None,
     chunk_size_numel: int = 0,
-    scalar_all_reduce: Callable[[torch.Tensor, dist.ProcessGroup, dist.ReduceOp], None]
-    | None = None,
+    scalar_all_reduce: (
+        Callable[[torch.Tensor, dist.ProcessGroup, dist.ReduceOp], None] | None
+    ) = None,
 ) -> torch.Tensor:
     """Return global L2 grad squared-sum for Tensor/DTensor parameters.
 
@@ -39,18 +40,11 @@ def sharded_grad_sq_sum(
     groups = _group_grads(params)
     total: torch.Tensor | None = None
     for group in groups.values():
-        local_sq = _group_local_sq_sum(
-            group,
-            dtype=dtype,
-            chunk_size_numel=chunk_size_numel,
-        )
+        local_sq = _group_local_sq_sum(group, dtype=dtype, chunk_size_numel=chunk_size_numel)
         meta = group[0][2]
         if meta is not None and not _has_partial_placement(meta) and dist.is_initialized():
             _reduce_dtensor_scalar_(
-                local_sq,
-                meta,
-                op=dist.ReduceOp.SUM,
-                scalar_all_reduce=scalar_all_reduce,
+                local_sq, meta, op=dist.ReduceOp.SUM, scalar_all_reduce=scalar_all_reduce
             )
         total = local_sq if total is None else total.to(local_sq.device) + local_sq
 
@@ -76,19 +70,12 @@ def sharded_grad_norm(
 
     if math.isinf(float(norm_type)):
         total = sharded_grad_abs_max(
-            params,
-            pp_group=pp_group,
-            accum_dtype=accum_dtype,
-            default_device=default_device,
+            params, pp_group=pp_group, accum_dtype=accum_dtype, default_device=default_device
         )
         return total
     if float(norm_type) != 2.0:
         raise ValueError(f"sharded_grad_norm supports norm_type=2.0 or inf, got {norm_type!r}.")
-    sq_sum = sharded_grad_sq_sum(
-        params,
-        accum_dtype=accum_dtype,
-        default_device=default_device,
-    )
+    sq_sum = sharded_grad_sq_sum(params, accum_dtype=accum_dtype, default_device=default_device)
     if pp_group is not None and dist.is_initialized() and dist.get_world_size(pp_group) > 1:
         dist.all_reduce(sq_sum, op=dist.ReduceOp.SUM, group=pp_group)
     return sq_sum.sqrt()
@@ -122,9 +109,7 @@ def sharded_grad_abs_max(
 
 @torch.no_grad()
 def clip_grads_with_sharded_norm_(
-    params: Iterable[nn.Parameter],
-    max_norm: float,
-    total_norm: torch.Tensor | float,
+    params: Iterable[nn.Parameter], max_norm: float, total_norm: torch.Tensor | float
 ) -> None:
     """Scale gradients in-place using a precomputed global norm."""
 
@@ -165,8 +150,8 @@ def resolve_torch_dtype(dtype: str | torch.dtype) -> torch.dtype:
 def _group_grads(
     params: Iterable[nn.Parameter],
 ) -> dict[tuple[Any, ...], list[tuple[nn.Parameter, torch.Tensor, Any | None]]]:
-    groups: dict[tuple[Any, ...], list[tuple[nn.Parameter, torch.Tensor, Any | None]]] = defaultdict(
-        list
+    groups: dict[tuple[Any, ...], list[tuple[nn.Parameter, torch.Tensor, Any | None]]] = (
+        defaultdict(list)
     )
     for param in params:
         grad = param.grad
@@ -195,19 +180,12 @@ def _group_local_sq_sum(
     total = torch.zeros((), device=device, dtype=dtype)
     for _param, grad, meta in group:
         local_grad = _local_grad(grad, meta)
-        total += _tensor_sq_sum(
-            local_grad.detach(),
-            dtype=dtype,
-            chunk_size_numel=chunk_size_numel,
-        )
+        total += _tensor_sq_sum(local_grad.detach(), dtype=dtype, chunk_size_numel=chunk_size_numel)
     return total
 
 
 def _tensor_sq_sum(
-    tensor: torch.Tensor,
-    *,
-    dtype: torch.dtype,
-    chunk_size_numel: int = 0,
+    tensor: torch.Tensor, *, dtype: torch.dtype, chunk_size_numel: int = 0
 ) -> torch.Tensor:
     if chunk_size_numel <= 0 or tensor.numel() <= chunk_size_numel:
         return tensor.to(dtype).pow(2).sum()
@@ -223,9 +201,7 @@ def _tensor_sq_sum(
 
 
 def _group_local_abs_max(
-    group: list[tuple[nn.Parameter, torch.Tensor, Any | None]],
-    *,
-    dtype: torch.dtype,
+    group: list[tuple[nn.Parameter, torch.Tensor, Any | None]], *, dtype: torch.dtype
 ) -> torch.Tensor:
     device = _local_grad(group[0][1], group[0][2]).device
     total = torch.zeros((), device=device, dtype=dtype)
@@ -299,8 +275,9 @@ def _reduce_dtensor_scalar_(
     dtensor: Any,
     *,
     op: dist.ReduceOp,
-    scalar_all_reduce: Callable[[torch.Tensor, dist.ProcessGroup, dist.ReduceOp], None]
-    | None = None,
+    scalar_all_reduce: (
+        Callable[[torch.Tensor, dist.ProcessGroup, dist.ReduceOp], None] | None
+    ) = None,
 ) -> None:
     for mesh_dim, placement in enumerate(dtensor.placements):
         if _is_replicate_placement(placement):

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/optimizer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/optimizer.py
@@ -40,7 +40,6 @@ from megatron.lite.primitive.optimizers.fsdp2.wrap import (
 )
 from megatron.lite.primitive.parallel.state import ParallelState
 
-
 _DEFAULT_RESHARD_AFTER_FORWARD: bool | int | None = True
 _DEFAULT_WRAP_ROOT = True
 _DEFAULT_LEAF_MODULE_NAMES = ("embed", "head")
@@ -75,7 +74,6 @@ class FSDP2Optimizer:
         tp_replicated_grad_params: Iterable[nn.Parameter] | None = None,
         tp_replicated_grad_sync_group: dist.ProcessGroup | None = None,
         grad_norm_accum_dtype: str | torch.dtype = torch.float32,
-        optimizer_offload_dtensor_state: bool = True,
         param_names: dict[int, str] | None = None,
     ):
         self.optimizer = optimizer
@@ -98,11 +96,8 @@ class FSDP2Optimizer:
         )
         self.expert_sharded_grad_norm_group = expert_sharded_grad_norm_group
         self.tp_replicated_grad_params = list(tp_replicated_grad_params or ())
-        self._tp_replicated_grad_param_ids = {
-            id(param) for param in self.tp_replicated_grad_params
-        }
+        self._tp_replicated_grad_param_ids = {id(param) for param in self.tp_replicated_grad_params}
         self.tp_replicated_grad_sync_group = tp_replicated_grad_sync_group
-        self.optimizer_offload_dtensor_state = bool(optimizer_offload_dtensor_state)
         self._cpu_offloaded_state: dict[tuple[int, str], OffloadedStateEntry] = {}
         self.grad_sync_enabled = False
 
@@ -182,8 +177,7 @@ class FSDP2Optimizer:
             param for param in sharded_params if not has_dtensor_grad_or_param(param)
         ]
         total_sq = sharded_grad_sq_sum(
-            dtensor_sharded_params,
-            accum_dtype=self.grad_norm_accum_dtype,
+            dtensor_sharded_params, accum_dtype=self.grad_norm_accum_dtype
         )
         plain_sharded_sq = local_grad_sq_sum(
             plain_sharded_params,
@@ -198,11 +192,7 @@ class FSDP2Optimizer:
             and dist.is_initialized()
             and dist.get_world_size(plain_sharded_group) > 1
         ):
-            dist.all_reduce(
-                plain_sharded_sq,
-                op=dist.ReduceOp.SUM,
-                group=plain_sharded_group,
-            )
+            dist.all_reduce(plain_sharded_sq, op=dist.ReduceOp.SUM, group=plain_sharded_group)
         total_sq = total_sq.to(plain_sharded_sq.device) + plain_sharded_sq
         if (
             self.ps is not None
@@ -228,9 +218,7 @@ class FSDP2Optimizer:
             and dist.get_world_size(self.replicated_grad_norm_group) > 1
         ):
             dist.all_reduce(
-                replicated_sq,
-                op=dist.ReduceOp.SUM,
-                group=self.replicated_grad_norm_group,
+                replicated_sq, op=dist.ReduceOp.SUM, group=self.replicated_grad_norm_group
             )
 
         expert_sharded_sq = sharded_grad_sq_sum(
@@ -244,9 +232,7 @@ class FSDP2Optimizer:
             and dist.get_world_size(self.expert_sharded_grad_norm_group) > 1
         ):
             dist.all_reduce(
-                expert_sharded_sq,
-                op=dist.ReduceOp.SUM,
-                group=self.expert_sharded_grad_norm_group,
+                expert_sharded_sq, op=dist.ReduceOp.SUM, group=self.expert_sharded_grad_norm_group
             )
 
         total_sq = (
@@ -276,9 +262,7 @@ class FSDP2Optimizer:
 
     def offload_state_to_cpu(self) -> None:
         move_optimizer_state_to_cpu(
-            self.optimizer,
-            self._cpu_offloaded_state,
-            include_dtensor_state=self.optimizer_offload_dtensor_state,
+            self.optimizer, self._cpu_offloaded_state, include_dtensor_state=True
         )
 
     def load_state_to_device(self) -> None:
@@ -301,7 +285,6 @@ def build_fsdp2_adamw(
     tp_replicated_grad_sync_group: dist.ProcessGroup | None = None,
     grad_norm_accum_dtype: str | torch.dtype = torch.float32,
     adamw_foreach: bool | str = "auto",
-    optimizer_offload_dtensor_state: bool = True,
     use_fp32_master: bool = False,
     model_param_dtypes: dict[tuple[int, str], torch.dtype] | None = None,
 ) -> FSDP2Optimizer:
@@ -349,9 +332,6 @@ def build_fsdp2_adamw(
         tp_replicated_grad_params=tp_replicated_grad_params,
         tp_replicated_grad_sync_group=tp_replicated_grad_sync_group,
         grad_norm_accum_dtype=grad_norm_accum_dtype,
-        optimizer_offload_dtensor_state=(
-            optimizer_offload_dtensor_state or float(offload_fraction) > 0.0
-        ),
         param_names=param_names,
     )
 
@@ -384,10 +364,7 @@ def build_fsdp2_training_optimizer(
 
     expert_params = _collect_expert_params(model_chunks, ps, expert_classifier)
     expert_modules = _collect_expert_modules(
-        model_chunks,
-        ps,
-        expert_classifier,
-        expert_module_leaf_name=expert_module_leaf_name,
+        model_chunks, ps, expert_classifier, expert_module_leaf_name=expert_module_leaf_name
     )
     if expert_params and not expert_modules:
         raise RuntimeError("FSDP2 expert parameters were found but no expert module was found.")
@@ -409,25 +386,16 @@ def build_fsdp2_training_optimizer(
     effective_use_fp32_shards = (
         bool(use_fp32_shards)
         if use_fp32_shards is not None
-        else get_bool_opt(
-            opt,
-            "fsdp2_use_fp32_shards",
-            default=_DEFAULT_USE_FP32_SHARDS,
-        )
+        else get_bool_opt(opt, "fsdp2_use_fp32_shards", default=_DEFAULT_USE_FP32_SHARDS)
     )
     effective_use_fp32_master = (
         bool(use_fp32_master)
         if use_fp32_master is not None
-        else get_bool_opt(
-            opt,
-            "fsdp2_use_fp32_master",
-            default=_DEFAULT_USE_FP32_MASTER,
-        )
+        else get_bool_opt(opt, "fsdp2_use_fp32_master", default=_DEFAULT_USE_FP32_MASTER)
     )
 
     unit_reshard_after_forward = _fsdp2_unit_reshard_after_forward(
-        ps,
-        reshard_after_forward=reshard_after_forward,
+        ps, reshard_after_forward=reshard_after_forward
     )
     fsdp2_config = FSDP2Config(
         unit_modules=unit_modules,
@@ -436,14 +404,8 @@ def build_fsdp2_training_optimizer(
         last_unit_reshard_after_forward=unit_reshard_after_forward,
         root_reshard_after_forward=False,
         wrap_root=wrap_root,
-        forward_prefetch_depth=_fsdp2_prefetch_depth(
-            ps,
-            default_depth=forward_prefetch_depth,
-        ),
-        backward_prefetch_depth=_fsdp2_prefetch_depth(
-            ps,
-            default_depth=backward_prefetch_depth,
-        ),
+        forward_prefetch_depth=_fsdp2_prefetch_depth(ps, default_depth=forward_prefetch_depth),
+        backward_prefetch_depth=_fsdp2_prefetch_depth(ps, default_depth=backward_prefetch_depth),
         param_dtype=param_dtype,
         reduce_dtype=reduce_dtype,
     )
@@ -454,9 +416,7 @@ def build_fsdp2_training_optimizer(
     else:
         model_param_dtypes = {}
 
-    tp_replicated_grad_param_names = _collect_tp_replicated_grad_param_names(
-        model_chunks
-    )
+    tp_replicated_grad_param_names = _collect_tp_replicated_grad_param_names(model_chunks)
 
     dense_shard_placement_fn = build_fsdp2_shard_placement_fn(ps.dp_cp_size)
     expert_shard_placement_fn = build_fsdp2_shard_placement_fn(ps.expert_dp_size)
@@ -465,9 +425,7 @@ def build_fsdp2_training_optimizer(
         if ps.ep_dp_group is None:
             raise RuntimeError("FSDP2 expert sharding requires ParallelState.ep_dp_group.")
         expert_mesh = build_fsdp2_process_group_mesh(
-            ps.ep_dp_group,
-            mesh_dim_name="expert_dp",
-            device_type=fsdp2_config.device_type,
+            ps.ep_dp_group, mesh_dim_name="expert_dp", device_type=fsdp2_config.device_type
         )
         for module in expert_modules:
             wrap_fsdp2_module(
@@ -492,8 +450,7 @@ def build_fsdp2_training_optimizer(
         _restore_model_param_dtypes(model_chunks, model_param_dtypes)
 
     tp_replicated_grad_params = _collect_tp_replicated_grad_params(
-        model_chunks,
-        param_names=tp_replicated_grad_param_names,
+        model_chunks, param_names=tp_replicated_grad_param_names
     )
     return build_fsdp2_adamw(
         model_chunks,
@@ -501,8 +458,7 @@ def build_fsdp2_training_optimizer(
         ps,
         expert_sharded_grad_params=list(ignored_expert_params),
         expert_sharded_grad_scale=(
-            float(ps.expert_dp_size) / float(ps.dp_cp_size)
-            if ignored_expert_params else None
+            float(ps.expert_dp_size) / float(ps.dp_cp_size) if ignored_expert_params else None
         ),
         expert_sharded_grad_norm_group=ps.ep_group if ignored_expert_params else None,
         tp_replicated_grad_params=tp_replicated_grad_params,
@@ -515,9 +471,7 @@ def build_fsdp2_training_optimizer(
 
 
 def _collect_expert_params(
-    chunks: Iterable[nn.Module],
-    ps: ParallelState,
-    expert_classifier: Callable[[str], bool] | None,
+    chunks: Iterable[nn.Module], ps: ParallelState, expert_classifier: Callable[[str], bool] | None
 ) -> set[nn.Parameter]:
     if ps.ep_size <= 1 or expert_classifier is None:
         return set()
@@ -561,9 +515,7 @@ def _collect_module_params(modules: Iterable[nn.Module]) -> set[nn.Parameter]:
     return {param for module in modules for param in module.parameters()}
 
 
-def _collect_model_param_dtypes(
-    chunks: Iterable[nn.Module],
-) -> dict[tuple[int, str], torch.dtype]:
+def _collect_model_param_dtypes(chunks: Iterable[nn.Module]) -> dict[tuple[int, str], torch.dtype]:
     return {
         (chunk_idx, name): param.dtype
         for chunk_idx, chunk in enumerate(chunks)
@@ -573,8 +525,7 @@ def _collect_model_param_dtypes(
 
 
 def _restore_model_param_dtypes(
-    chunks: Iterable[nn.Module],
-    model_param_dtypes: dict[tuple[int, str], torch.dtype],
+    chunks: Iterable[nn.Module], model_param_dtypes: dict[tuple[int, str], torch.dtype]
 ) -> None:
     for chunk_idx, chunk in enumerate(chunks):
         for name, param in chunk.named_parameters():
@@ -583,9 +534,7 @@ def _restore_model_param_dtypes(
                 param._fsdp2_model_param_dtype = model_dtype
 
 
-def _collect_tp_replicated_grad_param_names(
-    chunks: Iterable[nn.Module],
-) -> list[tuple[int, str]]:
+def _collect_tp_replicated_grad_param_names(chunks: Iterable[nn.Module]) -> list[tuple[int, str]]:
     names: list[tuple[int, str]] = []
     for chunk_idx, chunk in enumerate(chunks):
         sp_param_ids = {id(param) for param in getattr(chunk, "sp_params", ())}
@@ -598,9 +547,7 @@ def _collect_tp_replicated_grad_param_names(
 
 
 def _collect_tp_replicated_grad_params(
-    chunks: Iterable[nn.Module],
-    *,
-    param_names: Iterable[tuple[int, str]] | None = None,
+    chunks: Iterable[nn.Module], *, param_names: Iterable[tuple[int, str]] | None = None
 ) -> list[nn.Parameter]:
     chunk_list = list(chunks)
     params: list[nn.Parameter] = []
@@ -626,9 +573,7 @@ def _collect_tp_replicated_grad_params(
 
 
 def _fsdp2_unit_reshard_after_forward(
-    ps: ParallelState,
-    *,
-    reshard_after_forward: bool | int | None,
+    ps: ParallelState, *, reshard_after_forward: bool | int | None
 ) -> bool | int | None:
     if ps.pp_size > 1:
         return False
@@ -685,19 +630,14 @@ def _build_adamw_param_groups(
 
 
 def _matches_megatron_no_weight_decay(
-    name: str,
-    param: nn.Parameter,
-    apply_wd_to_qk_layernorm: bool,
+    name: str, param: nn.Parameter, apply_wd_to_qk_layernorm: bool
 ) -> bool:
     if len(param.shape) != 1 and not name.endswith(".bias"):
         return False
     if not apply_wd_to_qk_layernorm:
         return True
     return not (
-        "q_layernorm." in name
-        or "k_layernorm." in name
-        or "q_norm." in name
-        or "k_norm." in name
+        "q_layernorm." in name or "k_layernorm." in name or "q_norm." in name or "k_norm." in name
     )
 
 
@@ -721,11 +661,7 @@ class FSDP2OptimizerBackend:
     def state_dict(self, optimizer: FSDP2Optimizer) -> dict:
         return optimizer.state_dict()
 
-    def load_state_dict(
-        self,
-        optimizer: FSDP2Optimizer,
-        state_dict: dict,
-    ) -> None:
+    def load_state_dict(self, optimizer: FSDP2Optimizer, state_dict: dict) -> None:
         optimizer.load_state_dict(state_dict)
 
 

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/state.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/state.py
@@ -58,8 +58,7 @@ def move_optimizer_state_to_cpu(
 
 
 def move_offloaded_optimizer_state_to_device(
-    optimizer: Any,
-    offloaded: dict[tuple[int, str], OffloadedStateEntry],
+    optimizer: Any, offloaded: dict[tuple[int, str], OffloadedStateEntry]
 ) -> None:
     if not offloaded:
         return
@@ -80,9 +79,7 @@ def move_offloaded_optimizer_state_to_device(
                     device_value = value.to(entry.device, non_blocking=True)
                     if entry.is_dtensor:
                         param_state[state_key] = dtensor_from_local(
-                            device_value,
-                            entry.device_mesh,
-                            entry.placements,
+                            device_value, entry.device_mesh, entry.placements
                         )
                     else:
                         param_state[state_key] = device_value

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/wrap.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/wrap.py
@@ -90,17 +90,12 @@ def build_fsdp2_device_mesh(ps: ParallelState, config: FSDP2Config | None = None
     from torch.distributed import DeviceMesh
 
     return DeviceMesh.from_group(
-        group,
-        device_type=cfg.device_type,
-        mesh_dim_names=(cfg.mesh_dim_name,),
+        group, device_type=cfg.device_type, mesh_dim_names=(cfg.mesh_dim_name,)
     )
 
 
 def build_fsdp2_process_group_mesh(
-    group: dist.ProcessGroup,
-    *,
-    mesh_dim_name: str,
-    device_type: str = "cuda",
+    group: dist.ProcessGroup, *, mesh_dim_name: str, device_type: str = "cuda"
 ) -> Any:
     """Build a one-dimensional FSDP2 DeviceMesh from an explicit process group."""
 
@@ -115,11 +110,7 @@ def build_fsdp2_process_group_mesh(
 
     from torch.distributed import DeviceMesh
 
-    return DeviceMesh.from_group(
-        group,
-        device_type=device_type,
-        mesh_dim_names=(mesh_dim_name,),
-    )
+    return DeviceMesh.from_group(group, device_type=device_type, mesh_dim_names=(mesh_dim_name,))
 
 
 def build_fsdp2_shard_placement_fn(fsdp_size: int) -> Callable[[nn.Parameter], Any]:
@@ -181,8 +172,7 @@ def wrap_fsdp2(
     for idx, sub_module in enumerate(unit_modules):
         kwargs = dict(common_kwargs)
         _set_optional_reshard_after_forward(
-            kwargs,
-            _unit_reshard_after_forward(cfg, idx, len(unit_modules)),
+            kwargs, _unit_reshard_after_forward(cfg, idx, len(unit_modules))
         )
         fully_shard(sub_module, **kwargs)
         wrapped_units.append(sub_module)
@@ -263,9 +253,7 @@ def _warn_tp_not_recommended(ps: ParallelState) -> None:
 
 
 def promote_fsdp2_trainable_params_to_fp32(
-    model: nn.Module,
-    *,
-    ignored_params: set[nn.Parameter] | None = None,
+    model: nn.Module, *, ignored_params: set[nn.Parameter] | None = None
 ) -> int:
     """Promote FSDP2-owned trainable floating parameters to FP32 shards.
 
@@ -294,10 +282,7 @@ def promote_fsdp2_trainable_params_to_fp32(
 
 
 def set_fsdp2_requires_gradient_sync(
-    module: nn.Module,
-    requires_gradient_sync: bool,
-    *,
-    recurse: bool = True,
+    module: nn.Module, requires_gradient_sync: bool, *, recurse: bool = True
 ) -> int:
     """Set FSDP2 gradient sync state and return the number of touched roots."""
 
@@ -355,9 +340,7 @@ def _import_module_type(path: str) -> type[nn.Module]:
 
 
 def _iter_fsdp2_unit_modules(
-    root: nn.Module,
-    unit_types: tuple[type[nn.Module], ...],
-    leaf_module_names: tuple[str, ...],
+    root: nn.Module, unit_types: tuple[type[nn.Module], ...], leaf_module_names: tuple[str, ...]
 ) -> Iterable[nn.Module]:
     leaf_names = set(leaf_module_names)
     if not unit_types and not leaf_names:
@@ -398,17 +381,12 @@ def _module_has_trainable_param(module: nn.Module) -> bool:
 
 def _is_fsdp2_module(module: nn.Module) -> bool:
     return hasattr(module, "set_modules_to_forward_prefetch") and hasattr(
-        module,
-        "set_modules_to_backward_prefetch",
+        module, "set_modules_to_backward_prefetch"
     )
 
 
 def _apply_fsdp2_prefetch(
-    root: nn.Module,
-    wrapped_units: list[nn.Module],
-    *,
-    forward_depth: int,
-    backward_depth: int,
+    root: nn.Module, wrapped_units: list[nn.Module], *, forward_depth: int, backward_depth: int
 ) -> None:
     fsdp_units = [module for module in wrapped_units if _is_fsdp2_module(module)]
     fsdp_root = root if _is_fsdp2_module(root) else None
@@ -429,19 +407,14 @@ def _apply_fsdp2_prefetch(
                 fsdp_units[idx].set_modules_to_backward_prefetch(targets)
 
 
-def _unit_reshard_after_forward(
-    cfg: FSDP2Config,
-    idx: int,
-    total_units: int,
-) -> bool | int | None:
+def _unit_reshard_after_forward(cfg: FSDP2Config, idx: int, total_units: int) -> bool | int | None:
     if total_units > 0 and idx == total_units - 1:
         return cfg.last_unit_reshard_after_forward
     return cfg.reshard_after_forward
 
 
 def _set_optional_reshard_after_forward(
-    kwargs: dict[str, Any],
-    reshard_after_forward: bool | int | None,
+    kwargs: dict[str, Any], reshard_after_forward: bool | int | None
 ) -> None:
     if reshard_after_forward is not None:
         kwargs["reshard_after_forward"] = reshard_after_forward

--- a/experimental/lite/megatron/lite/primitive/optimizers/megatron_wrap.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/megatron_wrap.py
@@ -16,9 +16,7 @@ def validate_mc_config(engine_cfg) -> None:
     """Validate dist_opt constraints owned by this optimizer primitive."""
     p = engine_cfg.parallel
     if p.vpp > 1 and p.pp == 1:
-        raise ValueError(
-            "dist_opt requires pp>1 when vpp>1."
-        )
+        raise ValueError("dist_opt requires pp>1 when vpp>1.")
 
 
 # Legacy alias — kept for compat shim path
@@ -35,13 +33,7 @@ def _ensure_mc_mpu_parallel_state(engine_cfg) -> None:
     from megatron.core import parallel_state as mpu  # pyright: ignore[reportMissingImports]
 
     p = engine_cfg.parallel
-    expected = (
-        int(p.tp),
-        int(p.ep),
-        _effective_etp(p),
-        int(p.pp),
-        int(p.cp),
-    )
+    expected = (int(p.tp), int(p.ep), _effective_etp(p), int(p.pp), int(p.cp))
     if mpu.is_initialized():
         current = (
             int(mpu.get_tensor_model_parallel_world_size()),
@@ -76,8 +68,8 @@ def build_mc_optimizer_config(opt, *, override_optimizer_config: dict[str, Any] 
     Works on either `runtime.contracts.config.OptimizerConfig` (real dataclass)
     or a `SimpleNamespace` with the same field names (legacy lite path).
     """
-    from megatron.core.optimizer.optimizer_config import (  # pyright: ignore[reportMissingImports]
-        OptimizerConfig as MCOptimizerConfig,
+    from megatron.core.optimizer.optimizer_config import (
+        OptimizerConfig as MCOptimizerConfig,  # pyright: ignore[reportMissingImports]
     )
 
     offload = getattr(opt, "offload_fraction", None) or 0.0
@@ -159,9 +151,7 @@ def build_mc_stack(
         wrapped_chunks = list(model_chunks)
     else:
         ddp_config = DistributedDataParallelConfig(
-            use_distributed_optimizer=True,
-            overlap_grad_reduce=False,
-            grad_reduce_in_fp32=True,
+            use_distributed_optimizer=True, overlap_grad_reduce=False, grad_reduce_in_fp32=True
         )
         wrapped_chunks = []
         for chunk_idx, chunk in enumerate(model_chunks):
@@ -188,10 +178,7 @@ def build_mc_stack(
     # groups. Long term, this primitive should always pass its own
     # `pg_collection`.
     if skip_ddp_wrap or use_mpu_groups:
-        optimizer = get_megatron_optimizer(
-            config=opt_config,
-            model_chunks=wrapped_chunks,
-        )
+        optimizer = get_megatron_optimizer(config=opt_config, model_chunks=wrapped_chunks)
         optimizer._mc_pg_collection = None  # pyright: ignore[reportAttributeAccessIssue]
     else:
         optimizer = get_megatron_optimizer(
@@ -292,7 +279,7 @@ def _build_transformer_config(model_cfg, engine_cfg):
 
 
 def _mark_mc_parallel_attrs(
-    model: nn.Module, is_expert_param: ExpertClassifierFn, *, tp_size: int,
+    model: nn.Module, is_expert_param: ExpertClassifierFn, *, tp_size: int
 ) -> None:
     """Mark per-param MC metadata (allreduce / tensor_model_parallel / sequence_parallel).
 
@@ -329,6 +316,7 @@ def _mark_mc_parallel_attrs(
 
 def _build_pg_collection(ps, engine_cfg):
     import torch.distributed as dist  # pyright: ignore[reportMissingImports]
+
     from megatron.core.process_groups_config import ProcessGroupCollection
 
     if ps.pp_group is None:
@@ -349,7 +337,9 @@ def _build_pg_collection(ps, engine_cfg):
         if rank == singleton_rank:
             singleton_group = group
     if singleton_group is None:
-        raise RuntimeError("Failed to construct singleton process group for optional MC reductions.")
+        raise RuntimeError(
+            "Failed to construct singleton process group for optional MC reductions."
+        )
 
     if engine_cfg.parallel.pp == 1:
         mp_group = ps.tp_group

--- a/experimental/lite/megatron/lite/primitive/parallel/cp.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/cp.py
@@ -6,7 +6,7 @@ import torch
 
 
 def zigzag_split_for_cp(
-    tensor: torch.Tensor, cp_rank: int, cp_size: int, seq_dim: int = 1,
+    tensor: torch.Tensor, cp_rank: int, cp_size: int, seq_dim: int = 1
 ) -> torch.Tensor:
     """Split tensor along sequence dim using zigzag (striped) pattern for CP.
 
@@ -20,37 +20,33 @@ def zigzag_split_for_cp(
     if cp_size <= 1:
         return tensor
     seq_len = tensor.shape[seq_dim]
-    assert seq_len % (2 * cp_size) == 0, (
-        f"seq_len={seq_len} must be divisible by 2*cp_size={2 * cp_size}"
-    )
+    assert (
+        seq_len % (2 * cp_size) == 0
+    ), f"seq_len={seq_len} must be divisible by 2*cp_size={2 * cp_size}"
     shape = list(tensor.shape)
-    shape[seq_dim:seq_dim + 1] = [2 * cp_size, seq_len // (2 * cp_size)]
+    shape[seq_dim : seq_dim + 1] = [2 * cp_size, seq_len // (2 * cp_size)]
     tensor = tensor.view(*shape)
-    idx = torch.tensor(
-        [cp_rank, 2 * cp_size - cp_rank - 1],
-        dtype=torch.long, device=tensor.device,
-    )
+    idx = torch.tensor([cp_rank, 2 * cp_size - cp_rank - 1], dtype=torch.long, device=tensor.device)
     tensor = tensor.index_select(seq_dim, idx)
-    shape[seq_dim:seq_dim + 2] = [seq_len // cp_size]
+    shape[seq_dim : seq_dim + 2] = [seq_len // cp_size]
     return tensor.reshape(*shape)
 
 
 def zigzag_reconstruct_from_cp_parts(
-    parts: list[torch.Tensor] | tuple[torch.Tensor, ...],
-    seq_dim: int = 1,
+    parts: list[torch.Tensor] | tuple[torch.Tensor, ...], seq_dim: int = 1
 ) -> torch.Tensor:
     """Reconstruct a full sequence from per-rank zigzag CP shards."""
     cp_size = len(parts)
     if cp_size <= 1:
         return parts[0]
     local_len = parts[0].shape[seq_dim]
-    assert local_len % 2 == 0, (
-        f"local seq_len={local_len} must be divisible by 2 for zigzag CP reconstruction"
-    )
+    assert (
+        local_len % 2 == 0
+    ), f"local seq_len={local_len} must be divisible by 2 for zigzag CP reconstruction"
     for idx, part in enumerate(parts):
-        assert part.shape == parts[0].shape, (
-            f"CP part {idx} shape {tuple(part.shape)} != {tuple(parts[0].shape)}"
-        )
+        assert (
+            part.shape == parts[0].shape
+        ), f"CP part {idx} shape {tuple(part.shape)} != {tuple(parts[0].shape)}"
 
     chunk = local_len // 2
     full_len = local_len * cp_size
@@ -66,18 +62,15 @@ def zigzag_reconstruct_from_cp_parts(
 
 
 def zigzag_slice_for_cp(
-    tensor: torch.Tensor,
-    cp_rank: int,
-    cp_size: int,
-    seq_dim: int = 1,
+    tensor: torch.Tensor, cp_rank: int, cp_size: int, seq_dim: int = 1
 ) -> torch.Tensor:
     """Return one rank's zigzag CP shard from a full sequence tensor."""
     if cp_size <= 1:
         return tensor
     seq_len = tensor.shape[seq_dim]
-    assert seq_len % (2 * cp_size) == 0, (
-        f"seq_len={seq_len} must be divisible by 2*cp_size={2 * cp_size}"
-    )
+    assert (
+        seq_len % (2 * cp_size) == 0
+    ), f"seq_len={seq_len} must be divisible by 2*cp_size={2 * cp_size}"
     chunk = seq_len // (2 * cp_size)
     first = tensor.narrow(seq_dim, cp_rank * chunk, chunk)
     second_start = seq_len - (cp_rank + 1) * chunk
@@ -86,7 +79,7 @@ def zigzag_slice_for_cp(
 
 
 def zigzag_position_ids_for_cp(
-    seq_len: int, cp_rank: int, cp_size: int, device: torch.device,
+    seq_len: int, cp_rank: int, cp_size: int, device: torch.device
 ) -> torch.Tensor:
     """Return global position IDs for this CP rank under zigzag splitting.
 
@@ -131,16 +124,16 @@ def split_packed_for_cp(
         start = int(cu_seqlens[i].item())
         end = int(cu_seqlens[i + 1].item())
         seq_len = end - start
-        assert seq_len % (2 * cp_size) == 0, (
-            f"Sample {i} length {seq_len} not divisible by 2*cp_size={2 * cp_size}"
-        )
+        assert (
+            seq_len % (2 * cp_size) == 0
+        ), f"Sample {i} length {seq_len} not divisible by 2*cp_size={2 * cp_size}"
         chunk = seq_len // (2 * cp_size)
         c1 = start + cp_rank * chunk
         c2 = start + (2 * cp_size - cp_rank - 1) * chunk
-        ids_parts.append(input_ids[c1:c1 + chunk])
-        ids_parts.append(input_ids[c2:c2 + chunk])
-        pos_parts.append(position_ids[c1:c1 + chunk])
-        pos_parts.append(position_ids[c2:c2 + chunk])
+        ids_parts.append(input_ids[c1 : c1 + chunk])
+        ids_parts.append(input_ids[c2 : c2 + chunk])
+        pos_parts.append(position_ids[c1 : c1 + chunk])
+        pos_parts.append(position_ids[c2 : c2 + chunk])
         new_lengths.append(2 * chunk)
 
     new_ids = torch.cat(ids_parts)

--- a/experimental/lite/megatron/lite/primitive/parallel/linear.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/linear.py
@@ -77,9 +77,7 @@ class _VanillaColParallelMatmulSP(torch.autograd.Function):
         if ws > 1:
             s_local = input_.shape[0]
             total_shape = (s_local * ws, *input_.shape[1:])
-            total_input = torch.empty(
-                total_shape, dtype=input_.dtype, device=input_.device,
-            )
+            total_input = torch.empty(total_shape, dtype=input_.dtype, device=input_.device)
             dist.all_gather_into_tensor(total_input, input_.contiguous(), group=tp_group)
         else:
             total_input = input_
@@ -96,13 +94,9 @@ class _VanillaColParallelMatmulSP(torch.autograd.Function):
         if ctx.tp_size > 1:
             out_shape = (ctx.local_s, *grad_input_full.shape[1:])
             grad_input = torch.empty(
-                out_shape,
-                dtype=grad_input_full.dtype,
-                device=grad_input_full.device,
+                out_shape, dtype=grad_input_full.dtype, device=grad_input_full.device
             )
-            dist.reduce_scatter_tensor(
-                grad_input, grad_input_full.contiguous(), group=ctx.tp_group,
-            )
+            dist.reduce_scatter_tensor(grad_input, grad_input_full.contiguous(), group=ctx.tp_group)
         else:
             grad_input = grad_input_full
         gi = grad_output.reshape(-1, grad_output.shape[-1])
@@ -124,22 +118,13 @@ class _VanillaColLinear(nn.Module):
     `sp=False`, input is assumed replicated and grad_input is all-reduced.
     """
 
-    def __init__(
-        self,
-        in_features: int,
-        out_features: int,
-        ps: ParallelState,
-        *,
-        sp: bool = False,
-    ):
+    def __init__(self, in_features: int, out_features: int, ps: ParallelState, *, sp: bool = False):
         super().__init__()
         self.tp_group = ps.tp_group
         self.tp_size = ps.tp_size
         self.sp = sp
         local_out = ensure_divisible(out_features, ps.tp_size)
-        self.weight = nn.Parameter(
-            torch.empty(local_out, in_features, dtype=torch.bfloat16)
-        )
+        self.weight = nn.Parameter(torch.empty(local_out, in_features, dtype=torch.bfloat16))
         nn.init.xavier_uniform_(self.weight)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -197,7 +182,9 @@ class ColumnParallelLinear(nn.Module):
         self.tp_rank = ps.tp_rank
         self.tp_group = ps.tp_group
         self.local_out = ensure_divisible(out_features, ps.tp_size)
-        self.use_sp = ps.tp_size > 1 and not gather_output if sequence_parallel is None else sequence_parallel
+        self.use_sp = (
+            ps.tp_size > 1 and not gather_output if sequence_parallel is None else sequence_parallel
+        )
         if normalization is not None:
             self.linear = te.LayerNormLinear(
                 in_features,
@@ -286,12 +273,7 @@ class VocabParallelEmbedding(nn.Module):
     """Embedding table split across TP on the vocab dimension."""
 
     def __init__(
-        self,
-        vocab_size: int,
-        hidden_size: int,
-        ps: ParallelState,
-        *,
-        deterministic: bool = False,
+        self, vocab_size: int, hidden_size: int, ps: ParallelState, *, deterministic: bool = False
     ):
         super().__init__()
         self.tp_size = ps.tp_size
@@ -347,8 +329,7 @@ class _ColForLMHead(nn.Module):
             # under bf16, producing ~3e-4 loss-level drift. Keep for future
             # FP8 / fused-norm paths.
             _wrapper = ColumnParallelLinear(
-                in_features, out_features, ps,
-                bias=False, gather_output=not sp,
+                in_features, out_features, ps, bias=False, gather_output=not sp
             )
             self.linear = _wrapper.linear
         else:
@@ -364,21 +345,14 @@ class VocabParallelOutput(nn.Module):
     """
 
     def __init__(
-        self,
-        vocab_size: int,
-        hidden_size: int,
-        ps: ParallelState,
-        *,
-        backend: str = "vanilla",
+        self, vocab_size: int, hidden_size: int, ps: ParallelState, *, backend: str = "vanilla"
     ):
         super().__init__()
         padded_vocab = pad_vocab_for_tp(vocab_size, ps.tp_size)
         # SP-aware head: when tp>1 we run on SP-sharded input (matches MC
         # GPTModel where final_layernorm runs on SP-sharded hiddens and
         # output_layer gathers internally + reduce-scatters on backward).
-        self.col = _ColForLMHead(
-            hidden_size, padded_vocab, ps, backend=backend, sp=ps.tp_size > 1,
-        )
+        self.col = _ColForLMHead(hidden_size, padded_vocab, ps, backend=backend, sp=ps.tp_size > 1)
         self.padded_vocab = padded_vocab
         self.local_vocab = padded_vocab // ps.tp_size
         self.vocab_size = vocab_size
@@ -393,7 +367,7 @@ class VocabParallelOutput(nn.Module):
             chunks = [torch.empty_like(logits) for _ in range(self.ps.tp_size)]
             dist.all_gather(chunks, logits, group=self.ps.tp_group)
             logits = torch.cat(chunks, dim=-1)
-        return logits[..., :self.vocab_size]
+        return logits[..., : self.vocab_size]
 
 
 class _AllGatherLastDim(torch.autograd.Function):
@@ -412,7 +386,7 @@ class _AllGatherLastDim(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad_output):
         start = ctx.rank * ctx.local_dim
-        return grad_output[..., start:start + ctx.local_dim].contiguous(), None, None
+        return grad_output[..., start : start + ctx.local_dim].contiguous(), None, None
 
 
 class _ReduceFromTP(torch.autograd.Function):

--- a/experimental/lite/megatron/lite/primitive/parallel/pipeline.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/pipeline.py
@@ -139,7 +139,9 @@ def _batch_input_ids(batch):
     return input_ids
 
 
-def _apply_external_loss(out: dict, batch, loss_fn) -> tuple[torch.Tensor, dict] | tuple[None, None]:
+def _apply_external_loss(
+    out: dict, batch, loss_fn
+) -> tuple[torch.Tensor, dict] | tuple[None, None]:
     if loss_fn is None:
         return None, None
     loss, metrics = loss_fn(out, batch)
@@ -195,14 +197,7 @@ def _no_pipeline(
 
 
 def _forward_only_no_pipeline(
-    forward_step_fn,
-    model,
-    data_iter,
-    config,
-    ps,
-    *,
-    pre_forward_hook=None,
-    loss_fn=None,
+    forward_step_fn, model, data_iter, config, ps, *, pre_forward_hook=None, loss_fn=None
 ):
     num_microbatches = _num_microbatches_from_config(config, ps)
     del ps
@@ -400,9 +395,7 @@ def _deallocate_output_tensor(tensor: torch.Tensor | None) -> None:
 # Interleaved 1F1B (VPP) Schedule
 # ══════════════════════════════════════════════════════════════════════
 def _build_schedule_table(
-    num_microbatches: int,
-    num_chunks: int,
-    group_size: int,
+    num_microbatches: int, num_chunks: int, group_size: int
 ) -> list[tuple[int, int]]:
     """Build (microbatch_id, model_chunk_id) table for VPP scheduling."""
     table: list[tuple[int, int]] = []
@@ -554,9 +547,7 @@ def _run_pipeline_chunk_forward(
         _apply_external_loss(out, batch, loss_fn)
         return out
     return model(
-        hidden_states=input_tensor,
-        position_ids=position_ids,
-        packed_seq_params=packed_seq_params,
+        hidden_states=input_tensor, position_ids=position_ids, packed_seq_params=packed_seq_params
     )
 
 
@@ -670,7 +661,9 @@ def _interleaved_1f1b_schedule(
     for mb_id in range(num_microbatches):
         batch = next(data_iter)
         _set_aux_loss_scale(pre_forward_hook, num_microbatches)
-        saved: dict[int, tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None, dict]] = {}
+        saved: dict[
+            int, tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None, dict]
+        ] = {}
         pending_activation: torch.Tensor | None = None
 
         # Forward in true virtual-stage order:

--- a/experimental/lite/megatron/lite/primitive/parallel/pp.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/pp.py
@@ -46,11 +46,7 @@ def build_pipeline_chunk_layout(
         layer_indices = list(range(start, start + layers_per_stage))
         has_embed = ps.pp_is_first
         has_head = ps.pp_is_last
-    return PipelineChunkLayout(
-        layer_indices=layer_indices,
-        has_embed=has_embed,
-        has_head=has_head,
-    )
+    return PipelineChunkLayout(layer_indices=layer_indices, has_embed=has_embed, has_head=has_head)
 
 
 __all__ = ["PipelineChunkLayout", "build_pipeline_chunk_layout"]

--- a/experimental/lite/megatron/lite/primitive/parallel/sp.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/sp.py
@@ -6,7 +6,11 @@ from typing import TYPE_CHECKING
 
 import torch  # pyright: ignore[reportMissingImports]
 
-from megatron.lite.primitive.ops.sp_ops import AllGatherDim0, AllGatherDim0ForNonSPConsumer, ScatterToSP
+from megatron.lite.primitive.ops.sp_ops import (
+    AllGatherDim0,
+    AllGatherDim0ForNonSPConsumer,
+    ScatterToSP,
+)
 
 if TYPE_CHECKING:
     from megatron.lite.primitive.parallel.state import ParallelState

--- a/experimental/lite/megatron/lite/primitive/parallel/thd.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/thd.py
@@ -119,12 +119,7 @@ def _assign_along_dim(dst: torch.Tensor, dim: int, start: int, src: torch.Tensor
 
 
 def _split_full_to_cp_local(
-    tensor: torch.Tensor,
-    *,
-    cu_seqlens_padded: torch.Tensor,
-    cp_size: int,
-    cp_rank: int,
-    dim: int,
+    tensor: torch.Tensor, *, cu_seqlens_padded: torch.Tensor, cp_size: int, cp_rank: int, dim: int
 ) -> torch.Tensor:
     if cp_size <= 1:
         return tensor
@@ -144,16 +139,10 @@ def _split_full_to_cp_local(
         local_start = full_start // cp_size
 
         first = _slice_along_dim(
-            tensor,
-            dim,
-            full_start + cp_rank * chunk,
-            full_start + (cp_rank + 1) * chunk,
+            tensor, dim, full_start + cp_rank * chunk, full_start + (cp_rank + 1) * chunk
         )
         second = _slice_along_dim(
-            tensor,
-            dim,
-            full_end - (cp_rank + 1) * chunk,
-            full_end - cp_rank * chunk,
+            tensor, dim, full_end - (cp_rank + 1) * chunk, full_end - cp_rank * chunk
         )
         _assign_along_dim(local, dim, local_start, first)
         _assign_along_dim(local, dim, local_start + chunk, second)
@@ -162,11 +151,7 @@ def _split_full_to_cp_local(
 
 
 def _reconstruct_full_from_cp_parts(
-    parts: list[torch.Tensor],
-    *,
-    cu_seqlens_padded: torch.Tensor,
-    cp_size: int,
-    dim: int,
+    parts: list[torch.Tensor], *, cu_seqlens_padded: torch.Tensor, cp_size: int, dim: int
 ) -> torch.Tensor:
     if cp_size <= 1:
         return parts[0]
@@ -195,40 +180,26 @@ def _reconstruct_full_from_cp_parts(
 
 
 def reconstruct_packed_from_cp_parts(
-    parts: list[torch.Tensor],
-    *,
-    cu_seqlens_padded: torch.Tensor,
-    cp_size: int,
-    dim: int,
+    parts: list[torch.Tensor], *, cu_seqlens_padded: torch.Tensor, cp_size: int, dim: int
 ) -> torch.Tensor:
     """Reconstruct a full packed THD tensor from CP-local zigzag parts."""
     return _reconstruct_full_from_cp_parts(
-        parts,
-        cu_seqlens_padded=cu_seqlens_padded,
-        cp_size=cp_size,
-        dim=dim,
+        parts, cu_seqlens_padded=cu_seqlens_padded, cp_size=cp_size, dim=dim
     )
 
 
 def split_packed_to_cp_local(
-    tensor: torch.Tensor,
-    *,
-    cu_seqlens_padded: torch.Tensor,
-    cp_size: int,
-    cp_rank: int,
-    dim: int,
+    tensor: torch.Tensor, *, cu_seqlens_padded: torch.Tensor, cp_size: int, cp_rank: int, dim: int
 ) -> torch.Tensor:
     """Slice a full packed THD tensor back to one CP rank's zigzag shard."""
     return _split_full_to_cp_local(
-        tensor,
-        cu_seqlens_padded=cu_seqlens_padded,
-        cp_size=cp_size,
-        cp_rank=cp_rank,
-        dim=dim,
+        tensor, cu_seqlens_padded=cu_seqlens_padded, cp_size=cp_size, cp_rank=cp_rank, dim=dim
     )
 
 
-def _all_gather_cp_tensor(tensor: torch.Tensor, *, cp_size: int, cp_group: Any) -> list[torch.Tensor]:
+def _all_gather_cp_tensor(
+    tensor: torch.Tensor, *, cp_size: int, cp_group: Any
+) -> list[torch.Tensor]:
     if cp_size <= 1:
         return [tensor]
     if cp_group is None:
@@ -244,10 +215,7 @@ def _all_gather_cp_tensor(tensor: torch.Tensor, *, cp_size: int, cp_group: Any) 
 
 
 def _roll_packed_thd_left_local(
-    tensor: torch.Tensor,
-    *,
-    cu_seqlens_padded: torch.Tensor,
-    dims: int = -1,
+    tensor: torch.Tensor, *, cu_seqlens_padded: torch.Tensor, dims: int = -1
 ) -> tuple[torch.Tensor, torch.Tensor]:
     dim = dims if dims >= 0 else tensor.dim() + dims
     if dim < 0 or dim >= tensor.dim():
@@ -298,22 +266,13 @@ def roll_packed_thd_left(
 
     parts = _all_gather_cp_tensor(tensor, cp_size=cp_size, cp_group=cp_group)
     full = _reconstruct_full_from_cp_parts(
-        parts,
-        cu_seqlens_padded=cu_seqlens_padded,
-        cp_size=cp_size,
-        dim=dim,
+        parts, cu_seqlens_padded=cu_seqlens_padded, cp_size=cp_size, dim=dim
     )
     rolled_full, token_sum = _roll_packed_thd_left_local(
-        full,
-        cu_seqlens_padded=cu_seqlens_padded,
-        dims=dim,
+        full, cu_seqlens_padded=cu_seqlens_padded, dims=dim
     )
     local = _split_full_to_cp_local(
-        rolled_full,
-        cu_seqlens_padded=cu_seqlens_padded,
-        cp_size=cp_size,
-        cp_rank=cp_rank,
-        dim=dim,
+        rolled_full, cu_seqlens_padded=cu_seqlens_padded, cp_size=cp_size, cp_rank=cp_rank, dim=dim
     )
     return local, token_sum
 
@@ -345,9 +304,13 @@ def pack_nested_thd(
     if not getattr(input_ids, "is_nested", False):
         raise TypeError("pack_nested_thd expects a jagged NestedTensor input_ids.")
     if labels is not None and not getattr(labels, "is_nested", False):
-        raise TypeError("pack_nested_thd expects jagged NestedTensor labels when labels are provided.")
+        raise TypeError(
+            "pack_nested_thd expects jagged NestedTensor labels when labels are provided."
+        )
     if loss_mask is not None and not getattr(loss_mask, "is_nested", False):
-        raise TypeError("pack_nested_thd expects jagged NestedTensor loss_mask when loss_mask is provided.")
+        raise TypeError(
+            "pack_nested_thd expects jagged NestedTensor loss_mask when loss_mask is provided."
+        )
 
     align_size = max(int(tp_size), 1) * (2 * cp_size if cp_size > 1 else 1)
     device = input_ids.device
@@ -356,11 +319,7 @@ def pack_nested_thd(
     pad_size = (align_size - lengths % align_size) % align_size
     padded_lengths = lengths + pad_size
 
-    cu_seqlens_padded = torch.zeros(
-        lengths.numel() + 1,
-        dtype=torch.int32,
-        device=device,
-    )
+    cu_seqlens_padded = torch.zeros(lengths.numel() + 1, dtype=torch.int32, device=device)
     cu_seqlens_padded[1:] = torch.cumsum(padded_lengths, dim=0)
     total_padded = int(cu_seqlens_padded[-1].item())
     total_local = total_padded // cp_size
@@ -368,9 +327,7 @@ def pack_nested_thd(
 
     packed_input = torch.zeros(total_local, dtype=input_ids.dtype, device=device)
     packed_labels = (
-        torch.zeros(total_local, dtype=labels.dtype, device=device)
-        if labels is not None
-        else None
+        torch.zeros(total_local, dtype=labels.dtype, device=device) if labels is not None else None
     )
     packed_loss_mask = (
         torch.zeros(total_local, dtype=loss_mask.dtype, device=device)
@@ -419,7 +376,9 @@ def pack_nested_thd(
         if seq_labels is not None:
             local_labels = _split_full_to_cp_local(
                 seq_labels,
-                cu_seqlens_padded=torch.tensor([0, padded_length], dtype=torch.int32, device=device),
+                cu_seqlens_padded=torch.tensor(
+                    [0, padded_length], dtype=torch.int32, device=device
+                ),
                 cp_size=cp_size,
                 cp_rank=cp_rank,
                 dim=0,
@@ -429,7 +388,9 @@ def pack_nested_thd(
         if seq_loss_mask is not None:
             local_loss_mask = _split_full_to_cp_local(
                 seq_loss_mask,
-                cu_seqlens_padded=torch.tensor([0, padded_length], dtype=torch.int32, device=device),
+                cu_seqlens_padded=torch.tensor(
+                    [0, padded_length], dtype=torch.int32, device=device
+                ),
                 cp_size=cp_size,
                 cp_rank=cp_rank,
                 dim=0,
@@ -473,10 +434,7 @@ def unpack_packed_thd_to_nested(output: torch.Tensor, batch: PackedTHDBatch) -> 
         dim = 0
         parts = _all_gather_cp_tensor(flat, cp_size=batch.cp_size, cp_group=batch.cp_group)
         flat = _reconstruct_full_from_cp_parts(
-            parts,
-            cu_seqlens_padded=batch.cu_seqlens_padded,
-            cp_size=batch.cp_size,
-            dim=dim,
+            parts, cu_seqlens_padded=batch.cu_seqlens_padded, cp_size=batch.cp_size, dim=dim
         )
 
     pieces = []

--- a/experimental/lite/megatron/lite/primitive/protocols.py
+++ b/experimental/lite/megatron/lite/primitive/protocols.py
@@ -20,9 +20,4 @@ def default_placement_fn(name: str) -> list:
     return [Replicate(), Replicate(), Replicate(), Replicate()]
 
 
-__all__ = [
-    "ExpertClassifierFn",
-    "PlacementFn",
-    "default_expert_classifier",
-    "default_placement_fn",
-]
+__all__ = ["ExpertClassifierFn", "PlacementFn", "default_expert_classifier", "default_placement_fn"]

--- a/experimental/lite/megatron/lite/primitive/recompute.py
+++ b/experimental/lite/megatron/lite/primitive/recompute.py
@@ -65,7 +65,9 @@ class _CheckpointWithoutOutputFn(torch.autograd.Function):
             ctx.cuda_rng_state = torch.cuda.get_rng_state()
 
         ctx.tensor_indices = [i for i, a in enumerate(args) if isinstance(a, torch.Tensor)]
-        ctx.non_tensor_args = [(i, a) for i, a in enumerate(args) if not isinstance(a, torch.Tensor)]
+        ctx.non_tensor_args = [
+            (i, a) for i, a in enumerate(args) if not isinstance(a, torch.Tensor)
+        ]
         ctx.num_args = len(args)
         ctx.save_for_backward(*[a for a in args if isinstance(a, torch.Tensor)])
 
@@ -204,16 +206,10 @@ def apply_recompute(
                 if mod_name in module_map:
                     submod = module_map[mod_name](layer)
                     if submod is not None:
-                        wrap_checkpoint(
-                            submod, preserve_rng_state=mod_name not in no_rng,
-                        )
+                        wrap_checkpoint(submod, preserve_rng_state=mod_name not in no_rng)
 
 
-def apply_offload(
-    layers: nn.ModuleList,
-    module_names: list[str],
-    module_map: ModuleMap,
-) -> None:
+def apply_offload(layers: nn.ModuleList, module_names: list[str], module_map: ModuleMap) -> None:
     """Wrap specified sub-modules with activation offloading to CPU."""
     if not module_names:
         return
@@ -241,7 +237,7 @@ class CheckpointFunction(torch.autograd.Function):
 
     @staticmethod
     def forward(
-        ctx: Any, run_function: Callable, preserve_rng_state: bool, *args: torch.Tensor,
+        ctx: Any, run_function: Callable, preserve_rng_state: bool, *args: torch.Tensor
     ) -> Any:
         ctx.run_function = run_function
         ctx.preserve_rng_state = preserve_rng_state
@@ -302,9 +298,7 @@ class CheckpointFunction(torch.autograd.Function):
         if outputs_with_grad:
             torch.autograd.backward(outputs_with_grad, grad_for_outputs)
 
-        grads = tuple(
-            inp.grad if isinstance(inp, torch.Tensor) else None for inp in detached
-        )
+        grads = tuple(inp.grad if isinstance(inp, torch.Tensor) else None for inp in detached)
         # None for run_function, None for preserve_rng_state, then grads for each input.
         return (None, None) + grads
 
@@ -327,14 +321,17 @@ def wrap_checkpoint(module: nn.Module, *, preserve_rng_state: bool = True) -> No
                     for r, s in zip(_routers, saved, strict=False):
                         r.expert_bias.copy_(s)
                 return original_forward(*a, **kw)
+
         else:
             _fwd = original_forward
 
         # CheckpointFunction.apply only accepts positional tensor args.
         # Wrap kwargs into the function closure.
         if kwargs:
+
             def _fn(*a):
                 return _fwd(*a, **kwargs)
+
         else:
             _fn = _fwd
 
@@ -349,7 +346,7 @@ def wrap_offload(module: nn.Module) -> None:
 
     def _offloaded_forward(*args, **kwargs):
         return torch.utils.checkpoint.checkpoint(
-            original_forward, *args, use_reentrant=False, **kwargs,
+            original_forward, *args, use_reentrant=False, **kwargs
         )
 
     module.forward = _offloaded_forward

--- a/experimental/lite/megatron/lite/primitive/train_step.py
+++ b/experimental/lite/megatron/lite/primitive/train_step.py
@@ -90,11 +90,7 @@ def compute_and_clip_grad_norm(
     if report_global_norm:
         if ps is None:
             raise ValueError("`ps` is required when `report_global_norm=True`.")
-        report_norm = compute_global_grad_norm(
-            model,
-            ps,
-            is_expert_param=is_expert_param,
-        )
+        report_norm = compute_global_grad_norm(model, ps, is_expert_param=is_expert_param)
     if use_dist_opt:
         optimizer.finish_grad_sync()
         return optimizer.clip_grad_norm()
@@ -103,10 +99,7 @@ def compute_and_clip_grad_norm(
 
 
 def compute_global_grad_norm(
-    model,
-    ps: ParallelState,
-    *,
-    is_expert_param: ExpertClassifierFn = default_expert_classifier,
+    model, ps: ParallelState, *, is_expert_param: ExpertClassifierFn = default_expert_classifier
 ) -> torch.Tensor:
     """Compute benchmark global grad norm with dist-opt-aligned reduction order."""
     dense_sq = _bucketed_grad_sq_sum(

--- a/experimental/lite/megatron/lite/primitive/utils.py
+++ b/experimental/lite/megatron/lite/primitive/utils.py
@@ -22,8 +22,4 @@ def log_rank0(msg: str) -> None:
         print(f"[megatron.lite] {msg}", flush=True)
 
 
-__all__ = [
-    "build_fp8_recipe",
-    "ensure_divisible",
-    "log_rank0",
-]
+__all__ = ["build_fp8_recipe", "ensure_divisible", "log_rank0"]

--- a/experimental/lite/megatron/lite/runtime/backends/__init__.py
+++ b/experimental/lite/megatron/lite/runtime/backends/__init__.py
@@ -43,12 +43,7 @@ class Runtime(ABC):
     # Model lifecycle
 
     @abstractmethod
-    def build_model(
-        self,
-        hf_path: str | None = None,
-        cfg: Any = None,
-        **kwargs,
-    ) -> ModelHandle:
+    def build_model(self, hf_path: str | None = None, cfg: Any = None, **kwargs) -> ModelHandle:
         """Build model state for this runtime.
 
         Implementations should default to the ``hf_path`` / ``backend_cfg``
@@ -123,9 +118,7 @@ class Runtime(ABC):
 
     # ── L2: RL Ready (覆盖即解锁) ───────────────────────────────
 
-    def export_weights(
-        self, handle: ModelHandle, **kwargs,
-    ) -> Iterator[tuple[str, torch.Tensor]]:
+    def export_weights(self, handle: ModelHandle, **kwargs) -> Iterator[tuple[str, torch.Tensor]]:
         """Iterate over (name, tensor) pairs for HF-compatible weight export.
 
         Required by RL frameworks to send weights to the inference engine.

--- a/experimental/lite/megatron/lite/runtime/backends/bridge/config.py
+++ b/experimental/lite/megatron/lite/runtime/backends/bridge/config.py
@@ -47,9 +47,7 @@ class BridgeConfig:
 
         parallel_src = cfg.get("parallel")
         parallel_data = (
-            pick_fields(ParallelConfig, parallel_src)
-            if isinstance(parallel_src, dict)
-            else {}
+            pick_fields(ParallelConfig, parallel_src) if isinstance(parallel_src, dict) else {}
         )
         parallel_data.update(pick_fields(ParallelConfig, cfg))
         parallel = ParallelConfig(**parallel_data)

--- a/experimental/lite/megatron/lite/runtime/backends/bridge/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/bridge/runtime.py
@@ -126,8 +126,8 @@ def _register_bridge_compat_aliases() -> None:
     from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
     from megatron.bridge.models.conversion.param_mapping import (
         AutoMapping,
-        GDNConv1dMapping,
         GatedMLPMapping,
+        GDNConv1dMapping,
         QKVMapping,
         ReplicatedMapping,
         RMSNorm2ZeroCenteredRMSNormMapping,
@@ -142,10 +142,14 @@ def _register_bridge_compat_aliases() -> None:
         """Bridge mapping for Qwen3.5 split GDN in-proj weights."""
 
         def __init__(self, megatron_param: str, qkv: str, z: str, b: str, a: str):
-            super().__init__(megatron_param=megatron_param, hf_param={"qkv": qkv, "z": z, "b": b, "a": a})
+            super().__init__(
+                megatron_param=megatron_param, hf_param={"qkv": qkv, "z": z, "b": b, "a": a}
+            )
             self._tp_mapping = AutoMapping(megatron_param, megatron_param)
 
-        def hf_to_megatron(self, hf_weights: dict[str, torch.Tensor], megatron_module) -> torch.Tensor:
+        def hf_to_megatron(
+            self, hf_weights: dict[str, torch.Tensor], megatron_module
+        ) -> torch.Tensor:
             if self.tp_rank == 0:
                 config = self._get_config(megatron_module)
                 qkvz = torch.cat([hf_weights["qkv"], hf_weights["z"]], dim=0)
@@ -185,18 +189,16 @@ def _register_bridge_compat_aliases() -> None:
         def resolve(self, captures):
             megatron_param, hf_param = self._resolve_names(captures)
             return type(self)(
-                megatron_param,
-                hf_param["qkv"],
-                hf_param["z"],
-                hf_param["b"],
-                hf_param["a"],
+                megatron_param, hf_param["qkv"], hf_param["z"], hf_param["b"], hf_param["a"]
             )
 
     class Qwen35PackedExpertDownMapping(AutoMapping):
         """Bridge mapping for Qwen3.5 packed expert down-projection weights."""
 
         def __init__(self, megatron_param: str, hf_param: str, permute_dims=None):
-            super().__init__(megatron_param=megatron_param, hf_param=hf_param, permute_dims=permute_dims)
+            super().__init__(
+                megatron_param=megatron_param, hf_param=hf_param, permute_dims=permute_dims
+            )
             self.allow_hf_name_mismatch = True
 
         def hf_to_megatron(self, hf_weights: torch.Tensor, megatron_module) -> torch.Tensor:
@@ -225,7 +227,9 @@ def _register_bridge_compat_aliases() -> None:
         """Bridge mapping for Qwen3.5 packed expert gate/up projection weights."""
 
         def __init__(self, megatron_param: str, hf_param: str, permute_dims=None):
-            super().__init__(megatron_param=megatron_param, hf_param=hf_param, permute_dims=permute_dims)
+            super().__init__(
+                megatron_param=megatron_param, hf_param=hf_param, permute_dims=permute_dims
+            )
             self.allow_hf_name_mismatch = True
             GatedMLPMapping._validate_patterns = lambda *args, **kwargs: None
             self._gated_mapping = GatedMLPMapping(
@@ -255,7 +259,9 @@ def _register_bridge_compat_aliases() -> None:
                     continue
                 gate_tensor = tensor.contiguous()
                 up_tensor = up_tensor.contiguous()
-                fused[base_name] = torch.stack([gate_tensor, up_tensor], dim=0 if up_tensor.ndim == 2 else 1)
+                fused[base_name] = torch.stack(
+                    [gate_tensor, up_tensor], dim=0 if up_tensor.ndim == 2 else 1
+                )
             return fused
 
         def _validate_patterns(self, *args, **kwargs):
@@ -280,7 +286,9 @@ def _register_bridge_compat_aliases() -> None:
                 if partial_rotary_factor is not None:
                     text_config.partial_rotary_factor = partial_rotary_factor
 
-            if not hasattr(text_config, "tie_word_embeddings") and hasattr(config, "tie_word_embeddings"):
+            if not hasattr(text_config, "tie_word_embeddings") and hasattr(
+                config, "tie_word_embeddings"
+            ):
                 text_config.tie_word_embeddings = config.tie_word_embeddings
 
             return text_config
@@ -381,9 +389,7 @@ def _register_bridge_compat_aliases() -> None:
     for source in ("Qwen3_5MoeForConditionalGeneration", "Qwen3_5MoeForCausalLM"):
         if source not in registry:
             model_bridge.register_bridge_implementation(
-                source=source,
-                target=GPTModel,
-                bridge_class=Qwen35MoEBridge,
+                source=source, target=GPTModel, bridge_class=Qwen35MoEBridge
             )
 
 
@@ -408,8 +414,7 @@ def _build_optimizer(model_list: list, cfg: BridgeConfig):
 
     return get_megatron_optimizer(
         config=build_mc_optimizer_config(
-            cfg.optimizer,
-            override_optimizer_config=cfg.override_optimizer_config,
+            cfg.optimizer, override_optimizer_config=cfg.override_optimizer_config
         ),
         model_chunks=model_list,
     )
@@ -495,10 +500,7 @@ class BridgeRuntime(RuntimeBase):
         self._offload_optimizer = self._cfg.optimizer_offload
 
     def build_model(
-        self,
-        hf_path: str | None = None,
-        cfg: BridgeConfig | dict[str, Any] | None = None,
-        **kwargs,
+        self, hf_path: str | None = None, cfg: BridgeConfig | dict[str, Any] | None = None, **kwargs
     ) -> ModelHandle:
         from megatron.core import parallel_state as mpu
         from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
@@ -534,8 +536,7 @@ class BridgeRuntime(RuntimeBase):
 
         bridge = _build_bridge(hf_path, rt_cfg)
         provider = bridge.to_megatron_provider(
-            load_weights=rt_cfg.load_hf_weights,
-            hf_path=hf_path if rt_cfg.load_hf_weights else None,
+            load_weights=rt_cfg.load_hf_weights, hf_path=hf_path if rt_cfg.load_hf_weights else None
         )
         _configure_provider(provider, rt_cfg)
         if hasattr(provider, "finalize"):
@@ -557,13 +558,7 @@ class BridgeRuntime(RuntimeBase):
         if self._offload_optimizer and optimizer is not None:
             offload_optimizer(optimizer)
 
-        logger.info(
-            "BridgeRuntime: model built, tp=%d ep=%d pp=%d cp=%d",
-            p.tp,
-            p.ep,
-            p.pp,
-            p.cp,
-        )
+        logger.info("BridgeRuntime: model built, tp=%d ep=%d pp=%d cp=%d", p.tp, p.ep, p.pp, p.cp)
 
         return ModelHandle(
             model=model_list[0],

--- a/experimental/lite/megatron/lite/runtime/backends/mbridge/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mbridge/runtime.py
@@ -13,10 +13,10 @@ import torch.distributed as dist
 from megatron.lite.runtime.backends.bridge.config import BridgeConfig
 from megatron.lite.runtime.backends.bridge.runtime import (
     BridgeRuntime,
-    _MpuParallelState,
     _build_lr_scheduler,
     _build_optimizer,
     _lower_transformer_overrides,
+    _MpuParallelState,
 )
 from megatron.lite.runtime.contracts.handle import ModelHandle
 from megatron.lite.runtime.megatron_utils import (
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 def _build_mbridge(hf_path: str, cfg: BridgeConfig):
     """Build the legacy mbridge AutoBridge lazily from an HF model path."""
     from mbridge import AutoBridge
+
     from megatron.lite.primitive.deterministic import deterministic_requested
 
     bridge = AutoBridge.from_pretrained(hf_path, trust_remote_code=True)
@@ -48,8 +49,7 @@ def _build_mbridge(hf_path: str, cfg: BridgeConfig):
 
     if cfg.model_name == "qwen3_5":
         bridge.set_extra_args(
-            deterministic_mode=deterministic_requested(),
-            fused_single_qkv_rope=False,
+            deterministic_mode=deterministic_requested(), fused_single_qkv_rope=False
         )
 
     if callable(cfg.bridge_post_init):
@@ -79,10 +79,7 @@ class MBridgeRuntime(BridgeRuntime):
     """mbridge training backend using Megatron-Core optimizer state."""
 
     def build_model(
-        self,
-        hf_path: str | None = None,
-        cfg: BridgeConfig | dict[str, Any] | None = None,
-        **kwargs,
+        self, hf_path: str | None = None, cfg: BridgeConfig | dict[str, Any] | None = None, **kwargs
     ) -> ModelHandle:
         from megatron.core import parallel_state as mpu
         from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
@@ -126,9 +123,7 @@ class MBridgeRuntime(BridgeRuntime):
         ddp_config.update(rt_cfg.override_ddp_config)
 
         model_list = bridge.get_model(
-            model_type=ModelType.encoder_or_decoder,
-            wrap_with_ddp=True,
-            ddp_config=ddp_config,
+            model_type=ModelType.encoder_or_decoder, wrap_with_ddp=True, ddp_config=ddp_config
         )
         if rt_cfg.load_hf_weights:
             bridge.load_weights(model_list, hf_path, memory_efficient=True)
@@ -142,13 +137,7 @@ class MBridgeRuntime(BridgeRuntime):
         if self._offload_optimizer and optimizer is not None:
             offload_optimizer(optimizer)
 
-        logger.info(
-            "MBridgeRuntime: model built, tp=%d ep=%d pp=%d cp=%d",
-            p.tp,
-            p.ep,
-            p.pp,
-            p.cp,
-        )
+        logger.info("MBridgeRuntime: model built, tp=%d ep=%d pp=%d cp=%d", p.tp, p.ep, p.pp, p.cp)
 
         return ModelHandle(
             model=model_list[0],

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/config.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/config.py
@@ -92,7 +92,4 @@ class MegatronLiteConfig:
         )
 
 
-__all__ = [
-    "MegatronLiteConfig",
-    "DebugConfig",
-]
+__all__ = ["MegatronLiteConfig", "DebugConfig"]

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -27,11 +27,7 @@ def _build_impl_cfg(proto, rt_cfg: MegatronLiteConfig):
         and impl_cfg_kwargs.get("attention_backend_override") is None
     ):
         impl_cfg_kwargs["attention_backend_override"] = rt_cfg.attention_backend_override
-    if (
-        "hf_path" in init_fields
-        and impl_cfg_kwargs.get("hf_path") in (None, "")
-        and rt_cfg.hf_path
-    ):
+    if "hf_path" in init_fields and impl_cfg_kwargs.get("hf_path") in (None, "") and rt_cfg.hf_path:
         impl_cfg_kwargs["hf_path"] = rt_cfg.hf_path
     # Thread the user-level OptimizerConfig so the protocol can pass it to
     # optimizer primitives without reading runtime internals.
@@ -111,7 +107,9 @@ def _checkpoint_module(model: Any) -> torch.nn.Module:
         return model
     if isinstance(model, list | tuple):
         return torch.nn.ModuleList(model)
-    raise TypeError(f"Checkpoint model must be an nn.Module or sequence of modules, got {type(model).__name__}.")
+    raise TypeError(
+        f"Checkpoint model must be an nn.Module or sequence of modules, got {type(model).__name__}."
+    )
 
 
 class MegatronLiteRuntime(RuntimeBase):
@@ -119,11 +117,20 @@ class MegatronLiteRuntime(RuntimeBase):
 
     def __init__(self, hf_path: str, cfg: MegatronLiteConfig | dict[str, Any]):
         self._hf_path = hf_path
-        self._cfg = cfg if isinstance(cfg, MegatronLiteConfig) else MegatronLiteConfig.from_dict(hf_path, cfg)
+        self._cfg = (
+            cfg
+            if isinstance(cfg, MegatronLiteConfig)
+            else MegatronLiteConfig.from_dict(hf_path, cfg)
+        )
 
     # ── build_model ──
 
-    def build_model(self, hf_path: str | None = None, cfg: MegatronLiteConfig | dict[str, Any] | None = None, **kwargs) -> ModelHandle:
+    def build_model(
+        self,
+        hf_path: str | None = None,
+        cfg: MegatronLiteConfig | dict[str, Any] | None = None,
+        **kwargs,
+    ) -> ModelHandle:
         if cfg is not None and isinstance(cfg, dict):
             rt_cfg = MegatronLiteConfig.from_dict(hf_path or self._hf_path, cfg)
         elif cfg is not None and isinstance(cfg, MegatronLiteConfig):
@@ -141,8 +148,7 @@ class MegatronLiteRuntime(RuntimeBase):
         proto = self._load_protocol(rt_cfg)
 
         _apply_attention_backend_env(
-            rt_cfg.attention_backend_override,
-            tag=f"{rt_cfg.model_name}:{rt_cfg.impl}",
+            rt_cfg.attention_backend_override, tag=f"{rt_cfg.model_name}:{rt_cfg.impl}"
         )
 
         # ── escape hatch: model takes over ──
@@ -233,9 +239,7 @@ class MegatronLiteRuntime(RuntimeBase):
 
         for fn_name in ("build_model_config", "build_model"):
             if not callable(getattr(proto, fn_name, None)):
-                raise ValueError(
-                    f"Protocol module {mod_path} missing required function: {fn_name}"
-                )
+                raise ValueError(f"Protocol module {mod_path} missing required function: {fn_name}")
         if not hasattr(proto, "ImplConfig"):
             raise ValueError(f"Protocol module {mod_path} missing ImplConfig class")
 
@@ -313,8 +317,13 @@ class MegatronLiteRuntime(RuntimeBase):
     # ── Memory ──
 
     def to(
-        self, handle: ModelHandle, device: str,
-        *, model: bool = True, optimizer: bool = True, grad: bool = True,
+        self,
+        handle: ModelHandle,
+        device: str,
+        *,
+        model: bool = True,
+        optimizer: bool = True,
+        grad: bool = True,
     ) -> None:
         model_chunks = handle._extras.get("model_chunks", [handle._model])
         from megatron.lite.runtime.megatron_utils import (
@@ -354,8 +363,13 @@ class MegatronLiteRuntime(RuntimeBase):
     # ── Training atoms ──
 
     def forward_backward(
-        self, handle: ModelHandle, data: Any, loss_fn: Callable | None,
-        *, num_microbatches: int = 1, forward_only: bool = False,
+        self,
+        handle: ModelHandle,
+        data: Any,
+        loss_fn: Callable | None,
+        *,
+        num_microbatches: int = 1,
+        forward_only: bool = False,
     ) -> ForwardResult:
         from megatron.lite.primitive.train_step import run_microbatch_loop
 
@@ -379,9 +393,7 @@ class MegatronLiteRuntime(RuntimeBase):
             first_batch = next(data_iter)
             data_iter = chain([first_batch], data_iter)
             tensor_shape = _infer_pipeline_tensor_shape(
-                first_batch,
-                handle._extras.get("model_cfg"),
-                ps,
+                first_batch, handle._extras.get("model_cfg"), ps
             )
             outputs = forward_backward_pipelining(
                 forward_step,
@@ -402,16 +414,15 @@ class MegatronLiteRuntime(RuntimeBase):
                 loss_float = float(loss_obj)
             else:
                 loss_float = 0.0
-            loss_t = torch.tensor(
-                [loss_float],
-                device="cuda",
-            )
+            loss_t = torch.tensor([loss_float], device="cuda")
             if ps.pp_group is not None and ps.pp_global_ranks is not None:
                 dist.broadcast(loss_t, src=ps.pp_global_ranks[-1], group=ps.pp_group)
             out = {"loss": loss_t.squeeze(0)}
         else:
             out = run_microbatch_loop(
-                handle._model, data_iter, num_microbatches,
+                handle._model,
+                data_iter,
+                num_microbatches,
                 forward_step,
                 optimizer=handle._optimizer if not forward_only else None,
                 dist_opt=not forward_only,
@@ -425,7 +436,11 @@ class MegatronLiteRuntime(RuntimeBase):
                 finalize_grads()
 
         loss_tensor = out.get("loss") if out else None
-        loss_val = loss_tensor.item() if isinstance(loss_tensor, torch.Tensor) else float(loss_tensor or 0.0)
+        loss_val = (
+            loss_tensor.item()
+            if isinstance(loss_tensor, torch.Tensor)
+            else float(loss_tensor or 0.0)
+        )
         metrics: dict = {"loss": loss_val}
         for m in out.get("_loss_fn_metrics", []) if out else []:
             for k, v in m.items():
@@ -521,10 +536,7 @@ def _checkpoint_model(handle: ModelHandle, *, use_dcp: bool):
 
 
 def _checkpoint_hooks(handle: ModelHandle):
-    from megatron.lite.primitive.protocols import (
-        default_expert_classifier,
-        default_placement_fn,
-    )
+    from megatron.lite.primitive.protocols import default_expert_classifier, default_placement_fn
 
     proto = handle._extras.get("protocol")
     return (

--- a/experimental/lite/megatron/lite/runtime/contracts/__init__.py
+++ b/experimental/lite/megatron/lite/runtime/contracts/__init__.py
@@ -12,8 +12,12 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from megatron.lite.runtime.backends.bridge.config import BridgeConfig
-    from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig, DebugConfig
-    from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig, RuntimeConfig
+    from megatron.lite.runtime.backends.mlite.config import DebugConfig, MegatronLiteConfig
+    from megatron.lite.runtime.contracts.config import (
+        OptimizerConfig,
+        ParallelConfig,
+        RuntimeConfig,
+    )
     from megatron.lite.runtime.contracts.data import (
         Batch,
         ForwardResult,

--- a/experimental/lite/megatron/lite/runtime/contracts/config.py
+++ b/experimental/lite/megatron/lite/runtime/contracts/config.py
@@ -11,6 +11,7 @@ def pick_fields(cls, src: dict[str, Any]) -> dict[str, Any]:
     """Extract fields of dataclass *cls* that exist in *src*."""
     return {f.name: src[f.name] for f in dc_fields(cls) if f.name in src}
 
+
 if TYPE_CHECKING:
     from megatron.lite.runtime.backends.bridge.config import BridgeConfig
     from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig
@@ -76,13 +77,7 @@ class RuntimeConfig:
 
     backend: str = "mlite"
     hf_path: str = ""
-    backend_cfg: MegatronLiteConfig | BridgeConfig | dict[str, Any] = field(
-        default_factory=dict
-    )
+    backend_cfg: MegatronLiteConfig | BridgeConfig | dict[str, Any] = field(default_factory=dict)
 
 
-__all__ = [
-    "OptimizerConfig",
-    "ParallelConfig",
-    "RuntimeConfig",
-]
+__all__ = ["OptimizerConfig", "ParallelConfig", "RuntimeConfig"]

--- a/experimental/lite/megatron/lite/runtime/contracts/data.py
+++ b/experimental/lite/megatron/lite/runtime/contracts/data.py
@@ -40,10 +40,10 @@ class PackedBatch(Batch):
     ``cu_seqlens`` and ``position_ids`` are derived automatically.
     """
 
-    input_ids: torch.Tensor       # [total_tokens]
-    labels: torch.Tensor          # [total_tokens]
-    seq_lens: torch.Tensor        # [num_seqs]
-    loss_mask: torch.Tensor | None = None   # [total_tokens]
+    input_ids: torch.Tensor  # [total_tokens]
+    labels: torch.Tensor  # [total_tokens]
+    seq_lens: torch.Tensor  # [num_seqs]
+    loss_mask: torch.Tensor | None = None  # [total_tokens]
     position_ids: torch.Tensor | None = None  # [total_tokens], auto if None
     routed_experts: torch.Tensor | None = None
     extras: dict[str, Any] = field(default_factory=dict)
@@ -62,10 +62,12 @@ class PackedBatch(Batch):
     @property
     def cu_seqlens(self) -> torch.Tensor:
         """Cumulative sequence lengths for THD attention.  Shape ``[num_seqs+1]``."""
-        return torch.cat([
-            torch.zeros(1, dtype=torch.int32, device=self.seq_lens.device),
-            self.seq_lens.cumsum(0).to(torch.int32),
-        ])
+        return torch.cat(
+            [
+                torch.zeros(1, dtype=torch.int32, device=self.seq_lens.device),
+                self.seq_lens.cumsum(0).to(torch.int32),
+            ]
+        )
 
     @property
     def total_tokens(self) -> int:
@@ -75,9 +77,9 @@ class PackedBatch(Batch):
         """Generate per-token position_ids from seq_lens."""
         if self.position_ids is not None:
             return self.position_ids
-        return torch.cat([
-            torch.arange(s, device=self.seq_lens.device) for s in self.seq_lens.tolist()
-        ])
+        return torch.cat(
+            [torch.arange(s, device=self.seq_lens.device) for s in self.seq_lens.tolist()]
+        )
 
 
 @dataclass(slots=True)
@@ -117,10 +119,4 @@ class ForwardResult:
     metrics: dict[str, Any] = field(default_factory=dict)
 
 
-__all__ = [
-    "Batch",
-    "ForwardResult",
-    "ModelOutputs",
-    "PackedBatch",
-    "TrainBatch",
-]
+__all__ = ["Batch", "ForwardResult", "ModelOutputs", "PackedBatch", "TrainBatch"]

--- a/experimental/lite/megatron/lite/runtime/megatron_utils.py
+++ b/experimental/lite/megatron/lite/runtime/megatron_utils.py
@@ -146,7 +146,9 @@ def offload_optimizer(optimizer) -> None:
     for _opt in _iter_opts(optimizer, ChainedOptimizer):
         if _opt.optimizer is not None:
             hdo = _opt.optimizer
-            if all(hasattr(hdo, a) for a in ("sub_optimizers", "inner_param_to_orig_param", "state")):
+            if all(
+                hasattr(hdo, a) for a in ("sub_optimizers", "inner_param_to_orig_param", "state")
+            ):
                 for sub_opt in hdo.sub_optimizers:
                     for param, state in sub_opt.state.items():
                         for k, v in state.items():
@@ -196,9 +198,7 @@ def _iter_opts(optimizer, chained_cls):
 
 
 def build_sharded_state_dict(
-    model_list: list,
-    optimizer: Any = None,
-    lr_scheduler: Any = None,
+    model_list: list, optimizer: Any = None, lr_scheduler: Any = None
 ) -> dict[str, Any]:
     """Build sharded state dict for model + optimizer + lr_scheduler.
 
@@ -212,9 +212,7 @@ def build_sharded_state_dict(
         sharded_state_dict.update(chunk_sd)
 
     if optimizer is not None:
-        opt_sd = optimizer.sharded_state_dict(
-            model_sharded_state_dict=sharded_state_dict,
-        )
+        opt_sd = optimizer.sharded_state_dict(model_sharded_state_dict=sharded_state_dict)
         sharded_state_dict.update(opt_sd)
 
     if lr_scheduler is not None:

--- a/experimental/lite/tests/conftest.py
+++ b/experimental/lite/tests/conftest.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 import pytest
 
-
 LITE_ROOT = Path(__file__).resolve().parents[1]
 REPO_ROOT = Path(__file__).resolve().parents[3]
 VERL_EXAMPLE_ROOT = LITE_ROOT / "examples" / "verl"
@@ -28,10 +27,7 @@ def pytest_configure(config):
 
 def pytest_addoption(parser):
     parser.addoption(
-        "--mlite-smoke",
-        action="store_true",
-        default=False,
-        help="run Megatron Lite smoke tests",
+        "--mlite-smoke", action="store_true", default=False, help="run Megatron Lite smoke tests"
     )
 
 
@@ -58,9 +54,7 @@ def transformer_engine_import_stub(monkeypatch):
 
         class _UnavailableTE:
             def __init__(self, *args, **kwargs):
-                raise RuntimeError(
-                    "Transformer Engine is not installed in this test environment."
-                )
+                raise RuntimeError("Transformer Engine is not installed in this test environment.")
 
         root = types.ModuleType("transformer_engine")
         root.__version__ = "0.0.0"

--- a/experimental/lite/tests/smoke/model/test_qwen_lite_forward_smoke.py
+++ b/experimental/lite/tests/smoke/model/test_qwen_lite_forward_smoke.py
@@ -7,13 +7,7 @@ import pytest
 import torch
 import torch.distributed as dist
 
-
-pytestmark = [
-    pytest.mark.mlite,
-    pytest.mark.smoke,
-    pytest.mark.gpu,
-    pytest.mark.distributed,
-]
+pytestmark = [pytest.mark.mlite, pytest.mark.smoke, pytest.mark.gpu, pytest.mark.distributed]
 
 
 def _qwen3_symbols():
@@ -117,9 +111,7 @@ def _assert_loss_and_backward(output: dict, model: torch.nn.Module):
     assert torch.isfinite(loss)
     loss.backward()
     grad_params = [
-        param
-        for param in model.parameters()
-        if param.requires_grad and param.grad is not None
+        param for param in model.parameters() if param.requires_grad and param.grad is not None
     ]
     assert grad_params
     assert all(torch.isfinite(param.grad.detach().float()).all() for param in grad_params)

--- a/experimental/lite/tests/smoke/primitive/test_distopt_checkpoint_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_distopt_checkpoint_smoke.py
@@ -22,13 +22,7 @@ from megatron.lite.runtime.contracts.config import ParallelConfig
 from megatron.lite.runtime.contracts.handle import ModelHandle
 from tests.unit_tests.test_utilities import Utils
 
-
-pytestmark = [
-    pytest.mark.mlite,
-    pytest.mark.smoke,
-    pytest.mark.gpu,
-    pytest.mark.distributed,
-]
+pytestmark = [pytest.mark.mlite, pytest.mark.smoke, pytest.mark.gpu, pytest.mark.distributed]
 
 
 class TinyDense(nn.Module):
@@ -70,8 +64,7 @@ def _single_node_cuda_distopt():
         pytest.skip("Megatron Lite smoke tests are capped at single-node 8 GPUs.")
 
     Utils.set_world_size(
-        int(os.environ.get("WORLD_SIZE", "1")),
-        int(os.environ.get("LOCAL_RANK", "0")),
+        int(os.environ.get("WORLD_SIZE", "1")), int(os.environ.get("LOCAL_RANK", "0"))
     )
     Utils.initialize_model_parallel()
     yield
@@ -82,12 +75,7 @@ def _global_tensor(shape: tuple[int, ...], offset: float) -> torch.Tensor:
     return torch.arange(offset, offset + int(torch.tensor(shape).prod().item())).reshape(shape)
 
 
-def _local_shard(
-    tensor: torch.Tensor,
-    dim: int,
-    rank: int,
-    size: int,
-) -> torch.Tensor:
+def _local_shard(tensor: torch.Tensor, dim: int, rank: int, size: int) -> torch.Tensor:
     if size <= 1:
         return tensor.clone()
     chunks = torch.chunk(tensor, size, dim=dim)
@@ -122,18 +110,11 @@ def _build_sharded_model_and_distopt(parallel: ParallelConfig):
         deterministic=False,
     )
     wrapped_chunks, optimizer = build_mc_stack(
-        [model],
-        model_cfg=model_cfg,
-        engine_cfg=engine_cfg,
-        ps=ps,
-        is_expert=_is_expert_param,
+        [model], model_cfg=model_cfg, engine_cfg=engine_cfg, ps=ps, is_expert=_is_expert_param
     )
     _seed_optimizer_state(optimizer)
     attach_model_sharded_state_dict(
-        wrapped_chunks,
-        ps,
-        get_placements=_topology_placements,
-        is_expert=_is_expert_param,
+        wrapped_chunks, ps, get_placements=_topology_placements, is_expert=_is_expert_param
     )
     return wrapped_chunks, optimizer, ps
 
@@ -172,8 +153,7 @@ def _distopt_handle(wrapped_chunks, optimizer, ps: ParallelState, parallel: Para
         _extras={
             "model_chunks": wrapped_chunks,
             "protocol": SimpleNamespace(
-                PLACEMENT_FN=_topology_placements,
-                EXPERT_CLASSIFIER=_is_expert_param,
+                PLACEMENT_FN=_topology_placements, EXPERT_CLASSIFIER=_is_expert_param
             ),
         },
     )
@@ -184,9 +164,7 @@ def _build_model_and_distopt():
     model = TinyDense().bfloat16().cuda()
     ddp_config = DistributedDataParallelConfig(use_distributed_optimizer=True)
     wrapped = DistributedDataParallel(
-        TransformerConfig(num_attention_heads=1, num_layers=1),
-        ddp_config,
-        model,
+        TransformerConfig(num_attention_heads=1, num_layers=1), ddp_config, model
     )
     optimizer = get_megatron_optimizer(
         OptimizerConfig(optimizer="adam", lr=1.0e-3, bf16=True, use_distributed_optimizer=True),
@@ -254,14 +232,17 @@ def test_distopt_checkpoint_load_matches_uninterrupted_training_single_node(tmp_
         checkpoint_dir,
         step=1,
     )
-    assert runtime.load_checkpoint(
-        ModelHandle(
-            model=loaded_model,
-            optimizer=loaded_optimizer,
-            _extras={"model_chunks": [loaded_model]},
-        ),
-        checkpoint_dir,
-    ) == 1
+    assert (
+        runtime.load_checkpoint(
+            ModelHandle(
+                model=loaded_model,
+                optimizer=loaded_optimizer,
+                _extras={"model_chunks": [loaded_model]},
+            ),
+            checkpoint_dir,
+        )
+        == 1
+    )
 
     _train_step(direct_model, direct_optimizer, x1)
     _train_step(loaded_model, loaded_optimizer, x1)
@@ -288,11 +269,14 @@ def test_distopt_checkpoint_reshards_from_pp_ep_to_tp_pp_ep_etp(tmp_path):
     )
 
     target_chunks, target_optimizer, target_ps = _build_sharded_model_and_distopt(target_parallel)
-    assert runtime.load_checkpoint(
-        _distopt_handle(target_chunks, target_optimizer, target_ps, target_parallel),
-        source_dir,
-        load_rng=False,
-    ) == 3
+    assert (
+        runtime.load_checkpoint(
+            _distopt_handle(target_chunks, target_optimizer, target_ps, target_parallel),
+            source_dir,
+            load_rng=False,
+        )
+        == 3
+    )
     runtime.save_checkpoint(
         _distopt_handle(target_chunks, target_optimizer, target_ps, target_parallel),
         reserialized_dir,

--- a/experimental/lite/tests/smoke/primitive/test_fsdp2_offload_checkpoint_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_fsdp2_offload_checkpoint_smoke.py
@@ -21,13 +21,7 @@ from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
 from megatron.lite.runtime.contracts.config import ParallelConfig
 from megatron.lite.runtime.contracts.handle import ModelHandle
 
-
-pytestmark = [
-    pytest.mark.mlite,
-    pytest.mark.smoke,
-    pytest.mark.gpu,
-    pytest.mark.distributed,
-]
+pytestmark = [pytest.mark.mlite, pytest.mark.smoke, pytest.mark.gpu, pytest.mark.distributed]
 
 
 class TinyUnit(nn.Module):
@@ -171,10 +165,7 @@ def test_fsdp2_runtime_model_and_optimizer_offload_roundtrip_single_node():
     model, ps = _build_fsdp2_model()
     optimizer = _build_optimizer(model, ps, offload_fraction=0.0)
     handle = ModelHandle(
-        model=model,
-        optimizer=optimizer,
-        parallel_state=ps,
-        _extras={"model_chunks": [model]},
+        model=model, optimizer=optimizer, parallel_state=ps, _extras={"model_chunks": [model]}
     )
     runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
 
@@ -239,16 +230,19 @@ def test_fsdp2_checkpoint_load_matches_uninterrupted_training_single_node(tmp_pa
         checkpoint_dir,
         step=1,
     )
-    assert runtime.load_checkpoint(
-        ModelHandle(
-            model=loaded_model,
-            optimizer=loaded_optimizer,
-            parallel_state=loaded_ps,
-            config=_checkpoint_config(),
-            _extras={"model_chunks": [loaded_model]},
-        ),
-        checkpoint_dir,
-    ) == 1
+    assert (
+        runtime.load_checkpoint(
+            ModelHandle(
+                model=loaded_model,
+                optimizer=loaded_optimizer,
+                parallel_state=loaded_ps,
+                config=_checkpoint_config(),
+                _extras={"model_chunks": [loaded_model]},
+            ),
+            checkpoint_dir,
+        )
+        == 1
+    )
 
     _train_step(direct_model, direct_optimizer, x1, y1)
     _train_step(loaded_model, loaded_optimizer, x1, y1)

--- a/experimental/lite/tests/smoke/primitive/test_parallel_topologies_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_parallel_topologies_smoke.py
@@ -9,13 +9,7 @@ import torch.distributed as dist
 
 from megatron.lite.primitive.parallel import init_parallel
 
-
-pytestmark = [
-    pytest.mark.mlite,
-    pytest.mark.smoke,
-    pytest.mark.gpu,
-    pytest.mark.distributed,
-]
+pytestmark = [pytest.mark.mlite, pytest.mark.smoke, pytest.mark.gpu, pytest.mark.distributed]
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/experimental/lite/tests/smoke/primitive/test_qwen3_moe_distopt_checkpoint_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_qwen3_moe_distopt_checkpoint_smoke.py
@@ -13,13 +13,7 @@ from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
 from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
 from megatron.lite.runtime.contracts.handle import ModelHandle
 
-
-pytestmark = [
-    pytest.mark.mlite,
-    pytest.mark.smoke,
-    pytest.mark.gpu,
-    pytest.mark.distributed,
-]
+pytestmark = [pytest.mark.mlite, pytest.mark.smoke, pytest.mark.gpu, pytest.mark.distributed]
 
 
 def _qwen3_moe_symbols():
@@ -97,22 +91,21 @@ def _build_handle(model_seed: int) -> ModelHandle:
         parallel=parallel,
         optimizer="mc",
         optimizer_config=OptimizerConfig(
-            optimizer="adam",
-            lr=1.0e-3,
-            weight_decay=0.0,
-            clip_grad=1.0,
+            optimizer="adam", lr=1.0e-3, weight_decay=0.0, clip_grad=1.0
         ),
         use_deepep=False,
         deterministic=True,
     )
     bundle = protocol.build_model(model_cfg, impl_cfg=impl_cfg)
     extras = dict(bundle.extras)
-    extras.update({
-        "model_chunks": bundle.chunks,
-        "forward_step": bundle.forward_step,
-        "finalize_grads": bundle.finalize_grads,
-        "protocol": protocol,
-    })
+    extras.update(
+        {
+            "model_chunks": bundle.chunks,
+            "forward_step": bundle.forward_step,
+            "finalize_grads": bundle.finalize_grads,
+            "protocol": protocol,
+        }
+    )
     return ModelHandle(
         model=bundle.chunks,
         optimizer=bundle.optimizer,

--- a/experimental/lite/tests/unit/examples/test_bench_example.py
+++ b/experimental/lite/tests/unit/examples/test_bench_example.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from contextlib import nullcontext
 import json
-from pathlib import Path
 import sys
+from contextlib import nullcontext
+from pathlib import Path
 
 from megatron.lite.runtime.contracts.config import ParallelConfig
 from megatron.lite.runtime.contracts.data import ForwardResult
@@ -49,11 +49,7 @@ def test_bench_mlite_deterministic_mounts_native_vision_not_mbridge(monkeypatch)
     monkeypatch.setenv("MEGATRON_LITE_DETERMINISTIC", "1")
 
     runtime_cfg = build_runtime_config(
-        BenchCliConfig(
-            backend="mlite",
-            hf_path="/tmp/hf",
-            model_name="qwen3_5",
-        )
+        BenchCliConfig(backend="mlite", hf_path="/tmp/hf", model_name="qwen3_5")
     )
 
     impl_cfg = runtime_cfg.backend_cfg.impl_cfg
@@ -156,13 +152,7 @@ def test_pretrain_session_runs_with_fake_runtime_on_cpu():
         optimizer=object(),
         parallel_state=None,
         config=type(
-            "Cfg",
-            (),
-            {
-                "model_name": "fake",
-                "impl": "lite",
-                "parallel": ParallelConfig(),
-            },
+            "Cfg", (), {"model_name": "fake", "impl": "lite", "parallel": ParallelConfig()}
         )(),
         _extras={"optimizer_backend": "fake"},
     )
@@ -233,11 +223,7 @@ def test_bench_main_writes_output_json_only_on_rank_zero(tmp_path, monkeypatch):
 
 
 def test_result_artifact_summary_and_trace_compare(tmp_path):
-    from examples.bench.results import (
-        compare_step_traces,
-        load_result_artifact,
-        result_summary,
-    )
+    from examples.bench.results import compare_step_traces, load_result_artifact, result_summary
 
     baseline = {
         "summary": {
@@ -280,18 +266,10 @@ def test_result_trace_compare_reports_metric_level_failures():
     from examples.bench.results import compare_step_traces
 
     baseline = {
-        "result": {
-            "step_traces": [
-                {"step": 0, "loss": 1.0, "grad_norm": 2.0, "step_ms": 10.0},
-            ]
-        },
+        "result": {"step_traces": [{"step": 0, "loss": 1.0, "grad_norm": 2.0, "step_ms": 10.0}]}
     }
     candidate = {
-        "result": {
-            "step_traces": [
-                {"step": 0, "loss": 1.00001, "grad_norm": 3.0, "step_ms": 10.0},
-            ]
-        },
+        "result": {"step_traces": [{"step": 0, "loss": 1.00001, "grad_norm": 3.0, "step_ms": 10.0}]}
     }
 
     comparison = compare_step_traces(baseline, candidate, atol=1e-3, rtol=0.0)
@@ -308,10 +286,10 @@ def test_correctness_compare_requires_bitwise_fields():
         "eval_logits": {"sha256": "a", "shape": [1], "dtype": "torch.bfloat16"},
         "steps": [
             {
-                "loss": {"value": 1.0, "float_hex": 1.0.hex()},
+                "loss": {"value": 1.0, "float_hex": (1.0).hex()},
                 "logits": {"sha256": "b"},
                 "grad_fingerprint": {"sha256": "c", "tensor_count": 1},
-                "grad_norm": {"value": 2.0, "float_hex": 2.0.hex()},
+                "grad_norm": {"value": 2.0, "float_hex": (2.0).hex()},
                 "update_successful": True,
                 "num_zeros": 0,
                 "post_step_weights": {"sha256": "d", "tensor_count": 1},
@@ -322,7 +300,7 @@ def test_correctness_compare_requires_bitwise_fields():
 
     assert compare_correctness_artifacts(baseline, candidate)["passed"] is True
 
-    candidate["steps"][0]["grad_norm"] = {"value": 2.5, "float_hex": 2.5.hex()}
+    candidate["steps"][0]["grad_norm"] = {"value": 2.5, "float_hex": (2.5).hex()}
     comparison = compare_correctness_artifacts(baseline, candidate)
 
     assert comparison["passed"] is False

--- a/experimental/lite/tests/unit/model/test_qwen35_export.py
+++ b/experimental/lite/tests/unit/model/test_qwen35_export.py
@@ -6,8 +6,8 @@ import torch.nn as nn
 from megatron.lite.model.qwen3_5.config import Qwen35Config
 from megatron.lite.model.qwen3_5.lite.checkpoint import (
     Qwen35WeightSpec,
-    _merge_gate_up_tp_shards,
     _merge_full_attn_qkvg,
+    _merge_gate_up_tp_shards,
     _merge_linear_attn_conv1d_tp_shards,
     _merge_linear_attn_in_proj_tp_shards,
     export_hf_weights,
@@ -39,13 +39,7 @@ def _tiny_config() -> Qwen35Config:
 
 def _single_rank_parallel_state() -> SimpleNamespace:
     return SimpleNamespace(
-        pp_size=1,
-        tp_size=1,
-        tp_group=None,
-        ep_size=1,
-        ep_group=None,
-        etp_size=1,
-        etp_group=None,
+        pp_size=1, tp_size=1, tp_group=None, ep_size=1, ep_group=None, etp_size=1, etp_group=None
     )
 
 
@@ -95,13 +89,11 @@ def test_qwen35_export_dtype_cast_is_opt_in() -> None:
             rows = config.moe_intermediate_size * 2
             for expert_idx in range(config.num_experts):
                 tensor = torch.arange(rows * config.hidden_size, dtype=torch.float32).reshape(
-                    rows,
-                    config.hidden_size,
+                    rows, config.hidden_size
                 )
                 tensor = tensor + expert_idx * 1000
                 self.layers[0].moe.experts.fc1.register_parameter(
-                    f"weight{expert_idx}",
-                    nn.Parameter(tensor),
+                    f"weight{expert_idx}", nn.Parameter(tensor)
                 )
 
     cfg = _tiny_config()
@@ -109,18 +101,19 @@ def test_qwen35_export_dtype_cast_is_opt_in() -> None:
 
     default_export = dict(export_hf_weights(model, cfg, _single_rank_parallel_state()))
     bf16_export = dict(
-        export_hf_weights(
-            model,
-            cfg,
-            _single_rank_parallel_state(),
-            export_dtype="bfloat16",
-        )
+        export_hf_weights(model, cfg, _single_rank_parallel_state(), export_dtype="bfloat16")
     )
 
     assert default_export["model.language_model.norm.weight"].dtype == torch.float32
     assert bf16_export["model.language_model.norm.weight"].dtype == torch.bfloat16
-    assert default_export["model.language_model.layers.0.mlp.experts.gate_up_proj"].dtype == torch.float32
-    assert bf16_export["model.language_model.layers.0.mlp.experts.gate_up_proj"].dtype == torch.bfloat16
+    assert (
+        default_export["model.language_model.layers.0.mlp.experts.gate_up_proj"].dtype
+        == torch.float32
+    )
+    assert (
+        bf16_export["model.language_model.layers.0.mlp.experts.gate_up_proj"].dtype
+        == torch.bfloat16
+    )
 
 
 def test_qwen35_export_preserves_runtime_parameter_dtype_by_default() -> None:
@@ -136,13 +129,11 @@ def test_qwen35_export_preserves_runtime_parameter_dtype_by_default() -> None:
             rows = config.moe_intermediate_size * 2
             for expert_idx in range(config.num_experts):
                 tensor = torch.arange(rows * config.hidden_size, dtype=torch.bfloat16).reshape(
-                    rows,
-                    config.hidden_size,
+                    rows, config.hidden_size
                 )
                 tensor = tensor + expert_idx * 1000
                 self.layers[0].moe.experts.fc1.register_parameter(
-                    f"weight{expert_idx}",
-                    nn.Parameter(tensor),
+                    f"weight{expert_idx}", nn.Parameter(tensor)
                 )
 
     cfg = _tiny_config()
@@ -151,7 +142,9 @@ def test_qwen35_export_preserves_runtime_parameter_dtype_by_default() -> None:
     exported = dict(export_hf_weights(model, cfg, _single_rank_parallel_state()))
 
     assert exported["model.language_model.norm.weight"].dtype == torch.bfloat16
-    assert exported["model.language_model.layers.0.mlp.experts.gate_up_proj"].dtype == torch.bfloat16
+    assert (
+        exported["model.language_model.layers.0.mlp.experts.gate_up_proj"].dtype == torch.bfloat16
+    )
 
 
 def test_qwen35_export_batches_ep_expert_gather(monkeypatch) -> None:
@@ -166,13 +159,11 @@ def test_qwen35_export_batches_ep_expert_gather(monkeypatch) -> None:
             rows = config.moe_intermediate_size * 2
             for local_idx in range(config.num_experts // 2):
                 tensor = torch.arange(rows * config.hidden_size, dtype=torch.bfloat16).reshape(
-                    rows,
-                    config.hidden_size,
+                    rows, config.hidden_size
                 )
                 tensor = tensor + local_idx * 1000
                 self.layers[0].moe.experts.fc1.register_parameter(
-                    f"weight{local_idx}",
-                    nn.Parameter(tensor),
+                    f"weight{local_idx}", nn.Parameter(tensor)
                 )
 
     cfg = _tiny_config()
@@ -194,10 +185,7 @@ def test_qwen35_export_batches_ep_expert_gather(monkeypatch) -> None:
         outputs[0].copy_(tensor)
         outputs[1].copy_(tensor + 2000)
 
-    monkeypatch.setattr(
-        "megatron.lite.primitive.ckpt.hf_weights.dist.all_gather",
-        fake_all_gather,
-    )
+    monkeypatch.setattr("megatron.lite.primitive.ckpt.hf_weights.dist.all_gather", fake_all_gather)
 
     exported = dict(export_hf_weights(model, cfg, ps))
 
@@ -208,18 +196,10 @@ def test_qwen35_export_batches_ep_expert_gather(monkeypatch) -> None:
         model.layers[0].moe.experts.fc1.weight1.detach(),
     ]
     expected = torch.stack(
-        [
-            local_tensors[0],
-            local_tensors[1],
-            local_tensors[0] + 2000,
-            local_tensors[1] + 2000,
-        ],
+        [local_tensors[0], local_tensors[1], local_tensors[0] + 2000, local_tensors[1] + 2000],
         dim=0,
     )
-    assert torch.equal(
-        exported["model.language_model.layers.0.mlp.experts.gate_up_proj"],
-        expected,
-    )
+    assert torch.equal(exported["model.language_model.layers.0.mlp.experts.gate_up_proj"], expected)
 
 
 def test_qwen35_export_uses_packed_expert_group_names(monkeypatch) -> None:
@@ -234,13 +214,11 @@ def test_qwen35_export_uses_packed_expert_group_names(monkeypatch) -> None:
             rows = config.moe_intermediate_size * 2
             for expert_idx in range(config.num_experts):
                 tensor = torch.arange(rows * config.hidden_size, dtype=torch.bfloat16).reshape(
-                    rows,
-                    config.hidden_size,
+                    rows, config.hidden_size
                 )
                 tensor = tensor + expert_idx * 1000
                 self.layers[0].moe.experts.fc1.register_parameter(
-                    f"weight{expert_idx}",
-                    nn.Parameter(tensor),
+                    f"weight{expert_idx}", nn.Parameter(tensor)
                 )
 
     cfg = _tiny_config()
@@ -272,8 +250,7 @@ def test_qwen35_export_rank0_only_still_participates_in_ep_gather(monkeypatch) -
             for local_idx in range(config.num_experts // 2):
                 tensor = torch.zeros(rows, config.hidden_size, dtype=torch.bfloat16) + local_idx
                 self.layers[0].moe.experts.fc1.register_parameter(
-                    f"weight{local_idx}",
-                    nn.Parameter(tensor),
+                    f"weight{local_idx}", nn.Parameter(tensor)
                 )
 
     cfg = _tiny_config()
@@ -296,10 +273,7 @@ def test_qwen35_export_rank0_only_still_participates_in_ep_gather(monkeypatch) -
 
     monkeypatch.setattr("megatron.lite.primitive.ckpt.hf_weights.dist.is_initialized", lambda: True)
     monkeypatch.setattr("megatron.lite.primitive.ckpt.hf_weights.dist.get_rank", lambda: 1)
-    monkeypatch.setattr(
-        "megatron.lite.primitive.ckpt.hf_weights.dist.all_gather",
-        fake_all_gather,
-    )
+    monkeypatch.setattr("megatron.lite.primitive.ckpt.hf_weights.dist.all_gather", fake_all_gather)
 
     exported = list(export_hf_weights(TinyQwen35Module(cfg), cfg, ps, rank0_only=True))
 
@@ -332,23 +306,13 @@ def test_qwen35_export_unpacks_full_attention_q_gate() -> None:
     cfg = _tiny_config()
     spec = Qwen35WeightSpec(cfg)
     hidden = cfg.hidden_size
-    q_gate = torch.arange(
-        cfg.num_attention_heads * 2 * cfg.head_dim * hidden,
-    ).reshape(-1, hidden)
+    q_gate = torch.arange(cfg.num_attention_heads * 2 * cfg.head_dim * hidden).reshape(-1, hidden)
     key = torch.arange(
-        q_gate.numel(),
-        q_gate.numel() + cfg.num_key_value_heads * cfg.head_dim * hidden,
-    ).reshape(
-        -1,
-        hidden,
-    )
+        q_gate.numel(), q_gate.numel() + cfg.num_key_value_heads * cfg.head_dim * hidden
+    ).reshape(-1, hidden)
     value = torch.arange(
-        key[-1, -1] + 1,
-        key[-1, -1] + 1 + cfg.num_key_value_heads * cfg.head_dim * hidden,
-    ).reshape(
-        -1,
-        hidden,
-    )
+        key[-1, -1] + 1, key[-1, -1] + 1 + cfg.num_key_value_heads * cfg.head_dim * hidden
+    ).reshape(-1, hidden)
 
     packed = _merge_full_attn_qkvg(q_gate, key, value, cfg=cfg)
     exported = dict(spec.native_to_hf("layers.0.full_attn.qkv.linear.weight", packed))
@@ -405,19 +369,14 @@ def test_qwen35_export_reorders_linear_attention_tp_shards_before_hf_split() -> 
         torch.arange(200, 200 + v_dim * hidden).reshape(v_dim, hidden),
         torch.arange(300, 300 + v_dim * hidden).reshape(v_dim, hidden),
         torch.arange(400, 400 + cfg.linear_num_value_heads * hidden).reshape(
-            cfg.linear_num_value_heads,
-            hidden,
+            cfg.linear_num_value_heads, hidden
         ),
         torch.arange(500, 500 + cfg.linear_num_value_heads * hidden).reshape(
-            cfg.linear_num_value_heads,
-            hidden,
+            cfg.linear_num_value_heads, hidden
         ),
     ]
     full = torch.cat(parts, dim=0)
-    shards = [
-        torch.cat([part.chunk(2, dim=0)[rank] for part in parts], dim=0)
-        for rank in range(2)
-    ]
+    shards = [torch.cat([part.chunk(2, dim=0)[rank] for part in parts], dim=0) for rank in range(2)]
 
     merged = _merge_linear_attn_in_proj_tp_shards(shards, cfg=cfg)
 
@@ -431,25 +390,17 @@ def test_qwen35_export_reorders_linear_attention_conv1d_tp_shards() -> None:
     trailing = (1, cfg.linear_conv_kernel_dim)
     parts = [
         torch.arange(0, qk_dim * trailing[0] * trailing[1], dtype=torch.float32).reshape(
-            qk_dim,
-            *trailing,
+            qk_dim, *trailing
         ),
-        torch.arange(
-            100,
-            100 + qk_dim * trailing[0] * trailing[1],
-            dtype=torch.float32,
-        ).reshape(qk_dim, *trailing),
-        torch.arange(
-            200,
-            200 + v_dim * trailing[0] * trailing[1],
-            dtype=torch.float32,
-        ).reshape(v_dim, *trailing),
+        torch.arange(100, 100 + qk_dim * trailing[0] * trailing[1], dtype=torch.float32).reshape(
+            qk_dim, *trailing
+        ),
+        torch.arange(200, 200 + v_dim * trailing[0] * trailing[1], dtype=torch.float32).reshape(
+            v_dim, *trailing
+        ),
     ]
     full = torch.cat(parts, dim=0)
-    shards = [
-        torch.cat([part.chunk(2, dim=0)[rank] for part in parts], dim=0)
-        for rank in range(2)
-    ]
+    shards = [torch.cat([part.chunk(2, dim=0)[rank] for part in parts], dim=0) for rank in range(2)]
 
     merged = _merge_linear_attn_conv1d_tp_shards(shards, cfg=cfg)
 
@@ -464,8 +415,7 @@ def test_qwen35_export_uses_mbridge_conv1d_tp_gather(monkeypatch) -> None:
             self.layers[0].linear_attn = nn.Module()
             self.layers[0].linear_attn.conv1d = nn.Module()
             self.layers[0].linear_attn.conv1d.register_parameter(
-                "weight",
-                nn.Parameter(local_shard.clone()),
+                "weight", nn.Parameter(local_shard.clone())
             )
 
     cfg = _tiny_config()
@@ -474,25 +424,17 @@ def test_qwen35_export_uses_mbridge_conv1d_tp_gather(monkeypatch) -> None:
     trailing = (1, cfg.linear_conv_kernel_dim)
     parts = [
         torch.arange(0, qk_dim * trailing[0] * trailing[1], dtype=torch.float32).reshape(
-            qk_dim,
-            *trailing,
+            qk_dim, *trailing
         ),
-        torch.arange(
-            100,
-            100 + qk_dim * trailing[0] * trailing[1],
-            dtype=torch.float32,
-        ).reshape(qk_dim, *trailing),
-        torch.arange(
-            200,
-            200 + v_dim * trailing[0] * trailing[1],
-            dtype=torch.float32,
-        ).reshape(v_dim, *trailing),
+        torch.arange(100, 100 + qk_dim * trailing[0] * trailing[1], dtype=torch.float32).reshape(
+            qk_dim, *trailing
+        ),
+        torch.arange(200, 200 + v_dim * trailing[0] * trailing[1], dtype=torch.float32).reshape(
+            v_dim, *trailing
+        ),
     ]
     full = torch.cat(parts, dim=0)
-    shards = [
-        torch.cat([part.chunk(2, dim=0)[rank] for part in parts], dim=0)
-        for rank in range(2)
-    ]
+    shards = [torch.cat([part.chunk(2, dim=0)[rank] for part in parts], dim=0) for rank in range(2)]
     ps = SimpleNamespace(
         pp_size=1,
         tp_size=2,
@@ -511,18 +453,14 @@ def test_qwen35_export_uses_mbridge_conv1d_tp_gather(monkeypatch) -> None:
         outputs[1].copy_(shards[1])
 
     monkeypatch.setattr(
-        "megatron.lite.model.qwen3_5.lite.checkpoint.dist.all_gather",
-        fake_all_gather,
+        "megatron.lite.model.qwen3_5.lite.checkpoint.dist.all_gather", fake_all_gather
     )
 
     exported = dict(export_hf_weights(TinyQwen35Module(shards[0]), cfg, ps))
 
     assert len(gather_calls) == 1
     assert torch.equal(gather_calls[0], shards[0])
-    assert torch.equal(
-        exported["model.language_model.layers.0.linear_attn.conv1d.weight"],
-        full,
-    )
+    assert torch.equal(exported["model.language_model.layers.0.linear_attn.conv1d.weight"], full)
 
 
 def test_qwen35_export_reorders_shared_expert_gate_up_tp_shards() -> None:
@@ -548,17 +486,16 @@ def test_qwen35_export_restores_zero_centered_linear_attention_norm() -> None:
 
     assert set(exported) == {"model.language_model.layers.0.linear_attn.norm.weight"}
     assert torch.equal(
-        exported["model.language_model.layers.0.linear_attn.norm.weight"],
-        tensor + 1,
+        exported["model.language_model.layers.0.linear_attn.norm.weight"], tensor + 1
     )
 
 
 def test_qwen35_export_maps_shared_expert_to_hf_checkpoint_names() -> None:
     cfg = _tiny_config()
     spec = Qwen35WeightSpec(cfg)
-    tensor = torch.arange(
-        cfg.shared_expert_intermediate_size * 2 * cfg.hidden_size,
-    ).reshape(-1, cfg.hidden_size)
+    tensor = torch.arange(cfg.shared_expert_intermediate_size * 2 * cfg.hidden_size).reshape(
+        -1, cfg.hidden_size
+    )
 
     exported = dict(spec.native_to_hf("layers.0.moe.shared_expert.gate_up.linear.weight", tensor))
 
@@ -568,21 +505,19 @@ def test_qwen35_export_maps_shared_expert_to_hf_checkpoint_names() -> None:
     }
     gate, up = tensor.chunk(2, dim=0)
     assert torch.equal(
-        exported["model.language_model.layers.0.mlp.shared_expert.gate_proj.weight"],
-        gate,
+        exported["model.language_model.layers.0.mlp.shared_expert.gate_proj.weight"], gate
     )
     assert torch.equal(
-        exported["model.language_model.layers.0.mlp.shared_expert.up_proj.weight"],
-        up,
+        exported["model.language_model.layers.0.mlp.shared_expert.up_proj.weight"], up
     )
 
 
 def test_qwen35_export_packs_base_expert_fc1_to_hf_gate_up_proj() -> None:
     cfg = _tiny_config()
     spec = Qwen35WeightSpec(cfg)
-    base = torch.arange(
-        cfg.moe_intermediate_size * 2 * cfg.hidden_size,
-    ).reshape(-1, cfg.hidden_size)
+    base = torch.arange(cfg.moe_intermediate_size * 2 * cfg.hidden_size).reshape(
+        -1, cfg.hidden_size
+    )
 
     exported = {}
     expert_tensors = []
@@ -611,8 +546,7 @@ def test_qwen35_export_matches_mbridge_qwen35_moe_packed_expert_contract() -> No
     ]
     fc2_tensors = [
         torch.arange(cfg.hidden_size * cfg.moe_intermediate_size, dtype=torch.bfloat16).reshape(
-            cfg.hidden_size,
-            cfg.moe_intermediate_size,
+            cfg.hidden_size, cfg.moe_intermediate_size
         )
         + expert_idx * 1000
         for expert_idx in range(cfg.num_experts)
@@ -652,28 +586,27 @@ def test_qwen35_export_vllm_target_uses_runtime_prefix_and_packed_expert_names()
     assert set(exported_embed) == {"language_model.model.embed_tokens.weight"}
     assert set(exported_norm) == {"language_model.model.norm.weight"}
     assert set(exported_head) == {"language_model.lm_head.weight"}
-    assert set(exported_mlp_norm) == {"language_model.model.layers.0.post_attention_layernorm.weight"}
+    assert set(exported_mlp_norm) == {
+        "language_model.model.layers.0.post_attention_layernorm.weight"
+    }
     assert torch.equal(exported_embed["language_model.model.embed_tokens.weight"], dense)
     assert torch.equal(exported_norm["language_model.model.norm.weight"], dense)
     assert torch.equal(exported_head["language_model.lm_head.weight"], dense)
     assert torch.equal(
-        exported_mlp_norm["language_model.model.layers.0.post_attention_layernorm.weight"],
-        dense,
+        exported_mlp_norm["language_model.model.layers.0.post_attention_layernorm.weight"], dense
     )
 
     fc1_tensors = [
-        torch.arange(
-            cfg.moe_intermediate_size * 2 * cfg.hidden_size,
-            dtype=torch.bfloat16,
-        ).reshape(-1, cfg.hidden_size)
+        torch.arange(cfg.moe_intermediate_size * 2 * cfg.hidden_size, dtype=torch.bfloat16).reshape(
+            -1, cfg.hidden_size
+        )
         + expert_idx * 1000
         for expert_idx in range(cfg.num_experts)
     ]
     fc2_tensors = [
-        torch.arange(
-            cfg.hidden_size * cfg.moe_intermediate_size,
-            dtype=torch.bfloat16,
-        ).reshape(cfg.hidden_size, cfg.moe_intermediate_size)
+        torch.arange(cfg.hidden_size * cfg.moe_intermediate_size, dtype=torch.bfloat16).reshape(
+            cfg.hidden_size, cfg.moe_intermediate_size
+        )
         + expert_idx * 2000
         for expert_idx in range(cfg.num_experts)
     ]
@@ -713,35 +646,24 @@ def test_qwen35_export_vllm_target_packs_experts_with_runtime_prefix() -> None:
             rows = config.moe_intermediate_size * 2
             for expert_idx in range(config.num_experts):
                 fc1 = torch.arange(rows * config.hidden_size, dtype=torch.bfloat16).reshape(
-                    rows,
-                    config.hidden_size,
+                    rows, config.hidden_size
                 )
                 fc1 = fc1 + expert_idx * 1000
                 fc2 = torch.arange(
-                    config.hidden_size * config.moe_intermediate_size,
-                    dtype=torch.bfloat16,
+                    config.hidden_size * config.moe_intermediate_size, dtype=torch.bfloat16
                 ).reshape(config.hidden_size, config.moe_intermediate_size)
                 fc2 = fc2 + expert_idx * 2000
                 self.layers[0].moe.experts.fc1.register_parameter(
-                    f"weight{expert_idx}",
-                    nn.Parameter(fc1),
+                    f"weight{expert_idx}", nn.Parameter(fc1)
                 )
                 self.layers[0].moe.experts.fc2.register_parameter(
-                    f"weight{expert_idx}",
-                    nn.Parameter(fc2),
+                    f"weight{expert_idx}", nn.Parameter(fc2)
                 )
 
     cfg = _tiny_config()
     model = TinyQwen35Module(cfg)
 
-    exported = dict(
-        export_hf_weights(
-            model,
-            cfg,
-            _single_rank_parallel_state(),
-            target="vllm",
-        )
-    )
+    exported = dict(export_hf_weights(model, cfg, _single_rank_parallel_state(), target="vllm"))
 
     assert "model.language_model.layers.0.mlp.experts.gate_up_proj" not in exported
     assert "model.language_model.layers.0.mlp.experts.down_proj" not in exported
@@ -773,9 +695,9 @@ def test_qwen35_export_vllm_target_packs_experts_with_runtime_prefix() -> None:
 def test_qwen35_export_packs_base_expert_fc2_and_expert_metadata() -> None:
     cfg = _tiny_config()
     spec = Qwen35WeightSpec(cfg)
-    base = torch.arange(
-        cfg.hidden_size * cfg.moe_intermediate_size,
-    ).reshape(cfg.hidden_size, cfg.moe_intermediate_size)
+    base = torch.arange(cfg.hidden_size * cfg.moe_intermediate_size).reshape(
+        cfg.hidden_size, cfg.moe_intermediate_size
+    )
     native_name = "layers.0.moe.experts.fc2.weight2"
 
     exported = {}

--- a/experimental/lite/tests/unit/model/test_qwen_config_unit.py
+++ b/experimental/lite/tests/unit/model/test_qwen_config_unit.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
 
+import ast
+from pathlib import Path
+
 import pytest
 
 from megatron.lite.model.qwen3_5.config import Qwen35Config
 from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
-from megatron.lite.model.registry import (
-    resolve_model_type_from_hf,
-    resolve_runtime_model_name,
-)
-
+from megatron.lite.model.registry import resolve_model_type_from_hf, resolve_runtime_model_name
 
 pytestmark = pytest.mark.mlite
+
+LITE_ROOT = Path(__file__).resolve().parents[3]
 
 
 def _tiny_qwen3_hf_dict() -> dict:
@@ -47,10 +48,7 @@ def _tiny_qwen35_text_config() -> dict:
         "linear_conv_kernel_dim": 2,
         "num_nextn_predict_layers": 1,
         "layer_types": ["linear_attention", "full_attention", "full_attention"],
-        "rope_parameters": {
-            "partial_rotary_factor": 1.0,
-            "mrope_section": [1, 1, 0],
-        },
+        "rope_parameters": {"partial_rotary_factor": 1.0, "mrope_section": [1, 1, 0]},
     }
 
 
@@ -81,10 +79,7 @@ def test_qwen3_config_rejects_invalid_expert_topk():
 
 def test_qwen35_config_from_text_config_splits_mtp_layer_types():
     cfg = Qwen35Config._from_hf_dict(
-        {
-            "model_type": "qwen3_5_moe",
-            "text_config": _tiny_qwen35_text_config(),
-        }
+        {"model_type": "qwen3_5_moe", "text_config": _tiny_qwen35_text_config()}
     )
 
     assert cfg.layer_types == ["linear_attention", "full_attention"]
@@ -101,11 +96,50 @@ def test_qwen_lite_protocols_build_configs_from_hf_dicts():
 
     qwen3_cfg = qwen3_protocol.build_model_config(_tiny_qwen3_hf_dict(), vocab_size=128)
     qwen35_cfg = qwen35_protocol.build_model_config(
-        {"model_type": "qwen3_5_moe", "text_config": _tiny_qwen35_text_config()},
-        vocab_size=128,
+        {"model_type": "qwen3_5_moe", "text_config": _tiny_qwen35_text_config()}, vocab_size=128
     )
 
     assert qwen3_cfg.vocab_size == 128
     assert qwen35_cfg.vocab_size == 128
     assert qwen35_cfg.layer_type_at(0) == "linear_attention"
     assert qwen35_cfg.layer_type_at(1) == "full_attention"
+
+
+def test_qwen_lite_protocols_reexport_checkpoint_hook_names():
+    protocol_paths = [
+        LITE_ROOT / "megatron/lite/model/qwen3_moe/lite/protocol.py",
+        LITE_ROOT / "megatron/lite/model/qwen3_5/lite/protocol.py",
+    ]
+
+    for path in protocol_paths:
+        tree = ast.parse(path.read_text())
+        exported = _string_list_assignment(tree, "__all__")
+        checkpoint_imports = _checkpoint_import_names(tree)
+
+        assert "EXPERT_CLASSIFIER" in exported
+        assert "PLACEMENT_FN" in exported
+        assert "EXPERT_CLASSIFIER" in checkpoint_imports
+        assert "PLACEMENT_FN" in checkpoint_imports
+
+
+def _string_list_assignment(tree: ast.Module, name: str) -> set[str]:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(target, ast.Name) and target.id == name for target in node.targets):
+            continue
+        if not isinstance(node.value, (ast.List, ast.Tuple)):
+            return set()
+        return {item.value for item in node.value.elts if isinstance(item, ast.Constant)}
+    return set()
+
+
+def _checkpoint_import_names(tree: ast.Module) -> set[str]:
+    names: set[str] = set()
+    for node in tree.body:
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        if node.module is None or not node.module.endswith(".lite.checkpoint"):
+            continue
+        names.update(alias.name for alias in node.names)
+    return names

--- a/experimental/lite/tests/unit/primitive/test_attention_moe_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_attention_moe_unit.py
@@ -5,7 +5,6 @@ from types import SimpleNamespace
 import pytest
 import torch
 
-
 pytestmark = pytest.mark.mlite
 
 
@@ -35,10 +34,7 @@ def _router_and_parallel_state(monkeypatch):
 
 def _router_config():
     return SimpleNamespace(
-        hidden_size=4,
-        num_experts=4,
-        num_experts_per_tok=2,
-        router_aux_loss_coef=0.1,
+        hidden_size=4, num_experts=4, num_experts_per_tok=2, router_aux_loss_coef=0.1
     )
 
 
@@ -58,25 +54,14 @@ def test_gqa_split_grouped_qkvg_preserves_q_gate_kv_order():
     split_grouped_qkvg = _split_grouped_qkvg()
     qkv = torch.arange(24).reshape(1, 24)
 
-    query, gate, key, value = split_grouped_qkvg(
-        qkv,
-        num_heads=4,
-        num_kv_heads=2,
-        head_dim=2,
-    )
+    query, gate, key, value = split_grouped_qkvg(qkv, num_heads=4, num_kv_heads=2, head_dim=2)
 
     assert query.shape == (1, 4, 2)
     assert gate.shape == (1, 4, 2)
     assert key.shape == (1, 2, 2)
     assert value.shape == (1, 2, 2)
-    assert torch.equal(
-        query,
-        torch.tensor([[[0, 1], [2, 3], [12, 13], [14, 15]]]),
-    )
-    assert torch.equal(
-        gate,
-        torch.tensor([[[4, 5], [6, 7], [16, 17], [18, 19]]]),
-    )
+    assert torch.equal(query, torch.tensor([[[0, 1], [2, 3], [12, 13], [14, 15]]]))
+    assert torch.equal(gate, torch.tensor([[[4, 5], [6, 7], [16, 17], [18, 19]]]))
     assert torch.equal(key, torch.tensor([[[8, 9], [20, 21]]]))
     assert torch.equal(value, torch.tensor([[[10, 11], [22, 23]]]))
 

--- a/experimental/lite/tests/unit/primitive/test_checkpoint_runtime.py
+++ b/experimental/lite/tests/unit/primitive/test_checkpoint_runtime.py
@@ -18,11 +18,7 @@ from megatron.lite.runtime.contracts.handle import ModelHandle
 class TinyMLP(nn.Module):
     def __init__(self):
         super().__init__()
-        self.layers = nn.Sequential(
-            nn.Linear(4, 8),
-            nn.GELU(),
-            nn.Linear(8, 2),
-        )
+        self.layers = nn.Sequential(nn.Linear(4, 8), nn.GELU(), nn.Linear(8, 2))
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.layers(x)
@@ -44,9 +40,7 @@ def _clone_model_and_optimizer(model: nn.Module):
 
 def _assert_model_close(lhs: nn.Module, rhs: nn.Module):
     for (lhs_name, lhs_param), (rhs_name, rhs_param) in zip(
-        lhs.named_parameters(),
-        rhs.named_parameters(),
-        strict=True,
+        lhs.named_parameters(), rhs.named_parameters(), strict=True
     ):
         assert lhs_name == rhs_name
         torch.testing.assert_close(lhs_param, rhs_param, atol=0.0, rtol=0.0)
@@ -72,11 +66,14 @@ def test_runtime_local_checkpoint_load_matches_uninterrupted_training(tmp_path):
         use_dcp=False,
     )
 
-    assert runtime.load_checkpoint(
-        ModelHandle(model=loaded_model, optimizer=loaded_optimizer),
-        str(tmp_path),
-        use_dcp=False,
-    ) == 1
+    assert (
+        runtime.load_checkpoint(
+            ModelHandle(model=loaded_model, optimizer=loaded_optimizer),
+            str(tmp_path),
+            use_dcp=False,
+        )
+        == 1
+    )
 
     _step(direct_model, direct_optimizer, x1, y1)
     _step(loaded_model, loaded_optimizer, x1, y1)
@@ -132,21 +129,21 @@ def test_runtime_local_checkpoint_uses_optimizer_parameter_state_contract(tmp_pa
 
     runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
     runtime.save_checkpoint(
-        ModelHandle(model=model, optimizer=optimizer),
-        str(tmp_path),
-        step=7,
-        use_dcp=False,
+        ModelHandle(model=model, optimizer=optimizer), str(tmp_path), step=7, use_dcp=False
     )
 
     loaded_model = TinyMLP()
     loaded_optimizer = DistOptLike(torch.optim.AdamW(loaded_model.parameters(), lr=1.0e-3))
 
-    assert runtime.load_checkpoint(
-        ModelHandle(model=loaded_model, optimizer=loaded_optimizer),
-        str(tmp_path),
-        update_legacy_format=True,
-        use_dcp=False,
-    ) == 7
+    assert (
+        runtime.load_checkpoint(
+            ModelHandle(model=loaded_model, optimizer=loaded_optimizer),
+            str(tmp_path),
+            update_legacy_format=True,
+            use_dcp=False,
+        )
+        == 7
+    )
     assert loaded_optimizer.load_calls == 1
     assert loaded_optimizer.parameter_load_calls == 1
     assert loaded_optimizer.update_legacy_format is True
@@ -163,10 +160,7 @@ def test_runtime_local_checkpoint_restores_rng_state(tmp_path):
     torch.manual_seed(2031)
 
     runtime.save_checkpoint(
-        ModelHandle(model=model, optimizer=None),
-        str(tmp_path),
-        step=9,
-        use_dcp=False,
+        ModelHandle(model=model, optimizer=None), str(tmp_path), step=9, use_dcp=False
     )
 
     expected_python = random.random()
@@ -178,7 +172,9 @@ def test_runtime_local_checkpoint_restores_rng_state(tmp_path):
     torch.manual_seed(9999)
 
     assert (
-        runtime.load_checkpoint(ModelHandle(model=model, optimizer=None), str(tmp_path), use_dcp=False)
+        runtime.load_checkpoint(
+            ModelHandle(model=model, optimizer=None), str(tmp_path), use_dcp=False
+        )
         == 9
     )
     assert random.random() == expected_python
@@ -196,15 +192,14 @@ def test_runtime_local_checkpoint_uses_rank_specific_files_when_distributed(tmp_
         patch("megatron.lite.primitive.ckpt.dcp.dist.get_rank", return_value=3),
     ):
         runtime.save_checkpoint(
-            ModelHandle(model=model, optimizer=None),
-            str(tmp_path),
-            step=11,
-            use_dcp=False,
+            ModelHandle(model=model, optimizer=None), str(tmp_path), step=11, use_dcp=False
         )
         assert (tmp_path / "training_state_rank_00003.pt").exists()
         assert not (tmp_path / "training_state.pt").exists()
         assert (
-            runtime.load_checkpoint(ModelHandle(model=model, optimizer=None), str(tmp_path), use_dcp=False)
+            runtime.load_checkpoint(
+                ModelHandle(model=model, optimizer=None), str(tmp_path), use_dcp=False
+            )
             == 11
         )
 
@@ -214,13 +209,7 @@ def test_primitive_local_checkpoint_keeps_optimizer_checkpoints_local(tmp_path):
     optimizer = torch.optim.AdamW(model.parameters(), lr=1.0e-3)
 
     with patch("megatron.lite.primitive.ckpt.dcp.dcp.save") as dcp_save_mock:
-        save_training_checkpoint(
-            model,
-            optimizer,
-            12,
-            str(tmp_path),
-            use_dcp=False,
-        )
+        save_training_checkpoint(model, optimizer, 12, str(tmp_path), use_dcp=False)
 
     dcp_save_mock.assert_not_called()
     assert (tmp_path / "training_state.pt").exists()
@@ -240,13 +229,7 @@ def test_primitive_explicit_dcp_saves_optimizer_rank_sidecar(tmp_path):
         patch("megatron.lite.primitive.ckpt.dcp.dcp.save") as dcp_save_mock,
     ):
         save_training_checkpoint(
-            model,
-            optimizer,
-            12,
-            str(tmp_path),
-            parallel,
-            object(),
-            use_dcp=True,
+            model, optimizer, 12, str(tmp_path), parallel, object(), use_dcp=True
         )
 
     dcp_save_mock.assert_called_once()
@@ -264,10 +247,7 @@ def test_runtime_dcp_checkpoint_threads_parallel_config_and_protocol_hooks(tmp_p
     def expert_classifier(name: str):
         return name.endswith("expert")
 
-    proto = SimpleNamespace(
-        PLACEMENT_FN=placement_fn,
-        EXPERT_CLASSIFIER=expert_classifier,
-    )
+    proto = SimpleNamespace(PLACEMENT_FN=placement_fn, EXPERT_CLASSIFIER=expert_classifier)
     handle = ModelHandle(
         model=[model],
         optimizer=None,
@@ -294,8 +274,7 @@ def test_runtime_dcp_checkpoint_threads_parallel_config_and_protocol_hooks(tmp_p
     assert save_kwargs["save_rng"] is True
 
     with patch(
-        "megatron.lite.primitive.ckpt.load_training_checkpoint",
-        return_value=13,
+        "megatron.lite.primitive.ckpt.load_training_checkpoint", return_value=13
     ) as load_mock:
         assert runtime.load_checkpoint(handle, str(tmp_path), use_dcp=True) == 13
 

--- a/experimental/lite/tests/unit/primitive/test_checkpoint_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_checkpoint_unit.py
@@ -9,18 +9,13 @@ import torch.nn as nn
 from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
 from megatron.lite.runtime.contracts.handle import ModelHandle
 
-
 pytestmark = pytest.mark.mlite
 
 
 class TinyMLP(nn.Module):
     def __init__(self):
         super().__init__()
-        self.layers = nn.Sequential(
-            nn.Linear(4, 8),
-            nn.GELU(),
-            nn.Linear(8, 2),
-        )
+        self.layers = nn.Sequential(nn.Linear(4, 8), nn.GELU(), nn.Linear(8, 2))
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.layers(x)
@@ -42,9 +37,7 @@ def _clone_model_and_optimizer(model: nn.Module):
 
 def _assert_model_close(lhs: nn.Module, rhs: nn.Module):
     for (lhs_name, lhs_param), (rhs_name, rhs_param) in zip(
-        lhs.named_parameters(),
-        rhs.named_parameters(),
-        strict=True,
+        lhs.named_parameters(), rhs.named_parameters(), strict=True
     ):
         assert lhs_name == rhs_name
         torch.testing.assert_close(lhs_param, rhs_param, atol=0.0, rtol=0.0)
@@ -64,16 +57,12 @@ def test_runtime_checkpoint_load_matches_uninterrupted_training(tmp_path):
 
     runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
     ckpt_handle = ModelHandle(
-        model=ckpt_model,
-        optimizer=ckpt_optimizer,
-        _extras={"model_chunks": [ckpt_model]},
+        model=ckpt_model, optimizer=ckpt_optimizer, _extras={"model_chunks": [ckpt_model]}
     )
     runtime.save_checkpoint(ckpt_handle, str(tmp_path), step=1, use_dcp=False)
 
     loaded_handle = ModelHandle(
-        model=loaded_model,
-        optimizer=loaded_optimizer,
-        _extras={"model_chunks": [loaded_model]},
+        model=loaded_model, optimizer=loaded_optimizer, _extras={"model_chunks": [loaded_model]}
     )
     assert runtime.load_checkpoint(loaded_handle, str(tmp_path), use_dcp=False) == 1
 
@@ -138,9 +127,7 @@ def test_runtime_checkpoint_uses_optimizer_state_dict_contract(tmp_path):
     loaded_model = TinyMLP()
     loaded_optimizer = DistOptLike(torch.optim.AdamW(loaded_model.parameters(), lr=1.0e-3))
     loaded_handle = ModelHandle(
-        model=loaded_model,
-        optimizer=loaded_optimizer,
-        _extras={"model_chunks": [loaded_model]},
+        model=loaded_model, optimizer=loaded_optimizer, _extras={"model_chunks": [loaded_model]}
     )
 
     assert runtime.load_checkpoint(loaded_handle, str(tmp_path), use_dcp=False) == 7

--- a/experimental/lite/tests/unit/primitive/test_dist_opt_validation.py
+++ b/experimental/lite/tests/unit/primitive/test_dist_opt_validation.py
@@ -2,19 +2,13 @@ from __future__ import annotations
 
 import pytest
 
-from megatron.lite.primitive.optimizers.megatron_wrap import (
-    validate_mc_config,
-    validate_mc_session,
-)
+from megatron.lite.primitive.optimizers.megatron_wrap import validate_mc_config, validate_mc_session
 from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig
 from megatron.lite.runtime.contracts.config import ParallelConfig
 
 
 def _engine_cfg(*, model_name: str, pp: int = 1, vpp: int = 1) -> MegatronLiteConfig:
-    return MegatronLiteConfig(
-        model_name=model_name,
-        parallel=ParallelConfig(pp=pp, vpp=vpp),
-    )
+    return MegatronLiteConfig(model_name=model_name, parallel=ParallelConfig(pp=pp, vpp=vpp))
 
 
 def test_dist_opt_validation_accepts_model_agnostic_config():

--- a/experimental/lite/tests/unit/primitive/test_fsdp2_offload_gpu.py
+++ b/experimental/lite/tests/unit/primitive/test_fsdp2_offload_gpu.py
@@ -125,10 +125,7 @@ def test_fsdp2_runtime_model_and_optimizer_offload_roundtrip_single_gpu():
     model, ps = _build_fsdp2_model()
     optimizer = _build_optimizer(model, ps, offload_fraction=0.0)
     handle = ModelHandle(
-        model=model,
-        optimizer=optimizer,
-        parallel_state=ps,
-        _extras={"model_chunks": [model]},
+        model=model, optimizer=optimizer, parallel_state=ps, _extras={"model_chunks": [model]}
     )
     runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
 

--- a/experimental/lite/tests/unit/primitive/test_fsdp2_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_fsdp2_unit.py
@@ -10,6 +10,7 @@ import torch.nn as nn
 
 from megatron.lite.primitive.optimizers.fsdp2 import (
     FSDP2Config,
+    FSDP2Optimizer,
     clip_grads_with_sharded_norm_,
     fsdp2_available,
 )
@@ -17,10 +18,10 @@ from megatron.lite.primitive.optimizers.fsdp2.adamw import build_adamw_optimizer
 from megatron.lite.primitive.optimizers.fsdp2.wrap import build_fsdp2_shard_placement_fn
 from megatron.lite.primitive.parallel.state import ParallelState
 
-
 pytestmark = pytest.mark.mlite
 
 fsdp2_wrap = importlib.import_module("megatron.lite.primitive.optimizers.fsdp2.wrap")
+fsdp2_optimizer = importlib.import_module("megatron.lite.primitive.optimizers.fsdp2.optimizer")
 
 
 class ToyBlock(nn.Module):
@@ -78,6 +79,25 @@ def test_fsdp2_config_normalizes_unit_and_leaf_modules():
     assert isinstance(fsdp2_available(), bool)
 
 
+def test_fsdp2_optimizer_offloads_dtensor_state_without_extra_knob(monkeypatch):
+    model = ToyModel()
+    torch_optimizer = torch.optim.AdamW(model.parameters(), lr=1.0e-3)
+    optimizer = FSDP2Optimizer(torch_optimizer, model.parameters())
+    calls: list[bool] = []
+
+    def fake_move_optimizer_state_to_cpu(_optimizer, _offloaded_state, *, include_dtensor_state):
+        calls.append(include_dtensor_state)
+
+    monkeypatch.setattr(
+        fsdp2_optimizer, "move_optimizer_state_to_cpu", fake_move_optimizer_state_to_cpu
+    )
+
+    optimizer.offload_state_to_cpu()
+
+    assert calls == [True]
+    assert not hasattr(optimizer, "optimizer_offload_dtensor_state")
+
+
 def test_fsdp2_shard_placement_prefers_first_divisible_dimension():
     placement_for_two = build_fsdp2_shard_placement_fn(2)
     placement_for_three = build_fsdp2_shard_placement_fn(3)
@@ -102,11 +122,7 @@ def test_fsdp2_rejects_non_module_unit_path():
 
 
 def test_wrap_fsdp2_requires_distributed_when_mesh_is_not_provided(monkeypatch):
-    monkeypatch.setattr(
-        fsdp2_wrap,
-        "_load_fully_shard",
-        lambda: lambda module, **kwargs: module,
-    )
+    monkeypatch.setattr(fsdp2_wrap, "_load_fully_shard", lambda: lambda module, **kwargs: module)
 
     with pytest.raises(RuntimeError, match="torch.distributed"):
         fsdp2_wrap.wrap_fsdp2(ToyModel(), ParallelState(), FSDP2Config())
@@ -153,10 +169,7 @@ def test_wrap_fsdp2_accepts_unit_module_import_paths(monkeypatch):
     fsdp2_wrap.wrap_fsdp2(
         model,
         ParallelState(),
-        FSDP2Config(
-            unit_modules=("torch.nn.modules.linear.Linear",),
-            wrap_root=False,
-        ),
+        FSDP2Config(unit_modules=("torch.nn.modules.linear.Linear",), wrap_root=False),
         mesh=SimpleNamespace(name="mesh"),
     )
 
@@ -165,13 +178,7 @@ def test_wrap_fsdp2_accepts_unit_module_import_paths(monkeypatch):
 
 def test_wrap_fsdp2_uses_container_order_without_nested_unit_duplicates(monkeypatch):
     model = nn.Module()
-    model.layers = nn.ModuleDict(
-        {
-            "10": NestedToyBlock(),
-            "2": ToyBlock(),
-            "11": ToyBlock(),
-        }
-    )
+    model.layers = nn.ModuleDict({"10": NestedToyBlock(), "2": ToyBlock(), "11": ToyBlock()})
     calls: list[nn.Module] = []
 
     def fake_fully_shard(module, **kwargs):
@@ -188,12 +195,7 @@ def test_wrap_fsdp2_uses_container_order_without_nested_unit_duplicates(monkeypa
         mesh=SimpleNamespace(name="mesh"),
     )
 
-    assert calls == [
-        model.layers["10"],
-        model.layers["2"],
-        model.layers["11"],
-        model,
-    ]
+    assert calls == [model.layers["10"], model.layers["2"], model.layers["11"], model]
     assert model.layers["10"]._fake_fsdp2_kwargs["reshard_after_forward"] is True
     assert not hasattr(model.layers["10"].inner, "_fake_fsdp2_kwargs")
     assert model.layers["11"]._fake_fsdp2_kwargs["reshard_after_forward"] is False
@@ -224,10 +226,7 @@ def test_wrap_fsdp2_configures_default_forward_prefetch(monkeypatch):
     fsdp2_wrap.wrap_fsdp2(
         model,
         ParallelState(),
-        FSDP2Config(
-            unit_modules=(ToyBlock,),
-            reshard_after_forward=True,
-        ),
+        FSDP2Config(unit_modules=(ToyBlock,), reshard_after_forward=True),
         mesh=SimpleNamespace(name="mesh"),
     )
 

--- a/experimental/lite/tests/unit/primitive/test_module_primitives_independent_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_module_primitives_independent_unit.py
@@ -13,19 +13,11 @@ from megatron.lite.primitive.modules.lora import (
     trainable_param_stats,
 )
 
-
 pytestmark = pytest.mark.mlite
 
 
 def test_lora_config_aliases_and_trainable_param_accounting():
-    cfg = normalize_lora_config(
-        {
-            "enabled": True,
-            "rank": 2,
-            "alpha": 6,
-            "targets": ["qkv", "fc2"],
-        }
-    )
+    cfg = normalize_lora_config({"enabled": True, "rank": 2, "alpha": 6, "targets": ["qkv", "fc2"]})
 
     assert cfg.enabled
     assert cfg.scale == 3.0
@@ -78,10 +70,7 @@ def test_grouped_lora_respects_per_expert_splits():
     x = torch.tensor([[2.0, 9.0], [4.0, 1.0], [6.0, 3.0]])
     output = layer(x, [1, 2])
 
-    torch.testing.assert_close(
-        output,
-        torch.tensor([[4.0, 6.0], [5.0, 7.0], [15.0, 21.0]]),
-    )
+    torch.testing.assert_close(output, torch.tensor([[4.0, 6.0], [5.0, 7.0], [15.0, 21.0]]))
     with pytest.raises(ValueError, match="expected 2 splits"):
         layer(x, [3])
 
@@ -102,10 +91,7 @@ def test_mrope_interleaves_text_height_and_width_sections():
 
     base = torch.arange(3 * 2 * 6, dtype=torch.float32).reshape(3, 2, 6)
 
-    interleaved = MultimodalRotaryEmbedding._apply_interleaved_mrope(
-        base,
-        mrope_section=[1, 1, 1],
-    )
+    interleaved = MultimodalRotaryEmbedding._apply_interleaved_mrope(base, mrope_section=[1, 1, 1])
 
     expected = base[0].clone()
     expected[..., 1] = base[1, ..., 1]
@@ -135,12 +121,7 @@ def test_gated_delta_static_helpers_are_finite_and_shape_stable(transformer_engi
     alpha = torch.tensor([[[0.0, 1.0], [-1.0, 2.0]]])
     beta = torch.tensor([[[0.0, 2.0], [-2.0, 4.0]]])
 
-    g, beta_sigmoid = GatedDeltaNet._compute_g_and_beta(
-        torch.zeros(2),
-        torch.ones(2),
-        alpha,
-        beta,
-    )
+    g, beta_sigmoid = GatedDeltaNet._compute_g_and_beta(torch.zeros(2), torch.ones(2), alpha, beta)
 
     assert g.shape == alpha.shape
     assert beta_sigmoid.shape == beta.shape

--- a/experimental/lite/tests/unit/primitive/test_ops_data_trainstep_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_ops_data_trainstep_unit.py
@@ -15,7 +15,6 @@ from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_s
 from megatron.lite.primitive.train_step import compute_and_clip_grad_norm, run_microbatch_loop
 from megatron.lite.primitive.utils import ensure_divisible
 
-
 pytestmark = pytest.mark.mlite
 
 
@@ -25,9 +24,7 @@ def test_vocab_parallel_cross_entropy_matches_torch_cross_entropy():
 
     loss = vocab_parallel_cross_entropy(logits, labels)
     expected = F.cross_entropy(
-        logits.float().reshape(-1, 5),
-        labels.reshape(-1),
-        reduction="none",
+        logits.float().reshape(-1, 5), labels.reshape(-1), reduction="none"
     ).view_as(labels)
 
     torch.testing.assert_close(loss, expected)
@@ -41,10 +38,13 @@ def test_logprob_selects_labels_in_batch_sequence_or_sequence_batch_layout():
     labels_bsh = torch.tensor([[0, 1], [2, 3], [1, 0]])
 
     selected = vocab_parallel_log_probs_from_logits(logits, labels_bsh)
-    expected = torch.log_softmax(logits.float(), dim=-1).gather(
-        -1,
-        labels_bsh.transpose(0, 1).unsqueeze(-1),
-    ).squeeze(-1).transpose(0, 1).contiguous()
+    expected = (
+        torch.log_softmax(logits.float(), dim=-1)
+        .gather(-1, labels_bsh.transpose(0, 1).unsqueeze(-1))
+        .squeeze(-1)
+        .transpose(0, 1)
+        .contiguous()
+    )
 
     torch.testing.assert_close(selected, expected)
     with pytest.raises(ValueError, match="Could not align"):
@@ -54,21 +54,11 @@ def test_logprob_selects_labels_in_batch_sequence_or_sequence_batch_layout():
 def test_linear_cross_entropy_fallback_matches_explicit_matmul():
     hidden = torch.tensor([[1.0, -2.0, 0.5], [0.25, 1.5, -0.5]])
     weight = torch.tensor(
-        [
-            [0.5, -1.0, 0.25],
-            [1.0, 0.0, -0.5],
-            [-0.5, 0.75, 1.0],
-            [0.25, 0.5, -1.5],
-        ]
+        [[0.5, -1.0, 0.25], [1.0, 0.0, -0.5], [-0.5, 0.75, 1.0], [0.25, 0.5, -1.5]]
     )
     labels = torch.tensor([0, 3])
 
-    log_probs, entropy = linear_cross_entropy(
-        hidden,
-        weight,
-        labels,
-        temperature=2.0,
-    )
+    log_probs, entropy = linear_cross_entropy(hidden, weight, labels, temperature=2.0)
     logits = hidden.matmul(weight.t()) / 2.0
     expected_loss = F.cross_entropy(logits, labels, reduction="none")
     expected_entropy = torch.distributions.Categorical(logits=logits).entropy()
@@ -190,12 +180,7 @@ def test_train_step_microbatch_loop_and_grad_clip_cpu_contract():
     assert model.weight.grad is not None
     assert torch.isfinite(model.weight.grad).all()
 
-    grad_norm = compute_and_clip_grad_norm(
-        model,
-        optimizer=None,
-        max_norm=0.25,
-        use_dist_opt=False,
-    )
+    grad_norm = compute_and_clip_grad_norm(model, optimizer=None, max_norm=0.25, use_dist_opt=False)
 
     assert torch.isfinite(grad_norm)
     assert model.weight.grad.norm() <= 0.25 + 1.0e-6

--- a/experimental/lite/tests/unit/primitive/test_parallel_dimensions_independent_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_parallel_dimensions_independent_unit.py
@@ -15,7 +15,6 @@ from megatron.lite.primitive.parallel.sp import (
 )
 from megatron.lite.primitive.parallel.state import ParallelState
 
-
 pytestmark = pytest.mark.mlite
 
 
@@ -35,8 +34,7 @@ def test_tp_vocab_embedding_and_output_single_rank_contract(transformer_engine_i
     embedding = VocabParallelEmbedding(5, 3, ps, deterministic=True)
     with torch.no_grad():
         values = torch.arange(embedding.local_vocab * 3, dtype=torch.float32).view(
-            embedding.local_vocab,
-            3,
+            embedding.local_vocab, 3
         )
         embedding.embedding.weight.copy_(values)
 
@@ -69,20 +67,10 @@ def test_cp_packed_split_handles_each_sample_independently():
     cu_seqlens = torch.tensor([0, 8, 16], dtype=torch.int32)
 
     rank0 = split_packed_for_cp(
-        input_ids,
-        position_ids,
-        cu_seqlens,
-        max_seqlen=8,
-        cp_rank=0,
-        cp_size=2,
+        input_ids, position_ids, cu_seqlens, max_seqlen=8, cp_rank=0, cp_size=2
     )
     rank1 = split_packed_for_cp(
-        input_ids,
-        position_ids,
-        cu_seqlens,
-        max_seqlen=8,
-        cp_rank=1,
-        cp_size=2,
+        input_ids, position_ids, cu_seqlens, max_seqlen=8, cp_rank=1, cp_size=2
     )
 
     torch.testing.assert_close(rank0[0], torch.tensor([0, 1, 6, 7, 8, 9, 14, 15]))
@@ -121,17 +109,12 @@ def test_ep_token_dispatcher_local_roundtrip_is_independent_of_deepep():
 
     ps = ParallelState(ep_size=1, ep_rank=0)
     dispatcher = TokenDispatcher(num_experts=3, hidden_size=2, ps=ps, use_deepep=False)
-    hidden = torch.tensor(
-        [[1.0, 10.0], [2.0, 20.0], [3.0, 30.0], [4.0, 40.0]],
-        requires_grad=True,
-    )
+    hidden = torch.tensor([[1.0, 10.0], [2.0, 20.0], [3.0, 30.0], [4.0, 40.0]], requires_grad=True)
     topk_indices = torch.tensor([[0], [2], [1], [2]])
     topk_scores = torch.ones(4, 1)
 
     dispatched, tokens_per_expert, dispatched_probs = dispatcher.dispatch(
-        hidden,
-        topk_scores,
-        topk_indices,
+        hidden, topk_scores, topk_indices
     )
     combined = dispatcher.combine(dispatched)
 

--- a/experimental/lite/tests/unit/primitive/test_parallel_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_parallel_unit.py
@@ -15,7 +15,6 @@ from megatron.lite.primitive.parallel import (
     zigzag_split_for_cp,
 )
 
-
 pytestmark = pytest.mark.mlite
 
 
@@ -62,11 +61,7 @@ def test_pp_layout_marks_stage_boundaries_and_vpp_chunks():
 
 def test_thd_roll_keeps_sequence_boundaries():
     cu_seqlens = torch.tensor([0, 4, 8], dtype=torch.int32)
-    rolled, token_sum = roll_packed_thd_left(
-        torch.arange(8),
-        cu_seqlens_padded=cu_seqlens,
-        dims=0,
-    )
+    rolled, token_sum = roll_packed_thd_left(torch.arange(8), cu_seqlens_padded=cu_seqlens, dims=0)
 
     assert torch.equal(rolled, torch.tensor([1, 2, 3, 0, 5, 6, 7, 0]))
     assert token_sum.item() == 24
@@ -77,11 +72,7 @@ def test_thd_cp_split_and_reconstruct_roundtrip():
     tensor = torch.arange(8)
     parts = [
         split_packed_to_cp_local(
-            tensor,
-            cu_seqlens_padded=cu_seqlens,
-            cp_size=2,
-            cp_rank=rank,
-            dim=0,
+            tensor, cu_seqlens_padded=cu_seqlens, cp_size=2, cp_rank=rank, dim=0
         )
         for rank in range(2)
     ]

--- a/experimental/lite/tests/unit/primitive/test_runtime_config_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_runtime_config_unit.py
@@ -6,7 +6,6 @@ from megatron.lite.runtime import RuntimeConfig, create_runtime
 from megatron.lite.runtime.backends.mlite.config import DebugConfig, MegatronLiteConfig
 from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
 
-
 pytestmark = pytest.mark.mlite
 
 
@@ -60,8 +59,7 @@ def test_mlite_config_from_dict_preserves_parallel_optimizer_and_impl_cfg():
 def test_mlite_config_rejects_num_microbatches_in_backend_config():
     with pytest.raises(ValueError, match="num_microbatches"):
         MegatronLiteConfig.from_dict(
-            "/models/qwen",
-            {"model_name": "qwen3_moe", "num_microbatches": 2},
+            "/models/qwen", {"model_name": "qwen3_moe", "num_microbatches": 2}
         )
 
 

--- a/experimental/lite/tests/unit/primitive/test_training_checkpoint.py
+++ b/experimental/lite/tests/unit/primitive/test_training_checkpoint.py
@@ -111,10 +111,7 @@ def test_distopt_checkpoint_dispatches_to_mcore_distckpt(monkeypatch, tmp_path) 
         saved["checkpoint_dir"] = checkpoint_dir
         saved["kwargs"] = kwargs
 
-    monkeypatch.setattr(
-        "megatron.lite.primitive.ckpt.distckpt.dist_checkpointing.save",
-        fake_save,
-    )
+    monkeypatch.setattr("megatron.lite.primitive.ckpt.distckpt.dist_checkpointing.save", fake_save)
 
     dcp.save_training_checkpoint(model, optimizer, 5, str(tmp_path), use_dcp=True)
 
@@ -150,14 +147,10 @@ def test_distopt_checkpoint_offsets_cover_tp_pp_ep_etp_topology() -> None:
     )
 
     dense_offsets, dense_replica = _rank_offsets_and_replica_id(
-        [Replicate(), Replicate(), Replicate(), Shard(0)],
-        ps,
-        expert=False,
+        [Replicate(), Replicate(), Replicate(), Shard(0)], ps, expert=False
     )
     expert_offsets, expert_replica = _rank_offsets_and_replica_id(
-        [Replicate(), Replicate(), Shard(0), Shard(0)],
-        ps,
-        expert=True,
+        [Replicate(), Replicate(), Shard(0), Shard(0)], ps, expert=True
     )
 
     assert dense_offsets == ((0, 1, 2),)
@@ -169,14 +162,10 @@ def test_distopt_checkpoint_offsets_cover_tp_pp_ep_etp_topology() -> None:
 def test_distopt_replica_id_groups_sharded_axes_by_placement() -> None:
     placements = [Replicate(), Replicate(), Replicate(), Shard(0)]
     rank_offsets0, replica_id0 = _rank_offsets_and_replica_id(
-        placements,
-        ParallelState(tp_size=2, tp_rank=0),
-        expert=False,
+        placements, ParallelState(tp_size=2, tp_rank=0), expert=False
     )
     rank_offsets1, replica_id1 = _rank_offsets_and_replica_id(
-        placements,
-        ParallelState(tp_size=2, tp_rank=1),
-        expert=False,
+        placements, ParallelState(tp_size=2, tp_rank=1), expert=False
     )
 
     assert rank_offsets0 == ((0, 0, 2),)
@@ -219,8 +208,7 @@ def test_distopt_pp_rank_one_model_keys_survive_torch_dist_main_replica_filter()
 
     model_sd = _model_sharded_state_dict(model)
     filtered_sd, _flat_mapping, _rename_mapping = _replace_state_dict_keys_with_sharded_keys(
-        model_sd,
-        keep_only_main_replica=True,
+        model_sd, keep_only_main_replica=True
     )
 
     assert set(filtered_sd) == {"model_pp1.weight", "model_pp1.bias"}
@@ -271,10 +259,7 @@ def test_distopt_checkpoint_loads_from_mcore_distckpt(monkeypatch, tmp_path) -> 
             "optimizer": {"loaded": True},
         }
 
-    monkeypatch.setattr(
-        "megatron.lite.primitive.ckpt.distckpt.dist_checkpointing.load",
-        fake_load,
-    )
+    monkeypatch.setattr("megatron.lite.primitive.ckpt.distckpt.dist_checkpointing.load", fake_load)
 
     step = dcp.load_training_checkpoint(model, optimizer, str(tmp_path / "step_5"), use_dcp=True)
 
@@ -289,8 +274,7 @@ def test_distopt_step_sync_traverses_multi_optimizer_chain_without_optimizer_pro
     class FakeTorchOptimizer:
         def __init__(self, steps):
             self.state = {
-                object(): {"step": torch.tensor(step, dtype=torch.int64)}
-                for step in steps
+                object(): {"step": torch.tensor(step, dtype=torch.int64)} for step in steps
             }
 
     class FakeDistOpt:
@@ -316,7 +300,9 @@ def test_distopt_step_sync_traverses_multi_optimizer_chain_without_optimizer_pro
         assert steps == [max(steps)] * len(steps)
 
 
-def test_runtime_checkpoint_api_passes_current_training_checkpoint_signature(monkeypatch, tmp_path) -> None:
+def test_runtime_checkpoint_api_passes_current_training_checkpoint_signature(
+    monkeypatch, tmp_path
+) -> None:
     calls = {}
 
     def fake_save(model, optimizer, step, path, config, ps, **kwargs):
@@ -342,17 +328,10 @@ def test_runtime_checkpoint_api_passes_current_training_checkpoint_signature(mon
     )
 
     runtime.save_checkpoint(
-        handle,
-        str(tmp_path),
-        global_step=7,
-        save_model=True,
-        save_optimizer=False,
+        handle, str(tmp_path), global_step=7, save_model=True, save_optimizer=False
     )
     loaded_step = runtime.load_checkpoint(
-        handle,
-        str(tmp_path),
-        load_model=False,
-        load_optimizer=True,
+        handle, str(tmp_path), load_model=False, load_optimizer=True
     )
 
     assert calls["save"] == (

--- a/experimental/lite/tests/unit/runtime/test_bridge_backend.py
+++ b/experimental/lite/tests/unit/runtime/test_bridge_backend.py
@@ -95,12 +95,7 @@ def test_bridge_builds_mcore_ddp_config_object(monkeypatch):
     )
 
     ddp_config = _build_ddp_config(
-        BridgeConfig(
-            override_ddp_config={
-                "overlap_grad_reduce": True,
-                "bucket_size": 1024,
-            }
-        )
+        BridgeConfig(override_ddp_config={"overlap_grad_reduce": True, "bucket_size": 1024})
     )
 
     assert isinstance(ddp_config, _FakeDDPConfig)
@@ -165,10 +160,20 @@ def test_bridge_registers_qwen35_moe_compat_aliases(monkeypatch):
     common_utils_mod = types.SimpleNamespace(extract_expert_number_from_param=lambda name: 0)
     gpt_mod = types.SimpleNamespace(GPTModel=object)
 
-    monkeypatch.setitem(sys.modules, "megatron.bridge.models.conversion", types.SimpleNamespace(model_bridge=model_bridge))
-    monkeypatch.setitem(sys.modules, "megatron.bridge.models.conversion.mapping_registry", mapping_registry_mod)
-    monkeypatch.setitem(sys.modules, "megatron.bridge.models.conversion.param_mapping", param_mapping_mod)
-    monkeypatch.setitem(sys.modules, "megatron.bridge.models.qwen.qwen3_next_bridge", qwen_bridge_mod)
+    monkeypatch.setitem(
+        sys.modules,
+        "megatron.bridge.models.conversion",
+        types.SimpleNamespace(model_bridge=model_bridge),
+    )
+    monkeypatch.setitem(
+        sys.modules, "megatron.bridge.models.conversion.mapping_registry", mapping_registry_mod
+    )
+    monkeypatch.setitem(
+        sys.modules, "megatron.bridge.models.conversion.param_mapping", param_mapping_mod
+    )
+    monkeypatch.setitem(
+        sys.modules, "megatron.bridge.models.qwen.qwen3_next_bridge", qwen_bridge_mod
+    )
     monkeypatch.setitem(sys.modules, "megatron.bridge.utils.common_utils", common_utils_mod)
     monkeypatch.setitem(sys.modules, "megatron.core.models.gpt.gpt_model", gpt_mod)
 

--- a/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
+++ b/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 import os
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -16,13 +16,8 @@ from megatron.lite.runtime.backends.mlite.runtime import (
     _apply_attention_backend_env,
     _build_impl_cfg,
 )
-from megatron.lite.runtime.contracts.config import (
-    OptimizerConfig,
-    ParallelConfig,
-    RuntimeConfig,
-)
+from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig, RuntimeConfig
 from megatron.lite.runtime.contracts.handle import ModelHandle
-
 
 pytestmark = pytest.mark.mlite
 
@@ -39,12 +34,7 @@ def test_runtime_config_accepts_mlite_backend_cfg():
     cfg = RuntimeConfig(
         backend="mlite",
         hf_path="/models/Qwen3",
-        backend_cfg={
-            "model_name": "qwen3",
-            "impl": "lite",
-            "tp": 2,
-            "ep": 4,
-        },
+        backend_cfg={"model_name": "qwen3", "impl": "lite", "tp": 2, "ep": 4},
     )
 
     assert cfg.backend == "mlite"
@@ -54,8 +44,7 @@ def test_runtime_config_accepts_mlite_backend_cfg():
 
 def test_mlite_config_defaults_and_parallel_fields():
     cfg = MegatronLiteConfig(
-        model_name="qwen3_moe",
-        parallel=ParallelConfig(tp=4, etp=1, ep=8, pp=2, vpp=2, cp=2),
+        model_name="qwen3_moe", parallel=ParallelConfig(tp=4, etp=1, ep=8, pp=2, vpp=2, cp=2)
     )
 
     assert cfg.model_name == "qwen3_moe"
@@ -92,8 +81,8 @@ def test_mlite_config_from_dict_accepts_optimizer_override_config():
                 "override_optimizer_config": {
                     "fsdp2_use_fp32_master": False,
                     "offload_fraction": 1.0,
-                },
-            },
+                }
+            }
         },
     )
 
@@ -106,12 +95,7 @@ def test_mlite_config_from_dict_accepts_optimizer_override_config():
 def test_mlite_config_from_dict_rejects_num_microbatches():
     with pytest.raises(ValueError, match="num_microbatches"):
         MegatronLiteConfig.from_dict(
-            "/models/Qwen3",
-            {
-                "model_name": "qwen3",
-                "tp": 4,
-                "num_microbatches": 2,
-            },
+            "/models/Qwen3", {"model_name": "qwen3", "tp": 4, "num_microbatches": 2}
         )
 
 
@@ -126,9 +110,7 @@ class _FakeImplConfig:
 def test_build_impl_cfg_backfills_top_level_hf_path_and_runtime_fields():
     proto = type("Proto", (), {"ImplConfig": _FakeImplConfig})
     cfg = MegatronLiteConfig(
-        model_name="qwen3",
-        hf_path="/models/top",
-        attention_backend_override="local",
+        model_name="qwen3", hf_path="/models/top", attention_backend_override="local"
     )
 
     impl_cfg = _build_impl_cfg(proto, cfg)
@@ -142,9 +124,7 @@ def test_build_impl_cfg_backfills_top_level_hf_path_and_runtime_fields():
 def test_build_impl_cfg_preserves_explicit_impl_hf_path():
     proto = type("Proto", (), {"ImplConfig": _FakeImplConfig})
     cfg = MegatronLiteConfig(
-        model_name="qwen3",
-        hf_path="/models/top",
-        impl_cfg={"hf_path": "/models/impl"},
+        model_name="qwen3", hf_path="/models/top", impl_cfg={"hf_path": "/models/impl"}
     )
 
     impl_cfg = _build_impl_cfg(proto, cfg)
@@ -193,11 +173,7 @@ class HookedOptimizer:
 
 def test_runtime_to_prefers_optimizer_specific_offload_hooks():
     optimizer = HookedOptimizer()
-    handle = ModelHandle(
-        model=nn.Linear(2, 2),
-        optimizer=optimizer,
-        _extras={"model_chunks": []},
-    )
+    handle = ModelHandle(model=nn.Linear(2, 2), optimizer=optimizer, _extras={"model_chunks": []})
     runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
 
     runtime.to(handle, "cpu", model=False, optimizer=True, grad=False)
@@ -230,11 +206,7 @@ def test_model_handle_dp_from_parallel_state():
 def test_model_handle_cp_range_and_config_properties():
     cfg = {"tp": 8, "ep": 4}
     default_handle = ModelHandle(model=MagicMock())
-    configured_handle = ModelHandle(
-        model=MagicMock(),
-        config=cfg,
-        _extras={"cp_range": (1, 8)},
-    )
+    configured_handle = ModelHandle(model=MagicMock(), config=cfg, _extras={"cp_range": (1, 8)})
 
     assert default_handle.cp_range == (1, 1)
     assert configured_handle.cp_range == (1, 8)
@@ -248,9 +220,7 @@ def test_runtime_dispatch_creates_mlite_backend():
 
         runtime = create_runtime(
             RuntimeConfig(
-                backend="mlite",
-                hf_path="/models/test",
-                backend_cfg={"model_name": "qwen3"},
+                backend="mlite", hf_path="/models/test", backend_cfg={"model_name": "qwen3"}
             )
         )
 
@@ -279,13 +249,7 @@ def _run_verl_sft_dry_run(script: Path, tmp_path: Path, **env_overrides: str) ->
         "ETP_SIZE": "1",
         **env_overrides,
     }
-    completed = subprocess.run(
-        [str(script)],
-        env=env,
-        text=True,
-        capture_output=True,
-        check=True,
-    )
+    completed = subprocess.run([str(script)], env=env, text=True, capture_output=True, check=True)
     return completed.stdout
 
 
@@ -322,10 +286,7 @@ def test_verl_sft_script_does_not_emit_optimizer_state_offload_when_disabled(tmp
     )
 
     command = _run_verl_sft_dry_run(
-        script,
-        tmp_path,
-        PARAM_OFFLOAD="False",
-        OPTIMIZER_OFFLOAD="False",
+        script, tmp_path, PARAM_OFFLOAD="False", OPTIMIZER_OFFLOAD="False"
     )
 
     assert "engine.param_offload=False" in command

--- a/experimental/lite/tests/unit/verl/test_mlite_engine_checkpoint.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_engine_checkpoint.py
@@ -2,7 +2,6 @@ from types import SimpleNamespace
 
 import pytest
 import torch
-
 from verl_mlite.engine.config import MegatronLiteEngineConfig
 from verl_mlite.engine.mlite_engine import MegatronLiteEngine
 

--- a/experimental/lite/tests/unit/verl/test_mlite_engine_config.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_engine_config.py
@@ -28,15 +28,11 @@ def _optimizer_config(**override_optimizer_config) -> SimpleNamespace:
 
 
 def _engine(
-    *,
-    engine_config: MegatronLiteEngineConfig,
-    optimizer_config: SimpleNamespace | None = None,
+    *, engine_config: MegatronLiteEngineConfig, optimizer_config: SimpleNamespace | None = None
 ) -> MegatronLiteEngine:
     return MegatronLiteEngine(
         model_config=SimpleNamespace(
-            local_path="/tmp/qwen35",
-            hf_config={"model_type": "qwen3_5_moe"},
-            mtp=None,
+            local_path="/tmp/qwen35", hf_config={"model_type": "qwen3_5_moe"}, mtp=None
         ),
         engine_config=engine_config,
         optimizer_config=optimizer_config or _optimizer_config(),
@@ -54,8 +50,7 @@ def test_optimizer_offload_enables_full_optimizer_state_offload_by_default() -> 
     engine = _engine(
         engine_config=_engine_config(optimizer_offload=True),
         optimizer_config=_optimizer_config(
-            use_precision_aware_optimizer=True,
-            decoupled_weight_decay=True,
+            use_precision_aware_optimizer=True, decoupled_weight_decay=True
         ),
     )
 
@@ -101,7 +96,7 @@ def test_mlite_config_threads_rl_parallel_and_impl_settings() -> None:
             optimizer_offload=True,
             attention_backend_override="flash",
             impl_cfg={"use_thd": True, "deterministic": False},
-        ),
+        )
     )
 
     config = engine._build_mlite_config()


### PR DESCRIPTION
## Summary
- Add a Megatron Lite-local pre-commit config for pinned isort/black formatting without changing repository-root hooks.
- Apply isort/black formatting across `experimental/lite` and remove unused LoRA export locals.
- Remove the redundant internal FSDP2 optimizer DTensor-state offload knob while preserving the existing always-offload behavior.
- Re-export Qwen checkpoint hook names explicitly and cover the export surface in unit tests.

## Validation
- `pre-commit run -c experimental/lite/.pre-commit-config.yaml --all-files`
- `python -m ruff check --select F401,F841 experimental/lite`
- `git diff --check`
- `PYTHONPATH="$(pwd):$(pwd)/experimental/lite" pytest experimental/lite/tests/unit` (`151 passed, 3 skipped`)
- Slurm job `12684271`: container unit suite `154 passed`; 8-GPU smoke suite completed on all ranks with `8 passed, 1 xfailed` (known FSDP2 offload_fraction multi-rank grad clipping follow-up).
