### PR TITLE
Fix FSDP2 offload grad clipping on multi-rank

### DIFF
--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from megatron.lite.primitive.optimizers.fsdp2.grad_clip import (
+    all_reduce_scalar_,
     clip_grads_with_sharded_norm_,
     resolve_torch_dtype,
     sharded_grad_abs_max,
@@ -33,6 +34,7 @@ __all__ = [
     "FSDP2Config",
     "FSDP2Optimizer",
     "FSDP2OptimizerBackend",
+    "all_reduce_scalar_",
     "build_fsdp2_adamw",
     "build_fsdp2_training_optimizer",
     "build_fsdp2_device_mesh",

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/grad_clip.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/grad_clip.py
@@ -77,7 +77,7 @@ def sharded_grad_norm(
         raise ValueError(f"sharded_grad_norm supports norm_type=2.0 or inf, got {norm_type!r}.")
     sq_sum = sharded_grad_sq_sum(params, accum_dtype=accum_dtype, default_device=default_device)
     if pp_group is not None and dist.is_initialized() and dist.get_world_size(pp_group) > 1:
-        dist.all_reduce(sq_sum, op=dist.ReduceOp.SUM, group=pp_group)
+        all_reduce_scalar_(sq_sum, op=dist.ReduceOp.SUM, group=pp_group)
     return sq_sum.sqrt()
 
 
@@ -103,8 +103,22 @@ def sharded_grad_abs_max(
     if total is None:
         total = torch.zeros((), device=default_device or torch.device("cpu"), dtype=dtype)
     if pp_group is not None and dist.is_initialized() and dist.get_world_size(pp_group) > 1:
-        dist.all_reduce(total, op=dist.ReduceOp.MAX, group=pp_group)
+        all_reduce_scalar_(total, op=dist.ReduceOp.MAX, group=pp_group)
     return total
+
+
+def all_reduce_scalar_(
+    value: torch.Tensor,
+    *,
+    op: dist.ReduceOp,
+    group: dist.ProcessGroup,
+) -> None:
+    """All-reduce a scalar on a device compatible with the process group backend."""
+
+    reduced = _scalar_for_process_group(value, group)
+    dist.all_reduce(reduced, op=op, group=group)
+    if reduced is not value:
+        value.copy_(reduced.to(device=value.device, dtype=value.dtype))
 
 
 @torch.no_grad()
@@ -285,12 +299,33 @@ def _reduce_dtensor_scalar_(
         group = dtensor.device_mesh.get_group(mesh_dim)
         if dist.get_world_size(group) > 1:
             if scalar_all_reduce is None:
-                dist.all_reduce(value, op=op, group=group)
+                all_reduce_scalar_(value, op=op, group=group)
             else:
                 scalar_all_reduce(value, group, op)
 
 
+def _scalar_for_process_group(
+    value: torch.Tensor, group: dist.ProcessGroup
+) -> torch.Tensor:
+    backend = _process_group_backend(group)
+    if "nccl" in backend and value.device.type != "cuda":
+        if not torch.cuda.is_available():
+            raise RuntimeError("NCCL scalar all_reduce requires a CUDA tensor.")
+        return value.to(device=torch.device("cuda", torch.cuda.current_device()))
+    if "gloo" in backend and value.device.type != "cpu":
+        return value.to(device=torch.device("cpu"))
+    return value
+
+
+def _process_group_backend(group: dist.ProcessGroup) -> str:
+    try:
+        return str(dist.get_backend(group)).lower()
+    except (RuntimeError, ValueError, TypeError):
+        return ""
+
+
 __all__ = [
+    "all_reduce_scalar_",
     "clip_grads_with_sharded_norm_",
     "resolve_torch_dtype",
     "sharded_grad_abs_max",

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/optimizer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/optimizer.py
@@ -21,6 +21,7 @@ from megatron.lite.primitive.optimizers.fsdp2.adamw import (
     local_grad_sq_sum,
 )
 from megatron.lite.primitive.optimizers.fsdp2.grad_clip import (
+    all_reduce_scalar_,
     clip_grads_with_sharded_norm_,
     resolve_torch_dtype,
     sharded_grad_sq_sum,
@@ -192,7 +193,7 @@ class FSDP2Optimizer:
             and dist.is_initialized()
             and dist.get_world_size(plain_sharded_group) > 1
         ):
-            dist.all_reduce(plain_sharded_sq, op=dist.ReduceOp.SUM, group=plain_sharded_group)
+            all_reduce_scalar_(plain_sharded_sq, op=dist.ReduceOp.SUM, group=plain_sharded_group)
         total_sq = total_sq.to(plain_sharded_sq.device) + plain_sharded_sq
         if (
             self.ps is not None
@@ -200,7 +201,7 @@ class FSDP2Optimizer:
             and dist.is_initialized()
             and dist.get_world_size(self.ps.tp_group) > 1
         ):
-            dist.all_reduce(total_sq, op=dist.ReduceOp.SUM, group=self.ps.tp_group)
+            all_reduce_scalar_(total_sq, op=dist.ReduceOp.SUM, group=self.ps.tp_group)
 
         tp_replicated_sq = sharded_grad_sq_sum(
             self.tp_replicated_grad_params,
@@ -217,7 +218,7 @@ class FSDP2Optimizer:
             and dist.is_initialized()
             and dist.get_world_size(self.replicated_grad_norm_group) > 1
         ):
-            dist.all_reduce(
+            all_reduce_scalar_(
                 replicated_sq, op=dist.ReduceOp.SUM, group=self.replicated_grad_norm_group
             )
 
@@ -231,8 +232,10 @@ class FSDP2Optimizer:
             and dist.is_initialized()
             and dist.get_world_size(self.expert_sharded_grad_norm_group) > 1
         ):
-            dist.all_reduce(
-                expert_sharded_sq, op=dist.ReduceOp.SUM, group=self.expert_sharded_grad_norm_group
+            all_reduce_scalar_(
+                expert_sharded_sq,
+                op=dist.ReduceOp.SUM,
+                group=self.expert_sharded_grad_norm_group,
             )
 
         total_sq = (
@@ -247,7 +250,7 @@ class FSDP2Optimizer:
             and dist.is_initialized()
             and dist.get_world_size(self.ps.pp_group) > 1
         ):
-            dist.all_reduce(total_sq, op=dist.ReduceOp.SUM, group=self.ps.pp_group)
+            all_reduce_scalar_(total_sq, op=dist.ReduceOp.SUM, group=self.ps.pp_group)
 
         grad_norm = total_sq.sqrt()
         if torch.isfinite(grad_norm):

--- a/experimental/lite/tests/README.md
+++ b/experimental/lite/tests/README.md
@@ -40,7 +40,7 @@ Current matrix:
 | Checkpoint restore vs direct training | `unit/primitive/test_checkpoint_unit.py`, `unit/primitive/test_checkpoint_runtime.py` | FSDP2 and distopt checkpoint smokes cover distributed restore paths |
 | Runtime backend registry/config | `unit/primitive/test_runtime_config_unit.py`, `unit/runtime/test_runtime_backend_unit.py` | covered through checkpoint/model handles |
 | Runtime env/offload controls | `unit/runtime/test_runtime_backend_unit.py` | `smoke/primitive/test_fsdp2_offload_checkpoint_smoke.py` |
-| Optimizer update-state offload fraction | `unit/primitive/test_runtime_config_unit.py` and single-process CUDA coverage in `unit/primitive/test_fsdp2_offload_gpu.py` | multi-rank FSDP2 grad clipping is xfail until the follow-up bugfix PR |
+| Optimizer update-state offload fraction | `unit/primitive/test_runtime_config_unit.py` and single-process CUDA coverage in `unit/primitive/test_fsdp2_offload_gpu.py` | multi-rank offloaded grad clipping is checked against the non-offloaded baseline in `smoke/primitive/test_fsdp2_offload_checkpoint_smoke.py` |
 | Qwen3 MoE lite config/build/forward | `unit/model/test_qwen_config_unit.py` | `smoke/model/test_qwen_lite_forward_smoke.py` |
 | Qwen3.5 MoE lite config/build/forward | `unit/model/test_qwen_config_unit.py` | `smoke/model/test_qwen_lite_forward_smoke.py` |
 

--- a/experimental/lite/tests/smoke/primitive/test_fsdp2_offload_checkpoint_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_fsdp2_offload_checkpoint_smoke.py
@@ -138,7 +138,7 @@ def _optimizer_state_devices(optimizer) -> set[str]:
 
 def _local_named_params(model: nn.Module) -> dict[str, torch.Tensor]:
     return {
-        name: to_local_tensor(param.detach()).cpu().float().clone()
+        name: to_local_tensor(param.detach()).cpu().clone()
         for name, param in model.named_parameters()
     }
 
@@ -150,7 +150,11 @@ def _train_step(model: nn.Module, optimizer, x: torch.Tensor, target: torch.Tens
     success, grad_norm, _ = optimizer.step()
     assert success
     assert torch.isfinite(torch.tensor(grad_norm))
-    return loss.detach()
+    return loss.detach(), float(grad_norm)
+
+
+def _assert_grad_norm_exact(lhs: float, rhs: float) -> None:
+    assert lhs == rhs
 
 
 def _assert_local_params_close(lhs: nn.Module, rhs: nn.Module):
@@ -181,23 +185,36 @@ def test_fsdp2_runtime_model_and_optimizer_offload_roundtrip_single_node():
     assert _optimizer_state_devices(optimizer) == {"cuda"}
 
 
-@pytest.mark.xfail(
-    int(os.environ.get("WORLD_SIZE", "1")) > 1,
-    reason="MLite FSDP2 offload_fraction multi-rank grad clipping is covered by a follow-up bugfix PR.",
-    strict=True,
-)
-def test_fsdp2_offload_fraction_keeps_optimizer_update_state_on_cpu_single_node():
-    model, ps = _build_fsdp2_model()
-    optimizer = _build_optimizer(model, ps, offload_fraction=1.0)
+def test_fsdp2_offload_fraction_matches_non_offloaded_grad_clip_single_node():
+    if dist.get_world_size() < 2:
+        pytest.skip(
+            "multi-rank FSDP2 grad clipping equivalence requires WORLD_SIZE > 1."
+        )
 
-    assert _optimizer_state_devices(optimizer) == {"cpu"}
+    baseline_model, baseline_ps = _build_fsdp2_model()
+    baseline_optimizer = _build_optimizer(
+        baseline_model, baseline_ps, offload_fraction=0.0
+    )
+    offload_model, offload_ps = _build_fsdp2_model()
+    offload_optimizer = _build_optimizer(
+        offload_model, offload_ps, offload_fraction=1.0
+    )
 
+    assert _optimizer_state_devices(baseline_optimizer) == {"cuda"}
+    assert _optimizer_state_devices(offload_optimizer) == {"cpu"}
+
+    torch.manual_seed(4321)
     x = torch.randn(4, 8, device="cuda", dtype=torch.bfloat16)
     target = torch.randn(4, 4, device="cuda", dtype=torch.bfloat16)
-    _train_step(model, optimizer, x, target)
+    _loss, baseline_grad_norm = _train_step(
+        baseline_model, baseline_optimizer, x, target
+    )
+    _loss, offload_grad_norm = _train_step(offload_model, offload_optimizer, x, target)
 
-    assert _local_param_devices(model) == {"cuda"}
-    assert _optimizer_state_devices(optimizer) == {"cpu"}
+    _assert_grad_norm_exact(offload_grad_norm, baseline_grad_norm)
+    _assert_local_params_close(offload_model, baseline_model)
+    assert _local_param_devices(offload_model) == {"cuda"}
+    assert _optimizer_state_devices(offload_optimizer) == {"cpu"}
 
 
 def test_fsdp2_checkpoint_load_matches_uninterrupted_training_single_node(tmp_path):

--- a/experimental/lite/tests/unit/primitive/test_fsdp2_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_fsdp2_unit.py
@@ -6,11 +6,13 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 
 from megatron.lite.primitive.optimizers.fsdp2 import (
     FSDP2Config,
     FSDP2Optimizer,
+    all_reduce_scalar_,
     clip_grads_with_sharded_norm_,
     fsdp2_available,
 )
@@ -22,6 +24,7 @@ pytestmark = pytest.mark.mlite
 
 fsdp2_wrap = importlib.import_module("megatron.lite.primitive.optimizers.fsdp2.wrap")
 fsdp2_optimizer = importlib.import_module("megatron.lite.primitive.optimizers.fsdp2.optimizer")
+fsdp2_grad_clip = importlib.import_module("megatron.lite.primitive.optimizers.fsdp2.grad_clip")
 
 
 class ToyBlock(nn.Module):
@@ -286,6 +289,85 @@ def test_clip_grads_with_sharded_norm_scales_cpu_grads_once():
     scale = 6.5 / (13.0 + 1.0e-6)
     torch.testing.assert_close(p0.grad, torch.tensor([3.0, 4.0]) * scale)
     torch.testing.assert_close(p1.grad, torch.tensor([0.0, 12.0]) * scale)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for NCCL scalar test.")
+def test_all_reduce_scalar_moves_cpu_value_to_nccl_device(monkeypatch):
+    group = object()
+    reduced_devices: list[str] = []
+
+    def fake_all_reduce(value, *, op, group):
+        assert group is fake_all_reduce.group
+        assert op == dist.ReduceOp.SUM
+        reduced_devices.append(value.device.type)
+        value.add_(5.0)
+
+    fake_all_reduce.group = group
+    monkeypatch.setattr(fsdp2_grad_clip.dist, "get_backend", lambda _group: "nccl")
+    monkeypatch.setattr(fsdp2_grad_clip.dist, "all_reduce", fake_all_reduce)
+
+    value = torch.tensor(7.0)
+    all_reduce_scalar_(value, op=dist.ReduceOp.SUM, group=group)
+
+    assert reduced_devices == ["cuda"]
+    assert value.device.type == "cpu"
+    torch.testing.assert_close(value, torch.tensor(12.0))
+
+
+def test_fsdp2_optimizer_uses_scalar_all_reduce_for_all_norm_groups(monkeypatch):
+    groups = SimpleNamespace(
+        dp_cp=object(),
+        tp=object(),
+        replicated=object(),
+        expert=object(),
+        pp=object(),
+    )
+    reduced_groups: list[object] = []
+
+    def fake_all_reduce_scalar(value, *, op, group):
+        assert value.ndim == 0
+        assert op == dist.ReduceOp.SUM
+        reduced_groups.append(group)
+
+    monkeypatch.setattr(fsdp2_optimizer, "all_reduce_scalar_", fake_all_reduce_scalar)
+    monkeypatch.setattr(fsdp2_optimizer.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(fsdp2_optimizer.dist, "get_world_size", lambda _group: 2)
+
+    sharded = nn.Parameter(torch.tensor([1.0]))
+    replicated = nn.Parameter(torch.tensor([1.0]))
+    expert = nn.Parameter(torch.tensor([1.0]))
+    tp_replicated = nn.Parameter(torch.tensor([1.0]))
+    sharded.grad = torch.tensor([2.0])
+    replicated.grad = torch.tensor([3.0])
+    expert.grad = torch.tensor([4.0])
+    tp_replicated.grad = torch.tensor([5.0])
+
+    optimizer = FSDP2Optimizer(
+        torch.optim.SGD([sharded, replicated, expert, tp_replicated], lr=0.0),
+        [sharded, replicated, expert, tp_replicated],
+        ParallelState(
+            dp_cp_group=groups.dp_cp,
+            tp_group=groups.tp,
+            pp_group=groups.pp,
+        ),
+        clip_grad=100.0,
+        replicated_grad_params=[replicated],
+        replicated_grad_norm_group=groups.replicated,
+        expert_sharded_grad_params=[expert],
+        expert_sharded_grad_norm_group=groups.expert,
+        tp_replicated_grad_params=[tp_replicated],
+    )
+
+    assert optimizer.clip_grad_norm() == pytest.approx(
+        (2.0**2 + 3.0**2 + 4.0**2 + 5.0**2) ** 0.5
+    )
+    assert reduced_groups == [
+        groups.dp_cp,
+        groups.tp,
+        groups.replicated,
+        groups.expert,
+        groups.pp,
+    ]
 
 
 def test_fp32_adamw_state_dict_roundtrip_cpu():


### PR DESCRIPTION
## Summary
- Route FSDP2 scalar grad-norm all-reduces through a backend-aware helper so CPU accumulators are reduced on CUDA for NCCL groups.
- Cover optimizer dp/tp/replicated/expert/pp reductions plus grad_clip DTensor/pp reductions.
- Add a multi-rank offload_fraction=1.0 vs offload_fraction=0.0 smoke check with exact grad-norm and parameter equality after the clipped step.
- Update the MLite test matrix now that multi-rank offloaded grad clipping is no longer xfail-only coverage.

## Validation
- `PYTHONPATH="$PWD:$PWD/experimental/lite:${PYTHONPATH:-}" PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q experimental/lite/tests/unit/primitive/test_fsdp2_unit.py` (20 passed, 1 skipped)
- `git diff --check is/devlite...HEAD`
- Slurm job 12685815: 2-GPU H100 torchrun smoke, `test_fsdp2_offload_fraction_matches_non_offloaded_grad_clip_single_node`, COMPLETED rc=0 by sacct, both ranks 1 passed.