### PR TITLE
Add MLite Python copyright headers

### DIFF
--- a/experimental/lite/examples/__init__.py
+++ b/experimental/lite/examples/__init__.py
@@ -1,1 +1,2 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Megatron Lite examples package."""

--- a/experimental/lite/examples/bench/__init__.py
+++ b/experimental/lite/examples/bench/__init__.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Benchmark example for Megatron Lite runtime backends."""
 
 from .results import RunResult, StepTrace

--- a/experimental/lite/examples/bench/bench.py
+++ b/experimental/lite/examples/bench/bench.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Benchmark MLite and reference runtime backends.
 
 Run from the Megatron-LM repo root after adding ``experimental/lite`` to

--- a/experimental/lite/examples/bench/correctness.py
+++ b/experimental/lite/examples/bench/correctness.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Deterministic correctness runner for MLite and reference backends."""
 
 from __future__ import annotations

--- a/experimental/lite/examples/bench/results.py
+++ b/experimental/lite/examples/bench/results.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Benchmark result dataclasses."""
 
 from __future__ import annotations

--- a/experimental/lite/examples/bench/session.py
+++ b/experimental/lite/examples/bench/session.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Small pretrain benchmark session composed from runtime atoms."""
 
 from __future__ import annotations

--- a/experimental/lite/examples/verl/sitecustomize.py
+++ b/experimental/lite/examples/verl/sitecustomize.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Process-wide compatibility hooks for the VERL MLite examples."""
 
 from verl_mlite.compat import apply_runtime_patches

--- a/experimental/lite/examples/verl/verl_mlite/__init__.py
+++ b/experimental/lite/examples/verl/verl_mlite/__init__.py
@@ -1,1 +1,2 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """VERL integration package for Megatron Lite."""

--- a/experimental/lite/examples/verl/verl_mlite/compat.py
+++ b/experimental/lite/examples/verl/verl_mlite/compat.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Small compatibility patches for dependency-version gaps in examples."""
 
 from __future__ import annotations

--- a/experimental/lite/examples/verl/verl_mlite/config/__init__.py
+++ b/experimental/lite/examples/verl/verl_mlite/config/__init__.py
@@ -1,1 +1,2 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Hydra config package for Verl MLite."""

--- a/experimental/lite/examples/verl/verl_mlite/config/actor/__init__.py
+++ b/experimental/lite/examples/verl/verl_mlite/config/actor/__init__.py
@@ -1,1 +1,2 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Hydra actor config group for Verl MLite."""

--- a/experimental/lite/examples/verl/verl_mlite/config/engine/__init__.py
+++ b/experimental/lite/examples/verl/verl_mlite/config/engine/__init__.py
@@ -1,1 +1,2 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Engine config group for Verl MLite."""

--- a/experimental/lite/examples/verl/verl_mlite/engine/__init__.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/__init__.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Engine entrypoints for Verl MLite."""
 
 from verl_mlite.engine.mlite_engine import MegatronLiteEngine

--- a/experimental/lite/examples/verl/verl_mlite/engine/config.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/config.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Config objects for the Verl MLite Megatron Lite engine."""
 
 from __future__ import annotations

--- a/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """External VERL engine backed by Megatron Lite runtime primitives."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/__init__.py
+++ b/experimental/lite/megatron/lite/__init__.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Top-level Megatron Lite package exports."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/model/__init__.py
+++ b/experimental/lite/megatron/lite/model/__init__.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Public model-registry helpers for Megatron Lite."""
 
 from megatron.lite.model.registry import (

--- a/experimental/lite/megatron/lite/model/qwen3_5/__init__.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/__init__.py
@@ -1,1 +1,2 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Qwen3.5 model package."""

--- a/experimental/lite/megatron/lite/model/qwen3_5/config.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/config.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Qwen3.5 model configuration."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/__init__.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/__init__.py
@@ -1,1 +1,2 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Qwen3.5 lite native sub-package."""

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/checkpoint.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Qwen3.5 lite native checkpoint mapping.
 
 The loader reads HF safetensors directly into lite's native module names.

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Qwen3.5 lite native model.
 
 This implementation keeps the lightweight qwen3_moe/lite composition style

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Qwen3.5 lite impl — native model protocol for Megatron Lite runtime."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/model/qwen3_5/stats.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/stats.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Model-level Qwen3.5 benchmark statistics."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/model/qwen3_moe/__init__.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/__init__.py
@@ -1,1 +1,2 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """qwen3_moe model package for Megatron Lite."""

--- a/experimental/lite/megatron/lite/model/qwen3_moe/common.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/common.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Shared Qwen3MoE model helpers."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/model/qwen3_moe/config.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/config.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Qwen3MoE model configuration — pure architecture parameters.
 
 Like HuggingFace's model config: only describes the model architecture.

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/__init__.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/__init__.py
@@ -1,1 +1,2 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Native Qwen3MoE implementation."""

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/checkpoint.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Qwen3MoE WeightSpec — name mapping + format conversion.
 
 Orchestration (TP scatter, EP sharding, PP remap) lives in

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/lora_adapter.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/lora_adapter.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """PEFT adapter import/export for Qwen3-MoE lite native LoRA."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Native Qwen3MoE: TransformerLayer + Qwen3MoEModel.
 
 Attention and MoE come from primitive/modules; this file only

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Qwen3MoE lite impl — model protocol for Megatron Lite runtime.
 
 This file is the reference implementation of the Megatron Lite model protocol.

--- a/experimental/lite/megatron/lite/model/qwen3_moe/stats.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/stats.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Model-level Qwen3MoE benchmark statistics."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/model/registry.py
+++ b/experimental/lite/megatron/lite/model/registry.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Model and protocol registry."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/primitive/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/__init__.py
@@ -1,1 +1,2 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Public primitive-layer entrypoints."""

--- a/experimental/lite/megatron/lite/primitive/bundle.py
+++ b/experimental/lite/megatron/lite/primitive/bundle.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """ModelBundle — return type of protocol.build_model()."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/primitive/ckpt/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/__init__.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Checkpoint helpers."""
 
 from megatron.lite.primitive.ckpt.dcp import load_training_checkpoint, save_training_checkpoint

--- a/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """
 DCP (Distributed Checkpoint) framework for training checkpoints.
 

--- a/experimental/lite/megatron/lite/primitive/ckpt/distckpt.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/distckpt.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Megatron Core distributed checkpoint bridge for MLite distopt."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """HF ↔ Megatron Lite weight conversion.
 
 Everything needed for HuggingFace safetensors ↔ Megatron Lite model conversion:

--- a/experimental/lite/megatron/lite/primitive/config.py
+++ b/experimental/lite/megatron/lite/primitive/config.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Configuration utilities.
 
 Model-specific configs live under `megatron.lite/models/*/config.py`

--- a/experimental/lite/megatron/lite/primitive/data.py
+++ b/experimental/lite/megatron/lite/primitive/data.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Batch generation utilities for Megatron Lite runtime."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/primitive/deterministic.py
+++ b/experimental/lite/megatron/lite/primitive/deterministic.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Deterministic computation utilities for bitwise reproducible experiments."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/primitive/modules/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/modules/__init__.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Shared model modules owned by Megatron Lite."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
+++ b/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Token dispatcher: AllToAll and DeepEP dispatch/combine."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/primitive/modules/experts.py
+++ b/experimental/lite/megatron/lite/primitive/modules/experts.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """MoE expert compute: SwiGLU fusions, _AllReduceETP, and Experts."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Qwen-style Gated DeltaNet primitive."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/primitive/modules/gqa.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gqa.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Grouped Query Attention + Rotary Embedding (MC-atoms).
 
 Model-agnostic: takes explicit params instead of model-specific config.

--- a/experimental/lite/megatron/lite/primitive/modules/gqa_utils.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gqa_utils.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Pure grouped-query attention helpers."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/primitive/modules/lora.py
+++ b/experimental/lite/megatron/lite/primitive/modules/lora.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """LoRA helpers for Megatron Lite native model implementations.
 
 This module is intentionally narrow: it supports the Qwen3-MoE lite path's

--- a/experimental/lite/megatron/lite/primitive/modules/moe.py
+++ b/experimental/lite/megatron/lite/primitive/modules/moe.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Shared MoE utilities: _AllToAll and MoEAuxLossAutoScaler.
 
 Extracted from models/*/moe.py (Level 0 Option C — pure extraction, no behavior change).

--- a/experimental/lite/megatron/lite/primitive/modules/mrope.py
+++ b/experimental/lite/megatron/lite/primitive/modules/mrope.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Multimodal rotary embedding primitive."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/primitive/modules/mtp.py
+++ b/experimental/lite/megatron/lite/primitive/modules/mtp.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Multi-token prediction primitives."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/primitive/modules/router.py
+++ b/experimental/lite/megatron/lite/primitive/modules/router.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """MoE router implementations: TopKRouter (softmax) and SigmoidTopKRouter.
 
 Internals call the atomic free functions in Megatron-Core's

--- a/experimental/lite/megatron/lite/primitive/ops/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/ops/__init__.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Runtime math primitives for Megatron Lite."""
 
 from megatron.lite.primitive.ops.cross_entropy import vocab_parallel_cross_entropy

--- a/experimental/lite/megatron/lite/primitive/ops/cross_entropy.py
+++ b/experimental/lite/megatron/lite/primitive/ops/cross_entropy.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Vocab-parallel cross entropy loss (copied from Megatron-Core).
 
 Computes cross entropy when logits are split across TP ranks.

--- a/experimental/lite/megatron/lite/primitive/ops/gated_delta_rule.py
+++ b/experimental/lite/megatron/lite/primitive/ops/gated_delta_rule.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Gated Delta Rule math helpers."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/primitive/ops/linear_cross_entropy.py
+++ b/experimental/lite/megatron/lite/primitive/ops/linear_cross_entropy.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Linear + vocab-parallel cross entropy helpers.
 
 The fast path delegates to VERL's Triton-backed fused kernel when available.

--- a/experimental/lite/megatron/lite/primitive/ops/logprob.py
+++ b/experimental/lite/megatron/lite/primitive/ops/logprob.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Probability-first primitives for Megatron Lite phase 1."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/primitive/ops/sp_ops.py
+++ b/experimental/lite/megatron/lite/primitive/ops/sp_ops.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Sequence-parallel autograd primitives for non-TE layers (embedding, scatter/gather).
 
 AllGather/ReduceScatter operate on the sequence dimension (dim 0) with layout

--- a/experimental/lite/megatron/lite/primitive/optimizers/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/__init__.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Optimizer backend registry."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/__init__.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """FSDP2 primitive surface."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/adamw.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/adamw.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """AdamW helpers for the FSDP2 optimizer primitive."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/grad_clip.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/grad_clip.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Sharded gradient norm and clipping primitive for FSDP2 optimizers."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/optimizer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/optimizer.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """FSDP2 optimizer adapter for Megatron Lite runtime contracts."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/state.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/state.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Optimizer state movement helpers for the FSDP2 primitive."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/wrap.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/wrap.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """PyTorch FSDP2 wrapping primitive.
 
 This module is intentionally independent from Megatron Lite model and runtime

--- a/experimental/lite/megatron/lite/primitive/optimizers/megatron_wrap.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/megatron_wrap.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Megatron-Core optimizer wrap backend for Megatron Lite."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/primitive/parallel/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/__init__.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Megatron Lite-owned parallel runtime exports."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/primitive/parallel/cp.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/cp.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Context parallel zigzag sequence splitting helpers."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/primitive/parallel/linear.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/linear.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """TP-parallel linear layers and vocab-parallel embedding/output."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/primitive/parallel/pipeline.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/pipeline.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Pipeline parallel: 1F1B schedule with correct backward handling."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/primitive/parallel/pp.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/pp.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Context/pipeline parallel sequence splitting utilities."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/primitive/parallel/sp.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/sp.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Sequence parallel scatter/gather helpers."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/primitive/parallel/state.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/state.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """ParallelState and process group initialization."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/primitive/parallel/thd.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/thd.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Packed sequence helpers for variable-length (THD) attention."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/primitive/protocols.py
+++ b/experimental/lite/megatron/lite/primitive/protocols.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Train-side lightweight protocols and defaults."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/primitive/recompute.py
+++ b/experimental/lite/megatron/lite/primitive/recompute.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Model-agnostic activation recompute and offload wrappers."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/primitive/train_step.py
+++ b/experimental/lite/megatron/lite/primitive/train_step.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Reusable train-step primitives owned by Megatron Lite."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/primitive/utils.py
+++ b/experimental/lite/megatron/lite/primitive/utils.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from __future__ import annotations
 
 import torch  # pyright: ignore[reportMissingImports]

--- a/experimental/lite/megatron/lite/runtime/__init__.py
+++ b/experimental/lite/megatron/lite/runtime/__init__.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Runtime entrypoints for Megatron Lite."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/runtime/backends/__init__.py
+++ b/experimental/lite/megatron/lite/runtime/backends/__init__.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Runtime ABC and registry.
 
 Runtime API tiers

--- a/experimental/lite/megatron/lite/runtime/backends/bridge/__init__.py
+++ b/experimental/lite/megatron/lite/runtime/backends/bridge/__init__.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Megatron-Bridge backend for the Megatron Lite runtime API."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/runtime/backends/bridge/config.py
+++ b/experimental/lite/megatron/lite/runtime/backends/bridge/config.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Megatron-Bridge backend configuration."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/runtime/backends/bridge/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/bridge/runtime.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Runtime backend backed by Megatron-Bridge."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/runtime/backends/mbridge/__init__.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mbridge/__init__.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """mbridge backend for the Megatron Lite runtime API."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/runtime/backends/mbridge/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mbridge/runtime.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Runtime backend backed by the legacy ``mbridge`` package."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/__init__.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/__init__.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Megatron Lite backend — Megatron Lite's own training engine."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/config.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/config.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Megatron Lite backend configuration."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """MegatronLiteRuntime — Megatron Lite's default training backend."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/runtime/contracts/__init__.py
+++ b/experimental/lite/megatron/lite/runtime/contracts/__init__.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Lazy re-export hub for ``megatron.lite.runtime.contracts``.
 
 This preserves imports like ``from megatron.lite.runtime.contracts import X`` while

--- a/experimental/lite/megatron/lite/runtime/contracts/config.py
+++ b/experimental/lite/megatron/lite/runtime/contracts/config.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Shared runtime configuration for Megatron Lite."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/runtime/contracts/data.py
+++ b/experimental/lite/megatron/lite/runtime/contracts/data.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Data contracts — forward_backward input/output types."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/runtime/contracts/handle.py
+++ b/experimental/lite/megatron/lite/runtime/contracts/handle.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """ModelHandle — opaque handle returned by Runtime.build_model()."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/runtime/megatron_utils.py
+++ b/experimental/lite/megatron/lite/runtime/megatron_utils.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Megatron-Core utilities aligned with VERL's megatron_utils.
 
 All functions here are ported from VERL and could theoretically be replaced

--- a/experimental/lite/tests/conftest.py
+++ b/experimental/lite/tests/conftest.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from __future__ import annotations
 
 import os

--- a/experimental/lite/tests/smoke/model/test_qwen_lite_forward_smoke.py
+++ b/experimental/lite/tests/smoke/model/test_qwen_lite_forward_smoke.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from __future__ import annotations
 
 import os

--- a/experimental/lite/tests/smoke/primitive/test_distopt_checkpoint_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_distopt_checkpoint_smoke.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from __future__ import annotations
 
 import os

--- a/experimental/lite/tests/smoke/primitive/test_fsdp2_offload_checkpoint_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_fsdp2_offload_checkpoint_smoke.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from __future__ import annotations
 
 import os

--- a/experimental/lite/tests/smoke/primitive/test_parallel_topologies_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_parallel_topologies_smoke.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from __future__ import annotations
 
 import os

--- a/experimental/lite/tests/smoke/primitive/test_qwen3_moe_distopt_checkpoint_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_qwen3_moe_distopt_checkpoint_smoke.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from __future__ import annotations
 
 import os

--- a/experimental/lite/tests/unit/examples/test_bench_example.py
+++ b/experimental/lite/tests/unit/examples/test_bench_example.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Unit tests for the benchmark example."""
 
 from __future__ import annotations

--- a/experimental/lite/tests/unit/model/test_qwen35_export.py
+++ b/experimental/lite/tests/unit/model/test_qwen35_export.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from types import SimpleNamespace
 
 import torch

--- a/experimental/lite/tests/unit/model/test_qwen_config_unit.py
+++ b/experimental/lite/tests/unit/model/test_qwen_config_unit.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from __future__ import annotations
 
 import ast

--- a/experimental/lite/tests/unit/primitive/test_attention_moe_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_attention_moe_unit.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from __future__ import annotations
 
 from types import SimpleNamespace

--- a/experimental/lite/tests/unit/primitive/test_checkpoint_runtime.py
+++ b/experimental/lite/tests/unit/primitive/test_checkpoint_runtime.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from __future__ import annotations
 
 import copy

--- a/experimental/lite/tests/unit/primitive/test_checkpoint_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_checkpoint_unit.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from __future__ import annotations
 
 import copy

--- a/experimental/lite/tests/unit/primitive/test_dist_opt_validation.py
+++ b/experimental/lite/tests/unit/primitive/test_dist_opt_validation.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from __future__ import annotations
 
 import pytest

--- a/experimental/lite/tests/unit/primitive/test_fsdp2_offload_gpu.py
+++ b/experimental/lite/tests/unit/primitive/test_fsdp2_offload_gpu.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from __future__ import annotations
 
 import os

--- a/experimental/lite/tests/unit/primitive/test_fsdp2_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_fsdp2_unit.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from __future__ import annotations
 
 import copy

--- a/experimental/lite/tests/unit/primitive/test_module_primitives_independent_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_module_primitives_independent_unit.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from __future__ import annotations
 
 import pytest

--- a/experimental/lite/tests/unit/primitive/test_ops_data_trainstep_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_ops_data_trainstep_unit.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from __future__ import annotations
 
 import pytest

--- a/experimental/lite/tests/unit/primitive/test_parallel_dimensions_independent_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_parallel_dimensions_independent_unit.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from __future__ import annotations
 
 from types import SimpleNamespace

--- a/experimental/lite/tests/unit/primitive/test_parallel_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_parallel_unit.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from __future__ import annotations
 
 import pytest

--- a/experimental/lite/tests/unit/primitive/test_runtime_config_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_runtime_config_unit.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from __future__ import annotations
 
 import pytest

--- a/experimental/lite/tests/unit/primitive/test_training_checkpoint.py
+++ b/experimental/lite/tests/unit/primitive/test_training_checkpoint.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from __future__ import annotations
 
 import copy

--- a/experimental/lite/tests/unit/runtime/test_bridge_backend.py
+++ b/experimental/lite/tests/unit/runtime/test_bridge_backend.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Unit tests for the Megatron-Bridge runtime backend surface."""
 
 from __future__ import annotations

--- a/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
+++ b/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from __future__ import annotations
 
 import os

--- a/experimental/lite/tests/unit/verl/test_mlite_engine_checkpoint.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_engine_checkpoint.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from types import SimpleNamespace
 
 import pytest

--- a/experimental/lite/tests/unit/verl/test_mlite_engine_config.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_engine_config.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from types import SimpleNamespace
 
 from verl_mlite.engine.config import MegatronLiteEngineConfig


### PR DESCRIPTION
Adds NVIDIA copyright headers to Python files under experimental/lite so the upstream PR copyright checks cover the latest devlite tree.\n\nValidation:\n- python3 -m compileall -q experimental/lite\n- git diff --check\n- header scan: bad=0, duplicate=0