### PR TITLE
Add GDN allgather context parallelism + Qwen3.5 update

### DIFF
--- a/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
@@ -108,8 +108,13 @@ class GatedDeltaNet(nn.Module):
         self, x: torch.Tensor, position_ids: torch.Tensor | None = None, packed_seq_params=None
     ) -> torch.Tensor:
         del position_ids
-        qkvzba = self.in_proj(x).transpose(0, 1).contiguous()
         is_packed = packed_seq_params is not None
+        if self.ps.cp_size > 1 and is_packed:
+            raise NotImplementedError(
+                "GatedDeltaNet packed THD with all-gather CP is not validated yet."
+            )
+
+        qkvzba = self.in_proj(x).transpose(0, 1).contiguous()
         cu_seqlens = self._packed_cu_seqlens(packed_seq_params) if is_packed else None
         cp_context = None
         if self.ps.cp_size > 1:

--- a/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
@@ -4,21 +4,23 @@
 from __future__ import annotations
 
 import torch
-import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 import transformer_engine.pytorch as te
 
 from megatron.core.jit import jit_fuser
-from megatron.lite.primitive.ops.gated_delta_rule import l2norm, torch_chunk_gated_delta_rule
-from megatron.lite.primitive.parallel import ColumnParallelLinear, ParallelState, RowParallelLinear
-from megatron.lite.primitive.parallel.cp import (
-    zigzag_reconstruct_from_cp_parts,
-    zigzag_slice_for_cp,
+from megatron.lite.primitive.ops.gated_delta_rule import (
+    l2norm,
+    torch_chunk_gated_delta_rule,
 )
-from megatron.lite.primitive.parallel.thd import (
-    reconstruct_packed_from_cp_parts,
-    split_packed_to_cp_local,
+from megatron.lite.primitive.parallel import (
+    ColumnParallelLinear,
+    ParallelState,
+    RowParallelLinear,
+)
+from megatron.lite.primitive.parallel.cp import (
+    contiguous_to_zigzag_chunks,
+    zigzag_to_contiguous_chunks,
 )
 from megatron.lite.primitive.utils import ensure_divisible
 
@@ -34,9 +36,14 @@ try:
 except ImportError:
     _HAS_FLA = False
 
+try:
+    from fla.ops.cp import build_cp_context as _fla_build_cp_context  # pyright: ignore[reportMissingImports]
+except ImportError:
+    _fla_build_cp_context = None
+
 
 class GatedDeltaNet(nn.Module):
-    """Native Gated DeltaNet with dense/packed CP reconstruction."""
+    """Native Gated DeltaNet with dense/packed all-gather CP support."""
 
     def __init__(
         self,
@@ -85,19 +92,44 @@ class GatedDeltaNet(nn.Module):
             bias=False,
             padding=linear_conv_kernel_dim - 1,
         )
-        self.dt_bias = nn.Parameter(torch.ones(self.num_v_heads_local, dtype=torch.float32))
-        self.A_log = nn.Parameter(torch.zeros(self.num_v_heads_local, dtype=torch.float32))
+        self.dt_bias = nn.Parameter(
+            torch.ones(self.num_v_heads_local, dtype=torch.float32)
+        )
+        self.A_log = nn.Parameter(
+            torch.zeros(self.num_v_heads_local, dtype=torch.float32)
+        )
         self.norm = te.RMSNorm(self.dv, eps=rms_norm_eps, zero_centered_gamma=True)
         self.o_proj = RowParallelLinear(self.v_dim, hidden_size, ps, bias=False)
+        self._cp_context_cache: dict[
+            tuple[int, int, torch.device], tuple[torch.Tensor, object]
+        ] = {}
 
     def forward(
         self, x: torch.Tensor, position_ids: torch.Tensor | None = None, packed_seq_params=None
     ) -> torch.Tensor:
         del position_ids
         qkvzba = self.in_proj(x).transpose(0, 1).contiguous()
-        cp_restore = None
+        is_packed = packed_seq_params is not None
+        cu_seqlens = self._packed_cu_seqlens(packed_seq_params) if is_packed else None
+        cp_context = None
         if self.ps.cp_size > 1:
-            qkvzba, cp_restore = self._gather_cp_qkvzba(qkvzba, packed_seq_params)
+            if self.ps.cp_group is None:
+                raise RuntimeError("CP>1 requires ParallelState.cp_group.")
+            if not _HAS_FLA or _fla_build_cp_context is None:
+                raise NotImplementedError(
+                    "GatedDeltaNet all-gather CP requires FLA kernels."
+                )
+            if not is_packed and qkvzba.shape[0] > 1:
+                raise ValueError(
+                    "GatedDeltaNet all-gather CP with SBHD inputs currently requires "
+                    "micro_batch_size == 1. Use packed THD input or micro_batch_size=1."
+                )
+            qkvzba = self._cp_swap_qkvzba(
+                qkvzba,
+                cu_seqlens if is_packed else None,
+                to_contiguous=True,
+            )
+            cu_seqlens, cp_context = self._build_cp_context(qkvzba, cu_seqlens)
         batch, seq_len = qkvzba.shape[:2]
         query, key, value, gate, beta, alpha = self._split_proj(qkvzba)
         qkv = torch.cat(
@@ -109,17 +141,9 @@ class GatedDeltaNet(nn.Module):
             dim=-1,
         )
 
-        cu_seqlens = None
-        if packed_seq_params is not None:
-            cu_seqlens = (
-                packed_seq_params.cu_seqlens_q_padded
-                if getattr(packed_seq_params, "cu_seqlens_q_padded", None) is not None
-                else packed_seq_params.cu_seqlens_q
-            )
-            if not _HAS_FLA:
-                raise NotImplementedError("GatedDeltaNet packed THD requires FLA kernels.")
-
-        qkv = self._causal_conv1d(qkv, seq_len, cu_seqlens=cu_seqlens)
+        qkv = self._causal_conv1d(
+            qkv, seq_len, cu_seqlens=cu_seqlens, cp_context=cp_context
+        )
         query, key, value, gate, beta, alpha = self._prepare_qkv(
             qkv, gate, beta, alpha, batch, seq_len
         )
@@ -133,66 +157,118 @@ class GatedDeltaNet(nn.Module):
             initial_state=None,
             output_final_state=False,
             cu_seqlens=cu_seqlens,
+            cp_context=cp_context,
         )
 
-        if cp_restore is not None:
-            out = self._slice_cp_output(out, cp_restore)
-            gate = self._slice_cp_output(gate, cp_restore)
-            batch, seq_len = out.shape[:2]
         out = self._apply_gated_norm(out, gate)
-        out = out.reshape(batch, seq_len, self.v_dim_local).transpose(0, 1).contiguous()
+        out = out.reshape(batch, seq_len, self.v_dim_local)
+        if self.ps.cp_size > 1:
+            out = self._cp_swap_qkvzba(
+                out,
+                cu_seqlens if is_packed else None,
+                to_contiguous=False,
+            )
+            batch, seq_len = out.shape[:2]
+        out = out.transpose(0, 1).contiguous()
         return self.o_proj(out)
 
-    def _all_gather_cp(self, tensor: torch.Tensor) -> list[torch.Tensor]:
-        if self.ps.cp_group is None:
-            raise RuntimeError("CP>1 requires ParallelState.cp_group.")
-        try:
-            from torch.distributed.nn.functional import all_gather
-
-            return list(all_gather(tensor, group=self.ps.cp_group))
-        except Exception:
-            parts = [torch.empty_like(tensor) for _ in range(self.ps.cp_size)]
-            dist.all_gather(parts, tensor, group=self.ps.cp_group)
-            return parts
-
-    def _gather_cp_qkvzba(self, qkvzba: torch.Tensor, packed_seq_params):
-        parts = self._all_gather_cp(qkvzba)
-        if packed_seq_params is not None:
-            cu_seqlens = self._packed_cu_seqlens(packed_seq_params)
-            full = reconstruct_packed_from_cp_parts(
-                parts, cu_seqlens_padded=cu_seqlens, cp_size=self.ps.cp_size, dim=1
-            )
-            return full, ("packed", cu_seqlens)
-        full = zigzag_reconstruct_from_cp_parts(parts, seq_dim=1)
-        return full, ("dense",)
-
-    def _slice_cp_output(self, out: torch.Tensor, cp_restore) -> torch.Tensor:
-        kind = cp_restore[0]
-        if kind == "packed":
-            return split_packed_to_cp_local(
-                out,
-                cu_seqlens_padded=cp_restore[1],
-                cp_size=self.ps.cp_size,
-                cp_rank=self.ps.cp_rank,
-                dim=1,
-            )
-        if kind == "dense":
-            return zigzag_slice_for_cp(out, self.ps.cp_rank, self.ps.cp_size, seq_dim=1)
-        raise RuntimeError(f"Unknown CP restore kind: {kind!r}")
-
-    def _causal_conv1d(
-        self, qkv: torch.Tensor, seq_len: int, *, cu_seqlens: torch.Tensor | None
+    def _cp_swap_qkvzba(
+        self,
+        tensor: torch.Tensor,
+        cu_seqlens: torch.Tensor | None,
+        *,
+        to_contiguous: bool,
     ) -> torch.Tensor:
         if cu_seqlens is None:
-            qkv_t = qkv.transpose(1, 2).contiguous()
-            return F.silu(self.conv1d(qkv_t)[:, :, :seq_len].transpose(1, 2))
+            swap = (
+                zigzag_to_contiguous_chunks
+                if to_contiguous
+                else contiguous_to_zigzag_chunks
+            )
+            return swap(tensor, self.ps.cp_group, seq_dim=1)
+        if tensor.shape[0] != 1:
+            raise ValueError(
+                "Packed THD GatedDeltaNet expects a single packed batch row."
+            )
+        local_cu_seqlens = cu_seqlens // self.ps.cp_size
+        pieces = []
+        swap = (
+            zigzag_to_contiguous_chunks
+            if to_contiguous
+            else contiguous_to_zigzag_chunks
+        )
+        for idx in range(int(local_cu_seqlens.numel()) - 1):
+            start = int(local_cu_seqlens[idx].item())
+            end = int(local_cu_seqlens[idx + 1].item())
+            if end <= start:
+                continue
+            pieces.append(swap(tensor[:, start:end, :], self.ps.cp_group, seq_dim=1))
+        if not pieces:
+            return tensor
+        return torch.cat(pieces, dim=1).contiguous()
+
+    def _build_cp_context(
+        self,
+        qkvzba: torch.Tensor,
+        cu_seqlens: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, object]:
+        if _fla_build_cp_context is None:
+            raise NotImplementedError(
+                "GatedDeltaNet all-gather CP requires FLA cp context."
+            )
+        if cu_seqlens is not None:
+            return (
+                cu_seqlens,
+                _fla_build_cp_context(
+                    cu_seqlens=cu_seqlens,
+                    group=self.ps.cp_group,
+                    conv1d_kernel_size=self.conv1d.kernel_size[0],
+                ),
+            )
+
+        batch, local_seq_len = qkvzba.shape[:2]
+        global_seq_len = local_seq_len * self.ps.cp_size
+        cache_key = (global_seq_len, batch, qkvzba.device)
+        cached = self._cp_context_cache.get(cache_key)
+        if cached is None:
+            dense_cu_seqlens = (
+                torch.arange(batch + 1, device=qkvzba.device, dtype=torch.long)
+                * global_seq_len
+            )
+            cached = (
+                dense_cu_seqlens,
+                _fla_build_cp_context(
+                    cu_seqlens=dense_cu_seqlens,
+                    group=self.ps.cp_group,
+                    conv1d_kernel_size=self.conv1d.kernel_size[0],
+                ),
+            )
+            self._cp_context_cache[cache_key] = cached
+        return cached
+
+    def _causal_conv1d(
+        self,
+        qkv: torch.Tensor,
+        seq_len: int,
+        *,
+        cu_seqlens: torch.Tensor | None,
+        cp_context,
+    ) -> torch.Tensor:
+        if cu_seqlens is None and cp_context is None:
+            return F.silu(
+                self.conv1d(qkv.transpose(1, 2))[:, :, :seq_len].transpose(1, 2)
+            )
         if _HAS_FLA:
+            kwargs = {}
+            if cp_context is not None:
+                kwargs["cp_context"] = cp_context
             qkv, _ = _fla_causal_conv1d(
                 x=qkv,
                 weight=self.conv1d.weight.squeeze(1),
                 bias=None,
                 activation="silu",
                 cu_seqlens=cu_seqlens,
+                **kwargs,
             )
             return qkv
         raise NotImplementedError("GatedDeltaNet packed THD requires FLA causal conv.")
@@ -208,8 +284,12 @@ class GatedDeltaNet(nn.Module):
         initial_state: torch.Tensor | None,
         output_final_state: bool,
         cu_seqlens: torch.Tensor | None,
+        cp_context,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        if _HAS_FLA and not self.deterministic:
+        if _HAS_FLA and (cp_context is not None or not self.deterministic):
+            kwargs = {}
+            if cp_context is not None:
+                kwargs["cp_context"] = cp_context
             return _fla_chunk_gated_delta_rule(
                 query,
                 key,
@@ -220,6 +300,11 @@ class GatedDeltaNet(nn.Module):
                 output_final_state=output_final_state,
                 use_qk_l2norm_in_kernel=False,
                 cu_seqlens=cu_seqlens,
+                **kwargs,
+            )
+        if cp_context is not None:
+            raise NotImplementedError(
+                "GatedDeltaNet all-gather CP requires FLA gated delta rule."
             )
         return torch_chunk_gated_delta_rule(
             query,
@@ -239,7 +324,9 @@ class GatedDeltaNet(nn.Module):
             else packed_seq_params.cu_seqlens_q
         )
         if cu_seqlens is None:
-            raise ValueError("packed_seq_params must carry cu_seqlens_q for CP GatedDeltaNet.")
+            raise ValueError(
+                "packed_seq_params must carry cu_seqlens_q for CP GatedDeltaNet."
+            )
         return cu_seqlens
 
     def _split_proj(self, qkvzba: torch.Tensor):
@@ -264,9 +351,13 @@ class GatedDeltaNet(nn.Module):
             a.reshape(batch, seq_len, self.num_v_heads_local),
         )
 
-    def _prepare_qkv(self, qkv: torch.Tensor, gate, beta, alpha, batch: int, seq_len: int):
+    def _prepare_qkv(
+        self, qkv: torch.Tensor, gate, beta, alpha, batch: int, seq_len: int
+    ):
         query_key, value = qkv.split([2 * self.qk_dim_local, self.v_dim_local], dim=-1)
-        query_key = query_key.reshape(batch, seq_len, 2 * self.num_k_heads_local, self.dk)
+        query_key = query_key.reshape(
+            batch, seq_len, 2 * self.num_k_heads_local, self.dk
+        )
         value = value.reshape(batch, seq_len, self.num_v_heads_local, self.dv)
         query, key = query_key.split(self.num_k_heads_local, dim=2)
         query = self._l2norm(query.contiguous())

--- a/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
@@ -8,7 +8,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 import transformer_engine.pytorch as te
 
-from megatron.core.jit import jit_fuser
 from megatron.lite.primitive.ops.gated_delta_rule import (
     l2norm,
     torch_chunk_gated_delta_rule,
@@ -23,6 +22,11 @@ from megatron.lite.primitive.parallel.cp import (
     zigzag_to_contiguous_chunks,
 )
 from megatron.lite.primitive.utils import ensure_divisible
+
+
+def jit_fuser(fn):
+    return fn
+
 
 try:
     from fla.modules.convolution import (

--- a/experimental/lite/megatron/lite/primitive/parallel/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/__init__.py
@@ -4,14 +4,19 @@
 from __future__ import annotations
 
 from megatron.lite.primitive.parallel.cp import (
+    contiguous_to_zigzag_chunks,
     split_packed_for_cp,
     zigzag_position_ids_for_cp,
     zigzag_reconstruct_from_cp_parts,
     zigzag_slice_for_cp,
     zigzag_split_for_cp,
+    zigzag_to_contiguous_chunks,
 )
 from megatron.lite.primitive.parallel.pipeline import forward_backward_pipelining
-from megatron.lite.primitive.parallel.pp import PipelineChunkLayout, build_pipeline_chunk_layout
+from megatron.lite.primitive.parallel.pp import (
+    PipelineChunkLayout,
+    build_pipeline_chunk_layout,
+)
 from megatron.lite.primitive.parallel.sp import (
     gather_for_non_sp_head,
     gather_from_sequence_parallel,
@@ -48,6 +53,7 @@ def __getattr__(name: str):
 
 __all__ = [
     "ColumnParallelLinear",
+    "contiguous_to_zigzag_chunks",
     "PackedSeqParams",
     "PackedTHDBatch",
     "PipelineChunkLayout",
@@ -73,4 +79,5 @@ __all__ = [
     "zigzag_reconstruct_from_cp_parts",
     "zigzag_slice_for_cp",
     "zigzag_split_for_cp",
+    "zigzag_to_contiguous_chunks",
 ]

--- a/experimental/lite/megatron/lite/primitive/parallel/cp.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/cp.py
@@ -3,11 +3,17 @@
 
 from __future__ import annotations
 
+from typing import Optional
+
 import torch
+import torch.distributed as dist
 
 
 def zigzag_split_for_cp(
-    tensor: torch.Tensor, cp_rank: int, cp_size: int, seq_dim: int = 1
+    tensor: torch.Tensor,
+    cp_rank: int,
+    cp_size: int,
+    seq_dim: int = 1,
 ) -> torch.Tensor:
     """Split tensor along sequence dim using zigzag (striped) pattern for CP.
 
@@ -27,7 +33,11 @@ def zigzag_split_for_cp(
     shape = list(tensor.shape)
     shape[seq_dim : seq_dim + 1] = [2 * cp_size, seq_len // (2 * cp_size)]
     tensor = tensor.view(*shape)
-    idx = torch.tensor([cp_rank, 2 * cp_size - cp_rank - 1], dtype=torch.long, device=tensor.device)
+    idx = torch.tensor(
+        [cp_rank, 2 * cp_size - cp_rank - 1],
+        dtype=torch.long,
+        device=tensor.device,
+    )
     tensor = tensor.index_select(seq_dim, idx)
     shape[seq_dim : seq_dim + 2] = [seq_len // cp_size]
     return tensor.reshape(*shape)
@@ -79,8 +89,129 @@ def zigzag_slice_for_cp(
     return torch.cat((first, second), dim=seq_dim).contiguous()
 
 
+def zigzag_to_contiguous_chunks(
+    tensor: torch.Tensor,
+    cp_group: dist.ProcessGroup | None,
+    seq_dim: int = 1,
+) -> torch.Tensor:
+    """Swap a CP-local tensor from Megatron zigzag layout to contiguous chunks.
+
+    Zigzag CP layout assigns rank ``r`` global chunks ``[r, 2*cp-r-1]``.
+    Linear-attention all-gather CP kernels expect rank ``r`` to hold chunks
+    ``[2*r, 2*r+1]``. The conversion is a chunk-level all-to-all and preserves
+    the local tensor shape.
+    """
+    return _zigzag_contiguous_chunk_swap(tensor, cp_group, seq_dim, to_contiguous=True)
+
+
+def contiguous_to_zigzag_chunks(
+    tensor: torch.Tensor,
+    cp_group: dist.ProcessGroup | None,
+    seq_dim: int = 1,
+) -> torch.Tensor:
+    """Inverse of :func:`zigzag_to_contiguous_chunks`."""
+    return _zigzag_contiguous_chunk_swap(tensor, cp_group, seq_dim, to_contiguous=False)
+
+
+def _zigzag_contiguous_chunk_swap(
+    tensor: torch.Tensor,
+    cp_group: Optional[dist.ProcessGroup],
+    seq_dim: int,
+    *,
+    to_contiguous: bool,
+) -> torch.Tensor:
+    cp_size = dist.get_world_size(cp_group) if cp_group is not None else 1
+    if cp_size <= 1:
+        return tensor
+    cp_rank = dist.get_rank(cp_group)
+
+    if seq_dim != 0:
+        tensor = tensor.movedim(seq_dim, 0)
+    tensor = tensor.contiguous()
+
+    local_len = tensor.size(0)
+    if local_len % 2 != 0:
+        raise ValueError(
+            f"zigzag/contiguous CP chunk swap requires even local sequence length, got {local_len}."
+        )
+    chunk_len = local_len // 2
+
+    def rank_to_chunks(rank: int, in_zigzag: bool) -> tuple[int, int]:
+        if in_zigzag:
+            return rank, 2 * cp_size - rank - 1
+        return 2 * rank, 2 * rank + 1
+
+    def chunk_to_dest(chunk_idx: int, target_zigzag: bool) -> tuple[int, int]:
+        if target_zigzag:
+            if chunk_idx < cp_size:
+                return chunk_idx, 0
+            return 2 * cp_size - chunk_idx - 1, 1
+        return chunk_idx // 2, chunk_idx % 2
+
+    source_in_zigzag = to_contiguous
+    target_in_zigzag = not to_contiguous
+    local_chunks = [tensor[:chunk_len], tensor[chunk_len:]]
+    local_chunk_indices = rank_to_chunks(cp_rank, source_in_zigzag)
+    local_dests = [
+        chunk_to_dest(chunk_idx, target_in_zigzag) for chunk_idx in local_chunk_indices
+    ]
+    local_slot_order = sorted(range(2), key=lambda slot: local_dests[slot])
+    send_buf = torch.cat(
+        [local_chunks[slot] for slot in local_slot_order], dim=0
+    ).contiguous()
+
+    input_split_chunks = [0] * cp_size
+    for dst_rank, _dst_slot in local_dests:
+        input_split_chunks[dst_rank] += 1
+
+    output_split_chunks = [0] * cp_size
+    recv_dst_slots_per_source: list[list[int]] = [[] for _ in range(cp_size)]
+    for src_rank in range(cp_size):
+        src_chunks = rank_to_chunks(src_rank, source_in_zigzag)
+        src_dests = [
+            chunk_to_dest(chunk_idx, target_in_zigzag) for chunk_idx in src_chunks
+        ]
+        src_slot_order = sorted(range(2), key=lambda slot: src_dests[slot])
+        for slot in src_slot_order:
+            dst_rank, dst_slot = src_dests[slot]
+            if dst_rank == cp_rank:
+                output_split_chunks[src_rank] += 1
+                recv_dst_slots_per_source[src_rank].append(dst_slot)
+
+    input_split_sizes = [count * chunk_len for count in input_split_chunks]
+    output_split_sizes = [count * chunk_len for count in output_split_chunks]
+    recv_shape = (sum(output_split_sizes), *send_buf.shape[1:])
+    recv_buf = torch.empty(recv_shape, dtype=send_buf.dtype, device=send_buf.device)
+    from torch.distributed.nn.functional import all_to_all_single
+
+    recv_buf = all_to_all_single(
+        recv_buf,
+        send_buf,
+        output_split_sizes=output_split_sizes,
+        input_split_sizes=input_split_sizes,
+        group=cp_group,
+    )
+
+    target_slots: list[torch.Tensor | None] = [None, None]
+    offset = 0
+    for src_rank in range(cp_size):
+        for dst_slot in recv_dst_slots_per_source[src_rank]:
+            target_slots[dst_slot] = recv_buf[offset : offset + chunk_len]
+            offset += chunk_len
+    if any(slot is None for slot in target_slots):
+        raise RuntimeError("Incomplete CP chunk reassembly.")
+
+    out = torch.cat([slot for slot in target_slots if slot is not None], dim=0)
+    if seq_dim != 0:
+        out = out.movedim(0, seq_dim)
+    return out.contiguous()
+
+
 def zigzag_position_ids_for_cp(
-    seq_len: int, cp_rank: int, cp_size: int, device: torch.device
+    seq_len: int,
+    cp_rank: int,
+    cp_size: int,
+    device: torch.device,
 ) -> torch.Tensor:
     """Return global position IDs for this CP rank under zigzag splitting.
 
@@ -146,7 +277,9 @@ def split_packed_for_cp(
 
 
 __all__ = [
+    "contiguous_to_zigzag_chunks",
     "split_packed_for_cp",
+    "zigzag_to_contiguous_chunks",
     "zigzag_reconstruct_from_cp_parts",
     "zigzag_position_ids_for_cp",
     "zigzag_slice_for_cp",

--- a/experimental/lite/tests/smoke/model/test_qwen_lite_forward_smoke.py
+++ b/experimental/lite/tests/smoke/model/test_qwen_lite_forward_smoke.py
@@ -88,7 +88,7 @@ def _tiny_qwen35_config():
         max_position_embeddings=16,
         partial_rotary_factor=1.0,
         mrope_section=[1, 1, 0],
-        layer_types=["full_attention"],
+        layer_types=["linear_attention"],
     )
 
 
@@ -115,13 +115,19 @@ def _assert_loss_and_backward(output: dict, model: torch.nn.Module):
         param for param in model.parameters() if param.requires_grad and param.grad is not None
     ]
     assert grad_params
-    assert all(torch.isfinite(param.grad.detach().float()).all() for param in grad_params)
+    assert all(
+        torch.isfinite(param.grad.detach().float()).all() for param in grad_params
+    )
 
 
 def test_qwen3_moe_lite_tiny_forward_backward_smoke():
     _Qwen3MoEConfig, Qwen3MoEModel = _qwen3_symbols()
     config = _tiny_qwen3_config()
-    model = Qwen3MoEModel(config, _parallel_state(), use_deepep=False).cuda().to(torch.bfloat16)
+    model = (
+        Qwen3MoEModel(config, _parallel_state(), use_deepep=False)
+        .cuda()
+        .to(torch.bfloat16)
+    )
     input_ids, labels = _token_batch(config.vocab_size)
 
     output = model(input_ids=input_ids, labels=labels, return_log_probs=True)
@@ -146,7 +152,9 @@ def test_qwen35_lite_tiny_forward_backward_smoke():
         recompute_modules=[],
         deterministic=True,
     )
-    model = Qwen35Model(config, train_config, _parallel_state()).cuda().to(torch.bfloat16)
+    model = (
+        Qwen35Model(config, train_config, _parallel_state()).cuda().to(torch.bfloat16)
+    )
     input_ids, labels = _token_batch(config.vocab_size)
 
     output = model(input_ids=input_ids, labels=labels)

--- a/experimental/lite/tests/smoke/primitive/test_parallel_topologies_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_parallel_topologies_smoke.py
@@ -9,6 +9,7 @@ import torch
 import torch.distributed as dist
 
 from megatron.lite.primitive.parallel import (
+    PackedSeqParams,
     contiguous_to_zigzag_chunks,
     init_parallel,
     zigzag_split_for_cp,
@@ -118,3 +119,33 @@ def test_cp_zigzag_contiguous_chunk_swap_roundtrip():
 
     restored = contiguous_to_zigzag_chunks(local_contiguous, ps.cp_group, seq_dim=1)
     assert torch.equal(restored, local_zigzag)
+
+
+def test_gdn_rejects_thd_context_parallel_until_validated():
+    if dist.get_world_size() < 2:
+        pytest.skip("GDN THD+CP guard smoke requires at least 2 ranks.")
+
+    pytest.importorskip("transformer_engine.pytorch")
+    from megatron.lite.primitive.modules.gated_delta_net import GatedDeltaNet
+
+    ps = init_parallel(SimpleNamespace(tp=1, ep=1, etp=1, cp=2, pp=1))
+    gdn = (
+        GatedDeltaNet(
+            hidden_size=16,
+            linear_num_key_heads=2,
+            linear_key_head_dim=4,
+            linear_num_value_heads=2,
+            linear_value_head_dim=4,
+            linear_conv_kernel_dim=2,
+            rms_norm_eps=1e-6,
+            ps=ps,
+        )
+        .cuda()
+        .to(torch.bfloat16)
+    )
+    cu_seqlens = torch.tensor([0, 8], dtype=torch.int32, device="cuda")
+    packed_seq_params = PackedSeqParams.from_cu_seqlens(cu_seqlens, max_seqlen=8)
+    local_hidden = torch.randn(4, 1, 16, device="cuda", dtype=torch.bfloat16)
+
+    with pytest.raises(NotImplementedError, match="packed THD with all-gather CP"):
+        gdn(local_hidden, packed_seq_params=packed_seq_params)

--- a/experimental/lite/tests/smoke/primitive/test_parallel_topologies_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_parallel_topologies_smoke.py
@@ -8,7 +8,12 @@ import pytest
 import torch
 import torch.distributed as dist
 
-from megatron.lite.primitive.parallel import init_parallel
+from megatron.lite.primitive.parallel import (
+    contiguous_to_zigzag_chunks,
+    init_parallel,
+    zigzag_split_for_cp,
+    zigzag_to_contiguous_chunks,
+)
 
 pytestmark = [pytest.mark.mlite, pytest.mark.smoke, pytest.mark.gpu, pytest.mark.distributed]
 
@@ -94,3 +99,22 @@ def test_parallel_state_builds_expected_primitive_groups():
         if cfg.pp > 1:
             assert ps.pp_next_rank in ps.pp_global_ranks
             assert ps.pp_prev_rank in ps.pp_global_ranks
+
+
+def test_cp_zigzag_contiguous_chunk_swap_roundtrip():
+    if dist.get_world_size() < 2:
+        pytest.skip("CP chunk swap smoke requires at least 2 ranks.")
+
+    ps = init_parallel(SimpleNamespace(tp=1, ep=1, etp=1, cp=2, pp=1))
+    full = (
+        torch.arange(8, device="cuda", dtype=torch.float32).reshape(1, 8, 1)
+        + 100 * ps.dp_rank
+    )
+    local_zigzag = zigzag_split_for_cp(full, ps.cp_rank, cp_size=2, seq_dim=1)
+
+    local_contiguous = zigzag_to_contiguous_chunks(local_zigzag, ps.cp_group, seq_dim=1)
+    expected = full[:, ps.cp_rank * 4 : (ps.cp_rank + 1) * 4, :]
+    assert torch.equal(local_contiguous, expected)
+
+    restored = contiguous_to_zigzag_chunks(local_contiguous, ps.cp_group, seq_dim=1)
+    assert torch.equal(restored, local_zigzag)


### PR DESCRIPTION
## Summary
- Add all-gather context parallelism support for the MLite Gated Delta Net path, including explicit zigzag/contiguous sequence reshaping.
- Wire the GDN path into the Qwen3.5 lite implementation.
- Guard unvalidated packed THD + context-parallel execution instead of silently running it.
- Rebase onto `main` and remove the remaining Megatron-Core import from the MLite GDN primitive.

## Benchmark
GDN CP benchmark: BF16 fwd+bwd+AdamW step, hidden=256, sequence length=2048, batch=1, CP=4 on 4 GPUs.

| CP mode | Step time (ms) | Throughput (tokens/s) | Peak memory (MiB) |
| --- | ---: | ---: | ---: |
| Legacy A2A-style CP | 7.952 | 257,539.6 | 39.6 |
| FLA all-gather CP | 6.387 | 320,639.9 | 39.3 |

FLA all-gather CP is 1.245x faster in this benchmark and uses 0.4 MiB less peak memory.

## Validation
- `python -m compileall experimental/lite`
- `ruff check experimental/lite`
- `pytest experimental/lite/tests/unit/primitive/test_parallel_unit.py`
- Slurm GPU validation job `12752688`, `sacct` completed with `ExitCode 0:0`; distributed smoke covered CP>1 GDN numerical parity, CP+EP training step, and the THD context-parallel guard.
- Slurm GPU benchmark job `12756773`, `sacct` completed with `ExitCode 0:0`; covered legacy A2A-style CP vs FLA all-gather CP with CP=4.