### PR TITLE
Validate Qwen3.5 precision, MTP, and GDN CP

### DIFF
--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/checkpoint.py
@@ -760,10 +760,19 @@ def export_hf_weights(
     )
 
 
+def save_hf_weights(
+    model: nn.Module | list[nn.Module], path: str, config: Qwen35Config, ps: ParallelState
+) -> None:
+    from megatron.lite.primitive.ckpt.hf_weights import save_hf_weights as _save
+
+    _save(model, path, Qwen35WeightSpec(config), ps, vocab_size=config.vocab_size)
+
+
 __all__ = [
     "EXPERT_CLASSIFIER",
     "PLACEMENT_FN",
     "Qwen35WeightSpec",
     "export_hf_weights",
     "load_hf_weights",
+    "save_hf_weights",
 ]

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
@@ -2,9 +2,7 @@
 """Qwen3.5 lite native model.
 
 This implementation keeps the lightweight qwen3_moe/lite composition style
-and does not wrap Megatron-Core layer modules. It still reuses Megatron Lite
-parallel/TE primitives and small Megatron atomic RoPE helpers where those are
-already used by other native Megatron Lite modules.
+and uses Megatron Lite parallel, TE, RoPE, and MoE primitives directly.
 """
 
 from __future__ import annotations
@@ -16,15 +14,19 @@ import torch.distributed as dist
 import torch.nn as nn
 import transformer_engine.pytorch as te
 
-from megatron.core.fusions.fused_bias_swiglu import bias_swiglu_impl
 from megatron.lite.model.qwen3_5.config import Qwen35Config
 from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
-from megatron.lite.primitive.modules.experts import Experts
+from megatron.lite.primitive.modules.experts import Experts, swiglu_with_probs
 from megatron.lite.primitive.modules.gated_delta_net import GatedDeltaNet
 from megatron.lite.primitive.modules.gqa import GQAttention as FullAttention
 from megatron.lite.primitive.modules.gqa import split_grouped_qkvg as _split_grouped_qkvg
 from megatron.lite.primitive.modules.mrope import MultimodalRotaryEmbedding as Qwen35MRoPE
-from megatron.lite.primitive.modules.mtp import MTPBlock, MTPDecoderLayer, MTPLossAutoScaler
+from megatron.lite.primitive.modules.mtp import (
+    MTPBlock,
+    MTPDecoderLayer,
+    MTPLossAutoScaler,
+    roll_mtp_tensor_left,
+)
 from megatron.lite.primitive.modules.router import TopKRouter
 from megatron.lite.primitive.ops.cross_entropy import vocab_parallel_cross_entropy
 from megatron.lite.primitive.ops.linear_cross_entropy import linear_cross_entropy
@@ -37,7 +39,6 @@ from megatron.lite.primitive.parallel import (
     VocabParallelOutput,
     build_pipeline_chunk_layout,
     gather_from_sequence_parallel,
-    roll_packed_thd_left,
     scatter_to_sequence_parallel,
 )
 from megatron.lite.primitive.utils import build_fp8_recipe
@@ -66,7 +67,7 @@ def _collect_sp_grad_params(model: nn.Module) -> list[nn.Parameter]:
 
 
 def _swiglu(x: torch.Tensor) -> torch.Tensor:
-    return bias_swiglu_impl(x, bias=None)
+    return swiglu_with_probs(x, probs=None)
 
 
 def _qwen_mrope_section(config: Qwen35Config) -> list[int]:
@@ -552,10 +553,10 @@ class Qwen35Model(nn.Module):
         mtp_loss_mask = loss_mask.clone()
         mtp_loss_values = []
         for mtp_hidden in mtp_hidden_states:
-            mtp_labels, _ = roll_packed_thd_left(
+            mtp_labels, _ = roll_mtp_tensor_left(
                 mtp_labels, packed_seq_params=packed_seq_params, dims=-1
             )
-            mtp_loss_mask, num_tokens = roll_packed_thd_left(
+            mtp_loss_mask, num_tokens = roll_mtp_tensor_left(
                 mtp_loss_mask, packed_seq_params=packed_seq_params, dims=-1
             )
             labels_sb = mtp_labels.transpose(0, 1).contiguous()

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
@@ -232,6 +232,7 @@ class Qwen35Layer(nn.Module):
         moe_act_recompute: bool = False,
         use_thd: bool = False,
         deterministic: bool = False,
+        gdn_cp_mode: str = "fla_allgather",
     ):
         super().__init__()
         self.layer_idx = layer_idx
@@ -265,6 +266,7 @@ class Qwen35Layer(nn.Module):
                 rms_norm_eps=config.rms_norm_eps,
                 ps=ps,
                 deterministic=deterministic,
+                cp_mode=gdn_cp_mode,
             )
         self.mlp_norm = te.RMSNorm(
             config.hidden_size, eps=config.rms_norm_eps, zero_centered_gamma=True
@@ -333,6 +335,7 @@ class Qwen35Model(nn.Module):
         mtp_enable_train: bool = False,
         mtp_detach_encoder: bool = False,
         mount_vision_model: bool = False,
+        gdn_cp_mode: str = "fla_allgather",
     ):
         super().__init__()
         del attention_backend_override
@@ -374,6 +377,7 @@ class Qwen35Model(nn.Module):
                     moe_act_recompute=moe_act_recompute,
                     use_thd=use_thd,
                     deterministic=getattr(train_config, "deterministic", False),
+                    gdn_cp_mode=gdn_cp_mode,
                 )
                 for idx in self.layer_indices
             ]
@@ -411,6 +415,7 @@ class Qwen35Model(nn.Module):
                         moe_act_recompute=moe_act_recompute,
                         use_thd=use_thd,
                         deterministic=getattr(train_config, "deterministic", False),
+                        gdn_cp_mode=gdn_cp_mode,
                     ),
                     detach_encoder=mtp_detach_encoder,
                 )

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
@@ -58,6 +58,7 @@ class ImplConfig:
     mtp_loss_scaling_factor: float = 0.1
     mtp_use_repeated_layer: bool | None = None
     mount_vision_model: bool = False
+    gdn_cp_mode: str = "fla_allgather"
 
 
 def _full_attn_module(layer, name: str):
@@ -177,6 +178,7 @@ def build_model(model_cfg: Qwen35Config, *, impl_cfg: ImplConfig) -> ModelBundle
         mtp_enable_train=mtp_enable_train,
         mtp_detach_encoder=impl_cfg.mtp_detach_encoder,
         mount_vision_model=impl_cfg.mount_vision_model,
+        gdn_cp_mode=impl_cfg.gdn_cp_mode,
     )
 
     if vpp is None:

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
@@ -15,6 +15,7 @@ from megatron.lite.model.qwen3_5.config import Qwen35Config
 from megatron.lite.model.qwen3_5.lite.checkpoint import EXPERT_CLASSIFIER, PLACEMENT_FN
 from megatron.lite.model.qwen3_5.lite.checkpoint import export_hf_weights as _export_hf_weights_impl
 from megatron.lite.model.qwen3_5.lite.checkpoint import load_hf_weights as _load_hf_weights_impl
+from megatron.lite.model.qwen3_5.lite.checkpoint import save_hf_weights as _save_hf_weights_impl
 from megatron.lite.primitive.bundle import ModelBundle
 from megatron.lite.primitive.parallel import ParallelState, init_parallel
 from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec
@@ -28,6 +29,7 @@ __all__ = [
     "build_model_config",
     "export_hf_weights",
     "load_hf_weights",
+    "save_hf_weights",
     "vocab_size",
 ]
 
@@ -39,7 +41,7 @@ def is_expert_param(name: str) -> bool:
 @dataclass(frozen=True)
 class ImplConfig:
     parallel: ParallelConfig = field(default_factory=ParallelConfig)
-    optimizer: str | None = "mc_full"
+    optimizer: str | None = "distopt"
     recompute: list[str] = field(default_factory=list)
     offload: list[str] = field(default_factory=list)
     use_deepep: bool = False
@@ -111,10 +113,12 @@ def _make_aux_loss_hook():
     return hook
 
 
-def _build_mc_optimizer(chunks, model_cfg: Qwen35Config, impl_cfg: ImplConfig, ps: ParallelState):
-    from megatron.lite.primitive.optimizers.megatron_wrap import build_mc_training_optimizer
+def _build_distopt_optimizer(chunks, model_cfg: Qwen35Config, impl_cfg: ImplConfig, ps: ParallelState):
+    from megatron.lite.primitive.optimizers.megatron_wrap import (
+        build_distopt_training_optimizer,
+    )
 
-    return build_mc_training_optimizer(
+    return build_distopt_training_optimizer(
         chunks,
         model_cfg=model_cfg,
         impl_cfg=impl_cfg,
@@ -199,8 +203,8 @@ def build_model(model_cfg: Qwen35Config, *, impl_cfg: ImplConfig) -> ModelBundle
     finalize_grads = None
     post_model_load_hook = None
     optimizer_backend = "none"
-    if impl_cfg.optimizer in {"mc", "mc_full"}:
-        optimizer, finalize_grads = _build_mc_optimizer(chunks, model_cfg, impl_cfg, ps)
+    if impl_cfg.optimizer == "distopt":
+        optimizer, finalize_grads = _build_distopt_optimizer(chunks, model_cfg, impl_cfg, ps)
         from megatron.lite.primitive.ckpt import attach_model_sharded_state_dict
         from megatron.lite.runtime.megatron_utils import register_training_hooks
 
@@ -260,6 +264,12 @@ def export_hf_weights(
     chunks: list[nn.Module], model_cfg: Qwen35Config, ps: ParallelState, **kwargs
 ):
     yield from _export_hf_weights_impl(chunks, model_cfg, ps, **kwargs)
+
+
+def save_hf_weights(
+    chunks: list[nn.Module], path: str, model_cfg: Qwen35Config, ps: ParallelState
+) -> None:
+    _save_hf_weights_impl(chunks, path, model_cfg, ps)
 
 
 def vocab_size(model_cfg) -> int | None:

--- a/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
@@ -45,6 +45,8 @@ try:
 except ImportError:
     _fla_build_cp_context = None
 
+_CONV_PAD_ALIGNMENT = 4096
+
 
 class GatedDeltaNet(nn.Module):
     """Native Gated DeltaNet with dense/packed all-gather CP support."""
@@ -263,23 +265,34 @@ class GatedDeltaNet(nn.Module):
         cu_seqlens: torch.Tensor | None,
         cp_context,
     ) -> torch.Tensor:
-        if cu_seqlens is None and cp_context is None:
-            return F.silu(
-                self.conv1d(qkv.transpose(1, 2))[:, :, :seq_len].transpose(1, 2)
-            )
-        if _HAS_FLA:
+        if _HAS_FLA and (cp_context is not None or cu_seqlens is not None or not self.deterministic):
+            orig_seq_len = qkv.shape[1]
+            pad_n = 0 if cp_context is not None else (-orig_seq_len % _CONV_PAD_ALIGNMENT)
+            conv_input = qkv
+            conv_cu_seqlens = cu_seqlens
+            if pad_n > 0:
+                conv_input = F.pad(qkv, (0, 0, 0, pad_n))
+                if conv_cu_seqlens is not None:
+                    conv_cu_seqlens = conv_cu_seqlens.clone()
+                    conv_cu_seqlens[-1] += pad_n
             kwargs = {}
             if cp_context is not None:
                 kwargs["cp_context"] = cp_context
             qkv, _ = _fla_causal_conv1d(
-                x=qkv,
+                x=conv_input,
                 weight=self.conv1d.weight.squeeze(1),
                 bias=None,
                 activation="silu",
-                cu_seqlens=cu_seqlens,
+                cu_seqlens=conv_cu_seqlens,
                 **kwargs,
             )
+            if pad_n > 0:
+                qkv = qkv[:, :orig_seq_len, :]
             return qkv
+        if cu_seqlens is None and cp_context is None:
+            return F.silu(
+                self.conv1d(qkv.transpose(1, 2))[:, :, :seq_len].transpose(1, 2)
+            )
         raise NotImplementedError("GatedDeltaNet packed THD requires FLA causal conv.")
 
     def _gated_delta_rule(

--- a/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
@@ -4,23 +4,29 @@
 from __future__ import annotations
 
 import torch
-import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 import transformer_engine.pytorch as te
 
-from megatron.core.jit import jit_fuser
-from megatron.lite.primitive.ops.gated_delta_rule import l2norm, torch_chunk_gated_delta_rule
-from megatron.lite.primitive.parallel import ColumnParallelLinear, ParallelState, RowParallelLinear
-from megatron.lite.primitive.parallel.cp import (
-    zigzag_reconstruct_from_cp_parts,
-    zigzag_slice_for_cp,
+from megatron.lite.primitive.ops.gated_delta_rule import (
+    l2norm,
+    torch_chunk_gated_delta_rule,
 )
-from megatron.lite.primitive.parallel.thd import (
-    reconstruct_packed_from_cp_parts,
-    split_packed_to_cp_local,
+from megatron.lite.primitive.parallel import (
+    ColumnParallelLinear,
+    ParallelState,
+    RowParallelLinear,
+)
+from megatron.lite.primitive.parallel.cp import (
+    contiguous_to_zigzag_chunks,
+    zigzag_to_contiguous_chunks,
 )
 from megatron.lite.primitive.utils import ensure_divisible
+
+
+def jit_fuser(fn):
+    return fn
+
 
 try:
     from fla.modules.convolution import (
@@ -34,9 +40,14 @@ try:
 except ImportError:
     _HAS_FLA = False
 
+try:
+    from fla.ops.cp import build_cp_context as _fla_build_cp_context  # pyright: ignore[reportMissingImports]
+except ImportError:
+    _fla_build_cp_context = None
+
 
 class GatedDeltaNet(nn.Module):
-    """Native Gated DeltaNet with dense/packed CP reconstruction."""
+    """Native Gated DeltaNet with dense/packed all-gather CP support."""
 
     def __init__(
         self,
@@ -85,19 +96,49 @@ class GatedDeltaNet(nn.Module):
             bias=False,
             padding=linear_conv_kernel_dim - 1,
         )
-        self.dt_bias = nn.Parameter(torch.ones(self.num_v_heads_local, dtype=torch.float32))
-        self.A_log = nn.Parameter(torch.zeros(self.num_v_heads_local, dtype=torch.float32))
+        self.dt_bias = nn.Parameter(
+            torch.ones(self.num_v_heads_local, dtype=torch.float32)
+        )
+        self.A_log = nn.Parameter(
+            torch.zeros(self.num_v_heads_local, dtype=torch.float32)
+        )
         self.norm = te.RMSNorm(self.dv, eps=rms_norm_eps, zero_centered_gamma=True)
         self.o_proj = RowParallelLinear(self.v_dim, hidden_size, ps, bias=False)
+        self._cp_context_cache: dict[
+            tuple[int, int, torch.device], tuple[torch.Tensor, object]
+        ] = {}
 
     def forward(
         self, x: torch.Tensor, position_ids: torch.Tensor | None = None, packed_seq_params=None
     ) -> torch.Tensor:
         del position_ids
+        is_packed = packed_seq_params is not None
+        if self.ps.cp_size > 1 and is_packed:
+            raise NotImplementedError(
+                "GatedDeltaNet packed THD with all-gather CP is not validated yet."
+            )
+
         qkvzba = self.in_proj(x).transpose(0, 1).contiguous()
-        cp_restore = None
+        cu_seqlens = self._packed_cu_seqlens(packed_seq_params) if is_packed else None
+        cp_context = None
         if self.ps.cp_size > 1:
-            qkvzba, cp_restore = self._gather_cp_qkvzba(qkvzba, packed_seq_params)
+            if self.ps.cp_group is None:
+                raise RuntimeError("CP>1 requires ParallelState.cp_group.")
+            if not _HAS_FLA or _fla_build_cp_context is None:
+                raise NotImplementedError(
+                    "GatedDeltaNet all-gather CP requires FLA kernels."
+                )
+            if not is_packed and qkvzba.shape[0] > 1:
+                raise ValueError(
+                    "GatedDeltaNet all-gather CP with SBHD inputs currently requires "
+                    "micro_batch_size == 1. Use packed THD input or micro_batch_size=1."
+                )
+            qkvzba = self._cp_swap_qkvzba(
+                qkvzba,
+                cu_seqlens if is_packed else None,
+                to_contiguous=True,
+            )
+            cu_seqlens, cp_context = self._build_cp_context(qkvzba, cu_seqlens)
         batch, seq_len = qkvzba.shape[:2]
         query, key, value, gate, beta, alpha = self._split_proj(qkvzba)
         qkv = torch.cat(
@@ -109,17 +150,9 @@ class GatedDeltaNet(nn.Module):
             dim=-1,
         )
 
-        cu_seqlens = None
-        if packed_seq_params is not None:
-            cu_seqlens = (
-                packed_seq_params.cu_seqlens_q_padded
-                if getattr(packed_seq_params, "cu_seqlens_q_padded", None) is not None
-                else packed_seq_params.cu_seqlens_q
-            )
-            if not _HAS_FLA:
-                raise NotImplementedError("GatedDeltaNet packed THD requires FLA kernels.")
-
-        qkv = self._causal_conv1d(qkv, seq_len, cu_seqlens=cu_seqlens)
+        qkv = self._causal_conv1d(
+            qkv, seq_len, cu_seqlens=cu_seqlens, cp_context=cp_context
+        )
         query, key, value, gate, beta, alpha = self._prepare_qkv(
             qkv, gate, beta, alpha, batch, seq_len
         )
@@ -133,66 +166,118 @@ class GatedDeltaNet(nn.Module):
             initial_state=None,
             output_final_state=False,
             cu_seqlens=cu_seqlens,
+            cp_context=cp_context,
         )
 
-        if cp_restore is not None:
-            out = self._slice_cp_output(out, cp_restore)
-            gate = self._slice_cp_output(gate, cp_restore)
-            batch, seq_len = out.shape[:2]
         out = self._apply_gated_norm(out, gate)
-        out = out.reshape(batch, seq_len, self.v_dim_local).transpose(0, 1).contiguous()
+        out = out.reshape(batch, seq_len, self.v_dim_local)
+        if self.ps.cp_size > 1:
+            out = self._cp_swap_qkvzba(
+                out,
+                cu_seqlens if is_packed else None,
+                to_contiguous=False,
+            )
+            batch, seq_len = out.shape[:2]
+        out = out.transpose(0, 1).contiguous()
         return self.o_proj(out)
 
-    def _all_gather_cp(self, tensor: torch.Tensor) -> list[torch.Tensor]:
-        if self.ps.cp_group is None:
-            raise RuntimeError("CP>1 requires ParallelState.cp_group.")
-        try:
-            from torch.distributed.nn.functional import all_gather
-
-            return list(all_gather(tensor, group=self.ps.cp_group))
-        except Exception:
-            parts = [torch.empty_like(tensor) for _ in range(self.ps.cp_size)]
-            dist.all_gather(parts, tensor, group=self.ps.cp_group)
-            return parts
-
-    def _gather_cp_qkvzba(self, qkvzba: torch.Tensor, packed_seq_params):
-        parts = self._all_gather_cp(qkvzba)
-        if packed_seq_params is not None:
-            cu_seqlens = self._packed_cu_seqlens(packed_seq_params)
-            full = reconstruct_packed_from_cp_parts(
-                parts, cu_seqlens_padded=cu_seqlens, cp_size=self.ps.cp_size, dim=1
-            )
-            return full, ("packed", cu_seqlens)
-        full = zigzag_reconstruct_from_cp_parts(parts, seq_dim=1)
-        return full, ("dense",)
-
-    def _slice_cp_output(self, out: torch.Tensor, cp_restore) -> torch.Tensor:
-        kind = cp_restore[0]
-        if kind == "packed":
-            return split_packed_to_cp_local(
-                out,
-                cu_seqlens_padded=cp_restore[1],
-                cp_size=self.ps.cp_size,
-                cp_rank=self.ps.cp_rank,
-                dim=1,
-            )
-        if kind == "dense":
-            return zigzag_slice_for_cp(out, self.ps.cp_rank, self.ps.cp_size, seq_dim=1)
-        raise RuntimeError(f"Unknown CP restore kind: {kind!r}")
-
-    def _causal_conv1d(
-        self, qkv: torch.Tensor, seq_len: int, *, cu_seqlens: torch.Tensor | None
+    def _cp_swap_qkvzba(
+        self,
+        tensor: torch.Tensor,
+        cu_seqlens: torch.Tensor | None,
+        *,
+        to_contiguous: bool,
     ) -> torch.Tensor:
         if cu_seqlens is None:
-            qkv_t = qkv.transpose(1, 2).contiguous()
-            return F.silu(self.conv1d(qkv_t)[:, :, :seq_len].transpose(1, 2))
+            swap = (
+                zigzag_to_contiguous_chunks
+                if to_contiguous
+                else contiguous_to_zigzag_chunks
+            )
+            return swap(tensor, self.ps.cp_group, seq_dim=1)
+        if tensor.shape[0] != 1:
+            raise ValueError(
+                "Packed THD GatedDeltaNet expects a single packed batch row."
+            )
+        local_cu_seqlens = cu_seqlens // self.ps.cp_size
+        pieces = []
+        swap = (
+            zigzag_to_contiguous_chunks
+            if to_contiguous
+            else contiguous_to_zigzag_chunks
+        )
+        for idx in range(int(local_cu_seqlens.numel()) - 1):
+            start = int(local_cu_seqlens[idx].item())
+            end = int(local_cu_seqlens[idx + 1].item())
+            if end <= start:
+                continue
+            pieces.append(swap(tensor[:, start:end, :], self.ps.cp_group, seq_dim=1))
+        if not pieces:
+            return tensor
+        return torch.cat(pieces, dim=1).contiguous()
+
+    def _build_cp_context(
+        self,
+        qkvzba: torch.Tensor,
+        cu_seqlens: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, object]:
+        if _fla_build_cp_context is None:
+            raise NotImplementedError(
+                "GatedDeltaNet all-gather CP requires FLA cp context."
+            )
+        if cu_seqlens is not None:
+            return (
+                cu_seqlens,
+                _fla_build_cp_context(
+                    cu_seqlens=cu_seqlens,
+                    group=self.ps.cp_group,
+                    conv1d_kernel_size=self.conv1d.kernel_size[0],
+                ),
+            )
+
+        batch, local_seq_len = qkvzba.shape[:2]
+        global_seq_len = local_seq_len * self.ps.cp_size
+        cache_key = (global_seq_len, batch, qkvzba.device)
+        cached = self._cp_context_cache.get(cache_key)
+        if cached is None:
+            dense_cu_seqlens = (
+                torch.arange(batch + 1, device=qkvzba.device, dtype=torch.long)
+                * global_seq_len
+            )
+            cached = (
+                dense_cu_seqlens,
+                _fla_build_cp_context(
+                    cu_seqlens=dense_cu_seqlens,
+                    group=self.ps.cp_group,
+                    conv1d_kernel_size=self.conv1d.kernel_size[0],
+                ),
+            )
+            self._cp_context_cache[cache_key] = cached
+        return cached
+
+    def _causal_conv1d(
+        self,
+        qkv: torch.Tensor,
+        seq_len: int,
+        *,
+        cu_seqlens: torch.Tensor | None,
+        cp_context,
+    ) -> torch.Tensor:
+        if cu_seqlens is None and cp_context is None:
+            return F.silu(
+                self.conv1d(qkv.transpose(1, 2))[:, :, :seq_len].transpose(1, 2)
+            )
         if _HAS_FLA:
+            kwargs = {}
+            if cp_context is not None:
+                kwargs["cp_context"] = cp_context
             qkv, _ = _fla_causal_conv1d(
                 x=qkv,
                 weight=self.conv1d.weight.squeeze(1),
                 bias=None,
                 activation="silu",
                 cu_seqlens=cu_seqlens,
+                **kwargs,
             )
             return qkv
         raise NotImplementedError("GatedDeltaNet packed THD requires FLA causal conv.")
@@ -208,8 +293,12 @@ class GatedDeltaNet(nn.Module):
         initial_state: torch.Tensor | None,
         output_final_state: bool,
         cu_seqlens: torch.Tensor | None,
+        cp_context,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        if _HAS_FLA and not self.deterministic:
+        if _HAS_FLA and (cp_context is not None or not self.deterministic):
+            kwargs = {}
+            if cp_context is not None:
+                kwargs["cp_context"] = cp_context
             return _fla_chunk_gated_delta_rule(
                 query,
                 key,
@@ -220,6 +309,11 @@ class GatedDeltaNet(nn.Module):
                 output_final_state=output_final_state,
                 use_qk_l2norm_in_kernel=False,
                 cu_seqlens=cu_seqlens,
+                **kwargs,
+            )
+        if cp_context is not None:
+            raise NotImplementedError(
+                "GatedDeltaNet all-gather CP requires FLA gated delta rule."
             )
         return torch_chunk_gated_delta_rule(
             query,
@@ -239,7 +333,9 @@ class GatedDeltaNet(nn.Module):
             else packed_seq_params.cu_seqlens_q
         )
         if cu_seqlens is None:
-            raise ValueError("packed_seq_params must carry cu_seqlens_q for CP GatedDeltaNet.")
+            raise ValueError(
+                "packed_seq_params must carry cu_seqlens_q for CP GatedDeltaNet."
+            )
         return cu_seqlens
 
     def _split_proj(self, qkvzba: torch.Tensor):
@@ -264,9 +360,13 @@ class GatedDeltaNet(nn.Module):
             a.reshape(batch, seq_len, self.num_v_heads_local),
         )
 
-    def _prepare_qkv(self, qkv: torch.Tensor, gate, beta, alpha, batch: int, seq_len: int):
+    def _prepare_qkv(
+        self, qkv: torch.Tensor, gate, beta, alpha, batch: int, seq_len: int
+    ):
         query_key, value = qkv.split([2 * self.qk_dim_local, self.v_dim_local], dim=-1)
-        query_key = query_key.reshape(batch, seq_len, 2 * self.num_k_heads_local, self.dk)
+        query_key = query_key.reshape(
+            batch, seq_len, 2 * self.num_k_heads_local, self.dk
+        )
         value = value.reshape(batch, seq_len, self.num_v_heads_local, self.dv)
         query, key = query_key.split(self.num_k_heads_local, dim=2)
         query = self._l2norm(query.contiguous())

--- a/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
@@ -108,8 +108,13 @@ class GatedDeltaNet(nn.Module):
         self, x: torch.Tensor, position_ids: torch.Tensor | None = None, packed_seq_params=None
     ) -> torch.Tensor:
         del position_ids
-        qkvzba = self.in_proj(x).transpose(0, 1).contiguous()
         is_packed = packed_seq_params is not None
+        if self.ps.cp_size > 1 and is_packed:
+            raise NotImplementedError(
+                "GatedDeltaNet packed THD with all-gather CP is not validated yet."
+            )
+
+        qkvzba = self.in_proj(x).transpose(0, 1).contiguous()
         cu_seqlens = self._packed_cu_seqlens(packed_seq_params) if is_packed else None
         cp_context = None
         if self.ps.cp_size > 1:

--- a/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
@@ -19,7 +19,13 @@ from megatron.lite.primitive.parallel import (
 )
 from megatron.lite.primitive.parallel.cp import (
     contiguous_to_zigzag_chunks,
+    zigzag_reconstruct_from_cp_parts,
+    zigzag_slice_for_cp,
     zigzag_to_contiguous_chunks,
+)
+from megatron.lite.primitive.parallel.thd import (
+    reconstruct_packed_from_cp_parts,
+    split_packed_to_cp_local,
 )
 from megatron.lite.primitive.utils import ensure_divisible
 
@@ -63,10 +69,14 @@ class GatedDeltaNet(nn.Module):
         rms_norm_eps: float,
         ps: ParallelState,
         deterministic: bool = False,
+        cp_mode: str = "fla_allgather",
     ):
         super().__init__()
+        if cp_mode not in {"fla_allgather", "legacy_full_gather"}:
+            raise ValueError(f"Unsupported GatedDeltaNet CP mode: {cp_mode!r}.")
         self.ps = ps
         self.deterministic = bool(deterministic)
+        self.cp_mode = cp_mode
         self.num_k_heads = linear_num_key_heads
         self.num_v_heads = linear_num_value_heads
         self.dk = linear_key_head_dim
@@ -115,32 +125,32 @@ class GatedDeltaNet(nn.Module):
     ) -> torch.Tensor:
         del position_ids
         is_packed = packed_seq_params is not None
-        if self.ps.cp_size > 1 and is_packed:
-            raise NotImplementedError(
-                "GatedDeltaNet packed THD with all-gather CP is not validated yet."
-            )
-
         qkvzba = self.in_proj(x).transpose(0, 1).contiguous()
         cu_seqlens = self._packed_cu_seqlens(packed_seq_params) if is_packed else None
         cp_context = None
+        legacy_full_gather = False
         if self.ps.cp_size > 1:
             if self.ps.cp_group is None:
                 raise RuntimeError("CP>1 requires ParallelState.cp_group.")
-            if not _HAS_FLA or _fla_build_cp_context is None:
-                raise NotImplementedError(
-                    "GatedDeltaNet all-gather CP requires FLA kernels."
+            if self.cp_mode == "legacy_full_gather":
+                qkvzba, cu_seqlens = self._legacy_full_gather_qkvzba(qkvzba, cu_seqlens)
+                legacy_full_gather = True
+            else:
+                if not _HAS_FLA or _fla_build_cp_context is None:
+                    raise NotImplementedError(
+                        "GatedDeltaNet all-gather CP requires FLA kernels."
+                    )
+                if not is_packed and qkvzba.shape[0] > 1:
+                    raise ValueError(
+                        "GatedDeltaNet all-gather CP with SBHD inputs currently requires "
+                        "micro_batch_size == 1. Use packed THD input or micro_batch_size=1."
+                    )
+                qkvzba = self._cp_swap_qkvzba(
+                    qkvzba,
+                    cu_seqlens if is_packed else None,
+                    to_contiguous=True,
                 )
-            if not is_packed and qkvzba.shape[0] > 1:
-                raise ValueError(
-                    "GatedDeltaNet all-gather CP with SBHD inputs currently requires "
-                    "micro_batch_size == 1. Use packed THD input or micro_batch_size=1."
-                )
-            qkvzba = self._cp_swap_qkvzba(
-                qkvzba,
-                cu_seqlens if is_packed else None,
-                to_contiguous=True,
-            )
-            cu_seqlens, cp_context = self._build_cp_context(qkvzba, cu_seqlens)
+                cu_seqlens, cp_context = self._build_cp_context(qkvzba, cu_seqlens)
         batch, seq_len = qkvzba.shape[:2]
         query, key, value, gate, beta, alpha = self._split_proj(qkvzba)
         qkv = torch.cat(
@@ -174,14 +184,66 @@ class GatedDeltaNet(nn.Module):
         out = self._apply_gated_norm(out, gate)
         out = out.reshape(batch, seq_len, self.v_dim_local)
         if self.ps.cp_size > 1:
-            out = self._cp_swap_qkvzba(
-                out,
-                cu_seqlens if is_packed else None,
-                to_contiguous=False,
-            )
+            if legacy_full_gather:
+                out = self._legacy_slice_output(out, cu_seqlens)
+            else:
+                out = self._cp_swap_qkvzba(
+                    out,
+                    cu_seqlens if is_packed else None,
+                    to_contiguous=False,
+                )
             batch, seq_len = out.shape[:2]
         out = out.transpose(0, 1).contiguous()
         return self.o_proj(out)
+
+    def _all_gather_cp_tensor(self, tensor: torch.Tensor) -> list[torch.Tensor]:
+        if self.ps.cp_size <= 1:
+            return [tensor]
+        try:
+            from torch.distributed.nn.functional import all_gather
+
+            return list(all_gather(tensor, group=self.ps.cp_group))
+        except Exception:
+            parts = [torch.empty_like(tensor) for _ in range(self.ps.cp_size)]
+            torch.distributed.all_gather(parts, tensor, group=self.ps.cp_group)
+            return parts
+
+    def _legacy_full_gather_qkvzba(
+        self,
+        qkvzba: torch.Tensor,
+        cu_seqlens: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        if cu_seqlens is None:
+            parts = self._all_gather_cp_tensor(qkvzba)
+            return zigzag_reconstruct_from_cp_parts(parts, seq_dim=1), None
+        if qkvzba.shape[0] != 1:
+            raise ValueError("Packed THD GatedDeltaNet expects a single packed batch row.")
+        parts = self._all_gather_cp_tensor(qkvzba[0].contiguous())
+        full = reconstruct_packed_from_cp_parts(
+            parts,
+            cu_seqlens_padded=cu_seqlens,
+            cp_size=self.ps.cp_size,
+            dim=0,
+        )
+        return full.unsqueeze(0).contiguous(), cu_seqlens
+
+    def _legacy_slice_output(
+        self,
+        out: torch.Tensor,
+        cu_seqlens: torch.Tensor | None,
+    ) -> torch.Tensor:
+        if cu_seqlens is None:
+            return zigzag_slice_for_cp(out, self.ps.cp_rank, self.ps.cp_size, seq_dim=1)
+        if out.shape[0] != 1:
+            raise ValueError("Packed THD GatedDeltaNet expects a single packed batch row.")
+        local = split_packed_to_cp_local(
+            out[0].contiguous(),
+            cu_seqlens_padded=cu_seqlens,
+            cp_size=self.ps.cp_size,
+            cp_rank=self.ps.cp_rank,
+            dim=0,
+        )
+        return local.unsqueeze(0).contiguous()
 
     def _cp_swap_qkvzba(
         self,

--- a/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
@@ -4,21 +4,23 @@
 from __future__ import annotations
 
 import torch
-import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 import transformer_engine.pytorch as te
 
 from megatron.core.jit import jit_fuser
-from megatron.lite.primitive.ops.gated_delta_rule import l2norm, torch_chunk_gated_delta_rule
-from megatron.lite.primitive.parallel import ColumnParallelLinear, ParallelState, RowParallelLinear
-from megatron.lite.primitive.parallel.cp import (
-    zigzag_reconstruct_from_cp_parts,
-    zigzag_slice_for_cp,
+from megatron.lite.primitive.ops.gated_delta_rule import (
+    l2norm,
+    torch_chunk_gated_delta_rule,
 )
-from megatron.lite.primitive.parallel.thd import (
-    reconstruct_packed_from_cp_parts,
-    split_packed_to_cp_local,
+from megatron.lite.primitive.parallel import (
+    ColumnParallelLinear,
+    ParallelState,
+    RowParallelLinear,
+)
+from megatron.lite.primitive.parallel.cp import (
+    contiguous_to_zigzag_chunks,
+    zigzag_to_contiguous_chunks,
 )
 from megatron.lite.primitive.utils import ensure_divisible
 
@@ -34,9 +36,14 @@ try:
 except ImportError:
     _HAS_FLA = False
 
+try:
+    from fla.ops.cp import build_cp_context as _fla_build_cp_context  # pyright: ignore[reportMissingImports]
+except ImportError:
+    _fla_build_cp_context = None
+
 
 class GatedDeltaNet(nn.Module):
-    """Native Gated DeltaNet with dense/packed CP reconstruction."""
+    """Native Gated DeltaNet with dense/packed all-gather CP support."""
 
     def __init__(
         self,
@@ -85,19 +92,44 @@ class GatedDeltaNet(nn.Module):
             bias=False,
             padding=linear_conv_kernel_dim - 1,
         )
-        self.dt_bias = nn.Parameter(torch.ones(self.num_v_heads_local, dtype=torch.float32))
-        self.A_log = nn.Parameter(torch.zeros(self.num_v_heads_local, dtype=torch.float32))
+        self.dt_bias = nn.Parameter(
+            torch.ones(self.num_v_heads_local, dtype=torch.float32)
+        )
+        self.A_log = nn.Parameter(
+            torch.zeros(self.num_v_heads_local, dtype=torch.float32)
+        )
         self.norm = te.RMSNorm(self.dv, eps=rms_norm_eps, zero_centered_gamma=True)
         self.o_proj = RowParallelLinear(self.v_dim, hidden_size, ps, bias=False)
+        self._cp_context_cache: dict[
+            tuple[int, int, torch.device], tuple[torch.Tensor, object]
+        ] = {}
 
     def forward(
         self, x: torch.Tensor, position_ids: torch.Tensor | None = None, packed_seq_params=None
     ) -> torch.Tensor:
         del position_ids
         qkvzba = self.in_proj(x).transpose(0, 1).contiguous()
-        cp_restore = None
+        is_packed = packed_seq_params is not None
+        cu_seqlens = self._packed_cu_seqlens(packed_seq_params) if is_packed else None
+        cp_context = None
         if self.ps.cp_size > 1:
-            qkvzba, cp_restore = self._gather_cp_qkvzba(qkvzba, packed_seq_params)
+            if self.ps.cp_group is None:
+                raise RuntimeError("CP>1 requires ParallelState.cp_group.")
+            if not _HAS_FLA or _fla_build_cp_context is None:
+                raise NotImplementedError(
+                    "GatedDeltaNet all-gather CP requires FLA kernels."
+                )
+            if not is_packed and qkvzba.shape[0] > 1:
+                raise ValueError(
+                    "GatedDeltaNet all-gather CP with SBHD inputs currently requires "
+                    "micro_batch_size == 1. Use packed THD input or micro_batch_size=1."
+                )
+            qkvzba = self._cp_swap_qkvzba(
+                qkvzba,
+                cu_seqlens if is_packed else None,
+                to_contiguous=True,
+            )
+            cu_seqlens, cp_context = self._build_cp_context(qkvzba, cu_seqlens)
         batch, seq_len = qkvzba.shape[:2]
         query, key, value, gate, beta, alpha = self._split_proj(qkvzba)
         qkv = torch.cat(
@@ -109,17 +141,9 @@ class GatedDeltaNet(nn.Module):
             dim=-1,
         )
 
-        cu_seqlens = None
-        if packed_seq_params is not None:
-            cu_seqlens = (
-                packed_seq_params.cu_seqlens_q_padded
-                if getattr(packed_seq_params, "cu_seqlens_q_padded", None) is not None
-                else packed_seq_params.cu_seqlens_q
-            )
-            if not _HAS_FLA:
-                raise NotImplementedError("GatedDeltaNet packed THD requires FLA kernels.")
-
-        qkv = self._causal_conv1d(qkv, seq_len, cu_seqlens=cu_seqlens)
+        qkv = self._causal_conv1d(
+            qkv, seq_len, cu_seqlens=cu_seqlens, cp_context=cp_context
+        )
         query, key, value, gate, beta, alpha = self._prepare_qkv(
             qkv, gate, beta, alpha, batch, seq_len
         )
@@ -133,66 +157,118 @@ class GatedDeltaNet(nn.Module):
             initial_state=None,
             output_final_state=False,
             cu_seqlens=cu_seqlens,
+            cp_context=cp_context,
         )
 
-        if cp_restore is not None:
-            out = self._slice_cp_output(out, cp_restore)
-            gate = self._slice_cp_output(gate, cp_restore)
-            batch, seq_len = out.shape[:2]
         out = self._apply_gated_norm(out, gate)
-        out = out.reshape(batch, seq_len, self.v_dim_local).transpose(0, 1).contiguous()
+        out = out.reshape(batch, seq_len, self.v_dim_local)
+        if self.ps.cp_size > 1:
+            out = self._cp_swap_qkvzba(
+                out,
+                cu_seqlens if is_packed else None,
+                to_contiguous=False,
+            )
+            batch, seq_len = out.shape[:2]
+        out = out.transpose(0, 1).contiguous()
         return self.o_proj(out)
 
-    def _all_gather_cp(self, tensor: torch.Tensor) -> list[torch.Tensor]:
-        if self.ps.cp_group is None:
-            raise RuntimeError("CP>1 requires ParallelState.cp_group.")
-        try:
-            from torch.distributed.nn.functional import all_gather
-
-            return list(all_gather(tensor, group=self.ps.cp_group))
-        except Exception:
-            parts = [torch.empty_like(tensor) for _ in range(self.ps.cp_size)]
-            dist.all_gather(parts, tensor, group=self.ps.cp_group)
-            return parts
-
-    def _gather_cp_qkvzba(self, qkvzba: torch.Tensor, packed_seq_params):
-        parts = self._all_gather_cp(qkvzba)
-        if packed_seq_params is not None:
-            cu_seqlens = self._packed_cu_seqlens(packed_seq_params)
-            full = reconstruct_packed_from_cp_parts(
-                parts, cu_seqlens_padded=cu_seqlens, cp_size=self.ps.cp_size, dim=1
-            )
-            return full, ("packed", cu_seqlens)
-        full = zigzag_reconstruct_from_cp_parts(parts, seq_dim=1)
-        return full, ("dense",)
-
-    def _slice_cp_output(self, out: torch.Tensor, cp_restore) -> torch.Tensor:
-        kind = cp_restore[0]
-        if kind == "packed":
-            return split_packed_to_cp_local(
-                out,
-                cu_seqlens_padded=cp_restore[1],
-                cp_size=self.ps.cp_size,
-                cp_rank=self.ps.cp_rank,
-                dim=1,
-            )
-        if kind == "dense":
-            return zigzag_slice_for_cp(out, self.ps.cp_rank, self.ps.cp_size, seq_dim=1)
-        raise RuntimeError(f"Unknown CP restore kind: {kind!r}")
-
-    def _causal_conv1d(
-        self, qkv: torch.Tensor, seq_len: int, *, cu_seqlens: torch.Tensor | None
+    def _cp_swap_qkvzba(
+        self,
+        tensor: torch.Tensor,
+        cu_seqlens: torch.Tensor | None,
+        *,
+        to_contiguous: bool,
     ) -> torch.Tensor:
         if cu_seqlens is None:
-            qkv_t = qkv.transpose(1, 2).contiguous()
-            return F.silu(self.conv1d(qkv_t)[:, :, :seq_len].transpose(1, 2))
+            swap = (
+                zigzag_to_contiguous_chunks
+                if to_contiguous
+                else contiguous_to_zigzag_chunks
+            )
+            return swap(tensor, self.ps.cp_group, seq_dim=1)
+        if tensor.shape[0] != 1:
+            raise ValueError(
+                "Packed THD GatedDeltaNet expects a single packed batch row."
+            )
+        local_cu_seqlens = cu_seqlens // self.ps.cp_size
+        pieces = []
+        swap = (
+            zigzag_to_contiguous_chunks
+            if to_contiguous
+            else contiguous_to_zigzag_chunks
+        )
+        for idx in range(int(local_cu_seqlens.numel()) - 1):
+            start = int(local_cu_seqlens[idx].item())
+            end = int(local_cu_seqlens[idx + 1].item())
+            if end <= start:
+                continue
+            pieces.append(swap(tensor[:, start:end, :], self.ps.cp_group, seq_dim=1))
+        if not pieces:
+            return tensor
+        return torch.cat(pieces, dim=1).contiguous()
+
+    def _build_cp_context(
+        self,
+        qkvzba: torch.Tensor,
+        cu_seqlens: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, object]:
+        if _fla_build_cp_context is None:
+            raise NotImplementedError(
+                "GatedDeltaNet all-gather CP requires FLA cp context."
+            )
+        if cu_seqlens is not None:
+            return (
+                cu_seqlens,
+                _fla_build_cp_context(
+                    cu_seqlens=cu_seqlens,
+                    group=self.ps.cp_group,
+                    conv1d_kernel_size=self.conv1d.kernel_size[0],
+                ),
+            )
+
+        batch, local_seq_len = qkvzba.shape[:2]
+        global_seq_len = local_seq_len * self.ps.cp_size
+        cache_key = (global_seq_len, batch, qkvzba.device)
+        cached = self._cp_context_cache.get(cache_key)
+        if cached is None:
+            dense_cu_seqlens = (
+                torch.arange(batch + 1, device=qkvzba.device, dtype=torch.long)
+                * global_seq_len
+            )
+            cached = (
+                dense_cu_seqlens,
+                _fla_build_cp_context(
+                    cu_seqlens=dense_cu_seqlens,
+                    group=self.ps.cp_group,
+                    conv1d_kernel_size=self.conv1d.kernel_size[0],
+                ),
+            )
+            self._cp_context_cache[cache_key] = cached
+        return cached
+
+    def _causal_conv1d(
+        self,
+        qkv: torch.Tensor,
+        seq_len: int,
+        *,
+        cu_seqlens: torch.Tensor | None,
+        cp_context,
+    ) -> torch.Tensor:
+        if cu_seqlens is None and cp_context is None:
+            return F.silu(
+                self.conv1d(qkv.transpose(1, 2))[:, :, :seq_len].transpose(1, 2)
+            )
         if _HAS_FLA:
+            kwargs = {}
+            if cp_context is not None:
+                kwargs["cp_context"] = cp_context
             qkv, _ = _fla_causal_conv1d(
                 x=qkv,
                 weight=self.conv1d.weight.squeeze(1),
                 bias=None,
                 activation="silu",
                 cu_seqlens=cu_seqlens,
+                **kwargs,
             )
             return qkv
         raise NotImplementedError("GatedDeltaNet packed THD requires FLA causal conv.")
@@ -208,8 +284,12 @@ class GatedDeltaNet(nn.Module):
         initial_state: torch.Tensor | None,
         output_final_state: bool,
         cu_seqlens: torch.Tensor | None,
+        cp_context,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        if _HAS_FLA and not self.deterministic:
+        if _HAS_FLA and (cp_context is not None or not self.deterministic):
+            kwargs = {}
+            if cp_context is not None:
+                kwargs["cp_context"] = cp_context
             return _fla_chunk_gated_delta_rule(
                 query,
                 key,
@@ -220,6 +300,11 @@ class GatedDeltaNet(nn.Module):
                 output_final_state=output_final_state,
                 use_qk_l2norm_in_kernel=False,
                 cu_seqlens=cu_seqlens,
+                **kwargs,
+            )
+        if cp_context is not None:
+            raise NotImplementedError(
+                "GatedDeltaNet all-gather CP requires FLA gated delta rule."
             )
         return torch_chunk_gated_delta_rule(
             query,
@@ -239,7 +324,9 @@ class GatedDeltaNet(nn.Module):
             else packed_seq_params.cu_seqlens_q
         )
         if cu_seqlens is None:
-            raise ValueError("packed_seq_params must carry cu_seqlens_q for CP GatedDeltaNet.")
+            raise ValueError(
+                "packed_seq_params must carry cu_seqlens_q for CP GatedDeltaNet."
+            )
         return cu_seqlens
 
     def _split_proj(self, qkvzba: torch.Tensor):
@@ -264,9 +351,13 @@ class GatedDeltaNet(nn.Module):
             a.reshape(batch, seq_len, self.num_v_heads_local),
         )
 
-    def _prepare_qkv(self, qkv: torch.Tensor, gate, beta, alpha, batch: int, seq_len: int):
+    def _prepare_qkv(
+        self, qkv: torch.Tensor, gate, beta, alpha, batch: int, seq_len: int
+    ):
         query_key, value = qkv.split([2 * self.qk_dim_local, self.v_dim_local], dim=-1)
-        query_key = query_key.reshape(batch, seq_len, 2 * self.num_k_heads_local, self.dk)
+        query_key = query_key.reshape(
+            batch, seq_len, 2 * self.num_k_heads_local, self.dk
+        )
         value = value.reshape(batch, seq_len, self.num_v_heads_local, self.dv)
         query, key = query_key.split(self.num_k_heads_local, dim=2)
         query = self._l2norm(query.contiguous())

--- a/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
@@ -8,7 +8,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 import transformer_engine.pytorch as te
 
-from megatron.core.jit import jit_fuser
 from megatron.lite.primitive.ops.gated_delta_rule import (
     l2norm,
     torch_chunk_gated_delta_rule,
@@ -23,6 +22,11 @@ from megatron.lite.primitive.parallel.cp import (
     zigzag_to_contiguous_chunks,
 )
 from megatron.lite.primitive.utils import ensure_divisible
+
+
+def jit_fuser(fn):
+    return fn
+
 
 try:
     from fla.modules.convolution import (

--- a/experimental/lite/megatron/lite/primitive/modules/mtp.py
+++ b/experimental/lite/megatron/lite/primitive/modules/mtp.py
@@ -17,7 +17,22 @@ from megatron.lite.primitive.parallel import (
     scatter_to_sequence_parallel,
 )
 
-__all__ = ["MTPBlock", "MTPDecoderLayer", "MTPLossAutoScaler"]
+__all__ = ["MTPBlock", "MTPDecoderLayer", "MTPLossAutoScaler", "roll_mtp_tensor_left"]
+
+
+def roll_mtp_tensor_left(
+    tensor: torch.Tensor, *, packed_seq_params=None, dims: int = -1
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Roll MTP inputs/labels one token left for dense or packed THD batches."""
+    if packed_seq_params is not None:
+        return roll_packed_thd_left(tensor, packed_seq_params=packed_seq_params, dims=dims)
+
+    dim = dims if dims >= 0 else tensor.dim() + dims
+    rolled = torch.roll(tensor, shifts=-1, dims=dim)
+    index = [slice(None)] * tensor.dim()
+    index[dim] = slice(-1, None)
+    rolled[tuple(index)] = 0
+    return rolled, rolled.sum()
 
 
 class MTPLossAutoScaler(torch.autograd.Function):
@@ -76,9 +91,9 @@ class MTPDecoderLayer(nn.Module):
         attention_position_ids = (
             rotary_position_ids if rotary_position_ids is not None else position_ids
         )
-        input_ids, _ = roll_packed_thd_left(input_ids, packed_seq_params=packed_seq_params, dims=-1)
+        input_ids, _ = roll_mtp_tensor_left(input_ids, packed_seq_params=packed_seq_params, dims=-1)
         if position_ids is not None:
-            position_ids, _ = roll_packed_thd_left(
+            position_ids, _ = roll_mtp_tensor_left(
                 position_ids, packed_seq_params=packed_seq_params, dims=-1
             )
         decoder_input = scatter_to_sequence_parallel(self.embedding(input_ids), self.ps)

--- a/experimental/lite/megatron/lite/primitive/optimizers/megatron_wrap.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/megatron_wrap.py
@@ -243,6 +243,12 @@ def build_mc_training_optimizer(
     return optimizer, finalize_grads
 
 
+def build_distopt_training_optimizer(*args, **kwargs):
+    """Build the distopt DDP+optimizer stack from a Megatron Lite model ImplConfig."""
+
+    return build_mc_training_optimizer(*args, **kwargs)
+
+
 def finalize_mc_grads(model_chunks: list[nn.Module], optimizer) -> None:
     """Run MC gradient finalization to match the optimizer's expected contract."""
     from megatron.core.distributed.finalize_model_grads import finalize_model_grads
@@ -436,6 +442,7 @@ BACKEND = MCBackend()
 __all__ = [
     "BACKEND",
     "MCBackend",
+    "build_distopt_training_optimizer",
     "build_mc_stack",
     "build_mc_training_optimizer",
     "finalize_mc_grads",

--- a/experimental/lite/megatron/lite/primitive/parallel/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/__init__.py
@@ -4,14 +4,19 @@
 from __future__ import annotations
 
 from megatron.lite.primitive.parallel.cp import (
+    contiguous_to_zigzag_chunks,
     split_packed_for_cp,
     zigzag_position_ids_for_cp,
     zigzag_reconstruct_from_cp_parts,
     zigzag_slice_for_cp,
     zigzag_split_for_cp,
+    zigzag_to_contiguous_chunks,
 )
 from megatron.lite.primitive.parallel.pipeline import forward_backward_pipelining
-from megatron.lite.primitive.parallel.pp import PipelineChunkLayout, build_pipeline_chunk_layout
+from megatron.lite.primitive.parallel.pp import (
+    PipelineChunkLayout,
+    build_pipeline_chunk_layout,
+)
 from megatron.lite.primitive.parallel.sp import (
     gather_for_non_sp_head,
     gather_from_sequence_parallel,
@@ -48,6 +53,7 @@ def __getattr__(name: str):
 
 __all__ = [
     "ColumnParallelLinear",
+    "contiguous_to_zigzag_chunks",
     "PackedSeqParams",
     "PackedTHDBatch",
     "PipelineChunkLayout",
@@ -73,4 +79,5 @@ __all__ = [
     "zigzag_reconstruct_from_cp_parts",
     "zigzag_slice_for_cp",
     "zigzag_split_for_cp",
+    "zigzag_to_contiguous_chunks",
 ]

--- a/experimental/lite/megatron/lite/primitive/parallel/cp.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/cp.py
@@ -3,11 +3,17 @@
 
 from __future__ import annotations
 
+from typing import Optional
+
 import torch
+import torch.distributed as dist
 
 
 def zigzag_split_for_cp(
-    tensor: torch.Tensor, cp_rank: int, cp_size: int, seq_dim: int = 1
+    tensor: torch.Tensor,
+    cp_rank: int,
+    cp_size: int,
+    seq_dim: int = 1,
 ) -> torch.Tensor:
     """Split tensor along sequence dim using zigzag (striped) pattern for CP.
 
@@ -27,7 +33,11 @@ def zigzag_split_for_cp(
     shape = list(tensor.shape)
     shape[seq_dim : seq_dim + 1] = [2 * cp_size, seq_len // (2 * cp_size)]
     tensor = tensor.view(*shape)
-    idx = torch.tensor([cp_rank, 2 * cp_size - cp_rank - 1], dtype=torch.long, device=tensor.device)
+    idx = torch.tensor(
+        [cp_rank, 2 * cp_size - cp_rank - 1],
+        dtype=torch.long,
+        device=tensor.device,
+    )
     tensor = tensor.index_select(seq_dim, idx)
     shape[seq_dim : seq_dim + 2] = [seq_len // cp_size]
     return tensor.reshape(*shape)
@@ -79,8 +89,129 @@ def zigzag_slice_for_cp(
     return torch.cat((first, second), dim=seq_dim).contiguous()
 
 
+def zigzag_to_contiguous_chunks(
+    tensor: torch.Tensor,
+    cp_group: dist.ProcessGroup | None,
+    seq_dim: int = 1,
+) -> torch.Tensor:
+    """Swap a CP-local tensor from Megatron zigzag layout to contiguous chunks.
+
+    Zigzag CP layout assigns rank ``r`` global chunks ``[r, 2*cp-r-1]``.
+    Linear-attention all-gather CP kernels expect rank ``r`` to hold chunks
+    ``[2*r, 2*r+1]``. The conversion is a chunk-level all-to-all and preserves
+    the local tensor shape.
+    """
+    return _zigzag_contiguous_chunk_swap(tensor, cp_group, seq_dim, to_contiguous=True)
+
+
+def contiguous_to_zigzag_chunks(
+    tensor: torch.Tensor,
+    cp_group: dist.ProcessGroup | None,
+    seq_dim: int = 1,
+) -> torch.Tensor:
+    """Inverse of :func:`zigzag_to_contiguous_chunks`."""
+    return _zigzag_contiguous_chunk_swap(tensor, cp_group, seq_dim, to_contiguous=False)
+
+
+def _zigzag_contiguous_chunk_swap(
+    tensor: torch.Tensor,
+    cp_group: Optional[dist.ProcessGroup],
+    seq_dim: int,
+    *,
+    to_contiguous: bool,
+) -> torch.Tensor:
+    cp_size = dist.get_world_size(cp_group) if cp_group is not None else 1
+    if cp_size <= 1:
+        return tensor
+    cp_rank = dist.get_rank(cp_group)
+
+    if seq_dim != 0:
+        tensor = tensor.movedim(seq_dim, 0)
+    tensor = tensor.contiguous()
+
+    local_len = tensor.size(0)
+    if local_len % 2 != 0:
+        raise ValueError(
+            f"zigzag/contiguous CP chunk swap requires even local sequence length, got {local_len}."
+        )
+    chunk_len = local_len // 2
+
+    def rank_to_chunks(rank: int, in_zigzag: bool) -> tuple[int, int]:
+        if in_zigzag:
+            return rank, 2 * cp_size - rank - 1
+        return 2 * rank, 2 * rank + 1
+
+    def chunk_to_dest(chunk_idx: int, target_zigzag: bool) -> tuple[int, int]:
+        if target_zigzag:
+            if chunk_idx < cp_size:
+                return chunk_idx, 0
+            return 2 * cp_size - chunk_idx - 1, 1
+        return chunk_idx // 2, chunk_idx % 2
+
+    source_in_zigzag = to_contiguous
+    target_in_zigzag = not to_contiguous
+    local_chunks = [tensor[:chunk_len], tensor[chunk_len:]]
+    local_chunk_indices = rank_to_chunks(cp_rank, source_in_zigzag)
+    local_dests = [
+        chunk_to_dest(chunk_idx, target_in_zigzag) for chunk_idx in local_chunk_indices
+    ]
+    local_slot_order = sorted(range(2), key=lambda slot: local_dests[slot])
+    send_buf = torch.cat(
+        [local_chunks[slot] for slot in local_slot_order], dim=0
+    ).contiguous()
+
+    input_split_chunks = [0] * cp_size
+    for dst_rank, _dst_slot in local_dests:
+        input_split_chunks[dst_rank] += 1
+
+    output_split_chunks = [0] * cp_size
+    recv_dst_slots_per_source: list[list[int]] = [[] for _ in range(cp_size)]
+    for src_rank in range(cp_size):
+        src_chunks = rank_to_chunks(src_rank, source_in_zigzag)
+        src_dests = [
+            chunk_to_dest(chunk_idx, target_in_zigzag) for chunk_idx in src_chunks
+        ]
+        src_slot_order = sorted(range(2), key=lambda slot: src_dests[slot])
+        for slot in src_slot_order:
+            dst_rank, dst_slot = src_dests[slot]
+            if dst_rank == cp_rank:
+                output_split_chunks[src_rank] += 1
+                recv_dst_slots_per_source[src_rank].append(dst_slot)
+
+    input_split_sizes = [count * chunk_len for count in input_split_chunks]
+    output_split_sizes = [count * chunk_len for count in output_split_chunks]
+    recv_shape = (sum(output_split_sizes), *send_buf.shape[1:])
+    recv_buf = torch.empty(recv_shape, dtype=send_buf.dtype, device=send_buf.device)
+    from torch.distributed.nn.functional import all_to_all_single
+
+    recv_buf = all_to_all_single(
+        recv_buf,
+        send_buf,
+        output_split_sizes=output_split_sizes,
+        input_split_sizes=input_split_sizes,
+        group=cp_group,
+    )
+
+    target_slots: list[torch.Tensor | None] = [None, None]
+    offset = 0
+    for src_rank in range(cp_size):
+        for dst_slot in recv_dst_slots_per_source[src_rank]:
+            target_slots[dst_slot] = recv_buf[offset : offset + chunk_len]
+            offset += chunk_len
+    if any(slot is None for slot in target_slots):
+        raise RuntimeError("Incomplete CP chunk reassembly.")
+
+    out = torch.cat([slot for slot in target_slots if slot is not None], dim=0)
+    if seq_dim != 0:
+        out = out.movedim(0, seq_dim)
+    return out.contiguous()
+
+
 def zigzag_position_ids_for_cp(
-    seq_len: int, cp_rank: int, cp_size: int, device: torch.device
+    seq_len: int,
+    cp_rank: int,
+    cp_size: int,
+    device: torch.device,
 ) -> torch.Tensor:
     """Return global position IDs for this CP rank under zigzag splitting.
 
@@ -146,7 +277,9 @@ def split_packed_for_cp(
 
 
 __all__ = [
+    "contiguous_to_zigzag_chunks",
     "split_packed_for_cp",
+    "zigzag_to_contiguous_chunks",
     "zigzag_reconstruct_from_cp_parts",
     "zigzag_position_ids_for_cp",
     "zigzag_slice_for_cp",

--- a/experimental/lite/tests/smoke/model/test_qwen_lite_forward_smoke.py
+++ b/experimental/lite/tests/smoke/model/test_qwen_lite_forward_smoke.py
@@ -88,7 +88,7 @@ def _tiny_qwen35_config():
         max_position_embeddings=16,
         partial_rotary_factor=1.0,
         mrope_section=[1, 1, 0],
-        layer_types=["full_attention"],
+        layer_types=["linear_attention"],
     )
 
 
@@ -115,13 +115,19 @@ def _assert_loss_and_backward(output: dict, model: torch.nn.Module):
         param for param in model.parameters() if param.requires_grad and param.grad is not None
     ]
     assert grad_params
-    assert all(torch.isfinite(param.grad.detach().float()).all() for param in grad_params)
+    assert all(
+        torch.isfinite(param.grad.detach().float()).all() for param in grad_params
+    )
 
 
 def test_qwen3_moe_lite_tiny_forward_backward_smoke():
     _Qwen3MoEConfig, Qwen3MoEModel = _qwen3_symbols()
     config = _tiny_qwen3_config()
-    model = Qwen3MoEModel(config, _parallel_state(), use_deepep=False).cuda().to(torch.bfloat16)
+    model = (
+        Qwen3MoEModel(config, _parallel_state(), use_deepep=False)
+        .cuda()
+        .to(torch.bfloat16)
+    )
     input_ids, labels = _token_batch(config.vocab_size)
 
     output = model(input_ids=input_ids, labels=labels, return_log_probs=True)
@@ -146,7 +152,9 @@ def test_qwen35_lite_tiny_forward_backward_smoke():
         recompute_modules=[],
         deterministic=True,
     )
-    model = Qwen35Model(config, train_config, _parallel_state()).cuda().to(torch.bfloat16)
+    model = (
+        Qwen35Model(config, train_config, _parallel_state()).cuda().to(torch.bfloat16)
+    )
     input_ids, labels = _token_batch(config.vocab_size)
 
     output = model(input_ids=input_ids, labels=labels)

--- a/experimental/lite/tests/smoke/primitive/test_parallel_topologies_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_parallel_topologies_smoke.py
@@ -9,6 +9,7 @@ import torch
 import torch.distributed as dist
 
 from megatron.lite.primitive.parallel import (
+    PackedSeqParams,
     contiguous_to_zigzag_chunks,
     init_parallel,
     zigzag_split_for_cp,
@@ -118,3 +119,33 @@ def test_cp_zigzag_contiguous_chunk_swap_roundtrip():
 
     restored = contiguous_to_zigzag_chunks(local_contiguous, ps.cp_group, seq_dim=1)
     assert torch.equal(restored, local_zigzag)
+
+
+def test_gdn_rejects_thd_context_parallel_until_validated():
+    if dist.get_world_size() < 2:
+        pytest.skip("GDN THD+CP guard smoke requires at least 2 ranks.")
+
+    pytest.importorskip("transformer_engine.pytorch")
+    from megatron.lite.primitive.modules.gated_delta_net import GatedDeltaNet
+
+    ps = init_parallel(SimpleNamespace(tp=1, ep=1, etp=1, cp=2, pp=1))
+    gdn = (
+        GatedDeltaNet(
+            hidden_size=16,
+            linear_num_key_heads=2,
+            linear_key_head_dim=4,
+            linear_num_value_heads=2,
+            linear_value_head_dim=4,
+            linear_conv_kernel_dim=2,
+            rms_norm_eps=1e-6,
+            ps=ps,
+        )
+        .cuda()
+        .to(torch.bfloat16)
+    )
+    cu_seqlens = torch.tensor([0, 8], dtype=torch.int32, device="cuda")
+    packed_seq_params = PackedSeqParams.from_cu_seqlens(cu_seqlens, max_seqlen=8)
+    local_hidden = torch.randn(4, 1, 16, device="cuda", dtype=torch.bfloat16)
+
+    with pytest.raises(NotImplementedError, match="packed THD with all-gather CP"):
+        gdn(local_hidden, packed_seq_params=packed_seq_params)

--- a/experimental/lite/tests/smoke/primitive/test_parallel_topologies_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_parallel_topologies_smoke.py
@@ -8,7 +8,13 @@ import pytest
 import torch
 import torch.distributed as dist
 
-from megatron.lite.primitive.parallel import init_parallel
+from megatron.lite.primitive.parallel import (
+    PackedSeqParams,
+    contiguous_to_zigzag_chunks,
+    init_parallel,
+    zigzag_split_for_cp,
+    zigzag_to_contiguous_chunks,
+)
 
 pytestmark = [pytest.mark.mlite, pytest.mark.smoke, pytest.mark.gpu, pytest.mark.distributed]
 
@@ -94,3 +100,52 @@ def test_parallel_state_builds_expected_primitive_groups():
         if cfg.pp > 1:
             assert ps.pp_next_rank in ps.pp_global_ranks
             assert ps.pp_prev_rank in ps.pp_global_ranks
+
+
+def test_cp_zigzag_contiguous_chunk_swap_roundtrip():
+    if dist.get_world_size() < 2:
+        pytest.skip("CP chunk swap smoke requires at least 2 ranks.")
+
+    ps = init_parallel(SimpleNamespace(tp=1, ep=1, etp=1, cp=2, pp=1))
+    full = (
+        torch.arange(8, device="cuda", dtype=torch.float32).reshape(1, 8, 1)
+        + 100 * ps.dp_rank
+    )
+    local_zigzag = zigzag_split_for_cp(full, ps.cp_rank, cp_size=2, seq_dim=1)
+
+    local_contiguous = zigzag_to_contiguous_chunks(local_zigzag, ps.cp_group, seq_dim=1)
+    expected = full[:, ps.cp_rank * 4 : (ps.cp_rank + 1) * 4, :]
+    assert torch.equal(local_contiguous, expected)
+
+    restored = contiguous_to_zigzag_chunks(local_contiguous, ps.cp_group, seq_dim=1)
+    assert torch.equal(restored, local_zigzag)
+
+
+def test_gdn_rejects_thd_context_parallel_until_validated():
+    if dist.get_world_size() < 2:
+        pytest.skip("GDN THD+CP guard smoke requires at least 2 ranks.")
+
+    pytest.importorskip("transformer_engine.pytorch")
+    from megatron.lite.primitive.modules.gated_delta_net import GatedDeltaNet
+
+    ps = init_parallel(SimpleNamespace(tp=1, ep=1, etp=1, cp=2, pp=1))
+    gdn = (
+        GatedDeltaNet(
+            hidden_size=16,
+            linear_num_key_heads=2,
+            linear_key_head_dim=4,
+            linear_num_value_heads=2,
+            linear_value_head_dim=4,
+            linear_conv_kernel_dim=2,
+            rms_norm_eps=1e-6,
+            ps=ps,
+        )
+        .cuda()
+        .to(torch.bfloat16)
+    )
+    cu_seqlens = torch.tensor([0, 8], dtype=torch.int32, device="cuda")
+    packed_seq_params = PackedSeqParams.from_cu_seqlens(cu_seqlens, max_seqlen=8)
+    local_hidden = torch.randn(4, 1, 16, device="cuda", dtype=torch.bfloat16)
+
+    with pytest.raises(NotImplementedError, match="packed THD with all-gather CP"):
+        gdn(local_hidden, packed_seq_params=packed_seq_params)

--- a/experimental/lite/tests/smoke/primitive/test_parallel_topologies_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_parallel_topologies_smoke.py
@@ -8,7 +8,12 @@ import pytest
 import torch
 import torch.distributed as dist
 
-from megatron.lite.primitive.parallel import init_parallel
+from megatron.lite.primitive.parallel import (
+    contiguous_to_zigzag_chunks,
+    init_parallel,
+    zigzag_split_for_cp,
+    zigzag_to_contiguous_chunks,
+)
 
 pytestmark = [pytest.mark.mlite, pytest.mark.smoke, pytest.mark.gpu, pytest.mark.distributed]
 
@@ -94,3 +99,22 @@ def test_parallel_state_builds_expected_primitive_groups():
         if cfg.pp > 1:
             assert ps.pp_next_rank in ps.pp_global_ranks
             assert ps.pp_prev_rank in ps.pp_global_ranks
+
+
+def test_cp_zigzag_contiguous_chunk_swap_roundtrip():
+    if dist.get_world_size() < 2:
+        pytest.skip("CP chunk swap smoke requires at least 2 ranks.")
+
+    ps = init_parallel(SimpleNamespace(tp=1, ep=1, etp=1, cp=2, pp=1))
+    full = (
+        torch.arange(8, device="cuda", dtype=torch.float32).reshape(1, 8, 1)
+        + 100 * ps.dp_rank
+    )
+    local_zigzag = zigzag_split_for_cp(full, ps.cp_rank, cp_size=2, seq_dim=1)
+
+    local_contiguous = zigzag_to_contiguous_chunks(local_zigzag, ps.cp_group, seq_dim=1)
+    expected = full[:, ps.cp_rank * 4 : (ps.cp_rank + 1) * 4, :]
+    assert torch.equal(local_contiguous, expected)
+
+    restored = contiguous_to_zigzag_chunks(local_contiguous, ps.cp_group, seq_dim=1)
+    assert torch.equal(restored, local_zigzag)

--- a/experimental/lite/tests/unit/primitive/test_parallel_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_parallel_unit.py
@@ -60,6 +60,16 @@ def test_pp_layout_marks_stage_boundaries_and_vpp_chunks():
     assert vpp_rank1_chunk1.has_head is True
 
 
+def test_pp_layout_rejects_non_divisible_vpp_layer_counts():
+    ps = ParallelState(pp_size=2, pp_rank=0, pp_is_first=True, pp_is_last=False)
+
+    with pytest.raises(ValueError, match="10 is not divisible by 6"):
+        build_pipeline_chunk_layout(10, ps, vpp=3)
+
+    with pytest.raises(ValueError, match="10 is not divisible by 6"):
+        build_pipeline_chunk_layout(10, ps, vpp=3, vpp_chunk_id=0)
+
+
 def test_thd_roll_keeps_sequence_boundaries():
     cu_seqlens = torch.tensor([0, 4, 8], dtype=torch.int32)
     rolled, token_sum = roll_packed_thd_left(torch.arange(8), cu_seqlens_padded=cu_seqlens, dims=0)


### PR DESCRIPTION
## Summary
- Combine the previous GDN all-gather CP branch and the Qwen3.5 validation branch into one Qwen3.5 PR.
- Keep the Qwen3.5 save/export/save_hf and PP guard validation work, plus the GDN FLA fused-path fix used by fused-vs-fused Megatron-Core parity.
- Add Qwen3.5-35B MTP validation against the real checkpoint config: `Qwen/Qwen3.5-35B-A3B` parses as `num_nextn_predict_layers=1`, so MTP is validated and is not N/A.
- Add explicit Qwen3.5 GDN CP mode selection so the 32-GPU bench can compare FLA all-gather CP and legacy full-gather CP under the same model path.
- Remove the Qwen3.5 model-local Megatron-Core SwiGLU import by using the current lite helper; the canonical shared primitive/modules cleanup is tracked by the shared primitive PR and should be inherited on rebase.

## Gate Checklist

### Precision Alignment
- ✅ forward fused-vs-fused: MLite fused vs Megatron-Core fused, same weights, layer/final/logits within tolerance with true nonzero diffs. Job `12775949`, `sacct` COMPLETED `0:0`, `NON_SKIP_QWEN35_MCORE_PARITY_PASSED`; fused config includes `NVTE_FUSED_ATTN=1`, MCore `AttnBackend.fused`, MLite/MCore GDN FLA enabled, `unmapped_lite=[]`; diffs: layer0 `2.44140625e-4`, layer1 `2.44140625e-4`, final hidden `0.015625`, logits `0.00390625`, `failures={}`.
- ✅ HF secondary reference: real Qwen3.5-35B HF class via transformers overlay (`transformers.Qwen3_5MoeForCausalLM`, `qwen3_5_moe`). Job `12776488`, `sacct` COMPLETED `0:0`, `NON_SKIP_QWEN35_HF_REF_IO_PRECISION_PASSED`; attention paths `layer0_gated_delta_net` and `layer1_full_attention_mrope_gate`; layer0/layer1 max_abs `4.8828125e-4`, final hidden max_abs `0.03125`, logits max_abs `0.00390625`, true nonzero diffs observed and within tolerance.
- ✅ run-to-run deterministic reproducibility: distopt+deterministic independent rerun produced bitwise-identical loss, grad norm, 41 gradient tensors, and 41 post-step params. Job `12773978`, `sacct` COMPLETED `0:0`, `NON_SKIP_QWEN35_DISTOPT_RUN_TO_RUN_DETERMINISM_PASSED`.

### Key Features
- ✅ MTP: real Qwen3.5-35B checkpoint has `num_nextn_predict_layers=1` (`text_config.mtp_num_hidden_layers=1`), so MTP was validated against Megatron-Core. Job `12775950`, `sacct` COMPLETED `0:0`, `NON_SKIP_QWEN35_MTP_PARITY_PASSED`; `unmapped_lite=[]`, main loss max_abs `5.96e-5`, MTP hidden max_abs `0.03125`, MTP loss max_abs `6.70e-4`, MTP backward grad tensors `22`.
- ✅ THD + CP bench, FLA all-gather CP: 32 GPU / 128k / FSDP2 EP8 CP8 / full recompute. Job `12777333`, `sacct` COMPLETED `0:0`, `NON_SKIP_QWEN35_CP_BENCH_PASSED mode=fla_allgather`; `avg_step_ms=7000.903`, `tok_per_s=599108.985`, `tok_per_s_per_gpu=18722.156`, `peak_mem_gb=47.104`, `tflops_per_gpu=117.343`.
- ✅ THD + CP bench, legacy full-gather CP: 32 GPU / 128k / FSDP2 EP8 CP8 / full recompute. Job `12777334`, `sacct` COMPLETED `0:0`, `NON_SKIP_QWEN35_CP_BENCH_PASSED mode=legacy_full_gather`; `avg_step_ms=12205.006`, `tok_per_s=343654.395`, `tok_per_s_per_gpu=10739.200`, `peak_mem_gb=49.034`, `tflops_per_gpu=67.309`.
- ✅ proxy smoke: focused Qwen smoke job `12775951`, `sacct` COMPLETED `0:0`, `NON_SKIP_QWEN35_UNIT_SMOKE_PASSED`; focused validation refresh job `12777426`, `sacct` COMPLETED `0:0`, `18 passed`.
- N/A end-to-end 128-GPU SFT: explicitly deferred for this validation pass.

### Weight IO
- ✅ load/save/export_weights/save_hf_weights roundtrip: job `12773155`, `sacct` COMPLETED `0:0`, covered MLite IO roundtrip and mismatch count 0.
- ✅ HF secondary IO refresh with real Qwen3.5 HF class: job `12776488`, `export_mismatch_count=0`, `save_hf_mismatch_count=0`, runtime save roundtrip logits max_abs `0`, save_hf roundtrip logits max_abs `0`; save throughput `0.0347 GiB/s`, save_hf throughput `0.0376 GiB/s` on the tiny precision fixture.
- ✅ save_hf bf16 standalone reload: job `12773183`, `sacct` COMPLETED `0:0`, `NON_SKIP_QWEN35_SAVE_HF_BF16_ROUNDTRIP_PASSED`, bf16 reload logits `max_abs=0`.

### Structure / Engineering
- ✅ PP non-divisible behavior: targeted local pytest `2 passed`; container smoke `12773216` and refreshed smoke `12775951` both completed `0:0` with non-skip markers.
- ✅ PR hygiene: tracked diff contains only source changes; no devlog, internal task IDs, or Chinese text in tracked diff.
- ⚠️ shared primitive/modules mcore-import cleanup: Qwen3.5 `model.py` no longer imports `megatron.core`. Shared primitive/modules cleanup is intentionally not duplicated here per ownership guidance and should be inherited from the canonical shared primitive PR on rebase.
- ✅ distopt naming: Qwen3.5 protocol uses `distopt`; remaining `mc` names are in the established Megatron-Core optimizer wrapper compatibility surface.
