### PR TITLE
Rename Kimi K2 lite model to DeepSeek V3

### DIFF
--- a/experimental/lite/megatron/lite/model/deepseek_v3/__init__.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v3/__init__.py
@@ -1,2 +1,2 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-"""Kimi K2 model package."""
+"""DeepSeekV3 model package."""

--- a/experimental/lite/megatron/lite/model/deepseek_v3/config.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v3/config.py
@@ -1,11 +1,55 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-"""Kimi K2 / DeepSeekV3-style model configuration."""
+"""DeepSeek-V3 model configuration."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 
 from megatron.lite.primitive.config import load_hf_config_dict
+
+_KIMI_K25_FAMILY = {
+    "rms_norm_eps": 1e-5,
+    "max_position_embeddings": 262144,
+    "rope_scaling": {
+        "type": "yarn",
+        "factor": 64.0,
+        "original_max_position_embeddings": 4096,
+        "beta_fast": 32.0,
+        "beta_slow": 1.0,
+        "mscale": 1.0,
+        "mscale_all_dim": 1.0,
+    },
+}
+
+_VARIANT_ALIASES = {
+    "deepseek-v3": "kimi-k2",
+    "deepseek_v3": "kimi-k2",
+    "kimi-k2": "kimi-k2",
+    "kimi-k2-instruct": "kimi-k2",
+    "kimi_k2": "kimi-k2",
+    "kimi_k2_instruct": "kimi-k2",
+    "kimi-k2.5": "kimi-k2.5",
+    "kimi_k2.5": "kimi-k2.5",
+    "kimi_k25": "kimi-k2.5",
+    "kimi_k2_5": "kimi-k2.5",
+    "kimi-k2.6": "kimi-k2.6",
+    "kimi_k2.6": "kimi-k2.6",
+    "kimi_k26": "kimi-k2.6",
+    "kimi_k2_6": "kimi-k2.6",
+    "kimi-k2.7": "kimi-k2.7",
+    "kimi-k2.7-code": "kimi-k2.7",
+    "kimi_k2.7": "kimi-k2.7",
+    "kimi_k27": "kimi-k2.7",
+    "kimi_k2_7": "kimi-k2.7",
+    "kimi_k27_code": "kimi-k2.7",
+}
+
+DEEPSEEK_V3_VARIANT_CONFIGS = {
+    "kimi-k2": {},
+    "kimi-k2.5": _KIMI_K25_FAMILY,
+    "kimi-k2.6": _KIMI_K25_FAMILY,
+    "kimi-k2.7": _KIMI_K25_FAMILY,
+}
 
 _HF_FIELDS = frozenset(
     {
@@ -46,10 +90,56 @@ _HF_FIELDS = frozenset(
 )
 
 
-@dataclass
-class KimiK2Config:
-    """Pure architecture parameters for Kimi K2 Instruct."""
+def _normalize_variant(name: str | None) -> str:
+    if not name:
+        return "kimi-k2"
+    normalized = str(name).strip().lower().replace("_", "-")
+    normalized = normalized.removeprefix("moonshotai/")
+    normalized = normalized.removeprefix("moonshot/")
+    normalized = normalized.replace("kimi-k25", "kimi-k2.5")
+    normalized = normalized.replace("kimi-k26", "kimi-k2.6")
+    normalized = normalized.replace("kimi-k27-code", "kimi-k2.7-code")
+    normalized = normalized.replace("kimi-k27", "kimi-k2.7")
+    return _VARIANT_ALIASES.get(normalized, _VARIANT_ALIASES.get(str(name), normalized))
 
+
+def _variant_defaults(variant: str) -> dict:
+    defaults = DEEPSEEK_V3_VARIANT_CONFIGS.get(_normalize_variant(variant), {})
+    return {k: (dict(v) if isinstance(v, dict) else v) for k, v in defaults.items()}
+
+
+def _infer_variant_from_text(text: str | None) -> str | None:
+    if not text:
+        return None
+    normalized = str(text).lower().replace("_", "-")
+    if "k2.7" in normalized or "k27" in normalized:
+        return "kimi-k2.7"
+    if "k2.6" in normalized or "k26" in normalized:
+        return "kimi-k2.6"
+    if "k2.5" in normalized or "k25" in normalized:
+        return "kimi-k2.5"
+    if "kimi-k2" in normalized or "deepseek-v3" in normalized:
+        return "kimi-k2"
+    return None
+
+
+def _infer_variant(hf: dict) -> str:
+    for key in ("variant", "_name_or_path", "model_type"):
+        if key in hf:
+            variant = _infer_variant_from_text(hf[key]) or _normalize_variant(hf[key])
+            if variant in DEEPSEEK_V3_VARIANT_CONFIGS:
+                return variant
+    architectures = hf.get("architectures")
+    if isinstance(architectures, list) and any("KimiK25" in str(item) for item in architectures):
+        return "kimi-k2.5"
+    return "kimi-k2"
+
+
+@dataclass
+class DeepSeekV3Config:
+    """Pure architecture parameters for DeepSeekV3 Instruct."""
+
+    variant: str = "kimi-k2"
     num_hidden_layers: int = 61
     hidden_size: int = 7168
     num_attention_heads: int = 64
@@ -107,6 +197,7 @@ class KimiK2Config:
         return self.qk_nope_head_dim + self.qk_rope_head_dim
 
     def __post_init__(self) -> None:
+        self.variant = _normalize_variant(self.variant)
         errors: list[str] = []
 
         def _check(cond: bool, msg: str) -> None:
@@ -145,23 +236,40 @@ class KimiK2Config:
         _check(0 <= self.first_k_dense_replace <= self.num_hidden_layers, "bad dense prefix")
         _check(self.num_nextn_predict_layers >= 0, "num_nextn_predict_layers must be >= 0")
         if errors:
-            raise ValueError("Invalid KimiK2Config:\n  " + "\n  ".join(errors))
+            raise ValueError("Invalid DeepSeekV3Config:\n  " + "\n  ".join(errors))
 
     @classmethod
-    def from_hf(cls, path: str, **overrides) -> KimiK2Config:
+    def from_hf(cls, path: str, **overrides) -> DeepSeekV3Config:
+        path_variant = _infer_variant_from_text(path)
+        if path_variant is not None:
+            overrides.setdefault("variant", path_variant)
         return cls._from_hf_dict(load_hf_config_dict(path), **overrides)
 
     @classmethod
-    def from_hf_config(cls, hf_config, **overrides) -> KimiK2Config:
+    def from_hf_config(cls, hf_config, **overrides) -> DeepSeekV3Config:
         return cls._from_hf_dict(hf_config.to_dict(), **overrides)
 
     @classmethod
-    def _from_hf_dict(cls, hf: dict, **overrides) -> KimiK2Config:
+    def _from_hf_dict(cls, hf: dict, **overrides) -> DeepSeekV3Config:
+        overrides = dict(overrides)
+        variant = _infer_variant(hf)
+        if "variant" in overrides:
+            variant = _normalize_variant(overrides.pop("variant"))
         if "text_config" in hf and isinstance(hf["text_config"], dict):
             hf = hf["text_config"]
-        kwargs = {k: v for k, v in hf.items() if k in _HF_FIELDS}
+        kwargs = _variant_defaults(variant)
+        kwargs.update({k: v for k, v in hf.items() if k in _HF_FIELDS})
         if "rope_scaling" in kwargs and kwargs["rope_scaling"] is None:
             kwargs.pop("rope_scaling")
+        kwargs["variant"] = variant
+        kwargs.update(overrides)
+        return cls(**kwargs)
+
+    @classmethod
+    def from_variant(cls, variant: str, **overrides) -> DeepSeekV3Config:
+        canonical = _normalize_variant(variant)
+        kwargs = _variant_defaults(canonical)
+        kwargs["variant"] = canonical
         kwargs.update(overrides)
         return cls(**kwargs)
 
@@ -172,4 +280,4 @@ class KimiK2Config:
         return (layer_idx - self.first_k_dense_replace) % freq == 0
 
 
-__all__ = ["KimiK2Config"]
+__all__ = ["DeepSeekV3Config", "DEEPSEEK_V3_VARIANT_CONFIGS"]

--- a/experimental/lite/megatron/lite/model/deepseek_v3/config.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v3/config.py
@@ -3,9 +3,13 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import dataclass, field
+from typing import Any
 
 from megatron.lite.primitive.config import load_hf_config_dict
+
+DEFAULT_DEEPSEEK_V3_VARIANT = "kimi-k2"
 
 _KIMI_K25_FAMILY = {
     "rms_norm_eps": 1e-5,
@@ -21,35 +25,41 @@ _KIMI_K25_FAMILY = {
     },
 }
 
-_VARIANT_ALIASES = {
-    "deepseek-v3": "kimi-k2",
-    "deepseek_v3": "kimi-k2",
-    "kimi-k2": "kimi-k2",
-    "kimi-k2-instruct": "kimi-k2",
-    "kimi_k2": "kimi-k2",
-    "kimi_k2_instruct": "kimi-k2",
-    "kimi-k2.5": "kimi-k2.5",
-    "kimi_k2.5": "kimi-k2.5",
-    "kimi_k25": "kimi-k2.5",
-    "kimi_k2_5": "kimi-k2.5",
-    "kimi-k2.6": "kimi-k2.6",
-    "kimi_k2.6": "kimi-k2.6",
-    "kimi_k26": "kimi-k2.6",
-    "kimi_k2_6": "kimi-k2.6",
-    "kimi-k2.7": "kimi-k2.7",
-    "kimi-k2.7-code": "kimi-k2.7",
-    "kimi_k2.7": "kimi-k2.7",
-    "kimi_k27": "kimi-k2.7",
-    "kimi_k2_7": "kimi-k2.7",
-    "kimi_k27_code": "kimi-k2.7",
+
+@dataclass(frozen=True)
+class DeepSeekV3VariantConfig:
+    name: str
+    defaults: dict[str, Any] = field(default_factory=dict)
+    hf_model_types: tuple[str, ...] = ()
+
+
+DEEPSEEK_V3_VARIANTS = {
+    "kimi-k2": DeepSeekV3VariantConfig(
+        "kimi-k2",
+        hf_model_types=("deepseek_v3", "kimi_k2"),
+    ),
+    "kimi-k2.5": DeepSeekV3VariantConfig(
+        "kimi-k2.5",
+        defaults=_KIMI_K25_FAMILY,
+        hf_model_types=("kimi_k25",),
+    ),
+    "kimi-k2.6": DeepSeekV3VariantConfig(
+        "kimi-k2.6",
+        defaults=_KIMI_K25_FAMILY,
+        hf_model_types=("kimi_k26",),
+    ),
+    "kimi-k2.7": DeepSeekV3VariantConfig(
+        "kimi-k2.7",
+        defaults=_KIMI_K25_FAMILY,
+        hf_model_types=("kimi_k27",),
+    ),
 }
 
-DEEPSEEK_V3_VARIANT_CONFIGS = {
-    "kimi-k2": {},
-    "kimi-k2.5": _KIMI_K25_FAMILY,
-    "kimi-k2.6": _KIMI_K25_FAMILY,
-    "kimi-k2.7": _KIMI_K25_FAMILY,
-}
+DEEPSEEK_V3_HF_MODEL_TYPES = tuple(
+    hf_model_type
+    for variant_config in DEEPSEEK_V3_VARIANTS.values()
+    for hf_model_type in variant_config.hf_model_types
+)
 
 _HF_FIELDS = frozenset(
     {
@@ -90,56 +100,34 @@ _HF_FIELDS = frozenset(
 )
 
 
-def _normalize_variant(name: str | None) -> str:
-    if not name:
-        return "kimi-k2"
-    normalized = str(name).strip().lower().replace("_", "-")
-    normalized = normalized.removeprefix("moonshotai/")
-    normalized = normalized.removeprefix("moonshot/")
-    normalized = normalized.replace("kimi-k25", "kimi-k2.5")
-    normalized = normalized.replace("kimi-k26", "kimi-k2.6")
-    normalized = normalized.replace("kimi-k27-code", "kimi-k2.7-code")
-    normalized = normalized.replace("kimi-k27", "kimi-k2.7")
-    return _VARIANT_ALIASES.get(normalized, _VARIANT_ALIASES.get(str(name), normalized))
+def _variant_entry(variant: str) -> DeepSeekV3VariantConfig:
+    if variant not in DEEPSEEK_V3_VARIANTS:
+        raise ValueError(
+            f"Unknown DeepSeekV3 variant: {variant!r}. "
+            f"Available variants: {tuple(DEEPSEEK_V3_VARIANTS)}"
+        )
+    return DEEPSEEK_V3_VARIANTS[variant]
 
 
-def _variant_defaults(variant: str) -> dict:
-    defaults = DEEPSEEK_V3_VARIANT_CONFIGS.get(_normalize_variant(variant), {})
-    return {k: (dict(v) if isinstance(v, dict) else v) for k, v in defaults.items()}
+def _variant_defaults(variant: str) -> dict[str, Any]:
+    return deepcopy(_variant_entry(variant).defaults)
 
 
-def _infer_variant_from_text(text: str | None) -> str | None:
-    if not text:
-        return None
-    normalized = str(text).lower().replace("_", "-")
-    if "k2.7" in normalized or "k27" in normalized:
-        return "kimi-k2.7"
-    if "k2.6" in normalized or "k26" in normalized:
-        return "kimi-k2.6"
-    if "k2.5" in normalized or "k25" in normalized:
-        return "kimi-k2.5"
-    if "kimi-k2" in normalized or "deepseek-v3" in normalized:
-        return "kimi-k2"
+def _explicit_variant_from_hf(hf: dict) -> str | None:
+    variant = hf.get("variant")
+    if isinstance(variant, str):
+        return variant
+    text_config = hf.get("text_config")
+    if isinstance(text_config, dict) and isinstance(text_config.get("variant"), str):
+        return text_config["variant"]
     return None
-
-
-def _infer_variant(hf: dict) -> str:
-    for key in ("variant", "_name_or_path", "model_type"):
-        if key in hf:
-            variant = _infer_variant_from_text(hf[key]) or _normalize_variant(hf[key])
-            if variant in DEEPSEEK_V3_VARIANT_CONFIGS:
-                return variant
-    architectures = hf.get("architectures")
-    if isinstance(architectures, list) and any("KimiK25" in str(item) for item in architectures):
-        return "kimi-k2.5"
-    return "kimi-k2"
 
 
 @dataclass
 class DeepSeekV3Config:
     """Pure architecture parameters for DeepSeekV3 Instruct."""
 
-    variant: str = "kimi-k2"
+    variant: str = DEFAULT_DEEPSEEK_V3_VARIANT
     num_hidden_layers: int = 61
     hidden_size: int = 7168
     num_attention_heads: int = 64
@@ -197,7 +185,7 @@ class DeepSeekV3Config:
         return self.qk_nope_head_dim + self.qk_rope_head_dim
 
     def __post_init__(self) -> None:
-        self.variant = _normalize_variant(self.variant)
+        _variant_entry(self.variant)
         errors: list[str] = []
 
         def _check(cond: bool, msg: str) -> None:
@@ -240,9 +228,6 @@ class DeepSeekV3Config:
 
     @classmethod
     def from_hf(cls, path: str, **overrides) -> DeepSeekV3Config:
-        path_variant = _infer_variant_from_text(path)
-        if path_variant is not None:
-            overrides.setdefault("variant", path_variant)
         return cls._from_hf_dict(load_hf_config_dict(path), **overrides)
 
     @classmethod
@@ -252,9 +237,11 @@ class DeepSeekV3Config:
     @classmethod
     def _from_hf_dict(cls, hf: dict, **overrides) -> DeepSeekV3Config:
         overrides = dict(overrides)
-        variant = _infer_variant(hf)
         if "variant" in overrides:
-            variant = _normalize_variant(overrides.pop("variant"))
+            variant = overrides.pop("variant")
+        else:
+            variant = _explicit_variant_from_hf(hf) or DEFAULT_DEEPSEEK_V3_VARIANT
+        _variant_entry(variant)
         if "text_config" in hf and isinstance(hf["text_config"], dict):
             hf = hf["text_config"]
         kwargs = _variant_defaults(variant)
@@ -267,9 +254,8 @@ class DeepSeekV3Config:
 
     @classmethod
     def from_variant(cls, variant: str, **overrides) -> DeepSeekV3Config:
-        canonical = _normalize_variant(variant)
-        kwargs = _variant_defaults(canonical)
-        kwargs["variant"] = canonical
+        kwargs = _variant_defaults(variant)
+        kwargs["variant"] = variant
         kwargs.update(overrides)
         return cls(**kwargs)
 
@@ -280,4 +266,10 @@ class DeepSeekV3Config:
         return (layer_idx - self.first_k_dense_replace) % freq == 0
 
 
-__all__ = ["DeepSeekV3Config", "DEEPSEEK_V3_VARIANT_CONFIGS"]
+__all__ = [
+    "DEFAULT_DEEPSEEK_V3_VARIANT",
+    "DEEPSEEK_V3_HF_MODEL_TYPES",
+    "DEEPSEEK_V3_VARIANTS",
+    "DeepSeekV3Config",
+    "DeepSeekV3VariantConfig",
+]

--- a/experimental/lite/megatron/lite/model/deepseek_v3/lite/__init__.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v3/lite/__init__.py
@@ -1,2 +1,2 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-"""Kimi K2 lite native sub-package."""
+"""DeepSeekV3 lite native sub-package."""

--- a/experimental/lite/megatron/lite/model/deepseek_v3/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v3/lite/checkpoint.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-"""Kimi K2 lite native checkpoint mapping."""
+"""DeepSeekV3 lite native checkpoint mapping."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ import torch.distributed as dist
 import torch.nn as nn
 from torch.distributed.tensor import Replicate, Shard
 
-from megatron.lite.model.kimi_k2.config import KimiK2Config
+from megatron.lite.model.deepseek_v3.config import DeepSeekV3Config
 from megatron.lite.primitive.ckpt.hf_weights import (
     SafeTensorReader,
     _cast_export_tensor,
@@ -135,7 +135,7 @@ def _text_prefix(reader: SafeTensorReader) -> str:
     for prefix in ("model", "language_model.model", "model.language_model"):
         if _has(reader, f"{prefix}.embed_tokens.weight"):
             return prefix
-    raise KeyError("Could not find Kimi K2 text model prefix in HF checkpoint.")
+    raise KeyError("Could not find DeepSeekV3 text model prefix in HF checkpoint.")
 
 
 def _lm_head_name(reader: SafeTensorReader, text_prefix: str) -> str:
@@ -147,11 +147,11 @@ def _lm_head_name(reader: SafeTensorReader, text_prefix: str) -> str:
     for name in candidates:
         if _has(reader, name):
             return name
-    raise KeyError("Could not find Kimi K2 lm_head.weight in HF checkpoint.")
+    raise KeyError("Could not find DeepSeekV3 lm_head.weight in HF checkpoint.")
 
 
 def _load_vocab(
-    reader: SafeTensorReader, name: str, cfg: KimiK2Config, ps: ParallelState
+    reader: SafeTensorReader, name: str, cfg: DeepSeekV3Config, ps: ParallelState
 ) -> torch.Tensor:
     from megatron.lite.primitive.parallel import pad_vocab_for_tp
 
@@ -273,7 +273,7 @@ def _load_experts(
     *,
     local_prefix: str,
     hf_mlp_prefix: str,
-    cfg: KimiK2Config,
+    cfg: DeepSeekV3Config,
     ps: ParallelState,
     reader: SafeTensorReader,
 ) -> None:
@@ -310,7 +310,7 @@ def _copy_loaded_state(model: nn.Module, loaded: dict[str, torch.Tensor]) -> Non
         if actual is not None:
             resolved[actual] = tensor
         else:
-            log_rank0(f"WARNING: kimi_k2 checkpoint tensor has no target param: {name}")
+            log_rank0(f"WARNING: deepseek_v3 checkpoint tensor has no target param: {name}")
 
     for name, target in model.named_parameters():
         if name not in resolved:
@@ -326,10 +326,10 @@ def _copy_loaded_state(model: nn.Module, loaded: dict[str, torch.Tensor]) -> Non
         target.data.copy_(tensor.to(dtype=target.dtype) if target.is_floating_point() else tensor)
 
 
-class KimiK2WeightSpec:
-    """Export Kimi K2 lite weights to HF DeepSeekV3/Kimi-style names."""
+class DeepSeekV3WeightSpec:
+    """Export DeepSeekV3 lite weights to HF DeepSeekV3/Kimi-style names."""
 
-    def __init__(self, config: KimiK2Config):
+    def __init__(self, config: DeepSeekV3Config):
         self.config = config
 
     @property
@@ -485,7 +485,9 @@ class KimiK2WeightSpec:
         return f"{prefix}.weight{local_idx}"
 
 
-def load_hf_weights(model: nn.Module, path: str, config: KimiK2Config, ps: ParallelState) -> None:
+def load_hf_weights(
+    model: nn.Module, path: str, config: DeepSeekV3Config, ps: ParallelState
+) -> None:
     base_model = unwrap_model(model)
     reader = SafeTensorReader(path)
     out: dict[str, torch.Tensor] = {}
@@ -613,10 +615,10 @@ def load_hf_weights(model: nn.Module, path: str, config: KimiK2Config, ps: Paral
     _copy_loaded_state(base_model, out)
 
 
-def export_hf_weights(model, config: KimiK2Config, ps: ParallelState, **kwargs):
+def export_hf_weights(model, config: DeepSeekV3Config, ps: ParallelState, **kwargs):
     from megatron.lite.primitive.ckpt.hf_weights import export_hf_weights as _export
 
-    spec = KimiK2WeightSpec(config)
+    spec = DeepSeekV3WeightSpec(config)
     rank0_only = bool(kwargs.get("rank0_only", False))
     export_dtype = _resolve_export_dtype(kwargs.get("export_dtype"))
     yield from _export(model, spec, ps, vocab_size=config.vocab_size, **kwargs)
@@ -639,7 +641,7 @@ def export_hf_weights(model, config: KimiK2Config, ps: ParallelState, **kwargs):
                 yield hf_name, _cast_export_tensor(hf_tensor, export_dtype)
 
 
-def save_hf_weights(model, path: str, config: KimiK2Config, ps: ParallelState) -> None:
+def save_hf_weights(model, path: str, config: DeepSeekV3Config, ps: ParallelState) -> None:
     from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
 
     rank = dist.get_rank() if dist.is_initialized() else 0
@@ -652,7 +654,7 @@ def save_hf_weights(model, path: str, config: KimiK2Config, ps: ParallelState) -
 
 __all__ = [
     "EXPERT_CLASSIFIER",
-    "KimiK2WeightSpec",
+    "DeepSeekV3WeightSpec",
     "PLACEMENT_FN",
     "_dequant_int4_weight",
     "_dequant_fp8_weight",

--- a/experimental/lite/megatron/lite/model/deepseek_v3/lite/model.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v3/lite/model.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-"""Kimi K2 lite native model."""
+"""DeepSeekV3 lite native model."""
 
 from __future__ import annotations
 
@@ -13,7 +13,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import transformer_engine.pytorch as te
 
-from megatron.lite.model.kimi_k2.config import KimiK2Config
+from megatron.lite.model.deepseek_v3.config import DeepSeekV3Config
 from megatron.lite.primitive.attention import MultiLatentAttention
 from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
 from megatron.lite.primitive.modules.experts import Experts
@@ -112,12 +112,12 @@ def _topk_routing_supports_groups() -> bool:
     return "num_groups" in params and "group_topk" in params
 
 
-class KimiK2SigmoidTopKRouter(nn.Module):
-    """Kimi K2 sigmoid router with group-limited routing and persistent expert bias."""
+class DeepSeekV3SigmoidTopKRouter(nn.Module):
+    """DeepSeekV3 sigmoid router with group-limited routing and persistent expert bias."""
 
     def __init__(
         self,
-        config: KimiK2Config,
+        config: DeepSeekV3Config,
         ps: ParallelState,
         *,
         router_bias_rate: float = 0.0,
@@ -128,7 +128,7 @@ class KimiK2SigmoidTopKRouter(nn.Module):
         super().__init__()
         if router_bias_rate > 0:
             raise NotImplementedError(
-                "Kimi K2 expert-bias EMA update is not implemented in lite yet."
+                "DeepSeekV3 expert-bias EMA update is not implemented in lite yet."
             )
         self.topk = config.num_experts_per_tok
         self.num_experts = config.n_routed_experts
@@ -213,7 +213,7 @@ class KimiK2SigmoidTopKRouter(nn.Module):
 
 
 class DenseMLP(nn.Module):
-    def __init__(self, config: KimiK2Config, ps: ParallelState):
+    def __init__(self, config: DeepSeekV3Config, ps: ParallelState):
         super().__init__()
         self.gate_up = ColumnParallelLinear(
             config.hidden_size,
@@ -230,7 +230,7 @@ class DenseMLP(nn.Module):
 
 
 class SharedExpert(nn.Module):
-    def __init__(self, config: KimiK2Config, ps: ParallelState):
+    def __init__(self, config: DeepSeekV3Config, ps: ParallelState):
         super().__init__()
         self.ps = ps
         ffn = config.shared_expert_intermediate_size
@@ -266,7 +266,7 @@ class _LocalLinear(nn.Module):
 class MoELayer(nn.Module):
     def __init__(
         self,
-        config: KimiK2Config,
+        config: DeepSeekV3Config,
         ps: ParallelState,
         *,
         use_deepep: bool,
@@ -276,8 +276,8 @@ class MoELayer(nn.Module):
     ):
         super().__init__()
         if fp8:
-            raise NotImplementedError("Kimi K2 lite MoE fp8 training is not implemented yet.")
-        self.router = KimiK2SigmoidTopKRouter(
+            raise NotImplementedError("DeepSeekV3 lite MoE fp8 training is not implemented yet.")
+        self.router = DeepSeekV3SigmoidTopKRouter(
             config,
             ps,
             router_bias_rate=router_bias_rate,
@@ -319,10 +319,10 @@ class MoELayer(nn.Module):
         return output.to(x.dtype)
 
 
-class KimiK2Layer(nn.Module):
+class DeepSeekV3Layer(nn.Module):
     def __init__(
         self,
-        config: KimiK2Config,
+        config: DeepSeekV3Config,
         ps: ParallelState,
         layer_idx: int,
         *,
@@ -391,10 +391,10 @@ def _roll_mtp_left(
     return rolled, rolled.sum()
 
 
-class KimiK2MTPLayer(nn.Module):
+class DeepSeekV3MTPLayer(nn.Module):
     def __init__(
         self,
-        config: KimiK2Config,
+        config: DeepSeekV3Config,
         ps: ParallelState,
         layer_idx: int,
         *,
@@ -419,7 +419,7 @@ class KimiK2MTPLayer(nn.Module):
             sp=ps.tp_size > 1,
             gather_output=True,
         )
-        self.transformer_layer = KimiK2Layer(
+        self.transformer_layer = DeepSeekV3Layer(
             config,
             ps,
             config.num_hidden_layers + layer_idx,
@@ -463,10 +463,10 @@ class KimiK2MTPLayer(nn.Module):
         return hidden_states, input_ids, position_ids
 
 
-class KimiK2MTPBlock(nn.Module):
+class DeepSeekV3MTPBlock(nn.Module):
     def __init__(
         self,
-        config: KimiK2Config,
+        config: DeepSeekV3Config,
         ps: ParallelState,
         *,
         embedding: VocabParallelEmbedding,
@@ -484,7 +484,7 @@ class KimiK2MTPBlock(nn.Module):
         layers_to_build = 1 if repeated_layer else self.num_layers
         self.layers = nn.ModuleList(
             [
-                KimiK2MTPLayer(
+                DeepSeekV3MTPLayer(
                     config,
                     ps,
                     idx,
@@ -526,7 +526,7 @@ class KimiK2MTPBlock(nn.Module):
 def _temperature_to_float(temperature: float | torch.Tensor) -> float:
     if isinstance(temperature, torch.Tensor):
         if temperature.numel() != 1:
-            raise ValueError("KimiK2Model supports scalar temperature only.")
+            raise ValueError("DeepSeekV3Model supports scalar temperature only.")
         return float(temperature.detach().float().item())
     return float(temperature)
 
@@ -553,10 +553,10 @@ def _apply_attention_backend_override(backend: str | None) -> None:
     ) = env
 
 
-class KimiK2Model(nn.Module):
+class DeepSeekV3Model(nn.Module):
     def __init__(
         self,
-        config: KimiK2Config,
+        config: DeepSeekV3Config,
         train_config,
         ps: ParallelState,
         *,
@@ -596,7 +596,7 @@ class KimiK2Model(nn.Module):
         moe_act_recompute = "moe_act" in recompute_modules and "moe" not in recompute_modules
         self.layers = nn.ModuleList(
             [
-                KimiK2Layer(
+                DeepSeekV3Layer(
                     config,
                     ps,
                     idx,
@@ -617,13 +617,13 @@ class KimiK2Model(nn.Module):
             self.head = VocabParallelOutput(config.vocab_size, config.hidden_size, ps)
 
         self.mtp_embed: VocabParallelEmbedding | None = None
-        self.mtp: KimiK2MTPBlock | None = None
+        self.mtp: DeepSeekV3MTPBlock | None = None
         if mtp_enable and config.num_nextn_predict_layers > 0 and self.head is not None:
             mtp_embedding = self.embed
             if mtp_embedding is None:
                 mtp_embedding = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
                 self.mtp_embed = mtp_embedding
-            self.mtp = KimiK2MTPBlock(
+            self.mtp = DeepSeekV3MTPBlock(
                 config,
                 ps,
                 embedding=mtp_embedding,
@@ -643,7 +643,7 @@ class KimiK2Model(nn.Module):
     def set_input_tensor(self, input_tensor):
         if isinstance(input_tensor, list):
             if len(input_tensor) > 1:
-                raise ValueError("KimiK2Model expects a single pipeline input tensor.")
+                raise ValueError("DeepSeekV3Model expects a single pipeline input tensor.")
             input_tensor = input_tensor[0] if input_tensor else None
         self._input_tensor = input_tensor
 
@@ -839,10 +839,10 @@ class KimiK2Model(nn.Module):
 
 __all__ = [
     "DenseMLP",
-    "KimiK2MTPBlock",
-    "KimiK2MTPLayer",
-    "KimiK2Layer",
-    "KimiK2Model",
+    "DeepSeekV3MTPBlock",
+    "DeepSeekV3MTPLayer",
+    "DeepSeekV3Layer",
+    "DeepSeekV3Model",
     "MoELayer",
     "MTPLossAutoScaler",
     "MultiLatentAttention",

--- a/experimental/lite/megatron/lite/model/deepseek_v3/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v3/lite/protocol.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-"""Kimi K2 lite impl - native model protocol for Megatron Lite runtime."""
+"""DeepSeekV3 lite impl - native model protocol for Megatron Lite runtime."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ from typing import Any
 import torch
 import torch.nn as nn
 
-from megatron.lite.model.kimi_k2.config import KimiK2Config
+from megatron.lite.model.deepseek_v3.config import DeepSeekV3Config
 from megatron.lite.primitive.bundle import ModelBundle
 from megatron.lite.primitive.parallel import ParallelState, init_parallel
 from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec
@@ -23,7 +23,7 @@ def EXPERT_CLASSIFIER(name: str) -> bool:
 
 
 def PLACEMENT_FN(param_name: str) -> list:
-    from megatron.lite.model.kimi_k2.lite.checkpoint import PLACEMENT_FN as placement_fn
+    from megatron.lite.model.deepseek_v3.lite.checkpoint import PLACEMENT_FN as placement_fn
 
     return placement_fn(param_name)
 
@@ -81,11 +81,11 @@ class ImplConfig:
     mtp_use_repeated_layer: bool | None = None
 
 
-def build_model_config(source: str | Path | dict, **overrides) -> KimiK2Config:
+def build_model_config(source: str | Path | dict, **overrides) -> DeepSeekV3Config:
     if isinstance(source, dict):
-        cfg = KimiK2Config._from_hf_dict(source)
+        cfg = DeepSeekV3Config._from_hf_dict(source)
     else:
-        cfg = KimiK2Config.from_hf(str(source))
+        cfg = DeepSeekV3Config.from_hf(str(source))
     for key, value in overrides.items():
         if hasattr(cfg, key):
             setattr(cfg, key, value)
@@ -119,7 +119,7 @@ def _make_aux_loss_hook():
 
 
 def _build_distopt_optimizer(
-    chunks, model_cfg: KimiK2Config, impl_cfg: ImplConfig, ps: ParallelState
+    chunks, model_cfg: DeepSeekV3Config, impl_cfg: ImplConfig, ps: ParallelState
 ):
     from megatron.lite.primitive.optimizers.megatron_wrap import build_distopt_training_optimizer
 
@@ -128,13 +128,13 @@ def _build_distopt_optimizer(
         model_cfg=model_cfg,
         impl_cfg=impl_cfg,
         ps=ps,
-        model_name="kimi_k2",
+        model_name="deepseek_v3",
         is_expert=is_expert_param,
         deterministic=impl_cfg.deterministic,
     )
 
 
-def build_model(model_cfg: KimiK2Config, *, impl_cfg: ImplConfig) -> ModelBundle:
+def build_model(model_cfg: DeepSeekV3Config, *, impl_cfg: ImplConfig) -> ModelBundle:
     p = impl_cfg.parallel
     if impl_cfg.use_deepep and (p.etp is not None and p.etp > 1):
         raise ValueError("use_deepep and etp>1 are mutually exclusive")
@@ -151,7 +151,7 @@ def build_model(model_cfg: KimiK2Config, *, impl_cfg: ImplConfig) -> ModelBundle
     elif hasattr(model_cfg, "num_nextn_predict_layers"):
         model_cfg.num_nextn_predict_layers = 0
 
-    from megatron.lite.model.kimi_k2.lite.model import KimiK2Model
+    from megatron.lite.model.deepseek_v3.lite.model import DeepSeekV3Model
 
     ps = init_parallel(p)
     recompute_spec = parse_recompute_spec(impl_cfg.recompute)
@@ -179,10 +179,12 @@ def build_model(model_cfg: KimiK2Config, *, impl_cfg: ImplConfig) -> ModelBundle
     )
 
     if vpp is None:
-        chunks = [KimiK2Model(model_cfg, train_cfg, ps, **model_kwargs).to(torch.bfloat16).cuda()]
+        chunks = [
+            DeepSeekV3Model(model_cfg, train_cfg, ps, **model_kwargs).to(torch.bfloat16).cuda()
+        ]
     else:
         chunks = [
-            KimiK2Model(
+            DeepSeekV3Model(
                 model_cfg,
                 train_cfg,
                 ps,
@@ -222,7 +224,7 @@ def build_model(model_cfg: KimiK2Config, *, impl_cfg: ImplConfig) -> ModelBundle
         optimizer_backend = "fsdp2"
 
         def _post_model_load_hook():
-            from megatron.lite.model.kimi_k2.lite.model import KimiK2Layer
+            from megatron.lite.model.deepseek_v3.lite.model import DeepSeekV3Layer
             from megatron.lite.primitive.optimizers.fsdp2 import build_fsdp2_training_optimizer
 
             return {
@@ -230,7 +232,7 @@ def build_model(model_cfg: KimiK2Config, *, impl_cfg: ImplConfig) -> ModelBundle
                     chunks,
                     impl_cfg.optimizer_config,
                     ps,
-                    unit_modules=(KimiK2Layer,),
+                    unit_modules=(DeepSeekV3Layer,),
                     expert_classifier=is_expert_param,
                     deterministic=impl_cfg.deterministic,
                     vpp=impl_cfg.parallel.vpp,
@@ -240,7 +242,7 @@ def build_model(model_cfg: KimiK2Config, *, impl_cfg: ImplConfig) -> ModelBundle
 
         post_model_load_hook = _post_model_load_hook
     elif impl_cfg.optimizer is not None:
-        raise ValueError(f"Unknown kimi_k2 lite optimizer: {impl_cfg.optimizer!r}.")
+        raise ValueError(f"Unknown deepseek_v3 lite optimizer: {impl_cfg.optimizer!r}.")
 
     return ModelBundle(
         chunks=chunks,
@@ -258,17 +260,17 @@ def build_model(model_cfg: KimiK2Config, *, impl_cfg: ImplConfig) -> ModelBundle
 
 
 def load_hf_weights(
-    chunk: nn.Module, hf_path: str, model_cfg: KimiK2Config, ps: ParallelState
+    chunk: nn.Module, hf_path: str, model_cfg: DeepSeekV3Config, ps: ParallelState
 ) -> None:
     if not hf_path:
         return
-    from megatron.lite.model.kimi_k2.lite.checkpoint import load_hf_weights as load_impl
+    from megatron.lite.model.deepseek_v3.lite.checkpoint import load_hf_weights as load_impl
 
     load_impl(chunk, hf_path, model_cfg, ps)
 
 
-def export_hf_weights(chunks, model_cfg: KimiK2Config, ps: ParallelState, **kwargs):
-    from megatron.lite.model.kimi_k2.lite.checkpoint import export_hf_weights as export_impl
+def export_hf_weights(chunks, model_cfg: DeepSeekV3Config, ps: ParallelState, **kwargs):
+    from megatron.lite.model.deepseek_v3.lite.checkpoint import export_hf_weights as export_impl
 
     yield from export_impl(chunks, model_cfg, ps, **kwargs)
 

--- a/experimental/lite/megatron/lite/model/deepseek_v3/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v3/lite/protocol.py
@@ -83,13 +83,9 @@ class ImplConfig:
 
 def build_model_config(source: str | Path | dict, **overrides) -> DeepSeekV3Config:
     if isinstance(source, dict):
-        cfg = DeepSeekV3Config._from_hf_dict(source)
+        return DeepSeekV3Config._from_hf_dict(source, **overrides)
     else:
-        cfg = DeepSeekV3Config.from_hf(str(source))
-    for key, value in overrides.items():
-        if hasattr(cfg, key):
-            setattr(cfg, key, value)
-    return cfg
+        return DeepSeekV3Config.from_hf(str(source), **overrides)
 
 
 def _forward_step(model: nn.Module, batch: dict) -> dict:

--- a/experimental/lite/megatron/lite/model/registry.py
+++ b/experimental/lite/megatron/lite/model/registry.py
@@ -7,6 +7,8 @@ import importlib
 import json
 from pathlib import Path
 
+from megatron.lite.model.deepseek_v3.config import DEEPSEEK_V3_HF_MODEL_TYPES
+
 # ---------------------------------------------------------------------------
 # Registry tables (populated by register_model)
 # ---------------------------------------------------------------------------
@@ -97,7 +99,7 @@ _DEEPSEEK_V3_LITE = "megatron.lite.model.deepseek_v3.lite.protocol"
 register_model(
     "deepseek_v3",
     package="megatron.lite.model.deepseek_v3",
-    hf_model_types=["deepseek_v3", "kimi_k2", "kimi_k25", "kimi_k26", "kimi_k27"],
+    hf_model_types=list(DEEPSEEK_V3_HF_MODEL_TYPES),
     impls={"lite": _DEEPSEEK_V3_LITE},
 )
 

--- a/experimental/lite/megatron/lite/model/registry.py
+++ b/experimental/lite/megatron/lite/model/registry.py
@@ -92,11 +92,13 @@ register_model(
     impls={"lite": "megatron.lite.model.qwen3_5.lite.protocol"},
 )
 
+_DEEPSEEK_V3_LITE = "megatron.lite.model.deepseek_v3.lite.protocol"
+
 register_model(
-    "kimi_k2",
-    package="megatron.lite.model.kimi_k2",
-    hf_model_types=["kimi_k2", "deepseek_v3"],
-    impls={"lite": "megatron.lite.model.kimi_k2.lite.protocol"},
+    "deepseek_v3",
+    package="megatron.lite.model.deepseek_v3",
+    hf_model_types=["deepseek_v3", "kimi_k2", "kimi_k25", "kimi_k26", "kimi_k27"],
+    impls={"lite": _DEEPSEEK_V3_LITE},
 )
 
 

--- a/experimental/lite/tests/unit/model/test_deepseek_v3_lite_cp_smoke.py
+++ b/experimental/lite/tests/unit/model/test_deepseek_v3_lite_cp_smoke.py
@@ -13,7 +13,7 @@ def _init_dist_or_skip():
     import torch.distributed as dist
 
     if not torch.cuda.is_available():
-        pytest.skip("CUDA is required for Kimi K2 CP smoke.")
+        pytest.skip("CUDA is required for DeepSeekV3 CP smoke.")
     if "RANK" not in os.environ or "WORLD_SIZE" not in os.environ:
         pytest.skip("Run with torchrun so CP ranks are available.")
 
@@ -22,14 +22,14 @@ def _init_dist_or_skip():
     if not dist.is_initialized():
         dist.init_process_group("nccl")
     if dist.get_world_size() < 2:
-        pytest.skip("Kimi K2 CP smoke requires at least 2 ranks.")
+        pytest.skip("DeepSeekV3 CP smoke requires at least 2 ranks.")
     return torch.device("cuda", local_rank)
 
 
 def _tiny_config():
-    from megatron.lite.model.kimi_k2.config import KimiK2Config
+    from megatron.lite.model.deepseek_v3.config import DeepSeekV3Config
 
-    return KimiK2Config(
+    return DeepSeekV3Config(
         num_hidden_layers=2,
         hidden_size=64,
         num_attention_heads=4,
@@ -63,9 +63,9 @@ def _tiny_config():
 
 
 def _tiny_hf_parity_config():
-    from megatron.lite.model.kimi_k2.config import KimiK2Config
+    from megatron.lite.model.deepseek_v3.config import DeepSeekV3Config
 
-    return KimiK2Config(
+    return DeepSeekV3Config(
         num_hidden_layers=2,
         hidden_size=64,
         num_attention_heads=4,
@@ -168,7 +168,7 @@ def _distributed_diff_stats(actual, expected) -> tuple[float, float]:
     return float(stats[0].item()), float((stats[0] / stats[1]).item())
 
 
-def _hf_state_dict_for_kimi_loader(model):
+def _hf_state_dict_for_deepseek_v3_loader(model):
     state = {
         name: tensor.detach().cpu().contiguous().clone()
         for name, tensor in model.state_dict().items()
@@ -189,7 +189,7 @@ def _hf_state_dict_for_kimi_loader(model):
     return state
 
 
-def test_kimi_k2_mla_cp2_matches_full_sequence_reference_forward_and_grad():
+def test_deepseek_v3_mla_cp2_matches_full_sequence_reference_forward_and_grad():
     import torch
     import torch.distributed as dist
 
@@ -244,12 +244,12 @@ def test_kimi_k2_mla_cp2_matches_full_sequence_reference_forward_and_grad():
     torch.testing.assert_close(local_x.grad, expected_grad, atol=1e-1, rtol=1e-1)
 
 
-def test_kimi_k2_tiny_model_cp2_matches_full_sequence_reference_forward():
+def test_deepseek_v3_tiny_model_cp2_matches_full_sequence_reference_forward():
     import torch
     import torch.distributed as dist
 
     device = _init_dist_or_skip()
-    from megatron.lite.model.kimi_k2.lite.model import KimiK2Model
+    from megatron.lite.model.deepseek_v3.lite.model import DeepSeekV3Model
     from megatron.lite.primitive.parallel import ParallelState
     from megatron.lite.primitive.parallel.cp import zigzag_slice_for_cp
     from megatron.lite.primitive.parallel.state import init_parallel
@@ -261,12 +261,12 @@ def test_kimi_k2_tiny_model_cp2_matches_full_sequence_reference_forward():
     ps = init_parallel(ParallelConfig(tp=1, ep=1, etp=1, cp=world, pp=1))
 
     torch.manual_seed(777)
-    cp_model = KimiK2Model(cfg, _train_cfg(world), ps, use_thd=False).to(
+    cp_model = DeepSeekV3Model(cfg, _train_cfg(world), ps, use_thd=False).to(
         device=device,
         dtype=torch.bfloat16,
     )
     torch.manual_seed(777)
-    ref_model = KimiK2Model(cfg, _train_cfg(1), ParallelState(), use_thd=False).to(
+    ref_model = DeepSeekV3Model(cfg, _train_cfg(1), ParallelState(), use_thd=False).to(
         device=device,
         dtype=torch.bfloat16,
     )
@@ -290,14 +290,14 @@ def test_kimi_k2_tiny_model_cp2_matches_full_sequence_reference_forward():
     torch.testing.assert_close(cp_out["log_probs"], expected_log_probs, atol=1e-1, rtol=1e-1)
 
 
-def test_kimi_k2_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
+def test_deepseek_v3_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
     import torch
     import torch.distributed as dist
     from transformers.models.deepseek_v3.modeling_deepseek_v3 import DeepseekV3ForCausalLM
 
     device = _init_dist_or_skip()
-    from megatron.lite.model.kimi_k2.lite.checkpoint import load_hf_weights
-    from megatron.lite.model.kimi_k2.lite.model import KimiK2Model
+    from megatron.lite.model.deepseek_v3.lite.checkpoint import load_hf_weights
+    from megatron.lite.model.deepseek_v3.lite.model import DeepSeekV3Model
     from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
     from megatron.lite.primitive.parallel.cp import zigzag_slice_for_cp
     from megatron.lite.primitive.parallel.state import init_parallel
@@ -315,12 +315,12 @@ def test_kimi_k2_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
     hf_ref.eval()
     rank_tmp_path = tmp_path / f"rank{rank}"
     save_safetensors(
-        _hf_state_dict_for_kimi_loader(hf_ref),
+        _hf_state_dict_for_deepseek_v3_loader(hf_ref),
         str(rank_tmp_path),
     )
 
     ps = init_parallel(ParallelConfig(tp=1, ep=1, etp=1, cp=world, pp=1))
-    native = KimiK2Model(cfg, _train_cfg(world), ps, use_thd=False).to(
+    native = DeepSeekV3Model(cfg, _train_cfg(world), ps, use_thd=False).to(
         device=device,
         dtype=torch.bfloat16,
     )
@@ -355,7 +355,7 @@ def test_kimi_k2_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
     with torch.no_grad():
         if rank == 0:
             print(
-                "kimi_k2_hf_native_parity reference=transformers.DeepseekV3ForCausalLM "
+                "deepseek_v3_hf_native_parity reference=transformers.DeepseekV3ForCausalLM "
                 "rope=DeepseekV3RotaryEmbedding+apply_rotary_pos_emb_interleave"
             )
         hf_logits = hf_ref(full_ids).logits
@@ -374,7 +374,7 @@ def test_kimi_k2_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
         max_abs, max_rel = _distributed_diff_stats(actual, expected)
         if rank == 0:
             print(
-                f"kimi_k2_hf_native_parity layer={layer_idx} "
+                f"deepseek_v3_hf_native_parity layer={layer_idx} "
                 f"max_abs_diff={max_abs:.6e} max_rel_diff={max_rel:.6e}"
             )
         torch.testing.assert_close(
@@ -388,7 +388,7 @@ def test_kimi_k2_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
     max_abs, max_rel = _distributed_diff_stats(native_logits, expected)
     if rank == 0:
         print(
-            "kimi_k2_hf_native_parity logits "
+            "deepseek_v3_hf_native_parity logits "
             f"max_abs_diff={max_abs:.6e} max_rel_diff={max_rel:.6e}"
         )
     torch.testing.assert_close(
@@ -399,12 +399,12 @@ def test_kimi_k2_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
     )
 
 
-def test_kimi_k2_packed_thd_variable_sequence_cp2_smoke():
+def test_deepseek_v3_packed_thd_variable_sequence_cp2_smoke():
     import torch
     import torch.distributed as dist
 
     device = _init_dist_or_skip()
-    from megatron.lite.model.kimi_k2.lite.model import KimiK2Model
+    from megatron.lite.model.deepseek_v3.lite.model import DeepSeekV3Model
     from megatron.lite.primitive.parallel.state import init_parallel
     from megatron.lite.primitive.parallel.thd import pack_nested_thd, unpack_packed_thd_to_nested
     from megatron.lite.runtime.contracts import ParallelConfig
@@ -415,7 +415,7 @@ def test_kimi_k2_packed_thd_variable_sequence_cp2_smoke():
     ps = init_parallel(ParallelConfig(tp=1, ep=1, etp=1, cp=world, pp=1))
 
     torch.manual_seed(20260614)
-    model = KimiK2Model(cfg, _train_cfg(world), ps, use_thd=True).to(
+    model = DeepSeekV3Model(cfg, _train_cfg(world), ps, use_thd=True).to(
         device=device,
         dtype=torch.bfloat16,
     )
@@ -464,18 +464,18 @@ def test_kimi_k2_packed_thd_variable_sequence_cp2_smoke():
 
     if rank == 0:
         print(
-            "NON_SKIP_KIMI_K2_THD_CP_SMOKE_PASSED "
+            "NON_SKIP_DeepSeekV3_THD_CP_SMOKE_PASSED "
             f"world_size={world} lengths={lengths} "
             f"loss={float(out['loss'].detach().item()):.6e}"
         )
 
 
-def test_kimi_k2_tiny_model_fsdp2_optimizer_step_smoke():
+def test_deepseek_v3_tiny_model_fsdp2_optimizer_step_smoke():
     import torch
     import torch.distributed as dist
 
     device = _init_dist_or_skip()
-    from megatron.lite.model.kimi_k2.lite.protocol import ImplConfig, build_model
+    from megatron.lite.model.deepseek_v3.lite.protocol import ImplConfig, build_model
     from megatron.lite.primitive.optimizers.fsdp2 import FSDP2Optimizer, fsdp2_available
     from megatron.lite.runtime.contracts import OptimizerConfig, ParallelConfig
 
@@ -529,7 +529,7 @@ def test_kimi_k2_tiny_model_fsdp2_optimizer_step_smoke():
     assert torch.isfinite(torch.tensor(grad_norm))
     if rank == 0:
         print(
-            "kimi_k2_fsdp2_smoke optimizer=fsdp2 "
+            "deepseek_v3_fsdp2_smoke optimizer=fsdp2 "
             f"world_size={world} loss={float(loss.detach().item()):.6e} "
             f"grad_norm={grad_norm:.6e}"
         )

--- a/experimental/lite/tests/unit/model/test_deepseek_v3_lite_static.py
+++ b/experimental/lite/tests/unit/model/test_deepseek_v3_lite_static.py
@@ -84,7 +84,7 @@ def test_deepseek_v3_kimi_variant_configs_capture_public_hf_differences(tmp_path
     k2 = DeepSeekV3Config.from_variant("kimi-k2")
     k25 = DeepSeekV3Config.from_variant("kimi-k2.5")
     k26 = DeepSeekV3Config.from_variant("kimi-k2.6")
-    k27 = DeepSeekV3Config.from_variant("kimi-k2.7-code")
+    k27 = DeepSeekV3Config.from_variant("kimi-k2.7")
 
     assert k2.variant == "kimi-k2"
     assert k2.rms_norm_eps == 1e-6
@@ -106,11 +106,32 @@ def test_deepseek_v3_kimi_variant_configs_capture_public_hf_differences(tmp_path
             "model_type": "kimi_k25",
             "architectures": ["KimiK25ForConditionalGeneration"],
             "text_config": {"model_type": "kimi_k2"},
-        }
+        },
+        variant="kimi-k2.5",
     )
     assert hf_cfg.variant == "kimi-k2.5"
     assert hf_cfg.max_position_embeddings == 262144
     assert hf_cfg.rope_scaling["factor"] == 64.0
+
+    implicit_hf_cfg = DeepSeekV3Config._from_hf_dict(
+        {
+            "model_type": "kimi_k25",
+            "architectures": ["KimiK25ForConditionalGeneration"],
+            "text_config": {"model_type": "kimi_k2"},
+        }
+    )
+    assert implicit_hf_cfg.variant == "kimi-k2"
+    assert implicit_hf_cfg.max_position_embeddings == 131072
+    assert implicit_hf_cfg.rope_scaling["factor"] == 32.0
+
+    embedded_variant_cfg = DeepSeekV3Config._from_hf_dict(
+        {
+            "model_type": "kimi_k25",
+            "variant": "kimi-k2.6",
+            "text_config": {"model_type": "kimi_k2"},
+        }
+    )
+    assert embedded_variant_cfg.variant == "kimi-k2.6"
 
     local_repo = tmp_path / "moonshotai" / "Kimi-K2.6"
     local_repo.mkdir(parents=True)
@@ -124,8 +145,16 @@ def test_deepseek_v3_kimi_variant_configs_capture_public_hf_differences(tmp_path
         )
     )
     path_cfg = DeepSeekV3Config.from_hf(str(local_repo))
-    assert path_cfg.variant == "kimi-k2.6"
-    assert path_cfg.max_position_embeddings == 262144
+    assert path_cfg.variant == "kimi-k2"
+    assert path_cfg.max_position_embeddings == 131072
+
+    explicit_path_cfg = DeepSeekV3Config.from_hf(str(local_repo), variant="kimi-k2.6")
+    assert explicit_path_cfg.variant == "kimi-k2.6"
+    assert explicit_path_cfg.max_position_embeddings == 262144
+
+    for implicit_name in ("kimi_k25", "kimi-k2.7-code", "moonshotai/Kimi-K2.6"):
+        with pytest.raises(ValueError, match="Unknown DeepSeekV3 variant"):
+            DeepSeekV3Config.from_variant(implicit_name)
 
 
 def test_deepseek_v3_lite_does_not_import_wrappers_or_sibling_models():

--- a/experimental/lite/tests/unit/model/test_deepseek_v3_lite_static.py
+++ b/experimental/lite/tests/unit/model/test_deepseek_v3_lite_static.py
@@ -1,34 +1,48 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-"""Static smoke coverage for Kimi K2 lite native implementation."""
+"""Static smoke coverage for DeepSeekV3 lite native implementation."""
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
 
 
-def test_kimi_k2_lite_registry_resolves():
+def test_deepseek_v3_lite_registry_resolves():
     from megatron.lite.model.registry import (
         get_train_runtime_module,
         resolve_model_type_from_hf,
         resolve_runtime_model_name,
     )
 
-    runtime_name = resolve_runtime_model_name("kimi_k2", "lite")
-    assert runtime_name == "kimi_k2"
-    assert resolve_model_type_from_hf({"model_type": "kimi_k2"}) == "kimi_k2"
-    assert resolve_model_type_from_hf({"model_type": "deepseek_v3"}) == "kimi_k2"
+    runtime_name = resolve_runtime_model_name("deepseek_v3", "lite")
+    assert runtime_name == "deepseek_v3"
+    assert resolve_model_type_from_hf({"model_type": "deepseek_v3"}) == "deepseek_v3"
+    assert resolve_model_type_from_hf({"model_type": "kimi_k2"}) == "deepseek_v3"
+    assert resolve_model_type_from_hf({"model_type": "kimi_k25"}) == "deepseek_v3"
+    assert resolve_model_type_from_hf({"model_type": "kimi_k26"}) == "deepseek_v3"
+    assert resolve_model_type_from_hf({"model_type": "kimi_k27"}) == "deepseek_v3"
     module = get_train_runtime_module(runtime_name)
-    assert module.__name__ == "megatron.lite.model.kimi_k2.lite.protocol"
+    assert module.__name__ == "megatron.lite.model.deepseek_v3.lite.protocol"
+
+    with pytest.raises(ValueError, match="No runtime"):
+        resolve_runtime_model_name("kimi_k2", "lite")
 
 
-def test_kimi_k2_config_reads_hf_fields():
-    from megatron.lite.model.kimi_k2.config import KimiK2Config
+def test_deepseek_v3_has_no_independent_kimi_k2_model_dir():
+    model_root = Path(__file__).resolve().parents[3] / "megatron" / "lite" / "model"
 
-    cfg = KimiK2Config._from_hf_dict(
+    assert (model_root / "deepseek_v3").is_dir()
+    assert not (model_root / "kimi_k2").exists()
+
+
+def test_deepseek_v3_config_reads_hf_fields():
+    from megatron.lite.model.deepseek_v3.config import DeepSeekV3Config
+
+    cfg = DeepSeekV3Config._from_hf_dict(
         {
-            "model_type": "kimi_k2",
+            "model_type": "deepseek_v3",
             "num_hidden_layers": 3,
             "hidden_size": 32,
             "num_attention_heads": 4,
@@ -64,8 +78,60 @@ def test_kimi_k2_config_reads_hf_fields():
     assert cfg.is_moe_layer(1)
 
 
-def test_kimi_k2_lite_does_not_import_wrappers_or_sibling_models():
-    root = Path(__file__).resolve().parents[3] / "megatron" / "lite" / "model" / "kimi_k2" / "lite"
+def test_deepseek_v3_kimi_variant_configs_capture_public_hf_differences(tmp_path):
+    from megatron.lite.model.deepseek_v3.config import DeepSeekV3Config
+
+    k2 = DeepSeekV3Config.from_variant("kimi-k2")
+    k25 = DeepSeekV3Config.from_variant("kimi-k2.5")
+    k26 = DeepSeekV3Config.from_variant("kimi-k2.6")
+    k27 = DeepSeekV3Config.from_variant("kimi-k2.7-code")
+
+    assert k2.variant == "kimi-k2"
+    assert k2.rms_norm_eps == 1e-6
+    assert k2.max_position_embeddings == 131072
+    assert k2.rope_scaling["factor"] == 32.0
+    assert k2.rope_scaling["beta_fast"] == 1.0
+
+    for variant_cfg, variant in ((k25, "kimi-k2.5"), (k26, "kimi-k2.6"), (k27, "kimi-k2.7")):
+        assert variant_cfg.variant == variant
+        assert variant_cfg.rms_norm_eps == 1e-5
+        assert variant_cfg.max_position_embeddings == 262144
+        assert variant_cfg.rope_scaling["factor"] == 64.0
+        assert variant_cfg.rope_scaling["beta_fast"] == 32.0
+        assert variant_cfg.hidden_size == k2.hidden_size
+        assert variant_cfg.n_routed_experts == k2.n_routed_experts
+
+    hf_cfg = DeepSeekV3Config._from_hf_dict(
+        {
+            "model_type": "kimi_k25",
+            "architectures": ["KimiK25ForConditionalGeneration"],
+            "text_config": {"model_type": "kimi_k2"},
+        }
+    )
+    assert hf_cfg.variant == "kimi-k2.5"
+    assert hf_cfg.max_position_embeddings == 262144
+    assert hf_cfg.rope_scaling["factor"] == 64.0
+
+    local_repo = tmp_path / "moonshotai" / "Kimi-K2.6"
+    local_repo.mkdir(parents=True)
+    (local_repo / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "kimi_k25",
+                "architectures": ["KimiK25ForConditionalGeneration"],
+                "text_config": {"model_type": "kimi_k2"},
+            }
+        )
+    )
+    path_cfg = DeepSeekV3Config.from_hf(str(local_repo))
+    assert path_cfg.variant == "kimi-k2.6"
+    assert path_cfg.max_position_embeddings == 262144
+
+
+def test_deepseek_v3_lite_does_not_import_wrappers_or_sibling_models():
+    root = (
+        Path(__file__).resolve().parents[3] / "megatron" / "lite" / "model" / "deepseek_v3" / "lite"
+    )
     forbidden = (
         "megatron.lite.model.qwen3_5",
         "megatron.lite.model.qwen3_moe",
@@ -81,16 +147,18 @@ def test_kimi_k2_lite_does_not_import_wrappers_or_sibling_models():
             assert token not in text
 
 
-def test_kimi_k2_lite_implementation_files_stay_small():
-    root = Path(__file__).resolve().parents[3] / "megatron" / "lite" / "model" / "kimi_k2" / "lite"
+def test_deepseek_v3_lite_implementation_files_stay_small():
+    root = (
+        Path(__file__).resolve().parents[3] / "megatron" / "lite" / "model" / "deepseek_v3" / "lite"
+    )
     for name in ("model.py", "protocol.py", "checkpoint.py"):
         line_count = len((root / name).read_text().splitlines())
         assert line_count < 1000, f"{name} has {line_count} lines"
 
 
-def test_kimi_k2_lite_uses_shared_mla_primitive():
+def test_deepseek_v3_lite_uses_shared_mla_primitive():
     lite_root = Path(__file__).resolve().parents[3] / "megatron" / "lite"
-    model_root = lite_root / "model" / "kimi_k2" / "lite"
+    model_root = lite_root / "model" / "deepseek_v3" / "lite"
     primitive_mla = lite_root / "primitive" / "attention" / "mla.py"
     model_text = (model_root / "model.py").read_text()
     mla_text = primitive_mla.read_text()
@@ -100,11 +168,13 @@ def test_kimi_k2_lite_uses_shared_mla_primitive():
     assert "class MultiLatentAttention" not in model_text
     assert "class MultiLatentAttention" in mla_text
     assert "megatron.core" not in mla_text
-    assert "KimiK2SigmoidTopKRouter" in model_text
+    assert "DeepSeekV3SigmoidTopKRouter" in model_text
 
 
-def test_kimi_k2_lite_optimizer_names_are_current():
-    root = Path(__file__).resolve().parents[3] / "megatron" / "lite" / "model" / "kimi_k2" / "lite"
+def test_deepseek_v3_lite_optimizer_names_are_current():
+    root = (
+        Path(__file__).resolve().parents[3] / "megatron" / "lite" / "model" / "deepseek_v3" / "lite"
+    )
     protocol_text = (root / "protocol.py").read_text()
 
     assert 'optimizer: str | None = "distopt"' in protocol_text
@@ -114,8 +184,8 @@ def test_kimi_k2_lite_optimizer_names_are_current():
         assert forbidden not in protocol_text
 
 
-def test_kimi_k2_distopt_deterministic_default_is_enabled():
-    from megatron.lite.model.kimi_k2.lite.protocol import ImplConfig
+def test_deepseek_v3_distopt_deterministic_default_is_enabled():
+    from megatron.lite.model.deepseek_v3.lite.protocol import ImplConfig
 
     cfg = ImplConfig(optimizer="distopt", deterministic=True, mtp_enable=True)
 
@@ -124,11 +194,11 @@ def test_kimi_k2_distopt_deterministic_default_is_enabled():
     assert cfg.mtp_enable is True
 
 
-def test_kimi_k2_impl_config_accepts_runtime_mtp_fields():
-    from megatron.lite.model.kimi_k2.config import KimiK2Config
-    from megatron.lite.model.kimi_k2.lite.protocol import ImplConfig
+def test_deepseek_v3_impl_config_accepts_runtime_mtp_fields():
+    from megatron.lite.model.deepseek_v3.config import DeepSeekV3Config
+    from megatron.lite.model.deepseek_v3.lite.protocol import ImplConfig
 
-    cfg = KimiK2Config(
+    cfg = DeepSeekV3Config(
         num_hidden_layers=1,
         hidden_size=8,
         num_attention_heads=2,
@@ -155,7 +225,7 @@ def test_kimi_k2_impl_config_accepts_runtime_mtp_fields():
     assert cfg.num_nextn_predict_layers == 1
 
 
-def test_kimi_k2_mtp_and_pp_layout_rules_are_explicit():
+def test_deepseek_v3_mtp_and_pp_layout_rules_are_explicit():
     from megatron.lite.primitive.parallel import ParallelState, build_pipeline_chunk_layout
 
     model_text = (
@@ -163,7 +233,7 @@ def test_kimi_k2_mtp_and_pp_layout_rules_are_explicit():
         / "megatron"
         / "lite"
         / "model"
-        / "kimi_k2"
+        / "deepseek_v3"
         / "lite"
         / "model.py"
     ).read_text()
@@ -187,18 +257,18 @@ def test_kimi_k2_mtp_and_pp_layout_rules_are_explicit():
         build_pipeline_chunk_layout(3, rank0, vpp=2, vpp_chunk_id=0)
 
 
-def test_kimi_k2_checkpoint_exports_hf_names():
+def test_deepseek_v3_checkpoint_exports_hf_names():
     torch = pytest.importorskip("torch")
 
-    from megatron.lite.model.kimi_k2.config import KimiK2Config
-    from megatron.lite.model.kimi_k2.lite import protocol
-    from megatron.lite.model.kimi_k2.lite.checkpoint import (
-        KimiK2WeightSpec,
+    from megatron.lite.model.deepseek_v3.config import DeepSeekV3Config
+    from megatron.lite.model.deepseek_v3.lite import protocol
+    from megatron.lite.model.deepseek_v3.lite.checkpoint import (
+        DeepSeekV3WeightSpec,
         export_hf_weights,
         save_hf_weights,
     )
 
-    cfg = KimiK2Config(
+    cfg = DeepSeekV3Config(
         num_hidden_layers=2,
         hidden_size=8,
         num_attention_heads=2,
@@ -219,7 +289,7 @@ def test_kimi_k2_checkpoint_exports_hf_names():
         v_head_dim=2,
         num_nextn_predict_layers=1,
     )
-    spec = KimiK2WeightSpec(cfg)
+    spec = DeepSeekV3WeightSpec(cfg)
 
     assert callable(export_hf_weights)
     assert callable(save_hf_weights)
@@ -265,12 +335,12 @@ def test_kimi_k2_checkpoint_exports_hf_names():
     }
 
 
-def test_kimi_k2_fp8_checkpoint_dequant_cpu_path():
+def test_deepseek_v3_fp8_checkpoint_dequant_cpu_path():
     torch = pytest.importorskip("torch")
     if not hasattr(torch, "float8_e4m3fn"):
         pytest.skip("torch float8_e4m3fn is required for this smoke.")
 
-    from megatron.lite.model.kimi_k2.lite.checkpoint import _dequant_fp8_weight
+    from megatron.lite.model.deepseek_v3.lite.checkpoint import _dequant_fp8_weight
 
     class Reader:
         index = {"w_scale_inv": "fake.safetensors"}
@@ -286,10 +356,10 @@ def test_kimi_k2_fp8_checkpoint_dequant_cpu_path():
     torch.testing.assert_close(out, weight.float() * 2.0)
 
 
-def test_kimi_k2_int4_checkpoint_dequant_cpu_path():
+def test_deepseek_v3_int4_checkpoint_dequant_cpu_path():
     torch = pytest.importorskip("torch")
 
-    from megatron.lite.model.kimi_k2.lite.checkpoint import _get
+    from megatron.lite.model.deepseek_v3.lite.checkpoint import _get
 
     values = torch.tensor([[-8, -7, -1, 0, 1, 2, 6, 7, -8, 7]], dtype=torch.int8)
     unsigned = (values + 8).to(torch.int32)
@@ -320,8 +390,8 @@ def test_kimi_k2_int4_checkpoint_dequant_cpu_path():
     torch.testing.assert_close(out, expected)
 
 
-def test_kimi_k2_real_checkpoint_prefix_helpers():
-    from megatron.lite.model.kimi_k2.lite.checkpoint import _lm_head_name, _text_prefix
+def test_deepseek_v3_real_checkpoint_prefix_helpers():
+    from megatron.lite.model.deepseek_v3.lite.checkpoint import _lm_head_name, _text_prefix
 
     class Reader:
         index = {


### PR DESCRIPTION
## Summary
- Rename the native Kimi K2 Lite model package to `deepseek_v3` and register only `deepseek_v3` as the model/runtime name.
- Replace the variant handling with explicit per-variant config entries. `kimi-k2`, `kimi-k2.5`, `kimi-k2.6`, and `kimi-k2.7` are selected only by the exact `variant` field; there is no alias normalization or text/path-based inference.
- Keep HF `model_type` coverage as registry metadata exported from the variant config table, so adding a variant is a config-table change rather than logic change.
- Keep the shared `MultiLatentAttention` primitive path and preserve the Kimi HF prefix / INT4 checkpoint handling.

## Validation
- `PYTHONPATH=experimental/lite python -m pytest experimental/lite/tests/unit/model/test_deepseek_v3_lite_static.py -q` -> 15 passed.
- `PYTHONPATH=experimental/lite python -m py_compile ...deepseek_v3... registry.py` passed.
- `python -m black --line-length 100 --check ...` passed.
- `git diff --check` passed.
- Static grep: no `_VARIANT_ALIASES`, `DEEPSEEK_V3_VARIANT_CONFIGS`, `_normalize_variant`, `_infer_variant_from_text`, or `def _infer_variant` remains.
- Static grep: no `megatron.core` imports in the touched DeepSeek V3 model/primitive/kernel paths.
- Slurm job 12800486: 2-GPU torchrun DeepSeek V3 HF parity + packed THD+CP smoke, COMPLETED 0:0, non-skip, 2 passed / 3 deselected. Logits max_abs_diff=1.953125e-03; THD+CP marker `NON_SKIP_DeepSeekV3_THD_CP_SMOKE_PASSED`.
- Prior evidence rechecked with sacct: 12779439, 12779424, 12779422, and 12798659 all COMPLETED 0:0.
