### PR TITLE
Consolidate MLite model validation harness

### DIFF
--- a/experimental/lite/examples/verl/verl_mlite/compat.py
+++ b/experimental/lite/examples/verl/verl_mlite/compat.py
@@ -76,7 +76,15 @@ def _load_verl_file(relative_path: str, module_name: str):
 
 
 def load_verl_engine_api():
+    # Prefer the canonical package import so the MLite engine registers into the
+    # SAME EngineRegistry that verl's trainers resolve against. Loading base.py as
+    # a standalone module (below) creates a *duplicate* registry, which silently
+    # drops the mlite backend ("Unknown backend: mlite"). The file-load path is
+    # only a fallback for environments where verl isn't importable as a package.
     try:
+        from verl.workers.engine.base import BaseEngine, BaseEngineCtx, EngineRegistry
+        from verl.workers.engine.utils import postprocess_batch_func, prepare_micro_batches
+    except (ModuleNotFoundError, ImportError):
         base = _load_verl_file("workers/engine/base.py", "_verl_mlite_verl_engine_base")
         utils = _load_verl_file("workers/engine/utils.py", "_verl_mlite_verl_engine_utils")
         BaseEngine = base.BaseEngine
@@ -84,8 +92,5 @@ def load_verl_engine_api():
         EngineRegistry = base.EngineRegistry
         postprocess_batch_func = utils.postprocess_batch_func
         prepare_micro_batches = utils.prepare_micro_batches
-    except (FileNotFoundError, ModuleNotFoundError, ImportError):
-        from verl.workers.engine.base import BaseEngine, BaseEngineCtx, EngineRegistry
-        from verl.workers.engine.utils import postprocess_batch_func, prepare_micro_batches
 
     return BaseEngine, BaseEngineCtx, EngineRegistry, postprocess_batch_func, prepare_micro_batches

--- a/experimental/lite/examples/verl/verl_mlite/engine/config.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/config.py
@@ -28,6 +28,7 @@ class MegatronLiteEngineConfig(EngineConfig):
 
     attention_backend_override: str | None = "flash"
     router_aux_loss_coef: float | None = None
+    cross_entropy_fusion: bool | None = None
     export_dtype: str | None = "bfloat16"
     load_hf_weights: bool = True
     impl_cfg: dict[str, Any] = field(default_factory=dict)

--- a/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
@@ -10,21 +10,20 @@ from typing import Any
 
 import torch
 import torch.distributed as dist
+from megatron.lite.model import resolve_model_type_from_hf
+from megatron.lite.primitive.ckpt import load_training_checkpoint, save_training_checkpoint
+from megatron.lite.primitive.protocols import default_expert_classifier, default_placement_fn
+from megatron.lite.runtime import create_runtime
+from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig
+from megatron.lite.runtime.contracts import LossContext, PackedBatch
+from megatron.lite.runtime.contracts.config import OptimizerConfig as MegatronLiteOptimizerConfig
+from megatron.lite.runtime.contracts.config import ParallelConfig, RuntimeConfig
 from tensordict import TensorDict
+
 from verl.trainer.config import CheckpointConfig
 from verl.utils import tensordict_utils as tu
 from verl.utils.device import get_device_id, get_device_name
 from verl.workers.config import HFModelConfig, OptimizerConfig
-
-from megatron.lite.model import resolve_model_type_from_hf
-from megatron.lite.primitive.ckpt import load_training_checkpoint, save_training_checkpoint
-from megatron.lite.primitive.parallel import pack_nested_thd, unpack_packed_thd_to_nested
-from megatron.lite.primitive.protocols import default_expert_classifier, default_placement_fn
-from megatron.lite.runtime import create_runtime
-from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig
-from megatron.lite.runtime.contracts import PackedBatch
-from megatron.lite.runtime.contracts.config import OptimizerConfig as MegatronLiteOptimizerConfig
-from megatron.lite.runtime.contracts.config import ParallelConfig, RuntimeConfig
 from verl_mlite.compat import load_verl_engine_api
 
 from .config import MegatronLiteEngineConfig
@@ -350,72 +349,15 @@ class MegatronLiteEngine(BaseEngine):
             data=data, dp_group=self.get_data_parallel_group(), same_micro_num_in_dp=True
         )
 
-        if self._use_runtime_forward_backward():
-            return self._forward_backward_batch_with_runtime(
-                data=data,
-                micro_batches=micro_batches,
-                indices=indices,
-                loss_function=loss_function,
-                forward_only=forward_only,
-            )
-
-        outputs = []
-        num_micro_batches = len(micro_batches)
-        for micro_idx, micro_batch in enumerate(micro_batches):
-            tu.assign_non_tensor(micro_batch, micro_batch_idx=micro_idx)
-            micro_batch = micro_batch.to(get_device_id())
-            model_inputs = self._make_model_inputs(micro_batch)
-
-            pre_forward_hook = self.handle._extras.get("pre_forward_hook")
-            if pre_forward_hook is not None:
-                pre_forward_hook(torch.tensor(1.0 / num_micro_batches, device=get_device_id()))
-
-            with torch.no_grad() if forward_only else torch.enable_grad():
-                raw_output = self.module(
-                    input_ids=model_inputs["input_ids"],
-                    position_ids=model_inputs["position_ids"],
-                    packed_seq_params=model_inputs["packed_seq_params"],
-                    labels=model_inputs["labels"],
-                    loss_mask=model_inputs.get("loss_mask"),
-                    temperature=model_inputs["temperature"],
-                    use_fused_kernels=model_inputs["use_fused_kernels"],
-                    calculate_entropy=model_inputs["calculate_entropy"],
-                )
-
-                model_output = self._build_verl_model_output(
-                    raw_output=raw_output, micro_batch=micro_batch, inputs=model_inputs
-                )
-
-                if loss_function is not None:
-                    loss, metrics = loss_function(
-                        model_output=model_output,
-                        data=micro_batch,
-                        dp_group=self.get_data_parallel_group(),
-                    )
-                else:
-                    loss = torch.zeros((), device=get_device_id(), dtype=torch.float32)
-                    metrics = {}
-                if raw_output.get("mtp_loss") is not None:
-                    metrics = dict(metrics)
-                    mtp_loss = self._reduce_mtp_metric(raw_output["mtp_loss"])
-                    metrics["mtp_losses/mtp_1_loss"] = (
-                        float(mtp_loss.item()) if mtp_loss.numel() == 1 else mtp_loss.cpu().tolist()
-                    )
-
-            if not forward_only and loss_function is not None:
-                loss.backward()
-
-            outputs.append(
-                {"model_output": model_output, "loss": loss.detach().item(), "metrics": metrics}
-            )
-
-        if not forward_only:
-            finalize_grads = self.handle._extras.get("finalize_grads")
-            if finalize_grads is not None:
-                finalize_grads()
-
-        result = postprocess_batch_func(output_lst=outputs, indices=indices, data=data)
-        return result
+        # Megatron drives every forward through the runtime's forward_backward
+        # callback; the engine never calls the module directly.
+        return self._forward_backward_batch_with_runtime(
+            data=data,
+            micro_batches=micro_batches,
+            indices=indices,
+            loss_function=loss_function,
+            forward_only=forward_only,
+        )
 
     def get_per_tensor_param(self, **kwargs):
         self._require_initialized()
@@ -601,6 +543,10 @@ class MegatronLiteEngine(BaseEngine):
                 "MegatronLiteEngine supports only THD/no-padding SFT; set engine.impl_cfg.use_thd=True."
             )
         impl_cfg["use_thd"] = True
+        cross_entropy_fusion = getattr(self.engine_config, "cross_entropy_fusion", None)
+        if cross_entropy_fusion is None:
+            cross_entropy_fusion = getattr(self.engine_config, "use_fused_kernels", False)
+        impl_cfg.setdefault("cross_entropy_fusion", bool(cross_entropy_fusion))
         mtp_cfg = getattr(self.model_config, "mtp", None)
         if mtp_cfg is not None:
             mtp_enable = bool(getattr(mtp_cfg, "enable", False))
@@ -686,10 +632,6 @@ class MegatronLiteEngine(BaseEngine):
             return model[0]
         return model
 
-    def _use_runtime_forward_backward(self) -> bool:
-        ps = self.handle._parallel_state
-        return ps.pp_size > 1 or ps.cp_size > 1
-
     def _forward_backward_batch_with_runtime(
         self,
         *,
@@ -712,9 +654,11 @@ class MegatronLiteEngine(BaseEngine):
         for micro_idx, micro_batch in enumerate(micro_batches):
             tu.assign_non_tensor(micro_batch, micro_batch_idx=micro_idx)
             micro_batch = micro_batch.to(get_device_id())
-            model_inputs = self._make_model_inputs(micro_batch)
             runtime_batches.append(
-                self._make_runtime_batch(micro_batch, model_inputs, loss_scale=loss_scale)
+                (
+                    self._make_runtime_batch(micro_batch),
+                    self._make_runtime_loss_context(micro_batch, loss_scale=loss_scale),
+                )
             )
 
         runtime_loss_fn = None
@@ -739,82 +683,41 @@ class MegatronLiteEngine(BaseEngine):
             "metrics": {key: [value] for key, value in metrics.items()},
         }
 
-    def _make_model_inputs(self, micro_batch: TensorDict) -> dict[str, torch.Tensor]:
+    def _make_runtime_batch(self, micro_batch: TensorDict) -> PackedBatch:
+        """Flatten a jagged no-padding batch to a model-agnostic ``PackedBatch``.
+
+        No CP split, no padding, no ``PackedSeqParams`` here: each model's
+        protocol owns its pack/unpack pair (zigzag vs contiguous). ``labels`` are
+        the unrolled tokens; the protocol rolls them while packing.
+        """
         input_ids = micro_batch["input_ids"]
         if not getattr(input_ids, "is_nested", False):
             raise NotImplementedError(
                 "MegatronLiteEngine supports only nested no-padding THD batches."
             )
-
-        ps = self.handle._parallel_state
-        loss_mask = self._loss_mask_for_packing(micro_batch, input_ids)
-        packed_batch = pack_nested_thd(
-            input_ids,
-            tp_size=ps.tp_size,
-            cp_size=ps.cp_size,
-            cp_rank=ps.cp_rank,
-            cp_group=ps.cp_group if ps.cp_size > 1 else None,
-            split_cp=False,
-            labels=input_ids,
-            roll_labels=True,
-            loss_mask=loss_mask,
-            roll_loss_mask=True,
-        )
-        use_fused_kernels = tu.get_non_tensor_data(
-            data=micro_batch, key="use_fused_kernels", default=self.engine_config.use_fused_kernels
-        )
-
-        return {
-            "input_ids": packed_batch.input_ids,
-            "labels": packed_batch.labels,
-            "loss_mask": packed_batch.loss_mask,
-            "position_ids": packed_batch.position_ids,
-            "packed_seq_params": packed_batch.packed_seq_params,
-            "packed_batch": packed_batch,
-            "temperature": self._scalar_temperature(micro_batch),
-            "use_fused_kernels": use_fused_kernels,
-            "calculate_entropy": tu.get_non_tensor_data(
-                data=micro_batch, key="calculate_entropy", default=False
-            ),
-        }
-
-    def _make_runtime_batch(
-        self,
-        micro_batch: TensorDict,
-        model_inputs: dict[str, Any],
-        *,
-        loss_scale: float,
-    ) -> PackedBatch:
-        input_ids = micro_batch["input_ids"]
-        seq_lens = input_ids.offsets().diff().to(dtype=torch.int64)
         loss_mask = self._loss_mask_for_packing(micro_batch, input_ids)
         return PackedBatch(
             input_ids=input_ids.values().contiguous(),
-            labels=self._roll_nested_values_left(input_ids),
-            loss_mask=(
-                None if loss_mask is None else self._roll_nested_values_left(loss_mask).float()
-            ),
-            seq_lens=seq_lens,
-            extras={
-                "temperature": model_inputs["temperature"],
-                "use_fused_kernels": model_inputs["use_fused_kernels"],
-                "calculate_entropy": model_inputs["calculate_entropy"],
-                "loss_scale": loss_scale,
-                "_verl_micro_batch": micro_batch,
-                "_verl_inputs": model_inputs,
-            },
+            labels=input_ids.values().contiguous(),
+            loss_mask=None if loss_mask is None else loss_mask.values().contiguous().float(),
+            seq_lens=input_ids.offsets().diff().to(dtype=torch.int64),
         )
 
-    @staticmethod
-    def _roll_nested_values_left(nested: torch.Tensor) -> torch.Tensor:
-        offsets = nested.offsets()
-        values = nested.values()
-        rolled = torch.zeros_like(values)
-        for start_t, end_t in zip(offsets[:-1], offsets[1:], strict=True):
-            start, end = int(start_t.item()), int(end_t.item())
-            if end - start > 1:
-                rolled[start : end - 1] = values[start + 1 : end]
-        return rolled
+    def _make_runtime_loss_context(
+        self,
+        micro_batch: TensorDict,
+        *,
+        loss_scale: float,
+    ) -> LossContext:
+        return LossContext(
+            temperature=float(self._scalar_temperature(micro_batch)),
+            calculate_entropy=bool(
+                tu.get_non_tensor_data(data=micro_batch, key="calculate_entropy", default=False)
+            ),
+            return_log_probs=True,
+            loss_scale=loss_scale,
+            source_batch=micro_batch,
+        )
 
     @staticmethod
     def _loss_mask_for_packing(
@@ -845,26 +748,32 @@ class MegatronLiteEngine(BaseEngine):
         self,
         *,
         raw_output: dict[str, torch.Tensor],
-        micro_batch: TensorDict,
-        inputs: dict[str, torch.Tensor],
+        runtime_batch: PackedBatch,
     ) -> dict[str, torch.Tensor]:
-        del micro_batch
         log_probs = raw_output.get("log_probs")
         if log_probs is None:
             raise ValueError("Megatron Lite THD model output must contain token log_probs.")
-        nested_log_probs = unpack_packed_thd_to_nested(log_probs, inputs["packed_batch"])
-        output = {"log_probs": nested_log_probs}
+        proto = self.handle._extras.get("protocol")
+        unpack = getattr(proto, "unpack_forward_output", None)
+        if unpack is None:
+            raise ValueError(
+                "Model protocol must expose unpack_forward_output to reverse THD outputs."
+            )
+        output = {"log_probs": unpack(self.module, runtime_batch, log_probs)}
         entropy = raw_output.get("entropy")
         if entropy is not None:
-            output["entropy"] = unpack_packed_thd_to_nested(entropy, inputs["packed_batch"])
+            output["entropy"] = unpack(self.module, runtime_batch, entropy)
         return output
 
     def _make_runtime_loss_fn(self, loss_function, *, forward_only: bool):
-        def _loss_fn(raw_output: dict[str, torch.Tensor], runtime_batch: PackedBatch):
-            micro_batch = runtime_batch.extras["_verl_micro_batch"]
-            inputs = runtime_batch.extras["_verl_inputs"]
+        def _loss_fn(
+            raw_output: dict[str, torch.Tensor],
+            runtime_batch: PackedBatch,
+            loss_context: LossContext,
+        ):
+            micro_batch = loss_context.source_batch
             model_output = self._build_verl_model_output(
-                raw_output=raw_output, micro_batch=micro_batch, inputs=inputs
+                raw_output=raw_output, runtime_batch=runtime_batch
             )
             raw_output["_verl_model_output"] = model_output
             if loss_function is not None:

--- a/experimental/lite/examples/verl/verl_mlite/launch.py
+++ b/experimental/lite/examples/verl/verl_mlite/launch.py
@@ -15,6 +15,10 @@ def main() -> None:
     module = sys.argv[1]
     sys.argv = [module, *sys.argv[2:]]
     apply_runtime_patches()
+    # Import the engine so its EngineRegistry.register decorator runs before the
+    # verl trainer resolves the "mlite" backend.
+    import verl_mlite.engine  # noqa: F401
+
     runpy.run_module(module, run_name="__main__", alter_sys=True)
 
 

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
@@ -14,6 +14,7 @@ from megatron.lite.model.deepseek_v4.lite.checkpoint import (
     load_hf_weights as _load_hf_weights_impl,
     save_hf_weights as _save_hf_weights_impl,
 )
+from megatron.lite.model.protocol_utils import add_loss_context_kwargs
 from megatron.lite.primitive.bundle import ModelBundle
 from megatron.lite.primitive.parallel import ParallelState, init_parallel
 from megatron.lite.primitive.parallel.cp import (
@@ -22,9 +23,9 @@ from megatron.lite.primitive.parallel.cp import (
     local_position_ids_for_cp,
     local_sequence_tensor_for_cp,
 )
-from megatron.lite.primitive.parallel.thd import pack_nested_thd
+from megatron.lite.primitive.parallel.thd import pack_nested_thd, thd_pack_meta, unpack_thd_to_nested
 from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec
-from megatron.lite.runtime.contracts import Batch, OptimizerConfig, PackedBatch, ParallelConfig
+from megatron.lite.runtime.contracts import OptimizerConfig, PackedBatch, ParallelConfig
 
 
 def is_expert_param(name: str) -> bool:
@@ -61,7 +62,6 @@ MODULE_MAP = {
     "ffn_norm": lambda layer: layer.post_attention_layernorm,
 }
 
-_OPTIONAL_MODEL_KWARGS = ("attention_mask", "loss_mask", "temperature", "calculate_entropy")
 _MODEL_FORWARD_KEYS = (
     "input_ids",
     "position_ids",
@@ -72,7 +72,6 @@ _MODEL_FORWARD_KEYS = (
     "calculate_entropy",
     "enable_mtp",
 )
-_MISSING = object()
 
 
 def build_model_config(source: str | Path | dict, **overrides) -> DeepseekV4Config:
@@ -119,14 +118,6 @@ def _infer_cp_local_seq_len(
     return seq_len // cp_size if seq_len % cp_size == 0 else seq_len
 
 
-def _batch_value(batch, key, default=None):
-    if hasattr(batch, key):
-        value = getattr(batch, key)
-        return default if value is None and default is _MISSING else value
-    extras = getattr(batch, "extras", None)
-    return extras.get(key, default) if isinstance(extras, dict) else default
-
-
 def _nested_from_packed_tensor(tensor, seq_lens):
     if tensor is None:
         return None
@@ -166,32 +157,20 @@ def _prepare_packed_batch_kwargs(model, batch: PackedBatch) -> dict[str, Any]:
         "packed_seq_params": packed.packed_seq_params,
         "enable_mtp": False,
     }
-    for key in ("attention_mask", "temperature", "calculate_entropy"):
-        value = _batch_value(batch, key, _MISSING)
-        if value is not _MISSING:
-            kwargs[key] = value
+    add_loss_context_kwargs(kwargs)
     _prepare_packed_contiguous_cp_kwargs(model, kwargs)
     kwargs.pop("packed_seq_params", None)
     return {key: value for key, value in kwargs.items() if key in _MODEL_FORWARD_KEYS}
 
 
-def _base_model_forward_kwargs(batch):
-    input_ids = _batch_value(batch, "input_ids", _MISSING)
-    if input_ids is _MISSING:
-        raise KeyError("DeepSeek V4 forward batch requires input_ids.")
-    input_ids = _as_batch_row(input_ids)
-    kwargs: dict[str, Any] = {
-        "input_ids": input_ids,
-        "labels": _as_batch_row(_batch_value(batch, "labels")),
-    }
-    for key in _OPTIONAL_MODEL_KWARGS:
-        value = _batch_value(batch, key, _MISSING)
-        if value is not _MISSING:
-            if key == "loss_mask":
-                value = _as_batch_row(value)
-            kwargs[key] = value
-    position_ids = _batch_value(batch, "position_ids")
-    position_ids = _normalize_ds4_position_ids(position_ids)
+def _base_model_forward_kwargs(batch: PackedBatch):
+    kwargs: dict[str, Any] = {"input_ids": _as_batch_row(batch.input_ids)}
+    if batch.labels is not None:
+        kwargs["labels"] = _as_batch_row(batch.labels)
+    if batch.loss_mask is not None:
+        kwargs["loss_mask"] = _as_batch_row(batch.loss_mask)
+    add_loss_context_kwargs(kwargs)
+    position_ids = _normalize_ds4_position_ids(batch.position_ids)
     if position_ids is not None:
         kwargs["position_ids"] = position_ids
     return kwargs
@@ -251,15 +230,34 @@ def _prepare_contiguous_cp_kwargs(model, kwargs):
     return kwargs
 
 
-def _prepare_model_forward_kwargs(model, batch):
-    if isinstance(batch, PackedBatch):
+def _prepare_model_forward_kwargs(model, batch: PackedBatch):
+    # THD-packed inputs (1-D values, or a single padded [1, S] row) carry their own
+    # cu_seqlens and go through the packed builder. A dense multi-row [B, S] batch is
+    # split per row under contiguous CP, where contiguous_position_ids_for_cp rebuilds
+    # the per-rank global position ids.
+    input_ids = batch.input_ids
+    is_thd_packed = input_ids.dim() == 1 or (input_ids.dim() == 2 and input_ids.size(0) == 1)
+    if is_thd_packed:
         return _prepare_packed_batch_kwargs(model, batch)
     kwargs = _base_model_forward_kwargs(batch)
     return _prepare_contiguous_cp_kwargs(model, kwargs)
 
 
-def _forward_step(model, batch) -> dict:
+def _forward_step(model: nn.Module, batch: PackedBatch) -> dict:
     return model(**_prepare_model_forward_kwargs(model, batch))
+
+
+def unpack_forward_output(model: nn.Module, batch: PackedBatch, output) -> Any:
+    # DeepSeek-V4 packs each sequence to the (zigzag) TE alignment but slices CP
+    # contiguously for the fused DSA indexer, so reconstruct contiguously.
+    ps = getattr(model, "ps", ParallelState())
+    meta = thd_pack_meta(
+        batch.seq_lens,
+        tp_size=ps.tp_size,
+        cp_size=ps.cp_size,
+        cp_group=ps.cp_group if ps.cp_size > 1 else None,
+    )
+    return unpack_thd_to_nested(output, meta, contiguous=True)
 
 
 def _apply_mtp_config(model_cfg: DeepseekV4Config, impl_cfg: ImplConfig) -> None:

--- a/experimental/lite/megatron/lite/model/glm5/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/protocol.py
@@ -9,20 +9,30 @@ from typing import Any
 
 import torch
 import torch.nn as nn
-
 from megatron.lite.model.glm5.config import Glm5Config
 from megatron.lite.model.glm5.lite.checkpoint import (
     EXPERT_CLASSIFIER,
+)
+from megatron.lite.model.glm5.lite.checkpoint import (
     export_hf_weights as _export_hf_weights_impl,
-    save_hf_weights as _save_hf_weights_impl,
-    save_weights as _save_weights_impl,
 )
 from megatron.lite.model.glm5.lite.checkpoint import load_hf_weights as _load_hf_weights_impl
+from megatron.lite.model.glm5.lite.checkpoint import (
+    save_hf_weights as _save_hf_weights_impl,
+)
+from megatron.lite.model.glm5.lite.checkpoint import (
+    save_weights as _save_weights_impl,
+)
+from megatron.lite.model.protocol_utils import (
+    add_loss_context_kwargs,
+    pack_thd_forward_kwargs,
+    unpack_thd_forward_output,
+)
 from megatron.lite.primitive.bundle import ModelBundle
 from megatron.lite.primitive.parallel import ParallelState, init_parallel
-from megatron.lite.primitive.parallel.thd import prepare_packed_thd_kwargs_for_context_parallel
 from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec, wrap_checkpoint
 from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
+from megatron.lite.runtime.contracts.data import PackedBatch
 
 MODULE_MAP = {
     "self_attn": lambda layer: layer.self_attn,
@@ -66,18 +76,14 @@ def build_model_config(source: str | Path | dict, **overrides) -> Glm5Config:
     return cfg
 
 
-def _forward_step(model: nn.Module, batch: dict) -> dict:
-    kwargs: dict[str, Any] = {"input_ids": batch["input_ids"], "labels": batch.get("labels")}
-    if kwargs["input_ids"].dim() == 1:
-        kwargs["input_ids"] = kwargs["input_ids"].unsqueeze(0)
-    for key in ("position_ids", "attention_mask", "packed_seq_params"):
-        if key in batch:
-            kwargs[key] = batch[key]
-    for key in ("loss_mask", "temperature", "calculate_entropy"):
-        if key in batch:
-            kwargs[key] = batch[key]
-    prepare_packed_thd_kwargs_for_context_parallel(model, kwargs)
+def _forward_step(model: nn.Module, batch: PackedBatch) -> dict:
+    kwargs = pack_thd_forward_kwargs(model, batch)
+    add_loss_context_kwargs(kwargs)
     return model(**kwargs)
+
+
+def unpack_forward_output(model: nn.Module, batch: PackedBatch, output) -> Any:
+    return unpack_thd_forward_output(model, batch, output)
 
 
 def _apply_glm5_recompute(

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/protocol.py
@@ -10,13 +10,19 @@ from typing import Any
 
 import torch
 import torch.nn as nn
-
 from megatron.lite.model.kimi_k2.config import KimiK2Config
+from megatron.lite.model.protocol_utils import (
+    add_cross_entropy_fusion,
+    add_loss_context_kwargs,
+    pack_thd_forward_kwargs,
+    set_cross_entropy_fusion,
+    unpack_thd_forward_output,
+)
 from megatron.lite.primitive.bundle import ModelBundle
 from megatron.lite.primitive.parallel import ParallelState, init_parallel
-from megatron.lite.primitive.parallel.thd import prepare_packed_thd_kwargs_for_context_parallel
 from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec
 from megatron.lite.runtime.contracts import OptimizerConfig, ParallelConfig
+from megatron.lite.runtime.contracts.data import PackedBatch
 
 
 def EXPERT_CLASSIFIER(name: str) -> bool:
@@ -69,6 +75,7 @@ class ImplConfig:
     offload: list[str] = field(default_factory=list)
     use_deepep: bool = False
     use_thd: bool = False
+    cross_entropy_fusion: bool = False
     hf_path: str = ""
     attention_backend_override: str | None = None
     router_aux_loss_coef: float | None = None
@@ -93,20 +100,15 @@ def build_model_config(source: str | Path | dict, **overrides) -> KimiK2Config:
     return cfg
 
 
-def _forward_step(model: nn.Module, batch: dict) -> dict:
-    kwargs: dict[str, Any] = {
-        "input_ids": batch["input_ids"],
-        "labels": batch["labels"],
-    }
-    if "packed_seq_params" in batch:
-        kwargs["packed_seq_params"] = batch["packed_seq_params"]
-    for key in ("loss_mask", "temperature", "use_fused_kernels", "calculate_entropy"):
-        if key in batch:
-            kwargs[key] = batch[key]
-    if kwargs["input_ids"].dim() == 1:
-        kwargs["input_ids"] = kwargs["input_ids"].unsqueeze(0)
-    prepare_packed_thd_kwargs_for_context_parallel(model, kwargs)
+def _forward_step(model: nn.Module, batch: PackedBatch) -> dict:
+    kwargs = pack_thd_forward_kwargs(model, batch)
+    add_loss_context_kwargs(kwargs)
+    add_cross_entropy_fusion(kwargs, model)
     return model(**kwargs)
+
+
+def unpack_forward_output(model: nn.Module, batch: PackedBatch, output) -> Any:
+    return unpack_thd_forward_output(model, batch, output)
 
 
 def _make_aux_loss_hook():
@@ -195,6 +197,7 @@ def build_model(model_cfg: KimiK2Config, *, impl_cfg: ImplConfig) -> ModelBundle
             .cuda()
             for i in range(vpp)
         ]
+    set_cross_entropy_fusion(chunks, impl_cfg.cross_entropy_fusion)
 
     if recompute_spec:
         for chunk in chunks:

--- a/experimental/lite/megatron/lite/model/protocol_utils.py
+++ b/experimental/lite/megatron/lite/model/protocol_utils.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Helpers shared by model protocol forward steps.
+
+The verl/runtime layers hand each protocol a raw, model-agnostic ``PackedBatch``
+(true per-sequence lengths, no padding, no ``PackedSeqParams``). Each model owns
+its pack/unpack pair: ``pack_thd_forward_kwargs`` pads + CP-splits the batch into
+model forward kwargs, and ``unpack_thd_forward_output`` reverses a model output
+back to jagged true-length form. THD models share the zigzag-CP pair below;
+models with a different CP layout (e.g. DeepSeek-V4 contiguous DSA) provide their
+own pair.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+from megatron.lite.primitive.parallel import ParallelState
+from megatron.lite.primitive.parallel.thd import (
+    pack_nested_thd,
+    parallel_state_from_model,
+    prepare_packed_thd_kwargs_for_context_parallel,
+    thd_pack_meta,
+    unpack_thd_to_nested,
+)
+from megatron.lite.primitive.utils.packed_seq import PackedSeqParams
+from megatron.lite.runtime.contracts.data import PackedBatch
+from megatron.lite.runtime.contracts.loss import get_loss_context
+
+
+def _parallel_state(model) -> ParallelState:
+    return parallel_state_from_model(model) or ParallelState()
+
+
+def nested_from_packed(tensor: torch.Tensor | None, seq_lens: torch.Tensor):
+    """Split a 1-D packed (true, unpadded) tensor back into a jagged nested tensor."""
+    if tensor is None:
+        return None
+    if tensor.dim() == 2 and tensor.size(0) == 1:
+        tensor = tensor.squeeze(0)
+    if tensor.dim() != 1:
+        raise ValueError(f"PackedBatch tensor must be 1-D, got {tuple(tensor.shape)}.")
+    pieces = []
+    offset = 0
+    for length_t in seq_lens:
+        length = int(length_t.item())
+        pieces.append(tensor.narrow(0, offset, length))
+        offset += length
+    if offset != tensor.numel():
+        raise ValueError(f"PackedBatch sizes sum to {offset}, tensor has {tensor.numel()} tokens.")
+    return torch.nested.as_nested_tensor(pieces, layout=torch.jagged)
+
+
+def pack_thd_forward_kwargs(model, batch: PackedBatch) -> dict[str, Any]:
+    """Pad + zigzag-CP-split a raw THD batch into model forward kwargs.
+
+    Pads each sequence to the TE/zigzag alignment, then CP-splits tokens,
+    labels, masks and position ids through the shared THD primitive — the same
+    layout the model was validated against, now produced inside the protocol
+    rather than the connector.
+    """
+    ps = _parallel_state(model)
+    seq_lens = batch.seq_lens
+    packed = pack_nested_thd(
+        nested_from_packed(batch.input_ids, seq_lens),
+        tp_size=ps.tp_size,
+        cp_size=ps.cp_size,
+        cp_rank=ps.cp_rank,
+        cp_group=ps.cp_group if ps.cp_size > 1 else None,
+        split_cp=False,
+        labels=nested_from_packed(batch.labels, seq_lens),
+        roll_labels=batch.labels is not None,
+        loss_mask=nested_from_packed(batch.loss_mask, seq_lens),
+        roll_loss_mask=batch.loss_mask is not None,
+    )
+    max_seqlen = int(packed.padded_lengths.max().item()) if packed.padded_lengths.numel() else 0
+    # pack_nested_thd already returns [1, T] token rows; do not unsqueeze again.
+    kwargs: dict[str, Any] = {
+        "input_ids": packed.input_ids,
+        "labels": packed.labels,
+        "loss_mask": packed.loss_mask,
+        "position_ids": packed.position_ids,
+        "packed_seq_params": PackedSeqParams.from_cu_seqlens(
+            packed.cu_seqlens_padded, max_seqlen=max_seqlen
+        ),
+    }
+    prepare_packed_thd_kwargs_for_context_parallel(model, kwargs)
+    return kwargs
+
+
+def unpack_thd_forward_output(model, batch: PackedBatch, output: torch.Tensor) -> torch.Tensor:
+    """Reverse a zigzag-CP THD model output back to jagged true-length form."""
+    ps = _parallel_state(model)
+    meta = thd_pack_meta(
+        batch.seq_lens,
+        tp_size=ps.tp_size,
+        cp_size=ps.cp_size,
+        cp_group=ps.cp_group if ps.cp_size > 1 else None,
+    )
+    return unpack_thd_to_nested(output, meta, contiguous=False)
+
+
+def add_loss_context_kwargs(kwargs: dict[str, Any], *, include_return_log_probs: bool = False) -> None:
+    loss_context = get_loss_context()
+    if loss_context is None:
+        return
+    kwargs["temperature"] = loss_context.temperature
+    kwargs["calculate_entropy"] = loss_context.calculate_entropy
+    if include_return_log_probs:
+        kwargs["return_log_probs"] = loss_context.return_log_probs
+
+
+def add_cross_entropy_fusion(kwargs: dict[str, Any], model) -> None:
+    kwargs["use_fused_kernels"] = bool(getattr(model, "cross_entropy_fusion", False))
+
+
+def set_cross_entropy_fusion(chunks: list, enabled: bool) -> None:
+    for chunk in chunks:
+        chunk.cross_entropy_fusion = bool(enabled)
+
+
+__all__ = [
+    "add_cross_entropy_fusion",
+    "add_loss_context_kwargs",
+    "nested_from_packed",
+    "pack_thd_forward_kwargs",
+    "set_cross_entropy_fusion",
+    "unpack_thd_forward_output",
+]

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/checkpoint.py
@@ -35,9 +35,13 @@ def PLACEMENT_FN(param_name: str) -> list:
         return [Replicate(), Replicate(), Replicate(), Shard(0)]
     if "qkv" in param_name and "layer_norm" not in param_name:
         return [Replicate(), Replicate(), Replicate(), Shard(0)]
-    if ("proj" in param_name or "o_proj" in param_name) and (
-        "full_attn" in param_name or "linear_attn" in param_name
+    if (
+        ("proj" in param_name or "o_proj" in param_name)
+        and ("full_attn" in param_name or "linear_attn" in param_name)
+        and "layer_norm" not in param_name
     ):
+        # Row-parallel output proj weight: TP-shard on dim 1. Exclude layer_norm_weight (1-D, replicated
+        # under TP) which otherwise matches here ("in_proj" contains "proj") and gets an invalid Shard(1).
         return [Replicate(), Replicate(), Replicate(), Shard(1)]
     if "gate_up" in param_name and "shared" in param_name:
         return [Replicate(), Replicate(), Replicate(), Shard(0)]

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
@@ -665,7 +665,7 @@ def _hook_vision_params_avg_grad_across_tp(module: nn.Module) -> None:
         param.average_gradients_across_tp_domain = True  # type: ignore[assignment]
 
 
-def _build_native_vision_model(hf_path: str) -> nn.Module:
+def _build_native_vision_model(hf_path: str) -> nn.Module | None:
     if not hf_path:
         raise ValueError("mount_vision_model requires hf_path.")
     try:
@@ -676,12 +676,22 @@ def _build_native_vision_model(hf_path: str) -> nn.Module:
     hf_config = AutoConfig.from_pretrained(hf_path, trust_remote_code=True)
     vision_config = getattr(hf_config, "vision_config", None)
     if vision_config is None:
-        raise RuntimeError("HF config does not expose vision_config; cannot build vision_model.")
-    hf_vision_cls = _resolve_hf_vision_cls(hf_config, hf_path)
-    if hasattr(hf_vision_cls, "_from_config"):
-        vision = hf_vision_cls._from_config(vision_config)
+        # Text-only checkpoint (no vision tower): nothing to mount -> graceful skip.
+        return None
+    auto_map = getattr(hf_config, "auto_map", None) or {}
+    if auto_map:
+        # Remote-code checkpoint: resolve the vision class from its dynamic module.
+        hf_vision_cls = _resolve_hf_vision_cls(hf_config, hf_path)
+        if hasattr(hf_vision_cls, "_from_config"):
+            vision = hf_vision_cls._from_config(vision_config)
+        else:
+            vision = hf_vision_cls(vision_config)
     else:
-        vision = hf_vision_cls(vision_config)
+        # Native-transformers checkpoint (auto_map=None, e.g. Qwen3.5-35B-A3B): build the vision tower
+        # directly from its vision_config via the native AutoModel registry (no remote code).
+        from transformers import AutoModel
+
+        vision = AutoModel.from_config(vision_config)
     _hook_fp32_rotary_emb(vision)
     _hook_vision_params_avg_grad_across_tp(vision)
     return vision.to(torch.bfloat16)

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
@@ -10,7 +10,13 @@ from typing import Any
 
 import torch
 import torch.nn as nn
-
+from megatron.lite.model.protocol_utils import (
+    add_cross_entropy_fusion,
+    add_loss_context_kwargs,
+    pack_thd_forward_kwargs,
+    set_cross_entropy_fusion,
+    unpack_thd_forward_output,
+)
 from megatron.lite.model.qwen3_5.config import Qwen35Config
 from megatron.lite.model.qwen3_5.lite.checkpoint import EXPERT_CLASSIFIER, PLACEMENT_FN
 from megatron.lite.model.qwen3_5.lite.checkpoint import export_hf_weights as _export_hf_weights_impl
@@ -18,9 +24,9 @@ from megatron.lite.model.qwen3_5.lite.checkpoint import load_hf_weights as _load
 from megatron.lite.model.qwen3_5.lite.checkpoint import save_hf_weights as _save_hf_weights_impl
 from megatron.lite.primitive.bundle import ModelBundle
 from megatron.lite.primitive.parallel import ParallelState, init_parallel
-from megatron.lite.primitive.parallel.thd import prepare_packed_thd_kwargs_for_context_parallel
 from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec
 from megatron.lite.runtime.contracts import OptimizerConfig, ParallelConfig
+from megatron.lite.runtime.contracts.data import PackedBatch
 
 __all__ = [
     "EXPERT_CLASSIFIER",
@@ -47,6 +53,7 @@ class ImplConfig:
     offload: list[str] = field(default_factory=list)
     use_deepep: bool = False
     use_thd: bool = False
+    cross_entropy_fusion: bool = False
     hf_path: str = ""
     attention_backend_override: str | None = None
     router_aux_loss_coef: float | None = None
@@ -90,19 +97,15 @@ def build_model_config(source: str | Path | dict, **overrides) -> Qwen35Config:
     return cfg
 
 
-def _forward_step(model: nn.Module, batch: dict) -> dict:
-    kwargs: dict[str, Any] = {"input_ids": batch["input_ids"], "labels": batch["labels"]}
-    if "position_ids" in batch:
-        kwargs["position_ids"] = batch["position_ids"]
-    if "packed_seq_params" in batch:
-        kwargs["packed_seq_params"] = batch["packed_seq_params"]
-    for key in ("loss_mask", "temperature", "use_fused_kernels", "calculate_entropy"):
-        if key in batch:
-            kwargs[key] = batch[key]
-    if kwargs["input_ids"].dim() == 1:
-        kwargs["input_ids"] = kwargs["input_ids"].unsqueeze(0)
-    prepare_packed_thd_kwargs_for_context_parallel(model, kwargs)
+def _forward_step(model: nn.Module, batch: PackedBatch) -> dict:
+    kwargs = pack_thd_forward_kwargs(model, batch)
+    add_loss_context_kwargs(kwargs)
+    add_cross_entropy_fusion(kwargs, model)
     return model(**kwargs)
+
+
+def unpack_forward_output(model: nn.Module, batch: PackedBatch, output) -> Any:
+    return unpack_thd_forward_output(model, batch, output)
 
 
 def _make_aux_loss_hook():
@@ -194,6 +197,7 @@ def build_model(model_cfg: Qwen35Config, *, impl_cfg: ImplConfig) -> ModelBundle
             .cuda()
             for i in range(vpp)
         ]
+    set_cross_entropy_fusion(chunks, impl_cfg.cross_entropy_fusion)
 
     if recompute_spec:
         for chunk in chunks:

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
@@ -25,7 +25,13 @@ from typing import Any
 
 import torch
 import torch.nn as nn
-
+from megatron.lite.model.protocol_utils import (
+    add_cross_entropy_fusion,
+    add_loss_context_kwargs,
+    pack_thd_forward_kwargs,
+    set_cross_entropy_fusion,
+    unpack_thd_forward_output,
+)
 from megatron.lite.model.qwen3_moe.common import is_expert_param
 from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
 from megatron.lite.model.qwen3_moe.lite.checkpoint import EXPERT_CLASSIFIER, PLACEMENT_FN
@@ -39,9 +45,9 @@ from megatron.lite.primitive.modules.lora import (
     trainable_param_stats,
 )
 from megatron.lite.primitive.parallel import ParallelState, init_parallel
-from megatron.lite.primitive.parallel.thd import prepare_packed_thd_kwargs_for_context_parallel
 from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec
 from megatron.lite.runtime.contracts import OptimizerConfig, ParallelConfig
+from megatron.lite.runtime.contracts.data import PackedBatch
 
 __all__ = [
     "EXPERT_CLASSIFIER",
@@ -69,6 +75,7 @@ class ImplConfig:
     offload: list[str] = field(default_factory=list)
     use_deepep: bool = False
     use_thd: bool = False
+    cross_entropy_fusion: bool = False
     router_aux_loss_coef: float | None = None
     router_bias_rate: float = 0.0
     # User-level OptimizerConfig threaded through the runtime.
@@ -118,25 +125,15 @@ def build_model_config(source: str | Path | dict, **overrides) -> Qwen3MoEConfig
 # ---------------------------------------------------------------------------
 
 
-def _forward_step(model: nn.Module, batch: dict) -> dict:
-    kwargs = {"input_ids": batch["input_ids"], "labels": batch["labels"]}
-    if "packed_seq_params" in batch:
-        kwargs["packed_seq_params"] = batch["packed_seq_params"]
-    if "position_ids" in batch:
-        kwargs["position_ids"] = batch["position_ids"]
-    for key in (
-        "loss_mask",
-        "temperature",
-        "use_fused_kernels",
-        "calculate_entropy",
-        "return_log_probs",
-    ):
-        if key in batch:
-            kwargs[key] = batch[key]
-    if kwargs["input_ids"].dim() == 1:
-        kwargs["input_ids"] = kwargs["input_ids"].unsqueeze(0)
-    prepare_packed_thd_kwargs_for_context_parallel(model, kwargs)
+def _forward_step(model: nn.Module, batch: PackedBatch) -> dict:
+    kwargs = pack_thd_forward_kwargs(model, batch)
+    add_loss_context_kwargs(kwargs, include_return_log_probs=True)
+    add_cross_entropy_fusion(kwargs, model)
     return model(**kwargs)
+
+
+def unpack_forward_output(model: nn.Module, batch: PackedBatch, output) -> Any:
+    return unpack_thd_forward_output(model, batch, output)
 
 
 def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBundle:
@@ -194,6 +191,8 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
                 .to(torch.bfloat16)
                 .cuda()
             )
+
+    set_cross_entropy_fusion(chunks, impl_cfg.cross_entropy_fusion)
 
     # ── recompute ──
     if recompute_spec:

--- a/experimental/lite/megatron/lite/primitive/bundle.py
+++ b/experimental/lite/megatron/lite/primitive/bundle.py
@@ -24,6 +24,6 @@ class ModelBundle:
     parallel_state: ParallelState
     optimizer: Any | None = None
     finalize_grads: Callable[[], None] | None = None
-    forward_step: Callable[[nn.Module, dict], dict] | None = None
+    forward_step: Callable[..., dict] | None = None
     # extra metadata (expert_classifier, model_cfg, etc.)
     extras: dict[str, Any] = field(default_factory=dict)

--- a/experimental/lite/megatron/lite/primitive/ckpt/distckpt.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/distckpt.py
@@ -113,7 +113,22 @@ def load_dist_opt_checkpoint(
             )
         finally:
             _restore_state_dict_patches(patches)
-    state_dict = dist_checkpointing.load(load_sd, checkpoint_dir, validate_access_integrity=False)
+    # torch>=2.6 flips torch.load's weights_only default to True, which rejects the trusted dist_opt
+    # common state (mcore's load_common torch.loads optimizer/scheduler classes like AdamW). We are
+    # loading our OWN checkpoint -> force weights_only=False for the duration of the load.
+    _orig_torch_load = torch.load
+
+    def _trusted_torch_load(*args, **kwargs):
+        kwargs.setdefault("weights_only", False)
+        return _orig_torch_load(*args, **kwargs)
+
+    torch.load = _trusted_torch_load
+    try:
+        state_dict = dist_checkpointing.load(
+            load_sd, checkpoint_dir, validate_access_integrity=False
+        )
+    finally:
+        torch.load = _orig_torch_load
     if load_model:
         _load_model_state_dict(model, state_dict)
     if load_optimizer and optimizer is not None and "optimizer" in state_dict:

--- a/experimental/lite/megatron/lite/primitive/modules/attention/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/modules/attention/__init__.py
@@ -6,3 +6,11 @@ from megatron.lite.primitive.modules.attention.dsa import (
     build_rotary_embeddings,
 )
 from megatron.lite.primitive.modules.attention.mla import MultiLatentAttention
+
+__all__ = [
+    "DynamicSparseAttention",
+    "MultiLatentAttention",
+    "RMSNorm",
+    "build_rope_cache",
+    "build_rotary_embeddings",
+]

--- a/experimental/lite/megatron/lite/primitive/modules/attention/csa.py
+++ b/experimental/lite/megatron/lite/primitive/modules/attention/csa.py
@@ -308,6 +308,7 @@ class CompressedSparseAttention(nn.Module):
         if (
             use_sparse_backend
             and self.compress_ratio == 4
+            and self.ps.cp_size == 1
             and self.compressor is not None
             and self.indexer is not None
         ):

--- a/experimental/lite/megatron/lite/primitive/modules/attention/mla.py
+++ b/experimental/lite/megatron/lite/primitive/modules/attention/mla.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import inspect
 import math
 
 import torch
@@ -46,28 +45,10 @@ _KEPT_PSP_FIELDS = (
 )
 
 
-def _accepts_kwarg(fn, name: str) -> bool:
-    try:
-        params = inspect.signature(fn).parameters
-    except (TypeError, ValueError):
-        return False
-    return name in params or any(
-        param.kind == inspect.Parameter.VAR_KEYWORD for param in params.values()
-    )
-
-
-_ROPE_BSHD_ACCEPTS_MLA = _accepts_kwarg(_apply_rotary_pos_emb_bshd, "mla_rotary_interleaved")
-_ROPE_THD_ACCEPTS_MLA = _accepts_kwarg(_apply_rotary_pos_emb_thd, "mla_rotary_interleaved")
-_TE_DPA_ACCEPTS_SOFTMAX_SCALE = _accepts_kwarg(te.DotProductAttention, "softmax_scale")
-
-
 def _apply_mla_rope_bshd(t: torch.Tensor, freqs: torch.Tensor, *, mscale: float) -> torch.Tensor:
-    kwargs = dict(rotary_interleaved=False, mscale=mscale)
-    if _ROPE_BSHD_ACCEPTS_MLA:
-        kwargs["mla_rotary_interleaved"] = True
-    else:
-        kwargs["multi_latent_attention"] = True
-    return _apply_rotary_pos_emb_bshd(t, freqs, **kwargs)
+    return _apply_rotary_pos_emb_bshd(
+        t, freqs, rotary_interleaved=False, mscale=mscale, mla_rotary_interleaved=True
+    )
 
 
 def _apply_mla_rope_thd(
@@ -78,16 +59,15 @@ def _apply_mla_rope_thd(
     mscale: float,
     cp_group,
 ) -> torch.Tensor:
-    kwargs = dict(
+    return _apply_rotary_pos_emb_thd(
+        t,
+        cu_seqlens,
+        freqs,
         rotary_interleaved=False,
         mscale=mscale,
         cp_group=cp_group,
+        mla_rotary_interleaved=True,
     )
-    if _ROPE_THD_ACCEPTS_MLA:
-        kwargs["mla_rotary_interleaved"] = True
-    else:
-        kwargs["multi_latent_attention"] = True
-    return _apply_rotary_pos_emb_thd(t, cu_seqlens, freqs, **kwargs)
 
 
 class MultiLatentAttention(nn.Module):
@@ -181,7 +161,7 @@ class MultiLatentAttention(nn.Module):
         else:
             raise ValueError(f"Unsupported MLA rope type: {rope_type!r}")
         self._softmax_scale = attn_mscale * attn_mscale / math.sqrt(self.q_head_dim)
-        self._query_scale = 1.0 if _TE_DPA_ACCEPTS_SOFTMAX_SCALE else attn_mscale * attn_mscale
+        self._query_scale = 1.0
 
         cp_kwargs = {}
         if ps.cp_size > 1:
@@ -195,9 +175,7 @@ class MultiLatentAttention(nn.Module):
         self._use_torch_core = ps.cp_size > 1 and v_head_dim != self.q_head_dim
         self.core_attn = None
         if not self._use_torch_core:
-            dpa_kwargs = dict(cp_kwargs)
-            if _TE_DPA_ACCEPTS_SOFTMAX_SCALE:
-                dpa_kwargs["softmax_scale"] = self._softmax_scale
+            dpa_kwargs = dict(cp_kwargs, softmax_scale=self._softmax_scale)
             kv_channels = (
                 (self.q_head_dim, v_head_dim) if v_head_dim != self.q_head_dim else self.q_head_dim
             )

--- a/experimental/lite/megatron/lite/primitive/modules/gqa.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gqa.py
@@ -7,8 +7,6 @@ Supports sequence parallel, context parallel, and THD (packed sequences).
 
 from __future__ import annotations
 
-import inspect
-
 import torch
 import torch.nn as nn
 import transformer_engine.pytorch as te
@@ -33,16 +31,6 @@ _KEPT_PSP_FIELDS = (
     "max_seqlen_q",
     "max_seqlen_kv",
 )
-
-
-def _callable_accepts_kwarg(fn, kwarg: str) -> bool:
-    try:
-        parameters = inspect.signature(fn).parameters.values()
-    except (TypeError, ValueError):
-        return False
-    return any(
-        param.kind is inspect.Parameter.VAR_KEYWORD or param.name == kwarg for param in parameters
-    )
 
 
 class GQAttention(nn.Module):
@@ -162,10 +150,6 @@ class GQAttention(nn.Module):
                 rotary_base=rope_theta,
                 cp_group=ps.cp_group if ps.cp_size > 1 else None,
             )
-        self._rotary_accepts_packed_seq = self._mrope_section is None and _callable_accepts_kwarg(
-            self.rotary.forward, "packed_seq"
-        )
-
         cp_kwargs = {}
         if ps.cp_size > 1:
             if GQAttention._cp_stream is None:
@@ -226,10 +210,7 @@ class GQAttention(nn.Module):
                 seq_len_for_rope = int(max(max_q, max_kv))
             # Packed THD uses max per-sequence padded length, not total packed tokens.
             # The THD apply helper handles CP-zigzag frequency slicing per sequence.
-            if self._rotary_accepts_packed_seq:
-                freqs = self.rotary(seq_len_for_rope, packed_seq=True)
-            else:
-                freqs = self.rotary(seq_len_for_rope)
+            freqs = self.rotary(seq_len_for_rope, packed_seq=True)
             q = _apply_rotary_pos_emb_thd(
                 q,
                 packed_seq_params.cu_seqlens_q,

--- a/experimental/lite/megatron/lite/primitive/parallel/pipeline.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/pipeline.py
@@ -11,6 +11,7 @@ import torch  # pyright: ignore[reportMissingImports]
 import torch.distributed as dist  # pyright: ignore[reportMissingImports]
 
 from megatron.lite.primitive.utils import ensure_divisible
+from megatron.lite.runtime.contracts.loss import split_loss_context, use_loss_context
 
 if TYPE_CHECKING:
     from megatron.lite.primitive.parallel.state import ParallelState
@@ -134,11 +135,15 @@ def _batch_get(batch, key: str):
 
 
 def _apply_external_loss(
-    out: dict, batch, loss_fn
+    out: dict, batch, loss_fn, loss_context=None
 ) -> tuple[torch.Tensor, dict] | tuple[None, None]:
     if loss_fn is None:
         return None, None
-    loss, metrics = loss_fn(out, batch)
+    # Mirror run_microbatch_loop: pass loss_context as 3rd arg when present.
+    if loss_context is None:
+        loss, metrics = loss_fn(out, batch)
+    else:
+        loss, metrics = loss_fn(out, batch, loss_context)
     out["loss"] = loss
     out["_loss_fn_metrics"] = metrics
     return loss, metrics
@@ -229,7 +234,9 @@ def _1f1b_schedule(
     num_warmup = min(ps.pp_size - ps.pp_rank - 1, num_microbatches)
     num_steady = num_microbatches - num_warmup
 
-    batches = [next(data_iter) for _ in range(num_microbatches)]
+    # Split each microbatch into (PackedBatch, LossContext) like run_microbatch_loop; the connector
+    # yields (batch, loss_context) tuples, so forward_step must receive the unwrapped batch.
+    batches = [split_loss_context(next(data_iter)) for _ in range(num_microbatches)]
     mb_idx = 0
 
     input_tensors: list[torch.Tensor | None] = []
@@ -249,13 +256,14 @@ def _1f1b_schedule(
         else None
     )
 
-    def _run_forward(input_tensor, batch):
+    def _run_forward(input_tensor, batch, loss_context=None):
         _set_aux_loss_scale(pre_forward_hook, num_microbatches)
         if not ps.pp_is_first:
             model.set_input_tensor(input_tensor)
-        out = forward_step_fn(model, batch)
-        if ps.pp_is_last:
-            _apply_external_loss(out, batch, loss_fn)
+        with use_loss_context(loss_context):
+            out = forward_step_fn(model, batch)
+            if ps.pp_is_last:
+                _apply_external_loss(out, batch, loss_fn, loss_context)
         return out
 
     def _run_backward(inp_t, hid_t, loss_t, grad_t):
@@ -285,10 +293,10 @@ def _1f1b_schedule(
         if not ps.pp_is_first and k == 0:
             fwd_input, _ = _p2p(recv_fwd=True)
 
-        batch = batches[mb_idx]
+        batch, loss_ctx = batches[mb_idx]
         mb_idx += 1
         current_input = fwd_input
-        out = _run_forward(fwd_input, batch)
+        out = _run_forward(fwd_input, batch, loss_ctx)
         hidden = out.get("hidden_states")
         loss_s = out["loss"] / num_microbatches if "loss" in out and ps.pp_is_last else None
 
@@ -312,9 +320,9 @@ def _1f1b_schedule(
         if not ps.pp_is_first and k == 0 and num_warmup == 0:
             fwd_input, _ = _p2p(recv_fwd=True)
 
-        batch = batches[mb_idx]
+        batch, loss_ctx = batches[mb_idx]
         mb_idx += 1
-        out = _run_forward(fwd_input, batch)
+        out = _run_forward(fwd_input, batch, loss_ctx)
         hidden = out.get("hidden_states")
         loss_s = out["loss"] / num_microbatches if "loss" in out and ps.pp_is_last else None
 

--- a/experimental/lite/megatron/lite/primitive/parallel/pipeline.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/pipeline.py
@@ -259,7 +259,10 @@ def _1f1b_schedule(
     def _run_forward(input_tensor, batch, loss_context=None):
         _set_aux_loss_scale(pre_forward_hook, num_microbatches)
         if not ps.pp_is_first:
-            model.set_input_tensor(input_tensor)
+            # `model` is the dist_opt DDP-wrapped chunk; set_input_tensor lives on the base lite model.
+            from megatron.lite.primitive.ckpt.hf_weights import unwrap_model
+
+            unwrap_model(model).set_input_tensor(input_tensor)
         with use_loss_context(loss_context):
             out = forward_step_fn(model, batch)
             if ps.pp_is_last:

--- a/experimental/lite/megatron/lite/primitive/parallel/thd.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/thd.py
@@ -257,6 +257,78 @@ def prepare_packed_thd_kwargs_for_context_parallel(
             kwargs[key] = tensor
 
 
+@dataclass(frozen=True)
+class ThdPackMeta:
+    """Per-sequence THD padding layout, recomputable from true seq lengths.
+
+    Shared by a model's pack/unpack pair so the connector never needs to hold
+    ``PackedSeqParams`` or padded token tensors to reverse a model output.
+    """
+
+    lengths: torch.Tensor
+    padded_lengths: torch.Tensor
+    cu_seqlens_padded: torch.Tensor
+    cp_size: int
+    cp_group: Any | None
+
+
+def thd_pack_meta(
+    seq_lens: torch.Tensor,
+    *,
+    tp_size: int = 1,
+    cp_size: int = 1,
+    cp_group: Any | None = None,
+    contiguous: bool = False,
+) -> ThdPackMeta:
+    """Compute the padded THD layout for ``seq_lens`` without copying tokens.
+
+    ``contiguous=False`` aligns to Megatron/TE zigzag CP (``2*cp``); ``True``
+    aligns to contiguous CP (``cp``). Mirrors :func:`pack_nested_thd` padding.
+    """
+    lengths = seq_lens.to(dtype=torch.int32)
+    cp_align = (cp_size if contiguous else 2 * cp_size) if cp_size > 1 else 1
+    align_size = max(int(tp_size), 1) * cp_align
+    pad_size = (align_size - lengths % align_size) % align_size
+    padded_lengths = lengths + pad_size
+    cu_seqlens_padded = torch.zeros(
+        lengths.numel() + 1, dtype=torch.int32, device=lengths.device
+    )
+    cu_seqlens_padded[1:] = torch.cumsum(padded_lengths, dim=0)
+    return ThdPackMeta(lengths, padded_lengths, cu_seqlens_padded, cp_size, cp_group)
+
+
+def unpack_thd_to_nested(
+    output: torch.Tensor, meta: ThdPackMeta, *, contiguous: bool = False
+) -> torch.Tensor:
+    """Reverse a model output back to jagged true-length form using ``meta``.
+
+    Gathers CP-local shards (zigzag or contiguous reconstruct) then slices each
+    sequence's true length out of the padded layout.
+    """
+    if output.dim() >= 2 and output.shape[0] == 1:
+        flat = output[0]
+    elif output.dim() >= 2 and output.shape[1] == 1:
+        flat = output[:, 0]
+    else:
+        flat = output
+
+    if meta.cp_size > 1:
+        parts = _all_gather_cp_tensor(flat, cp_size=meta.cp_size, cp_group=meta.cp_group)
+        if contiguous:
+            flat = torch.cat(parts, dim=0)
+        else:
+            flat = _reconstruct_full_from_cp_parts(
+                parts, cu_seqlens_padded=meta.cu_seqlens_padded, cp_size=meta.cp_size, dim=0
+            )
+
+    pieces = []
+    for idx, length_t in enumerate(meta.lengths):
+        length = int(length_t.item())
+        start = int(meta.cu_seqlens_padded[idx].item())
+        pieces.append(flat[start : start + length])
+    return torch.nested.as_nested_tensor(pieces, layout=torch.jagged)
+
+
 def _all_gather_cp_tensor(
     tensor: torch.Tensor, *, cp_size: int, cp_group: Any
 ) -> list[torch.Tensor]:
@@ -526,6 +598,7 @@ def unpack_packed_thd_to_nested(output: torch.Tensor, batch: PackedTHDBatch) -> 
 __all__ = [
     "PackedSeqParams",
     "PackedTHDBatch",
+    "ThdPackMeta",
     "has_packed_thd_params",
     "pack_nested_thd",
     "parallel_state_from_model",
@@ -534,5 +607,7 @@ __all__ = [
     "reconstruct_packed_from_cp_parts",
     "roll_packed_thd_left",
     "split_packed_to_cp_local",
+    "thd_pack_meta",
     "unpack_packed_thd_to_nested",
+    "unpack_thd_to_nested",
 ]

--- a/experimental/lite/megatron/lite/primitive/train_step.py
+++ b/experimental/lite/megatron/lite/primitive/train_step.py
@@ -21,6 +21,7 @@ def run_microbatch_loop(
     dist_opt: bool = False,
     pre_forward_hook: Callable[[torch.Tensor], None] | None = None,
     loss_fn: Callable | None = None,
+    forward_only: bool = False,
 ):
     """Run forward-backward over microbatches with loss accumulation.
 
@@ -40,6 +41,10 @@ def run_microbatch_loop(
             ``loss_fn(model_output: dict, batch) -> (loss: Tensor, metrics: dict)``.
             When provided, ``forward_fn`` output is passed to ``loss_fn`` instead of
             reading ``out["loss"]`` directly. This enables RLHF policy/value losses.
+        forward_only: When True, run forward without backward (e.g. validation /
+            ``infer_batch``). The caller (verl) runs the forward under ``no_grad`` so the
+            loss has no ``grad_fn``; calling ``.backward()`` then raises. Mirrors the
+            pipeline path, which already threads ``forward_only`` to skip backward.
     """
     last_out = None
     all_metrics: list[dict] = []
@@ -57,10 +62,11 @@ def run_microbatch_loop(
                 loss, metrics = loss_fn(out, batch)
             else:
                 loss, metrics = loss_fn(out, batch, loss_context)
-            (loss / num_microbatches).backward()
+            if not forward_only:
+                (loss / num_microbatches).backward()
             out["loss"] = loss.detach()
             all_metrics.append(metrics)
-        else:
+        elif not forward_only:
             (out["loss"] / num_microbatches).backward()
         last_out = out
     if last_out is not None and all_metrics:

--- a/experimental/lite/megatron/lite/primitive/train_step.py
+++ b/experimental/lite/megatron/lite/primitive/train_step.py
@@ -7,9 +7,9 @@ from collections.abc import Callable
 
 import torch
 import torch.distributed as dist
-
 from megatron.lite.primitive.parallel import ParallelState
 from megatron.lite.primitive.protocols import ExpertClassifierFn, default_expert_classifier
+from megatron.lite.runtime.contracts.loss import split_loss_context, use_loss_context
 
 
 def run_microbatch_loop(
@@ -44,15 +44,19 @@ def run_microbatch_loop(
     last_out = None
     all_metrics: list[dict] = []
     for mb in range(num_microbatches):
-        batch = next(data_iter)
+        batch, loss_context = split_loss_context(next(data_iter))
         if pre_forward_hook is not None:
             scale = torch.tensor(1.0 / num_microbatches, device="cuda")
             pre_forward_hook(scale)
-        out = forward_fn(model, batch)
+        with use_loss_context(loss_context):
+            out = forward_fn(model, batch)
         if dist_opt and optimizer is not None and mb == num_microbatches - 1:
             optimizer.grad_sync_enabled = True
         if loss_fn is not None:
-            loss, metrics = loss_fn(out, batch)
+            if loss_context is None:
+                loss, metrics = loss_fn(out, batch)
+            else:
+                loss, metrics = loss_fn(out, batch, loss_context)
             (loss / num_microbatches).backward()
             out["loss"] = loss.detach()
             all_metrics.append(metrics)

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -12,17 +12,20 @@ from typing import Any
 
 import torch
 import torch.distributed as dist
-
 from megatron.lite.runtime.backends import Runtime as RuntimeBase
 from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig
-from megatron.lite.runtime.contracts.data import ForwardResult, ModelOutputs
+from megatron.lite.runtime.contracts.data import ForwardResult, ModelOutputs, PackedBatch
 from megatron.lite.runtime.contracts.handle import ModelHandle
+from megatron.lite.runtime.contracts.loss import split_loss_context
 
 
 def _build_impl_cfg(proto, rt_cfg: MegatronLiteConfig):
     """Construct typed impl config, backfilling hf_path + optimizer_config."""
-    impl_cfg_kwargs = {**rt_cfg.impl_cfg, "parallel": rt_cfg.parallel}
     init_fields = {f.name for f in dc_fields(proto.ImplConfig) if f.init}
+    # Only forward impl_cfg keys this model's ImplConfig declares: the connector
+    # may pass knobs (e.g. cross_entropy_fusion) that some models don't model.
+    impl_cfg_kwargs = {key: value for key, value in rt_cfg.impl_cfg.items() if key in init_fields}
+    impl_cfg_kwargs["parallel"] = rt_cfg.parallel
     if (
         "attention_backend_override" in init_fields
         and impl_cfg_kwargs.get("attention_backend_override") is None
@@ -64,13 +67,13 @@ def _apply_attention_backend_env(backend: str | None, *, tag: str) -> None:
     os.environ["NVTE_UNFUSED_ATTN"] = unfused
 
 
-def _infer_pipeline_tensor_shape(batch: Any, model_cfg: Any, ps) -> tuple[int, int, int]:
+def _infer_pipeline_tensor_shape(batch: PackedBatch, model_cfg: Any, ps) -> tuple[int, int, int]:
     if model_cfg is None or not hasattr(model_cfg, "hidden_size"):
         raise ValueError("Megatron Lite pipeline runtime requires model_cfg.hidden_size.")
-    if not isinstance(batch, dict) or "input_ids" not in batch:
-        raise TypeError("Megatron Lite pipeline runtime requires dict batches with input_ids.")
+    if not isinstance(batch, PackedBatch):
+        raise TypeError("Megatron Lite pipeline runtime requires PackedBatch inputs.")
 
-    input_ids = batch["input_ids"]
+    input_ids = batch.input_ids
     if input_ids.dim() == 1:
         batch_size = 1
         local_seq_len = int(input_ids.size(0))
@@ -195,8 +198,8 @@ class MegatronLiteRuntime(RuntimeBase):
             if callable(reload_model_params):
                 reload_model_params()
 
-        # ── forward_step default ──
-        forward_fn = bundle.forward_step or (lambda m, b: m(**b))
+        if bundle.forward_step is None:
+            raise ValueError("Megatron Lite model bundles must provide a typed forward_step.")
 
         p = rt_cfg.parallel
         model = bundle.chunks[0] if len(bundle.chunks) == 1 else bundle.chunks
@@ -209,7 +212,7 @@ class MegatronLiteRuntime(RuntimeBase):
             _extras={
                 "model_chunks": bundle.chunks,
                 "model_cfg": model_cfg,
-                "forward_step": forward_fn,
+                "forward_step": bundle.forward_step,
                 "protocol": proto,
                 "finalize_grads": bundle.finalize_grads,
                 "world_size": dist.get_world_size(),
@@ -391,8 +394,9 @@ class MegatronLiteRuntime(RuntimeBase):
 
             from megatron.lite.primitive.parallel.pipeline import forward_backward_pipelining
 
-            first_batch = next(data_iter)
-            data_iter = chain([first_batch], data_iter)
+            first_item = next(data_iter)
+            first_batch, _loss_context = split_loss_context(first_item)
+            data_iter = chain([first_item], data_iter)
             tensor_shape = _infer_pipeline_tensor_shape(
                 first_batch, handle._extras.get("model_cfg"), ps
             )

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -433,6 +433,7 @@ class MegatronLiteRuntime(RuntimeBase):
                 dist_opt=not forward_only,
                 pre_forward_hook=handle._extras.get("pre_forward_hook"),
                 loss_fn=loss_fn,
+                forward_only=forward_only,
             )
 
         if not forward_only:

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -87,13 +87,25 @@ def _infer_pipeline_tensor_shape(batch: PackedBatch, model_cfg: Any, ps) -> tupl
         raise ValueError("Pipeline tensor shape requires non-empty sequence.")
 
     tp_size = int(getattr(ps, "tp_size", 1) or 1)
-    if tp_size > 1:
+    cp_size = int(getattr(ps, "cp_size", 1) or 1)
+    # The model scatters THD activations into Megatron sequence-parallel + context-parallel form
+    # before the first layer, so PP-communicated hidden states carry padded_S / (CP * TP) per rank.
+    # The raw input_ids length is UNPADDED and not CP-divided; sizing the P2P buffer from it makes the
+    # receiver wait for CP*TP-too-many elements -> NCCL recv hang. Replicate thd.pack_nested_thd padding
+    # (each sequence padded to align = tp * (2*cp if cp>1 else 1)) then divide by CP*TP.
+    seq_lens = getattr(batch, "seq_lens", None)
+    if seq_lens is not None and cp_size * tp_size > 1:
+        sl = seq_lens if isinstance(seq_lens, torch.Tensor) else torch.as_tensor(seq_lens)
+        sl = sl.to(torch.int64).reshape(-1)
+        align = tp_size * (2 * cp_size if cp_size > 1 else 1)
+        padded = sl + (align - sl % align) % align
+        total_padded = int(padded.sum().item())
+        local_seq_len = total_padded // (cp_size * tp_size)
+    elif tp_size > 1:
         if local_seq_len % tp_size != 0:
             raise ValueError(
                 f"Pipeline tensor sequence length {local_seq_len} is not divisible by TP={tp_size}."
             )
-        # Megatron Lite Qwen3.5 scatters embeddings into Megatron sequence-parallel form
-        # before the first layer, so PP activations carry S / (CP * TP).
         local_seq_len //= tp_size
 
     return (local_seq_len, batch_size, int(model_cfg.hidden_size))

--- a/experimental/lite/megatron/lite/runtime/contracts/__init__.py
+++ b/experimental/lite/megatron/lite/runtime/contracts/__init__.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
         TrainBatch,
     )
     from megatron.lite.runtime.contracts.handle import ModelHandle
+    from megatron.lite.runtime.contracts.loss import LossContext
 
 __all__ = [
     "MegatronLiteConfig",
@@ -34,6 +35,7 @@ __all__ = [
     "BridgeConfig",
     "DebugConfig",
     "ForwardResult",
+    "LossContext",
     "ModelHandle",
     "ModelOutputs",
     "OptimizerConfig",
@@ -51,6 +53,7 @@ def __getattr__(name: str):
         "DebugConfig": "megatron.lite.runtime.backends.mlite.config",
         "MegatronLiteConfig": "megatron.lite.runtime.backends.mlite.config",
         "ForwardResult": "megatron.lite.runtime.contracts.data",
+        "LossContext": "megatron.lite.runtime.contracts.loss",
         "ModelHandle": "megatron.lite.runtime.contracts.handle",
         "ModelOutputs": "megatron.lite.runtime.contracts.data",
         "OptimizerConfig": "megatron.lite.runtime.contracts.config",

--- a/experimental/lite/megatron/lite/runtime/contracts/data.py
+++ b/experimental/lite/megatron/lite/runtime/contracts/data.py
@@ -28,10 +28,6 @@ class Batch:
         """Per-sequence token counts.  Shape ``[num_seqs]``."""
         raise NotImplementedError
 
-    def __getitem__(self, key: str) -> Any:
-        """Dict-like field access (``batch["input_ids"]``)."""
-        raise NotImplementedError
-
 
 @dataclass(slots=True)
 class PackedBatch(Batch):
@@ -54,11 +50,6 @@ class PackedBatch(Batch):
 
     def sizes(self) -> torch.Tensor:
         return self.seq_lens
-
-    def __getitem__(self, key: str) -> Any:
-        if key in self.__slots__:
-            return getattr(self, key)
-        return self.extras[key]
 
     @property
     def cu_seqlens(self) -> torch.Tensor:
@@ -120,4 +111,10 @@ class ForwardResult:
     metrics: dict[str, Any] = field(default_factory=dict)
 
 
-__all__ = ["Batch", "ForwardResult", "ModelOutputs", "PackedBatch", "TrainBatch"]
+__all__ = [
+    "Batch",
+    "ForwardResult",
+    "ModelOutputs",
+    "PackedBatch",
+    "TrainBatch",
+]

--- a/experimental/lite/megatron/lite/runtime/contracts/loss.py
+++ b/experimental/lite/megatron/lite/runtime/contracts/loss.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Loss-side runtime context, kept separate from batch data contracts."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class LossContext:
+    """Per-microbatch loss/output policy for model-owned loss helpers."""
+
+    temperature: float = 1.0
+    calculate_entropy: bool = False
+    return_log_probs: bool = True
+    loss_scale: float = 1.0
+    source_batch: Any | None = None
+
+
+_CURRENT_LOSS_CONTEXT: ContextVar[LossContext | None] = ContextVar(
+    "megatron_lite_loss_context", default=None
+)
+
+
+def get_loss_context() -> LossContext | None:
+    return _CURRENT_LOSS_CONTEXT.get()
+
+
+@contextmanager
+def use_loss_context(loss_context: LossContext | None) -> Iterator[None]:
+    token = _CURRENT_LOSS_CONTEXT.set(loss_context)
+    try:
+        yield
+    finally:
+        _CURRENT_LOSS_CONTEXT.reset(token)
+
+
+def split_loss_context(item):
+    if (
+        isinstance(item, tuple)
+        and len(item) == 2
+        and (item[1] is None or isinstance(item[1], LossContext))
+    ):
+        return item
+    return item, None
+
+
+__all__ = ["LossContext", "get_loss_context", "split_loss_context", "use_loss_context"]

--- a/experimental/lite/tests/smoke/primitive/test_qwen3_moe_distopt_checkpoint_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_qwen3_moe_distopt_checkpoint_smoke.py
@@ -12,6 +12,7 @@ import torch.distributed as dist
 from megatron.lite.primitive.deterministic import set_deterministic
 from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
 from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
+from megatron.lite.runtime.contracts.data import PackedBatch
 from megatron.lite.runtime.contracts.handle import ModelHandle
 
 pytestmark = [pytest.mark.mlite, pytest.mark.smoke, pytest.mark.gpu, pytest.mark.distributed]
@@ -122,29 +123,26 @@ def _shared_tmp_path(tmp_path) -> str:
     return payload[0]
 
 
-def _random_batch(vocab_size: int) -> dict[str, torch.Tensor | bool]:
-    return {
-        "input_ids": torch.randint(0, vocab_size, (2, 4), device="cuda"),
-        "labels": torch.randint(0, vocab_size, (2, 4), device="cuda"),
-        "return_log_probs": False,
-    }
+def _random_batch(vocab_size: int) -> PackedBatch:
+    # Raw THD PackedBatch: 1-D packed tokens + true seq lengths (protocol packs).
+    return PackedBatch(
+        input_ids=torch.randint(0, vocab_size, (8,), device="cuda"),
+        labels=torch.randint(0, vocab_size, (8,), device="cuda"),
+        seq_lens=torch.full((2,), 4, dtype=torch.int64, device="cuda"),
+    )
 
 
-def _clone_batch(batch: dict[str, Any]) -> dict[str, Any]:
-    return {
-        key: value.detach().clone() if torch.is_tensor(value) else value
-        for key, value in batch.items()
-    }
+def _clone_batch(batch: PackedBatch) -> PackedBatch:
+    return PackedBatch(
+        input_ids=batch.input_ids.detach().clone(),
+        labels=batch.labels.detach().clone(),
+        seq_lens=batch.seq_lens.detach().clone(),
+    )
 
 
-def _assert_batch_equal(actual: dict[str, Any], expected: dict[str, Any]) -> None:
-    assert actual.keys() == expected.keys()
-    for key, expected_value in expected.items():
-        actual_value = actual[key]
-        if torch.is_tensor(expected_value):
-            assert torch.equal(actual_value, expected_value), key
-        else:
-            assert actual_value == expected_value
+def _assert_batch_equal(actual: PackedBatch, expected: PackedBatch) -> None:
+    assert torch.equal(actual.input_ids, expected.input_ids)
+    assert torch.equal(actual.labels, expected.labels)
 
 
 def _train_step(runtime: MegatronLiteRuntime, handle: ModelHandle, batch: dict[str, Any]) -> None:

--- a/experimental/lite/tests/unit/verl/test_mlite_engine_cp_smoke.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_engine_cp_smoke.py
@@ -205,7 +205,12 @@ def test_mlite_engine_runtime_thd_cp_uses_typed_packed_batch(
         engine_config=MegatronLiteEngineConfig(
             model_name=model_name,
             cp=world,
-            impl_cfg={"use_thd": True, "optimizer": None, "deterministic": False},
+            impl_cfg={
+                "use_thd": True,
+                "optimizer": None,
+                "deterministic": False,
+                "mtp_enable": False,
+            },
             use_fused_kernels=False,
         ),
         optimizer_config=_optimizer_config(),
@@ -239,24 +244,18 @@ def test_mlite_engine_runtime_thd_cp_uses_typed_packed_batch(
         device=device,
     )
 
-    model_inputs = engine._make_model_inputs(micro_batch)
-    assert model_inputs["packed_seq_params"].local_cp_size is None
-    assert model_inputs["input_ids"].shape[-1] == int(
-        model_inputs["packed_batch"].cu_seqlens_padded[-1].item()
-    )
-
-    runtime_batch = engine._make_runtime_batch(
-        micro_batch=micro_batch,
-        inputs=model_inputs,
-        loss_scale=1.0,
-    )
+    runtime_batch = engine._make_runtime_batch(micro_batch)
+    loss_context = engine._make_runtime_loss_context(micro_batch, loss_scale=1.0)
     assert isinstance(runtime_batch, PackedBatch)
-    assert "packed_seq_params" not in runtime_batch.extras
+    # Connector batch is model-agnostic: true seq lengths, no padding, no extras.
+    assert runtime_batch.seq_lens.tolist() == lengths
+    assert int(runtime_batch.input_ids.numel()) == sum(lengths)
+    assert not runtime_batch.extras
 
     with engine.train_mode():
         result = engine.runtime.forward_backward(
             engine.handle,
-            iter([runtime_batch]),
+            iter([(runtime_batch, loss_context)]),
             loss_fn=None,
             num_microbatches=1,
             forward_only=False,
@@ -274,8 +273,7 @@ def test_mlite_engine_runtime_thd_cp_uses_typed_packed_batch(
 
     verl_output = engine._build_verl_model_output(
         raw_output={"log_probs": result.model_output.log_probs},
-        micro_batch=micro_batch,
-        inputs=model_inputs,
+        runtime_batch=runtime_batch,
     )
     nested_log_probs = verl_output["log_probs"]
     assert [int(x) for x in nested_log_probs.offsets().diff().cpu()] == lengths


### PR DESCRIPTION
## Summary
- Add a shared MLite model validation harness for registry, PP layout, checkpoint entrypoint, CUDA forward/backward, token batch, run-to-run bitwise checks, and VERL CP/THD+CP smoke execution.
- Parameterize the Qwen3/Qwen3.5 model smoke so both run the fused loss path and the same run-to-run loss/log-prob/grad bitwise gate.
- Reuse the harness from Kimi K2 static coverage, Qwen3.5 export tests, and the canonical VERL plain-packed THD+CP smoke, reducing duplicated per-model scaffolding while keeping coverage.
- Move the canonical VERL CP smoke to a case-driven entry point and remove the duplicate Kimi model-side THD+CP smoke; GLM5 keeps its direct model THD+CP smoke because GLM5 is intentionally outside the protocol-level VERL THD CP split path on current main.
- Document that new model validation should extend the shared harness and canonical VERL CP case list before adding bespoke model smoke.

## Validation
- `PYTHONPATH="$(pwd):$(pwd)/experimental/lite" pytest -q experimental/lite/tests/unit` -> 184 passed, 14 skipped
- `PYTHONPATH="$(pwd):$(pwd)/experimental/lite" pytest -q experimental/lite/tests/smoke/model/test_qwen_lite_forward_smoke.py experimental/lite/tests/unit/verl/test_mlite_engine_cp_smoke.py` -> 3 skipped by default smoke gating
- Slurm VERL CP/THD+CP smoke: job 12803357, `sacct` COMPLETED 0:0, `torchrun --nproc_per_node=2 -m pytest -q -s experimental/lite/tests/unit/verl/test_mlite_engine_cp_smoke.py --mlite-smoke` -> 1 passed, non-skip sentinel `NON_SKIP_VERL_MLITE_RUNTIME_THD_CP_SMOKE_PASSED model=kimi_k2 world_size=2 lengths=[5, 7, 9]`
- `python -m black --check --line-length 100 experimental/lite/tests/harness/model_validation.py experimental/lite/tests/unit/verl/test_mlite_engine_cp_smoke.py experimental/lite/tests/unit/model/test_kimi_k2_lite_cp_smoke.py`
- `git diff --check`
- Checked that this diff/touched files add no Megatron-Core imports.