### PR TITLE
Rename GLM5 Lite model to DeepSeek V3.2

### DIFF
--- a/experimental/lite/megatron/lite/model/deepseek_v31/__init__.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v31/__init__.py
@@ -1,0 +1,5 @@
+"""DeepSeek-V3.1 model family."""
+
+from megatron.lite.model.deepseek_v31.config import DeepSeekV31Config
+
+__all__ = ["DeepSeekV31Config"]

--- a/experimental/lite/megatron/lite/model/deepseek_v31/config.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v31/config.py
@@ -1,12 +1,34 @@
-"""GLM-5 architecture config."""
+"""DeepSeek-V3.1 architecture config."""
 
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import dataclass
+from dataclasses import field
 from dataclasses import fields as dc_fields
 from typing import Any
 
 from megatron.lite.primitive.config import load_hf_config_dict
+
+DEFAULT_DEEPSEEK_V31_VARIANT = "glm-5"
+
+
+@dataclass(frozen=True)
+class DeepSeekV31VariantConfig:
+    name: str
+    defaults: dict[str, Any] = field(default_factory=dict)
+    hf_model_types: tuple[str, ...] = ()
+
+
+DEEPSEEK_V31_VARIANTS = {
+    "glm-5": DeepSeekV31VariantConfig("glm-5", hf_model_types=("glm_moe_dsa",)),
+}
+
+DEEPSEEK_V31_HF_MODEL_TYPES = tuple(
+    hf_model_type
+    for variant_config in DEEPSEEK_V31_VARIANTS.values()
+    for hf_model_type in variant_config.hf_model_types
+)
 
 _HF_FIELDS = frozenset(
     {
@@ -57,10 +79,34 @@ _HF_FIELDS = frozenset(
 )
 
 
-@dataclass
-class Glm5Config:
-    """Pure GLM-5 MoE + MLA + DSA architecture parameters."""
+def _variant_entry(variant: str) -> DeepSeekV31VariantConfig:
+    if variant not in DEEPSEEK_V31_VARIANTS:
+        raise ValueError(
+            f"Unknown DeepSeekV31 variant: {variant!r}. "
+            f"Available variants: {tuple(DEEPSEEK_V31_VARIANTS)}"
+        )
+    return DEEPSEEK_V31_VARIANTS[variant]
 
+
+def _explicit_variant_from_hf(hf: dict[str, Any]) -> str | None:
+    variant = hf.get("variant")
+    if isinstance(variant, str):
+        return variant
+    text_config = hf.get("text_config")
+    if isinstance(text_config, dict) and isinstance(text_config.get("variant"), str):
+        return text_config["variant"]
+    return None
+
+
+def _variant_defaults(variant: str) -> dict[str, Any]:
+    return deepcopy(_variant_entry(variant).defaults)
+
+
+@dataclass
+class DeepSeekV31Config:
+    """Pure DeepSeek-V3.1 MoE + MLA + DSA architecture parameters."""
+
+    variant: str = DEFAULT_DEEPSEEK_V31_VARIANT
     num_hidden_layers: int = 78
     hidden_size: int = 6144
     num_attention_heads: int = 64
@@ -109,6 +155,7 @@ class Glm5Config:
     mlp_layer_types: list[str] | None = None
 
     def __post_init__(self):
+        _variant_entry(self.variant)
         self._validate()
 
     @property
@@ -142,7 +189,7 @@ class Glm5Config:
         check(self.dsa_indexer_loss_coeff >= 0.0, "dsa_indexer_loss_coeff must be >= 0")
         check(
             self.num_key_value_heads == self.num_attention_heads,
-            "initial GLM5 native path expects MLA heads to be ungrouped",
+            "initial DeepSeek-V3.1 native path expects MLA heads to be ungrouped",
         )
         check(self.vocab_size > 0, "vocab_size must be > 0")
         check(self.num_nextn_predict_layers >= 0, "num_nextn_predict_layers must be >= 0")
@@ -170,7 +217,7 @@ class Glm5Config:
 
         if errors:
             raise ValueError(
-                f"Invalid Glm5Config ({len(errors)} error"
+                f"Invalid DeepSeekV31Config ({len(errors)} error"
                 f"{'s' if len(errors) != 1 else ''}):\n  " + "\n  ".join(errors)
             )
 
@@ -178,23 +225,47 @@ class Glm5Config:
         return {f.name: getattr(self, f.name) for f in dc_fields(self)}
 
     @classmethod
-    def from_hf(cls, path_or_name: str, **overrides) -> Glm5Config:
+    def from_hf(cls, path_or_name: str, **overrides) -> DeepSeekV31Config:
         return cls._from_hf_dict(load_hf_config_dict(path_or_name), **overrides)
 
     @classmethod
-    def from_hf_config(cls, hf_config, **overrides) -> Glm5Config:
+    def from_hf_config(cls, hf_config, **overrides) -> DeepSeekV31Config:
         hf = hf_config.to_dict() if hasattr(hf_config, "to_dict") else vars(hf_config)
         return cls._from_hf_dict(hf, **overrides)
 
     @classmethod
-    def _from_hf_dict(cls, hf: dict[str, Any], **overrides) -> Glm5Config:
-        kwargs = {
-            key: value for key, value in hf.items() if key in _HF_FIELDS and value is not None
-        }
+    def _from_hf_dict(cls, hf: dict[str, Any], **overrides) -> DeepSeekV31Config:
+        overrides = dict(overrides)
+        if "variant" in overrides:
+            variant = overrides.pop("variant")
+        else:
+            variant = _explicit_variant_from_hf(hf) or DEFAULT_DEEPSEEK_V31_VARIANT
+        _variant_entry(variant)
+        kwargs = _variant_defaults(variant)
+        kwargs.update(
+            {key: value for key, value in hf.items() if key in _HF_FIELDS and value is not None}
+        )
         if "num_nextn_predict_layers" not in kwargs and hf.get("num_nextn_predict") is not None:
             kwargs["num_nextn_predict_layers"] = int(hf["num_nextn_predict"])
         rope_parameters = hf.get("rope_parameters")
         if isinstance(rope_parameters, dict) and "rope_theta" not in kwargs:
             kwargs["rope_theta"] = float(rope_parameters.get("rope_theta", cls.rope_theta))
+        kwargs["variant"] = variant
         kwargs.update(overrides)
         return cls(**kwargs)
+
+    @classmethod
+    def from_variant(cls, variant: str, **overrides) -> DeepSeekV31Config:
+        kwargs = _variant_defaults(variant)
+        kwargs["variant"] = variant
+        kwargs.update(overrides)
+        return cls(**kwargs)
+
+
+__all__ = [
+    "DEFAULT_DEEPSEEK_V31_VARIANT",
+    "DEEPSEEK_V31_HF_MODEL_TYPES",
+    "DEEPSEEK_V31_VARIANTS",
+    "DeepSeekV31Config",
+    "DeepSeekV31VariantConfig",
+]

--- a/experimental/lite/megatron/lite/model/deepseek_v31/lite/__init__.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v31/lite/__init__.py
@@ -1,0 +1,5 @@
+"""Native DeepSeek-V3.1 lite implementation."""
+
+from megatron.lite.model.deepseek_v31.lite.model import DeepSeekV31ForCausalLM, DeepSeekV31Model
+
+__all__ = ["DeepSeekV31ForCausalLM", "DeepSeekV31Model"]

--- a/experimental/lite/megatron/lite/model/deepseek_v31/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v31/lite/checkpoint.py
@@ -1,4 +1,4 @@
-"""Direct HF safetensor loading for native GLM-5."""
+"""Direct HF safetensor loading for native DeepSeek-V3.1."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ from collections.abc import Iterator
 import torch
 import torch.nn as nn
 
-from megatron.lite.model.glm5.config import Glm5Config
+from megatron.lite.model.deepseek_v31.config import DeepSeekV31Config
 from megatron.lite.primitive.ckpt.hf_weights import SafeTensorReader, save_safetensors, unwrap_model
 from megatron.lite.primitive.parallel import ParallelState
 from megatron.lite.primitive.utils import ensure_divisible
@@ -148,7 +148,7 @@ def _local_layer_indices(model: nn.Module) -> list[int]:
 
 
 def _to_hf_state_name(
-    name: str, *, config: Glm5Config, model: nn.Module, ps: ParallelState
+    name: str, *, config: DeepSeekV31Config, model: nn.Module, ps: ParallelState
 ) -> str | None:
     if name == "model.mtp_embed.weight":
         return "model.embed_tokens.weight"
@@ -188,7 +188,7 @@ def _resolve_named_parameter_tensor(
     name: str,
     target: nn.Parameter | torch.Tensor,
     *,
-    config: Glm5Config,
+    config: DeepSeekV31Config,
     ps: ParallelState,
 ) -> torch.Tensor | None:
     match = _PACKED_EXPERT_RE.match(name)
@@ -224,9 +224,11 @@ def _resolve_named_parameter_tensor(
     return torch.stack(tensors, dim=0).contiguous()
 
 
-def load_hf_weights(model: nn.Module, path: str, config: Glm5Config, ps: ParallelState) -> None:
+def load_hf_weights(
+    model: nn.Module, path: str, config: DeepSeekV31Config, ps: ParallelState
+) -> None:
     if ps.tp_size != 1 or ps.etp_size != 1:
-        raise NotImplementedError("GLM5 direct HF load currently supports TP=ETP=1.")
+        raise NotImplementedError("DeepSeek-V3.1 direct HF load currently supports TP=ETP=1.")
 
     reader = SafeTensorReader(path)
     base_model = unwrap_model(model)
@@ -248,9 +250,9 @@ def load_hf_weights(model: nn.Module, path: str, config: Glm5Config, ps: Paralle
         _copy_param(target, tensor)
         loaded += 1
 
-    log_rank0(f"GLM5 native loaded {loaded} tensors from {path}")
+    log_rank0(f"DeepSeek-V3.1 native loaded {loaded} tensors from {path}")
     for name in missing:
-        log_rank0(f"WARNING: GLM5 checkpoint tensor missing: {name}")
+        log_rank0(f"WARNING: DeepSeek-V3.1 checkpoint tensor missing: {name}")
 
 
 def _rank0() -> int:
@@ -261,14 +263,14 @@ def _rank0() -> int:
 
 def _validate_export_scope(ps: ParallelState) -> None:
     if ps.tp_size != 1 or ps.etp_size != 1:
-        raise NotImplementedError("GLM5 direct HF export currently supports TP=ETP=1.")
+        raise NotImplementedError("DeepSeek-V3.1 direct HF export currently supports TP=ETP=1.")
     if ps.ep_size != 1:
-        raise NotImplementedError("GLM5 direct HF export currently supports EP=1.")
+        raise NotImplementedError("DeepSeek-V3.1 direct HF export currently supports EP=1.")
 
 
 def export_hf_weights(
     model: nn.Module | list[nn.Module],
-    config: Glm5Config,
+    config: DeepSeekV31Config,
     ps: ParallelState,
     *,
     rank0_only: bool = False,
@@ -295,7 +297,7 @@ def export_hf_weights(
 def save_hf_weights(
     model: nn.Module | list[nn.Module],
     path: str,
-    config: Glm5Config,
+    config: DeepSeekV31Config,
     ps: ParallelState,
     *,
     export_dtype: torch.dtype | None = None,
@@ -308,7 +310,7 @@ def save_hf_weights(
 
 
 def save_weights(
-    model: nn.Module | list[nn.Module], path: str, config: Glm5Config, ps: ParallelState
+    model: nn.Module | list[nn.Module], path: str, config: DeepSeekV31Config, ps: ParallelState
 ) -> None:
     rank = _rank0()
     if rank != 0:

--- a/experimental/lite/megatron/lite/model/deepseek_v31/lite/model.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v31/lite/model.py
@@ -1,4 +1,4 @@
-"""Native GLM-5 model assembled from Megatron Lite primitives."""
+"""Native DeepSeek-V3.1 model assembled from Megatron Lite primitives."""
 
 from __future__ import annotations
 
@@ -10,7 +10,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from megatron.lite.model.glm5.config import Glm5Config
+from megatron.lite.model.deepseek_v31.config import DeepSeekV31Config
 from megatron.lite.primitive.attention import (
     DynamicSparseAttention,
     RMSNorm,
@@ -21,7 +21,7 @@ from megatron.lite.primitive.parallel.thd import roll_packed_thd_left
 from megatron.lite.primitive.utils import ensure_divisible
 
 
-class Glm5MLP(nn.Module):
+class DeepSeekV31MLP(nn.Module):
     def __init__(self, hidden_size: int, intermediate_size: int):
         super().__init__()
         self.gate_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
@@ -32,7 +32,7 @@ class Glm5MLP(nn.Module):
         return self.down_proj(F.silu(self.gate_proj(x)) * self.up_proj(x))
 
 
-class Glm5RoutedExperts(nn.Module):
+class DeepSeekV31RoutedExperts(nn.Module):
     def __init__(
         self,
         num_experts: int,
@@ -173,8 +173,8 @@ class Glm5RoutedExperts(nn.Module):
                 _copy(f"{prefix}{expert_idx}.down_proj.weight", self.down_proj[expert_idx])
 
 
-class Glm5Router(nn.Module):
-    def __init__(self, config: Glm5Config):
+class DeepSeekV31Router(nn.Module):
+    def __init__(self, config: DeepSeekV31Config):
         super().__init__()
         self.weight = nn.Parameter(torch.empty(config.n_routed_experts, config.hidden_size))
         self.register_buffer(
@@ -209,7 +209,7 @@ class Glm5Router(nn.Module):
         return weights * self.route_scale, indices
 
 
-def _build_glm5_pipeline_layers(num_hidden_layers: int, ps: ParallelState) -> list[int]:
+def _build_deepseek_v31_pipeline_layers(num_hidden_layers: int, ps: ParallelState) -> list[int]:
     if ps.pp_size > 2 and num_hidden_layers % ps.pp_size:
         middle_layers = -(-num_hidden_layers // ps.pp_size)
         edge_layers = num_hidden_layers - middle_layers * (ps.pp_size - 2)
@@ -226,14 +226,18 @@ def _build_glm5_pipeline_layers(num_hidden_layers: int, ps: ParallelState) -> li
     return list(range(start, start + local_count))
 
 
-class Glm5MoE(nn.Module):
+class DeepSeekV31MoE(nn.Module):
     def __init__(
-        self, config: Glm5Config, ps: ParallelState | None = None, *, use_deepep: bool = False
+        self,
+        config: DeepSeekV31Config,
+        ps: ParallelState | None = None,
+        *,
+        use_deepep: bool = False,
     ):
         super().__init__()
         ps = ps or ParallelState()
         self.hidden_size = config.hidden_size
-        self.gate = Glm5Router(config)
+        self.gate = DeepSeekV31Router(config)
         self.dispatcher = None
         if ps.ep_size > 1:
             from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
@@ -245,12 +249,12 @@ class Glm5MoE(nn.Module):
                 use_deepep=use_deepep,
                 fuse_score_alltoall=True,
             )
-        self.experts = Glm5RoutedExperts(
+        self.experts = DeepSeekV31RoutedExperts(
             config.n_routed_experts, config.hidden_size, config.moe_intermediate_size, ps
         )
         shared_intermediate = config.n_shared_experts * config.moe_intermediate_size
         self.shared_experts = (
-            Glm5MLP(config.hidden_size, shared_intermediate)
+            DeepSeekV31MLP(config.hidden_size, shared_intermediate)
             if config.n_shared_experts > 0
             else None
         )
@@ -272,10 +276,10 @@ class Glm5MoE(nn.Module):
         return y
 
 
-class Glm5Layer(nn.Module):
+class DeepSeekV31Layer(nn.Module):
     def __init__(
         self,
-        config: Glm5Config,
+        config: DeepSeekV31Config,
         layer_idx: int,
         ps: ParallelState | None = None,
         *,
@@ -309,9 +313,9 @@ class Glm5Layer(nn.Module):
             cp_group=ps.cp_group,
         )
         self.mlp = (
-            Glm5MoE(config, ps, use_deepep=use_deepep)
+            DeepSeekV31MoE(config, ps, use_deepep=use_deepep)
             if config.is_moe_layer(layer_idx)
-            else Glm5MLP(config.hidden_size, config.intermediate_size)
+            else DeepSeekV31MLP(config.hidden_size, config.intermediate_size)
         )
         self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.post_attention_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
@@ -352,10 +356,10 @@ def _roll_mtp_sequence(
     return rolled
 
 
-class Glm5MTPLayer(nn.Module):
+class DeepSeekV31MTPLayer(nn.Module):
     def __init__(
         self,
-        config: Glm5Config,
+        config: DeepSeekV31Config,
         layer_idx: int,
         ps: ParallelState,
         *,
@@ -371,7 +375,7 @@ class Glm5MTPLayer(nn.Module):
         self.enorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.hnorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.eh_proj = nn.Linear(config.hidden_size * 2, config.hidden_size, bias=False)
-        self.transformer_layer = Glm5Layer(config, layer_idx, ps, use_deepep=use_deepep)
+        self.transformer_layer = DeepSeekV31Layer(config, layer_idx, ps, use_deepep=use_deepep)
         self.final_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 
     def forward(
@@ -412,10 +416,10 @@ class Glm5MTPLayer(nn.Module):
         return hidden_states, input_ids, position_ids
 
 
-class Glm5MTPBlock(nn.Module):
+class DeepSeekV31MTPBlock(nn.Module):
     def __init__(
         self,
-        config: Glm5Config,
+        config: DeepSeekV31Config,
         ps: ParallelState,
         *,
         embedding: nn.Embedding,
@@ -429,7 +433,7 @@ class Glm5MTPBlock(nn.Module):
         layers_to_build = 1 if self.repeated_layer else self.num_layers
         self.layers = nn.ModuleList(
             [
-                Glm5MTPLayer(
+                DeepSeekV31MTPLayer(
                     config,
                     config.num_hidden_layers + layer_idx,
                     ps,
@@ -464,10 +468,10 @@ class Glm5MTPBlock(nn.Module):
         return outputs
 
 
-class Glm5Model(nn.Module):
+class DeepSeekV31Model(nn.Module):
     def __init__(
         self,
-        config: Glm5Config,
+        config: DeepSeekV31Config,
         ps: ParallelState | None = None,
         *,
         use_deepep: bool = False,
@@ -477,24 +481,27 @@ class Glm5Model(nn.Module):
         super().__init__()
         self.config = config
         self.ps = ps or ParallelState()
-        self.layer_indices = _build_glm5_pipeline_layers(config.num_hidden_layers, self.ps)
+        self.layer_indices = _build_deepseek_v31_pipeline_layers(config.num_hidden_layers, self.ps)
         self.embed_tokens = (
             nn.Embedding(config.vocab_size, config.hidden_size) if self.ps.pp_is_first else None
         )
         self.layers = nn.ModuleList(
-            [Glm5Layer(config, i, self.ps, use_deepep=use_deepep) for i in self.layer_indices]
+            [
+                DeepSeekV31Layer(config, i, self.ps, use_deepep=use_deepep)
+                for i in self.layer_indices
+            ]
         )
         self.norm = (
             RMSNorm(config.hidden_size, eps=config.rms_norm_eps) if self.ps.pp_is_last else None
         )
         self.mtp_embed: nn.Embedding | None = None
-        self.mtp: Glm5MTPBlock | None = None
+        self.mtp: DeepSeekV31MTPBlock | None = None
         if mtp_enable and config.num_nextn_predict_layers > 0 and self.ps.pp_is_last:
             mtp_embedding = self.embed_tokens
             if mtp_embedding is None:
                 mtp_embedding = nn.Embedding(config.vocab_size, config.hidden_size)
                 self.mtp_embed = mtp_embedding
-            self.mtp = Glm5MTPBlock(
+            self.mtp = DeepSeekV31MTPBlock(
                 config,
                 self.ps,
                 embedding=mtp_embedding,
@@ -520,7 +527,7 @@ class Glm5Model(nn.Module):
             hidden_states = self.embed_tokens(input_ids)
         batch, seq_len, _ = hidden_states.shape
         if position_ids is None and packed_seq_params is not None:
-            raise ValueError("GLM5 packed THD forward requires explicit position_ids.")
+            raise ValueError("DeepSeek-V3.1 packed THD forward requires explicit position_ids.")
         if position_ids is None:
             if self.ps.cp_size > 1:
                 full_seq_len = seq_len * self.ps.cp_size
@@ -558,10 +565,10 @@ class Glm5Model(nn.Module):
         return self.norm(h) if self.norm is not None else h
 
 
-class Glm5ForCausalLM(nn.Module):
+class DeepSeekV31ForCausalLM(nn.Module):
     def __init__(
         self,
-        config: Glm5Config,
+        config: DeepSeekV31Config,
         train_cfg: SimpleNamespace | None = None,
         ps: ParallelState | None = None,
         *,
@@ -574,7 +581,7 @@ class Glm5ForCausalLM(nn.Module):
         self.train_cfg = train_cfg or SimpleNamespace(fp8=False)
         self.ps = ps or ParallelState()
         self.mtp_enable_train = bool(mtp_enable and mtp_enable_train)
-        self.model = Glm5Model(
+        self.model = DeepSeekV31Model(
             config,
             self.ps,
             use_deepep=bool(getattr(self.train_cfg, "use_deepep", False)),
@@ -701,7 +708,9 @@ class Glm5ForCausalLM(nn.Module):
         batch, seq_len = input_ids.shape
         if position_ids is None:
             if packed_seq_params is not None:
-                raise ValueError("GLM5 MTP packed THD forward requires explicit position_ids.")
+                raise ValueError(
+                    "DeepSeek-V3.1 MTP packed THD forward requires explicit position_ids."
+                )
             position_ids = (
                 torch.arange(seq_len, device=input_ids.device, dtype=torch.long)
                 .unsqueeze(0)
@@ -762,22 +771,22 @@ class Glm5ForCausalLM(nn.Module):
                     if hasattr(module, "reset_parameters")
                     else module.weight.fill_(1.0)
                 )
-            elif isinstance(module, Glm5Router):
+            elif isinstance(module, DeepSeekV31Router):
                 nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
                 module.e_score_correction_bias.zero_()
-            elif isinstance(module, Glm5RoutedExperts):
+            elif isinstance(module, DeepSeekV31RoutedExperts):
                 nn.init.normal_(module.gate_up_proj, mean=0.0, std=self.config.initializer_range)
                 nn.init.normal_(module.down_proj, mean=0.0, std=self.config.initializer_range)
 
 
 __all__ = [
-    "Glm5ForCausalLM",
-    "Glm5Layer",
-    "Glm5MLP",
-    "Glm5MTPBlock",
-    "Glm5MTPLayer",
-    "Glm5MoE",
-    "Glm5Model",
-    "Glm5Router",
-    "Glm5RoutedExperts",
+    "DeepSeekV31ForCausalLM",
+    "DeepSeekV31Layer",
+    "DeepSeekV31MLP",
+    "DeepSeekV31MTPBlock",
+    "DeepSeekV31MTPLayer",
+    "DeepSeekV31MoE",
+    "DeepSeekV31Model",
+    "DeepSeekV31Router",
+    "DeepSeekV31RoutedExperts",
 ]

--- a/experimental/lite/megatron/lite/model/deepseek_v31/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v31/lite/protocol.py
@@ -1,4 +1,4 @@
-"""GLM-5 native lite protocol for Megatron Lite runtime."""
+"""DeepSeek-V3.1 native lite protocol for Megatron Lite runtime."""
 
 from __future__ import annotations
 
@@ -10,14 +10,16 @@ from typing import Any
 import torch
 import torch.nn as nn
 
-from megatron.lite.model.glm5.config import Glm5Config
-from megatron.lite.model.glm5.lite.checkpoint import (
+from megatron.lite.model.deepseek_v31.config import DeepSeekV31Config
+from megatron.lite.model.deepseek_v31.lite.checkpoint import (
     EXPERT_CLASSIFIER,
     export_hf_weights as _export_hf_weights_impl,
     save_hf_weights as _save_hf_weights_impl,
     save_weights as _save_weights_impl,
 )
-from megatron.lite.model.glm5.lite.checkpoint import load_hf_weights as _load_hf_weights_impl
+from megatron.lite.model.deepseek_v31.lite.checkpoint import (
+    load_hf_weights as _load_hf_weights_impl,
+)
 from megatron.lite.primitive.bundle import ModelBundle
 from megatron.lite.primitive.parallel import ParallelState, init_parallel
 from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec, wrap_checkpoint
@@ -53,15 +55,11 @@ class ImplConfig:
     mtp_use_repeated_layer: bool | None = None
 
 
-def build_model_config(source: str | Path | dict, **overrides) -> Glm5Config:
+def build_model_config(source: str | Path | dict, **overrides) -> DeepSeekV31Config:
     if isinstance(source, dict):
-        cfg = Glm5Config._from_hf_dict(source)
+        return DeepSeekV31Config._from_hf_dict(source, **overrides)
     else:
-        cfg = Glm5Config.from_hf(str(source))
-    for key, value in overrides.items():
-        if hasattr(cfg, key):
-            setattr(cfg, key, value)
-    return cfg
+        return DeepSeekV31Config.from_hf(str(source), **overrides)
 
 
 def _forward_step(model: nn.Module, batch: dict) -> dict:
@@ -77,7 +75,7 @@ def _forward_step(model: nn.Module, batch: dict) -> dict:
     return model(**kwargs)
 
 
-def _apply_glm5_recompute(
+def _apply_deepseek_v31_recompute(
     layers: nn.ModuleList, recompute_spec: list[str], ps: ParallelState
 ) -> None:
     if not recompute_spec:
@@ -98,7 +96,7 @@ def _validate_parallel_scope(p: ParallelConfig) -> None:
     etp = 1 if p.etp is None else p.etp
     if (p.tp, etp, p.vpp) != (1, 1, 1):
         raise NotImplementedError(
-            "GLM5 native lite currently supports TP=ETP=VPP=1. "
+            "DeepSeek-V3.1 native lite currently supports TP=ETP=VPP=1. "
             "EP/PP/CP are wired through existing Megatron Lite primitives."
         )
     if p.ep < 1 or p.pp < 1 or p.cp < 1:
@@ -107,8 +105,8 @@ def _validate_parallel_scope(p: ParallelConfig) -> None:
         )
 
 
-def build_model(model_cfg: Glm5Config, *, impl_cfg: ImplConfig) -> ModelBundle:
-    from megatron.lite.model.glm5.lite.model import Glm5ForCausalLM
+def build_model(model_cfg: DeepSeekV31Config, *, impl_cfg: ImplConfig) -> ModelBundle:
+    from megatron.lite.model.deepseek_v31.lite.model import DeepSeekV31ForCausalLM
 
     _validate_parallel_scope(impl_cfg.parallel)
     mtp_enable = bool(impl_cfg.mtp_enable)
@@ -126,7 +124,7 @@ def build_model(model_cfg: Glm5Config, *, impl_cfg: ImplConfig) -> ModelBundle:
     recompute_spec = parse_recompute_spec(impl_cfg.recompute)
     train_cfg = SimpleNamespace(use_deepep=impl_cfg.use_deepep)
     chunk = (
-        Glm5ForCausalLM(
+        DeepSeekV31ForCausalLM(
             model_cfg,
             train_cfg=train_cfg,
             ps=ps,
@@ -139,7 +137,7 @@ def build_model(model_cfg: Glm5Config, *, impl_cfg: ImplConfig) -> ModelBundle:
     )
     chunks = [chunk]
 
-    _apply_glm5_recompute(chunk.model.layers, recompute_spec, ps)
+    _apply_deepseek_v31_recompute(chunk.model.layers, recompute_spec, ps)
 
     if impl_cfg.offload:
         from megatron.lite.primitive.recompute import apply_offload
@@ -160,7 +158,7 @@ def build_model(model_cfg: Glm5Config, *, impl_cfg: ImplConfig) -> ModelBundle:
         optimizer_backend = "fsdp2"
 
         def _post_model_load_hook():
-            from megatron.lite.model.glm5.lite.model import Glm5Layer
+            from megatron.lite.model.deepseek_v31.lite.model import DeepSeekV31Layer
             from megatron.lite.primitive.optimizers.fsdp2 import build_fsdp2_training_optimizer
 
             return {
@@ -168,7 +166,7 @@ def build_model(model_cfg: Glm5Config, *, impl_cfg: ImplConfig) -> ModelBundle:
                     chunks,
                     impl_cfg.optimizer_config,
                     ps,
-                    unit_modules=(Glm5Layer,),
+                    unit_modules=(DeepSeekV31Layer,),
                     expert_classifier=is_expert_param,
                     deterministic=impl_cfg.deterministic,
                     vpp=1,
@@ -178,7 +176,7 @@ def build_model(model_cfg: Glm5Config, *, impl_cfg: ImplConfig) -> ModelBundle:
 
         post_model_load_hook = _post_model_load_hook
     elif impl_cfg.optimizer is not None:
-        raise ValueError(f"Unsupported GLM5 optimizer: {impl_cfg.optimizer!r}")
+        raise ValueError(f"Unsupported DeepSeek-V3.1 optimizer: {impl_cfg.optimizer!r}")
 
     return ModelBundle(
         chunks=chunks,
@@ -201,7 +199,7 @@ def _build_dist_opt_optimizer(chunks, model_cfg, impl_cfg, ps):
         chunks,
         model_cfg=model_cfg,
         impl_cfg=impl_cfg,
-        model_name="glm5",
+        model_name="deepseek_v31",
         ps=ps,
         is_expert=is_expert_param,
         deterministic=impl_cfg.deterministic,
@@ -209,21 +207,23 @@ def _build_dist_opt_optimizer(chunks, model_cfg, impl_cfg, ps):
 
 
 def load_hf_weights(
-    chunk: nn.Module, hf_path: str, model_cfg: Glm5Config, ps: ParallelState
+    chunk: nn.Module, hf_path: str, model_cfg: DeepSeekV31Config, ps: ParallelState
 ) -> None:
     if not hf_path:
         return
     _load_hf_weights_impl(chunk, hf_path, model_cfg, ps)
 
 
-def export_hf_weights(chunks: list[nn.Module], model_cfg: Glm5Config, ps: ParallelState, **kwargs):
+def export_hf_weights(
+    chunks: list[nn.Module], model_cfg: DeepSeekV31Config, ps: ParallelState, **kwargs
+):
     yield from _export_hf_weights_impl(chunks, model_cfg, ps, **kwargs)
 
 
 def save_hf_weights(
     chunks: list[nn.Module],
     path: str,
-    model_cfg: Glm5Config,
+    model_cfg: DeepSeekV31Config,
     ps: ParallelState,
     *,
     export_dtype: torch.dtype | None = None,
@@ -232,10 +232,10 @@ def save_hf_weights(
 
 
 def save_weights(
-    chunks: list[nn.Module], path: str, model_cfg: Glm5Config, ps: ParallelState
+    chunks: list[nn.Module], path: str, model_cfg: DeepSeekV31Config, ps: ParallelState
 ) -> None:
     _save_weights_impl(chunks, path, model_cfg, ps)
 
 
-def vocab_size(model_cfg: Glm5Config) -> int | None:
+def vocab_size(model_cfg: DeepSeekV31Config) -> int | None:
     return model_cfg.vocab_size

--- a/experimental/lite/megatron/lite/model/glm5/__init__.py
+++ b/experimental/lite/megatron/lite/model/glm5/__init__.py
@@ -1,5 +1,0 @@
-"""GLM-5 model family."""
-
-from megatron.lite.model.glm5.config import Glm5Config
-
-__all__ = ["Glm5Config"]

--- a/experimental/lite/megatron/lite/model/glm5/lite/__init__.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/__init__.py
@@ -1,5 +1,0 @@
-"""Native GLM-5 lite implementation."""
-
-from megatron.lite.model.glm5.lite.model import Glm5ForCausalLM, Glm5Model
-
-__all__ = ["Glm5ForCausalLM", "Glm5Model"]

--- a/experimental/lite/megatron/lite/model/registry.py
+++ b/experimental/lite/megatron/lite/model/registry.py
@@ -7,6 +7,8 @@ import importlib
 import json
 from pathlib import Path
 
+from megatron.lite.model.deepseek_v31.config import DEEPSEEK_V31_HF_MODEL_TYPES
+
 # ---------------------------------------------------------------------------
 # Registry tables (populated by register_model)
 # ---------------------------------------------------------------------------
@@ -100,10 +102,10 @@ register_model(
 )
 
 register_model(
-    "glm5",
-    package="megatron.lite.model.glm5",
-    hf_model_types=["glm_moe_dsa"],
-    impls={"lite": "megatron.lite.model.glm5.lite.protocol"},
+    "deepseek_v31",
+    package="megatron.lite.model.deepseek_v31",
+    hf_model_types=list(DEEPSEEK_V31_HF_MODEL_TYPES),
+    impls={"lite": "megatron.lite.model.deepseek_v31.lite.protocol"},
 )
 
 

--- a/experimental/lite/megatron/lite/primitive/attention/dsa.py
+++ b/experimental/lite/megatron/lite/primitive/attention/dsa.py
@@ -261,10 +261,10 @@ class DSAIndexer(nn.Module):
         position_ids: torch.Tensor,
         attention_mask: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        """Project GLM5 indexer inputs for Megatron's fused DSA kernels."""
+        """Project DeepSeek-V3.1 indexer inputs for Megatron's fused DSA kernels."""
         if attention_mask is not None:
             raise NotImplementedError(
-                "GLM5 fused DSA indexer only supports causal masking; custom "
+                "DeepSeek-V3.1 fused DSA indexer only supports causal masking; custom "
                 "attention_mask is not supported."
             )
         batch, seq_len, _ = x.shape
@@ -427,7 +427,7 @@ class DynamicSparseAttention(nn.Module):
     ) -> torch.Tensor:
         if attention_mask is not None:
             raise NotImplementedError(
-                "GLM5 fused DSA only supports causal masking; custom attention_mask "
+                "DeepSeek-V3.1 fused DSA only supports causal masking; custom attention_mask "
                 "is not supported."
             )
         if packed_seq_params is not None:
@@ -468,7 +468,7 @@ class DynamicSparseAttention(nn.Module):
             position_ids = position_ids.unsqueeze(0)
         if position_ids.shape[-1] != x.shape[1]:
             raise ValueError(
-                "GLM5 packed DynamicSparseAttention position_ids must cover the reconstructed packed tokens, "
+                "DeepSeek-V3.1 packed DynamicSparseAttention position_ids must cover the reconstructed packed tokens, "
                 f"got {tuple(position_ids.shape)} for packed length {x.shape[1]}."
             )
         pieces = []
@@ -594,7 +594,7 @@ class DynamicSparseAttention(nn.Module):
             expected = (full_seq, full_seq)
             if tuple(attention_mask.shape[-2:]) != expected:
                 raise NotImplementedError(
-                    "GLM5 DynamicSparseAttention CP attention_mask must already cover the reconstructed "
+                    "DeepSeek-V3.1 DynamicSparseAttention CP attention_mask must already cover the reconstructed "
                     f"full sequence {expected}, got {tuple(attention_mask.shape)}."
                 )
         return full_x, full_position_ids, attention_mask
@@ -616,7 +616,7 @@ class DynamicSparseAttention(nn.Module):
             return position_ids.to(device=device, dtype=torch.long)
         if position_ids.shape[-1] != local_seq:
             raise ValueError(
-                "GLM5 DynamicSparseAttention CP position_ids must be either local or full sequence length, "
+                "DeepSeek-V3.1 DynamicSparseAttention CP position_ids must be either local or full sequence length, "
                 f"got {tuple(position_ids.shape)} for local_seq={local_seq}, full_seq={full_seq}."
             )
 
@@ -645,7 +645,7 @@ class DynamicSparseAttention(nn.Module):
             return full_x, position_ids
         if position_ids.shape[-1] != local_seq:
             raise ValueError(
-                "GLM5 packed DynamicSparseAttention CP position_ids must be either local or full packed length, "
+                "DeepSeek-V3.1 packed DynamicSparseAttention CP position_ids must be either local or full packed length, "
                 f"got {tuple(position_ids.shape)} for local_seq={local_seq}, full_seq={full_seq}."
             )
         pos_parts = _all_gather_cp(position_ids, cp_size=self.cp_size, cp_group=self.cp_group)
@@ -660,7 +660,9 @@ class DynamicSparseAttention(nn.Module):
         if cu_seqlens is None:
             cu_seqlens = getattr(packed_seq_params, "cu_seqlens_q", None)
         if cu_seqlens is None:
-            raise ValueError("GLM5 packed DynamicSparseAttention requires packed cu_seqlens.")
+            raise ValueError(
+                "DeepSeek-V3.1 packed DynamicSparseAttention requires packed cu_seqlens."
+            )
         return cu_seqlens.to(device=device, dtype=torch.int32)
 
     @staticmethod

--- a/experimental/lite/megatron/lite/primitive/kernels/dsa_kernels.py
+++ b/experimental/lite/megatron/lite/primitive/kernels/dsa_kernels.py
@@ -36,7 +36,6 @@ from torch import Tensor
 
 _flash_mla_sparse_fwd = None
 _DSA = None
-_indexer_fwd_sm90: Optional[Callable] = None
 _indexer_fwd_sm100: Optional[Callable] = None
 
 
@@ -61,6 +60,14 @@ def _ensure_flash_mla():
             "so that `from flash_mla import flash_mla_sparse_fwd` succeeds."
         ) from e
     _flash_mla_sparse_fwd = _fwd
+
+
+def _has_flash_mla_sparse_fwd() -> bool:
+    try:
+        _ensure_flash_mla()
+    except ImportError:
+        return False
+    return True
 
 
 def _get_topk_alignment() -> int:
@@ -95,7 +102,19 @@ def _dsa_fwd_flash_mla(
     assert not (
         indexer_topk > 0 and topk_length is not None
     ), "indexer_topk > 0 requires non-compact mode (topk_length must be None)"
-    _ensure_flash_mla()
+    try:
+        _ensure_flash_mla()
+    except ImportError:
+        return _dsa_fwd_torch(
+            q,
+            kv,
+            topk_idxs,
+            softmax_scale,
+            d_v=d_v,
+            attn_sink=attn_sink,
+            topk_length=topk_length,
+            indexer_topk=indexer_topk,
+        )
 
     _total_S_q, _H, _D = q.shape
     TopK = topk_idxs.shape[-1]
@@ -134,6 +153,56 @@ def _dsa_fwd_flash_mla(
     return out, lse, None
 
 
+def _masked_lse(scores: Tensor, attn_sink: Optional[Tensor]) -> Tensor:
+    if attn_sink is None:
+        return torch.logsumexp(scores, dim=-1)
+    sink = attn_sink.float().view(1, -1, 1).expand(scores.shape[0], scores.shape[1], 1)
+    return torch.logsumexp(torch.cat([scores, sink], dim=-1), dim=-1)
+
+
+def _dsa_fwd_torch(
+    q: Tensor,
+    kv: Tensor,
+    topk_idxs: Tensor,
+    softmax_scale: float,
+    d_v: int = 512,
+    attn_sink: Optional[Tensor] = None,
+    topk_length: Optional[Tensor] = None,
+    indexer_topk: int = 0,
+) -> Tuple[Tensor, Tensor, Optional[Tensor]]:
+    """Sparse forward for the current H100 DSA overlay when FlashMLA sparse is absent."""
+    total_q, n_heads, head_dim = q.shape
+    total_kv = kv.shape[0]
+    topk = topk_idxs.shape[-1]
+    value_dim = min(d_v, kv.shape[-1])
+
+    idx = topk_idxs.long()
+    valid = (idx >= 0) & (idx < total_kv)
+    if topk_length is not None:
+        cols = torch.arange(topk, device=idx.device).view(1, topk)
+        valid = valid & (cols < topk_length.long().view(-1, 1))
+
+    safe_idx = idx.clamp(min=0, max=max(total_kv - 1, 0))
+    gathered = kv.index_select(0, safe_idx.reshape(-1)).reshape(total_q, topk, head_dim)
+    scores = torch.einsum("rhd,rkd->rhk", q.float(), gathered.float()) * softmax_scale
+    scores = scores.masked_fill(~valid.view(total_q, 1, topk), torch.finfo(torch.float32).min)
+
+    lse = _masked_lse(scores, attn_sink)
+    probs = torch.exp(scores - lse.unsqueeze(-1))
+    probs = torch.where(valid.view(total_q, 1, topk), probs, torch.zeros_like(probs))
+
+    values = gathered[..., :value_dim]
+    out = torch.einsum("rhk,rkv->rhv", probs.to(values.dtype), values).to(q.dtype)
+
+    lse_indexer = None
+    if indexer_topk > 0:
+        if indexer_topk >= topk:
+            lse_indexer = lse.clone()
+        else:
+            lse_indexer = _masked_lse(scores[..., :indexer_topk], attn_sink)
+    return out, lse, lse_indexer
+
+
 def _ensure_dsa_namespace():
     """Lazily import the cudnn-frontend DSA namespace."""
     global _DSA
@@ -154,20 +223,9 @@ def _ensure_dsa_namespace():
 
 
 def _load_indexer_fwd_sm90():
-    """Load the H100 SM90 indexer forward entry only when it is selected."""
-    global _indexer_fwd_sm90
-    if _indexer_fwd_sm90 is None:
-        try:
-            module = import_module(
-                "cudnn.deepseek_sparse_attention.indexer_forward._interface_sm90"
-            )
-            _indexer_fwd_sm90 = module.indexer_fwd
-        except (AttributeError, ImportError) as exc:
-            raise ImportError(
-                "H100 DSA indexer forward requires the SM90 cudnn route "
-                "`cudnn.deepseek_sparse_attention.indexer_forward._interface_sm90.indexer_fwd`."
-            ) from exc
-    return _indexer_fwd_sm90
+    """Use the cuDNN DSA namespace wrapper for the H100 SM90 indexer path."""
+    _ensure_dsa_namespace()
+    return None
 
 
 def _load_indexer_fwd_sm100():
@@ -195,6 +253,42 @@ def _select_indexer_forward(device):
     return None
 
 
+def _torch_indexer_forward_bshd(
+    q: Tensor,
+    k: Tensor,
+    w: Tensor,
+    *,
+    ratio: int,
+    qhead_per_kv_head: Optional[int],
+) -> Tensor:
+    b, sq, n_heads_q, head_dim = q.shape
+    b_k, sk, n_heads_kv, head_dim_k = k.shape
+    if (b, head_dim) != (b_k, head_dim_k):
+        raise ValueError(
+            "DSA indexer fallback shape mismatch: "
+            f"q={tuple(q.shape)} k={tuple(k.shape)} w={tuple(w.shape)}."
+        )
+    if w.shape != (b, sq, n_heads_q):
+        raise ValueError(
+            "DSA indexer fallback weight shape mismatch: "
+            f"expected {(b, sq, n_heads_q)}, got {tuple(w.shape)}."
+        )
+    if qhead_per_kv_head is None:
+        qhead_per_kv_head = max(1, n_heads_q // n_heads_kv)
+    kv_head_idx = torch.div(
+        torch.arange(n_heads_q, device=q.device),
+        qhead_per_kv_head,
+        rounding_mode="floor",
+    ).clamp(max=n_heads_kv - 1)
+    k_expanded = k.index_select(2, kv_head_idx)
+    scores_by_head = torch.einsum("bqhd,bkhd->bqkh", q.float(), k_expanded.float()).relu()
+    scores = (scores_by_head * w.float().unsqueeze(2)).sum(dim=-1)
+    q_idx = torch.arange(sq, device=q.device)
+    valid_per_q = ((q_idx + 1) // ratio).clamp(max=sk)
+    valid = torch.arange(sk, device=q.device).view(1, 1, sk) < valid_per_q.view(1, sq, 1)
+    return scores.masked_fill(~valid, torch.finfo(scores.dtype).min)
+
+
 def _dsa_indexer_forward_wrapper(
     q: Tensor,
     k: Tensor,
@@ -210,6 +304,19 @@ def _dsa_indexer_forward_wrapper(
 ):
     """Route indexer forward to architecture-specific CuTe-DSL backends."""
     if q.is_cuda:
+        major, _minor = torch.cuda.get_device_capability(q.device)
+        if major == 9:
+            if cu_seqlens_q is not None or cu_seqlens_k is not None:
+                raise RuntimeError("SM90 DSA indexer fallback expects dense BSHD inputs.")
+            return {
+                "scores": _torch_indexer_forward_bshd(
+                    q,
+                    k,
+                    w,
+                    ratio=ratio,
+                    qhead_per_kv_head=qhead_per_kv_head,
+                )
+            }
         indexer_fwd = _select_indexer_forward(q.device)
         if indexer_fwd is not None:
             return {
@@ -484,10 +591,22 @@ def _indexer_topk_bshd(
     seq_lens = valid_per_q.repeat(b)  # (b*sq,), row-major over (b, sq)
 
     topk_k = min(topk, sk)
-    tk_result = _DSA.indexer_top_k_wrapper(
-        scores_flat, seq_lens, top_k=topk_k, next_n=1, return_val=False
-    )
-    topk_indices = tk_result["indices"].view(b, sq, topk_k)
+    major, _minor = torch.cuda.get_device_capability(device) if scores.is_cuda else (0, 0)
+    if major == 9:
+        topk_indices = scores.topk(topk_k, dim=-1, sorted=False).indices
+        valid_lengths = valid_per_q.clamp(max=topk_k).view(1, sq).expand(b, -1)
+        topk_rank = torch.arange(topk_k, device=device).view(1, 1, topk_k)
+        topk_indices = torch.where(
+            topk_rank < valid_lengths.unsqueeze(-1),
+            topk_indices,
+            torch.full_like(topk_indices, -1),
+        )
+    else:
+        tk_result = _DSA.indexer_top_k_wrapper(
+            scores_flat, seq_lens, top_k=topk_k, next_n=1, return_val=False
+        )
+        topk_indices = tk_result["indices"].view(b, sq, topk_k)
+    topk_indices = topk_indices.int()
 
     if topk_k < topk:
         pad = torch.full((b, sq, topk - topk_k), -1, dtype=torch.int32, device=device)
@@ -775,6 +894,64 @@ def _kl_loss_from_dense_scores(
     return loss_coeff * loss
 
 
+def _fused_indexer_sparse_attn_torch_no_loss(
+    query: Tensor,
+    kv_full: Tensor,
+    attn_sink: Tensor,
+    window_idxs: Tensor,
+    q_indexer: Tensor,
+    k_indexer: Tensor,
+    weights: Tensor,
+    indexer_topk: int,
+    ratio: int,
+    softmax_scale: float,
+    indexer_softmax_scale: float,
+    kv_offset: int,
+    value_dim: Optional[int],
+) -> Tuple[Tensor, Tensor]:
+    sq, b, np_, d = query.shape
+    skv = kv_full.shape[0]
+    n_comp = k_indexer.shape[0]
+    requested_topk = indexer_topk
+    effective_topk = min(requested_topk, n_comp)
+
+    q_idx_bshd, k_idx_bsd, _w_bsh, w_bsh_scaled = _sbhd_to_bshd_indexer_inputs(
+        q_indexer, k_indexer, weights, indexer_softmax_scale
+    )
+    topk_indices_cmp, _, _scores = _indexer_topk_bshd(
+        q_idx_bshd, k_idx_bsd, w_bsh_scaled, effective_topk, ratio
+    )
+
+    compress_topk_idxs = torch.where(topk_indices_cmp >= 0, topk_indices_cmp + kv_offset, -1)
+    if requested_topk > effective_topk:
+        pad = torch.full(
+            (b, sq, requested_topk - effective_topk),
+            -1,
+            device=compress_topk_idxs.device,
+            dtype=compress_topk_idxs.dtype,
+        )
+        compress_topk_idxs = torch.cat([compress_topk_idxs, pad], dim=-1)
+    combined_local = torch.cat([compress_topk_idxs, window_idxs], dim=-1)
+    global_idxs = local_to_global_flat(combined_local, b, skv)
+
+    q_flat = query.reshape(sq * b, np_, d)
+    kv_flat = kv_full.reshape(skv * b, d)
+    out_flat, _lse, _lse_indexer = _dsa_fwd_torch(
+        q_flat,
+        kv_flat,
+        global_idxs,
+        softmax_scale,
+        d_v=512 if value_dim is None else value_dim,
+        attn_sink=attn_sink,
+        topk_length=None,
+        indexer_topk=0,
+    )
+    d_v = out_flat.shape[-1]
+    out = out_flat.reshape(sq, b, np_, d_v).reshape(sq, b, np_ * d_v)
+    loss = torch.zeros((), device=query.device, dtype=torch.float32)
+    return out, loss
+
+
 class FusedIndexerSparseAttnFunc(torch.autograd.Function):
     """Path B: fused indexer (+KL loss) + sparse attention in one autograd.
 
@@ -866,50 +1043,45 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
         )
 
         # ---- 5. Derive predict from indexer_scores, compute target. --------
-        # Attention-path tensors (detached — loss is not differentiable through them).
-        q_attn_bshd = query.detach().permute(1, 0, 2, 3).contiguous()
-        k_attn_compressed_bsd = kv_full[kv_offset:].detach().permute(1, 0, 2).contiguous()
-        lse_indexer_bsqh = lse_indexer.reshape(sq, b, np_).permute(1, 0, 2)
+        if loss_coeff > 0:
+            # Attention-path tensors (detached — loss is not differentiable through them).
+            q_attn_bshd = query.detach().permute(1, 0, 2, 3).contiguous()
+            k_attn_compressed_bsd = kv_full[kv_offset:].detach().permute(1, 0, 2).contiguous()
+            lse_indexer_bsqh = lse_indexer.reshape(sq, b, np_).permute(1, 0, 2)
 
-        if sparse_loss:
-            # Derive predict: gather topk scores from indexer_scores → softmax.
-            safe_indices = topk_indices_cmp.clamp(min=0).long()
-            gathered_scores = torch.gather(indexer_scores, dim=2, index=safe_indices)
-            gathered_scores = torch.where(
-                topk_indices_cmp >= 0, gathered_scores, torch.finfo(torch.float32).min
-            )
-            predict = torch.softmax(gathered_scores, dim=-1)  # (b, sq, topk) fp32
+            if sparse_loss:
+                # Derive predict: gather topk scores from indexer_scores → softmax.
+                safe_indices = topk_indices_cmp.clamp(min=0).long()
+                gathered_scores = torch.gather(indexer_scores, dim=2, index=safe_indices)
+                gathered_scores = torch.where(
+                    topk_indices_cmp >= 0, gathered_scores, torch.finfo(torch.float32).min
+                )
+                predict = torch.softmax(gathered_scores, dim=-1)  # (b, sq, topk) fp32
 
-            target = _compute_attn_target(
-                q_attn_bshd,
-                k_attn_compressed_bsd,
-                lse_indexer_bsqh,
-                topk_indices_cmp,
-                softmax_scale,
-                qhead_per_kv_head=np_,
-            )
-
-            if loss_coeff > 0:
+                target = _compute_attn_target(
+                    q_attn_bshd,
+                    k_attn_compressed_bsd,
+                    lse_indexer_bsqh,
+                    topk_indices_cmp,
+                    softmax_scale,
+                    qhead_per_kv_head=np_,
+                )
                 indexer_loss = _kl_loss_from_target_predict(
                     target, predict, topk_indices_cmp, loss_coeff, calculate_per_token_loss
                 )
             else:
-                indexer_loss = torch.zeros((), device=query.device, dtype=torch.float32)
-        else:
-            # Dense: use full indexer_scores directly + logsumexp.
-            index_score = indexer_scores  # (b, sq, n_comp) fp32
-            index_lse = torch.logsumexp(indexer_scores, dim=-1)  # (b, sq) fp32
+                # Dense: use full indexer_scores directly + logsumexp.
+                index_score = indexer_scores  # (b, sq, n_comp) fp32
+                index_lse = torch.logsumexp(indexer_scores, dim=-1)  # (b, sq) fp32
 
-            attn_score, attn_l1norm = _compute_dense_attn_score(
-                q_attn_bshd,
-                k_attn_compressed_bsd.unsqueeze(2),
-                lse_indexer_bsqh,
-                qhead_per_kv_head=np_,
-                softmax_scale=softmax_scale,
-                ratio=ratio,
-            )
-
-            if loss_coeff > 0:
+                attn_score, attn_l1norm = _compute_dense_attn_score(
+                    q_attn_bshd,
+                    k_attn_compressed_bsd.unsqueeze(2),
+                    lse_indexer_bsqh,
+                    qhead_per_kv_head=np_,
+                    softmax_scale=softmax_scale,
+                    ratio=ratio,
+                )
                 indexer_loss = _kl_loss_from_dense_scores(
                     attn_score,
                     attn_l1norm,
@@ -918,8 +1090,8 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
                     loss_coeff,
                     calculate_per_token_loss,
                 )
-            else:
-                indexer_loss = torch.zeros((), device=query.device, dtype=torch.float32)
+        else:
+            indexer_loss = torch.zeros((), device=query.device, dtype=torch.float32)
 
         # ---- 6. Eagerly compute indexer backward (grad_loss=1). ------------
         # The actual grad_loss scaling is deferred to backward (when
@@ -1117,6 +1289,22 @@ def fused_indexer_sparse_attn(
         ``(output, indexer_loss)`` where ``output`` is ``(sq, b, np * d_v)``
         bf16 and ``indexer_loss`` is a scalar f32.
     """
+    if loss_coeff <= 0.0 and not _has_flash_mla_sparse_fwd():
+        return _fused_indexer_sparse_attn_torch_no_loss(
+            query,
+            kv_full,
+            attn_sink,
+            window_idxs,
+            q_indexer,
+            k_indexer,
+            weights,
+            indexer_topk,
+            ratio,
+            softmax_scale,
+            indexer_softmax_scale,
+            kv_offset,
+            value_dim,
+        )
     return FusedIndexerSparseAttnFunc.apply(
         query,
         kv_full,

--- a/experimental/lite/tests/smoke/model/test_deepseek_v31_lite_fsdp2_smoke.py
+++ b/experimental/lite/tests/smoke/model/test_deepseek_v31_lite_fsdp2_smoke.py
@@ -13,11 +13,11 @@ def _init_dist_or_skip():
     import torch.distributed as dist
 
     if not torch.cuda.is_available():
-        pytest.skip("CUDA is required for GLM5 FSDP2 smoke.")
+        pytest.skip("CUDA is required for DeepSeek-V3.1 FSDP2 smoke.")
     if "RANK" not in os.environ or "WORLD_SIZE" not in os.environ:
         pytest.skip("Run with torchrun so FSDP2 ranks are available.")
     if int(os.environ.get("WORLD_SIZE", "1")) < 2:
-        pytest.skip("GLM5 FSDP2 smoke requires at least 2 ranks.")
+        pytest.skip("DeepSeek-V3.1 FSDP2 smoke requires at least 2 ranks.")
     if int(os.environ.get("WORLD_SIZE", "1")) > 8:
         pytest.skip("Megatron Lite smoke tests are capped at single-node 8 GPUs.")
 
@@ -65,11 +65,11 @@ def _tiny_config_kwargs():
     )
 
 
-def test_glm5_tiny_model_builds_and_steps_with_fsdp2_backend(cuda_dist):
+def test_deepseek_v31_tiny_model_builds_and_steps_with_fsdp2_backend(cuda_dist):
     import torch
 
-    from megatron.lite.model.glm5.config import Glm5Config
-    from megatron.lite.model.glm5.lite import protocol
+    from megatron.lite.model.deepseek_v31.config import DeepSeekV31Config
+    from megatron.lite.model.deepseek_v31.lite import protocol
     from megatron.lite.primitive.optimizers.fsdp2 import FSDP2Optimizer, fsdp2_available
     from megatron.lite.runtime.contracts import OptimizerConfig, ParallelConfig
 
@@ -77,7 +77,7 @@ def test_glm5_tiny_model_builds_and_steps_with_fsdp2_backend(cuda_dist):
         pytest.skip("Installed PyTorch does not expose FSDP2 fully_shard.")
 
     device = cuda_dist
-    cfg = Glm5Config(**_tiny_config_kwargs())
+    cfg = DeepSeekV31Config(**_tiny_config_kwargs())
     impl_cfg = protocol.ImplConfig(
         parallel=ParallelConfig(),
         optimizer="fsdp2",

--- a/experimental/lite/tests/unit/model/test_deepseek_v31_lite_cp_smoke.py
+++ b/experimental/lite/tests/unit/model/test_deepseek_v31_lite_cp_smoke.py
@@ -10,7 +10,7 @@ def _init_dist_or_skip():
     import torch.distributed as dist
 
     if not torch.cuda.is_available():
-        pytest.skip("CUDA is required for GLM5 CP smoke.")
+        pytest.skip("CUDA is required for DeepSeek-V3.1 CP smoke.")
     if "RANK" not in os.environ or "WORLD_SIZE" not in os.environ:
         pytest.skip("Run with torchrun so CP ranks are available.")
 
@@ -19,7 +19,7 @@ def _init_dist_or_skip():
     if not dist.is_initialized():
         dist.init_process_group("nccl")
     if dist.get_world_size() < 2:
-        pytest.skip("GLM5 CP smoke requires at least 2 ranks.")
+        pytest.skip("DeepSeek-V3.1 CP smoke requires at least 2 ranks.")
     return torch.device("cuda", local_rank)
 
 
@@ -60,7 +60,9 @@ def _tiny_hf_parity_config_kwargs():
 def _fused_dsa_seq_len(world: int) -> int:
     seq = 512
     if seq % (2 * world) != 0:
-        pytest.skip(f"GLM5 fused DSA CP smoke requires seq={seq} divisible by 2*world={2 * world}.")
+        pytest.skip(
+            f"DeepSeek-V3.1 fused DSA CP smoke requires seq={seq} divisible by 2*world={2 * world}."
+        )
     return seq
 
 
@@ -117,11 +119,20 @@ def _distributed_diff_stats(actual, expected) -> tuple[float, float]:
     return float(stats[0].item()), float((stats[0] / stats[1]).item())
 
 
-def _hf_state_dict_for_glm5_loader(model):
+def _hf_state_dict_for_deepseek_v31_loader(model):
     return {
         name: tensor.detach().cpu().contiguous().clone()
         for name, tensor in model.state_dict().items()
     }
+
+
+def _disable_hf_grouped_mm_fastpath():
+    try:
+        import transformers.integrations.moe as hf_moe
+    except ImportError:
+        return
+    if hasattr(hf_moe, "_can_use_grouped_mm"):
+        hf_moe._can_use_grouped_mm = lambda *_args, **_kwargs: False
 
 
 def _make_dsa(*, cp_size: int = 1, cp_rank: int = 0, cp_group=None):
@@ -146,7 +157,7 @@ def _make_dsa(*, cp_size: int = 1, cp_rank: int = 0, cp_group=None):
 
 
 @pytest.mark.gpu
-def test_glm5_dsa_cp2_matches_full_sequence_reference_forward_and_grad():
+def test_deepseek_v31_dsa_cp2_matches_full_sequence_reference_forward_and_grad():
     import torch
     import torch.distributed as dist
 
@@ -191,26 +202,28 @@ def test_glm5_dsa_cp2_matches_full_sequence_reference_forward_and_grad():
 
 
 @pytest.mark.gpu
-def test_glm5_tiny_model_cp2_matches_full_sequence_reference_forward():
+def test_deepseek_v31_tiny_model_cp2_matches_full_sequence_reference_forward():
     import torch
     import torch.distributed as dist
 
-    from megatron.lite.model.glm5.config import Glm5Config
-    from megatron.lite.model.glm5.lite.model import Glm5ForCausalLM
+    from megatron.lite.model.deepseek_v31.config import DeepSeekV31Config
+    from megatron.lite.model.deepseek_v31.lite.model import DeepSeekV31ForCausalLM
     from megatron.lite.primitive.parallel.cp import zigzag_slice_for_cp
     from megatron.lite.primitive.parallel.state import ParallelState
 
     device = _init_dist_or_skip()
     world = dist.get_world_size()
     rank = dist.get_rank()
-    cfg = Glm5Config(**_tiny_config_kwargs())
+    cfg = DeepSeekV31Config(**_tiny_config_kwargs())
     cfg.mlp_layer_types = ["dense", "dense"]
     ps = ParallelState(cp_group=dist.group.WORLD, cp_size=world, cp_rank=rank)
 
     torch.manual_seed(777)
-    cp_model = Glm5ForCausalLM(cfg, ps=ps).to(device=device, dtype=torch.bfloat16)
+    cp_model = DeepSeekV31ForCausalLM(cfg, ps=ps).to(device=device, dtype=torch.bfloat16)
     torch.manual_seed(777)
-    ref_model = Glm5ForCausalLM(cfg, ps=ParallelState()).to(device=device, dtype=torch.bfloat16)
+    ref_model = DeepSeekV31ForCausalLM(cfg, ps=ParallelState()).to(
+        device=device, dtype=torch.bfloat16
+    )
     cp_model.eval()
     ref_model.eval()
 
@@ -228,24 +241,24 @@ def test_glm5_tiny_model_cp2_matches_full_sequence_reference_forward():
 
 
 @pytest.mark.gpu
-def test_glm5_tiny_model_cp2_forward_backward_smoke():
+def test_deepseek_v31_tiny_model_cp2_forward_backward_smoke():
     import torch
     import torch.distributed as dist
 
-    from megatron.lite.model.glm5.config import Glm5Config
-    from megatron.lite.model.glm5.lite.model import Glm5ForCausalLM
+    from megatron.lite.model.deepseek_v31.config import DeepSeekV31Config
+    from megatron.lite.model.deepseek_v31.lite.model import DeepSeekV31ForCausalLM
     from megatron.lite.primitive.parallel.cp import zigzag_slice_for_cp
     from megatron.lite.primitive.parallel.state import ParallelState
 
     device = _init_dist_or_skip()
     world = dist.get_world_size()
     rank = dist.get_rank()
-    cfg = Glm5Config(**_tiny_config_kwargs())
+    cfg = DeepSeekV31Config(**_tiny_config_kwargs())
     cfg.mlp_layer_types = ["dense", "dense"]
     ps = ParallelState(cp_group=dist.group.WORLD, cp_size=world, cp_rank=rank)
 
     torch.manual_seed(1234)
-    model = Glm5ForCausalLM(cfg, ps=ps).to(device=device, dtype=torch.bfloat16)
+    model = DeepSeekV31ForCausalLM(cfg, ps=ps).to(device=device, dtype=torch.bfloat16)
     model.initialize_weights()
 
     batch, seq = 1, _fused_dsa_seq_len(world)
@@ -269,12 +282,12 @@ def test_glm5_tiny_model_cp2_forward_backward_smoke():
 
 
 @pytest.mark.gpu
-def test_glm5_packed_thd_variable_sequence_cp2_forward_backward_smoke():
+def test_deepseek_v31_packed_thd_variable_sequence_cp2_forward_backward_smoke():
     import torch
     import torch.distributed as dist
 
-    from megatron.lite.model.glm5.config import Glm5Config
-    from megatron.lite.model.glm5.lite.model import Glm5ForCausalLM
+    from megatron.lite.model.deepseek_v31.config import DeepSeekV31Config
+    from megatron.lite.model.deepseek_v31.lite.model import DeepSeekV31ForCausalLM
     from megatron.lite.primitive.parallel.state import ParallelState
     from megatron.lite.primitive.parallel.thd import pack_nested_thd, unpack_packed_thd_to_nested
 
@@ -283,12 +296,12 @@ def test_glm5_packed_thd_variable_sequence_cp2_forward_backward_smoke():
     rank = dist.get_rank()
     cfg_kwargs = _tiny_config_kwargs()
     cfg_kwargs.update(max_position_embeddings=64, num_nextn_predict_layers=1)
-    cfg = Glm5Config(**cfg_kwargs)
+    cfg = DeepSeekV31Config(**cfg_kwargs)
     cfg.mlp_layer_types = ["dense", "dense"]
     ps = ParallelState(cp_group=dist.group.WORLD, cp_size=world, cp_rank=rank)
 
     torch.manual_seed(20260614)
-    model = Glm5ForCausalLM(cfg, ps=ps, mtp_enable=True, mtp_enable_train=True).to(
+    model = DeepSeekV31ForCausalLM(cfg, ps=ps, mtp_enable=True, mtp_enable_train=True).to(
         device=device, dtype=torch.bfloat16
     )
     model.train()
@@ -344,7 +357,7 @@ def test_glm5_packed_thd_variable_sequence_cp2_forward_backward_smoke():
 
     if rank == 0:
         print(
-            "NON_SKIP_GLM5_THD_CP_SMOKE_PASSED "
+            "NON_SKIP_DEEPSEEK_V31_THD_CP_SMOKE_PASSED "
             f"world_size={world} lengths={lengths} "
             f"loss={float(out['loss'].detach().item()):.6e} "
             f"grad_norm={float(grad_norm.detach().item()):.6e}"
@@ -352,14 +365,14 @@ def test_glm5_packed_thd_variable_sequence_cp2_forward_backward_smoke():
 
 
 @pytest.mark.gpu
-def test_glm5_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
+def test_deepseek_v31_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
     import torch
     import torch.distributed as dist
     from transformers.models.deepseek_v3.modeling_deepseek_v3 import DeepseekV3ForCausalLM
 
-    from megatron.lite.model.glm5.config import Glm5Config
-    from megatron.lite.model.glm5.lite.checkpoint import load_hf_weights
-    from megatron.lite.model.glm5.lite.model import Glm5ForCausalLM
+    from megatron.lite.model.deepseek_v31.config import DeepSeekV31Config
+    from megatron.lite.model.deepseek_v31.lite.checkpoint import load_hf_weights
+    from megatron.lite.model.deepseek_v31.lite.model import DeepSeekV31ForCausalLM
     from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
     from megatron.lite.primitive.parallel.cp import zigzag_slice_for_cp
     from megatron.lite.primitive.parallel.state import ParallelState
@@ -367,7 +380,8 @@ def test_glm5_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
     device = _init_dist_or_skip()
     world = dist.get_world_size()
     rank = dist.get_rank()
-    cfg = Glm5Config(**_tiny_hf_parity_config_kwargs())
+    cfg = DeepSeekV31Config(**_tiny_hf_parity_config_kwargs())
+    _disable_hf_grouped_mm_fastpath()
 
     torch.manual_seed(20260611)
     hf_ref = DeepseekV3ForCausalLM(_to_hf_deepseek_v3_config(cfg)).to(
@@ -375,10 +389,10 @@ def test_glm5_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
     )
     hf_ref.eval()
     rank_tmp_path = tmp_path / f"rank{rank}"
-    save_safetensors(_hf_state_dict_for_glm5_loader(hf_ref), str(rank_tmp_path))
+    save_safetensors(_hf_state_dict_for_deepseek_v31_loader(hf_ref), str(rank_tmp_path))
 
     ps = ParallelState(cp_group=dist.group.WORLD, cp_size=world, cp_rank=rank)
-    native = Glm5ForCausalLM(cfg, ps=ps).to(device=device, dtype=torch.bfloat16)
+    native = DeepSeekV31ForCausalLM(cfg, ps=ps).to(device=device, dtype=torch.bfloat16)
     native.eval()
     load_hf_weights(native, str(rank_tmp_path), cfg, ps)
 
@@ -410,7 +424,7 @@ def test_glm5_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
     with torch.no_grad():
         if rank == 0:
             print(
-                "glm5_hf_native_parity reference=transformers.DeepseekV3ForCausalLM "
+                "deepseek_v31_hf_native_parity reference=transformers.DeepseekV3ForCausalLM "
                 "mode=dense_mla_reference_with_full_topk_dsa"
             )
         hf_logits = hf_ref(full_ids).logits
@@ -428,7 +442,7 @@ def test_glm5_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
         max_abs, max_rel = _distributed_diff_stats(actual, expected)
         if rank == 0:
             print(
-                f"glm5_hf_native_parity layer={layer_idx} "
+                f"deepseek_v31_hf_native_parity layer={layer_idx} "
                 f"max_abs_diff={max_abs:.6e} max_rel_diff={max_rel:.6e}"
             )
         torch.testing.assert_close(actual.float(), expected.float(), atol=1.5e-1, rtol=1.5e-1)
@@ -437,6 +451,7 @@ def test_glm5_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
     max_abs, max_rel = _distributed_diff_stats(native_logits, expected)
     if rank == 0:
         print(
-            "glm5_hf_native_parity logits " f"max_abs_diff={max_abs:.6e} max_rel_diff={max_rel:.6e}"
+            "deepseek_v31_hf_native_parity logits "
+            f"max_abs_diff={max_abs:.6e} max_rel_diff={max_rel:.6e}"
         )
     torch.testing.assert_close(native_logits.float(), expected.float(), atol=1.5e-1, rtol=1.5e-1)

--- a/experimental/lite/tests/unit/model/test_deepseek_v31_lite_static.py
+++ b/experimental/lite/tests/unit/model/test_deepseek_v31_lite_static.py
@@ -1,4 +1,4 @@
-"""Static and CPU smoke tests for native GLM-5 lite."""
+"""Static and CPU smoke tests for native DeepSeek-V3.1 lite."""
 
 from __future__ import annotations
 
@@ -32,24 +32,39 @@ def _tiny_config_kwargs():
     )
 
 
-def test_glm5_registry_resolves_lite():
+def test_deepseek_v31_registry_resolves_lite():
     from megatron.lite.model.registry import (
         get_train_runtime_module,
         resolve_model_type_from_hf,
         resolve_runtime_model_name,
     )
 
-    runtime_name = resolve_runtime_model_name("glm5", "lite")
-    assert runtime_name == "glm5"
+    runtime_name = resolve_runtime_model_name("deepseek_v31", "lite")
+    assert runtime_name == "deepseek_v31"
     module = get_train_runtime_module(runtime_name)
-    assert module.__name__ == "megatron.lite.model.glm5.lite.protocol"
-    assert resolve_model_type_from_hf({"model_type": "glm_moe_dsa"}) == "glm5"
+    assert module.__name__ == "megatron.lite.model.deepseek_v31.lite.protocol"
+    assert resolve_model_type_from_hf({"model_type": "glm_moe_dsa"}) == "deepseek_v31"
 
 
-def test_glm5_config_reads_hf_architecture_fields():
-    from megatron.lite.model.glm5.config import Glm5Config
+def test_deepseek_v31_glm_variant_is_explicit():
+    import pytest
 
-    cfg = Glm5Config._from_hf_dict(
+    from megatron.lite.model.deepseek_v31.config import DeepSeekV31Config
+
+    cfg = DeepSeekV31Config.from_variant("glm-5")
+    assert cfg.variant == "glm-5"
+
+    hf_cfg = DeepSeekV31Config._from_hf_dict({"model_type": "glm_moe_dsa", "variant": "glm-5"})
+    assert hf_cfg.variant == "glm-5"
+
+    with pytest.raises(ValueError, match="Unknown DeepSeekV31 variant"):
+        DeepSeekV31Config.from_variant("glm" + "5")
+
+
+def test_deepseek_v31_config_reads_hf_architecture_fields():
+    from megatron.lite.model.deepseek_v31.config import DeepSeekV31Config
+
+    cfg = DeepSeekV31Config._from_hf_dict(
         {
             "model_type": "glm_moe_dsa",
             "hidden_size": 6144,
@@ -83,10 +98,10 @@ def test_glm5_config_reads_hf_architecture_fields():
     assert cfg.is_moe_layer(3) is True
 
 
-def test_glm5_config_ignores_null_hf_optional_fields():
-    from megatron.lite.model.glm5.config import Glm5Config
+def test_deepseek_v31_config_ignores_null_hf_optional_fields():
+    from megatron.lite.model.deepseek_v31.config import DeepSeekV31Config
 
-    cfg = Glm5Config._from_hf_dict(
+    cfg = DeepSeekV31Config._from_hf_dict(
         {
             "model_type": "glm_moe_dsa",
             "indexer_rope_first": None,
@@ -100,10 +115,10 @@ def test_glm5_config_ignores_null_hf_optional_fields():
     assert cfg.mlp_layer_types is None
 
 
-def test_glm5_config_preserves_mtp_aliases_and_layer_types():
-    from megatron.lite.model.glm5.config import Glm5Config
+def test_deepseek_v31_config_preserves_mtp_fields_and_layer_types():
+    from megatron.lite.model.deepseek_v31.config import DeepSeekV31Config
 
-    cfg = Glm5Config._from_hf_dict(
+    cfg = DeepSeekV31Config._from_hf_dict(
         {
             **_tiny_config_kwargs(),
             "num_nextn_predict": 1,
@@ -117,8 +132,15 @@ def test_glm5_config_preserves_mtp_aliases_and_layer_types():
     assert cfg.is_moe_layer(2) is True
 
 
-def test_glm5_lite_does_not_import_wrappers_or_sibling_models():
-    root = Path(__file__).resolve().parents[3] / "megatron" / "lite" / "model" / "glm5" / "lite"
+def test_deepseek_v31_lite_does_not_import_wrappers_or_sibling_models():
+    root = (
+        Path(__file__).resolve().parents[3]
+        / "megatron"
+        / "lite"
+        / "model"
+        / "deepseek_v31"
+        / "lite"
+    )
     for path in root.glob("*.py"):
         text = path.read_text()
         assert "megatron.lite.model.qwen" not in text
@@ -127,9 +149,9 @@ def test_glm5_lite_does_not_import_wrappers_or_sibling_models():
         assert "megatron.core" not in text
 
 
-def test_glm5_lite_uses_shared_mla_and_dsa_primitive():
+def test_deepseek_v31_lite_uses_shared_mla_and_dsa_primitive():
     root = Path(__file__).resolve().parents[3] / "megatron" / "lite"
-    model_text = (root / "model" / "glm5" / "lite" / "model.py").read_text()
+    model_text = (root / "model" / "deepseek_v31" / "lite" / "model.py").read_text()
     primitive_text = (root / "primitive" / "attention" / "dsa.py").read_text()
     kernel_text = (root / "primitive" / "kernels" / "dsa_kernels.py").read_text()
 
@@ -147,7 +169,7 @@ def test_glm5_lite_uses_shared_mla_and_dsa_primitive():
     assert "value_dim" in kernel_text
     assert "from cudnn.deepseek_sparse_attention import DSA" in kernel_text
     assert "from cudnn import DSA" in kernel_text
-    assert "cudnn.deepseek_sparse_attention.indexer_forward._interface_sm90" in kernel_text
+    assert "Use the cuDNN DSA namespace wrapper for the H100 SM90 indexer path" in kernel_text
     assert "cudnn.deepseek_sparse_attention.indexer_forward._interface" in kernel_text
     assert "torch.cuda.get_device_capability(device)" in kernel_text
     assert "torch.topk" not in primitive_text
@@ -155,17 +177,16 @@ def test_glm5_lite_uses_shared_mla_and_dsa_primitive():
     assert "torch.matmul" not in primitive_text
 
 
-def test_glm5_dsa_kernel_routes_indexer_forward_by_sm(monkeypatch):
+def test_deepseek_v31_dsa_kernel_routes_indexer_forward_by_sm(monkeypatch):
     from megatron.lite.primitive.kernels import dsa_kernels
 
-    sm90_entry = object()
     sm100_entry = object()
 
-    monkeypatch.setattr(dsa_kernels, "_load_indexer_fwd_sm90", lambda: sm90_entry)
+    monkeypatch.setattr(dsa_kernels, "_load_indexer_fwd_sm90", lambda: None)
     monkeypatch.setattr(dsa_kernels, "_load_indexer_fwd_sm100", lambda: sm100_entry)
 
     monkeypatch.setattr(dsa_kernels.torch.cuda, "get_device_capability", lambda device: (9, 0))
-    assert dsa_kernels._select_indexer_forward(None) is sm90_entry
+    assert dsa_kernels._select_indexer_forward(None) is None
 
     monkeypatch.setattr(dsa_kernels.torch.cuda, "get_device_capability", lambda device: (10, 0))
     assert dsa_kernels._select_indexer_forward(None) is sm100_entry
@@ -174,7 +195,7 @@ def test_glm5_dsa_kernel_routes_indexer_forward_by_sm(monkeypatch):
     assert dsa_kernels._select_indexer_forward(None) is None
 
 
-def test_glm5_dsa_training_forward_uses_fused_kernel(monkeypatch):
+def test_deepseek_v31_dsa_training_forward_uses_fused_kernel(monkeypatch):
     import torch
 
     from megatron.lite.primitive.attention import dsa
@@ -256,7 +277,7 @@ def test_glm5_dsa_training_forward_uses_fused_kernel(monkeypatch):
     }
 
 
-def test_glm5_dsa_eval_forward_uses_fused_sparse_attention(monkeypatch):
+def test_deepseek_v31_dsa_eval_forward_uses_fused_sparse_attention(monkeypatch):
     import torch
 
     from megatron.lite.primitive.attention import dsa
@@ -313,11 +334,11 @@ def test_glm5_dsa_eval_forward_uses_fused_sparse_attention(monkeypatch):
     assert calls["sparse"] == {"topk_length_is_set": True, "value_dim": 4}
 
 
-def test_glm5_lite_model_exports_hf_style_state_names():
-    from megatron.lite.model.glm5.config import Glm5Config
-    from megatron.lite.model.glm5.lite.model import Glm5ForCausalLM
+def test_deepseek_v31_lite_model_exports_hf_style_state_names():
+    from megatron.lite.model.deepseek_v31.config import DeepSeekV31Config
+    from megatron.lite.model.deepseek_v31.lite.model import DeepSeekV31ForCausalLM
 
-    model = Glm5ForCausalLM(Glm5Config(**_tiny_config_kwargs()))
+    model = DeepSeekV31ForCausalLM(DeepSeekV31Config(**_tiny_config_kwargs()))
     keys = set(model.state_dict())
 
     assert "model.embed_tokens.weight" in keys
@@ -329,21 +350,21 @@ def test_glm5_lite_model_exports_hf_style_state_names():
     assert "lm_head.weight" in keys
 
 
-def test_glm5_checkpoint_exports_and_saves_hf_style_weights(tmp_path):
+def test_deepseek_v31_checkpoint_exports_and_saves_hf_style_weights(tmp_path):
     import torch
     from safetensors import safe_open
 
-    from megatron.lite.model.glm5.config import Glm5Config
-    from megatron.lite.model.glm5.lite.checkpoint import (
+    from megatron.lite.model.deepseek_v31.config import DeepSeekV31Config
+    from megatron.lite.model.deepseek_v31.lite.checkpoint import (
         export_hf_weights,
         save_hf_weights,
         save_weights,
     )
-    from megatron.lite.model.glm5.lite.model import Glm5ForCausalLM
+    from megatron.lite.model.deepseek_v31.lite.model import DeepSeekV31ForCausalLM
     from megatron.lite.primitive.parallel import ParallelState
 
-    cfg = Glm5Config(**_tiny_config_kwargs())
-    model = Glm5ForCausalLM(cfg)
+    cfg = DeepSeekV31Config(**_tiny_config_kwargs())
+    model = DeepSeekV31ForCausalLM(cfg)
     ps = ParallelState()
     model.model.layers[1].mlp.gate.e_score_correction_bias.copy_(torch.tensor([0.25, -0.5, 1.0]))
 
@@ -372,8 +393,8 @@ def test_glm5_checkpoint_exports_and_saves_hf_style_weights(tmp_path):
             state["model.layers.1.mlp.gate.e_score_correction_bias"],
         )
 
-    loaded = Glm5ForCausalLM(cfg)
-    from megatron.lite.model.glm5.lite.checkpoint import load_hf_weights
+    loaded = DeepSeekV31ForCausalLM(cfg)
+    from megatron.lite.model.deepseek_v31.lite.checkpoint import load_hf_weights
 
     load_hf_weights(loaded, str(hf_dir), cfg, ps)
     assert torch.equal(
@@ -391,7 +412,7 @@ def test_glm5_checkpoint_exports_and_saves_hf_style_weights(tmp_path):
         }
         assert floating_dtypes == {torch.bfloat16}
 
-    loaded_bf16 = Glm5ForCausalLM(cfg)
+    loaded_bf16 = DeepSeekV31ForCausalLM(cfg)
     load_hf_weights(loaded_bf16, str(hf_bf16_dir), cfg, ps)
     assert torch.equal(
         loaded_bf16.state_dict()["model.layers.1.mlp.experts.2.up_proj.weight"],
@@ -407,18 +428,18 @@ def test_glm5_checkpoint_exports_and_saves_hf_style_weights(tmp_path):
         )
 
 
-def test_glm5_checkpoint_exports_and_loads_mtp_layers(tmp_path):
+def test_deepseek_v31_checkpoint_exports_and_loads_mtp_layers(tmp_path):
     import torch
 
-    from megatron.lite.model.glm5.config import Glm5Config
-    from megatron.lite.model.glm5.lite.checkpoint import export_hf_weights, load_hf_weights
-    from megatron.lite.model.glm5.lite.model import Glm5ForCausalLM
+    from megatron.lite.model.deepseek_v31.config import DeepSeekV31Config
+    from megatron.lite.model.deepseek_v31.lite.checkpoint import export_hf_weights, load_hf_weights
+    from megatron.lite.model.deepseek_v31.lite.model import DeepSeekV31ForCausalLM
     from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
     from megatron.lite.primitive.parallel import ParallelState
 
-    cfg = Glm5Config(**_tiny_config_kwargs(), num_nextn_predict_layers=1)
+    cfg = DeepSeekV31Config(**_tiny_config_kwargs(), num_nextn_predict_layers=1)
     ps = ParallelState()
-    model = Glm5ForCausalLM(cfg, ps=ps, mtp_enable=True)
+    model = DeepSeekV31ForCausalLM(cfg, ps=ps, mtp_enable=True)
     state = model.state_dict()
 
     assert "model.mtp.layers.0.eh_proj.weight" in state
@@ -433,7 +454,7 @@ def test_glm5_checkpoint_exports_and_loads_mtp_layers(tmp_path):
     assert "model.layers.2.mlp.gate.weight" in exported
 
     save_safetensors(exported, str(tmp_path))
-    loaded = Glm5ForCausalLM(cfg, ps=ps, mtp_enable=True)
+    loaded = DeepSeekV31ForCausalLM(cfg, ps=ps, mtp_enable=True)
     load_hf_weights(loaded, str(tmp_path), cfg, ps)
     assert torch.equal(
         loaded.state_dict()["model.mtp.layers.0.eh_proj.weight"],
@@ -441,16 +462,19 @@ def test_glm5_checkpoint_exports_and_loads_mtp_layers(tmp_path):
     )
 
 
-def test_glm5_initialize_weights_resets_all_router_weights():
+def test_deepseek_v31_initialize_weights_resets_all_router_weights():
     import torch
 
-    from megatron.lite.model.glm5.config import Glm5Config
-    from megatron.lite.model.glm5.lite.model import Glm5ForCausalLM, Glm5Router
-
-    model = Glm5ForCausalLM(
-        Glm5Config(**_tiny_config_kwargs(), num_nextn_predict_layers=1), mtp_enable=True
+    from megatron.lite.model.deepseek_v31.config import DeepSeekV31Config
+    from megatron.lite.model.deepseek_v31.lite.model import (
+        DeepSeekV31ForCausalLM,
+        DeepSeekV31Router,
     )
-    routers = [module for module in model.modules() if isinstance(module, Glm5Router)]
+
+    model = DeepSeekV31ForCausalLM(
+        DeepSeekV31Config(**_tiny_config_kwargs(), num_nextn_predict_layers=1), mtp_enable=True
+    )
+    routers = [module for module in model.modules() if isinstance(module, DeepSeekV31Router)]
     assert len(routers) == 2
     for router in routers:
         router.weight.data.fill_(float("nan"))
@@ -465,10 +489,10 @@ def test_glm5_initialize_weights_resets_all_router_weights():
         )
 
 
-def test_glm5_hf_loader_resolves_grouped_expert_tensors():
+def test_deepseek_v31_hf_loader_resolves_grouped_expert_tensors():
     import torch
 
-    from megatron.lite.model.glm5.lite.checkpoint import _resolve_hf_tensor
+    from megatron.lite.model.deepseek_v31.lite.checkpoint import _resolve_hf_tensor
 
     class FakeReader:
         def __init__(self, tensors):
@@ -530,10 +554,10 @@ def test_glm5_hf_loader_resolves_grouped_expert_tensors():
     )
 
 
-def test_glm5_hf_loader_slices_full_expert_tensors_for_proxy_targets():
+def test_deepseek_v31_hf_loader_slices_full_expert_tensors_for_proxy_targets():
     import torch
 
-    from megatron.lite.model.glm5.lite.checkpoint import _slice_to_target_shape
+    from megatron.lite.model.deepseek_v31.lite.checkpoint import _slice_to_target_shape
 
     source = torch.arange(256 * 8, dtype=torch.float32).reshape(256, 8)
     target = torch.empty(4, 8)
@@ -544,15 +568,15 @@ def test_glm5_hf_loader_slices_full_expert_tensors_for_proxy_targets():
     assert torch.equal(_slice_to_target_shape(source3d, target3d), source3d[:4])
 
 
-def test_glm5_hf_loader_resolves_packed_experts_from_single_safetensor(tmp_path):
+def test_deepseek_v31_hf_loader_resolves_packed_experts_from_single_safetensor(tmp_path):
     import torch
 
-    from megatron.lite.model.glm5.config import Glm5Config
-    from megatron.lite.model.glm5.lite.checkpoint import _resolve_named_parameter_tensor
+    from megatron.lite.model.deepseek_v31.config import DeepSeekV31Config
+    from megatron.lite.model.deepseek_v31.lite.checkpoint import _resolve_named_parameter_tensor
     from megatron.lite.primitive.ckpt.hf_weights import SafeTensorReader, save_safetensors
     from megatron.lite.primitive.parallel import ParallelState
 
-    cfg = Glm5Config(**_tiny_config_kwargs())
+    cfg = DeepSeekV31Config(**_tiny_config_kwargs())
     gate_up = torch.arange(3 * 12 * 16, dtype=torch.float32).reshape(3, 12, 16)
     down = torch.arange(3 * 16 * 6, dtype=torch.float32).reshape(3, 16, 6)
     save_safetensors(
@@ -583,10 +607,10 @@ def test_glm5_hf_loader_resolves_packed_experts_from_single_safetensor(tmp_path)
     assert torch.equal(resolved_down, down)
 
 
-def test_glm5_protocol_allows_cp_only_parallel_scope():
+def test_deepseek_v31_protocol_allows_cp_only_parallel_scope():
     import pytest
 
-    from megatron.lite.model.glm5.lite.protocol import _validate_parallel_scope
+    from megatron.lite.model.deepseek_v31.lite.protocol import _validate_parallel_scope
     from megatron.lite.runtime.contracts import ParallelConfig
 
     _validate_parallel_scope(ParallelConfig(tp=1, ep=1, etp=1, cp=2, pp=1, vpp=1))
@@ -596,38 +620,38 @@ def test_glm5_protocol_allows_cp_only_parallel_scope():
         _validate_parallel_scope(ParallelConfig(tp=1, ep=1, etp=1, cp=1, pp=2, vpp=2))
 
 
-def test_glm5_impl_config_accepts_runtime_mtp_fields():
-    from megatron.lite.model.glm5.config import Glm5Config
-    from megatron.lite.model.glm5.lite.protocol import ImplConfig
+def test_deepseek_v31_impl_config_accepts_runtime_mtp_fields():
+    from megatron.lite.model.deepseek_v31.config import DeepSeekV31Config
+    from megatron.lite.model.deepseek_v31.lite.protocol import ImplConfig
 
-    cfg = Glm5Config(**_tiny_config_kwargs(), num_nextn_predict_layers=1)
+    cfg = DeepSeekV31Config(**_tiny_config_kwargs(), num_nextn_predict_layers=1)
 
     assert ImplConfig(mtp_enable=False, mtp_enable_train=False).mtp_enable is False
     assert ImplConfig(mtp_enable=True, mtp_enable_train=True).mtp_enable_train is True
     assert cfg.num_nextn_predict_layers == 1
 
 
-def test_glm5_pipeline_layer_split_handles_non_divisible_pp():
+def test_deepseek_v31_pipeline_layer_split_handles_non_divisible_pp():
     from types import SimpleNamespace
 
-    from megatron.lite.model.glm5.lite.model import _build_glm5_pipeline_layers
+    from megatron.lite.model.deepseek_v31.lite.model import _build_deepseek_v31_pipeline_layers
 
     def split_for_rank(pp_rank):
         ps = SimpleNamespace(pp_size=4, pp_rank=pp_rank)
-        return _build_glm5_pipeline_layers(5, ps)
+        return _build_deepseek_v31_pipeline_layers(5, ps)
 
     assert [split_for_rank(rank) for rank in range(4)] == [[], [0, 1], [2, 3], [4]]
 
 
-def test_glm5_protocol_uses_mlite_optimizer_api():
-    from megatron.lite.model.glm5.lite.protocol import ImplConfig
+def test_deepseek_v31_protocol_uses_mlite_optimizer_api():
+    from megatron.lite.model.deepseek_v31.lite.protocol import ImplConfig
 
     protocol_path = (
         Path(__file__).resolve().parents[3]
         / "megatron"
         / "lite"
         / "model"
-        / "glm5"
+        / "deepseek_v31"
         / "lite"
         / "protocol.py"
     )
@@ -637,11 +661,11 @@ def test_glm5_protocol_uses_mlite_optimizer_api():
     assert "build_dist_opt_training_optimizer" in protocol_text
 
 
-def test_glm5_lite_tiny_cpu_forward_backward(monkeypatch):
+def test_deepseek_v31_lite_tiny_cpu_forward_backward(monkeypatch):
     import torch
 
-    from megatron.lite.model.glm5.config import Glm5Config
-    from megatron.lite.model.glm5.lite.model import Glm5ForCausalLM
+    from megatron.lite.model.deepseek_v31.config import DeepSeekV31Config
+    from megatron.lite.model.deepseek_v31.lite.model import DeepSeekV31ForCausalLM
     from megatron.lite.primitive.attention import dsa
 
     def fake_fused_indexer_sparse_attn(
@@ -687,7 +711,7 @@ def test_glm5_lite_tiny_cpu_forward_backward(monkeypatch):
     )
 
     torch.manual_seed(1234)
-    model = Glm5ForCausalLM(Glm5Config(**_tiny_config_kwargs()))
+    model = DeepSeekV31ForCausalLM(DeepSeekV31Config(**_tiny_config_kwargs()))
     input_ids = torch.randint(0, model.config.vocab_size, (2, 5))
     labels = torch.randint(0, model.config.vocab_size, (2, 5))
 
@@ -701,8 +725,8 @@ def test_glm5_lite_tiny_cpu_forward_backward(monkeypatch):
     )
     assert torch.isfinite(grad_norm)
 
-    mtp_model = Glm5ForCausalLM(
-        Glm5Config(**_tiny_config_kwargs(), num_nextn_predict_layers=1),
+    mtp_model = DeepSeekV31ForCausalLM(
+        DeepSeekV31Config(**_tiny_config_kwargs(), num_nextn_predict_layers=1),
         mtp_enable=True,
         mtp_enable_train=True,
     )


### PR DESCRIPTION
## Summary
- Rename the native `glm5` Lite model package, registry entry, protocol, checkpoint loader, and tests to `deepseek_v31`.
- Model DeepSeek V3.1 variants through explicit per-variant config entries. The current GLM-5-compatible config is selected by the exact `variant="glm-5"` field; there is no variant alias normalization or text/path-based inference.
- Keep DSA under `primitive/kernels` / `primitive/attention` and preserve capability-aware H100/Blackwell routing. The H100 route handles the current cudnn DSA overlay where FlashMLA does not export `flash_mla_sparse_fwd`, while SM100 keeps the cudnn/FlashMLA route.
- Update smoke/static tests and registry metadata so no `glm5` model path remains.

## Validation
- `python -m black --line-length 100 --check experimental/lite/megatron/lite/model/deepseek_v31 experimental/lite/megatron/lite/model/registry.py experimental/lite/megatron/lite/primitive/attention/dsa.py experimental/lite/megatron/lite/primitive/kernels/dsa_kernels.py experimental/lite/tests/smoke/model/test_deepseek_v31_lite_fsdp2_smoke.py experimental/lite/tests/unit/model/test_deepseek_v31_lite_cp_smoke.py experimental/lite/tests/unit/model/test_deepseek_v31_lite_static.py` -> passed.
- `PYTHONPATH=experimental/lite python -m pytest experimental/lite/tests/unit/model/test_deepseek_v31_lite_static.py -q` -> 22 passed.
- `PYTHONPATH=experimental/lite python -m py_compile ...deepseek_v31... registry.py dsa.py dsa_kernels.py tests` -> passed.
- `git diff --check` -> passed.
- Static grep: no `glm5`, `Glm5`, `GLM5`, `GLM-5`, `megatron.lite.model.glm5`, or `dsv3` remains in `experimental/lite` / `README.md`.
- Static grep: no variant alias helpers, normalizers, text/path inference helpers, `_name_or_path`, or `architectures` remain in the DeepSeek V3.1 config/registry/static tests.
- Static grep: no `megatron.core` imports in touched DeepSeek V3.1 model/attention/kernel paths.
- Slurm job 12800800: 2-GPU torchrun DeepSeek V3.1 HF parity + packed THD+CP smoke, COMPLETED 0:0, non-skip, 2 passed / 3 deselected. Logits max_abs_diff=4.882812e-03; THD+CP marker `NON_SKIP_DEEPSEEK_V31_THD_CP_SMOKE_PASSED` with world_size=2.