### PR TITLE
Fix GLM5 packed THD context parallel runtime

### DIFF
--- a/experimental/lite/examples/verl/verl_mlite/compat.py
+++ b/experimental/lite/examples/verl/verl_mlite/compat.py
@@ -77,11 +77,6 @@ def _load_verl_file(relative_path: str, module_name: str):
 
 def load_verl_engine_api():
     try:
-        from verl.workers.engine.base import BaseEngine, BaseEngineCtx, EngineRegistry
-        from verl.workers.engine.utils import postprocess_batch_func, prepare_micro_batches
-    except ModuleNotFoundError as exc:
-        if exc.name != "megatron.core":
-            raise
         base = _load_verl_file("workers/engine/base.py", "_verl_mlite_verl_engine_base")
         utils = _load_verl_file("workers/engine/utils.py", "_verl_mlite_verl_engine_utils")
         BaseEngine = base.BaseEngine
@@ -89,5 +84,8 @@ def load_verl_engine_api():
         EngineRegistry = base.EngineRegistry
         postprocess_batch_func = utils.postprocess_batch_func
         prepare_micro_batches = utils.prepare_micro_batches
+    except (FileNotFoundError, ModuleNotFoundError, ImportError):
+        from verl.workers.engine.base import BaseEngine, BaseEngineCtx, EngineRegistry
+        from verl.workers.engine.utils import postprocess_batch_func, prepare_micro_batches
 
     return BaseEngine, BaseEngineCtx, EngineRegistry, postprocess_batch_func, prepare_micro_batches

--- a/experimental/lite/megatron/lite/model/glm5/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/protocol.py
@@ -20,6 +20,7 @@ from megatron.lite.model.glm5.lite.checkpoint import (
 from megatron.lite.model.glm5.lite.checkpoint import load_hf_weights as _load_hf_weights_impl
 from megatron.lite.primitive.bundle import ModelBundle
 from megatron.lite.primitive.parallel import ParallelState, init_parallel
+from megatron.lite.primitive.parallel.thd import prepare_packed_thd_kwargs_for_context_parallel
 from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec, wrap_checkpoint
 from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
 
@@ -75,6 +76,7 @@ def _forward_step(model: nn.Module, batch: dict) -> dict:
     for key in ("loss_mask", "temperature", "calculate_entropy"):
         if key in batch:
             kwargs[key] = batch[key]
+    prepare_packed_thd_kwargs_for_context_parallel(model, kwargs)
     return model(**kwargs)
 
 

--- a/experimental/lite/megatron/lite/runtime/megatron_utils.py
+++ b/experimental/lite/megatron/lite/runtime/megatron_utils.py
@@ -82,12 +82,21 @@ def register_training_hooks(model_list: list, optimizer) -> None:
 # ======================================================================
 
 
+def _is_megatron_ddp(model_chunk: Any) -> bool:
+    cls = model_chunk.__class__
+    return (
+        cls.__name__ == "DistributedDataParallel"
+        and cls.__module__.startswith("megatron.core.")
+        and hasattr(model_chunk, "buffers")
+        and hasattr(model_chunk, "expert_parallel_buffers")
+        and hasattr(model_chunk, "module")
+    )
+
+
 def offload_model_to_cpu(model_list: list) -> None:
     """Offload DDP model to CPU via buffer-resize (zero-copy on GPU side)."""
-    from megatron.core.distributed import DistributedDataParallel as DDP
-
     for model_chunk in model_list:
-        if isinstance(model_chunk, DDP):
+        if _is_megatron_ddp(model_chunk):
             all_buffers = [model_chunk.buffers, model_chunk.expert_parallel_buffers]
             for buffers in all_buffers:
                 for buffer in buffers:
@@ -109,10 +118,8 @@ def offload_model_to_cpu(model_list: list) -> None:
 
 def load_model_to_gpu(model_list: list, load_grad: bool = True) -> None:
     """Load DDP model back to GPU from pinned CPU copy."""
-    from megatron.core.distributed import DistributedDataParallel as DDP
-
     for model_chunk in model_list:
-        if isinstance(model_chunk, DDP):
+        if _is_megatron_ddp(model_chunk):
             all_buffers = [model_chunk.buffers, model_chunk.expert_parallel_buffers]
             for buffers in all_buffers:
                 for buffer in buffers:

--- a/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
+++ b/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -181,6 +182,26 @@ def test_runtime_to_prefers_optimizer_specific_offload_hooks():
     runtime.to(handle, "cuda", model=False, optimizer=True, grad=False)
 
     assert optimizer.calls == ["offload", "load"]
+
+
+def test_native_model_move_helpers_do_not_require_megatron_core(monkeypatch):
+    from megatron.lite.runtime.megatron_utils import load_model_to_gpu, offload_model_to_cpu
+
+    class NativeModel:
+        def __init__(self):
+            self.calls: list[str] = []
+
+        def to(self, device):
+            self.calls.append(device)
+            return self
+
+    monkeypatch.setitem(sys.modules, "megatron.core", None)
+    model = NativeModel()
+
+    offload_model_to_cpu([model])
+    load_model_to_gpu([model])
+
+    assert model.calls == ["cpu", "cuda"]
 
 
 def test_model_handle_dp_defaults():

--- a/experimental/lite/tests/unit/verl/test_mlite_engine_cp_smoke.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_engine_cp_smoke.py
@@ -71,6 +71,39 @@ def _write_kimi_config(path) -> None:
     (path / "config.json").write_text(json.dumps(config), encoding="utf-8")
 
 
+def _write_glm5_config(path) -> None:
+    config = {
+        "model_type": "glm_moe_dsa",
+        "num_hidden_layers": 2,
+        "hidden_size": 128,
+        "num_attention_heads": 64,
+        "num_key_value_heads": 64,
+        "head_dim": 256,
+        "vocab_size": 32,
+        "max_position_embeddings": 64,
+        "initializer_range": 0.002,
+        "q_lora_rank": 16,
+        "kv_lora_rank": 512,
+        "qk_head_dim": 256,
+        "qk_nope_head_dim": 192,
+        "qk_rope_head_dim": 64,
+        "v_head_dim": 256,
+        "index_head_dim": 128,
+        "index_n_heads": 32,
+        "index_topk": 512,
+        "intermediate_size": 20,
+        "moe_intermediate_size": 6,
+        "first_k_dense_replace": 1,
+        "n_routed_experts": 3,
+        "n_shared_experts": 1,
+        "num_experts_per_tok": 3,
+        "num_nextn_predict_layers": 1,
+        "mlp_layer_types": ["dense", "dense"],
+    }
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+
+
 def _optimizer_config() -> SimpleNamespace:
     return SimpleNamespace(
         optimizer="adam",
@@ -94,7 +127,16 @@ def _optimizer_config() -> SimpleNamespace:
     )
 
 
-def test_mlite_engine_runtime_thd_cp_uses_plain_verl_packed_seq_params(tmp_path):
+@pytest.mark.parametrize(
+    ("model_name", "model_type", "write_config", "vocab_size", "lengths"),
+    [
+        ("kimi_k2", "deepseek_v3", _write_kimi_config, 128, [5, 7, 9]),
+        ("glm5", "glm_moe_dsa", _write_glm5_config, 32, [16, 20, 24]),
+    ],
+)
+def test_mlite_engine_runtime_thd_cp_uses_plain_verl_packed_seq_params(
+    tmp_path, model_name, model_type, write_config, vocab_size, lengths
+):
     torch = pytest.importorskip("torch")
     dist = pytest.importorskip("torch.distributed")
     TensorDict = pytest.importorskip("tensordict").TensorDict
@@ -107,17 +149,17 @@ def test_mlite_engine_runtime_thd_cp_uses_plain_verl_packed_seq_params(tmp_path)
     device = _init_dist_or_skip()
     world = dist.get_world_size()
     rank = dist.get_rank()
-    hf_path = tmp_path / "tiny-kimi"
-    _write_kimi_config(hf_path)
+    hf_path = tmp_path / f"tiny-{model_name}"
+    write_config(hf_path)
 
     engine = MegatronLiteEngine(
         model_config=SimpleNamespace(
             local_path=str(hf_path),
-            hf_config={"model_type": "deepseek_v3"},
+            hf_config={"model_type": model_type},
             mtp=None,
         ),
         engine_config=MegatronLiteEngineConfig(
-            model_name="kimi_k2",
+            model_name=model_name,
             cp=world,
             impl_cfg={"use_thd": True, "optimizer": None, "deterministic": False},
             use_fused_kernels=False,
@@ -136,9 +178,11 @@ def test_mlite_engine_runtime_thd_cp_uses_plain_verl_packed_seq_params(tmp_path)
     engine.initialize()
     engine.optimizer_zero_grad()
 
-    lengths = [5, 7, 9]
     input_ids = torch.nested.as_nested_tensor(
-        [torch.randint(0, 128, (length,), device=device, dtype=torch.long) for length in lengths],
+        [
+            torch.randint(0, vocab_size, (length,), device=device, dtype=torch.long)
+            for length in lengths
+        ],
         layout=torch.jagged,
     )
     loss_mask = torch.nested.as_nested_tensor(
@@ -198,6 +242,7 @@ def test_mlite_engine_runtime_thd_cp_uses_plain_verl_packed_seq_params(tmp_path)
     if rank == 0:
         print(
             "NON_SKIP_VERL_MLITE_RUNTIME_THD_CP_SMOKE_PASSED "
+            f"model={model_name} "
             f"world_size={world} lengths={lengths} "
             f"loss={float(result.model_output.loss.detach().item()):.6e} "
             f"grad_norm_sum={float(grad_norm.item()):.6e}"


### PR DESCRIPTION
## Summary
- split plain packed THD VERL inputs in the GLM5 protocol before the model enters CP-aware DSA
- extend the VERL MLite THD+CP runtime smoke to cover GLM5
- avoid importing unrelated VERL engine backends and Megatron-Core DDP helpers on native MLite runtime paths

## Root cause
VERL passes full packed THD tensors with `packed_seq_params.local_cp_size=None`. GLM5 did not run the shared packed-THD CP splitter at the protocol boundary, so the DSA module received full packed inputs while its CP path expected local CP shards. The first incorrect step was the protocol/model boundary before DSA gather/reconstruct; the DSA kernel route itself was unchanged.

## Validation
- `python -m compileall -q experimental/lite/examples/verl/verl_mlite/compat.py experimental/lite/megatron/lite/model/glm5/lite/protocol.py experimental/lite/megatron/lite/runtime/megatron_utils.py experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py experimental/lite/tests/unit/verl/test_mlite_engine_cp_smoke.py`
- `python -m pytest experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py experimental/lite/tests/unit/primitive/test_parallel_unit.py experimental/lite/tests/unit/model/test_glm5_lite_static.py experimental/lite/tests/unit/verl/test_mlite_engine_config.py -q` -> 60 passed
- Slurm `12803994` (`glm5-verl-thd-cp`): rc=0, non-skip, `NON_SKIP_VERL_MLITE_RUNTIME_THD_CP_SMOKE_PASSED model=glm5 world_size=2 lengths=[16, 20, 24] loss=3.499442e+00 grad_norm_sum=2.590740e+01`
- Slurm `12803480` (`glm5-thd-cp-model`): rc=0, non-skip, fused DSA packed THD+CP forward/backward finite