### PR TITLE
MLite layering contract guard + CP-correct bench/runtime data boundary

### DIFF
--- a/experimental/lite/examples/bench/correctness.py
+++ b/experimental/lite/examples/bench/correctness.py
@@ -22,11 +22,12 @@ if str(_EXPERIMENTAL_LITE_ROOT) not in sys.path:
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(1, str(_REPO_ROOT))
 
+from megatron.lite.primitive.deterministic import set_deterministic
+from megatron.lite.runtime import create_runtime
+
 from examples.bench.bench import BenchCliConfig, build_runtime_config, build_session_config
 from examples.bench.results import compare_correctness_artifacts, load_result_artifact
 from examples.bench.session import _make_data_iter
-from megatron.lite.primitive.deterministic import set_deterministic
-from megatron.lite.runtime import create_runtime
 
 
 def _distributed_rank() -> int:
@@ -299,48 +300,15 @@ def _weight_fingerprint(rt, handle) -> dict[str, Any]:
     return result
 
 
-def _batch_without_labels(batch: Any) -> dict[str, Any]:
-    if not isinstance(batch, dict):
-        return {
-            "input_ids": batch["input_ids"],
-            "position_ids": getattr(batch, "position_ids", None),
-            "packed_seq_params": getattr(batch, "packed_seq_params", None),
-        }
-    return {k: v for k, v in batch.items() if k != "labels"}
-
-
 def _forward_logits(rt, handle, batch: Any) -> torch.Tensor | None:
-    sample = _batch_without_labels(batch)
-    if "forward_step" in handle._extras:
-        try:
-            out = handle._model(**sample)
-        except (KeyError, TypeError):
-            out = handle._extras["forward_step"](handle._model, sample)
-        if isinstance(out, dict):
-            logits = out.get("logits")
-            if logits is not None:
-                return logits
-            return out.get("vocab_parallel_logits")
-        return out if isinstance(out, torch.Tensor) else None
-
-    model_list = handle._extras.get("model_list")
-    if model_list:
-        out = model_list[0](
-            input_ids=sample.get("input_ids"),
-            position_ids=sample.get("position_ids"),
-            attention_mask=sample.get("attention_mask"),
-            packed_seq_params=sample.get("packed_seq_params"),
-        )
-        if isinstance(out, tuple):
-            out = out[0]
-        if isinstance(out, dict):
-            logits = out.get("logits")
-            if logits is not None:
-                return logits
-            return out.get("vocab_parallel_logits")
-        return out if isinstance(out, torch.Tensor) else None
-
-    return None
+    result = rt.forward_backward(
+        handle,
+        iter([batch]),
+        loss_fn=None,
+        num_microbatches=1,
+        forward_only=True,
+    )
+    return result.model_output.vocab_parallel_logits
 
 
 def run_backend(

--- a/experimental/lite/examples/bench/session.py
+++ b/experimental/lite/examples/bench/session.py
@@ -10,7 +10,6 @@ from dataclasses import dataclass
 from typing import Any
 
 import torch
-
 from megatron.lite.runtime.backends import Runtime
 from megatron.lite.runtime.contracts.handle import ModelHandle
 
@@ -66,26 +65,33 @@ def _resolve_vocab_size(handle: ModelHandle) -> int:
     return 151936
 
 
+def _infinite_packed_batches(
+    vocab_size: int, seq_len: int, *, device: str, seed: int
+):
+    """Yield raw, model-agnostic :class:`PackedBatch` objects for the bench.
+
+    The bench is the single source of truth for one unpadded packed batch (1-D
+    ``input_ids``/``labels`` plus true per-sequence ``seq_lens``). Padding, CP
+    layout and THD metadata (``packed_seq_params``) are derived by whichever
+    runtime/model consumes the batch at the forward boundary, never baked into
+    bench data — that is what keeps the mlite-vs-bridge comparison fair.
+    """
+    from megatron.lite.runtime.contracts.data import PackedBatch
+
+    g = torch.Generator(device=device).manual_seed(seed)
+    seq_lens = torch.tensor([seq_len], dtype=torch.int64, device=device)
+    while True:
+        yield PackedBatch(
+            input_ids=torch.randint(0, vocab_size, (seq_len,), device=device, generator=g),
+            labels=torch.randint(0, vocab_size, (seq_len,), device=device, generator=g),
+            seq_lens=seq_lens.clone(),
+        )
+
+
 def _make_data_iter(handle: ModelHandle, cfg: PretrainSessionConfig):
     data_seed = cfg.seed if cfg.same_data_across_dp else cfg.seed + handle.dp_rank
     vocab_size = _resolve_vocab_size(handle)
-
-    if cfg.use_thd:
-        from megatron.lite.primitive.data import infinite_batches_thd
-
-        ps = handle._parallel_state
-        return infinite_batches_thd(
-            vocab_size,
-            cfg.seq_len,
-            cp_size=getattr(ps, "cp_size", 1),
-            cp_rank=getattr(ps, "cp_rank", 0),
-            device=cfg.device,
-            seed=data_seed,
-        )
-
-    from megatron.lite.primitive.data import infinite_batches
-
-    return infinite_batches(vocab_size, cfg.seq_len, device=cfg.device, seed=data_seed)
+    return _infinite_packed_batches(vocab_size, cfg.seq_len, device=cfg.device, seed=data_seed)
 
 
 def _calc_tflops_per_gpu(

--- a/experimental/lite/megatron/lite/runtime/backends/bridge/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/bridge/runtime.py
@@ -11,11 +11,10 @@ from typing import Any
 
 import torch
 import torch.distributed as dist
-
 from megatron.lite.primitive.optimizers.megatron_wrap import build_dist_opt_optimizer_config
 from megatron.lite.runtime.backends import Runtime as RuntimeBase
 from megatron.lite.runtime.backends.bridge.config import BridgeConfig
-from megatron.lite.runtime.contracts.data import Batch, ForwardResult, ModelOutputs
+from megatron.lite.runtime.contracts.data import Batch, ForwardResult, ModelOutputs, PackedBatch
 from megatron.lite.runtime.contracts.handle import ModelHandle
 from megatron.lite.runtime.megatron_utils import (
     build_sharded_state_dict,
@@ -496,6 +495,88 @@ def _as_data_iter(data: Any):
     return iter([data])
 
 
+# MLITE_LAYERING_ALLOW_BRIDGE_FORWARD_METADATA_BEGIN
+def _nested_from_packed(tensor: torch.Tensor | None, seq_lens: torch.Tensor):
+    """Split a 1-D packed (true, unpadded) tensor into a jagged nested tensor."""
+    if tensor is None:
+        return None
+    flat = tensor.reshape(-1)
+    pieces = []
+    offset = 0
+    for length_t in seq_lens.tolist():
+        length = int(length_t)
+        pieces.append(flat.narrow(0, offset, length))
+        offset += length
+    if offset != flat.numel():
+        raise ValueError(
+            f"PackedBatch sizes sum to {offset}, tensor has {flat.numel()} tokens."
+        )
+    return torch.nested.as_nested_tensor(pieces, layout=torch.jagged)
+
+
+def _bridge_forward_kwargs_from_packed_batch(
+    batch: PackedBatch,
+    *,
+    tp_size: int = 1,
+    cp_size: int = 1,
+    cp_rank: int = 0,
+    cp_group: Any = None,
+) -> dict[str, Any]:
+    """Render transient Megatron-Core THD kwargs for BridgeRuntime.forward_step only.
+
+    Reuses the same canonical packing the native lite protocols use
+    (:func:`pack_nested_thd` + :func:`prepare_packed_thd_for_context_parallel`):
+    each sequence is padded to the TP/CP zigzag alignment, ``labels`` are rolled
+    one position left, and for ``cp_size > 1`` the token rows / labels / loss
+    mask / position ids are zigzag-split to this CP rank while ``packed_seq_params``
+    keeps full ``cu_seqlens`` plus CP metadata. Identical layout on both backends
+    keeps the mlite-vs-bridge comparison fair and CP-correct.
+    """
+    from megatron.lite.primitive.parallel.thd import (
+        pack_nested_thd,
+        prepare_packed_thd_for_context_parallel,
+    )
+
+    seq_lens = batch.seq_lens
+    has_loss_mask = batch.loss_mask is not None
+    packed = pack_nested_thd(
+        _nested_from_packed(batch.input_ids, seq_lens),
+        tp_size=tp_size,
+        cp_size=cp_size,
+        cp_rank=cp_rank,
+        cp_group=cp_group if cp_size > 1 else None,
+        split_cp=False,
+        labels=_nested_from_packed(batch.labels, seq_lens),
+        roll_labels=batch.labels is not None,
+        loss_mask=_nested_from_packed(batch.loss_mask, seq_lens) if has_loss_mask else None,
+        roll_loss_mask=has_loss_mask,
+    )
+    sample: dict[str, Any] = {
+        "input_ids": packed.input_ids,
+        "labels": packed.labels,
+        "position_ids": packed.position_ids,
+        "packed_seq_params": packed.packed_seq_params,
+    }
+    if packed.loss_mask is not None:
+        sample["loss_mask"] = packed.loss_mask
+
+    if cp_size > 1:
+        tensor_keys = ("input_ids", "labels", "loss_mask", "position_ids")
+        psp, tensors = prepare_packed_thd_for_context_parallel(
+            sample["packed_seq_params"],
+            tuple(sample.get(key) for key in tensor_keys),
+            cp_size=cp_size,
+            cp_rank=cp_rank,
+            cp_group=cp_group,
+        )
+        sample["packed_seq_params"] = psp
+        for key, tensor in zip(tensor_keys, tensors, strict=True):
+            if tensor is not None or key in sample:
+                sample[key] = tensor
+    return sample
+# MLITE_LAYERING_ALLOW_BRIDGE_FORWARD_METADATA_END
+
+
 class BridgeRuntime(RuntimeBase):
     """Megatron-Bridge training backend using Megatron-Core optimizer state."""
 
@@ -602,19 +683,40 @@ class BridgeRuntime(RuntimeBase):
         model_list = handle._extras["model_list"]
         data_iter = _as_data_iter(data)
         last_loss: list[float | None] = [None]
+        last_output: list[torch.Tensor | None] = [None]
+
+        # CP geometry for the transient PackedBatch -> THD kwargs rendering below.
+        cp_size = mpu.get_context_parallel_world_size()
+        cp_kwargs = {
+            "tp_size": mpu.get_tensor_model_parallel_world_size(),
+            "cp_size": cp_size,
+            "cp_rank": mpu.get_context_parallel_rank(),
+            "cp_group": mpu.get_context_parallel_group() if cp_size > 1 else None,
+        }
 
         def _fwd_step(data_iterator, model):
+            # MLITE_LAYERING_ALLOW_BRIDGE_FORWARD_METADATA_BEGIN
             sample = next(data_iterator)
-            if isinstance(sample, Batch):
+            owns_transient_metadata = False
+            if isinstance(sample, PackedBatch):
+                sample = _bridge_forward_kwargs_from_packed_batch(sample, **cp_kwargs)
+                owns_transient_metadata = True
+            elif isinstance(sample, Batch):
                 sample = {
                     "input_ids": sample["input_ids"],
                     "labels": sample["labels"],
-                    "position_ids": getattr(sample, "position_ids", None),
                 }
             if not isinstance(sample, dict):
                 raise TypeError(
                     f"BridgeRuntime expected dict or Batch data, got {type(sample).__name__}."
                 )
+            if not owns_transient_metadata:
+                leaked = {"packed_seq_params", "position_ids"}.intersection(sample)
+                if leaked:
+                    raise ValueError(
+                        "BridgeRuntime data must not carry model-internal keys "
+                        f"{sorted(leaked)}; pass a raw PackedBatch instead."
+                    )
 
             output_tensor = model(
                 input_ids=sample["input_ids"],
@@ -625,10 +727,17 @@ class BridgeRuntime(RuntimeBase):
             )
             if isinstance(output_tensor, tuple):
                 output_tensor = output_tensor[0]
+            last_output[0] = output_tensor
+            loss_sample = {
+                key: value
+                for key, value in sample.items()
+                if key not in {"packed_seq_params", "position_ids"}
+            }
+            # MLITE_LAYERING_ALLOW_BRIDGE_FORWARD_METADATA_END
 
             def _bridge_loss_fn(output_tensor, non_loss_data=False):
                 if loss_fn is not None:
-                    loss, _metrics = loss_fn({"output_tensor": output_tensor}, sample)
+                    loss, _metrics = loss_fn({"output_tensor": output_tensor}, loss_sample)
                 else:
                     loss = output_tensor.mean()
                 last_loss[0] = float(loss.detach().item())
@@ -666,7 +775,7 @@ class BridgeRuntime(RuntimeBase):
 
         result_loss = torch.tensor(loss_val or 0.0)
         return ForwardResult(
-            model_output=ModelOutputs(loss=result_loss),
+            model_output=ModelOutputs(loss=result_loss, vocab_parallel_logits=last_output[0]),
             metrics={"loss": loss_val if loss_val is not None else 0.0},
         )
 

--- a/experimental/lite/tests/run_layering_contracts.sh
+++ b/experimental/lite/tests/run_layering_contracts.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$REPO_ROOT"
+
+export PYTHONPATH="$REPO_ROOT:$REPO_ROOT/experimental/lite${PYTHONPATH:+:$PYTHONPATH}"
+pytest -q experimental/lite/tests/unit/runtime/test_layering_contracts.py "$@"

--- a/experimental/lite/tests/unit/runtime/test_layering_contracts.py
+++ b/experimental/lite/tests/unit/runtime/test_layering_contracts.py
@@ -1,0 +1,235 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Static layering guards for MLite public data boundaries and imports.
+
+Five layers — bench, verl_mlite, runtime, model, primitive — have directional
+import boundaries (``test_layer_import_boundaries``). On top of that the bench
+and verl connector layers must hand the runtime only a model-agnostic batch:
+``packed_seq_params`` / ``position_ids`` are *transient* THD metadata that may be
+materialised only at the immediate forward boundary, inside the explicitly marked
+allow range in the bridge runtime.
+
+The guard enforces the contract; it does not police prose. Substring scans ignore
+string/comment content (so a docstring may still document a dependency), and the
+import denylist honours :data:`IMPORT_ALLOWLIST` for vetted, optional cross-layer
+imports whose reason is recorded inline.
+"""
+
+from __future__ import annotations
+
+import ast
+import io
+import tokenize
+from collections.abc import Iterable
+from pathlib import Path
+
+LITE_ROOT = Path(__file__).resolve().parents[3]
+BENCH_ROOT = LITE_ROOT / "examples" / "bench"
+VERL_MLITE_ROOT = LITE_ROOT / "examples" / "verl" / "verl_mlite"
+RUNTIME_ROOT = LITE_ROOT / "megatron" / "lite" / "runtime"
+MODEL_ROOT = LITE_ROOT / "megatron" / "lite" / "model"
+PRIMITIVE_ROOT = LITE_ROOT / "megatron" / "lite" / "primitive"
+BRIDGE_RUNTIME = RUNTIME_ROOT / "backends" / "bridge" / "runtime.py"
+
+ALLOW_BEGIN = "MLITE_LAYERING_ALLOW_BRIDGE_FORWARD_METADATA_BEGIN"
+ALLOW_END = "MLITE_LAYERING_ALLOW_BRIDGE_FORWARD_METADATA_END"
+LAYER_ROOTS = {
+    "bench": BENCH_ROOT,
+    "verl_mlite": VERL_MLITE_ROOT,
+    "runtime": RUNTIME_ROOT,
+    "model": MODEL_ROOT,
+    "primitive": PRIMITIVE_ROOT,
+}
+MODEL_PACKAGE_PREFIXES = (
+    "megatron.lite.model.deepseek_v4",
+    "megatron.lite.model.glm5",
+    "megatron.lite.model.kimi_k2",
+    "megatron.lite.model.qwen3_5",
+    "megatron.lite.model.qwen3_moe",
+)
+MODEL_NAME_TERMS = {"deepseek_v4", "glm5", "kimi_k2", "qwen3", "qwen3_5", "qwen3_moe"}
+DENIED_IMPORT_PREFIXES = {
+    "bench": ("examples.verl", "verl", "verl_mlite", "megatron.lite.model"),
+    "verl_mlite": ("examples.bench", *MODEL_PACKAGE_PREFIXES),
+    "runtime": ("examples", "verl", "verl_mlite", *MODEL_PACKAGE_PREFIXES),
+    "model": ("examples", "verl", "verl_mlite", "megatron.lite.runtime.backends"),
+    "primitive": (
+        "examples",
+        "verl",
+        "verl_mlite",
+        "megatron.lite.model",
+        "megatron.lite.runtime.backends",
+        "megatron.lite.runtime.megatron_utils",
+    ),
+}
+
+# Vetted cross-layer imports that override the denylist. Each entry is a single
+# file -> {allowed module prefix: reason}. Use this ONLY for a sanctioned,
+# self-contained optional dependency — never to paper over a structural leak.
+IMPORT_ALLOWLIST: dict[str, dict[str, str]] = {
+    # The primitive linear-cross-entropy op uses VERL's Triton-backed fused kernel
+    # as an optional CUDA fast path and falls back to the local torch implementation
+    # when the kernel (or verl) is not importable. It is a legitimate optional
+    # dependency on a single leaf op, not a connector back-edge, so it overrides the
+    # primitive `verl` denylist.
+    "megatron/lite/primitive/ops/linear_cross_entropy.py": {
+        "verl.utils.kernel.linear_cross_entropy": (
+            "optional VERL fused linear-cross-entropy kernel fast-path with local fallback"
+        ),
+    },
+}
+
+
+def _python_files(root: Path) -> list[Path]:
+    return sorted(path for path in root.rglob("*.py") if path.is_file())
+
+
+def _matches_prefix(module: str, prefix: str) -> bool:
+    return module == prefix or module.startswith(prefix + ".")
+
+
+def _allowlisted_import(rel_path: str, module: str) -> bool:
+    for allowed in IMPORT_ALLOWLIST.get(rel_path, {}):
+        if _matches_prefix(module, allowed):
+            return True
+    return False
+
+
+def _imported_modules(path: Path) -> list[tuple[int, str]]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imports: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.extend((node.lineno, alias.name) for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            imports.append((node.lineno, node.module))
+    return imports
+
+
+def _code_lines(path: Path) -> list[str]:
+    """Return source lines with string/comment spans blanked out.
+
+    The contract guard targets executable references, not documentation: a
+    docstring or comment may legitimately mention ``packed_seq_params`` or a model
+    name to explain provenance. Blanking string/comment tokens keeps those out of
+    the substring scan while preserving exact line numbers. Falls back to raw lines
+    if the file does not tokenize (fail toward flagging, never toward hiding).
+    """
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    blanked = [list(line) for line in lines]
+    masked_types = {tokenize.STRING, tokenize.COMMENT}
+    fstring_middle = getattr(tokenize, "FSTRING_MIDDLE", None)
+    if fstring_middle is not None:
+        masked_types.add(fstring_middle)
+    try:
+        tokens = list(tokenize.generate_tokens(io.StringIO(text).readline))
+    except (tokenize.TokenError, IndentationError, SyntaxError):
+        return lines
+    for tok in tokens:
+        if tok.type not in masked_types:
+            continue
+        (srow, scol), (erow, ecol) = tok.start, tok.end
+        for row in range(srow, erow + 1):
+            chars = blanked[row - 1]
+            start = scol if row == srow else 0
+            end = ecol if row == erow else len(chars)
+            for col in range(start, min(end, len(chars))):
+                chars[col] = " "
+    return ["".join(chars) for chars in blanked]
+
+
+def _allow_ranges(path: Path) -> list[range]:
+    if path != BRIDGE_RUNTIME:
+        return []
+
+    ranges: list[range] = []
+    start: int | None = None
+    for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if ALLOW_BEGIN in line:
+            if start is not None:
+                raise AssertionError(f"nested allow range in {path}")
+            start = lineno
+        elif ALLOW_END in line:
+            if start is None:
+                raise AssertionError(f"unmatched allow range end in {path}:{lineno}")
+            ranges.append(range(start, lineno + 1))
+            start = None
+    if start is not None:
+        raise AssertionError(f"unclosed allow range in {path}")
+    return ranges
+
+
+def _violations(paths: Iterable[Path], denied_terms: set[str]) -> list[str]:
+    found: list[str] = []
+    for path in paths:
+        ranges = _allow_ranges(path)
+        for lineno, line in enumerate(_code_lines(path), start=1):
+            if any(lineno in allowed for allowed in ranges):
+                continue
+            for term in sorted(denied_terms):
+                if term in line:
+                    rel = path.relative_to(LITE_ROOT)
+                    found.append(f"{rel}:{lineno}: {term}")
+    return found
+
+
+def _import_violations(layer: str) -> list[str]:
+    denied = DENIED_IMPORT_PREFIXES[layer]
+    found: list[str] = []
+    for path in _python_files(LAYER_ROOTS[layer]):
+        rel = path.relative_to(LITE_ROOT).as_posix()
+        for lineno, module in _imported_modules(path):
+            if _allowlisted_import(rel, module):
+                continue
+            for prefix in denied:
+                if _matches_prefix(module, prefix):
+                    found.append(f"{rel}:{lineno}: {module} matches denied {prefix}")
+    return found
+
+
+def test_layer_import_boundaries() -> None:
+    violations = []
+    for layer in LAYER_ROOTS:
+        violations.extend(_import_violations(layer))
+    assert violations == []
+
+
+def test_import_allowlist_entries_are_live() -> None:
+    """Each allowlisted import must still exist — stop the allowlist from rotting."""
+    stale: list[str] = []
+    for rel_path, allowed in IMPORT_ALLOWLIST.items():
+        path = LITE_ROOT / rel_path
+        if not path.is_file():
+            stale.append(f"{rel_path}: file missing")
+            continue
+        modules = {module for _, module in _imported_modules(path)}
+        for allowed_module in allowed:
+            if not any(_matches_prefix(module, allowed_module) for module in modules):
+                stale.append(f"{rel_path}: no import matches allowlisted {allowed_module}")
+    assert stale == []
+
+
+def test_bench_layer_does_not_see_model_internal_batch_fields() -> None:
+    violations = _violations(
+        _python_files(BENCH_ROOT),
+        {"packed_seq_params", "position_ids", "to_bridge_dict"},
+    )
+    assert violations == []
+
+
+def test_verl_mlite_layer_does_not_see_model_internal_batch_fields() -> None:
+    violations = _violations(
+        _python_files(VERL_MLITE_ROOT),
+        {"packed_seq_params", "position_ids", "to_bridge_dict"},
+    )
+    assert violations == []
+
+
+def test_runtime_packed_seq_params_is_bridge_forward_transient_only() -> None:
+    violations = _violations(_python_files(RUNTIME_ROOT), {"packed_seq_params"})
+    assert violations == []
+
+
+def test_primitive_layer_is_model_name_agnostic() -> None:
+    violations = _violations(_python_files(PRIMITIVE_ROOT), MODEL_NAME_TERMS)
+    assert violations == []

--- a/experimental/lite/tests/unit/runtime/test_packed_batch_bridge.py
+++ b/experimental/lite/tests/unit/runtime/test_packed_batch_bridge.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Unit coverage for the PackedBatch -> bridge forward metadata boundary.
+
+CPU-only. The public ``PackedBatch`` contract stays free of transient THD metadata
+(``packed_seq_params``); the bridge runtime renders Megatron-Core THD kwargs at the
+forward call using the same canonical packing as the native lite protocols, so the
+mlite-vs-bridge comparison is fair and context-parallel-correct.
+"""
+
+from __future__ import annotations
+
+import torch
+from examples.bench.session import _infinite_packed_batches
+from megatron.lite.primitive.parallel.thd import (
+    pack_nested_thd,
+    reconstruct_packed_from_cp_parts,
+)
+from megatron.lite.runtime.backends.bridge.runtime import (
+    _bridge_forward_kwargs_from_packed_batch,
+    _nested_from_packed,
+)
+from megatron.lite.runtime.contracts.data import Batch, PackedBatch
+
+
+def _packed_batch() -> PackedBatch:
+    return PackedBatch(
+        input_ids=torch.arange(8, dtype=torch.long),
+        labels=torch.arange(100, 108, dtype=torch.long),
+        seq_lens=torch.tensor([3, 5], dtype=torch.int64),
+    )
+
+
+def test_packed_batch_contract_carries_no_transient_thd_metadata() -> None:
+    # The contract keeps its optional extensibility slots (position_ids for custom
+    # layouts, routed_experts for router replay, extras for multimodal) but must
+    # never carry the transient Megatron-Core THD metadata the bridge derives.
+    batch = _packed_batch()
+    assert hasattr(batch, "position_ids")
+    assert hasattr(batch, "routed_experts")
+    assert hasattr(batch, "extras")
+    assert batch.position_ids is None
+    assert not hasattr(batch, "packed_seq_params")
+    assert not hasattr(batch, "to_bridge_dict")
+
+
+def test_packed_batch_is_batch_subclass() -> None:
+    assert issubclass(PackedBatch, Batch)
+
+
+def test_bridge_forward_kwargs_are_transient_bridge_metadata() -> None:
+    batch = _packed_batch()
+    out = _bridge_forward_kwargs_from_packed_batch(batch)
+
+    assert set(out) == {"input_ids", "labels", "position_ids", "packed_seq_params"}
+    assert out["input_ids"].shape == (1, 8)
+    assert out["labels"].shape == (1, 8)
+    assert out["position_ids"].shape == (1, 8)
+    # tp=cp=1 -> no padding, input ids unchanged.
+    assert torch.equal(out["input_ids"].reshape(-1), batch.input_ids)
+    # Labels are rolled one position left per sequence (last token zeroed), exactly
+    # like the native pack_thd_forward_kwargs path, so both backends train on the
+    # same shifted targets.
+    assert torch.equal(
+        out["labels"].reshape(-1),
+        torch.tensor([101, 102, 0, 104, 105, 106, 107, 0]),
+    )
+    assert torch.equal(
+        out["position_ids"].reshape(-1),
+        torch.tensor([0, 1, 2, 0, 1, 2, 3, 4]),
+    )
+
+    psp = out["packed_seq_params"]
+    assert psp.qkv_format == "thd"
+    assert torch.equal(psp.cu_seqlens_q, torch.tensor([0, 3, 8], dtype=torch.int32))
+    assert psp.max_seqlen_q == 5
+
+
+def test_bridge_forward_kwargs_carry_loss_mask_only_inside_bridge() -> None:
+    batch = _packed_batch()
+    batch.loss_mask = torch.tensor([1, 1, 0, 1, 1, 1, 0, 1], dtype=torch.long)
+    out = _bridge_forward_kwargs_from_packed_batch(batch)
+    assert "loss_mask" in out
+    # loss_mask is rolled with the labels so it masks the shifted targets.
+    assert torch.equal(
+        out["loss_mask"].reshape(-1),
+        torch.tensor([1, 0, 0, 1, 1, 0, 1, 0]),
+    )
+
+
+def test_bridge_forward_kwargs_are_context_parallel_correct() -> None:
+    # cp_size=2 must pad to the zigzag (2*cp) alignment, keep full cu_seqlens, and
+    # hand each rank only its half of the tokens — the exact behaviour the previous
+    # hand-rolled implementation lacked.
+    batch = _packed_batch()
+    seq_lens = batch.seq_lens
+
+    # Full CP-aligned reference (padded but not yet CP-split).
+    ref = pack_nested_thd(
+        _nested_from_packed(batch.input_ids, seq_lens),
+        tp_size=1,
+        cp_size=2,
+        cp_rank=0,
+        split_cp=False,
+    )
+    full_padded = int(ref.cu_seqlens_padded[-1].item())
+    assert full_padded == 12  # [3->4, 5->8] padded to 2*cp alignment
+
+    rank0 = _bridge_forward_kwargs_from_packed_batch(batch, cp_size=2, cp_rank=0)
+    rank1 = _bridge_forward_kwargs_from_packed_batch(batch, cp_size=2, cp_rank=1)
+
+    for local in (rank0, rank1):
+        assert local["input_ids"].shape == (1, full_padded // 2)
+        assert local["position_ids"].shape == (1, full_padded // 2)
+        psp = local["packed_seq_params"]
+        # cu_seqlens stays full (CP-aligned), not the unpadded [0, 3, 8].
+        assert torch.equal(psp.cu_seqlens_q, ref.cu_seqlens_padded)
+        assert int(getattr(psp, "local_cp_size", 1)) == 2
+
+    # The two rank-local zigzag shards reconstruct the full padded sequence.
+    recon = reconstruct_packed_from_cp_parts(
+        [rank0["input_ids"][0], rank1["input_ids"][0]],
+        cu_seqlens_padded=ref.cu_seqlens_padded,
+        cp_size=2,
+        dim=0,
+    )
+    assert torch.equal(recon, ref.input_ids[0])
+
+
+def test_infinite_packed_batches_shape_and_determinism() -> None:
+    gen_a = _infinite_packed_batches(vocab_size=32, seq_len=6, device="cpu", seed=7)
+    gen_b = _infinite_packed_batches(vocab_size=32, seq_len=6, device="cpu", seed=7)
+
+    a = next(gen_a)
+    b = next(gen_b)
+    assert isinstance(a, PackedBatch)
+    assert a.input_ids.shape == (6,)
+    assert a.labels.shape == (6,)
+    assert torch.equal(a.seq_lens, torch.tensor([6], dtype=torch.int64))
+    # No transient THD metadata baked into bench data.
+    assert a.position_ids is None
+    assert torch.equal(a.input_ids, b.input_ids)
+    assert torch.equal(a.labels, b.labels)


### PR DESCRIPTION
## MLite layering contract guard + CP-correct bench/runtime data boundary

Executable layered-architecture contract for MLite, plus the bench/runtime data-boundary cleanup it requires — done carefully to enforce the contract **without breaking functionality**.

### Layering contract guard (mlite unit tests)
`tests/unit/runtime/test_layering_contracts.py` (via `tests/run_layering_contracts.sh`): dependency-direction + per-layer symbol denylist across `verl_mlite / runtime / model / primitive / bench`.
- `packed_seq_params` is **transient** — created/destroyed only inside the bridge runtime `forward_step` compute region; not a persistent field in `verl_mlite` / general `runtime` / `bench`, nor in the data contract.
- Legitimate exceptions are explicitly allowlisted with rationale (e.g. the `linear_cross_entropy` op legitimately imports an op from `verl` — allowlisted, not flagged).

### bench/runtime data boundary (CP-correct)
- bench no longer sees `packed_seq_params`; it consumes a model-agnostic `PackedBatch`.
- The bridge runtime forward path now **correctly supports context parallel (CP)** when constructing/consuming the transient `packed_seq_params`.
- The `PackedBatch` data contract is left intact — `routed_experts` / `extras` (needed for router replay + multimodal) are preserved.

### Validation
`run_layering_contracts` + `test_packed_batch_bridge` + runtime/bench unit tests pass on CPU; compileall + diff-check clean.

Note: this supersedes the earlier layering-guard attempt (the one that over-reached into the data contract); that earlier PR can be closed in favor of this. The model-agnostic `PackedBatch` boundary here is a prerequisite for the save/load/export smoke coverage (a follow-on PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
