### PR TITLE
Rename glm5->deepseek_v3_2 and kimi_k2->deepseek_v3 to real arch names

### DIFF
--- a/experimental/lite/megatron/lite/model/deepseek_v3/__init__.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v3/__init__.py
@@ -1,2 +1,2 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-"""Kimi K2 lite native sub-package."""
+"""DeepSeek-V3 model package."""

--- a/experimental/lite/megatron/lite/model/deepseek_v3/config.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v3/config.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-"""Kimi K2 / DeepSeekV3-style model configuration."""
+"""DeepSeek-V3 / DeepSeekV3-style model configuration."""
 
 from __future__ import annotations
 
@@ -47,8 +47,8 @@ _HF_FIELDS = frozenset(
 
 
 @dataclass
-class KimiK2Config:
-    """Pure architecture parameters for Kimi K2 Instruct."""
+class DeepseekV3Config:
+    """Pure architecture parameters for DeepSeek-V3 Instruct."""
 
     num_hidden_layers: int = 61
     hidden_size: int = 7168
@@ -145,18 +145,18 @@ class KimiK2Config:
         _check(0 <= self.first_k_dense_replace <= self.num_hidden_layers, "bad dense prefix")
         _check(self.num_nextn_predict_layers >= 0, "num_nextn_predict_layers must be >= 0")
         if errors:
-            raise ValueError("Invalid KimiK2Config:\n  " + "\n  ".join(errors))
+            raise ValueError("Invalid DeepseekV3Config:\n  " + "\n  ".join(errors))
 
     @classmethod
-    def from_hf(cls, path: str, **overrides) -> KimiK2Config:
+    def from_hf(cls, path: str, **overrides) -> DeepseekV3Config:
         return cls._from_hf_dict(load_hf_config_dict(path), **overrides)
 
     @classmethod
-    def from_hf_config(cls, hf_config, **overrides) -> KimiK2Config:
+    def from_hf_config(cls, hf_config, **overrides) -> DeepseekV3Config:
         return cls._from_hf_dict(hf_config.to_dict(), **overrides)
 
     @classmethod
-    def _from_hf_dict(cls, hf: dict, **overrides) -> KimiK2Config:
+    def _from_hf_dict(cls, hf: dict, **overrides) -> DeepseekV3Config:
         if "text_config" in hf and isinstance(hf["text_config"], dict):
             hf = hf["text_config"]
         kwargs = {k: v for k, v in hf.items() if k in _HF_FIELDS}
@@ -172,4 +172,4 @@ class KimiK2Config:
         return (layer_idx - self.first_k_dense_replace) % freq == 0
 
 
-__all__ = ["KimiK2Config"]
+__all__ = ["DeepseekV3Config"]

--- a/experimental/lite/megatron/lite/model/deepseek_v3/lite/__init__.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v3/lite/__init__.py
@@ -1,2 +1,2 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-"""Kimi K2 model package."""
+"""DeepSeek-V3 lite native sub-package."""

--- a/experimental/lite/megatron/lite/model/deepseek_v3/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v3/lite/checkpoint.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-"""Kimi K2 lite native checkpoint mapping."""
+"""DeepSeek-V3 lite native checkpoint mapping."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ import torch.distributed as dist
 import torch.nn as nn
 from torch.distributed.tensor import Replicate, Shard
 
-from megatron.lite.model.kimi_k2.config import KimiK2Config
+from megatron.lite.model.deepseek_v3.config import DeepseekV3Config
 from megatron.lite.primitive.ckpt.hf_weights import (
     SafeTensorReader,
     _cast_export_tensor,
@@ -135,7 +135,7 @@ def _text_prefix(reader: SafeTensorReader) -> str:
     for prefix in ("model", "language_model.model", "model.language_model"):
         if _has(reader, f"{prefix}.embed_tokens.weight"):
             return prefix
-    raise KeyError("Could not find Kimi K2 text model prefix in HF checkpoint.")
+    raise KeyError("Could not find DeepSeek-V3 text model prefix in HF checkpoint.")
 
 
 def _lm_head_name(reader: SafeTensorReader, text_prefix: str) -> str:
@@ -147,11 +147,11 @@ def _lm_head_name(reader: SafeTensorReader, text_prefix: str) -> str:
     for name in candidates:
         if _has(reader, name):
             return name
-    raise KeyError("Could not find Kimi K2 lm_head.weight in HF checkpoint.")
+    raise KeyError("Could not find DeepSeek-V3 lm_head.weight in HF checkpoint.")
 
 
 def _load_vocab(
-    reader: SafeTensorReader, name: str, cfg: KimiK2Config, ps: ParallelState
+    reader: SafeTensorReader, name: str, cfg: DeepseekV3Config, ps: ParallelState
 ) -> torch.Tensor:
     from megatron.lite.primitive.parallel import pad_vocab_for_tp
 
@@ -273,7 +273,7 @@ def _load_experts(
     *,
     local_prefix: str,
     hf_mlp_prefix: str,
-    cfg: KimiK2Config,
+    cfg: DeepseekV3Config,
     ps: ParallelState,
     reader: SafeTensorReader,
 ) -> None:
@@ -310,7 +310,7 @@ def _copy_loaded_state(model: nn.Module, loaded: dict[str, torch.Tensor]) -> Non
         if actual is not None:
             resolved[actual] = tensor
         else:
-            log_rank0(f"WARNING: kimi_k2 checkpoint tensor has no target param: {name}")
+            log_rank0(f"WARNING: deepseek_v3 checkpoint tensor has no target param: {name}")
 
     for name, target in model.named_parameters():
         if name not in resolved:
@@ -326,10 +326,10 @@ def _copy_loaded_state(model: nn.Module, loaded: dict[str, torch.Tensor]) -> Non
         target.data.copy_(tensor.to(dtype=target.dtype) if target.is_floating_point() else tensor)
 
 
-class KimiK2WeightSpec:
-    """Export Kimi K2 lite weights to HF DeepSeekV3/Kimi-style names."""
+class DeepseekV3WeightSpec:
+    """Export DeepSeek-V3 lite weights to HF DeepSeekV3/DeepSeek-V3-style names."""
 
-    def __init__(self, config: KimiK2Config):
+    def __init__(self, config: DeepseekV3Config):
         self.config = config
 
     @property
@@ -485,7 +485,9 @@ class KimiK2WeightSpec:
         return f"{prefix}.weight{local_idx}"
 
 
-def load_hf_weights(model: nn.Module, path: str, config: KimiK2Config, ps: ParallelState) -> None:
+def load_hf_weights(
+    model: nn.Module, path: str, config: DeepseekV3Config, ps: ParallelState
+) -> None:
     base_model = unwrap_model(model)
     reader = SafeTensorReader(path)
     out: dict[str, torch.Tensor] = {}
@@ -613,10 +615,10 @@ def load_hf_weights(model: nn.Module, path: str, config: KimiK2Config, ps: Paral
     _copy_loaded_state(base_model, out)
 
 
-def export_hf_weights(model, config: KimiK2Config, ps: ParallelState, **kwargs):
+def export_hf_weights(model, config: DeepseekV3Config, ps: ParallelState, **kwargs):
     from megatron.lite.primitive.ckpt.hf_weights import export_hf_weights as _export
 
-    spec = KimiK2WeightSpec(config)
+    spec = DeepseekV3WeightSpec(config)
     rank0_only = bool(kwargs.get("rank0_only", False))
     export_dtype = _resolve_export_dtype(kwargs.get("export_dtype"))
     yield from _export(model, spec, ps, vocab_size=config.vocab_size, **kwargs)
@@ -639,7 +641,7 @@ def export_hf_weights(model, config: KimiK2Config, ps: ParallelState, **kwargs):
                 yield hf_name, _cast_export_tensor(hf_tensor, export_dtype)
 
 
-def save_hf_weights(model, path: str, config: KimiK2Config, ps: ParallelState) -> None:
+def save_hf_weights(model, path: str, config: DeepseekV3Config, ps: ParallelState) -> None:
     from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
 
     rank = dist.get_rank() if dist.is_initialized() else 0
@@ -652,7 +654,7 @@ def save_hf_weights(model, path: str, config: KimiK2Config, ps: ParallelState) -
 
 __all__ = [
     "EXPERT_CLASSIFIER",
-    "KimiK2WeightSpec",
+    "DeepseekV3WeightSpec",
     "PLACEMENT_FN",
     "_dequant_int4_weight",
     "_dequant_fp8_weight",

--- a/experimental/lite/megatron/lite/model/deepseek_v3/lite/model.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v3/lite/model.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-"""Kimi K2 lite native model."""
+"""DeepSeek-V3 lite native model."""
 
 from __future__ import annotations
 
@@ -13,7 +13,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import transformer_engine.pytorch as te
 
-from megatron.lite.model.kimi_k2.config import KimiK2Config
+from megatron.lite.model.deepseek_v3.config import DeepseekV3Config
 from megatron.lite.primitive.modules.attention import MultiLatentAttention
 from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
 from megatron.lite.primitive.modules.experts import Experts
@@ -112,12 +112,12 @@ def _topk_routing_supports_groups() -> bool:
     return "num_groups" in params and "group_topk" in params
 
 
-class KimiK2SigmoidTopKRouter(nn.Module):
-    """Kimi K2 sigmoid router with group-limited routing and persistent expert bias."""
+class DeepseekV3SigmoidTopKRouter(nn.Module):
+    """DeepSeek-V3 sigmoid router with group-limited routing and persistent expert bias."""
 
     def __init__(
         self,
-        config: KimiK2Config,
+        config: DeepseekV3Config,
         ps: ParallelState,
         *,
         router_bias_rate: float = 0.0,
@@ -128,7 +128,7 @@ class KimiK2SigmoidTopKRouter(nn.Module):
         super().__init__()
         if router_bias_rate > 0:
             raise NotImplementedError(
-                "Kimi K2 expert-bias EMA update is not implemented in lite yet."
+                "DeepSeek-V3 expert-bias EMA update is not implemented in lite yet."
             )
         self.topk = config.num_experts_per_tok
         self.num_experts = config.n_routed_experts
@@ -213,7 +213,7 @@ class KimiK2SigmoidTopKRouter(nn.Module):
 
 
 class DenseMLP(nn.Module):
-    def __init__(self, config: KimiK2Config, ps: ParallelState):
+    def __init__(self, config: DeepseekV3Config, ps: ParallelState):
         super().__init__()
         self.gate_up = ColumnParallelLinear(
             config.hidden_size,
@@ -230,7 +230,7 @@ class DenseMLP(nn.Module):
 
 
 class SharedExpert(nn.Module):
-    def __init__(self, config: KimiK2Config, ps: ParallelState):
+    def __init__(self, config: DeepseekV3Config, ps: ParallelState):
         super().__init__()
         self.ps = ps
         ffn = config.shared_expert_intermediate_size
@@ -266,7 +266,7 @@ class _LocalLinear(nn.Module):
 class MoELayer(nn.Module):
     def __init__(
         self,
-        config: KimiK2Config,
+        config: DeepseekV3Config,
         ps: ParallelState,
         *,
         use_deepep: bool,
@@ -276,8 +276,8 @@ class MoELayer(nn.Module):
     ):
         super().__init__()
         if fp8:
-            raise NotImplementedError("Kimi K2 lite MoE fp8 training is not implemented yet.")
-        self.router = KimiK2SigmoidTopKRouter(
+            raise NotImplementedError("DeepSeek-V3 lite MoE fp8 training is not implemented yet.")
+        self.router = DeepseekV3SigmoidTopKRouter(
             config,
             ps,
             router_bias_rate=router_bias_rate,
@@ -319,10 +319,10 @@ class MoELayer(nn.Module):
         return output.to(x.dtype)
 
 
-class KimiK2Layer(nn.Module):
+class DeepseekV3Layer(nn.Module):
     def __init__(
         self,
-        config: KimiK2Config,
+        config: DeepseekV3Config,
         ps: ParallelState,
         layer_idx: int,
         *,
@@ -391,10 +391,10 @@ def _roll_mtp_left(
     return rolled, rolled.sum()
 
 
-class KimiK2MTPLayer(nn.Module):
+class DeepseekV3MTPLayer(nn.Module):
     def __init__(
         self,
-        config: KimiK2Config,
+        config: DeepseekV3Config,
         ps: ParallelState,
         layer_idx: int,
         *,
@@ -419,7 +419,7 @@ class KimiK2MTPLayer(nn.Module):
             sp=ps.tp_size > 1,
             gather_output=True,
         )
-        self.transformer_layer = KimiK2Layer(
+        self.transformer_layer = DeepseekV3Layer(
             config,
             ps,
             config.num_hidden_layers + layer_idx,
@@ -463,10 +463,10 @@ class KimiK2MTPLayer(nn.Module):
         return hidden_states, input_ids, position_ids
 
 
-class KimiK2MTPBlock(nn.Module):
+class DeepseekV3MTPBlock(nn.Module):
     def __init__(
         self,
-        config: KimiK2Config,
+        config: DeepseekV3Config,
         ps: ParallelState,
         *,
         embedding: VocabParallelEmbedding,
@@ -484,7 +484,7 @@ class KimiK2MTPBlock(nn.Module):
         layers_to_build = 1 if repeated_layer else self.num_layers
         self.layers = nn.ModuleList(
             [
-                KimiK2MTPLayer(
+                DeepseekV3MTPLayer(
                     config,
                     ps,
                     idx,
@@ -526,7 +526,7 @@ class KimiK2MTPBlock(nn.Module):
 def _temperature_to_float(temperature: float | torch.Tensor) -> float:
     if isinstance(temperature, torch.Tensor):
         if temperature.numel() != 1:
-            raise ValueError("KimiK2Model supports scalar temperature only.")
+            raise ValueError("DeepseekV3Model supports scalar temperature only.")
         return float(temperature.detach().float().item())
     return float(temperature)
 
@@ -553,10 +553,10 @@ def _apply_attention_backend_override(backend: str | None) -> None:
     ) = env
 
 
-class KimiK2Model(nn.Module):
+class DeepseekV3Model(nn.Module):
     def __init__(
         self,
-        config: KimiK2Config,
+        config: DeepseekV3Config,
         train_config,
         ps: ParallelState,
         *,
@@ -596,7 +596,7 @@ class KimiK2Model(nn.Module):
         moe_act_recompute = "moe_act" in recompute_modules and "moe" not in recompute_modules
         self.layers = nn.ModuleList(
             [
-                KimiK2Layer(
+                DeepseekV3Layer(
                     config,
                     ps,
                     idx,
@@ -617,13 +617,13 @@ class KimiK2Model(nn.Module):
             self.head = VocabParallelOutput(config.vocab_size, config.hidden_size, ps)
 
         self.mtp_embed: VocabParallelEmbedding | None = None
-        self.mtp: KimiK2MTPBlock | None = None
+        self.mtp: DeepseekV3MTPBlock | None = None
         if mtp_enable and config.num_nextn_predict_layers > 0 and self.head is not None:
             mtp_embedding = self.embed
             if mtp_embedding is None:
                 mtp_embedding = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
                 self.mtp_embed = mtp_embedding
-            self.mtp = KimiK2MTPBlock(
+            self.mtp = DeepseekV3MTPBlock(
                 config,
                 ps,
                 embedding=mtp_embedding,
@@ -643,7 +643,7 @@ class KimiK2Model(nn.Module):
     def set_input_tensor(self, input_tensor):
         if isinstance(input_tensor, list):
             if len(input_tensor) > 1:
-                raise ValueError("KimiK2Model expects a single pipeline input tensor.")
+                raise ValueError("DeepseekV3Model expects a single pipeline input tensor.")
             input_tensor = input_tensor[0] if input_tensor else None
         self._input_tensor = input_tensor
 
@@ -839,10 +839,10 @@ class KimiK2Model(nn.Module):
 
 __all__ = [
     "DenseMLP",
-    "KimiK2MTPBlock",
-    "KimiK2MTPLayer",
-    "KimiK2Layer",
-    "KimiK2Model",
+    "DeepseekV3MTPBlock",
+    "DeepseekV3MTPLayer",
+    "DeepseekV3Layer",
+    "DeepseekV3Model",
     "MoELayer",
     "MTPLossAutoScaler",
     "MultiLatentAttention",

--- a/experimental/lite/megatron/lite/model/deepseek_v3/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v3/lite/protocol.py
@@ -1,18 +1,5 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-"""GLM-5 (deepseek_v3_2) lite native model protocol for Megatron Lite runtime.
-
-Cloned from ``megatron/lite/model/kimi_k2/lite/protocol.py`` (deepseek_v3) and
-renamed KimiK2 -> Glm5.  The build / optimizer / checkpoint plumbing is
-identical to Kimi; the only adaptations are:
-  * the config type (``Glm5Config``),
-  * the DSA indexer-loss pre-forward hook (``DSAIndexerLossAutoScaler`` in
-    addition to the MoE aux-loss scaler),
-  * the attention ``MODULE_MAP`` entries point at the DSA ``self_attention``
-    instead of MLA, and
-  * a ``_validate_parallel_scope`` gate: GLM-5's DSA attention is NOT
-    tensor-parallel-capable, so TP>1 / ETP>1 raise ``NotImplementedError``.
-    PP / VPP / EP / CP all work (inherited from Kimi).
-"""
+"""DeepSeek-V3 lite impl - native model protocol for Megatron Lite runtime."""
 
 from __future__ import annotations
 
@@ -23,7 +10,7 @@ from typing import Any
 
 import torch
 import torch.nn as nn
-from megatron.lite.model.glm5.config import Glm5Config
+from megatron.lite.model.deepseek_v3.config import DeepseekV3Config
 from megatron.lite.model.protocol_utils import (
     add_cross_entropy_fusion,
     add_loss_context_kwargs,
@@ -43,7 +30,7 @@ def EXPERT_CLASSIFIER(name: str) -> bool:
 
 
 def PLACEMENT_FN(param_name: str) -> list:
-    from megatron.lite.model.glm5.lite.checkpoint import PLACEMENT_FN as placement_fn
+    from megatron.lite.model.deepseek_v3.lite.checkpoint import PLACEMENT_FN as placement_fn
 
     return placement_fn(param_name)
 
@@ -68,18 +55,15 @@ def _moe_module(name: str):
     return getter
 
 
-# GLM-5 ONLY: attention entries point at the DSA wrapper / module instead of
-# Kimi's MLA.  Everything else mirrors Kimi's MODULE_MAP.
 MODULE_MAP = {
-    "core_attn": lambda layer: layer.self_attention.self_attention,
+    "core_attn": lambda layer: layer.self_attention.core_attn,
     "experts": _moe_module("experts"),
     "moe": _maybe("moe"),
     "router": _moe_module("router"),
     "mlp": _maybe("mlp"),
     "mlp_norm": lambda layer: layer.mlp_norm,
-    "attn_proj": lambda layer: layer.self_attention.self_attention.o_proj,
-    "self_attn": lambda layer: layer.self_attention,
-    "dsa": lambda layer: layer.self_attention.self_attention,
+    "attn_proj": lambda layer: layer.self_attention.linear_proj,
+    "mla": lambda layer: layer.self_attention,
 }
 
 
@@ -105,11 +89,11 @@ class ImplConfig:
     mtp_use_repeated_layer: bool | None = None
 
 
-def build_model_config(source: str | Path | dict, **overrides) -> Glm5Config:
+def build_model_config(source: str | Path | dict, **overrides) -> DeepseekV3Config:
     if isinstance(source, dict):
-        cfg = Glm5Config._from_hf_dict(source)
+        cfg = DeepseekV3Config._from_hf_dict(source)
     else:
-        cfg = Glm5Config.from_hf(str(source))
+        cfg = DeepseekV3Config.from_hf(str(source))
     for key, value in overrides.items():
         if hasattr(cfg, key):
             setattr(cfg, key, value)
@@ -128,40 +112,18 @@ def unpack_forward_output(model: nn.Module, batch: PackedBatch, output) -> Any:
 
 
 def _make_aux_loss_hook():
-    # GLM-5 ONLY: also scale the DSA indexer auxiliary loss (Kimi has no indexer).
-    from megatron.lite.primitive.modules.attention.dsa import DSAIndexerLossAutoScaler
     from megatron.lite.primitive.modules.moe import MoEAuxLossAutoScaler
     from megatron.lite.primitive.modules.mtp import MTPLossAutoScaler
 
     def hook(scale: torch.Tensor) -> None:
         MoEAuxLossAutoScaler.set_loss_scale(scale)
         MTPLossAutoScaler.set_loss_scale(scale)
-        DSAIndexerLossAutoScaler.set_loss_scale(scale)
 
     return hook
 
 
-def _validate_parallel_scope(p: ParallelConfig) -> None:
-    """GLM-5 DSA attention is not tensor-parallel-capable (documented TP=1 case).
-
-    PP / VPP / EP / CP are inherited from the Kimi skeleton and work; only
-    TP>1 / ETP>1 are unsupported.
-    """
-    etp = 1 if p.etp is None else p.etp
-    if p.tp > 1:
-        raise NotImplementedError(
-            "GLM-5 native DSA attention does not support tensor parallelism; "
-            f"got tp={p.tp}. Use tp=1 (PP/VPP/EP/CP are supported)."
-        )
-    if etp > 1:
-        raise NotImplementedError(
-            "GLM-5 native DSA attention does not support expert tensor parallelism; "
-            f"got etp={etp}. Use etp=1 (EP is supported)."
-        )
-
-
 def _build_dist_opt_optimizer(
-    chunks, model_cfg: Glm5Config, impl_cfg: ImplConfig, ps: ParallelState
+    chunks, model_cfg: DeepseekV3Config, impl_cfg: ImplConfig, ps: ParallelState
 ):
     from megatron.lite.primitive.optimizers.megatron_wrap import build_dist_opt_training_optimizer
 
@@ -170,19 +132,17 @@ def _build_dist_opt_optimizer(
         model_cfg=model_cfg,
         impl_cfg=impl_cfg,
         ps=ps,
-        model_name="glm5",
+        model_name="deepseek_v3",
         is_expert=is_expert_param,
         deterministic=impl_cfg.deterministic,
     )
 
 
-def build_model(model_cfg: Glm5Config, *, impl_cfg: ImplConfig) -> ModelBundle:
+def build_model(model_cfg: DeepseekV3Config, *, impl_cfg: ImplConfig) -> ModelBundle:
     p = impl_cfg.parallel
-    _validate_parallel_scope(p)
     if impl_cfg.use_deepep and (p.etp is not None and p.etp > 1):
         raise ValueError("use_deepep and etp>1 are mutually exclusive")
     if impl_cfg.router_aux_loss_coef is not None:
-        # GLM-5 has no aux_loss_alpha HF field; honour an explicit override only.
         model_cfg.aux_loss_alpha = impl_cfg.router_aux_loss_coef
     mtp_enable = bool(impl_cfg.mtp_enable)
     mtp_enable_train = mtp_enable and bool(impl_cfg.mtp_enable_train)
@@ -195,7 +155,7 @@ def build_model(model_cfg: Glm5Config, *, impl_cfg: ImplConfig) -> ModelBundle:
     elif hasattr(model_cfg, "num_nextn_predict_layers"):
         model_cfg.num_nextn_predict_layers = 0
 
-    from megatron.lite.model.glm5.lite.model import Glm5Model
+    from megatron.lite.model.deepseek_v3.lite.model import DeepseekV3Model
 
     ps = init_parallel(p)
     recompute_spec = parse_recompute_spec(impl_cfg.recompute)
@@ -223,10 +183,12 @@ def build_model(model_cfg: Glm5Config, *, impl_cfg: ImplConfig) -> ModelBundle:
     )
 
     if vpp is None:
-        chunks = [Glm5Model(model_cfg, train_cfg, ps, **model_kwargs).to(torch.bfloat16).cuda()]
+        chunks = [
+            DeepseekV3Model(model_cfg, train_cfg, ps, **model_kwargs).to(torch.bfloat16).cuda()
+        ]
     else:
         chunks = [
-            Glm5Model(
+            DeepseekV3Model(
                 model_cfg,
                 train_cfg,
                 ps,
@@ -267,7 +229,7 @@ def build_model(model_cfg: Glm5Config, *, impl_cfg: ImplConfig) -> ModelBundle:
         optimizer_backend = "fsdp2"
 
         def _post_model_load_hook():
-            from megatron.lite.model.glm5.lite.model import Glm5Layer
+            from megatron.lite.model.deepseek_v3.lite.model import DeepseekV3Layer
             from megatron.lite.primitive.optimizers.fsdp2 import build_fsdp2_training_optimizer
 
             return {
@@ -275,7 +237,7 @@ def build_model(model_cfg: Glm5Config, *, impl_cfg: ImplConfig) -> ModelBundle:
                     chunks,
                     impl_cfg.optimizer_config,
                     ps,
-                    unit_modules=(Glm5Layer,),
+                    unit_modules=(DeepseekV3Layer,),
                     expert_classifier=is_expert_param,
                     deterministic=impl_cfg.deterministic,
                     vpp=impl_cfg.parallel.vpp,
@@ -285,7 +247,7 @@ def build_model(model_cfg: Glm5Config, *, impl_cfg: ImplConfig) -> ModelBundle:
 
         post_model_load_hook = _post_model_load_hook
     elif impl_cfg.optimizer is not None:
-        raise ValueError(f"Unknown glm5 lite optimizer: {impl_cfg.optimizer!r}.")
+        raise ValueError(f"Unknown deepseek_v3 lite optimizer: {impl_cfg.optimizer!r}.")
 
     return ModelBundle(
         chunks=chunks,
@@ -303,25 +265,19 @@ def build_model(model_cfg: Glm5Config, *, impl_cfg: ImplConfig) -> ModelBundle:
 
 
 def load_hf_weights(
-    chunk: nn.Module, hf_path: str, model_cfg: Glm5Config, ps: ParallelState
+    chunk: nn.Module, hf_path: str, model_cfg: DeepseekV3Config, ps: ParallelState
 ) -> None:
     if not hf_path:
         return
-    from megatron.lite.model.glm5.lite.checkpoint import load_hf_weights as load_impl
+    from megatron.lite.model.deepseek_v3.lite.checkpoint import load_hf_weights as load_impl
 
     load_impl(chunk, hf_path, model_cfg, ps)
 
 
-def export_hf_weights(chunks, model_cfg: Glm5Config, ps: ParallelState, **kwargs):
-    from megatron.lite.model.glm5.lite.checkpoint import export_hf_weights as export_impl
+def export_hf_weights(chunks, model_cfg: DeepseekV3Config, ps: ParallelState, **kwargs):
+    from megatron.lite.model.deepseek_v3.lite.checkpoint import export_hf_weights as export_impl
 
     yield from export_impl(chunks, model_cfg, ps, **kwargs)
-
-
-def save_hf_weights(chunks, path: str, model_cfg: Glm5Config, ps: ParallelState, **kwargs):
-    from megatron.lite.model.glm5.lite.checkpoint import save_hf_weights as save_impl
-
-    save_impl(chunks, path, model_cfg, ps, **kwargs)
 
 
 def vocab_size(model_cfg) -> int | None:
@@ -338,6 +294,5 @@ __all__ = [
     "export_hf_weights",
     "is_expert_param",
     "load_hf_weights",
-    "save_hf_weights",
     "vocab_size",
 ]

--- a/experimental/lite/megatron/lite/model/deepseek_v3_2/__init__.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v3_2/__init__.py
@@ -1,0 +1,5 @@
+"""DeepSeek-V3.2 model family."""
+
+from megatron.lite.model.deepseek_v3_2.config import DeepseekV32Config
+
+__all__ = ["DeepseekV32Config"]

--- a/experimental/lite/megatron/lite/model/deepseek_v3_2/config.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v3_2/config.py
@@ -1,4 +1,4 @@
-"""GLM-5 architecture config."""
+"""DeepSeek-V3.2 architecture config."""
 
 from __future__ import annotations
 
@@ -58,8 +58,8 @@ _HF_FIELDS = frozenset(
 
 
 @dataclass
-class Glm5Config:
-    """Pure GLM-5 MoE + MLA + DSA architecture parameters."""
+class DeepseekV32Config:
+    """Pure DeepSeek-V3.2 MoE + MLA + DSA architecture parameters."""
 
     num_hidden_layers: int = 78
     hidden_size: int = 6144
@@ -142,7 +142,7 @@ class Glm5Config:
         check(self.dsa_indexer_loss_coeff >= 0.0, "dsa_indexer_loss_coeff must be >= 0")
         check(
             self.num_key_value_heads == self.num_attention_heads,
-            "initial GLM5 native path expects MLA heads to be ungrouped",
+            "initial DeepSeek-V3.2 native path expects MLA heads to be ungrouped",
         )
         check(self.vocab_size > 0, "vocab_size must be > 0")
         check(self.num_nextn_predict_layers >= 0, "num_nextn_predict_layers must be >= 0")
@@ -170,7 +170,7 @@ class Glm5Config:
 
         if errors:
             raise ValueError(
-                f"Invalid Glm5Config ({len(errors)} error"
+                f"Invalid DeepseekV32Config ({len(errors)} error"
                 f"{'s' if len(errors) != 1 else ''}):\n  " + "\n  ".join(errors)
             )
 
@@ -178,16 +178,16 @@ class Glm5Config:
         return {f.name: getattr(self, f.name) for f in dc_fields(self)}
 
     @classmethod
-    def from_hf(cls, path_or_name: str, **overrides) -> Glm5Config:
+    def from_hf(cls, path_or_name: str, **overrides) -> DeepseekV32Config:
         return cls._from_hf_dict(load_hf_config_dict(path_or_name), **overrides)
 
     @classmethod
-    def from_hf_config(cls, hf_config, **overrides) -> Glm5Config:
+    def from_hf_config(cls, hf_config, **overrides) -> DeepseekV32Config:
         hf = hf_config.to_dict() if hasattr(hf_config, "to_dict") else vars(hf_config)
         return cls._from_hf_dict(hf, **overrides)
 
     @classmethod
-    def _from_hf_dict(cls, hf: dict[str, Any], **overrides) -> Glm5Config:
+    def _from_hf_dict(cls, hf: dict[str, Any], **overrides) -> DeepseekV32Config:
         kwargs = {
             key: value for key, value in hf.items() if key in _HF_FIELDS and value is not None
         }

--- a/experimental/lite/megatron/lite/model/deepseek_v3_2/lite/__init__.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v3_2/lite/__init__.py
@@ -1,0 +1,5 @@
+"""Native DeepSeek-V3.2 lite implementation."""
+
+from megatron.lite.model.deepseek_v3_2.lite.model import DeepseekV32Model
+
+__all__ = ["DeepseekV32Model"]

--- a/experimental/lite/megatron/lite/model/deepseek_v3_2/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v3_2/lite/checkpoint.py
@@ -1,24 +1,24 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-"""GLM-5 (deepseek_v3_2) lite native checkpoint mapping.
+"""DeepSeek-V3.2 (deepseek_v3_2) lite native checkpoint mapping.
 
-Cloned from ``megatron/lite/model/kimi_k2/lite/checkpoint.py`` (deepseek_v3)
-and renamed KimiK2 -> Glm5.  The MoE / dense-MLP / embed / head / MTP weight
-mapping is structurally identical to Kimi.  The ONLY adaptations are in the
+Cloned from ``megatron/lite/model/deepseek_v3/lite/checkpoint.py`` (deepseek_v3)
+and renamed DeepseekV3 -> DeepseekV32.  The MoE / dense-MLP / embed / head / MTP weight
+mapping is structurally identical to DeepSeek-V3.  The ONLY adaptations are in the
 attention block:
 
-  * GLM-5's attention is the DSA primitive ``DynamicSparseAttention`` (wrapped
-    by ``Glm5DSAAttention``), whose native parameters live under
+  * DeepSeek-V3.2's attention is the DSA primitive ``DynamicSparseAttention`` (wrapped
+    by ``DeepseekV32DSAAttention``), whose native parameters live under
     ``self_attention.self_attention.*`` -- i.e. ``q_a_proj`` / ``q_a_layernorm``
     / ``q_b_proj`` / ``kv_a_proj_with_mqa`` / ``kv_a_layernorm`` / ``kv_b_proj``
     / ``o_proj`` plus the indexer (``indexer.wq_b`` / ``indexer.wk`` /
-    ``indexer.k_norm`` / ``indexer.weights_proj``).  Kimi's MLA names
+    ``indexer.k_norm`` / ``indexer.weights_proj``).  DeepSeek-V3's MLA names
     (``linear_q_down_proj`` etc.) are replaced accordingly.
-  * The HF weight NAMES match GLM-5's HF model: the DSA submodule names map 1:1
+  * The HF weight NAMES match DeepSeek-V3.2's HF model: the DSA submodule names map 1:1
     to ``model.layers.{i}.self_attn.*`` (and ``...self_attn.indexer.*``),
-    preserving the names the previous GLM-5 checkpoint used.
+    preserving the names the previous DeepSeek-V3.2 checkpoint used.
 
-GLM-5 is TP=1 (DSA is not tensor-parallel-capable), so the ``_tp`` helpers are
-no-ops here; they are kept for structural parity with Kimi.
+DeepSeek-V3.2 is TP=1 (DSA is not tensor-parallel-capable), so the ``_tp`` helpers are
+no-ops here; they are kept for structural parity with DeepSeek-V3.
 """
 
 from __future__ import annotations
@@ -28,7 +28,7 @@ import torch.distributed as dist
 import torch.nn as nn
 from torch.distributed.tensor import Replicate, Shard
 
-from megatron.lite.model.glm5.config import Glm5Config
+from megatron.lite.model.deepseek_v3_2.config import DeepseekV32Config
 from megatron.lite.primitive.ckpt.hf_weights import (
     SafeTensorReader,
     _cast_export_tensor,
@@ -54,7 +54,7 @@ def PLACEMENT_FN(param_name: str) -> list:
         return [Replicate(), Replicate(), Replicate(), Replicate()]
     if "eh_proj.linear.weight" in param_name:
         return [Replicate(), Replicate(), Replicate(), Shard(0)]
-    # GLM-5 DSA is TP=1 (no head sharding of attention projections).
+    # DeepSeek-V3.2 DSA is TP=1 (no head sharding of attention projections).
     if "gate_up" in param_name:
         return [Replicate(), Replicate(), Replicate(), Shard(0)]
     if "down" in param_name:
@@ -150,7 +150,7 @@ def _text_prefix(reader: SafeTensorReader) -> str:
     for prefix in ("model", "language_model.model", "model.language_model"):
         if _has(reader, f"{prefix}.embed_tokens.weight"):
             return prefix
-    raise KeyError("Could not find GLM-5 text model prefix in HF checkpoint.")
+    raise KeyError("Could not find DeepSeek-V3.2 text model prefix in HF checkpoint.")
 
 
 def _lm_head_name(reader: SafeTensorReader, text_prefix: str) -> str:
@@ -162,11 +162,11 @@ def _lm_head_name(reader: SafeTensorReader, text_prefix: str) -> str:
     for name in candidates:
         if _has(reader, name):
             return name
-    raise KeyError("Could not find GLM-5 lm_head.weight in HF checkpoint.")
+    raise KeyError("Could not find DeepSeek-V3.2 lm_head.weight in HF checkpoint.")
 
 
 def _load_vocab(
-    reader: SafeTensorReader, name: str, cfg: Glm5Config, ps: ParallelState
+    reader: SafeTensorReader, name: str, cfg: DeepseekV32Config, ps: ParallelState
 ) -> torch.Tensor:
     from megatron.lite.primitive.parallel import pad_vocab_for_tp
 
@@ -186,17 +186,15 @@ def _load_attention(
     reader: SafeTensorReader,
     ps: ParallelState,
 ) -> None:
-    # GLM-5 ONLY: DSA attention.  Native params live under
+    # DeepSeek-V3.2 ONLY: DSA attention.  Native params live under
     # `<local_prefix>.self_attention.self_attention.*` (the wrapper adds one
-    # `self_attention` level around the DSA module).  HF names are GLM-5's
+    # `self_attention` level around the DSA module).  HF names are DeepSeek-V3.2's
     # `<hf_prefix>.{...}` (DSA submodule names map 1:1 to the HF model).
     ap = f"{local_prefix}.self_attention.self_attention"
     out[f"{ap}.q_a_proj.weight"] = _get(reader, f"{hf_prefix}.q_a_proj.weight")
     out[f"{ap}.q_a_layernorm.weight"] = _get(reader, f"{hf_prefix}.q_a_layernorm.weight")
     out[f"{ap}.q_b_proj.weight"] = _get(reader, f"{hf_prefix}.q_b_proj.weight")
-    out[f"{ap}.kv_a_proj_with_mqa.weight"] = _get(
-        reader, f"{hf_prefix}.kv_a_proj_with_mqa.weight"
-    )
+    out[f"{ap}.kv_a_proj_with_mqa.weight"] = _get(reader, f"{hf_prefix}.kv_a_proj_with_mqa.weight")
     out[f"{ap}.kv_a_layernorm.weight"] = _get(reader, f"{hf_prefix}.kv_a_layernorm.weight")
     out[f"{ap}.kv_b_proj.weight"] = _get(reader, f"{hf_prefix}.kv_b_proj.weight")
     out[f"{ap}.o_proj.weight"] = _get(reader, f"{hf_prefix}.o_proj.weight")
@@ -279,7 +277,7 @@ def _load_experts(
     *,
     local_prefix: str,
     hf_mlp_prefix: str,
-    cfg: Glm5Config,
+    cfg: DeepseekV32Config,
     ps: ParallelState,
     reader: SafeTensorReader,
 ) -> None:
@@ -316,7 +314,7 @@ def _copy_loaded_state(model: nn.Module, loaded: dict[str, torch.Tensor]) -> Non
         if actual is not None:
             resolved[actual] = tensor
         else:
-            log_rank0(f"WARNING: glm5 checkpoint tensor has no target param: {name}")
+            log_rank0(f"WARNING: deepseek_v3_2 checkpoint tensor has no target param: {name}")
 
     for name, target in model.named_parameters():
         if name not in resolved:
@@ -332,10 +330,10 @@ def _copy_loaded_state(model: nn.Module, loaded: dict[str, torch.Tensor]) -> Non
         target.data.copy_(tensor.to(dtype=target.dtype) if target.is_floating_point() else tensor)
 
 
-class Glm5WeightSpec:
-    """Export GLM-5 lite weights to HF GLM-5 (deepseek_v3_2) names."""
+class DeepseekV32WeightSpec:
+    """Export DeepSeek-V3.2 lite weights to HF DeepSeek-V3.2 (deepseek_v3_2) names."""
 
-    def __init__(self, config: Glm5Config):
+    def __init__(self, config: DeepseekV32Config):
         self.config = config
 
     @property
@@ -349,7 +347,7 @@ class Glm5WeightSpec:
         del native_name
         return hf_tensors[0]
 
-    # GLM-5 ONLY: DSA attention native suffix -> HF suffix.  The wrapper places
+    # DeepSeek-V3.2 ONLY: DSA attention native suffix -> HF suffix.  The wrapper places
     # the DSA module under `self_attention.self_attention.*`; the HF model uses
     # `self_attn.*` with identical submodule names.
     _ATTN_SUFFIX_MAP: dict[str, str] = {
@@ -409,7 +407,7 @@ class Glm5WeightSpec:
         if suffix == "input_layernorm.weight":
             return [(f"{hp}.input_layernorm.weight", tensor)]
 
-        # GLM-5 ONLY: DSA attention (incl. indexer) maps 1:1 onto self_attn.*.
+        # DeepSeek-V3.2 ONLY: DSA attention (incl. indexer) maps 1:1 onto self_attn.*.
         attn_hf = self._ATTN_SUFFIX_MAP.get(suffix)
         if attn_hf is not None:
             return [(f"{ap}.{attn_hf}", tensor)]
@@ -458,7 +456,7 @@ class Glm5WeightSpec:
         return None
 
     def tp_spec(self, native_name: str) -> tuple[int, int] | None:
-        # GLM-5 is TP=1 (DSA not TP-capable); only EP / ETP shard tensors.
+        # DeepSeek-V3.2 is TP=1 (DSA not TP-capable); only EP / ETP shard tensors.
         if native_name.startswith("mtp.layers.") and ".transformer_layer." in native_name:
             proxy = native_name.replace(".transformer_layer.", ".")
             return self.tp_spec(proxy)
@@ -495,7 +493,9 @@ class Glm5WeightSpec:
         return f"{prefix}.weight{local_idx}"
 
 
-def load_hf_weights(model: nn.Module, path: str, config: Glm5Config, ps: ParallelState) -> None:
+def load_hf_weights(
+    model: nn.Module, path: str, config: DeepseekV32Config, ps: ParallelState
+) -> None:
     base_model = unwrap_model(model)
     reader = SafeTensorReader(path)
     out: dict[str, torch.Tensor] = {}
@@ -623,10 +623,10 @@ def load_hf_weights(model: nn.Module, path: str, config: Glm5Config, ps: Paralle
     _copy_loaded_state(base_model, out)
 
 
-def export_hf_weights(model, config: Glm5Config, ps: ParallelState, **kwargs):
+def export_hf_weights(model, config: DeepseekV32Config, ps: ParallelState, **kwargs):
     from megatron.lite.primitive.ckpt.hf_weights import export_hf_weights as _export
 
-    spec = Glm5WeightSpec(config)
+    spec = DeepseekV32WeightSpec(config)
     rank0_only = bool(kwargs.get("rank0_only", False))
     export_dtype = _resolve_export_dtype(kwargs.get("export_dtype"))
     yield from _export(model, spec, ps, vocab_size=config.vocab_size, **kwargs)
@@ -649,7 +649,9 @@ def export_hf_weights(model, config: Glm5Config, ps: ParallelState, **kwargs):
                 yield hf_name, _cast_export_tensor(hf_tensor, export_dtype)
 
 
-def save_hf_weights(model, path: str, config: Glm5Config, ps: ParallelState, **kwargs) -> None:
+def save_hf_weights(
+    model, path: str, config: DeepseekV32Config, ps: ParallelState, **kwargs
+) -> None:
     from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
 
     rank = dist.get_rank() if dist.is_initialized() else 0
@@ -662,7 +664,7 @@ def save_hf_weights(model, path: str, config: Glm5Config, ps: ParallelState, **k
 
 __all__ = [
     "EXPERT_CLASSIFIER",
-    "Glm5WeightSpec",
+    "DeepseekV32WeightSpec",
     "PLACEMENT_FN",
     "_dequant_int4_weight",
     "_dequant_fp8_weight",

--- a/experimental/lite/megatron/lite/model/deepseek_v3_2/lite/model.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v3_2/lite/model.py
@@ -1,25 +1,25 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-"""GLM-5 (deepseek_v3_2) lite native model.
+"""DeepSeek-V3.2 (deepseek_v3_2) lite native model.
 
-This model is a near-verbatim clone of the Kimi-K2 (deepseek_v3) lite model
-(``megatron/lite/model/kimi_k2/lite/model.py``).  It inherits ALL of Kimi's
+This model is a near-verbatim clone of the DeepSeek-V3 (deepseek_v3) lite model
+(``megatron/lite/model/deepseek_v3/lite/model.py``).  It inherits ALL of DeepSeek-V3's
 Megatron plumbing unchanged: SBHD ``[S, B, H]`` layout, sequence-parallel
 scatter/gather, ``VocabParallelEmbedding`` / ``VocabParallelOutput``,
 ``share_embeddings_and_output_weights``, ``set_input_tensor``,
 ``build_pipeline_chunk_layout``-based pipeline boundaries, MTP, and the
 dist-opt / distckpt integration.
 
-The ONLY functional difference from Kimi is the attention module: where Kimi
-uses ``MultiLatentAttention`` (MLA), GLM-5 uses Dynamic Sparse Attention (DSA).
+The ONLY functional difference from DeepSeek-V3 is the attention module: where DeepSeek-V3
+uses ``MultiLatentAttention`` (MLA), DeepSeek-V3.2 uses Dynamic Sparse Attention (DSA).
 The DSA primitive is hard-wired batch-first ``[B, S, H]`` and expects explicit
 ``cos`` / ``sin`` / ``position_ids`` + ``packed_seq_params``, so it is wrapped
-by ``Glm5DSAAttention`` which transposes ``[S, B, H] -> [B, S, H]`` before DSA
+by ``DeepseekV32DSAAttention`` which transposes ``[S, B, H] -> [B, S, H]`` before DSA
 and back after, and builds the rotary embeddings / position ids locally.  The
-surrounding Kimi skeleton therefore stays byte-for-byte SBHD and untouched.
+surrounding DeepSeek-V3 skeleton therefore stays byte-for-byte SBHD and untouched.
 
-NOTE: DSA is NOT tensor-parallel-capable, so GLM-5 is a documented TP=1 special
+NOTE: DSA is NOT tensor-parallel-capable, so DeepSeek-V3.2 is a documented TP=1 special
 case (the protocol gate raises for TP>1 / ETP>1).  VPP / PP / EP / CP work,
-inherited from Kimi.
+inherited from DeepSeek-V3.
 """
 
 from __future__ import annotations
@@ -34,7 +34,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import transformer_engine.pytorch as te
 
-from megatron.lite.model.glm5.config import Glm5Config
+from megatron.lite.model.deepseek_v3_2.config import DeepseekV32Config
 from megatron.lite.primitive.modules.attention import (
     DynamicSparseAttention,
     build_rotary_embeddings,
@@ -68,12 +68,12 @@ from megatron.lite.primitive.utils.moe import (
     topk_routing_with_score_function,
 )
 
-# -- GLM-5 ONLY: SP-grad parameter suffixes for the DSA attention (Kimi's MLA
+# -- DeepSeek-V3.2 ONLY: SP-grad parameter suffixes for the DSA attention (DeepSeek-V3's MLA
 # suffixes -- linear_q_down_proj / linear_kv_down_proj / *_up_proj.linear.* --
 # are replaced by the DSA module's parameter names).  These tag the
 # layernorm-fronted columns whose grads must be all-reduced across SP ranks.
-# (At GLM-5's enforced TP=1 this list is unused, but is kept structurally so
-# the model stays a faithful Kimi clone.)
+# (At DeepSeek-V3.2's enforced TP=1 this list is unused, but is kept structurally so
+# the model stays a faithful DeepSeek-V3 clone.)
 _SP_GRAD_SUFFIXES: tuple[str, ...] = (
     ".input_layernorm.weight",
     ".self_attention.q_a_proj.weight",
@@ -142,24 +142,24 @@ def _topk_routing_supports_groups() -> bool:
     return "num_groups" in params and "group_topk" in params
 
 
-# -- GLM-5 ONLY: DSA attention wrapper.  Holds ``DynamicSparseAttention`` and
-# adapts it to Kimi's SBHD-in / SBHD-out attention contract.  Everything outside
+# -- DeepSeek-V3.2 ONLY: DSA attention wrapper.  Holds ``DynamicSparseAttention`` and
+# adapts it to DeepSeek-V3's SBHD-in / SBHD-out attention contract.  Everything outside
 # this class (norms, residual, MoE, MTP, embed, head, SP scatter/gather) is
-# identical to Kimi.
-class Glm5DSAAttention(nn.Module):
+# identical to DeepSeek-V3.
+class DeepseekV32DSAAttention(nn.Module):
     """SBHD ``[S, B, H]`` shim around the batch-first DSA primitive.
 
-    Kimi's decoder layer calls ``self.self_attention(x_sbhd, packed_seq_params=)``
+    DeepSeek-V3's decoder layer calls ``self.self_attention(x_sbhd, packed_seq_params=)``
     where ``x_sbhd`` is ``[S, B, H]``.  DSA is hard-wired ``[B, S, H]`` and needs
     explicit ``cos`` / ``sin`` / ``position_ids``.  This wrapper:
       1. transposes ``[S, B, H] -> [B, S, H]``,
       2. builds ``position_ids`` (local sequence) and the rotary ``cos`` / ``sin``,
       3. runs DSA,
       4. transposes the ``[B, S, H]`` output back to ``[S, B, H]``.
-    The Kimi skeleton therefore never observes the batch-first interior.
+    The DeepSeek-V3 skeleton therefore never observes the batch-first interior.
     """
 
-    def __init__(self, config: Glm5Config, ps: ParallelState):
+    def __init__(self, config: DeepseekV32Config, ps: ParallelState):
         super().__init__()
         self.ps = ps
         self.qk_rope_head_dim = config.qk_rope_head_dim
@@ -191,7 +191,7 @@ class Glm5DSAAttention(nn.Module):
         )
 
     def forward(self, x: torch.Tensor, packed_seq_params=None) -> torch.Tensor:
-        # Kimi feeds SBHD [S, B, H]; DSA needs batch-first [B, S, H].
+        # DeepSeek-V3 feeds SBHD [S, B, H]; DSA needs batch-first [B, S, H].
         x_bsh = x.transpose(0, 1).contiguous()
         batch, seq_len, _ = x_bsh.shape
         # Local (this-rank) position ids; DSA reconstructs the full sequence
@@ -215,21 +215,21 @@ class Glm5DSAAttention(nn.Module):
             attention_mask=None,
             packed_seq_params=packed_seq_params,
         )
-        # Back to SBHD [S, B, H] for the Kimi skeleton.
+        # Back to SBHD [S, B, H] for the DeepSeek-V3 skeleton.
         return out_bsh.transpose(0, 1).contiguous()
 
 
-class Glm5SigmoidTopKRouter(nn.Module):
-    """GLM-5 sigmoid router with group-limited routing and persistent expert bias.
+class DeepseekV32SigmoidTopKRouter(nn.Module):
+    """DeepSeek-V3.2 sigmoid router with group-limited routing and persistent expert bias.
 
-    Byte-identical to Kimi's ``KimiK2SigmoidTopKRouter`` except for the config
-    type and that GLM-5 has no ``aux_loss_alpha`` HF field -- the aux coefficient
+    Byte-identical to DeepSeek-V3's ``DeepseekV3SigmoidTopKRouter`` except for the config
+    type and that DeepSeek-V3.2 has no ``aux_loss_alpha`` HF field -- the aux coefficient
     therefore defaults to 0 (aux loss contributes 0).
     """
 
     def __init__(
         self,
-        config: Glm5Config,
+        config: DeepseekV32Config,
         ps: ParallelState,
         *,
         router_bias_rate: float = 0.0,
@@ -240,11 +240,11 @@ class Glm5SigmoidTopKRouter(nn.Module):
         super().__init__()
         if router_bias_rate > 0:
             raise NotImplementedError(
-                "GLM-5 expert-bias EMA update is not implemented in lite yet."
+                "DeepSeek-V3.2 expert-bias EMA update is not implemented in lite yet."
             )
         self.topk = config.num_experts_per_tok
         self.num_experts = config.n_routed_experts
-        # GLM-5 has no aux_loss_alpha HF field; default the coefficient to 0.
+        # DeepSeek-V3.2 has no aux_loss_alpha HF field; default the coefficient to 0.
         self.aux_loss_coeff = getattr(config, "aux_loss_alpha", 0.0)
         self.scaling_factor = config.routed_scaling_factor
         self.num_groups = config.n_group if (config.n_group and config.n_group > 1) else None
@@ -326,7 +326,7 @@ class Glm5SigmoidTopKRouter(nn.Module):
 
 
 class DenseMLP(nn.Module):
-    def __init__(self, config: Glm5Config, ps: ParallelState):
+    def __init__(self, config: DeepseekV32Config, ps: ParallelState):
         super().__init__()
         self.gate_up = ColumnParallelLinear(
             config.hidden_size,
@@ -343,11 +343,11 @@ class DenseMLP(nn.Module):
 
 
 class SharedExpert(nn.Module):
-    def __init__(self, config: Glm5Config, ps: ParallelState):
+    def __init__(self, config: DeepseekV32Config, ps: ParallelState):
         super().__init__()
         self.ps = ps
-        # GLM-5 has no shared_expert_intermediate_size property; compute it from
-        # n_shared_experts * moe_intermediate_size (matches Kimi's property).
+        # DeepSeek-V3.2 has no shared_expert_intermediate_size property; compute it from
+        # n_shared_experts * moe_intermediate_size (matches DeepSeek-V3's property).
         ffn = config.n_shared_experts * config.moe_intermediate_size
         self.gate_up = _LocalLinear(config.hidden_size, ffn * 2 // ps.tp_size)
         self.down = _LocalLinear(ffn // ps.tp_size, config.hidden_size)
@@ -381,7 +381,7 @@ class _LocalLinear(nn.Module):
 class MoELayer(nn.Module):
     def __init__(
         self,
-        config: Glm5Config,
+        config: DeepseekV32Config,
         ps: ParallelState,
         *,
         use_deepep: bool,
@@ -391,8 +391,8 @@ class MoELayer(nn.Module):
     ):
         super().__init__()
         if fp8:
-            raise NotImplementedError("GLM-5 lite MoE fp8 training is not implemented yet.")
-        self.router = Glm5SigmoidTopKRouter(
+            raise NotImplementedError("DeepSeek-V3.2 lite MoE fp8 training is not implemented yet.")
+        self.router = DeepseekV32SigmoidTopKRouter(
             config,
             ps,
             router_bias_rate=router_bias_rate,
@@ -434,10 +434,10 @@ class MoELayer(nn.Module):
         return output.to(x.dtype)
 
 
-class Glm5Layer(nn.Module):
+class DeepseekV32Layer(nn.Module):
     def __init__(
         self,
-        config: Glm5Config,
+        config: DeepseekV32Config,
         ps: ParallelState,
         layer_idx: int,
         *,
@@ -450,11 +450,11 @@ class Glm5Layer(nn.Module):
         super().__init__()
         self.layer_idx = layer_idx
         self.input_layernorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        # GLM-5 ONLY: DSA attention (Kimi builds MultiLatentAttention here).
+        # DeepSeek-V3.2 ONLY: DSA attention (DeepSeek-V3 builds MultiLatentAttention here).
         # The wrapper preserves the SBHD self_attention(x, packed_seq_params=)
-        # contract so this layer's forward stays identical to Kimi's.
+        # contract so this layer's forward stays identical to DeepSeek-V3's.
         del use_thd  # DSA derives its own THD handling from packed_seq_params.
-        self.self_attention = Glm5DSAAttention(config, ps)
+        self.self_attention = DeepseekV32DSAAttention(config, ps)
         if config.is_moe_layer(layer_idx):
             self.mlp_norm: nn.Module | None = te.RMSNorm(
                 config.hidden_size, eps=config.rms_norm_eps
@@ -497,10 +497,10 @@ def _roll_mtp_left(
     return rolled, rolled.sum()
 
 
-class Glm5MTPLayer(nn.Module):
+class DeepseekV32MTPLayer(nn.Module):
     def __init__(
         self,
-        config: Glm5Config,
+        config: DeepseekV32Config,
         ps: ParallelState,
         layer_idx: int,
         *,
@@ -525,7 +525,7 @@ class Glm5MTPLayer(nn.Module):
             sp=ps.tp_size > 1,
             gather_output=True,
         )
-        self.transformer_layer = Glm5Layer(
+        self.transformer_layer = DeepseekV32Layer(
             config,
             ps,
             config.num_hidden_layers + layer_idx,
@@ -569,10 +569,10 @@ class Glm5MTPLayer(nn.Module):
         return hidden_states, input_ids, position_ids
 
 
-class Glm5MTPBlock(nn.Module):
+class DeepseekV32MTPBlock(nn.Module):
     def __init__(
         self,
-        config: Glm5Config,
+        config: DeepseekV32Config,
         ps: ParallelState,
         *,
         embedding: VocabParallelEmbedding,
@@ -590,7 +590,7 @@ class Glm5MTPBlock(nn.Module):
         layers_to_build = 1 if repeated_layer else self.num_layers
         self.layers = nn.ModuleList(
             [
-                Glm5MTPLayer(
+                DeepseekV32MTPLayer(
                     config,
                     ps,
                     idx,
@@ -632,7 +632,7 @@ class Glm5MTPBlock(nn.Module):
 def _temperature_to_float(temperature: float | torch.Tensor) -> float:
     if isinstance(temperature, torch.Tensor):
         if temperature.numel() != 1:
-            raise ValueError("Glm5Model supports scalar temperature only.")
+            raise ValueError("DeepseekV32Model supports scalar temperature only.")
         return float(temperature.detach().float().item())
     return float(temperature)
 
@@ -659,10 +659,10 @@ def _apply_attention_backend_override(backend: str | None) -> None:
     ) = env
 
 
-class Glm5Model(nn.Module):
+class DeepseekV32Model(nn.Module):
     def __init__(
         self,
-        config: Glm5Config,
+        config: DeepseekV32Config,
         train_config,
         ps: ParallelState,
         *,
@@ -691,7 +691,7 @@ class Glm5Model(nn.Module):
         self.layer_indices = layout.layer_indices
         self.pre_process = layout.has_embed
         self.post_process = layout.has_head
-        # GLM-5 does not tie embeddings (no tie_word_embeddings HF field); the
+        # DeepSeek-V3.2 does not tie embeddings (no tie_word_embeddings HF field); the
         # attribute is preserved for the dist-opt / distckpt interface.
         self.share_embeddings_and_output_weights = bool(
             getattr(config, "tie_word_embeddings", False)
@@ -706,7 +706,7 @@ class Glm5Model(nn.Module):
         moe_act_recompute = "moe_act" in recompute_modules and "moe" not in recompute_modules
         self.layers = nn.ModuleList(
             [
-                Glm5Layer(
+                DeepseekV32Layer(
                     config,
                     ps,
                     idx,
@@ -727,13 +727,13 @@ class Glm5Model(nn.Module):
             self.head = VocabParallelOutput(config.vocab_size, config.hidden_size, ps)
 
         self.mtp_embed: VocabParallelEmbedding | None = None
-        self.mtp: Glm5MTPBlock | None = None
+        self.mtp: DeepseekV32MTPBlock | None = None
         if mtp_enable and config.num_nextn_predict_layers > 0 and self.head is not None:
             mtp_embedding = self.embed
             if mtp_embedding is None:
                 mtp_embedding = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
                 self.mtp_embed = mtp_embedding
-            self.mtp = Glm5MTPBlock(
+            self.mtp = DeepseekV32MTPBlock(
                 config,
                 ps,
                 embedding=mtp_embedding,
@@ -753,7 +753,7 @@ class Glm5Model(nn.Module):
     def set_input_tensor(self, input_tensor):
         if isinstance(input_tensor, list):
             if len(input_tensor) > 1:
-                raise ValueError("Glm5Model expects a single pipeline input tensor.")
+                raise ValueError("DeepseekV32Model expects a single pipeline input tensor.")
             input_tensor = input_tensor[0] if input_tensor else None
         self._input_tensor = input_tensor
 
@@ -950,12 +950,12 @@ class Glm5Model(nn.Module):
 __all__ = [
     "DenseMLP",
     "DynamicSparseAttention",
-    "Glm5DSAAttention",
-    "Glm5Layer",
-    "Glm5MTPBlock",
-    "Glm5MTPLayer",
-    "Glm5Model",
-    "Glm5SigmoidTopKRouter",
+    "DeepseekV32DSAAttention",
+    "DeepseekV32Layer",
+    "DeepseekV32MTPBlock",
+    "DeepseekV32MTPLayer",
+    "DeepseekV32Model",
+    "DeepseekV32SigmoidTopKRouter",
     "MoELayer",
     "MTPLossAutoScaler",
     "SharedExpert",

--- a/experimental/lite/megatron/lite/model/deepseek_v3_2/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v3_2/lite/protocol.py
@@ -1,5 +1,18 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-"""Kimi K2 lite impl - native model protocol for Megatron Lite runtime."""
+"""DeepSeek-V3.2 (deepseek_v3_2) lite native model protocol for Megatron Lite runtime.
+
+Cloned from ``megatron/lite/model/deepseek_v3/lite/protocol.py`` (deepseek_v3) and
+renamed DeepseekV3 -> DeepseekV32.  The build / optimizer / checkpoint plumbing is
+identical to DeepSeek-V3; the only adaptations are:
+  * the config type (``DeepseekV32Config``),
+  * the DSA indexer-loss pre-forward hook (``DSAIndexerLossAutoScaler`` in
+    addition to the MoE aux-loss scaler),
+  * the attention ``MODULE_MAP`` entries point at the DSA ``self_attention``
+    instead of MLA, and
+  * a ``_validate_parallel_scope`` gate: DeepSeek-V3.2's DSA attention is NOT
+    tensor-parallel-capable, so TP>1 / ETP>1 raise ``NotImplementedError``.
+    PP / VPP / EP / CP all work (inherited from DeepSeek-V3).
+"""
 
 from __future__ import annotations
 
@@ -10,7 +23,7 @@ from typing import Any
 
 import torch
 import torch.nn as nn
-from megatron.lite.model.kimi_k2.config import KimiK2Config
+from megatron.lite.model.deepseek_v3_2.config import DeepseekV32Config
 from megatron.lite.model.protocol_utils import (
     add_cross_entropy_fusion,
     add_loss_context_kwargs,
@@ -30,7 +43,7 @@ def EXPERT_CLASSIFIER(name: str) -> bool:
 
 
 def PLACEMENT_FN(param_name: str) -> list:
-    from megatron.lite.model.kimi_k2.lite.checkpoint import PLACEMENT_FN as placement_fn
+    from megatron.lite.model.deepseek_v3_2.lite.checkpoint import PLACEMENT_FN as placement_fn
 
     return placement_fn(param_name)
 
@@ -55,15 +68,18 @@ def _moe_module(name: str):
     return getter
 
 
+# DeepSeek-V3.2 ONLY: attention entries point at the DSA wrapper / module instead of
+# DeepSeek-V3's MLA.  Everything else mirrors DeepSeek-V3's MODULE_MAP.
 MODULE_MAP = {
-    "core_attn": lambda layer: layer.self_attention.core_attn,
+    "core_attn": lambda layer: layer.self_attention.self_attention,
     "experts": _moe_module("experts"),
     "moe": _maybe("moe"),
     "router": _moe_module("router"),
     "mlp": _maybe("mlp"),
     "mlp_norm": lambda layer: layer.mlp_norm,
-    "attn_proj": lambda layer: layer.self_attention.linear_proj,
-    "mla": lambda layer: layer.self_attention,
+    "attn_proj": lambda layer: layer.self_attention.self_attention.o_proj,
+    "self_attn": lambda layer: layer.self_attention,
+    "dsa": lambda layer: layer.self_attention.self_attention,
 }
 
 
@@ -89,11 +105,11 @@ class ImplConfig:
     mtp_use_repeated_layer: bool | None = None
 
 
-def build_model_config(source: str | Path | dict, **overrides) -> KimiK2Config:
+def build_model_config(source: str | Path | dict, **overrides) -> DeepseekV32Config:
     if isinstance(source, dict):
-        cfg = KimiK2Config._from_hf_dict(source)
+        cfg = DeepseekV32Config._from_hf_dict(source)
     else:
-        cfg = KimiK2Config.from_hf(str(source))
+        cfg = DeepseekV32Config.from_hf(str(source))
     for key, value in overrides.items():
         if hasattr(cfg, key):
             setattr(cfg, key, value)
@@ -112,18 +128,40 @@ def unpack_forward_output(model: nn.Module, batch: PackedBatch, output) -> Any:
 
 
 def _make_aux_loss_hook():
+    # DeepSeek-V3.2 ONLY: also scale the DSA indexer auxiliary loss (DeepSeek-V3 has no indexer).
+    from megatron.lite.primitive.modules.attention.dsa import DSAIndexerLossAutoScaler
     from megatron.lite.primitive.modules.moe import MoEAuxLossAutoScaler
     from megatron.lite.primitive.modules.mtp import MTPLossAutoScaler
 
     def hook(scale: torch.Tensor) -> None:
         MoEAuxLossAutoScaler.set_loss_scale(scale)
         MTPLossAutoScaler.set_loss_scale(scale)
+        DSAIndexerLossAutoScaler.set_loss_scale(scale)
 
     return hook
 
 
+def _validate_parallel_scope(p: ParallelConfig) -> None:
+    """DeepSeek-V3.2 DSA attention is not tensor-parallel-capable (documented TP=1 case).
+
+    PP / VPP / EP / CP are inherited from the DeepSeek-V3 skeleton and work; only
+    TP>1 / ETP>1 are unsupported.
+    """
+    etp = 1 if p.etp is None else p.etp
+    if p.tp > 1:
+        raise NotImplementedError(
+            "DeepSeek-V3.2 native DSA attention does not support tensor parallelism; "
+            f"got tp={p.tp}. Use tp=1 (PP/VPP/EP/CP are supported)."
+        )
+    if etp > 1:
+        raise NotImplementedError(
+            "DeepSeek-V3.2 native DSA attention does not support expert tensor parallelism; "
+            f"got etp={etp}. Use etp=1 (EP is supported)."
+        )
+
+
 def _build_dist_opt_optimizer(
-    chunks, model_cfg: KimiK2Config, impl_cfg: ImplConfig, ps: ParallelState
+    chunks, model_cfg: DeepseekV32Config, impl_cfg: ImplConfig, ps: ParallelState
 ):
     from megatron.lite.primitive.optimizers.megatron_wrap import build_dist_opt_training_optimizer
 
@@ -132,17 +170,19 @@ def _build_dist_opt_optimizer(
         model_cfg=model_cfg,
         impl_cfg=impl_cfg,
         ps=ps,
-        model_name="kimi_k2",
+        model_name="deepseek_v3_2",
         is_expert=is_expert_param,
         deterministic=impl_cfg.deterministic,
     )
 
 
-def build_model(model_cfg: KimiK2Config, *, impl_cfg: ImplConfig) -> ModelBundle:
+def build_model(model_cfg: DeepseekV32Config, *, impl_cfg: ImplConfig) -> ModelBundle:
     p = impl_cfg.parallel
+    _validate_parallel_scope(p)
     if impl_cfg.use_deepep and (p.etp is not None and p.etp > 1):
         raise ValueError("use_deepep and etp>1 are mutually exclusive")
     if impl_cfg.router_aux_loss_coef is not None:
+        # DeepSeek-V3.2 has no aux_loss_alpha HF field; honour an explicit override only.
         model_cfg.aux_loss_alpha = impl_cfg.router_aux_loss_coef
     mtp_enable = bool(impl_cfg.mtp_enable)
     mtp_enable_train = mtp_enable and bool(impl_cfg.mtp_enable_train)
@@ -155,7 +195,7 @@ def build_model(model_cfg: KimiK2Config, *, impl_cfg: ImplConfig) -> ModelBundle
     elif hasattr(model_cfg, "num_nextn_predict_layers"):
         model_cfg.num_nextn_predict_layers = 0
 
-    from megatron.lite.model.kimi_k2.lite.model import KimiK2Model
+    from megatron.lite.model.deepseek_v3_2.lite.model import DeepseekV32Model
 
     ps = init_parallel(p)
     recompute_spec = parse_recompute_spec(impl_cfg.recompute)
@@ -183,10 +223,12 @@ def build_model(model_cfg: KimiK2Config, *, impl_cfg: ImplConfig) -> ModelBundle
     )
 
     if vpp is None:
-        chunks = [KimiK2Model(model_cfg, train_cfg, ps, **model_kwargs).to(torch.bfloat16).cuda()]
+        chunks = [
+            DeepseekV32Model(model_cfg, train_cfg, ps, **model_kwargs).to(torch.bfloat16).cuda()
+        ]
     else:
         chunks = [
-            KimiK2Model(
+            DeepseekV32Model(
                 model_cfg,
                 train_cfg,
                 ps,
@@ -227,7 +269,7 @@ def build_model(model_cfg: KimiK2Config, *, impl_cfg: ImplConfig) -> ModelBundle
         optimizer_backend = "fsdp2"
 
         def _post_model_load_hook():
-            from megatron.lite.model.kimi_k2.lite.model import KimiK2Layer
+            from megatron.lite.model.deepseek_v3_2.lite.model import DeepseekV32Layer
             from megatron.lite.primitive.optimizers.fsdp2 import build_fsdp2_training_optimizer
 
             return {
@@ -235,7 +277,7 @@ def build_model(model_cfg: KimiK2Config, *, impl_cfg: ImplConfig) -> ModelBundle
                     chunks,
                     impl_cfg.optimizer_config,
                     ps,
-                    unit_modules=(KimiK2Layer,),
+                    unit_modules=(DeepseekV32Layer,),
                     expert_classifier=is_expert_param,
                     deterministic=impl_cfg.deterministic,
                     vpp=impl_cfg.parallel.vpp,
@@ -245,7 +287,7 @@ def build_model(model_cfg: KimiK2Config, *, impl_cfg: ImplConfig) -> ModelBundle
 
         post_model_load_hook = _post_model_load_hook
     elif impl_cfg.optimizer is not None:
-        raise ValueError(f"Unknown kimi_k2 lite optimizer: {impl_cfg.optimizer!r}.")
+        raise ValueError(f"Unknown deepseek_v3_2 lite optimizer: {impl_cfg.optimizer!r}.")
 
     return ModelBundle(
         chunks=chunks,
@@ -263,19 +305,25 @@ def build_model(model_cfg: KimiK2Config, *, impl_cfg: ImplConfig) -> ModelBundle
 
 
 def load_hf_weights(
-    chunk: nn.Module, hf_path: str, model_cfg: KimiK2Config, ps: ParallelState
+    chunk: nn.Module, hf_path: str, model_cfg: DeepseekV32Config, ps: ParallelState
 ) -> None:
     if not hf_path:
         return
-    from megatron.lite.model.kimi_k2.lite.checkpoint import load_hf_weights as load_impl
+    from megatron.lite.model.deepseek_v3_2.lite.checkpoint import load_hf_weights as load_impl
 
     load_impl(chunk, hf_path, model_cfg, ps)
 
 
-def export_hf_weights(chunks, model_cfg: KimiK2Config, ps: ParallelState, **kwargs):
-    from megatron.lite.model.kimi_k2.lite.checkpoint import export_hf_weights as export_impl
+def export_hf_weights(chunks, model_cfg: DeepseekV32Config, ps: ParallelState, **kwargs):
+    from megatron.lite.model.deepseek_v3_2.lite.checkpoint import export_hf_weights as export_impl
 
     yield from export_impl(chunks, model_cfg, ps, **kwargs)
+
+
+def save_hf_weights(chunks, path: str, model_cfg: DeepseekV32Config, ps: ParallelState, **kwargs):
+    from megatron.lite.model.deepseek_v3_2.lite.checkpoint import save_hf_weights as save_impl
+
+    save_impl(chunks, path, model_cfg, ps, **kwargs)
 
 
 def vocab_size(model_cfg) -> int | None:
@@ -292,5 +340,6 @@ __all__ = [
     "export_hf_weights",
     "is_expert_param",
     "load_hf_weights",
+    "save_hf_weights",
     "vocab_size",
 ]

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
@@ -1,12 +1,12 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """DeepSeek V4 (ds4flash) lite native <-> HF checkpoint mapping.
 
-Like kimi_k2 / glm5: ``DeepseekV4WeightSpec`` encodes the per-param native -> HF
+Like deepseek_v3 / deepseek_v3_2: ``DeepseekV4WeightSpec`` encodes the per-param native -> HF
 name (+ TP/EP shard spec); export/save route through the shared
 ``primitive/ckpt/hf_weights.py`` exporter (its PP ``all_gather_object`` is
 reached by all ranks before any ``rank0_only`` filter, so PP>1 export doesn't
 desync).  Native names are bare ``DeepseekV4Model`` keys; ``self.layers`` is a
-ModuleDict keyed by GLOBAL layer index (kimi uses a local ModuleList), so the
+ModuleDict keyed by GLOBAL layer index (deepseek_v3 uses a local ModuleList), so the
 exporter's local->global remap is an identity here.
 
 HF targets are canonical HF DeepSeek (``model.embed_tokens.weight`` /
@@ -19,7 +19,7 @@ HF targets are canonical HF DeepSeek (``model.embed_tokens.weight`` /
     model.-rooted; fidelity vs Megatron's latest mHC is a TODO).
   * MTP: folded into the decoder namespace at ``model.layers.<num_hidden+i>``.
 
-CSA is not TP-capable: DS4 runs TP=ETP=1 (only EP shards experts), like GLM-5.
+CSA is not TP-capable: DS4 runs TP=ETP=1 (only EP shards experts), like DeepSeek-V3.2.
 """
 
 from __future__ import annotations
@@ -49,7 +49,7 @@ def EXPERT_CLASSIFIER(name: str) -> bool:
 
 
 def PLACEMENT_FN(param_name: str) -> list:
-    # distckpt sharded placement (TP=ETP=1 for ds4; shares kimi/glm5's
+    # distckpt sharded placement (TP=ETP=1 for ds4; shares deepseek_v3/deepseek_v3_2's
     # Experts/SwiGLUMLP/VocabParallel structure). EP-sharded experts must carry
     # an explicit placement or the dist-opt checkpoint won't restore them
     # bit-exactly. The CSA/mHC/MTP-norm params fall through to all-Replicate.
@@ -116,7 +116,11 @@ def _map_block_attr(attr: str, block: str) -> str | tuple[str, ...] | None:
         return f"mlp.shared_experts.{_PROJ_TO_HF.get(proj, proj)}.weight"
     # mHC params have no upstream HF analogue; keep them under self_attn / mlp /
     # hc_head sub-namespaces so every key stays ``model.layers.{i}.*``-rooted.
-    for prefix, target in (("attn_hc", "self_attn.hc"), ("ffn_hc", "mlp.hc"), ("hc_head", "hc_head")):
+    for prefix, target in (
+        ("attn_hc", "self_attn.hc"),
+        ("ffn_hc", "mlp.hc"),
+        ("hc_head", "hc_head"),
+    ):
         if attr.startswith(f"{prefix}."):
             return f"{target}_{attr.rsplit('.', 1)[-1].removeprefix('hc_')}"
     if block == "mtp" and attr in {
@@ -130,7 +134,9 @@ def _map_block_attr(attr: str, block: str) -> str | tuple[str, ...] | None:
     return None
 
 
-def _global_expert_idx_from_local(local_idx: int, config: DeepseekV4Config, ps: ParallelState) -> int:
+def _global_expert_idx_from_local(
+    local_idx: int, config: DeepseekV4Config, ps: ParallelState
+) -> int:
     num_local = ensure_divisible(config.n_routed_experts, ps.ep_size)
     return ps.ep_rank * num_local + local_idx
 
@@ -374,7 +380,7 @@ def _to_global_expert_name(name: str, config: DeepseekV4Config, ps: ParallelStat
 class DeepseekV4WeightSpec:
     """Export DS4 lite weights to HF DeepSeek-V4 names (CSA / mHC / MTP / MoE).
 
-    Mirrors ``KimiK2WeightSpec`` / ``Glm5WeightSpec`` on DS4's bare native names
+    Mirrors ``DeepseekV3WeightSpec`` / ``DeepseekV32WeightSpec`` on DS4's bare native names
     with global layer indices.  The shared exporter rewrites EP-local expert
     ``weight<local>`` ids to global before calling ``native_to_hf``.
     """
@@ -453,7 +459,7 @@ class DeepseekV4WeightSpec:
 def export_hf_weights(model, config: DeepseekV4Config, ps: ParallelState, **kwargs):
     """Export DS4 weights as HF (name, tensor) pairs via the SHARED exporter.
 
-    Identical structure to kimi/glm5: delegate to the shared ``_export`` (which
+    Identical structure to deepseek_v3/deepseek_v3_2: delegate to the shared ``_export`` (which
     does the TP/ETP/EP/PP gather, including the PP ``all_gather_object`` reached
     by ALL ranks before any ``rank0_only`` filter), then append the persistent
     router buffers (``tid2eid`` for hash layers, ``expert_bias`` for non-hash
@@ -487,7 +493,9 @@ def export_hf_weights(model, config: DeepseekV4Config, ps: ParallelState, **kwar
                 yield hf_name, _cast_export_tensor(hf_tensor, export_dtype)
 
 
-def save_hf_weights(model, path: str, config: DeepseekV4Config, ps: ParallelState, **kwargs) -> None:
+def save_hf_weights(
+    model, path: str, config: DeepseekV4Config, ps: ParallelState, **kwargs
+) -> None:
     from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
 
     rank = dist.get_rank() if dist.is_initialized() else 0

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/model.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/model.py
@@ -1,15 +1,15 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """DeepSeek V4 (ds4flash) lite native model.
 
-A clone of the Kimi-K2 (deepseek_v3) lite model -- same approach as GLM-5 --
-inheriting Kimi's Megatron plumbing (SBHD ``[S, B, H]`` layout, VocabParallel
+A clone of the DeepSeek-V3 (deepseek_v3) lite model -- same approach as DeepSeek-V3.2 --
+inheriting DeepSeek-V3's Megatron plumbing (SBHD ``[S, B, H]`` layout, VocabParallel
 embed/head, ``set_input_tensor``, ``build_pipeline_chunk_layout`` boundaries,
 MTP via ``layout.has_head``, dist-opt/distckpt via the protocol).  Three
 model-wide DS4 deviations (documented inline at each site):
 
 1. Attention = CSA, not MLA.  The CSA primitive is batch-first ``[B, S, H]`` and
    needs explicit ``position_ids``; ``DeepseekV4CSAAttention`` wraps it with an
-   SBHD<->BSHD shim (like GLM-5's DSA shim).  Per-layer behaviour is driven by
+   SBHD<->BSHD shim (like DeepSeek-V3.2's DSA shim).  Per-layer behaviour is driven by
    ``config.compress_ratios[layer_idx]`` inside CSA.
 
 2. mHC (multi-head hyper-connection): the hidden carries ``hc_mult`` parallel
@@ -25,7 +25,7 @@ model-wide DS4 deviations (documented inline at each site):
    shared Experts/Router/Dispatcher).
 
 CSA is not TP-capable, so DS4 is a documented TP=1 case (protocol gate raises
-for TP>1/ETP>1); VPP/PP/EP/CP work, inherited from the Kimi skeleton.
+for TP>1/ETP>1); VPP/PP/EP/CP work, inherited from the DeepSeek-V3 skeleton.
 """
 
 from __future__ import annotations
@@ -71,7 +71,7 @@ def _roll_mtp_left(
     """Shift labels/ids one position left (next-token target for MTP depth d).
 
     DS4 inputs are dense ``[B, S]`` (TP=1, MTP runs only at CP==1), so -- unlike
-    Kimi -- there is no packed-THD branch here; a plain ``torch.roll`` on the
+    DeepSeek-V3 -- there is no packed-THD branch here; a plain ``torch.roll`` on the
     sequence dim suffices.
     """
     dim = dims if dims >= 0 else tensor.dim() + dims
@@ -82,7 +82,7 @@ def _roll_mtp_left(
 
 # -- DS4 ONLY: CSA attention wrapper.  Holds ``CompressedSparseAttention`` and
 # adapts it to the skeleton's SBHD-in / SBHD-out attention contract, mirroring
-# GLM-5's ``Glm5DSAAttention`` DSA shim.  Per-layer behaviour (window / compress
+# DeepSeek-V3.2's ``DeepseekV32DSAAttention`` DSA shim.  Per-layer behaviour (window / compress
 # / indexer) is selected inside CSA via ``config.compress_ratios[layer_idx]``.
 class DeepseekV4CSAAttention(nn.Module):
     """SBHD ``[S, B, H]`` shim around the batch-first CSA primitive.
@@ -111,7 +111,7 @@ class DeepseekV4CSAAttention(nn.Module):
 class DeepseekV4Layer(nn.Module):
     """One decoder layer.
 
-    Structurally the Kimi layer, but the plain ``x = x + sublayer(norm(x))``
+    Structurally the DeepSeek-V3 layer, but the plain ``x = x + sublayer(norm(x))``
     residual is replaced by DS4's per-layer ``HyperConnection`` (mHC), and
     attention is CSA via the SBHD shim above.  The hidden is the 4-D SBHD mHC
     tensor ``[S, B, hc_mult, H]`` end-to-end.  Attribute names (``self_attn`` /
@@ -133,7 +133,7 @@ class DeepseekV4Layer(nn.Module):
         self.ps = ps
         self.input_layernorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.post_attention_layernorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        # DS4 ONLY: CSA attention behind the SBHD shim (Kimi builds MLA here).
+        # DS4 ONLY: CSA attention behind the SBHD shim (DeepSeek-V3 builds MLA here).
         self.self_attn = DeepseekV4CSAAttention(config, layer_idx=layer_idx, ps=ps)
         # DS4 ONLY: hash-routed MoE family (shared Experts/Router/dispatcher).
         self.mlp = DeepseekV4MoE(config, ps, layer_idx=layer_idx, use_deepep=use_deepep)
@@ -172,9 +172,9 @@ class DeepseekV4Layer(nn.Module):
 
 
 class DeepseekV4MTPLayer(DeepseekV4Layer):
-    """MTP depth layer: Kimi's MTP combiner, adapted to DS4's mHC hidden.
+    """MTP depth layer: DeepSeek-V3's MTP combiner, adapted to DS4's mHC hidden.
 
-    Like Kimi's ``KimiK2MTPLayer`` it owns ``enorm`` / ``hnorm`` and a projection
+    Like DeepSeek-V3's ``DeepseekV3MTPLayer`` it owns ``enorm`` / ``hnorm`` and a projection
     to fuse the rolled-token embedding with the running hidden, then runs one
     transformer layer.  DS4 differences: the projection uses DS4's
     ``e_proj`` / ``h_proj`` names (preserved for HF export), the embedding /
@@ -201,7 +201,9 @@ class DeepseekV4MTPLayer(DeepseekV4Layer):
         self.enorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.hnorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.norm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.hc_head = MultiHeadHyperConnectionHead(config.hidden_size, config.hc_mult, config.hc_eps)
+        self.hc_head = MultiHeadHyperConnectionHead(
+            config.hidden_size, config.hc_mult, config.hc_eps
+        )
 
     def forward(
         self,
@@ -258,7 +260,7 @@ def _apply_attention_backend_override(backend: str | None) -> None:
 
 
 class DeepseekV4Model(nn.Module):
-    """DS4 model.  Mirrors ``KimiK2Model``: ``build_pipeline_chunk_layout`` for
+    """DS4 model.  Mirrors ``DeepseekV3Model``: ``build_pipeline_chunk_layout`` for
     embed/head/layer placement, ``set_input_tensor`` for the PP recv buffer, a
     shared embed/head, MTP gated on ``layout.has_head``, SBHD scatter at embed,
     and a single forward producing the loss / logits / MTP outputs.
@@ -410,9 +412,7 @@ class DeepseekV4Model(nn.Module):
         # that crosses into the batch-first CSA interior.
         if position_ids is None:
             seq_len, batch = h.size(0), h.size(1)
-            position_ids = (
-                torch.arange(seq_len, device=h.device).unsqueeze(0).expand(batch, -1)
-            )
+            position_ids = torch.arange(seq_len, device=h.device).unsqueeze(0).expand(batch, -1)
 
         fp8_ctx = (
             te.fp8_autocast(enabled=True, fp8_recipe=build_fp8_recipe(self.train_config))
@@ -431,19 +431,16 @@ class DeepseekV4Model(nn.Module):
             return output
 
         # Last stage: contract the mHC streams, then run head / MTP / loss
-        # exactly as the Kimi skeleton does.
+        # exactly as the DeepSeek-V3 skeleton does.
         mtp_source = h
         hidden_for_head = contract_mhc_hidden_for_pipeline(h, norm=self.norm, head=self.hc_head)
 
         # MTP runs on the head stage (where self.mtp is built with a valid bound
         # embedding -- self.embed_tokens when present, else the self.mtp_embed
-        # fallback, mirroring Kimi).  Disabled at CP>1 (the rolled MTP targets are
+        # fallback, mirroring DeepSeek-V3).  Disabled at CP>1 (the rolled MTP targets are
         # not CP-sliced) and when no input_ids are available.
         run_mtp = (
-            enable_mtp
-            and input_ids is not None
-            and len(self.mtp) > 0
-            and self.ps.cp_size == 1
+            enable_mtp and input_ids is not None and len(self.mtp) > 0 and self.ps.cp_size == 1
         )
         mtp_hidden_states = self._apply_mtp(
             mtp_source, input_ids=input_ids, position_ids=position_ids, run_mtp=run_mtp
@@ -511,7 +508,7 @@ class DeepseekV4Model(nn.Module):
         assert input_ids is not None
         # DS4 MTP rolls input_ids per depth and runs each MTP layer on the
         # running per-stream source, contracting each depth's output to [S, B, H]
-        # for the head.  Mirrors Kimi's KimiK2MTPBlock loop.
+        # for the head.  Mirrors DeepSeek-V3's DeepseekV3MTPBlock loop.
         mtp_input_ids = input_ids
         source = mtp_source
         outputs: list[torch.Tensor] = []

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
@@ -24,7 +24,11 @@ from megatron.lite.primitive.parallel.cp import (
     local_position_ids_for_cp,
     local_sequence_tensor_for_cp,
 )
-from megatron.lite.primitive.parallel.thd import pack_nested_thd, thd_pack_meta, unpack_thd_to_nested
+from megatron.lite.primitive.parallel.thd import (
+    pack_nested_thd,
+    thd_pack_meta,
+    unpack_thd_to_nested,
+)
 from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec
 from megatron.lite.runtime.contracts import OptimizerConfig, PackedBatch, ParallelConfig
 
@@ -63,7 +67,7 @@ MODULE_MAP = {
     "ffn_norm": lambda layer: layer.post_attention_layernorm,
 }
 
-# The Kimi-derived model has no ``attention_mask`` arg (CSA derives its causal /
+# The DeepSeek-V3-derived model has no ``attention_mask`` arg (CSA derives its causal /
 # sliding-window masking from ``position_ids``, as the previous DS4 did with
 # attention_mask=None); keep it out of the forward whitelist.
 _MODEL_FORWARD_KEYS = (
@@ -305,8 +309,8 @@ def _iter_transformer_units(chunk: nn.Module) -> list[nn.Module]:
 def _validate_parallel_scope(p: ParallelConfig) -> None:
     """DS4 CSA attention is not tensor-parallel-capable (documented TP=1 case).
 
-    PP / VPP / EP / CP are inherited from the Kimi skeleton and work; only
-    TP>1 / ETP>1 are unsupported.  Mirrors GLM-5's gate.
+    PP / VPP / EP / CP are inherited from the DeepSeek-V3 skeleton and work; only
+    TP>1 / ETP>1 are unsupported.  Mirrors DeepSeek-V3.2's gate.
     """
     etp = 1 if p.etp is None else p.etp
     if p.tp > 1:

--- a/experimental/lite/megatron/lite/model/glm5/__init__.py
+++ b/experimental/lite/megatron/lite/model/glm5/__init__.py
@@ -1,5 +1,0 @@
-"""GLM-5 model family."""
-
-from megatron.lite.model.glm5.config import Glm5Config
-
-__all__ = ["Glm5Config"]

--- a/experimental/lite/megatron/lite/model/glm5/lite/__init__.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/__init__.py
@@ -1,5 +1,0 @@
-"""Native GLM-5 lite implementation."""
-
-from megatron.lite.model.glm5.lite.model import Glm5Model
-
-__all__ = ["Glm5Model"]

--- a/experimental/lite/megatron/lite/model/registry.py
+++ b/experimental/lite/megatron/lite/model/registry.py
@@ -92,18 +92,24 @@ register_model(
     impls={"lite": "megatron.lite.model.qwen3_5.lite.protocol"},
 )
 
+# DeepSeek-V3 (MLA) -- Kimi K2/K2.5/K2.6/K2.7 are config variants of this
+# architecture.  "kimi_k2" is kept only as an external HF model_type alias so
+# existing Kimi checkpoints (whose config.json declares model_type=kimi_k2)
+# still resolve; the native model name is deepseek_v3.
 register_model(
-    "kimi_k2",
-    package="megatron.lite.model.kimi_k2",
+    "deepseek_v3",
+    package="megatron.lite.model.deepseek_v3",
     hf_model_types=["kimi_k2", "deepseek_v3"],
-    impls={"lite": "megatron.lite.model.kimi_k2.lite.protocol"},
+    impls={"lite": "megatron.lite.model.deepseek_v3.lite.protocol"},
 )
 
+# DeepSeek-V3.2 (MLA + DSA) -- GLM-5.1 is a config variant of this architecture
+# (HF model_type "glm_moe_dsa").
 register_model(
-    "glm5",
-    package="megatron.lite.model.glm5",
+    "deepseek_v3_2",
+    package="megatron.lite.model.deepseek_v3_2",
     hf_model_types=["glm_moe_dsa"],
-    impls={"lite": "megatron.lite.model.glm5.lite.protocol"},
+    impls={"lite": "megatron.lite.model.deepseek_v3_2.lite.protocol"},
 )
 
 register_model(

--- a/experimental/lite/megatron/lite/primitive/modules/attention/dsa.py
+++ b/experimental/lite/megatron/lite/primitive/modules/attention/dsa.py
@@ -252,10 +252,10 @@ class DSAIndexer(nn.Module):
         position_ids: torch.Tensor,
         attention_mask: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        """Project GLM5 indexer inputs for Megatron's fused DSA kernels."""
+        """Project DeepSeek-V3.2 indexer inputs for Megatron's fused DSA kernels."""
         if attention_mask is not None:
             raise NotImplementedError(
-                "GLM5 fused DSA indexer only supports causal masking; custom "
+                "DeepSeek-V3.2 fused DSA indexer only supports causal masking; custom "
                 "attention_mask is not supported."
             )
         batch, seq_len, _ = x.shape
@@ -418,7 +418,7 @@ class DynamicSparseAttention(nn.Module):
     ) -> torch.Tensor:
         if attention_mask is not None:
             raise NotImplementedError(
-                "GLM5 fused DSA only supports causal masking; custom attention_mask "
+                "DeepSeek-V3.2 fused DSA only supports causal masking; custom attention_mask "
                 "is not supported."
             )
         if packed_seq_params is not None:
@@ -460,7 +460,7 @@ class DynamicSparseAttention(nn.Module):
             position_ids = position_ids.unsqueeze(0)
         if position_ids.shape[-1] != x.shape[1]:
             raise ValueError(
-                "GLM5 packed DynamicSparseAttention position_ids must cover the reconstructed packed tokens, "
+                "DeepSeek-V3.2 packed DynamicSparseAttention position_ids must cover the reconstructed packed tokens, "
                 f"got {tuple(position_ids.shape)} for packed length {x.shape[1]}."
             )
         pieces = []
@@ -586,7 +586,7 @@ class DynamicSparseAttention(nn.Module):
             expected = (full_seq, full_seq)
             if tuple(attention_mask.shape[-2:]) != expected:
                 raise NotImplementedError(
-                    "GLM5 DynamicSparseAttention CP attention_mask must already cover the reconstructed "
+                    "DeepSeek-V3.2 DynamicSparseAttention CP attention_mask must already cover the reconstructed "
                     f"full sequence {expected}, got {tuple(attention_mask.shape)}."
                 )
         return full_x, full_position_ids, attention_mask
@@ -608,7 +608,7 @@ class DynamicSparseAttention(nn.Module):
             return position_ids.to(device=device, dtype=torch.long)
         if position_ids.shape[-1] != local_seq:
             raise ValueError(
-                "GLM5 DynamicSparseAttention CP position_ids must be either local or full sequence length, "
+                "DeepSeek-V3.2 DynamicSparseAttention CP position_ids must be either local or full sequence length, "
                 f"got {tuple(position_ids.shape)} for local_seq={local_seq}, full_seq={full_seq}."
             )
 
@@ -637,7 +637,7 @@ class DynamicSparseAttention(nn.Module):
             return full_x, position_ids
         if position_ids.shape[-1] != local_seq:
             raise ValueError(
-                "GLM5 packed DynamicSparseAttention CP position_ids must be either local or full packed length, "
+                "DeepSeek-V3.2 packed DynamicSparseAttention CP position_ids must be either local or full packed length, "
                 f"got {tuple(position_ids.shape)} for local_seq={local_seq}, full_seq={full_seq}."
             )
         pos_parts = _all_gather_cp(position_ids, cp_size=self.cp_size, cp_group=self.cp_group)
@@ -671,7 +671,9 @@ class DynamicSparseAttention(nn.Module):
         if cu_seqlens is None:
             cu_seqlens = getattr(packed_seq_params, "cu_seqlens_q", None)
         if cu_seqlens is None:
-            raise ValueError("GLM5 packed DynamicSparseAttention requires packed cu_seqlens.")
+            raise ValueError(
+                "DeepSeek-V3.2 packed DynamicSparseAttention requires packed cu_seqlens."
+            )
         return cu_seqlens.to(device=device, dtype=torch.int32)
 
     @staticmethod

--- a/experimental/lite/tests/smoke/model/test_deepseek_v3_2_lite_fsdp2_smoke.py
+++ b/experimental/lite/tests/smoke/model/test_deepseek_v3_2_lite_fsdp2_smoke.py
@@ -13,11 +13,11 @@ def _init_dist_or_skip():
     import torch.distributed as dist
 
     if not torch.cuda.is_available():
-        pytest.skip("CUDA is required for GLM5 FSDP2 smoke.")
+        pytest.skip("CUDA is required for DeepSeek-V3.2 FSDP2 smoke.")
     if "RANK" not in os.environ or "WORLD_SIZE" not in os.environ:
         pytest.skip("Run with torchrun so FSDP2 ranks are available.")
     if int(os.environ.get("WORLD_SIZE", "1")) < 2:
-        pytest.skip("GLM5 FSDP2 smoke requires at least 2 ranks.")
+        pytest.skip("DeepSeek-V3.2 FSDP2 smoke requires at least 2 ranks.")
     if int(os.environ.get("WORLD_SIZE", "1")) > 8:
         pytest.skip("Megatron Lite smoke tests are capped at single-node 8 GPUs.")
 
@@ -65,11 +65,11 @@ def _tiny_config_kwargs():
     )
 
 
-def test_glm5_tiny_model_builds_and_steps_with_fsdp2_backend(cuda_dist):
+def test_deepseek_v3_2_tiny_model_builds_and_steps_with_fsdp2_backend(cuda_dist):
     import torch
 
-    from megatron.lite.model.glm5.config import Glm5Config
-    from megatron.lite.model.glm5.lite import protocol
+    from megatron.lite.model.deepseek_v3_2.config import DeepseekV32Config
+    from megatron.lite.model.deepseek_v3_2.lite import protocol
     from megatron.lite.primitive.optimizers.fsdp2 import FSDP2Optimizer, fsdp2_available
     from megatron.lite.runtime.contracts import OptimizerConfig, ParallelConfig
 
@@ -77,7 +77,7 @@ def test_glm5_tiny_model_builds_and_steps_with_fsdp2_backend(cuda_dist):
         pytest.skip("Installed PyTorch does not expose FSDP2 fully_shard.")
 
     device = cuda_dist
-    cfg = Glm5Config(**_tiny_config_kwargs())
+    cfg = DeepseekV32Config(**_tiny_config_kwargs())
     impl_cfg = protocol.ImplConfig(
         parallel=ParallelConfig(),
         optimizer="fsdp2",

--- a/experimental/lite/tests/smoke/primitive/test_save_load_export_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_save_load_export_smoke.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Save / load / export coverage smoke across the supported models and backends.
 
-Matrix: {qwen3_5, qwen3_moe, kimi_k2, glm5, deepseek_v4} x {dist_opt, fsdp2}.
+Matrix: {qwen3_5, qwen3_moe, deepseek_v3, deepseek_v3_2, deepseek_v4} x {dist_opt, fsdp2}.
 
 Each (model, backend) case does a faithful round-trip:
   build -> train one real step -> save checkpoint -> build fresh -> load ->
@@ -101,12 +101,12 @@ def _qwen3_moe():
     return cfg, protocol
 
 
-def _kimi_k2():
+def _deepseek_v3():
     _require_te()
-    from megatron.lite.model.kimi_k2.config import KimiK2Config
-    from megatron.lite.model.kimi_k2.lite import protocol
+    from megatron.lite.model.deepseek_v3.config import DeepseekV3Config
+    from megatron.lite.model.deepseek_v3.lite import protocol
 
-    cfg = KimiK2Config(
+    cfg = DeepseekV3Config(
         num_hidden_layers=2,
         hidden_size=64,
         num_attention_heads=4,
@@ -140,13 +140,13 @@ def _kimi_k2():
     return cfg, protocol
 
 
-def _glm5():
-    pytest.importorskip("cudnn", reason="glm5 fused DSA needs the cudnn DSA stack.")
+def _deepseek_v3_2():
+    pytest.importorskip("cudnn", reason="deepseek_v3_2 fused DSA needs the cudnn DSA stack.")
     _require_te()
-    from megatron.lite.model.glm5.config import Glm5Config
-    from megatron.lite.model.glm5.lite import protocol
+    from megatron.lite.model.deepseek_v3_2.config import DeepseekV32Config
+    from megatron.lite.model.deepseek_v3_2.lite import protocol
 
-    cfg = Glm5Config(
+    cfg = DeepseekV32Config(
         num_hidden_layers=2,
         hidden_size=128,
         num_attention_heads=64,
@@ -215,8 +215,8 @@ def _deepseek_v4():
 MODELS = {
     "qwen3_5": _qwen3_5,
     "qwen3_moe": _qwen3_moe,
-    "kimi_k2": _kimi_k2,
-    "glm5": _glm5,
+    "deepseek_v3": _deepseek_v3,
+    "deepseek_v3_2": _deepseek_v3_2,
     "deepseek_v4": _deepseek_v4,
 }
 
@@ -287,9 +287,9 @@ def _reset_parallel_state_between_tests():
         mpu.destroy_model_parallel()
 
 
-# GLM5 / DeepSeek-V4 native lite support TP=ETP=VPP=1 only (EP/PP/CP wired
+# DeepSeek-V3.2 / DeepSeek-V4 native lite support TP=ETP=VPP=1 only (EP/PP/CP wired
 # through primitives), so their dist_opt topology shards via ep/pp/cp instead.
-_TP1_ONLY = {"glm5", "deepseek_v4"}
+_TP1_ONLY = {"deepseek_v3_2", "deepseek_v4"}
 
 
 def _topology(model_name: str, backend: str) -> ParallelConfig:
@@ -466,17 +466,19 @@ def _export_and_reload(handle: ModelHandle, cfg, protocol, out_dir: str) -> None
             for key in fh.keys():
                 tensor = fh.get_tensor(key)
                 if tensor.dtype.is_floating_point:
-                    assert tensor.dtype == torch.bfloat16, (
-                        f"{key} exported as {tensor.dtype}, want bf16"
-                    )
+                    assert (
+                        tensor.dtype == torch.bfloat16
+                    ), f"{key} exported as {tensor.dtype}, want bf16"
                 else:
-                    assert tensor.dtype in (torch.int64, torch.int32, torch.bool), (
-                        f"{key} exported as unexpected non-float dtype {tensor.dtype}"
-                    )
+                    assert tensor.dtype in (
+                        torch.int64,
+                        torch.int32,
+                        torch.bool,
+                    ), f"{key} exported as unexpected non-float dtype {tensor.dtype}"
                 assert torch.isfinite(tensor.float()).all(), f"{key} has non-finite values"
-                assert key.startswith("model.") or key in ("lm_head.weight",), (
-                    f"unexpected non-HF export key: {key}"
-                )
+                assert key.startswith("model.") or key in (
+                    "lm_head.weight",
+                ), f"unexpected non-HF export key: {key}"
                 keys.add(key)
     assert keys, "exported zero tensors"
     # PP-gather completeness: the rank-0 export must carry EVERY decoder layer's

--- a/experimental/lite/tests/unit/model/test_deepseek_v3_2_lite_cp_smoke.py
+++ b/experimental/lite/tests/unit/model/test_deepseek_v3_2_lite_cp_smoke.py
@@ -10,7 +10,7 @@ def _init_dist_or_skip():
     import torch.distributed as dist
 
     if not torch.cuda.is_available():
-        pytest.skip("CUDA is required for GLM5 CP smoke.")
+        pytest.skip("CUDA is required for DeepSeek-V3.2 CP smoke.")
     if "RANK" not in os.environ or "WORLD_SIZE" not in os.environ:
         pytest.skip("Run with torchrun so CP ranks are available.")
 
@@ -19,7 +19,7 @@ def _init_dist_or_skip():
     if not dist.is_initialized():
         dist.init_process_group("nccl")
     if dist.get_world_size() < 2:
-        pytest.skip("GLM5 CP smoke requires at least 2 ranks.")
+        pytest.skip("DeepSeek-V3.2 CP smoke requires at least 2 ranks.")
     return torch.device("cuda", local_rank)
 
 
@@ -60,7 +60,9 @@ def _tiny_hf_parity_config_kwargs():
 def _fused_dsa_seq_len(world: int) -> int:
     seq = 512
     if seq % (2 * world) != 0:
-        pytest.skip(f"GLM5 fused DSA CP smoke requires seq={seq} divisible by 2*world={2 * world}.")
+        pytest.skip(
+            f"DeepSeek-V3.2 fused DSA CP smoke requires seq={seq} divisible by 2*world={2 * world}."
+        )
     return seq
 
 
@@ -117,7 +119,7 @@ def _distributed_diff_stats(actual, expected) -> tuple[float, float]:
     return float(stats[0].item()), float((stats[0] / stats[1]).item())
 
 
-def _hf_state_dict_for_glm5_loader(model):
+def _hf_state_dict_for_deepseek_v3_2_loader(model):
     return {
         name: tensor.detach().cpu().contiguous().clone()
         for name, tensor in model.state_dict().items()
@@ -146,7 +148,7 @@ def _make_dsa(*, cp_size: int = 1, cp_rank: int = 0, cp_group=None):
 
 
 @pytest.mark.gpu
-def test_glm5_dsa_cp2_matches_full_sequence_reference_forward_and_grad():
+def test_deepseek_v3_2_dsa_cp2_matches_full_sequence_reference_forward_and_grad():
     import torch
     import torch.distributed as dist
 
@@ -191,26 +193,28 @@ def test_glm5_dsa_cp2_matches_full_sequence_reference_forward_and_grad():
 
 
 @pytest.mark.gpu
-def test_glm5_tiny_model_cp2_matches_full_sequence_reference_forward():
+def test_deepseek_v3_2_tiny_model_cp2_matches_full_sequence_reference_forward():
     import torch
     import torch.distributed as dist
 
-    from megatron.lite.model.glm5.config import Glm5Config
-    from megatron.lite.model.glm5.lite.model import Glm5ForCausalLM
+    from megatron.lite.model.deepseek_v3_2.config import DeepseekV32Config
+    from megatron.lite.model.deepseek_v3_2.lite.model import DeepseekV32ForCausalLM
     from megatron.lite.primitive.parallel.cp import zigzag_slice_for_cp
     from megatron.lite.primitive.parallel.state import ParallelState
 
     device = _init_dist_or_skip()
     world = dist.get_world_size()
     rank = dist.get_rank()
-    cfg = Glm5Config(**_tiny_config_kwargs())
+    cfg = DeepseekV32Config(**_tiny_config_kwargs())
     cfg.mlp_layer_types = ["dense", "dense"]
     ps = ParallelState(cp_group=dist.group.WORLD, cp_size=world, cp_rank=rank)
 
     torch.manual_seed(777)
-    cp_model = Glm5ForCausalLM(cfg, ps=ps).to(device=device, dtype=torch.bfloat16)
+    cp_model = DeepseekV32ForCausalLM(cfg, ps=ps).to(device=device, dtype=torch.bfloat16)
     torch.manual_seed(777)
-    ref_model = Glm5ForCausalLM(cfg, ps=ParallelState()).to(device=device, dtype=torch.bfloat16)
+    ref_model = DeepseekV32ForCausalLM(cfg, ps=ParallelState()).to(
+        device=device, dtype=torch.bfloat16
+    )
     cp_model.eval()
     ref_model.eval()
 
@@ -228,24 +232,24 @@ def test_glm5_tiny_model_cp2_matches_full_sequence_reference_forward():
 
 
 @pytest.mark.gpu
-def test_glm5_tiny_model_cp2_forward_backward_smoke():
+def test_deepseek_v3_2_tiny_model_cp2_forward_backward_smoke():
     import torch
     import torch.distributed as dist
 
-    from megatron.lite.model.glm5.config import Glm5Config
-    from megatron.lite.model.glm5.lite.model import Glm5ForCausalLM
+    from megatron.lite.model.deepseek_v3_2.config import DeepseekV32Config
+    from megatron.lite.model.deepseek_v3_2.lite.model import DeepseekV32ForCausalLM
     from megatron.lite.primitive.parallel.cp import zigzag_slice_for_cp
     from megatron.lite.primitive.parallel.state import ParallelState
 
     device = _init_dist_or_skip()
     world = dist.get_world_size()
     rank = dist.get_rank()
-    cfg = Glm5Config(**_tiny_config_kwargs())
+    cfg = DeepseekV32Config(**_tiny_config_kwargs())
     cfg.mlp_layer_types = ["dense", "dense"]
     ps = ParallelState(cp_group=dist.group.WORLD, cp_size=world, cp_rank=rank)
 
     torch.manual_seed(1234)
-    model = Glm5ForCausalLM(cfg, ps=ps).to(device=device, dtype=torch.bfloat16)
+    model = DeepseekV32ForCausalLM(cfg, ps=ps).to(device=device, dtype=torch.bfloat16)
     model.initialize_weights()
 
     batch, seq = 1, _fused_dsa_seq_len(world)
@@ -269,12 +273,12 @@ def test_glm5_tiny_model_cp2_forward_backward_smoke():
 
 
 @pytest.mark.gpu
-def test_glm5_packed_thd_variable_sequence_cp2_forward_backward_smoke():
+def test_deepseek_v3_2_packed_thd_variable_sequence_cp2_forward_backward_smoke():
     import torch
     import torch.distributed as dist
 
-    from megatron.lite.model.glm5.config import Glm5Config
-    from megatron.lite.model.glm5.lite.model import Glm5ForCausalLM
+    from megatron.lite.model.deepseek_v3_2.config import DeepseekV32Config
+    from megatron.lite.model.deepseek_v3_2.lite.model import DeepseekV32ForCausalLM
     from megatron.lite.primitive.parallel.state import ParallelState
     from megatron.lite.primitive.parallel.thd import pack_nested_thd, unpack_packed_thd_to_nested
 
@@ -283,12 +287,12 @@ def test_glm5_packed_thd_variable_sequence_cp2_forward_backward_smoke():
     rank = dist.get_rank()
     cfg_kwargs = _tiny_config_kwargs()
     cfg_kwargs.update(max_position_embeddings=64, num_nextn_predict_layers=1)
-    cfg = Glm5Config(**cfg_kwargs)
+    cfg = DeepseekV32Config(**cfg_kwargs)
     cfg.mlp_layer_types = ["dense", "dense"]
     ps = ParallelState(cp_group=dist.group.WORLD, cp_size=world, cp_rank=rank)
 
     torch.manual_seed(20260614)
-    model = Glm5ForCausalLM(cfg, ps=ps, mtp_enable=True, mtp_enable_train=True).to(
+    model = DeepseekV32ForCausalLM(cfg, ps=ps, mtp_enable=True, mtp_enable_train=True).to(
         device=device, dtype=torch.bfloat16
     )
     model.train()
@@ -344,7 +348,7 @@ def test_glm5_packed_thd_variable_sequence_cp2_forward_backward_smoke():
 
     if rank == 0:
         print(
-            "NON_SKIP_GLM5_THD_CP_SMOKE_PASSED "
+            "NON_SKIP_DeepSeek-V3.2_THD_CP_SMOKE_PASSED "
             f"world_size={world} lengths={lengths} "
             f"loss={float(out['loss'].detach().item()):.6e} "
             f"grad_norm={float(grad_norm.detach().item()):.6e}"
@@ -352,14 +356,14 @@ def test_glm5_packed_thd_variable_sequence_cp2_forward_backward_smoke():
 
 
 @pytest.mark.gpu
-def test_glm5_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
+def test_deepseek_v3_2_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
     import torch
     import torch.distributed as dist
     from transformers.models.deepseek_v3.modeling_deepseek_v3 import DeepseekV3ForCausalLM
 
-    from megatron.lite.model.glm5.config import Glm5Config
-    from megatron.lite.model.glm5.lite.checkpoint import load_hf_weights
-    from megatron.lite.model.glm5.lite.model import Glm5ForCausalLM
+    from megatron.lite.model.deepseek_v3_2.config import DeepseekV32Config
+    from megatron.lite.model.deepseek_v3_2.lite.checkpoint import load_hf_weights
+    from megatron.lite.model.deepseek_v3_2.lite.model import DeepseekV32ForCausalLM
     from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
     from megatron.lite.primitive.parallel.cp import zigzag_slice_for_cp
     from megatron.lite.primitive.parallel.state import ParallelState
@@ -367,7 +371,7 @@ def test_glm5_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
     device = _init_dist_or_skip()
     world = dist.get_world_size()
     rank = dist.get_rank()
-    cfg = Glm5Config(**_tiny_hf_parity_config_kwargs())
+    cfg = DeepseekV32Config(**_tiny_hf_parity_config_kwargs())
 
     torch.manual_seed(20260611)
     hf_ref = DeepseekV3ForCausalLM(_to_hf_deepseek_v3_config(cfg)).to(
@@ -375,10 +379,10 @@ def test_glm5_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
     )
     hf_ref.eval()
     rank_tmp_path = tmp_path / f"rank{rank}"
-    save_safetensors(_hf_state_dict_for_glm5_loader(hf_ref), str(rank_tmp_path))
+    save_safetensors(_hf_state_dict_for_deepseek_v3_2_loader(hf_ref), str(rank_tmp_path))
 
     ps = ParallelState(cp_group=dist.group.WORLD, cp_size=world, cp_rank=rank)
-    native = Glm5ForCausalLM(cfg, ps=ps).to(device=device, dtype=torch.bfloat16)
+    native = DeepseekV32ForCausalLM(cfg, ps=ps).to(device=device, dtype=torch.bfloat16)
     native.eval()
     load_hf_weights(native, str(rank_tmp_path), cfg, ps)
 
@@ -410,7 +414,7 @@ def test_glm5_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
     with torch.no_grad():
         if rank == 0:
             print(
-                "glm5_hf_native_parity reference=transformers.DeepseekV3ForCausalLM "
+                "deepseek_v3_2_hf_native_parity reference=transformers.DeepseekV3ForCausalLM "
                 "mode=dense_mla_reference_with_full_topk_dsa"
             )
         hf_logits = hf_ref(full_ids).logits
@@ -428,7 +432,7 @@ def test_glm5_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
         max_abs, max_rel = _distributed_diff_stats(actual, expected)
         if rank == 0:
             print(
-                f"glm5_hf_native_parity layer={layer_idx} "
+                f"deepseek_v3_2_hf_native_parity layer={layer_idx} "
                 f"max_abs_diff={max_abs:.6e} max_rel_diff={max_rel:.6e}"
             )
         torch.testing.assert_close(actual.float(), expected.float(), atol=1.5e-1, rtol=1.5e-1)
@@ -437,6 +441,7 @@ def test_glm5_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
     max_abs, max_rel = _distributed_diff_stats(native_logits, expected)
     if rank == 0:
         print(
-            "glm5_hf_native_parity logits " f"max_abs_diff={max_abs:.6e} max_rel_diff={max_rel:.6e}"
+            "deepseek_v3_2_hf_native_parity logits "
+            f"max_abs_diff={max_abs:.6e} max_rel_diff={max_rel:.6e}"
         )
     torch.testing.assert_close(native_logits.float(), expected.float(), atol=1.5e-1, rtol=1.5e-1)

--- a/experimental/lite/tests/unit/model/test_deepseek_v3_2_lite_static.py
+++ b/experimental/lite/tests/unit/model/test_deepseek_v3_2_lite_static.py
@@ -1,4 +1,4 @@
-"""Static and CPU smoke tests for native GLM-5 lite."""
+"""Static and CPU smoke tests for native DeepSeek-V3.2 lite."""
 
 from __future__ import annotations
 
@@ -32,24 +32,24 @@ def _tiny_config_kwargs():
     )
 
 
-def test_glm5_registry_resolves_lite():
+def test_deepseek_v3_2_registry_resolves_lite():
     from megatron.lite.model.registry import (
         get_train_runtime_module,
         resolve_model_type_from_hf,
         resolve_runtime_model_name,
     )
 
-    runtime_name = resolve_runtime_model_name("glm5", "lite")
-    assert runtime_name == "glm5"
+    runtime_name = resolve_runtime_model_name("deepseek_v3_2", "lite")
+    assert runtime_name == "deepseek_v3_2"
     module = get_train_runtime_module(runtime_name)
-    assert module.__name__ == "megatron.lite.model.glm5.lite.protocol"
-    assert resolve_model_type_from_hf({"model_type": "glm_moe_dsa"}) == "glm5"
+    assert module.__name__ == "megatron.lite.model.deepseek_v3_2.lite.protocol"
+    assert resolve_model_type_from_hf({"model_type": "glm_moe_dsa"}) == "deepseek_v3_2"
 
 
-def test_glm5_config_reads_hf_architecture_fields():
-    from megatron.lite.model.glm5.config import Glm5Config
+def test_deepseek_v3_2_config_reads_hf_architecture_fields():
+    from megatron.lite.model.deepseek_v3_2.config import DeepseekV32Config
 
-    cfg = Glm5Config._from_hf_dict(
+    cfg = DeepseekV32Config._from_hf_dict(
         {
             "model_type": "glm_moe_dsa",
             "hidden_size": 6144,
@@ -83,10 +83,10 @@ def test_glm5_config_reads_hf_architecture_fields():
     assert cfg.is_moe_layer(3) is True
 
 
-def test_glm5_config_ignores_null_hf_optional_fields():
-    from megatron.lite.model.glm5.config import Glm5Config
+def test_deepseek_v3_2_config_ignores_null_hf_optional_fields():
+    from megatron.lite.model.deepseek_v3_2.config import DeepseekV32Config
 
-    cfg = Glm5Config._from_hf_dict(
+    cfg = DeepseekV32Config._from_hf_dict(
         {
             "model_type": "glm_moe_dsa",
             "indexer_rope_first": None,
@@ -100,10 +100,10 @@ def test_glm5_config_ignores_null_hf_optional_fields():
     assert cfg.mlp_layer_types is None
 
 
-def test_glm5_config_preserves_mtp_aliases_and_layer_types():
-    from megatron.lite.model.glm5.config import Glm5Config
+def test_deepseek_v3_2_config_preserves_mtp_aliases_and_layer_types():
+    from megatron.lite.model.deepseek_v3_2.config import DeepseekV32Config
 
-    cfg = Glm5Config._from_hf_dict(
+    cfg = DeepseekV32Config._from_hf_dict(
         {
             **_tiny_config_kwargs(),
             "num_nextn_predict": 1,
@@ -117,8 +117,15 @@ def test_glm5_config_preserves_mtp_aliases_and_layer_types():
     assert cfg.is_moe_layer(2) is True
 
 
-def test_glm5_lite_does_not_import_wrappers_or_sibling_models():
-    root = Path(__file__).resolve().parents[3] / "megatron" / "lite" / "model" / "glm5" / "lite"
+def test_deepseek_v3_2_lite_does_not_import_wrappers_or_sibling_models():
+    root = (
+        Path(__file__).resolve().parents[3]
+        / "megatron"
+        / "lite"
+        / "model"
+        / "deepseek_v3_2"
+        / "lite"
+    )
     for path in root.glob("*.py"):
         text = path.read_text()
         assert "megatron.lite.model.qwen" not in text
@@ -127,9 +134,9 @@ def test_glm5_lite_does_not_import_wrappers_or_sibling_models():
         assert "megatron.core" not in text
 
 
-def test_glm5_lite_uses_shared_mla_and_dsa_primitive():
+def test_deepseek_v3_2_lite_uses_shared_mla_and_dsa_primitive():
     root = Path(__file__).resolve().parents[3] / "megatron" / "lite"
-    model_text = (root / "model" / "glm5" / "lite" / "model.py").read_text()
+    model_text = (root / "model" / "deepseek_v3_2" / "lite" / "model.py").read_text()
     primitive_text = (root / "primitive" / "modules" / "attention" / "dsa.py").read_text()
     kernel_text = (root / "primitive" / "kernels" / "dsa_kernels.py").read_text()
 
@@ -156,7 +163,7 @@ def test_glm5_lite_uses_shared_mla_and_dsa_primitive():
     assert "torch.matmul" not in primitive_text
 
 
-def test_glm5_dsa_kernel_routes_indexer_forward_by_sm(monkeypatch):
+def test_deepseek_v3_2_dsa_kernel_routes_indexer_forward_by_sm(monkeypatch):
     from megatron.lite.primitive.kernels import dsa_kernels
 
     sm90_entry = object()
@@ -175,7 +182,7 @@ def test_glm5_dsa_kernel_routes_indexer_forward_by_sm(monkeypatch):
     assert dsa_kernels._select_indexer_forward(None) is None
 
 
-def test_glm5_dsa_training_forward_uses_fused_kernel(monkeypatch):
+def test_deepseek_v3_2_dsa_training_forward_uses_fused_kernel(monkeypatch):
     import torch
 
     from megatron.lite.primitive.modules.attention import dsa
@@ -257,7 +264,7 @@ def test_glm5_dsa_training_forward_uses_fused_kernel(monkeypatch):
     }
 
 
-def test_glm5_dsa_eval_forward_uses_fused_sparse_attention(monkeypatch):
+def test_deepseek_v3_2_dsa_eval_forward_uses_fused_sparse_attention(monkeypatch):
     import torch
 
     from megatron.lite.primitive.modules.attention import dsa
@@ -314,11 +321,11 @@ def test_glm5_dsa_eval_forward_uses_fused_sparse_attention(monkeypatch):
     assert calls["sparse"] == {"topk_length_is_set": True, "value_dim": 4}
 
 
-def test_glm5_lite_model_exports_hf_style_state_names():
-    from megatron.lite.model.glm5.config import Glm5Config
-    from megatron.lite.model.glm5.lite.model import Glm5ForCausalLM
+def test_deepseek_v3_2_lite_model_exports_hf_style_state_names():
+    from megatron.lite.model.deepseek_v3_2.config import DeepseekV32Config
+    from megatron.lite.model.deepseek_v3_2.lite.model import DeepseekV32ForCausalLM
 
-    model = Glm5ForCausalLM(Glm5Config(**_tiny_config_kwargs()))
+    model = DeepseekV32ForCausalLM(DeepseekV32Config(**_tiny_config_kwargs()))
     keys = set(model.state_dict())
 
     assert "model.embed_tokens.weight" in keys
@@ -330,21 +337,21 @@ def test_glm5_lite_model_exports_hf_style_state_names():
     assert "lm_head.weight" in keys
 
 
-def test_glm5_checkpoint_exports_and_saves_hf_style_weights(tmp_path):
+def test_deepseek_v3_2_checkpoint_exports_and_saves_hf_style_weights(tmp_path):
     import torch
     from safetensors import safe_open
 
-    from megatron.lite.model.glm5.config import Glm5Config
-    from megatron.lite.model.glm5.lite.checkpoint import (
+    from megatron.lite.model.deepseek_v3_2.config import DeepseekV32Config
+    from megatron.lite.model.deepseek_v3_2.lite.checkpoint import (
         export_hf_weights,
         save_hf_weights,
         save_weights,
     )
-    from megatron.lite.model.glm5.lite.model import Glm5ForCausalLM
+    from megatron.lite.model.deepseek_v3_2.lite.model import DeepseekV32ForCausalLM
     from megatron.lite.primitive.parallel import ParallelState
 
-    cfg = Glm5Config(**_tiny_config_kwargs())
-    model = Glm5ForCausalLM(cfg)
+    cfg = DeepseekV32Config(**_tiny_config_kwargs())
+    model = DeepseekV32ForCausalLM(cfg)
     ps = ParallelState()
     model.model.layers[1].mlp.gate.e_score_correction_bias.copy_(torch.tensor([0.25, -0.5, 1.0]))
 
@@ -373,8 +380,8 @@ def test_glm5_checkpoint_exports_and_saves_hf_style_weights(tmp_path):
             state["model.layers.1.mlp.gate.e_score_correction_bias"],
         )
 
-    loaded = Glm5ForCausalLM(cfg)
-    from megatron.lite.model.glm5.lite.checkpoint import load_hf_weights
+    loaded = DeepseekV32ForCausalLM(cfg)
+    from megatron.lite.model.deepseek_v3_2.lite.checkpoint import load_hf_weights
 
     load_hf_weights(loaded, str(hf_dir), cfg, ps)
     assert torch.equal(
@@ -392,7 +399,7 @@ def test_glm5_checkpoint_exports_and_saves_hf_style_weights(tmp_path):
         }
         assert floating_dtypes == {torch.bfloat16}
 
-    loaded_bf16 = Glm5ForCausalLM(cfg)
+    loaded_bf16 = DeepseekV32ForCausalLM(cfg)
     load_hf_weights(loaded_bf16, str(hf_bf16_dir), cfg, ps)
     assert torch.equal(
         loaded_bf16.state_dict()["model.layers.1.mlp.experts.2.up_proj.weight"],
@@ -408,18 +415,18 @@ def test_glm5_checkpoint_exports_and_saves_hf_style_weights(tmp_path):
         )
 
 
-def test_glm5_checkpoint_exports_and_loads_mtp_layers(tmp_path):
+def test_deepseek_v3_2_checkpoint_exports_and_loads_mtp_layers(tmp_path):
     import torch
 
-    from megatron.lite.model.glm5.config import Glm5Config
-    from megatron.lite.model.glm5.lite.checkpoint import export_hf_weights, load_hf_weights
-    from megatron.lite.model.glm5.lite.model import Glm5ForCausalLM
+    from megatron.lite.model.deepseek_v3_2.config import DeepseekV32Config
+    from megatron.lite.model.deepseek_v3_2.lite.checkpoint import export_hf_weights, load_hf_weights
+    from megatron.lite.model.deepseek_v3_2.lite.model import DeepseekV32ForCausalLM
     from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
     from megatron.lite.primitive.parallel import ParallelState
 
-    cfg = Glm5Config(**_tiny_config_kwargs(), num_nextn_predict_layers=1)
+    cfg = DeepseekV32Config(**_tiny_config_kwargs(), num_nextn_predict_layers=1)
     ps = ParallelState()
-    model = Glm5ForCausalLM(cfg, ps=ps, mtp_enable=True)
+    model = DeepseekV32ForCausalLM(cfg, ps=ps, mtp_enable=True)
     state = model.state_dict()
 
     assert "model.mtp.layers.0.eh_proj.weight" in state
@@ -434,7 +441,7 @@ def test_glm5_checkpoint_exports_and_loads_mtp_layers(tmp_path):
     assert "model.layers.2.mlp.gate.weight" in exported
 
     save_safetensors(exported, str(tmp_path))
-    loaded = Glm5ForCausalLM(cfg, ps=ps, mtp_enable=True)
+    loaded = DeepseekV32ForCausalLM(cfg, ps=ps, mtp_enable=True)
     load_hf_weights(loaded, str(tmp_path), cfg, ps)
     assert torch.equal(
         loaded.state_dict()["model.mtp.layers.0.eh_proj.weight"],
@@ -442,16 +449,19 @@ def test_glm5_checkpoint_exports_and_loads_mtp_layers(tmp_path):
     )
 
 
-def test_glm5_initialize_weights_resets_all_router_weights():
+def test_deepseek_v3_2_initialize_weights_resets_all_router_weights():
     import torch
 
-    from megatron.lite.model.glm5.config import Glm5Config
-    from megatron.lite.model.glm5.lite.model import Glm5ForCausalLM, Glm5Router
-
-    model = Glm5ForCausalLM(
-        Glm5Config(**_tiny_config_kwargs(), num_nextn_predict_layers=1), mtp_enable=True
+    from megatron.lite.model.deepseek_v3_2.config import DeepseekV32Config
+    from megatron.lite.model.deepseek_v3_2.lite.model import (
+        DeepseekV32ForCausalLM,
+        DeepseekV32Router,
     )
-    routers = [module for module in model.modules() if isinstance(module, Glm5Router)]
+
+    model = DeepseekV32ForCausalLM(
+        DeepseekV32Config(**_tiny_config_kwargs(), num_nextn_predict_layers=1), mtp_enable=True
+    )
+    routers = [module for module in model.modules() if isinstance(module, DeepseekV32Router)]
     assert len(routers) == 2
     for router in routers:
         router.weight.data.fill_(float("nan"))
@@ -466,10 +476,10 @@ def test_glm5_initialize_weights_resets_all_router_weights():
         )
 
 
-def test_glm5_hf_loader_resolves_grouped_expert_tensors():
+def test_deepseek_v3_2_hf_loader_resolves_grouped_expert_tensors():
     import torch
 
-    from megatron.lite.model.glm5.lite.checkpoint import _resolve_hf_tensor
+    from megatron.lite.model.deepseek_v3_2.lite.checkpoint import _resolve_hf_tensor
 
     class FakeReader:
         def __init__(self, tensors):
@@ -531,10 +541,10 @@ def test_glm5_hf_loader_resolves_grouped_expert_tensors():
     )
 
 
-def test_glm5_hf_loader_slices_full_expert_tensors_for_proxy_targets():
+def test_deepseek_v3_2_hf_loader_slices_full_expert_tensors_for_proxy_targets():
     import torch
 
-    from megatron.lite.model.glm5.lite.checkpoint import _slice_to_target_shape
+    from megatron.lite.model.deepseek_v3_2.lite.checkpoint import _slice_to_target_shape
 
     source = torch.arange(256 * 8, dtype=torch.float32).reshape(256, 8)
     target = torch.empty(4, 8)
@@ -545,15 +555,15 @@ def test_glm5_hf_loader_slices_full_expert_tensors_for_proxy_targets():
     assert torch.equal(_slice_to_target_shape(source3d, target3d), source3d[:4])
 
 
-def test_glm5_hf_loader_resolves_packed_experts_from_single_safetensor(tmp_path):
+def test_deepseek_v3_2_hf_loader_resolves_packed_experts_from_single_safetensor(tmp_path):
     import torch
 
-    from megatron.lite.model.glm5.config import Glm5Config
-    from megatron.lite.model.glm5.lite.checkpoint import _resolve_named_parameter_tensor
+    from megatron.lite.model.deepseek_v3_2.config import DeepseekV32Config
+    from megatron.lite.model.deepseek_v3_2.lite.checkpoint import _resolve_named_parameter_tensor
     from megatron.lite.primitive.ckpt.hf_weights import SafeTensorReader, save_safetensors
     from megatron.lite.primitive.parallel import ParallelState
 
-    cfg = Glm5Config(**_tiny_config_kwargs())
+    cfg = DeepseekV32Config(**_tiny_config_kwargs())
     gate_up = torch.arange(3 * 12 * 16, dtype=torch.float32).reshape(3, 12, 16)
     down = torch.arange(3 * 16 * 6, dtype=torch.float32).reshape(3, 16, 6)
     save_safetensors(
@@ -584,10 +594,10 @@ def test_glm5_hf_loader_resolves_packed_experts_from_single_safetensor(tmp_path)
     assert torch.equal(resolved_down, down)
 
 
-def test_glm5_protocol_allows_cp_only_parallel_scope():
+def test_deepseek_v3_2_protocol_allows_cp_only_parallel_scope():
     import pytest
 
-    from megatron.lite.model.glm5.lite.protocol import _validate_parallel_scope
+    from megatron.lite.model.deepseek_v3_2.lite.protocol import _validate_parallel_scope
     from megatron.lite.runtime.contracts import ParallelConfig
 
     _validate_parallel_scope(ParallelConfig(tp=1, ep=1, etp=1, cp=2, pp=1, vpp=1))
@@ -597,38 +607,38 @@ def test_glm5_protocol_allows_cp_only_parallel_scope():
         _validate_parallel_scope(ParallelConfig(tp=1, ep=1, etp=1, cp=1, pp=2, vpp=2))
 
 
-def test_glm5_impl_config_accepts_runtime_mtp_fields():
-    from megatron.lite.model.glm5.config import Glm5Config
-    from megatron.lite.model.glm5.lite.protocol import ImplConfig
+def test_deepseek_v3_2_impl_config_accepts_runtime_mtp_fields():
+    from megatron.lite.model.deepseek_v3_2.config import DeepseekV32Config
+    from megatron.lite.model.deepseek_v3_2.lite.protocol import ImplConfig
 
-    cfg = Glm5Config(**_tiny_config_kwargs(), num_nextn_predict_layers=1)
+    cfg = DeepseekV32Config(**_tiny_config_kwargs(), num_nextn_predict_layers=1)
 
     assert ImplConfig(mtp_enable=False, mtp_enable_train=False).mtp_enable is False
     assert ImplConfig(mtp_enable=True, mtp_enable_train=True).mtp_enable_train is True
     assert cfg.num_nextn_predict_layers == 1
 
 
-def test_glm5_pipeline_layer_split_handles_non_divisible_pp():
+def test_deepseek_v3_2_pipeline_layer_split_handles_non_divisible_pp():
     from types import SimpleNamespace
 
-    from megatron.lite.model.glm5.lite.model import _build_glm5_pipeline_layers
+    from megatron.lite.model.deepseek_v3_2.lite.model import _build_deepseek_v3_2_pipeline_layers
 
     def split_for_rank(pp_rank):
         ps = SimpleNamespace(pp_size=4, pp_rank=pp_rank)
-        return _build_glm5_pipeline_layers(5, ps)
+        return _build_deepseek_v3_2_pipeline_layers(5, ps)
 
     assert [split_for_rank(rank) for rank in range(4)] == [[], [0, 1], [2, 3], [4]]
 
 
-def test_glm5_protocol_uses_mlite_optimizer_api():
-    from megatron.lite.model.glm5.lite.protocol import ImplConfig
+def test_deepseek_v3_2_protocol_uses_mlite_optimizer_api():
+    from megatron.lite.model.deepseek_v3_2.lite.protocol import ImplConfig
 
     protocol_path = (
         Path(__file__).resolve().parents[3]
         / "megatron"
         / "lite"
         / "model"
-        / "glm5"
+        / "deepseek_v3_2"
         / "lite"
         / "protocol.py"
     )
@@ -638,11 +648,11 @@ def test_glm5_protocol_uses_mlite_optimizer_api():
     assert "build_dist_opt_training_optimizer" in protocol_text
 
 
-def test_glm5_lite_tiny_cpu_forward_backward(monkeypatch):
+def test_deepseek_v3_2_lite_tiny_cpu_forward_backward(monkeypatch):
     import torch
 
-    from megatron.lite.model.glm5.config import Glm5Config
-    from megatron.lite.model.glm5.lite.model import Glm5ForCausalLM
+    from megatron.lite.model.deepseek_v3_2.config import DeepseekV32Config
+    from megatron.lite.model.deepseek_v3_2.lite.model import DeepseekV32ForCausalLM
     from megatron.lite.primitive.modules.attention import dsa
 
     def fake_fused_indexer_sparse_attn(
@@ -688,7 +698,7 @@ def test_glm5_lite_tiny_cpu_forward_backward(monkeypatch):
     )
 
     torch.manual_seed(1234)
-    model = Glm5ForCausalLM(Glm5Config(**_tiny_config_kwargs()))
+    model = DeepseekV32ForCausalLM(DeepseekV32Config(**_tiny_config_kwargs()))
     input_ids = torch.randint(0, model.config.vocab_size, (2, 5))
     labels = torch.randint(0, model.config.vocab_size, (2, 5))
 
@@ -702,8 +712,8 @@ def test_glm5_lite_tiny_cpu_forward_backward(monkeypatch):
     )
     assert torch.isfinite(grad_norm)
 
-    mtp_model = Glm5ForCausalLM(
-        Glm5Config(**_tiny_config_kwargs(), num_nextn_predict_layers=1),
+    mtp_model = DeepseekV32ForCausalLM(
+        DeepseekV32Config(**_tiny_config_kwargs(), num_nextn_predict_layers=1),
         mtp_enable=True,
         mtp_enable_train=True,
     )

--- a/experimental/lite/tests/unit/model/test_deepseek_v3_lite_cp_smoke.py
+++ b/experimental/lite/tests/unit/model/test_deepseek_v3_lite_cp_smoke.py
@@ -13,7 +13,7 @@ def _init_dist_or_skip():
     import torch.distributed as dist
 
     if not torch.cuda.is_available():
-        pytest.skip("CUDA is required for Kimi K2 CP smoke.")
+        pytest.skip("CUDA is required for DeepSeek-V3 CP smoke.")
     if "RANK" not in os.environ or "WORLD_SIZE" not in os.environ:
         pytest.skip("Run with torchrun so CP ranks are available.")
 
@@ -22,14 +22,14 @@ def _init_dist_or_skip():
     if not dist.is_initialized():
         dist.init_process_group("nccl")
     if dist.get_world_size() < 2:
-        pytest.skip("Kimi K2 CP smoke requires at least 2 ranks.")
+        pytest.skip("DeepSeek-V3 CP smoke requires at least 2 ranks.")
     return torch.device("cuda", local_rank)
 
 
 def _tiny_config():
-    from megatron.lite.model.kimi_k2.config import KimiK2Config
+    from megatron.lite.model.deepseek_v3.config import DeepseekV3Config
 
-    return KimiK2Config(
+    return DeepseekV3Config(
         num_hidden_layers=2,
         hidden_size=64,
         num_attention_heads=4,
@@ -63,9 +63,9 @@ def _tiny_config():
 
 
 def _tiny_hf_parity_config():
-    from megatron.lite.model.kimi_k2.config import KimiK2Config
+    from megatron.lite.model.deepseek_v3.config import DeepseekV3Config
 
-    return KimiK2Config(
+    return DeepseekV3Config(
         num_hidden_layers=2,
         hidden_size=64,
         num_attention_heads=4,
@@ -168,7 +168,7 @@ def _distributed_diff_stats(actual, expected) -> tuple[float, float]:
     return float(stats[0].item()), float((stats[0] / stats[1]).item())
 
 
-def _hf_state_dict_for_kimi_loader(model):
+def _hf_state_dict_for_deepseek_v3_loader(model):
     state = {
         name: tensor.detach().cpu().contiguous().clone()
         for name, tensor in model.state_dict().items()
@@ -189,7 +189,7 @@ def _hf_state_dict_for_kimi_loader(model):
     return state
 
 
-def test_kimi_k2_mla_cp2_matches_full_sequence_reference_forward_and_grad():
+def test_deepseek_v3_mla_cp2_matches_full_sequence_reference_forward_and_grad():
     import torch
     import torch.distributed as dist
 
@@ -244,12 +244,12 @@ def test_kimi_k2_mla_cp2_matches_full_sequence_reference_forward_and_grad():
     torch.testing.assert_close(local_x.grad, expected_grad, atol=1e-1, rtol=1e-1)
 
 
-def test_kimi_k2_tiny_model_cp2_matches_full_sequence_reference_forward():
+def test_deepseek_v3_tiny_model_cp2_matches_full_sequence_reference_forward():
     import torch
     import torch.distributed as dist
 
     device = _init_dist_or_skip()
-    from megatron.lite.model.kimi_k2.lite.model import KimiK2Model
+    from megatron.lite.model.deepseek_v3.lite.model import DeepseekV3Model
     from megatron.lite.primitive.parallel import ParallelState
     from megatron.lite.primitive.parallel.cp import zigzag_slice_for_cp
     from megatron.lite.primitive.parallel.state import init_parallel
@@ -261,12 +261,12 @@ def test_kimi_k2_tiny_model_cp2_matches_full_sequence_reference_forward():
     ps = init_parallel(ParallelConfig(tp=1, ep=1, etp=1, cp=world, pp=1))
 
     torch.manual_seed(777)
-    cp_model = KimiK2Model(cfg, _train_cfg(world), ps, use_thd=False).to(
+    cp_model = DeepseekV3Model(cfg, _train_cfg(world), ps, use_thd=False).to(
         device=device,
         dtype=torch.bfloat16,
     )
     torch.manual_seed(777)
-    ref_model = KimiK2Model(cfg, _train_cfg(1), ParallelState(), use_thd=False).to(
+    ref_model = DeepseekV3Model(cfg, _train_cfg(1), ParallelState(), use_thd=False).to(
         device=device,
         dtype=torch.bfloat16,
     )
@@ -290,14 +290,14 @@ def test_kimi_k2_tiny_model_cp2_matches_full_sequence_reference_forward():
     torch.testing.assert_close(cp_out["log_probs"], expected_log_probs, atol=1e-1, rtol=1e-1)
 
 
-def test_kimi_k2_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
+def test_deepseek_v3_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
     import torch
     import torch.distributed as dist
     from transformers.models.deepseek_v3.modeling_deepseek_v3 import DeepseekV3ForCausalLM
 
     device = _init_dist_or_skip()
-    from megatron.lite.model.kimi_k2.lite.checkpoint import load_hf_weights
-    from megatron.lite.model.kimi_k2.lite.model import KimiK2Model
+    from megatron.lite.model.deepseek_v3.lite.checkpoint import load_hf_weights
+    from megatron.lite.model.deepseek_v3.lite.model import DeepseekV3Model
     from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
     from megatron.lite.primitive.parallel.cp import zigzag_slice_for_cp
     from megatron.lite.primitive.parallel.state import init_parallel
@@ -315,12 +315,12 @@ def test_kimi_k2_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
     hf_ref.eval()
     rank_tmp_path = tmp_path / f"rank{rank}"
     save_safetensors(
-        _hf_state_dict_for_kimi_loader(hf_ref),
+        _hf_state_dict_for_deepseek_v3_loader(hf_ref),
         str(rank_tmp_path),
     )
 
     ps = init_parallel(ParallelConfig(tp=1, ep=1, etp=1, cp=world, pp=1))
-    native = KimiK2Model(cfg, _train_cfg(world), ps, use_thd=False).to(
+    native = DeepseekV3Model(cfg, _train_cfg(world), ps, use_thd=False).to(
         device=device,
         dtype=torch.bfloat16,
     )
@@ -355,7 +355,7 @@ def test_kimi_k2_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
     with torch.no_grad():
         if rank == 0:
             print(
-                "kimi_k2_hf_native_parity reference=transformers.DeepseekV3ForCausalLM "
+                "deepseek_v3_hf_native_parity reference=transformers.DeepseekV3ForCausalLM "
                 "rope=DeepseekV3RotaryEmbedding+apply_rotary_pos_emb_interleave"
             )
         hf_logits = hf_ref(full_ids).logits
@@ -374,7 +374,7 @@ def test_kimi_k2_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
         max_abs, max_rel = _distributed_diff_stats(actual, expected)
         if rank == 0:
             print(
-                f"kimi_k2_hf_native_parity layer={layer_idx} "
+                f"deepseek_v3_hf_native_parity layer={layer_idx} "
                 f"max_abs_diff={max_abs:.6e} max_rel_diff={max_rel:.6e}"
             )
         torch.testing.assert_close(
@@ -388,7 +388,7 @@ def test_kimi_k2_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
     max_abs, max_rel = _distributed_diff_stats(native_logits, expected)
     if rank == 0:
         print(
-            "kimi_k2_hf_native_parity logits "
+            "deepseek_v3_hf_native_parity logits "
             f"max_abs_diff={max_abs:.6e} max_rel_diff={max_rel:.6e}"
         )
     torch.testing.assert_close(
@@ -399,12 +399,12 @@ def test_kimi_k2_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
     )
 
 
-def test_kimi_k2_packed_thd_variable_sequence_cp2_smoke():
+def test_deepseek_v3_packed_thd_variable_sequence_cp2_smoke():
     import torch
     import torch.distributed as dist
 
     device = _init_dist_or_skip()
-    from megatron.lite.model.kimi_k2.lite.model import KimiK2Model
+    from megatron.lite.model.deepseek_v3.lite.model import DeepseekV3Model
     from megatron.lite.primitive.parallel.state import init_parallel
     from megatron.lite.primitive.parallel.thd import pack_nested_thd, unpack_packed_thd_to_nested
     from megatron.lite.runtime.contracts import ParallelConfig
@@ -415,7 +415,7 @@ def test_kimi_k2_packed_thd_variable_sequence_cp2_smoke():
     ps = init_parallel(ParallelConfig(tp=1, ep=1, etp=1, cp=world, pp=1))
 
     torch.manual_seed(20260614)
-    model = KimiK2Model(cfg, _train_cfg(world), ps, use_thd=True).to(
+    model = DeepseekV3Model(cfg, _train_cfg(world), ps, use_thd=True).to(
         device=device,
         dtype=torch.bfloat16,
     )
@@ -470,12 +470,12 @@ def test_kimi_k2_packed_thd_variable_sequence_cp2_smoke():
         )
 
 
-def test_kimi_k2_tiny_model_fsdp2_optimizer_step_smoke():
+def test_deepseek_v3_tiny_model_fsdp2_optimizer_step_smoke():
     import torch
     import torch.distributed as dist
 
     device = _init_dist_or_skip()
-    from megatron.lite.model.kimi_k2.lite.protocol import ImplConfig, build_model
+    from megatron.lite.model.deepseek_v3.lite.protocol import ImplConfig, build_model
     from megatron.lite.primitive.optimizers.fsdp2 import FSDP2Optimizer, fsdp2_available
     from megatron.lite.runtime.contracts import OptimizerConfig, ParallelConfig
 
@@ -529,7 +529,7 @@ def test_kimi_k2_tiny_model_fsdp2_optimizer_step_smoke():
     assert torch.isfinite(torch.tensor(grad_norm))
     if rank == 0:
         print(
-            "kimi_k2_fsdp2_smoke optimizer=fsdp2 "
+            "deepseek_v3_fsdp2_smoke optimizer=fsdp2 "
             f"world_size={world} loss={float(loss.detach().item()):.6e} "
             f"grad_norm={grad_norm:.6e}"
         )

--- a/experimental/lite/tests/unit/model/test_deepseek_v3_lite_static.py
+++ b/experimental/lite/tests/unit/model/test_deepseek_v3_lite_static.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-"""Static smoke coverage for Kimi K2 lite native implementation."""
+"""Static smoke coverage for DeepSeek-V3 lite native implementation."""
 
 from __future__ import annotations
 
@@ -8,27 +8,27 @@ from pathlib import Path
 import pytest
 
 
-def test_kimi_k2_lite_registry_resolves():
+def test_deepseek_v3_lite_registry_resolves():
     from megatron.lite.model.registry import (
         get_train_runtime_module,
         resolve_model_type_from_hf,
         resolve_runtime_model_name,
     )
 
-    runtime_name = resolve_runtime_model_name("kimi_k2", "lite")
-    assert runtime_name == "kimi_k2"
-    assert resolve_model_type_from_hf({"model_type": "kimi_k2"}) == "kimi_k2"
-    assert resolve_model_type_from_hf({"model_type": "deepseek_v3"}) == "kimi_k2"
+    runtime_name = resolve_runtime_model_name("deepseek_v3", "lite")
+    assert runtime_name == "deepseek_v3"
+    assert resolve_model_type_from_hf({"model_type": "deepseek_v3"}) == "deepseek_v3"
+    assert resolve_model_type_from_hf({"model_type": "deepseek_v3"}) == "deepseek_v3"
     module = get_train_runtime_module(runtime_name)
-    assert module.__name__ == "megatron.lite.model.kimi_k2.lite.protocol"
+    assert module.__name__ == "megatron.lite.model.deepseek_v3.lite.protocol"
 
 
-def test_kimi_k2_config_reads_hf_fields():
-    from megatron.lite.model.kimi_k2.config import KimiK2Config
+def test_deepseek_v3_config_reads_hf_fields():
+    from megatron.lite.model.deepseek_v3.config import DeepseekV3Config
 
-    cfg = KimiK2Config._from_hf_dict(
+    cfg = DeepseekV3Config._from_hf_dict(
         {
-            "model_type": "kimi_k2",
+            "model_type": "deepseek_v3",
             "num_hidden_layers": 3,
             "hidden_size": 32,
             "num_attention_heads": 4,
@@ -64,8 +64,10 @@ def test_kimi_k2_config_reads_hf_fields():
     assert cfg.is_moe_layer(1)
 
 
-def test_kimi_k2_lite_does_not_import_wrappers_or_sibling_models():
-    root = Path(__file__).resolve().parents[3] / "megatron" / "lite" / "model" / "kimi_k2" / "lite"
+def test_deepseek_v3_lite_does_not_import_wrappers_or_sibling_models():
+    root = (
+        Path(__file__).resolve().parents[3] / "megatron" / "lite" / "model" / "deepseek_v3" / "lite"
+    )
     forbidden = (
         "megatron.lite.model.qwen3_5",
         "megatron.lite.model.qwen3_moe",
@@ -81,16 +83,18 @@ def test_kimi_k2_lite_does_not_import_wrappers_or_sibling_models():
             assert token not in text
 
 
-def test_kimi_k2_lite_implementation_files_stay_small():
-    root = Path(__file__).resolve().parents[3] / "megatron" / "lite" / "model" / "kimi_k2" / "lite"
+def test_deepseek_v3_lite_implementation_files_stay_small():
+    root = (
+        Path(__file__).resolve().parents[3] / "megatron" / "lite" / "model" / "deepseek_v3" / "lite"
+    )
     for name in ("model.py", "protocol.py", "checkpoint.py"):
         line_count = len((root / name).read_text().splitlines())
         assert line_count < 1000, f"{name} has {line_count} lines"
 
 
-def test_kimi_k2_lite_uses_shared_mla_primitive():
+def test_deepseek_v3_lite_uses_shared_mla_primitive():
     lite_root = Path(__file__).resolve().parents[3] / "megatron" / "lite"
-    model_root = lite_root / "model" / "kimi_k2" / "lite"
+    model_root = lite_root / "model" / "deepseek_v3" / "lite"
     primitive_mla = lite_root / "primitive" / "modules" / "attention" / "mla.py"
     model_text = (model_root / "model.py").read_text()
     mla_text = primitive_mla.read_text()
@@ -102,11 +106,13 @@ def test_kimi_k2_lite_uses_shared_mla_primitive():
     assert "class MultiLatentAttention" not in model_text
     assert "class MultiLatentAttention" in mla_text
     assert "megatron.core" not in mla_text
-    assert "KimiK2SigmoidTopKRouter" in model_text
+    assert "DeepseekV3SigmoidTopKRouter" in model_text
 
 
-def test_kimi_k2_lite_optimizer_names_are_current():
-    root = Path(__file__).resolve().parents[3] / "megatron" / "lite" / "model" / "kimi_k2" / "lite"
+def test_deepseek_v3_lite_optimizer_names_are_current():
+    root = (
+        Path(__file__).resolve().parents[3] / "megatron" / "lite" / "model" / "deepseek_v3" / "lite"
+    )
     protocol_text = (root / "protocol.py").read_text()
 
     assert 'optimizer: str | None = "dist_opt"' in protocol_text
@@ -116,8 +122,8 @@ def test_kimi_k2_lite_optimizer_names_are_current():
         assert forbidden not in protocol_text
 
 
-def test_kimi_k2_dist_opt_deterministic_default_is_enabled():
-    from megatron.lite.model.kimi_k2.lite.protocol import ImplConfig
+def test_deepseek_v3_dist_opt_deterministic_default_is_enabled():
+    from megatron.lite.model.deepseek_v3.lite.protocol import ImplConfig
 
     cfg = ImplConfig(optimizer="dist_opt", deterministic=True, mtp_enable=True)
 
@@ -126,11 +132,11 @@ def test_kimi_k2_dist_opt_deterministic_default_is_enabled():
     assert cfg.mtp_enable is True
 
 
-def test_kimi_k2_impl_config_accepts_runtime_mtp_fields():
-    from megatron.lite.model.kimi_k2.config import KimiK2Config
-    from megatron.lite.model.kimi_k2.lite.protocol import ImplConfig
+def test_deepseek_v3_impl_config_accepts_runtime_mtp_fields():
+    from megatron.lite.model.deepseek_v3.config import DeepseekV3Config
+    from megatron.lite.model.deepseek_v3.lite.protocol import ImplConfig
 
-    cfg = KimiK2Config(
+    cfg = DeepseekV3Config(
         num_hidden_layers=1,
         hidden_size=8,
         num_attention_heads=2,
@@ -157,7 +163,7 @@ def test_kimi_k2_impl_config_accepts_runtime_mtp_fields():
     assert cfg.num_nextn_predict_layers == 1
 
 
-def test_kimi_k2_mtp_and_pp_layout_rules_are_explicit():
+def test_deepseek_v3_mtp_and_pp_layout_rules_are_explicit():
     from megatron.lite.primitive.parallel import ParallelState, build_pipeline_chunk_layout
 
     model_text = (
@@ -165,7 +171,7 @@ def test_kimi_k2_mtp_and_pp_layout_rules_are_explicit():
         / "megatron"
         / "lite"
         / "model"
-        / "kimi_k2"
+        / "deepseek_v3"
         / "lite"
         / "model.py"
     ).read_text()
@@ -189,18 +195,18 @@ def test_kimi_k2_mtp_and_pp_layout_rules_are_explicit():
         build_pipeline_chunk_layout(3, rank0, vpp=2, vpp_chunk_id=0)
 
 
-def test_kimi_k2_checkpoint_exports_hf_names():
+def test_deepseek_v3_checkpoint_exports_hf_names():
     torch = pytest.importorskip("torch")
 
-    from megatron.lite.model.kimi_k2.config import KimiK2Config
-    from megatron.lite.model.kimi_k2.lite import protocol
-    from megatron.lite.model.kimi_k2.lite.checkpoint import (
-        KimiK2WeightSpec,
+    from megatron.lite.model.deepseek_v3.config import DeepseekV3Config
+    from megatron.lite.model.deepseek_v3.lite import protocol
+    from megatron.lite.model.deepseek_v3.lite.checkpoint import (
+        DeepseekV3WeightSpec,
         export_hf_weights,
         save_hf_weights,
     )
 
-    cfg = KimiK2Config(
+    cfg = DeepseekV3Config(
         num_hidden_layers=2,
         hidden_size=8,
         num_attention_heads=2,
@@ -221,7 +227,7 @@ def test_kimi_k2_checkpoint_exports_hf_names():
         v_head_dim=2,
         num_nextn_predict_layers=1,
     )
-    spec = KimiK2WeightSpec(cfg)
+    spec = DeepseekV3WeightSpec(cfg)
 
     assert callable(export_hf_weights)
     assert callable(save_hf_weights)
@@ -267,12 +273,12 @@ def test_kimi_k2_checkpoint_exports_hf_names():
     }
 
 
-def test_kimi_k2_fp8_checkpoint_dequant_cpu_path():
+def test_deepseek_v3_fp8_checkpoint_dequant_cpu_path():
     torch = pytest.importorskip("torch")
     if not hasattr(torch, "float8_e4m3fn"):
         pytest.skip("torch float8_e4m3fn is required for this smoke.")
 
-    from megatron.lite.model.kimi_k2.lite.checkpoint import _dequant_fp8_weight
+    from megatron.lite.model.deepseek_v3.lite.checkpoint import _dequant_fp8_weight
 
     class Reader:
         index = {"w_scale_inv": "fake.safetensors"}
@@ -288,10 +294,10 @@ def test_kimi_k2_fp8_checkpoint_dequant_cpu_path():
     torch.testing.assert_close(out, weight.float() * 2.0)
 
 
-def test_kimi_k2_int4_checkpoint_dequant_cpu_path():
+def test_deepseek_v3_int4_checkpoint_dequant_cpu_path():
     torch = pytest.importorskip("torch")
 
-    from megatron.lite.model.kimi_k2.lite.checkpoint import _get
+    from megatron.lite.model.deepseek_v3.lite.checkpoint import _get
 
     values = torch.tensor([[-8, -7, -1, 0, 1, 2, 6, 7, -8, 7]], dtype=torch.int8)
     unsigned = (values + 8).to(torch.int32)
@@ -322,8 +328,8 @@ def test_kimi_k2_int4_checkpoint_dequant_cpu_path():
     torch.testing.assert_close(out, expected)
 
 
-def test_kimi_k2_real_checkpoint_prefix_helpers():
-    from megatron.lite.model.kimi_k2.lite.checkpoint import _lm_head_name, _text_prefix
+def test_deepseek_v3_real_checkpoint_prefix_helpers():
+    from megatron.lite.model.deepseek_v3.lite.checkpoint import _lm_head_name, _text_prefix
 
     class Reader:
         index = {

--- a/experimental/lite/tests/unit/runtime/test_layering_contracts.py
+++ b/experimental/lite/tests/unit/runtime/test_layering_contracts.py
@@ -41,12 +41,12 @@ LAYER_ROOTS = {
 }
 MODEL_PACKAGE_PREFIXES = (
     "megatron.lite.model.deepseek_v4",
-    "megatron.lite.model.glm5",
-    "megatron.lite.model.kimi_k2",
+    "megatron.lite.model.deepseek_v3_2",
+    "megatron.lite.model.deepseek_v3",
     "megatron.lite.model.qwen3_5",
     "megatron.lite.model.qwen3_moe",
 )
-MODEL_NAME_TERMS = {"deepseek_v4", "glm5", "kimi_k2", "qwen3", "qwen3_5", "qwen3_moe"}
+MODEL_NAME_TERMS = {"deepseek_v4", "deepseek_v3_2", "deepseek_v3", "qwen3", "qwen3_5", "qwen3_moe"}
 DENIED_IMPORT_PREFIXES = {
     "bench": ("examples.verl", "verl", "verl_mlite", "megatron.lite.model"),
     "verl_mlite": ("examples.bench", *MODEL_PACKAGE_PREFIXES),

--- a/experimental/lite/tests/unit/verl/test_mlite_engine_cp_smoke.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_engine_cp_smoke.py
@@ -34,7 +34,7 @@ def _init_dist_or_skip():
     return torch.device("cuda", local_rank)
 
 
-def _write_kimi_config(path) -> None:
+def _write_deepseek_v3_config(path) -> None:
     config = {
         "model_type": "deepseek_v3",
         "num_hidden_layers": 2,
@@ -71,7 +71,7 @@ def _write_kimi_config(path) -> None:
     (path / "config.json").write_text(json.dumps(config), encoding="utf-8")
 
 
-def _write_glm5_config(path) -> None:
+def _write_deepseek_v3_2_config(path) -> None:
     config = {
         "model_type": "glm_moe_dsa",
         "num_hidden_layers": 2,
@@ -172,8 +172,8 @@ def _optimizer_config() -> SimpleNamespace:
 @pytest.mark.parametrize(
     ("model_name", "model_type", "write_config", "vocab_size", "lengths"),
     [
-        ("kimi_k2", "deepseek_v3", _write_kimi_config, 128, [5, 7, 9]),
-        ("glm5", "glm_moe_dsa", _write_glm5_config, 32, [16, 20, 24]),
+        ("deepseek_v3", "deepseek_v3", _write_deepseek_v3_config, 128, [5, 7, 9]),
+        ("deepseek_v3_2", "glm_moe_dsa", _write_deepseek_v3_2_config, 32, [16, 20, 24]),
         ("deepseek_v4", "deepseek_v4", _write_deepseek_v4_config, 128, [16, 20, 24]),
     ],
 )


### PR DESCRIPTION
## What

Rename the two release-instance model names to their real architecture full
names, per the model-naming convention (architecture full name is the registry/
dir/protocol identity; product/version variants live as config + HF aliases, not
standalone dirs/wrappers):

- `glm5/`     → `deepseek_v3_2/`  (MLA + DSA);  classes `Glm5*`  → `DeepseekV32*`
- `kimi_k2/`  → `deepseek_v3/`    (MLA);        classes `KimiK2*` → `DeepseekV3*`

GLM-5.1 is a config variant of DeepSeek-V3.2; Kimi K2/K2.5/K2.6/K2.7 are config
variants of DeepSeek-V3. No standalone `glm5`/`kimi_k2` model dirs or wrappers
remain. The only old short-name kept is `kimi_k2` as an **external HF
`model_type` alias** in the registry, so existing Kimi checkpoints (whose
`config.json` declares `model_type=kimi_k2`) still resolve.

Updated: model dirs + classes, `registry.py`, DSA primitive error messages,
`deepseek_v4` cross-reference comments, layering-contract terms, and the
save/load/export + verl-engine smoke tests; test files renamed to match.

## Verification

- `py_compile`, `black -l 100 --check`, `git diff --check` all clean.
- Whole-repo old-name residual scan clean (only the intentional `kimi_k2` HF
  alias + its explanatory comments remain in `registry.py`).
- Registry import + resolution: `deepseek_v3` / `deepseek_v3_2` packages,
  protocols, and HF model_type aliases (`kimi_k2`, `deepseek_v3`, `glm_moe_dsa`)
  all resolve.
- **8-GPU smoke (Slurm job 12861277, rc=0)** on `pytorch_26.04` +
  `mlite-2604-verl-dsa-sm90-overlay`: `test_save_load_export_smoke` **6 passed**
  — `test_save_load_roundtrip[deepseek_v3-dist_opt]` (tp2/ep2/pp2),
  `[deepseek_v3-fsdp2]`, `[deepseek_v3_2-dist_opt]`, `[deepseek_v3_2-fsdp2]`,
  and `test_export_hf_bf16_reload[deepseek_v3]` / `[deepseek_v3_2]`
  (build → train 1 step → save → load bit-exact → export HF bf16 → reload).
  `test_layering_contracts` 6 passed.

## Out of scope (pre-existing, NOT introduced by this rename)

`test_deepseek_v3_2_lite_static.py` has 12 failures that already exist on
`main` (49ce92e9): the test references symbols that the glm5 source never
defined at HEAD~1 — `Glm5ForCausalLM`, `save_weights`, `_resolve_hf_tensor`,
`_slice_to_target_shape`, `_resolve_named_parameter_tensor`,
`_build_glm5_pipeline_layers` (orphaned by the earlier "drop ForCausalLM
wrapper" refactor) — plus 2 TE-on-CPU `CUDAGuardImpl` env limits. This rename
mechanically renamed both sides 1:1, so the same failures persist with the new
symbol names. The `deepseek_v3` (kimi) static tests all pass. Left for the owner
to decide whether to repair these stale tests separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
