### PR TITLE
qwen3.5 SFT: BSHD dense-bridge path + Megatron-core parity

### DIFF
--- a/experimental/lite/examples/bench/bench.py
+++ b/experimental/lite/examples/bench/bench.py
@@ -289,6 +289,7 @@ def build_runtime_config(cfg: BenchCliConfig) -> RuntimeConfig:
             model_name=cfg.model_name,
             parallel=parallel,
             optimizer=optimizer,
+            use_thd=cfg.use_thd,
             load_hf_weights=not cfg.skip_load_hf_weights,
             build_optimizer=not cfg.skip_optimizer_build,
             override_ddp_config=_json_mapping(cfg.override_ddp_json, name="override_ddp_json"),

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
@@ -104,6 +104,20 @@ def _forward_step(model: nn.Module, batch: PackedBatch) -> dict:
     return model(**kwargs)
 
 
+def _forward_step_bshd(model: nn.Module, batch: PackedBatch) -> dict:
+    """Dense [b=1, s] forward for a single packed sequence (no THD packing).
+
+    Used for deterministic parity comparison vs a dense Megatron-Core reference:
+    the THD GatedDeltaNet kernel is non-deterministic, whereas the dense path is
+    deterministic. CP=1 only (single unpadded sequence => dense == THD tokens).
+    """
+    input_ids = batch.input_ids.reshape(1, -1)
+    labels = batch.labels.reshape(1, -1) if batch.labels is not None else None
+    kwargs: dict[str, Any] = {"input_ids": input_ids, "labels": labels, "packed_seq_params": None}
+    add_cross_entropy_fusion(kwargs, model)
+    return model(**kwargs)
+
+
 def unpack_forward_output(model: nn.Module, batch: PackedBatch, output) -> Any:
     return unpack_thd_forward_output(model, batch, output)
 
@@ -252,7 +266,7 @@ def build_model(model_cfg: Qwen35Config, *, impl_cfg: ImplConfig) -> ModelBundle
         parallel_state=ps,
         optimizer=optimizer,
         finalize_grads=finalize_grads,
-        forward_step=_forward_step,
+        forward_step=_forward_step if impl_cfg.use_thd else _forward_step_bshd,
         extras={
             "model_cfg": model_cfg,
             "optimizer_backend": optimizer_backend,

--- a/experimental/lite/megatron/lite/runtime/backends/bridge/config.py
+++ b/experimental/lite/megatron/lite/runtime/backends/bridge/config.py
@@ -27,6 +27,11 @@ class BridgeConfig:
     load_hf_weights: bool = True
     build_optimizer: bool = True
 
+    # When False, the bridge feeds a dense [b=1, s] forward (no THD packing).
+    # Used for deterministic layout-matched parity vs models whose Megatron-Core
+    # kernel is dense-only (e.g. GatedDeltaNet). Default True keeps THD packing.
+    use_thd: bool = True
+
     override_ddp_config: dict[str, Any] = field(default_factory=dict)
     override_transformer_config: dict[str, Any] = field(default_factory=dict)
     override_optimizer_config: dict[str, Any] = field(default_factory=dict)

--- a/experimental/lite/megatron/lite/runtime/backends/bridge/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/bridge/runtime.py
@@ -577,6 +577,27 @@ def _bridge_forward_kwargs_from_packed_batch(
 # MLITE_LAYERING_ALLOW_BRIDGE_FORWARD_METADATA_END
 
 
+def _bridge_forward_kwargs_bshd(batch: PackedBatch) -> dict[str, Any]:
+    """Render dense [b=1, s] forward kwargs for a single packed sequence.
+
+    Used when ``use_thd`` is False so the Megatron-Core reference runs its dense
+    kernel (e.g. GatedDeltaNet, whose THD path is unsupported / non-deterministic
+    in the pinned core), giving a deterministic, layout-matched parity vs the
+    native lite dense forward on identical tokens. Carries no THD packing
+    metadata (no ``packed_seq_params`` / ``position_ids``) — single unpadded
+    sequence, so an all-ones attention mask reproduces the full causal sequence.
+    CP=1 only.
+    """
+    total = int(batch.seq_lens.sum().item())
+    return {
+        "input_ids": batch.input_ids.reshape(1, total).contiguous(),
+        "labels": (
+            batch.labels.reshape(1, total).contiguous() if batch.labels is not None else None
+        ),
+        "attention_mask": torch.ones((1, total), dtype=torch.long, device=batch.input_ids.device),
+    }
+
+
 class BridgeRuntime(RuntimeBase):
     """Megatron-Bridge training backend using Megatron-Core optimizer state."""
 
@@ -699,8 +720,11 @@ class BridgeRuntime(RuntimeBase):
             sample = next(data_iterator)
             owns_transient_metadata = False
             if isinstance(sample, PackedBatch):
-                sample = _bridge_forward_kwargs_from_packed_batch(sample, **cp_kwargs)
-                owns_transient_metadata = True
+                if self._cfg.use_thd:
+                    sample = _bridge_forward_kwargs_from_packed_batch(sample, **cp_kwargs)
+                    owns_transient_metadata = True
+                else:
+                    sample = _bridge_forward_kwargs_bshd(sample)
             elif isinstance(sample, Batch):
                 sample = {
                     "input_ids": sample["input_ids"],


### PR DESCRIPTION
## What

Add the qwen3.5 SFT path to Megatron Lite and align it with an independent Megatron-core (mbridge) dense bridge, rebased onto current main (PR#40 + PR#41).

## Changes
- `model/qwen3_5/lite/protocol.py` — BSHD path for the SFT bridge.
- `runtime/backends/bridge/{config,runtime}.py` — dense-bridge runtime wiring.
- `examples/bench/bench.py` — bench harness touch-up.

## Validation (real, non-dry-run)
- Layering compliance: `test_layering_contracts` (6 passed) + `test_packed_batch_bridge` (passed) — PR#40 layering contract honored.
- BSHD parity smoke (8-GPU, rc=0): mlite-BSHD vs independent Megatron-core mbridge-dense → **max_loss_abs_diff = 0.01485** (no regression vs pre-rebase 0.0148).
- Speed: mlite 2.834 / mbridge 2.881 TFLOPs/GPU (comparable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)