### PR TITLE
primitive: automatic pipeline layout for non-divisible layer counts

### DIFF
--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/model.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/model.py
@@ -299,7 +299,11 @@ class DeepseekV4Model(nn.Module):
         self.mtp_loss_scaling_factor = config.mtp_loss_scaling_factor
 
         layout = build_pipeline_chunk_layout(
-            config.num_hidden_layers, ps, train_config.vpp, vpp_chunk_id
+            config.num_hidden_layers,
+            ps,
+            train_config.vpp,
+            vpp_chunk_id,
+            num_mtp_layers=config.num_nextn_predict_layers if mtp_enable else 0,
         )
         self.layer_indices = layout.layer_indices
         self.pre_process = layout.has_embed

--- a/experimental/lite/megatron/lite/model/glm5/lite/model.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/model.py
@@ -686,7 +686,11 @@ class Glm5Model(nn.Module):
         self.mtp_loss_scaling_factor = config.mtp_loss_scaling_factor
 
         layout = build_pipeline_chunk_layout(
-            config.num_hidden_layers, ps, train_config.vpp, vpp_chunk_id
+            config.num_hidden_layers,
+            ps,
+            train_config.vpp,
+            vpp_chunk_id,
+            num_mtp_layers=config.num_nextn_predict_layers if mtp_enable else 0,
         )
         self.layer_indices = layout.layer_indices
         self.pre_process = layout.has_embed

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/model.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/model.py
@@ -580,7 +580,11 @@ class KimiK2Model(nn.Module):
         self.mtp_loss_scaling_factor = config.mtp_loss_scaling_factor
 
         layout = build_pipeline_chunk_layout(
-            config.num_hidden_layers, ps, train_config.vpp, vpp_chunk_id
+            config.num_hidden_layers,
+            ps,
+            train_config.vpp,
+            vpp_chunk_id,
+            num_mtp_layers=config.num_nextn_predict_layers if mtp_enable else 0,
         )
         self.layer_indices = layout.layer_indices
         self.pre_process = layout.has_embed

--- a/experimental/lite/megatron/lite/primitive/parallel/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/__init__.py
@@ -15,6 +15,7 @@ from megatron.lite.primitive.parallel.cp import (
 from megatron.lite.primitive.parallel.pipeline import forward_backward_pipelining
 from megatron.lite.primitive.parallel.pp import (
     PipelineChunkLayout,
+    auto_pipeline_layer_counts,
     build_pipeline_chunk_layout,
 )
 from megatron.lite.primitive.parallel.sp import (
@@ -61,6 +62,7 @@ __all__ = [
     "PackedSeqParams",
     "PackedTHDBatch",
     "PipelineChunkLayout",
+    "auto_pipeline_layer_counts",
     "ParallelState",
     "RowParallelLinear",
     "VanillaColumnParallelLinear",

--- a/experimental/lite/megatron/lite/primitive/parallel/pp.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/pp.py
@@ -19,35 +19,113 @@ class PipelineChunkLayout:
     has_head: bool = False
 
 
+def auto_pipeline_layer_counts(
+    num_hidden_layers: int,
+    pp_size: int,
+    *,
+    extra_first: int = 0,
+    extra_last: int = 0,
+) -> list[int]:
+    """Megatron-style auto pipeline layout: split ``num_hidden_layers`` transformer
+    layers across ``pp_size`` stages so the per-stage cost is balanced, even when the
+    layer count is *not* divisible by ``pp_size``.
+
+    ``extra_first`` / ``extra_last`` are pseudo-layers that model the extra cost the
+    first/last stage carries on top of the transformer layers (embedding on the first
+    stage; final norm + LM head + MTP layers on the last stage). They only steer the
+    balancing — they are not real transformer layers and are never emitted in the
+    returned counts. Accounting for them keeps the first/last stages from being
+    overloaded once embedding/head/MTP work is added back in.
+
+    Layer order is preserved: stage ``s`` always owns a contiguous range, so the
+    global layer index of every transformer layer is stable and HF/distckpt weight
+    mapping is unaffected by the split.
+    """
+    assert pp_size >= 1
+    if pp_size == 1:
+        return [num_hidden_layers]
+
+    # Lay out a virtual sequence of [embed pseudo | real layers | head/MTP pseudo]
+    # units and split it into ``pp_size`` contiguous chunks as evenly as possible
+    # (remainder to the earlier stages). A real layer lands on the stage whose chunk
+    # covers its virtual position; the pseudo units only shift those boundaries.
+    total = num_hidden_layers + extra_first + extra_last
+    base, rem = divmod(total, pp_size)
+    chunk_ends: list[int] = []
+    acc = 0
+    for i in range(pp_size):
+        acc += base + (1 if i < rem else 0)
+        chunk_ends.append(acc)
+
+    counts = [0] * pp_size
+    stage = 0
+    for layer in range(num_hidden_layers):
+        vpos = extra_first + layer
+        while vpos >= chunk_ends[stage]:
+            stage += 1
+        counts[stage] += 1
+    return counts
+
+
 def build_pipeline_chunk_layout(
     num_hidden_layers: int,
     ps: ParallelState,
     vpp: int | None = None,
     vpp_chunk_id: int | None = None,
+    *,
+    num_mtp_layers: int = 0,
 ) -> PipelineChunkLayout:
-    """Compute layer_indices, has_embed, has_head for this PP rank / VPP chunk."""
-    if vpp_chunk_id is not None:
-        assert vpp is not None
-        layers_per_chunk = ensure_divisible(num_hidden_layers, ps.pp_size * vpp)
-        start = ps.pp_rank * layers_per_chunk + vpp_chunk_id * (ps.pp_size * layers_per_chunk)
-        layer_indices = list(range(start, start + layers_per_chunk))
-        has_embed = ps.pp_is_first and vpp_chunk_id == 0
-        has_head = ps.pp_is_last and vpp_chunk_id == vpp - 1
-    elif vpp is not None:
-        layers_per_chunk = ensure_divisible(num_hidden_layers, ps.pp_size * vpp)
-        layer_indices = []
-        for chunk in range(vpp):
-            start = ps.pp_rank * layers_per_chunk + chunk * (ps.pp_size * layers_per_chunk)
-            layer_indices.extend(range(start, start + layers_per_chunk))
-        has_embed = ps.pp_is_first
-        has_head = ps.pp_is_last
-    else:
-        layers_per_stage = ensure_divisible(num_hidden_layers, ps.pp_size)
+    """Compute layer_indices, has_embed, has_head for this PP rank / VPP chunk.
+
+    When ``num_hidden_layers`` is divisible by the pipeline width the layout is the
+    plain even split (unchanged behaviour). Otherwise — and only for the non-interleaved
+    path (``vpp`` unset or 1) — the layers are auto-balanced via
+    :func:`auto_pipeline_layer_counts` so a non-divisible count no longer raises and
+    does not require hand-tuning TP/PP. ``num_mtp_layers`` (the multi-token-prediction
+    layers that always live on the last stage) is folded into the balancing so the last
+    stage is not overloaded.
+
+    Interleaved VPP (``vpp > 1``) still requires divisibility by ``pp_size * vpp``;
+    balanced interleaving is out of scope.
+    """
+    if vpp is not None and vpp > 1:
+        if vpp_chunk_id is not None:
+            layers_per_chunk = ensure_divisible(num_hidden_layers, ps.pp_size * vpp)
+            start = ps.pp_rank * layers_per_chunk + vpp_chunk_id * (ps.pp_size * layers_per_chunk)
+            layer_indices = list(range(start, start + layers_per_chunk))
+            has_embed = ps.pp_is_first and vpp_chunk_id == 0
+            has_head = ps.pp_is_last and vpp_chunk_id == vpp - 1
+        else:
+            layers_per_chunk = ensure_divisible(num_hidden_layers, ps.pp_size * vpp)
+            layer_indices = []
+            for chunk in range(vpp):
+                start = ps.pp_rank * layers_per_chunk + chunk * (ps.pp_size * layers_per_chunk)
+                layer_indices.extend(range(start, start + layers_per_chunk))
+            has_embed = ps.pp_is_first
+            has_head = ps.pp_is_last
+        return PipelineChunkLayout(
+            layer_indices=layer_indices, has_embed=has_embed, has_head=has_head
+        )
+
+    # Non-interleaved path (vpp is None or 1).
+    if num_hidden_layers % ps.pp_size == 0:
+        layers_per_stage = num_hidden_layers // ps.pp_size
         start = ps.pp_rank * layers_per_stage
         layer_indices = list(range(start, start + layers_per_stage))
-        has_embed = ps.pp_is_first
-        has_head = ps.pp_is_last
+    else:
+        # Auto layout for non-divisible counts: account for embedding on the first
+        # stage and final norm + head + MTP layers on the last stage.
+        counts = auto_pipeline_layer_counts(
+            num_hidden_layers,
+            ps.pp_size,
+            extra_first=1,
+            extra_last=1 + max(0, num_mtp_layers),
+        )
+        start = sum(counts[: ps.pp_rank])
+        layer_indices = list(range(start, start + counts[ps.pp_rank]))
+    has_embed = ps.pp_is_first
+    has_head = ps.pp_is_last
     return PipelineChunkLayout(layer_indices=layer_indices, has_embed=has_embed, has_head=has_head)
 
 
-__all__ = ["PipelineChunkLayout", "build_pipeline_chunk_layout"]
+__all__ = ["PipelineChunkLayout", "auto_pipeline_layer_counts", "build_pipeline_chunk_layout"]

--- a/experimental/lite/tests/smoke/primitive/test_auto_pipeline_layout_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_auto_pipeline_layout_smoke.py
@@ -1,0 +1,395 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Auto pipeline-layout smoke: non-divisible layer counts run end-to-end on PP>1.
+
+The claim under test: when ``num_hidden_layers`` is *not* divisible
+by the pipeline width, ``build_pipeline_chunk_layout`` auto-balances the layers
+across PP stages (Megatron-style uneven split, accounting for embedding / head /
+MTP overhead) instead of raising "not divisible" — so no hand-tuning of TP/PP is
+required.
+
+Matrix: {qwen3_5, qwen3_moe, kimi_k2, glm5, deepseek_v4}, each built with an
+odd ``num_hidden_layers`` (3) on a pp=2 topology so the split is necessarily
+uneven ([2, 1]). DeepSeek-V4 additionally carries an MTP layer on the last
+stage, exercising the MTP-aware balancing.
+
+PP is the variable under test and is fixed at 2 for every model; the remaining
+dims match the save/load/export smoke's proven dist_opt topology so an orthogonal
+limitation cannot mask the layout result:
+  * tp2/pp2/cp1/ep2 for the TP-capable models (qwen3_5, qwen3_moe, kimi_k2);
+  * tp1/pp2/cp1/ep2 for glm5 / deepseek_v4 (native lite is TP=1 only).
+CP is held at 1: cp>1 with these tiny proxy sequences makes Transformer Engine
+report "no dot product attention backend available" (and risks the known
+fused-DSA CP+tiny-seq hang) — both orthogonal to pipeline layout. CP fidelity
+is covered by the dedicated CP smokes.
+
+Run with torchrun --nproc_per_node=8 -m pytest --mlite-smoke, selecting per-env
+subsets with -k like the save/load/export smoke: qwen3_5 on the qwen3.5 site; the
+glm5 / deepseek_v4 / qwen3_moe / kimi_k2 models on the DSA overlay. Models also
+gate themselves with importorskip.
+"""
+from __future__ import annotations
+
+import os
+from datetime import timedelta
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from megatron.lite.primitive.ckpt.hf_weights import unwrap_model
+from megatron.lite.primitive.deterministic import set_deterministic
+from megatron.lite.primitive.parallel.pp import auto_pipeline_layer_counts
+from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
+from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
+from megatron.lite.runtime.contracts.data import PackedBatch
+
+pytestmark = [pytest.mark.mlite, pytest.mark.smoke, pytest.mark.gpu, pytest.mark.distributed]
+
+# pp=2 with an odd layer count forces an uneven split; small enough to stay fast.
+_NUM_LAYERS = 3
+_PP = 2
+
+# GLM5 / DeepSeek-V4 native lite support TP=1 only (matches the save/load smoke).
+_TP1_ONLY = {"glm5", "deepseek_v4"}
+
+
+def _require_te() -> None:
+    te = pytest.importorskip(
+        "transformer_engine.pytorch",
+        reason="auto pipeline-layout smoke requires real Transformer Engine.",
+    )
+    assert hasattr(te, "Linear"), "smoke requires real Transformer Engine Linear."
+
+
+def _optimizer_config() -> OptimizerConfig:
+    return OptimizerConfig(
+        optimizer="adam",
+        lr=1.0e-3,
+        weight_decay=0.0,
+        adam_beta1=0.9,
+        adam_beta2=0.95,
+        adam_eps=1.0e-8,
+        clip_grad=1.0,
+        offload_fraction=0.0,
+    )
+
+
+def _random_packed_batch(vocab_size: int) -> PackedBatch:
+    return PackedBatch(
+        input_ids=torch.randint(0, vocab_size, (2048,), device="cuda"),
+        labels=torch.randint(0, vocab_size, (2048,), device="cuda"),
+        seq_lens=torch.full((1,), 2048, dtype=torch.int64, device="cuda"),
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Non-divisible model configs (mirror the save/load smoke's tiny configs but
+# with num_hidden_layers=3 and layer_types extended to match).
+# ──────────────────────────────────────────────────────────────────────────
+def _qwen3_5():
+    pytest.importorskip("fla", reason="qwen3_5 needs the FLA / GatedDeltaNet stack.")
+    _require_te()
+    from megatron.lite.model.qwen3_5.config import Qwen35Config
+    from megatron.lite.model.qwen3_5.lite import protocol
+
+    cfg = Qwen35Config(
+        num_hidden_layers=_NUM_LAYERS,
+        hidden_size=16,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=4,
+        vocab_size=64,
+        num_experts=4,
+        num_experts_per_tok=2,
+        moe_intermediate_size=8,
+        shared_expert_intermediate_size=8,
+        linear_num_key_heads=2,
+        linear_key_head_dim=4,
+        linear_num_value_heads=2,
+        linear_value_head_dim=4,
+        linear_conv_kernel_dim=4,
+        layer_types=["full_attention", "linear_attention", "full_attention"],
+        partial_rotary_factor=1.0,
+        max_position_embeddings=4096,
+    )
+    return cfg, protocol
+
+
+def _qwen3_moe():
+    _require_te()
+    from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
+    from megatron.lite.model.qwen3_moe.lite import protocol
+
+    cfg = Qwen3MoEConfig(
+        num_hidden_layers=_NUM_LAYERS,
+        hidden_size=16,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=4,
+        vocab_size=64,
+        num_experts=4,
+        num_experts_per_tok=1,
+        moe_intermediate_size=8,
+        max_position_embeddings=4096,
+        layer_types=["full_attention", "full_attention", "full_attention"],
+    )
+    return cfg, protocol
+
+
+def _kimi_k2():
+    _require_te()
+    from megatron.lite.model.kimi_k2.config import KimiK2Config
+    from megatron.lite.model.kimi_k2.lite import protocol
+
+    cfg = KimiK2Config(
+        num_hidden_layers=_NUM_LAYERS,
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        vocab_size=128,
+        intermediate_size=96,
+        moe_intermediate_size=16,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        n_group=2,
+        topk_group=1,
+        first_k_dense_replace=1,
+        q_lora_rank=16,
+        kv_lora_rank=12,
+        qk_nope_head_dim=8,
+        qk_rope_head_dim=8,
+        v_head_dim=8,
+        max_position_embeddings=4096,
+        rope_theta=10000.0,
+        rope_scaling={
+            "type": "yarn",
+            "factor": 1.0,
+            "original_max_position_embeddings": 4096,
+            "beta_fast": 1.0,
+            "beta_slow": 1.0,
+            "mscale": 1.0,
+            "mscale_all_dim": 1.0,
+        },
+    )
+    return cfg, protocol
+
+
+def _glm5():
+    pytest.importorskip("cudnn", reason="glm5 fused DSA needs the cudnn DSA stack.")
+    _require_te()
+    from megatron.lite.model.glm5.config import Glm5Config
+    from megatron.lite.model.glm5.lite import protocol
+
+    cfg = Glm5Config(
+        num_hidden_layers=_NUM_LAYERS,
+        hidden_size=128,
+        num_attention_heads=64,
+        num_key_value_heads=64,
+        head_dim=256,
+        vocab_size=32,
+        max_position_embeddings=4096,
+        initializer_range=0.002,
+        q_lora_rank=16,
+        kv_lora_rank=512,
+        qk_head_dim=256,
+        qk_nope_head_dim=192,
+        qk_rope_head_dim=64,
+        v_head_dim=256,
+        index_head_dim=128,
+        index_n_heads=32,
+        index_topk=512,
+        intermediate_size=20,
+        moe_intermediate_size=6,
+        first_k_dense_replace=1,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+    )
+    return cfg, protocol
+
+
+def _deepseek_v4():
+    pytest.importorskip("cudnn", reason="deepseek_v4 fused DSA needs the cudnn DSA stack.")
+    _require_te()
+    from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
+    from megatron.lite.model.deepseek_v4.lite import protocol
+
+    cfg = DeepseekV4Config(
+        vocab_size=64,
+        hidden_size=128,
+        moe_intermediate_size=16,
+        num_hidden_layers=_NUM_LAYERS,
+        num_attention_heads=8,
+        num_key_value_heads=1,
+        head_dim=64,
+        qk_rope_head_dim=16,
+        q_lora_rank=32,
+        o_lora_rank=32,
+        o_groups=2,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        routed_scaling_factor=1.5,
+        max_position_embeddings=4096,
+        compress_ratios=[4, 4],
+        sliding_window=128,
+        num_hash_layers=2,
+        hc_mult=2,
+        index_head_dim=64,
+        index_n_heads=8,
+        index_topk=512,
+        # Real MTP: an extra nextn layer on the last stage exercises the
+        # MTP-aware branch of the auto layout balancing.
+        num_nextn_predict_layers=1,
+        rms_norm_eps=1e-6,
+    )
+    return cfg, protocol
+
+
+MODELS = {
+    "qwen3_5": _qwen3_5,
+    "qwen3_moe": _qwen3_moe,
+    "kimi_k2": _kimi_k2,
+    "glm5": _glm5,
+    "deepseek_v4": _deepseek_v4,
+}
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Distributed harness (mirrors the save/load/export smoke).
+# ──────────────────────────────────────────────────────────────────────────
+@pytest.fixture(scope="module", autouse=True)
+def _single_node_cuda_dist():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for auto pipeline-layout smoke.")
+    if int(os.environ.get("WORLD_SIZE", "1")) > 8:
+        pytest.skip("Megatron Lite smoke tests are capped at single-node 8 GPUs.")
+
+    os.environ.setdefault("CUBLAS_WORKSPACE_CONFIG", ":4096:8")
+    os.environ.setdefault("NVTE_ALLOW_NONDETERMINISTIC_ALGO", "0")
+    os.environ.setdefault("RANK", "0")
+    os.environ.setdefault("WORLD_SIZE", "1")
+    os.environ.setdefault("LOCAL_RANK", "0")
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29577")
+
+    torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
+    created_pg = False
+    if not dist.is_initialized():
+        timeout_s = int(os.environ.get("MLITE_DIST_TIMEOUT_S", "180"))
+        dist.init_process_group(
+            backend="nccl", init_method="env://", timeout=timedelta(seconds=timeout_s)
+        )
+        created_pg = True
+    yield
+    try:
+        from megatron.core import parallel_state as mpu
+
+        if mpu.is_initialized():
+            mpu.destroy_model_parallel()
+    finally:
+        if created_pg and dist.is_initialized():
+            dist.destroy_process_group()
+
+
+@pytest.fixture(autouse=True)
+def _reset_parallel_state_between_tests():
+    yield
+    from megatron.core import parallel_state as mpu
+
+    if mpu.is_initialized():
+        mpu.destroy_model_parallel()
+
+
+def _proxy_topology(model_name: str) -> ParallelConfig:
+    # PP is held at 2 (the layout axis under test); the rest match the save/load
+    # smoke's proven dist_opt topology. CP=1 — see module docstring.
+    if model_name in _TP1_ONLY:  # glm5 / deepseek_v4: native lite is TP=1 only.
+        return ParallelConfig(tp=1, ep=2, etp=1, pp=_PP, cp=1)
+    return ParallelConfig(tp=2, ep=2, etp=1, pp=_PP, cp=1)
+
+
+def _build_handle(model_name: str, *, seed: int):
+    from types import SimpleNamespace
+
+    from megatron.lite.runtime.contracts.handle import ModelHandle
+
+    cfg, protocol = MODELS[model_name]()
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+    parallel = _proxy_topology(model_name)
+    impl_cfg = protocol.ImplConfig(
+        parallel=parallel,
+        optimizer="dist_opt",
+        optimizer_config=_optimizer_config(),
+        use_deepep=False,
+        deterministic=True,
+    )
+    bundle = protocol.build_model(cfg, impl_cfg=impl_cfg)
+    chunks = bundle.chunks
+    extras = dict(bundle.extras)
+    extras.update(
+        {
+            "model_chunks": chunks,
+            "forward_step": bundle.forward_step,
+            "finalize_grads": bundle.finalize_grads,
+            "protocol": protocol,
+        }
+    )
+    handle = ModelHandle(
+        model=chunks,
+        optimizer=bundle.optimizer,
+        parallel_state=bundle.parallel_state,
+        config=SimpleNamespace(parallel=parallel),
+        _extras=extras,
+    )
+    return handle, cfg
+
+
+def _local_layer_indices(handle) -> list[int]:
+    chunk = unwrap_model(handle._extras["model_chunks"][0])
+    return list(getattr(chunk, "layer_indices"))
+
+
+@pytest.mark.parametrize("model_name", list(MODELS))
+def test_non_divisible_layers_auto_balance_and_train(model_name):
+    """A non-divisible layer count builds an uneven PP split and trains a step."""
+    if dist.get_world_size() != 8:
+        pytest.skip("auto pipeline-layout proxy smoke requires exactly 8 GPUs.")
+
+    set_deterministic(2026)
+
+    handle, cfg = _build_handle(model_name, seed=4242)
+    ps = handle._parallel_state
+    assert ps.pp_size == _PP
+
+    # The non-divisible count must produce the balanced uneven split, not raise.
+    expected_counts = auto_pipeline_layer_counts(
+        cfg.num_hidden_layers,
+        ps.pp_size,
+        extra_first=1,
+        extra_last=1 + (getattr(cfg, "num_nextn_predict_layers", 0) or 0),
+    )
+    local = _local_layer_indices(handle)
+    start = sum(expected_counts[: ps.pp_rank])
+    assert local == list(range(start, start + expected_counts[ps.pp_rank])), (
+        f"{model_name} rank{ps.pp_rank}: layer_indices {local} "
+        f"!= expected balanced split {expected_counts}"
+    )
+    assert sum(expected_counts) == cfg.num_hidden_layers
+    assert max(expected_counts) - min(expected_counts) <= 1  # balanced
+
+    # End-to-end: one real train step over the uneven pipeline must produce a
+    # finite loss (proves PP P2P across stages of unequal depth actually runs).
+    runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
+    batch = _random_packed_batch(cfg.vocab_size)
+    runtime.zero_grad(handle)
+    result = runtime.forward_backward(handle, iter([batch]), None, num_microbatches=1)
+    runtime.optimizer_step(handle)
+
+    loss = result.model_output.loss
+    assert loss is not None and torch.isfinite(loss).all(), (
+        f"{model_name}: non-finite loss {loss} on uneven PP layout"
+    )

--- a/experimental/lite/tests/unit/primitive/test_parallel_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_parallel_unit.py
@@ -6,6 +6,7 @@ import torch
 
 from megatron.lite.primitive.parallel import (
     ParallelState,
+    auto_pipeline_layer_counts,
     build_pipeline_chunk_layout,
     pack_nested_thd,
     parallel_state_from_model,
@@ -71,6 +72,63 @@ def test_pp_layout_rejects_non_divisible_vpp_layer_counts():
 
     with pytest.raises(ValueError, match="10 is not divisible by 6"):
         build_pipeline_chunk_layout(10, ps, vpp=3, vpp_chunk_id=0)
+
+
+def _ranks(pp_size: int) -> list[ParallelState]:
+    return [
+        ParallelState(
+            pp_size=pp_size,
+            pp_rank=r,
+            pp_is_first=(r == 0),
+            pp_is_last=(r == pp_size - 1),
+        )
+        for r in range(pp_size)
+    ]
+
+
+def _plain_layout_indices(num_layers: int, pp_size: int, **kw) -> list[list[int]]:
+    return [
+        build_pipeline_chunk_layout(num_layers, ps, **kw).layer_indices for ps in _ranks(pp_size)
+    ]
+
+
+def test_auto_layer_counts_balance_and_cover_when_not_divisible():
+    # 10 layers over 4 stages: balanced, contiguous, no layer dropped/duplicated.
+    counts = auto_pipeline_layer_counts(10, 4)
+    assert sum(counts) == 10
+    assert max(counts) - min(counts) <= 1
+    # embedding (+first) and head/MTP (+last) pull layers off the end stages.
+    counts_acc = auto_pipeline_layer_counts(10, 4, extra_first=1, extra_last=1 + 2)
+    assert sum(counts_acc) == 10
+    assert counts_acc[-1] <= counts[-1]  # MTP-laden last stage gets no more layers
+
+
+def test_pp_layout_auto_balances_non_divisible_counts_without_error():
+    # 10 layers, pp=4 — previously raised "not divisible"; now auto-balanced.
+    indices = _plain_layout_indices(10, 4)
+    flat = [i for stage in indices for i in stage]
+    assert flat == list(range(10))  # contiguous, ordered, complete
+    sizes = [len(s) for s in indices]
+    assert sum(sizes) == 10 and max(sizes) - min(sizes) <= 1
+    # vpp=1 (the model default) takes the same non-interleaved path.
+    assert _plain_layout_indices(10, 4, vpp=1) == indices
+
+
+def test_pp_layout_accounts_for_mtp_on_last_stage_when_non_divisible():
+    # With MTP layers on the last stage, the last stage should not carry more
+    # transformer layers than without accounting.
+    plain = _plain_layout_indices(7, 2)
+    with_mtp = _plain_layout_indices(7, 2, num_mtp_layers=2)
+    assert [i for s in with_mtp for i in s] == list(range(7))
+    assert len(with_mtp[-1]) <= len(plain[-1])
+
+
+def test_pp_layout_divisible_split_is_unchanged_by_auto_layout():
+    # Divisible counts must keep the plain even split (no checkpoint/layout drift),
+    # regardless of vpp=1 or MTP accounting.
+    assert _plain_layout_indices(8, 4) == [[0, 1], [2, 3], [4, 5], [6, 7]]
+    assert _plain_layout_indices(8, 4, vpp=1) == [[0, 1], [2, 3], [4, 5], [6, 7]]
+    assert _plain_layout_indices(8, 4, num_mtp_layers=3) == [[0, 1], [2, 3], [4, 5], [6, 7]]
 
 
 def test_virtual_pipeline_rank_is_tracked_on_lite_parallel_state():


### PR DESCRIPTION
## What

Add automatic pipeline layout for **non-divisible** layer counts in Megatron Lite, so layer-count / PP mismatches no longer require manual TP/PP tuning.

## Changes
- `primitive/parallel/pp.py` (+ `parallel/__init__.py`) — new `auto_pipeline_layer_counts`: Megatron-style balanced split that folds per-stage overhead into balancing (embedding on first stage; final norm/head + MTP layers on last stage). Never raises, never needs manual PP. Layer order preserved → global indices stable → HF/distckpt mapping untouched.
- `model/{deepseek_v4,glm5,kimi_k2}/lite/model.py` — pass `num_mtp_layers`; qwen models default 0.
- VPP > 1 unchanged (still requires divisibility; out of scope).

## Validation (real, non-dry-run)
- Unit: 15 passed (divisible-unchanged, non-divisible-balanced-complete, MTP-aware, VPP-reject preserved).
- 8-GPU proxy, all 5 models with `num_hidden_layers=3` (not divisible by pp=2), real train step + finite loss + asserted uneven split:
  - DSA env: deepseek_v4 (with MTP), glm5, qwen3_moe, kimi_k2 (4 passed).
  - non-DSA env: qwen3_5 (1 passed).
- Held CP=1 (proven save/load topology); cp>1+tiny-seq trips a Transformer Engine "no attention backend" error orthogonal to PP layout — documented, not descoped.

## Note
Touches shared `pp.py` + 3 model files — has a land-order dependency with the model-rename PR (#42) and parallel model tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)