### PR TITLE
mlite: unified MoE router replay across 5 models

### DIFF
--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/moe.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/moe.py
@@ -32,6 +32,10 @@ class DeepseekV4MoE(nn.Module):
         self.is_hash_layer = layer_idx < config.num_hash_layers
         self.gate = SigmoidTopKRouter(config, ps, compute_aux_loss=False)
         if self.is_hash_layer:
+            # Hash layers route by token id (tid2eid), never through the gate's
+            # topk — their routing is weight-independent, so they are excluded
+            # from router replay (recording/replaying them would be a no-op).
+            self.gate._router_replay_exclude = True
             self.gate.register_buffer(
                 "tid2eid",
                 torch.zeros(config.vocab_size, self.topk, dtype=torch.int64),

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/moe.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/moe.py
@@ -2,7 +2,6 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-
 from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
 from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
 from megatron.lite.primitive.modules.experts import Experts

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
@@ -6,13 +6,18 @@ from typing import Any
 
 import torch
 import torch.nn as nn
-
 from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
 from megatron.lite.model.deepseek_v4.lite.checkpoint import (
     EXPERT_CLASSIFIER,
     PLACEMENT_FN,
+)
+from megatron.lite.model.deepseek_v4.lite.checkpoint import (
     export_hf_weights as _export_hf_weights_impl,
+)
+from megatron.lite.model.deepseek_v4.lite.checkpoint import (
     load_hf_weights as _load_hf_weights_impl,
+)
+from megatron.lite.model.deepseek_v4.lite.checkpoint import (
     save_hf_weights as _save_hf_weights_impl,
 )
 from megatron.lite.model.protocol_utils import add_loss_context_kwargs
@@ -24,7 +29,11 @@ from megatron.lite.primitive.parallel.cp import (
     local_position_ids_for_cp,
     local_sequence_tensor_for_cp,
 )
-from megatron.lite.primitive.parallel.thd import pack_nested_thd, thd_pack_meta, unpack_thd_to_nested
+from megatron.lite.primitive.parallel.thd import (
+    pack_nested_thd,
+    thd_pack_meta,
+    unpack_thd_to_nested,
+)
 from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec
 from megatron.lite.runtime.contracts import OptimizerConfig, PackedBatch, ParallelConfig
 

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
@@ -263,6 +263,20 @@ def unpack_forward_output(model: nn.Module, batch: PackedBatch, output) -> Any:
     return unpack_thd_to_nested(output, meta, contiguous=True)
 
 
+def pack_routed_experts(model: nn.Module, batch: PackedBatch, routed_experts):
+    """Router-replay targets for DS4: contiguous CP split (matches the fused DSA
+    indexer layout). Hash-routed layers are excluded upstream from replay."""
+    from megatron.lite.model import protocol_utils
+
+    return protocol_utils.pack_routed_experts(model, batch, routed_experts, contiguous=True)
+
+
+def unpack_routed_experts(model: nn.Module, batch: PackedBatch, recorded):
+    from megatron.lite.model import protocol_utils
+
+    return protocol_utils.unpack_routed_experts(model, batch, recorded, contiguous=True)
+
+
 def _apply_mtp_config(model_cfg: DeepseekV4Config, impl_cfg: ImplConfig) -> None:
     override = impl_cfg.num_nextn_predict_layers
     if override is None:

--- a/experimental/lite/megatron/lite/model/glm5/lite/model.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/model.py
@@ -43,6 +43,7 @@ from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
 from megatron.lite.primitive.modules.experts import Experts
 from megatron.lite.primitive.modules.moe import MoEAuxLossAutoScaler
 from megatron.lite.primitive.modules.mtp import MTPLossAutoScaler
+from megatron.lite.primitive.modules.router import RouterReplay
 from megatron.lite.primitive.ops.cross_entropy import vocab_parallel_cross_entropy
 from megatron.lite.primitive.ops.linear_cross_entropy import linear_cross_entropy
 from megatron.lite.primitive.ops.logprob import vocab_parallel_entropy
@@ -236,6 +237,7 @@ class Glm5SigmoidTopKRouter(nn.Module):
         compute_aux_loss: bool = True,
         use_pre_softmax: bool = False,
         moe_router_fusion: bool = False,
+        enable_routing_replay: bool = False,
     ):
         super().__init__()
         if router_bias_rate > 0:
@@ -253,6 +255,7 @@ class Glm5SigmoidTopKRouter(nn.Module):
         self.compute_aux_loss = compute_aux_loss
         self.use_pre_softmax = use_pre_softmax
         self.moe_router_fusion = moe_router_fusion
+        self.router_replay = RouterReplay() if enable_routing_replay else None
 
         self.gate = nn.Linear(config.hidden_size, config.n_routed_experts, bias=False)
         self.register_buffer(
@@ -300,6 +303,10 @@ class Glm5SigmoidTopKRouter(nn.Module):
         topk_scores, topk_indices = _ordered_topk_from_routing_map(
             probs_dense, routing_map, self.topk
         )
+        if self.router_replay is not None:
+            topk_scores, topk_indices = self.router_replay.apply(
+                probs_dense, topk_scores, topk_indices
+            )
         topk_scores = topk_scores.to(logits.dtype)
 
         if self.compute_aux_loss and self.training and torch.is_grad_enabled():

--- a/experimental/lite/megatron/lite/model/glm5/lite/model.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/model.py
@@ -33,8 +33,8 @@ import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 import transformer_engine.pytorch as te
-
 from megatron.lite.model.glm5.config import Glm5Config
+from megatron.lite.primitive.kernels.swiglu import bias_swiglu_impl
 from megatron.lite.primitive.modules.attention import (
     DynamicSparseAttention,
     build_rotary_embeddings,
@@ -48,7 +48,6 @@ from megatron.lite.primitive.ops.cross_entropy import vocab_parallel_cross_entro
 from megatron.lite.primitive.ops.linear_cross_entropy import linear_cross_entropy
 from megatron.lite.primitive.ops.logprob import vocab_parallel_entropy
 from megatron.lite.primitive.ops.sp_ops import ReduceScatterDim0
-from megatron.lite.primitive.kernels.swiglu import bias_swiglu_impl
 from megatron.lite.primitive.parallel import (
     ColumnParallelLinear,
     ParallelState,

--- a/experimental/lite/megatron/lite/model/glm5/lite/model.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/model.py
@@ -43,7 +43,6 @@ from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
 from megatron.lite.primitive.modules.experts import Experts
 from megatron.lite.primitive.modules.moe import MoEAuxLossAutoScaler
 from megatron.lite.primitive.modules.mtp import MTPLossAutoScaler
-from megatron.lite.primitive.modules.router import RouterReplay
 from megatron.lite.primitive.ops.cross_entropy import vocab_parallel_cross_entropy
 from megatron.lite.primitive.ops.linear_cross_entropy import linear_cross_entropy
 from megatron.lite.primitive.ops.logprob import vocab_parallel_entropy
@@ -236,7 +235,6 @@ class Glm5SigmoidTopKRouter(nn.Module):
         compute_aux_loss: bool = True,
         use_pre_softmax: bool = False,
         moe_router_fusion: bool = False,
-        enable_routing_replay: bool = False,
     ):
         super().__init__()
         if router_bias_rate > 0:
@@ -254,7 +252,9 @@ class Glm5SigmoidTopKRouter(nn.Module):
         self.compute_aux_loss = compute_aux_loss
         self.use_pre_softmax = use_pre_softmax
         self.moe_router_fusion = moe_router_fusion
-        self.router_replay = RouterReplay() if enable_routing_replay else None
+        # Router replay is enabled uniformly via attach_router_replay() — one path,
+        # one default for all models; no per-model replay knob.
+        self.router_replay = None
 
         self.gate = nn.Linear(config.hidden_size, config.n_routed_experts, bias=False)
         self.register_buffer(

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/model.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/model.py
@@ -19,6 +19,7 @@ from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
 from megatron.lite.primitive.modules.experts import Experts
 from megatron.lite.primitive.modules.moe import MoEAuxLossAutoScaler
 from megatron.lite.primitive.modules.mtp import MTPLossAutoScaler
+from megatron.lite.primitive.modules.router import RouterReplay
 from megatron.lite.primitive.ops.cross_entropy import vocab_parallel_cross_entropy
 from megatron.lite.primitive.ops.linear_cross_entropy import linear_cross_entropy
 from megatron.lite.primitive.ops.logprob import vocab_parallel_entropy
@@ -124,6 +125,7 @@ class KimiK2SigmoidTopKRouter(nn.Module):
         compute_aux_loss: bool = True,
         use_pre_softmax: bool = False,
         moe_router_fusion: bool = False,
+        enable_routing_replay: bool = False,
     ):
         super().__init__()
         if router_bias_rate > 0:
@@ -140,6 +142,7 @@ class KimiK2SigmoidTopKRouter(nn.Module):
         self.compute_aux_loss = compute_aux_loss
         self.use_pre_softmax = use_pre_softmax
         self.moe_router_fusion = moe_router_fusion
+        self.router_replay = RouterReplay() if enable_routing_replay else None
 
         self.gate = nn.Linear(config.hidden_size, config.n_routed_experts, bias=False)
         self.register_buffer(
@@ -187,6 +190,10 @@ class KimiK2SigmoidTopKRouter(nn.Module):
         topk_scores, topk_indices = _ordered_topk_from_routing_map(
             probs_dense, routing_map, self.topk
         )
+        if self.router_replay is not None:
+            topk_scores, topk_indices = self.router_replay.apply(
+                probs_dense, topk_scores, topk_indices
+            )
         topk_scores = topk_scores.to(logits.dtype)
 
         if self.compute_aux_loss and self.training and torch.is_grad_enabled():

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/model.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/model.py
@@ -19,7 +19,6 @@ from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
 from megatron.lite.primitive.modules.experts import Experts
 from megatron.lite.primitive.modules.moe import MoEAuxLossAutoScaler
 from megatron.lite.primitive.modules.mtp import MTPLossAutoScaler
-from megatron.lite.primitive.modules.router import RouterReplay
 from megatron.lite.primitive.ops.cross_entropy import vocab_parallel_cross_entropy
 from megatron.lite.primitive.ops.linear_cross_entropy import linear_cross_entropy
 from megatron.lite.primitive.ops.logprob import vocab_parallel_entropy
@@ -124,7 +123,6 @@ class KimiK2SigmoidTopKRouter(nn.Module):
         compute_aux_loss: bool = True,
         use_pre_softmax: bool = False,
         moe_router_fusion: bool = False,
-        enable_routing_replay: bool = False,
     ):
         super().__init__()
         if router_bias_rate > 0:
@@ -141,7 +139,9 @@ class KimiK2SigmoidTopKRouter(nn.Module):
         self.compute_aux_loss = compute_aux_loss
         self.use_pre_softmax = use_pre_softmax
         self.moe_router_fusion = moe_router_fusion
-        self.router_replay = RouterReplay() if enable_routing_replay else None
+        # Router replay is enabled uniformly via attach_router_replay() — one path,
+        # one default for all models; no per-model replay knob.
+        self.router_replay = None
 
         self.gate = nn.Linear(config.hidden_size, config.n_routed_experts, bias=False)
         self.register_buffer(

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/model.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/model.py
@@ -12,8 +12,8 @@ import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 import transformer_engine.pytorch as te
-
 from megatron.lite.model.kimi_k2.config import KimiK2Config
+from megatron.lite.primitive.kernels.swiglu import bias_swiglu_impl
 from megatron.lite.primitive.modules.attention import MultiLatentAttention
 from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
 from megatron.lite.primitive.modules.experts import Experts
@@ -24,7 +24,6 @@ from megatron.lite.primitive.ops.cross_entropy import vocab_parallel_cross_entro
 from megatron.lite.primitive.ops.linear_cross_entropy import linear_cross_entropy
 from megatron.lite.primitive.ops.logprob import vocab_parallel_entropy
 from megatron.lite.primitive.ops.sp_ops import ReduceScatterDim0
-from megatron.lite.primitive.kernels.swiglu import bias_swiglu_impl
 from megatron.lite.primitive.parallel import (
     ColumnParallelLinear,
     ParallelState,

--- a/experimental/lite/megatron/lite/model/protocol_utils.py
+++ b/experimental/lite/megatron/lite/model/protocol_utils.py
@@ -113,12 +113,14 @@ def pack_routed_experts(
     per-layer targets the runtime feeds to ``RouterReplay.set_replay_data``.
     """
     ps = _parallel_state(model)
+    # Padding always uses the zigzag (2*cp) TE alignment — every model packs that
+    # way; only the CP split direction differs (zigzag interleave vs contiguous
+    # block, e.g. DeepSeek-V4's fused DSA indexer).
     meta = thd_pack_meta(
         batch.seq_lens,
         tp_size=ps.tp_size,
         cp_size=ps.cp_size,
         cp_group=ps.cp_group if ps.cp_size > 1 else None,
-        contiguous=contiguous,
     )
     rows = (
         list(routed_experts.unbind(0))
@@ -146,13 +148,19 @@ def pack_routed_experts(
             )
         start = int(meta.cu_seqlens_padded[idx].item())
         full[start : start + length] = row.to(device=device, dtype=torch.long)
-    local = split_packed_to_cp_local(
-        full,
-        cu_seqlens_padded=meta.cu_seqlens_padded,
-        cp_size=ps.cp_size,
-        cp_rank=ps.cp_rank,
-        dim=0,
-    )
+    if contiguous:
+        if ps.cp_size > 1:
+            local_len = total_padded // ps.cp_size
+            full = full[ps.cp_rank * local_len : (ps.cp_rank + 1) * local_len]
+        local = full
+    else:
+        local = split_packed_to_cp_local(
+            full,
+            cu_seqlens_padded=meta.cu_seqlens_padded,
+            cp_size=ps.cp_size,
+            cp_rank=ps.cp_rank,
+            dim=0,
+        )
     return [local[:, layer, :].contiguous() for layer in range(num_layers)]
 
 

--- a/experimental/lite/megatron/lite/model/protocol_utils.py
+++ b/experimental/lite/megatron/lite/model/protocol_utils.py
@@ -164,6 +164,7 @@ def unpack_routed_experts(model, batch: PackedBatch, recorded, *, contiguous: bo
     ``unpack_thd_forward_output``).
     """
     ps = _parallel_state(model)
+    num_layers, topk = int(recorded.size(1)), int(recorded.size(2))
     meta = thd_pack_meta(
         batch.seq_lens,
         tp_size=ps.tp_size,
@@ -171,7 +172,13 @@ def unpack_routed_experts(model, batch: PackedBatch, recorded, *, contiguous: bo
         cp_group=ps.cp_group if ps.cp_size > 1 else None,
         contiguous=contiguous,
     )
-    return unpack_thd_to_nested(recorded, meta, contiguous=contiguous)
+    # Flatten (layers, topk) into one feature dim so unpack_thd_to_nested's
+    # singleton-squeeze heuristic can't drop a 1-layer model's layer axis, then
+    # restore [seq, layers, topk] per sequence.
+    flat = recorded.reshape(recorded.size(0), num_layers * topk)
+    nested = unpack_thd_to_nested(flat, meta, contiguous=contiguous)
+    rows = [row.reshape(row.size(0), num_layers, topk) for row in nested.unbind(0)]
+    return torch.nested.as_nested_tensor(rows, layout=torch.jagged)
 
 
 def add_loss_context_kwargs(kwargs: dict[str, Any], *, include_return_log_probs: bool = False) -> None:

--- a/experimental/lite/megatron/lite/model/protocol_utils.py
+++ b/experimental/lite/megatron/lite/model/protocol_utils.py
@@ -161,24 +161,31 @@ def pack_routed_experts(
             cp_rank=ps.cp_rank,
             dim=0,
         )
+    # The router runs on the sequence-parallel (TP) shard of the CP-local tokens,
+    # so slice this TP rank's contiguous chunk to match what the gate sees.
+    if ps.tp_size > 1:
+        tp_local = local.size(0) // ps.tp_size
+        local = local[ps.tp_rank * tp_local : (ps.tp_rank + 1) * tp_local]
     return [local[:, layer, :].contiguous() for layer in range(num_layers)]
 
 
 def unpack_routed_experts(model, batch: PackedBatch, recorded, *, contiguous: bool = False):
     """Reverse recorded per-layer routing back to jagged ``[bs, seq, layers, topk]``.
 
-    ``recorded`` is this rank's stacked routing ``[local_padded_tokens, num_layers,
-    topk]``; CP-gathers and strips padding via the shared THD unpack (mirrors
-    ``unpack_thd_forward_output``).
+    ``recorded`` is this rank's stacked routing ``[tp_local_tokens, num_layers,
+    topk]``; TP-gather the sequence-parallel shards, then CP-gather and strip
+    padding via the shared THD unpack. Padding is always the zigzag (2*cp) TE
+    alignment; ``contiguous`` only selects the CP reconstruct mode (DS4).
     """
     ps = _parallel_state(model)
     num_layers, topk = int(recorded.size(1)), int(recorded.size(2))
+    if ps.tp_size > 1:
+        recorded = _gather_tp_sequence(recorded, ps)
     meta = thd_pack_meta(
         batch.seq_lens,
         tp_size=ps.tp_size,
         cp_size=ps.cp_size,
         cp_group=ps.cp_group if ps.cp_size > 1 else None,
-        contiguous=contiguous,
     )
     # Flatten (layers, topk) into one feature dim so unpack_thd_to_nested's
     # singleton-squeeze heuristic can't drop a 1-layer model's layer axis, then
@@ -187,6 +194,15 @@ def unpack_routed_experts(model, batch: PackedBatch, recorded, *, contiguous: bo
     nested = unpack_thd_to_nested(flat, meta, contiguous=contiguous)
     rows = [row.reshape(row.size(0), num_layers, topk) for row in nested.unbind(0)]
     return torch.nested.as_nested_tensor(rows, layout=torch.jagged)
+
+
+def _gather_tp_sequence(tensor: torch.Tensor, ps: ParallelState) -> torch.Tensor:
+    """All-gather a sequence-parallel-sharded tensor along dim 0 across TP ranks."""
+    import torch.distributed as dist
+
+    parts = [torch.empty_like(tensor) for _ in range(ps.tp_size)]
+    dist.all_gather(parts, tensor.contiguous(), group=ps.tp_group)
+    return torch.cat(parts, dim=0)
 
 
 def add_loss_context_kwargs(kwargs: dict[str, Any], *, include_return_log_probs: bool = False) -> None:

--- a/experimental/lite/megatron/lite/model/protocol_utils.py
+++ b/experimental/lite/megatron/lite/model/protocol_utils.py
@@ -20,6 +20,7 @@ from megatron.lite.primitive.parallel.thd import (
     pack_nested_thd,
     parallel_state_from_model,
     prepare_packed_thd_kwargs_for_context_parallel,
+    split_packed_to_cp_local,
     thd_pack_meta,
     unpack_thd_to_nested,
 )
@@ -100,6 +101,79 @@ def unpack_thd_forward_output(model, batch: PackedBatch, output: torch.Tensor) -
     return unpack_thd_to_nested(output, meta, contiguous=False)
 
 
+def pack_routed_experts(
+    model, batch: PackedBatch, routed_experts, *, contiguous: bool = False
+) -> list[torch.Tensor]:
+    """Split a full routing tensor into one CP rank's per-layer replay targets.
+
+    ``routed_experts`` is jagged ``[bs, seq, num_layers, topk]`` (true lengths,
+    matching ``batch`` tokens). Pads each sequence to the same THD layout the
+    model uses for tokens, CP-splits (zigzag by default), and returns a list of
+    ``num_layers`` integer tensors shaped ``[local_padded_tokens, topk]`` — the
+    per-layer targets the runtime feeds to ``RouterReplay.set_replay_data``.
+    """
+    ps = _parallel_state(model)
+    meta = thd_pack_meta(
+        batch.seq_lens,
+        tp_size=ps.tp_size,
+        cp_size=ps.cp_size,
+        cp_group=ps.cp_group if ps.cp_size > 1 else None,
+        contiguous=contiguous,
+    )
+    rows = (
+        list(routed_experts.unbind(0))
+        if getattr(routed_experts, "is_nested", False)
+        else [routed_experts[i] for i in range(routed_experts.size(0))]
+    )
+    if len(rows) != int(meta.lengths.numel()):
+        raise ValueError(
+            f"routed_experts has {len(rows)} sequences, batch has {int(meta.lengths.numel())}."
+        )
+    first = rows[0]
+    if first.dim() != 3:
+        raise ValueError(
+            f"routed_experts rows must be [seq, num_layers, topk], got {tuple(first.shape)}."
+        )
+    num_layers, topk = int(first.size(1)), int(first.size(2))
+    total_padded = int(meta.cu_seqlens_padded[-1].item())
+    device = batch.input_ids.device
+    full = torch.zeros(total_padded, num_layers, topk, dtype=torch.long, device=device)
+    for idx, row in enumerate(rows):
+        length = int(meta.lengths[idx].item())
+        if int(row.size(0)) != length:
+            raise ValueError(
+                f"routed_experts seq {idx} has {row.size(0)} tokens, expected {length}."
+            )
+        start = int(meta.cu_seqlens_padded[idx].item())
+        full[start : start + length] = row.to(device=device, dtype=torch.long)
+    local = split_packed_to_cp_local(
+        full,
+        cu_seqlens_padded=meta.cu_seqlens_padded,
+        cp_size=ps.cp_size,
+        cp_rank=ps.cp_rank,
+        dim=0,
+    )
+    return [local[:, layer, :].contiguous() for layer in range(num_layers)]
+
+
+def unpack_routed_experts(model, batch: PackedBatch, recorded, *, contiguous: bool = False):
+    """Reverse recorded per-layer routing back to jagged ``[bs, seq, layers, topk]``.
+
+    ``recorded`` is this rank's stacked routing ``[local_padded_tokens, num_layers,
+    topk]``; CP-gathers and strips padding via the shared THD unpack (mirrors
+    ``unpack_thd_forward_output``).
+    """
+    ps = _parallel_state(model)
+    meta = thd_pack_meta(
+        batch.seq_lens,
+        tp_size=ps.tp_size,
+        cp_size=ps.cp_size,
+        cp_group=ps.cp_group if ps.cp_size > 1 else None,
+        contiguous=contiguous,
+    )
+    return unpack_thd_to_nested(recorded, meta, contiguous=contiguous)
+
+
 def add_loss_context_kwargs(kwargs: dict[str, Any], *, include_return_log_probs: bool = False) -> None:
     loss_context = get_loss_context()
     if loss_context is None:
@@ -123,7 +197,9 @@ __all__ = [
     "add_cross_entropy_fusion",
     "add_loss_context_kwargs",
     "nested_from_packed",
+    "pack_routed_experts",
     "pack_thd_forward_kwargs",
     "set_cross_entropy_fusion",
+    "unpack_routed_experts",
     "unpack_thd_forward_output",
 ]

--- a/experimental/lite/megatron/lite/primitive/modules/router.py
+++ b/experimental/lite/megatron/lite/primitive/modules/router.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING
 import torch  # pyright: ignore[reportMissingImports]
 import torch.distributed as dist  # pyright: ignore[reportMissingImports]
 import torch.nn as nn  # pyright: ignore[reportMissingImports]
-
 from megatron.lite.primitive.modules.moe import MoEAuxLossAutoScaler
 from megatron.lite.primitive.utils.moe import (
     compute_routing_scores_for_aux_loss,
@@ -44,7 +43,7 @@ class RouterReplay:
     gate while the routing selection is held fixed.
     """
 
-    global_router_replay_instances: list["RouterReplay"] = []
+    global_router_replay_instances: list[RouterReplay] = []
 
     # ── global controls (one call fans out to every layer) ──
     @staticmethod

--- a/experimental/lite/megatron/lite/primitive/modules/router.py
+++ b/experimental/lite/megatron/lite/primitive/modules/router.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from enum import Enum
 from typing import TYPE_CHECKING
 
 import torch  # pyright: ignore[reportMissingImports]
@@ -19,6 +20,158 @@ from megatron.lite.primitive.utils.moe import (
 
 if TYPE_CHECKING:
     from megatron.lite.primitive.parallel import ParallelState
+
+
+class RouterReplayAction(Enum):
+    """Action for a router-replay step (mirrors the verl/mcore contract)."""
+
+    RECORD = "record"  # capture the topk expert indices for later replay
+    REPLAY_FORWARD = "replay_forward"  # force the recorded indices in the forward pass
+    REPLAY_BACKWARD = "replay_backward"  # force them again during backward recompute
+
+
+class RouterReplay:
+    """Native (no-mcore) record/replay of MoE routing decisions.
+
+    One instance per MoE router; instances register themselves in
+    ``global_router_replay_instances`` in construction order so the runtime can
+    address per-layer routing tensors positionally. API mirrors the verl
+    ``router_replay_patch.RouterReplay`` so the mlite verl engine and the
+    model-agnostic runtime drive every model through this single code path.
+
+    Replay only overrides the expert *indices*; the gating *scores* are gathered
+    fresh from the current ``probs_dense`` so gradients still flow through the
+    gate while the routing selection is held fixed.
+    """
+
+    global_router_replay_instances: list["RouterReplay"] = []
+
+    # ── global controls (one call fans out to every layer) ──
+    @staticmethod
+    def set_replay_data(all_layers_topk_indices: list[torch.Tensor]) -> None:
+        instances = RouterReplay.global_router_replay_instances
+        if len(all_layers_topk_indices) != len(instances):
+            raise ValueError(
+                f"router replay expects {len(instances)} per-layer tensors, "
+                f"got {len(all_layers_topk_indices)}."
+            )
+        for inst, idx in zip(instances, all_layers_topk_indices, strict=True):
+            inst.set_target_indices(idx)
+
+    @staticmethod
+    def get_recorded_data() -> list[torch.Tensor | None]:
+        return [inst.get_recorded_indices() for inst in RouterReplay.global_router_replay_instances]
+
+    @staticmethod
+    def clear_global_indices() -> None:
+        for inst in RouterReplay.global_router_replay_instances:
+            inst.clear_indices()
+
+    @staticmethod
+    def set_global_router_replay_action(action: RouterReplayAction) -> None:
+        for inst in RouterReplay.global_router_replay_instances:
+            inst.set_router_replay_action(action)
+
+    @staticmethod
+    def clear_global_router_replay_action() -> None:
+        for inst in RouterReplay.global_router_replay_instances:
+            inst.clear_router_replay_action()
+
+    @staticmethod
+    def clear_global_router_replay_instances() -> None:
+        RouterReplay.global_router_replay_instances.clear()
+
+    # ── per-instance state ──
+    def __init__(self) -> None:
+        self.target_topk_idx: torch.Tensor | None = None
+        self.recorded_topk_idx: torch.Tensor | None = None
+        self.router_replay_action: RouterReplayAction | None = None
+        self.replay_backward_list: list[torch.Tensor] = []
+        RouterReplay.global_router_replay_instances.append(self)
+
+    def set_target_indices(self, topk_indices: torch.Tensor) -> None:
+        self.target_topk_idx = topk_indices
+        # Each forward (incl. the backward recompute) pops one entry, in order.
+        self.replay_backward_list.append(topk_indices)
+
+    def get_recorded_indices(self) -> torch.Tensor | None:
+        return self.recorded_topk_idx
+
+    def record_indices(self, topk_indices: torch.Tensor) -> None:
+        self.recorded_topk_idx = topk_indices
+
+    def clear_indices(self) -> None:
+        self.recorded_topk_idx = None
+        self.target_topk_idx = None
+        self.replay_backward_list = []
+
+    def set_router_replay_action(self, action: RouterReplayAction) -> None:
+        self.router_replay_action = action
+
+    def clear_router_replay_action(self) -> None:
+        self.router_replay_action = None
+
+    def apply(
+        self,
+        probs_dense: torch.Tensor,
+        topk_scores: torch.Tensor,
+        topk_indices: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Shared replay hook every router calls after computing its own topk.
+
+        ``probs_dense`` is the dense gating score tensor ``[tokens, num_experts]``;
+        ``topk_scores``/``topk_indices`` are this router's freshly-computed
+        ``[tokens, topk]`` selection. Returns the (possibly overridden) pair.
+        """
+        action = self.router_replay_action
+        if action == RouterReplayAction.RECORD:
+            self.record_indices(topk_indices)
+            return topk_scores, topk_indices
+        if action == RouterReplayAction.REPLAY_FORWARD:
+            target = self._take_target(self.target_topk_idx).to(probs_dense.device)
+            return probs_dense.gather(-1, target).to(topk_scores.dtype), target
+        if action == RouterReplayAction.REPLAY_BACKWARD:
+            if not self.replay_backward_list:
+                raise RuntimeError("router replay backward list exhausted; recompute/forward mismatch.")
+            target = self.replay_backward_list.pop(0).to(probs_dense.device)
+            return probs_dense.gather(-1, target).to(topk_scores.dtype), target
+        return topk_scores, topk_indices
+
+    @staticmethod
+    def _take_target(target: torch.Tensor | None) -> torch.Tensor:
+        if target is None:
+            raise RuntimeError("router replay is in replay mode but no target indices were set.")
+        return target
+
+
+def attach_router_replay(model: nn.Module) -> int:
+    """Enable router replay on every MoE router in ``model`` (one shared path).
+
+    Walks the module tree and gives each replay-capable router (any module that
+    exposes a ``router_replay`` slot — all mlite routers do) a fresh
+    :class:`RouterReplay`, registered in module-traversal (== layer) order. This
+    lets the model-agnostic runtime turn replay on for all five models without
+    threading a constructor flag through any model. Returns the router count.
+
+    Each rank attaches only its *local* routers (its pipeline stage's layers),
+    so the per-layer registry is naturally local; the runtime gathers/scatters
+    routing tensors across pipeline ranks.
+    """
+    RouterReplay.clear_global_router_replay_instances()
+    count = 0
+    for module in model.modules():
+        if hasattr(module, "router_replay"):
+            module.router_replay = RouterReplay()
+            count += 1
+    return count
+
+
+def detach_router_replay(model: nn.Module) -> None:
+    """Disable router replay and clear the global registry (inverse of attach)."""
+    for module in model.modules():
+        if hasattr(module, "router_replay"):
+            module.router_replay = None
+    RouterReplay.clear_global_router_replay_instances()
 
 
 def _ordered_topk_from_routing_map(
@@ -48,6 +201,7 @@ class TopKRouter(nn.Module):
         use_pre_softmax: bool = False,
         moe_router_fusion: bool = False,
         router_dtype: torch.dtype | None = None,
+        enable_routing_replay: bool = False,
     ):
         super().__init__()
         if router_bias_rate > 0:
@@ -63,6 +217,7 @@ class TopKRouter(nn.Module):
         self.use_pre_softmax = use_pre_softmax
         self.moe_router_fusion = moe_router_fusion
         self.router_dtype = router_dtype
+        self.router_replay = RouterReplay() if enable_routing_replay else None
 
         self.gate = nn.Linear(config.hidden_size, config.num_experts, bias=False)
         self.register_buffer(
@@ -95,6 +250,10 @@ class TopKRouter(nn.Module):
             )
             topk_scores, topk_indices = _ordered_topk_from_routing_map(
                 probs_dense, routing_map, self.topk
+            )
+        if self.router_replay is not None:
+            topk_scores, topk_indices = self.router_replay.apply(
+                probs_dense, topk_scores, topk_indices
             )
         if self.router_dtype is None:
             topk_scores = topk_scores.to(x.dtype)
@@ -134,6 +293,7 @@ class SigmoidTopKRouter(nn.Module):
         compute_aux_loss: bool = True,
         use_pre_softmax: bool = False,
         moe_router_fusion: bool = False,
+        enable_routing_replay: bool = False,
     ):
         super().__init__()
         if router_bias_rate > 0:
@@ -150,6 +310,7 @@ class SigmoidTopKRouter(nn.Module):
         self.compute_aux_loss = compute_aux_loss
         self.use_pre_softmax = use_pre_softmax
         self.moe_router_fusion = moe_router_fusion
+        self.router_replay = RouterReplay() if enable_routing_replay else None
 
         self.gate = nn.Linear(config.hidden_size, config.n_routed_experts, bias=False)
         self.register_buffer(
@@ -175,6 +336,10 @@ class SigmoidTopKRouter(nn.Module):
         topk_scores, topk_indices = _ordered_topk_from_routing_map(
             probs_dense, routing_map, self.topk
         )
+        if self.router_replay is not None:
+            topk_scores, topk_indices = self.router_replay.apply(
+                probs_dense, topk_scores, topk_indices
+            )
         topk_scores = topk_scores.to(logits.dtype)
 
         if self.compute_aux_loss and self.training and torch.is_grad_enabled():
@@ -200,4 +365,11 @@ class SigmoidTopKRouter(nn.Module):
         return topk_scores, topk_indices
 
 
-__all__ = ["SigmoidTopKRouter", "TopKRouter"]
+__all__ = [
+    "RouterReplay",
+    "RouterReplayAction",
+    "SigmoidTopKRouter",
+    "TopKRouter",
+    "attach_router_replay",
+    "detach_router_replay",
+]

--- a/experimental/lite/megatron/lite/primitive/modules/router.py
+++ b/experimental/lite/megatron/lite/primitive/modules/router.py
@@ -210,7 +210,6 @@ class TopKRouter(nn.Module):
         use_pre_softmax: bool = False,
         moe_router_fusion: bool = False,
         router_dtype: torch.dtype | None = None,
-        enable_routing_replay: bool = False,
     ):
         super().__init__()
         if router_bias_rate > 0:
@@ -226,7 +225,9 @@ class TopKRouter(nn.Module):
         self.use_pre_softmax = use_pre_softmax
         self.moe_router_fusion = moe_router_fusion
         self.router_dtype = router_dtype
-        self.router_replay = RouterReplay() if enable_routing_replay else None
+        # Router replay is enabled uniformly via attach_router_replay() — one path,
+        # one default for all models; no per-model replay knob.
+        self.router_replay = None
 
         self.gate = nn.Linear(config.hidden_size, config.num_experts, bias=False)
         self.register_buffer(
@@ -302,7 +303,6 @@ class SigmoidTopKRouter(nn.Module):
         compute_aux_loss: bool = True,
         use_pre_softmax: bool = False,
         moe_router_fusion: bool = False,
-        enable_routing_replay: bool = False,
     ):
         super().__init__()
         if router_bias_rate > 0:
@@ -319,7 +319,9 @@ class SigmoidTopKRouter(nn.Module):
         self.compute_aux_loss = compute_aux_loss
         self.use_pre_softmax = use_pre_softmax
         self.moe_router_fusion = moe_router_fusion
-        self.router_replay = RouterReplay() if enable_routing_replay else None
+        # Router replay is enabled uniformly via attach_router_replay() — one path,
+        # one default for all models; no per-model replay knob.
+        self.router_replay = None
 
         self.gate = nn.Linear(config.hidden_size, config.n_routed_experts, bias=False)
         self.register_buffer(

--- a/experimental/lite/megatron/lite/primitive/modules/router.py
+++ b/experimental/lite/megatron/lite/primitive/modules/router.py
@@ -143,23 +143,33 @@ class RouterReplay:
         return target
 
 
-def attach_router_replay(model: nn.Module) -> int:
-    """Enable router replay on every MoE router in ``model`` (one shared path).
+def _is_replay_capable_router(module: nn.Module) -> bool:
+    """A module joins the replay registry iff it has a ``router_replay`` slot and
+    is not explicitly excluded (e.g. DeepSeek-V4 input-deterministic hash-routed
+    layers, whose routing never depends on weights and so needs no replay)."""
+    return hasattr(module, "router_replay") and not getattr(
+        module, "_router_replay_exclude", False
+    )
 
-    Walks the module tree and gives each replay-capable router (any module that
-    exposes a ``router_replay`` slot — all mlite routers do) a fresh
-    :class:`RouterReplay`, registered in module-traversal (== layer) order. This
-    lets the model-agnostic runtime turn replay on for all five models without
-    threading a constructor flag through any model. Returns the router count.
 
-    Each rank attaches only its *local* routers (its pipeline stage's layers),
-    so the per-layer registry is naturally local; the runtime gathers/scatters
-    routing tensors across pipeline ranks.
+def attach_router_replay(model: nn.Module, *, reset: bool = True) -> int:
+    """Enable router replay on every replay-capable MoE router in ``model``.
+
+    Walks the module tree and gives each router a fresh :class:`RouterReplay`,
+    registered in module-traversal (== layer) order. This lets the model-agnostic
+    runtime turn replay on for all five models without threading a constructor
+    flag through any model. Returns the router count.
+
+    ``reset=False`` appends to the existing registry instead of clearing it, so a
+    multi-chunk (PP/VPP) model can be attached chunk-by-chunk while keeping global
+    layer order. Each rank attaches only its *local* routers; the runtime
+    gathers/scatters routing tensors across pipeline ranks.
     """
-    RouterReplay.clear_global_router_replay_instances()
+    if reset:
+        RouterReplay.clear_global_router_replay_instances()
     count = 0
     for module in model.modules():
-        if hasattr(module, "router_replay"):
+        if _is_replay_capable_router(module):
             module.router_replay = RouterReplay()
             count += 1
     return count

--- a/experimental/lite/megatron/lite/primitive/parallel/pipeline.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/pipeline.py
@@ -509,13 +509,15 @@ def _run_pipeline_chunk_forward(
     num_microbatches: int,
     pre_forward_hook=None,
     loss_fn=None,
+    loss_context=None,
 ) -> dict:
     _set_aux_loss_scale(pre_forward_hook, num_microbatches)
     if not is_first_stage:
         model.set_input_tensor(input_tensor)
-    out = forward_step_fn(model, batch)
-    if is_last_stage:
-        _apply_external_loss(out, batch, loss_fn)
+    with use_loss_context(loss_context):
+        out = forward_step_fn(model, batch)
+        if is_last_stage:
+            _apply_external_loss(out, batch, loss_fn, loss_context)
     return out
 
 
@@ -536,7 +538,10 @@ def _forward_only_pipeline_schedule(
     outputs: list[dict] = []
 
     for _mb in range(num_microbatches):
-        batch = next(data_iter)
+        # Split (PackedBatch, LossContext) like 1F1B/run_microbatch_loop so the
+        # forward sees the unwrapped batch and log-prob inference applies the
+        # loss context (temperature / return_log_probs / loss scale).
+        batch, loss_context = split_loss_context(next(data_iter))
         _set_aux_loss_scale(pre_forward_hook, num_microbatches)
         pending_activation: torch.Tensor | None = None
         last_output: dict | None = None
@@ -562,6 +567,7 @@ def _forward_only_pipeline_schedule(
                     num_microbatches=num_microbatches,
                     pre_forward_hook=None,
                     loss_fn=loss_fn,
+                    loss_context=loss_context,
                 )
                 if is_last_stage:
                     last_output = out

--- a/experimental/lite/megatron/lite/primitive/parallel/pipeline.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/pipeline.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING
 
 import torch  # pyright: ignore[reportMissingImports]
 import torch.distributed as dist  # pyright: ignore[reportMissingImports]
-
 from megatron.lite.primitive.utils import ensure_divisible
 from megatron.lite.runtime.contracts.loss import split_loss_context, use_loss_context
 

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/router_replay.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/router_replay.py
@@ -20,6 +20,7 @@ from collections.abc import Callable
 from typing import Any
 
 import torch
+import torch.distributed as dist
 from megatron.lite.model import protocol_utils
 from megatron.lite.primitive.modules.router import (
     RouterReplay,
@@ -27,6 +28,7 @@ from megatron.lite.primitive.modules.router import (
     attach_router_replay,
     detach_router_replay,
 )
+from megatron.lite.primitive.parallel.thd import parallel_state_from_model
 
 _RECORD = "record"
 _REPLAY = "replay"
@@ -54,6 +56,11 @@ class RouterReplayDriver:
         self._chunks = handle._extras.get("model_chunks", [handle._model])
         self._protocol = handle._extras.get("protocol")
         self._num_routers = 0
+        self._ps = None
+        self._pp_offset = 0  # this rank's first global MoE-layer index
+        self._pp_total = 0  # total MoE layers across all pipeline stages
+        self._last_batch = None  # stashed for post-schedule record collection
+        self._last_model = None
 
     @classmethod
     def maybe_create(cls, handle, router_replay: Any) -> RouterReplayDriver | None:
@@ -75,8 +82,25 @@ class RouterReplayDriver:
         )
         if self._num_routers == 0:
             raise RuntimeError("router replay requested but the model has no MoE routers.")
+        self._ps = parallel_state_from_model(self._chunks[-1])
+        self._compute_pp_layout()
         if self.action == _RECORD:
             RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
+
+    def _compute_pp_layout(self) -> None:
+        """All-gather per-rank MoE-router counts so record/replay can map this
+        stage's local routers to their global MoE-layer indices."""
+        ps = self._ps
+        if ps is None or ps.pp_size <= 1:
+            self._pp_offset, self._pp_total = 0, self._num_routers
+            return
+        counts = [torch.zeros(1, dtype=torch.long, device="cuda") for _ in range(ps.pp_size)]
+        dist.all_gather(
+            counts, torch.tensor([self._num_routers], dtype=torch.long, device="cuda"), group=ps.pp_group
+        )
+        counts = [int(c.item()) for c in counts]
+        self._pp_offset = sum(counts[: ps.pp_rank])
+        self._pp_total = sum(counts)
 
     def wrap(self, forward_step: Callable) -> Callable:
         if self.action == _RECORD:
@@ -94,14 +118,9 @@ class RouterReplayDriver:
         def _stepped(model, batch):
             RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
             out = forward_step(model, batch)
-            recorded = RouterReplay.get_recorded_data()
-            if any(item is None for item in recorded):
-                raise RuntimeError("router replay record completed with missing per-layer indices.")
-            stacked = torch.stack([item.to(torch.long) for item in recorded], dim=1)
-            nested = _unpack_routed_experts(self._protocol, model, batch, stacked)
-            out = dict(out)
-            out["routed_experts"] = _to_uint8_if_small(nested)
-            RouterReplay.clear_global_indices()
+            # Collection is deferred to collect_recorded() after the schedule so a
+            # pipeline stage's local layers can be PP-gathered into global order.
+            self._last_batch, self._last_model = batch, model
             return out
 
         return _stepped
@@ -111,12 +130,52 @@ class RouterReplayDriver:
             routed = getattr(batch, "routed_experts", None)
             if routed is None:
                 raise ValueError("router replay 'replay' mode requires batch.routed_experts.")
+            routed = self._select_local_layers(routed)
             targets = _pack_routed_experts(self._protocol, model, batch, routed)
             RouterReplay.set_replay_data(targets)
             RouterReplay.set_global_router_replay_action(RouterReplayAction.REPLAY_FORWARD)
             return forward_step(model, batch)
 
         return _stepped
+
+    def collect_recorded(self):
+        """Assemble the recorded routing as jagged ``[bs, seq, total_layers, topk]``
+        (PP-gathered), or ``None`` if nothing was recorded."""
+        if self.action != _RECORD or self._last_batch is None:
+            return None
+        recorded = RouterReplay.get_recorded_data()
+        if not recorded or any(item is None for item in recorded):
+            raise RuntimeError("router replay record finished with missing per-layer indices.")
+        local = torch.stack([item.to(torch.long) for item in recorded], dim=1)  # [tok, n_local, topk]
+        full = self._pp_gather_layers(local)
+        nested = _unpack_routed_experts(self._protocol, self._last_model, self._last_batch, full)
+        return _to_uint8_if_small(nested)
+
+    # ── pipeline helpers ──
+    def _select_local_layers(self, routed):
+        """Slice the full routing down to this pipeline stage's MoE layers."""
+        ps = self._ps
+        if ps is None or ps.pp_size <= 1:
+            return routed
+        lo, hi = self._pp_offset, self._pp_offset + self._num_routers
+        rows = [row[:, lo:hi, :] for row in routed.unbind(0)]
+        return torch.nested.as_nested_tensor(rows, layout=torch.jagged)
+
+    def _pp_gather_layers(self, local: torch.Tensor) -> torch.Tensor:
+        """All-gather per-stage routing ``[tok, n_local, topk]`` and concat along
+        the layer axis in pipeline-rank order. Assumes a uniform per-stage layer
+        count (even split); uneven layouts are not yet supported."""
+        ps = self._ps
+        if ps is None or ps.pp_size <= 1:
+            return local
+        if self._pp_total != self._num_routers * ps.pp_size:
+            raise NotImplementedError(
+                "router replay PP gather requires an even MoE-layer split across stages "
+                f"(got total={self._pp_total}, local={self._num_routers}, pp={ps.pp_size})."
+            )
+        parts = [torch.empty_like(local) for _ in range(ps.pp_size)]
+        dist.all_gather(parts, local.contiguous(), group=ps.pp_group)
+        return torch.cat(parts, dim=1)
 
 
 def _to_uint8_if_small(nested):

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/router_replay.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/router_replay.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Model-agnostic router-replay driver for the mlite runtime.
+
+Drives RECORD / REPLAY of MoE routing across the runtime's microbatch loop using
+the shared :class:`RouterReplay` registry in ``primitive/modules/router.py`` — a
+single code path for every model. The model contributes only its THD CP layout
+through the protocol's ``pack_routed_experts`` / ``unpack_routed_experts`` pair
+(shared zigzag default; DeepSeek-V4 provides a contiguous variant).
+
+Modes:
+- ``record``: capture each layer's topk expert indices during the (forward-only)
+  log-prob pass and return them as ``out["routed_experts"]`` for verl to store.
+- ``replay``: force the recorded indices in the policy-update forward (and the
+  backward recompute), reading them from ``batch.routed_experts``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import torch
+from megatron.lite.model import protocol_utils
+from megatron.lite.primitive.modules.router import (
+    RouterReplay,
+    RouterReplayAction,
+    attach_router_replay,
+    detach_router_replay,
+)
+
+_RECORD = "record"
+_REPLAY = "replay"
+
+
+def _pack_routed_experts(protocol, model, batch, routed):
+    """Use the model protocol's pack if defined, else the shared zigzag THD one."""
+    fn = getattr(protocol, "pack_routed_experts", None) if protocol is not None else None
+    return (fn or protocol_utils.pack_routed_experts)(model, batch, routed)
+
+
+def _unpack_routed_experts(protocol, model, batch, recorded):
+    fn = getattr(protocol, "unpack_routed_experts", None) if protocol is not None else None
+    return (fn or protocol_utils.unpack_routed_experts)(model, batch, recorded)
+
+
+class RouterReplayDriver:
+    """Owns the replay lifecycle for one ``forward_backward`` call."""
+
+    def __init__(self, handle, action: str):
+        if action not in (_RECORD, _REPLAY):
+            raise ValueError(f"router replay action must be 'record' or 'replay', got {action!r}.")
+        self.handle = handle
+        self.action = action
+        self._chunks = handle._extras.get("model_chunks", [handle._model])
+        self._protocol = handle._extras.get("protocol")
+        self._num_routers = 0
+
+    @classmethod
+    def maybe_create(cls, handle, router_replay: Any) -> RouterReplayDriver | None:
+        """Build a driver from a ``{'action': ...}`` spec, or ``None`` if disabled."""
+        if not router_replay:
+            return None
+        action = router_replay.get("action") if isinstance(router_replay, dict) else router_replay
+        if action in (None, "disabled"):
+            return None
+        return cls(handle, action)
+
+    # ── lifecycle ──
+    def begin(self) -> None:
+        # Single pass across all chunks so the global per-layer registry is in
+        # pipeline-local layer order (attach_router_replay clears on each call,
+        # so we inline the equivalent walk here for the multi-chunk case).
+        RouterReplay.clear_global_router_replay_instances()
+        if len(self._chunks) == 1:
+            self._num_routers = attach_router_replay(self._chunks[0])
+        else:
+            self._num_routers = 0
+            for chunk in self._chunks:
+                for module in chunk.modules():
+                    if hasattr(module, "router_replay"):
+                        module.router_replay = RouterReplay()
+                        self._num_routers += 1
+        if self._num_routers == 0:
+            raise RuntimeError("router replay requested but the model has no MoE routers.")
+        if self.action == _RECORD:
+            RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
+
+    def wrap(self, forward_step: Callable) -> Callable:
+        if self.action == _RECORD:
+            return self._wrap_record(forward_step)
+        return self._wrap_replay(forward_step)
+
+    def end(self) -> None:
+        RouterReplay.clear_global_indices()
+        RouterReplay.clear_global_router_replay_action()
+        for chunk in self._chunks:
+            detach_router_replay(chunk)
+
+    # ── per-microbatch wrappers ──
+    def _wrap_record(self, forward_step: Callable) -> Callable:
+        def _stepped(model, batch):
+            RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
+            out = forward_step(model, batch)
+            recorded = RouterReplay.get_recorded_data()
+            if any(item is None for item in recorded):
+                raise RuntimeError("router replay record completed with missing per-layer indices.")
+            stacked = torch.stack([item.to(torch.long) for item in recorded], dim=1)
+            nested = _unpack_routed_experts(self._protocol, model, batch, stacked)
+            out = dict(out)
+            out["routed_experts"] = _to_uint8_if_small(nested)
+            RouterReplay.clear_global_indices()
+            return out
+
+        return _stepped
+
+    def _wrap_replay(self, forward_step: Callable) -> Callable:
+        def _stepped(model, batch):
+            routed = getattr(batch, "routed_experts", None)
+            if routed is None:
+                raise ValueError("router replay 'replay' mode requires batch.routed_experts.")
+            targets = _pack_routed_experts(self._protocol, model, batch, routed)
+            RouterReplay.set_replay_data(targets)
+            RouterReplay.set_global_router_replay_action(RouterReplayAction.REPLAY_FORWARD)
+            return forward_step(model, batch)
+
+        return _stepped
+
+
+def _to_uint8_if_small(nested):
+    """Match verl's uint8 routed_experts when expert ids fit in a byte."""
+    try:
+        values = nested.values() if getattr(nested, "is_nested", False) else nested
+        if values.numel() and int(values.max().item()) <= 255:
+            return nested.to(torch.uint8)
+    except Exception:
+        pass
+    return nested
+
+
+__all__ = ["RouterReplayDriver"]

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/router_replay.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/router_replay.py
@@ -67,19 +67,12 @@ class RouterReplayDriver:
 
     # ── lifecycle ──
     def begin(self) -> None:
-        # Single pass across all chunks so the global per-layer registry is in
-        # pipeline-local layer order (attach_router_replay clears on each call,
-        # so we inline the equivalent walk here for the multi-chunk case).
+        # Attach across all chunks in one registry so the global per-layer order
+        # matches pipeline-local layer order (clear once, then append per chunk).
         RouterReplay.clear_global_router_replay_instances()
-        if len(self._chunks) == 1:
-            self._num_routers = attach_router_replay(self._chunks[0])
-        else:
-            self._num_routers = 0
-            for chunk in self._chunks:
-                for module in chunk.modules():
-                    if hasattr(module, "router_replay"):
-                        module.router_replay = RouterReplay()
-                        self._num_routers += 1
+        self._num_routers = sum(
+            attach_router_replay(chunk, reset=False) for chunk in self._chunks
+        )
         if self._num_routers == 0:
             raise RuntimeError("router replay requested but the model has no MoE routers.")
         if self.action == _RECORD:

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -391,100 +391,111 @@ class MegatronLiteRuntime(RuntimeBase):
         *,
         num_microbatches: int = 1,
         forward_only: bool = False,
+        router_replay: Any = None,
     ) -> ForwardResult:
         from megatron.lite.primitive.train_step import run_microbatch_loop
+        from megatron.lite.runtime.backends.mlite.router_replay import RouterReplayDriver
 
         forward_step = handle._extras["forward_step"]
         if num_microbatches < 1:
             raise ValueError("num_microbatches must be >= 1")
 
-        if hasattr(data, "__next__"):
-            data_iter = data
-        elif hasattr(data, "__iter__"):
-            data_iter = iter(data)
-        else:
-            data_iter = iter([data])
+        replay_driver = RouterReplayDriver.maybe_create(handle, router_replay)
+        if replay_driver is not None:
+            replay_driver.begin()
+            forward_step = replay_driver.wrap(forward_step)
 
-        ps = handle._parallel_state
-        if ps.pp_size > 1:
-            from types import SimpleNamespace
-
-            from megatron.lite.primitive.parallel.pipeline import forward_backward_pipelining
-
-            first_item = next(data_iter)
-            first_batch, _loss_context = split_loss_context(first_item)
-            data_iter = chain([first_item], data_iter)
-            tensor_shape = _infer_pipeline_tensor_shape(
-                first_batch, handle._extras.get("model_cfg"), ps
-            )
-            outputs = forward_backward_pipelining(
-                forward_step,
-                handle._extras.get("model_chunks", [handle._model]),
-                data_iter,
-                SimpleNamespace(num_microbatches=num_microbatches),
-                ps,
-                tensor_shape=tensor_shape,
-                pre_forward_hook=handle._extras.get("pre_forward_hook"),
-                loss_fn=loss_fn,
-                forward_only=forward_only,
-            )
-            out = _last_loss_output(outputs)
-            loss_obj = out.get("loss") if out else None
-            if isinstance(loss_obj, torch.Tensor):
-                loss_float = float(loss_obj.detach().item())
-            elif loss_obj is not None:
-                loss_float = float(loss_obj)
+        try:
+            if hasattr(data, "__next__"):
+                data_iter = data
+            elif hasattr(data, "__iter__"):
+                data_iter = iter(data)
             else:
-                loss_float = 0.0
-            loss_t = torch.tensor([loss_float], device="cuda")
-            if ps.pp_group is not None and ps.pp_global_ranks is not None:
-                dist.broadcast(loss_t, src=ps.pp_global_ranks[-1], group=ps.pp_group)
-            out = {"loss": loss_t.squeeze(0)}
-        else:
-            out = run_microbatch_loop(
-                handle._model,
-                data_iter,
-                num_microbatches,
-                forward_step,
-                optimizer=handle._optimizer if not forward_only else None,
-                dist_opt=not forward_only,
-                pre_forward_hook=handle._extras.get("pre_forward_hook"),
-                loss_fn=loss_fn,
-                forward_only=forward_only,
+                data_iter = iter([data])
+
+            ps = handle._parallel_state
+            if ps.pp_size > 1:
+                from types import SimpleNamespace
+
+                from megatron.lite.primitive.parallel.pipeline import forward_backward_pipelining
+
+                first_item = next(data_iter)
+                first_batch, _loss_context = split_loss_context(first_item)
+                data_iter = chain([first_item], data_iter)
+                tensor_shape = _infer_pipeline_tensor_shape(
+                    first_batch, handle._extras.get("model_cfg"), ps
+                )
+                outputs = forward_backward_pipelining(
+                    forward_step,
+                    handle._extras.get("model_chunks", [handle._model]),
+                    data_iter,
+                    SimpleNamespace(num_microbatches=num_microbatches),
+                    ps,
+                    tensor_shape=tensor_shape,
+                    pre_forward_hook=handle._extras.get("pre_forward_hook"),
+                    loss_fn=loss_fn,
+                    forward_only=forward_only,
+                )
+                out = _last_loss_output(outputs)
+                loss_obj = out.get("loss") if out else None
+                if isinstance(loss_obj, torch.Tensor):
+                    loss_float = float(loss_obj.detach().item())
+                elif loss_obj is not None:
+                    loss_float = float(loss_obj)
+                else:
+                    loss_float = 0.0
+                loss_t = torch.tensor([loss_float], device="cuda")
+                if ps.pp_group is not None and ps.pp_global_ranks is not None:
+                    dist.broadcast(loss_t, src=ps.pp_global_ranks[-1], group=ps.pp_group)
+                out = {"loss": loss_t.squeeze(0)}
+            else:
+                out = run_microbatch_loop(
+                    handle._model,
+                    data_iter,
+                    num_microbatches,
+                    forward_step,
+                    optimizer=handle._optimizer if not forward_only else None,
+                    dist_opt=not forward_only,
+                    pre_forward_hook=handle._extras.get("pre_forward_hook"),
+                    loss_fn=loss_fn,
+                    forward_only=forward_only,
+                )
+
+            if not forward_only:
+                finalize_grads = handle._extras.get("finalize_grads")
+                if finalize_grads is not None:
+                    finalize_grads()
+
+            loss_tensor = out.get("loss") if out else None
+            loss_val = (
+                loss_tensor.item()
+                if isinstance(loss_tensor, torch.Tensor)
+                else float(loss_tensor or 0.0)
             )
-
-        if not forward_only:
-            finalize_grads = handle._extras.get("finalize_grads")
-            if finalize_grads is not None:
-                finalize_grads()
-
-        loss_tensor = out.get("loss") if out else None
-        loss_val = (
-            loss_tensor.item()
-            if isinstance(loss_tensor, torch.Tensor)
-            else float(loss_tensor or 0.0)
-        )
-        metrics: dict = {"loss": loss_val}
-        for m in out.get("_loss_fn_metrics", []) if out else []:
-            for k, v in m.items():
-                if k not in metrics:
-                    metrics[k] = v
-        if ps.pp_size > 1:
-            for item in outputs:
-                for k, v in item.get("metrics", {}).items():
+            metrics: dict = {"loss": loss_val}
+            for m in out.get("_loss_fn_metrics", []) if out else []:
+                for k, v in m.items():
                     if k not in metrics:
                         metrics[k] = v
-            metrics["_micro_outputs"] = outputs
+            if ps.pp_size > 1:
+                for item in outputs:
+                    for k, v in item.get("metrics", {}).items():
+                        if k not in metrics:
+                            metrics[k] = v
+                metrics["_micro_outputs"] = outputs
 
-        return ForwardResult(
-            model_output=ModelOutputs(
-                loss=loss_tensor,
-                vocab_parallel_logits=out.get("logits") if out else None,
-                log_probs=out.get("log_probs") if out else None,
-                routed_experts=out.get("routed_experts") if out else None,
-            ),
-            metrics=metrics,
-        )
+            return ForwardResult(
+                model_output=ModelOutputs(
+                    loss=loss_tensor,
+                    vocab_parallel_logits=out.get("logits") if out else None,
+                    log_probs=out.get("log_probs") if out else None,
+                    routed_experts=out.get("routed_experts") if out else None,
+                ),
+                metrics=metrics,
+            )
+        finally:
+            if replay_driver is not None:
+                replay_driver.end()
 
     def is_mp_src_rank_with_outputs(self, handle: ModelHandle) -> bool:
         ps = handle._parallel_state

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -484,12 +484,17 @@ class MegatronLiteRuntime(RuntimeBase):
                             metrics[k] = v
                 metrics["_micro_outputs"] = outputs
 
+            if replay_driver is not None and replay_driver.action == "record":
+                routed_experts = replay_driver.collect_recorded()
+            else:
+                routed_experts = out.get("routed_experts") if out else None
+
             return ForwardResult(
                 model_output=ModelOutputs(
                     loss=loss_tensor,
                     vocab_parallel_logits=out.get("logits") if out else None,
                     log_probs=out.get("log_probs") if out else None,
-                    routed_experts=out.get("routed_experts") if out else None,
+                    routed_experts=routed_experts,
                 ),
                 metrics=metrics,
             )

--- a/experimental/lite/tests/unit/primitive/test_router_replay_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_router_replay_unit.py
@@ -1,0 +1,211 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Native (no-mcore) router-replay semantics — the single shared code path that
+all five MoE models (qwen3.5 / qwen3_moe / kimi / glm5 / ds4) route through.
+
+These exercise the primitive layer directly (CPU), so they cover the unified
+``RouterReplay`` logic and both shared routers without needing GPU. Per-model
+clones (kimi/glm5) call the identical ``RouterReplay.apply`` hook and are covered
+by the verl-faithful GPU smoke.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.mlite
+
+
+@pytest.fixture(autouse=True)
+def _te_import_stub(transformer_engine_import_stub):
+    transformer_engine_import_stub()
+
+
+@pytest.fixture(autouse=True)
+def _clean_replay_registry():
+    from megatron.lite.primitive.modules.router import RouterReplay
+
+    RouterReplay.clear_global_router_replay_instances()
+    yield
+    RouterReplay.clear_global_router_replay_instances()
+
+
+def _topk_router(enable_routing_replay: bool):
+    from megatron.lite.primitive.modules.router import TopKRouter
+    from megatron.lite.primitive.parallel import ParallelState
+
+    config = SimpleNamespace(
+        hidden_size=8, num_experts=8, num_experts_per_tok=2, router_aux_loss_coef=0.1
+    )
+    return TopKRouter(
+        config,
+        ParallelState(),
+        compute_aux_loss=False,
+        enable_routing_replay=enable_routing_replay,
+    )
+
+
+def _sigmoid_router(enable_routing_replay: bool):
+    from megatron.lite.primitive.modules.router import SigmoidTopKRouter
+    from megatron.lite.primitive.parallel import ParallelState
+
+    config = SimpleNamespace(
+        hidden_size=8,
+        n_routed_experts=8,
+        num_experts_per_tok=2,
+        routed_scaling_factor=1.0,
+        scoring_func="sigmoid",
+        aux_loss_alpha=0.0,
+    )
+    return SigmoidTopKRouter(
+        config,
+        ParallelState(),
+        compute_aux_loss=False,
+        enable_routing_replay=enable_routing_replay,
+    )
+
+
+ROUTER_FACTORIES = {"topk_softmax": _topk_router, "sigmoid_topk": _sigmoid_router}
+
+
+@pytest.mark.parametrize("factory", ROUTER_FACTORIES.values(), ids=ROUTER_FACTORIES.keys())
+def test_record_captures_topk_indices(factory):
+    from megatron.lite.primitive.modules.router import RouterReplay, RouterReplayAction
+
+    router = factory(True)
+    router.eval()
+    hidden = torch.randn(6, router.gate.in_features)
+
+    RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
+    scores, indices = router(hidden)
+
+    recorded = RouterReplay.get_recorded_data()
+    assert len(recorded) == 1
+    assert torch.equal(recorded[0], indices)
+    # RECORD leaves the freshly-computed routing untouched.
+    assert scores.shape == (6, router.topk)
+
+
+@pytest.mark.parametrize("factory", ROUTER_FACTORIES.values(), ids=ROUTER_FACTORIES.keys())
+def test_replay_forward_reproduces_recorded_indices(factory):
+    from megatron.lite.primitive.modules.router import RouterReplay, RouterReplayAction
+
+    router = factory(True)
+    router.eval()
+    hidden = torch.randn(6, router.gate.in_features)
+
+    RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
+    _, recorded_indices = router(hidden)
+    target = recorded_indices.clone()
+
+    RouterReplay.set_replay_data([target])
+    RouterReplay.set_global_router_replay_action(RouterReplayAction.REPLAY_FORWARD)
+    replay_scores, replay_indices = router(hidden)
+
+    assert torch.equal(replay_indices, target)
+    # Scores are gathered fresh from the current dense probs at the replayed
+    # indices (verl semantics): same input → identical to the recorded forward.
+    assert replay_scores.shape == (6, router.topk)
+    assert torch.isfinite(replay_scores).all()
+
+
+@pytest.mark.parametrize("factory", ROUTER_FACTORIES.values(), ids=ROUTER_FACTORIES.keys())
+def test_replay_forward_overrides_recomputed_routing(factory):
+    """The whole point: after the gate weights move, the forward must still
+    select the *recorded* experts, not whatever topk now recomputes."""
+    from megatron.lite.primitive.modules.router import RouterReplay, RouterReplayAction
+
+    router = factory(True)
+    router.eval()
+    hidden = torch.randn(6, router.gate.in_features)
+
+    RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
+    _, recorded_indices = router(hidden)
+    target = recorded_indices.clone()
+
+    # Perturb the gate so a fresh topk would (very likely) choose other experts.
+    with torch.no_grad():
+        router.gate.weight.add_(torch.randn_like(router.gate.weight) * 5.0)
+
+    RouterReplay.set_global_router_replay_action(None)
+    _, recomputed_indices = router(hidden)
+
+    RouterReplay.set_replay_data([target])
+    RouterReplay.set_global_router_replay_action(RouterReplayAction.REPLAY_FORWARD)
+    _, replay_indices = router(hidden)
+
+    assert torch.equal(replay_indices, target)
+    # Sanity: the perturbation actually changed the natural routing, so the
+    # override above is meaningful (not vacuously true).
+    assert not torch.equal(recomputed_indices, target)
+
+
+@pytest.mark.parametrize("factory", ROUTER_FACTORIES.values(), ids=ROUTER_FACTORIES.keys())
+def test_replay_forward_keeps_gate_gradient(factory):
+    from megatron.lite.primitive.modules.router import RouterReplay, RouterReplayAction
+
+    router = factory(True)
+    router.train()
+    hidden = torch.randn(6, router.gate.in_features)
+
+    RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
+    _, recorded_indices = router(hidden)
+
+    RouterReplay.set_replay_data([recorded_indices.clone()])
+    RouterReplay.set_global_router_replay_action(RouterReplayAction.REPLAY_FORWARD)
+    replay_scores, _ = router(hidden)
+    replay_scores.sum().backward()
+
+    assert router.gate.weight.grad is not None
+    assert torch.isfinite(router.gate.weight.grad).all()
+    assert router.gate.weight.grad.abs().sum().item() > 0.0
+
+
+def test_replay_backward_pops_target_in_order():
+    from megatron.lite.primitive.modules.router import RouterReplay, RouterReplayAction
+
+    router = _topk_router(True)
+    router.eval()
+    hidden = torch.randn(6, router.gate.in_features)
+
+    RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
+    _, recorded_indices = router(hidden)
+    target = recorded_indices.clone()
+
+    # Forward (replay) then backward-recompute (replay again) must both work.
+    RouterReplay.set_replay_data([target])
+    RouterReplay.set_global_router_replay_action(RouterReplayAction.REPLAY_FORWARD)
+    _, fwd_indices = router(hidden)
+    RouterReplay.set_global_router_replay_action(RouterReplayAction.REPLAY_BACKWARD)
+    _, bwd_indices = router(hidden)
+
+    assert torch.equal(fwd_indices, target)
+    assert torch.equal(bwd_indices, target)
+    # The single queued entry is consumed; a second recompute would now error.
+    with pytest.raises(RuntimeError):
+        router(hidden)
+
+
+def test_disabled_replay_is_noop():
+    from megatron.lite.primitive.modules.router import RouterReplay, RouterReplayAction
+
+    router = _topk_router(False)
+    router.eval()
+    hidden = torch.randn(6, router.gate.in_features)
+
+    # No instance is registered when replay is disabled.
+    assert RouterReplay.global_router_replay_instances == []
+    RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
+    scores, indices = router(hidden)
+    assert scores.shape == (6, router.topk)
+    assert RouterReplay.get_recorded_data() == []
+
+
+def test_set_replay_data_length_mismatch_raises():
+    from megatron.lite.primitive.modules.router import RouterReplay
+
+    _topk_router(True)  # registers exactly one instance
+    with pytest.raises(ValueError):
+        RouterReplay.set_replay_data([torch.zeros(2, 2, dtype=torch.long)] * 2)

--- a/experimental/lite/tests/unit/primitive/test_router_replay_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_router_replay_unit.py
@@ -218,3 +218,54 @@ def test_set_replay_data_length_mismatch_raises():
     _topk_router(True)  # registers exactly one instance
     with pytest.raises(ValueError):
         RouterReplay.set_replay_data([torch.zeros(2, 2, dtype=torch.long)] * 2)
+
+
+def test_attach_skips_router_replay_excluded_modules():
+    """DeepSeek-V4 hash-routed layers set ``_router_replay_exclude`` so they stay
+    out of the replay registry (their routing is weight-independent)."""
+    import torch.nn as nn
+
+    from megatron.lite.primitive.modules.router import RouterReplay, attach_router_replay
+
+    class _FakeRouter(nn.Module):
+        def __init__(self, exclude=False):
+            super().__init__()
+            self.router_replay = None
+            if exclude:
+                self._router_replay_exclude = True
+
+    model = nn.ModuleList([_FakeRouter(), _FakeRouter(exclude=True), _FakeRouter()])
+    count = attach_router_replay(model)
+    assert count == 2
+    assert len(RouterReplay.global_router_replay_instances) == 2
+
+
+@pytest.mark.parametrize("contiguous", [False, True], ids=["zigzag", "contiguous"])
+def test_routed_experts_pack_unpack_round_trip(contiguous):
+    """pack -> stack -> unpack recovers the routing (CP=1; pure tensor path,
+    covers both the shared zigzag layout and DS4's contiguous layout)."""
+    from megatron.lite.model.protocol_utils import pack_routed_experts, unpack_routed_experts
+    from megatron.lite.primitive.parallel import ParallelState
+    from megatron.lite.runtime.contracts import PackedBatch
+
+    seq_lens = torch.tensor([3, 5], dtype=torch.int64)
+    total = int(seq_lens.sum())
+    model = SimpleNamespace(ps=ParallelState())  # cp1 tp1
+    batch = PackedBatch(
+        input_ids=torch.zeros(total, dtype=torch.long),
+        labels=torch.zeros(total, dtype=torch.long),
+        seq_lens=seq_lens,
+    )
+    num_layers, topk = 2, 2
+    rows = [
+        torch.randint(0, 8, (int(n), num_layers, topk), dtype=torch.long) for n in seq_lens
+    ]
+    routed = torch.nested.as_nested_tensor(rows, layout=torch.jagged)
+
+    targets = pack_routed_experts(model, batch, routed, contiguous=contiguous)
+    assert len(targets) == num_layers
+    stacked = torch.stack(targets, dim=1)  # [tokens_padded, num_layers, topk]
+    recovered = unpack_routed_experts(model, batch, stacked, contiguous=contiguous)
+
+    for original, got in zip(rows, recovered.unbind(0), strict=True):
+        assert torch.equal(original, got)

--- a/experimental/lite/tests/unit/primitive/test_router_replay_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_router_replay_unit.py
@@ -224,7 +224,6 @@ def test_attach_skips_router_replay_excluded_modules():
     """DeepSeek-V4 hash-routed layers set ``_router_replay_exclude`` so they stay
     out of the replay registry (their routing is weight-independent)."""
     import torch.nn as nn
-
     from megatron.lite.primitive.modules.router import RouterReplay, attach_router_replay
 
     class _FakeRouter(nn.Module):

--- a/experimental/lite/tests/unit/primitive/test_router_replay_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_router_replay_unit.py
@@ -32,6 +32,13 @@ def _clean_replay_registry():
     RouterReplay.clear_global_router_replay_instances()
 
 
+def _device():
+    # TopKRouter.gate uses TE's router_gating_linear (CUDA-only gemm); run on GPU
+    # when one is present (e.g. inside the container), CPU otherwise (login node
+    # with the TE import stub handling the fallback).
+    return "cuda" if torch.cuda.is_available() else "cpu"
+
+
 def _topk_router(enable_routing_replay: bool):
     from megatron.lite.primitive.modules.router import TopKRouter
     from megatron.lite.primitive.parallel import ParallelState
@@ -44,7 +51,7 @@ def _topk_router(enable_routing_replay: bool):
         ParallelState(),
         compute_aux_loss=False,
         enable_routing_replay=enable_routing_replay,
-    )
+    ).to(_device())
 
 
 def _sigmoid_router(enable_routing_replay: bool):
@@ -64,7 +71,7 @@ def _sigmoid_router(enable_routing_replay: bool):
         ParallelState(),
         compute_aux_loss=False,
         enable_routing_replay=enable_routing_replay,
-    )
+    ).to(_device())
 
 
 ROUTER_FACTORIES = {"topk_softmax": _topk_router, "sigmoid_topk": _sigmoid_router}
@@ -76,7 +83,7 @@ def test_record_captures_topk_indices(factory):
 
     router = factory(True)
     router.eval()
-    hidden = torch.randn(6, router.gate.in_features)
+    hidden = torch.randn(6, router.gate.in_features, device=_device())
 
     RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
     scores, indices = router(hidden)
@@ -94,7 +101,7 @@ def test_replay_forward_reproduces_recorded_indices(factory):
 
     router = factory(True)
     router.eval()
-    hidden = torch.randn(6, router.gate.in_features)
+    hidden = torch.randn(6, router.gate.in_features, device=_device())
 
     RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
     _, recorded_indices = router(hidden)
@@ -119,7 +126,7 @@ def test_replay_forward_overrides_recomputed_routing(factory):
 
     router = factory(True)
     router.eval()
-    hidden = torch.randn(6, router.gate.in_features)
+    hidden = torch.randn(6, router.gate.in_features, device=_device())
 
     RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
     _, recorded_indices = router(hidden)
@@ -148,7 +155,7 @@ def test_replay_forward_keeps_gate_gradient(factory):
 
     router = factory(True)
     router.train()
-    hidden = torch.randn(6, router.gate.in_features)
+    hidden = torch.randn(6, router.gate.in_features, device=_device())
 
     RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
     _, recorded_indices = router(hidden)
@@ -156,7 +163,9 @@ def test_replay_forward_keeps_gate_gradient(factory):
     RouterReplay.set_replay_data([recorded_indices.clone()])
     RouterReplay.set_global_router_replay_action(RouterReplayAction.REPLAY_FORWARD)
     replay_scores, _ = router(hidden)
-    replay_scores.sum().backward()
+    # Sum-of-squares, not sum: a post-softmax router's topk scores sum to 1 per
+    # token (constant), so a plain .sum() would have zero gradient by design.
+    (replay_scores.float() ** 2).sum().backward()
 
     assert router.gate.weight.grad is not None
     assert torch.isfinite(router.gate.weight.grad).all()
@@ -168,7 +177,7 @@ def test_replay_backward_pops_target_in_order():
 
     router = _topk_router(True)
     router.eval()
-    hidden = torch.randn(6, router.gate.in_features)
+    hidden = torch.randn(6, router.gate.in_features, device=_device())
 
     RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
     _, recorded_indices = router(hidden)
@@ -193,7 +202,7 @@ def test_disabled_replay_is_noop():
 
     router = _topk_router(False)
     router.eval()
-    hidden = torch.randn(6, router.gate.in_features)
+    hidden = torch.randn(6, router.gate.in_features, device=_device())
 
     # No instance is registered when replay is disabled.
     assert RouterReplay.global_router_replay_instances == []

--- a/experimental/lite/tests/unit/primitive/test_router_replay_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_router_replay_unit.py
@@ -39,6 +39,15 @@ def _device():
     return "cuda" if torch.cuda.is_available() else "cpu"
 
 
+def _enable_replay(router, enable: bool):
+    # Single shared enablement path — same call the runtime uses for every model.
+    if enable:
+        from megatron.lite.primitive.modules.router import attach_router_replay
+
+        attach_router_replay(router)
+    return router
+
+
 def _topk_router(enable_routing_replay: bool):
     from megatron.lite.primitive.modules.router import TopKRouter
     from megatron.lite.primitive.parallel import ParallelState
@@ -46,12 +55,8 @@ def _topk_router(enable_routing_replay: bool):
     config = SimpleNamespace(
         hidden_size=8, num_experts=8, num_experts_per_tok=2, router_aux_loss_coef=0.1
     )
-    return TopKRouter(
-        config,
-        ParallelState(),
-        compute_aux_loss=False,
-        enable_routing_replay=enable_routing_replay,
-    ).to(_device())
+    router = TopKRouter(config, ParallelState(), compute_aux_loss=False).to(_device())
+    return _enable_replay(router, enable_routing_replay)
 
 
 def _sigmoid_router(enable_routing_replay: bool):
@@ -66,12 +71,8 @@ def _sigmoid_router(enable_routing_replay: bool):
         scoring_func="sigmoid",
         aux_loss_alpha=0.0,
     )
-    return SigmoidTopKRouter(
-        config,
-        ParallelState(),
-        compute_aux_loss=False,
-        enable_routing_replay=enable_routing_replay,
-    ).to(_device())
+    router = SigmoidTopKRouter(config, ParallelState(), compute_aux_loss=False).to(_device())
+    return _enable_replay(router, enable_routing_replay)
 
 
 ROUTER_FACTORIES = {"topk_softmax": _topk_router, "sigmoid_topk": _sigmoid_router}

--- a/experimental/lite/tests/unit/verl/test_mlite_router_replay_smoke.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_router_replay_smoke.py
@@ -331,13 +331,21 @@ def test_router_replay_record_then_replay_aligns(
     # assertions are guarded on availability; routed_experts is PP-gathered to all
     # ranks, so its shape is checked everywhere.
 
-    # 0) Run-to-run noise floor: two identical no-replay forwards. Deterministic
-    #    models give 0; non-deterministic fused kernels (e.g. DSA attention) give
-    #    a small floor we accept replay reproduction against (red-line #4).
-    lp_a = _flat(_forward(engine, runtime_batch, loss_context, None).model_output.log_probs)
-    lp_b = _flat(_forward(engine, runtime_batch, loss_context, None).model_output.log_probs)
-    has_lp = lp_a is not None
-    noise = (lp_a - lp_b).abs().max().item() if has_lp else 0.0
+    # 0) Run-to-run noise floor: several identical no-replay forwards, taking the
+    #    max pairwise diff. A single pair undersamples the intermittent atomic
+    #    non-determinism of the MoE all-to-all combine / DSA kernels; a robust
+    #    upper bound lets replay be accepted "same order as noise" (red-line #4).
+    #    Deterministic models give 0 → replay must then be bitwise.
+    plains = [
+        _flat(_forward(engine, runtime_batch, loss_context, None).model_output.log_probs)
+        for _ in range(4)
+    ]
+    has_lp = plains[0] is not None
+    noise = (
+        max((plains[i] - plains[0]).abs().max().item() for i in range(1, len(plains)))
+        if has_lp
+        else 0.0
+    )
 
     # 1) RECORD the routing during a log-prob pass.
     rec = _forward(engine, runtime_batch, loss_context, {"action": "record"})

--- a/experimental/lite/tests/unit/verl/test_mlite_router_replay_smoke.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_router_replay_smoke.py
@@ -265,7 +265,10 @@ def _build_engine(tmp_path, model_name, model_type, write_config, world):
 
 
 def _flat(log_probs):
-    """Raw runtime log_probs are packed/strided; nested only after protocol unpack."""
+    """Raw runtime log_probs are packed/strided; nested only after protocol unpack.
+    ``None`` on non-last pipeline stages (only the last stage emits log_probs)."""
+    if log_probs is None:
+        return None
     return log_probs.values() if getattr(log_probs, "is_nested", False) else log_probs
 
 
@@ -303,7 +306,9 @@ def test_router_replay_record_then_replay_aligns(
     rank = dist.get_rank()
     engine = _build_engine(tmp_path, model_name, model_type, write_config, world)
 
-    torch.manual_seed(1234 + rank)
+    # Same seed on every rank: CP/PP all see identical full sequences (CP splits
+    # internally; PP stages must agree on the batch).
+    torch.manual_seed(1234)
     input_ids = torch.nested.as_nested_tensor(
         [torch.randint(0, vocab_size, (n,), device=device, dtype=torch.long) for n in lengths],
         layout=torch.jagged,
@@ -320,18 +325,24 @@ def test_router_replay_record_then_replay_aligns(
     runtime_batch = engine._make_runtime_batch(micro_batch)
     loss_context = engine._make_runtime_loss_context(micro_batch, loss_scale=1.0)
 
+    # All forwards run on every rank (collective: pipeline comm + the PP-gather in
+    # record). Only the last pipeline stage produces log_probs, so log-prob
+    # assertions are guarded on availability; routed_experts is PP-gathered to all
+    # ranks, so its shape is checked everywhere.
+
     # 0) Run-to-run noise floor: two identical no-replay forwards. Deterministic
     #    models give 0; non-deterministic fused kernels (e.g. DSA attention) give
     #    a small floor we accept replay reproduction against (red-line #4).
     lp_a = _flat(_forward(engine, runtime_batch, loss_context, None).model_output.log_probs)
     lp_b = _flat(_forward(engine, runtime_batch, loss_context, None).model_output.log_probs)
-    noise = (lp_a - lp_b).abs().max().item()
+    has_lp = lp_a is not None
+    noise = (lp_a - lp_b).abs().max().item() if has_lp else 0.0
 
     # 1) RECORD the routing during a log-prob pass.
     rec = _forward(engine, runtime_batch, loss_context, {"action": "record"})
     routed = rec.model_output.routed_experts
     assert routed is not None, "record mode must emit routed_experts"
-    # [bs, seq, num_moe_layers, topk]
+    # [bs, seq, num_moe_layers, topk] — PP-gathered to every rank.
     assert [int(x) for x in routed.offsets().diff().cpu()] == lengths
     lp_record = _flat(rec.model_output.log_probs)
 
@@ -340,12 +351,13 @@ def test_router_replay_record_then_replay_aligns(
     replay_batch = dataclasses.replace(runtime_batch, routed_experts=routed)
     rep = _forward(engine, replay_batch, loss_context, {"action": "replay"})
     lp_replay = _flat(rep.model_output.log_probs)
-    replay_diff = (lp_replay - lp_record).abs().max().item()
+    replay_diff = (lp_replay - lp_record).abs().max().item() if has_lp else 0.0
     tol = max(noise * 4.0, 1e-6)
-    assert replay_diff <= tol, (
-        f"replay must reproduce the recorded forward (diff={replay_diff:.3e} > tol={tol:.3e}, "
-        f"noise floor={noise:.3e})"
-    )
+    if has_lp:
+        assert replay_diff <= tol, (
+            f"replay must reproduce the recorded forward (diff={replay_diff:.3e} > tol={tol:.3e}, "
+            f"noise floor={noise:.3e})"
+        )
 
     # 3) Move the gate so natural routing changes; replay must still force the
     #    recorded experts (log-probs diverge from fresh routing, well above noise).
@@ -357,13 +369,12 @@ def test_router_replay_record_then_replay_aligns(
     lp_replay2 = _flat(
         _forward(engine, replay_batch, loss_context, {"action": "replay"}).model_output.log_probs
     )
-    override_diff = (lp_replay2 - lp_natural).abs().max().item()
-    assert torch.isfinite(lp_replay2).all()
-    assert override_diff > max(noise * 10.0, 1e-4), (
-        f"replay should override perturbed routing (override={override_diff:.3e}, noise={noise:.3e})"
-    )
-
-    if rank == 0:
+    override_diff = (lp_replay2 - lp_natural).abs().max().item() if has_lp else None
+    if has_lp:
+        assert torch.isfinite(lp_replay2).all()
+        assert override_diff > max(noise * 10.0, 1e-4), (
+            f"replay should override perturbed routing (override={override_diff:.3e}, noise={noise:.3e})"
+        )
         print(
             "NON_SKIP_VERL_MLITE_ROUTER_REPLAY_ALIGN_PASSED "
             f"model={model_name} world_size={world} lengths={lengths} "

--- a/experimental/lite/tests/unit/verl/test_mlite_router_replay_smoke.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_router_replay_smoke.py
@@ -303,7 +303,6 @@ def test_router_replay_record_then_replay_aligns(
 
     device = _init_dist_or_skip()
     world = dist.get_world_size()
-    rank = dist.get_rank()
     engine = _build_engine(tmp_path, model_name, model_type, write_config, world)
 
     # Same seed on every rank: CP/PP all see identical full sequences (CP splits

--- a/experimental/lite/tests/unit/verl/test_mlite_router_replay_smoke.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_router_replay_smoke.py
@@ -204,6 +204,21 @@ def _optimizer_config() -> SimpleNamespace:
     )
 
 
+def _parallel_dims(world):
+    """Parallel layout from $MLITE_RR_PARALLEL (e.g. 'pp2cp2tp2ep2'); default cp=world."""
+    import os
+    import re
+
+    spec = os.environ.get("MLITE_RR_PARALLEL", "")
+    dims = {"tp": 1, "ep": 1, "pp": 1, "cp": 1}
+    if not spec:
+        dims["cp"] = world
+        return dims
+    for key, val in re.findall(r"(tp|ep|pp|cp)(\d+)", spec):
+        dims[key] = int(val)
+    return dims
+
+
 def _build_engine(tmp_path, model_name, model_type, write_config, world):
     from verl_mlite.compat import apply_runtime_patches
 
@@ -213,6 +228,7 @@ def _build_engine(tmp_path, model_name, model_type, write_config, world):
 
     hf_path = tmp_path / f"tiny-{model_name}"
     write_config(hf_path)
+    dims = _parallel_dims(world)
     engine = MegatronLiteEngine(
         model_config=SimpleNamespace(
             local_path=str(hf_path),
@@ -221,7 +237,10 @@ def _build_engine(tmp_path, model_name, model_type, write_config, world):
         ),
         engine_config=MegatronLiteEngineConfig(
             model_name=model_name,
-            cp=world,
+            tp=dims["tp"],
+            ep=dims["ep"],
+            pp=dims["pp"],
+            cp=dims["cp"],
             impl_cfg={
                 "use_thd": True,
                 "optimizer": None,

--- a/experimental/lite/tests/unit/verl/test_mlite_router_replay_smoke.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_router_replay_smoke.py
@@ -83,6 +83,62 @@ def _write_kimi_config(path) -> None:
     (path / "config.json").write_text(json.dumps(config), encoding="utf-8")
 
 
+def _write_qwen3_moe_config(path) -> None:
+    config = {
+        "model_type": "qwen3_moe",
+        "num_hidden_layers": 2,
+        "hidden_size": 64,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "head_dim": 16,
+        "vocab_size": 128,
+        "num_experts": 8,
+        "num_experts_per_tok": 2,
+        "moe_intermediate_size": 32,
+        "rope_theta": 1000000.0,
+        "rms_norm_eps": 1e-6,
+        "max_position_embeddings": 128,
+        "router_aux_loss_coef": 0.001,
+        "num_nextn_predict_layers": 0,
+        "layer_types": ["full_attention", "full_attention"],
+    }
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+
+
+def _write_glm5_moe_config(path) -> None:
+    config = {
+        "model_type": "glm_moe_dsa",
+        "num_hidden_layers": 2,
+        "hidden_size": 128,
+        "num_attention_heads": 64,
+        "num_key_value_heads": 64,
+        "head_dim": 256,
+        "vocab_size": 32,
+        "max_position_embeddings": 64,
+        "initializer_range": 0.002,
+        "q_lora_rank": 16,
+        "kv_lora_rank": 512,
+        "qk_head_dim": 256,
+        "qk_nope_head_dim": 192,
+        "qk_rope_head_dim": 64,
+        "v_head_dim": 256,
+        "index_head_dim": 128,
+        "index_n_heads": 32,
+        "index_topk": 512,
+        "intermediate_size": 20,
+        "moe_intermediate_size": 6,
+        "first_k_dense_replace": 1,
+        "n_routed_experts": 4,
+        "n_shared_experts": 1,
+        "num_experts_per_tok": 3,
+        "num_nextn_predict_layers": 0,
+        "mlp_layer_types": ["dense", "sparse"],
+    }
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+
+
 def _optimizer_config() -> SimpleNamespace:
     return SimpleNamespace(
         optimizer="adam",
@@ -147,6 +203,11 @@ def _build_engine(tmp_path, model_name, model_type, write_config, world):
     return engine
 
 
+def _flat(log_probs):
+    """Raw runtime log_probs are packed/strided; nested only after protocol unpack."""
+    return log_probs.values() if getattr(log_probs, "is_nested", False) else log_probs
+
+
 def _forward(engine, runtime_batch, loss_context, router_replay):
     result = engine.runtime.forward_backward(
         engine.handle,
@@ -161,7 +222,11 @@ def _forward(engine, runtime_batch, loss_context, router_replay):
 
 @pytest.mark.parametrize(
     ("model_name", "model_type", "write_config", "vocab_size", "lengths"),
-    [("kimi_k2", "deepseek_v3", _write_kimi_config, 128, [16, 24, 32])],
+    [
+        ("kimi_k2", "deepseek_v3", _write_kimi_config, 128, [16, 24, 32]),
+        ("qwen3_moe", "qwen3_moe", _write_qwen3_moe_config, 128, [16, 24, 32]),
+        ("glm5", "glm_moe_dsa", _write_glm5_moe_config, 32, [16, 24, 32]),
+    ],
 )
 def test_router_replay_record_then_replay_aligns(
     tmp_path, model_name, model_type, write_config, vocab_size, lengths
@@ -199,14 +264,14 @@ def test_router_replay_record_then_replay_aligns(
     assert routed is not None, "record mode must emit routed_experts"
     # [bs, seq, num_moe_layers, topk]
     assert [int(x) for x in routed.offsets().diff().cpu()] == lengths
-    lp_record = rec.model_output.log_probs
+    lp_record = _flat(rec.model_output.log_probs)
 
     # 2) REPLAY the recorded routing — must reproduce the recorded log-probs.
     replay_batch = dataclasses.replace(runtime_batch, routed_experts=routed)
     rep = _forward(engine, replay_batch, loss_context, {"action": "replay"})
-    lp_replay = rep.model_output.log_probs
+    lp_replay = _flat(rep.model_output.log_probs)
     torch.testing.assert_close(
-        lp_replay.values(), lp_record.values(), atol=0.0, rtol=0.0,
+        lp_replay, lp_record, atol=0.0, rtol=0.0,
         msg="replay must reproduce the recorded forward bitwise",
     )
 
@@ -216,10 +281,12 @@ def test_router_replay_record_then_replay_aligns(
         for name, param in engine.module.named_parameters():
             if name.endswith("router.gate.weight") or name.endswith("gate.weight"):
                 param.add_(torch.randn_like(param) * 3.0)
-    lp_natural = _forward(engine, runtime_batch, loss_context, None).model_output.log_probs
-    lp_replay2 = _forward(engine, replay_batch, loss_context, {"action": "replay"}).model_output.log_probs
-    max_diff = (lp_replay2.values() - lp_natural.values()).abs().max()
-    assert torch.isfinite(lp_replay2.values()).all()
+    lp_natural = _flat(_forward(engine, runtime_batch, loss_context, None).model_output.log_probs)
+    lp_replay2 = _flat(
+        _forward(engine, replay_batch, loss_context, {"action": "replay"}).model_output.log_probs
+    )
+    max_diff = (lp_replay2 - lp_natural).abs().max()
+    assert torch.isfinite(lp_replay2).all()
     assert max_diff.item() > 0.0, "replay should override the perturbed natural routing"
 
     if rank == 0:

--- a/experimental/lite/tests/unit/verl/test_mlite_router_replay_smoke.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_router_replay_smoke.py
@@ -258,6 +258,13 @@ def test_router_replay_record_then_replay_aligns(
     runtime_batch = engine._make_runtime_batch(micro_batch)
     loss_context = engine._make_runtime_loss_context(micro_batch, loss_scale=1.0)
 
+    # 0) Run-to-run noise floor: two identical no-replay forwards. Deterministic
+    #    models give 0; non-deterministic fused kernels (e.g. DSA attention) give
+    #    a small floor we accept replay reproduction against (red-line #4).
+    lp_a = _flat(_forward(engine, runtime_batch, loss_context, None).model_output.log_probs)
+    lp_b = _flat(_forward(engine, runtime_batch, loss_context, None).model_output.log_probs)
+    noise = (lp_a - lp_b).abs().max().item()
+
     # 1) RECORD the routing during a log-prob pass.
     rec = _forward(engine, runtime_batch, loss_context, {"action": "record"})
     routed = rec.model_output.routed_experts
@@ -266,17 +273,20 @@ def test_router_replay_record_then_replay_aligns(
     assert [int(x) for x in routed.offsets().diff().cpu()] == lengths
     lp_record = _flat(rec.model_output.log_probs)
 
-    # 2) REPLAY the recorded routing — must reproduce the recorded log-probs.
+    # 2) REPLAY the recorded routing — must reproduce the recorded forward within
+    #    the kernel-noise floor (bitwise when the model is deterministic).
     replay_batch = dataclasses.replace(runtime_batch, routed_experts=routed)
     rep = _forward(engine, replay_batch, loss_context, {"action": "replay"})
     lp_replay = _flat(rep.model_output.log_probs)
-    torch.testing.assert_close(
-        lp_replay, lp_record, atol=0.0, rtol=0.0,
-        msg="replay must reproduce the recorded forward bitwise",
+    replay_diff = (lp_replay - lp_record).abs().max().item()
+    tol = max(noise * 4.0, 1e-6)
+    assert replay_diff <= tol, (
+        f"replay must reproduce the recorded forward (diff={replay_diff:.3e} > tol={tol:.3e}, "
+        f"noise floor={noise:.3e})"
     )
 
     # 3) Move the gate so natural routing changes; replay must still force the
-    #    recorded experts (log-probs diverge from the fresh natural routing).
+    #    recorded experts (log-probs diverge from fresh routing, well above noise).
     with torch.no_grad():
         for name, param in engine.module.named_parameters():
             if name.endswith("router.gate.weight") or name.endswith("gate.weight"):
@@ -285,13 +295,16 @@ def test_router_replay_record_then_replay_aligns(
     lp_replay2 = _flat(
         _forward(engine, replay_batch, loss_context, {"action": "replay"}).model_output.log_probs
     )
-    max_diff = (lp_replay2 - lp_natural).abs().max()
+    override_diff = (lp_replay2 - lp_natural).abs().max().item()
     assert torch.isfinite(lp_replay2).all()
-    assert max_diff.item() > 0.0, "replay should override the perturbed natural routing"
+    assert override_diff > max(noise * 10.0, 1e-4), (
+        f"replay should override perturbed routing (override={override_diff:.3e}, noise={noise:.3e})"
+    )
 
     if rank == 0:
         print(
             "NON_SKIP_VERL_MLITE_ROUTER_REPLAY_ALIGN_PASSED "
             f"model={model_name} world_size={world} lengths={lengths} "
-            f"replay_vs_record_max_abs=0 perturbed_replay_vs_natural_max_abs={max_diff.item():.6e}"
+            f"noise={noise:.3e} replay_vs_record={replay_diff:.3e} "
+            f"perturbed_replay_vs_natural={override_diff:.3e}"
         )

--- a/experimental/lite/tests/unit/verl/test_mlite_router_replay_smoke.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_router_replay_smoke.py
@@ -139,6 +139,48 @@ def _write_glm5_moe_config(path) -> None:
     (path / "config.json").write_text(json.dumps(config), encoding="utf-8")
 
 
+def _write_deepseek_v4_config(path) -> None:
+    config = {
+        "model_type": "deepseek_v4",
+        "num_hidden_layers": 2,
+        "hidden_size": 128,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 1,
+        "head_dim": 32,
+        "vocab_size": 128,
+        "max_position_embeddings": 128,
+        "initializer_range": 0.02,
+        "q_lora_rank": 64,
+        "qk_rope_head_dim": 16,
+        "o_lora_rank": 64,
+        "o_groups": 4,
+        "index_head_dim": 16,
+        "index_n_heads": 4,
+        "index_topk": 4,
+        "moe_intermediate_size": 32,
+        "n_routed_experts": 8,
+        "n_shared_experts": 1,
+        "num_experts_per_tok": 2,
+        "num_hash_layers": 1,
+        "num_nextn_predict_layers": 0,
+        "compress_ratios": [4, 4],
+        "compress_rope_theta": 160000.0,
+        "hc_mult": 2,
+        "hc_eps": 1e-6,
+        "hc_sinkhorn_iters": 4,
+        "rms_norm_eps": 1e-6,
+        "rope_theta": 10000.0,
+        "sliding_window": 128,
+        "swiglu_limit": 10.0,
+        "scoring_func": "sqrtsoftplus",
+        "topk_method": "noaux_tc",
+        "norm_topk_prob": True,
+        "routed_scaling_factor": 1.0,
+    }
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+
+
 def _optimizer_config() -> SimpleNamespace:
     return SimpleNamespace(
         optimizer="adam",
@@ -226,6 +268,7 @@ def _forward(engine, runtime_batch, loss_context, router_replay):
         ("kimi_k2", "deepseek_v3", _write_kimi_config, 128, [16, 24, 32]),
         ("qwen3_moe", "qwen3_moe", _write_qwen3_moe_config, 128, [16, 24, 32]),
         ("glm5", "glm_moe_dsa", _write_glm5_moe_config, 32, [16, 24, 32]),
+        ("deepseek_v4", "deepseek_v4", _write_deepseek_v4_config, 128, [16, 20, 24]),
     ],
 )
 def test_router_replay_record_then_replay_aligns(

--- a/experimental/lite/tests/unit/verl/test_mlite_router_replay_smoke.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_router_replay_smoke.py
@@ -49,7 +49,9 @@ def _init_dist_or_skip():
 def _write_kimi_config(path) -> None:
     config = {
         "model_type": "deepseek_v3",
-        "num_hidden_layers": 3,
+        # 2 all-MoE layers: even split across pp2 (one MoE router per stage), so
+        # the same config exercises cp2 and the proxy2 pp2ep2cp2tp2 layout.
+        "num_hidden_layers": 2,
         "hidden_size": 64,
         "num_attention_heads": 4,
         "num_key_value_heads": 4,
@@ -61,7 +63,7 @@ def _write_kimi_config(path) -> None:
         "num_experts_per_tok": 2,
         "n_group": 2,
         "topk_group": 1,
-        "first_k_dense_replace": 1,
+        "first_k_dense_replace": 0,
         "q_lora_rank": 16,
         "kv_lora_rank": 12,
         "qk_nope_head_dim": 8,

--- a/experimental/lite/tests/unit/verl/test_mlite_router_replay_smoke.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_router_replay_smoke.py
@@ -1,0 +1,230 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""verl-faithful router-replay alignment smoke (runs through the real runtime).
+
+RECORD a MoE model's routing during a (forward-only) log-prob pass, then REPLAY
+those decisions in a second pass and assert:
+1. replay reproduces the recorded forward's log-probs bitwise (replay routes the
+   model exactly the way it was recorded), and
+2. after the gate weights move, replay still forces the *recorded* routing — its
+   log-probs diverge from the fresh natural routing.
+
+This is the same RECORD -> REPLAY contract verl uses for MoE RL; here it goes
+through the shared primitive ``RouterReplay`` + runtime driver + protocol THD
+pack/unpack, the single path all five models share.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from types import MethodType, SimpleNamespace
+
+import pytest
+
+pytestmark = [
+    pytest.mark.mlite,
+    pytest.mark.smoke,
+    pytest.mark.gpu,
+    pytest.mark.distributed,
+]
+
+
+def _init_dist_or_skip():
+    import os
+
+    import torch
+    import torch.distributed as dist
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for MLite router-replay smoke.")
+    if "RANK" not in os.environ or "WORLD_SIZE" not in os.environ:
+        pytest.skip("Run with torchrun so CP ranks are available.")
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    torch.cuda.set_device(local_rank)
+    if not dist.is_initialized():
+        dist.init_process_group("nccl")
+    return torch.device("cuda", local_rank)
+
+
+def _write_kimi_config(path) -> None:
+    config = {
+        "model_type": "deepseek_v3",
+        "num_hidden_layers": 3,
+        "hidden_size": 64,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 4,
+        "vocab_size": 128,
+        "intermediate_size": 96,
+        "moe_intermediate_size": 16,
+        "n_routed_experts": 8,
+        "n_shared_experts": 1,
+        "num_experts_per_tok": 2,
+        "n_group": 2,
+        "topk_group": 1,
+        "first_k_dense_replace": 1,
+        "q_lora_rank": 16,
+        "kv_lora_rank": 12,
+        "qk_nope_head_dim": 8,
+        "qk_rope_head_dim": 8,
+        "v_head_dim": 8,
+        "max_position_embeddings": 128,
+        "rope_theta": 10000.0,
+        "rope_scaling": {
+            "type": "yarn",
+            "factor": 1.0,
+            "original_max_position_embeddings": 128,
+            "beta_fast": 1.0,
+            "beta_slow": 1.0,
+            "mscale": 1.0,
+            "mscale_all_dim": 1.0,
+        },
+    }
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+
+
+def _optimizer_config() -> SimpleNamespace:
+    return SimpleNamespace(
+        optimizer="adam",
+        lr=1e-6,
+        min_lr=None,
+        min_lr_ratio=None,
+        clip_grad=1.0,
+        weight_decay=0.0,
+        lr_warmup_steps_ratio=0.0,
+        total_training_steps=1,
+        lr_warmup_steps=0,
+        lr_warmup_init=0.0,
+        lr_decay_steps=None,
+        lr_decay_style="constant",
+        weight_decay_incr_style="constant",
+        lr_wsd_decay_style="exponential",
+        lr_wsd_decay_steps=None,
+        use_checkpoint_opt_param_scheduler=False,
+        betas=(0.9, 0.95),
+        override_optimizer_config={},
+    )
+
+
+def _build_engine(tmp_path, model_name, model_type, write_config, world):
+    from verl_mlite.compat import apply_runtime_patches
+
+    apply_runtime_patches()
+    from verl_mlite.engine.config import MegatronLiteEngineConfig
+    from verl_mlite.engine.mlite_engine import MegatronLiteEngine
+
+    hf_path = tmp_path / f"tiny-{model_name}"
+    write_config(hf_path)
+    engine = MegatronLiteEngine(
+        model_config=SimpleNamespace(
+            local_path=str(hf_path),
+            hf_config={"model_type": model_type},
+            mtp=None,
+        ),
+        engine_config=MegatronLiteEngineConfig(
+            model_name=model_name,
+            cp=world,
+            impl_cfg={
+                "use_thd": True,
+                "optimizer": None,
+                "deterministic": True,
+                "mtp_enable": False,
+            },
+            use_fused_kernels=False,
+        ),
+        optimizer_config=_optimizer_config(),
+        checkpoint_config={},
+    )
+    original_build_config = engine._build_mlite_config
+
+    def _no_weights(self):
+        config = original_build_config()
+        config.load_hf_weights = False
+        return config
+
+    engine._build_mlite_config = MethodType(_no_weights, engine)
+    engine.initialize()
+    return engine
+
+
+def _forward(engine, runtime_batch, loss_context, router_replay):
+    result = engine.runtime.forward_backward(
+        engine.handle,
+        iter([(runtime_batch, loss_context)]),
+        loss_fn=None,
+        num_microbatches=1,
+        forward_only=True,
+        router_replay=router_replay,
+    )
+    return result
+
+
+@pytest.mark.parametrize(
+    ("model_name", "model_type", "write_config", "vocab_size", "lengths"),
+    [("kimi_k2", "deepseek_v3", _write_kimi_config, 128, [16, 24, 32])],
+)
+def test_router_replay_record_then_replay_aligns(
+    tmp_path, model_name, model_type, write_config, vocab_size, lengths
+):
+    import torch
+    import torch.distributed as dist
+
+    TensorDict = pytest.importorskip("tensordict").TensorDict
+
+    device = _init_dist_or_skip()
+    world = dist.get_world_size()
+    rank = dist.get_rank()
+    engine = _build_engine(tmp_path, model_name, model_type, write_config, world)
+
+    torch.manual_seed(1234 + rank)
+    input_ids = torch.nested.as_nested_tensor(
+        [torch.randint(0, vocab_size, (n,), device=device, dtype=torch.long) for n in lengths],
+        layout=torch.jagged,
+    )
+    loss_mask = torch.nested.as_nested_tensor(
+        [torch.ones(n, device=device, dtype=torch.float32) for n in lengths],
+        layout=torch.jagged,
+    )
+    micro_batch = TensorDict(
+        {"input_ids": input_ids, "loss_mask": loss_mask},
+        batch_size=[len(lengths)],
+        device=device,
+    )
+    runtime_batch = engine._make_runtime_batch(micro_batch)
+    loss_context = engine._make_runtime_loss_context(micro_batch, loss_scale=1.0)
+
+    # 1) RECORD the routing during a log-prob pass.
+    rec = _forward(engine, runtime_batch, loss_context, {"action": "record"})
+    routed = rec.model_output.routed_experts
+    assert routed is not None, "record mode must emit routed_experts"
+    # [bs, seq, num_moe_layers, topk]
+    assert [int(x) for x in routed.offsets().diff().cpu()] == lengths
+    lp_record = rec.model_output.log_probs
+
+    # 2) REPLAY the recorded routing — must reproduce the recorded log-probs.
+    replay_batch = dataclasses.replace(runtime_batch, routed_experts=routed)
+    rep = _forward(engine, replay_batch, loss_context, {"action": "replay"})
+    lp_replay = rep.model_output.log_probs
+    torch.testing.assert_close(
+        lp_replay.values(), lp_record.values(), atol=0.0, rtol=0.0,
+        msg="replay must reproduce the recorded forward bitwise",
+    )
+
+    # 3) Move the gate so natural routing changes; replay must still force the
+    #    recorded experts (log-probs diverge from the fresh natural routing).
+    with torch.no_grad():
+        for name, param in engine.module.named_parameters():
+            if name.endswith("router.gate.weight") or name.endswith("gate.weight"):
+                param.add_(torch.randn_like(param) * 3.0)
+    lp_natural = _forward(engine, runtime_batch, loss_context, None).model_output.log_probs
+    lp_replay2 = _forward(engine, replay_batch, loss_context, {"action": "replay"}).model_output.log_probs
+    max_diff = (lp_replay2.values() - lp_natural.values()).abs().max()
+    assert torch.isfinite(lp_replay2.values()).all()
+    assert max_diff.item() > 0.0, "replay should override the perturbed natural routing"
+
+    if rank == 0:
+        print(
+            "NON_SKIP_VERL_MLITE_ROUTER_REPLAY_ALIGN_PASSED "
+            f"model={model_name} world_size={world} lengths={lengths} "
+            f"replay_vs_record_max_abs=0 perturbed_replay_vs_natural_max_abs={max_diff.item():.6e}"
+        )


### PR DESCRIPTION
## Unified MoE router replay across all 5 models

Reintroduces MoE **router replay** (record/replay of expert routing for RL, e.g. verl R2/R3) as a **single shared code path** every model routes through — no per-model branching, no Megatron-Core import.

### Design (mechanism in `primitive/modules/router.py` + `PackedBatch.routed_experts` + `runtime`)
- **`RouterReplay` / `RouterReplayAction`** (native, mirrors the verl/mcore contract): per-layer global registry + `apply()` hook. Replay overrides expert *indices* and gathers scores fresh from the live dense probs, so gate gradients still flow.
- **All 4 router classes** (`TopKRouter`, `SigmoidTopKRouter`, Kimi/GLM-5 routers) call the identical `RouterReplay.apply()`.
- **`attach_router_replay()` / `detach_router_replay()`** enable replay by walking `model.modules()` — **zero model-constructor edits**.
- **`RouterReplayDriver`** (runtime) drives RECORD/REPLAY across the microbatch loop, with PP gather/scatter and TP sequence-parallel slice/gather.
- **`protocol_utils.pack/unpack_routed_experts`** route the routing tensor through each model's own THD CP layout (shared zigzag; DeepSeek-V4 contiguous override). DS4 input-deterministic hash layers are excluded.

### Verification (real Slurm GPU, non-dry-run)
- **CPU unit (14)**: primitive record→replay semantics, gradient flow, backward-pop ordering, DS4 hash-exclusion, zigzag+contiguous `routed_experts` pack/unpack round-trip.
- **cp2 forward record→replay align**: `kimi_k2`, `qwen3_moe` bitwise (replay_vs_record=0); `glm5` (DSA, non-deterministic) accept-with-proof (replay within run-to-run noise, routing override ≫ noise).
- **Full proxy2 `pp2ep2cp2tp2` (8 GPU)**: `kimi_k2` + `qwen3_moe` (jobs 12864137 / 12864660, rc=0).
- `glm5` / `deepseek_v4` are DSA = **TP=1 only** (protocol gates TP>1), so proxy2-tp2 is N/A by design — verified at cp2 (glm5) / unit (ds4). `qwen3_5` shares `qwen3_moe`'s `TopKRouter` path.

### Incidental fix
Forward-only pipeline schedule never split `(batch, loss_context)` nor activated the loss context — log-prob inference under PP silently dropped `return_log_probs` / temperature / loss scale. Fixed to mirror the 1F1B schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
