### PR TITLE
csa: pass seqlen_kv to build_flat_topk_idxs in CP1 fused-sparse path

### DIFF
--- a/experimental/lite/megatron/lite/primitive/modules/attention/csa.py
+++ b/experimental/lite/megatron/lite/primitive/modules/attention/csa.py
@@ -550,11 +550,13 @@ class CompressedSparseAttention(nn.Module):
                 window_idxs,
                 compress_topk_idxs,
                 batch_size=batch,
+                seqlen_kv=kv_full.size(0),
             )
         else:
             flat_idxs, _flat_tlen = dsa_kernels.build_flat_topk_idxs(
                 window_idxs,
                 batch_size=batch,
+                seqlen_kv=kv_full.size(0),
             )
 
         out = dsa_kernels.dsa_sparse_attn(


### PR DESCRIPTION
## What

`build_flat_topk_idxs` requires the keyword-only `seqlen_kv` (total KV length per batch), but the CP1 no-indexer fused-sparse path in `CompressedSparseAttention._forward_fused_sparse_no_indexer_cp1` omitted it at both call sites, raising `TypeError` at forward time.

This path is DeepSeek-V4 full-DSA at CP=1. The CP>1 path (exercised by prior CP2 validation) was unaffected, so the bug only surfaced on a CP1 run. The sibling indexer call site in the same file already passes `seqlen_kv=kv_full.size(0)`, confirming the correct value.

## Fix

Pass `seqlen_kv=kv_full.size(0)` at both CP1 call sites (the KV length: `seq_len`, or `seq_len + n_compressed` after the compressed cat — both equal `kv_full.size(0)`).

## Validation

Surfaced by a CP1 proxy run of `deepseek_v4` through the precision bench (mlite backend); after the fix the model runs forward/backward to completion and the run-to-run reproducibility compare succeeds (loss/grad noise floor 5.4e-4 / 3.8e-5, consistent with DSA fused-backward non-determinism).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
