### PR TITLE
ds4: load the real DeepSeek-V4-Flash FP8 release weights

### DIFF
--- a/experimental/lite/examples/bench/bench.py
+++ b/experimental/lite/examples/bench/bench.py
@@ -156,18 +156,18 @@ def _make_mlite_model_config_hook(cfg: BenchCliConfig):
 
         def truncate_layers_hook(model_cfg):
             old_layers = getattr(model_cfg, "num_hidden_layers", None)
-            layer_types = getattr(model_cfg, "layer_types", None)
-            if old_layers is None or layer_types is None:
-                raise ValueError("truncate_layers requires num_hidden_layers and layer_types.")
+            if old_layers is None:
+                raise ValueError("truncate_layers requires num_hidden_layers.")
             if keep_layers <= 0 or keep_layers > old_layers:
                 raise ValueError(
                     f"truncate_layers must be in [1, {old_layers}], got {keep_layers}."
                 )
-            return replace(
-                model_cfg,
-                num_hidden_layers=keep_layers,
-                layer_types=list(layer_types[:keep_layers]),
-            )
+            updates = {"num_hidden_layers": keep_layers}
+            # layer_types is qwen-style metadata; deepseek_v4 / kimi_k2 configs don't carry it.
+            layer_types = getattr(model_cfg, "layer_types", None)
+            if layer_types is not None:
+                updates["layer_types"] = list(layer_types[:keep_layers])
+            return replace(model_cfg, **updates)
 
         hooks.append(truncate_layers_hook)
 

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
@@ -76,49 +76,58 @@ def PLACEMENT_FN(param_name: str) -> list:
 # names are bare DeepseekV4Model state_dict keys with GLOBAL layer indices.
 _BLOCK_KEY_RE = re.compile(r"^(layers|mtp)\.(\d+)\.(.+)$")
 _GROUPED_EXPERT_RE = re.compile(r"^mlp\.experts\.fc([12])\.weight(\d+)$")
-_PROJ_TO_HF = {"gate_proj": "w1", "up_proj": "w3", "down_proj": "w2"}
-
-# Native top-level params -> HF target names.  mHC ``hc_head`` has no HF
-# analogue, so it keeps a ``model.``-rooted name to stay self-consistent.
+# Native top-level params -> real DeepSeek-V4-Flash release names (NOT DeepSeek-V3 HF
+# names; the V4 release uses bare `embed.weight` / `head.weight` / `norm.weight` and a
+# `layers.N.attn.* / ffn.* / hc_*` layout). This same mapping drives both the load path
+# and the export spec, so MLite round-trips against the real release / vLLM ds4 format.
 _TOP_LEVEL = {
-    "embed_tokens.embedding.weight": "model.embed_tokens.weight",
-    "norm.weight": "model.norm.weight",
-    "hc_head.hc_fn": "model.hc_head.hc_fn",
-    "hc_head.hc_base": "model.hc_head.hc_base",
-    "hc_head.hc_scale": "model.hc_head.hc_scale",
-    "lm_head.col.linear.weight": "lm_head.weight",
+    "embed_tokens.embedding.weight": "embed.weight",
+    "norm.weight": "norm.weight",
+    "hc_head.hc_fn": "hc_head_fn",
+    "hc_head.hc_base": "hc_head_base",
+    "hc_head.hc_scale": "hc_head_scale",
+    "lm_head.col.linear.weight": "head.weight",
 }
 
 
 def _map_block_attr(attr: str, block: str) -> str | tuple[str, ...] | None:
+    """Map a native per-block attr -> real V4-Flash suffix (relative to layers.N / mtp.N)."""
     if attr == "input_layernorm.weight":
-        return "input_layernorm.weight"
+        return "attn_norm.weight"
     if attr == "post_attention_layernorm.weight":
-        return "post_attention_layernorm.weight"
-    if attr.startswith("self_attn."):
-        suffix = attr.removeprefix("self_attn.")
-        return "self_attn.attn_sink" if suffix == "sinks" else f"self_attn.{suffix}"
+        return "ffn_norm.weight"
+    # CSA attention: native `self_attn.self_attn.*` (the SBHD wrapper adds one extra
+    # `self_attn` level) -> real `attn.*`. Covers compressor.* / indexer.* / wq_a / wkv / ...
+    sub = None
+    if attr.startswith("self_attn.self_attn."):
+        sub = attr.removeprefix("self_attn.self_attn.")
+    elif attr.startswith("self_attn."):
+        sub = attr.removeprefix("self_attn.")
+    if sub is not None:
+        return "attn.attn_sink" if sub == "sinks" else f"attn.{sub}"
     if attr.startswith("mlp.gate."):
         suffix = attr.removeprefix("mlp.gate.")
-        return "mlp.gate." + {
+        return "ffn.gate." + {
             "gate.weight": "weight",
             "weight": "weight",
-            "expert_bias": "e_score_correction_bias",
-            "e_score_correction_bias": "e_score_correction_bias",
+            "expert_bias": "bias",
+            "e_score_correction_bias": "bias",
             "tid2eid": "tid2eid",
         }.get(suffix, suffix)
     if attr.startswith("mlp.shared_experts."):
         proj = attr.removeprefix("mlp.shared_experts.").removesuffix(".weight")
         if proj == "gate_up":
-            return "mlp.shared_experts.gate_proj.weight", "mlp.shared_experts.up_proj.weight"
+            return "ffn.shared_experts.w1.weight", "ffn.shared_experts.w3.weight"
         if proj == "down":
-            return "mlp.shared_experts.down_proj.weight"
-        return f"mlp.shared_experts.{_PROJ_TO_HF.get(proj, proj)}.weight"
-    # mHC params have no upstream HF analogue; keep them under self_attn / mlp /
-    # hc_head sub-namespaces so every key stays ``model.layers.{i}.*``-rooted.
-    for prefix, target in (("attn_hc", "self_attn.hc"), ("ffn_hc", "mlp.hc"), ("hc_head", "hc_head")):
+            return "ffn.shared_experts.w2.weight"
+        return f"ffn.shared_experts.{proj}.weight"
+    # mHC (hyper-connections): native attn_hc/ffn_hc.{base,fn,scale} -> hc_attn_*/hc_ffn_*;
+    # mtp carries its own hc_head.hc_* -> hc_head_*.
+    for prefix, target in (("attn_hc", "hc_attn"), ("ffn_hc", "hc_ffn")):
         if attr.startswith(f"{prefix}."):
-            return f"{target}_{attr.rsplit('.', 1)[-1].removeprefix('hc_')}"
+            return f"{target}_{attr.rsplit('.', 1)[-1]}"
+    if attr.startswith("hc_head."):
+        return f"hc_head_{attr.rsplit('.', 1)[-1].removeprefix('hc_')}"
     if block == "mtp" and attr in {
         "e_proj.weight",
         "h_proj.weight",
@@ -147,20 +156,9 @@ def _hf_names_for_state_key(name: str, config: DeepseekV4Config) -> list[str]:
     if match is None:
         return []
     block, index, attr = match.groups()
-    # HF places MTP layers right after the decoder stack, so they share the
-    # ``model.layers.{i}`` namespace with a continued global index.
-    if block == "layers":
-        prefix = f"model.layers.{index}"
-    else:  # mtp
-        prefix = f"model.layers.{config.num_hidden_layers + int(index)}"
-    # CSA lives under ``self_attn.self_attn.*`` (the SBHD wrapper adds one extra
-    # ``self_attn`` level).  Collapse it so the HF attention names are unchanged.
-    if attr.startswith("self_attn.self_attn."):
-        attr = "self_attn." + attr.removeprefix("self_attn.self_attn.")
-    if attr.startswith("self_attn.compressor."):
-        return [f"{prefix}.self_attn.compressor.{attr.removeprefix('self_attn.compressor.')}"]
-    if attr.startswith("self_attn.indexer."):
-        return [f"{prefix}.self_attn.indexer.{attr.removeprefix('self_attn.indexer.')}"]
+    # Real V4-Flash keeps decoder layers under ``layers.{i}`` and the MTP block under its
+    # own ``mtp.{i}`` namespace (no ``model.`` prefix, no continued global index).
+    prefix = f"layers.{index}" if block == "layers" else f"mtp.{index}"
     mapped = _map_block_attr(attr, block)
     if mapped is not None:
         if isinstance(mapped, tuple):
@@ -170,10 +168,11 @@ def _hf_names_for_state_key(name: str, config: DeepseekV4Config) -> list[str]:
     if expert is None:
         return []
     fc, expert_id = expert.groups()
-    expert_prefix = f"{prefix}.mlp.experts.{int(expert_id)}"
+    # native fused gate_up (fc1) -> real w1 (gate) + w3 (up); fc2 -> w2 (down).
+    expert_prefix = f"{prefix}.ffn.experts.{int(expert_id)}"
     if fc == "1":
-        return [f"{expert_prefix}.gate_proj.weight", f"{expert_prefix}.up_proj.weight"]
-    return [f"{expert_prefix}.down_proj.weight"]
+        return [f"{expert_prefix}.w1.weight", f"{expert_prefix}.w3.weight"]
+    return [f"{expert_prefix}.w2.weight"]
 
 
 # ======================================================================

--- a/experimental/lite/tests/smoke/primitive/test_save_load_export_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_save_load_export_smoke.py
@@ -509,7 +509,14 @@ def _export_and_reload(handle: ModelHandle, cfg, protocol, out_dir: str, model_n
     # weights (all pipeline stages gathered), not just the first stage's — guards
     # against a pp-blind export silently dropping later stages' layers.
     num_layers = int(getattr(cfg, "num_hidden_layers"))
-    missing = [i for i in range(num_layers) if not any(f".layers.{i}." in k for k in keys)]
+
+    def _has_layer(i: int) -> bool:
+        # Match both the ``model.``-rooted convention (``model.layers.{i}.``) and
+        # the bare DeepSeek-V4-Flash layout (``layers.{i}.``), which has no prefix.
+        prefix = f"layers.{i}."
+        return any(k.startswith(prefix) or f".{prefix}" in k for k in keys)
+
+    missing = [i for i in range(num_layers) if not _has_layer(i)]
     assert not missing, (
         f"export missing decoder layers {missing} (PP gather incomplete); "
         f"sample keys: {sorted(keys)[:6]}"

--- a/experimental/lite/tests/smoke/primitive/test_save_load_export_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_save_load_export_smoke.py
@@ -430,7 +430,26 @@ def _assert_params_bitwise_equal(lhs: ModelHandle, rhs: ModelHandle) -> None:
     assert not mismatches, "save/load not bitwise; mismatched params:\n" + "\n".join(mismatches)
 
 
-def _export_and_reload(handle: ModelHandle, cfg, protocol, out_dir: str) -> None:
+def _is_valid_hf_export_key(key: str, model_name: str) -> bool:
+    """Whether an exported key matches the model's real HF release naming.
+
+    Most models use the ``model.``-rooted HF convention. DeepSeek-V4-Flash ships
+    a bare layout (``embed.weight`` / ``head.weight`` / ``norm.weight`` /
+    ``layers.N.*`` / ``mtp.N.*`` / ``hc_head_*``), so allow that for deepseek_v4.
+    """
+    if model_name == "deepseek_v4":
+        return key.startswith(("layers.", "mtp.")) or key in (
+            "embed.weight",
+            "head.weight",
+            "norm.weight",
+            "hc_head_base",
+            "hc_head_fn",
+            "hc_head_scale",
+        )
+    return key.startswith("model.") or key in ("lm_head.weight",)
+
+
+def _export_and_reload(handle: ModelHandle, cfg, protocol, out_dir: str, model_name: str) -> None:
     """Export HF weights (bf16) and assert the reloaded shards are valid.
 
     Prefer the model's ``save_hf_weights`` wrapper; some models only expose the
@@ -481,7 +500,7 @@ def _export_and_reload(handle: ModelHandle, cfg, protocol, out_dir: str) -> None
                         f"{key} exported as unexpected non-float dtype {tensor.dtype}"
                     )
                 assert torch.isfinite(tensor.float()).all(), f"{key} has non-finite values"
-                assert key.startswith("model.") or key in ("lm_head.weight",), (
+                assert _is_valid_hf_export_key(key, model_name), (
                     f"unexpected non-HF export key: {key}"
                 )
                 keys.add(key)
@@ -542,7 +561,7 @@ def test_export_hf_bf16_reload(model_name, tmp_path):
     _train_step(handle, "dist_opt", cfg)
 
     export_dir = _shared_tmp_path(tmp_path, "hf_export")
-    _export_and_reload(handle, cfg, protocol, export_dir)
+    _export_and_reload(handle, cfg, protocol, export_dir, model_name)
 
 
 # ──────────────────────────────────────────────────────────────────────────

--- a/experimental/lite/tests/unit/model/test_kimi_k2_int4_dequant.py
+++ b/experimental/lite/tests/unit/model/test_kimi_k2_int4_dequant.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Bit-exact parity for the Kimi K2 INT4 load-path dequant.
+
+Kimi ships INT4-packed release weights (eight offset-binary INT4 values per
+int32 slot + per-group scales).  The MLite load path dequantizes them in
+``kimi_k2/lite/checkpoint.py`` without any ``transformers`` / external-bridge
+dependency.  This test pins that dequant to be bit-exact against the reference
+algorithm in ``megatron.bridge`` (``conversion/quantization_utils.py``:
+``quantize_to_int4`` / ``dequantize_int4``), which the load path was written to
+match.  The reference is vendored here (CPU-only, no GPU) so the guard runs in
+unit CI and does not import megatron.bridge.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+# ---------------------------------------------------------------------------
+# Reference INT4 quant/dequant, copied verbatim from megatron.bridge
+# conversion/quantization_utils.py (quantize_to_int4 / dequantize_int4).  These
+# define the "ground truth" packed layout + group-scale semantics that the
+# MLite load path must reproduce exactly.
+# ---------------------------------------------------------------------------
+def _bridge_quantize_to_int4(
+    weight: torch.Tensor, group_size: int = 32, scale_dtype: torch.dtype = torch.bfloat16
+):
+    out_features, in_features = weight.shape
+    weight_shape = torch.tensor([out_features, in_features], dtype=torch.int32)
+
+    w = weight.float()
+    num_groups = (in_features + group_size - 1) // group_size
+    w_grouped = w.view(out_features, num_groups, -1)
+
+    group_max = w_grouped.abs().amax(dim=-1)
+    scale = (group_max / 7.0).clamp(min=1e-10)
+
+    scale_expanded = scale.unsqueeze(-1).expand_as(w_grouped)
+    w_q = (w_grouped / scale_expanded).round().clamp(-8, 7)
+
+    w_q = w_q.view(out_features, -1)[:, :in_features]
+    w_q = (w_q + 8).to(torch.uint8)
+
+    assert in_features % 8 == 0
+    w_q_grouped = w_q.view(out_features, in_features // 8, 8).to(torch.int32)
+    packed = torch.zeros(out_features, in_features // 8, dtype=torch.int32)
+    for i in range(8):
+        packed |= (w_q_grouped[:, :, i] & 0xF) << (i * 4)
+
+    return packed, scale.to(scale_dtype), weight_shape
+
+
+def _bridge_dequantize_int4(
+    weight_packed: torch.Tensor, weight_scale: torch.Tensor, weight_shape: torch.Tensor
+) -> torch.Tensor:
+    local_out, local_packed_in = weight_packed.shape
+    local_in = local_packed_in * 8
+
+    shifts = torch.arange(8) * 4
+    unpacked = ((weight_packed.unsqueeze(-1) >> shifts) & 0xF).float()
+    unpacked = unpacked.reshape(local_out, local_in) - 8
+
+    scale = weight_scale.float()
+    if scale.ndim == 1:
+        scale = scale.view(local_out, scale.numel() // local_out)
+    else:
+        scale = scale.view(local_out, -1)
+    elements_per_group = local_in // scale.shape[1]
+    scale_expanded = scale.repeat_interleave(elements_per_group, dim=1)[:, :local_in]
+
+    return (unpacked * scale_expanded).to(torch.bfloat16)
+
+
+class _StubReader:
+    """Minimal ``SafeTensorReader`` stand-in for the dequant helpers.
+
+    The load helpers only call ``.get_tensor(name)`` and consult ``.index`` (via
+    ``_has``); a dict + key set is enough.
+    """
+
+    def __init__(self, tensors: dict[str, torch.Tensor]):
+        self._tensors = dict(tensors)
+        self.index = set(self._tensors)
+
+    def get_tensor(self, name: str) -> torch.Tensor:
+        return self._tensors[name]
+
+
+def test_kimi_int4_dequant_bit_exact_to_bridge():
+    from megatron.lite.model.kimi_k2.lite.checkpoint import _dequant_int4_weight
+
+    torch.manual_seed(2026)
+    # out_features arbitrary; in_features divisible by both 8 (pack factor) and 32
+    # (group_size) so the packed/group layout is exercised with >1 group per row.
+    weight = torch.randn(40, 128, dtype=torch.bfloat16)
+
+    packed, scale, shape = _bridge_quantize_to_int4(weight)
+    reference = _bridge_dequantize_int4(packed, scale, shape)
+
+    reader = _StubReader(
+        {"w_packed": packed, "w_scale": scale, "w_shape": shape}
+    )
+    got = _dequant_int4_weight(reader, "w")
+
+    assert got.dtype == torch.bfloat16
+    assert got.shape == reference.shape
+    assert torch.equal(got, reference), (
+        "MLite INT4 dequant diverged from the megatron.bridge reference: "
+        f"max|diff|={(got.float() - reference.float()).abs().max().item()}"
+    )
+
+
+def test_kimi_get_passes_through_bf16_when_unquantized():
+    """``_get`` must load a plain bf16 tensor unchanged (no scale, no packing).
+
+    MLite export/save emits bf16, so reloading an exported (or already bf16)
+    checkpoint must hit the no-dequant path — the third load case alongside
+    FP8 (``*_scale_inv``) and INT4 (``*_packed``).
+    """
+    from megatron.lite.model.kimi_k2.lite.checkpoint import _get
+
+    torch.manual_seed(7)
+    weight = torch.randn(16, 24, dtype=torch.bfloat16)
+    reader = _StubReader({"layer.weight": weight})
+
+    got = _get(reader, "layer.weight")
+    assert got.dtype == torch.bfloat16
+    assert torch.equal(got, weight)
+
+
+def test_kimi_get_dispatches_to_int4_when_packed_present():
+    """When only ``*_packed`` exists (no plain tensor), ``_get`` dequantizes INT4."""
+    from megatron.lite.model.kimi_k2.lite.checkpoint import _get
+
+    torch.manual_seed(11)
+    weight = torch.randn(8, 64, dtype=torch.bfloat16)
+    packed, scale, shape = _bridge_quantize_to_int4(weight)
+    reader = _StubReader({"w_packed": packed, "w_scale": scale, "w_shape": shape})
+
+    got = _get(reader, "w")
+    assert torch.equal(got, _bridge_dequantize_int4(packed, scale, shape))


### PR DESCRIPTION
## What

Make MLite load (and export) the **real DeepSeek-V4-Flash FP8 release** weights.

The ds4 native↔HF name map (`_hf_names_for_state_key` / `_TOP_LEVEL` / `_map_block_attr`,
shared by `load_hf_weights` and the export `DeepseekV4WeightSpec`) targeted DeepSeek-**V3**-style
names (`model.layers.N.self_attn.*`, `mlp.experts.K.gate_proj`, `model.embed_tokens.weight`,
`input/post_attention_layernorm`). The real V4-Flash release uses a bare layout, so on the real
checkpoint `load_hf_weights` matched **nothing** — `native loaded 0 tensors` / 458 missing — and the
(correct) FP8 block/K-tile dequant never ran.

## Change

Remap to the real release names (the same names megatron-bridge's `deepseek_v4` bridge uses — not a
reinvention):

- `embed.weight`, `head.weight`, `norm.weight` (no `model.` prefix)
- `layers.N.attn.{wq_a,wq_b,wkv,wo_a,wo_b,q_norm,kv_norm,attn_sink,compressor.*,indexer.*}`
- `layers.N.attn_norm` / `ffn_norm`
- `layers.N.ffn.gate.{weight,bias,tid2eid}`
- `layers.N.ffn.experts.K.{w1,w3,w2}`  (fused gate_up `fc1` → `w1`+`w3`, `fc2` → `w2`)
- `layers.N.ffn.shared_experts.{w1,w3,w2}`
- `layers.N.hc_attn_*` / `hc_ffn_*`, `hc_head_*`, `mtp.N.*`

Same map drives load and export, so MLite round-trips against the real release / vLLM ds4 format.
The save/load/export smoke asserted a `model.`-rooted convention for every model; relax it to the
bare layout for `deepseek_v4`. Also: bench `--truncate-layers` now works for `deepseek_v4`/`kimi_k2`
configs (they lack the qwen-style `layer_types`), to allow reduced-layer load validation.

## Validation (real checkpoints, 8×H100, `transformers` import blocked → load path proven transformers-free)

- **ds4 FP8** (`DeepSeek-V4-Flash`): truncated load→forward **rc=0**, **0 missing** (was loaded-0/458-missing). FP8 dequant bit-exact (maxdiff 0) to megatron-bridge `dequantize_fp8_e4m3fn_with_scale`.
- **kimi INT4** (`Kimi-K2.6`, unchanged loader): truncated load→forward **rc=0**, 0 missing; INT4 dequant bit-exact (maxdiff 0) to bridge `dequantize_int4`. Included to confirm the validation harness change is general.

Note: ds4's fused-DSA forward requires the SM90 DSA stack (flash-mla `b7643bd` with `flash_mla_sparse_fwd`); orthogonal to this load change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)