### PR TITLE
primitive: pipeline layer layout via Megatron-core PipelineParallelLayerLayout (uneven + MTP)

### DIFF
--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/model.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/model.py
@@ -4,7 +4,7 @@
 A clone of the Kimi-K2 (deepseek_v3) lite model -- same approach as GLM-5 --
 inheriting Kimi's Megatron plumbing (SBHD ``[S, B, H]`` layout, VocabParallel
 embed/head, ``set_input_tensor``, ``build_pipeline_chunk_layout`` boundaries,
-MTP via ``layout.has_head``, dist-opt/distckpt via the protocol).  Three
+MTP via ``layout.has_mtp``, dist-opt/distckpt via the protocol).  Three
 model-wide DS4 deviations (documented inline at each site):
 
 1. Attention = CSA, not MLA.  The CSA primitive is batch-first ``[B, S, H]`` and
@@ -260,7 +260,7 @@ def _apply_attention_backend_override(backend: str | None) -> None:
 class DeepseekV4Model(nn.Module):
     """DS4 model.  Mirrors ``KimiK2Model``: ``build_pipeline_chunk_layout`` for
     embed/head/layer placement, ``set_input_tensor`` for the PP recv buffer, a
-    shared embed/head, MTP gated on ``layout.has_head``, SBHD scatter at embed,
+    shared embed/head, MTP gated on ``layout.has_mtp``, SBHD scatter at embed,
     and a single forward producing the loss / logits / MTP outputs.
 
     DS4 differences (all documented inline): the hidden is the 4-D SBHD mHC
@@ -299,7 +299,11 @@ class DeepseekV4Model(nn.Module):
         self.mtp_loss_scaling_factor = config.mtp_loss_scaling_factor
 
         layout = build_pipeline_chunk_layout(
-            config.num_hidden_layers, ps, train_config.vpp, vpp_chunk_id
+            config.num_hidden_layers,
+            ps,
+            train_config.vpp,
+            vpp_chunk_id,
+            num_mtp_layers=config.num_nextn_predict_layers if mtp_enable else 0,
         )
         self.layer_indices = layout.layer_indices
         self.pre_process = layout.has_embed
@@ -313,10 +317,18 @@ class DeepseekV4Model(nn.Module):
         if layout.has_embed:
             self.embed_tokens = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
 
+        # Key by LOCAL pipeline-stage position (0..len-1), not the global layer id,
+        # so parameter names ("layers.{local}.…") follow the same convention as the
+        # other lite models (glm5 / kimi_k2 use nn.ModuleList → local names). The
+        # shared HF weight map (build via enumerate(layer_indices)) is keyed by local
+        # position; keying this dict by the global id instead double-maps under an
+        # uneven PP split (a stage owning [1,2] would remap layers.1→layers.2 and
+        # drop layer 1 on export/load). The global id is still passed to the layer
+        # for its dense-vs-MoE / per-layer logic.
         self.layers = nn.ModuleDict(
             {
-                str(idx): DeepseekV4Layer(config, ps, idx, use_deepep=use_deepep)
-                for idx in self.layer_indices
+                str(local): DeepseekV4Layer(config, ps, global_idx, use_deepep=use_deepep)
+                for local, global_idx in enumerate(self.layer_indices)
             }
         )
 
@@ -332,7 +344,7 @@ class DeepseekV4Model(nn.Module):
 
         self.mtp_embed: VocabParallelEmbedding | None = None
         self.mtp: nn.ModuleList = nn.ModuleList()
-        if mtp_enable and config.num_nextn_predict_layers > 0 and self.lm_head is not None:
+        if mtp_enable and config.num_nextn_predict_layers > 0 and layout.has_mtp:
             mtp_embedding = self.embed_tokens
             if mtp_embedding is None:
                 mtp_embedding = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)

--- a/experimental/lite/megatron/lite/model/glm5/lite/model.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/model.py
@@ -686,7 +686,11 @@ class Glm5Model(nn.Module):
         self.mtp_loss_scaling_factor = config.mtp_loss_scaling_factor
 
         layout = build_pipeline_chunk_layout(
-            config.num_hidden_layers, ps, train_config.vpp, vpp_chunk_id
+            config.num_hidden_layers,
+            ps,
+            train_config.vpp,
+            vpp_chunk_id,
+            num_mtp_layers=config.num_nextn_predict_layers if mtp_enable else 0,
         )
         self.layer_indices = layout.layer_indices
         self.pre_process = layout.has_embed
@@ -728,7 +732,7 @@ class Glm5Model(nn.Module):
 
         self.mtp_embed: VocabParallelEmbedding | None = None
         self.mtp: Glm5MTPBlock | None = None
-        if mtp_enable and config.num_nextn_predict_layers > 0 and self.head is not None:
+        if mtp_enable and config.num_nextn_predict_layers > 0 and layout.has_mtp:
             mtp_embedding = self.embed
             if mtp_embedding is None:
                 mtp_embedding = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/model.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/model.py
@@ -580,7 +580,11 @@ class KimiK2Model(nn.Module):
         self.mtp_loss_scaling_factor = config.mtp_loss_scaling_factor
 
         layout = build_pipeline_chunk_layout(
-            config.num_hidden_layers, ps, train_config.vpp, vpp_chunk_id
+            config.num_hidden_layers,
+            ps,
+            train_config.vpp,
+            vpp_chunk_id,
+            num_mtp_layers=config.num_nextn_predict_layers if mtp_enable else 0,
         )
         self.layer_indices = layout.layer_indices
         self.pre_process = layout.has_embed
@@ -618,7 +622,7 @@ class KimiK2Model(nn.Module):
 
         self.mtp_embed: VocabParallelEmbedding | None = None
         self.mtp: KimiK2MTPBlock | None = None
-        if mtp_enable and config.num_nextn_predict_layers > 0 and self.head is not None:
+        if mtp_enable and config.num_nextn_predict_layers > 0 and layout.has_mtp:
             mtp_embedding = self.embed
             if mtp_embedding is None:
                 mtp_embedding = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)

--- a/experimental/lite/megatron/lite/primitive/parallel/pp.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/pp.py
@@ -1,12 +1,20 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-"""Context/pipeline parallel sequence splitting utilities."""
+"""Pipeline parallel layer layout — a thin wrapper over Megatron-core's
+``PipelineParallelLayerLayout`` (authorized mcore-reuse), which owns the per-stage
+split for non-divisible decoder counts plus MTP. Two pp-only modes:
+
+* **auto** (default, only ``pp`` set): balance ``[E, decoder*N, mtp*K, loss]`` across stages.
+* **custom** (``ParallelConfig.pp_layout``): an explicit mcore layout string/list,
+  e.g. ``"E|t*5|t*6|t,m,L"``.
+
+Not supported (raise, never mis-place): VPP, and standalone MTP (``m`` off the
+final/loss stage — mlite's MTP shares the head there; cross-stage MTP is a follow-up).
+"""
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
-
-from megatron.lite.primitive.utils import ensure_divisible
 
 if TYPE_CHECKING:
     from megatron.lite.primitive.parallel.state import ParallelState
@@ -17,6 +25,24 @@ class PipelineChunkLayout:
     layer_indices: list[int] = field(default_factory=list)
     has_embed: bool = False
     has_head: bool = False
+    has_mtp: bool = False
+
+
+def _auto_layout(num_hidden_layers: int, pp_size: int, num_mtp_layers: int):
+    """Balance ``[E, decoder*N, mtp*K, loss]`` into even contiguous chunks; the
+    embedding/MTP/loss slots make their stages carry fewer decoders (e.g. 6/pp4 ->
+    [1,2,2,1]) — Megatron's embedding/loss split accounting."""
+    from megatron.core.transformer.pipeline_parallel_layer_layout import (
+        PipelineParallelLayerLayout,
+    )
+
+    units = ["embedding"] + ["decoder"] * num_hidden_layers + ["mtp"] * max(num_mtp_layers, 0) + ["loss"]
+    base, remainder = divmod(len(units), pp_size)
+    rows, pos = [], 0
+    for size in (base + (1 if s < remainder else 0) for s in range(pp_size)):
+        rows.append(units[pos : pos + size])
+        pos += size
+    return PipelineParallelLayerLayout(rows, pipeline_model_parallel_size=pp_size)
 
 
 def build_pipeline_chunk_layout(
@@ -24,30 +50,50 @@ def build_pipeline_chunk_layout(
     ps: ParallelState,
     vpp: int | None = None,
     vpp_chunk_id: int | None = None,
+    *,
+    num_mtp_layers: int = 0,
 ) -> PipelineChunkLayout:
-    """Compute layer_indices, has_embed, has_head for this PP rank / VPP chunk."""
-    if vpp_chunk_id is not None:
-        assert vpp is not None
-        layers_per_chunk = ensure_divisible(num_hidden_layers, ps.pp_size * vpp)
-        start = ps.pp_rank * layers_per_chunk + vpp_chunk_id * (ps.pp_size * layers_per_chunk)
-        layer_indices = list(range(start, start + layers_per_chunk))
-        has_embed = ps.pp_is_first and vpp_chunk_id == 0
-        has_head = ps.pp_is_last and vpp_chunk_id == vpp - 1
-    elif vpp is not None:
-        layers_per_chunk = ensure_divisible(num_hidden_layers, ps.pp_size * vpp)
-        layer_indices = []
-        for chunk in range(vpp):
-            start = ps.pp_rank * layers_per_chunk + chunk * (ps.pp_size * layers_per_chunk)
-            layer_indices.extend(range(start, start + layers_per_chunk))
-        has_embed = ps.pp_is_first
-        has_head = ps.pp_is_last
+    """``layer_indices`` / ``has_embed`` / ``has_head`` / ``has_mtp`` for this PP rank,
+    from ``ps.pp_layout`` (custom) or an auto-balanced layout. ``has_mtp`` follows the
+    layout's ``m`` placement, so MTP is built where the layout says, not a fixed rank."""
+    if (vpp is not None and vpp > 1) or vpp_chunk_id is not None:
+        raise NotImplementedError("VPP / interleaved pipeline layout is not supported (use vpp=1).")
+
+    if ps.pp_size <= 1:  # no pipeline: this stage owns everything
+        return PipelineChunkLayout(
+            layer_indices=list(range(num_hidden_layers)),
+            has_embed=True,
+            has_head=True,
+            has_mtp=num_mtp_layers > 0,
+        )
+
+    from megatron.core.transformer.enums import LayerType
+    from megatron.core.transformer.pipeline_parallel_layer_layout import (
+        PipelineParallelLayerLayout,
+    )
+
+    pp_layout = getattr(ps, "pp_layout", None)
+    if pp_layout is not None:
+        layout = PipelineParallelLayerLayout(pp_layout, pipeline_model_parallel_size=ps.pp_size)
+        if layout.virtual_pipeline_model_parallel_size > 1:
+            raise NotImplementedError("VPP pp_layout is not supported (one stage per pp rank).")
     else:
-        layers_per_stage = ensure_divisible(num_hidden_layers, ps.pp_size)
-        start = ps.pp_rank * layers_per_stage
-        layer_indices = list(range(start, start + layers_per_stage))
-        has_embed = ps.pp_is_first
-        has_head = ps.pp_is_last
-    return PipelineChunkLayout(layer_indices=layer_indices, has_embed=has_embed, has_head=has_head)
+        layout = _auto_layout(num_hidden_layers, ps.pp_size, num_mtp_layers)
+
+    # validate_layer_layout checks legality and returns mtp_standalone=True when `m` is
+    # off the final stage — which mlite's head-coupled MTP cannot run.
+    if layout.validate_layer_layout(num_hidden_layers, num_mtp_layers or None):
+        raise NotImplementedError(
+            "Standalone MTP (pp_layout with `m` off the final/loss stage) is not "
+            "implemented yet — mlite's MTP shares the output head there. Use the auto "
+            "layout (set only `pp`), or place `m` on the same stage as `L`."
+        )
+    return PipelineChunkLayout(
+        layer_indices=layout.get_layer_id_list(LayerType.decoder, vp_stage=0, pp_rank=ps.pp_rank),
+        has_embed=ps.pp_is_first,
+        has_head=ps.pp_is_last,
+        has_mtp=layout.get_num_layers_to_build(LayerType.mtp, vp_stage=0, pp_rank=ps.pp_rank) > 0,
+    )
 
 
 __all__ = ["PipelineChunkLayout", "build_pipeline_chunk_layout"]

--- a/experimental/lite/megatron/lite/primitive/parallel/state.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/state.py
@@ -50,6 +50,9 @@ class ParallelState:
     virtual_pipeline_size: int | None = None
     virtual_pipeline_rank: int | None = None
 
+    # Optional explicit mcore pipeline layout (custom mode); None -> auto-infer.
+    pp_layout: str | list | None = None
+
 
 def init_parallel(config) -> ParallelState:
     """
@@ -68,6 +71,7 @@ def init_parallel(config) -> ParallelState:
     expert_dp = ensure_divisible(world, etp * ep * pp)
 
     ps = ParallelState()
+    ps.pp_layout = getattr(config, "pp_layout", None)
     ps.tp_size, ps.ep_size, ps.etp_size = tp, ep, etp
     ps.cp_size, ps.pp_size, ps.dp_size = cp, pp, dense_dp
     ps.expert_dp_size = expert_dp

--- a/experimental/lite/megatron/lite/runtime/contracts/config.py
+++ b/experimental/lite/megatron/lite/runtime/contracts/config.py
@@ -28,6 +28,10 @@ class ParallelConfig:
     pp: int = 1
     vpp: int = 1
     cp: int = 1
+    # Optional explicit mcore pipeline layout for advanced users (custom mode),
+    # e.g. "E|t*5|t*6|t,m,L" (MTP `m` must sit on the final/loss stage; standalone MTP
+    # is not supported yet). None -> auto-balanced from (num_layers, pp, mtp).
+    pp_layout: str | list | None = None
 
 
 @dataclass

--- a/experimental/lite/tests/smoke/primitive/test_auto_pipeline_layout_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_auto_pipeline_layout_smoke.py
@@ -1,0 +1,454 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Pipeline-layout smoke: real models build through the layout and train on PP>1.
+
+Builds {qwen3_5, qwen3_moe, kimi_k2, glm5, deepseek_v4} with ``num_hidden_layers=9``
+on pp=4 (not divisible) and asserts the layout drives a real model, not just the
+layout math: each builds, trains a finite-loss step over the uneven split, and HF
+export reconstructs every decoder layer. This exercises the auto layout mode on real
+models; the custom ``pp_layout`` string mode and the exact per-stage splits (incl.
+the real 43/61/78 counts) are pinned in the deterministic unit tests.
+
+Topology follows the save/load/export smoke's validated dist_opt capability:
+tp2/ep2 for TP-capable models, tp1/ep2 for glm5 / deepseek_v4 (native lite TP=1).
+CP=1: cp>1 on these tiny proxy seqs breaks TE attention backend selection
+(orthogonal to layout; covered by the dedicated CP smokes).
+
+Run: torchrun --nproc_per_node=8 -m pytest --mlite-smoke, selecting per-env subsets
+with -k (qwen3_5 on the qwen3.5 site; the rest on the DSA overlay). Models also
+gate themselves with importorskip.
+"""
+from __future__ import annotations
+
+import os
+import re
+from datetime import timedelta
+
+import pytest
+import torch
+import torch.distributed as dist
+from megatron.lite.primitive.ckpt.hf_weights import unwrap_model
+from megatron.lite.primitive.deterministic import set_deterministic
+from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
+from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
+from megatron.lite.runtime.contracts.data import PackedBatch
+
+pytestmark = [pytest.mark.mlite, pytest.mark.smoke, pytest.mark.gpu, pytest.mark.distributed]
+
+# 9 decoders over pp=4 is non-divisible; 9 is small enough to stay fast yet leaves no
+# empty stage even for the MTP model (deepseek_v4 adds a slot on the last stage).
+_NUM_LAYERS = 9
+_PP = 4
+
+# GLM5 / DeepSeek-V4 native lite support TP=1 only (matches the save/load smoke).
+_TP1_ONLY = {"glm5", "deepseek_v4"}
+
+
+def _require_te() -> None:
+    te = pytest.importorskip(
+        "transformer_engine.pytorch",
+        reason="auto pipeline-layout smoke requires real Transformer Engine.",
+    )
+    assert hasattr(te, "Linear"), "smoke requires real Transformer Engine Linear."
+
+
+def _optimizer_config() -> OptimizerConfig:
+    return OptimizerConfig(
+        optimizer="adam",
+        lr=1.0e-3,
+        weight_decay=0.0,
+        adam_beta1=0.9,
+        adam_beta2=0.95,
+        adam_eps=1.0e-8,
+        clip_grad=1.0,
+        offload_fraction=0.0,
+    )
+
+
+def _random_packed_batch(vocab_size: int) -> PackedBatch:
+    return PackedBatch(
+        input_ids=torch.randint(0, vocab_size, (2048,), device="cuda"),
+        labels=torch.randint(0, vocab_size, (2048,), device="cuda"),
+        seq_lens=torch.full((1,), 2048, dtype=torch.int64, device="cuda"),
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Tiny non-divisible model configs (mirror the save/load smoke, num_hidden_layers=9).
+# ──────────────────────────────────────────────────────────────────────────
+def _qwen3_5():
+    pytest.importorskip("fla", reason="qwen3_5 needs the FLA / GatedDeltaNet stack.")
+    _require_te()
+    from megatron.lite.model.qwen3_5.config import Qwen35Config
+    from megatron.lite.model.qwen3_5.lite import protocol
+
+    cfg = Qwen35Config(
+        num_hidden_layers=_NUM_LAYERS,
+        hidden_size=16,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=4,
+        vocab_size=64,
+        num_experts=4,
+        num_experts_per_tok=2,
+        moe_intermediate_size=8,
+        shared_expert_intermediate_size=8,
+        linear_num_key_heads=2,
+        linear_key_head_dim=4,
+        linear_num_value_heads=2,
+        linear_value_head_dim=4,
+        linear_conv_kernel_dim=4,
+        layer_types=(["full_attention", "linear_attention"] * ((_NUM_LAYERS + 1) // 2))[
+            :_NUM_LAYERS
+        ],
+        partial_rotary_factor=1.0,
+        max_position_embeddings=4096,
+    )
+    return cfg, protocol
+
+
+def _qwen3_moe():
+    _require_te()
+    from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
+    from megatron.lite.model.qwen3_moe.lite import protocol
+
+    cfg = Qwen3MoEConfig(
+        num_hidden_layers=_NUM_LAYERS,
+        hidden_size=16,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=4,
+        vocab_size=64,
+        num_experts=4,
+        num_experts_per_tok=1,
+        moe_intermediate_size=8,
+        max_position_embeddings=4096,
+        layer_types=["full_attention"] * _NUM_LAYERS,
+    )
+    return cfg, protocol
+
+
+def _kimi_k2():
+    _require_te()
+    from megatron.lite.model.kimi_k2.config import KimiK2Config
+    from megatron.lite.model.kimi_k2.lite import protocol
+
+    cfg = KimiK2Config(
+        num_hidden_layers=_NUM_LAYERS,
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        vocab_size=128,
+        intermediate_size=96,
+        moe_intermediate_size=16,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        n_group=2,
+        topk_group=1,
+        first_k_dense_replace=1,
+        q_lora_rank=16,
+        kv_lora_rank=12,
+        qk_nope_head_dim=8,
+        qk_rope_head_dim=8,
+        v_head_dim=8,
+        max_position_embeddings=4096,
+        rope_theta=10000.0,
+        rope_scaling={
+            "type": "yarn",
+            "factor": 1.0,
+            "original_max_position_embeddings": 4096,
+            "beta_fast": 1.0,
+            "beta_slow": 1.0,
+            "mscale": 1.0,
+            "mscale_all_dim": 1.0,
+        },
+    )
+    return cfg, protocol
+
+
+def _glm5():
+    pytest.importorskip("cudnn", reason="glm5 fused DSA needs the cudnn DSA stack.")
+    _require_te()
+    from megatron.lite.model.glm5.config import Glm5Config
+    from megatron.lite.model.glm5.lite import protocol
+
+    cfg = Glm5Config(
+        num_hidden_layers=_NUM_LAYERS,
+        hidden_size=128,
+        num_attention_heads=64,
+        num_key_value_heads=64,
+        head_dim=256,
+        vocab_size=32,
+        max_position_embeddings=4096,
+        initializer_range=0.002,
+        q_lora_rank=16,
+        kv_lora_rank=512,
+        qk_head_dim=256,
+        qk_nope_head_dim=192,
+        qk_rope_head_dim=64,
+        v_head_dim=256,
+        index_head_dim=128,
+        index_n_heads=32,
+        index_topk=512,
+        intermediate_size=20,
+        moe_intermediate_size=6,
+        first_k_dense_replace=1,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+    )
+    return cfg, protocol
+
+
+def _deepseek_v4():
+    pytest.importorskip("cudnn", reason="deepseek_v4 fused DSA needs the cudnn DSA stack.")
+    _require_te()
+    from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
+    from megatron.lite.model.deepseek_v4.lite import protocol
+
+    cfg = DeepseekV4Config(
+        vocab_size=64,
+        hidden_size=128,
+        moe_intermediate_size=16,
+        num_hidden_layers=_NUM_LAYERS,
+        num_attention_heads=8,
+        num_key_value_heads=1,
+        head_dim=64,
+        qk_rope_head_dim=16,
+        q_lora_rank=32,
+        o_lora_rank=32,
+        o_groups=2,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        routed_scaling_factor=1.5,
+        max_position_embeddings=4096,
+        compress_ratios=[4, 4],
+        sliding_window=128,
+        num_hash_layers=2,
+        hc_mult=2,
+        index_head_dim=64,
+        index_n_heads=8,
+        index_topk=512,
+        # Real MTP: an extra nextn layer on the last stage exercises the
+        # MTP-aware branch of the auto layout balancing.
+        num_nextn_predict_layers=1,
+        rms_norm_eps=1e-6,
+    )
+    return cfg, protocol
+
+
+MODELS = {
+    "qwen3_5": _qwen3_5,
+    "qwen3_moe": _qwen3_moe,
+    "kimi_k2": _kimi_k2,
+    "glm5": _glm5,
+    "deepseek_v4": _deepseek_v4,
+}
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Distributed harness (mirrors the save/load/export smoke).
+# ──────────────────────────────────────────────────────────────────────────
+@pytest.fixture(scope="module", autouse=True)
+def _single_node_cuda_dist():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for auto pipeline-layout smoke.")
+    if int(os.environ.get("WORLD_SIZE", "1")) > 8:
+        pytest.skip("Megatron Lite smoke tests are capped at single-node 8 GPUs.")
+
+    os.environ.setdefault("CUBLAS_WORKSPACE_CONFIG", ":4096:8")
+    os.environ.setdefault("NVTE_ALLOW_NONDETERMINISTIC_ALGO", "0")
+    os.environ.setdefault("RANK", "0")
+    os.environ.setdefault("WORLD_SIZE", "1")
+    os.environ.setdefault("LOCAL_RANK", "0")
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29577")
+
+    torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
+    created_pg = False
+    if not dist.is_initialized():
+        timeout_s = int(os.environ.get("MLITE_DIST_TIMEOUT_S", "180"))
+        dist.init_process_group(
+            backend="nccl", init_method="env://", timeout=timedelta(seconds=timeout_s)
+        )
+        created_pg = True
+    yield
+    try:
+        from megatron.core import parallel_state as mpu
+
+        if mpu.is_initialized():
+            mpu.destroy_model_parallel()
+    finally:
+        if created_pg and dist.is_initialized():
+            dist.destroy_process_group()
+
+
+# Process groups lite's init_parallel creates per build, recorded so the autouse
+# teardown can free them (mcore's destroy_model_parallel frees only mcore's groups).
+_BUILT_PARALLEL_STATES: list = []
+_PS_GROUP_ATTRS = (
+    "tp_group", "ep_group", "etp_group", "cp_group", "pp_group", "pp_cpu_group",
+    "dp_group", "dp_cp_group", "tp_ep_group", "ep_dp_group",
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_parallel_state_between_tests():
+    yield
+    import gc
+
+    from megatron.core import parallel_state as mpu
+
+    if mpu.is_initialized():
+        mpu.destroy_model_parallel()
+    # Finalize the just-built model first so DDP releases its group references, then
+    # explicitly destroy the process groups lite's init_parallel created for this
+    # test. Without this, lite's ~10 fresh NCCL/gloo groups per build leak across the
+    # ~6 builds in one torchrun process and make a later PP P2P / export collective
+    # fail nondeterministically (mcore's destroy_model_parallel frees only its own).
+    gc.collect()
+    for ps in _BUILT_PARALLEL_STATES:
+        for attr in _PS_GROUP_ATTRS:
+            group = getattr(ps, attr, None)
+            if group is not None:
+                try:
+                    dist.destroy_process_group(group)
+                except Exception:
+                    pass
+    _BUILT_PARALLEL_STATES.clear()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+
+def _proxy_topology(model_name: str, pp_layout=None) -> ParallelConfig:
+    # PP is held at 4 (the layout axis under test); the rest follow the save/load
+    # smoke's validated dist_opt capability. CP=1 — see module docstring.
+    # pp_layout=None -> auto mode; a string -> custom mode (advanced explicit layout).
+    if model_name in _TP1_ONLY:  # glm5 / deepseek_v4: native lite is TP=1 only.
+        return ParallelConfig(tp=1, ep=2, etp=1, pp=_PP, cp=1, pp_layout=pp_layout)
+    return ParallelConfig(tp=2, ep=2, etp=1, pp=_PP, cp=1, pp_layout=pp_layout)
+
+
+def _build_handle(model_name: str, *, seed: int, pp_layout=None):
+    from types import SimpleNamespace
+
+    from megatron.lite.runtime.contracts.handle import ModelHandle
+
+    cfg, protocol = MODELS[model_name]()
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+    parallel = _proxy_topology(model_name, pp_layout=pp_layout)
+    impl_cfg = protocol.ImplConfig(
+        parallel=parallel,
+        optimizer="dist_opt",
+        optimizer_config=_optimizer_config(),
+        use_deepep=False,
+        deterministic=True,
+    )
+    bundle = protocol.build_model(cfg, impl_cfg=impl_cfg)
+    chunks = bundle.chunks
+    extras = dict(bundle.extras)
+    extras.update(
+        {
+            "model_chunks": chunks,
+            "forward_step": bundle.forward_step,
+            "finalize_grads": bundle.finalize_grads,
+            "protocol": protocol,
+        }
+    )
+    handle = ModelHandle(
+        model=chunks,
+        optimizer=bundle.optimizer,
+        parallel_state=bundle.parallel_state,
+        config=SimpleNamespace(parallel=parallel),
+        _extras=extras,
+    )
+    _BUILT_PARALLEL_STATES.append(bundle.parallel_state)
+    return handle, cfg
+
+
+def _local_layer_indices(handle) -> list[int]:
+    chunk = unwrap_model(handle._extras["model_chunks"][0])
+    return list(chunk.layer_indices)
+
+
+# Decoder layer ids in exported HF names: matches both `model.layers.N.` (HF-rooted,
+# most models) and bare `layers.N.` (deepseek_v4-flash release naming).
+_HF_LAYER_RE = re.compile(r"(?:^|\.)layers\.(\d+)\.")
+
+
+def _hf_decoder_layer_indices(names) -> set[int]:
+    """Decoder layer ids referenced by exported HF weight names (``...layers.N...``)."""
+    return {int(m.group(1)) for n in names if (m := _HF_LAYER_RE.search(n))}
+
+
+@pytest.mark.parametrize("model_name", list(MODELS))
+def test_uneven_pp_builds_trains_and_exports(model_name):
+    """A non-divisible layer count builds an uneven PP split, trains a step, and
+    exports every layer. Build + train + export share one model build (one heavy
+    distributed build per test keeps the builds in one torchrun process bounded).
+
+    - build: the non-divisible count produces a valid balanced uneven split (not
+      "not divisible"); this stage owns a sorted, in-range, contiguous decoder run.
+    - train: one real step over the uneven pipeline yields a finite loss (proves PP
+      P2P across stages of unequal depth actually runs the built model).
+    - export: HF export all-gathers the per-stage shards (keyed on global layer
+      names) back to a complete state — every decoder layer 0..N-1 reconstructed,
+      every tensor finite. Regression guard for the deepseek_v4 local-vs-global
+      layer-key bug; a dropped/duplicated stage would silently corrupt exports.
+    """
+    if dist.get_world_size() != 8:
+        pytest.skip("auto pipeline-layout proxy smoke requires exactly 8 GPUs.")
+
+    set_deterministic(2026)
+
+    handle, cfg = _build_handle(model_name, seed=4242)
+    ps = handle._parallel_state
+    assert ps.pp_size == _PP
+    assert cfg.num_hidden_layers == _NUM_LAYERS
+
+    local = _local_layer_indices(handle)
+    assert local == sorted(local) and len(set(local)) == len(local), local
+    assert local and all(0 <= i < _NUM_LAYERS for i in local), local
+    assert local == list(range(local[0], local[0] + len(local))), local
+
+    runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
+    batch = _random_packed_batch(cfg.vocab_size)
+    runtime.zero_grad(handle)
+    result = runtime.forward_backward(handle, iter([batch]), None, num_microbatches=1)
+    runtime.optimizer_step(handle)
+    loss = result.model_output.loss
+    assert loss is not None and torch.isfinite(loss).all(), (
+        f"{model_name}: non-finite loss {loss} on uneven PP layout"
+    )
+
+    # Export across the uneven PP split (every rank materializes the full HF state).
+    protocol = handle._extras["protocol"]
+    chunks = handle._extras["model_chunks"]
+    exported = list(protocol.export_hf_weights(chunks, cfg, ps))
+    present = _hf_decoder_layer_indices([name for name, _ in exported])
+    expected = set(range(cfg.num_hidden_layers))
+    assert expected.issubset(present), (
+        f"{model_name}: uneven-PP export dropped decoder layers "
+        f"{sorted(expected - present)} (have {sorted(present)}); PP gather lost a stage"
+    )
+    for name, tensor in exported:
+        assert torch.isfinite(tensor.float()).all(), (
+            f"{model_name}: non-finite exported tensor {name} from uneven PP gather"
+        )
+    if dist.get_rank() == 0:
+        print(
+            "NON_SKIP_UNEVEN_PP_BUILD_TRAIN_EXPORT "
+            f"model={model_name} num_layers={cfg.num_hidden_layers} "
+            f"split={local} exported_decoder_layers={len(present & expected)}"
+        )
+
+
+# Custom-string mode (``ParallelConfig.pp_layout``) is covered by the deterministic
+# unit tests (test_parallel_unit.py: the explicit string is honored verbatim, differs
+# from the auto split, and a >pp-stage string raises). It shares the build path with
+# the auto matrix above (only ``ps.pp_layout`` differs), so it is not given a separate
+# GPU build here: keeping this smoke to one heavy distributed build per model avoids a
+# trailing build tripping NCCL P2P comm-init timeouts from process-group churn.

--- a/experimental/lite/tests/unit/model/test_kimi_k2_lite_static.py
+++ b/experimental/lite/tests/unit/model/test_kimi_k2_lite_static.py
@@ -175,18 +175,21 @@ def test_kimi_k2_mtp_and_pp_layout_rules_are_explicit():
 
     assert build_pipeline_chunk_layout(4, rank0).layer_indices == [0, 1]
     assert build_pipeline_chunk_layout(4, rank1).layer_indices == [2, 3]
+    # MTP is built on the stage the layout designates (layout.has_mtp), not a
+    # hard-coded head rank.
     assert (
-        "if mtp_enable and config.num_nextn_predict_layers > 0 and self.head is not None"
+        "if mtp_enable and config.num_nextn_predict_layers > 0 and layout.has_mtp"
         in model_text
     )
     assert "self.mtp_embed = mtp_embedding" in model_text
 
-    vpp_last = build_pipeline_chunk_layout(4, rank1, vpp=2, vpp_chunk_id=1)
-    assert vpp_last.layer_indices == [3]
-    assert vpp_last.has_head is True
+    # pp-only: VPP / interleaving raises rather than silently mis-splitting.
+    with pytest.raises(NotImplementedError):
+        build_pipeline_chunk_layout(4, rank1, vpp=2, vpp_chunk_id=1)
 
-    with pytest.raises(ValueError, match="not divisible"):
-        build_pipeline_chunk_layout(3, rank0, vpp=2, vpp_chunk_id=0)
+    # Non-divisible counts auto-balance (no "not divisible" error): 3/pp2 -> [2, 1].
+    assert build_pipeline_chunk_layout(3, rank0).layer_indices == [0, 1]
+    assert build_pipeline_chunk_layout(3, rank1).layer_indices == [2]
 
 
 def test_kimi_k2_checkpoint_exports_hf_names():

--- a/experimental/lite/tests/unit/primitive/test_parallel_dimensions_independent_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_parallel_dimensions_independent_unit.py
@@ -85,11 +85,15 @@ def test_cp_packed_split_handles_each_sample_independently():
     assert rank1[3] == 4
 
 
-def test_pp_layout_rejects_non_divisible_layer_counts():
-    ps = ParallelState(pp_size=2, pp_rank=0, pp_is_first=True, pp_is_last=False)
+def test_pp_layout_auto_balances_non_divisible_layer_counts():
+    # Non-divisible counts no longer raise "not divisible": mcore's layout balances
+    # them. 7/pp2 with embedding/loss accounting -> [4, 3]. (Needs megatron.core.)
+    pytest.importorskip("megatron.core.transformer.pipeline_parallel_layer_layout")
+    rank0 = ParallelState(pp_size=2, pp_rank=0, pp_is_first=True, pp_is_last=False)
+    rank1 = ParallelState(pp_size=2, pp_rank=1, pp_is_first=False, pp_is_last=True)
 
-    with pytest.raises(ValueError, match="not divisible"):
-        build_pipeline_chunk_layout(7, ps)
+    assert build_pipeline_chunk_layout(7, rank0).layer_indices == [0, 1, 2, 3]
+    assert build_pipeline_chunk_layout(7, rank1).layer_indices == [4, 5, 6]
 
 
 def test_dp_dimension_controls_dense_microbatch_contract():

--- a/experimental/lite/tests/unit/primitive/test_parallel_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_parallel_unit.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import pytest
 import torch
-
 from megatron.lite.primitive.parallel import (
     ParallelState,
     build_pipeline_chunk_layout,
@@ -44,10 +43,49 @@ def test_cp_position_ids_follow_zigzag_order():
     )
 
 
-def test_pp_layout_marks_stage_boundaries_and_vpp_chunks():
-    rank0 = ParallelState(pp_size=2, pp_rank=0, pp_is_first=True, pp_is_last=False)
-    rank1 = ParallelState(pp_size=2, pp_rank=1, pp_is_first=False, pp_is_last=True)
+# The pipeline layout wires to Megatron-core's layer-layout machinery, so these
+# tests need megatron.core importable (present in the mlite GPU/smoke containers).
+_mcore_layout = pytest.importorskip(
+    "megatron.core.transformer.pipeline_parallel_layer_layout"
+)
 
+
+def _ranks(pp_size: int, pp_layout=None) -> list[ParallelState]:
+    return [
+        ParallelState(
+            pp_size=pp_size,
+            pp_rank=r,
+            pp_is_first=(r == 0),
+            pp_is_last=(r == pp_size - 1),
+            pp_layout=pp_layout,
+        )
+        for r in range(pp_size)
+    ]
+
+
+def _layout_indices(num_layers: int, pp_size: int, *, pp_layout=None, **kw) -> list[list[int]]:
+    return [
+        build_pipeline_chunk_layout(num_layers, ps, **kw).layer_indices
+        for ps in _ranks(pp_size, pp_layout)
+    ]
+
+
+def _mtp_flags(num_layers: int, pp_size: int, *, pp_layout=None, **kw) -> list[bool]:
+    return [
+        build_pipeline_chunk_layout(num_layers, ps, **kw).has_mtp
+        for ps in _ranks(pp_size, pp_layout)
+    ]
+
+
+def _assert_full_contiguous_cover(indices: list[list[int]], num_layers: int) -> None:
+    """Every decoder 0..N-1 placed exactly once, in order, each stage a contiguous run."""
+    assert [i for stage in indices for i in stage] == list(range(num_layers))
+    for stage in indices:
+        assert not stage or stage == list(range(stage[0], stage[0] + len(stage)))
+
+
+def test_pp_layout_marks_stage_boundaries():
+    rank0, rank1 = _ranks(2)
     assert build_pipeline_chunk_layout(8, rank0).layer_indices == [0, 1, 2, 3]
     assert build_pipeline_chunk_layout(8, rank0).has_embed is True
     assert build_pipeline_chunk_layout(8, rank0).has_head is False
@@ -55,22 +93,142 @@ def test_pp_layout_marks_stage_boundaries_and_vpp_chunks():
     assert build_pipeline_chunk_layout(8, rank1).has_embed is False
     assert build_pipeline_chunk_layout(8, rank1).has_head is True
 
-    vpp_rank0_chunk1 = build_pipeline_chunk_layout(8, rank0, vpp=2, vpp_chunk_id=1)
-    vpp_rank1_chunk1 = build_pipeline_chunk_layout(8, rank1, vpp=2, vpp_chunk_id=1)
-    assert vpp_rank0_chunk1.layer_indices == [4, 5]
-    assert vpp_rank0_chunk1.has_head is False
-    assert vpp_rank1_chunk1.layer_indices == [6, 7]
-    assert vpp_rank1_chunk1.has_head is True
+
+def test_pp_layout_vpp_is_not_supported_yet():
+    # pp-only: requesting VPP raises rather than silently mis-splitting.
+    rank0 = ParallelState(pp_size=2, pp_rank=0, pp_is_first=True, pp_is_last=False)
+    with pytest.raises(NotImplementedError):
+        build_pipeline_chunk_layout(8, rank0, vpp=2)
+    with pytest.raises(NotImplementedError):
+        build_pipeline_chunk_layout(8, rank0, vpp=2, vpp_chunk_id=1)
 
 
-def test_pp_layout_rejects_non_divisible_vpp_layer_counts():
-    ps = ParallelState(pp_size=2, pp_rank=0, pp_is_first=True, pp_is_last=False)
+def test_pp_layout_auto_balances_non_divisible_counts():
+    # account_for_embedding/loss: the embedding/loss stages each give up a decoder,
+    # so 6/pp4 balances to [1,2,2,1] (not [2,2,1,1]) and never raises "not divisible".
+    assert _layout_indices(6, 4) == [[0], [1, 2], [3, 4], [5]]
+    assert _layout_indices(6, 4, vpp=1) == _layout_indices(6, 4)  # vpp=1 == pp-only
+    # An MTP head occupies the last stage's slot -> it gives up its decoder: [2,2,2,0].
+    assert _layout_indices(6, 4, num_mtp_layers=1) == [[0, 1], [2, 3], [4, 5], []]
 
-    with pytest.raises(ValueError, match="10 is not divisible by 6"):
-        build_pipeline_chunk_layout(10, ps, vpp=3)
 
-    with pytest.raises(ValueError, match="10 is not divisible by 6"):
-        build_pipeline_chunk_layout(10, ps, vpp=3, vpp_chunk_id=0)
+def test_pp_layout_accounts_for_head_tail_even_when_divisible():
+    # Embedding/loss occupy head/tail slots, so 8/pp4 is [2,3,2,1] not [2,2,2,2].
+    assert _layout_indices(8, 4) == [[0, 1], [2, 3, 4], [5, 6], [7]]
+    assert _layout_indices(8, 4, num_mtp_layers=1) == [[0, 1], [2, 3, 4], [5, 6, 7], []]
+    assert _layout_indices(8, 2) == [[0, 1, 2, 3], [4, 5, 6, 7]]
+
+
+# --- Correctness matrix: real delivery counts x MTP{off,on} x PP{2,4,8} ---
+_REAL_LAYERS = {"deepseek_v4": 43, "kimi_k2": 61, "glm5": 78}
+_CORRECTNESS_CASES = [(m, pp, mtp) for m in _REAL_LAYERS for pp in (2, 4, 8) for mtp in (0, 1)]
+
+
+def _mcore_reference_decoder_ids(num_layers: int, pp: int, mtp: int) -> list[list[int]]:
+    """Per-stage decoder ids from mcore's PipelineParallelLayerLayout, built directly
+    from the canonical unit sequence — the independent reference the glue must match."""
+    from megatron.core.transformer.enums import LayerType
+    from megatron.core.transformer.pipeline_parallel_layer_layout import (
+        PipelineParallelLayerLayout,
+    )
+
+    units = ["embedding"] + ["decoder"] * num_layers + ["mtp"] * mtp + ["loss"]
+    base, rem = divmod(len(units), pp)
+    rows, pos = [], 0
+    for size in (base + (1 if s < rem else 0) for s in range(pp)):
+        rows.append(units[pos : pos + size])
+        pos += size
+    ref = PipelineParallelLayerLayout(rows, pipeline_model_parallel_size=pp)
+    return [ref.get_layer_id_list(LayerType.decoder, vp_stage=0, pp_rank=r) for r in range(pp)]
+
+
+@pytest.mark.parametrize("model, pp, mtp", _CORRECTNESS_CASES)
+def test_auto_layout_is_bit_equal_to_mcore(model, pp, mtp):
+    # Faithful reuse: the glue's per-stage decoder ids are exactly mcore's for the same
+    # canonical layout, so correctness is inherited from mcore (not re-derived).
+    n = _REAL_LAYERS[model]
+    assert _layout_indices(n, pp, num_mtp_layers=mtp) == _mcore_reference_decoder_ids(n, pp, mtp)
+
+
+@pytest.mark.parametrize("model, pp, mtp", _CORRECTNESS_CASES)
+def test_auto_layout_is_legal_and_balanced(model, pp, mtp):
+    n = _REAL_LAYERS[model]
+    chunks = [build_pipeline_chunk_layout(n, ps, num_mtp_layers=mtp) for ps in _ranks(pp)]
+    # complete + ordered, no missing/dup decoder -> sum == num_layers
+    assert [i for c in chunks for i in c.layer_indices] == list(range(n))
+    # embedding only on stage 0; loss/head only on the last stage
+    assert [c.has_embed for c in chunks] == [r == 0 for r in range(pp)]
+    assert [c.has_head for c in chunks] == [r == pp - 1 for r in range(pp)]
+    # MTP placed exactly `mtp` times, on the final (head) stage
+    assert sum(c.has_mtp for c in chunks) == mtp and chunks[-1].has_mtp == bool(mtp)
+    # balanced: per-stage unit cells (decoders + embedding/loss/mtp slots) differ by <=1
+    cells = [len(c.layer_indices) + c.has_embed + c.has_head + (mtp if c.has_mtp else 0) for c in chunks]
+    assert max(cells) - min(cells) <= 1
+
+
+def test_pp_layout_custom_string_mode_is_used_verbatim():
+    # Advanced users pin an explicit mcore layout string (custom mode) instead of the
+    # auto split. "Ettt|t|t|tL" front-loads 3 decoders onto stage 0; mcore parses
+    # E=embedding t=decoder L=loss. This is NOT the auto [1,2,2,1] for 6/pp4.
+    custom = _layout_indices(6, 4, pp_layout="Ettt|t|t|tL")
+    assert [len(stage) for stage in custom] == [3, 1, 1, 1]
+    _assert_full_contiguous_cover(custom, 6)
+    assert custom != _layout_indices(6, 4)  # custom overrides auto
+
+    # A custom string carrying MTP after the decoders validates against num_mtp_layers.
+    mtp_custom = _layout_indices(6, 4, pp_layout="Ett|tt|t|tmL", num_mtp_layers=1)
+    assert [len(stage) for stage in mtp_custom] == [2, 2, 1, 1]
+    _assert_full_contiguous_cover(mtp_custom, 6)
+
+
+def test_pp_layout_custom_string_rejects_vpp_multi_chunk():
+    # A custom layout with more stages than pp implies VPP, which is not supported.
+    with pytest.raises(NotImplementedError):
+        _layout_indices(6, 2, pp_layout="Et|t|t|ttL")  # 4 stages over pp2 -> vpp=2
+
+
+def test_pp_layout_marks_mtp_stage_from_the_layout_not_a_fixed_rank():
+    # auto: the MTP slot sits just before loss, so it lands on the final (head) stage
+    # -- has_mtp marks exactly that stage, and shifts the decoder split [2,2,2,0].
+    assert _mtp_flags(6, 4, num_mtp_layers=1) == [False, False, False, True]
+    assert _layout_indices(6, 4, num_mtp_layers=1) == [[0, 1], [2, 3], [4, 5], []]
+    # no MTP requested -> no stage owns MTP.
+    assert _mtp_flags(6, 4) == [False, False, False, False]
+    # single stage owns the MTP too.
+    assert build_pipeline_chunk_layout(
+        5, ParallelState(pp_size=1, pp_rank=0, pp_is_first=True, pp_is_last=True), num_mtp_layers=1
+    ).has_mtp is True
+
+
+def test_pp_layout_custom_string_mtp_lands_on_the_designated_stage():
+    # The `m` token co-located with loss on the final stage: has_mtp marks that stage
+    # (== the head stage), driven by the layout, not a hard-coded rank.
+    flags = _mtp_flags(6, 4, pp_layout="Ett|tt|t|tmL", num_mtp_layers=1)
+    assert flags == [False, False, False, True]
+    assert _layout_indices(6, 4, pp_layout="Ett|tt|t|tmL", num_mtp_layers=1) == [
+        [0, 1], [2, 3], [4], [5]
+    ]
+
+
+@pytest.mark.xfail(
+    reason="Standalone MTP (a custom pp_layout placing `m` off the final/head stage) is a "
+    "planned follow-up: mlite's MTP shares the output head on the loss stage, so it "
+    "currently raises NotImplementedError instead of building MTP on the `m` stage. "
+    "When cross-stage standalone MTP lands, this should pass and the marker be removed.",
+    strict=True,
+    raises=NotImplementedError,
+)
+def test_pp_layout_custom_string_standalone_mtp_builds_on_designated_stage():
+    # DESIRED (follow-up): `m` on a non-final stage builds MTP on that stage.
+    # "E|ttttttm|L" over pp3 -> [E], [t*6, m], [L]; MTP belongs on the middle stage.
+    assert _mtp_flags(6, 3, pp_layout="E|ttttttm|L", num_mtp_layers=1) == [False, True, False]
+
+
+def test_pp_layout_single_stage_owns_all_layers():
+    ps = ParallelState(pp_size=1, pp_rank=0, pp_is_first=True, pp_is_last=True)
+    layout = build_pipeline_chunk_layout(5, ps)
+    assert layout.layer_indices == [0, 1, 2, 3, 4]
+    assert layout.has_embed and layout.has_head
 
 
 def test_virtual_pipeline_rank_is_tracked_on_lite_parallel_state():


### PR DESCRIPTION
## What

Pipeline layer layout for an **arbitrary, non-divisible** decoder count + MTP across PP stages — the prerequisite for DeepSeek-V4 (43), Kimi-K2 (61), GLM-5 (78). Set only `pp` (auto-balanced); advanced users can pin an explicit layout.

**Supersedes #47** (the hand-rolled `account_for` split). Please close #47 manually (not auto-closed).

## Approach — reuse Megatron-core

`build_pipeline_chunk_layout` is a thin wrapper over mcore's `PipelineParallelLayerLayout` (authorized reuse, alongside distckpt/distopt): it builds the canonical unit sequence `[E, decoder*N, mtp*K, loss]` and lets mcore own the per-stage split / offsets / validation — no divisibility assert, so 43 / 61 / 78 over any `pp` just work. Two pp-only modes:

- **auto** (default): balanced from `(num_layers, pp, mtp)`.
- **custom**: an explicit mcore string via `ParallelConfig.pp_layout`, e.g. `"E|t*5|t*6|t,m,L"`.

MTP placement is layout-driven (`has_mtp` from the `m` token), so models build MTP where the layout designates. `deepseek_v4` keys `self.layers` by **local** pipeline position (the HF weight map is local-keyed; global-id keying corrupted exports under uneven splits).

**Not supported — raise, never mis-place:** VPP; and standalone MTP (`m` off the final stage — mlite's MTP shares the head there; cross-stage MTP is a tracked follow-up, kept as a `strict` xfail test).

## Correctness

Reuse makes the proof hard and deterministic — job **12898115** (`sacct COMPLETED 0:0`): unit **56 passed, 1 xfailed**; 8-GPU smoke **4 passed**.

- **(a) bit-equal to mcore** — `test_auto_layout_is_bit_equal_to_mcore`, ds4=43 / kimi=61 / glm5=78 × MTP{off,on} × PP{2,4,8} (18 cases): the glue's per-stage decoder ids `==` a freshly-built mcore `PipelineParallelLayerLayout` for the same canonical sequence ⇒ the split **is** mcore's, not re-derived.
- **(b) legal + balanced** — `test_auto_layout_is_legal_and_balanced` (same 18 cases): `sum(decoders)==num_layers` (no missing/dup, ordered) · embedding only @stage0 · loss/head only @last stage · MTP placed exactly `mtp×` on the final stage · per-stage unit cells `max−min ≤ 1`.
- **(c) build + forward (real PP)** — 8-GPU smoke `test_uneven_pp_builds_trains_and_exports` (4/4): each delivery model builds **through** the layout over the real uneven split, trains a finite-loss step (PP P2P across unequal-depth stages), and HF export reconstructs every decoder layer (`exported_decoder_layers=9`, 0 missing/dup, all finite).

Custom + VPP + standalone-MTP rejection are covered by the same unit suite (string honored verbatim; VPP and standalone raise; standalone is the 1 xfail = follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
