### PR TITLE
deepseek_v4 full-SFT: local→global HF load + fsdp2 uneven-shard + CSA cp1 seqlen

### DIFF
--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
@@ -308,6 +308,10 @@ def load_hf_weights(
     ``_hf_names_for_state_key`` -- the SAME mapping the export spec uses, so the
     round-trip names stay consistent.  EP-local expert ids are converted to
     global before mapping.  CSA is TP=ETP=1, so there is no TP split here.
+
+    Under PP the ``self.layers`` ModuleDict is keyed by LOCAL pipeline position,
+    so -- like the exporter -- the local layer index is lifted to global before
+    mapping (identity at PP=1); else a non-first stage reads the wrong layer.
     """
     if (ps.tp_size, ps.etp_size) != (1, 1):
         raise NotImplementedError("DeepSeek V4 direct HF load currently supports only TP=ETP=1.")
@@ -315,12 +319,19 @@ def load_hf_weights(
     reader = SafeTensorReader(path)
     base_model = unwrap_model(model)
     state = base_model.state_dict()
+    # local pipeline position -> global layer index (identity at PP=1)
+    layer_map = (
+        {i: base_model.layer_indices[i] for i in range(len(base_model.layer_indices))}
+        if hasattr(base_model, "layer_indices")
+        else {}
+    )
     loaded = 0
     missing: list[str] = []
     for name, target in state.items():
         if _is_native_metadata_key(name):
             continue
-        hf_names = _hf_names_for_state_key(_to_global_expert_name(name, config, ps), config)
+        global_name = to_global_layer_name(name, layer_map)
+        hf_names = _hf_names_for_state_key(_to_global_expert_name(global_name, config, ps), config)
         if not hf_names or not all(_has(reader, hf_name) for hf_name in hf_names):
             missing.append(name)
             continue

--- a/experimental/lite/megatron/lite/primitive/modules/attention/csa.py
+++ b/experimental/lite/megatron/lite/primitive/modules/attention/csa.py
@@ -590,6 +590,23 @@ class CompressedSparseAttention(nn.Module):
                 "DeepSeek V4 fused DSA path currently supports causal masking only."
             )
         dsa_kernels = _load_dsa_kernels()
+        # The cuDNN SM90 indexer requires seqlen_q <= seqlen_k * ratio, but the
+        # compressor floors to seq_len // ratio blocks, so a seq_len that is not a
+        # multiple of ratio leaves the last query token(s) without a compressed key
+        # block. Right-pad to a multiple of ratio (the causal tail attends only real
+        # tokens and is sliced off the output) so seqlen_k * ratio == seqlen_q.
+        orig_seq_len = x.shape[1]
+        ratio = self.compress_ratio
+        pad = (-orig_seq_len) % ratio
+        if pad:
+            pos_tail = position_ids[:, -1:] + torch.arange(
+                1, pad + 1, device=position_ids.device, dtype=position_ids.dtype
+            )
+            position_ids = torch.cat([position_ids, pos_tail], dim=1)
+            x = torch.nn.functional.pad(x, (0, 0, 0, pad))
+            q = torch.nn.functional.pad(q, (0, 0, 0, pad))
+            q_low = torch.nn.functional.pad(q_low, (0, 0, 0, pad))
+            kv = torch.nn.functional.pad(kv, (0, 0, 0, pad))
         batch, seq_len, _ = x.shape
         compressed = self.compressor(
             x,
@@ -692,4 +709,6 @@ class CompressedSparseAttention(nn.Module):
         context = (
             out.view(seq_len, batch, self.num_heads, self.head_dim).permute(1, 2, 0, 3).contiguous()
         )
+        if pad:
+            context = context[:, :, :orig_seq_len, :].contiguous()
         return self._project_context(context, cos, sin)

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/adamw.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/adamw.py
@@ -65,21 +65,20 @@ def copy_local_tensor_to_param_(param: nn.Parameter, local_tensor: torch.Tensor)
         param.detach().copy_(local_tensor.to(device=param.device, dtype=param.dtype))
         return
 
+    # Copy straight into the param's local shard. Reconstructing via
+    # DTensor.from_local mis-sizes an unevenly-sharded param (it infers global =
+    # local * mesh, e.g. a (3,) param over 8 ranks -> 0 or 8), so copy local->local
+    # (master is init'd from this same local shard, so shapes match).
     local_param = to_local_tensor(param)
-    local_value = local_tensor.to(device=local_param.device, dtype=local_param.dtype)
-    from torch.distributed.tensor import DTensor
-
-    param.detach().copy_(DTensor.from_local(local_value, param.device_mesh, param.placements))
+    local_param.copy_(local_tensor.to(device=local_param.device, dtype=local_param.dtype))
 
 
 def all_reduce_grad_(grad: torch.Tensor, *, group: dist.ProcessGroup) -> None:
+    # ``to_local_tensor`` returns the DTensor's local shard storage, so the
+    # in-place all-reduce updates the grad directly -- no DTensor.from_local
+    # round-trip (which mis-sizes unevenly-sharded grads, e.g. (3,) over 8 ranks).
     local_grad = to_local_tensor(grad)
     dist.all_reduce(local_grad, op=dist.ReduceOp.SUM, group=group)
-    if local_grad is grad:
-        return
-    from torch.distributed.tensor import DTensor
-
-    grad.copy_(DTensor.from_local(local_grad, grad.device_mesh, grad.placements))
 
 
 class ChainedOptimizer:

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/grad_clip.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/grad_clip.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import math
 from collections import defaultdict
 from collections.abc import Callable, Iterable
-from numbers import Number
 from typing import Any
 
 import torch
@@ -239,20 +238,13 @@ def _local_grad(grad: torch.Tensor, meta: Any | None) -> torch.Tensor:
 
 
 def _scale_grad_(grad: torch.Tensor, scale: float | torch.Tensor) -> None:
-    to_local = getattr(grad, "to_local", None)
-    if not callable(to_local):
-        grad.mul_(_scale_for_tensor(scale, grad))
-        return
-    local_grad = to_local()
-    local_grad.mul_(_scale_for_tensor(scale, local_grad))
-    if DTensor is not None and isinstance(grad, DTensor):
-        grad.copy_(DTensor.from_local(local_grad, grad.device_mesh, grad.placements))
-
-
-def _scale_for_tensor(scale: float | torch.Tensor, tensor: torch.Tensor) -> float | torch.Tensor:
-    if isinstance(scale, Number):
-        return float(scale)
-    return scale.to(device=tensor.device, dtype=tensor.dtype)
+    # clip_coef is a scalar; scale every shard by it in place. A plain scalar mul_
+    # is correct for ANY DTensor placement (Shard/Replicate/Partial) and avoids a
+    # to_local()/from_local() round-trip, which mis-reconstructs the global shape of
+    # an unevenly-sharded param -- e.g. a (3,) mHC scale FSDP-sharded over 8 ranks:
+    # from_local assumes even sharding and infers dim0=8, so copy_ raises
+    # "tensor a (3) must match tensor b (8) at dim 0".
+    grad.mul_(float(scale) if isinstance(scale, torch.Tensor) else scale)
 
 
 def _dtensor_meta(param: nn.Parameter, grad: torch.Tensor) -> Any | None:

--- a/experimental/lite/tests/unit/model/test_deepseek_v4_hf_load_local_to_global.py
+++ b/experimental/lite/tests/unit/model/test_deepseek_v4_hf_load_local_to_global.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""DeepSeek-V4 HF load must lift LOCAL pipeline layer indices to GLOBAL.
+
+Under PP the model's ``self.layers`` ModuleDict is keyed by LOCAL pipeline
+position, so a non-first stage's native ``state_dict`` keys carry local indices
+(``layers.0`` ...). The HF release is keyed by GLOBAL layer index, so -- exactly
+like the exporter -- ``load_hf_weights`` must map local->global via
+``to_global_layer_name(name, layer_map)`` before resolving HF names. Without it a
+non-first stage reads the wrong global layer's weights.
+
+This is a CPU unit test: a minimal stand-in stage (no GPU/TE) whose layers are
+keyed locally but carry ``layer_indices`` = the global ids it owns, plus a tiny
+on-disk safetensors keyed by GLOBAL names. ``load_hf_weights`` must copy each
+local layer the GLOBAL layer's tensor; pre-fix it resolves local names, finds
+nothing, and leaves the params untouched.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+pytestmark = pytest.mark.mlite
+
+
+class _LayerNorm(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.weight = nn.Parameter(torch.zeros(dim))
+
+
+class _Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.input_layernorm = _LayerNorm(dim)
+
+
+class _Stage(nn.Module):
+    """A non-first PP stage: layers keyed by LOCAL position, ``layer_indices``
+    gives the GLOBAL ids it owns (e.g. [4, 5] for the 3rd stage of pp)."""
+
+    def __init__(self, global_ids: list[int], dim: int):
+        super().__init__()
+        self.layer_indices = list(global_ids)
+        self.layers = nn.ModuleDict({str(i): _Block(dim) for i in range(len(global_ids))})
+
+
+def test_ds4_load_hf_resolves_local_pp_layer_to_global(tmp_path):
+    from safetensors.torch import save_file
+
+    from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
+    from megatron.lite.model.deepseek_v4.lite import checkpoint as ckpt
+
+    dim = 4
+    global_ids = [4, 5]  # this stage owns global layers 4 and 5, keyed local 0 and 1
+    model = _Stage(global_ids, dim)
+    cfg = DeepseekV4Config(num_hidden_layers=8, n_routed_experts=8)
+    ps = SimpleNamespace(tp_size=1, etp_size=1, ep_size=1, ep_rank=0)
+
+    # Real-release layout is keyed by GLOBAL layer index; input_layernorm maps to
+    # the bare V4-Flash ``attn_norm.weight``.
+    save_file(
+        {f"layers.{g}.attn_norm.weight": torch.full((dim,), float(g)) for g in global_ids},
+        str(tmp_path / "model.safetensors"),
+    )
+
+    ckpt.load_hf_weights(model, str(tmp_path), cfg, ps)
+
+    # local layer 0 -> global 4 -> filled with 4.0; local 1 -> global 5 -> 5.0.
+    # Pre-fix, load resolved layers.0/layers.1 (local), found nothing, left zeros.
+    torch.testing.assert_close(
+        model.layers["0"].input_layernorm.weight.detach(), torch.full((dim,), 4.0)
+    )
+    torch.testing.assert_close(
+        model.layers["1"].input_layernorm.weight.detach(), torch.full((dim,), 5.0)
+    )


### PR DESCRIPTION
Complete the DeepSeek-V4 (ds4flash) full-SFT path on the mlite backend. Three fixes uncovered by the first real-weight 128-GPU run; each is an interaction bug that only triggers at the full combination (real FP8 weights + PP>1 + ds4's real dims/ratios + THD-packed lengths + the chosen optimizer), which no prior single test exercised.

## 1. `load_hf_weights`: lift local PP layer index → global  (`deepseek_v4/lite/checkpoint.py`)
`self.layers` is keyed by **local** pipeline position, but the HF release is keyed by **global** layer index. The exporter already maps local→global via `to_global_layer_name`; `load_hf_weights` did not, so every **non-first PP stage** read the wrong global layer's weights — a size mismatch where the mis-resolved layer's `compress_ratio` differed (CSA `compressor.ape` 512-vs-1024), silently wrong values otherwise. Only manifests at PP>1 (proxy random-init loads no HF weights; PP=1 makes local==global). glm5/kimi/qwen already do this. **Guarded by** `tests/unit/model/test_deepseek_v4_hf_load_local_to_global.py` (CPU: a non-first stage must load each local layer the right GLOBAL layer's tensor).

## 2. fsdp2 grad-clip / adamw DTensor reshard  (`optimizers/fsdp2/{grad_clip,adamw}.py`)
The fsdp2 optimizer mishandled **unevenly-sharded** DTensors — ds4's `(3,)`/`(1,)` mHC scale params sharded over 8 ranks. `_scale_grad_`, `copy_local_tensor_to_param_`, `all_reduce_grad_` round-tripped through `DTensor.from_local`, which infers `global = local*mesh` and mis-sizes the shard (`tensor a (3) must match b (8)`). Now operate on the local shard in place (scalar `mul_` / local `copy_` / in-place all-reduce) — correct for any placement. Only triggers with fsdp2 + clip-actually-fires (real grad_norm ~180) + optimizer offload (cpu_update); the matrix used dist_opt or offload_fraction=0 or non-ds4 models.

## 3. ds4 CSA cp1 indexer seqlen pad  (`modules/attention/csa.py`)
The cuDNN SM90 indexer requires `seqlen_q <= seqlen_k * ratio`, but the compressor floors to `seq_len // ratio` blocks, so a `seq_len` not divisible by `ratio` (THD-packed lengths) left the last query token without a key block. `_forward_fused_dsa_cp1` now right-pads to a multiple of `ratio` (causal tail, sliced off the output) — **no token dropped**, all tokens attended. CP>1 already uses the gather path and is unaffected.

## Validation (real DeepSeek-V4-Flash FP8 weights)
- **128-GPU full SFT** (delivery script `run_deepseek_v4_megatron.sh`, 16 nodes, real 43-layer FP8, gsm8k 30 steps): loaded 991 tensors across PP stages, **real loss 11.96 → 8.23 → 5.16 → 4.29 → … → 1.5e-5**, save@30 verified.
- **Numerical correctness (not just descending loss):** dist_opt vs fsdp2 at the same mesh/seed match step-by-step (28.2588/28.2583, 27.0089/27.0097, 24.5510/24.5517) → load + forward + fsdp2 update are numerically correct.
- **No fsdp2 regression:** `test_offload_onload_roundtrip` passes for all of deepseek_v4 / glm5 / kimi_k2 × dist_opt/fsdp2; the fsdp2 unit + equivalence tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
