### PR TITLE
Add slime Megatron Lite backend example (SFT)

### DIFF
--- a/experimental/lite/examples/slime/README.md
+++ b/experimental/lite/examples/slime/README.md
@@ -1,0 +1,59 @@
+# slime Megatron Lite Example
+
+This directory contains the Megatron Lite training backend for the
+[slime](https://github.com/THUDM/slime) RL framework, plus a Qwen3 MoE
+(Qwen3-30B-A3B) SFT launch script.
+
+The Python package is `slime_mlite`. Importing it registers slime's training
+backend as `mlite` (via slime's train-backend registry), while Megatron Lite
+model implementations still use `impl=lite`.
+
+Unlike the VERL integration, slime has no built-in backend registry, so this
+example pairs with a small **seam** in slime itself (the train-backend registry
+in `slime/ray/train_backend.py` plus registry-based dispatch in
+`slime/ray/actor_group.py` and `slime/utils/arguments.py`). All Megatron Lite
+specific code lives here; slime only learns how to load and dispatch a backend
+by name.
+
+## Layout
+
+- `slime_mlite/actor.py`: `MLiteTrainRayActor(TrainRayActor)` backed by
+  `megatron.lite.runtime` (build model from HF, SFT training step, checkpoint
+  save).
+- `slime_mlite/arguments.py`: `mlite_parse_args` (thin wrapper over Megatron's
+  parser) and `add_mlite_arguments` (the `--mlite-*` flags).
+- `slime_mlite/data.py`: packs slime rollout data into Megatron Lite THD
+  micro-batches using `megatron.lite.primitive.pack_nested_thd`.
+- `slime_mlite/loss.py`: supervised fine-tuning loss over masked tokens.
+- `scripts/run_qwen3moe_sft.sh`: Qwen3 MoE SFT launcher (`--debug-train-only`,
+  no SGLang).
+
+## Prerequisites
+
+Expose these before running (GPU runs go through Slurm):
+
+- slime with the train-backend seam. See
+  [`REQUIRED_SLIME.txt`](REQUIRED_SLIME.txt) for the reference commit.
+- Megatron-LM from this repository (add `experimental/lite` to `PYTHONPATH`).
+- A Qwen3-30B-A3B HF checkpoint.
+
+## Usage
+
+```bash
+export SLIME_ROOT=/path/to/slime
+export MODEL_PATH=/path/to/Qwen3-30B-A3B
+export TRAIN_DATA=/path/to/sft_messages.parquet
+bash scripts/run_qwen3moe_sft.sh
+```
+
+The launcher selects this backend with `--train-backend mlite
+--train-backend-module slime_mlite`. SFT data flows through slime's
+`slime.rollout.sft_rollout.generate_rollout`, and the loss is
+`--loss-type sft_loss`.
+
+## Scope
+
+This is the S1 slice: the slime seam, the `MLiteTrainRayActor` skeleton, and the
+SFT training step. Weight resync to the rollout engine (colocate/disaggregate)
+and the RL training step are follow-ups; `update_weights` is a no-op on the
+SFT-only `--debug-train-only` path and raises otherwise.

--- a/experimental/lite/examples/slime/REQUIRED_SLIME.txt
+++ b/experimental/lite/examples/slime/REQUIRED_SLIME.txt
@@ -1,0 +1,10 @@
+# Reference slime commit for the Megatron Lite slime example.
+#
+# The example needs slime's train-backend seam (the train-backend registry,
+# --train-backend-module loading, and registry-based actor/argument dispatch).
+# Until that seam is upstreamed to THUDM/slime, use the ISEEKYAN/slime fork:
+#
+#   git clone https://github.com/ISEEKYAN/slime.git
+#   git checkout 77037513d079b7ebfd0f070879cfd4de566aaac0  # or newer fork main with the seam
+#
+# slime @ git+https://github.com/ISEEKYAN/slime.git

--- a/experimental/lite/examples/slime/scripts/run_qwen3moe_sft.sh
+++ b/experimental/lite/examples/slime/scripts/run_qwen3moe_sft.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Supervised fine-tuning of qwen3_moe (Qwen3-30B-A3B) with the Megatron Lite
+# backend inside the slime framework. Mirrors slime's SFT examples (e.g.
+# examples/retool/retool_qwen3_4b_sft.sh): SGLang rollout is bypassed via
+# --debug-train-only and SFT data comes from slime.rollout.sft_rollout.
+#
+# Run this inside an allocation that already has slime + Megatron Lite + their
+# dependencies importable (see README.md). GPU runs go through Slurm.
+set -euo pipefail
+
+if [[ "${VERBOSE:-0}" == "1" ]]; then set -x; fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -L)"
+EXAMPLE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd -L)"          # .../examples/slime
+LITE_ROOT="$(cd "${EXAMPLE_ROOT}/../.." && pwd -L)"        # .../experimental/lite
+REPO_ROOT="$(cd "${LITE_ROOT}/../.." && pwd -L)"           # Megatron-LM repo root
+
+add_pythonpath() { [[ -n "${1:-}" ]] && export PYTHONPATH="${1}:${PYTHONPATH:-}"; }
+add_pythonpath "${EXAMPLE_ROOT}"   # so `import slime_mlite` resolves
+add_pythonpath "${LITE_ROOT}"      # so `import megatron.lite` resolves
+add_pythonpath "${REPO_ROOT}"
+
+# ---- 1. user-adjustable -----------------------------------------------------
+: "${SLIME_ROOT:?set SLIME_ROOT to the slime checkout (with the train-backend seam)}"
+: "${MODEL_PATH:?set MODEL_PATH to a Qwen3-30B-A3B HF checkpoint directory}"
+: "${TRAIN_DATA:?set TRAIN_DATA to an SFT messages parquet path}"
+
+MODEL_SCRIPT="${MODEL_SCRIPT:-${SLIME_ROOT}/scripts/models/qwen3-30B-A3B.sh}"
+NUM_GPUS="${NUM_GPUS:-8}"
+SAVE_DIR="${SAVE_DIR:-${EXAMPLE_ROOT}/outputs/qwen3moe_sft}"
+
+TP_SIZE="${TP_SIZE:-2}"
+PP_SIZE="${PP_SIZE:-1}"
+CP_SIZE="${CP_SIZE:-1}"
+EP_SIZE="${EP_SIZE:-8}"
+ETP_SIZE="${ETP_SIZE:-1}"
+MLITE_MODEL_NAME="${MLITE_MODEL_NAME:-qwen3_moe}"
+MLITE_OPTIMIZER_BACKEND="${MLITE_OPTIMIZER_BACKEND:-dist_opt}"
+# Offload optimizer state to CPU; needed to fit Qwen3-30B-A3B on 8x80GB.
+OPTIMIZER_OFFLOAD="${OPTIMIZER_OFFLOAD:-1}"
+
+LR="${LR:-1e-5}"
+ROLLOUT_BATCH_SIZE="${ROLLOUT_BATCH_SIZE:-128}"
+GLOBAL_BATCH_SIZE="${GLOBAL_BATCH_SIZE:-128}"
+MAX_TOKENS_PER_GPU="${MAX_TOKENS_PER_GPU:-9216}"
+NUM_EPOCH="${NUM_EPOCH:-1}"
+SAVE_INTERVAL="${SAVE_INTERVAL:-1000}"
+DRY_RUN="${DRY_RUN:-0}"
+
+# ---- 2. derived -------------------------------------------------------------
+mkdir -p "${SAVE_DIR}"
+# shellcheck disable=SC1090
+source "${MODEL_SCRIPT}"
+
+export CUDA_DEVICE_MAX_CONNECTIONS="${CUDA_DEVICE_MAX_CONNECTIONS:-1}"
+export PYTHONUNBUFFERED=1
+
+# ---- 3. arg groups ----------------------------------------------------------
+BACKEND_ARGS=(
+   --train-backend mlite
+   --train-backend-module slime_mlite
+   --mlite-model-name "${MLITE_MODEL_NAME}"
+   --mlite-impl lite
+   --mlite-optimizer-backend "${MLITE_OPTIMIZER_BACKEND}"
+)
+if [[ "${OPTIMIZER_OFFLOAD}" == "1" || "${OPTIMIZER_OFFLOAD}" == "True" || "${OPTIMIZER_OFFLOAD}" == "true" ]]; then
+   BACKEND_ARGS+=(--mlite-optimizer-offload)
+fi
+
+CKPT_ARGS=(
+   --hf-checkpoint "${MODEL_PATH}"
+   --save "${SAVE_DIR}"
+   --save-interval "${SAVE_INTERVAL}"
+)
+
+SFT_ARGS=(
+   --rollout-function-path slime.rollout.sft_rollout.generate_rollout
+   --prompt-data "${TRAIN_DATA}"
+   --input-key messages
+   --rollout-shuffle
+   --num-epoch "${NUM_EPOCH}"
+   --rollout-batch-size "${ROLLOUT_BATCH_SIZE}"
+   --global-batch-size "${GLOBAL_BATCH_SIZE}"
+   --loss-type sft_loss
+   --calculate-per-token-loss
+   --disable-compute-advantages-and-returns
+   --debug-train-only
+)
+
+PERF_ARGS=(
+   --tensor-model-parallel-size "${TP_SIZE}"
+   --pipeline-model-parallel-size "${PP_SIZE}"
+   --context-parallel-size "${CP_SIZE}"
+   --expert-model-parallel-size "${EP_SIZE}"
+   --expert-tensor-parallel-size "${ETP_SIZE}"
+   --use-dynamic-batch-size
+   --max-tokens-per-gpu "${MAX_TOKENS_PER_GPU}"
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr "${LR}"
+   --lr-decay-style constant
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.95
+   --clip-grad 1.0
+)
+
+MISC_ARGS=(
+   --attention-dropout 0.0
+   --hidden-dropout 0.0
+   --attention-backend flash
+)
+
+# ---- 4. launch --------------------------------------------------------------
+COMMAND=(
+   python3 "${SLIME_ROOT}/train_async.py"
+   --actor-num-nodes 1
+   --actor-num-gpus-per-node "${NUM_GPUS}"
+   "${MODEL_ARGS[@]}"
+   "${BACKEND_ARGS[@]}"
+   "${CKPT_ARGS[@]}"
+   "${SFT_ARGS[@]}"
+   "${OPTIMIZER_ARGS[@]}"
+   "${PERF_ARGS[@]}"
+   "${MISC_ARGS[@]}"
+)
+
+if [[ "${DRY_RUN}" == "1" ]]; then
+   printf '%q ' "${COMMAND[@]}"; printf '\n'
+   exit 0
+fi
+
+"${COMMAND[@]}"

--- a/experimental/lite/examples/slime/slime_mlite/__init__.py
+++ b/experimental/lite/examples/slime/slime_mlite/__init__.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Megatron Lite training backend for the slime RL framework.
+
+Importing this package registers ``mlite`` with slime's train-backend registry,
+so a slime launch only needs ``--train-backend mlite --train-backend-module
+slime_mlite``. All Megatron Lite specific code lives here; slime itself carries
+only a small backend-dispatch seam (see ``slime.ray.train_backend``).
+"""
+
+from __future__ import annotations
+
+
+def _register() -> None:
+    from slime.ray.train_backend import register_train_backend
+
+    from .arguments import mlite_parse_args, validate_args
+
+    def _actor_loader() -> type:
+        from .actor import MLiteTrainRayActor
+
+        return MLiteTrainRayActor
+
+    register_train_backend(
+        "mlite",
+        actor_loader=_actor_loader,
+        parse_args=mlite_parse_args,
+        validate_args=validate_args,
+    )
+
+
+_register()

--- a/experimental/lite/examples/slime/slime_mlite/actor.py
+++ b/experimental/lite/examples/slime/slime_mlite/actor.py
@@ -1,0 +1,215 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Megatron Lite training actor for slime.
+
+``MLiteTrainRayActor`` implements slime's ``TrainRayActor`` contract on top of
+the Megatron Lite runtime (``create_runtime`` / ``build_model`` /
+``forward_backward`` / ``optimizer_step`` / ``save_checkpoint``). Because
+Megatron Lite loads weights straight from the HF checkpoint, there is no
+HF->torch_dist conversion stage like the megatron backend.
+
+S1 scope: model build + supervised fine-tuning training step + checkpoint save.
+Weight resync to the rollout engine (``update_weights``) and offload-driven
+sleep/wake are wired as follow-ups (S2); ``update_weights`` is a no-op in the
+SFT-only ``--debug-train-only`` path that S1 targets.
+"""
+
+from __future__ import annotations
+
+import logging
+from argparse import Namespace
+from typing import Any
+
+import torch
+
+from slime.ray.train_actor import TrainRayActor
+from slime.utils.data import process_rollout_data
+from slime.utils.misc import Box
+
+from .arguments import optimizer_backend_to_impl
+from .data import build_sft_microbatches
+from .loss import make_sft_loss_fn
+
+logger = logging.getLogger(__name__)
+
+
+class MLiteTrainRayActor(TrainRayActor):
+    def _build_mlite_config(self, args: Namespace):
+        from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig
+        from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
+
+        parallel = ParallelConfig(
+            tp=args.tensor_model_parallel_size,
+            etp=getattr(args, "expert_tensor_parallel_size", None),
+            ep=getattr(args, "expert_model_parallel_size", 1),
+            pp=args.pipeline_model_parallel_size,
+            vpp=getattr(args, "virtual_pipeline_model_parallel_size", None) or 1,
+            cp=args.context_parallel_size,
+        )
+        optimizer = OptimizerConfig(
+            optimizer=args.optimizer,
+            lr=args.lr,
+            min_lr=args.min_lr if args.min_lr is not None else 0.0,
+            clip_grad=args.clip_grad,
+            weight_decay=args.weight_decay,
+            lr_decay_style=args.lr_decay_style,
+            adam_beta1=getattr(args, "adam_beta1", None),
+            adam_beta2=getattr(args, "adam_beta2", None),
+            adam_eps=getattr(args, "adam_eps", None),
+        )
+        if getattr(args, "mlite_optimizer_offload", False):
+            optimizer.offload_fraction = 1.0
+            optimizer.use_precision_aware_optimizer = True
+            optimizer.decoupled_weight_decay = True
+        # Megatron parses --attention-backend into an AttnBackend enum; Megatron
+        # Lite's attention_backend_override expects the string name (e.g. "flash").
+        attention_backend = args.mlite_attention_backend
+        if attention_backend is None:
+            raw = getattr(args, "attention_backend", None)
+            attention_backend = getattr(raw, "name", raw)
+        attention_backend = attention_backend or "flash"
+        return MegatronLiteConfig(
+            model_name=args.mlite_model_name,
+            impl=args.mlite_impl,
+            hf_path=args.hf_checkpoint,
+            parallel=parallel,
+            optimizer=optimizer,
+            attention_backend_override=attention_backend,
+            load_hf_weights=True,
+            impl_cfg={
+                "use_thd": True,
+                "optimizer": optimizer_backend_to_impl(args.mlite_optimizer_backend),
+            },
+        )
+
+    def init(
+        self,
+        args: Namespace,
+        role: str,
+        with_ref: bool = False,
+        with_opd_teacher: bool = False,
+    ) -> int | None:
+        if args.debug_rollout_only:
+            self.args = args
+            return 0
+
+        super().init(args, role, with_ref, with_opd_teacher)
+
+        if role != "actor":
+            raise NotImplementedError(
+                "Megatron Lite slime backend currently supports the actor role only."
+            )
+
+        from megatron.lite.runtime import RuntimeConfig, create_runtime
+
+        self._cfg = self._build_mlite_config(args)
+        self.runtime = create_runtime(
+            RuntimeConfig(backend="mlite", hf_path=args.hf_checkpoint, backend_cfg=self._cfg)
+        )
+        self.handle = self.runtime.build_model()
+
+        ps = self.handle._parallel_state
+        self.train_parallel_config = {
+            "dp_size": ps.dp_size,
+            "cp_size": ps.cp_size,
+            "vpp_size": self._cfg.parallel.vpp or 1,
+            "microbatch_group_size_per_vp_stage": 1,
+        }
+
+        start_rollout_id = 0
+        if getattr(args, "load", None):
+            loaded = self.runtime.load_checkpoint(self.handle, args.load)
+            start_rollout_id = int(loaded) + 1
+
+        return start_rollout_id
+
+    def _get_rollout_data(self, rollout_data_ref: Box) -> dict[str, Any]:
+        ps = self.handle._parallel_state
+        rollout_data = process_rollout_data(self.args, rollout_data_ref, ps.dp_rank, ps.dp_size)
+        device = torch.cuda.current_device()
+        rollout_data["tokens"] = [
+            t.to(device=device, dtype=torch.long, non_blocking=True) for t in rollout_data["tokens"]
+        ]
+        rollout_data["loss_masks"] = [
+            t.to(device=device, dtype=torch.float32, non_blocking=True)
+            for t in rollout_data["loss_masks"]
+        ]
+        return rollout_data
+
+    def train(self, rollout_id: int, rollout_data_ref: Box, external_data=None):
+        if self.args.debug_rollout_only:
+            return None
+
+        if getattr(self.args, "loss_type", "sft_loss") != "sft_loss":
+            raise NotImplementedError(
+                f"Megatron Lite slime backend S1 supports --loss-type sft_loss only, "
+                f"got {self.args.loss_type!r} (RL losses land in a follow-up)."
+            )
+
+        rollout_data = self._get_rollout_data(rollout_data_ref)
+        ps = self.handle._parallel_state
+        microbatches, num_microbatches = build_sft_microbatches(
+            rollout_data,
+            micro_batch_size=getattr(self.args, "micro_batch_size", 1) or 1,
+            use_dynamic_batch_size=getattr(self.args, "use_dynamic_batch_size", False),
+            max_tokens_per_gpu=getattr(self.args, "max_tokens_per_gpu", 0) or 0,
+            tp_size=ps.tp_size,
+            cp_size=ps.cp_size,
+            cp_rank=ps.cp_rank,
+            cp_group=ps.cp_group,
+            use_fused_kernels=False,
+        )
+        if num_microbatches == 0:
+            logger.warning("rollout %s: empty data shard on dp_rank %s", rollout_id, ps.dp_rank)
+            return None
+
+        loss_fn = make_sft_loss_fn()
+        with self.runtime.train_mode(self.handle):
+            self.runtime.zero_grad(self.handle)
+            result = self.runtime.forward_backward(
+                self.handle,
+                iter(microbatches),
+                loss_fn=loss_fn,
+                num_microbatches=num_microbatches,
+                forward_only=False,
+            )
+            _, grad_norm, _ = self.runtime.optimizer_step(self.handle)
+            lr = self.runtime.lr_scheduler_step(self.handle)
+
+        loss = result.metrics.get("loss")
+        logger.info(
+            "rollout %s | train/loss %s | grad_norm %.4f | lr %s | num_microbatches %s",
+            rollout_id,
+            loss,
+            float(grad_norm),
+            lr,
+            num_microbatches,
+        )
+        return None
+
+    def save_model(self, rollout_id: int, force_sync: bool = False) -> None:
+        if self.args.debug_rollout_only:
+            return
+        save_dir = getattr(self.args, "save", None)
+        if not save_dir:
+            return
+        self.runtime.save_checkpoint(self.handle, save_dir, step=rollout_id)
+
+    def update_weights(self) -> None:
+        if self.args.debug_train_only or self.args.debug_rollout_only:
+            return
+        raise NotImplementedError(
+            "Megatron Lite weight resync to the rollout engine is implemented in a follow-up."
+        )
+
+    def sleep(self, *args, **kwargs) -> None:
+        if not getattr(self.args, "offload_train", False):
+            return
+        self.runtime.to(self.handle, "cpu")
+
+    def wake_up(self, *args, **kwargs) -> None:
+        if not getattr(self.args, "offload_train", False):
+            return
+        self.runtime.to(self.handle, "cuda")
+
+    def _get_parallel_config(self):
+        return self.train_parallel_config

--- a/experimental/lite/examples/slime/slime_mlite/arguments.py
+++ b/experimental/lite/examples/slime/slime_mlite/arguments.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Argument parsing for the Megatron Lite slime backend.
+
+Megatron Lite is Megatron-Core based, so the slime launch reuses Megatron's
+argument parser for model/parallelism/optimizer flags exactly like the built-in
+``megatron`` backend. ``mlite_parse_args`` is a thin wrapper that layers a few
+``--mlite-*`` flags (model implementation knobs that have no Megatron
+equivalent) on top of that parser. Megatron Lite reads the model architecture
+straight from the HF checkpoint, so we skip Megatron's HF<->arg validation.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["add_mlite_arguments", "mlite_parse_args", "validate_args"]
+
+# User-facing optimizer-backend names. ``dist_opt`` selects Megatron-Core's
+# distributed optimizer (DDP + distopt); ``fsdp2`` selects Megatron Lite's
+# FSDP2 wrapper. Megatron Lite's protocol layer still keys its internal
+# ``impl_cfg.optimizer`` enum on the legacy value ``"mc"`` for the distributed
+# optimizer; that rename is a separate cross-model cleanup, so we expose the
+# current name here and bridge it in exactly one place below.
+_OPTIMIZER_BACKEND_TO_IMPL = {
+    "dist_opt": "mc",
+    "fsdp2": "fsdp2",
+}
+
+
+def optimizer_backend_to_impl(backend: str) -> str:
+    """Map a user-facing optimizer-backend name to the Megatron Lite impl key."""
+    if backend not in _OPTIMIZER_BACKEND_TO_IMPL:
+        raise ValueError(
+            f"Unsupported --mlite-optimizer-backend {backend!r}; "
+            f"expected one of {sorted(_OPTIMIZER_BACKEND_TO_IMPL)}."
+        )
+    return _OPTIMIZER_BACKEND_TO_IMPL[backend]
+
+
+def add_mlite_arguments(parser):
+    """Register Megatron Lite specific flags that have no Megatron equivalent."""
+    group = parser.add_argument_group(title="megatron-lite")
+    group.add_argument(
+        "--mlite-model-name",
+        type=str,
+        default="auto",
+        help="Megatron Lite model registry name; 'auto' infers it from the HF config.",
+    )
+    group.add_argument(
+        "--mlite-impl",
+        type=str,
+        default="lite",
+        help="Megatron Lite model implementation variant.",
+    )
+    group.add_argument(
+        "--mlite-optimizer-backend",
+        type=str,
+        default="dist_opt",
+        choices=sorted(_OPTIMIZER_BACKEND_TO_IMPL),
+        help="Optimizer backend: dist_opt (Megatron-Core distributed optimizer) or fsdp2.",
+    )
+    group.add_argument(
+        "--mlite-attention-backend",
+        type=str,
+        default=None,
+        help="Override attention backend (defaults to --attention-backend, else 'flash').",
+    )
+    group.add_argument(
+        "--mlite-optimizer-offload",
+        action="store_true",
+        default=False,
+        help="Offload optimizer state to CPU (offload_fraction=1.0 + precision-aware "
+        "optimizer + decoupled weight decay), matching the verl example. Needed to fit "
+        "large MoE models on limited GPU memory.",
+    )
+    return parser
+
+
+def mlite_parse_args(extra_args_provider, skip_hf_validate: bool = False):
+    """Parse Megatron + slime + Megatron-Lite args.
+
+    Mirrors ``slime.backends.megatron_utils.arguments.megatron_parse_args`` but
+    skips the Megatron<->HF config cross-check: Megatron Lite builds the model
+    from the HF checkpoint directly, so the Megatron model args only need to be
+    self-consistent, not mirror the HF config.
+    """
+    from megatron.training.arguments import parse_args as _megatron_parse_args
+    from slime.backends.megatron_utils.arguments import set_default_megatron_args
+
+    def _provider(parser):
+        if extra_args_provider is not None:
+            parser = extra_args_provider(parser)
+        return add_mlite_arguments(parser)
+
+    args = _megatron_parse_args(extra_args_provider=_provider, ignore_unknown_args=True)
+
+    args.rank = 0
+    args.world_size = args.actor_num_nodes * args.actor_num_gpus_per_node
+    args = set_default_megatron_args(args)
+    return args
+
+
+def validate_args(args):
+    """Light validation for the Megatron Lite backend.
+
+    Unlike the megatron backend we do not run Megatron's ``validate_args``
+    (which assumes a Megatron-Core training loop and an HF-matching config).
+    """
+    # slime always uses variable sequence lengths (packed THD).
+    args.variable_seq_lengths = True
+    if not getattr(args, "hf_checkpoint", None):
+        raise ValueError("--hf-checkpoint is required for the Megatron Lite backend.")

--- a/experimental/lite/examples/slime/slime_mlite/arguments.py
+++ b/experimental/lite/examples/slime/slime_mlite/arguments.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 __all__ = ["add_mlite_arguments", "mlite_parse_args", "validate_args"]
 
 # User-facing optimizer-backend names. ``dist_opt`` selects Megatron-Core's
-# distributed optimizer (DDP + distopt); ``fsdp2`` selects Megatron Lite's
+# distributed optimizer (DDP wrapper + distributed optimizer); ``fsdp2`` selects Megatron Lite's
 # FSDP2 wrapper. Megatron Lite's protocol layer still keys its internal
 # ``impl_cfg.optimizer`` enum on the legacy value ``"mc"`` for the distributed
 # optimizer; that rename is a separate cross-model cleanup, so we expose the

--- a/experimental/lite/examples/slime/slime_mlite/data.py
+++ b/experimental/lite/examples/slime/slime_mlite/data.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Bridge slime rollout data into Megatron Lite THD micro-batches.
+
+slime hands the train actor a per-DP-rank shard of samples (full prompt+response
+token streams plus a response-only loss mask). Megatron Lite consumes packed
+THD micro-batches (1-D concatenated tokens with ``PackedSeqParams``), so this
+module groups the shard into micro-batches and packs each one with Megatron
+Lite's own ``pack_nested_thd`` primitive (no reinvented packing/CP logic).
+
+Loss-mask convention matches slime's megatron backend (see
+``slime/backends/megatron_utils/data.py:get_batch``): the response-only mask is
+left-padded by ``prompt_length - 1`` and right-padded by 1 so that mask position
+``i`` selects the token predicted at position ``i`` (i.e. ``token[i+1]``). Labels
+are produced by Megatron Lite's ``roll_labels=True`` (shift input_ids left), so
+the already-aligned mask is passed with ``roll_loss_mask=False``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+from megatron.lite.primitive.parallel import pack_nested_thd
+
+
+def _group_microbatches(total_lengths: list[int], *, micro_batch_size: int,
+                        use_dynamic_batch_size: bool, max_tokens_per_gpu: int) -> list[list[int]]:
+    """Return sample-index groups, one per micro-batch."""
+    num_samples = len(total_lengths)
+    if num_samples == 0:
+        return []
+
+    if not use_dynamic_batch_size:
+        mbs = max(int(micro_batch_size), 1)
+        return [list(range(i, min(i + mbs, num_samples))) for i in range(0, num_samples, mbs)]
+
+    budget = max(int(max_tokens_per_gpu), 1)
+    groups: list[list[int]] = []
+    current: list[int] = []
+    current_tokens = 0
+    for idx, length in enumerate(total_lengths):
+        length = int(length)
+        if current and current_tokens + length > budget:
+            groups.append(current)
+            current, current_tokens = [], 0
+        current.append(idx)
+        current_tokens += length
+    if current:
+        groups.append(current)
+    return groups
+
+
+def _aligned_loss_mask(loss_mask: torch.Tensor, total_length: int, response_length: int) -> torch.Tensor:
+    """Left/right pad a response-only mask to the full token stream (next-token aligned)."""
+    prompt_length = total_length - response_length
+    left_pad = max(prompt_length - 1, 0)
+    right_pad = total_length - response_length - left_pad
+    return F.pad(loss_mask.float(), (left_pad, right_pad), value=0.0)
+
+
+def build_sft_microbatches(
+    rollout_data: dict[str, Any],
+    *,
+    micro_batch_size: int,
+    use_dynamic_batch_size: bool,
+    max_tokens_per_gpu: int,
+    tp_size: int,
+    cp_size: int,
+    cp_rank: int,
+    cp_group: Any | None,
+    temperature: float = 1.0,
+    use_fused_kernels: bool = False,
+) -> tuple[list[dict[str, Any]], int]:
+    """Build packed THD micro-batch dicts for ``runtime.forward_backward``.
+
+    Returns ``(microbatches, num_microbatches)``.
+    """
+    tokens = rollout_data["tokens"]
+    loss_masks = rollout_data["loss_masks"]
+    total_lengths = [int(x) for x in rollout_data["total_lengths"]]
+    response_lengths = [int(x) for x in rollout_data["response_lengths"]]
+
+    groups = _group_microbatches(
+        total_lengths,
+        micro_batch_size=micro_batch_size,
+        use_dynamic_batch_size=use_dynamic_batch_size,
+        max_tokens_per_gpu=max_tokens_per_gpu,
+    )
+
+    microbatches: list[dict[str, Any]] = []
+    for group in groups:
+        seq_tokens = [tokens[i].reshape(-1).long() for i in group]
+        seq_masks = [
+            _aligned_loss_mask(loss_masks[i].reshape(-1), total_lengths[i], response_lengths[i])
+            for i in group
+        ]
+        nested_tokens = torch.nested.as_nested_tensor(seq_tokens, layout=torch.jagged)
+        nested_masks = torch.nested.as_nested_tensor(seq_masks, layout=torch.jagged)
+
+        packed = pack_nested_thd(
+            nested_tokens,
+            tp_size=tp_size,
+            cp_size=cp_size,
+            cp_rank=cp_rank,
+            cp_group=cp_group,
+            labels=nested_tokens,
+            roll_labels=True,
+            loss_mask=nested_masks,
+            roll_loss_mask=False,
+        )
+        microbatches.append(
+            {
+                "input_ids": packed.input_ids,
+                "labels": packed.labels,
+                "position_ids": packed.position_ids,
+                "packed_seq_params": packed.packed_seq_params,
+                "loss_mask": packed.loss_mask,
+                "temperature": temperature,
+                "use_fused_kernels": use_fused_kernels,
+                "calculate_entropy": False,
+            }
+        )
+
+    return microbatches, len(microbatches)

--- a/experimental/lite/examples/slime/slime_mlite/loss.py
+++ b/experimental/lite/examples/slime/slime_mlite/loss.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Loss functions for the Megatron Lite slime backend.
+
+Megatron Lite's ``forward_backward`` calls ``loss_fn(model_output, batch)`` per
+micro-batch, where ``model_output["log_probs"]`` is the per-token log-probability
+of each label (i.e. ``-cross_entropy``), packed as ``[1, total_tokens]``. The
+runtime divides each micro-batch loss by ``num_microbatches`` before backward,
+so a loss_fn returns the per-micro-batch mean directly.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+import torch
+
+
+def make_sft_loss_fn() -> Callable[[dict[str, Any], dict[str, Any]], tuple[torch.Tensor, dict]]:
+    """Supervised fine-tuning loss: mean negative log-likelihood over masked tokens."""
+
+    def _sft_loss(model_output: dict[str, Any], batch: dict[str, Any]) -> tuple[torch.Tensor, dict]:
+        log_probs = model_output["log_probs"]
+        if log_probs is None:
+            raise ValueError("Megatron Lite model output must contain per-token log_probs for SFT.")
+        nll = -log_probs.reshape(-1)
+
+        loss_mask = batch.get("loss_mask")
+        if loss_mask is not None:
+            mask = loss_mask.reshape(-1).to(dtype=nll.dtype)
+            denom = mask.sum().clamp_min(1.0)
+            loss = (nll * mask).sum() / denom
+        else:
+            loss = nll.mean()
+
+        return loss, {"loss": loss.detach()}
+
+    return _sft_loss


### PR DESCRIPTION
## slime Megatron Lite backend example (SFT)

Adds `experimental/lite/examples/slime/` — the Megatron Lite training backend
for the slime RL framework, mirroring the existing `examples/verl` integration.

### Contents
- **`slime_mlite/actor.py`**: `MLiteTrainRayActor(TrainRayActor)` backed by
  `megatron.lite.runtime` — `init` = `create_runtime` + `build_model` (loads
  weights straight from the HF checkpoint, so no HF→torch_dist conversion stage),
  `train` = `forward_backward(loss_fn=sft)` + `optimizer_step` +
  `lr_scheduler_step`, `save_model` = `save_checkpoint`.
- **`slime_mlite/arguments.py`**: `mlite_parse_args` (thin wrapper over Megatron's
  arg parser, since Megatron Lite is Megatron-Core based) and the `--mlite-*`
  flags.
- **`slime_mlite/data.py`**: packs slime rollout data into Megatron Lite THD
  micro-batches using `megatron.lite.primitive.pack_nested_thd` (no reinvented
  packing/CP logic). Loss-mask alignment matches slime's megatron backend.
- **`slime_mlite/loss.py`**: supervised fine-tuning loss over masked tokens.
- **`scripts/run_qwen3moe_sft.sh`**: Qwen3-30B-A3B SFT launcher
  (`--debug-train-only`, no SGLang), `README.md`, `REQUIRED_SLIME.txt`.

The backend is selected with `--train-backend mlite --train-backend-module
slime_mlite`; it pairs with the slime train-backend seam
(ISEEKYAN/slime#mlite-train-backend-seam).

### Status
This is the model-build + SFT-step slice. Weight resync to the rollout engine
and the RL training step are follow-ups; the end-to-end GPU run is validated
separately (slime runs on the `slimerl/slime` image). New code has no
megatron.core imports (Megatron Lite only) and is CPU-smoke verified (seam
dispatch, THD packing, loss math).
