### PR TITLE
fix(deepseek_v4): scale MTP aux-loss gradient via pre_forward_hook

### DIFF
--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
@@ -284,6 +284,26 @@ def _apply_mtp_config(model_cfg: DeepseekV4Config, impl_cfg: ImplConfig) -> None
         model_cfg.num_nextn_predict_layers = 0
 
 
+def _make_aux_loss_hook():
+    """Per-step hook that syncs the MTP auxiliary-loss backward scale to the main
+    loss scale (DP size / gradient accumulation), mirroring the sibling protocols
+    (kimi_k2 / glm5 / qwen3_5 / qwen3_moe).
+
+    DS4 only injects an MTP auxiliary loss: its MoE router is aux-loss-free
+    (``SigmoidTopKRouter(..., compute_aux_loss=False)``) and its CSA indexer runs
+    with ``sparse_loss=False``, so -- unlike GLM-5, which also scales the MoE-aux
+    and DSA-indexer losses -- only ``MTPLossAutoScaler`` needs scaling here.
+    Without this hook the injected MTP gradient keeps ``MTPLossAutoScaler``'s
+    class-default scale of 1.0 and is mis-weighted relative to the main loss.
+    """
+    from megatron.lite.primitive.modules.mtp import MTPLossAutoScaler
+
+    def hook(scale: torch.Tensor) -> None:
+        MTPLossAutoScaler.set_loss_scale(scale)
+
+    return hook
+
+
 def _optimizer_backend_name(optimizer: Any) -> str | None:
     if isinstance(optimizer, dict) or isinstance(optimizer, OptimizerConfig):
         return "dist_opt"
@@ -443,6 +463,7 @@ def build_model(model_cfg: DeepseekV4Config, *, impl_cfg: ImplConfig) -> ModelBu
             "model_cfg": model_cfg,
             "optimizer_backend": optimizer_backend,
             "post_model_load_hook": post_model_load_hook,
+            "pre_forward_hook": _make_aux_loss_hook(),
         },
     )
 


### PR DESCRIPTION
## Problem

DS4's protocol (`deepseek_v4/lite/protocol.py`) never registered a `pre_forward_hook`, so `MTPLossAutoScaler.main_loss_backward_scale` stays at the class default **1.0** for the whole run. DS4 *does* inject the MTP auxiliary loss via `MTPLossAutoScaler.apply` (`deepseek_v4/lite/model.py:586`), so that injected gradient is **mis-weighted relative to the main loss** under data parallelism / gradient accumulation.

Every sibling MTP-bearing protocol registers a per-step hook that calls `set_loss_scale` — `glm5/lite/protocol.py` (`_make_aux_loss_hook` → `extras["pre_forward_hook"]`, L300), and likewise `kimi_k2` / `qwen3_5` / `qwen3_moe`. **DS4 was the only one missing it.**

This is **train-time only** and invisible to forward/eval, so a forward-parity check does not surface it.

## Fix

Add `_make_aux_loss_hook()` and wire it into the model-bundle `extras` as `pre_forward_hook` (the mlite runtime already consumes `extras["pre_forward_hook"]` — `runtime/backends/mlite/runtime.py:427,451`).

It is **MTP-only on purpose**. I checked the other two auxiliary losses GLM-5 scales:
- **MoE router-aux** — not injected for DS4: `DeepseekV4MoE` uses `SigmoidTopKRouter(..., compute_aux_loss=False)` (aux-loss-free balancing, by DSv4 design). No scaler needed.
- **DSA indexer loss** — not injected for DS4: `csa.py` calls `fused_indexer_sparse_attn(..., sparse_loss=False)` and drops the returned `_indexer_loss`. No scaler needed.
- **MTP** — injected but unscaled → this fix.

## Validation

- Syntax-checked (`ast.parse`).
- Confirmed the runtime consumes `extras["pre_forward_hook"]`, so this is not a no-op.
- No behavior change when MTP is disabled (`MTPLossAutoScaler.apply` is never reached, so `set_loss_scale` is inert).
- **Pending (not in this PR):** an on-cluster train-step check that the MTP grad now scales with DP / grad-accum (suggest a small unit/integration assert that the hook fires with the right `scale`).