### PR TITLE
Add ds4 (deepseek_v4) MTP aux-loss backward-scale pre_forward_hook

### DIFF
--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
@@ -255,6 +255,22 @@ def _forward_step(model: nn.Module, batch: PackedBatch) -> dict:
     return model(**_prepare_model_forward_kwargs(model, batch))
 
 
+def _make_aux_loss_hook():
+    # DeepSeek-V4: the only active auxiliary loss is multi-token prediction (MTP).
+    # The MoE router is aux-loss-free (bias-based load balancing) and the DSA
+    # indexer KL loss is disabled, so unlike Kimi/GLM-5 we only scale MTP.
+    # The runtime invokes this once per microbatch with scale=1/num_microbatches
+    # so the MTP backward gradient is consistent with the main loss (which is
+    # divided by num_microbatches before backward); without it MTP gradients are
+    # amplified num_microbatches-fold under gradient accumulation.
+    from megatron.lite.primitive.modules.mtp import MTPLossAutoScaler
+
+    def hook(scale: torch.Tensor) -> None:
+        MTPLossAutoScaler.set_loss_scale(scale)
+
+    return hook
+
+
 def unpack_forward_output(model: nn.Module, batch: PackedBatch, output) -> Any:
     # DeepSeek-V4 packs each sequence to the (zigzag) TE alignment but slices CP
     # contiguously for the fused DSA indexer, so reconstruct contiguously.
@@ -443,6 +459,7 @@ def build_model(model_cfg: DeepseekV4Config, *, impl_cfg: ImplConfig) -> ModelBu
             "model_cfg": model_cfg,
             "optimizer_backend": optimizer_backend,
             "post_model_load_hook": post_model_load_hook,
+            "pre_forward_hook": _make_aux_loss_hook(),
         },
     )
 

--- a/experimental/lite/tests/unit/model/test_deepseek_v4_mtp_loss_scale_hook.py
+++ b/experimental/lite/tests/unit/model/test_deepseek_v4_mtp_loss_scale_hook.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""DeepSeek-V4 must register a ``pre_forward_hook`` that scales the multi-token
+prediction (MTP) auxiliary loss by ``1/num_microbatches``.
+
+The runtime divides the main loss by ``num_microbatches`` before backward, but
+the MTP loss is threaded into the graph through ``MTPLossAutoScaler`` whose
+backward uses a class-level ``main_loss_backward_scale`` (default ``1.0``). The
+hook is the only thing that sets that scale to ``1/num_microbatches`` per
+microbatch (matching Megatron-core ``pipeline_parallel/schedules.forward_step``).
+
+Without the hook the scale stays ``1.0``: with ``num_microbatches == 1`` that
+happens to be correct, but under gradient accumulation (``num_microbatches > 1``)
+the MTP gradient is amplified ``num_microbatches``-fold relative to the main
+loss. DeepSeek-V4's only active auxiliary loss is MTP (the MoE router is
+aux-loss-free and the DSA indexer KL loss is disabled), so the hook only scales
+the MTP scaler.
+
+This is a CPU unit test: it stubs Transformer Engine and exercises the scaler
+arithmetic directly, with no GPU / ``build_model``.
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.mlite
+
+
+def _accumulated_mtp_grad(num_microbatches: int, *, hook) -> torch.Tensor:
+    """Mimic ``run_microbatch_loop`` for the MTP path only.
+
+    A shared parameter ``w`` feeds an MTP loss that is injected through
+    ``MTPLossAutoScaler``; the main loss is set to zero so the returned gradient
+    is purely the MTP-injected contribution. Per microbatch the loop divides the
+    forwarded output by ``num_microbatches`` before backward, exactly like the
+    real runtime. When ``hook`` is provided it is called with
+    ``1/num_microbatches`` before each microbatch (as the runtime does).
+    """
+    from megatron.lite.primitive.modules.mtp import MTPLossAutoScaler
+
+    MTPLossAutoScaler.main_loss_backward_scale = 1.0  # default, as at process start
+    w = torch.ones(3, requires_grad=True)
+    x_mtp = torch.tensor([1.0, 2.0, 3.0])
+    for _ in range(num_microbatches):
+        if hook is not None:
+            hook(torch.tensor(1.0 / num_microbatches))
+        main_loss = (w * 0.0).sum()  # zero main loss -> isolates the MTP grad
+        mtp_loss = (w * x_mtp).sum()
+        out = MTPLossAutoScaler.apply(main_loss, mtp_loss)
+        (out / num_microbatches).backward()
+    grad = w.grad.detach().clone()
+    MTPLossAutoScaler.main_loss_backward_scale = 1.0  # leave global pristine
+    return grad
+
+
+def test_ds4_hook_sets_mtp_scale(transformer_engine_import_stub):
+    """The DeepSeek-V4 hook sets the MTP backward scale to the value it is given."""
+    transformer_engine_import_stub()
+    from megatron.lite.model.deepseek_v4.lite.protocol import _make_aux_loss_hook
+    from megatron.lite.primitive.modules.mtp import MTPLossAutoScaler
+
+    hook = _make_aux_loss_hook()
+    try:
+        hook(torch.tensor(0.25))
+        assert MTPLossAutoScaler.main_loss_backward_scale == pytest.approx(0.25)
+    finally:
+        MTPLossAutoScaler.main_loss_backward_scale = 1.0
+
+
+def test_ds4_hook_keeps_mtp_grad_invariant_to_num_microbatches(transformer_engine_import_stub):
+    """With the hook, the accumulated MTP gradient is independent of nmb;
+    without it, nmb>1 amplifies the MTP gradient nmb-fold (the regression)."""
+    transformer_engine_import_stub()
+    from megatron.lite.model.deepseek_v4.lite.protocol import _make_aux_loss_hook
+
+    hook = _make_aux_loss_hook()
+
+    grad_nmb1 = _accumulated_mtp_grad(1, hook=hook)
+    grad_nmb4 = _accumulated_mtp_grad(4, hook=hook)
+    # Correct behaviour: gradient is invariant to the microbatch count.
+    torch.testing.assert_close(grad_nmb4, grad_nmb1)
+
+    # Document the bug the hook fixes: no hook -> scale stuck at 1.0 -> the
+    # nmb=4 MTP gradient is exactly 4x the nmb=1 one.
+    buggy_nmb1 = _accumulated_mtp_grad(1, hook=None)
+    buggy_nmb4 = _accumulated_mtp_grad(4, hook=None)
+    torch.testing.assert_close(buggy_nmb1, grad_nmb1)  # nmb=1 is fine either way
+    torch.testing.assert_close(buggy_nmb4, 4.0 * grad_nmb1)
+
+
+def test_ds4_build_model_wires_pre_forward_hook(transformer_engine_import_stub):
+    """The protocol source registers the hook in the ModelBundle extras so the
+    runtime (runtime.py / train_step / pipeline) can pick it up."""
+    transformer_engine_import_stub()
+    import inspect
+
+    from megatron.lite.model.deepseek_v4.lite import protocol
+
+    src = inspect.getsource(protocol.build_model)
+    assert '"pre_forward_hook": _make_aux_loss_hook()' in src


### PR DESCRIPTION
## Problem
deepseek_v4's `build_model` did not register a `pre_forward_hook` in its `ModelBundle.extras` (only model_cfg/optimizer_backend/post_model_load_hook). As a result the runtime's `set_loss_scale` path was skipped, so `MTPLossAutoScaler.main_loss_backward_scale` stayed at its default 1.0 and was never set to `1/num_microbatches`.

- With num_microbatches=1 the default 1.0 happens to be correct (so forward-parity / round-trip checks never caught it).
- With num_microbatches>1 (gradient accumulation) the main loss is divided by nmb while the MTP aux-loss gradient is still injected at scale 1.0, amplifying the MTP gradient by nmb x relative to the main loss.

deepseek_v4's MTP head is an active path (num_nextn_predict_layers > 0), so this is a real training-correctness bug under gradient accumulation.

## Fix
Register a `pre_forward_hook` in deepseek_v4 `build_model` (mirroring the existing glm5/deepseek_v3_2 pattern) that calls `set_loss_scale` so the MTP backward scale tracks `1/num_microbatches`.

Scope is intentionally limited to MTP: deepseek_v4's other aux-losses are inactive (MoE is aux-loss-free, the CSA indexer KL loss is disabled, HyperConnection/MHC carry no loss), consistent with megatron-core which only sets loss scale for moe/mtp/dsa.

## Validation
New CPU unit test (`test_deepseek_v4_mtp_loss_scale_hook.py`) asserting the hook is wired and the MTP backward scale resolves to 1/num_microbatches for nmb>1.