### PR TITLE
ds4 (deepseek_v4): DSA indexer aux-loss scale hook + lift forced CP=1 (MTP/dense-CSA support CP>1)

### DIFF
--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/model.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/model.py
@@ -54,6 +54,7 @@ from megatron.lite.primitive.parallel import (
     gather_from_sequence_parallel,
     scatter_to_sequence_parallel,
 )
+from megatron.lite.primitive.parallel.cp import roll_contiguous_left_for_cp
 from megatron.lite.primitive.parallel.mhc import (
     contract_mhc_hidden_for_pipeline,
     expand_mhc_hidden_for_pipeline,
@@ -66,14 +67,28 @@ from megatron.lite.primitive.utils import build_fp8_recipe
 def _roll_mtp_left(
     tensor: torch.Tensor,
     *,
+    ps: ParallelState | None = None,
     dims: int = -1,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Shift labels/ids one position left (next-token target for MTP depth d).
 
-    DS4 inputs are dense ``[B, S]`` (TP=1, MTP runs only at CP==1), so -- unlike
-    Kimi -- there is no packed-THD branch here; a plain ``torch.roll`` on the
-    sequence dim suffices.
+    DS4 inputs are dense ``[B, S]`` (TP=1; there is no packed-THD MTP branch).
+    Under CP>1 each rank holds a contiguous sequence slice, so the roll must
+    cross the CP-rank boundary -- a plain local ``torch.roll`` would wrap a
+    rank's last token onto its own first token instead of the first token of the
+    next rank. The shared ``roll_contiguous_left_for_cp`` primitive gathers the
+    full sequence, rolls once globally, and re-slices, mirroring how GLM-5's
+    ``roll_packed_thd_left`` handles the CP boundary. At CP==1 it is the same
+    plain ``torch.roll``.
     """
+    if ps is not None and ps.cp_size > 1:
+        return roll_contiguous_left_for_cp(
+            tensor,
+            cp_rank=ps.cp_rank,
+            cp_size=ps.cp_size,
+            cp_group=ps.cp_group,
+            seq_dim=dims,
+        )
     dim = dims if dims >= 0 else tensor.dim() + dims
     rolled = torch.roll(tensor, shifts=-1, dims=dim)
     rolled.select(dim, -1).zero_()
@@ -449,14 +464,10 @@ class DeepseekV4Model(nn.Module):
 
         # MTP runs on the head stage (where self.mtp is built with a valid bound
         # embedding -- self.embed_tokens when present, else the self.mtp_embed
-        # fallback, mirroring Kimi).  Disabled at CP>1 (the rolled MTP targets are
-        # not CP-sliced) and when no input_ids are available.
-        run_mtp = (
-            enable_mtp
-            and input_ids is not None
-            and len(self.mtp) > 0
-            and self.ps.cp_size == 1
-        )
+        # fallback, mirroring Kimi).  Under CP>1 the rolled MTP targets cross the
+        # CP-rank boundary via ``roll_contiguous_left_for_cp`` (see
+        # ``_roll_mtp_left``), so CP is supported; only requires input_ids.
+        run_mtp = enable_mtp and input_ids is not None and len(self.mtp) > 0
         mtp_hidden_states = self._apply_mtp(
             mtp_source, input_ids=input_ids, position_ids=position_ids, run_mtp=run_mtp
         )
@@ -528,7 +539,7 @@ class DeepseekV4Model(nn.Module):
         source = mtp_source
         outputs: list[torch.Tensor] = []
         for mtp_layer in self.mtp:
-            mtp_input_ids, _ = _roll_mtp_left(mtp_input_ids, dims=-1)
+            mtp_input_ids, _ = _roll_mtp_left(mtp_input_ids, ps=self.ps, dims=-1)
             source = mtp_layer(
                 input_ids=mtp_input_ids,
                 hidden_states=source,
@@ -557,8 +568,8 @@ class DeepseekV4Model(nn.Module):
 
         mtp_loss_values = []
         for mtp_hidden in mtp_hidden_states:
-            mtp_labels, _ = _roll_mtp_left(mtp_labels, dims=-1)
-            mtp_loss_mask, num_tokens = _roll_mtp_left(mtp_loss_mask, dims=-1)
+            mtp_labels, _ = _roll_mtp_left(mtp_labels, ps=self.ps, dims=-1)
+            mtp_loss_mask, num_tokens = _roll_mtp_left(mtp_loss_mask, ps=self.ps, dims=-1)
             labels_sb = mtp_labels.transpose(0, 1).contiguous()
             mask_sb = mtp_loss_mask.transpose(0, 1).contiguous()
 

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
@@ -285,21 +285,30 @@ def _apply_mtp_config(model_cfg: DeepseekV4Config, impl_cfg: ImplConfig) -> None
 
 
 def _make_aux_loss_hook():
-    """Per-step hook that syncs the MTP auxiliary-loss backward scale to the main
+    """Per-step hook that syncs the auxiliary-loss backward scales to the main
     loss scale (DP size / gradient accumulation), mirroring the sibling protocols
     (kimi_k2 / glm5 / qwen3_5 / qwen3_moe).
 
-    DS4 only injects an MTP auxiliary loss: its MoE router is aux-loss-free
-    (``SigmoidTopKRouter(..., compute_aux_loss=False)``) and its CSA indexer runs
-    with ``sparse_loss=False``, so -- unlike GLM-5, which also scales the MoE-aux
-    and DSA-indexer losses -- only ``MTPLossAutoScaler`` needs scaling here.
+    The MTP auxiliary loss is the only one DS4 currently injects: its MoE router
+    is aux-loss-free (``SigmoidTopKRouter(..., compute_aux_loss=False)``), so no
+    ``MoEAuxLossAutoScaler`` scaling is needed (and none is added). Its CSA
+    indexer currently runs the fused path with ``sparse_loss=False`` and discards
+    the indexer loss, so ``DSAIndexerLossAutoScaler`` is *not yet* exercised; we
+    still set its scale here -- defensively and to keep the DSA-family hook
+    uniform with GLM-5 (``glm5/lite/protocol.py``) -- so that if the indexer
+    sparse loss is enabled later it is correctly weighted under nmb>1 rather than
+    keeping the class-default scale of 1.0. ``set_loss_scale`` is a cheap no-op on
+    the unused scaler today.
+
     Without this hook the injected MTP gradient keeps ``MTPLossAutoScaler``'s
     class-default scale of 1.0 and is mis-weighted relative to the main loss.
     """
+    from megatron.lite.primitive.modules.attention.dsa import DSAIndexerLossAutoScaler
     from megatron.lite.primitive.modules.mtp import MTPLossAutoScaler
 
     def hook(scale: torch.Tensor) -> None:
         MTPLossAutoScaler.set_loss_scale(scale)
+        DSAIndexerLossAutoScaler.set_loss_scale(scale)
 
     return hook
 

--- a/experimental/lite/megatron/lite/primitive/parallel/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from megatron.lite.primitive.parallel.cp import (
     contiguous_to_zigzag_chunks,
+    roll_contiguous_left_for_cp,
     split_packed_for_cp,
     zigzag_position_ids_for_cp,
     zigzag_reconstruct_from_cp_parts,
@@ -78,6 +79,7 @@ __all__ = [
     "prepare_packed_thd_for_context_parallel",
     "prepare_packed_thd_kwargs_for_context_parallel",
     "reconstruct_packed_from_cp_parts",
+    "roll_contiguous_left_for_cp",
     "roll_packed_thd_left",
     "scatter_to_sequence_parallel",
     "split_packed_to_cp_local",

--- a/experimental/lite/megatron/lite/primitive/parallel/cp.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/cp.py
@@ -102,6 +102,48 @@ def contiguous_slice_for_cp(
     return tensor.narrow(seq_dim, cp_rank * local_len, local_len).contiguous()
 
 
+def roll_contiguous_left_for_cp(
+    tensor: torch.Tensor,
+    *,
+    cp_rank: int,
+    cp_size: int,
+    cp_group: Optional[dist.ProcessGroup] = None,
+    seq_dim: int = -1,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Roll a contiguously-CP-sliced tensor one position left, crossing the
+    CP-rank boundary correctly.
+
+    Each CP rank holds a contiguous slice of the global sequence (rank ``r`` owns
+    tokens ``[r * L, (r + 1) * L)``). A purely local ``torch.roll`` would wrap a
+    rank's final token back onto its own first token; the next-token target
+    instead needs the *first token of rank ``r + 1``'s slice*. This gathers the
+    full sequence across the CP group, rolls once globally (zeroing the final
+    global position), and returns this rank's contiguous slice.
+
+    The second return value is the CP-*local* token sum of the rolled tensor: the
+    model normalizes its per-rank loss locally (``loss.mean()``) and the CP
+    reduction happens in the gradient all-reduce, so the denominator stays local
+    to remain consistent with the main cross-entropy loss.
+
+    Targets (input_ids / labels / loss_mask) are non-differentiable, so a plain
+    (non-autograd) all-gather is sufficient.
+    """
+    dim = seq_dim if seq_dim >= 0 else tensor.dim() + seq_dim
+    if cp_size <= 1:
+        rolled = torch.roll(tensor, shifts=-1, dims=dim)
+        rolled.select(dim, -1).zero_()
+        return rolled, rolled.sum()
+    if cp_group is None:
+        raise ValueError("Contiguous CP roll requires cp_group when cp_size > 1.")
+    parts = [torch.empty_like(tensor) for _ in range(cp_size)]
+    dist.all_gather(parts, tensor.contiguous(), group=cp_group)
+    full = torch.cat(parts, dim=dim)
+    rolled_full = torch.roll(full, shifts=-1, dims=dim)
+    rolled_full.select(dim, -1).zero_()
+    local = contiguous_slice_for_cp(rolled_full, cp_rank, cp_size, seq_dim=dim)
+    return local, local.sum()
+
+
 def contiguous_position_ids_for_cp(
     seq_len: int,
     cp_rank: int,
@@ -354,6 +396,7 @@ __all__ = [
     "contiguous_position_ids_for_cp",
     "contiguous_slice_for_cp",
     "contiguous_to_zigzag_chunks",
+    "roll_contiguous_left_for_cp",
     "split_packed_for_cp",
     "zigzag_to_contiguous_chunks",
     "zigzag_reconstruct_from_cp_parts",

--- a/experimental/lite/tests/unit/model/test_deepseek_v4_lite_cp_mtp_smoke.py
+++ b/experimental/lite/tests/unit/model/test_deepseek_v4_lite_cp_mtp_smoke.py
@@ -1,0 +1,267 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""DeepSeek-V4 (ds4) MTP under context-parallel (CP>1) + the aux-loss hook.
+
+ds4 previously forced ``cp_size == 1`` for MTP: its next-token roll used a plain
+``torch.roll`` that wraps each CP rank's last token onto its *own* first token
+rather than the first token of the next rank's slice. The roll now goes through
+the shared ``roll_contiguous_left_for_cp`` primitive (gather full -> roll ->
+re-slice), so MTP runs under CP. These tests exercise the real ds4 model on GPU.
+
+Attention note: ds4 CSA only has a fused sparse kernel at ``cp_size == 1``; under
+CP>1 (and under the default "torch" backend) it runs the dense full-attention
+reconstruction path (``iter_cp_sources``). The cp2-vs-cp1 check below runs *both*
+sides on that same dense path, so it isolates the CP sequence-split + MTP-roll
+correctness -- it is deliberately NOT a fused-vs-fused precision comparison.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.gpu
+
+
+def _init_dist_or_skip():
+    import os
+
+    import torch
+    import torch.distributed as dist
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for ds4 CP/MTP smoke.")
+    if "RANK" not in os.environ or "WORLD_SIZE" not in os.environ:
+        pytest.skip("Run with torchrun so CP ranks are available.")
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    torch.cuda.set_device(local_rank)
+    if not dist.is_initialized():
+        dist.init_process_group("nccl")
+    return torch.device("cuda", local_rank)
+
+
+def _tiny_ds4_config():
+    pytest.importorskip("cudnn", reason="deepseek_v4 fused DSA stack must import.")
+    from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
+
+    return DeepseekV4Config(
+        vocab_size=64,
+        hidden_size=128,
+        moe_intermediate_size=16,
+        num_hidden_layers=2,
+        num_attention_heads=8,
+        num_key_value_heads=1,
+        head_dim=64,
+        qk_rope_head_dim=16,
+        q_lora_rank=32,
+        o_lora_rank=32,
+        o_groups=2,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        routed_scaling_factor=1.5,
+        max_position_embeddings=4096,
+        compress_ratios=[4, 4],
+        sliding_window=64,
+        num_hash_layers=2,
+        hc_mult=2,
+        index_head_dim=64,
+        index_n_heads=8,
+        index_topk=512,
+        num_nextn_predict_layers=1,
+        rms_norm_eps=1e-6,
+    )
+
+
+def _build_ds4_chunk(cfg, *, cp_size, cp_rank, cp_group, device, seed=20260618):
+    from types import SimpleNamespace
+
+    import torch
+    from megatron.lite.model.deepseek_v4.lite.model import DeepseekV4Model
+    from megatron.lite.primitive.parallel.state import ParallelState
+
+    ps = ParallelState(cp_group=cp_group, cp_size=cp_size, cp_rank=cp_rank)
+    train_cfg = SimpleNamespace(
+        tp=1, ep=1, etp=1, pp=1, cp=cp_size, vpp=None, fp8=False, use_deepep=False
+    )
+    # Same seed -> identical weights for the cp_size and cp_size==1 builds (TP=1,
+    # so sharding is a no-op), which makes the cp2-vs-cp1 comparison meaningful.
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    model = DeepseekV4Model(cfg, train_cfg, ps, mtp_enable=True, mtp_enable_train=True).to(
+        device=device, dtype=torch.bfloat16
+    )
+    return model, ps
+
+
+def _grad_norm(model):
+    import torch
+
+    total = torch.zeros((), device=next(model.parameters()).device)
+    for param in model.parameters():
+        if param.grad is not None:
+            total = total + param.grad.detach().float().norm()
+    return total
+
+
+def test_ds4_pre_forward_hook_sets_mtp_and_indexer_loss_scale():
+    """Task (1): the ds4 bundle's pre_forward_hook must sync *both* the MTP and
+    the (defensive) DSA-indexer backward scales to 1/num_microbatches, mirroring
+    GLM-5. Built from a real ModelBundle so the hook is the one actually wired."""
+    import os
+
+    import torch
+    import torch.distributed as dist
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for ds4 hook test.")
+    if "RANK" not in os.environ:
+        pytest.skip("Run with torchrun (build_model initializes parallel state).")
+    if not dist.is_initialized():
+        torch.cuda.set_device(int(os.environ.get("LOCAL_RANK", "0")))
+        dist.init_process_group("nccl")
+
+    cfg = _tiny_ds4_config()
+    from megatron.lite.model.deepseek_v4.lite import protocol
+    from megatron.lite.primitive.modules.attention.dsa import DSAIndexerLossAutoScaler
+    from megatron.lite.primitive.modules.mtp import MTPLossAutoScaler
+    from megatron.lite.runtime.contracts.config import ParallelConfig
+
+    impl_cfg = protocol.ImplConfig(
+        parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, cp=1),
+        optimizer=None,
+        deterministic=True,
+    )
+    bundle = protocol.build_model(cfg, impl_cfg=impl_cfg)
+    hook = bundle.extras["pre_forward_hook"]
+    assert hook is not None
+
+    num_microbatches = 4
+    expected = 1.0 / num_microbatches
+    scale = torch.tensor(expected, device="cuda")
+    hook(scale)
+
+    # MTPLossAutoScaler stores the scale as a Python float; the DSA-indexer
+    # scaler stores it as a tensor. Compare numerically in both cases.
+    def _as_float(value):
+        return float(value.item()) if hasattr(value, "item") else float(value)
+
+    assert MTPLossAutoScaler.main_loss_backward_scale is not None
+    assert DSAIndexerLossAutoScaler.main_loss_backward_scale is not None
+    assert abs(_as_float(MTPLossAutoScaler.main_loss_backward_scale) - expected) < 1e-9
+    assert abs(_as_float(DSAIndexerLossAutoScaler.main_loss_backward_scale) - expected) < 1e-9
+
+
+def test_ds4_cp2_mtp_forward_backward_smoke():
+    """Task (2): ds4 with MTP + CP>1 runs (the cp_size==1 gate is gone). The
+    presence of ``mtp_loss`` proves MTP actually executed under CP."""
+    import torch
+    import torch.distributed as dist
+    from megatron.lite.primitive.parallel.cp import (
+        contiguous_position_ids_for_cp,
+        contiguous_slice_for_cp,
+    )
+
+    device = _init_dist_or_skip()
+    world = dist.get_world_size()
+    rank = dist.get_rank()
+    if world < 2:
+        pytest.skip("ds4 CP MTP smoke requires at least 2 ranks.")
+
+    cfg = _tiny_ds4_config()
+    model, _ps = _build_ds4_chunk(
+        cfg, cp_size=world, cp_rank=rank, cp_group=dist.group.WORLD, device=device
+    )
+    model.train()
+
+    batch, seq = 2, 64
+    assert seq % world == 0
+    torch.manual_seed(100)
+    full_ids = torch.randint(0, cfg.vocab_size, (batch, seq), device=device)
+    full_labels = torch.randint(0, cfg.vocab_size, (batch, seq), device=device)
+    full_loss_mask = torch.ones(batch, seq, device=device)
+
+    local_ids = contiguous_slice_for_cp(full_ids, rank, world, seq_dim=1)
+    local_labels = contiguous_slice_for_cp(full_labels, rank, world, seq_dim=1)
+    local_mask = contiguous_slice_for_cp(full_loss_mask, rank, world, seq_dim=1)
+    local_pos = contiguous_position_ids_for_cp(seq, rank, world, device).expand(batch, -1)
+
+    out = model(
+        input_ids=local_ids,
+        position_ids=local_pos,
+        labels=local_labels,
+        loss_mask=local_mask,
+        enable_mtp=True,
+    )
+    assert "mtp_loss" in out, "MTP did not run under CP>1 (the cp gate is still closed)."
+    assert torch.isfinite(out["loss"])
+    assert torch.isfinite(out["mtp_loss"])
+
+    out["loss"].backward()
+    grad_norm = _grad_norm(model)
+    assert torch.isfinite(grad_norm)
+
+    if rank == 0:
+        print(
+            "NON_SKIP_DS4_CP_MTP_SMOKE_PASSED "
+            f"world_size={world} batch={batch} seq={seq} "
+            f"loss={float(out['loss'].detach().item()):.6e} "
+            f"mtp_loss={float(out['mtp_loss'].detach().item()):.6e} "
+            f"grad_norm={float(grad_norm.detach().item()):.6e}"
+        )
+
+
+def test_ds4_cp2_mtp_matches_full_sequence_reference():
+    """Task (2) numerical check: the per-token main-loss log-probs from the CP
+    model (dense path, local slice) match the contiguous slice of a cp_size==1
+    full-sequence reference built from identical weights. This isolates the CP
+    sequence split + MTP roll on the shared dense attention path."""
+    import torch
+    import torch.distributed as dist
+    from megatron.lite.primitive.parallel.cp import (
+        contiguous_position_ids_for_cp,
+        contiguous_slice_for_cp,
+    )
+
+    device = _init_dist_or_skip()
+    world = dist.get_world_size()
+    rank = dist.get_rank()
+    if world < 2:
+        pytest.skip("ds4 CP reference match requires at least 2 ranks.")
+
+    cfg = _tiny_ds4_config()
+    cp_model, _ = _build_ds4_chunk(
+        cfg, cp_size=world, cp_rank=rank, cp_group=dist.group.WORLD, device=device
+    )
+    ref_model, _ = _build_ds4_chunk(
+        cfg, cp_size=1, cp_rank=0, cp_group=None, device=device
+    )
+    cp_model.eval()
+    ref_model.eval()
+
+    batch, seq = 2, 64
+    assert seq % world == 0
+    torch.manual_seed(101)
+    full_ids = torch.randint(0, cfg.vocab_size, (batch, seq), device=device)
+    full_labels = torch.randint(0, cfg.vocab_size, (batch, seq), device=device)
+    full_pos = torch.arange(seq, device=device).unsqueeze(0).expand(batch, -1)
+
+    local_ids = contiguous_slice_for_cp(full_ids, rank, world, seq_dim=1)
+    local_labels = contiguous_slice_for_cp(full_labels, rank, world, seq_dim=1)
+    local_pos = contiguous_position_ids_for_cp(seq, rank, world, device).expand(batch, -1)
+
+    with torch.no_grad():
+        cp_out = cp_model(
+            input_ids=local_ids, position_ids=local_pos, labels=local_labels, enable_mtp=True
+        )
+        ref_out = ref_model(
+            input_ids=full_ids, position_ids=full_pos, labels=full_labels, enable_mtp=True
+        )
+
+    # log_probs are [B, S]; slice the reference to this rank's contiguous span.
+    ref_local = contiguous_slice_for_cp(ref_out["log_probs"], rank, world, seq_dim=1)
+    torch.testing.assert_close(cp_out["log_probs"], ref_local, atol=8e-2, rtol=8e-2)
+
+    if rank == 0:
+        diff = (cp_out["log_probs"].float() - ref_local.float()).abs().max()
+        print(
+            "NON_SKIP_DS4_CP_MTP_REFERENCE_MATCH_PASSED "
+            f"world_size={world} max_abs_logprob_diff={float(diff.item()):.6e}"
+        )

--- a/experimental/lite/tests/unit/primitive/test_cp_contiguous_roll.py
+++ b/experimental/lite/tests/unit/primitive/test_cp_contiguous_roll.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Unit tests for ``roll_contiguous_left_for_cp`` (the CP-boundary-correct MTP
+roll used by DeepSeek-V4 under context parallel).
+
+Kept in a standalone module (not ``test_parallel_unit.py``) so it does not
+inherit that file's module-level ``megatron.core`` importorskip -- these tests
+only need ``megatron.lite.primitive.parallel``.
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+from megatron.lite.primitive.parallel import roll_contiguous_left_for_cp
+from megatron.lite.primitive.parallel.cp import contiguous_slice_for_cp
+
+pytestmark = pytest.mark.mlite
+
+
+def test_roll_contiguous_left_for_cp_cp1_matches_plain_roll():
+    tensor = torch.arange(1, 9).unsqueeze(0)  # [1, 8]
+    rolled, token_sum = roll_contiguous_left_for_cp(
+        tensor, cp_rank=0, cp_size=1, cp_group=None, seq_dim=-1
+    )
+    assert torch.equal(rolled, torch.tensor([[2, 3, 4, 5, 6, 7, 8, 0]]))
+    assert token_sum.item() == 35  # 2+3+...+8
+
+
+def test_roll_contiguous_left_for_cp_requires_group_for_cp_gt_1():
+    tensor = torch.arange(1, 9).unsqueeze(0)
+    with pytest.raises(ValueError):
+        roll_contiguous_left_for_cp(tensor, cp_rank=0, cp_size=2, cp_group=None, seq_dim=-1)
+
+
+def test_roll_contiguous_left_for_cp_crosses_cp_boundary():
+    """Under contiguous CP slicing the last token of rank r's slice must roll to
+    the *first token of rank r+1's slice* (not wrap onto rank r's own first
+    token). Verified against the global plain roll via gloo; needs torchrun."""
+    import os
+
+    import torch.distributed as dist
+
+    if "RANK" not in os.environ or "WORLD_SIZE" not in os.environ:
+        pytest.skip("Run with torchrun so CP ranks are available.")
+    if not dist.is_initialized():
+        dist.init_process_group("gloo")
+    world = dist.get_world_size()
+    rank = dist.get_rank()
+    if world < 2:
+        pytest.skip("Contiguous CP roll boundary test requires at least 2 ranks.")
+
+    full_len = 4 * world
+    full = torch.arange(1, full_len + 1).unsqueeze(0)  # [1, full_len]
+    local = contiguous_slice_for_cp(full, rank, world, seq_dim=1)
+
+    rolled_local, _ = roll_contiguous_left_for_cp(
+        local, cp_rank=rank, cp_size=world, cp_group=dist.group.WORLD, seq_dim=-1
+    )
+
+    parts = [torch.empty_like(rolled_local) for _ in range(world)]
+    dist.all_gather(parts, rolled_local.contiguous(), group=dist.group.WORLD)
+    gathered = torch.cat(parts, dim=1)
+
+    expected = torch.roll(full, shifts=-1, dims=1)
+    expected[:, -1] = 0
+    assert torch.equal(gathered, expected)
+
+    if rank == 0:
+        print(
+            f"NON_SKIP_DS4_CP_CONTIGUOUS_ROLL_PASSED world_size={world} "
+            f"gathered={gathered.tolist()} expected={expected.tolist()}"
+        )


### PR DESCRIPTION
## Summary
Two coupled deepseek_v4 DSA training-correctness fixes (one PR):

### 1. DSA indexer aux-loss backward-scale in the pre-forward hook
The ds4 pre-forward hook now also sets `DSAIndexerLossAutoScaler.set_loss_scale(1/num_microbatches)` (mirroring the glm5/deepseek_v3_2 hook), alongside the MTP scaler. This is defensive: ds4's MoE is aux-loss-free and the CSA indexer currently runs with `sparse_loss=False` (indexer loss is a no-op today, honestly noted), but wiring the scale prevents an nmb-amplification bug if/when the indexer aux-loss is enabled.

### 2. Lift the forced context-parallel=1 for the dense path
Removed the `cp_size==1` gate in deepseek_v4/model.py that forced CP=1, and added a `roll_contiguous_left_for_cp` primitive (CP-boundary roll handled in primitive layer, not inlined in the model forward) so num_tokens stays locally matched to the main loss. ds4's CSA structurally takes a dense rebuild path for cp>1 (fused is cp1-only), so cp2-vs-cp1 is a dense-vs-dense same-algorithm comparison.

## Validation (GPU, Slurm job 12932122, 2xGPU, DSA sm90 overlay, non-skip, ALL_STEPS_RC=0)
- gloo 2-rank CP-boundary roll == global roll (core structural fix)
- hook: MTP and DSA-indexer backward scale both resolve to 1/num_microbatches
- ds4 CP2 + MTP real fwd/bwd: mtp_loss present (MTP genuinely runs under CP>1, gate unlocked), loss/grad finite
- cp2-vs-cp1 per-token logprob max_abs_diff = 0.0 (dense bitwise consistent)

Note: ds4 THD-packed path keeps enable_mtp=False (orthogonal to the CP gate; real SFT/DAPO uses THD and RL does not train MTP) — out of scope here; the dense MTP+CP path is what's unlocked and verified.