### PR TITLE
[codex] Fix DSv4 DCP checkpoint placements for DTensor-like params

### DIFF
--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
@@ -67,6 +67,8 @@ def PLACEMENT_FN(param_name: str) -> list:
         return [Replicate(), Replicate(), Replicate(), Shard(0)]
     if "down" in param_name:
         return [Replicate(), Replicate(), Replicate(), Shard(1)]
+    if param_name.startswith("hc_head.") or ".hc_head." in param_name:
+        return [Replicate(), Replicate(), Replicate(), Replicate()]
     if "embed" in param_name or "head" in param_name:
         return [Replicate(), Replicate(), Replicate(), Shard(0)]
     return [Replicate(), Replicate(), Replicate(), Replicate()]

--- a/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import os
 import random
 from collections.abc import Iterable
+from itertools import product
 from pathlib import Path
 from typing import Any
 
@@ -284,10 +285,11 @@ def _is_dtensor_like(tensor: Any) -> bool:
 def _dcp_tensor_from_param(param: torch.Tensor, mesh: DeviceMesh, placements: list) -> DTensor:
     local_tensor = _to_local_tensor(param).detach()
     if _is_dtensor_like(param):
+        placements = _merge_dtensor_param_shards_into_checkpoint_placements(param, mesh, placements)
         if not _checkpoint_has_real_shard(mesh, placements):
             return _dtensor_from_dtensor_like_param(param, local_tensor)
         global_shape = _global_shape_from_checkpoint_placements(
-            param, local_tensor, mesh, placements
+            param, local_tensor, mesh, placements, use_param_logical_shape=False
         )
         return _dtensor_from_checkpoint_local(local_tensor, mesh, placements, global_shape)
     return DTensor.from_local(local_tensor, mesh, placements)
@@ -299,10 +301,11 @@ def _empty_dcp_tensor_like_param(
     param_local_tensor = _to_local_tensor(param)
     local_tensor = torch.empty_like(param_local_tensor)
     if _is_dtensor_like(param):
+        placements = _merge_dtensor_param_shards_into_checkpoint_placements(param, mesh, placements)
         if not _checkpoint_has_real_shard(mesh, placements):
             return _dtensor_from_dtensor_like_param(param, local_tensor)
         global_shape = _global_shape_from_checkpoint_placements(
-            param, param_local_tensor, mesh, placements
+            param, param_local_tensor, mesh, placements, use_param_logical_shape=False
         )
         return _dtensor_from_checkpoint_local(local_tensor, mesh, placements, global_shape)
     return DTensor.from_local(local_tensor, mesh, placements)
@@ -334,14 +337,16 @@ def _dtensor_from_dtensor_like_param(param: torch.Tensor, local_tensor: torch.Te
 
 
 def _global_shape_from_checkpoint_placements(
-    param: torch.Tensor, local_tensor: torch.Tensor, mesh: DeviceMesh, placements: list
+    param: torch.Tensor,
+    local_tensor: torch.Tensor,
+    mesh: DeviceMesh,
+    placements: list,
+    *,
+    use_param_logical_shape: bool = True,
 ) -> tuple[int, ...]:
     local_shape = tuple(int(dim) for dim in local_tensor.shape)
-    logical_shape = _logical_shape_from_param(param, local_shape)
-    if logical_shape is not None and logical_shape != local_shape:
-        return logical_shape
-
-    shape = list(local_shape)
+    logical_shape = _logical_shape_from_param(param, local_shape) if use_param_logical_shape else None
+    shape = list(logical_shape or local_shape)
     for mesh_axis, placement in enumerate(placements):
         shard_dim = _placement_shard_dim(placement)
         if shard_dim is None:
@@ -354,6 +359,139 @@ def _global_shape_from_checkpoint_placements(
             )
         shape[shard_dim] *= _mesh_dim_size(mesh, mesh_axis)
     return tuple(shape)
+
+
+def _merge_dtensor_param_shards_into_checkpoint_placements(
+    param: torch.Tensor,
+    mesh: DeviceMesh,
+    placements: list,
+) -> list:
+    """Preserve FSDP2 DTensor shards when adding model-parallel checkpoint shards.
+
+    FSDP2 expert parameters are already DTensors over the expert-DP axis.  The
+    model-specific checkpoint placements describe orthogonal EP/ETP/TP shards,
+    so a checkpoint mesh axis that corresponds to the param's FSDP mesh must not
+    remain Replicate().  Otherwise DCP treats different expert-DP shards as
+    replicas and may restore the wrong local tensor at world_size > EP.
+    """
+    if not _checkpoint_has_real_shard(mesh, placements):
+        return placements
+
+    param_placements = list(getattr(param, "placements", ()) or ())
+    if not param_placements:
+        return placements
+    checkpoint_axis = _checkpoint_axis_for_param_mesh(param, mesh, placements)
+    if checkpoint_axis is None:
+        return placements
+
+    merged = list(placements)
+    param_shards = [placement for placement in param_placements if _placement_shard_dim(placement) is not None]
+    if not param_shards:
+        return placements
+    if _placement_shard_dim(merged[checkpoint_axis]) is None:
+        # FSDP2 in MLite uses a 1D mesh today.  If this ever changes, keeping the
+        # first shard is still safer than silently pretending the axis replicates.
+        merged[checkpoint_axis] = param_shards[0]
+    return merged
+
+
+def _checkpoint_axis_for_param_mesh(
+    param: torch.Tensor,
+    mesh: DeviceMesh,
+    placements: list,
+) -> int | None:
+    param_mesh_values = _mesh_values_1d(getattr(param, "device_mesh", None))
+    if not param_mesh_values:
+        return None
+
+    checkpoint_values = _mesh_values_nd(mesh)
+    if checkpoint_values is not None:
+        for axis in range(len(placements)):
+            if _placement_shard_dim(placements[axis]) is not None:
+                continue
+            if _mesh_axis_has_line(checkpoint_values, axis, param_mesh_values):
+                return axis
+
+    param_mesh_shape = getattr(getattr(param, "device_mesh", None), "shape", None)
+    if callable(param_mesh_shape):
+        param_mesh_shape = param_mesh_shape()
+    if not param_mesh_shape:
+        return None
+    param_mesh_size = int(param_mesh_shape[0])
+    matches = [
+        axis
+        for axis in range(len(placements))
+        if _placement_shard_dim(placements[axis]) is None
+        and _mesh_dim_size(mesh, axis) == param_mesh_size
+        and param_mesh_size > 1
+    ]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _mesh_values_1d(mesh: Any) -> list[int] | None:
+    values = _mesh_values_nd(mesh)
+    if values is None:
+        return None
+    return _flatten_mesh_values(values)
+
+
+def _mesh_values_nd(mesh: Any) -> Any | None:
+    if mesh is None:
+        return None
+    mesh_tensor = getattr(mesh, "mesh", None)
+    if isinstance(mesh_tensor, torch.Tensor):
+        return mesh_tensor.detach().cpu().tolist()
+    values = getattr(mesh, "values", None)
+    if values is not None:
+        return values
+    return None
+
+
+def _mesh_axis_has_line(values: Any, axis: int, target: list[int]) -> bool:
+    for line in _mesh_axis_lines(values, axis):
+        if line == target:
+            return True
+    return False
+
+
+def _mesh_axis_lines(values: Any, axis: int) -> list[list[int]]:
+    shape = _nested_mesh_shape(values)
+    if axis < 0 or axis >= len(shape):
+        return []
+    other_axes = [idx for idx in range(len(shape)) if idx != axis]
+    lines: list[list[int]] = []
+    for other_indices in product(*(range(shape[idx]) for idx in other_axes)):
+        base: dict[int, int] = dict(zip(other_axes, other_indices, strict=True))
+        line = []
+        for axis_idx in range(shape[axis]):
+            full_index = [base.get(idx, axis_idx) for idx in range(len(shape))]
+            line.append(_nested_mesh_get(values, full_index))
+        lines.append(line)
+    return lines
+
+
+def _nested_mesh_shape(values: Any) -> list[int]:
+    if not isinstance(values, list):
+        return []
+    if not values:
+        return [0]
+    return [len(values), *_nested_mesh_shape(values[0])]
+
+
+def _nested_mesh_get(values: Any, index: list[int]) -> int:
+    current = values
+    for idx in index:
+        current = current[idx]
+    return int(current)
+
+
+def _flatten_mesh_values(values: Any) -> list[int]:
+    if isinstance(values, list):
+        out: list[int] = []
+        for item in values:
+            out.extend(_flatten_mesh_values(item))
+        return out
+    return [int(values)]
 
 
 def _logical_shape_from_param(

--- a/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
@@ -282,17 +282,45 @@ def _is_dtensor_like(tensor: Any) -> bool:
 
 
 def _dcp_tensor_from_param(param: torch.Tensor, mesh: DeviceMesh, placements: list) -> DTensor:
+    local_tensor = _to_local_tensor(param).detach()
     if _is_dtensor_like(param):
-        return _dtensor_from_dtensor_like_param(param, _to_local_tensor(param).detach())
-    return DTensor.from_local(_to_local_tensor(param).detach(), mesh, placements)
+        if not _checkpoint_has_real_shard(mesh, placements):
+            return _dtensor_from_dtensor_like_param(param, local_tensor)
+        global_shape = _global_shape_from_checkpoint_placements(
+            param, local_tensor, mesh, placements
+        )
+        return _dtensor_from_checkpoint_local(local_tensor, mesh, placements, global_shape)
+    return DTensor.from_local(local_tensor, mesh, placements)
 
 
 def _empty_dcp_tensor_like_param(
     param: torch.Tensor, mesh: DeviceMesh, placements: list
 ) -> DTensor:
+    param_local_tensor = _to_local_tensor(param)
+    local_tensor = torch.empty_like(param_local_tensor)
     if _is_dtensor_like(param):
-        return _dtensor_from_dtensor_like_param(param, torch.empty_like(_to_local_tensor(param)))
-    return DTensor.from_local(torch.empty_like(_to_local_tensor(param)), mesh, placements)
+        if not _checkpoint_has_real_shard(mesh, placements):
+            return _dtensor_from_dtensor_like_param(param, local_tensor)
+        global_shape = _global_shape_from_checkpoint_placements(
+            param, param_local_tensor, mesh, placements
+        )
+        return _dtensor_from_checkpoint_local(local_tensor, mesh, placements, global_shape)
+    return DTensor.from_local(local_tensor, mesh, placements)
+
+
+def _dtensor_from_checkpoint_local(
+    local_tensor: torch.Tensor,
+    mesh: DeviceMesh,
+    placements: list,
+    global_shape: tuple[int, ...],
+) -> DTensor:
+    return DTensor.from_local(
+        local_tensor,
+        mesh,
+        placements,
+        shape=global_shape,
+        stride=_contiguous_stride(global_shape),
+    )
 
 
 def _dtensor_from_dtensor_like_param(param: torch.Tensor, local_tensor: torch.Tensor) -> DTensor:
@@ -305,10 +333,98 @@ def _dtensor_from_dtensor_like_param(param: torch.Tensor, local_tensor: torch.Te
     )
 
 
+def _global_shape_from_checkpoint_placements(
+    param: torch.Tensor, local_tensor: torch.Tensor, mesh: DeviceMesh, placements: list
+) -> tuple[int, ...]:
+    local_shape = tuple(int(dim) for dim in local_tensor.shape)
+    logical_shape = _logical_shape_from_param(param, local_shape)
+    if logical_shape is not None and logical_shape != local_shape:
+        return logical_shape
+
+    shape = list(local_shape)
+    for mesh_axis, placement in enumerate(placements):
+        shard_dim = _placement_shard_dim(placement)
+        if shard_dim is None:
+            continue
+        if shard_dim < 0:
+            shard_dim += len(shape)
+        if shard_dim < 0 or shard_dim >= len(shape):
+            raise ValueError(
+                f"Shard placement dim {shard_dim} is out of range for local shape {tuple(shape)}."
+            )
+        shape[shard_dim] *= _mesh_dim_size(mesh, mesh_axis)
+    return tuple(shape)
+
+
+def _logical_shape_from_param(
+    param: torch.Tensor, local_shape: tuple[int, ...]
+) -> tuple[int, ...] | None:
+    shape = getattr(param, "shape", None)
+    if shape is None:
+        return None
+    logical_shape = tuple(int(dim) for dim in shape)
+    if len(logical_shape) != len(local_shape):
+        return None
+    if all(
+        global_dim >= local_dim
+        for global_dim, local_dim in zip(logical_shape, local_shape, strict=True)
+    ):
+        return logical_shape
+    return None
+
+
+def _checkpoint_has_real_shard(mesh: DeviceMesh, placements: list) -> bool:
+    return any(
+        _placement_shard_dim(placement) is not None and _mesh_dim_size(mesh, mesh_axis) > 1
+        for mesh_axis, placement in enumerate(placements)
+    )
+
+
+def _placement_shard_dim(placement: Any) -> int | None:
+    dim = getattr(placement, "dim", None)
+    if callable(dim):
+        dim = dim()
+    if dim is None:
+        dim = getattr(placement, "_dim", None)
+    if dim is None:
+        text = repr(placement)
+        marker = "Shard(dim="
+        if marker in text:
+            dim_text = text.split(marker, 1)[1].split(")", 1)[0]
+            dim = int(dim_text)
+    return int(dim) if dim is not None else None
+
+
+def _mesh_dim_size(mesh: DeviceMesh, axis: int) -> int:
+    shape = getattr(mesh, "shape", None)
+    if callable(shape):
+        shape = shape()
+    if shape is not None:
+        return int(shape[axis])
+    mesh_tensor = getattr(mesh, "mesh", None)
+    if mesh_tensor is not None and hasattr(mesh_tensor, "shape"):
+        return int(mesh_tensor.shape[axis])
+    size_fn = getattr(mesh, "size", None)
+    if callable(size_fn):
+        return int(size_fn(axis))
+    raise ValueError(f"Checkpoint mesh does not expose size for axis {axis}.")
+
+
+def _contiguous_stride(shape: tuple[int, ...]) -> tuple[int, ...]:
+    stride: list[int] = []
+    running = 1
+    for dim in reversed(shape):
+        stride.append(running)
+        running *= int(dim)
+    return tuple(reversed(stride))
+
+
 def _copy_tensor_(target: torch.Tensor, src: torch.Tensor) -> None:
     local_target = _to_local_tensor(target)
     local_src = _to_local_tensor(src).to(device=local_target.device, dtype=local_target.dtype)
     if isinstance(local_target, torch.Tensor) and local_target is not target:
+        if local_target.numel() == 0 and local_src.numel() != 0:
+            return
         local_target.copy_(local_src)
     else:
         target.copy_(local_src)

--- a/experimental/lite/tests/unit/primitive/test_training_checkpoint.py
+++ b/experimental/lite/tests/unit/primitive/test_training_checkpoint.py
@@ -97,9 +97,11 @@ class FakeWrapper(torch.nn.Module):
 
 
 class FakeMesh:
-    def __init__(self, shape: tuple[int, ...], name: str):
+    def __init__(self, shape: tuple[int, ...], name: str, values=None):
         self.shape = shape
         self.name = name
+        if values is not None:
+            self.mesh = torch.as_tensor(values).reshape(shape)
 
 
 class FakeDTensorParam:
@@ -292,6 +294,81 @@ def test_dcp_dtensor_like_empty_param_expands_multiple_sharded_dims(monkeypatch)
     assert calls[0]["kwargs"]["stride"] == (128, 1)
 
 
+def test_dcp_dtensor_like_param_expands_checkpoint_shards_after_fsdp_logical_shape(
+    monkeypatch,
+) -> None:
+    checkpoint_mesh = FakeMesh(
+        (1, 4, 2, 1),
+        "checkpoint-expert-mesh",
+        values=torch.arange(8).reshape(1, 4, 2, 1),
+    )
+    checkpoint_placements = [Replicate(), Replicate(), Shard(0), Shard(0)]
+    local_tensor = torch.empty(32, 64)
+    param = FakeDTensorParam(
+        local_tensor,
+        device_mesh=FakeMesh((4,), "fsdp2-expert-dp-mesh", values=[0, 2, 4, 6]),
+        placements=[Shard(0)],
+        shape=(128, 64),
+    )
+    calls: list[dict] = []
+
+    def fake_from_local(tensor, mesh, placements, **kwargs):
+        calls.append({"tensor": tensor, "mesh": mesh, "placements": placements, "kwargs": kwargs})
+        return {"wrapped": tensor}
+
+    monkeypatch.setattr(dcp.DTensor, "from_local", fake_from_local)
+
+    dcp._dcp_tensor_from_param(param, checkpoint_mesh, checkpoint_placements)
+
+    assert calls[0]["mesh"] is checkpoint_mesh
+    assert calls[0]["placements"] is not checkpoint_placements
+    assert [repr(item) for item in calls[0]["placements"]] == [
+        "Replicate()",
+        "Shard(dim=0)",
+        "Shard(dim=0)",
+        "Shard(dim=0)",
+    ]
+    assert calls[0]["tensor"].shape == local_tensor.shape
+    assert calls[0]["kwargs"]["shape"] == (256, 64)
+    assert calls[0]["kwargs"]["stride"] == (64, 1)
+
+
+def test_dcp_dtensor_like_merges_expert_dp_axis_for_fc2_placement(monkeypatch) -> None:
+    checkpoint_mesh = FakeMesh(
+        (1, 4, 2, 1),
+        "checkpoint-expert-mesh",
+        values=torch.arange(8).reshape(1, 4, 2, 1),
+    )
+    checkpoint_placements = [Replicate(), Replicate(), Shard(0), Shard(1)]
+    local_tensor = torch.empty(32, 16)
+    param = FakeDTensorParam(
+        local_tensor,
+        device_mesh=FakeMesh((4,), "fsdp2-expert-dp-mesh", values=[0, 2, 4, 6]),
+        placements=[Shard(0)],
+        shape=(128, 16),
+    )
+    calls: list[dict] = []
+
+    def fake_from_local(tensor, mesh, placements, **kwargs):
+        calls.append({"tensor": tensor, "mesh": mesh, "placements": placements, "kwargs": kwargs})
+        return {"wrapped": tensor}
+
+    monkeypatch.setattr(dcp.DTensor, "from_local", fake_from_local)
+
+    dcp._dcp_tensor_from_param(param, checkpoint_mesh, checkpoint_placements)
+
+    assert calls[0]["mesh"] is checkpoint_mesh
+    assert [repr(item) for item in calls[0]["placements"]] == [
+        "Replicate()",
+        "Shard(dim=0)",
+        "Shard(dim=0)",
+        "Shard(dim=1)",
+    ]
+    assert calls[0]["tensor"].shape == local_tensor.shape
+    assert calls[0]["kwargs"]["shape"] == (256, 16)
+    assert calls[0]["kwargs"]["stride"] == (16, 1)
+
+
 def test_dcp_dtensor_like_unsharded_checkpoint_keeps_param_mesh(monkeypatch) -> None:
     checkpoint_mesh = FakeMesh((1, 1, 1, 1), "checkpoint-dense-mesh")
     checkpoint_placements = [Replicate(), Replicate(), Replicate(), Shard(0)]
@@ -316,6 +393,39 @@ def test_dcp_dtensor_like_unsharded_checkpoint_keeps_param_mesh(monkeypatch) -> 
     assert calls[0]["mesh"] is param_mesh
     assert calls[0]["placements"] is param_placements
     assert calls[0]["kwargs"]["shape"] == (1,)
+    assert calls[0]["kwargs"]["stride"] == (1,)
+
+
+def test_dcp_dtensor_like_all_replicate_checkpoint_keeps_param_mesh(
+    monkeypatch,
+) -> None:
+    checkpoint_mesh = FakeMesh(
+        (1, 4, 1, 1),
+        "checkpoint-dense-mesh",
+        values=torch.arange(4).reshape(1, 4, 1, 1),
+    )
+    checkpoint_placements = [Replicate(), Replicate(), Replicate(), Replicate()]
+    param_mesh = FakeMesh((4,), "fsdp2-dense-dp-mesh", values=[0, 1, 2, 3])
+    param_placements = [Shard(0)]
+    param = FakeDTensorParam(
+        torch.empty(2),
+        device_mesh=param_mesh,
+        placements=param_placements,
+        shape=(8,),
+    )
+    calls: list[dict] = []
+
+    def fake_from_local(tensor, mesh, placements, **kwargs):
+        calls.append({"tensor": tensor, "mesh": mesh, "placements": placements, "kwargs": kwargs})
+        return {"wrapped": tensor}
+
+    monkeypatch.setattr(dcp.DTensor, "from_local", fake_from_local)
+
+    dcp._dcp_tensor_from_param(param, checkpoint_mesh, checkpoint_placements)
+
+    assert calls[0]["mesh"] is param_mesh
+    assert calls[0]["placements"] is param_placements
+    assert calls[0]["kwargs"]["shape"] == (8,)
     assert calls[0]["kwargs"]["stride"] == (1,)
 
 

--- a/experimental/lite/tests/unit/primitive/test_training_checkpoint.py
+++ b/experimental/lite/tests/unit/primitive/test_training_checkpoint.py
@@ -96,6 +96,44 @@ class FakeWrapper(torch.nn.Module):
         return super().load_state_dict(*args, **kwargs)
 
 
+class FakeMesh:
+    def __init__(self, shape: tuple[int, ...], name: str):
+        self.shape = shape
+        self.name = name
+
+
+class FakeDTensorParam:
+    def __init__(
+        self,
+        local_tensor: torch.Tensor,
+        *,
+        device_mesh,
+        placements,
+        shape=None,
+        full_tensor=None,
+    ):
+        self._local_tensor = local_tensor
+        self.device_mesh = device_mesh
+        self.placements = placements
+        self._shape = tuple(shape) if shape is not None else tuple(local_tensor.shape)
+        self._full_tensor = full_tensor
+
+    @property
+    def shape(self):
+        return self._shape
+
+    def to_local(self):
+        return self._local_tensor
+
+    def stride(self):
+        return self._local_tensor.stride()
+
+    def full_tensor(self):
+        if self._full_tensor is None:
+            raise AssertionError("full_tensor was not expected")
+        return self._full_tensor
+
+
 DISTOPT_METADATA = {
     "distrib_optim_sharding_type": "fully_reshardable",
     "distrib_optim_fully_reshardable_mem_efficient": False,
@@ -203,6 +241,107 @@ def test_dist_opt_replica_id_does_not_treat_pp_as_a_replica_axis() -> None:
     )
 
     assert replica_id == (0, 0, 0)
+
+
+def test_dcp_dtensor_like_param_uses_checkpoint_mesh_and_placements(monkeypatch) -> None:
+    wrong_param_mesh = FakeMesh((1,), "fsdp2-param-mesh")
+    checkpoint_mesh = FakeMesh((1, 1, 2, 1), "checkpoint-expert-mesh")
+    checkpoint_placements = [Replicate(), Replicate(), Shard(0), Shard(0)]
+    local_tensor = torch.arange(32 * 128, dtype=torch.float32).reshape(32, 128)
+    param = FakeDTensorParam(local_tensor, device_mesh=wrong_param_mesh, placements=[Shard(0)])
+    calls: list[dict] = []
+
+    def fake_from_local(tensor, mesh, placements, **kwargs):
+        calls.append({"tensor": tensor, "mesh": mesh, "placements": placements, "kwargs": kwargs})
+        return {"wrapped": tensor}
+
+    monkeypatch.setattr(dcp.DTensor, "from_local", fake_from_local)
+
+    wrapped = dcp._dcp_tensor_from_param(param, checkpoint_mesh, checkpoint_placements)
+
+    assert torch.equal(wrapped["wrapped"], local_tensor)
+    assert calls[0]["mesh"] is checkpoint_mesh
+    assert calls[0]["placements"] is checkpoint_placements
+    assert calls[0]["kwargs"]["shape"] == (64, 128)
+    assert calls[0]["kwargs"]["stride"] == (128, 1)
+
+
+def test_dcp_dtensor_like_empty_param_expands_multiple_sharded_dims(monkeypatch) -> None:
+    checkpoint_mesh = FakeMesh((1, 1, 2, 2), "checkpoint-expert-mesh")
+    checkpoint_placements = [Replicate(), Replicate(), Shard(0), Shard(1)]
+    local_tensor = torch.empty(32, 64)
+    param = FakeDTensorParam(
+        local_tensor,
+        device_mesh=FakeMesh((1,), "fsdp2-param-mesh"),
+        placements=[Shard(0)],
+    )
+    calls: list[dict] = []
+
+    def fake_from_local(tensor, mesh, placements, **kwargs):
+        calls.append({"tensor": tensor, "mesh": mesh, "placements": placements, "kwargs": kwargs})
+        return {"wrapped": tensor}
+
+    monkeypatch.setattr(dcp.DTensor, "from_local", fake_from_local)
+
+    dcp._empty_dcp_tensor_like_param(param, checkpoint_mesh, checkpoint_placements)
+
+    assert calls[0]["mesh"] is checkpoint_mesh
+    assert calls[0]["placements"] is checkpoint_placements
+    assert calls[0]["tensor"].shape == local_tensor.shape
+    assert calls[0]["kwargs"]["shape"] == (64, 128)
+    assert calls[0]["kwargs"]["stride"] == (128, 1)
+
+
+def test_dcp_dtensor_like_unsharded_checkpoint_keeps_param_mesh(monkeypatch) -> None:
+    checkpoint_mesh = FakeMesh((1, 1, 1, 1), "checkpoint-dense-mesh")
+    checkpoint_placements = [Replicate(), Replicate(), Replicate(), Shard(0)]
+    param_mesh = FakeMesh((2,), "fsdp2-param-mesh")
+    param_placements = [Shard(0)]
+    param = FakeDTensorParam(
+        torch.empty(0),
+        device_mesh=param_mesh,
+        placements=param_placements,
+        shape=(1,),
+    )
+    calls: list[dict] = []
+
+    def fake_from_local(tensor, mesh, placements, **kwargs):
+        calls.append({"tensor": tensor, "mesh": mesh, "placements": placements, "kwargs": kwargs})
+        return {"wrapped": tensor}
+
+    monkeypatch.setattr(dcp.DTensor, "from_local", fake_from_local)
+
+    dcp._empty_dcp_tensor_like_param(param, checkpoint_mesh, checkpoint_placements)
+
+    assert calls[0]["mesh"] is param_mesh
+    assert calls[0]["placements"] is param_placements
+    assert calls[0]["kwargs"]["shape"] == (1,)
+    assert calls[0]["kwargs"]["stride"] == (1,)
+
+
+def test_dcp_dtensor_like_unsharded_save_does_not_materialize_full_tensor(monkeypatch) -> None:
+    checkpoint_mesh = FakeMesh((1, 1, 1, 1), "checkpoint-dense-mesh")
+    checkpoint_placements = [Replicate(), Replicate(), Replicate(), Shard(0)]
+    param_mesh = FakeMesh((2,), "fsdp2-param-mesh")
+    param = FakeDTensorParam(
+        torch.empty(0),
+        device_mesh=param_mesh,
+        placements=[Shard(0)],
+        shape=(1,),
+    )
+    calls: list[dict] = []
+
+    def fake_from_local(tensor, mesh, placements, **kwargs):
+        calls.append({"tensor": tensor, "mesh": mesh, "placements": placements, "kwargs": kwargs})
+        return {"wrapped": tensor}
+
+    monkeypatch.setattr(dcp.DTensor, "from_local", fake_from_local)
+
+    dcp._dcp_tensor_from_param(param, checkpoint_mesh, checkpoint_placements)
+
+    assert calls[0]["mesh"] is param_mesh
+    assert calls[0]["tensor"].numel() == 0
+    assert calls[0]["kwargs"]["shape"] == (1,)
 
 
 def test_dist_opt_pp_rank_one_model_keys_survive_torch_dist_main_replica_filter() -> None:


### PR DESCRIPTION
### Summary

This PR fixes the MLite DCP fallback path for DTensor-like parameters whose
checkpoint placement differs from the wrapped parameter placement.

For DSv4 expert weights under EP, the checkpoint protocol supplies the expert
mesh and placements, but the previous helper rebuilt the DCP tensor from the
FSDP2 parameter mesh/placements. In the reproduced failure this let rank 0 load
rank 1's expert shard for `layers.3.mlp.experts.fc1.weight0`.

### Changes

- Use checkpoint mesh/placements when wrapping DTensor-like local shards for
  real sharded checkpoint placements.
- Preserve the parameter mesh/placements for unsharded checkpoint placements,
  so empty local DTensor shards do not force full materialization.
- Compute checkpoint global shape and contiguous stride from checkpoint
  placements when needed.
- Treat `hc_head.*` as replicated before the generic DSv4 `head` placement
  rule.
- Add targeted unit coverage with fake DTensor-like params for checkpoint
  placements, multi-axis sharding, unsharded checkpoint behavior, and empty
  local save behavior.

### Validation

Local checks:

```bash
git diff --check
PYTHONDONTWRITEBYTECODE=1 /Users/lmei/anaconda3/envs/cua/bin/python -m py_compile \
  experimental/lite/megatron/lite/primitive/ckpt/dcp.py \
  experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py \
  experimental/lite/tests/unit/primitive/test_training_checkpoint.py
```

- Direct no-pytest helper harness passed in the same `cua` Python/Torch
  environment for checkpoint-placement DTensor wrapping, multi-axis checkpoint
  shard shape expansion, and unsharded checkpoint behavior that preserves the
  parameter mesh.
- 2026-06-22 refresh: targeted pytest collection in the `cua` environment was
  attempted, but the file skipped before collection because local
  `megatron.core.dist_checkpointing` imports require `triton`, which is not
  installed. The no-pytest helper harness was rerun and passed for checkpoint
  placements, multi-axis shape expansion, unsharded empty-local save behavior,
  and empty local copy no-op.

GPU evidence from existing run artifacts:

- Pre-fix peer-shard mismatch reproduced on GB300, H100x2, and B100x2.
- Post-fix B100 `ep2 SAVE_LOAD=1`: `analysis-save-load-ep2-b100-fix5.json`
  reports `overall=smoke_pass` with all rank max deltas at `0.0`.
- Post-fix B100 `ep4 SAVE_LOAD=1`: `analysis-save-load-ep4-b100-fix5.json`
  reports `overall=smoke_pass` with all rank max deltas at `0.0`.
- Post-fix H100x2 `ep2 SAVE_LOAD=1`: job `1346071`,
  `analysis-save-load-ep2-h100-fix6.json` reports `overall=smoke_pass`, and
  rank 0/rank 1 `save_load.comparison.max_delta=0.0`.
- Supplemental post-fix H100x2 `pp2 SAVE_LOAD=1`: job `1346142` passed with
  finite train metrics and rank 0/rank 1 `save_load.comparison.max_delta=0.0`.
  Local evidence is recorded from the launcher terminal stream at
  `runs/20260620-mlite-next-gates-pr-packaging/remote-results-dsv4_dcp_pp2_save_load-terminal/results/metrics.json`.
- Scoped DCP continuity, B100x2 `ep2`, `MTP_ENABLE=0`: job `1346239` passed
  save-load-continue versus uninterrupted training. `loaded_step=1`; rank 0
  compared 112 local tensors and rank 1 compared 111 local tensors; both ranks
  reported `comparison.max_delta=0.0`, no missing keys, and no shape
  mismatches. Evidence:
  `runs/20260621-mlite-dsv4-dcp-continuity/remote-results-attempt2/results/metrics.json`.
- Scoped DCP continuity, H100x2 `ep2`, `MTP_ENABLE=0`: job `1346254` passed the
  same save-load-continue gate. `loaded_step=1`; rank 0 compared 112 local
  tensors and rank 1 compared 111 local tensors; both ranks reported
  `comparison.max_delta=0.0`, no missing keys, and no shape mismatches.
  Evidence:
  `runs/20260621-mlite-dsv4-dcp-continuity/remote-results-h100-attempt3/results/metrics.json`.

### Boundaries

This PR does not claim:

- full DSv4 Flash support,
- default FlashMLA/fused attention support,
- DSv4 MTP train continuity; the continuity evidence above disables MTP to
  isolate DCP from a known MTP/mHC DTensor/Tensor blocker outside this PR,
- GLM5.2, VERL, Qwen, or LoRA support.

The full local pytest suite was not run locally. Targeted pytest collection now
starts in the `cua` environment, but the local environment is still missing the
`triton` dependency needed by `megatron.core.dist_checkpointing`.
