### PR TITLE
MLite Qwen3.5 RL: FSDP2 DTensor weight export + reference-policy support

### DIFF
--- a/experimental/lite/examples/verl/README.md
+++ b/experimental/lite/examples/verl/README.md
@@ -25,7 +25,7 @@ Install or expose these packages before running:
 
 - VERL with the new engine worker path.
   See [`REQUIRED_VERL.txt`](REQUIRED_VERL.txt) for the reference upstream
-  release tag.
+  source pin (commit).
 - Megatron-LM from this repository, or another source tree via
   `MEGATRON_ROOT=/path/to/Megatron-LM`.
 - Megatron Lite from this repository. The script automatically adds

--- a/experimental/lite/examples/verl/README.md
+++ b/experimental/lite/examples/verl/README.md
@@ -149,16 +149,15 @@ Useful GRPO knobs:
 - `ACTOR_TP`, `ACTOR_PP`, `ACTOR_VPP`, `ACTOR_CP`, `ACTOR_EP`, `ACTOR_ETP`
 - `PARAM_OFFLOAD`, `OPTIMIZER_OFFLOAD`, `GRAD_OFFLOAD`
 - `INFER_BACKEND=vllm`
-- `USE_LEGACY_WORKER_IMPL=disable` to use VERL's new engine worker path
 - `POLICY_LOSS_MODE=vanilla` and `LOSS_AGG_MODE=seq-mean-token-sum-norm`
   select the pure GRPO baseline policy loss and aggregation mode.
 
 The GRPO launcher keeps the reference policy disabled by default
 (`algorithm.use_kl_in_reward=False`, `actor_rollout_ref.actor.use_kl_loss=False`)
 so the example exercises the current MLite actor path without expanding scope
-to a separate reference model. It also disables VERL's legacy worker path by
-default so `actor@actor_rollout_ref.actor=mlite_actor` is handled by the new
-engine worker implementation.
+to a separate reference model. On latest verl, both the v0 and V1 trainer paths
+route `actor@actor_rollout_ref.actor=mlite_actor` to the unified engine workers,
+so the MLite actor is wired up correctly without any extra worker-path knob.
 
 By default, GSM8K GRPO artifacts are written under
 `experimental/lite/examples/verl/outputs/qwen35_gsm8k_grpo`.
@@ -189,4 +188,4 @@ cover end-to-end SFT or GRPO training.
     `actor_rollout_ref.actor.engine.impl=lite`,
     `actor_rollout_ref.actor.engine.ep=8`,
     `algorithm.adv_estimator=grpo`, `actor_rollout_ref.actor.policy_loss.loss_mode=vanilla`,
-    `critic.enable=False`, and `trainer.use_legacy_worker_impl=disable`.
+    and `critic.enable=False`.

--- a/experimental/lite/examples/verl/REQUIRED_VERL.txt
+++ b/experimental/lite/examples/verl/REQUIRED_VERL.txt
@@ -1,3 +1,4 @@
-# Reference VERL release for the Megatron Lite VERL example.
-# Latest GitHub release checked on 2026-06-06: v0.8.0.
-verl @ git+https://github.com/verl-project/verl.git@v0.8.0
+# Reference VERL source for the Megatron Lite VERL example.
+# Requires verl latest main (engine-worker / V1 trainer architecture).
+# Pinned reference commit: a6ef5009 (verl main as of 2026-06-22).
+verl @ git+https://github.com/verl-project/verl.git@a6ef5009

--- a/experimental/lite/examples/verl/scripts/run_qwen3moe_gsm8k_grpo.sh
+++ b/experimental/lite/examples/verl/scripts/run_qwen3moe_gsm8k_grpo.sh
@@ -163,8 +163,8 @@ export TRITON_CACHE_DIR="${TRITON_CACHE_DIR:-${CACHE_ROOT}/triton_${USER:-user}}
 
 ALGORITHM=(
   "algorithm.adv_estimator=grpo"
-  "algorithm.use_kl_in_reward=False"
-  "algorithm.kl_ctrl.kl_coef=0.0"
+  "algorithm.use_kl_in_reward=${USE_KL_IN_REWARD:-False}"
+  "algorithm.kl_ctrl.kl_coef=${KL_COEF:-0.0}"
   "algorithm.rollout_correction.bypass_mode=True"
   "algorithm.norm_adv_by_std_in_grpo=False"
 )
@@ -200,8 +200,8 @@ ACTOR=(
   "actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=${ACTOR_PPO_MICRO_BATCH_SIZE_PER_GPU}"
   "actor_rollout_ref.actor.use_dynamic_bsz=${USE_DYNAMIC_BSZ}"
   "actor_rollout_ref.actor.ppo_max_token_len_per_gpu=${PPO_MAX_TOKEN_LEN_PER_GPU}"
-  "actor_rollout_ref.actor.use_kl_loss=False"
-  "actor_rollout_ref.actor.kl_loss_coef=0.0"
+  "actor_rollout_ref.actor.use_kl_loss=${USE_KL_LOSS:-False}"
+  "actor_rollout_ref.actor.kl_loss_coef=${KL_LOSS_COEF:-0.0}"
   "actor_rollout_ref.actor.entropy_coeff=${ENTROPY_COEFF}"
   "actor_rollout_ref.actor.policy_loss.loss_mode=${POLICY_LOSS_MODE}"
   "actor_rollout_ref.actor.loss_agg_mode=${LOSS_AGG_MODE}"
@@ -228,6 +228,15 @@ if [[ "${OPTIMIZER_OFFLOAD}" == "True" || "${OPTIMIZER_OFFLOAD}" == "true" || "$
     "+actor_rollout_ref.actor.optim.override_optimizer_config.use_precision_aware_optimizer=${USE_PRECISION_AWARE_OPTIMIZER}"
     "+actor_rollout_ref.actor.optim.override_optimizer_config.decoupled_weight_decay=${DECOUPLED_WEIGHT_DECAY}"
   )
+fi
+
+# Reference policy: only built when KL loss/reward is enabled. Route it through
+# the mlite engine (forward-only) so it runs on the same mesh as the actor;
+# otherwise the ref worker falls back to the FSDP engine config and mlite's
+# get_data_parallel_size() raises AttributeError on the missing `tp` field. Left
+# off the default path so KL-free GRPO never composes the ref override.
+if [[ "${USE_KL_LOSS:-False}" == "True" || "${USE_KL_IN_REWARD:-False}" == "True" ]]; then
+  ACTOR+=("ref@actor_rollout_ref.ref=mlite_ref")
 fi
 
 ROLLOUT=(

--- a/experimental/lite/examples/verl/scripts/run_qwen3moe_gsm8k_grpo.sh
+++ b/experimental/lite/examples/verl/scripts/run_qwen3moe_gsm8k_grpo.sh
@@ -114,7 +114,8 @@ RESUME_MODE="${RESUME_MODE:-auto}"
 RESUME_FROM_PATH="${RESUME_FROM_PATH:-null}"
 LOG_VAL_GENERATIONS="${LOG_VAL_GENERATIONS:-10}"
 LOGGER="${LOGGER:-[console,file]}"
-USE_LEGACY_WORKER_IMPL="${USE_LEGACY_WORKER_IMPL:-disable}"
+# Recent VERL removed trainer.use_legacy_worker_impl and always uses the unified
+# engine worker, so the launcher never sets it (legacy path is not supported).
 DRY_RUN="${DRY_RUN:-0}"
 EXTRA_ARGS=("$@")
 
@@ -288,7 +289,6 @@ TRAINER=(
   "trainer.default_local_dir=${CKPT_DIR}"
   "trainer.val_before_train=False"
   "trainer.log_val_generations=${LOG_VAL_GENERATIONS}"
-  "trainer.use_legacy_worker_impl=${USE_LEGACY_WORKER_IMPL}"
 )
 
 COMMAND=(

--- a/experimental/lite/examples/verl/scripts/run_qwen3moe_gsm8k_grpo.sh
+++ b/experimental/lite/examples/verl/scripts/run_qwen3moe_gsm8k_grpo.sh
@@ -235,7 +235,7 @@ fi
 # otherwise the ref worker falls back to the FSDP engine config and mlite's
 # get_data_parallel_size() raises AttributeError on the missing `tp` field. Left
 # off the default path so KL-free GRPO never composes the ref override.
-if [[ "${USE_KL_LOSS:-False}" == "True" || "${USE_KL_IN_REWARD:-False}" == "True" ]]; then
+if [[ "${USE_KL_LOSS:-False}" =~ ^(True|true|1)$ || "${USE_KL_IN_REWARD:-False}" =~ ^(True|true|1)$ ]]; then
   ACTOR+=("ref@actor_rollout_ref.ref=mlite_ref")
 fi
 

--- a/experimental/lite/examples/verl/scripts/run_qwen3moe_gsm8k_grpo.sh
+++ b/experimental/lite/examples/verl/scripts/run_qwen3moe_gsm8k_grpo.sh
@@ -114,8 +114,8 @@ RESUME_MODE="${RESUME_MODE:-auto}"
 RESUME_FROM_PATH="${RESUME_FROM_PATH:-null}"
 LOG_VAL_GENERATIONS="${LOG_VAL_GENERATIONS:-10}"
 LOGGER="${LOGGER:-[console,file]}"
-# Recent VERL removed trainer.use_legacy_worker_impl and always uses the unified
-# engine worker, so the launcher never sets it (legacy path is not supported).
+# Recent VERL always uses the unified engine workers; the launcher sets no
+# worker-path override.
 DRY_RUN="${DRY_RUN:-0}"
 EXTRA_ARGS=("$@")
 

--- a/experimental/lite/examples/verl/verl_mlite/config/ref/mlite_ref.yaml
+++ b/experimental/lite/examples/verl/verl_mlite/config/ref/mlite_ref.yaml
@@ -1,0 +1,41 @@
+# Megatron Lite reference-model config for VERL's new engine worker path.
+#
+# The reference policy is built by ActorRolloutRefWorker from
+# `actor_rollout_ref.ref.engine`, independently of the actor. Without an mlite
+# ref config the ref worker falls back to the default FSDP engine config, whose
+# object has no `tp`/`cp`/`pp`, so mlite's get_data_parallel_size() raises
+# `AttributeError: 'FSDPEngineConfig' object has no attribute 'tp'` as soon as a
+# reference policy is requested (use_kl_loss / use_kl_in_reward). This config
+# routes the ref worker through the mlite engine, forward-only, mirroring the
+# actor's parallel layout so the reference log-probs are computed on the same
+# mesh as the actor.
+#
+# Wire it from the launcher with:  ref@actor_rollout_ref.ref=mlite_ref
+defaults:
+  - ref
+  - /optim@optim: megatron
+  - /engine@engine: mlite
+  - _self_
+
+_target_: verl.workers.config.ActorConfig
+
+strategy: mlite
+
+engine:
+  # ref model is forward-only (no optimizer / backward)
+  forward_only: True
+  # mirror the actor's parallel layout so ref runs on the same mesh
+  model_name: ${oc.select:actor_rollout_ref.actor.engine.model_name,auto}
+  impl: ${oc.select:actor_rollout_ref.actor.engine.impl,lite}
+  dtype: ${oc.select:actor_rollout_ref.actor.engine.dtype,bfloat16}
+  tp: ${oc.select:actor_rollout_ref.actor.engine.tp,1}
+  pp: ${oc.select:actor_rollout_ref.actor.engine.pp,1}
+  vpp: ${oc.select:actor_rollout_ref.actor.engine.vpp,1}
+  cp: ${oc.select:actor_rollout_ref.actor.engine.cp,1}
+  ep: ${oc.select:actor_rollout_ref.actor.engine.ep,1}
+  etp: ${oc.select:actor_rollout_ref.actor.engine.etp,null}
+  attention_backend_override: ${oc.select:actor_rollout_ref.actor.engine.attention_backend_override,flash}
+  # ref only runs forward, so default to offloading params to free GPU memory
+  param_offload: ${oc.select:actor_rollout_ref.ref.param_offload,True}
+  impl_cfg:
+    use_thd: ${oc.select:actor_rollout_ref.actor.engine.impl_cfg.use_thd,true}

--- a/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
@@ -26,6 +26,13 @@ from verl.utils.device import get_device_id, get_device_name
 from verl.workers.config import HFModelConfig, OptimizerConfig
 from verl_mlite.compat import load_verl_engine_api
 
+try:
+    # Recent VERL wraps per-step metric values in a Metric aggregator that
+    # reduce_metrics() knows how to fold; older VERL expects list-of-scalars.
+    from verl.utils.metric import Metric as _VerlMetric
+except Exception:  # pragma: no cover - older VERL without Metric
+    _VerlMetric = None
+
 from .config import MegatronLiteEngineConfig
 
 BaseEngine, BaseEngineCtx, EngineRegistry, postprocess_batch_func, prepare_micro_batches = (
@@ -680,7 +687,14 @@ class MegatronLiteEngine(BaseEngine):
         return {
             "model_output": {},
             "loss": [loss],
-            "metrics": {key: [value] for key, value in metrics.items()},
+            # Pass Metric aggregators through unchanged (reduce_metrics folds them);
+            # list-wrap plain scalars as the legacy contract expects.
+            "metrics": {
+                key: value
+                if (_VerlMetric is not None and isinstance(value, _VerlMetric))
+                else [value]
+                for key, value in metrics.items()
+            },
         }
 
     def _make_runtime_batch(self, micro_batch: TensorDict) -> PackedBatch:

--- a/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
@@ -23,6 +23,28 @@ import torch.nn as nn
 from safetensors import safe_open
 from safetensors.torch import save_file as _safe_save
 
+try:
+    from torch.distributed.tensor import DTensor
+except Exception:  # pragma: no cover - older torch without DTensor
+    DTensor = None  # type: ignore[assignment]
+
+
+def _materialize_dtensor(tensor: torch.Tensor) -> torch.Tensor:
+    """Reconstruct a plain local tensor from an FSDP2 ``DTensor`` parameter.
+
+    FSDP2 (``fully_shard``) stores parameters as ``DTensor`` sharded over the
+    data-parallel mesh, while manual TP/EP sharding leaves each rank holding its
+    own local shard as a regular tensor. The HF export gather (``_gather_dense`` /
+    ``_gather_expert``) and the downstream rollout weight sender both assume plain
+    ``torch.Tensor`` inputs; handing them a ``DTensor`` raises
+    ``aten.copy_.default: got mixed torch.Tensor and DTensor``. ``full_tensor()``
+    gathers the FSDP shards back into the full (TP/EP-local) tensor; non-DTensor
+    params (dist_opt backend) pass through untouched.
+    """
+    if DTensor is not None and isinstance(tensor, DTensor):
+        return tensor.full_tensor()
+    return tensor
+
 
 @runtime_checkable
 class HFWeights(Protocol):
@@ -406,7 +428,7 @@ def export_hf_weights(
             )
             for name, param in base_chunk.named_parameters():
                 gname = to_global_layer_name(name, layer_map)
-                tensor = param.data.detach()
+                tensor = _materialize_dtensor(param.data.detach())
 
                 gathered_one: dict[str, torch.Tensor] = {}
                 if spec.is_expert(gname):
@@ -454,7 +476,7 @@ def export_hf_weights(
         )
         for name, param in base_chunk.named_parameters():
             gname = to_global_layer_name(name, layer_map)
-            t = param.data.detach()
+            t = _materialize_dtensor(param.data.detach())
 
             if spec.is_expert(gname):
                 _gather_expert(gname, t, spec, ps, gathered)

--- a/experimental/lite/tests/smoke/primitive/test_qwen35_hf_numeric_roundtrip_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_qwen35_hf_numeric_roundtrip_smoke.py
@@ -1,0 +1,224 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Qwen3.5 HF<->lite checkpoint NUMERIC round-trip + ground-truth smoke.
+
+The existing export unit tests (tests/unit/model/test_qwen35_export.py) and the
+save/load/export coverage smoke only assert NAMES / DTYPE / FINITENESS, never
+numeric fidelity — so a transform that is self-consistent on the round-trip but
+wrong vs real HF would pass silently. This smoke closes that blind spot:
+
+  test_qwen35_save_load_numeric_roundtrip
+    build A(seed1) -> save_hf -> build B(seed2) -> load_hf(B) -> assert every
+    param allclose(A, B). Catches ASYMMETRIC load/export bugs (load != inverse
+    of export). Vocab embed/head rows >= vocab_size are unused TP-padding (random
+    in A, zeroed on reload) and are excluded; the real model has vocab%128==0 so
+    no padding exists.
+
+  test_qwen35_real_hf_load_export_matches_original  [opt-in: QWEN35_HF_DIR]
+    GROUND TRUTH against real Qwen3.5 safetensors: load real HF -> export ->
+    compare to the ORIGINAL safetensors tensor-by-tensor. Catches HF-file-level
+    mismatches that native round-trip cannot see. It does NOT prove the loaded
+    native layout is semantically correct if load/export are mutually inverse but
+    both wrong vs forward semantics. Needs an 80GB GPU; loads only the first 8
+    decoder layers to bound memory/time.
+
+Run single GPU:
+  torchrun --nproc_per_node=1 -m pytest tests/smoke/primitive/test_qwen35_hf_numeric_roundtrip_smoke.py
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+
+pytestmark = [pytest.mark.mlite, pytest.mark.smoke, pytest.mark.gpu]
+
+
+def _qwen35_tiny_cfg():
+    pytest.importorskip("fla", reason="qwen3_5 needs the FLA / GatedDeltaNet stack.")
+    pytest.importorskip(
+        "transformer_engine.pytorch", reason="qwen3_5 smoke needs real Transformer Engine."
+    )
+    from megatron.lite.model.qwen3_5.config import Qwen35Config
+
+    return Qwen35Config(
+        num_hidden_layers=2,
+        hidden_size=16,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=4,
+        vocab_size=64,
+        num_experts=4,
+        num_experts_per_tok=2,
+        moe_intermediate_size=8,
+        shared_expert_intermediate_size=8,
+        linear_num_key_heads=2,
+        linear_key_head_dim=4,
+        linear_num_value_heads=2,
+        linear_value_head_dim=4,
+        linear_conv_kernel_dim=4,
+        layer_types=["full_attention", "linear_attention"],
+        partial_rotary_factor=1.0,
+        max_position_embeddings=4096,
+    )
+
+
+def _build(cfg, seed):
+    from megatron.lite.model.qwen3_5.lite import protocol
+    from megatron.lite.runtime.contracts.config import ParallelConfig
+
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    parallel = ParallelConfig(tp=1, pp=1, cp=1, ep=1, etp=1, vpp=1)
+    impl = protocol.ImplConfig(
+        parallel=parallel, optimizer="dist_opt", use_deepep=False, deterministic=True
+    )
+    bundle = protocol.build_model(cfg, impl_cfg=impl)
+    return bundle, protocol
+
+
+def _named(chunks):
+    out = {}
+    for i, chunk in enumerate(chunks):
+        for name, param in chunk.named_parameters():
+            out[f"{i}.{name}"] = param.detach().float().cpu().clone()
+    return out
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _single_rank_dist():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required for qwen3.5 numeric round-trip smoke.")
+    created = False
+    if not dist.is_initialized():
+        for k, v in {
+            "MASTER_ADDR": "127.0.0.1",
+            "MASTER_PORT": "29597",
+            "RANK": "0",
+            "WORLD_SIZE": "1",
+            "LOCAL_RANK": "0",
+        }.items():
+            os.environ.setdefault(k, v)
+        local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+        torch.cuda.set_device(local_rank)
+        dist.init_process_group("nccl")
+        created = True
+    yield
+    if created and dist.is_initialized():
+        dist.destroy_process_group()
+
+
+def test_qwen35_save_load_numeric_roundtrip(tmp_path):
+    if dist.get_world_size() != 1:
+        pytest.skip("numeric round-trip smoke runs single-rank (tp1).")
+    cfg = _qwen35_tiny_cfg()
+    a, proto = _build(cfg, seed=1)
+    b, _ = _build(cfg, seed=2)
+
+    before = _named(a.chunks)
+    b_before = _named(b.chunks)
+    assert sum(1 for k in before if not torch.equal(before[k], b_before[k])) > 0
+
+    out_dir = str(tmp_path / "hf")
+    os.makedirs(out_dir, exist_ok=True)
+    proto.save_hf_weights(a.chunks, out_dir, cfg, a.parallel_state)
+    proto.load_hf_weights(b.chunks[0], out_dir, cfg, b.parallel_state)
+
+    pa, pb = _named(a.chunks), _named(b.chunks)
+    vocab = cfg.vocab_size
+    mism = []
+    for k in pa:
+        ta, tb = pa[k], pb[k]
+        if k.endswith("embed.embedding.weight") or k.endswith("head.col.linear.weight"):
+            assert ta.shape[0] >= vocab
+            ta, tb = ta[:vocab], tb[:vocab]  # exclude unused TP-padding rows
+        # atol/rtol=1e-3 are bf16-cast round-trip tolerances.
+        if not torch.allclose(ta, tb, atol=1e-3, rtol=1e-3):
+            mism.append(f"{k} (max_abs_diff={(ta - tb).abs().max().item()})")
+    assert not mism, "HF save->load not numeric round-trip:\n" + "\n".join(mism)
+
+
+@pytest.mark.skipif(
+    not os.environ.get("QWEN35_HF_DIR"),
+    reason="set QWEN35_HF_DIR to a real Qwen3.5 HF checkpoint to run the ground-truth check.",
+)
+def test_qwen35_real_hf_load_export_matches_original(tmp_path):
+    if dist.get_world_size() != 1:
+        pytest.skip("ground-truth smoke runs single-rank (tp1).")
+    import json
+
+    from safetensors import safe_open
+
+    from megatron.lite.model.qwen3_5.config import Qwen35Config
+    from megatron.lite.model.qwen3_5.lite import protocol
+    from megatron.lite.runtime.contracts.config import ParallelConfig
+
+    model_dir = os.environ["QWEN35_HF_DIR"]
+    cfg = Qwen35Config.from_hf(model_dir)
+    n = min(8, cfg.num_hidden_layers)
+    cfg.num_hidden_layers = n
+    cfg.layer_types = cfg.layer_types[:n]
+    cfg.num_nextn_predict_layers = 0
+    # Ensure both attention branches are actually exercised in the truncated model.
+    assert "full_attention" in cfg.layer_types
+    assert "linear_attention" in cfg.layer_types
+
+    parallel = ParallelConfig(tp=1, pp=1, cp=1, ep=1, etp=1, vpp=1)
+    impl = protocol.ImplConfig(
+        parallel=parallel, optimizer="dist_opt", use_deepep=False, deterministic=True
+    )
+    bundle = protocol.build_model(cfg, impl_cfg=impl)
+    protocol.load_hf_weights(bundle.chunks[0], model_dir, cfg, bundle.parallel_state)
+
+    out_dir = str(tmp_path / "hf_export")
+    os.makedirs(out_dir, exist_ok=True)
+    protocol.save_hf_weights(bundle.chunks, out_dir, cfg, bundle.parallel_state)
+
+    orig_map = json.load(open(os.path.join(model_dir, "model.safetensors.index.json")))[
+        "weight_map"
+    ]
+
+    def _orig(key):
+        with safe_open(os.path.join(model_dir, orig_map[key]), framework="pt") as fh:
+            return fh.get_tensor(key).float()
+
+    exported = {}
+    for fn in os.listdir(out_dir):
+        if fn.endswith(".safetensors"):
+            with safe_open(os.path.join(out_dir, fn), framework="pt") as fh:
+                for key in fh.keys():
+                    exported[key] = fh.get_tensor(key).float()
+
+    # Derive the expected comparison set from the ORIGINAL weight map (not from
+    # `exported`): otherwise a tensor the exporter silently drops would never be
+    # compared and a missing-export bug would pass undetected.
+    #
+    # Scope to what this truncated text-only build actually produces: the first
+    # `n` decoder layers (prefix `model.language_model.layers.{i}.`) plus the
+    # global embed/norm/head tensors. The original checkpoint also carries the
+    # MTP head (`mtp.*`, disabled here via num_nextn_predict_layers=0) and the
+    # vision tower (`model.visual.*`, not built on the text path); both are
+    # intentionally NOT built/exported, so they are excluded from expected_keys.
+    global_keys = (
+        "model.language_model.embed_tokens.weight",
+        "model.language_model.norm.weight",
+        "lm_head.weight",
+    )
+    layer_prefixes = tuple(f"model.language_model.layers.{i}." for i in range(n))
+    expected_keys = {
+        k for k in orig_map if k.startswith(layer_prefixes) or k in global_keys
+    }
+    assert expected_keys, "no comparable tensors found in original weight map."
+
+    missing = expected_keys - set(exported)
+    assert not missing, "export missing tensors: " + ", ".join(sorted(missing))
+
+    mism = []
+    for k in sorted(expected_keys):
+        o, e = _orig(k), exported[k]
+        if o.shape != e.shape:
+            mism.append(f"{k} shape {tuple(o.shape)} != {tuple(e.shape)}")
+        elif not torch.allclose(o, e, atol=2e-2, rtol=2e-2):  # bf16-cast export tolerance
+            mism.append(f"{k} max_abs_diff={(o - e).abs().max().item()}")
+    assert not mism, "lite export does not match original HF safetensors:\n" + "\n".join(mism)


### PR DESCRIPTION
## Summary

Fixes that let Qwen3.5 (GDN MoE) run GRPO/PPO RL through the MLite VERL engine with the FSDP2 optimizer backend, surfaced while reproducing a Qwen3.5-35B-A3B GRPO run.

### 1. HF export: materialize FSDP2 `DTensor` params before gather
Under the `fsdp2` optimizer backend, `fully_shard` stores parameters as `DTensor` sharded over the data-parallel mesh. The HF weight export (`primitive/ckpt/hf_weights.py`) and the downstream vLLM rollout weight sender both assume plain `torch.Tensor`s, so during RL weight sync the exported `DTensor`s reach the sender and raise:

```
RuntimeError: aten.copy_.default: got mixed torch.Tensor and DTensor,
need to convert all torch.Tensor to DTensor before calling distributed operators!
```

`export_hf_weights` now reconstructs the full local tensor via `full_tensor()` at export entry before the TP/ETP/EP/PP gather. `dist_opt` (non-DTensor) params pass through unchanged.

### 2. Reference policy via a forward-only MLite engine
The reference policy is built from `actor_rollout_ref.ref.engine` independently of the actor. With no MLite ref config it falls back to the default FSDP engine config, whose object has no `tp`/`cp`/`pp`, so `get_data_parallel_size()` raises `AttributeError: 'FSDPEngineConfig' object has no attribute 'tp'` as soon as a reference policy is requested (`use_kl_loss` / `use_kl_in_reward`).

Adds `verl_mlite/config/ref/mlite_ref.yaml`: a forward-only MLite ref config mirroring the actor's parallel layout. The GRPO example launcher wires `ref@actor_rollout_ref.ref=mlite_ref` only when KL is enabled, so KL-free GRPO never composes the override. KL knobs (`USE_KL_LOSS` / `USE_KL_IN_REWARD`) are now env-configurable in the launcher.

## Validation
- DTensor export fix: 8-GPU Qwen3.5 (GDN MoE) GRPO, fsdp2, reproduced the mixed-DTensor error pre-fix and passed RL weight sync post-fix.
- Ref config: Hydra `--cfg job` compose check with KL enabled resolves `ref.strategy=mlite` cleanly.
