### PR TITLE
[lite] Harden GLM5.2 readiness and checkpoint recovery (#66 follow-up)

### DIFF
--- a/experimental/lite/.pre-commit-config.yaml
+++ b/experimental/lite/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
     language: python
     additional_dependencies: ["isort==5.13.2"]
     files: ^experimental/lite/.*\.py$
+    args: ["--profile", "black"]
   - id: black
     name: black
     entry: black

--- a/experimental/lite/examples/verl/REQUIRED_VERL.txt
+++ b/experimental/lite/examples/verl/REQUIRED_VERL.txt
@@ -1,4 +1,6 @@
 # Reference VERL source for the Megatron Lite VERL example.
-# Requires verl latest main (engine-worker / V1 trainer architecture).
-# Pinned reference commit: a6ef5009 (verl main as of 2026-06-22).
-verl @ git+https://github.com/verl-project/verl.git@a6ef5009
+# Requires the engine-worker / V1 trainer architecture on upstream main.
+# Pinned upstream main commit: 1ff76cc625e9820d2434dad1b6d9b8e5dd26a359
+# (2026-06-27). The former a6ef5009 pin was PR #6791's pre-squash head,
+# not a main-branch authority commit.
+verl @ git+https://github.com/verl-project/verl.git@1ff76cc625e9820d2434dad1b6d9b8e5dd26a359

--- a/experimental/lite/examples/verl/scripts/run_qwen3moe_sft.sh
+++ b/experimental/lite/examples/verl/scripts/run_qwen3moe_sft.sh
@@ -224,8 +224,10 @@ COMMAND=(
   verl.trainer.sft_trainer
   "${COMMON_ARGS[@]}"
   "${BACKEND_ARGS[@]}"
-  "${EXTRA_ARGS[@]}"
 )
+if (( ${#EXTRA_ARGS[@]} > 0 )); then
+  COMMAND+=("${EXTRA_ARGS[@]}")
+fi
 
 printf '%q ' "${COMMAND[@]}" > "${CMD_FILE}"
 printf '\n' >> "${CMD_FILE}"

--- a/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
@@ -3,23 +3,33 @@
 
 from __future__ import annotations
 
+import copy
 import math
 import os
+from collections.abc import Mapping
 from enum import Enum
+from pathlib import Path
 from typing import Any
 
 import torch
 import torch.distributed as dist
 from megatron.lite.model import resolve_model_type_from_hf
-from megatron.lite.primitive.ckpt import load_training_checkpoint, save_training_checkpoint
-from megatron.lite.primitive.protocols import default_expert_classifier, default_placement_fn
+from megatron.lite.primitive.ckpt import (
+    load_training_checkpoint,
+    save_training_checkpoint,
+)
+from megatron.lite.primitive.protocols import (
+    default_expert_classifier,
+    default_placement_fn,
+)
 from megatron.lite.runtime import create_runtime
 from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig
 from megatron.lite.runtime.contracts import LossContext, PackedBatch
-from megatron.lite.runtime.contracts.config import OptimizerConfig as MegatronLiteOptimizerConfig
+from megatron.lite.runtime.contracts.config import (
+    OptimizerConfig as MegatronLiteOptimizerConfig,
+)
 from megatron.lite.runtime.contracts.config import ParallelConfig, RuntimeConfig
 from tensordict import TensorDict
-
 from verl.trainer.config import CheckpointConfig
 from verl.utils import tensordict_utils as tu
 from verl.utils.device import get_device_id, get_device_name
@@ -35,9 +45,13 @@ except Exception:  # pragma: no cover - older VERL without Metric
 
 from .config import MegatronLiteEngineConfig
 
-BaseEngine, BaseEngineCtx, EngineRegistry, postprocess_batch_func, prepare_micro_batches = (
-    load_verl_engine_api()
-)
+(
+    BaseEngine,
+    BaseEngineCtx,
+    EngineRegistry,
+    postprocess_batch_func,
+    prepare_micro_batches,
+) = load_verl_engine_api()
 
 try:
     from verl.utils.dataset.dataset_utils import DatasetPadMode
@@ -48,6 +62,340 @@ except ImportError:
 
 
 _LR_SCHEDULER_STATE = "lr_scheduler.pt"
+_LR_SCHEDULER_FORMAT = "megatron_lite.lr_scheduler.v1"
+_LR_SCHEDULER_PAYLOAD_FORMAT = "megatron_lite.lr_scheduler_sidecar.v1"
+_LR_SCHEDULER_CONFIG_FIELDS = (
+    "init_lr",
+    "max_lr",
+    "min_lr",
+    "lr_warmup_steps",
+    "lr_decay_steps",
+    "lr_decay_style",
+    "start_wd",
+    "end_wd",
+    "wd_incr_steps",
+    "wd_incr_style",
+    "wsd_decay_steps",
+    "lr_wsd_decay_style",
+)
+_CHECKPOINT_CONTENT_KEYS = frozenset({"model", "optimizer", "extra"})
+
+
+def _content_set(contents: Any, *, key: str = "checkpoint contents") -> set[str]:
+    """Normalize VERL/Hydra checkpoint content values without substring matches."""
+
+    def normalize_entry(item: str) -> str:
+        return item.strip().strip("'\"").strip()
+
+    if contents is None:
+        return set()
+    if isinstance(contents, str):
+        contents = contents.strip()
+        if contents.startswith("[") and contents.endswith("]"):
+            contents = contents[1:-1].strip()
+        if "," in contents:
+            result = {
+                entry
+                for item in contents.split(",")
+                if (entry := normalize_entry(item))
+            }
+        else:
+            entry = normalize_entry(contents)
+            result = {entry} if entry else set()
+    else:
+        if isinstance(contents, Mapping):
+            raise TypeError(f"{key} must be None, a string, or a sequence of strings.")
+        try:
+            iterator = iter(contents)
+        except TypeError as exc:
+            raise TypeError(
+                f"{key} must be None, a string, or a sequence of strings."
+            ) from exc
+        result = set()
+        for item in iterator:
+            if not isinstance(item, str):
+                raise TypeError(
+                    f"{key} entries must be strings, got {type(item).__name__}."
+                )
+            entry = normalize_entry(item)
+            if entry:
+                result.add(entry)
+
+    unknown = sorted(result - _CHECKPOINT_CONTENT_KEYS)
+    if unknown:
+        raise ValueError(
+            f"{key} contains unsupported entries {unknown}; "
+            f"allowed={sorted(_CHECKPOINT_CONTENT_KEYS)}."
+        )
+    return result
+
+
+def _content_set_with_consensus(contents: Any, *, key: str) -> set[str]:
+    result: set[str] = set()
+    local_error: str | None = None
+    try:
+        result = _content_set(contents, key=key)
+    except Exception as exc:
+        local_error = f"{type(exc).__name__}: {exc}"
+    if dist.is_initialized():
+        errors: list[str | None] = [None] * dist.get_world_size()
+        dist.all_gather_object(errors, local_error)
+        first_error = next((error for error in errors if error is not None), None)
+        if first_error is not None:
+            raise RuntimeError(f"Megatron Lite {key} validation failed: {first_error}")
+        per_rank: list[tuple[str, ...] | None] = [None] * dist.get_world_size()
+        normalized = tuple(sorted(result))
+        dist.all_gather_object(per_rank, normalized)
+        if any(item != per_rank[0] for item in per_rank[1:]):
+            raise RuntimeError(f"Megatron Lite {key} differs across ranks: {per_rank}.")
+    elif local_error is not None:
+        raise RuntimeError(f"Megatron Lite {key} validation failed: {local_error}")
+    return result
+
+
+def _validate_lr_scheduler_state(state: Any) -> None:
+    """Reject incomplete or ambiguous scheduler state before core restore."""
+
+    if not isinstance(state, dict):
+        raise TypeError(
+            "Megatron Lite LR scheduler checkpoint state must be a dictionary, "
+            f"got {type(state).__name__}."
+        )
+    expected_keys = {"format", "num_steps", "config"}
+    if set(state) != expected_keys:
+        raise ValueError(
+            "Megatron Lite LR scheduler checkpoint state has an invalid schema: "
+            f"missing={sorted(expected_keys - set(state))}, "
+            f"unexpected={sorted(set(state) - expected_keys)}."
+        )
+    if state["format"] != _LR_SCHEDULER_FORMAT:
+        raise ValueError(
+            "Unsupported Megatron Lite LR scheduler checkpoint format: "
+            f"{state['format']!r}."
+        )
+    num_steps = state["num_steps"]
+    if isinstance(num_steps, bool) or not isinstance(num_steps, int):
+        raise TypeError(
+            "Megatron Lite LR scheduler checkpoint step must be a non-negative integer."
+        )
+    if num_steps < 0:
+        raise ValueError(
+            "Megatron Lite LR scheduler checkpoint step must be a non-negative integer."
+        )
+    config = state["config"]
+    if not isinstance(config, dict) or set(config) != set(_LR_SCHEDULER_CONFIG_FIELDS):
+        raise ValueError(
+            "Megatron Lite LR scheduler checkpoint config has an invalid schema."
+        )
+    int_fields = ("lr_warmup_steps", "lr_decay_steps", "wd_incr_steps")
+    for name in int_fields:
+        value = config[name]
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise TypeError(
+                f"Megatron Lite LR scheduler config {name} must be a non-negative integer."
+            )
+    if config["lr_decay_steps"] < config["lr_warmup_steps"] + 1:
+        raise ValueError(
+            "Megatron Lite LR scheduler config lr_decay_steps must be greater "
+            "than lr_warmup_steps."
+        )
+    if config["wd_incr_steps"] < 1:
+        raise ValueError(
+            "Megatron Lite LR scheduler config wd_incr_steps must be at least one."
+        )
+    wsd_decay_steps = config["wsd_decay_steps"]
+    if wsd_decay_steps is not None and (
+        isinstance(wsd_decay_steps, bool)
+        or not isinstance(wsd_decay_steps, int)
+        or wsd_decay_steps < 0
+    ):
+        raise TypeError(
+            "Megatron Lite LR scheduler config wsd_decay_steps must be None or "
+            "a non-negative integer."
+        )
+    float_fields = ("init_lr", "max_lr", "min_lr", "start_wd", "end_wd")
+    for name in float_fields:
+        value = config[name]
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(
+                f"Megatron Lite LR scheduler config {name} must be a finite number."
+            )
+        if not math.isfinite(float(value)):
+            raise ValueError(
+                f"Megatron Lite LR scheduler config {name} must be finite."
+            )
+    if config["min_lr"] < 0.0:
+        raise ValueError("Megatron Lite LR scheduler min_lr must be non-negative.")
+    if config["max_lr"] < config["min_lr"]:
+        raise ValueError(
+            "Megatron Lite LR scheduler max_lr must be greater than or equal to min_lr."
+        )
+    if config["init_lr"] < 0.0 or config["init_lr"] > config["max_lr"]:
+        raise ValueError(
+            "Megatron Lite LR scheduler init_lr must be non-negative and no greater "
+            "than max_lr."
+        )
+    if config["start_wd"] < 0.0:
+        raise ValueError("Megatron Lite LR scheduler start_wd must be non-negative.")
+    if config["end_wd"] < config["start_wd"]:
+        raise ValueError(
+            "Megatron Lite LR scheduler end_wd must be greater than or equal to start_wd."
+        )
+    lr_styles = {"constant", "linear", "cosine", "inverse-square-root", "wsd"}
+    wd_styles = {"constant", "linear", "cosine"}
+    wsd_styles = {"linear", "cosine", "exponential", "minus_sqrt"}
+    if config["lr_decay_style"] not in lr_styles:
+        raise ValueError(
+            "Megatron Lite LR scheduler checkpoint has unsupported lr_decay_style "
+            f"{config['lr_decay_style']!r}."
+        )
+    if config["lr_decay_style"] == "wsd":
+        max_wsd_steps = config["lr_decay_steps"] - config["lr_warmup_steps"]
+        if wsd_decay_steps is None or not 1 <= wsd_decay_steps <= max_wsd_steps:
+            raise ValueError(
+                "Megatron Lite WSD scheduler requires 1 <= wsd_decay_steps <= "
+                "lr_decay_steps - lr_warmup_steps."
+            )
+    if config["wd_incr_style"] not in wd_styles:
+        raise ValueError(
+            "Megatron Lite LR scheduler checkpoint has unsupported wd_incr_style "
+            f"{config['wd_incr_style']!r}."
+        )
+    if config["lr_wsd_decay_style"] not in wsd_styles:
+        raise ValueError(
+            "Megatron Lite LR scheduler checkpoint has unsupported lr_wsd_decay_style "
+            f"{config['lr_wsd_decay_style']!r}."
+        )
+
+
+def _scheduler_state_with_consensus(scheduler) -> dict[str, Any]:
+    state: dict[str, Any] = {}
+    local_error: str | None = None
+    try:
+        state = scheduler.state_dict()
+        _validate_lr_scheduler_state(state)
+    except Exception as exc:
+        local_error = f"{type(exc).__name__}: {exc}"
+    if dist.is_initialized():
+        errors: list[str | None] = [None] * dist.get_world_size()
+        dist.all_gather_object(errors, local_error)
+        first_error = next((error for error in errors if error is not None), None)
+        if first_error is not None:
+            raise RuntimeError(
+                "Megatron Lite LR scheduler state serialization failed on at least "
+                f"one rank: {first_error}"
+            )
+        per_rank_states: list[dict[str, Any] | None] = [None] * dist.get_world_size()
+        dist.all_gather_object(per_rank_states, state)
+        if any(item != per_rank_states[0] for item in per_rank_states[1:]):
+            raise RuntimeError(
+                "Megatron Lite LR scheduler state differs across ranks: "
+                f"states={per_rank_states}."
+            )
+    elif local_error is not None:
+        raise RuntimeError(
+            f"Megatron Lite LR scheduler state serialization failed: {local_error}"
+        )
+    return state
+
+
+def _scheduler_payload(scheduler, *, checkpoint_step: int) -> dict[str, Any]:
+    scheduler_state = _scheduler_state_with_consensus(scheduler)
+    payload: dict[str, Any] = {}
+    local_error: str | None = None
+    try:
+        payload = {
+            "format": _LR_SCHEDULER_PAYLOAD_FORMAT,
+            "checkpoint_step": int(checkpoint_step),
+            "scheduler_state": scheduler_state,
+        }
+        _validate_lr_scheduler_payload(payload, expected_step=checkpoint_step)
+    except Exception as exc:
+        local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(
+        local_error, context="LR scheduler checkpoint payload validation failed"
+    )
+    if dist.is_initialized():
+        per_rank_payloads: list[dict[str, Any] | None] = [None] * dist.get_world_size()
+        dist.all_gather_object(per_rank_payloads, payload)
+        if any(item != per_rank_payloads[0] for item in per_rank_payloads[1:]):
+            raise RuntimeError(
+                "Megatron Lite LR scheduler checkpoint payload differs across ranks: "
+                f"{per_rank_payloads}."
+            )
+    return payload
+
+
+def _validate_lr_scheduler_payload(
+    payload: Any, *, expected_step: int | None = None
+) -> None:
+    if not isinstance(payload, dict):
+        raise TypeError(
+            "Megatron Lite LR scheduler sidecar must be a dictionary, "
+            f"got {type(payload).__name__}."
+        )
+    expected_keys = {"format", "checkpoint_step", "scheduler_state"}
+    if set(payload) != expected_keys:
+        raise ValueError(
+            "Megatron Lite LR scheduler sidecar has an invalid schema: "
+            f"missing={sorted(expected_keys - set(payload))}, "
+            f"unexpected={sorted(set(payload) - expected_keys)}."
+        )
+    if payload["format"] != _LR_SCHEDULER_PAYLOAD_FORMAT:
+        raise ValueError(
+            "Unsupported Megatron Lite LR scheduler sidecar format: "
+            f"{payload['format']!r}."
+        )
+    checkpoint_step = payload["checkpoint_step"]
+    if (
+        isinstance(checkpoint_step, bool)
+        or not isinstance(checkpoint_step, int)
+        or checkpoint_step < 0
+    ):
+        raise TypeError(
+            "Megatron Lite LR scheduler sidecar checkpoint_step must be a "
+            "non-negative integer."
+        )
+    if expected_step is not None and checkpoint_step != expected_step:
+        raise RuntimeError(
+            "Megatron Lite LR scheduler sidecar/core step mismatch: "
+            f"scheduler={checkpoint_step}, core={expected_step}."
+        )
+    _validate_lr_scheduler_state(payload["scheduler_state"])
+    scheduler_step = payload["scheduler_state"]["num_steps"]
+    if scheduler_step != checkpoint_step:
+        raise RuntimeError(
+            "Megatron Lite LR scheduler progress/core step mismatch: "
+            f"scheduler={scheduler_step}, core={checkpoint_step}."
+        )
+
+
+def _checkpoint_components_with_consensus(
+    *, model: bool, optimizer: bool, extra: bool, scheduler_present: bool, context: str
+) -> None:
+    if not dist.is_initialized():
+        return
+    local = (bool(model), bool(optimizer), bool(extra), bool(scheduler_present))
+    per_rank: list[tuple[bool, bool, bool, bool] | None] = [
+        None
+    ] * dist.get_world_size()
+    dist.all_gather_object(per_rank, local)
+    if any(item != per_rank[0] for item in per_rank[1:]):
+        raise RuntimeError(
+            f"Megatron Lite {context} component policy differs across ranks: "
+            f"{per_rank}."
+        )
+
+
+def _distributed_raise_if_error(local_error: str | None, *, context: str) -> None:
+    if dist.is_initialized():
+        errors: list[str | None] = [None] * dist.get_world_size()
+        dist.all_gather_object(errors, local_error)
+        first_error = next((error for error in errors if error is not None), None)
+        if first_error is not None:
+            raise RuntimeError(f"Megatron Lite {context}: {first_error}")
+    elif local_error is not None:
+        raise RuntimeError(f"Megatron Lite {context}: {local_error}")
 
 
 def _isolate_compile_cache_per_rank() -> None:
@@ -92,31 +440,63 @@ class _MegatronLiteLRScheduler:
         wd_incr_style: str,
         wsd_decay_steps: int | None,
         lr_wsd_decay_style: str,
+        use_checkpoint_config: bool,
     ):
         self.optimizer = optimizer
+        if not isinstance(use_checkpoint_config, bool):
+            raise TypeError("use_checkpoint_config must be bool.")
+        self.use_checkpoint_config = use_checkpoint_config
         self.init_lr = init_lr
         self.max_lr = max_lr
         self.min_lr = min_lr
-        self.lr_warmup_steps = max(lr_warmup_steps, 0)
-        self.lr_decay_steps = max(lr_decay_steps, self.lr_warmup_steps + 1)
+        self.lr_warmup_steps = lr_warmup_steps
+        self.lr_decay_steps = lr_decay_steps
         self.lr_decay_style = lr_decay_style.lower()
+        if self.lr_decay_style == "inverse_square_root":
+            self.lr_decay_style = "inverse-square-root"
         self.start_wd = start_wd
         self.end_wd = end_wd
-        self.wd_incr_steps = max(wd_incr_steps, 1)
+        self.wd_incr_steps = wd_incr_steps
         self.wd_incr_style = wd_incr_style.lower()
         self.wsd_decay_steps = wsd_decay_steps
         self.lr_wsd_decay_style = lr_wsd_decay_style.lower()
         self.num_steps = 0
+        _validate_lr_scheduler_state(self.state_dict())
         self._apply()
 
     def state_dict(self) -> dict[str, Any]:
-        return {"num_steps": self.num_steps}
+        return {
+            "format": _LR_SCHEDULER_FORMAT,
+            "num_steps": self.num_steps,
+            "config": self._config_state(),
+        }
 
     def load_state_dict(self, state: dict[str, Any]) -> None:
-        self.num_steps = int(state.get("num_steps", state.get("step", 0)))
+        _validate_lr_scheduler_state(state)
+        checkpoint_config = state["config"]
+        if self.use_checkpoint_config:
+            self._set_config_state(checkpoint_config)
+        # Match VERL's MCore wrapper semantics: VERL passes
+        # override_opt_param_scheduler=not use_checkpoint_opt_param_scheduler.
+        # Thus false deliberately keeps runtime config (for example when
+        # extending total_training_steps), while true adopts checkpoint config.
+        self.num_steps = state["num_steps"]
         self._apply()
 
+    def _config_state(self) -> dict[str, Any]:
+        return {name: getattr(self, name) for name in _LR_SCHEDULER_CONFIG_FIELDS}
+
+    def _set_config_state(self, config: dict[str, Any]) -> None:
+        for name in _LR_SCHEDULER_CONFIG_FIELDS:
+            setattr(self, name, config[name])
+
     def step(self, increment: int = 1) -> None:
+        if (
+            isinstance(increment, bool)
+            or not isinstance(increment, int)
+            or increment < 0
+        ):
+            raise ValueError("LR scheduler increment must be a non-negative integer.")
         self.num_steps += increment
         self._apply()
 
@@ -124,46 +504,131 @@ class _MegatronLiteLRScheduler:
         return [group["lr"] for group in self.optimizer.param_groups]
 
     def _apply(self) -> None:
-        lr = self._get_lr()
-        wd = self._get_wd()
+        updates: list[tuple[dict[str, Any], float, float]] = []
         for param_group in self.optimizer.param_groups:
-            param_group["lr"] = lr
-            if param_group.get("weight_decay", None) is not None:
-                param_group["weight_decay"] = wd
+            lr = self._get_lr(param_group)
+            wd_mult = self._finite_group_number(
+                param_group, "wd_mult", default=1.0, non_negative=True
+            )
+            updates.append((param_group, lr, self._get_wd(param_group) * wd_mult))
+        for param_group, lr, weight_decay in updates:
+            if isinstance(param_group.get("lr"), torch.Tensor):
+                param_group["lr"].fill_(lr)
+            else:
+                param_group["lr"] = lr
+            param_group["weight_decay"] = weight_decay
 
-    def _get_lr(self) -> float:
+    @staticmethod
+    def _finite_group_number(
+        param_group: dict[str, Any], name: str, *, default: float, non_negative: bool
+    ) -> float:
+        value = param_group.get(name, default)
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(f"Optimizer param-group {name} must be a finite number.")
+        value = float(value)
+        if not math.isfinite(value):
+            raise ValueError(f"Optimizer param-group {name} must be finite.")
+        if non_negative and value < 0.0:
+            raise ValueError(f"Optimizer param-group {name} must be non-negative.")
+        return value
+
+    def _group_lr_bounds(
+        self, param_group: dict[str, Any]
+    ) -> tuple[float, float, float]:
+        lr_mult = self._finite_group_number(
+            param_group, "lr_mult", default=1.0, non_negative=True
+        )
+        has_explicit_bounds = "max_lr" in param_group or "min_lr" in param_group
+        if has_explicit_bounds and lr_mult != 1.0:
+            raise ValueError(
+                "Optimizer param-group mixes explicit max_lr/min_lr with a non-unit "
+                "legacy lr_mult; migrate to explicit final bounds."
+            )
+        if has_explicit_bounds:
+            max_lr = self._finite_group_number(
+                param_group, "max_lr", default=self.max_lr, non_negative=True
+            )
+            min_lr = self._finite_group_number(
+                param_group, "min_lr", default=self.min_lr, non_negative=True
+            )
+            init_lr = self.init_lr
+        else:
+            max_lr = self.max_lr * lr_mult
+            min_lr = self.min_lr * lr_mult
+            init_lr = self.init_lr * lr_mult
+        if max_lr < min_lr:
+            raise ValueError(
+                "Optimizer param-group max_lr must be greater than or equal to min_lr."
+            )
+        if init_lr > max_lr:
+            raise ValueError(
+                "Optimizer param-group warmup init_lr must be no greater than max_lr."
+            )
+        return init_lr, max_lr, min_lr
+
+    def _get_lr(self, param_group: dict[str, Any]) -> float:
+        init_lr, max_lr, min_lr = self._group_lr_bounds(param_group)
         if self.lr_warmup_steps > 0 and self.num_steps <= self.lr_warmup_steps:
             ratio = self.num_steps / self.lr_warmup_steps
-            return self.init_lr + (self.max_lr - self.init_lr) * ratio
+            return init_lr + (max_lr - init_lr) * ratio
 
         if self.lr_decay_style == "constant":
-            return self.max_lr
+            return max_lr
+
+        if self.num_steps > self.lr_decay_steps:
+            return min_lr
 
         if self.lr_decay_style == "inverse-square-root":
             warmup = max(self.lr_warmup_steps, 1)
             step = max(self.num_steps, 1)
-            return max(self.min_lr, self.max_lr * math.sqrt(warmup) / math.sqrt(step))
+            return max(min_lr, max_lr * math.sqrt(warmup) / math.sqrt(step))
 
         if self.lr_decay_style == "wsd":
-            return self._get_wsd_lr()
+            return self._get_wsd_lr(max_lr=max_lr, min_lr=min_lr)
 
         decay_span = max(self.lr_decay_steps - self.lr_warmup_steps, 1)
         ratio = min(max((self.num_steps - self.lr_warmup_steps) / decay_span, 0.0), 1.0)
-        return self._decay(self.max_lr, self.min_lr, ratio, self.lr_decay_style)
+        return self._decay(max_lr, min_lr, ratio, self.lr_decay_style)
 
-    def _get_wsd_lr(self) -> float:
+    def _get_wsd_lr(self, *, max_lr: float, min_lr: float) -> float:
         decay_steps = self.wsd_decay_steps or 0
         decay_start = max(self.lr_decay_steps - decay_steps, self.lr_warmup_steps)
         if decay_steps <= 0 or self.num_steps <= decay_start:
-            return self.max_lr
+            return max_lr
         ratio = min((self.num_steps - decay_start) / max(decay_steps, 1), 1.0)
-        return self._decay(self.max_lr, self.min_lr, ratio, self.lr_wsd_decay_style)
+        if self.lr_wsd_decay_style == "linear":
+            coeff = 1.0 - ratio
+        elif self.lr_wsd_decay_style == "cosine":
+            coeff = 0.5 * (math.cos(math.pi * ratio) + 1.0)
+        elif self.lr_wsd_decay_style == "exponential":
+            coeff = 2.0 * (0.5**ratio) - 1.0
+        elif self.lr_wsd_decay_style == "minus_sqrt":
+            coeff = 1.0 - math.sqrt(ratio)
+        else:  # Guard direct construction before state validation can regress.
+            raise ValueError(
+                f"Unsupported WSD LR decay style: {self.lr_wsd_decay_style!r}."
+            )
+        return min_lr + coeff * (max_lr - min_lr)
 
-    def _get_wd(self) -> float:
+    def _get_wd(self, param_group: dict[str, Any]) -> float:
+        start_wd = self._finite_group_number(
+            param_group, "start_wd", default=self.start_wd, non_negative=True
+        )
+        end_wd = self._finite_group_number(
+            param_group, "end_wd", default=self.end_wd, non_negative=True
+        )
+        if end_wd < start_wd:
+            raise ValueError(
+                "Optimizer param-group end_wd must be greater than or equal to start_wd."
+            )
         if self.wd_incr_style == "constant":
-            return self.end_wd
+            if start_wd != end_wd:
+                raise ValueError(
+                    "Constant weight-decay schedule requires start_wd == end_wd."
+                )
+            return end_wd
         ratio = min(max(self.num_steps / self.wd_incr_steps, 0.0), 1.0)
-        return self._decay(self.start_wd, self.end_wd, ratio, self.wd_incr_style)
+        return self._decay(start_wd, end_wd, ratio, self.wd_incr_style)
 
     @staticmethod
     def _decay(start: float, end: float, ratio: float, style: str) -> float:
@@ -172,15 +637,190 @@ class _MegatronLiteLRScheduler:
         if style == "cosine":
             coeff = 0.5 * (math.cos(math.pi * ratio) + 1.0)
             return end + (start - end) * coeff
-        if style == "exponential":
-            if start == 0.0:
-                return 0.0
-            if end == 0.0:
-                return start * (1.0 - ratio)
-            return start * ((end / start) ** ratio)
         if style == "constant":
             return start
         raise ValueError(f"Unsupported scheduler decay style: {style!r}")
+
+
+class _LRSchedulerCheckpointTarget:
+    """Small rollback/fingerprint adapter for the generic checkpoint transaction."""
+
+    _GROUP_FIELDS = (
+        "lr",
+        "weight_decay",
+        "min_lr",
+        "max_lr",
+        "lr_mult",
+        "wd_mult",
+        "start_wd",
+        "end_wd",
+    )
+
+    def __init__(self, scheduler):
+        self.scheduler = scheduler
+        self._last_checkpoint_step: int | None = None
+
+    @staticmethod
+    def _plain_value(value: Any) -> Any:
+        if isinstance(value, torch.Tensor):
+            return value.detach().cpu().tolist()
+        if isinstance(value, dict):
+            return {
+                key: _LRSchedulerCheckpointTarget._plain_value(item)
+                for key, item in value.items()
+            }
+        if isinstance(value, (list, tuple)):
+            return tuple(
+                _LRSchedulerCheckpointTarget._plain_value(item) for item in value
+            )
+        return value
+
+    def _group_state(self) -> tuple[tuple[tuple[str, bool, Any], ...], ...]:
+        return tuple(
+            tuple(
+                (field, field in group, self._plain_value(group.get(field)))
+                for field in self._GROUP_FIELDS
+            )
+            for group in self.scheduler.optimizer.param_groups
+        )
+
+    def snapshot(self) -> dict[str, Any]:
+        return {
+            "scheduler_state": copy.deepcopy(self.scheduler.state_dict()),
+            "param_groups": tuple(
+                tuple(
+                    (field, field in group, copy.deepcopy(group.get(field)))
+                    for field in self._GROUP_FIELDS
+                )
+                for group in self.scheduler.optimizer.param_groups
+            ),
+            "checkpoint_step": self._last_checkpoint_step,
+        }
+
+    def validate_step(self, candidate: Any, expected_step: int | None) -> None:
+        _validate_lr_scheduler_payload(candidate, expected_step=expected_step)
+
+    def apply(self, candidate: Any) -> None:
+        _validate_lr_scheduler_payload(candidate)
+        self.scheduler.load_state_dict(copy.deepcopy(candidate["scheduler_state"]))
+        self._last_checkpoint_step = candidate["checkpoint_step"]
+
+    def restore(self, snapshot: dict[str, Any]) -> None:
+        self.scheduler.load_state_dict(copy.deepcopy(snapshot["scheduler_state"]))
+        group_states = snapshot["param_groups"]
+        if len(group_states) != len(self.scheduler.optimizer.param_groups):
+            raise RuntimeError(
+                "LR scheduler optimizer param-group count changed during checkpoint load."
+            )
+        for group, saved_fields in zip(
+            self.scheduler.optimizer.param_groups, group_states, strict=True
+        ):
+            for field, present, value in saved_fields:
+                if present:
+                    current = group.get(field)
+                    if isinstance(current, torch.Tensor) and isinstance(
+                        value, torch.Tensor
+                    ):
+                        current.copy_(value)
+                    else:
+                        group[field] = copy.deepcopy(value)
+                else:
+                    group.pop(field, None)
+        self._last_checkpoint_step = snapshot["checkpoint_step"]
+
+    def fingerprint(self) -> dict[str, Any]:
+        return {
+            "scheduler_state": self._plain_value(self.scheduler.state_dict()),
+            "param_groups": self._group_state(),
+            "checkpoint_step": self._last_checkpoint_step,
+        }
+
+
+def _legacy_scheduler_payload_with_consensus(
+    local_path: str, scheduler
+) -> dict[str, Any] | None:
+    """Load the one explicit pre-manifest VERL scheduler migration layout."""
+
+    from megatron.lite.primitive.ckpt import dcp as dcp_impl
+
+    payload: dict[str, Any] | None = None
+    local_error: str | None = None
+    try:
+        resolved = Path(
+            dcp_impl._resolve_step_checkpoint_path(  # noqa: SLF001 - migration boundary
+                local_path, allow_legacy_checkpoint=True
+            )
+        )
+        if dcp_impl._checkpoint_manifest_path(resolved).exists():  # noqa: SLF001
+            payload = None
+        else:
+            try:
+                checkpoint_step = int(resolved.name.removeprefix("step_"))
+            except ValueError as exc:
+                raise RuntimeError(
+                    f"Legacy checkpoint path does not encode a step: {resolved}"
+                ) from exc
+
+            requested = Path(local_path)
+            candidates = [
+                requested / _LR_SCHEDULER_STATE,
+                resolved / _LR_SCHEDULER_STATE,
+            ]
+            if requested.name.startswith("step_"):
+                candidates.append(requested.parent / _LR_SCHEDULER_STATE)
+            existing = list(
+                dict.fromkeys(path for path in candidates if path.is_file())
+            )
+            if len(existing) != 1:
+                raise FileNotFoundError(
+                    "explicit legacy scheduler migration requires exactly one recognized "
+                    f"{_LR_SCHEDULER_STATE}; found {existing}"
+                )
+            legacy_state = torch.load(
+                existing[0], map_location="cpu", weights_only=False
+            )
+            if not isinstance(legacy_state, dict) or set(legacy_state) != {"num_steps"}:
+                raise RuntimeError(
+                    "legacy LR scheduler state must contain exactly num_steps; "
+                    "got keys="
+                    f"{sorted(legacy_state) if isinstance(legacy_state, dict) else None}"
+                )
+            num_steps = legacy_state["num_steps"]
+            current_state = copy.deepcopy(scheduler.state_dict())
+            current_state["num_steps"] = num_steps
+            payload = {
+                "format": _LR_SCHEDULER_PAYLOAD_FORMAT,
+                "checkpoint_step": checkpoint_step,
+                "scheduler_state": current_state,
+            }
+            _validate_lr_scheduler_payload(payload, expected_step=checkpoint_step)
+    except Exception as exc:
+        local_error = f"{type(exc).__name__}: {exc}"
+
+    if dist.is_initialized():
+        errors: list[str | None] = [None] * dist.get_world_size()
+        dist.all_gather_object(errors, local_error)
+        first_error = next((error for error in errors if error is not None), None)
+        if first_error is not None:
+            raise RuntimeError(f"Legacy LR scheduler migration failed: {first_error}")
+        per_rank_payloads: list[dict[str, Any] | None] = [None] * dist.get_world_size()
+        dist.all_gather_object(per_rank_payloads, payload)
+        if any(item != per_rank_payloads[0] for item in per_rank_payloads[1:]):
+            raise RuntimeError(
+                "Legacy LR scheduler migration payload differs across ranks: "
+                f"{per_rank_payloads}."
+            )
+        payload = per_rank_payloads[0]
+    elif local_error is not None:
+        raise RuntimeError(f"Legacy LR scheduler migration failed: {local_error}")
+
+    if payload is not None and (not dist.is_initialized() or dist.get_rank() == 0):
+        print(
+            "Migrating a pre-manifest VERL LR scheduler with the current runtime "
+            "schedule config; re-save the checkpoint immediately.",
+            flush=True,
+        )
+    return payload
 
 
 def _build_lr_scheduler(optimizer, opt: MegatronLiteOptimizerConfig):
@@ -214,6 +854,7 @@ def _build_lr_scheduler(optimizer, opt: MegatronLiteOptimizerConfig):
         wd_incr_style=opt.weight_decay_incr_style,
         wsd_decay_steps=opt.lr_wsd_decay_steps,
         lr_wsd_decay_style=opt.lr_wsd_decay_style,
+        use_checkpoint_config=opt.use_checkpoint_opt_param_scheduler,
     )
 
 
@@ -266,6 +907,7 @@ class MegatronLiteEngine(BaseEngine):
         self.module = None
         self._mlite_config = None
         self._rank = dist.get_rank() if dist.is_initialized() else 0
+        self._checkpoint_load_poisoned = False
 
     @property
     def is_param_offload_enabled(self) -> bool:
@@ -342,7 +984,9 @@ class MegatronLiteEngine(BaseEngine):
 
         tu.assign_non_tensor(data, sp_size=self.engine_config.cp)
 
-        token_mask = data["loss_mask"] if "loss_mask" in data.keys() else data["response_mask"]
+        token_mask = (
+            data["loss_mask"] if "loss_mask" in data.keys() else data["response_mask"]
+        )
         batch_num_tokens = token_mask.sum().to(get_device_id())
         torch.distributed.all_reduce(
             batch_num_tokens,
@@ -353,7 +997,9 @@ class MegatronLiteEngine(BaseEngine):
         tu.assign_non_tensor(data, dp_size=self.get_data_parallel_size())
 
         micro_batches, indices = prepare_micro_batches(
-            data=data, dp_group=self.get_data_parallel_group(), same_micro_num_in_dp=True
+            data=data,
+            dp_group=self.get_data_parallel_group(),
+            same_micro_num_in_dp=True,
         )
 
         # Megatron drives every forward through the runtime's forward_backward
@@ -408,11 +1054,15 @@ class MegatronLiteEngine(BaseEngine):
             return None
         return self.handle.dp_group
 
-    def to(self, device: str, model: bool = True, optimizer: bool = True, grad: bool = True):
+    def to(
+        self, device: str, model: bool = True, optimizer: bool = True, grad: bool = True
+    ):
         self._require_initialized()
         if model or not (optimizer or grad):
             super().to(device=device, model=model, optimizer=optimizer, grad=grad)
-        self.runtime.to(self.handle, device, model=model, optimizer=optimizer, grad=grad)
+        self.runtime.to(
+            self.handle, device, model=model, optimizer=optimizer, grad=grad
+        )
 
     def save_checkpoint(
         self,
@@ -426,9 +1076,27 @@ class MegatronLiteEngine(BaseEngine):
         self._require_initialized()
 
         save_contents = self.checkpoint_config.get("save_contents", None)
-        save_model = save_contents is None or "model" in save_contents
-        save_optimizer = save_contents is None or "optimizer" in save_contents
-        if not save_model and not save_optimizer:
+        save_content_keys = _content_set_with_consensus(
+            save_contents, key="checkpoint_config.save_contents"
+        )
+        save_model = save_contents is None or "model" in save_content_keys
+        save_optimizer = save_contents is None or "optimizer" in save_content_keys
+        save_extra = save_contents is None or "extra" in save_content_keys
+        scheduler = self.handle._lr_scheduler
+        _checkpoint_components_with_consensus(
+            model=save_model,
+            optimizer=save_optimizer,
+            extra=save_extra,
+            scheduler_present=scheduler is not None,
+            context="checkpoint save",
+        )
+        if scheduler is not None and save_optimizer and not save_extra:
+            raise ValueError(
+                "Saving optimizer state without extra state would omit the active LR "
+                "scheduler and cannot produce an exact-resume checkpoint. Include "
+                "'extra' in checkpoint_config.save_contents."
+            )
+        if not save_model and not save_optimizer and not save_extra:
             if self._rank == 0:
                 print(
                     f"Skipping Megatron Lite checkpoint save at step {global_step}: save_contents={save_contents}"
@@ -437,13 +1105,33 @@ class MegatronLiteEngine(BaseEngine):
                 dist.barrier()
             return
 
-        os.makedirs(local_path, exist_ok=True)
-        placement_fn, expert_classifier = self._checkpoint_hooks()
         reload_params_for_save = self.is_param_offload_enabled
-        if reload_params_for_save:
-            self.to(device="cuda", model=True, optimizer=False, grad=False)
-            torch.cuda.synchronize()
+        reload_started = False
+        placement_fn = None
+        expert_classifier = None
+        setup_error: str | None = None
         try:
+            os.makedirs(local_path, exist_ok=True)
+            placement_fn, expert_classifier = self._checkpoint_hooks()
+            if reload_params_for_save:
+                reload_started = True
+                self.to(device="cuda", model=True, optimizer=False, grad=False)
+                torch.cuda.synchronize()
+        except Exception as exc:
+            setup_error = f"{type(exc).__name__}: {exc}"
+        try:
+            _distributed_raise_if_error(
+                setup_error, context="checkpoint save setup failed"
+            )
+            extra_states = (
+                {
+                    _LR_SCHEDULER_STATE: _scheduler_payload(
+                        scheduler, checkpoint_step=global_step
+                    )
+                }
+                if save_extra and scheduler is not None
+                else None
+            )
             save_training_checkpoint(
                 self.module,
                 self.handle._optimizer,
@@ -453,19 +1141,23 @@ class MegatronLiteEngine(BaseEngine):
                 self.handle._parallel_state,
                 get_placements=placement_fn,
                 is_expert=expert_classifier,
+                save_rng=save_extra,
                 save_model=save_model,
                 save_optimizer=save_optimizer,
+                extra_states=extra_states,
             )
-            if self.handle._lr_scheduler is not None and self._rank == 0:
-                torch.save(
-                    self.handle._lr_scheduler.state_dict(),
-                    os.path.join(local_path, _LR_SCHEDULER_STATE),
-                )
             if dist.is_initialized():
                 dist.barrier()
         finally:
-            if reload_params_for_save:
-                self.to(device="cpu", model=True, optimizer=False, grad=False)
+            cleanup_error: str | None = None
+            if reload_started:
+                try:
+                    self.to(device="cpu", model=True, optimizer=False, grad=False)
+                except Exception as exc:
+                    cleanup_error = f"{type(exc).__name__}: {exc}"
+            _distributed_raise_if_error(
+                cleanup_error, context="checkpoint save offload cleanup failed"
+            )
 
     def load_checkpoint(
         self,
@@ -474,35 +1166,163 @@ class MegatronLiteEngine(BaseEngine):
         del_local_after_load: bool = True,
         **kwargs,
     ) -> None:
+        allow_legacy_checkpoint = bool(kwargs.pop("allow_legacy_checkpoint", False))
         del hdfs_path, del_local_after_load, kwargs
         self._require_initialized()
 
-        placement_fn, expert_classifier = self._checkpoint_hooks()
-        reload_params_for_load = self.is_param_offload_enabled
-        if reload_params_for_load:
-            self.to(device="cuda", model=True, optimizer=False, grad=False)
-            torch.cuda.synchronize()
         try:
-            load_training_checkpoint(
-                self.module,
-                self.handle._optimizer,
-                local_path,
-                self.handle._config.parallel,
-                self.handle._parallel_state,
-                get_placements=placement_fn,
-                is_expert=expert_classifier,
-                load_model=True,
-                load_optimizer=True,
+            load_contents = self.checkpoint_config.get(
+                "load_contents", self.checkpoint_config.get("save_contents", None)
             )
-            scheduler_path = os.path.join(local_path, _LR_SCHEDULER_STATE)
-            if self.handle._lr_scheduler is not None and os.path.exists(scheduler_path):
-                state = torch.load(scheduler_path, map_location="cpu", weights_only=False)
-                self.handle._lr_scheduler.load_state_dict(state)
-            if dist.is_initialized():
-                dist.barrier()
-        finally:
-            if reload_params_for_load:
-                self.to(device="cpu", model=True, optimizer=False, grad=False)
+            load_content_keys = _content_set_with_consensus(
+                load_contents, key="checkpoint_config.load_contents"
+            )
+            load_model = load_contents is None or "model" in load_content_keys
+            load_optimizer = load_contents is None or "optimizer" in load_content_keys
+            load_extra = load_contents is None or "extra" in load_content_keys
+            scheduler = self.handle._lr_scheduler
+            load_scheduler = load_extra and scheduler is not None
+            _checkpoint_components_with_consensus(
+                model=load_model,
+                optimizer=load_optimizer,
+                extra=load_extra,
+                scheduler_present=scheduler is not None,
+                context="checkpoint load",
+            )
+            if scheduler is not None and load_optimizer and not load_extra:
+                raise ValueError(
+                    "Loading optimizer state without extra state would restore optimizer "
+                    "LR/WD without the matching LR scheduler progress. Include 'extra' in "
+                    "checkpoint_config.load_contents."
+                )
+            if not load_model and not load_optimizer and not load_extra:
+                if dist.is_initialized():
+                    dist.barrier()
+                return
+
+            reload_params_for_load = self.is_param_offload_enabled and load_model
+            reload_started = False
+            placement_fn = None
+            expert_classifier = None
+            setup_error: str | None = None
+            try:
+                placement_fn, expert_classifier = self._checkpoint_hooks()
+                if reload_params_for_load:
+                    reload_started = True
+                    self.to(device="cuda", model=True, optimizer=False, grad=False)
+                    torch.cuda.synchronize()
+            except Exception as exc:
+                setup_error = f"{type(exc).__name__}: {exc}"
+            try:
+                _distributed_raise_if_error(
+                    setup_error, context="checkpoint load setup failed"
+                )
+                loaded_extra_states: dict[str, Any] | None = (
+                    {} if load_scheduler else None
+                )
+                scheduler_target = (
+                    _LRSchedulerCheckpointTarget(scheduler) if load_scheduler else None
+                )
+                legacy_scheduler_payload = (
+                    _legacy_scheduler_payload_with_consensus(local_path, scheduler)
+                    if load_scheduler and allow_legacy_checkpoint
+                    else None
+                )
+                strict_scheduler_extra = (
+                    load_scheduler and legacy_scheduler_payload is None
+                )
+                if legacy_scheduler_payload is not None:
+                    from megatron.lite.primitive.ckpt import dcp as dcp_impl
+
+                    assert scheduler_target is not None
+                    scheduler_target.validate_step(
+                        legacy_scheduler_payload,
+                        legacy_scheduler_payload["checkpoint_step"],
+                    )
+                    dcp_impl._preflight_extra_state_targets(  # noqa: SLF001
+                        {_LR_SCHEDULER_STATE: scheduler_target},
+                        {_LR_SCHEDULER_STATE: legacy_scheduler_payload},
+                    )
+                restored_step = load_training_checkpoint(
+                    self.module,
+                    self.handle._optimizer,
+                    local_path,
+                    self.handle._config.parallel,
+                    self.handle._parallel_state,
+                    get_placements=placement_fn,
+                    is_expert=expert_classifier,
+                    load_rng=load_extra,
+                    load_model=load_model,
+                    load_optimizer=load_optimizer,
+                    allow_legacy_checkpoint=allow_legacy_checkpoint,
+                    load_extra_state_files=(
+                        (_LR_SCHEDULER_STATE,) if strict_scheduler_extra else None
+                    ),
+                    loaded_extra_states=loaded_extra_states,
+                    extra_state_validators=(
+                        {_LR_SCHEDULER_STATE: _validate_lr_scheduler_payload}
+                        if strict_scheduler_extra
+                        else None
+                    ),
+                    extra_state_targets=(
+                        {_LR_SCHEDULER_STATE: scheduler_target}
+                        if strict_scheduler_extra and scheduler_target is not None
+                        else None
+                    ),
+                )
+                if legacy_scheduler_payload is not None:
+                    assert scheduler_target is not None
+                    legacy_error: str | None = None
+                    try:
+                        _validate_lr_scheduler_payload(
+                            legacy_scheduler_payload, expected_step=restored_step
+                        )
+                    except Exception as exc:
+                        legacy_error = f"{type(exc).__name__}: {exc}"
+                    _distributed_raise_if_error(
+                        legacy_error,
+                        context="legacy LR scheduler/core step validation failed",
+                    )
+                    dcp_impl._commit_extra_state_targets(  # noqa: SLF001
+                        {_LR_SCHEDULER_STATE: scheduler_target},
+                        {_LR_SCHEDULER_STATE: legacy_scheduler_payload},
+                    )
+                    assert loaded_extra_states is not None
+                    loaded_extra_states[_LR_SCHEDULER_STATE] = legacy_scheduler_payload
+                post_load_error: str | None = None
+                try:
+                    if load_scheduler:
+                        assert loaded_extra_states is not None
+                        if _LR_SCHEDULER_STATE not in loaded_extra_states:
+                            raise RuntimeError(
+                                "Megatron Lite checkpoint load completed without the "
+                                f"required {_LR_SCHEDULER_STATE} extra state."
+                            )
+                        payload = loaded_extra_states[_LR_SCHEDULER_STATE]
+                        _validate_lr_scheduler_payload(
+                            payload, expected_step=restored_step
+                        )
+                except Exception as exc:
+                    post_load_error = f"{type(exc).__name__}: {exc}"
+                _distributed_raise_if_error(
+                    post_load_error,
+                    context="checkpoint load post-commit validation failed",
+                )
+                if dist.is_initialized():
+                    dist.barrier()
+            finally:
+                cleanup_error: str | None = None
+                if reload_started:
+                    try:
+                        self.to(device="cpu", model=True, optimizer=False, grad=False)
+                    except Exception as exc:
+                        cleanup_error = f"{type(exc).__name__}: {exc}"
+                _distributed_raise_if_error(
+                    cleanup_error, context="checkpoint load offload cleanup failed"
+                )
+        except Exception:
+            self._checkpoint_load_poisoned = True
+            raise
 
     def is_mp_src_rank_with_outputs(self):
         if self.handle is None:
@@ -511,12 +1331,19 @@ class MegatronLiteEngine(BaseEngine):
             tp_rank = rank % self.engine_config.tp
             cp_rank = (rank // self.engine_config.tp) % self.engine_config.cp
             pp_rank = rank // (self.engine_config.tp * self.engine_config.cp * dense_dp)
-            return tp_rank == 0 and cp_rank == 0 and pp_rank == self.engine_config.pp - 1
+            return (
+                tp_rank == 0 and cp_rank == 0 and pp_rank == self.engine_config.pp - 1
+            )
         return self.runtime.is_mp_src_rank_with_outputs(self.handle)
 
     def _require_initialized(self) -> None:
         if self.runtime is None or self.handle is None:
             raise RuntimeError("MegatronLiteEngine is not initialized yet.")
+        if self._checkpoint_load_poisoned:
+            raise RuntimeError(
+                "MegatronLiteEngine is poisoned by a failed checkpoint load; "
+                "discard and reinitialize this engine before further use."
+            )
 
     def _build_mlite_config(self) -> MegatronLiteConfig:
         return MegatronLiteConfig(
@@ -552,15 +1379,21 @@ class MegatronLiteEngine(BaseEngine):
         impl_cfg["use_thd"] = True
         cross_entropy_fusion = getattr(self.engine_config, "cross_entropy_fusion", None)
         if cross_entropy_fusion is None:
-            cross_entropy_fusion = getattr(self.engine_config, "use_fused_kernels", False)
+            cross_entropy_fusion = getattr(
+                self.engine_config, "use_fused_kernels", False
+            )
         impl_cfg.setdefault("cross_entropy_fusion", bool(cross_entropy_fusion))
         mtp_cfg = getattr(self.model_config, "mtp", None)
         if mtp_cfg is not None:
             mtp_enable = bool(getattr(mtp_cfg, "enable", False))
-            mtp_enable_train = mtp_enable and bool(getattr(mtp_cfg, "enable_train", False))
+            mtp_enable_train = mtp_enable and bool(
+                getattr(mtp_cfg, "enable_train", False)
+            )
             impl_cfg["mtp_enable"] = mtp_enable
             impl_cfg["mtp_enable_train"] = mtp_enable_train
-            impl_cfg["mtp_detach_encoder"] = bool(getattr(mtp_cfg, "detach_encoder", False))
+            impl_cfg["mtp_detach_encoder"] = bool(
+                getattr(mtp_cfg, "detach_encoder", False)
+            )
             impl_cfg["mtp_loss_scaling_factor"] = float(
                 getattr(mtp_cfg, "mtp_loss_scaling_factor", 0.1)
             )
@@ -585,11 +1418,15 @@ class MegatronLiteEngine(BaseEngine):
         min_lr = getattr(self.optimizer_config, "min_lr", None)
         min_lr_ratio = getattr(self.optimizer_config, "min_lr_ratio", None)
         if min_lr is None:
-            min_lr = 0.0 if min_lr_ratio is None else self.optimizer_config.lr * min_lr_ratio
+            min_lr = (
+                0.0 if min_lr_ratio is None else self.optimizer_config.lr * min_lr_ratio
+            )
 
         lr_decay_style = getattr(self.optimizer_config, "lr_decay_style", None)
         if lr_decay_style is None:
-            lr_decay_style = getattr(self.optimizer_config, "lr_scheduler_type", "constant")
+            lr_decay_style = getattr(
+                self.optimizer_config, "lr_scheduler_type", "constant"
+            )
 
         return MegatronLiteOptimizerConfig(
             optimizer=optimizer_name,
@@ -606,8 +1443,12 @@ class MegatronLiteEngine(BaseEngine):
             weight_decay_incr_style=getattr(
                 self.optimizer_config, "weight_decay_incr_style", "constant"
             ),
-            lr_wsd_decay_style=getattr(self.optimizer_config, "lr_wsd_decay_style", "exponential"),
-            lr_wsd_decay_steps=getattr(self.optimizer_config, "lr_wsd_decay_steps", None),
+            lr_wsd_decay_style=getattr(
+                self.optimizer_config, "lr_wsd_decay_style", "exponential"
+            ),
+            lr_wsd_decay_steps=getattr(
+                self.optimizer_config, "lr_wsd_decay_steps", None
+            ),
             use_checkpoint_opt_param_scheduler=getattr(
                 self.optimizer_config, "use_checkpoint_opt_param_scheduler", False
             ),
@@ -633,7 +1474,9 @@ class MegatronLiteEngine(BaseEngine):
         model = self.handle._model
         if isinstance(model, list | tuple):
             if not model:
-                raise RuntimeError("Megatron Lite runtime returned an empty model chunk list.")
+                raise RuntimeError(
+                    "Megatron Lite runtime returned an empty model chunk list."
+                )
             if len(model) > 1:
                 return torch.nn.ModuleList(model)
             return model[0]
@@ -650,14 +1493,20 @@ class MegatronLiteEngine(BaseEngine):
     ) -> dict[str, Any]:
         runtime_batches = []
         num_micro_batches = len(micro_batches)
-        batch_num_tokens = tu.get_non_tensor_data(data=data, key="batch_num_tokens", default=None)
+        batch_num_tokens = tu.get_non_tensor_data(
+            data=data, key="batch_num_tokens", default=None
+        )
         if batch_num_tokens is None:
             raise ValueError(
                 "MegatronLiteEngine PP/CP SFT requires batch_num_tokens for VERL-compatible loss scaling."
             )
         if batch_num_tokens <= 0:
-            raise ValueError(f"batch_num_tokens must be positive, got {batch_num_tokens}.")
-        loss_scale = self.get_data_parallel_size() * num_micro_batches / float(batch_num_tokens)
+            raise ValueError(
+                f"batch_num_tokens must be positive, got {batch_num_tokens}."
+            )
+        loss_scale = (
+            self.get_data_parallel_size() * num_micro_batches / float(batch_num_tokens)
+        )
         for micro_idx, micro_batch in enumerate(micro_batches):
             tu.assign_non_tensor(micro_batch, micro_batch_idx=micro_idx)
             micro_batch = micro_batch.to(get_device_id())
@@ -670,7 +1519,9 @@ class MegatronLiteEngine(BaseEngine):
 
         runtime_loss_fn = None
         if loss_function is not None or forward_only:
-            runtime_loss_fn = self._make_runtime_loss_fn(loss_function, forward_only=forward_only)
+            runtime_loss_fn = self._make_runtime_loss_fn(
+                loss_function, forward_only=forward_only
+            )
 
         result = self.runtime.forward_backward(
             self.handle,
@@ -682,7 +1533,9 @@ class MegatronLiteEngine(BaseEngine):
         metrics = dict(result.metrics)
         micro_outputs = metrics.pop("_micro_outputs", None)
         if micro_outputs is not None and self.is_mp_src_rank_with_outputs():
-            return postprocess_batch_func(output_lst=micro_outputs, indices=indices, data=data)
+            return postprocess_batch_func(
+                output_lst=micro_outputs, indices=indices, data=data
+            )
         loss = float(metrics.get("loss", 0.0))
         return {
             "model_output": {},
@@ -690,9 +1543,11 @@ class MegatronLiteEngine(BaseEngine):
             # Pass Metric aggregators through unchanged (reduce_metrics folds them);
             # list-wrap plain scalars as the legacy contract expects.
             "metrics": {
-                key: value
-                if (_VerlMetric is not None and isinstance(value, _VerlMetric))
-                else [value]
+                key: (
+                    value
+                    if (_VerlMetric is not None and isinstance(value, _VerlMetric))
+                    else [value]
+                )
                 for key, value in metrics.items()
             },
         }
@@ -713,20 +1568,21 @@ class MegatronLiteEngine(BaseEngine):
         return PackedBatch(
             input_ids=input_ids.values().contiguous(),
             labels=input_ids.values().contiguous(),
-            loss_mask=None if loss_mask is None else loss_mask.values().contiguous().float(),
+            loss_mask=(
+                None if loss_mask is None else loss_mask.values().contiguous().float()
+            ),
             seq_lens=input_ids.offsets().diff().to(dtype=torch.int64),
         )
 
     def _make_runtime_loss_context(
-        self,
-        micro_batch: TensorDict,
-        *,
-        loss_scale: float,
+        self, micro_batch: TensorDict, *, loss_scale: float
     ) -> LossContext:
         return LossContext(
             temperature=float(self._scalar_temperature(micro_batch)),
             calculate_entropy=bool(
-                tu.get_non_tensor_data(data=micro_batch, key="calculate_entropy", default=False)
+                tu.get_non_tensor_data(
+                    data=micro_batch, key="calculate_entropy", default=False
+                )
             ),
             return_log_probs=True,
             loss_scale=loss_scale,
@@ -752,21 +1608,22 @@ class MegatronLiteEngine(BaseEngine):
                 raise ValueError(
                     f"response loss mask has {response_tokens} tokens but packed input sequence has {seq_len} tokens"
                 )
-            full_mask = torch.zeros(seq_len, dtype=row_mask.dtype, device=row_mask.device)
+            full_mask = torch.zeros(
+                seq_len, dtype=row_mask.dtype, device=row_mask.device
+            )
             if response_tokens:
                 full_mask[-response_tokens:] = row_mask[:response_tokens]
             rows.append(full_mask)
         return torch.nested.as_nested_tensor(rows, layout=torch.jagged)
 
     def _build_verl_model_output(
-        self,
-        *,
-        raw_output: dict[str, torch.Tensor],
-        runtime_batch: PackedBatch,
+        self, *, raw_output: dict[str, torch.Tensor], runtime_batch: PackedBatch
     ) -> dict[str, torch.Tensor]:
         log_probs = raw_output.get("log_probs")
         if log_probs is None:
-            raise ValueError("Megatron Lite THD model output must contain token log_probs.")
+            raise ValueError(
+                "Megatron Lite THD model output must contain token log_probs."
+            )
         proto = self.handle._extras.get("protocol")
         unpack = getattr(proto, "unpack_forward_output", None)
         if unpack is None:
@@ -804,7 +1661,9 @@ class MegatronLiteEngine(BaseEngine):
                 metrics = dict(metrics)
                 mtp_loss = self._reduce_mtp_metric(raw_output["mtp_loss"])
                 metrics["mtp_losses/mtp_1_loss"] = (
-                    float(mtp_loss.item()) if mtp_loss.numel() == 1 else mtp_loss.cpu().tolist()
+                    float(mtp_loss.item())
+                    if mtp_loss.numel() == 1
+                    else mtp_loss.cpu().tolist()
                 )
 
             raw_output["_verl_metrics"] = metrics
@@ -851,5 +1710,7 @@ class MegatronLiteEngine(BaseEngine):
     def _checkpoint_hooks(self):
         proto = self.handle._extras.get("protocol")
         placement_fn = getattr(proto, "PLACEMENT_FN", default_placement_fn)
-        expert_classifier = getattr(proto, "EXPERT_CLASSIFIER", default_expert_classifier)
+        expert_classifier = getattr(
+            proto, "EXPERT_CLASSIFIER", default_expert_classifier
+        )
         return placement_fn, expert_classifier

--- a/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
@@ -1021,7 +1021,8 @@ class MegatronLiteEngine(BaseEngine):
             for key in ("limit", "include_mtp_only", "include_local_prefixes")
             if key in kwargs
         }
-        if self.engine_config.model_name == "qwen3_5":
+        assert self._mlite_config is not None
+        if self._mlite_config.model_name == "qwen3_5":
             export_kwargs["target"] = "vllm"
         if self.engine_config.export_dtype:
             export_kwargs["export_dtype"] = self.engine_config.export_dtype

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/__init__.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/__init__.py
@@ -1,6 +1,23 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Native DeepSeek V4 (ds4flash) lite implementation."""
 
-from megatron.lite.model.deepseek_v4.lite.model import DeepseekV4Model
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from megatron.lite.model.deepseek_v4.lite.model import DeepseekV4Model
 
 __all__ = ["DeepseekV4Model"]
+
+
+def __getattr__(name: str):
+    """Load the TE-dependent model only when callers request the model class.
+
+    Checkpoint conversion and protocol inspection are intentionally usable in
+    CPU-only environments.  Importing either submodule must therefore not pull
+    in ``model.py`` (and Transformer Engine) as a package-import side effect.
+    """
+    if name == "DeepseekV4Model":
+        from megatron.lite.model.deepseek_v4.lite.model import DeepseekV4Model
+
+        return DeepseekV4Model
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
@@ -24,7 +24,6 @@ import re
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-
 from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
 from megatron.lite.primitive.ckpt.hf_weights import (
     SafeTensorReader,
@@ -376,8 +375,9 @@ def load_hf_weights(
     path: str,
     config: DeepseekV4Config,
     ps: ParallelState,
+    *,
+    participating_group: dist.ProcessGroup | None = None,
 ) -> None:
-    participating_group = dist.group.WORLD if dist.is_initialized() else None
     loaded_count = load_hf_model_chunks_atomically(
         model,
         lambda chunk: _materialize_hf_weights(chunk, path, config, ps),
@@ -554,9 +554,7 @@ def export_hf_weights(model, config: DeepseekV4Config, ps: ParallelState, **kwar
 def save_hf_weights(
     model, path: str, config: DeepseekV4Config, ps: ParallelState, **kwargs
 ) -> None:
-    from megatron.lite.primitive.ckpt.hf_weights import (
-        save_hf_weight_pairs_distributed,
-    )
+    from megatron.lite.primitive.ckpt.hf_weights import save_hf_weight_pairs_distributed
 
     save_hf_weight_pairs_distributed(
         export_hf_weights(model, config, ps, rank0_only=True, **kwargs), path

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
@@ -1,23 +1,17 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-"""DeepSeek V4 (ds4flash) lite native <-> HF checkpoint mapping.
+"""DeepSeek V4 lite native <-> V4-Flash release checkpoint mapping.
 
 Like kimi_k2 / glm5: ``DeepseekV4WeightSpec`` encodes the per-param native -> HF
 name (+ TP/EP shard spec); export/save route through the shared
 ``primitive/ckpt/hf_weights.py`` exporter (its PP ``all_gather_object`` is
 reached by all ranks before any ``rank0_only`` filter, so PP>1 export doesn't
-desync).  Native names are bare ``DeepseekV4Model`` keys; ``self.layers`` is a
-ModuleDict keyed by GLOBAL layer index (kimi uses a local ModuleList), so the
-exporter's local->global remap is an identity here.
+desync). Native decoder names are PP-local and are remapped to global indices.
 
-HF targets are canonical HF DeepSeek (``model.embed_tokens.weight`` /
-``model.norm.weight`` / ``lm_head.weight`` / ``model.layers.<i>.self_attn.*`` /
-``...mlp.experts.<id>.{gate,up,down}_proj.weight``).  DS4 extras:
-  * CSA: ``self_attn.*`` incl. ``compressor.*`` / ``indexer.*``; ``sinks`` ->
-    ``self_attn.attn_sink``.
-  * mHC: ``attn_hc`` / ``ffn_hc`` -> ``...self_attn.hc_*`` / ``...mlp.hc_*``;
-    model-wide ``hc_head`` -> ``model.hc_head.*`` (no HF analogue, kept
-    model.-rooted; fidelity vs Megatron's latest mHC is a TODO).
-  * MTP: folded into the decoder namespace at ``model.layers.<num_hidden+i>``.
+The target is the released V4-Flash / vLLM-style *bare* schema:
+``embed.weight``, ``head.weight``, ``layers.<i>.attn.*``, ``layers.<i>.ffn.*``,
+and ``mtp.<i>.*``. It is intentionally distinct from the Transformers 5.12
+``model.*`` schema used by the separate numeric attention-block oracle; callers
+must not treat the two checkpoint key spaces as interchangeable.
 
 CSA is not TP-capable: DS4 runs TP=ETP=1 (only EP shards experts), like GLM-5.
 """
@@ -36,6 +30,10 @@ from megatron.lite.primitive.ckpt.hf_weights import (
     SafeTensorReader,
     _cast_export_tensor,
     _resolve_export_dtype,
+    copy_hf_state_atomically,
+    gather_pipeline_state_dict,
+    load_hf_model_chunks_atomically,
+    named_persistent_buffers,
     parse_expert_idx,
     to_global_layer_name,
     unwrap_model,
@@ -139,7 +137,9 @@ def _map_block_attr(attr: str, block: str) -> str | tuple[str, ...] | None:
     return None
 
 
-def _global_expert_idx_from_local(local_idx: int, config: DeepseekV4Config, ps: ParallelState) -> int:
+def _global_expert_idx_from_local(
+    local_idx: int, config: DeepseekV4Config, ps: ParallelState
+) -> int:
     num_local = ensure_divisible(config.n_routed_experts, ps.ep_size)
     return ps.ep_rank * num_local + local_idx
 
@@ -271,20 +271,18 @@ def _dequantize_scaled_tensor(
     return _unpack_fp4_e2m1_if_needed(tensor, shape) * scale_f
 
 
-def _copy_param(
-    param: nn.Parameter | torch.Tensor,
-    tensor: torch.Tensor,
+def _copy_loaded_state(
+    model: nn.Module,
+    loaded: dict[str, torch.Tensor],
     *,
-    scale: torch.Tensor | None = None,
-) -> None:
-    if scale is not None:
-        tensor = _dequantize_scaled_tensor(tensor, scale, param.shape)
-    elif param.dtype.is_floating_point and not tensor.dtype.is_floating_point:
-        raise RuntimeError(
-            f"Refusing to copy quantized tensor with dtype {tensor.dtype} into {tuple(param.shape)} "
-            "without a matching .scale tensor."
-        )
-    param.data.copy_(tensor.to(device=param.device, dtype=param.dtype))
+    participating_group: dist.ProcessGroup | None = None,
+) -> int:
+    return copy_hf_state_atomically(
+        model,
+        loaded,
+        context="DeepSeek V4 HF load",
+        participating_group=participating_group,
+    )
 
 
 def _read_hf_tensor(
@@ -298,9 +296,9 @@ def _read_hf_tensor(
     return tensor
 
 
-def load_hf_weights(
+def _materialize_hf_weights(
     model: nn.Module, path: str, config: DeepseekV4Config, ps: ParallelState
-) -> None:
+) -> dict[str, torch.Tensor]:
     """Load HF safetensors into the DS4 model.
 
     Kept as DS4's native loader (the inverse of the spec's ``native_to_hf``):
@@ -314,7 +312,9 @@ def load_hf_weights(
     mapping (identity at PP=1); else a non-first stage reads the wrong layer.
     """
     if (ps.tp_size, ps.etp_size) != (1, 1):
-        raise NotImplementedError("DeepSeek V4 direct HF load currently supports only TP=ETP=1.")
+        raise NotImplementedError(
+            "DeepSeek V4 direct HF load currently supports only TP=ETP=1."
+        )
 
     reader = SafeTensorReader(path)
     base_model = unwrap_model(model)
@@ -325,15 +325,26 @@ def load_hf_weights(
         if hasattr(base_model, "layer_indices")
         else {}
     )
-    loaded = 0
+    out: dict[str, torch.Tensor] = {}
     missing: list[str] = []
     for name, target in state.items():
         if _is_native_metadata_key(name):
             continue
         global_name = to_global_layer_name(name, layer_map)
-        hf_names = _hf_names_for_state_key(_to_global_expert_name(global_name, config, ps), config)
-        if not hf_names or not all(_has(reader, hf_name) for hf_name in hf_names):
-            missing.append(name)
+        mapping_name = (
+            "embed_tokens.embedding.weight"
+            if global_name == "mtp_embed.embedding.weight"
+            else global_name
+        )
+        hf_names = _hf_names_for_state_key(
+            _to_global_expert_name(mapping_name, config, ps), config
+        )
+        if not hf_names:
+            missing.append(f"{name} (no V4-Flash mapping)")
+            continue
+        absent_hf_names = [hf_name for hf_name in hf_names if not _has(reader, hf_name)]
+        if absent_hf_names:
+            missing.append(f"{name} (missing HF keys {absent_hf_names})")
             continue
         if len(hf_names) == 2:
             first = target.shape[0] // 2
@@ -341,24 +352,44 @@ def load_hf_weights(
                 [
                     _read_hf_tensor(reader, hf_names[0], (first, *target.shape[1:])),
                     _read_hf_tensor(
-                        reader, hf_names[1], (target.shape[0] - first, *target.shape[1:])
+                        reader,
+                        hf_names[1],
+                        (target.shape[0] - first, *target.shape[1:]),
                     ),
                 ],
                 dim=0,
             )
-            target.data.copy_(tensor.to(device=target.device, dtype=target.dtype))
+            out[name] = tensor
         else:
-            scale_name = _scale_name_for_hf_name(hf_names[0])
-            scale = reader.get_tensor(scale_name) if _has(reader, scale_name) else None
-            _copy_param(target, reader.get_tensor(hf_names[0]), scale=scale)
-        loaded += 1
+            out[name] = _read_hf_tensor(reader, hf_names[0], target.shape)
 
-    log_rank0(f"DeepSeek V4 native loaded {loaded} tensors from {path}")
-    for name in missing:
-        log_rank0(f"WARNING: DeepSeek V4 checkpoint tensor missing: {name}")
+    if missing:
+        raise RuntimeError(
+            "DeepSeek V4 checkpoint does not cover local native state: "
+            + "; ".join(missing)
+        )
+    return out
 
 
-def _to_global_expert_name(name: str, config: DeepseekV4Config, ps: ParallelState) -> str:
+def load_hf_weights(
+    model: nn.Module | list[nn.Module],
+    path: str,
+    config: DeepseekV4Config,
+    ps: ParallelState,
+) -> None:
+    participating_group = dist.group.WORLD if dist.is_initialized() else None
+    loaded_count = load_hf_model_chunks_atomically(
+        model,
+        lambda chunk: _materialize_hf_weights(chunk, path, config, ps),
+        context="DeepSeek V4 HF load",
+        participating_group=participating_group,
+    )
+    log_rank0(f"DeepSeek V4 native loaded {loaded_count} tensors from {path}")
+
+
+def _to_global_expert_name(
+    name: str, config: DeepseekV4Config, ps: ParallelState
+) -> str:
     """Rewrite an EP-local expert ``weight<local>`` suffix to its global id.
 
     The native ``state_dict`` carries the EP-local expert index; the HF target
@@ -399,7 +430,9 @@ class DeepseekV4WeightSpec:
     def weight_map(self) -> dict[str, list[str]]:
         return {}
 
-    def hf_to_native(self, native_name: str, hf_tensors: list[torch.Tensor]) -> torch.Tensor:
+    def hf_to_native(
+        self, native_name: str, hf_tensors: list[torch.Tensor]
+    ) -> torch.Tensor:
         del native_name
         return hf_tensors[0]
 
@@ -421,7 +454,9 @@ class DeepseekV4WeightSpec:
                 (hf_names[0], first.contiguous()),
                 (hf_names[1], second.contiguous()),
             ]
-        raise AssertionError(f"Unexpected HF name fan-out for {native_name}: {hf_names}")
+        raise AssertionError(
+            f"Unexpected HF name fan-out for {native_name}: {hf_names}"
+        )
 
     def qkv_spec(self, native_name: str) -> tuple[int, int, int] | None:
         del native_name
@@ -442,6 +477,7 @@ class DeepseekV4WeightSpec:
             return (0, 0)
         if native_name in {
             "embed_tokens.embedding.weight",
+            "mtp_embed.embedding.weight",
             "lm_head.col.linear.weight",
         }:
             return (0, 0)
@@ -474,38 +510,57 @@ def export_hf_weights(model, config: DeepseekV4Config, ps: ParallelState, **kwar
     spec = DeepseekV4WeightSpec(config)
     rank0_only = bool(kwargs.get("rank0_only", False))
     export_dtype = _resolve_export_dtype(kwargs.get("export_dtype"))
-    yield from _export(model, spec, ps, vocab_size=config.vocab_size, **kwargs)
-
-    rank = dist.get_rank() if dist.is_initialized() else 0
-    if rank0_only and rank != 0:
-        return
     chunks = list(model) if isinstance(model, list | nn.ModuleList) else [model]
+    local_buffers: dict[str, torch.Tensor] = {}
     for chunk in chunks:
         base_chunk = unwrap_model(chunk)
         layer_map = (
-            {i: base_chunk.layer_indices[i] for i in range(len(base_chunk.layer_indices))}
+            {
+                i: base_chunk.layer_indices[i]
+                for i in range(len(base_chunk.layer_indices))
+            }
             if hasattr(base_chunk, "layer_indices")
             else {}
         )
-        for name, buffer in base_chunk.named_buffers():
+        for name, buffer in named_persistent_buffers(base_chunk):
             # Persistent router buffers carried into HF: hash-layer ``tid2eid``
             # and the (made-persistent for non-hash layers) ``expert_bias``.
-            if not (name.endswith(".mlp.gate.tid2eid") or name.endswith(".mlp.gate.expert_bias")):
+            if not (
+                name.endswith(".mlp.gate.tid2eid")
+                or name.endswith(".mlp.gate.expert_bias")
+            ):
                 continue
             global_name = to_global_layer_name(name, layer_map)
-            for hf_name, hf_tensor in spec.native_to_hf(global_name, buffer.detach().cpu()):
-                yield hf_name, _cast_export_tensor(hf_tensor, export_dtype)
-
-
-def save_hf_weights(model, path: str, config: DeepseekV4Config, ps: ParallelState, **kwargs) -> None:
-    from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
-
+            if global_name in local_buffers:
+                raise RuntimeError(
+                    f"duplicate local DeepSeek-V4 router buffer {global_name}"
+                )
+            local_buffers[global_name] = buffer.detach().cpu()
+    gathered_buffers = gather_pipeline_state_dict(
+        local_buffers,
+        ps,
+        participating_group=kwargs.get("participating_group", ps.pp_group),
+    )
+    # Complete every collective before exposing the first generator item.
+    yield from _export(model, spec, ps, vocab_size=config.vocab_size, **kwargs)
     rank = dist.get_rank() if dist.is_initialized() else 0
-    out = dict(export_hf_weights(model, config, ps, rank0_only=True, **kwargs))
-    if rank == 0 and out:
-        save_safetensors(out, path)
-    if dist.is_initialized():
-        dist.barrier()
+    if rank0_only and rank != 0:
+        return
+    for global_name, buffer in gathered_buffers.items():
+        for hf_name, hf_tensor in spec.native_to_hf(global_name, buffer):
+            yield hf_name, _cast_export_tensor(hf_tensor, export_dtype)
+
+
+def save_hf_weights(
+    model, path: str, config: DeepseekV4Config, ps: ParallelState, **kwargs
+) -> None:
+    from megatron.lite.primitive.ckpt.hf_weights import (
+        save_hf_weight_pairs_distributed,
+    )
+
+    save_hf_weight_pairs_distributed(
+        export_hf_weights(model, config, ps, rank0_only=True, **kwargs), path
+    )
 
 
 __all__ = [

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/model.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/model.py
@@ -25,7 +25,8 @@ model-wide DS4 deviations (documented inline at each site):
    shared Experts/Router/Dispatcher).
 
 CSA is not TP-capable, so DS4 is a documented TP=1 case (protocol gate raises
-for TP>1/ETP>1); VPP/PP/EP/CP work, inherited from the Kimi skeleton.
+for TP>1/ETP>1); PP/EP/CP work, inherited from the Kimi skeleton, while the
+shared pipeline layout still rejects VPP.
 """
 
 from __future__ import annotations
@@ -36,7 +37,6 @@ from contextlib import nullcontext
 import torch
 import torch.nn as nn
 import transformer_engine.pytorch as te
-
 from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
 from megatron.lite.model.deepseek_v4.lite.moe import DeepseekV4MoE
 from megatron.lite.primitive.modules.attention.csa import CompressedSparseAttention
@@ -64,9 +64,7 @@ from megatron.lite.primitive.utils import build_fp8_recipe
 
 
 def _roll_mtp_left(
-    tensor: torch.Tensor,
-    *,
-    dims: int = -1,
+    tensor: torch.Tensor, *, dims: int = -1
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Shift labels/ids one position left (next-token target for MTP depth d).
 
@@ -132,7 +130,9 @@ class DeepseekV4Layer(nn.Module):
         self.layer_idx = layer_idx
         self.ps = ps
         self.input_layernorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.post_attention_layernorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = te.RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
         # DS4 ONLY: CSA attention behind the SBHD shim (Kimi builds MLA here).
         self.self_attn = DeepseekV4CSAAttention(config, layer_idx=layer_idx, ps=ps)
         # DS4 ONLY: hash-routed MoE family (shared Experts/Router/dispatcher).
@@ -157,7 +157,9 @@ class DeepseekV4Layer(nn.Module):
         # HyperConnection.post recombines into the 4-D residual streams.
         residual = x
         attn_in, post, comb = self.attn_hc(x)
-        attn_out = self.self_attn(self.input_layernorm(attn_in), position_ids=position_ids)
+        attn_out = self.self_attn(
+            self.input_layernorm(attn_in), position_ids=position_ids
+        )
         x = HyperConnection.post(attn_out, residual, post, comb)
 
         residual = x
@@ -166,8 +168,12 @@ class DeepseekV4Layer(nn.Module):
         # align with the flattened hidden.  The skeleton is SBHD, so the FFN
         # input flattens in (S, B) order; transpose input_ids [B, S] -> [S, B]
         # so its flatten matches.  (No-op semantics for non-hash layers.)
-        mlp_input_ids = None if input_ids is None else input_ids.transpose(0, 1).contiguous()
-        ffn_out = self.mlp(self.post_attention_layernorm(ffn_in), input_ids=mlp_input_ids)
+        mlp_input_ids = (
+            None if input_ids is None else input_ids.transpose(0, 1).contiguous()
+        )
+        ffn_out = self.mlp(
+            self.post_attention_layernorm(ffn_in), input_ids=mlp_input_ids
+        )
         return HyperConnection.post(ffn_out, residual, post, comb)
 
 
@@ -201,13 +207,15 @@ class DeepseekV4MTPLayer(DeepseekV4Layer):
         self.enorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.hnorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.norm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.hc_head = MultiHeadHyperConnectionHead(config.hidden_size, config.hc_mult, config.hc_eps)
+        self.hc_head = MultiHeadHyperConnectionHead(
+            config.hidden_size, config.hc_mult, config.hc_eps
+        )
 
     def forward(
         self,
+        hidden_states: torch.Tensor,
         *,
         input_ids: torch.Tensor,
-        hidden_states: torch.Tensor,
         position_ids: torch.Tensor,
     ) -> torch.Tensor:
         # hidden_states is the per-stream mHC source [S, B, hc_mult, H].
@@ -219,8 +227,12 @@ class DeepseekV4MTPLayer(DeepseekV4Layer):
         embedded = self.enorm(embedded)
         # e_proj on the [S, B, H] embedding, broadcast across the hc_mult streams;
         # h_proj on the normed mHC hidden keeps the per-stream state.
-        projected = self.e_proj(embedded).unsqueeze(2) + self.h_proj(self.hnorm(hidden_states))
-        return super().forward(projected, position_ids=position_ids, input_ids=input_ids)
+        projected = self.e_proj(embedded).unsqueeze(2) + self.h_proj(
+            self.hnorm(hidden_states)
+        )
+        return super().forward(
+            projected, position_ids=position_ids, input_ids=input_ids
+        )
 
     def contract(self, x: torch.Tensor) -> torch.Tensor:
         # Collapse the hc_mult streams [S, B, hc_mult, H] -> [S, B, H].
@@ -315,7 +327,9 @@ class DeepseekV4Model(nn.Module):
 
         self.embed_tokens: VocabParallelEmbedding | None = None
         if layout.has_embed:
-            self.embed_tokens = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
+            self.embed_tokens = VocabParallelEmbedding(
+                config.vocab_size, config.hidden_size, ps
+            )
 
         # Key by LOCAL pipeline-stage position (0..len-1), not the global layer id,
         # so parameter names ("layers.{local}.…") follow the same convention as the
@@ -327,7 +341,9 @@ class DeepseekV4Model(nn.Module):
         # for its dense-vs-MoE / per-layer logic.
         self.layers = nn.ModuleDict(
             {
-                str(local): DeepseekV4Layer(config, ps, global_idx, use_deepep=use_deepep)
+                str(local): DeepseekV4Layer(
+                    config, ps, global_idx, use_deepep=use_deepep
+                )
                 for local, global_idx in enumerate(self.layer_indices)
             }
         )
@@ -340,14 +356,18 @@ class DeepseekV4Model(nn.Module):
             self.hc_head = MultiHeadHyperConnectionHead(
                 config.hidden_size, config.hc_mult, config.hc_eps
             )
-            self.lm_head = VocabParallelOutput(config.vocab_size, config.hidden_size, ps)
+            self.lm_head = VocabParallelOutput(
+                config.vocab_size, config.hidden_size, ps
+            )
 
         self.mtp_embed: VocabParallelEmbedding | None = None
         self.mtp: nn.ModuleList = nn.ModuleList()
         if mtp_enable and config.num_nextn_predict_layers > 0 and layout.has_mtp:
             mtp_embedding = self.embed_tokens
             if mtp_embedding is None:
-                mtp_embedding = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
+                mtp_embedding = VocabParallelEmbedding(
+                    config.vocab_size, config.hidden_size, ps
+                )
                 self.mtp_embed = mtp_embedding
             self.mtp = nn.ModuleList(
                 [
@@ -366,7 +386,9 @@ class DeepseekV4Model(nn.Module):
     def set_input_tensor(self, input_tensor):
         if isinstance(input_tensor, list):
             if len(input_tensor) > 1:
-                raise ValueError("DeepseekV4Model expects a single pipeline input tensor.")
+                raise ValueError(
+                    "DeepseekV4Model expects a single pipeline input tensor."
+                )
             input_tensor = input_tensor[0] if input_tensor else None
         self._input_tensor = input_tensor
 
@@ -427,7 +449,9 @@ class DeepseekV4Model(nn.Module):
             )
 
         fp8_ctx = (
-            te.fp8_autocast(enabled=True, fp8_recipe=build_fp8_recipe(self.train_config))
+            te.fp8_autocast(
+                enabled=True, fp8_recipe=build_fp8_recipe(self.train_config)
+            )
             if self.train_config.fp8
             else nullcontext()
         )
@@ -445,7 +469,9 @@ class DeepseekV4Model(nn.Module):
         # Last stage: contract the mHC streams, then run head / MTP / loss
         # exactly as the Kimi skeleton does.
         mtp_source = h
-        hidden_for_head = contract_mhc_hidden_for_pipeline(h, norm=self.norm, head=self.hc_head)
+        hidden_for_head = contract_mhc_hidden_for_pipeline(
+            h, norm=self.norm, head=self.hc_head
+        )
 
         # MTP runs on the head stage (where self.mtp is built with a valid bound
         # embedding -- self.embed_tokens when present, else the self.mtp_embed
@@ -505,7 +531,9 @@ class DeepseekV4Model(nn.Module):
             output["logits"] = self.lm_head.gather(logits).transpose(0, 1).contiguous()
             if mtp_hidden_states is not None:
                 output["mtp_logits"] = [
-                    self.lm_head.gather(self.lm_head(mtp_hidden)).transpose(0, 1).contiguous()
+                    self.lm_head.gather(self.lm_head(mtp_hidden))
+                    .transpose(0, 1)
+                    .contiguous()
                     for mtp_hidden in mtp_hidden_states
                 ]
         return output
@@ -530,9 +558,7 @@ class DeepseekV4Model(nn.Module):
         for mtp_layer in self.mtp:
             mtp_input_ids, _ = _roll_mtp_left(mtp_input_ids, dims=-1)
             source = mtp_layer(
-                input_ids=mtp_input_ids,
-                hidden_states=source,
-                position_ids=position_ids,
+                source, input_ids=mtp_input_ids, position_ids=position_ids
             )
             outputs.append(mtp_layer.contract(source))
         return outputs
@@ -576,16 +602,19 @@ class DeepseekV4Model(nn.Module):
                 logits = self.lm_head(mtp_hidden)
                 if temperature != 1.0:
                     logits = logits / temperature
-                token_loss = vocab_parallel_cross_entropy(logits, labels_sb, self.ps.tp_group)
+                token_loss = vocab_parallel_cross_entropy(
+                    logits, labels_sb, self.ps.tp_group
+                )
 
             token_loss = token_loss * mask_sb.to(dtype=token_loss.dtype)
             num_tokens = num_tokens.to(dtype=token_loss.dtype).clamp_min(1.0)
             mtp_loss_values.append(token_loss.sum() / num_tokens)
 
-            mtp_loss_scale = self.mtp_loss_scaling_factor / max(len(mtp_hidden_states), 1)
+            mtp_loss_scale = self.mtp_loss_scaling_factor / max(
+                len(mtp_hidden_states), 1
+            )
             hidden_states = MTPLossAutoScaler.apply(
-                hidden_states,
-                mtp_loss_scale * token_loss / num_tokens,
+                hidden_states, mtp_loss_scale * token_loss / num_tokens
             )
 
         if not mtp_loss_values:
@@ -599,7 +628,9 @@ class DeepseekV4Model(nn.Module):
         assert self.lm_head is not None
         weight = self.lm_head.col.linear.weight
         return (
-            weight if weight.dtype == hidden_states.dtype else weight.to(dtype=hidden_states.dtype)
+            weight
+            if weight.dtype == hidden_states.dtype
+            else weight.to(dtype=hidden_states.dtype)
         )
 
 

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
@@ -121,7 +121,10 @@ def _infer_cp_local_seq_len(
     seq_len = input_ids.size(1)
     if cp_size <= 1:
         return seq_len
-    if position_ids is not None and position_ids.size(-1) in (seq_len, seq_len * cp_size):
+    if position_ids is not None and position_ids.size(-1) in (
+        seq_len,
+        seq_len * cp_size,
+    ):
         return seq_len
     return seq_len // cp_size if seq_len % cp_size == 0 else seq_len
 
@@ -141,7 +144,9 @@ def _nested_from_packed_tensor(tensor, seq_lens):
         pieces.append(tensor.narrow(0, offset, length))
         offset += length
     if offset != tensor.numel():
-        raise ValueError(f"PackedBatch sizes sum to {offset}, tensor has {tensor.numel()} tokens.")
+        raise ValueError(
+            f"PackedBatch sizes sum to {offset}, tensor has {tensor.numel()} tokens."
+        )
     return torch.nested.as_nested_tensor(pieces, layout=torch.jagged)
 
 
@@ -163,7 +168,11 @@ def _prepare_packed_batch_kwargs(model, batch: PackedBatch) -> dict[str, Any]:
         "loss_mask": packed.loss_mask,
         "position_ids": packed.position_ids,
         "packed_seq_params": packed.packed_seq_params,
-        "enable_mtp": False,
+        # DS4's MTP target rolling is not yet segment-aware, so multiple THD
+        # sequences (or CP shards) must remain disabled to avoid crossing a
+        # physical sequence boundary. A single packed sequence at CP=1 has no
+        # such boundary and is the supported PP+MTP training path.
+        "enable_mtp": ps.cp_size == 1 and seq_lens.numel() == 1,
     }
     add_loss_context_kwargs(kwargs)
     _prepare_packed_contiguous_cp_kwargs(model, kwargs)
@@ -191,7 +200,9 @@ def _prepare_packed_contiguous_cp_kwargs(model, kwargs):
     for key in ("input_ids", "labels", "loss_mask", "position_ids"):
         tensor = kwargs.get(key)
         if tensor is not None:
-            kwargs[key] = contiguous_slice_for_cp(tensor, ps.cp_rank, ps.cp_size, seq_dim=1)
+            kwargs[key] = contiguous_slice_for_cp(
+                tensor, ps.cp_rank, ps.cp_size, seq_dim=1
+            )
     return kwargs
 
 
@@ -244,7 +255,9 @@ def _prepare_model_forward_kwargs(model, batch: PackedBatch):
     # split per row under contiguous CP, where contiguous_position_ids_for_cp rebuilds
     # the per-rank global position ids.
     input_ids = batch.input_ids
-    is_thd_packed = input_ids.dim() == 1 or (input_ids.dim() == 2 and input_ids.size(0) == 1)
+    is_thd_packed = input_ids.dim() == 1 or (
+        input_ids.dim() == 2 and input_ids.size(0) == 1
+    )
     if is_thd_packed:
         return _prepare_packed_batch_kwargs(model, batch)
     kwargs = _base_model_forward_kwargs(batch)
@@ -274,11 +287,15 @@ def _apply_mtp_config(model_cfg: DeepseekV4Config, impl_cfg: ImplConfig) -> None
         override = impl_cfg.mtp_num_layers
     if override is not None:
         if override < 0:
-            raise ValueError(f"DeepSeek V4 MTP layer count must be >=0, got {override}.")
+            raise ValueError(
+                f"DeepSeek V4 MTP layer count must be >=0, got {override}."
+            )
         model_cfg.num_nextn_predict_layers = int(override)
     if impl_cfg.mtp_enable:
         if model_cfg.num_nextn_predict_layers <= 0:
-            raise ValueError("mtp_enable=True but DeepSeek V4 config has no MTP layers.")
+            raise ValueError(
+                "mtp_enable=True but DeepSeek V4 config has no MTP layers."
+            )
         model_cfg.mtp_loss_scaling_factor = impl_cfg.mtp_loss_scaling_factor
     else:
         model_cfg.num_nextn_predict_layers = 0
@@ -310,7 +327,9 @@ def _optimizer_backend_name(optimizer: Any) -> str | None:
     return optimizer
 
 
-def _configure_attention_backend(chunks: list[nn.Module], *, backend: str | None) -> None:
+def _configure_attention_backend(
+    chunks: list[nn.Module], *, backend: str | None
+) -> None:
     backend_name = backend or "torch"
     for chunk in chunks:
         for module in chunk.modules():
@@ -354,7 +373,23 @@ def build_model(model_cfg: DeepseekV4Config, *, impl_cfg: ImplConfig) -> ModelBu
     _apply_mtp_config(model_cfg, impl_cfg)
     mtp_enable = bool(impl_cfg.mtp_enable) and model_cfg.num_nextn_predict_layers > 0
     mtp_enable_train = mtp_enable and bool(impl_cfg.mtp_enable_train)
+    if (
+        _optimizer_backend_name(impl_cfg.optimizer) == "fsdp2"
+        and mtp_enable
+        and p.pp > 1
+    ):
+        raise NotImplementedError(
+            "FSDP2 does not yet synchronize the PP-replicated MTP input embedding; "
+            "use dist_opt for PP+MTP training."
+        )
     ps = init_parallel(impl_cfg.parallel)
+    from megatron.lite.primitive.parallel import (
+        init_mtp_embedding_group,
+        synchronize_mtp_embedding_parameters,
+    )
+
+    if mtp_enable:
+        init_mtp_embedding_group(ps)
     vpp = None if p.vpp == 1 else p.vpp
     train_cfg = SimpleNamespace(
         tp=ps.tp_size,
@@ -387,6 +422,7 @@ def build_model(model_cfg: DeepseekV4Config, *, impl_cfg: ImplConfig) -> ModelBu
         )
 
     chunks = [_chunk(i) for i in range(vpp)] if vpp is not None else [_chunk()]
+    synchronize_mtp_embedding_parameters(chunks, ps, enabled=mtp_enable)
     _configure_attention_backend(chunks, backend=impl_cfg.attention_backend_override)
 
     recompute_spec = parse_recompute_spec(impl_cfg.recompute)
@@ -420,6 +456,7 @@ def build_model(model_cfg: DeepseekV4Config, *, impl_cfg: ImplConfig) -> ModelBu
             model_name="deepseek_v4",
             is_expert=is_expert_param,
             deterministic=impl_cfg.deterministic,
+            mtp_enabled=mtp_enable,
         )
         attach_model_sharded_state_dict(
             chunks, ps, get_placements=PLACEMENT_FN, is_expert=is_expert_param
@@ -431,7 +468,9 @@ def build_model(model_cfg: DeepseekV4Config, *, impl_cfg: ImplConfig) -> ModelBu
 
         def _post_model_load_hook():
             from megatron.lite.model.deepseek_v4.lite.model import DeepseekV4Layer
-            from megatron.lite.primitive.optimizers.fsdp2 import build_fsdp2_training_optimizer
+            from megatron.lite.primitive.optimizers.fsdp2 import (
+                build_fsdp2_training_optimizer,
+            )
 
             return {
                 "optimizer": build_fsdp2_training_optimizer(
@@ -469,11 +508,23 @@ def build_model(model_cfg: DeepseekV4Config, *, impl_cfg: ImplConfig) -> ModelBu
 
 
 def load_hf_weights(
-    chunk: nn.Module, hf_path: str, model_cfg: DeepseekV4Config, ps: ParallelState
+    chunk: nn.Module | list[nn.Module],
+    hf_path: str,
+    model_cfg: DeepseekV4Config,
+    ps: ParallelState,
 ) -> None:
     if not hf_path:
         return
     _load_hf_weights_impl(chunk, hf_path, model_cfg, ps)
+
+
+def load_hf_weights_many(
+    chunks: list[nn.Module],
+    hf_path: str,
+    model_cfg: DeepseekV4Config,
+    ps: ParallelState,
+) -> None:
+    load_hf_weights(chunks, hf_path, model_cfg, ps)
 
 
 def export_hf_weights(
@@ -483,7 +534,11 @@ def export_hf_weights(
 
 
 def save_hf_weights(
-    chunks: list[nn.Module], path: str, model_cfg: DeepseekV4Config, ps: ParallelState, **kwargs
+    chunks: list[nn.Module],
+    path: str,
+    model_cfg: DeepseekV4Config,
+    ps: ParallelState,
+    **kwargs,
 ) -> None:
     _save_hf_weights_impl(chunks, path, model_cfg, ps, **kwargs)
 

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
@@ -5,14 +5,20 @@ from types import SimpleNamespace
 from typing import Any
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
-
 from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
 from megatron.lite.model.deepseek_v4.lite.checkpoint import (
     EXPERT_CLASSIFIER,
     PLACEMENT_FN,
+)
+from megatron.lite.model.deepseek_v4.lite.checkpoint import (
     export_hf_weights as _export_hf_weights_impl,
+)
+from megatron.lite.model.deepseek_v4.lite.checkpoint import (
     load_hf_weights as _load_hf_weights_impl,
+)
+from megatron.lite.model.deepseek_v4.lite.checkpoint import (
     save_hf_weights as _save_hf_weights_impl,
 )
 from megatron.lite.model.protocol_utils import add_loss_context_kwargs
@@ -112,12 +118,7 @@ def _as_batch_row(tensor):
     return tensor
 
 
-def _infer_cp_local_seq_len(
-    *,
-    input_ids,
-    position_ids,
-    cp_size,
-):
+def _infer_cp_local_seq_len(*, input_ids, position_ids, cp_size):
     seq_len = input_ids.size(1)
     if cp_size <= 1:
         return seq_len
@@ -512,10 +513,14 @@ def load_hf_weights(
     hf_path: str,
     model_cfg: DeepseekV4Config,
     ps: ParallelState,
+    *,
+    participating_group: dist.ProcessGroup | None = None,
 ) -> None:
     if not hf_path:
         return
-    _load_hf_weights_impl(chunk, hf_path, model_cfg, ps)
+    _load_hf_weights_impl(
+        chunk, hf_path, model_cfg, ps, participating_group=participating_group
+    )
 
 
 def load_hf_weights_many(
@@ -523,8 +528,12 @@ def load_hf_weights_many(
     hf_path: str,
     model_cfg: DeepseekV4Config,
     ps: ParallelState,
+    *,
+    participating_group: dist.ProcessGroup | None = None,
 ) -> None:
-    load_hf_weights(chunks, hf_path, model_cfg, ps)
+    load_hf_weights(
+        chunks, hf_path, model_cfg, ps, participating_group=participating_group
+    )
 
 
 def export_hf_weights(

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
@@ -339,34 +339,178 @@ def _configure_attention_backend(
 
 
 def _iter_transformer_units(chunk: nn.Module) -> list[nn.Module]:
-    model = getattr(chunk, "model", None)
+    """Return the trunk and MTP transformer units owned by one model chunk.
+
+    ``build_model`` constructs bare :class:`DeepseekV4Model` chunks, while
+    older callers may still provide the former ``chunk.model`` wrapper.  The
+    wrapper-only lookup used here previously made every configured activation
+    recompute/offload policy a silent no-op for the native bare-model path.
+    """
+
+    model = getattr(chunk, "model", chunk)
     if model is None:
-        return []
-    layers = list(getattr(model, "layers", {}).values())
-    mtp_layers = list(getattr(model, "mtp", []))
+        model = chunk
+
+    def _modules(value: Any, *, field_name: str) -> list[nn.Module]:
+        if value is None:
+            return []
+        if isinstance(value, nn.ModuleDict):
+            modules = list(value.values())
+        elif isinstance(value, (nn.ModuleList, list, tuple)):
+            modules = list(value)
+        else:
+            raise TypeError(
+                "DeepSeek V4 activation memory controls require "
+                f"{field_name} to be a ModuleDict/ModuleList/sequence, got "
+                f"{type(value).__name__}."
+            )
+        if not all(isinstance(module, nn.Module) for module in modules):
+            raise TypeError(f"DeepSeek V4 {field_name} contains a non-module entry.")
+        return modules
+
+    if not hasattr(model, "layers"):
+        raise TypeError(
+            "DeepSeek V4 activation memory controls require every chunk to "
+            "expose a layers container."
+        )
+    layers = _modules(model.layers, field_name="layers")
+    mtp_layers = _modules(getattr(model, "mtp", None), field_name="mtp")
     return [*layers, *mtp_layers]
+
+
+def _validate_activation_module_names(
+    module_names: list[str], *, control: str, allow_full: bool
+) -> None:
+    if not isinstance(module_names, list) or not all(
+        isinstance(module_name, str) and module_name for module_name in module_names
+    ):
+        raise TypeError(
+            f"DeepSeek V4 {control} selectors must be a list of non-empty strings."
+        )
+    if len(module_names) != len(set(module_names)):
+        raise ValueError(
+            f"DeepSeek V4 {control} contains duplicate module selectors: "
+            f"{module_names}."
+        )
+    allowed = set(MODULE_MAP)
+    if allow_full:
+        allowed.add("full")
+    unknown = sorted(set(module_names) - allowed)
+    if unknown:
+        raise ValueError(
+            f"Unsupported DeepSeek V4 {control} module selectors {unknown}; "
+            f"supported selectors are {sorted(allowed)}."
+        )
+    if "full" in module_names and len(module_names) != 1:
+        raise ValueError(f"DeepSeek V4 {control} selector 'full' must be used alone.")
+    if {"attn", "core_attn"}.issubset(module_names):
+        raise ValueError(
+            f"DeepSeek V4 {control} selectors 'attn' and 'core_attn' target "
+            "the same module and cannot be combined."
+        )
+    nested_moe = sorted({"experts", "router"} & set(module_names))
+    if "moe" in module_names and nested_moe:
+        raise ValueError(
+            f"DeepSeek V4 {control} selector 'moe' contains {nested_moe}; "
+            "parent and child selectors cannot be combined."
+        )
+
+
+def _is_valid_empty_pipeline_chunk(chunk: nn.Module) -> bool:
+    model = getattr(chunk, "model", chunk)
+    if model is None:
+        model = chunk
+    layer_indices = getattr(model, "layer_indices", None)
+    ps = getattr(model, "ps", None)
+    pp_size = getattr(ps, "pp_size", 1)
+    return (
+        isinstance(layer_indices, (list, tuple))
+        and not layer_indices
+        and isinstance(pp_size, int)
+        and pp_size > 1
+    )
+
+
+def _apply_activation_memory_controls(
+    chunks: list[nn.Module], *, recompute_spec: list[str], offload_spec: list[str]
+) -> None:
+    """Apply DS4 activation policies, failing closed instead of silently no-oping."""
+
+    _validate_activation_module_names(
+        recompute_spec, control="recompute", allow_full=True
+    )
+    # The shared primitive named ``apply_offload`` currently performs
+    # recomputation rather than CPU offload.  Keep DS4 fail-closed until a real
+    # implementation has numerical and memory evidence.
+    _validate_activation_module_names(offload_spec, control="offload", allow_full=True)
+    if offload_spec:
+        raise NotImplementedError(
+            "DeepSeek V4 activation offload is not implemented: the shared "
+            "primitive currently performs activation recompute rather than "
+            "CPU offload. Use recompute or leave offload empty."
+        )
+    if not recompute_spec and not offload_spec:
+        return
+    if not chunks:
+        raise RuntimeError(
+            "DeepSeek V4 activation recompute was requested with no model chunks."
+        )
+
+    units_by_chunk = [_iter_transformer_units(chunk) for chunk in chunks]
+    for chunk, units in zip(chunks, units_by_chunk, strict=True):
+        if not units and not _is_valid_empty_pipeline_chunk(chunk):
+            raise RuntimeError(
+                "DeepSeek V4 activation recompute was requested, but a non-pipeline-empty "
+                "model chunk exposes no transformer or MTP units."
+            )
+
+    if recompute_spec:
+        for units in units_by_chunk:
+            if units:
+                apply_recompute(units, recompute_spec, MODULE_MAP)
 
 
 def _validate_parallel_scope(p: ParallelConfig) -> None:
     """DS4 CSA attention is not tensor-parallel-capable (documented TP=1 case).
 
-    PP / VPP / EP / CP are inherited from the Kimi skeleton and work; only
-    TP>1 / ETP>1 are unsupported.  Mirrors GLM-5's gate.
+    PP / EP / CP are inherited from the Kimi skeleton and work; TP>1 / ETP>1
+    and VPP are unsupported.  Mirrors GLM-5's tensor-parallel gate while
+    making the shared pipeline-layout restriction explicit before init.
     """
     etp = 1 if p.etp is None else p.etp
     if p.tp > 1:
         raise NotImplementedError(
             "DeepSeek V4 native CSA attention does not support tensor parallelism; "
-            f"got tp={p.tp}. Use tp=1 (PP/VPP/EP/CP are supported)."
+            f"got tp={p.tp}. Use tp=1 (PP/EP/CP are supported)."
         )
     if etp > 1:
         raise NotImplementedError(
             "DeepSeek V4 native CSA attention does not support expert tensor parallelism; "
             f"got etp={etp}. Use etp=1 (EP is supported)."
         )
+    if p.vpp != 1:
+        raise NotImplementedError(
+            "DeepSeek V4 virtual pipeline parallelism is not supported; "
+            f"got vpp={p.vpp}. Use vpp=1."
+        )
 
 
 def build_model(model_cfg: DeepseekV4Config, *, impl_cfg: ImplConfig) -> ModelBundle:
+    recompute_spec = parse_recompute_spec(impl_cfg.recompute)
+    offload_spec = parse_recompute_spec(impl_cfg.offload)
+    # Reject invalid policies before distributed initialization or CUDA model
+    # allocation.  The application helper validates again for direct callers.
+    _validate_activation_module_names(
+        recompute_spec, control="recompute", allow_full=True
+    )
+    _validate_activation_module_names(offload_spec, control="offload", allow_full=True)
+    if offload_spec:
+        raise NotImplementedError(
+            "DeepSeek V4 activation offload is not implemented: the shared "
+            "primitive currently performs activation recompute rather than "
+            "CPU offload. Use recompute or leave offload empty."
+        )
+
     from megatron.lite.model.deepseek_v4.lite.model import DeepseekV4Model
 
     p = impl_cfg.parallel
@@ -426,16 +570,9 @@ def build_model(model_cfg: DeepseekV4Config, *, impl_cfg: ImplConfig) -> ModelBu
     synchronize_mtp_embedding_parameters(chunks, ps, enabled=mtp_enable)
     _configure_attention_backend(chunks, backend=impl_cfg.attention_backend_override)
 
-    recompute_spec = parse_recompute_spec(impl_cfg.recompute)
-    if recompute_spec:
-        for chunk in chunks:
-            apply_recompute(_iter_transformer_units(chunk), recompute_spec, MODULE_MAP)
-
-    if impl_cfg.offload:
-        from megatron.lite.primitive.recompute import apply_offload
-
-        for chunk in chunks:
-            apply_offload(_iter_transformer_units(chunk), impl_cfg.offload, MODULE_MAP)
+    _apply_activation_memory_controls(
+        chunks, recompute_spec=recompute_spec, offload_spec=offload_spec
+    )
 
     optimizer = None
     finalize_grads = None

--- a/experimental/lite/megatron/lite/model/glm5/config.py
+++ b/experimental/lite/megatron/lite/model/glm5/config.py
@@ -19,6 +19,7 @@ _HF_FIELDS = frozenset(
         "hidden_size",
         "index_head_dim",
         "index_n_heads",
+        "index_share_for_mtp_iteration",
         "index_skip_topk_offset",
         "index_topk",
         "index_topk_freq",
@@ -61,10 +62,10 @@ _HF_FIELDS = frozenset(
 )
 _SERIALIZED_INTERNAL_FIELDS = frozenset({"dsa_rope_layout_revision"})
 
-# ``index_share_for_mtp_iteration`` is intentionally absent.  It is a serving
-# proposer control (draft step 0 computes; later draft steps reuse), not a
-# backbone architecture field.  MLite does not own that speculative iteration
-# loop, so claiming support here would silently turn metadata into a no-op.
+# ``index_share_for_mtp_iteration`` is preserved as opaque HF/serving metadata
+# for config API and serialization compatibility.  It is not a backbone
+# schedule input: MLite's appended training-time MTP layers always build their
+# own indexers because MLite does not own the speculative serving iteration.
 
 
 _INDEXER_TYPES = frozenset({"full", "shared"})
@@ -76,7 +77,9 @@ _INDEXER_PATTERN_TYPES = {
 }
 
 
-def _infer_dsa_indexer_type(layer_number: int, *, topk_freq: int, skip_topk_offset: int) -> str:
+def _infer_dsa_indexer_type(
+    layer_number: int, *, topk_freq: int, skip_topk_offset: int
+) -> str:
     if topk_freq <= 1:
         return "full"
     skip_topk = (max(layer_number - skip_topk_offset, 0) % topk_freq) != 0
@@ -149,11 +152,12 @@ class Glm5Config:
     mlp_layer_types: list[str] | None = None
 
     # GLM-5.2 extension fields stay at the end so positional construction of
-    # every pre-existing Glm5Config field keeps its historical slot.
+    # every field in the pre-PR public config keeps its historical slot.
     index_topk_freq: int = 1
     index_skip_topk_offset: int = 0
     index_topk_pattern: str | list[str] | None = None
     indexer_types: list[str] | None = None
+    index_share_for_mtp_iteration: bool = False
     # Internal compatibility revision. ``None`` infers configured RoPE only
     # for configs carrying GLM-5.2 IndexShare schedule metadata. Persisting the
     # resolved value prevents a later all-full override from silently changing
@@ -291,10 +295,7 @@ class Glm5Config:
             "index_head_dim must be >= qk_rope_head_dim",
         )
         check(self.index_topk_freq >= 1, "index_topk_freq must be >= 1")
-        check(
-            self.index_skip_topk_offset >= 0,
-            "index_skip_topk_offset must be >= 0",
-        )
+        check(self.index_skip_topk_offset >= 0, "index_skip_topk_offset must be >= 0")
         check(
             self.dsa_rope_layout_revision in {"legacy", "configured"},
             "dsa_rope_layout_revision must be 'legacy' or 'configured'",
@@ -305,13 +306,17 @@ class Glm5Config:
             "initial GLM5 native path expects MLA heads to be ungrouped",
         )
         check(self.vocab_size > 0, "vocab_size must be > 0")
-        check(self.num_nextn_predict_layers >= 0, "num_nextn_predict_layers must be >= 0")
+        check(
+            self.num_nextn_predict_layers >= 0, "num_nextn_predict_layers must be >= 0"
+        )
         check(self.n_routed_experts >= 1, "n_routed_experts must be >= 1")
         check(
             1 <= self.num_experts_per_tok <= self.n_routed_experts,
             "num_experts_per_tok must be in [1, n_routed_experts]",
         )
-        check(1 <= self.topk_group <= self.n_group, "topk_group must be in [1, n_group]")
+        check(
+            1 <= self.topk_group <= self.n_group, "topk_group must be in [1, n_group]"
+        )
         if self.mlp_layer_types is not None:
             expected_layer_type_lengths = {
                 self.num_hidden_layers,
@@ -420,10 +425,15 @@ class Glm5Config:
             kwargs["dsa_rope_layout_revision"] = (
                 "configured" if source_has_index_share_schedule else "legacy"
             )
-        if "num_nextn_predict_layers" not in kwargs and hf.get("num_nextn_predict") is not None:
+        if (
+            "num_nextn_predict_layers" not in kwargs
+            and hf.get("num_nextn_predict") is not None
+        ):
             kwargs["num_nextn_predict_layers"] = int(hf["num_nextn_predict"])
         rope_parameters = hf.get("rope_parameters")
         if isinstance(rope_parameters, dict) and "rope_theta" not in kwargs:
-            kwargs["rope_theta"] = float(rope_parameters.get("rope_theta", cls.rope_theta))
+            kwargs["rope_theta"] = float(
+                rope_parameters.get("rope_theta", cls.rope_theta)
+            )
         kwargs.update(overrides)
         return cls(**kwargs)

--- a/experimental/lite/megatron/lite/model/glm5/config.py
+++ b/experimental/lite/megatron/lite/model/glm5/config.py
@@ -19,10 +19,10 @@ _HF_FIELDS = frozenset(
         "hidden_size",
         "index_head_dim",
         "index_n_heads",
-        "index_share_for_mtp_iteration",
         "index_skip_topk_offset",
         "index_topk",
         "index_topk_freq",
+        "index_topk_pattern",
         "indexer_types",
         "indexer_layer_norm_eps",
         "indexer_rope_interleave",
@@ -59,9 +59,21 @@ _HF_FIELDS = frozenset(
         "vocab_size",
     }
 )
+_SERIALIZED_INTERNAL_FIELDS = frozenset({"dsa_rope_layout_revision"})
+
+# ``index_share_for_mtp_iteration`` is intentionally absent.  It is a serving
+# proposer control (draft step 0 computes; later draft steps reuse), not a
+# backbone architecture field.  MLite does not own that speculative iteration
+# loop, so claiming support here would silently turn metadata into a no-op.
 
 
 _INDEXER_TYPES = frozenset({"full", "shared"})
+_INDEXER_PATTERN_TYPES = {
+    "F": "full",
+    "S": "shared",
+    "full": "full",
+    "shared": "shared",
+}
 
 
 def _infer_dsa_indexer_type(layer_number: int, *, topk_freq: int, skip_topk_offset: int) -> str:
@@ -71,21 +83,18 @@ def _infer_dsa_indexer_type(layer_number: int, *, topk_freq: int, skip_topk_offs
     return "shared" if skip_topk else "full"
 
 
-def _source_dsa_compute_layer(layer_number: int, *, topk_freq: int, skip_topk_offset: int) -> int:
-    if (
-        _infer_dsa_indexer_type(
-            layer_number, topk_freq=topk_freq, skip_topk_offset=skip_topk_offset
-        )
-        == "full"
-    ):
-        return layer_number
-    source_layer = layer_number - (max(layer_number - skip_topk_offset, 0) % topk_freq)
-    if source_layer < 1:
-        raise ValueError(
-            "DSA IndexShare schedule makes layer "
-            f"{layer_number} shared before any full source layer."
-        )
-    return source_layer
+def _normalize_dsa_indexer_pattern(pattern: str | list[str]) -> tuple[str, ...]:
+    values = list(pattern)
+    normalized: list[str] = []
+    for idx, value in enumerate(values):
+        try:
+            normalized.append(_INDEXER_PATTERN_TYPES[value])
+        except (KeyError, TypeError) as exc:
+            raise ValueError(
+                "index_topk_pattern entries must be 'F', 'S', 'full', or 'shared'; "
+                f"got index_topk_pattern[{idx}]={value!r}"
+            ) from exc
+    return tuple(normalized)
 
 
 @dataclass
@@ -113,10 +122,6 @@ class Glm5Config:
     index_head_dim: int = 128
     index_n_heads: int = 32
     index_topk: int = 2048
-    index_topk_freq: int = 1
-    index_skip_topk_offset: int = 0
-    indexer_types: list[str] | None = None
-    index_share_for_mtp_iteration: bool = False
     indexer_layer_norm_eps: float = 1e-6
     indexer_rope_interleave: bool = False
     indexer_rope_first: bool = True
@@ -143,7 +148,23 @@ class Glm5Config:
     mtp_use_repeated_layer: bool = False
     mlp_layer_types: list[str] | None = None
 
+    # GLM-5.2 extension fields stay at the end so positional construction of
+    # every pre-existing Glm5Config field keeps its historical slot.
+    index_topk_freq: int = 1
+    index_skip_topk_offset: int = 0
+    index_topk_pattern: str | list[str] | None = None
+    indexer_types: list[str] | None = None
+    # Internal compatibility revision. ``None`` infers configured RoPE only
+    # for configs carrying GLM-5.2 IndexShare schedule metadata. Persisting the
+    # resolved value prevents a later all-full override from silently changing
+    # the checkpoint's rotary convention.
+    dsa_rope_layout_revision: str | None = None
+
     def __post_init__(self):
+        if self.dsa_rope_layout_revision is None:
+            self.dsa_rope_layout_revision = (
+                "configured" if self.has_dsa_index_share_schedule else "legacy"
+            )
         self._validate()
 
     @property
@@ -157,31 +178,98 @@ class Glm5Config:
 
     @property
     def uses_dsa_index_share(self) -> bool:
-        return self.index_topk_freq > 1
+        return "shared" in self.resolved_dsa_indexer_types
+
+    @property
+    def has_dsa_index_share_schedule(self) -> bool:
+        """Whether the current config carries GLM-5.2-style schedule metadata.
+
+        GLM-5/5.1 checkpoints expose RoPE interleave metadata too, but MLite's
+        pre-5.2 implementation historically used half-split RoPE. This metadata
+        infers the initial layout revision, even for an explicit all-full
+        schedule; the resolved revision itself remains stable after mutation.
+        """
+
+        return (
+            self.indexer_types is not None
+            or self.index_topk_pattern is not None
+            or self.index_topk_freq > 1
+            or self.index_skip_topk_offset > 0
+        )
+
+    @property
+    def uses_configured_dsa_rope_layout(self) -> bool:
+        return self.dsa_rope_layout_revision == "configured"
+
+    @property
+    def resolved_dsa_indexer_types(self) -> tuple[str, ...]:
+        """Canonical per-backbone-layer IndexShare schedule.
+
+        HF's explicit ``indexer_types`` is authoritative.  The older
+        ``index_topk_pattern`` is the next-priority source, and freq/offset is
+        only a fallback when neither explicit representation is present.
+        Appended MTP layers are deliberately excluded from this tuple because
+        they always build full indexers.
+        """
+
+        if self.indexer_types is not None:
+            return tuple(self.indexer_types)
+        if self.index_topk_pattern is not None:
+            return _normalize_dsa_indexer_pattern(self.index_topk_pattern)
+        return tuple(
+            _infer_dsa_indexer_type(
+                layer_idx + 1,
+                topk_freq=self.index_topk_freq,
+                skip_topk_offset=self.index_skip_topk_offset,
+            )
+            for layer_idx in range(self.num_hidden_layers)
+        )
 
     def dsa_indexer_type(self, layer_idx: int) -> str:
         if layer_idx < 0:
             raise ValueError(f"layer_idx must be non-negative, got {layer_idx}")
-        if layer_idx < self.num_hidden_layers and self.indexer_types is not None:
-            return self.indexer_types[layer_idx]
-        return _infer_dsa_indexer_type(
-            layer_idx + 1,
-            topk_freq=self.index_topk_freq,
-            skip_topk_offset=self.index_skip_topk_offset,
-        )
+        layer_count = self.num_hidden_layers + self.num_nextn_predict_layers
+        if layer_idx >= layer_count:
+            raise ValueError(
+                f"layer_idx must be less than total backbone + MTP layers ({layer_count}), "
+                f"got {layer_idx}"
+            )
+        if layer_idx >= self.num_hidden_layers:
+            return "full"
+        return self.resolved_dsa_indexer_types[layer_idx]
 
     def builds_dsa_indexer(self, layer_idx: int) -> bool:
         return self.dsa_indexer_type(layer_idx) == "full"
 
     def dsa_indexer_source_layer(self, layer_idx: int) -> int:
-        return (
-            _source_dsa_compute_layer(
-                layer_idx + 1,
-                topk_freq=self.index_topk_freq,
-                skip_topk_offset=self.index_skip_topk_offset,
-            )
-            - 1
+        if self.dsa_indexer_type(layer_idx) == "full":
+            return layer_idx
+        for source_idx in range(layer_idx - 1, -1, -1):
+            if self.dsa_indexer_type(source_idx) == "full":
+                return source_idx
+        raise ValueError(
+            "DSA IndexShare schedule makes layer "
+            f"{layer_idx} shared before any full source layer."
         )
+
+    def dsa_index_share_decoder_layer_groups(self) -> list[list[int]] | None:
+        """Return indivisible PP groups from the canonical backbone schedule."""
+
+        if not self.uses_dsa_index_share:
+            return None
+        groups: list[list[int]] = []
+        current: list[int] = []
+        current_source: int | None = None
+        for layer_idx in range(self.num_hidden_layers):
+            source_idx = self.dsa_indexer_source_layer(layer_idx)
+            if current and source_idx != current_source:
+                groups.append(current)
+                current = []
+            current.append(layer_idx)
+            current_source = source_idx
+        if current:
+            groups.append(current)
+        return groups
 
     def _validate(self) -> None:
         errors: list[str] = []
@@ -206,6 +294,10 @@ class Glm5Config:
         check(
             self.index_skip_topk_offset >= 0,
             "index_skip_topk_offset must be >= 0",
+        )
+        check(
+            self.dsa_rope_layout_revision in {"legacy", "configured"},
+            "dsa_rope_layout_revision must be 'legacy' or 'configured'",
         )
         check(self.dsa_indexer_loss_coeff >= 0.0, "dsa_indexer_loss_coeff must be >= 0")
         check(
@@ -236,40 +328,57 @@ class Glm5Config:
                     f"mlp_layer_types[{idx}] must be 'dense' or 'sparse'",
                 )
 
+        resolved_indexer_types: tuple[str, ...] | None = None
         if self.indexer_types is not None:
             check(
                 len(self.indexer_types) == self.num_hidden_layers,
-                "len(indexer_types) must equal num_hidden_layers",
+                "len(indexer_types) must equal num_hidden_layers; MTP layers always "
+                "build full indexers and must not appear in indexer_types",
             )
             for idx, indexer_type in enumerate(self.indexer_types):
                 check(
                     indexer_type in _INDEXER_TYPES,
                     f"indexer_types[{idx}] must be 'full' or 'shared'",
                 )
+            if len(self.indexer_types) == self.num_hidden_layers and all(
+                value in _INDEXER_TYPES for value in self.indexer_types
+            ):
+                resolved_indexer_types = tuple(self.indexer_types)
+        elif self.index_topk_pattern is not None:
+            try:
+                resolved_indexer_types = _normalize_dsa_indexer_pattern(
+                    self.index_topk_pattern
+                )
+            except ValueError as exc:
+                check(False, str(exc))
+            if resolved_indexer_types is not None:
+                check(
+                    len(resolved_indexer_types) == self.num_hidden_layers,
+                    "len(index_topk_pattern) must equal num_hidden_layers",
+                )
+        elif self.index_topk_freq >= 1 and self.index_skip_topk_offset >= 0:
+            resolved_indexer_types = tuple(
+                _infer_dsa_indexer_type(
+                    layer_idx + 1,
+                    topk_freq=self.index_topk_freq,
+                    skip_topk_offset=self.index_skip_topk_offset,
+                )
+                for layer_idx in range(self.num_hidden_layers)
+            )
 
-        if self.index_topk_freq >= 1 and self.index_skip_topk_offset >= 0:
-            layer_count = self.num_hidden_layers + self.num_nextn_predict_layers
-            for layer_idx in range(layer_count):
-                try:
-                    _source_dsa_compute_layer(
-                        layer_idx + 1,
-                        topk_freq=self.index_topk_freq,
-                        skip_topk_offset=self.index_skip_topk_offset,
-                    )
-                except ValueError as exc:
-                    check(False, str(exc))
-
-            if self.indexer_types is not None and len(self.indexer_types) == self.num_hidden_layers:
-                for idx, indexer_type in enumerate(self.indexer_types):
-                    expected = _infer_dsa_indexer_type(
-                        idx + 1,
-                        topk_freq=self.index_topk_freq,
-                        skip_topk_offset=self.index_skip_topk_offset,
-                    )
+        if (
+            resolved_indexer_types is not None
+            and len(resolved_indexer_types) == self.num_hidden_layers
+        ):
+            first_full_idx: int | None = None
+            for idx, indexer_type in enumerate(resolved_indexer_types):
+                if indexer_type == "full":
+                    first_full_idx = idx
+                elif first_full_idx is None:
                     check(
-                        indexer_type == expected,
-                        f"indexer_types[{idx}]={indexer_type!r} does not match "
-                        f"index_topk_freq/index_skip_topk_offset schedule {expected!r}",
+                        False,
+                        "DSA IndexShare schedule makes layer "
+                        f"{idx} shared before any full source layer",
                     )
 
         if errors:
@@ -293,8 +402,24 @@ class Glm5Config:
     @classmethod
     def _from_hf_dict(cls, hf: dict[str, Any], **overrides) -> Glm5Config:
         kwargs = {
-            key: value for key, value in hf.items() if key in _HF_FIELDS and value is not None
+            key: value
+            for key, value in hf.items()
+            if key in (_HF_FIELDS | _SERIALIZED_INTERNAL_FIELDS) and value is not None
         }
+        # Resolve the architecture revision from the source checkpoint before
+        # applying local schedule overrides. Turning a real 5.2 config into an
+        # all-full schedule must not also reinterpret its rotary layout, while
+        # adding an all-full schedule to a 5.1 config must not silently opt in.
+        if "dsa_rope_layout_revision" not in kwargs:
+            source_has_index_share_schedule = (
+                hf.get("indexer_types") is not None
+                or hf.get("index_topk_pattern") is not None
+                or int(hf.get("index_topk_freq") or 1) > 1
+                or int(hf.get("index_skip_topk_offset") or 0) > 0
+            )
+            kwargs["dsa_rope_layout_revision"] = (
+                "configured" if source_has_index_share_schedule else "legacy"
+            )
         if "num_nextn_predict_layers" not in kwargs and hf.get("num_nextn_predict") is not None:
             kwargs["num_nextn_predict_layers"] = int(hf["num_nextn_predict"])
         rope_parameters = hf.get("rope_parameters")

--- a/experimental/lite/megatron/lite/model/glm5/lite/__init__.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/__init__.py
@@ -1,5 +1,17 @@
 """Native GLM-5 lite implementation."""
 
-from megatron.lite.model.glm5.lite.model import Glm5Model
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from megatron.lite.model.glm5.lite.model import Glm5Model
 
 __all__ = ["Glm5Model"]
+
+
+def __getattr__(name: str):
+    """Load the TE-dependent model only when callers request the model class."""
+    if name == "Glm5Model":
+        from megatron.lite.model.glm5.lite.model import Glm5Model
+
+        return Glm5Model
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/experimental/lite/megatron/lite/model/glm5/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/checkpoint.py
@@ -33,12 +33,16 @@ from megatron.lite.primitive.ckpt.hf_weights import (
     SafeTensorReader,
     _cast_export_tensor,
     _resolve_export_dtype,
+    copy_hf_state_atomically,
+    gather_pipeline_state_dict,
+    load_hf_model_chunks_atomically,
+    named_persistent_buffers,
     parse_expert_idx,
     to_global_layer_name,
     unwrap_model,
 )
 from megatron.lite.primitive.parallel import ParallelState
-from megatron.lite.primitive.utils import ensure_divisible, log_rank0
+from megatron.lite.primitive.utils import ensure_divisible
 
 
 def EXPERT_CLASSIFIER(name: str) -> bool:
@@ -46,7 +50,11 @@ def EXPERT_CLASSIFIER(name: str) -> bool:
 
 
 def PLACEMENT_FN(param_name: str) -> list:
-    if "experts" in param_name and "router" not in param_name and "shared" not in param_name:
+    if (
+        "experts" in param_name
+        and "router" not in param_name
+        and "shared" not in param_name
+    ):
         if "fc1" in param_name:
             return [Replicate(), Replicate(), Shard(0), Shard(0)]
         if "fc2" in param_name:
@@ -87,7 +95,9 @@ def _has(reader: SafeTensorReader, name: str) -> bool:
     return True
 
 
-def _dequant_fp8_weight(reader: SafeTensorReader, name: str, weight: torch.Tensor) -> torch.Tensor:
+def _dequant_fp8_weight(
+    reader: SafeTensorReader, name: str, weight: torch.Tensor
+) -> torch.Tensor:
     scale_name = f"{name}_scale_inv"
     if weight.dim() != 2 or weight.element_size() != 1 or not _has(reader, scale_name):
         return weight
@@ -100,11 +110,15 @@ def _dequant_fp8_weight(reader: SafeTensorReader, name: str, weight: torch.Tenso
 
 def _unpack_int4_from_int32(packed: torch.Tensor, shape: torch.Size) -> torch.Tensor:
     if packed.dtype != torch.int32:
-        raise ValueError(f"Expected packed int4 tensor to be int32, got {packed.dtype}.")
+        raise ValueError(
+            f"Expected packed int4 tensor to be int32, got {packed.dtype}."
+        )
     pack_factor = 8
     mask = 0xF
     rows, cols = int(shape[0]), int(shape[1])
-    unpacked = torch.empty((packed.shape[0], packed.shape[1] * pack_factor), dtype=torch.int32)
+    unpacked = torch.empty(
+        (packed.shape[0], packed.shape[1] * pack_factor), dtype=torch.int32
+    )
     for offset in range(pack_factor):
         unpacked[:, offset::pack_factor] = (packed >> (4 * offset)) & mask
     return (unpacked[:rows, :cols] - 8).to(torch.int8)
@@ -134,9 +148,9 @@ def _dequant_int4_weight(reader: SafeTensorReader, name: str) -> torch.Tensor:
         )
 
     group_size = unpacked.shape[1] // scale.shape[1]
-    return (unpacked.unflatten(-1, (scale.shape[1], group_size)) * scale.unsqueeze(-1)).flatten(
-        start_dim=-2
-    )
+    return (
+        unpacked.unflatten(-1, (scale.shape[1], group_size)) * scale.unsqueeze(-1)
+    ).flatten(start_dim=-2)
 
 
 def _get(reader: SafeTensorReader, name: str) -> torch.Tensor:
@@ -193,10 +207,16 @@ def _load_attention(
     # `<hf_prefix>.{...}` (DSA submodule names map 1:1 to the HF model).
     ap = f"{local_prefix}.self_attention.self_attention"
     out[f"{ap}.q_a_proj.weight"] = _get(reader, f"{hf_prefix}.q_a_proj.weight")
-    out[f"{ap}.q_a_layernorm.weight"] = _get(reader, f"{hf_prefix}.q_a_layernorm.weight")
+    out[f"{ap}.q_a_layernorm.weight"] = _get(
+        reader, f"{hf_prefix}.q_a_layernorm.weight"
+    )
     out[f"{ap}.q_b_proj.weight"] = _get(reader, f"{hf_prefix}.q_b_proj.weight")
-    out[f"{ap}.kv_a_proj_with_mqa.weight"] = _get(reader, f"{hf_prefix}.kv_a_proj_with_mqa.weight")
-    out[f"{ap}.kv_a_layernorm.weight"] = _get(reader, f"{hf_prefix}.kv_a_layernorm.weight")
+    out[f"{ap}.kv_a_proj_with_mqa.weight"] = _get(
+        reader, f"{hf_prefix}.kv_a_proj_with_mqa.weight"
+    )
+    out[f"{ap}.kv_a_layernorm.weight"] = _get(
+        reader, f"{hf_prefix}.kv_a_layernorm.weight"
+    )
     out[f"{ap}.kv_b_proj.weight"] = _get(reader, f"{hf_prefix}.kv_b_proj.weight")
     out[f"{ap}.o_proj.weight"] = _get(reader, f"{hf_prefix}.o_proj.weight")
     # GLM5.2 shared IndexShare layers do not instantiate a local indexer and
@@ -257,7 +277,9 @@ def _load_shared_expert(
     ps: ParallelState,
 ) -> None:
     prefixes = [f"{hf_mlp_prefix}.shared_experts", f"{hf_mlp_prefix}.shared_expert"]
-    shared = next(prefix for prefix in prefixes if _has(reader, f"{prefix}.down_proj.weight"))
+    shared = next(
+        prefix for prefix in prefixes if _has(reader, f"{prefix}.down_proj.weight")
+    )
     gate_up = torch.cat(
         [
             _get(reader, f"{shared}.gate_proj.weight"),
@@ -307,33 +329,18 @@ def _load_experts(
         out[f"{local_prefix}.moe.experts.fc2.weight{local_idx}"] = fc2
 
 
-def _copy_loaded_state(model: nn.Module, loaded: dict[str, torch.Tensor]) -> None:
-    state = model.state_dict()
-    resolved: dict[str, torch.Tensor] = {}
-    for name, tensor in loaded.items():
-        actual = name if name in state else None
-        if actual is None:
-            for key in state:
-                if name in key:
-                    actual = key
-                    break
-        if actual is not None:
-            resolved[actual] = tensor
-        else:
-            log_rank0(f"WARNING: glm5 checkpoint tensor has no target param: {name}")
-
-    for name, target in model.named_parameters():
-        if name not in resolved:
-            log_rank0(f"WARNING: {name} not loaded from checkpoint")
-            continue
-        tensor = resolved[name].to(device=target.device)
-        target.data.copy_(tensor.to(dtype=target.dtype))
-
-    for name, target in model.named_buffers():
-        if name not in resolved:
-            continue
-        tensor = resolved[name].to(device=target.device)
-        target.data.copy_(tensor.to(dtype=target.dtype) if target.is_floating_point() else tensor)
+def _copy_loaded_state(
+    model: nn.Module,
+    loaded: dict[str, torch.Tensor],
+    *,
+    participating_group: dist.ProcessGroup | None = None,
+) -> None:
+    copy_hf_state_atomically(
+        model,
+        loaded,
+        context="GLM-5 HF load",
+        participating_group=participating_group,
+    )
 
 
 class Glm5WeightSpec:
@@ -349,7 +356,9 @@ class Glm5WeightSpec:
     def weight_map(self) -> dict[str, list[str]]:
         return {}
 
-    def hf_to_native(self, native_name: str, hf_tensors: list[torch.Tensor]) -> torch.Tensor:
+    def hf_to_native(
+        self, native_name: str, hf_tensors: list[torch.Tensor]
+    ) -> torch.Tensor:
         del native_name
         return hf_tensors[0]
 
@@ -468,7 +477,10 @@ class Glm5WeightSpec:
 
     def tp_spec(self, native_name: str) -> tuple[int, int] | None:
         # GLM-5 is TP=1 (DSA not TP-capable); only EP / ETP shard tensors.
-        if native_name.startswith("mtp.layers.") and ".transformer_layer." in native_name:
+        if (
+            native_name.startswith("mtp.layers.")
+            and ".transformer_layer." in native_name
+        ):
             proxy = native_name.replace(".transformer_layer.", ".")
             return self.tp_spec(proxy)
         if native_name.endswith(".eh_proj.linear.weight"):
@@ -479,7 +491,11 @@ class Glm5WeightSpec:
             if ".fc2." in native_name:
                 return (1, 1)
             return None
-        if native_name in {"embed.embedding.weight", "head.col.linear.weight"}:
+        if native_name in {
+            "embed.embedding.weight",
+            "mtp_embed.embedding.weight",
+            "head.col.linear.weight",
+        }:
             return (0, 0)
         if native_name.endswith(".mlp.gate_up.linear.weight"):
             return (0, 0)
@@ -504,7 +520,9 @@ class Glm5WeightSpec:
         return f"{prefix}.weight{local_idx}"
 
 
-def load_hf_weights(model: nn.Module, path: str, config: Glm5Config, ps: ParallelState) -> None:
+def _materialize_hf_weights(
+    model: nn.Module, path: str, config: Glm5Config, ps: ParallelState
+) -> dict[str, torch.Tensor]:
     base_model = unwrap_model(model)
     reader = SafeTensorReader(path)
     out: dict[str, torch.Tensor] = {}
@@ -532,7 +550,9 @@ def load_hf_weights(model: nn.Module, path: str, config: Glm5Config, ps: Paralle
     for local_idx, global_idx in enumerate(base_model.layer_indices):
         lp = f"layers.{local_idx}"
         hp = f"{prefix}.layers.{global_idx}"
-        out[f"{lp}.input_layernorm.weight"] = _get(reader, f"{hp}.input_layernorm.weight")
+        out[f"{lp}.input_layernorm.weight"] = _get(
+            reader, f"{hp}.input_layernorm.weight"
+        )
         _load_attention(
             out,
             local_prefix=lp,
@@ -542,7 +562,9 @@ def load_hf_weights(model: nn.Module, path: str, config: Glm5Config, ps: Paralle
             load_indexer=config.builds_dsa_indexer(global_idx),
         )
         if config.is_moe_layer(global_idx):
-            out[f"{lp}.mlp_norm.weight"] = _get(reader, f"{hp}.post_attention_layernorm.weight")
+            out[f"{lp}.mlp_norm.weight"] = _get(
+                reader, f"{hp}.post_attention_layernorm.weight"
+            )
             out[f"{lp}.moe.router.gate.weight"] = _get(reader, f"{hp}.mlp.gate.weight")
             bias_name = f"{hp}.mlp.gate.e_score_correction_bias"
             if _has(reader, bias_name):
@@ -589,7 +611,9 @@ def load_hf_weights(model: nn.Module, path: str, config: Glm5Config, ps: Paralle
                 else f"{hp}.final_layernorm.weight"
             )
             out[f"{lp}.final_layernorm.weight"] = _get(reader, final_norm)
-            out[f"{tlp}.input_layernorm.weight"] = _get(reader, f"{hp}.input_layernorm.weight")
+            out[f"{tlp}.input_layernorm.weight"] = _get(
+                reader, f"{hp}.input_layernorm.weight"
+            )
             _load_attention(
                 out,
                 local_prefix=tlp,
@@ -602,10 +626,14 @@ def load_hf_weights(model: nn.Module, path: str, config: Glm5Config, ps: Paralle
                 out[f"{tlp}.mlp_norm.weight"] = _get(
                     reader, f"{hp}.post_attention_layernorm.weight"
                 )
-                out[f"{tlp}.moe.router.gate.weight"] = _get(reader, f"{hp}.mlp.gate.weight")
+                out[f"{tlp}.moe.router.gate.weight"] = _get(
+                    reader, f"{hp}.mlp.gate.weight"
+                )
                 bias_name = f"{hp}.mlp.gate.e_score_correction_bias"
                 if _has(reader, bias_name):
-                    out[f"{tlp}.moe.router.expert_bias"] = _get(reader, bias_name).float()
+                    out[f"{tlp}.moe.router.expert_bias"] = _get(
+                        reader, bias_name
+                    ).float()
                 _load_shared_expert(
                     out,
                     local_prefix=tlp,
@@ -631,7 +659,22 @@ def load_hf_weights(model: nn.Module, path: str, config: Glm5Config, ps: Paralle
                     ps=ps,
                 )
 
-    _copy_loaded_state(base_model, out)
+    return out
+
+
+def load_hf_weights(
+    model: nn.Module | list[nn.Module],
+    path: str,
+    config: Glm5Config,
+    ps: ParallelState,
+) -> None:
+    participating_group = dist.group.WORLD if dist.is_initialized() else None
+    load_hf_model_chunks_atomically(
+        model,
+        lambda chunk: _materialize_hf_weights(chunk, path, config, ps),
+        context="GLM-5 HF load",
+        participating_group=participating_group,
+    )
 
 
 def export_hf_weights(model, config: Glm5Config, ps: ParallelState, **kwargs):
@@ -640,35 +683,51 @@ def export_hf_weights(model, config: Glm5Config, ps: ParallelState, **kwargs):
     spec = Glm5WeightSpec(config)
     rank0_only = bool(kwargs.get("rank0_only", False))
     export_dtype = _resolve_export_dtype(kwargs.get("export_dtype"))
+    chunks = list(model) if isinstance(model, list | nn.ModuleList) else [model]
+    local_buffers: dict[str, torch.Tensor] = {}
+    for chunk in chunks:
+        base_chunk = unwrap_model(chunk)
+        layer_map = (
+            {
+                i: base_chunk.layer_indices[i]
+                for i in range(len(base_chunk.layer_indices))
+            }
+            if hasattr(base_chunk, "layer_indices")
+            else {}
+        )
+        for name, buffer in named_persistent_buffers(base_chunk):
+            if not name.endswith(".moe.router.expert_bias"):
+                continue
+            global_name = to_global_layer_name(name, layer_map)
+            if global_name in local_buffers:
+                raise RuntimeError(f"duplicate local GLM router buffer {global_name}")
+            local_buffers[global_name] = buffer.detach().cpu()
+    gathered_buffers = gather_pipeline_state_dict(
+        local_buffers,
+        ps,
+        participating_group=kwargs.get("participating_group", ps.pp_group),
+    )
+    # Complete every collective before exposing the first generator item. A
+    # caller may intentionally consume only a prefix of the exported weights.
     yield from _export(model, spec, ps, vocab_size=config.vocab_size, **kwargs)
     rank = dist.get_rank() if dist.is_initialized() else 0
     if rank0_only and rank != 0:
         return
-    chunks = list(model) if isinstance(model, list | nn.ModuleList) else [model]
-    for chunk in chunks:
-        base_chunk = unwrap_model(chunk)
-        layer_map = (
-            {i: base_chunk.layer_indices[i] for i in range(len(base_chunk.layer_indices))}
-            if hasattr(base_chunk, "layer_indices")
-            else {}
-        )
-        for name, buffer in base_chunk.named_buffers():
-            if not name.endswith(".moe.router.expert_bias"):
-                continue
-            global_name = to_global_layer_name(name, layer_map)
-            for hf_name, hf_tensor in spec.native_to_hf(global_name, buffer.detach().cpu()):
-                yield hf_name, _cast_export_tensor(hf_tensor, export_dtype)
+    for global_name, buffer in gathered_buffers.items():
+        for hf_name, hf_tensor in spec.native_to_hf(global_name, buffer):
+            yield hf_name, _cast_export_tensor(hf_tensor, export_dtype)
 
 
-def save_hf_weights(model, path: str, config: Glm5Config, ps: ParallelState, **kwargs) -> None:
-    from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
+def save_hf_weights(
+    model, path: str, config: Glm5Config, ps: ParallelState, **kwargs
+) -> None:
+    from megatron.lite.primitive.ckpt.hf_weights import (
+        save_hf_weight_pairs_distributed,
+    )
 
-    rank = dist.get_rank() if dist.is_initialized() else 0
-    out = dict(export_hf_weights(model, config, ps, rank0_only=True, **kwargs))
-    if rank == 0 and out:
-        save_safetensors(out, path)
-    if dist.is_initialized():
-        dist.barrier()
+    save_hf_weight_pairs_distributed(
+        export_hf_weights(model, config, ps, rank0_only=True, **kwargs), path
+    )
 
 
 __all__ = [

--- a/experimental/lite/megatron/lite/model/glm5/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/checkpoint.py
@@ -26,8 +26,6 @@ from __future__ import annotations
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-from torch.distributed.tensor import Replicate, Shard
-
 from megatron.lite.model.glm5.config import Glm5Config
 from megatron.lite.primitive.ckpt.hf_weights import (
     SafeTensorReader,
@@ -43,6 +41,7 @@ from megatron.lite.primitive.ckpt.hf_weights import (
 )
 from megatron.lite.primitive.parallel import ParallelState
 from megatron.lite.primitive.utils import ensure_divisible
+from torch.distributed.tensor import Replicate, Shard
 
 
 def EXPERT_CLASSIFIER(name: str) -> bool:
@@ -98,11 +97,45 @@ def _has(reader: SafeTensorReader, name: str) -> bool:
 def _dequant_fp8_weight(
     reader: SafeTensorReader, name: str, weight: torch.Tensor
 ) -> torch.Tensor:
-    scale_name = f"{name}_scale_inv"
-    if weight.dim() != 2 or weight.element_size() != 1 or not _has(reader, scale_name):
+    float8_dtypes = {
+        dtype
+        for dtype in (
+            getattr(torch, "float8_e4m3fn", None),
+            getattr(torch, "float8_e4m3fnuz", None),
+            getattr(torch, "float8_e5m2", None),
+            getattr(torch, "float8_e5m2fnuz", None),
+        )
+        if dtype is not None
+    }
+    if weight.dtype not in float8_dtypes:
         return weight
-    scale = reader.get_tensor(scale_name).float()
+    if weight.dim() != 2:
+        raise ValueError(
+            f"FP8 weight {name} must be 2-D, got shape={tuple(weight.shape)}."
+        )
+
+    scale_name = f"{name}_scale_inv"
+    if not _has(reader, scale_name):
+        raise KeyError(
+            f"FP8 weight {name} is missing required block scale {scale_name}."
+        )
+    raw_scale = reader.get_tensor(scale_name)
     rows, cols = weight.shape
+    expected_scale_shape = ((rows + 127) // 128, (cols + 127) // 128)
+    if raw_scale.dtype != torch.float32:
+        raise ValueError(
+            f"FP8 scale {scale_name} must be float32, got {raw_scale.dtype}."
+        )
+    if tuple(raw_scale.shape) != expected_scale_shape:
+        raise ValueError(
+            f"FP8 scale {scale_name} has shape={tuple(raw_scale.shape)}, "
+            f"expected={expected_scale_shape} for weight shape={tuple(weight.shape)}."
+        )
+    scale = raw_scale.float()
+    if not torch.isfinite(scale).all():
+        raise ValueError(f"FP8 scale {scale_name} contains non-finite values.")
+    if not torch.all(scale > 0):
+        raise ValueError(f"FP8 scale {scale_name} must be strictly positive.")
     expanded = scale.repeat_interleave(128, dim=0).repeat_interleave(128, dim=1)
     expanded = expanded[:rows, :cols]
     return weight.float() * expanded
@@ -245,8 +278,7 @@ def _load_dense_mlp(
     ps: ParallelState,
 ) -> None:
     out[f"{local_prefix}.mlp.gate_up.linear.layer_norm_weight"] = _get(
-        reader,
-        f"{hf_layer_prefix}.post_attention_layernorm.weight",
+        reader, f"{hf_layer_prefix}.post_attention_layernorm.weight"
     )
     gate_up = torch.cat(
         [
@@ -256,15 +288,10 @@ def _load_dense_mlp(
         dim=0,
     )
     out[f"{local_prefix}.mlp.gate_up.linear.weight"] = _split_gate_up(
-        gate_up,
-        ps.tp_rank,
-        ps.tp_size,
+        gate_up, ps.tp_rank, ps.tp_size
     )
     out[f"{local_prefix}.mlp.down.linear.weight"] = _tp(
-        _get(reader, f"{hf_mlp_prefix}.down_proj.weight"),
-        ps.tp_rank,
-        ps.tp_size,
-        dim=1,
+        _get(reader, f"{hf_mlp_prefix}.down_proj.weight"), ps.tp_rank, ps.tp_size, dim=1
     )
 
 
@@ -288,15 +315,10 @@ def _load_shared_expert(
         dim=0,
     )
     out[f"{local_prefix}.moe.shared_expert.gate_up.linear.weight"] = _split_gate_up(
-        gate_up,
-        ps.tp_rank,
-        ps.tp_size,
+        gate_up, ps.tp_rank, ps.tp_size
     )
     out[f"{local_prefix}.moe.shared_expert.down.linear.weight"] = _tp(
-        _get(reader, f"{shared}.down_proj.weight"),
-        ps.tp_rank,
-        ps.tp_size,
-        dim=1,
+        _get(reader, f"{shared}.down_proj.weight"), ps.tp_rank, ps.tp_size, dim=1
     )
 
 
@@ -336,10 +358,7 @@ def _copy_loaded_state(
     participating_group: dist.ProcessGroup | None = None,
 ) -> None:
     copy_hf_state_atomically(
-        model,
-        loaded,
-        context="GLM-5 HF load",
-        participating_group=participating_group,
+        model, loaded, context="GLM-5 HF load", participating_group=participating_group
     )
 
 
@@ -399,8 +418,7 @@ class Glm5WeightSpec:
             if native_name.endswith(".final_layernorm.weight"):
                 return [(f"{hp}.shared_head.norm.weight", tensor)]
             proxy = native_name.replace(
-                f"mtp.layers.{mtp_idx}.transformer_layer",
-                f"layers.{hf_layer_idx}",
+                f"mtp.layers.{mtp_idx}.transformer_layer", f"layers.{hf_layer_idx}"
             )
             return self.native_to_hf(proxy, tensor)
         if native_name == "embed.embedding.weight":
@@ -535,10 +553,7 @@ def _materialize_hf_weights(
         )
     if getattr(base_model, "mtp_embed", None) is not None:
         out["mtp_embed.embedding.weight"] = _load_vocab(
-            reader,
-            f"{prefix}.embed_tokens.weight",
-            config,
-            ps,
+            reader, f"{prefix}.embed_tokens.weight", config, ps
         )
     if getattr(base_model, "norm", None) is not None:
         out["norm.weight"] = _get(reader, f"{prefix}.norm.weight")
@@ -600,9 +615,7 @@ def _materialize_hf_weights(
             out[f"{lp}.enorm.weight"] = _get(reader, f"{hp}.enorm.weight")
             out[f"{lp}.hnorm.weight"] = _get(reader, f"{hp}.hnorm.weight")
             out[f"{lp}.eh_proj.linear.weight"] = _tp(
-                _get(reader, f"{hp}.eh_proj.weight"),
-                ps.tp_rank,
-                ps.tp_size,
+                _get(reader, f"{hp}.eh_proj.weight"), ps.tp_rank, ps.tp_size
             )
             shared_head_norm = f"{hp}.shared_head.norm.weight"
             final_norm = (
@@ -667,8 +680,9 @@ def load_hf_weights(
     path: str,
     config: Glm5Config,
     ps: ParallelState,
+    *,
+    participating_group: dist.ProcessGroup | None = None,
 ) -> None:
-    participating_group = dist.group.WORLD if dist.is_initialized() else None
     load_hf_model_chunks_atomically(
         model,
         lambda chunk: _materialize_hf_weights(chunk, path, config, ps),
@@ -721,9 +735,7 @@ def export_hf_weights(model, config: Glm5Config, ps: ParallelState, **kwargs):
 def save_hf_weights(
     model, path: str, config: Glm5Config, ps: ParallelState, **kwargs
 ) -> None:
-    from megatron.lite.primitive.ckpt.hf_weights import (
-        save_hf_weight_pairs_distributed,
-    )
+    from megatron.lite.primitive.ckpt.hf_weights import save_hf_weight_pairs_distributed
 
     save_hf_weight_pairs_distributed(
         export_hf_weights(model, config, ps, rank0_only=True, **kwargs), path

--- a/experimental/lite/megatron/lite/model/glm5/lite/model.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/model.py
@@ -93,7 +93,8 @@ def _collect_sp_grad_params(model: nn.Module) -> list[nn.Parameter]:
     return [
         param
         for name, param in model.named_parameters()
-        if any(name.endswith(suffix) for suffix in _SP_GRAD_SUFFIXES) or name == "norm.weight"
+        if any(name.endswith(suffix) for suffix in _SP_GRAD_SUFFIXES)
+        or name == "norm.weight"
     ]
 
 
@@ -104,7 +105,9 @@ def _swiglu(x: torch.Tensor) -> torch.Tensor:
     return F.silu(x1) * x2
 
 
-def _reduce_scatter_to_sequence_parallel(x: torch.Tensor, ps: ParallelState) -> torch.Tensor:
+def _reduce_scatter_to_sequence_parallel(
+    x: torch.Tensor, ps: ParallelState
+) -> torch.Tensor:
     if ps.tp_size == 1:
         return x
     return ReduceScatterDim0.apply(x, ps.tp_size, ps.tp_rank, ps.tp_group)
@@ -156,17 +159,22 @@ class Glm5DSAAttention(nn.Module):
     explicit ``cos`` / ``sin`` / ``position_ids``.  This wrapper:
       1. transposes ``[S, B, H] -> [B, S, H]``,
       2. consumes explicit packed/CP ``position_ids`` and builds rotary
-         ``cos`` / ``sin``,
+         ``cos`` / ``sin`` while accepting either CP-local or full rows,
       3. runs DSA,
       4. transposes the ``[B, S, H]`` output back to ``[S, B, H]``.
     The Kimi skeleton therefore never observes the batch-first interior.
     """
 
-    def __init__(self, config: Glm5Config, ps: ParallelState, layer_idx: int):
+    def __init__(self, config: Glm5Config, ps: ParallelState, layer_idx: int = 0):
         super().__init__()
         self.ps = ps
         self.qk_rope_head_dim = config.qk_rope_head_dim
         self.rope_theta = config.rope_theta
+        # PR #66 promises gate-off compatibility with the existing GLM-5/5.1
+        # path. Those models historically ran half-split RoPE in MLite even
+        # though their HF metadata contains interleave flags. Only the
+        # GLM-5.2 IndexShare architecture opts into the configured layouts.
+        use_configured_rope_layout = config.uses_configured_dsa_rope_layout
         self.self_attention = DynamicSparseAttention(
             hidden_size=config.hidden_size,
             num_attention_heads=config.num_attention_heads,
@@ -179,16 +187,24 @@ class Glm5DSAAttention(nn.Module):
             index_head_dim=config.index_head_dim,
             index_topk=config.index_topk,
             rms_norm_eps=config.rms_norm_eps,
-            rope_interleaved=config.rope_interleave,
+            rope_interleaved=(
+                config.rope_interleave if use_configured_rope_layout else False
+            ),
             latent_rms_norm_eps=config.latent_rms_norm_eps,
             indexer_layer_norm_eps=config.indexer_layer_norm_eps,
-            indexer_rope_interleaved=config.indexer_rope_interleave,
+            indexer_rope_interleaved=(
+                config.indexer_rope_interleave if use_configured_rope_layout else False
+            ),
             indexer_rope_first=config.indexer_rope_first,
             indexer_use_hadamard=config.indexer_use_hadamard,
             layer_number=layer_idx + 1,
             index_topk_freq=config.index_topk_freq,
             index_skip_topk_offset=config.index_skip_topk_offset,
             indexer_type=config.dsa_indexer_type(layer_idx),
+            index_share_enabled=(
+                config.uses_dsa_index_share and layer_idx < config.num_hidden_layers
+            ),
+            index_share_source_layer=config.dsa_indexer_source_layer(layer_idx) + 1,
             indexer_loss_coeff=config.dsa_indexer_loss_coeff,
             indexer_use_sparse_loss=config.dsa_indexer_use_sparse_loss,
             calculate_per_token_loss=config.calculate_per_token_loss,
@@ -200,9 +216,9 @@ class Glm5DSAAttention(nn.Module):
     def forward(
         self,
         x: torch.Tensor,
-        position_ids: torch.Tensor | None = None,
         packed_seq_params=None,
         dsa_index_share_state: DSAIndexShareState | None = None,
+        position_ids: torch.Tensor | None = None,
     ) -> torch.Tensor:
         # Kimi feeds SBHD [S, B, H]; DSA needs batch-first [B, S, H].
         x_bsh = x.transpose(0, 1).contiguous()
@@ -210,33 +226,48 @@ class Glm5DSAAttention(nn.Module):
         if position_ids is None:
             if packed_seq_params is not None:
                 raise ValueError(
-                    "GLM5 packed DSA requires explicit per-sequence position_ids."
+                    "GLM5 DSA packed sequences require explicit position_ids so "
+                    "positions reset at every packed-sequence boundary."
                 )
+            # Compatibility fallback for direct callers that do not provide
+            # positions. This fallback is intentionally non-packed only.
             if self.ps.cp_size > 1:
                 position_ids = zigzag_position_ids_for_cp(
                     seq_len * self.ps.cp_size,
                     self.ps.cp_rank,
                     self.ps.cp_size,
                     x_bsh.device,
-                )
+                ).expand(batch, -1)
             else:
-                position_ids = torch.arange(
-                    seq_len, device=x_bsh.device, dtype=torch.long
-                ).unsqueeze(0)
-        position_ids = position_ids.to(device=x_bsh.device, dtype=torch.long)
-        if position_ids.dim() == 1:
-            position_ids = position_ids.unsqueeze(0)
-        if position_ids.shape[-1] != seq_len:
-            raise ValueError(
-                "GLM5 DSA position_ids must match the local sequence length, "
-                f"got {tuple(position_ids.shape)} for local length {seq_len}."
-            )
+                position_ids = (
+                    torch.arange(seq_len, device=x_bsh.device, dtype=torch.long)
+                    .unsqueeze(0)
+                    .expand(batch, -1)
+                )
+        else:
+            if position_ids.dim() == 1:
+                position_ids = position_ids.unsqueeze(0)
+            if position_ids.dim() != 2:
+                raise ValueError(
+                    "GLM5 DSA position_ids must be rank-1 or rank-2, got "
+                    f"shape={tuple(position_ids.shape)}."
+                )
+            position_ids = position_ids.to(device=x_bsh.device, dtype=torch.long)
         if position_ids.shape[0] == 1 and batch > 1:
             position_ids = position_ids.expand(batch, -1)
         elif position_ids.shape[0] != batch:
             raise ValueError(
-                "GLM5 DSA position_ids batch dimension must be 1 or match hidden states, "
-                f"got {tuple(position_ids.shape)} for batch {batch}."
+                "GLM5 DSA position_ids batch dimension must be 1 or match "
+                f"hidden states, got {tuple(position_ids.shape)} for batch {batch}."
+            )
+        allowed_lengths = {seq_len}
+        if self.ps.cp_size > 1:
+            allowed_lengths.add(seq_len * self.ps.cp_size)
+        if position_ids.shape[-1] not in allowed_lengths:
+            raise ValueError(
+                "GLM5 DSA position_ids must cover the local sequence"
+                + (" or reconstructed CP sequence" if self.ps.cp_size > 1 else "")
+                + f", got {tuple(position_ids.shape)} for local length {seq_len}."
             )
         cos, sin = build_rotary_embeddings(
             position_ids=position_ids,
@@ -285,7 +316,9 @@ class Glm5SigmoidTopKRouter(nn.Module):
         # GLM-5 has no aux_loss_alpha HF field; default the coefficient to 0.
         self.aux_loss_coeff = getattr(config, "aux_loss_alpha", 0.0)
         self.scaling_factor = config.routed_scaling_factor
-        self.num_groups = config.n_group if (config.n_group and config.n_group > 1) else None
+        self.num_groups = (
+            config.n_group if (config.n_group and config.n_group > 1) else None
+        )
         self.group_topk = config.topk_group if self.num_groups is not None else None
         self.router_bias_rate = router_bias_rate
         self.compute_aux_loss = compute_aux_loss
@@ -321,7 +354,9 @@ class Glm5SigmoidTopKRouter(nn.Module):
                 raise NotImplementedError(
                     "topk_routing_with_score_function does not support group-limited routing."
                 )
-            routing_kwargs = dict(num_groups=self.num_groups, group_topk=self.group_topk)
+            routing_kwargs = dict(
+                num_groups=self.num_groups, group_topk=self.group_topk
+            )
         probs_dense, routing_map = topk_routing_with_score_function(
             logits,
             self.topk,
@@ -342,13 +377,18 @@ class Glm5SigmoidTopKRouter(nn.Module):
 
         if self.compute_aux_loss and self.training and torch.is_grad_enabled():
             _, aux_scores = compute_routing_scores_for_aux_loss(
-                logits, self.topk, score_function="sigmoid", fused=self.moe_router_fusion
+                logits,
+                self.topk,
+                score_function="sigmoid",
+                fused=self.moe_router_fusion,
             )
             tokens_per_expert = routing_map.sum(dim=0).to(torch.int64)
             total_num_tokens = num_tokens
             if self._aux_loss_group is not None:
                 dist.all_reduce(tokens_per_expert, group=self._aux_loss_group)
-                total_num_tokens = num_tokens * dist.get_world_size(group=self._aux_loss_group)
+                total_num_tokens = num_tokens * dist.get_world_size(
+                    group=self._aux_loss_group
+                )
             aux_loss = switch_load_balancing_loss_func(
                 aux_scores,
                 tokens_per_expert,
@@ -374,7 +414,9 @@ class DenseMLP(nn.Module):
             normalization="RMSNorm",
             eps=config.rms_norm_eps,
         )
-        self.down = RowParallelLinear(config.intermediate_size, config.hidden_size, ps, bias=False)
+        self.down = RowParallelLinear(
+            config.intermediate_size, config.hidden_size, ps, bias=False
+        )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.down(_swiglu(self.gate_up(x)))
@@ -429,7 +471,9 @@ class MoELayer(nn.Module):
     ):
         super().__init__()
         if fp8:
-            raise NotImplementedError("GLM-5 lite MoE fp8 training is not implemented yet.")
+            raise NotImplementedError(
+                "GLM-5 lite MoE fp8 training is not implemented yet."
+            )
         self.router = Glm5SigmoidTopKRouter(
             config,
             ps,
@@ -456,7 +500,9 @@ class MoELayer(nn.Module):
 
         flat_x = x.view(-1, x.size(-1))
         scores, indices = self.router(flat_x)
-        dispatched, tpe, permuted_probs = self.dispatcher.dispatch(flat_x, scores, indices)
+        dispatched, tpe, permuted_probs = self.dispatcher.dispatch(
+            flat_x, scores, indices
+        )
         del scores, indices
         self.dispatcher.wait_dispatch_event()
         expert_out = self.experts(
@@ -514,15 +560,15 @@ class Glm5Layer(nn.Module):
     def forward(
         self,
         x: torch.Tensor,
-        position_ids: torch.Tensor | None = None,
         packed_seq_params=None,
         dsa_index_share_state: DSAIndexShareState | None = None,
+        position_ids: torch.Tensor | None = None,
     ) -> torch.Tensor:
         x = x + self.self_attention(
             self.input_layernorm(x),
-            position_ids=position_ids,
             packed_seq_params=packed_seq_params,
             dsa_index_share_state=dsa_index_share_state,
+            position_ids=position_ids,
         )
         if self.moe is not None:
             assert self.mlp_norm is not None
@@ -539,7 +585,9 @@ def _roll_mtp_left(
     dims: int = -1,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     if packed_seq_params is not None:
-        return roll_packed_thd_left(tensor, packed_seq_params=packed_seq_params, dims=dims)
+        return roll_packed_thd_left(
+            tensor, packed_seq_params=packed_seq_params, dims=dims
+        )
     dim = dims if dims >= 0 else tensor.dim() + dims
     rolled = torch.roll(tensor, shifts=-1, dims=dim)
     rolled.select(dim, -1).zero_()
@@ -596,10 +644,16 @@ class Glm5MTPLayer(nn.Module):
         packed_seq_params=None,
         dsa_index_share_state: DSAIndexShareState | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        # MTP shifts token/label positions for the next prediction depth, but
+        # its transformer layer keeps the original rotary coordinates.  This
+        # matches the reference MTP contract, where rotary embeddings are built once
+        # before entering the MTP block and reused at every prediction depth.
         attention_position_ids = (
             rotary_position_ids if rotary_position_ids is not None else position_ids
         )
-        input_ids, _ = _roll_mtp_left(input_ids, packed_seq_params=packed_seq_params, dims=-1)
+        input_ids, _ = _roll_mtp_left(
+            input_ids, packed_seq_params=packed_seq_params, dims=-1
+        )
         if position_ids is not None:
             position_ids, _ = _roll_mtp_left(
                 position_ids, packed_seq_params=packed_seq_params, dims=-1
@@ -618,9 +672,9 @@ class Glm5MTPLayer(nn.Module):
         hidden_states = scatter_to_sequence_parallel(hidden_states, self.ps)
         hidden_states = self.transformer_layer(
             hidden_states,
-            position_ids=attention_position_ids,
             packed_seq_params=packed_seq_params,
             dsa_index_share_state=dsa_index_share_state,
+            position_ids=attention_position_ids,
         )
         hidden_states = self.final_layernorm(hidden_states)
         return hidden_states, input_ids, position_ids
@@ -719,25 +773,69 @@ def _apply_attention_backend_override(backend: str | None) -> None:
 
 
 def _dsa_index_share_decoder_layer_groups(config: Glm5Config) -> list[list[int]] | None:
-    if not config.uses_dsa_index_share:
-        return None
+    return config.dsa_index_share_decoder_layer_groups()
 
-    groups: list[list[int]] = []
-    current: list[int] = []
-    current_source: int | None = None
-    for layer_idx in range(config.num_hidden_layers):
-        if config.dsa_indexer_type(layer_idx) == "shared":
-            source_idx = config.dsa_indexer_source_layer(layer_idx)
+
+def _local_dsa_index_share_consumer_counts(
+    layers: nn.ModuleList,
+    mtp: Glm5MTPBlock | None,
+) -> dict[int, int]:
+    """Count local shared-layer executions for each 1-indexed source layer."""
+    consumer_counts: dict[int, int] = {}
+
+    def register(layer: Glm5Layer, *, executions: int = 1) -> None:
+        dsa = layer.self_attention.self_attention
+        if not dsa.skip_topk:
+            return
+        source_layer = dsa.index_share_source_layer
+        consumer_counts[source_layer] = (
+            consumer_counts.get(source_layer, 0) + executions
+        )
+
+    for layer in layers:
+        register(layer)
+
+    if mtp is not None and mtp.layers:
+        if mtp.repeated_layer:
+            register(mtp.layers[0].transformer_layer, executions=mtp.num_layers)
         else:
-            source_idx = layer_idx
-        if current and source_idx != current_source:
-            groups.append(current)
-            current = []
-        current.append(layer_idx)
-        current_source = source_idx
-    if current:
-        groups.append(current)
-    return groups
+            for mtp_layer in mtp.layers:
+                register(mtp_layer.transformer_layer)
+
+    return consumer_counts
+
+
+def _validate_dsa_index_share_activation_replay(
+    index_share_enabled: bool,
+    *,
+    recompute_modules: list[str],
+    offload_modules: list[str] | None = None,
+) -> None:
+    """Reject wrappers that replay a shared layer after its top-k was released.
+
+    The check is intentionally based on the global architecture schedule, not
+    the layers local to one PP rank.  Model construction must fail consistently
+    on every rank instead of letting only the rank that owns a shared layer
+    abort while its peers enter collectives.
+    """
+
+    if not index_share_enabled:
+        return
+    attention_replay_modules = {"full", "core_attn", "self_attn", "dsa"}
+    unsafe_recompute = attention_replay_modules & set(recompute_modules)
+    unsafe_offload = attention_replay_modules & set(offload_modules or ())
+    if unsafe_recompute or unsafe_offload:
+        details = []
+        if unsafe_recompute:
+            details.append(f"recompute={sorted(unsafe_recompute)}")
+        if unsafe_offload:
+            details.append(f"offload={sorted(unsafe_offload)}")
+        raise ValueError(
+            "DSA IndexShare is incompatible with per-layer attention activation replay "
+            f"({', '.join(details)}): backward replays shared layers after their "
+            "bounded top-k cache entry has been released. A source+shared group-aware "
+            "checkpoint/offload implementation is required."
+        )
 
 
 class Glm5Model(nn.Module):
@@ -766,6 +864,14 @@ class Glm5Model(nn.Module):
         self.mtp_enable_train = bool(mtp_enable and mtp_enable_train)
         self.mtp_loss_scaling_factor = config.mtp_loss_scaling_factor
 
+        recompute_modules = list(getattr(train_config, "recompute_modules", []) or [])
+        offload_modules = list(getattr(train_config, "offload_modules", []) or [])
+        _validate_dsa_index_share_activation_replay(
+            config.uses_dsa_index_share,
+            recompute_modules=recompute_modules,
+            offload_modules=offload_modules,
+        )
+
         layout = build_pipeline_chunk_layout(
             config.num_hidden_layers,
             ps,
@@ -778,6 +884,7 @@ class Glm5Model(nn.Module):
         self.pre_process = layout.has_embed
         self.post_process = layout.has_head
         local_dsa_layer_indices = list(self.layer_indices)
+        resolved_indexer_types = list(config.resolved_dsa_indexer_types)
         if layout.has_mtp:
             mtp_layers_to_build = (
                 1 if config.mtp_use_repeated_layer else config.num_nextn_predict_layers
@@ -788,11 +895,15 @@ class Glm5Model(nn.Module):
                     config.num_hidden_layers + mtp_layers_to_build,
                 )
             )
+            # MTP predictors always own full indexers. Extending the explicit
+            # schedule avoids accidentally reapplying the trunk frequency
+            # pattern to appended predictor indices during PP validation.
+            resolved_indexer_types.extend(["full"] * mtp_layers_to_build)
         dsa.validate_dsa_index_share_pipeline_split(
             local_dsa_layer_indices,
             topk_freq=config.index_topk_freq,
             skip_topk_offset=config.index_skip_topk_offset,
-            indexer_types=config.indexer_types,
+            indexer_types=resolved_indexer_types,
         )
         # GLM-5 does not tie embeddings (no tie_word_embeddings HF field); the
         # attribute is preserved for the dist-opt / distckpt interface.
@@ -803,15 +914,13 @@ class Glm5Model(nn.Module):
 
         self.embed: VocabParallelEmbedding | None = None
         if layout.has_embed:
-            self.embed = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
+            self.embed = VocabParallelEmbedding(
+                config.vocab_size, config.hidden_size, ps
+            )
 
-        recompute_modules = getattr(train_config, "recompute_modules", [])
-        offload_modules = getattr(train_config, "offload_modules", [])
-        self._retain_index_share_for_recompute = bool(
-            {"full", "core_attn", "self_attn", "dsa"}
-            & set([*recompute_modules, *offload_modules])
+        moe_act_recompute = (
+            "moe_act" in recompute_modules and "moe" not in recompute_modules
         )
-        moe_act_recompute = "moe_act" in recompute_modules and "moe" not in recompute_modules
         self.layers = nn.ModuleList(
             [
                 Glm5Layer(
@@ -839,7 +948,9 @@ class Glm5Model(nn.Module):
         if mtp_enable and config.num_nextn_predict_layers > 0 and layout.has_mtp:
             mtp_embedding = self.embed
             if mtp_embedding is None:
-                mtp_embedding = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
+                mtp_embedding = VocabParallelEmbedding(
+                    config.vocab_size, config.hidden_size, ps
+                )
                 self.mtp_embed = mtp_embedding
             self.mtp = Glm5MTPBlock(
                 config,
@@ -853,6 +964,10 @@ class Glm5Model(nn.Module):
                 detach_encoder=mtp_detach_encoder,
                 repeated_layer=config.mtp_use_repeated_layer,
             )
+
+        self._dsa_index_share_consumer_counts = _local_dsa_index_share_consumer_counts(
+            self.layers, self.mtp
+        )
 
         self.sp_params: list[nn.Parameter] = []
         if ps.tp_size > 1:
@@ -887,16 +1002,16 @@ class Glm5Model(nn.Module):
             h = hidden_states
 
         fp8_ctx = (
-            te.fp8_autocast(enabled=True, fp8_recipe=build_fp8_recipe(self.train_config))
+            te.fp8_autocast(
+                enabled=True, fp8_recipe=build_fp8_recipe(self.train_config)
+            )
             if self.train_config.fp8
             else nullcontext()
         )
         with fp8_ctx:
             dsa_index_share_state = (
-                DSAIndexShareState(
-                    retain_for_recompute=self._retain_index_share_for_recompute
-                )
-                if self.config.uses_dsa_index_share
+                DSAIndexShareState(self._dsa_index_share_consumer_counts)
+                if self._dsa_index_share_consumer_counts
                 else None
             )
             if self.embed is not None:
@@ -904,9 +1019,9 @@ class Glm5Model(nn.Module):
             for layer in self.layers:
                 h = layer(
                     h,
-                    position_ids=position_ids,
                     packed_seq_params=packed_seq_params,
                     dsa_index_share_state=dsa_index_share_state,
+                    position_ids=position_ids,
                 )
 
         output = {"hidden_states": h}
@@ -938,7 +1053,9 @@ class Glm5Model(nn.Module):
                     output["mtp_loss"] = mtp_loss
                 labels_sb = labels.transpose(0, 1).contiguous()
                 if use_fused_kernels:
-                    hidden_full = gather_from_sequence_parallel(hidden_for_head, self.ps)
+                    hidden_full = gather_from_sequence_parallel(
+                        hidden_for_head, self.ps
+                    )
                     log_probs, entropy = linear_cross_entropy(
                         hidden_full,
                         self._head_weight_for_fused_ce(hidden_full),
@@ -954,7 +1071,9 @@ class Glm5Model(nn.Module):
                     logits = self.head(hidden_for_head)
                     if temperature_value != 1.0:
                         logits = logits / temperature_value
-                    loss = vocab_parallel_cross_entropy(logits, labels_sb, self.ps.tp_group)
+                    loss = vocab_parallel_cross_entropy(
+                        logits, labels_sb, self.ps.tp_group
+                    )
                     output["loss"] = loss.mean()
                     output["log_probs"] = (-loss).transpose(0, 1).contiguous()
                     if calculate_entropy:
@@ -965,11 +1084,11 @@ class Glm5Model(nn.Module):
                 output["logits"] = self.head.gather(logits).transpose(0, 1).contiguous()
                 if mtp_hidden_states is not None:
                     output["mtp_logits"] = [
-                        self.head.gather(self.head(mtp_hidden)).transpose(0, 1).contiguous()
+                        self.head.gather(self.head(mtp_hidden))
+                        .transpose(0, 1)
+                        .contiguous()
                         for mtp_hidden in mtp_hidden_states
                     ]
-        if dsa_index_share_state is not None:
-            dsa_index_share_state.finish_forward()
         return output
 
     def _apply_mtp(
@@ -1045,13 +1164,17 @@ class Glm5Model(nn.Module):
                 logits = self.head(mtp_hidden)
                 if temperature != 1.0:
                     logits = logits / temperature
-                token_loss = vocab_parallel_cross_entropy(logits, labels_sb, self.ps.tp_group)
+                token_loss = vocab_parallel_cross_entropy(
+                    logits, labels_sb, self.ps.tp_group
+                )
 
             token_loss = token_loss * mask_sb.to(dtype=token_loss.dtype)
             num_tokens = num_tokens.to(dtype=token_loss.dtype).clamp_min(1.0)
             mtp_loss_values.append(token_loss.sum() / num_tokens)
 
-            mtp_loss_scale = self.mtp_loss_scaling_factor / max(len(mtp_hidden_states), 1)
+            mtp_loss_scale = self.mtp_loss_scaling_factor / max(
+                len(mtp_hidden_states), 1
+            )
             hidden_states = MTPLossAutoScaler.apply(
                 hidden_states,
                 mtp_loss_scale * token_loss / num_tokens,
@@ -1068,7 +1191,9 @@ class Glm5Model(nn.Module):
         assert self.head is not None
         weight = self.head.col.linear.weight
         return (
-            weight if weight.dtype == hidden_states.dtype else weight.to(dtype=hidden_states.dtype)
+            weight
+            if weight.dtype == hidden_states.dtype
+            else weight.to(dtype=hidden_states.dtype)
         )
 
 

--- a/experimental/lite/megatron/lite/model/glm5/lite/model.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/model.py
@@ -448,10 +448,7 @@ class _LocalLinear(nn.Module):
     def __init__(self, in_features: int, out_features: int):
         super().__init__()
         self.linear = te.Linear(
-            in_features,
-            out_features,
-            bias=False,
-            params_dtype=torch.bfloat16,
+            in_features, out_features, bias=False, params_dtype=torch.bfloat16
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -481,17 +478,9 @@ class MoELayer(nn.Module):
             compute_aux_loss=True,
             use_pre_softmax=True,
         )
-        self.experts = Experts(
-            config,
-            ps,
-            fp8=fp8,
-            moe_act_recompute=moe_act_recompute,
-        )
+        self.experts = Experts(config, ps, fp8=fp8, moe_act_recompute=moe_act_recompute)
         self.dispatcher = TokenDispatcher(
-            config.num_experts,
-            config.hidden_size,
-            ps,
-            use_deepep=use_deepep,
+            config.num_experts, config.hidden_size, ps, use_deepep=use_deepep
         )
         self.shared_expert = SharedExpert(config, ps)
 
@@ -579,10 +568,7 @@ class Glm5Layer(nn.Module):
 
 
 def _roll_mtp_left(
-    tensor: torch.Tensor,
-    *,
-    packed_seq_params=None,
-    dims: int = -1,
+    tensor: torch.Tensor, *, packed_seq_params=None, dims: int = -1
 ) -> tuple[torch.Tensor, torch.Tensor]:
     if packed_seq_params is not None:
         return roll_packed_thd_left(
@@ -777,8 +763,7 @@ def _dsa_index_share_decoder_layer_groups(config: Glm5Config) -> list[list[int]]
 
 
 def _local_dsa_index_share_consumer_counts(
-    layers: nn.ModuleList,
-    mtp: Glm5MTPBlock | None,
+    layers: nn.ModuleList, mtp: Glm5MTPBlock | None
 ) -> dict[int, int]:
     """Count local shared-layer executions for each 1-indexed source layer."""
     consumer_counts: dict[int, int] = {}
@@ -1138,14 +1123,10 @@ class Glm5Model(nn.Module):
         mtp_loss_values = []
         for mtp_hidden in mtp_hidden_states:
             mtp_labels, _ = _roll_mtp_left(
-                mtp_labels,
-                packed_seq_params=packed_seq_params,
-                dims=-1,
+                mtp_labels, packed_seq_params=packed_seq_params, dims=-1
             )
             mtp_loss_mask, num_tokens = _roll_mtp_left(
-                mtp_loss_mask,
-                packed_seq_params=packed_seq_params,
-                dims=-1,
+                mtp_loss_mask, packed_seq_params=packed_seq_params, dims=-1
             )
             labels_sb = mtp_labels.transpose(0, 1).contiguous()
             mask_sb = mtp_loss_mask.transpose(0, 1).contiguous()
@@ -1176,8 +1157,7 @@ class Glm5Model(nn.Module):
                 len(mtp_hidden_states), 1
             )
             hidden_states = MTPLossAutoScaler.apply(
-                hidden_states,
-                mtp_loss_scale * token_loss / num_tokens,
+                hidden_states, mtp_loss_scale * token_loss / num_tokens
             )
 
         if not mtp_loss_values:

--- a/experimental/lite/megatron/lite/model/glm5/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/protocol.py
@@ -161,9 +161,16 @@ def _validate_parallel_scope(p: ParallelConfig) -> None:
 
 
 def _build_dist_opt_optimizer(
-    chunks, model_cfg: Glm5Config, impl_cfg: ImplConfig, ps: ParallelState
+    chunks,
+    model_cfg: Glm5Config,
+    impl_cfg: ImplConfig,
+    ps: ParallelState,
+    *,
+    mtp_enabled: bool,
 ):
-    from megatron.lite.primitive.optimizers.megatron_wrap import build_dist_opt_training_optimizer
+    from megatron.lite.primitive.optimizers.megatron_wrap import (
+        build_dist_opt_training_optimizer,
+    )
 
     return build_dist_opt_training_optimizer(
         chunks,
@@ -173,6 +180,7 @@ def _build_dist_opt_optimizer(
         model_name="glm5",
         is_expert=is_expert_param,
         deterministic=impl_cfg.deterministic,
+        mtp_enabled=mtp_enabled,
     )
 
 
@@ -188,17 +196,39 @@ def build_model(model_cfg: Glm5Config, *, impl_cfg: ImplConfig) -> ModelBundle:
     mtp_enable_train = mtp_enable and bool(impl_cfg.mtp_enable_train)
     if mtp_enable:
         if model_cfg.num_nextn_predict_layers <= 0:
-            raise ValueError("mtp_enable=True but HF config has no num_nextn_predict_layers.")
+            raise ValueError(
+                "mtp_enable=True but HF config has no num_nextn_predict_layers."
+            )
         model_cfg.mtp_loss_scaling_factor = impl_cfg.mtp_loss_scaling_factor
         if impl_cfg.mtp_use_repeated_layer is not None:
             model_cfg.mtp_use_repeated_layer = impl_cfg.mtp_use_repeated_layer
     elif hasattr(model_cfg, "num_nextn_predict_layers"):
         model_cfg.num_nextn_predict_layers = 0
+    if impl_cfg.optimizer == "fsdp2" and mtp_enable and p.pp > 1:
+        raise NotImplementedError(
+            "FSDP2 does not yet synchronize the PP-replicated MTP input embedding; "
+            "use dist_opt for PP+MTP training."
+        )
 
-    from megatron.lite.model.glm5.lite.model import Glm5Model
+    from megatron.lite.model.glm5.lite.model import (
+        Glm5Model,
+        _validate_dsa_index_share_activation_replay,
+    )
 
-    ps = init_parallel(p)
     recompute_spec = parse_recompute_spec(impl_cfg.recompute)
+    _validate_dsa_index_share_activation_replay(
+        model_cfg.uses_dsa_index_share,
+        recompute_modules=recompute_spec,
+        offload_modules=impl_cfg.offload,
+    )
+    ps = init_parallel(p)
+    from megatron.lite.primitive.parallel import (
+        init_mtp_embedding_group,
+        synchronize_mtp_embedding_parameters,
+    )
+
+    if mtp_enable:
+        init_mtp_embedding_group(ps)
     vpp = None if p.vpp == 1 else p.vpp
     train_cfg = SimpleNamespace(
         tp=ps.tp_size,
@@ -224,7 +254,11 @@ def build_model(model_cfg: Glm5Config, *, impl_cfg: ImplConfig) -> ModelBundle:
     )
 
     if vpp is None:
-        chunks = [Glm5Model(model_cfg, train_cfg, ps, **model_kwargs).to(torch.bfloat16).cuda()]
+        chunks = [
+            Glm5Model(model_cfg, train_cfg, ps, **model_kwargs)
+            .to(torch.bfloat16)
+            .cuda()
+        ]
     else:
         chunks = [
             Glm5Model(
@@ -238,6 +272,7 @@ def build_model(model_cfg: Glm5Config, *, impl_cfg: ImplConfig) -> ModelBundle:
             .cuda()
             for i in range(vpp)
         ]
+    synchronize_mtp_embedding_parameters(chunks, ps, enabled=mtp_enable)
     set_cross_entropy_fusion(chunks, impl_cfg.cross_entropy_fusion)
 
     if recompute_spec:
@@ -255,7 +290,9 @@ def build_model(model_cfg: Glm5Config, *, impl_cfg: ImplConfig) -> ModelBundle:
     post_model_load_hook = None
     optimizer_backend = "none"
     if impl_cfg.optimizer == "dist_opt":
-        optimizer, finalize_grads = _build_dist_opt_optimizer(chunks, model_cfg, impl_cfg, ps)
+        optimizer, finalize_grads = _build_dist_opt_optimizer(
+            chunks, model_cfg, impl_cfg, ps, mtp_enabled=mtp_enable
+        )
         from megatron.lite.primitive.ckpt import attach_model_sharded_state_dict
         from megatron.lite.runtime.megatron_utils import register_training_hooks
 
@@ -269,7 +306,9 @@ def build_model(model_cfg: Glm5Config, *, impl_cfg: ImplConfig) -> ModelBundle:
 
         def _post_model_load_hook():
             from megatron.lite.model.glm5.lite.model import Glm5Layer
-            from megatron.lite.primitive.optimizers.fsdp2 import build_fsdp2_training_optimizer
+            from megatron.lite.primitive.optimizers.fsdp2 import (
+                build_fsdp2_training_optimizer,
+            )
 
             return {
                 "optimizer": build_fsdp2_training_optimizer(
@@ -304,7 +343,10 @@ def build_model(model_cfg: Glm5Config, *, impl_cfg: ImplConfig) -> ModelBundle:
 
 
 def load_hf_weights(
-    chunk: nn.Module, hf_path: str, model_cfg: Glm5Config, ps: ParallelState
+    chunk: nn.Module | list[nn.Module],
+    hf_path: str,
+    model_cfg: Glm5Config,
+    ps: ParallelState,
 ) -> None:
     if not hf_path:
         return
@@ -313,13 +355,23 @@ def load_hf_weights(
     load_impl(chunk, hf_path, model_cfg, ps)
 
 
+def load_hf_weights_many(
+    chunks: list[nn.Module], hf_path: str, model_cfg: Glm5Config, ps: ParallelState
+) -> None:
+    load_hf_weights(chunks, hf_path, model_cfg, ps)
+
+
 def export_hf_weights(chunks, model_cfg: Glm5Config, ps: ParallelState, **kwargs):
-    from megatron.lite.model.glm5.lite.checkpoint import export_hf_weights as export_impl
+    from megatron.lite.model.glm5.lite.checkpoint import (
+        export_hf_weights as export_impl,
+    )
 
     yield from export_impl(chunks, model_cfg, ps, **kwargs)
 
 
-def save_hf_weights(chunks, path: str, model_cfg: Glm5Config, ps: ParallelState, **kwargs):
+def save_hf_weights(
+    chunks, path: str, model_cfg: Glm5Config, ps: ParallelState, **kwargs
+):
     from megatron.lite.model.glm5.lite.checkpoint import save_hf_weights as save_impl
 
     save_impl(chunks, path, model_cfg, ps, **kwargs)

--- a/experimental/lite/megatron/lite/model/glm5/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/protocol.py
@@ -22,6 +22,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 from megatron.lite.model.glm5.config import Glm5Config
 from megatron.lite.model.protocol_utils import (
@@ -261,13 +262,7 @@ def build_model(model_cfg: Glm5Config, *, impl_cfg: ImplConfig) -> ModelBundle:
         ]
     else:
         chunks = [
-            Glm5Model(
-                model_cfg,
-                train_cfg,
-                ps,
-                vpp_chunk_id=i,
-                **model_kwargs,
-            )
+            Glm5Model(model_cfg, train_cfg, ps, vpp_chunk_id=i, **model_kwargs)
             .to(torch.bfloat16)
             .cuda()
             for i in range(vpp)
@@ -347,18 +342,27 @@ def load_hf_weights(
     hf_path: str,
     model_cfg: Glm5Config,
     ps: ParallelState,
+    *,
+    participating_group: dist.ProcessGroup | None = None,
 ) -> None:
     if not hf_path:
         return
     from megatron.lite.model.glm5.lite.checkpoint import load_hf_weights as load_impl
 
-    load_impl(chunk, hf_path, model_cfg, ps)
+    load_impl(chunk, hf_path, model_cfg, ps, participating_group=participating_group)
 
 
 def load_hf_weights_many(
-    chunks: list[nn.Module], hf_path: str, model_cfg: Glm5Config, ps: ParallelState
+    chunks: list[nn.Module],
+    hf_path: str,
+    model_cfg: Glm5Config,
+    ps: ParallelState,
+    *,
+    participating_group: dist.ProcessGroup | None = None,
 ) -> None:
-    load_hf_weights(chunks, hf_path, model_cfg, ps)
+    load_hf_weights(
+        chunks, hf_path, model_cfg, ps, participating_group=participating_group
+    )
 
 
 def export_hf_weights(chunks, model_cfg: Glm5Config, ps: ParallelState, **kwargs):

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/checkpoint.py
@@ -6,8 +6,6 @@ from __future__ import annotations
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-from torch.distributed.tensor import Replicate, Shard
-
 from megatron.lite.model.kimi_k2.config import KimiK2Config
 from megatron.lite.primitive.ckpt.hf_weights import (
     SafeTensorReader,
@@ -23,6 +21,7 @@ from megatron.lite.primitive.ckpt.hf_weights import (
 )
 from megatron.lite.primitive.parallel import ParallelState
 from megatron.lite.primitive.utils import ensure_divisible
+from torch.distributed.tensor import Replicate, Shard
 
 
 def EXPERT_CLASSIFIER(name: str) -> bool:
@@ -186,40 +185,25 @@ def _load_attention(
     ps: ParallelState,
 ) -> None:
     out[f"{local_prefix}.self_attention.linear_q_down_proj.weight"] = _get(
-        reader,
-        f"{hf_prefix}.q_a_proj.weight",
+        reader, f"{hf_prefix}.q_a_proj.weight"
     )
     out[f"{local_prefix}.self_attention.linear_q_up_proj.linear.layer_norm_weight"] = (
-        _get(
-            reader,
-            f"{hf_prefix}.q_a_layernorm.weight",
-        )
+        _get(reader, f"{hf_prefix}.q_a_layernorm.weight")
     )
     out[f"{local_prefix}.self_attention.linear_q_up_proj.linear.weight"] = _tp(
-        _get(reader, f"{hf_prefix}.q_b_proj.weight"),
-        ps.tp_rank,
-        ps.tp_size,
+        _get(reader, f"{hf_prefix}.q_b_proj.weight"), ps.tp_rank, ps.tp_size
     )
     out[f"{local_prefix}.self_attention.linear_kv_down_proj.weight"] = _get(
-        reader,
-        f"{hf_prefix}.kv_a_proj_with_mqa.weight",
+        reader, f"{hf_prefix}.kv_a_proj_with_mqa.weight"
     )
     out[f"{local_prefix}.self_attention.linear_kv_up_proj.linear.layer_norm_weight"] = (
-        _get(
-            reader,
-            f"{hf_prefix}.kv_a_layernorm.weight",
-        )
+        _get(reader, f"{hf_prefix}.kv_a_layernorm.weight")
     )
     out[f"{local_prefix}.self_attention.linear_kv_up_proj.linear.weight"] = _tp(
-        _get(reader, f"{hf_prefix}.kv_b_proj.weight"),
-        ps.tp_rank,
-        ps.tp_size,
+        _get(reader, f"{hf_prefix}.kv_b_proj.weight"), ps.tp_rank, ps.tp_size
     )
     out[f"{local_prefix}.self_attention.linear_proj.linear.weight"] = _tp(
-        _get(reader, f"{hf_prefix}.o_proj.weight"),
-        ps.tp_rank,
-        ps.tp_size,
-        dim=1,
+        _get(reader, f"{hf_prefix}.o_proj.weight"), ps.tp_rank, ps.tp_size, dim=1
     )
 
 
@@ -233,8 +217,7 @@ def _load_dense_mlp(
     ps: ParallelState,
 ) -> None:
     out[f"{local_prefix}.mlp.gate_up.linear.layer_norm_weight"] = _get(
-        reader,
-        f"{hf_layer_prefix}.post_attention_layernorm.weight",
+        reader, f"{hf_layer_prefix}.post_attention_layernorm.weight"
     )
     gate_up = torch.cat(
         [
@@ -244,15 +227,10 @@ def _load_dense_mlp(
         dim=0,
     )
     out[f"{local_prefix}.mlp.gate_up.linear.weight"] = _split_gate_up(
-        gate_up,
-        ps.tp_rank,
-        ps.tp_size,
+        gate_up, ps.tp_rank, ps.tp_size
     )
     out[f"{local_prefix}.mlp.down.linear.weight"] = _tp(
-        _get(reader, f"{hf_mlp_prefix}.down_proj.weight"),
-        ps.tp_rank,
-        ps.tp_size,
-        dim=1,
+        _get(reader, f"{hf_mlp_prefix}.down_proj.weight"), ps.tp_rank, ps.tp_size, dim=1
     )
 
 
@@ -276,15 +254,10 @@ def _load_shared_expert(
         dim=0,
     )
     out[f"{local_prefix}.moe.shared_expert.gate_up.linear.weight"] = _split_gate_up(
-        gate_up,
-        ps.tp_rank,
-        ps.tp_size,
+        gate_up, ps.tp_rank, ps.tp_size
     )
     out[f"{local_prefix}.moe.shared_expert.down.linear.weight"] = _tp(
-        _get(reader, f"{shared}.down_proj.weight"),
-        ps.tp_rank,
-        ps.tp_size,
-        dim=1,
+        _get(reader, f"{shared}.down_proj.weight"), ps.tp_rank, ps.tp_size, dim=1
     )
 
 
@@ -369,8 +342,7 @@ class KimiK2WeightSpec:
             if native_name.endswith(".final_layernorm.weight"):
                 return [(f"{hp}.shared_head.norm.weight", tensor)]
             proxy = native_name.replace(
-                f"mtp.layers.{mtp_idx}.transformer_layer",
-                f"layers.{hf_layer_idx}",
+                f"mtp.layers.{mtp_idx}.transformer_layer", f"layers.{hf_layer_idx}"
             )
             return self.native_to_hf(proxy, tensor)
         if native_name == "embed.embedding.weight":
@@ -514,10 +486,7 @@ def _materialize_hf_weights(
         )
     if getattr(base_model, "mtp_embed", None) is not None:
         out["mtp_embed.embedding.weight"] = _load_vocab(
-            reader,
-            f"{prefix}.embed_tokens.weight",
-            config,
-            ps,
+            reader, f"{prefix}.embed_tokens.weight", config, ps
         )
     if getattr(base_model, "norm", None) is not None:
         out["norm.weight"] = _get(reader, f"{prefix}.norm.weight")
@@ -533,11 +502,7 @@ def _materialize_hf_weights(
             reader, f"{hp}.input_layernorm.weight"
         )
         _load_attention(
-            out,
-            local_prefix=lp,
-            hf_prefix=f"{hp}.self_attn",
-            reader=reader,
-            ps=ps,
+            out, local_prefix=lp, hf_prefix=f"{hp}.self_attn", reader=reader, ps=ps
         )
         if config.is_moe_layer(global_idx):
             out[f"{lp}.mlp_norm.weight"] = _get(
@@ -578,9 +543,7 @@ def _materialize_hf_weights(
             out[f"{lp}.enorm.weight"] = _get(reader, f"{hp}.enorm.weight")
             out[f"{lp}.hnorm.weight"] = _get(reader, f"{hp}.hnorm.weight")
             out[f"{lp}.eh_proj.linear.weight"] = _tp(
-                _get(reader, f"{hp}.eh_proj.weight"),
-                ps.tp_rank,
-                ps.tp_size,
+                _get(reader, f"{hp}.eh_proj.weight"), ps.tp_rank, ps.tp_size
             )
             shared_head_norm = f"{hp}.shared_head.norm.weight"
             final_norm = (
@@ -593,11 +556,7 @@ def _materialize_hf_weights(
                 reader, f"{hp}.input_layernorm.weight"
             )
             _load_attention(
-                out,
-                local_prefix=tlp,
-                hf_prefix=f"{hp}.self_attn",
-                reader=reader,
-                ps=ps,
+                out, local_prefix=tlp, hf_prefix=f"{hp}.self_attn", reader=reader, ps=ps
             )
             if config.is_moe_layer(global_idx):
                 out[f"{tlp}.mlp_norm.weight"] = _get(
@@ -644,8 +603,9 @@ def load_hf_weights(
     path: str,
     config: KimiK2Config,
     ps: ParallelState,
+    *,
+    participating_group: dist.ProcessGroup | None = None,
 ) -> None:
-    participating_group = dist.group.WORLD if dist.is_initialized() else None
     load_hf_model_chunks_atomically(
         model,
         lambda chunk: _materialize_hf_weights(chunk, path, config, ps),
@@ -697,9 +657,7 @@ def export_hf_weights(model, config: KimiK2Config, ps: ParallelState, **kwargs):
 
 
 def save_hf_weights(model, path: str, config: KimiK2Config, ps: ParallelState) -> None:
-    from megatron.lite.primitive.ckpt.hf_weights import (
-        save_hf_weight_pairs_distributed,
-    )
+    from megatron.lite.primitive.ckpt.hf_weights import save_hf_weight_pairs_distributed
 
     save_hf_weight_pairs_distributed(
         export_hf_weights(model, config, ps, rank0_only=True), path

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/checkpoint.py
@@ -13,12 +13,16 @@ from megatron.lite.primitive.ckpt.hf_weights import (
     SafeTensorReader,
     _cast_export_tensor,
     _resolve_export_dtype,
+    copy_hf_state_atomically,
+    gather_pipeline_state_dict,
+    load_hf_model_chunks_atomically,
+    named_persistent_buffers,
     parse_expert_idx,
     to_global_layer_name,
     unwrap_model,
 )
 from megatron.lite.primitive.parallel import ParallelState
-from megatron.lite.primitive.utils import ensure_divisible, log_rank0
+from megatron.lite.primitive.utils import ensure_divisible
 
 
 def EXPERT_CLASSIFIER(name: str) -> bool:
@@ -26,7 +30,11 @@ def EXPERT_CLASSIFIER(name: str) -> bool:
 
 
 def PLACEMENT_FN(param_name: str) -> list:
-    if "experts" in param_name and "router" not in param_name and "shared" not in param_name:
+    if (
+        "experts" in param_name
+        and "router" not in param_name
+        and "shared" not in param_name
+    ):
         if "fc1" in param_name:
             return [Replicate(), Replicate(), Shard(0), Shard(0)]
         if "fc2" in param_name:
@@ -72,7 +80,9 @@ def _has(reader: SafeTensorReader, name: str) -> bool:
     return True
 
 
-def _dequant_fp8_weight(reader: SafeTensorReader, name: str, weight: torch.Tensor) -> torch.Tensor:
+def _dequant_fp8_weight(
+    reader: SafeTensorReader, name: str, weight: torch.Tensor
+) -> torch.Tensor:
     scale_name = f"{name}_scale_inv"
     if weight.dim() != 2 or weight.element_size() != 1 or not _has(reader, scale_name):
         return weight
@@ -85,11 +95,15 @@ def _dequant_fp8_weight(reader: SafeTensorReader, name: str, weight: torch.Tenso
 
 def _unpack_int4_from_int32(packed: torch.Tensor, shape: torch.Size) -> torch.Tensor:
     if packed.dtype != torch.int32:
-        raise ValueError(f"Expected packed int4 tensor to be int32, got {packed.dtype}.")
+        raise ValueError(
+            f"Expected packed int4 tensor to be int32, got {packed.dtype}."
+        )
     pack_factor = 8
     mask = 0xF
     rows, cols = int(shape[0]), int(shape[1])
-    unpacked = torch.empty((packed.shape[0], packed.shape[1] * pack_factor), dtype=torch.int32)
+    unpacked = torch.empty(
+        (packed.shape[0], packed.shape[1] * pack_factor), dtype=torch.int32
+    )
     for offset in range(pack_factor):
         unpacked[:, offset::pack_factor] = (packed >> (4 * offset)) & mask
     return (unpacked[:rows, :cols] - 8).to(torch.int8)
@@ -119,9 +133,9 @@ def _dequant_int4_weight(reader: SafeTensorReader, name: str) -> torch.Tensor:
         )
 
     group_size = unpacked.shape[1] // scale.shape[1]
-    return (unpacked.unflatten(-1, (scale.shape[1], group_size)) * scale.unsqueeze(-1)).flatten(
-        start_dim=-2
-    )
+    return (
+        unpacked.unflatten(-1, (scale.shape[1], group_size)) * scale.unsqueeze(-1)
+    ).flatten(start_dim=-2)
 
 
 def _get(reader: SafeTensorReader, name: str) -> torch.Tensor:
@@ -175,9 +189,11 @@ def _load_attention(
         reader,
         f"{hf_prefix}.q_a_proj.weight",
     )
-    out[f"{local_prefix}.self_attention.linear_q_up_proj.linear.layer_norm_weight"] = _get(
-        reader,
-        f"{hf_prefix}.q_a_layernorm.weight",
+    out[f"{local_prefix}.self_attention.linear_q_up_proj.linear.layer_norm_weight"] = (
+        _get(
+            reader,
+            f"{hf_prefix}.q_a_layernorm.weight",
+        )
     )
     out[f"{local_prefix}.self_attention.linear_q_up_proj.linear.weight"] = _tp(
         _get(reader, f"{hf_prefix}.q_b_proj.weight"),
@@ -188,9 +204,11 @@ def _load_attention(
         reader,
         f"{hf_prefix}.kv_a_proj_with_mqa.weight",
     )
-    out[f"{local_prefix}.self_attention.linear_kv_up_proj.linear.layer_norm_weight"] = _get(
-        reader,
-        f"{hf_prefix}.kv_a_layernorm.weight",
+    out[f"{local_prefix}.self_attention.linear_kv_up_proj.linear.layer_norm_weight"] = (
+        _get(
+            reader,
+            f"{hf_prefix}.kv_a_layernorm.weight",
+        )
     )
     out[f"{local_prefix}.self_attention.linear_kv_up_proj.linear.weight"] = _tp(
         _get(reader, f"{hf_prefix}.kv_b_proj.weight"),
@@ -247,7 +265,9 @@ def _load_shared_expert(
     ps: ParallelState,
 ) -> None:
     prefixes = [f"{hf_mlp_prefix}.shared_experts", f"{hf_mlp_prefix}.shared_expert"]
-    shared = next(prefix for prefix in prefixes if _has(reader, f"{prefix}.down_proj.weight"))
+    shared = next(
+        prefix for prefix in prefixes if _has(reader, f"{prefix}.down_proj.weight")
+    )
     gate_up = torch.cat(
         [
             _get(reader, f"{shared}.gate_proj.weight"),
@@ -297,33 +317,18 @@ def _load_experts(
         out[f"{local_prefix}.moe.experts.fc2.weight{local_idx}"] = fc2
 
 
-def _copy_loaded_state(model: nn.Module, loaded: dict[str, torch.Tensor]) -> None:
-    state = model.state_dict()
-    resolved: dict[str, torch.Tensor] = {}
-    for name, tensor in loaded.items():
-        actual = name if name in state else None
-        if actual is None:
-            for key in state:
-                if name in key:
-                    actual = key
-                    break
-        if actual is not None:
-            resolved[actual] = tensor
-        else:
-            log_rank0(f"WARNING: kimi_k2 checkpoint tensor has no target param: {name}")
-
-    for name, target in model.named_parameters():
-        if name not in resolved:
-            log_rank0(f"WARNING: {name} not loaded from checkpoint")
-            continue
-        tensor = resolved[name].to(device=target.device)
-        target.data.copy_(tensor.to(dtype=target.dtype))
-
-    for name, target in model.named_buffers():
-        if name not in resolved:
-            continue
-        tensor = resolved[name].to(device=target.device)
-        target.data.copy_(tensor.to(dtype=target.dtype) if target.is_floating_point() else tensor)
+def _copy_loaded_state(
+    model: nn.Module,
+    loaded: dict[str, torch.Tensor],
+    *,
+    participating_group: dist.ProcessGroup | None = None,
+) -> None:
+    copy_hf_state_atomically(
+        model,
+        loaded,
+        context="Kimi K2 HF load",
+        participating_group=participating_group,
+    )
 
 
 class KimiK2WeightSpec:
@@ -339,7 +344,9 @@ class KimiK2WeightSpec:
     def weight_map(self) -> dict[str, list[str]]:
         return {}
 
-    def hf_to_native(self, native_name: str, hf_tensors: list[torch.Tensor]) -> torch.Tensor:
+    def hf_to_native(
+        self, native_name: str, hf_tensors: list[torch.Tensor]
+    ) -> torch.Tensor:
         del native_name
         return hf_tensors[0]
 
@@ -443,7 +450,10 @@ class KimiK2WeightSpec:
         return None
 
     def tp_spec(self, native_name: str) -> tuple[int, int] | None:
-        if native_name.startswith("mtp.layers.") and ".transformer_layer." in native_name:
+        if (
+            native_name.startswith("mtp.layers.")
+            and ".transformer_layer." in native_name
+        ):
             proxy = native_name.replace(".transformer_layer.", ".")
             return self.tp_spec(proxy)
         if native_name.endswith(".eh_proj.linear.weight"):
@@ -454,7 +464,11 @@ class KimiK2WeightSpec:
             if ".fc2." in native_name:
                 return (1, 1)
             return None
-        if native_name in {"embed.embedding.weight", "head.col.linear.weight"}:
+        if native_name in {
+            "embed.embedding.weight",
+            "mtp_embed.embedding.weight",
+            "head.col.linear.weight",
+        }:
             return (0, 0)
         if native_name.endswith(".self_attention.linear_q_up_proj.linear.weight"):
             return (0, 0)
@@ -485,7 +499,9 @@ class KimiK2WeightSpec:
         return f"{prefix}.weight{local_idx}"
 
 
-def load_hf_weights(model: nn.Module, path: str, config: KimiK2Config, ps: ParallelState) -> None:
+def _materialize_hf_weights(
+    model: nn.Module, path: str, config: KimiK2Config, ps: ParallelState
+) -> dict[str, torch.Tensor]:
     base_model = unwrap_model(model)
     reader = SafeTensorReader(path)
     out: dict[str, torch.Tensor] = {}
@@ -513,7 +529,9 @@ def load_hf_weights(model: nn.Module, path: str, config: KimiK2Config, ps: Paral
     for local_idx, global_idx in enumerate(base_model.layer_indices):
         lp = f"layers.{local_idx}"
         hp = f"{prefix}.layers.{global_idx}"
-        out[f"{lp}.input_layernorm.weight"] = _get(reader, f"{hp}.input_layernorm.weight")
+        out[f"{lp}.input_layernorm.weight"] = _get(
+            reader, f"{hp}.input_layernorm.weight"
+        )
         _load_attention(
             out,
             local_prefix=lp,
@@ -522,7 +540,9 @@ def load_hf_weights(model: nn.Module, path: str, config: KimiK2Config, ps: Paral
             ps=ps,
         )
         if config.is_moe_layer(global_idx):
-            out[f"{lp}.mlp_norm.weight"] = _get(reader, f"{hp}.post_attention_layernorm.weight")
+            out[f"{lp}.mlp_norm.weight"] = _get(
+                reader, f"{hp}.post_attention_layernorm.weight"
+            )
             out[f"{lp}.moe.router.gate.weight"] = _get(reader, f"{hp}.mlp.gate.weight")
             bias_name = f"{hp}.mlp.gate.e_score_correction_bias"
             if _has(reader, bias_name):
@@ -569,7 +589,9 @@ def load_hf_weights(model: nn.Module, path: str, config: KimiK2Config, ps: Paral
                 else f"{hp}.final_layernorm.weight"
             )
             out[f"{lp}.final_layernorm.weight"] = _get(reader, final_norm)
-            out[f"{tlp}.input_layernorm.weight"] = _get(reader, f"{hp}.input_layernorm.weight")
+            out[f"{tlp}.input_layernorm.weight"] = _get(
+                reader, f"{hp}.input_layernorm.weight"
+            )
             _load_attention(
                 out,
                 local_prefix=tlp,
@@ -581,10 +603,14 @@ def load_hf_weights(model: nn.Module, path: str, config: KimiK2Config, ps: Paral
                 out[f"{tlp}.mlp_norm.weight"] = _get(
                     reader, f"{hp}.post_attention_layernorm.weight"
                 )
-                out[f"{tlp}.moe.router.gate.weight"] = _get(reader, f"{hp}.mlp.gate.weight")
+                out[f"{tlp}.moe.router.gate.weight"] = _get(
+                    reader, f"{hp}.mlp.gate.weight"
+                )
                 bias_name = f"{hp}.mlp.gate.e_score_correction_bias"
                 if _has(reader, bias_name):
-                    out[f"{tlp}.moe.router.expert_bias"] = _get(reader, bias_name).float()
+                    out[f"{tlp}.moe.router.expert_bias"] = _get(
+                        reader, bias_name
+                    ).float()
                 _load_shared_expert(
                     out,
                     local_prefix=tlp,
@@ -610,7 +636,22 @@ def load_hf_weights(model: nn.Module, path: str, config: KimiK2Config, ps: Paral
                     ps=ps,
                 )
 
-    _copy_loaded_state(base_model, out)
+    return out
+
+
+def load_hf_weights(
+    model: nn.Module | list[nn.Module],
+    path: str,
+    config: KimiK2Config,
+    ps: ParallelState,
+) -> None:
+    participating_group = dist.group.WORLD if dist.is_initialized() else None
+    load_hf_model_chunks_atomically(
+        model,
+        lambda chunk: _materialize_hf_weights(chunk, path, config, ps),
+        context="Kimi K2 HF load",
+        participating_group=participating_group,
+    )
 
 
 def export_hf_weights(model, config: KimiK2Config, ps: ParallelState, **kwargs):
@@ -619,35 +660,50 @@ def export_hf_weights(model, config: KimiK2Config, ps: ParallelState, **kwargs):
     spec = KimiK2WeightSpec(config)
     rank0_only = bool(kwargs.get("rank0_only", False))
     export_dtype = _resolve_export_dtype(kwargs.get("export_dtype"))
+    chunks = list(model) if isinstance(model, list | nn.ModuleList) else [model]
+    local_buffers: dict[str, torch.Tensor] = {}
+    for chunk in chunks:
+        base_chunk = unwrap_model(chunk)
+        layer_map = (
+            {
+                i: base_chunk.layer_indices[i]
+                for i in range(len(base_chunk.layer_indices))
+            }
+            if hasattr(base_chunk, "layer_indices")
+            else {}
+        )
+        for name, buffer in named_persistent_buffers(base_chunk):
+            if not name.endswith(".moe.router.expert_bias"):
+                continue
+            global_name = to_global_layer_name(name, layer_map)
+            if global_name in local_buffers:
+                raise RuntimeError(
+                    f"duplicate local Kimi-K2 router buffer {global_name}"
+                )
+            local_buffers[global_name] = buffer.detach().cpu()
+    gathered_buffers = gather_pipeline_state_dict(
+        local_buffers,
+        ps,
+        participating_group=kwargs.get("participating_group", ps.pp_group),
+    )
+    # Complete every collective before exposing the first generator item.
     yield from _export(model, spec, ps, vocab_size=config.vocab_size, **kwargs)
     rank = dist.get_rank() if dist.is_initialized() else 0
     if rank0_only and rank != 0:
         return
-    chunks = list(model) if isinstance(model, list | nn.ModuleList) else [model]
-    for chunk in chunks:
-        base_chunk = unwrap_model(chunk)
-        layer_map = (
-            {i: base_chunk.layer_indices[i] for i in range(len(base_chunk.layer_indices))}
-            if hasattr(base_chunk, "layer_indices")
-            else {}
-        )
-        for name, buffer in base_chunk.named_buffers():
-            if not name.endswith(".moe.router.expert_bias"):
-                continue
-            global_name = to_global_layer_name(name, layer_map)
-            for hf_name, hf_tensor in spec.native_to_hf(global_name, buffer.detach().cpu()):
-                yield hf_name, _cast_export_tensor(hf_tensor, export_dtype)
+    for global_name, buffer in gathered_buffers.items():
+        for hf_name, hf_tensor in spec.native_to_hf(global_name, buffer):
+            yield hf_name, _cast_export_tensor(hf_tensor, export_dtype)
 
 
 def save_hf_weights(model, path: str, config: KimiK2Config, ps: ParallelState) -> None:
-    from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
+    from megatron.lite.primitive.ckpt.hf_weights import (
+        save_hf_weight_pairs_distributed,
+    )
 
-    rank = dist.get_rank() if dist.is_initialized() else 0
-    out = dict(export_hf_weights(model, config, ps, rank0_only=True))
-    if rank == 0 and out:
-        save_safetensors(out, path)
-    if dist.is_initialized():
-        dist.barrier()
+    save_hf_weight_pairs_distributed(
+        export_hf_weights(model, config, ps, rank0_only=True), path
+    )
 
 
 __all__ = [

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/protocol.py
@@ -123,9 +123,16 @@ def _make_aux_loss_hook():
 
 
 def _build_dist_opt_optimizer(
-    chunks, model_cfg: KimiK2Config, impl_cfg: ImplConfig, ps: ParallelState
+    chunks,
+    model_cfg: KimiK2Config,
+    impl_cfg: ImplConfig,
+    ps: ParallelState,
+    *,
+    mtp_enabled: bool,
 ):
-    from megatron.lite.primitive.optimizers.megatron_wrap import build_dist_opt_training_optimizer
+    from megatron.lite.primitive.optimizers.megatron_wrap import (
+        build_dist_opt_training_optimizer,
+    )
 
     return build_dist_opt_training_optimizer(
         chunks,
@@ -135,6 +142,7 @@ def _build_dist_opt_optimizer(
         model_name="kimi_k2",
         is_expert=is_expert_param,
         deterministic=impl_cfg.deterministic,
+        mtp_enabled=mtp_enabled,
     )
 
 
@@ -148,16 +156,30 @@ def build_model(model_cfg: KimiK2Config, *, impl_cfg: ImplConfig) -> ModelBundle
     mtp_enable_train = mtp_enable and bool(impl_cfg.mtp_enable_train)
     if mtp_enable:
         if model_cfg.num_nextn_predict_layers <= 0:
-            raise ValueError("mtp_enable=True but HF config has no num_nextn_predict_layers.")
+            raise ValueError(
+                "mtp_enable=True but HF config has no num_nextn_predict_layers."
+            )
         model_cfg.mtp_loss_scaling_factor = impl_cfg.mtp_loss_scaling_factor
         if impl_cfg.mtp_use_repeated_layer is not None:
             model_cfg.mtp_use_repeated_layer = impl_cfg.mtp_use_repeated_layer
     elif hasattr(model_cfg, "num_nextn_predict_layers"):
         model_cfg.num_nextn_predict_layers = 0
+    if impl_cfg.optimizer == "fsdp2" and mtp_enable and p.pp > 1:
+        raise NotImplementedError(
+            "FSDP2 does not yet synchronize the PP-replicated MTP input embedding; "
+            "use dist_opt for PP+MTP training."
+        )
 
     from megatron.lite.model.kimi_k2.lite.model import KimiK2Model
 
     ps = init_parallel(p)
+    from megatron.lite.primitive.parallel import (
+        init_mtp_embedding_group,
+        synchronize_mtp_embedding_parameters,
+    )
+
+    if mtp_enable:
+        init_mtp_embedding_group(ps)
     recompute_spec = parse_recompute_spec(impl_cfg.recompute)
     vpp = None if p.vpp == 1 else p.vpp
     train_cfg = SimpleNamespace(
@@ -183,7 +205,11 @@ def build_model(model_cfg: KimiK2Config, *, impl_cfg: ImplConfig) -> ModelBundle
     )
 
     if vpp is None:
-        chunks = [KimiK2Model(model_cfg, train_cfg, ps, **model_kwargs).to(torch.bfloat16).cuda()]
+        chunks = [
+            KimiK2Model(model_cfg, train_cfg, ps, **model_kwargs)
+            .to(torch.bfloat16)
+            .cuda()
+        ]
     else:
         chunks = [
             KimiK2Model(
@@ -197,6 +223,7 @@ def build_model(model_cfg: KimiK2Config, *, impl_cfg: ImplConfig) -> ModelBundle
             .cuda()
             for i in range(vpp)
         ]
+    synchronize_mtp_embedding_parameters(chunks, ps, enabled=mtp_enable)
     set_cross_entropy_fusion(chunks, impl_cfg.cross_entropy_fusion)
 
     if recompute_spec:
@@ -214,7 +241,9 @@ def build_model(model_cfg: KimiK2Config, *, impl_cfg: ImplConfig) -> ModelBundle
     post_model_load_hook = None
     optimizer_backend = "none"
     if impl_cfg.optimizer == "dist_opt":
-        optimizer, finalize_grads = _build_dist_opt_optimizer(chunks, model_cfg, impl_cfg, ps)
+        optimizer, finalize_grads = _build_dist_opt_optimizer(
+            chunks, model_cfg, impl_cfg, ps, mtp_enabled=mtp_enable
+        )
         from megatron.lite.primitive.ckpt import attach_model_sharded_state_dict
         from megatron.lite.runtime.megatron_utils import register_training_hooks
 
@@ -228,7 +257,9 @@ def build_model(model_cfg: KimiK2Config, *, impl_cfg: ImplConfig) -> ModelBundle
 
         def _post_model_load_hook():
             from megatron.lite.model.kimi_k2.lite.model import KimiK2Layer
-            from megatron.lite.primitive.optimizers.fsdp2 import build_fsdp2_training_optimizer
+            from megatron.lite.primitive.optimizers.fsdp2 import (
+                build_fsdp2_training_optimizer,
+            )
 
             return {
                 "optimizer": build_fsdp2_training_optimizer(
@@ -263,7 +294,10 @@ def build_model(model_cfg: KimiK2Config, *, impl_cfg: ImplConfig) -> ModelBundle
 
 
 def load_hf_weights(
-    chunk: nn.Module, hf_path: str, model_cfg: KimiK2Config, ps: ParallelState
+    chunk: nn.Module | list[nn.Module],
+    hf_path: str,
+    model_cfg: KimiK2Config,
+    ps: ParallelState,
 ) -> None:
     if not hf_path:
         return
@@ -272,8 +306,16 @@ def load_hf_weights(
     load_impl(chunk, hf_path, model_cfg, ps)
 
 
+def load_hf_weights_many(
+    chunks: list[nn.Module], hf_path: str, model_cfg: KimiK2Config, ps: ParallelState
+) -> None:
+    load_hf_weights(chunks, hf_path, model_cfg, ps)
+
+
 def export_hf_weights(chunks, model_cfg: KimiK2Config, ps: ParallelState, **kwargs):
-    from megatron.lite.model.kimi_k2.lite.checkpoint import export_hf_weights as export_impl
+    from megatron.lite.model.kimi_k2.lite.checkpoint import (
+        export_hf_weights as export_impl,
+    )
 
     yield from export_impl(chunks, model_cfg, ps, **kwargs)
 

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/protocol.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 from megatron.lite.model.kimi_k2.config import KimiK2Config
 from megatron.lite.model.protocol_utils import (
@@ -212,13 +213,7 @@ def build_model(model_cfg: KimiK2Config, *, impl_cfg: ImplConfig) -> ModelBundle
         ]
     else:
         chunks = [
-            KimiK2Model(
-                model_cfg,
-                train_cfg,
-                ps,
-                vpp_chunk_id=i,
-                **model_kwargs,
-            )
+            KimiK2Model(model_cfg, train_cfg, ps, vpp_chunk_id=i, **model_kwargs)
             .to(torch.bfloat16)
             .cuda()
             for i in range(vpp)
@@ -298,18 +293,27 @@ def load_hf_weights(
     hf_path: str,
     model_cfg: KimiK2Config,
     ps: ParallelState,
+    *,
+    participating_group: dist.ProcessGroup | None = None,
 ) -> None:
     if not hf_path:
         return
     from megatron.lite.model.kimi_k2.lite.checkpoint import load_hf_weights as load_impl
 
-    load_impl(chunk, hf_path, model_cfg, ps)
+    load_impl(chunk, hf_path, model_cfg, ps, participating_group=participating_group)
 
 
 def load_hf_weights_many(
-    chunks: list[nn.Module], hf_path: str, model_cfg: KimiK2Config, ps: ParallelState
+    chunks: list[nn.Module],
+    hf_path: str,
+    model_cfg: KimiK2Config,
+    ps: ParallelState,
+    *,
+    participating_group: dist.ProcessGroup | None = None,
 ) -> None:
-    load_hf_weights(chunks, hf_path, model_cfg, ps)
+    load_hf_weights(
+        chunks, hf_path, model_cfg, ps, participating_group=participating_group
+    )
 
 
 def export_hf_weights(chunks, model_cfg: KimiK2Config, ps: ParallelState, **kwargs):

--- a/experimental/lite/megatron/lite/model/protocol_utils.py
+++ b/experimental/lite/megatron/lite/model/protocol_utils.py
@@ -23,7 +23,6 @@ from megatron.lite.primitive.parallel.thd import (
     thd_pack_meta,
     unpack_thd_to_nested,
 )
-from megatron.lite.primitive.utils.packed_seq import PackedSeqParams
 from megatron.lite.runtime.contracts.data import PackedBatch
 from megatron.lite.runtime.contracts.loss import get_loss_context
 
@@ -73,16 +72,16 @@ def pack_thd_forward_kwargs(model, batch: PackedBatch) -> dict[str, Any]:
         loss_mask=nested_from_packed(batch.loss_mask, seq_lens),
         roll_loss_mask=batch.loss_mask is not None,
     )
-    max_seqlen = int(packed.padded_lengths.max().item()) if packed.padded_lengths.numel() else 0
     # pack_nested_thd already returns [1, T] token rows; do not unsqueeze again.
     kwargs: dict[str, Any] = {
         "input_ids": packed.input_ids,
         "labels": packed.labels,
         "loss_mask": packed.loss_mask,
         "position_ids": packed.position_ids,
-        "packed_seq_params": PackedSeqParams.from_cu_seqlens(
-            packed.cu_seqlens_padded, max_seqlen=max_seqlen
-        ),
+        # Preserve both true and padded cumulative lengths. Reconstructing
+        # from the padded offsets would silently classify THD alignment
+        # padding as real tokens for auxiliary losses.
+        "packed_seq_params": packed.packed_seq_params,
     }
     prepare_packed_thd_kwargs_for_context_parallel(model, kwargs)
     return kwargs

--- a/experimental/lite/megatron/lite/model/protocol_utils.py
+++ b/experimental/lite/megatron/lite/model/protocol_utils.py
@@ -46,7 +46,9 @@ def nested_from_packed(tensor: torch.Tensor | None, seq_lens: torch.Tensor):
         pieces.append(tensor.narrow(0, offset, length))
         offset += length
     if offset != tensor.numel():
-        raise ValueError(f"PackedBatch sizes sum to {offset}, tensor has {tensor.numel()} tokens.")
+        raise ValueError(
+            f"PackedBatch sizes sum to {offset}, tensor has {tensor.numel()} tokens."
+        )
     return torch.nested.as_nested_tensor(pieces, layout=torch.jagged)
 
 
@@ -87,7 +89,9 @@ def pack_thd_forward_kwargs(model, batch: PackedBatch) -> dict[str, Any]:
     return kwargs
 
 
-def unpack_thd_forward_output(model, batch: PackedBatch, output: torch.Tensor) -> torch.Tensor:
+def unpack_thd_forward_output(
+    model, batch: PackedBatch, output: torch.Tensor
+) -> torch.Tensor:
     """Reverse a zigzag-CP THD model output back to jagged true-length form."""
     ps = _parallel_state(model)
     meta = thd_pack_meta(
@@ -99,7 +103,9 @@ def unpack_thd_forward_output(model, batch: PackedBatch, output: torch.Tensor) -
     return unpack_thd_to_nested(output, meta, contiguous=False)
 
 
-def add_loss_context_kwargs(kwargs: dict[str, Any], *, include_return_log_probs: bool = False) -> None:
+def add_loss_context_kwargs(
+    kwargs: dict[str, Any], *, include_return_log_probs: bool = False
+) -> None:
     loss_context = get_loss_context()
     if loss_context is None:
         return

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/checkpoint.py
@@ -15,9 +15,15 @@ import torch.nn as nn
 from torch.distributed.tensor import Replicate, Shard
 
 from megatron.lite.model.qwen3_5.config import Qwen35Config
-from megatron.lite.primitive.ckpt.hf_weights import SafeTensorReader, unwrap_model
+from megatron.lite.primitive.ckpt.hf_weights import (
+    SafeTensorReader,
+    copy_hf_state_atomically,
+    load_hf_model_chunks_atomically,
+    named_persistent_buffers,
+    unwrap_model,
+)
 from megatron.lite.primitive.parallel import ParallelState
-from megatron.lite.primitive.utils import ensure_divisible, log_rank0
+from megatron.lite.primitive.utils import ensure_divisible
 
 
 def EXPERT_CLASSIFIER(name: str) -> bool:
@@ -25,12 +31,22 @@ def EXPERT_CLASSIFIER(name: str) -> bool:
 
 
 def PLACEMENT_FN(param_name: str) -> list:
-    if "experts" in param_name and "router" not in param_name and "shared" not in param_name:
+    if param_name.startswith("vision_model."):
+        # The mounted HF vision tower is replicated across the language-model
+        # TP domain; its gradients are averaged by the model hook.
+        return [Replicate(), Replicate(), Replicate(), Replicate()]
+    if (
+        "experts" in param_name
+        and "router" not in param_name
+        and "shared" not in param_name
+    ):
         if "fc1" in param_name:
             return [Replicate(), Replicate(), Shard(0), Shard(0)]
         if "fc2" in param_name:
             return [Replicate(), Replicate(), Shard(0), Shard(1)]
         return [Replicate(), Replicate(), Replicate(), Replicate()]
+    if "eh_proj.linear.weight" in param_name:
+        return [Replicate(), Replicate(), Replicate(), Shard(0)]
     if "in_proj" in param_name and "layer_norm" not in param_name:
         return [Replicate(), Replicate(), Replicate(), Shard(0)]
     if "qkv" in param_name and "layer_norm" not in param_name:
@@ -155,8 +171,12 @@ def _load_full_attn(
     out[f"{local_prefix}.full_attn.qkv.linear.weight"] = _tp(
         _merge_full_attn_qkvg(q, k, v, cfg=cfg), ps.tp_rank, ps.tp_size
     )
-    out[f"{local_prefix}.full_attn.q_norm.weight"] = _get(reader, f"{hf_prefix}.q_norm.weight")
-    out[f"{local_prefix}.full_attn.k_norm.weight"] = _get(reader, f"{hf_prefix}.k_norm.weight")
+    out[f"{local_prefix}.full_attn.q_norm.weight"] = _get(
+        reader, f"{hf_prefix}.q_norm.weight"
+    )
+    out[f"{local_prefix}.full_attn.k_norm.weight"] = _get(
+        reader, f"{hf_prefix}.k_norm.weight"
+    )
     out[f"{local_prefix}.full_attn.proj.linear.weight"] = _tp(
         _get(reader, f"{hf_prefix}.o_proj.weight"), ps.tp_rank, ps.tp_size, dim=1
     )
@@ -169,9 +189,15 @@ def _merge_full_attn_qkvg(
     head_dim = cfg.head_dim
     hidden = q_gate.shape[1]
     q_gate = q_gate.reshape(cfg.num_attention_heads, 2 * head_dim, hidden)
-    query = q_gate.narrow(1, 0, head_dim).reshape(cfg.num_attention_heads * head_dim, hidden)
-    gate = q_gate.narrow(1, head_dim, head_dim).reshape(cfg.num_attention_heads * head_dim, hidden)
-    q_heads_per_group = ensure_divisible(cfg.num_attention_heads, cfg.num_key_value_heads)
+    query = q_gate.narrow(1, 0, head_dim).reshape(
+        cfg.num_attention_heads * head_dim, hidden
+    )
+    gate = q_gate.narrow(1, head_dim, head_dim).reshape(
+        cfg.num_attention_heads * head_dim, hidden
+    )
+    q_heads_per_group = ensure_divisible(
+        cfg.num_attention_heads, cfg.num_key_value_heads
+    )
     q_group_width = q_heads_per_group * head_dim
     query = query.reshape(kv_heads, q_group_width, hidden)
     gate = gate.reshape(kv_heads, q_group_width, hidden)
@@ -184,7 +210,9 @@ def _unmerge_full_attn_qkvg(
     tensor: torch.Tensor, *, cfg: Qwen35Config
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Invert Qwen35 lite's full-attention q/g/k/v packing."""
-    q_heads_per_group = ensure_divisible(cfg.num_attention_heads, cfg.num_key_value_heads)
+    q_heads_per_group = ensure_divisible(
+        cfg.num_attention_heads, cfg.num_key_value_heads
+    )
     group_width = (2 * q_heads_per_group + 2) * cfg.head_dim
     hidden = tensor.shape[-1]
     packed = tensor.reshape(cfg.num_key_value_heads, group_width, hidden)
@@ -209,11 +237,20 @@ def _unmerge_full_attn_qkvg(
 
 def _split_linear_attn_in_proj(
     tensor: torch.Tensor, *, cfg: Qwen35Config
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+) -> tuple[
+    torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor
+]:
     qk_dim = cfg.linear_num_key_heads * cfg.linear_key_head_dim
     v_dim = cfg.linear_num_value_heads * cfg.linear_value_head_dim
     return tensor.split(
-        [qk_dim, qk_dim, v_dim, v_dim, cfg.linear_num_value_heads, cfg.linear_num_value_heads],
+        [
+            qk_dim,
+            qk_dim,
+            v_dim,
+            v_dim,
+            cfg.linear_num_value_heads,
+            cfg.linear_num_value_heads,
+        ],
         dim=0,
     )
 
@@ -222,15 +259,21 @@ def _merge_linear_attn_in_proj_tp_shards(
     shards: list[torch.Tensor], *, cfg: Qwen35Config
 ) -> torch.Tensor:
     world_size = len(shards)
-    qk_dim = ensure_divisible(cfg.linear_num_key_heads * cfg.linear_key_head_dim, world_size)
-    v_dim = ensure_divisible(cfg.linear_num_value_heads * cfg.linear_value_head_dim, world_size)
+    qk_dim = ensure_divisible(
+        cfg.linear_num_key_heads * cfg.linear_key_head_dim, world_size
+    )
+    v_dim = ensure_divisible(
+        cfg.linear_num_value_heads * cfg.linear_value_head_dim, world_size
+    )
     value_heads = ensure_divisible(cfg.linear_num_value_heads, world_size)
 
     parts: list[list[torch.Tensor]] = [[] for _ in range(6)]
     for shard in shards:
         for bucket, part in zip(
             parts,
-            shard.split([qk_dim, qk_dim, v_dim, v_dim, value_heads, value_heads], dim=0),
+            shard.split(
+                [qk_dim, qk_dim, v_dim, v_dim, value_heads, value_heads], dim=0
+            ),
             strict=True,
         ):
             bucket.append(part)
@@ -242,12 +285,18 @@ def _merge_linear_attn_conv1d_tp_shards(
     shards: list[torch.Tensor], *, cfg: Qwen35Config
 ) -> torch.Tensor:
     world_size = len(shards)
-    qk_dim = ensure_divisible(cfg.linear_num_key_heads * cfg.linear_key_head_dim, world_size)
-    v_dim = ensure_divisible(cfg.linear_num_value_heads * cfg.linear_value_head_dim, world_size)
+    qk_dim = ensure_divisible(
+        cfg.linear_num_key_heads * cfg.linear_key_head_dim, world_size
+    )
+    v_dim = ensure_divisible(
+        cfg.linear_num_value_heads * cfg.linear_value_head_dim, world_size
+    )
 
     parts: list[list[torch.Tensor]] = [[] for _ in range(3)]
     for shard in shards:
-        for bucket, part in zip(parts, shard.split([qk_dim, qk_dim, v_dim], dim=0), strict=True):
+        for bucket, part in zip(
+            parts, shard.split([qk_dim, qk_dim, v_dim], dim=0), strict=True
+        ):
             bucket.append(part)
 
     return torch.cat([torch.cat(bucket, dim=0) for bucket in parts], dim=0).contiguous()
@@ -260,7 +309,9 @@ def _merge_gate_up_tp_shards(shards: list[torch.Tensor]) -> torch.Tensor:
         gate, up = shard.chunk(2, dim=0)
         gates.append(gate)
         ups.append(up)
-    return torch.cat([torch.cat(gates, dim=0), torch.cat(ups, dim=0)], dim=0).contiguous()
+    return torch.cat(
+        [torch.cat(gates, dim=0), torch.cat(ups, dim=0)], dim=0
+    ).contiguous()
 
 
 def _allgather_tp_shards(tensor: torch.Tensor, ps: ParallelState) -> list[torch.Tensor]:
@@ -286,7 +337,9 @@ class Qwen35WeightSpec:
     def weight_map(self) -> dict[str, list[str]]:
         return {}
 
-    def hf_to_native(self, native_name: str, hf_tensors: list[torch.Tensor]) -> torch.Tensor:
+    def hf_to_native(
+        self, native_name: str, hf_tensors: list[torch.Tensor]
+    ) -> torch.Tensor:
         del native_name
         return hf_tensors[0]
 
@@ -308,15 +361,33 @@ class Qwen35WeightSpec:
         return None
 
     def packed_expert_group_name(self, native_name: str) -> str | None:
-        if re.fullmatch(r"layers\.\d+\.moe\.experts\.fc[12]\.weight\d+", native_name) is None:
+        if (
+            re.fullmatch(r"layers\.\d+\.moe\.experts\.fc[12]\.weight\d+", native_name)
+            is None
+        ):
             return None
         return re.sub(r"\.weight\d+$", ".packed", native_name)
 
     def native_to_hf(
         self, native_name: str, tensor: torch.Tensor
     ) -> list[tuple[str, torch.Tensor]]:
+        if native_name.startswith("vision_model."):
+            if self.target != "hf":
+                raise NotImplementedError(
+                    "Qwen3.5 mounted vision export is supported only for the HF target."
+                )
+            suffix = native_name.removeprefix("vision_model.")
+            return [(f"model.visual.{suffix}", tensor)]
         if self.target == "vllm":
             return self._native_to_vllm(native_name, tensor)
+
+        if native_name == "mtp_embed.embedding.weight":
+            # Qwen3.5 shares the canonical text embedding with its MTP head.
+            # Under PP the loss stage owns a physical replica, but the HF
+            # schema carries only model.language_model.embed_tokens.weight.
+            return []
+        if native_name.startswith("mtp.layers."):
+            return self._mtp_native_to_hf(native_name, tensor)
 
         if native_name == "embed.embedding.weight":
             return [("model.language_model.embed_tokens.weight", tensor)]
@@ -324,9 +395,6 @@ class Qwen35WeightSpec:
             return [("model.language_model.norm.weight", tensor)]
         if native_name == "head.col.linear.weight":
             return [("lm_head.weight", tensor)]
-        if native_name == "mtp_embed.embedding.weight" or native_name.startswith("mtp."):
-            return []
-
         match = re.match(r"layers\.(\d+)\.(.*)", native_name)
         if match is None:
             return []
@@ -415,6 +483,66 @@ class Qwen35WeightSpec:
 
         return []
 
+    def _mtp_native_to_hf(
+        self, native_name: str, tensor: torch.Tensor
+    ) -> list[tuple[str, torch.Tensor]]:
+        """Map the released Qwen3.5 MTP head without folding it into the trunk.
+
+        Qwen/Qwen3.5-35B-A3B stores the predictor under a root ``mtp``
+        namespace.  Its routed experts deliberately use per-expert tensors,
+        unlike the packed expert tensors in ``model.language_model.layers``.
+        """
+        match = re.fullmatch(r"mtp\.layers\.(\d+)\.(.*)", native_name)
+        if match is None:
+            return []
+        mtp_idx = int(match.group(1))
+        if mtp_idx != 0:
+            raise NotImplementedError(
+                "The released Qwen3.5 HF MTP schema has one predictor layer; "
+                f"cannot export mtp.layers.{mtp_idx}."
+            )
+        suffix = match.group(2)
+        prefix = f"mtp.layers.{mtp_idx}"
+
+        root_names = {
+            "enorm.weight": "mtp.pre_fc_norm_embedding.weight",
+            "hnorm.weight": "mtp.pre_fc_norm_hidden.weight",
+            "eh_proj.linear.weight": "mtp.fc.weight",
+            "final_layernorm.weight": "mtp.norm.weight",
+        }
+        root_name = root_names.get(suffix)
+        if root_name is not None:
+            return [(root_name, tensor)]
+
+        transformer_prefix = "transformer_layer."
+        if not suffix.startswith(transformer_prefix):
+            return []
+        layer_suffix = suffix.removeprefix(transformer_prefix)
+
+        expert_match = re.fullmatch(
+            r"moe\.experts\.fc([12])\.weight(\d+)", layer_suffix
+        )
+        if expert_match is not None:
+            kind, expert_idx = expert_match.groups()
+            expert_prefix = f"{prefix}.mlp.experts.{int(expert_idx)}"
+            if kind == "1":
+                gate, up = tensor.chunk(2, dim=0)
+                return [
+                    (f"{expert_prefix}.gate_proj.weight", gate.contiguous()),
+                    (f"{expert_prefix}.up_proj.weight", up.contiguous()),
+                ]
+            return [(f"{expert_prefix}.down_proj.weight", tensor)]
+
+        # Reuse the trunk conversion for attention, norms, router, and shared
+        # expert tensors, then replace only its layer namespace.
+        trunk_layer_idx = self.config.num_hidden_layers + mtp_idx
+        proxy_name = f"layers.{trunk_layer_idx}.{layer_suffix}"
+        trunk_prefix = f"model.language_model.layers.{trunk_layer_idx}"
+        return [
+            (hf_name.replace(trunk_prefix, prefix, 1), hf_tensor)
+            for hf_name, hf_tensor in self.native_to_hf(proxy_name, tensor)
+        ]
+
     def _native_to_vllm(
         self, native_name: str, tensor: torch.Tensor
     ) -> list[tuple[str, torch.Tensor]]:
@@ -424,7 +552,9 @@ class Qwen35WeightSpec:
             return [("language_model.model.norm.weight", tensor)]
         if native_name == "head.col.linear.weight":
             return [("language_model.lm_head.weight", tensor)]
-        if native_name == "mtp_embed.embedding.weight" or native_name.startswith("mtp."):
+        if native_name == "mtp_embed.embedding.weight" or native_name.startswith(
+            "mtp."
+        ):
             return []
 
         match = re.match(r"layers\.(\d+)\.(.*)", native_name)
@@ -520,13 +650,21 @@ class Qwen35WeightSpec:
         return None
 
     def tp_spec(self, native_name: str) -> tuple[int, int] | None:
+        if native_name.startswith("mtp.layers.") and native_name.endswith(
+            ".eh_proj.linear.weight"
+        ):
+            return (0, 0)
         if self.is_expert(native_name):
             if ".fc1." in native_name:
                 return (0, 1)
             if ".fc2." in native_name:
                 return (1, 1)
             return None
-        if native_name in {"embed.embedding.weight", "head.col.linear.weight"}:
+        if native_name in {
+            "embed.embedding.weight",
+            "mtp_embed.embedding.weight",
+            "head.col.linear.weight",
+        }:
             return (0, 0)
         if native_name.endswith(".full_attn.qkv.linear.weight"):
             return (0, 0)
@@ -616,7 +754,10 @@ def _load_shared_expert(
 ) -> None:
     shared = f"{hf_mlp_prefix}.shared_expert"
     gate_up = torch.cat(
-        [_get(reader, f"{shared}.gate_proj.weight"), _get(reader, f"{shared}.up_proj.weight")],
+        [
+            _get(reader, f"{shared}.gate_proj.weight"),
+            _get(reader, f"{shared}.up_proj.weight"),
+        ],
         dim=0,
     )
     out[f"{local_prefix}.moe.shared_expert.gate_up.linear.weight"] = _split_gate_up(
@@ -661,7 +802,11 @@ def _load_experts(
         global_idx = local_start + local_idx
         ep = f"{hf_mlp_prefix}.experts.{global_idx}"
         fc1 = torch.cat(
-            [_get(reader, f"{ep}.gate_proj.weight"), _get(reader, f"{ep}.up_proj.weight")], dim=0
+            [
+                _get(reader, f"{ep}.gate_proj.weight"),
+                _get(reader, f"{ep}.up_proj.weight"),
+            ],
+            dim=0,
         )
         fc2 = _get(reader, f"{ep}.down_proj.weight")
         if ps.etp_size > 1:
@@ -671,47 +816,49 @@ def _load_experts(
         out[f"{local_prefix}.moe.experts.fc2.weight{local_idx}"] = fc2
 
 
-def _copy_loaded_state(model: nn.Module, loaded: dict[str, torch.Tensor]) -> None:
-    state = model.state_dict()
-    resolved: dict[str, torch.Tensor] = {}
-    for name, tensor in loaded.items():
-        actual = name if name in state else None
-        if actual is None:
-            for key in state:
-                if name in key:
-                    actual = key
-                    break
-        if actual is not None:
-            resolved[actual] = tensor
-        else:
-            log_rank0(f"WARNING: lite checkpoint tensor has no target param: {name}")
-
-    fp32_names = ("A_log", "dt_bias")
-    for name, param in model.named_parameters():
-        if name not in resolved:
-            log_rank0(f"WARNING: {name} not loaded from checkpoint")
-            continue
-        tensor = resolved[name].to(device=param.device)
-        if any(k in name for k in fp32_names):
-            param.data.copy_(tensor.float())
-        else:
-            param.data.copy_(tensor.to(dtype=param.dtype))
+def _copy_loaded_state(
+    model: nn.Module,
+    loaded: dict[str, torch.Tensor],
+    *,
+    participating_group: dist.ProcessGroup | None = None,
+) -> None:
+    copy_hf_state_atomically(
+        model,
+        loaded,
+        context="Qwen3.5 HF load",
+        participating_group=participating_group,
+    )
 
 
-def load_hf_weights(model: nn.Module, path: str, config: Qwen35Config, ps: ParallelState) -> None:
+def _materialize_hf_weights(
+    model: nn.Module, path: str, config: Qwen35Config, ps: ParallelState
+) -> dict[str, torch.Tensor]:
     base_model = unwrap_model(model)
     reader = SafeTensorReader(path)
     out: dict[str, torch.Tensor] = {}
+
+    vision_model = getattr(base_model, "vision_model", None)
+    if vision_model is not None:
+        for name, _target in vision_model.named_parameters():
+            out[f"vision_model.{name}"] = _get(reader, f"model.visual.{name}")
+        for name, _target in named_persistent_buffers(vision_model):
+            out[f"vision_model.{name}"] = _get(reader, f"model.visual.{name}")
 
     prefix = "model.language_model"
     if getattr(base_model, "embed", None) is not None:
         out["embed.embedding.weight"] = _load_vocab(
             reader, f"{prefix}.embed_tokens.weight", config, ps
         )
+    if getattr(base_model, "mtp_embed", None) is not None:
+        out["mtp_embed.embedding.weight"] = _load_vocab(
+            reader, f"{prefix}.embed_tokens.weight", config, ps
+        )
     if getattr(base_model, "norm", None) is not None:
         out["norm.weight"] = _get(reader, f"{prefix}.norm.weight")
     if getattr(base_model, "head", None) is not None:
-        out["head.col.linear.weight"] = _load_vocab(reader, "lm_head.weight", config, ps)
+        out["head.col.linear.weight"] = _load_vocab(
+            reader, "lm_head.weight", config, ps
+        )
 
     for local_idx, global_idx in enumerate(base_model.layer_indices):
         lp = f"layers.{local_idx}"
@@ -737,20 +884,109 @@ def load_hf_weights(model: nn.Module, path: str, config: Qwen35Config, ps: Paral
                 ps=ps,
                 reader=reader,
             )
-        out[f"{lp}.mlp_norm.weight"] = _get(reader, f"{hp}.post_attention_layernorm.weight")
+        out[f"{lp}.mlp_norm.weight"] = _get(
+            reader, f"{hp}.post_attention_layernorm.weight"
+        )
         out[f"{lp}.moe.router.gate.weight"] = _get(reader, f"{hp}.mlp.gate.weight")[
             : config.num_experts
         ]
-        _load_shared_expert(out, local_prefix=lp, hf_mlp_prefix=f"{hp}.mlp", ps=ps, reader=reader)
+        _load_shared_expert(
+            out, local_prefix=lp, hf_mlp_prefix=f"{hp}.mlp", ps=ps, reader=reader
+        )
         _load_experts(
-            out, local_prefix=lp, hf_mlp_prefix=f"{hp}.mlp", cfg=config, ps=ps, reader=reader
+            out,
+            local_prefix=lp,
+            hf_mlp_prefix=f"{hp}.mlp",
+            cfg=config,
+            ps=ps,
+            reader=reader,
         )
 
-    _copy_loaded_state(base_model, out)
+    mtp = getattr(base_model, "mtp", None)
+    if mtp is not None:
+        physical_layers = list(mtp.layers)
+        if len(physical_layers) != 1:
+            raise NotImplementedError(
+                "The released Qwen3.5 HF MTP schema has one physical predictor "
+                f"layer; got {len(physical_layers)} local MTP layers. Use "
+                "mtp_use_repeated_layer=True for multiple prediction depths."
+            )
+        lp = "mtp.layers.0"
+        hp = "mtp.layers.0"
+        tlp = f"{lp}.transformer_layer"
+        out[f"{lp}.enorm.weight"] = _get(reader, "mtp.pre_fc_norm_embedding.weight")
+        out[f"{lp}.hnorm.weight"] = _get(reader, "mtp.pre_fc_norm_hidden.weight")
+        out[f"{lp}.eh_proj.linear.weight"] = _tp(
+            _get(reader, "mtp.fc.weight"), ps.tp_rank, ps.tp_size
+        )
+        out[f"{lp}.final_layernorm.weight"] = _get(reader, "mtp.norm.weight")
+
+        input_ln = _get(reader, f"{hp}.input_layernorm.weight")
+        if config.layer_type_at(config.num_hidden_layers) == "full_attention":
+            _load_full_attn(
+                out,
+                local_prefix=tlp,
+                hf_prefix=f"{hp}.self_attn",
+                input_ln=input_ln,
+                cfg=config,
+                ps=ps,
+                reader=reader,
+            )
+        else:
+            _load_linear_attn(
+                out,
+                local_prefix=tlp,
+                hf_prefix=f"{hp}.linear_attn",
+                input_ln=input_ln,
+                cfg=config,
+                ps=ps,
+                reader=reader,
+            )
+        out[f"{tlp}.mlp_norm.weight"] = _get(
+            reader, f"{hp}.post_attention_layernorm.weight"
+        )
+        out[f"{tlp}.moe.router.gate.weight"] = _get(reader, f"{hp}.mlp.gate.weight")[
+            : config.num_experts
+        ]
+        _load_shared_expert(
+            out,
+            local_prefix=tlp,
+            hf_mlp_prefix=f"{hp}.mlp",
+            ps=ps,
+            reader=reader,
+        )
+        _load_experts(
+            out,
+            local_prefix=tlp,
+            hf_mlp_prefix=f"{hp}.mlp",
+            cfg=config,
+            ps=ps,
+            reader=reader,
+        )
+
+    return out
+
+
+def load_hf_weights(
+    model: nn.Module | list[nn.Module],
+    path: str,
+    config: Qwen35Config,
+    ps: ParallelState,
+) -> None:
+    participating_group = dist.group.WORLD if dist.is_initialized() else None
+    load_hf_model_chunks_atomically(
+        model,
+        lambda chunk: _materialize_hf_weights(chunk, path, config, ps),
+        context="Qwen3.5 HF load",
+        participating_group=participating_group,
+    )
 
 
 def export_hf_weights(
-    model: nn.Module | list[nn.Module], config: Qwen35Config, ps: ParallelState, **kwargs
+    model: nn.Module | list[nn.Module],
+    config: Qwen35Config,
+    ps: ParallelState,
+    **kwargs,
 ):
     from megatron.lite.primitive.ckpt.hf_weights import export_hf_weights as _export
 
@@ -759,13 +995,28 @@ def export_hf_weights(
     target = kwargs.pop("target", "hf")
     if include_mtp_only:
         return
+    chunks = list(model) if isinstance(model, nn.ModuleList | list) else [model]
+    if target != "hf" and any(
+        getattr(unwrap_model(chunk), "vision_model", None) is not None
+        for chunk in chunks
+    ):
+        raise NotImplementedError(
+            "Qwen3.5 mounted vision export is supported only for the HF target."
+        )
     yield from _export(
-        model, Qwen35WeightSpec(config, target=target), ps, vocab_size=config.vocab_size, **kwargs
+        model,
+        Qwen35WeightSpec(config, target=target),
+        ps,
+        vocab_size=config.vocab_size,
+        **kwargs,
     )
 
 
 def save_hf_weights(
-    model: nn.Module | list[nn.Module], path: str, config: Qwen35Config, ps: ParallelState
+    model: nn.Module | list[nn.Module],
+    path: str,
+    config: Qwen35Config,
+    ps: ParallelState,
 ) -> None:
     from megatron.lite.primitive.ckpt.hf_weights import save_hf_weights as _save
 

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/checkpoint.py
@@ -12,8 +12,6 @@ import re
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-from torch.distributed.tensor import Replicate, Shard
-
 from megatron.lite.model.qwen3_5.config import Qwen35Config
 from megatron.lite.primitive.ckpt.hf_weights import (
     SafeTensorReader,
@@ -24,6 +22,7 @@ from megatron.lite.primitive.ckpt.hf_weights import (
 )
 from megatron.lite.primitive.parallel import ParallelState
 from megatron.lite.primitive.utils import ensure_divisible
+from torch.distributed.tensor import Replicate, Shard
 
 
 def EXPERT_CLASSIFIER(name: str) -> bool:
@@ -949,11 +948,7 @@ def _materialize_hf_weights(
             : config.num_experts
         ]
         _load_shared_expert(
-            out,
-            local_prefix=tlp,
-            hf_mlp_prefix=f"{hp}.mlp",
-            ps=ps,
-            reader=reader,
+            out, local_prefix=tlp, hf_mlp_prefix=f"{hp}.mlp", ps=ps, reader=reader
         )
         _load_experts(
             out,
@@ -972,8 +967,9 @@ def load_hf_weights(
     path: str,
     config: Qwen35Config,
     ps: ParallelState,
+    *,
+    participating_group: dist.ProcessGroup | None = None,
 ) -> None:
-    participating_group = dist.group.WORLD if dist.is_initialized() else None
     load_hf_model_chunks_atomically(
         model,
         lambda chunk: _materialize_hf_weights(chunk, path, config, ps),

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
@@ -15,13 +15,16 @@ import torch.nn as nn
 import transformer_engine.pytorch as te
 
 from megatron.lite.model.qwen3_5.config import Qwen35Config
-from megatron.lite.primitive.kernels.swiglu import bias_swiglu_impl
 from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
 from megatron.lite.primitive.modules.experts import Experts, swiglu_with_probs
 from megatron.lite.primitive.modules.gated_delta_net import GatedDeltaNet
 from megatron.lite.primitive.modules.gqa import GQAttention as FullAttention
-from megatron.lite.primitive.modules.gqa import split_grouped_qkvg as _split_grouped_qkvg
-from megatron.lite.primitive.modules.mrope import MultimodalRotaryEmbedding as Qwen35MRoPE
+from megatron.lite.primitive.modules.gqa import (
+    split_grouped_qkvg as _split_grouped_qkvg,
+)
+from megatron.lite.primitive.modules.mrope import (
+    MultimodalRotaryEmbedding as Qwen35MRoPE,
+)
 from megatron.lite.primitive.modules.mtp import (
     MTPBlock,
     MTPDecoderLayer,
@@ -114,7 +117,11 @@ class SharedExpert(nn.Module):
             return self.linear(x)
 
     def __init__(
-        self, config: Qwen35Config, ps: ParallelState, *, use_plain_te_linear: bool = False
+        self,
+        config: Qwen35Config,
+        ps: ParallelState,
+        *,
+        use_plain_te_linear: bool = False,
     ):
         super().__init__()
         ffn = config.shared_expert_intermediate_size
@@ -122,7 +129,9 @@ class SharedExpert(nn.Module):
             self.gate_up = self._PlainTELinear(config.hidden_size, ffn * 2)
             self.down = self._PlainTELinear(ffn, config.hidden_size)
         else:
-            self.gate_up = ColumnParallelLinear(config.hidden_size, ffn * 2, ps, bias=False)
+            self.gate_up = ColumnParallelLinear(
+                config.hidden_size, ffn * 2, ps, bias=False
+            )
             self.down = RowParallelLinear(ffn, config.hidden_size, ps, bias=False)
         self.shared_gate = nn.Linear(config.hidden_size, 1, bias=False)
         self.tp_group = ps.tp_group
@@ -180,7 +189,9 @@ class MoELayer(nn.Module):
         self.dispatcher = TokenDispatcher(
             config.num_experts, config.hidden_size, ps, use_deepep=use_deepep
         )
-        self.shared_expert = SharedExpert(config, ps, use_plain_te_linear=shared_expert_plain_te)
+        self.shared_expert = SharedExpert(
+            config, ps, use_plain_te_linear=shared_expert_plain_te
+        )
         self.preserve_3d_graph = bool(preserve_3d_graph)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -197,7 +208,9 @@ class MoELayer(nn.Module):
             with torch.cuda.stream(side_stream):
                 shared_out = self.shared_expert(shared_input)
         scores, indices = self.router(router_input)
-        dispatched, tpe, permuted_probs = self.dispatcher.dispatch(x_2d, scores, indices)
+        dispatched, tpe, permuted_probs = self.dispatcher.dispatch(
+            x_2d, scores, indices
+        )
         del scores, indices
         self.dispatcher.wait_dispatch_event()
         expert_out = self.experts(
@@ -285,14 +298,21 @@ class Qwen35Layer(nn.Module):
         )
 
     def forward(
-        self, x: torch.Tensor, position_ids: torch.Tensor | None = None, packed_seq_params=None
+        self,
+        x: torch.Tensor,
+        position_ids: torch.Tensor | None = None,
+        packed_seq_params=None,
     ) -> torch.Tensor:
         residual = x
         if self.full_attn is not None:
-            h = self.full_attn(x, position_ids=position_ids, packed_seq_params=packed_seq_params)
+            h = self.full_attn(
+                x, position_ids=position_ids, packed_seq_params=packed_seq_params
+            )
         else:
             assert self.linear_attn is not None
-            h = self.linear_attn(x, position_ids=position_ids, packed_seq_params=packed_seq_params)
+            h = self.linear_attn(
+                x, position_ids=position_ids, packed_seq_params=packed_seq_params
+            )
         x = residual + h
         residual = x
         x = residual + self.moe(self.mlp_norm(x))
@@ -302,12 +322,16 @@ class Qwen35Layer(nn.Module):
 def _temperature_to_float(temperature: float | torch.Tensor) -> float:
     if isinstance(temperature, torch.Tensor):
         if temperature.numel() != 1:
-            raise ValueError("Qwen35Model fused/MTP SFT supports scalar temperature only.")
+            raise ValueError(
+                "Qwen35Model fused/MTP SFT supports scalar temperature only."
+            )
         return float(temperature.detach().float().item())
     return float(temperature)
 
 
-def _ensure_mrope_position_ids(position_ids: torch.Tensor | None) -> torch.Tensor | None:
+def _ensure_mrope_position_ids(
+    position_ids: torch.Tensor | None,
+) -> torch.Tensor | None:
     if position_ids is None:
         return None
     if position_ids.dim() == 2:
@@ -317,7 +341,9 @@ def _ensure_mrope_position_ids(position_ids: torch.Tensor | None) -> torch.Tenso
             return position_ids.expand(3, -1, -1).contiguous()
         if position_ids.shape[0] == 3:
             return position_ids
-    raise ValueError("Qwen3.5 MRoPE expects position_ids shape (B,S), (1,B,S), or (3,B,S).")
+    raise ValueError(
+        "Qwen3.5 MRoPE expects position_ids shape (B,S), (1,B,S), or (3,B,S)."
+    )
 
 
 class Qwen35Model(nn.Module):
@@ -348,7 +374,11 @@ class Qwen35Model(nn.Module):
         self._input_tensor: torch.Tensor | None = None
 
         layout = build_pipeline_chunk_layout(
-            config.num_hidden_layers, ps, train_config.vpp, vpp_chunk_id
+            config.num_hidden_layers,
+            ps,
+            train_config.vpp,
+            vpp_chunk_id,
+            num_mtp_layers=config.num_nextn_predict_layers if mtp_enable else 0,
         )
         self.layer_indices = layout.layer_indices
         has_embed = layout.has_embed
@@ -357,15 +387,21 @@ class Qwen35Model(nn.Module):
         self.post_process = has_head
         self.share_embeddings_and_output_weights = False
         self.vision_model: nn.Module | None = (
-            _build_native_vision_model(hf_path) if has_embed and mount_vision_model else None
+            _build_native_vision_model(hf_path)
+            if has_embed and mount_vision_model
+            else None
         )
 
         self.embed: VocabParallelEmbedding | None = None
         if has_embed:
-            self.embed = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
+            self.embed = VocabParallelEmbedding(
+                config.vocab_size, config.hidden_size, ps
+            )
 
         recompute_modules = getattr(train_config, "recompute_modules", [])
-        moe_act_recompute = "moe_act" in recompute_modules and "moe" not in recompute_modules
+        moe_act_recompute = (
+            "moe_act" in recompute_modules and "moe" not in recompute_modules
+        )
         self.layers = nn.ModuleList(
             [
                 Qwen35Layer(
@@ -394,10 +430,12 @@ class Qwen35Model(nn.Module):
 
         self.mtp_embed: VocabParallelEmbedding | None = None
         self.mtp: MTPBlock | None = None
-        if mtp_enable and config.num_nextn_predict_layers > 0 and self.head is not None:
+        if mtp_enable and config.num_nextn_predict_layers > 0 and layout.has_mtp:
             mtp_embedding = self.embed
             if mtp_embedding is None:
-                mtp_embedding = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
+                mtp_embedding = VocabParallelEmbedding(
+                    config.vocab_size, config.hidden_size, ps
+                )
                 self.mtp_embed = mtp_embedding
 
             def make_mtp_layer(layer_idx: int) -> MTPDecoderLayer:
@@ -460,17 +498,25 @@ class Qwen35Model(nn.Module):
             h = hidden_states
 
         if packed_seq_params is not None:
-            assert position_ids is not None, "THD path requires caller-supplied MRoPE position_ids."
+            assert position_ids is not None, (
+                "THD path requires caller-supplied MRoPE position_ids."
+            )
         elif position_ids is None and input_ids is not None:
             if self.ps.cp_size > 1:
-                raise ValueError("CP>1 requires caller-supplied FULL position_ids (3,B,S).")
+                raise ValueError(
+                    "CP>1 requires caller-supplied FULL position_ids (3,B,S)."
+                )
             batch, seq = input_ids.shape
             pos = torch.arange(seq, device=input_ids.device, dtype=torch.long)
-            position_ids = pos.unsqueeze(0).unsqueeze(0).expand(3, batch, seq).contiguous()
+            position_ids = (
+                pos.unsqueeze(0).unsqueeze(0).expand(3, batch, seq).contiguous()
+            )
         position_ids = _ensure_mrope_position_ids(position_ids)
 
         fp8_ctx = (
-            te.fp8_autocast(enabled=True, fp8_recipe=build_fp8_recipe(self.train_config))
+            te.fp8_autocast(
+                enabled=True, fp8_recipe=build_fp8_recipe(self.train_config)
+            )
             if self.train_config.fp8
             else nullcontext()
         )
@@ -478,7 +524,9 @@ class Qwen35Model(nn.Module):
             if self.embed is not None:
                 h = scatter_to_sequence_parallel(h, self.ps)
             for layer in self.layers:
-                h = layer(h, position_ids=position_ids, packed_seq_params=packed_seq_params)
+                h = layer(
+                    h, position_ids=position_ids, packed_seq_params=packed_seq_params
+                )
 
         output = {"hidden_states": h}
         if self.head is not None:
@@ -501,7 +549,9 @@ class Qwen35Model(nn.Module):
                     output["mtp_loss"] = mtp_loss
                 labels_sb = labels.transpose(0, 1).contiguous()
                 if use_fused_kernels:
-                    hidden_full = gather_from_sequence_parallel(hidden_for_head, self.ps)
+                    hidden_full = gather_from_sequence_parallel(
+                        hidden_for_head, self.ps
+                    )
                     log_probs, entropy = linear_cross_entropy(
                         hidden_full,
                         self._head_weight_for_fused_ce(hidden_full),
@@ -517,7 +567,9 @@ class Qwen35Model(nn.Module):
                     logits = self.head(hidden_for_head)
                     if temperature_value != 1.0:
                         logits = logits / temperature_value
-                    loss = vocab_parallel_cross_entropy(logits, labels_sb, self.ps.tp_group)
+                    loss = vocab_parallel_cross_entropy(
+                        logits, labels_sb, self.ps.tp_group
+                    )
                     output["loss"] = loss.mean()
                     output["log_probs"] = (-loss).transpose(0, 1).contiguous()
                     if calculate_entropy:
@@ -582,11 +634,15 @@ class Qwen35Model(nn.Module):
                 logits = self.head(mtp_hidden)
                 if temperature != 1.0:
                     logits = logits / temperature
-                token_loss = vocab_parallel_cross_entropy(logits, labels_sb, self.ps.tp_group)
+                token_loss = vocab_parallel_cross_entropy(
+                    logits, labels_sb, self.ps.tp_group
+                )
             token_loss = token_loss * mask_sb.to(dtype=token_loss.dtype)
             num_tokens = num_tokens.to(dtype=token_loss.dtype).clamp_min(1.0)
             mtp_loss_values.append(token_loss.sum() / num_tokens)
-            mtp_loss_scale = self.mtp_loss_scaling_factor / max(len(mtp_hidden_states), 1)
+            mtp_loss_scale = self.mtp_loss_scaling_factor / max(
+                len(mtp_hidden_states), 1
+            )
             hidden_states = MTPLossAutoScaler.apply(
                 hidden_states, mtp_loss_scale * token_loss / num_tokens
             )
@@ -602,7 +658,9 @@ class Qwen35Model(nn.Module):
         assert self.head is not None
         weight = self.head.col.linear.weight
         return (
-            weight if weight.dtype == hidden_states.dtype else weight.to(dtype=hidden_states.dtype)
+            weight
+            if weight.dtype == hidden_states.dtype
+            else weight.to(dtype=hidden_states.dtype)
         )
 
 
@@ -635,7 +693,9 @@ def _resolve_hf_vision_cls(hf_config, hf_path: str) -> type:
     errors: list[str] = []
     for class_ref in _iter_auto_model_class_refs(hf_config):
         try:
-            model_cls = get_class_from_dynamic_module(class_ref, hf_path, trust_remote_code=True)
+            model_cls = get_class_from_dynamic_module(
+                class_ref, hf_path, trust_remote_code=True
+            )
         except Exception as exc:
             errors.append(f"{class_ref}: {exc}")
             continue
@@ -643,19 +703,27 @@ def _resolve_hf_vision_cls(hf_config, hf_path: str) -> type:
         if vision_cls is not None:
             return vision_cls
         errors.append(f"{class_ref}: missing HfVisionClass")
-    detail = "; ".join(errors) if errors else "config auto_map has no supported AutoModel entry"
+    detail = (
+        "; ".join(errors)
+        if errors
+        else "config auto_map has no supported AutoModel entry"
+    )
     raise RuntimeError(f"Cannot resolve native HF vision class for Qwen3.5: {detail}.")
 
 
 def _hook_fp32_rotary_emb(module: nn.Module) -> None:
     for submodule in module.modules():
         if hasattr(submodule, "inv_freq") and submodule.inv_freq is not None:
-            submodule._inv_freq_fp32_original = submodule.inv_freq.detach().clone().float()
+            submodule._inv_freq_fp32_original = (
+                submodule.inv_freq.detach().clone().float()
+            )
 
             def _hook(mod, args):
                 del args
                 if hasattr(mod, "_inv_freq_fp32_original"):
-                    mod.inv_freq = mod._inv_freq_fp32_original.to(device=mod.inv_freq.device)
+                    mod.inv_freq = mod._inv_freq_fp32_original.to(
+                        device=mod.inv_freq.device
+                    )
 
             submodule.register_forward_pre_hook(_hook)
 

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
@@ -13,7 +13,6 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 import transformer_engine.pytorch as te
-
 from megatron.lite.model.qwen3_5.config import Qwen35Config
 from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
 from megatron.lite.primitive.modules.experts import Experts, swiglu_with_probs
@@ -498,9 +497,9 @@ class Qwen35Model(nn.Module):
             h = hidden_states
 
         if packed_seq_params is not None:
-            assert position_ids is not None, (
-                "THD path requires caller-supplied MRoPE position_ids."
-            )
+            assert (
+                position_ids is not None
+            ), "THD path requires caller-supplied MRoPE position_ids."
         elif position_ids is None and input_ids is not None:
             if self.ps.cp_size > 1:
                 raise ValueError(

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
@@ -19,9 +19,15 @@ from megatron.lite.model.protocol_utils import (
 )
 from megatron.lite.model.qwen3_5.config import Qwen35Config
 from megatron.lite.model.qwen3_5.lite.checkpoint import EXPERT_CLASSIFIER, PLACEMENT_FN
-from megatron.lite.model.qwen3_5.lite.checkpoint import export_hf_weights as _export_hf_weights_impl
-from megatron.lite.model.qwen3_5.lite.checkpoint import load_hf_weights as _load_hf_weights_impl
-from megatron.lite.model.qwen3_5.lite.checkpoint import save_hf_weights as _save_hf_weights_impl
+from megatron.lite.model.qwen3_5.lite.checkpoint import (
+    export_hf_weights as _export_hf_weights_impl,
+)
+from megatron.lite.model.qwen3_5.lite.checkpoint import (
+    load_hf_weights as _load_hf_weights_impl,
+)
+from megatron.lite.model.qwen3_5.lite.checkpoint import (
+    save_hf_weights as _save_hf_weights_impl,
+)
 from megatron.lite.primitive.bundle import ModelBundle
 from megatron.lite.primitive.parallel import ParallelState, init_parallel
 from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec
@@ -113,7 +119,11 @@ def _forward_step_bshd(model: nn.Module, batch: PackedBatch) -> dict:
     """
     input_ids = batch.input_ids.reshape(1, -1)
     labels = batch.labels.reshape(1, -1) if batch.labels is not None else None
-    kwargs: dict[str, Any] = {"input_ids": input_ids, "labels": labels, "packed_seq_params": None}
+    kwargs: dict[str, Any] = {
+        "input_ids": input_ids,
+        "labels": labels,
+        "packed_seq_params": None,
+    }
     add_cross_entropy_fusion(kwargs, model)
     return model(**kwargs)
 
@@ -133,8 +143,32 @@ def _make_aux_loss_hook():
     return hook
 
 
+_FP32_CHECKPOINT_SUFFIXES = (
+    ".linear_attn.A_log",
+    ".linear_attn.norm.weight",
+)
+
+
+def _restore_checkpoint_parameter_dtypes(chunks: list[nn.Module]) -> None:
+    """Preserve Qwen3.5's published mixed-precision parameter contract.
+
+    ``Module.to(bfloat16)`` casts every parameter, but the released checkpoint
+    keeps GatedDeltaNet ``A_log`` and its gated RMSNorm weight in FP32.  The
+    adjacent ``dt_bias`` is intentionally BF16.
+    """
+    for chunk in chunks:
+        for name, parameter in chunk.named_parameters():
+            if name.endswith(_FP32_CHECKPOINT_SUFFIXES):
+                parameter.data = parameter.data.float()
+
+
 def _build_dist_opt_optimizer(
-    chunks, model_cfg: Qwen35Config, impl_cfg: ImplConfig, ps: ParallelState
+    chunks,
+    model_cfg: Qwen35Config,
+    impl_cfg: ImplConfig,
+    ps: ParallelState,
+    *,
+    mtp_enabled: bool,
 ):
     from megatron.lite.primitive.optimizers.megatron_wrap import (
         build_dist_opt_training_optimizer,
@@ -148,6 +182,7 @@ def _build_dist_opt_optimizer(
         is_expert=is_expert_param,
         model_name="qwen3_5",
         deterministic=impl_cfg.deterministic,
+        mtp_enabled=mtp_enabled,
     )
 
 
@@ -165,18 +200,42 @@ def build_model(model_cfg: Qwen35Config, *, impl_cfg: ImplConfig) -> ModelBundle
     mtp_enable_train = mtp_enable and bool(impl_cfg.mtp_enable_train)
     if mtp_enable:
         if model_cfg.num_nextn_predict_layers <= 0:
-            raise ValueError("mtp_enable=True but HF config has no num_nextn_predict_layers.")
+            raise ValueError(
+                "mtp_enable=True but HF config has no num_nextn_predict_layers."
+            )
+        if model_cfg.num_nextn_predict_layers != 1:
+            raise NotImplementedError(
+                "The released Qwen3.5 HF MTP schema supports exactly one "
+                "predictor layer (mtp_num_hidden_layers=1); got "
+                f"{model_cfg.num_nextn_predict_layers}."
+            )
         model_cfg.mtp_loss_scaling_factor = impl_cfg.mtp_loss_scaling_factor
         if impl_cfg.mtp_use_repeated_layer is not None:
             model_cfg.mtp_use_repeated_layer = impl_cfg.mtp_use_repeated_layer
     else:
         model_cfg.num_nextn_predict_layers = 0
+    if impl_cfg.optimizer == "fsdp2" and mtp_enable and p.pp > 1:
+        raise NotImplementedError(
+            "FSDP2 does not yet synchronize the PP-replicated MTP input embedding; "
+            "use dist_opt for PP+MTP training."
+        )
 
     ps = init_parallel(p)
+    from megatron.lite.primitive.parallel import (
+        init_mtp_embedding_group,
+        synchronize_mtp_embedding_parameters,
+    )
+
+    if mtp_enable:
+        init_mtp_embedding_group(ps)
     recompute_spec = parse_recompute_spec(impl_cfg.recompute)
     vpp = None if p.vpp == 1 else p.vpp
     deterministic = impl_cfg.deterministic
-    if impl_cfg.use_thd and deterministic and "linear_attention" in model_cfg.layer_types:
+    if (
+        impl_cfg.use_thd
+        and deterministic
+        and "linear_attention" in model_cfg.layer_types
+    ):
         deterministic = False
     train_cfg = SimpleNamespace(
         tp=ps.tp_size,
@@ -203,7 +262,11 @@ def build_model(model_cfg: Qwen35Config, *, impl_cfg: ImplConfig) -> ModelBundle
     )
 
     if vpp is None:
-        chunks = [Qwen35Model(model_cfg, train_cfg, ps, **model_kwargs).to(torch.bfloat16).cuda()]
+        chunks = [
+            Qwen35Model(model_cfg, train_cfg, ps, **model_kwargs)
+            .to(torch.bfloat16)
+            .cuda()
+        ]
     else:
         chunks = [
             Qwen35Model(model_cfg, train_cfg, ps, vpp_chunk_id=i, **model_kwargs)
@@ -211,6 +274,8 @@ def build_model(model_cfg: Qwen35Config, *, impl_cfg: ImplConfig) -> ModelBundle
             .cuda()
             for i in range(vpp)
         ]
+    _restore_checkpoint_parameter_dtypes(chunks)
+    synchronize_mtp_embedding_parameters(chunks, ps, enabled=mtp_enable)
     set_cross_entropy_fusion(chunks, impl_cfg.cross_entropy_fusion)
 
     if recompute_spec:
@@ -228,7 +293,9 @@ def build_model(model_cfg: Qwen35Config, *, impl_cfg: ImplConfig) -> ModelBundle
     post_model_load_hook = None
     optimizer_backend = "none"
     if impl_cfg.optimizer == "dist_opt":
-        optimizer, finalize_grads = _build_dist_opt_optimizer(chunks, model_cfg, impl_cfg, ps)
+        optimizer, finalize_grads = _build_dist_opt_optimizer(
+            chunks, model_cfg, impl_cfg, ps, mtp_enabled=mtp_enable
+        )
         from megatron.lite.primitive.ckpt import attach_model_sharded_state_dict
         from megatron.lite.runtime.megatron_utils import register_training_hooks
 
@@ -242,7 +309,9 @@ def build_model(model_cfg: Qwen35Config, *, impl_cfg: ImplConfig) -> ModelBundle
 
         def _post_model_load_hook():
             from megatron.lite.model.qwen3_5.lite.model import Qwen35Layer
-            from megatron.lite.primitive.optimizers.fsdp2 import build_fsdp2_training_optimizer
+            from megatron.lite.primitive.optimizers.fsdp2 import (
+                build_fsdp2_training_optimizer,
+            )
 
             return {
                 "optimizer": build_fsdp2_training_optimizer(
@@ -277,11 +346,20 @@ def build_model(model_cfg: Qwen35Config, *, impl_cfg: ImplConfig) -> ModelBundle
 
 
 def load_hf_weights(
-    chunk: nn.Module, hf_path: str, model_cfg: Qwen35Config, ps: ParallelState
+    chunk: nn.Module | list[nn.Module],
+    hf_path: str,
+    model_cfg: Qwen35Config,
+    ps: ParallelState,
 ) -> None:
     if not hf_path:
         return
     _load_hf_weights_impl(chunk, hf_path, model_cfg, ps)
+
+
+def load_hf_weights_many(
+    chunks: list[nn.Module], hf_path: str, model_cfg: Qwen35Config, ps: ParallelState
+) -> None:
+    load_hf_weights(chunks, hf_path, model_cfg, ps)
 
 
 def export_hf_weights(

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 from megatron.lite.model.protocol_utils import (
     add_cross_entropy_fusion,
@@ -143,10 +144,7 @@ def _make_aux_loss_hook():
     return hook
 
 
-_FP32_CHECKPOINT_SUFFIXES = (
-    ".linear_attn.A_log",
-    ".linear_attn.norm.weight",
-)
+_FP32_CHECKPOINT_SUFFIXES = (".linear_attn.A_log", ".linear_attn.norm.weight")
 
 
 def _restore_checkpoint_parameter_dtypes(chunks: list[nn.Module]) -> None:
@@ -350,16 +348,27 @@ def load_hf_weights(
     hf_path: str,
     model_cfg: Qwen35Config,
     ps: ParallelState,
+    *,
+    participating_group: dist.ProcessGroup | None = None,
 ) -> None:
     if not hf_path:
         return
-    _load_hf_weights_impl(chunk, hf_path, model_cfg, ps)
+    _load_hf_weights_impl(
+        chunk, hf_path, model_cfg, ps, participating_group=participating_group
+    )
 
 
 def load_hf_weights_many(
-    chunks: list[nn.Module], hf_path: str, model_cfg: Qwen35Config, ps: ParallelState
+    chunks: list[nn.Module],
+    hf_path: str,
+    model_cfg: Qwen35Config,
+    ps: ParallelState,
+    *,
+    participating_group: dist.ProcessGroup | None = None,
 ) -> None:
-    load_hf_weights(chunks, hf_path, model_cfg, ps)
+    load_hf_weights(
+        chunks, hf_path, model_cfg, ps, participating_group=participating_group
+    )
 
 
 def export_hf_weights(

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/checkpoint.py
@@ -9,8 +9,7 @@ model-specific: the weight map and tensor conversions.
 from __future__ import annotations
 
 import torch
-from torch.distributed.tensor import Replicate, Shard
-
+import torch.distributed as dist
 from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
 from megatron.lite.primitive.ckpt.dcp import (  # noqa: F401 — re-export
     canonicalize_fc1_for_dcp,
@@ -19,6 +18,7 @@ from megatron.lite.primitive.ckpt.dcp import (  # noqa: F401 — re-export
     decanon_qkv_after_dcp,
 )
 from megatron.lite.primitive.ckpt.hf_weights import extract_layer_idx, parse_expert_idx
+from torch.distributed.tensor import Replicate, Shard
 
 
 def _pack_mcore_qkv(
@@ -80,7 +80,9 @@ class Qwen3MoEWeightSpec:
                     f"{lp}.attn.q_norm.weight": [f"{ap}.q_norm.weight"],
                     f"{lp}.attn.k_norm.weight": [f"{ap}.k_norm.weight"],
                     f"{lp}.attn.proj.linear.weight": [f"{ap}.o_proj.weight"],
-                    f"{lp}.mlp_norm.weight": [f"model.layers.{li}.post_attention_layernorm.weight"],
+                    f"{lp}.mlp_norm.weight": [
+                        f"model.layers.{li}.post_attention_layernorm.weight"
+                    ],
                     f"{lp}.moe.router.gate.weight": [f"{mp}.gate.weight"],
                 }
             )
@@ -89,7 +91,9 @@ class Qwen3MoEWeightSpec:
                     f"{mp}.experts.{e}.gate_proj.weight",
                     f"{mp}.experts.{e}.up_proj.weight",
                 ]
-                wm[f"{lp}.moe.experts._fc2_weight_{e}"] = [f"{mp}.experts.{e}.down_proj.weight"]
+                wm[f"{lp}.moe.experts._fc2_weight_{e}"] = [
+                    f"{mp}.experts.{e}.down_proj.weight"
+                ]
         for mi in range(c.num_nextn_predict_layers):
             hf_li = c.num_hidden_layers + mi
             hp = f"model.layers.{hf_li}"
@@ -103,7 +107,9 @@ class Qwen3MoEWeightSpec:
                     f"{lp}.hnorm.weight": [f"{hp}.hnorm.weight"],
                     f"{lp}.eh_proj.linear.weight": [f"{hp}.eh_proj.weight"],
                     f"{lp}.final_layernorm.weight": [f"{hp}.shared_head.norm.weight"],
-                    f"{tlp}.attn.qkv.linear.layer_norm_weight": [f"{hp}.input_layernorm.weight"],
+                    f"{tlp}.attn.qkv.linear.layer_norm_weight": [
+                        f"{hp}.input_layernorm.weight"
+                    ],
                     f"{tlp}.attn.qkv.linear.weight": [
                         f"{ap}.q_proj.weight",
                         f"{ap}.k_proj.weight",
@@ -121,10 +127,14 @@ class Qwen3MoEWeightSpec:
                     f"{mp}.experts.{e}.gate_proj.weight",
                     f"{mp}.experts.{e}.up_proj.weight",
                 ]
-                wm[f"{tlp}.moe.experts._fc2_weight_{e}"] = [f"{mp}.experts.{e}.down_proj.weight"]
+                wm[f"{tlp}.moe.experts._fc2_weight_{e}"] = [
+                    f"{mp}.experts.{e}.down_proj.weight"
+                ]
         return wm
 
-    def hf_to_native(self, native_name: str, hf_tensors: list[torch.Tensor]) -> torch.Tensor:
+    def hf_to_native(
+        self, native_name: str, hf_tensors: list[torch.Tensor]
+    ) -> torch.Tensor:
         if len(hf_tensors) == 3 and "qkv" in native_name:
             # Match MCore SelfAttention's local qkv packing:
             # [q heads for kv-group 0, k0, v0, q heads for kv-group 1, k1, v1, ...].
@@ -252,10 +262,24 @@ class Qwen3MoEWeightSpec:
 # ---------------------------------------------------------------------------
 
 
-def load_hf_weights(model, path: str, config: Qwen3MoEConfig, ps) -> None:
+def load_hf_weights(
+    model: torch.nn.Module | list[torch.nn.Module],
+    path: str,
+    config: Qwen3MoEConfig,
+    ps,
+    *,
+    participating_group: dist.ProcessGroup | None = None,
+) -> None:
     from megatron.lite.primitive.ckpt.hf_weights import load_hf_weights as _load
 
-    _load(model, path, Qwen3MoEWeightSpec(config), ps, vocab_size=config.vocab_size)
+    _load(
+        model,
+        path,
+        Qwen3MoEWeightSpec(config),
+        ps,
+        vocab_size=config.vocab_size,
+        participating_group=participating_group,
+    )
 
 
 def export_hf_weights(model, config: Qwen3MoEConfig, ps, **kwargs):

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
@@ -58,7 +58,11 @@ class MoELayer(nn.Module):
             config, ps, router_bias_rate=router_bias_rate, compute_aux_loss=False
         )
         self.experts = Experts(
-            config, ps, fp8=fp8, moe_act_recompute=moe_act_recompute, lora_config=lora_config
+            config,
+            ps,
+            fp8=fp8,
+            moe_act_recompute=moe_act_recompute,
+            lora_config=lora_config,
         )
         self.dispatcher = TokenDispatcher(
             config.num_experts, config.hidden_size, ps, use_deepep=use_deepep
@@ -72,7 +76,9 @@ class MoELayer(nn.Module):
             x_2d = x
 
         scores, indices = self.router(x_2d)
-        dispatched, tpe, permuted_probs = self.dispatcher.dispatch(x_2d, scores, indices)
+        dispatched, tpe, permuted_probs = self.dispatcher.dispatch(
+            x_2d, scores, indices
+        )
         del scores, indices
         self.dispatcher.wait_dispatch_event()
         expert_out = self.experts(
@@ -159,7 +165,10 @@ class TransformerLayer(nn.Module):
         )
 
     def forward(
-        self, x: torch.Tensor, position_ids: torch.Tensor | None = None, packed_seq_params=None
+        self,
+        x: torch.Tensor,
+        position_ids: torch.Tensor | None = None,
+        packed_seq_params=None,
     ) -> torch.Tensor:
         residual = x
         h = self.attn(x, position_ids=position_ids, packed_seq_params=packed_seq_params)
@@ -186,7 +195,9 @@ class MTPLossAutoScaler(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad_output: torch.Tensor):
         (mtp_loss,) = ctx.saved_tensors
-        scaled_mtp_grad = torch.ones_like(mtp_loss) * MTPLossAutoScaler.main_loss_backward_scale
+        scaled_mtp_grad = (
+            torch.ones_like(mtp_loss) * MTPLossAutoScaler.main_loss_backward_scale
+        )
         return grad_output, scaled_mtp_grad
 
     @staticmethod
@@ -221,7 +232,11 @@ class MultiTokenPredictionLayer(nn.Module):
         self.enorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.hnorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.eh_proj = VanillaColumnParallelLinear(
-            config.hidden_size * 2, config.hidden_size, ps, sp=ps.tp_size > 1, gather_output=True
+            config.hidden_size * 2,
+            config.hidden_size,
+            ps,
+            sp=ps.tp_size > 1,
+            gather_output=True,
         )
         self.transformer_layer = TransformerLayer(
             config,
@@ -248,7 +263,9 @@ class MultiTokenPredictionLayer(nn.Module):
         attention_position_ids = (
             rotary_position_ids if rotary_position_ids is not None else position_ids
         )
-        input_ids, _ = roll_packed_thd_left(input_ids, packed_seq_params=packed_seq_params, dims=-1)
+        input_ids, _ = roll_packed_thd_left(
+            input_ids, packed_seq_params=packed_seq_params, dims=-1
+        )
         if position_ids is not None:
             position_ids, _ = roll_packed_thd_left(
                 position_ids, packed_seq_params=packed_seq_params, dims=-1
@@ -266,7 +283,9 @@ class MultiTokenPredictionLayer(nn.Module):
         hidden_states = self.eh_proj(hidden_states)
         hidden_states = scatter_to_sequence_parallel(hidden_states, self.ps)
         hidden_states = self.transformer_layer(
-            hidden_states, position_ids=attention_position_ids, packed_seq_params=packed_seq_params
+            hidden_states,
+            position_ids=attention_position_ids,
+            packed_seq_params=packed_seq_params,
         )
         hidden_states = self.final_layernorm(hidden_states)
         return hidden_states, input_ids, position_ids
@@ -369,7 +388,13 @@ class Qwen3MoEModel(nn.Module):
         self.mtp_enable_train = bool(mtp_enable and mtp_enable_train)
         self.mtp_loss_scaling_factor = config.mtp_loss_scaling_factor
         self._input_tensor: torch.Tensor | None = None
-        layout = build_pipeline_chunk_layout(config.num_hidden_layers, ps, vpp, vpp_chunk_id)
+        layout = build_pipeline_chunk_layout(
+            config.num_hidden_layers,
+            ps,
+            vpp,
+            vpp_chunk_id,
+            num_mtp_layers=config.num_nextn_predict_layers if mtp_enable else 0,
+        )
         self.layer_indices = layout.layer_indices
         has_embed = layout.has_embed
         has_head = layout.has_head
@@ -379,7 +404,9 @@ class Qwen3MoEModel(nn.Module):
 
         self.embed: VocabParallelEmbedding | None = None
         if has_embed:
-            self.embed = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
+            self.embed = VocabParallelEmbedding(
+                config.vocab_size, config.hidden_size, ps
+            )
 
         _recompute = recompute_modules or []
         moe_act_recompute = "moe_act" in _recompute and "moe" not in _recompute
@@ -408,10 +435,12 @@ class Qwen3MoEModel(nn.Module):
 
         self.mtp_embed: VocabParallelEmbedding | None = None
         self.mtp: MultiTokenPredictionBlock | None = None
-        if mtp_enable and config.num_nextn_predict_layers > 0 and self.head is not None:
+        if mtp_enable and config.num_nextn_predict_layers > 0 and layout.has_mtp:
             mtp_embedding = self.embed
             if mtp_embedding is None:
-                mtp_embedding = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
+                mtp_embedding = VocabParallelEmbedding(
+                    config.vocab_size, config.hidden_size, ps
+                )
                 self.mtp_embed = mtp_embedding
             self.mtp = MultiTokenPredictionBlock(
                 config,
@@ -434,7 +463,9 @@ class Qwen3MoEModel(nn.Module):
     def set_input_tensor(self, input_tensor):
         if isinstance(input_tensor, list):
             if len(input_tensor) > 1:
-                raise ValueError("Qwen3MoEModel expects a single pipeline input tensor.")
+                raise ValueError(
+                    "Qwen3MoEModel expects a single pipeline input tensor."
+                )
             input_tensor = input_tensor[0] if input_tensor else None
         self._input_tensor = input_tensor
 
@@ -470,7 +501,9 @@ class Qwen3MoEModel(nn.Module):
             if self.embed is not None:
                 h = scatter_to_sequence_parallel(h, self.ps)
             for layer in self.layers:
-                h = layer(h, position_ids=position_ids, packed_seq_params=packed_seq_params)
+                h = layer(
+                    h, position_ids=position_ids, packed_seq_params=packed_seq_params
+                )
             # Head path is SP-aware: norm runs on SP-sharded [S/tp, B, H] and
             # head's internal all-gather happens inside VocabParallelOutput.
             # Mirrors MC GPTModel's final_layernorm → output_layer(sp=True).
@@ -497,7 +530,9 @@ class Qwen3MoEModel(nn.Module):
                     output["mtp_loss"] = mtp_loss
                 labels_sb = labels.transpose(0, 1).contiguous()
                 if use_fused_kernels:
-                    hidden_full = gather_from_sequence_parallel(hidden_for_head, self.ps)
+                    hidden_full = gather_from_sequence_parallel(
+                        hidden_for_head, self.ps
+                    )
                     log_probs, entropy = linear_cross_entropy(
                         hidden_full,
                         self._head_weight_for_fused_ce(hidden_full),
@@ -515,7 +550,9 @@ class Qwen3MoEModel(nn.Module):
                     logits = self.head(hidden_for_head)
                     if temperature_value != 1.0:
                         logits = logits / temperature_value
-                    token_loss = vocab_parallel_cross_entropy(logits, labels_sb, self.ps.tp_group)
+                    token_loss = vocab_parallel_cross_entropy(
+                        logits, labels_sb, self.ps.tp_group
+                    )
                     output["loss"] = token_loss.mean()
                     if return_log_probs:
                         output["log_probs"] = (-token_loss).transpose(0, 1).contiguous()
@@ -586,12 +623,16 @@ class Qwen3MoEModel(nn.Module):
                 logits = self.head(mtp_hidden)
                 if temperature != 1.0:
                     logits = logits / temperature
-                token_loss = vocab_parallel_cross_entropy(logits, labels_sb, self.ps.tp_group)
+                token_loss = vocab_parallel_cross_entropy(
+                    logits, labels_sb, self.ps.tp_group
+                )
             token_loss = token_loss * mask_sb.to(dtype=token_loss.dtype)
             num_tokens = num_tokens.to(dtype=token_loss.dtype).clamp_min(1.0)
             mtp_loss_values.append(token_loss.sum() / num_tokens)
 
-            mtp_loss_scale = self.mtp_loss_scaling_factor / max(len(mtp_hidden_states), 1)
+            mtp_loss_scale = self.mtp_loss_scaling_factor / max(
+                len(mtp_hidden_states), 1
+            )
             hidden_states = MTPLossAutoScaler.apply(
                 hidden_states, mtp_loss_scale * token_loss / num_tokens
             )

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
@@ -13,7 +13,6 @@ from contextlib import nullcontext
 import torch
 import torch.nn as nn
 import transformer_engine.pytorch as te
-
 from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
 from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
 from megatron.lite.primitive.modules.experts import Experts

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Any
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 from megatron.lite.model.protocol_utils import (
     add_cross_entropy_fusion,
@@ -62,6 +63,7 @@ __all__ = [
     "build_model_config",
     "export_hf_weights",
     "load_hf_weights",
+    "load_hf_weights_many",
     "vocab_size",
 ]
 
@@ -323,12 +325,32 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
 
 
 def load_hf_weights(
-    chunk: nn.Module, hf_path: str, model_cfg: Qwen3MoEConfig, ps: ParallelState
+    chunk: nn.Module | list[nn.Module],
+    hf_path: str,
+    model_cfg: Qwen3MoEConfig,
+    ps: ParallelState,
+    *,
+    participating_group: dist.ProcessGroup | None = None,
 ) -> None:
     """Load HF pretrained weights into model chunk."""
     if not hf_path:
         return
-    _load_hf_weights_impl(chunk, hf_path, model_cfg, ps)
+    _load_hf_weights_impl(
+        chunk, hf_path, model_cfg, ps, participating_group=participating_group
+    )
+
+
+def load_hf_weights_many(
+    chunks: list[nn.Module],
+    hf_path: str,
+    model_cfg: Qwen3MoEConfig,
+    ps: ParallelState,
+    *,
+    participating_group: dist.ProcessGroup | None = None,
+) -> None:
+    load_hf_weights(
+        chunks, hf_path, model_cfg, ps, participating_group=participating_group
+    )
 
 
 def export_hf_weights(

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
@@ -34,8 +34,13 @@ from megatron.lite.model.protocol_utils import (
 )
 from megatron.lite.model.qwen3_moe.common import is_expert_param
 from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
-from megatron.lite.model.qwen3_moe.lite.checkpoint import EXPERT_CLASSIFIER, PLACEMENT_FN
-from megatron.lite.model.qwen3_moe.lite.checkpoint import load_hf_weights as _load_hf_weights_impl
+from megatron.lite.model.qwen3_moe.lite.checkpoint import (
+    EXPERT_CLASSIFIER,
+    PLACEMENT_FN,
+)
+from megatron.lite.model.qwen3_moe.lite.checkpoint import (
+    load_hf_weights as _load_hf_weights_impl,
+)
 from megatron.lite.model.qwen3_moe.lite.model import MTPLossAutoScaler, Qwen3MoEModel
 from megatron.lite.primitive.bundle import ModelBundle
 from megatron.lite.primitive.modules.lora import (
@@ -155,15 +160,29 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
     mtp_enable_train = mtp_enable and bool(impl_cfg.mtp_enable_train)
     if mtp_enable:
         if model_cfg.num_nextn_predict_layers <= 0:
-            raise ValueError("mtp_enable=True but HF config has no num_nextn_predict_layers.")
+            raise ValueError(
+                "mtp_enable=True but HF config has no num_nextn_predict_layers."
+            )
         model_cfg.mtp_loss_scaling_factor = impl_cfg.mtp_loss_scaling_factor
         if impl_cfg.mtp_use_repeated_layer is not None:
             model_cfg.mtp_use_repeated_layer = impl_cfg.mtp_use_repeated_layer
     else:
         model_cfg.num_nextn_predict_layers = 0
+    if impl_cfg.optimizer == "fsdp2" and mtp_enable and p.pp > 1:
+        raise NotImplementedError(
+            "FSDP2 does not yet synchronize the PP-replicated MTP input embedding; "
+            "use dist_opt for PP+MTP training."
+        )
 
     # ── parallel state (model creates its own) ──
     ps = init_parallel(p)
+    from megatron.lite.primitive.parallel import (
+        init_mtp_embedding_group,
+        synchronize_mtp_embedding_parameters,
+    )
+
+    if mtp_enable:
+        init_mtp_embedding_group(ps)
     deterministic = impl_cfg.deterministic
 
     # ── build chunks ──
@@ -182,7 +201,9 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
 
     vpp = None if p.vpp == 1 else p.vpp
     if vpp is None:
-        chunks = [Qwen3MoEModel(model_cfg, ps, **model_kwargs).to(torch.bfloat16).cuda()]
+        chunks = [
+            Qwen3MoEModel(model_cfg, ps, **model_kwargs).to(torch.bfloat16).cuda()
+        ]
     else:
         chunks = []
         for i in range(vpp):
@@ -192,6 +213,7 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
                 .cuda()
             )
 
+    synchronize_mtp_embedding_parameters(chunks, ps, enabled=mtp_enable)
     set_cross_entropy_fusion(chunks, impl_cfg.cross_entropy_fusion)
 
     # ── recompute ──
@@ -231,6 +253,7 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
             model_name="qwen3_moe",
             is_expert=is_expert_param,
             deterministic=deterministic,
+            mtp_enabled=mtp_enable,
         )
         from megatron.lite.primitive.ckpt import attach_model_sharded_state_dict
 
@@ -243,7 +266,9 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
 
         def _post_model_load_hook():
             from megatron.lite.model.qwen3_moe.lite.model import TransformerLayer
-            from megatron.lite.primitive.optimizers.fsdp2 import build_fsdp2_training_optimizer
+            from megatron.lite.primitive.optimizers.fsdp2 import (
+                build_fsdp2_training_optimizer,
+            )
 
             return {
                 "optimizer": build_fsdp2_training_optimizer(
@@ -310,7 +335,9 @@ def export_hf_weights(
     chunks: list[nn.Module], model_cfg: Qwen3MoEConfig, ps: ParallelState, **kwargs
 ):
     """Export HF weights from model chunks."""
-    from megatron.lite.model.qwen3_moe.lite.checkpoint import export_hf_weights as _export
+    from megatron.lite.model.qwen3_moe.lite.checkpoint import (
+        export_hf_weights as _export,
+    )
 
     for chunk in chunks:
         yield from _export(chunk, model_cfg, ps, **kwargs)

--- a/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
@@ -33,15 +33,17 @@ from megatron.lite.primitive.protocols import (
     default_expert_classifier,
     default_placement_fn,
 )
-from torch.distributed.device_mesh import (
+from torch.distributed.device_mesh import (  # pyright: ignore[reportMissingImports]
     DeviceMesh,
-)  # pyright: ignore[reportMissingImports]
+)
 from torch.distributed.tensor import DTensor  # pyright: ignore[reportMissingImports]
 
 _DCP_MODEL_SCHEMA_KEY = "mlite_model_schema_version"
 _DCP_MODEL_SCHEMA_VERSION = 2
 _CHECKPOINT_MANIFEST = "mlite_checkpoint_manifest.json"
 _CHECKPOINT_MANIFEST_FORMAT = "megatron_lite.training_checkpoint.v2"
+_LOCAL_TRAINING_FORMAT_V1 = "megatron_lite.local_training.v1"
+_LOCAL_TRAINING_FORMAT_V2 = "megatron_lite.local_training.v2"
 
 
 def save_training_checkpoint(
@@ -1860,14 +1862,18 @@ def _chunk_tensor_state(module: nn.Module) -> dict[str, torch.Tensor]:
     state: dict[str, torch.Tensor] = {}
     for name, param in module.named_parameters():
         state[f"param.{name}"] = _to_local_tensor(param.detach()).cpu().clone()
-    for name, buffer in module.named_buffers():
+    for name, buffer in named_persistent_buffers(module):
         state[f"buffer.{name}"] = _to_local_tensor(buffer.detach()).cpu().clone()
     return state
 
 
 def _preflight_chunk_tensor_state(
-    module: nn.Module, state: Any, *, chunk_index: int
-) -> None:
+    module: nn.Module,
+    state: Any,
+    *,
+    chunk_index: int,
+    allow_legacy_nonpersistent_buffers: bool = False,
+) -> tuple[str, ...]:
     """Validate one local model chunk without mutating any live tensor."""
 
     if not isinstance(state, dict):
@@ -1875,19 +1881,36 @@ def _preflight_chunk_tensor_state(
             f"checkpoint model chunk {chunk_index} must be a dict, got "
             f"{type(state).__name__}"
         )
+    persistent_buffers = dict(named_persistent_buffers(module))
     targets = {
         **{f"param.{name}": tensor for name, tensor in module.named_parameters()},
-        **{f"buffer.{name}": tensor for name, tensor in module.named_buffers()},
+        **{f"buffer.{name}": tensor for name, tensor in persistent_buffers.items()},
     }
     saved_keys = set(state)
     expected_keys = set(targets)
     missing = sorted(expected_keys - saved_keys)
-    unexpected = sorted(saved_keys - expected_keys, key=repr)
+    ignored_legacy_keys: set[str] = set()
+    if allow_legacy_nonpersistent_buffers:
+        persistent_buffer_names = set(persistent_buffers)
+        nonpersistent_buffer_keys = {
+            f"buffer.{name}"
+            for name, _buffer in module.named_buffers()
+            if name not in persistent_buffer_names
+        }
+        ignored_legacy_keys = (saved_keys - expected_keys) & nonpersistent_buffer_keys
+    unexpected = sorted(saved_keys - expected_keys - ignored_legacy_keys, key=repr)
     if missing or unexpected:
         raise RuntimeError(
             f"checkpoint model chunk {chunk_index} schema mismatch: "
             f"missing={missing}, unexpected={unexpected}"
         )
+    for key in sorted(ignored_legacy_keys):
+        source = state[key]
+        if not isinstance(source, torch.Tensor):
+            raise TypeError(
+                f"legacy checkpoint model chunk {chunk_index} non-persistent buffer "
+                f"{key!r} must be torch.Tensor, got {type(source).__name__}"
+            )
     for key, target in targets.items():
         source = state[key]
         if not isinstance(source, torch.Tensor):
@@ -1912,12 +1935,16 @@ def _preflight_chunk_tensor_state(
                 f"checkpoint={tuple(local_source.shape)}/{local_source.dtype}, "
                 f"target={tuple(local_target.shape)}/{local_target.dtype}"
             )
+    return tuple(sorted(ignored_legacy_keys))
 
 
 def _load_chunk_tensor_state(module: nn.Module, state: dict[str, torch.Tensor]) -> None:
     targets = {
         **{f"param.{name}": tensor for name, tensor in module.named_parameters()},
-        **{f"buffer.{name}": tensor for name, tensor in module.named_buffers()},
+        **{
+            f"buffer.{name}": tensor
+            for name, tensor in named_persistent_buffers(module)
+        },
     }
     for key, target in targets.items():
         with torch.no_grad():
@@ -2521,7 +2548,7 @@ def _save_local_training_checkpoint(
         else None
     )
     state = {
-        "format": "megatron_lite.local_training.v1",
+        "format": _LOCAL_TRAINING_FORMAT_V2,
         "step": int(step),
         "model": [_chunk_tensor_state(chunk) for chunk in chunks],
         "optimizer": optimizer.state_dict() if optimizer is not None else None,
@@ -2554,7 +2581,8 @@ def _load_local_training_checkpoint(
         raise TypeError(
             f"Local checkpoint root must be a dict, got {type(state).__name__}"
         )
-    if state.get("format") != "megatron_lite.local_training.v1":
+    checkpoint_format = state.get("format")
+    if checkpoint_format not in {_LOCAL_TRAINING_FORMAT_V1, _LOCAL_TRAINING_FORMAT_V2}:
         raise RuntimeError(f"Unsupported local checkpoint format in {ckpt_file}")
     expected_root_keys = {
         "format",
@@ -2579,10 +2607,21 @@ def _load_local_training_checkpoint(
     chunk_states = state.get("model")
     if not isinstance(chunk_states, list) or len(chunk_states) != len(chunks):
         raise RuntimeError("Checkpoint model chunk count does not match target model.")
+    ignored_legacy_buffer_keys: list[str] = []
     for chunk_index, (chunk, chunk_state) in enumerate(
         zip(chunks, chunk_states, strict=True)
     ):
-        _preflight_chunk_tensor_state(chunk, chunk_state, chunk_index=chunk_index)
+        ignored_legacy_buffer_keys.extend(
+            f"chunk{chunk_index}.{key}"
+            for key in _preflight_chunk_tensor_state(
+                chunk,
+                chunk_state,
+                chunk_index=chunk_index,
+                allow_legacy_nonpersistent_buffers=(
+                    checkpoint_format == _LOCAL_TRAINING_FORMAT_V1
+                ),
+            )
+        )
     saved_optimizer_state = state.get("optimizer")
     saved_has_optimizer = saved_optimizer_state is not None
     target_has_optimizer = optimizer is not None
@@ -2663,6 +2702,11 @@ def _load_local_training_checkpoint(
     finally:
         if staged_parameter_state_path is not None:
             staged_parameter_state_path.unlink(missing_ok=True)
+    if ignored_legacy_buffer_keys:
+        log_rank0(
+            "Loaded legacy local checkpoint while ignoring current non-persistent "
+            f"runtime buffers: {ignored_legacy_buffer_keys}"
+        )
     log_rank0(f"Loaded local training checkpoint from {ckpt_file} at step {step}")
     return step
 

--- a/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
@@ -8,9 +8,12 @@ HF weight loading/saving is model-specific and lives in models/<name>/checkpoint
 
 from __future__ import annotations
 
+import hashlib
+import json
+import math
 import os
 import random
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable, Mapping, MutableMapping
 from pathlib import Path
 from typing import Any
 
@@ -19,9 +22,10 @@ import torch  # pyright: ignore[reportMissingImports]
 import torch.distributed as dist  # pyright: ignore[reportMissingImports]
 import torch.distributed.checkpoint as dcp  # pyright: ignore[reportMissingImports]
 import torch.nn as nn  # pyright: ignore[reportMissingImports]
-from torch.distributed.device_mesh import DeviceMesh  # pyright: ignore[reportMissingImports]
-from torch.distributed.tensor import DTensor  # pyright: ignore[reportMissingImports]
-
+from megatron.lite.primitive.ckpt.hf_weights import (
+    _distributed_raise_if_error,
+    named_persistent_buffers,
+)
 from megatron.lite.primitive.parallel import ParallelState
 from megatron.lite.primitive.protocols import (
     ExpertClassifierFn,
@@ -29,6 +33,15 @@ from megatron.lite.primitive.protocols import (
     default_expert_classifier,
     default_placement_fn,
 )
+from torch.distributed.device_mesh import (
+    DeviceMesh,
+)  # pyright: ignore[reportMissingImports]
+from torch.distributed.tensor import DTensor  # pyright: ignore[reportMissingImports]
+
+_DCP_MODEL_SCHEMA_KEY = "mlite_model_schema_version"
+_DCP_MODEL_SCHEMA_VERSION = 2
+_CHECKPOINT_MANIFEST = "mlite_checkpoint_manifest.json"
+_CHECKPOINT_MANIFEST_FORMAT = "megatron_lite.training_checkpoint.v2"
 
 
 def save_training_checkpoint(
@@ -45,6 +58,7 @@ def save_training_checkpoint(
     save_rng: bool = True,
     save_model: bool = True,
     save_optimizer: bool = True,
+    extra_states: Mapping[str, Any] | None = None,
 ) -> None:
     """Save training checkpoint using DTensor + DCP for automatic resharding."""
     if path is None and isinstance(step, str):
@@ -52,20 +66,59 @@ def save_training_checkpoint(
         step = 0
     if path is None:
         raise ValueError("checkpoint path is required")
-    step = int(step)
+    if type(step) is not int or step < 0:
+        raise TypeError("checkpoint step must be a non-negative integer")
     if use_dcp is None:
         use_dcp = True
     if not use_dcp:
+        if not save_model or not save_optimizer:
+            raise ValueError(
+                "Local-format checkpoints do not support partial component selection; "
+                "use_dcp=False requires save_model=True and save_optimizer=True."
+            )
+        if extra_states:
+            raise ValueError("extra_states are supported only for DCP checkpoints")
         _save_local_training_checkpoint(model, optimizer, step, path, save_rng=save_rng)
         return
-    if _supports_dist_opt_distckpt(model, optimizer):
+    extra_states = _normalize_extra_states(extra_states)
+    if save_optimizer and optimizer is None:
+        raise ValueError(
+            "save_optimizer=True requires a non-None optimizer; pass save_optimizer=False "
+            "for a model-only checkpoint"
+        )
+    if _supports_dist_opt_distckpt(model, optimizer if save_optimizer else None):
         ckpt_path = os.path.join(path, f"step_{step}")
-        os.makedirs(ckpt_path, exist_ok=True)
-        _save_dist_opt_checkpoint(
-            model, optimizer, step, ckpt_path, save_model=save_model, save_optimizer=save_optimizer
+        manifest = _begin_checkpoint_transaction(
+            ckpt_path,
+            step=step,
+            save_model=save_model,
+            save_optimizer=save_optimizer,
+            save_rng=save_rng,
+            payload_format="distckpt",
+            optimizer_storage="distckpt" if save_optimizer else "none",
+            extra_state_files=extra_states,
+        )
+        local_error = None
+        try:
+            _save_dist_opt_checkpoint(
+                model,
+                optimizer,
+                step,
+                ckpt_path,
+                save_model=save_model,
+                save_optimizer=save_optimizer,
+            )
+        except Exception as exc:
+            local_error = f"{type(exc).__name__}: {exc}"
+        _distributed_raise_if_error(
+            local_error, context="dist_opt checkpoint payload save failed"
         )
         if save_rng:
-            _save_rng_sidecar(ckpt_path)
+            _save_rank_sidecar_with_consensus(
+                lambda: _save_rng_sidecar(ckpt_path), context="RNG sidecar save failed"
+            )
+        _save_rank0_extra_states_with_consensus(ckpt_path, extra_states)
+        _complete_checkpoint_transaction(ckpt_path, manifest)
         log_rank0(f"Saved dist_opt checkpoint at step {step} to {ckpt_path}")
         return
     if config is None or ps is None:
@@ -81,18 +134,44 @@ def save_training_checkpoint(
     model_prefix = f"model_pp{ps.pp_rank}" if ps.pp_size > 1 else "model"
 
     if save_model:
-        for name, param in model.named_parameters():
+        state_dict[_DCP_MODEL_SCHEMA_KEY] = _DCP_MODEL_SCHEMA_VERSION
+        for name, tensor in _named_model_checkpoint_tensors(model):
             placements = get_placements(name)
             mesh = expert_mesh if is_expert(name) else dense_mesh
-            state_dict[f"{model_prefix}.{name}"] = _dcp_tensor_from_param(param, mesh, placements)
+            state_dict[f"{model_prefix}.{name}"] = _dcp_tensor_from_param(
+                tensor, mesh, placements
+            )
 
     ckpt_path = os.path.join(path, f"step_{step}")
-    os.makedirs(ckpt_path, exist_ok=True)
-    dcp.save(state_dict, checkpoint_id=ckpt_path)
+    manifest = _begin_checkpoint_transaction(
+        ckpt_path,
+        step=step,
+        save_model=save_model,
+        save_optimizer=save_optimizer,
+        save_rng=save_rng,
+        payload_format="dcp",
+        optimizer_storage="rank_sidecar" if save_optimizer else "none",
+        extra_state_files=extra_states,
+    )
+    local_error = None
+    try:
+        dcp.save(state_dict, checkpoint_id=ckpt_path)
+    except Exception as exc:
+        local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(
+        local_error, context="DCP checkpoint payload save failed"
+    )
     if save_optimizer:
-        _save_optimizer_checkpoint(optimizer, ckpt_path)
+        _save_rank_sidecar_with_consensus(
+            lambda: _save_optimizer_checkpoint(optimizer, ckpt_path),
+            context="optimizer sidecar save failed",
+        )
     if save_rng:
-        _save_rng_sidecar(ckpt_path)
+        _save_rank_sidecar_with_consensus(
+            lambda: _save_rng_sidecar(ckpt_path), context="RNG sidecar save failed"
+        )
+    _save_rank0_extra_states_with_consensus(ckpt_path, extra_states)
+    _complete_checkpoint_transaction(ckpt_path, manifest)
     log_rank0(f"Saved training checkpoint at step {step} to {ckpt_path}")
 
 
@@ -110,11 +189,28 @@ def load_training_checkpoint(
     load_parameter_state_update_legacy_format: bool = False,
     load_model: bool = True,
     load_optimizer: bool = True,
+    allow_legacy_checkpoint: bool = False,
+    load_extra_state_files: Iterable[str] | None = None,
+    loaded_extra_states: MutableMapping[str, Any] | None = None,
+    extra_state_validators: Mapping[str, Callable[[Any], None]] | None = None,
+    extra_state_targets: Mapping[str, Any] | None = None,
 ) -> int:
     """Load training checkpoint with automatic resharding across different parallel configs."""
     if use_dcp is None:
         use_dcp = True
     if not use_dcp:
+        if not load_model or not load_optimizer:
+            raise ValueError(
+                "Local-format checkpoints do not support partial component selection; "
+                "use_dcp=False requires load_model=True and load_optimizer=True."
+            )
+        if (
+            load_extra_state_files is not None
+            or loaded_extra_states is not None
+            or extra_state_validators is not None
+            or extra_state_targets is not None
+        ):
+            raise ValueError("extra states are supported only for DCP checkpoints")
         return _load_local_training_checkpoint(
             model,
             optimizer,
@@ -122,67 +218,917 @@ def load_training_checkpoint(
             load_rng=load_rng,
             load_parameter_state_update_legacy_format=load_parameter_state_update_legacy_format,
         )
-    ckpt_path = _resolve_step_checkpoint_path(path)
-    if _supports_dist_opt_distckpt(model, optimizer):
-        step = _load_dist_opt_checkpoint(
-            model, optimizer, ckpt_path, load_model=load_model, load_optimizer=load_optimizer
+    if load_optimizer and optimizer is None:
+        raise ValueError(
+            "load_optimizer=True requires a non-None optimizer; pass load_optimizer=False "
+            "for a model-only checkpoint load"
         )
-        if load_rng:
-            _load_rng_sidecar(ckpt_path)
+    requested_extra_state_files = _normalize_extra_state_filenames(
+        load_extra_state_files
+    )
+    normalized_extra_state_validators = _normalize_extra_state_validators(
+        extra_state_validators, requested=requested_extra_state_files
+    )
+    normalized_extra_state_targets = _normalize_extra_state_targets(
+        extra_state_targets, requested=requested_extra_state_files
+    )
+    if loaded_extra_states is not None and not isinstance(
+        loaded_extra_states, MutableMapping
+    ):
+        raise TypeError("loaded_extra_states must be a mutable mapping")
+    if requested_extra_state_files and loaded_extra_states is None:
+        raise ValueError(
+            "loaded_extra_states is required when load_extra_state_files is non-empty"
+        )
+    ckpt_path = _resolve_step_checkpoint_path(
+        path, allow_legacy_checkpoint=allow_legacy_checkpoint
+    )
+    manifest = _validate_checkpoint_manifest(
+        ckpt_path,
+        load_model=load_model,
+        load_optimizer=load_optimizer,
+        load_rng=load_rng,
+        allow_legacy_checkpoint=allow_legacy_checkpoint,
+        load_extra_state_files=requested_extra_state_files,
+    )
+    expected_checkpoint_step = manifest["step"] if manifest is not None else None
+    current_supports_distckpt = False
+    requested_optimizer = optimizer if load_optimizer else None
+    local_error = None
+    if manifest is None:
+        try:
+            current_supports_distckpt = _supports_dist_opt_distckpt(
+                model, requested_optimizer
+            )
+        except Exception as exc:
+            local_error = f"{type(exc).__name__}: {exc}"
+        _distributed_raise_if_error(
+            local_error, context="legacy checkpoint backend detection failed"
+        )
+        _assert_world_consensus(
+            current_supports_distckpt,
+            context="legacy checkpoint backend detection differs across ranks",
+        )
+        use_dist_opt_distckpt = current_supports_distckpt
+    else:
+        use_dist_opt_distckpt = manifest["payload_format"] == "distckpt"
+        if use_dist_opt_distckpt and (load_model or load_optimizer):
+            try:
+                current_supports_distckpt = _supports_dist_opt_distckpt(
+                    model, requested_optimizer
+                )
+            except Exception as exc:
+                local_error = f"{type(exc).__name__}: {exc}"
+            if local_error is None and not current_supports_distckpt:
+                local_error = (
+                    "checkpoint payload_format='distckpt' requires an attached "
+                    "distckpt model and, when requested, a sharded optimizer"
+                )
+        _distributed_raise_if_error(
+            local_error, context="checkpoint payload backend validation failed"
+        )
+        _assert_world_consensus(
+            use_dist_opt_distckpt,
+            context="checkpoint payload backend differs across ranks",
+        )
+    local_error = None
+    if manifest is not None and load_optimizer:
+        expected_optimizer_storage = (
+            "distckpt" if use_dist_opt_distckpt else "rank_sidecar"
+        )
+        if manifest["optimizer_storage"] != expected_optimizer_storage:
+            local_error = (
+                "checkpoint optimizer storage is incompatible with the current "
+                f"optimizer: saved={manifest['optimizer_storage']!r}, "
+                f"required={expected_optimizer_storage!r}"
+            )
+    _distributed_raise_if_error(
+        local_error, context="checkpoint optimizer storage validation failed"
+    )
+    optimizer_state, rng_state, extra_state_values = _preload_checkpoint_sidecars(
+        ckpt_path,
+        optimizer=optimizer,
+        load_optimizer=load_optimizer and not use_dist_opt_distckpt,
+        allow_legacy_optimizer_state=(allow_legacy_checkpoint and manifest is None),
+        load_rng=load_rng,
+        rng_required=manifest is not None,
+        extra_state_files=requested_extra_state_files,
+        extra_state_validators=normalized_extra_state_validators,
+        extra_state_targets=normalized_extra_state_targets,
+        checkpoint_step=expected_checkpoint_step,
+    )
+    if use_dist_opt_distckpt:
+        step = _load_dist_opt_checkpoint(
+            model,
+            optimizer,
+            ckpt_path,
+            load_model=load_model,
+            load_optimizer=load_optimizer,
+            expected_step=expected_checkpoint_step,
+            allow_legacy_checkpoint=(allow_legacy_checkpoint and manifest is None),
+        )
+        local_error = None
+        if (
+            expected_checkpoint_step is not None
+            and int(step) != expected_checkpoint_step
+        ):
+            local_error = (
+                f"checkpoint payload step {step} does not match completion manifest "
+                f"step {expected_checkpoint_step}"
+            )
+        _distributed_raise_if_error(
+            local_error, context="distckpt returned step validation failed"
+        )
+        _commit_preloaded_sidecars(
+            optimizer=None,
+            optimizer_state=None,
+            rng_state=rng_state,
+            loaded_extra_states=loaded_extra_states,
+            extra_state_values=extra_state_values,
+            extra_state_targets=normalized_extra_state_targets,
+        )
         log_rank0(f"Loaded dist_opt checkpoint from {path} at step {step}")
         return step
-    if config is None or ps is None:
-        raise ValueError("DCP checkpointing requires config and ParallelState.")
-    if not isinstance(model, nn.Module):
-        raise TypeError("DCP checkpointing currently expects a single nn.Module.")
-    dense_mesh, expert_mesh = _build_meshes(config)
-
     state_dict: dict = {"step": 0}
-    # Same pp-aware keying as save (see save_training_checkpoint): per-stage
-    # disjoint keyspace so pp ranks don't read each other's colliding FQNs.
-    model_prefix = f"model_pp{ps.pp_rank}" if ps.pp_size > 1 else "model"
+    model_prefix = ""
+    parameter_items: list[tuple[str, torch.Tensor]] = []
+    buffer_items: list[tuple[str, torch.Tensor]] = []
+    checkpoint_tensor_items: list[tuple[str, torch.Tensor]] = []
 
     if load_model:
-        for name, param in model.named_parameters():
+        if config is None or ps is None:
+            raise ValueError("DCP model loading requires config and ParallelState.")
+        if not isinstance(model, nn.Module):
+            raise TypeError("DCP model loading currently expects a single nn.Module.")
+        dense_mesh, expert_mesh = _build_meshes(config)
+        # Same pp-aware keying as save (see save_training_checkpoint): per-stage
+        # disjoint keyspace so pp ranks don't read each other's colliding FQNs.
+        model_prefix = f"model_pp{ps.pp_rank}" if ps.pp_size > 1 else "model"
+        parameter_items = list(model.named_parameters())
+        buffer_items = list(named_persistent_buffers(model))
+        checkpoint_tensor_items = parameter_items
+        metadata_keys: set[str] = set()
+        local_error = None
+        try:
+            metadata = dcp.FileSystemReader(ckpt_path).read_metadata()
+            metadata_keys = set(metadata.state_dict_metadata)
+            schema_present, include_buffers = _validate_dcp_model_metadata(
+                metadata_keys,
+                model_prefix=model_prefix,
+                parameter_items=parameter_items,
+                buffer_items=buffer_items,
+                require_schema=manifest is not None,
+            )
+            if schema_present:
+                state_dict[_DCP_MODEL_SCHEMA_KEY] = 0
+            if include_buffers:
+                checkpoint_tensor_items = [*parameter_items, *buffer_items]
+            else:
+                log_rank0(
+                    "Loading a legacy MLite DCP checkpoint without persistent buffers; "
+                    "buffers retain their initialized values. Re-save the checkpoint to "
+                    "upgrade it to schema version 2."
+                )
+        except Exception as exc:
+            local_error = f"{type(exc).__name__}: {exc}"
+        _distributed_raise_if_error(
+            local_error, context="DCP model metadata validation failed"
+        )
+
+        for name, tensor in checkpoint_tensor_items:
             placements = get_placements(name)
             mesh = expert_mesh if is_expert(name) else dense_mesh
             state_dict[f"{model_prefix}.{name}"] = _empty_dcp_tensor_like_param(
-                param, mesh, placements
+                tensor, mesh, placements
             )
 
     dcp.load(state_dict, checkpoint_id=ckpt_path)
 
     if load_model:
-        for name, param in model.named_parameters():
-            key = f"{model_prefix}.{name}"
-            if key in state_dict:
-                t = state_dict[key]
-                with torch.no_grad():
-                    _copy_tensor_(param, t)
-
-    if load_optimizer:
-        _load_optimizer_checkpoint(optimizer, ckpt_path)
-
-    step = state_dict.get("step", 0)
-    if load_rng:
-        _load_rng_sidecar(ckpt_path)
+        local_error = None
+        if _DCP_MODEL_SCHEMA_KEY in state_dict:
+            loaded_schema = int(state_dict[_DCP_MODEL_SCHEMA_KEY])
+            if loaded_schema != _DCP_MODEL_SCHEMA_VERSION:
+                local_error = (
+                    f"unsupported MLite DCP model schema version {loaded_schema}; "
+                    f"expected {_DCP_MODEL_SCHEMA_VERSION}"
+                )
+        _distributed_raise_if_error(
+            local_error, context="DCP model schema validation failed"
+        )
+    step = int(state_dict.get("step", 0))
+    local_error = None
+    if expected_checkpoint_step is not None and step != expected_checkpoint_step:
+        local_error = (
+            f"checkpoint payload step {step} does not match completion manifest "
+            f"step {expected_checkpoint_step}"
+        )
+    _distributed_raise_if_error(
+        local_error, context="DCP checkpoint step validation failed"
+    )
+    if load_model:
+        local_error = None
+        try:
+            for name, tensor in checkpoint_tensor_items:
+                key = f"{model_prefix}.{name}"
+                if key in state_dict:
+                    with torch.no_grad():
+                        _copy_tensor_(tensor, state_dict[key])
+        except Exception as exc:
+            local_error = f"{type(exc).__name__}: {exc}"
+        _distributed_raise_if_error(
+            local_error, context="DCP staged model commit failed"
+        )
+    _commit_preloaded_sidecars(
+        optimizer=optimizer if load_optimizer else None,
+        optimizer_state=optimizer_state,
+        rng_state=rng_state,
+        loaded_extra_states=loaded_extra_states,
+        extra_state_values=extra_state_values,
+        extra_state_targets=normalized_extra_state_targets,
+    )
     log_rank0(f"Loaded training checkpoint from {path} at step {step}")
     return step
 
 
-def _resolve_step_checkpoint_path(path: str) -> str:
-    if os.path.basename(path).startswith("step_"):
-        return path
+def _resolve_step_checkpoint_path(
+    path: str, *, allow_legacy_checkpoint: bool = False
+) -> str:
+    selected = path
+    step_dirs: list[tuple[int, str]] = []
+    eligible: list[tuple[int, str]] = []
+    incomplete: list[str] = []
+    legacy: list[str] = []
+    selected_manifest_present = False
+    selected_manifest: dict[str, Any] | None = None
+    local_error = None
+    try:
+        if not os.path.basename(path).startswith("step_"):
+            for dirname in os.listdir(path):
+                if not dirname.startswith("step_"):
+                    continue
+                try:
+                    step = int(dirname.removeprefix("step_"))
+                except ValueError:
+                    continue
+                step_dirs.append((step, dirname))
 
-    step_dirs = sorted(
-        [d for d in os.listdir(path) if d.startswith("step_")], key=lambda d: int(d.split("_")[1])
+            for step, dirname in sorted(step_dirs):
+                candidate = os.path.join(path, dirname)
+                manifest_path = _checkpoint_manifest_path(candidate)
+                manifest_present = manifest_path.exists()
+                if not manifest_present:
+                    legacy.append(candidate)
+                    if allow_legacy_checkpoint:
+                        eligible.append((step, candidate))
+                    continue
+                manifest = json.loads(manifest_path.read_text())
+                _validate_checkpoint_manifest_schema(manifest)
+                if manifest["status"] == "complete":
+                    eligible.append((step, candidate))
+                else:
+                    incomplete.append(candidate)
+
+            if eligible:
+                selected = max(eligible)[1]
+            elif incomplete or legacy:
+                raise RuntimeError(
+                    f"No strict complete checkpoint is available under {path}; "
+                    f"incomplete={incomplete}, legacy={legacy}"
+                )
+
+        selected_manifest_path = _checkpoint_manifest_path(selected)
+        selected_manifest_present = selected_manifest_path.exists()
+        if selected_manifest_present:
+            selected_manifest = json.loads(selected_manifest_path.read_text())
+            _validate_checkpoint_manifest_schema(selected_manifest)
+    except Exception as exc:
+        local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(
+        local_error, context="checkpoint step resolution failed"
     )
-    if step_dirs:
-        return os.path.join(path, step_dirs[-1])
-    return path
+
+    resolution = {
+        "selected_path": _canonical_checkpoint_path(selected),
+        "manifest_present": selected_manifest_present,
+        "manifest": selected_manifest,
+        "eligible": [
+            _canonical_checkpoint_path(candidate) for _, candidate in eligible
+        ],
+        "incomplete": [
+            _canonical_checkpoint_path(candidate) for candidate in incomplete
+        ],
+        "legacy": [_canonical_checkpoint_path(candidate) for candidate in legacy],
+    }
+    _assert_world_consensus(
+        resolution, context="checkpoint step resolution differs across ranks"
+    )
+
+    if incomplete:
+        log_rank0(
+            "Ignoring incomplete checkpoint transactions while resolving latest step: "
+            f"{incomplete}"
+        )
+    if legacy and not allow_legacy_checkpoint:
+        log_rank0(
+            "Ignoring pre-manifest legacy checkpoints while resolving latest step: "
+            f"{legacy}"
+        )
+    return selected
 
 
-def _supports_dist_opt_distckpt(model: nn.Module | Iterable[nn.Module], optimizer) -> bool:
+def _checkpoint_manifest_path(path: str | os.PathLike[str]) -> Path:
+    return Path(path) / _CHECKPOINT_MANIFEST
+
+
+def _canonical_checkpoint_path(path: str | os.PathLike[str]) -> str:
+    return os.path.abspath(os.path.normpath(os.fspath(path)))
+
+
+def _gather_world_objects(value: Any) -> list[Any]:
+    if not dist.is_available() or not dist.is_initialized():
+        return [value]
+    gathered: list[Any] = [None] * dist.get_world_size()
+    local_error = None
+    try:
+        dist.all_gather_object(gathered, value)
+    except Exception as exc:
+        local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(
+        local_error, context="checkpoint WORLD metadata exchange failed"
+    )
+    return gathered
+
+
+def _assert_world_consensus(value: Any, *, context: str) -> None:
+    gathered = _gather_world_objects(value)
+    reference = gathered[0]
+    if any(item != reference for item in gathered[1:]):
+        raise RuntimeError(f"{context}: rank values={gathered!r}")
+
+
+def _validate_extra_state_filename(filename: str) -> str:
+    if not isinstance(filename, str) or not filename:
+        raise ValueError("extra-state filenames must be non-empty strings")
+    if Path(filename).name != filename or filename in {".", ".."}:
+        raise ValueError(
+            f"extra-state filename must be a basename inside the checkpoint: {filename!r}"
+        )
+    if (
+        filename == _CHECKPOINT_MANIFEST
+        or filename in {"common.pt", "metadata.json"}
+        or filename.startswith(".")
+        or filename.endswith(".distcp")
+        or filename.startswith("optimizer_rank_")
+        or filename.startswith("rng_state_")
+    ):
+        raise ValueError(f"extra-state filename is reserved by MLite: {filename!r}")
+    return filename
+
+
+def _normalize_extra_state_filenames(
+    filenames: Iterable[str] | None,
+) -> tuple[str, ...]:
+    if filenames is None:
+        return ()
+    if isinstance(filenames, (str, bytes)):
+        raise TypeError(
+            "load_extra_state_files must be an iterable of filenames, not a string"
+        )
+    normalized = tuple(_validate_extra_state_filename(name) for name in filenames)
+    if len(set(normalized)) != len(normalized):
+        raise ValueError(
+            f"duplicate extra-state filenames are not allowed: {normalized}"
+        )
+    return normalized
+
+
+def _normalize_extra_states(extra_states: Mapping[str, Any] | None) -> dict[str, Any]:
+    if extra_states is None:
+        return {}
+    if not isinstance(extra_states, Mapping):
+        raise TypeError(
+            "extra_states must be a mapping of filename to serializable state"
+        )
+    return {
+        _validate_extra_state_filename(filename): value
+        for filename, value in extra_states.items()
+    }
+
+
+def _normalize_extra_state_validators(
+    validators: Mapping[str, Callable[[Any], None]] | None, *, requested: Iterable[str]
+) -> dict[str, Callable[[Any], None]]:
+    if validators is None:
+        return {}
+    if not isinstance(validators, Mapping):
+        raise TypeError("extra_state_validators must be a mapping")
+    normalized: dict[str, Callable[[Any], None]] = {}
+    for filename, validator in validators.items():
+        filename = _validate_extra_state_filename(filename)
+        if not callable(validator):
+            raise TypeError(f"extra-state validator for {filename!r} must be callable")
+        normalized[filename] = validator
+    unrequested = sorted(set(normalized) - set(requested))
+    if unrequested:
+        raise ValueError(
+            f"extra-state validators require matching requested files: {unrequested}"
+        )
+    return normalized
+
+
+def _normalize_extra_state_targets(
+    targets: Mapping[str, Any] | None, *, requested: Iterable[str]
+) -> dict[str, Any]:
+    if targets is None:
+        return {}
+    if not isinstance(targets, Mapping):
+        raise TypeError("extra_state_targets must be a mapping")
+    normalized: dict[str, Any] = {}
+    required_methods = ("snapshot", "apply", "restore", "fingerprint")
+    for filename, target in targets.items():
+        filename = _validate_extra_state_filename(filename)
+        missing = [
+            method
+            for method in required_methods
+            if not callable(getattr(target, method, None))
+        ]
+        if missing:
+            raise TypeError(
+                f"extra-state target for {filename!r} is missing methods: {missing}"
+            )
+        normalized[filename] = target
+    unrequested = sorted(set(normalized) - set(requested))
+    if unrequested:
+        raise ValueError(
+            f"extra-state targets require matching requested files: {unrequested}"
+        )
+    return normalized
+
+
+def _checkpoint_world_size() -> int:
+    return dist.get_world_size() if dist.is_available() and dist.is_initialized() else 1
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f".{path.name}.tmp.{os.getpid()}")
+    try:
+        with open(tmp_path, "w") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, path)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def _write_checkpoint_manifest_with_consensus(
+    checkpoint_path: str, payload: dict[str, Any], *, context: str
+) -> None:
+    _assert_world_consensus(
+        {
+            "checkpoint_path": _canonical_checkpoint_path(checkpoint_path),
+            "manifest": payload,
+        },
+        context=f"{context}: manifest payload differs across ranks",
+    )
+    local_error = None
+    if not dist.is_initialized() or dist.get_rank() == 0:
+        try:
+            _atomic_write_json(_checkpoint_manifest_path(checkpoint_path), payload)
+        except Exception as exc:
+            local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(local_error, context=context)
+    readback: dict[str, Any] | None = None
+    local_error = None
+    try:
+        manifest_path = _checkpoint_manifest_path(checkpoint_path)
+        if not manifest_path.exists():
+            raise FileNotFoundError(
+                f"manifest is not visible after rank0 publication: {manifest_path}"
+            )
+        parsed = json.loads(manifest_path.read_text())
+        _validate_checkpoint_manifest_schema(parsed)
+        if parsed != payload:
+            raise RuntimeError(
+                f"manifest readback differs from published payload: {parsed!r}"
+            )
+        readback = parsed
+    except Exception as exc:
+        local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(
+        local_error, context=f"{context}: manifest readback failed"
+    )
+    _assert_world_consensus(
+        {
+            "checkpoint_path": _canonical_checkpoint_path(checkpoint_path),
+            "manifest": readback,
+        },
+        context=f"{context}: manifest readback differs across ranks",
+    )
+
+
+def _atomically_reserve_checkpoint_directory(destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        os.mkdir(destination)
+        return
+    except FileExistsError as exc:
+        if not destination.is_dir():
+            raise RuntimeError(
+                f"checkpoint destination is not a directory: {destination}"
+            ) from exc
+        destination_entries = sorted(entry.name for entry in destination.iterdir())
+        existing_manifest: dict[str, Any] | None = None
+        manifest_path = _checkpoint_manifest_path(destination)
+        if manifest_path.exists():
+            parsed = json.loads(manifest_path.read_text())
+            _validate_checkpoint_manifest_schema(parsed)
+            existing_manifest = parsed
+        status = (
+            existing_manifest.get("status")
+            if existing_manifest is not None
+            else "unmanifested"
+        )
+        detail = (
+            "checkpoint destination is non-empty and will not be overwritten"
+            if destination_entries
+            else "checkpoint destination already exists and cannot be atomically reserved"
+        )
+        raise FileExistsError(
+            f"{detail}: {destination} "
+            f"(status={status!r}, entries={destination_entries})"
+        ) from exc
+
+
+def _begin_checkpoint_transaction(
+    checkpoint_path: str,
+    *,
+    step: int,
+    save_model: bool,
+    save_optimizer: bool,
+    save_rng: bool,
+    payload_format: str,
+    optimizer_storage: str,
+    extra_state_files: Mapping[str, Any] | Iterable[str] = (),
+) -> dict[str, Any]:
+    extra_state_files = tuple(sorted(extra_state_files))
+    manifest = {
+        "format": _CHECKPOINT_MANIFEST_FORMAT,
+        "status": "incomplete",
+        "step": step,
+        "world_size": _checkpoint_world_size(),
+        "components": {
+            "model": bool(save_model),
+            "optimizer": bool(save_optimizer),
+            "rng": bool(save_rng),
+            "extra_states": bool(extra_state_files),
+        },
+        "payload_format": payload_format,
+        "optimizer_storage": optimizer_storage,
+        "extra_state_files": list(extra_state_files),
+    }
+    local_error = None
+    try:
+        _validate_checkpoint_manifest_schema(manifest, expected_status="incomplete")
+    except Exception as exc:
+        local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(
+        local_error,
+        context="checkpoint transaction reservation request validation failed",
+    )
+
+    destination = Path(checkpoint_path)
+    reservation = {
+        "checkpoint_path": _canonical_checkpoint_path(checkpoint_path),
+        "manifest": manifest,
+    }
+    _assert_world_consensus(
+        reservation,
+        context="checkpoint transaction reservation request differs across ranks",
+    )
+
+    local_error = None
+    if not dist.is_initialized() or dist.get_rank() == 0:
+        try:
+            _atomically_reserve_checkpoint_directory(destination)
+        except Exception as exc:
+            local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(
+        local_error, context="checkpoint transaction atomic reservation failed"
+    )
+
+    destination_entries: list[str] = []
+    local_error = None
+    try:
+        if not destination.is_dir():
+            raise RuntimeError(
+                "atomically reserved checkpoint directory is not visible: "
+                f"{destination}"
+            )
+        destination_entries = sorted(entry.name for entry in destination.iterdir())
+        if destination_entries:
+            raise RuntimeError(
+                "atomically reserved checkpoint directory was modified before "
+                f"manifest publication: {destination_entries}"
+            )
+    except Exception as exc:
+        local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(
+        local_error, context="checkpoint transaction reservation visibility failed"
+    )
+    _assert_world_consensus(
+        {
+            "checkpoint_path": _canonical_checkpoint_path(checkpoint_path),
+            "entries": destination_entries,
+        },
+        context="checkpoint transaction reservation differs across ranks",
+    )
+    _write_checkpoint_manifest_with_consensus(
+        checkpoint_path,
+        manifest,
+        context="checkpoint transaction initialization failed",
+    )
+    return manifest
+
+
+def _complete_checkpoint_transaction(
+    checkpoint_path: str, manifest: dict[str, Any]
+) -> None:
+    completed = dict(manifest)
+    completed["status"] = "complete"
+    _validate_checkpoint_manifest_schema(completed, expected_status="complete")
+    _write_checkpoint_manifest_with_consensus(
+        checkpoint_path,
+        completed,
+        context="checkpoint completion manifest write failed",
+    )
+
+
+def _save_rank_sidecar_with_consensus(save_fn, *, context: str) -> None:
+    local_error = None
+    try:
+        save_fn()
+    except Exception as exc:
+        local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(local_error, context=context)
+
+
+def _save_rank0_extra_states_with_consensus(
+    checkpoint_path: str, extra_states: Mapping[str, Any]
+) -> None:
+    if not extra_states:
+        return
+    local_error = None
+    if not dist.is_initialized() or dist.get_rank() == 0:
+        try:
+            for filename, value in extra_states.items():
+                _atomic_torch_save(value, Path(checkpoint_path) / filename)
+        except Exception as exc:
+            local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(local_error, context="rank0 extra-state save failed")
+
+
+def _validate_checkpoint_manifest_schema(
+    manifest: Any, *, expected_status: str | None = None
+) -> None:
+    """Validate the exact v2 completion-manifest schema without filesystem I/O."""
+
+    if not isinstance(manifest, dict):
+        raise RuntimeError("manifest must be a dictionary")
+    expected_top_level = {
+        "format",
+        "status",
+        "step",
+        "world_size",
+        "components",
+        "payload_format",
+        "optimizer_storage",
+        "extra_state_files",
+    }
+    actual_top_level = set(manifest)
+    if actual_top_level != expected_top_level:
+        raise RuntimeError(
+            "manifest top-level schema mismatch: "
+            f"missing={sorted(expected_top_level - actual_top_level)}, "
+            f"unexpected={sorted(actual_top_level - expected_top_level)}"
+        )
+    if manifest["format"] != _CHECKPOINT_MANIFEST_FORMAT:
+        raise RuntimeError(f"unsupported format {manifest['format']!r}")
+    if manifest["status"] not in {"incomplete", "complete"}:
+        raise RuntimeError(f"invalid checkpoint status {manifest['status']!r}")
+    if expected_status is not None and manifest["status"] != expected_status:
+        raise RuntimeError(f"checkpoint status is {manifest['status']!r}")
+
+    manifest_step = manifest["step"]
+    if type(manifest_step) is not int or manifest_step < 0:
+        raise RuntimeError("manifest step must be a non-negative integer")
+    world_size = manifest["world_size"]
+    if type(world_size) is not int or world_size <= 0:
+        raise RuntimeError("manifest world_size must be a positive integer")
+
+    components = manifest["components"]
+    expected_components = {"model", "optimizer", "rng", "extra_states"}
+    if not isinstance(components, dict) or set(components) != expected_components:
+        actual_components = set(components) if isinstance(components, dict) else set()
+        raise RuntimeError(
+            "manifest components schema mismatch: "
+            f"missing={sorted(expected_components - actual_components)}, "
+            f"unexpected={sorted(actual_components - expected_components)}"
+        )
+    non_boolean_components = sorted(
+        name for name, enabled in components.items() if type(enabled) is not bool
+    )
+    if non_boolean_components:
+        raise RuntimeError(
+            f"manifest component values must be booleans: {non_boolean_components}"
+        )
+
+    payload_format = manifest["payload_format"]
+    if not isinstance(payload_format, str) or payload_format not in {"dcp", "distckpt"}:
+        raise RuntimeError(
+            f"invalid payload_format {payload_format!r}; expected 'dcp' or 'distckpt'"
+        )
+
+    optimizer_storage = manifest["optimizer_storage"]
+    valid_optimizer_storage = {"none", "rank_sidecar", "distckpt"}
+    if (
+        not isinstance(optimizer_storage, str)
+        or optimizer_storage not in valid_optimizer_storage
+    ):
+        raise RuntimeError(
+            f"invalid optimizer_storage {optimizer_storage!r}; expected one of "
+            f"{sorted(valid_optimizer_storage)}"
+        )
+    if components["optimizer"] != (optimizer_storage != "none"):
+        raise RuntimeError(
+            "manifest optimizer component does not match optimizer_storage"
+        )
+    expected_optimizer_storage = (
+        "distckpt" if payload_format == "distckpt" else "rank_sidecar"
+    )
+    if components["optimizer"] and optimizer_storage != expected_optimizer_storage:
+        raise RuntimeError(
+            "manifest payload_format is inconsistent with optimizer_storage: "
+            f"payload_format={payload_format!r}, optimizer_storage={optimizer_storage!r}"
+        )
+
+    extra_state_files = manifest["extra_state_files"]
+    if not isinstance(extra_state_files, list):
+        raise RuntimeError("manifest extra_state_files must be a list")
+    normalized_extra_state_files = _normalize_extra_state_filenames(extra_state_files)
+    if components["extra_states"] != bool(normalized_extra_state_files):
+        raise RuntimeError(
+            "manifest extra_states component does not match extra_state_files"
+        )
+
+
+def _read_checkpoint_manifest_with_consensus(
+    checkpoint_path: str,
+) -> dict[str, Any] | None:
+    """Read one manifest locally, then require identical path/content on WORLD."""
+
+    manifest_path = _checkpoint_manifest_path(checkpoint_path)
+    manifest_present = False
+    manifest: dict[str, Any] | None = None
+    local_error = None
+    try:
+        manifest_present = manifest_path.exists()
+        if manifest_present:
+            parsed = json.loads(manifest_path.read_text())
+            if not isinstance(parsed, dict):
+                raise RuntimeError("manifest JSON root must be a dictionary")
+            manifest = parsed
+    except Exception as exc:
+        local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(
+        local_error, context="checkpoint completion manifest read failed"
+    )
+    snapshot = {
+        "checkpoint_path": _canonical_checkpoint_path(checkpoint_path),
+        "manifest_present": manifest_present,
+        "manifest": manifest,
+    }
+    _assert_world_consensus(
+        snapshot, context="checkpoint manifest differs across ranks"
+    )
+    return manifest
+
+
+def _validate_checkpoint_manifest(
+    checkpoint_path: str,
+    *,
+    load_model: bool,
+    load_optimizer: bool,
+    load_rng: bool,
+    allow_legacy_checkpoint: bool = False,
+    load_extra_state_files: Iterable[str] = (),
+) -> dict[str, Any] | None:
+    requested_extra_state_files = _normalize_extra_state_filenames(
+        load_extra_state_files
+    )
+    manifest = _read_checkpoint_manifest_with_consensus(checkpoint_path)
+    if manifest is None:
+        if not allow_legacy_checkpoint:
+            raise RuntimeError(
+                f"Checkpoint {checkpoint_path} has no completion manifest. "
+                "Legacy DCP checkpoints are rejected by default; pass "
+                "allow_legacy_checkpoint=True only for an explicit migration load."
+            )
+        log_rank0(
+            f"Checkpoint {checkpoint_path} predates completion manifests; "
+            "loading through the explicitly enabled legacy migration path."
+        )
+        return None
+
+    local_error = None
+    try:
+        _validate_checkpoint_manifest_schema(manifest, expected_status="complete")
+        manifest_step = manifest["step"]
+        dirname = Path(checkpoint_path).name
+        if dirname.startswith("step_"):
+            try:
+                directory_step = int(dirname.removeprefix("step_"))
+            except ValueError:
+                directory_step = None
+            if directory_step is not None and manifest_step != directory_step:
+                raise RuntimeError(
+                    f"manifest step {manifest_step} does not match directory {dirname!r}"
+                )
+        components = manifest["components"]
+        requested = {"model": load_model, "optimizer": load_optimizer, "rng": load_rng}
+        missing = [
+            name
+            for name, enabled in requested.items()
+            if enabled and not components[name]
+        ]
+        if missing:
+            raise RuntimeError(
+                f"requested checkpoint components were not saved: {missing}"
+            )
+
+        declared_extra_state_files = _normalize_extra_state_filenames(
+            manifest["extra_state_files"]
+        )
+        undeclared = sorted(
+            set(requested_extra_state_files) - set(declared_extra_state_files)
+        )
+        if undeclared:
+            raise RuntimeError(
+                f"requested extra-state files were not saved: {undeclared}"
+            )
+        for filename in declared_extra_state_files:
+            extra_state_path = Path(checkpoint_path) / filename
+            if not extra_state_path.exists():
+                raise FileNotFoundError(
+                    "completed checkpoint is missing declared extra-state file "
+                    f"{extra_state_path}"
+                )
+
+        saved_world_size = manifest["world_size"]
+        current_world_size = _checkpoint_world_size()
+        if load_rng and saved_world_size != current_world_size:
+            raise RuntimeError(
+                "exact RNG resume requires the saved world size: "
+                f"saved={saved_world_size}, current={current_world_size}"
+            )
+        if (
+            load_optimizer
+            and manifest["optimizer_storage"] == "rank_sidecar"
+            and saved_world_size != current_world_size
+        ):
+            raise RuntimeError(
+                "rank-local optimizer sidecars require the saved world size: "
+                f"saved={saved_world_size}, current={current_world_size}"
+            )
+        if load_rng and not _rng_sidecar_file(checkpoint_path).exists():
+            raise FileNotFoundError(
+                f"completed checkpoint is missing rank-local RNG sidecar "
+                f"{_rng_sidecar_file(checkpoint_path)}"
+            )
+        if (
+            load_optimizer
+            and manifest["optimizer_storage"] == "rank_sidecar"
+            and not Path(_optimizer_checkpoint_path(checkpoint_path)).exists()
+        ):
+            raise FileNotFoundError(
+                "completed checkpoint is missing rank-local optimizer sidecar "
+                f"{_optimizer_checkpoint_path(checkpoint_path)}"
+            )
+    except Exception as exc:
+        local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(
+        local_error, context="checkpoint completion manifest validation failed"
+    )
+    return manifest
+
+
+def _supports_dist_opt_distckpt(
+    model: nn.Module | Iterable[nn.Module], optimizer
+) -> bool:
     try:
         from megatron.lite.primitive.ckpt.distckpt import supports_dist_opt_distckpt
     except ModuleNotFoundError as exc:
@@ -191,6 +1137,59 @@ def _supports_dist_opt_distckpt(model: nn.Module | Iterable[nn.Module], optimize
         return False
 
     return supports_dist_opt_distckpt(model, optimizer)
+
+
+def _named_model_checkpoint_tensors(model: nn.Module):
+    """Yield parameters plus exactly the buffers PyTorch marks persistent."""
+    yield from model.named_parameters()
+    yield from named_persistent_buffers(model)
+
+
+def _validate_dcp_model_metadata(
+    metadata_keys: set[str],
+    *,
+    model_prefix: str,
+    parameter_items: list[tuple[str, torch.Tensor]],
+    buffer_items: list[tuple[str, torch.Tensor]],
+    require_schema: bool,
+) -> tuple[bool, bool]:
+    """Require an exact current-stage model schema before any DCP mutation."""
+    parameter_keys = {f"{model_prefix}.{name}" for name, _tensor in parameter_items}
+    buffer_keys = {f"{model_prefix}.{name}" for name, _tensor in buffer_items}
+    expected_model_keys = parameter_keys | buffer_keys
+    checkpoint_model_keys = {
+        key for key in metadata_keys if key.startswith(f"{model_prefix}.")
+    }
+    missing_parameters = sorted(parameter_keys - metadata_keys)
+    unexpected_model_keys = sorted(checkpoint_model_keys - expected_model_keys)
+    present_buffers = buffer_keys & metadata_keys
+    schema_present = _DCP_MODEL_SCHEMA_KEY in metadata_keys
+
+    if missing_parameters:
+        raise RuntimeError(
+            f"checkpoint is missing required model parameters: {missing_parameters}"
+        )
+    if unexpected_model_keys:
+        raise RuntimeError(
+            "checkpoint contains unexpected model tensors for the current "
+            f"pipeline stage: {unexpected_model_keys}"
+        )
+    if require_schema and not schema_present:
+        raise RuntimeError(
+            "completed versioned checkpoint is missing the required model "
+            f"schema key {_DCP_MODEL_SCHEMA_KEY!r}"
+        )
+    if buffer_keys and present_buffers and present_buffers != buffer_keys:
+        raise RuntimeError(
+            "checkpoint contains only a subset of persistent model buffers: "
+            f"missing={sorted(buffer_keys - present_buffers)}"
+        )
+    if schema_present and present_buffers != buffer_keys:
+        raise RuntimeError(
+            "versioned checkpoint is missing persistent model buffers: "
+            f"{sorted(buffer_keys - present_buffers)}"
+        )
+    return schema_present, not buffer_keys or present_buffers == buffer_keys
 
 
 def _save_dist_opt_checkpoint(
@@ -205,7 +1204,12 @@ def _save_dist_opt_checkpoint(
     from megatron.lite.primitive.ckpt.distckpt import save_dist_opt_checkpoint
 
     save_dist_opt_checkpoint(
-        model, optimizer, step, path, save_model=save_model, save_optimizer=save_optimizer
+        model,
+        optimizer,
+        step,
+        path,
+        save_model=save_model,
+        save_optimizer=save_optimizer,
     )
 
 
@@ -216,11 +1220,19 @@ def _load_dist_opt_checkpoint(
     *,
     load_model: bool,
     load_optimizer: bool,
+    expected_step: int | None = None,
+    allow_legacy_checkpoint: bool = False,
 ) -> int:
     from megatron.lite.primitive.ckpt.distckpt import load_dist_opt_checkpoint
 
     return load_dist_opt_checkpoint(
-        model, optimizer, path, load_model=load_model, load_optimizer=load_optimizer
+        model,
+        optimizer,
+        path,
+        load_model=load_model,
+        load_optimizer=load_optimizer,
+        expected_step=expected_step,
+        allow_legacy_checkpoint=allow_legacy_checkpoint,
     )
 
 
@@ -229,29 +1241,549 @@ def _optimizer_checkpoint_path(path: str) -> str:
     return os.path.join(path, f"optimizer_rank_{rank}.pt")
 
 
+def _atomic_torch_save(value: Any, path: str | os.PathLike[str]) -> None:
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = destination.with_name(f".{destination.name}.tmp.{os.getpid()}")
+    try:
+        torch.save(value, tmp_path)
+        os.replace(tmp_path, destination)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
 def _save_optimizer_checkpoint(optimizer, path: str) -> None:
     if optimizer is None:
         log_rank0("Skipping optimizer checkpoint save because optimizer is None")
         return
     state_dict_fn = getattr(optimizer, "state_dict", None)
     if not callable(state_dict_fn):
-        raise TypeError(f"Optimizer {type(optimizer).__name__} does not provide state_dict().")
-    torch.save(state_dict_fn(), _optimizer_checkpoint_path(path))
+        raise TypeError(
+            f"Optimizer {type(optimizer).__name__} does not provide state_dict()."
+        )
+    _atomic_torch_save(state_dict_fn(), _optimizer_checkpoint_path(path))
+
+
+def _read_optimizer_checkpoint(optimizer, path: str) -> Any:
+    if optimizer is None:
+        raise ValueError("optimizer checkpoint load requires a non-None optimizer")
+    ckpt_path = _optimizer_checkpoint_path(path)
+    if not os.path.exists(ckpt_path):
+        raise FileNotFoundError(
+            f"optimizer checkpoint requested by load_optimizer=True is missing: {ckpt_path}"
+        )
+    return torch.load(ckpt_path, map_location="cpu", weights_only=False)
+
+
+def _apply_optimizer_checkpoint_state(optimizer, state: Any) -> None:
+    load_state_dict_fn = getattr(optimizer, "load_state_dict", None)
+    if not callable(load_state_dict_fn):
+        raise TypeError(
+            f"Optimizer {type(optimizer).__name__} does not provide load_state_dict()."
+        )
+    load_state_dict_fn(state)
+
+
+def _preflight_optimizer_checkpoint_state(optimizer, state: Any) -> None:
+    """Validate optimizer state structurally without mutating live tensors.
+
+    A load/rollback dry-run is not safe at scale: FP32AdamW and similar
+    optimizers copy into existing moment/master tensors in place, so a shallow
+    state_dict snapshot aliases the mutation while a deep copy can require
+    tens of gigabytes per rank. Supported optimizers therefore use a pure
+    validator; custom wrappers must expose ``validate_state_dict``.
+    """
+
+    try:
+        if not callable(getattr(optimizer, "load_state_dict", None)):
+            raise TypeError(
+                f"Optimizer wrapper {type(optimizer).__name__} does not provide "
+                "load_state_dict()."
+            )
+        _validate_optimizer_checkpoint_state(optimizer, state)
+    except Exception as exc:
+        raise RuntimeError(
+            f"optimizer checkpoint is incompatible: {type(exc).__name__}: {exc}"
+        ) from exc
+
+
+def _migrate_legacy_optimizer_checkpoint_state(optimizer, state: Any) -> Any:
+    """Recursively apply an explicitly provided legacy-state migrator."""
+
+    try:
+        _validate_optimizer_checkpoint_state(optimizer, state)
+        return state
+    except Exception:
+        # A strict current-format state needs no migration. Invalid/legacy state
+        # continues below and is validated again after the opt-in migration.
+        pass
+
+    migrator = getattr(optimizer, "migrate_legacy_state_dict", None)
+    if callable(migrator):
+        migrated = migrator(state)
+        if migrated is None:
+            raise TypeError(
+                f"{type(optimizer).__name__}.migrate_legacy_state_dict returned None"
+            )
+        return migrated
+
+    inner = getattr(optimizer, "optimizer", None)
+    if inner is not None and inner is not optimizer:
+        return _migrate_legacy_optimizer_checkpoint_state(inner, state)
+
+    chained = getattr(optimizer, "optimizers", None)
+    if isinstance(chained, (list, tuple)) and isinstance(state, dict):
+        child_states = state.get("optimizers")
+        if isinstance(child_states, list) and len(child_states) == len(chained):
+            migrated_state = dict(state)
+            migrated_state["optimizers"] = [
+                _migrate_legacy_optimizer_checkpoint_state(child, child_state)
+                for child, child_state in zip(chained, child_states, strict=True)
+            ]
+            return migrated_state
+    return state
+
+
+def _prepare_optimizer_checkpoint_state(
+    optimizer, state: Any, *, allow_legacy_optimizer_state: bool
+) -> Any:
+    if not allow_legacy_optimizer_state:
+        _preflight_optimizer_checkpoint_state(optimizer, state)
+        return state
+    try:
+        _preflight_optimizer_checkpoint_state(optimizer, state)
+        return state
+    except RuntimeError:
+        migrated = _migrate_legacy_optimizer_checkpoint_state(optimizer, state)
+        _preflight_optimizer_checkpoint_state(optimizer, migrated)
+        return migrated
+
+
+def _validate_optimizer_checkpoint_state(optimizer, state: Any) -> None:
+    validator = getattr(optimizer, "validate_state_dict", None)
+    if callable(validator):
+        validator(state)
+        return
+
+    mcore_chained = getattr(optimizer, "chained_optimizers", None)
+    if isinstance(mcore_chained, (list, tuple)):
+        if len(mcore_chained) == 1:
+            _validate_optimizer_checkpoint_state(mcore_chained[0], state)
+            return
+        if not isinstance(state, list) or len(state) != len(mcore_chained):
+            raise ValueError("Invalid MCore chained optimizer state_dict cardinality.")
+        for child, child_state in zip(mcore_chained, state, strict=True):
+            _validate_optimizer_checkpoint_state(child, child_state)
+        return
+
+    chained = getattr(optimizer, "optimizers", None)
+    if isinstance(chained, (list, tuple)):
+        if (
+            not isinstance(state, dict)
+            or state.get("type") != "chained_torch_optimizer"
+        ):
+            raise ValueError("Invalid chained optimizer state_dict format.")
+        child_states = state.get("optimizers")
+        if not isinstance(child_states, list) or len(child_states) != len(chained):
+            raise ValueError("Invalid chained optimizer state_dict cardinality.")
+        for child, child_state in zip(chained, child_states, strict=True):
+            _validate_optimizer_checkpoint_state(child, child_state)
+        return
+
+    if (
+        callable(getattr(optimizer, "get_parameter_state_dp_zero", None))
+        and isinstance(state, dict)
+        and "optimizer" in state
+    ):
+        _validate_mcore_distributed_optimizer_checkpoint_state(optimizer, state)
+        return
+
+    inner = getattr(optimizer, "optimizer", None)
+    if inner is not None and inner is not optimizer:
+        _validate_optimizer_checkpoint_state(inner, state)
+        return
+
+    if isinstance(optimizer, torch.optim.Optimizer):
+        _validate_torch_optimizer_checkpoint_state(optimizer, state)
+        return
+
+    raise TypeError(
+        f"Optimizer {type(optimizer).__name__} must implement a non-mutating "
+        "validate_state_dict(state) method."
+    )
+
+
+def _validate_mcore_distributed_optimizer_checkpoint_state(
+    optimizer, state: dict[str, Any]
+) -> None:
+    if not isinstance(state, dict) or "optimizer" not in state:
+        raise ValueError(
+            "MCore distributed optimizer checkpoint must contain optimizer state."
+        )
+    unexpected_root = sorted(set(state) - {"optimizer", "grad_scaler"})
+    if unexpected_root:
+        raise ValueError(
+            f"MCore distributed optimizer root has unexpected keys: {unexpected_root}"
+        )
+    grad_scaler = getattr(optimizer, "grad_scaler", None)
+    if ("grad_scaler" in state) != (grad_scaler is not None):
+        raise ValueError(
+            "MCore distributed optimizer grad-scaler presence mismatch: "
+            f"checkpoint={'grad_scaler' in state}, runtime={grad_scaler is not None}"
+        )
+    saved_optimizer = state.get("optimizer")
+    if not isinstance(saved_optimizer, dict) or set(saved_optimizer) != {
+        "param_groups"
+    }:
+        raise ValueError("MCore distributed optimizer inner schema mismatch.")
+    saved_groups = saved_optimizer.get("param_groups")
+    inner_optimizer = getattr(optimizer, "optimizer", None)
+    runtime_groups = getattr(inner_optimizer, "param_groups", None)
+    if not isinstance(saved_groups, list) or not isinstance(runtime_groups, list):
+        raise TypeError("MCore distributed optimizer param_groups must be lists.")
+    if len(saved_groups) != len(runtime_groups):
+        raise ValueError("MCore distributed optimizer param-group count mismatch.")
+    identifier_keys = {
+        "wd_mult",
+        "lr_mult",
+        "is_expert_parallel",
+        "is_decoupled_lr",
+        "pre_wd_mult",
+        "pre_lr_mult",
+        "pre_is_expert_parallel",
+        "pre_is_decoupled_lr",
+    }
+    try:
+        from megatron.core.optimizer import distrib_optimizer as mcore_distrib_optimizer
+
+        native_fallback_requires_step = not bool(
+            getattr(mcore_distrib_optimizer, "HAVE_APEX_OR_TE")
+        )
+    except (ImportError, AttributeError):
+        native_fallback_requires_step = isinstance(
+            inner_optimizer, torch.optim.Optimizer
+        )
+    saved_steps: list[int | float] = []
+    for group_index, (saved_group, runtime_group) in enumerate(
+        zip(saved_groups, runtime_groups, strict=True)
+    ):
+        if not isinstance(saved_group, dict) or not isinstance(runtime_group, dict):
+            raise TypeError("MCore distributed optimizer param groups must be dicts.")
+        runtime_keys = set(runtime_group) - {"params"}
+        extra_keys = set(saved_group) - runtime_keys
+        required_keys = set(runtime_keys)
+        if native_fallback_requires_step:
+            required_keys.add("step")
+        if not required_keys <= set(saved_group) or extra_keys not in (set(), {"step"}):
+            raise ValueError(
+                f"MCore distributed optimizer param-group {group_index} schema mismatch."
+            )
+        for name, saved_value in saved_group.items():
+            if name == "step" and name not in runtime_group:
+                if (
+                    isinstance(saved_value, bool)
+                    or not isinstance(saved_value, (int, float))
+                    or not math.isfinite(float(saved_value))
+                    or saved_value < 0
+                ):
+                    raise ValueError(
+                        "MCore distributed optimizer group step is invalid: "
+                        f"{saved_value!r}"
+                    )
+                continue
+            runtime_value = runtime_group[name]
+            _validate_torch_optimizer_option_value(
+                f"optimizer.param_groups[{group_index}].{name}",
+                saved_value,
+                runtime_value,
+            )
+            if name in identifier_keys and (
+                type(saved_value) is not type(runtime_value)
+                or saved_value != runtime_value
+            ):
+                raise ValueError(
+                    f"MCore distributed optimizer group identifier {name!r} "
+                    f"mismatch: checkpoint={saved_value!r}, runtime={runtime_value!r}"
+                )
+        if "step" in saved_group:
+            saved_steps.append(saved_group["step"])
+    if native_fallback_requires_step and len(saved_steps) != len(saved_groups):
+        raise ValueError(
+            "MCore native distributed optimizer checkpoint requires step in every group."
+        )
+    if saved_steps and any(step != saved_steps[0] for step in saved_steps[1:]):
+        raise ValueError(
+            f"MCore distributed optimizer group steps are inconsistent: {saved_steps}"
+        )
+    if grad_scaler is not None:
+        _validate_optimizer_aux_state_tree(
+            state["grad_scaler"], grad_scaler.state_dict(), "optimizer.grad_scaler"
+        )
+
+
+def _validate_optimizer_aux_state_tree(
+    candidate: Any, reference: Any, path: str
+) -> None:
+    if isinstance(reference, torch.Tensor):
+        _validate_torch_optimizer_option_value(path, candidate, reference)
+        return
+    if isinstance(reference, Mapping):
+        if not isinstance(candidate, Mapping) or set(candidate) != set(reference):
+            raise ValueError(f"{path} mapping schema mismatch.")
+        for key, value in reference.items():
+            _validate_optimizer_aux_state_tree(
+                candidate[key], value, f"{path}[{key!r}]"
+            )
+        return
+    if isinstance(reference, (list, tuple)):
+        if type(candidate) is not type(reference) or len(candidate) != len(reference):
+            raise ValueError(f"{path} sequence schema mismatch.")
+        for index, (item, value) in enumerate(zip(candidate, reference, strict=True)):
+            _validate_optimizer_aux_state_tree(item, value, f"{path}[{index}]")
+        return
+    _validate_torch_optimizer_option_value(path, candidate, reference)
+
+
+def _validate_torch_optimizer_checkpoint_state(
+    optimizer: torch.optim.Optimizer, state: Any
+) -> None:
+    if not isinstance(state, dict) or set(state) != {"state", "param_groups"}:
+        raise ValueError("Invalid torch optimizer state_dict schema.")
+    saved_groups = state["param_groups"]
+    saved_state = state["state"]
+    if not isinstance(saved_groups, list) or not isinstance(saved_state, dict):
+        raise TypeError("Torch optimizer state and param_groups must be dict/list.")
+    if len(saved_groups) != len(optimizer.param_groups):
+        raise ValueError("Torch optimizer param-group count mismatch.")
+
+    runtime_state_dict = optimizer.state_dict()
+    runtime_groups = runtime_state_dict["param_groups"]
+    saved_id_to_param: dict[Any, torch.Tensor] = {}
+    saved_id_to_group: dict[Any, dict[str, Any]] = {}
+    for group_index, (saved_group, live_group, runtime_group) in enumerate(
+        zip(saved_groups, optimizer.param_groups, runtime_groups, strict=True)
+    ):
+        if not isinstance(saved_group, dict) or set(saved_group) != set(runtime_group):
+            raise ValueError(
+                f"Torch optimizer param-group {group_index} schema mismatch: "
+                f"checkpoint={sorted(saved_group) if isinstance(saved_group, dict) else None}, "
+                f"runtime={sorted(runtime_group)}."
+            )
+        saved_params = saved_group.get("params")
+        live_params = live_group.get("params")
+        if not isinstance(saved_params, list) or not isinstance(live_params, list):
+            raise TypeError(
+                "Torch optimizer param groups must contain parameter lists."
+            )
+        if len(saved_params) != len(live_params):
+            raise ValueError("Torch optimizer parameter count mismatch.")
+        for saved_id, live_param in zip(saved_params, live_params, strict=True):
+            if saved_id in saved_id_to_param:
+                raise ValueError(
+                    f"Duplicate saved optimizer parameter id {saved_id!r}."
+                )
+            saved_id_to_param[saved_id] = live_param
+            saved_id_to_group[saved_id] = saved_group
+        for name, reference in runtime_group.items():
+            if name == "params":
+                continue
+            _validate_torch_optimizer_option_value(
+                f"param_groups[{group_index}].{name}", saved_group[name], reference
+            )
+        if (
+            "max_lr" in saved_group
+            and "min_lr" in saved_group
+            and saved_group["max_lr"] < saved_group["min_lr"]
+        ):
+            raise ValueError(
+                f"Torch optimizer param-group {group_index} max_lr must be >= min_lr."
+            )
+        if (
+            "start_wd" in saved_group
+            and "end_wd" in saved_group
+            and saved_group["end_wd"] < saved_group["start_wd"]
+        ):
+            raise ValueError(
+                f"Torch optimizer param-group {group_index} end_wd must be >= start_wd."
+            )
+
+    unknown = sorted(set(saved_state) - set(saved_id_to_param), key=repr)
+    if unknown:
+        raise ValueError(f"Optimizer state contains unknown parameter ids: {unknown}")
+    current_state = optimizer.state
+    expected_initialized_ids = {
+        saved_id
+        for saved_id, live_param in saved_id_to_param.items()
+        if current_state.get(live_param)
+    }
+    missing_initialized_ids = sorted(
+        expected_initialized_ids - set(saved_state), key=repr
+    )
+    if missing_initialized_ids:
+        raise ValueError(
+            "Optimizer state is missing initialized parameter ids: "
+            f"{missing_initialized_ids}"
+        )
+    for saved_id, param_state in saved_state.items():
+        if not isinstance(param_state, dict):
+            raise TypeError(
+                f"Optimizer state for parameter {saved_id!r} must be a dict."
+            )
+        live_param = saved_id_to_param[saved_id]
+        live_state = current_state.get(live_param, {})
+        expected_keys = _expected_torch_optimizer_state_keys(
+            optimizer, saved_id_to_group[saved_id]
+        )
+        if expected_keys is not None and set(param_state) != expected_keys:
+            raise ValueError(
+                f"Optimizer state key mismatch for parameter {saved_id!r}: "
+                f"checkpoint={sorted(param_state)}, expected={sorted(expected_keys)}."
+            )
+        if live_state and set(param_state) != set(live_state):
+            raise ValueError(
+                f"Optimizer state key mismatch for parameter {saved_id!r}: "
+                f"checkpoint={sorted(param_state)}, runtime={sorted(live_state)}."
+            )
+        for name, value in param_state.items():
+            live_value = live_state.get(name)
+            if not isinstance(value, torch.Tensor):
+                if live_state:
+                    _validate_torch_optimizer_option_value(
+                        f"state[{saved_id!r}].{name}", value, live_value
+                    )
+                continue
+            local_value = _to_local_tensor(value)
+            if name == "step" and (
+                local_value.numel() != 1
+                or not torch.isfinite(local_value).all()
+                or local_value.item() < 0
+            ):
+                raise ValueError(
+                    f"Optimizer step for parameter {saved_id!r} must be a "
+                    "finite non-negative scalar."
+                )
+            if isinstance(live_value, torch.Tensor):
+                local_live = _to_local_tensor(live_value)
+                if (
+                    local_value.shape != local_live.shape
+                    or local_value.dtype != local_live.dtype
+                ):
+                    raise ValueError(
+                        f"Optimizer tensor {name!r} shape/dtype mismatch: "
+                        f"checkpoint={tuple(local_value.shape)}/{local_value.dtype}, "
+                        f"live={tuple(local_live.shape)}/{local_live.dtype}."
+                    )
+            elif local_value.numel() != 1:
+                local_param = _to_local_tensor(live_param)
+                if local_value.shape != local_param.shape:
+                    raise ValueError(
+                        f"Optimizer tensor {name!r} shape mismatch for parameter "
+                        f"{saved_id!r}: checkpoint={tuple(local_value.shape)}, "
+                        f"parameter={tuple(local_param.shape)}."
+                    )
+
+
+def _expected_torch_optimizer_state_keys(
+    optimizer: torch.optim.Optimizer, param_group: Mapping[str, Any]
+) -> set[str] | None:
+    if isinstance(optimizer, (torch.optim.Adam, torch.optim.AdamW)):
+        keys = {"step", "exp_avg", "exp_avg_sq"}
+        if bool(param_group.get("amsgrad", False)):
+            keys.add("max_exp_avg_sq")
+        return keys
+    if isinstance(optimizer, torch.optim.Adagrad):
+        return {"step", "sum"}
+    if isinstance(optimizer, torch.optim.RMSprop):
+        keys = {"step", "square_avg"}
+        if float(param_group.get("momentum", 0.0)) > 0.0:
+            keys.add("momentum_buffer")
+        if bool(param_group.get("centered", False)):
+            keys.add("grad_avg")
+        return keys
+    if isinstance(optimizer, torch.optim.SGD):
+        if float(param_group.get("momentum", 0.0)) > 0.0:
+            return {"momentum_buffer"}
+        return set()
+    return None
+
+
+def _validate_torch_optimizer_option_value(
+    name: str, value: Any, reference: Any
+) -> None:
+    if isinstance(reference, torch.Tensor):
+        if not isinstance(value, torch.Tensor):
+            raise TypeError(f"Torch optimizer {name} must be a tensor.")
+        if value.shape != reference.shape or value.dtype != reference.dtype:
+            raise ValueError(
+                f"Torch optimizer {name} shape/dtype mismatch: "
+                f"checkpoint={tuple(value.shape)}/{value.dtype}, "
+                f"runtime={tuple(reference.shape)}/{reference.dtype}."
+            )
+        if value.is_floating_point() and not torch.isfinite(value).all():
+            raise ValueError(f"Torch optimizer {name} must be finite.")
+        return
+    if isinstance(reference, bool):
+        if not isinstance(value, bool):
+            raise TypeError(f"Torch optimizer {name} must be bool.")
+        return
+    if isinstance(reference, (int, float)) and not isinstance(reference, bool):
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(f"Torch optimizer {name} must be numeric.")
+        if not math.isfinite(float(value)):
+            raise ValueError(f"Torch optimizer {name} must be finite.")
+        leaf_name = name.rsplit(".", maxsplit=1)[-1]
+        if (
+            leaf_name
+            in {
+                "lr",
+                "initial_lr",
+                "weight_decay",
+                "eps",
+                "step",
+                "wd_mult",
+                "lr_mult",
+                "max_lr",
+                "min_lr",
+                "start_wd",
+                "end_wd",
+            }
+            and value < 0
+        ):
+            raise ValueError(f"Torch optimizer {name} must be non-negative.")
+        return
+    if isinstance(reference, tuple):
+        if not isinstance(value, tuple) or len(value) != len(reference):
+            raise TypeError(f"Torch optimizer {name} must be a matching tuple.")
+        for index, (item, expected) in enumerate(zip(value, reference, strict=True)):
+            _validate_torch_optimizer_option_value(f"{name}[{index}]", item, expected)
+        if name.endswith(".betas") and not all(0.0 <= item < 1.0 for item in value):
+            raise ValueError(f"Torch optimizer {name} entries must lie in [0, 1).")
+        return
+    if isinstance(reference, list):
+        if not isinstance(value, list) or len(value) != len(reference):
+            raise TypeError(f"Torch optimizer {name} must be a matching list.")
+        for index, (item, expected) in enumerate(zip(value, reference, strict=True)):
+            _validate_torch_optimizer_option_value(f"{name}[{index}]", item, expected)
+        return
+    if reference is None:
+        if value is not None and not isinstance(value, (bool, int, float, str)):
+            raise TypeError(
+                f"Torch optimizer {name} must be None or a scalar option value."
+            )
+        if isinstance(value, float) and not math.isfinite(value):
+            raise ValueError(f"Torch optimizer {name} must be finite.")
+        return
+    if not isinstance(value, type(reference)):
+        raise TypeError(
+            f"Torch optimizer {name} must have type {type(reference).__name__}."
+        )
 
 
 def _load_optimizer_checkpoint(optimizer, path: str) -> None:
-    if optimizer is None:
-        log_rank0("Skipping optimizer checkpoint load because optimizer is None")
-        return
-    ckpt_path = _optimizer_checkpoint_path(path)
-    if not os.path.exists(ckpt_path):
-        log_rank0(f"No optimizer checkpoint found at {ckpt_path}; loading model state only")
-        return
-    load_state_dict_fn = getattr(optimizer, "load_state_dict", None)
-    if not callable(load_state_dict_fn):
-        raise TypeError(f"Optimizer {type(optimizer).__name__} does not provide load_state_dict().")
-    state = torch.load(ckpt_path, map_location="cpu", weights_only=False)
-    load_state_dict_fn(state)
+    state = _read_optimizer_checkpoint(optimizer, path)
+    _preflight_optimizer_checkpoint_state(optimizer, state)
+    _apply_optimizer_checkpoint_state(optimizer, state)
 
 
 def _model_chunks(model: nn.Module | Iterable[nn.Module]) -> list[nn.Module]:
@@ -281,7 +1813,9 @@ def _is_dtensor_like(tensor: Any) -> bool:
     )
 
 
-def _dcp_tensor_from_param(param: torch.Tensor, mesh: DeviceMesh, placements: list) -> DTensor:
+def _dcp_tensor_from_param(
+    param: torch.Tensor, mesh: DeviceMesh, placements: list
+) -> DTensor:
     if _is_dtensor_like(param):
         return _dtensor_from_dtensor_like_param(param, _to_local_tensor(param).detach())
     return DTensor.from_local(_to_local_tensor(param).detach(), mesh, placements)
@@ -291,11 +1825,17 @@ def _empty_dcp_tensor_like_param(
     param: torch.Tensor, mesh: DeviceMesh, placements: list
 ) -> DTensor:
     if _is_dtensor_like(param):
-        return _dtensor_from_dtensor_like_param(param, torch.empty_like(_to_local_tensor(param)))
-    return DTensor.from_local(torch.empty_like(_to_local_tensor(param)), mesh, placements)
+        return _dtensor_from_dtensor_like_param(
+            param, torch.empty_like(_to_local_tensor(param))
+        )
+    return DTensor.from_local(
+        torch.empty_like(_to_local_tensor(param)), mesh, placements
+    )
 
 
-def _dtensor_from_dtensor_like_param(param: torch.Tensor, local_tensor: torch.Tensor) -> DTensor:
+def _dtensor_from_dtensor_like_param(
+    param: torch.Tensor, local_tensor: torch.Tensor
+) -> DTensor:
     return DTensor.from_local(
         local_tensor,
         param.device_mesh,
@@ -307,7 +1847,9 @@ def _dtensor_from_dtensor_like_param(param: torch.Tensor, local_tensor: torch.Te
 
 def _copy_tensor_(target: torch.Tensor, src: torch.Tensor) -> None:
     local_target = _to_local_tensor(target)
-    local_src = _to_local_tensor(src).to(device=local_target.device, dtype=local_target.dtype)
+    local_src = _to_local_tensor(src).to(
+        device=local_target.device, dtype=local_target.dtype
+    )
     if isinstance(local_target, torch.Tensor) and local_target is not target:
         local_target.copy_(local_src)
     else:
@@ -323,22 +1865,63 @@ def _chunk_tensor_state(module: nn.Module) -> dict[str, torch.Tensor]:
     return state
 
 
+def _preflight_chunk_tensor_state(
+    module: nn.Module, state: Any, *, chunk_index: int
+) -> None:
+    """Validate one local model chunk without mutating any live tensor."""
+
+    if not isinstance(state, dict):
+        raise TypeError(
+            f"checkpoint model chunk {chunk_index} must be a dict, got "
+            f"{type(state).__name__}"
+        )
+    targets = {
+        **{f"param.{name}": tensor for name, tensor in module.named_parameters()},
+        **{f"buffer.{name}": tensor for name, tensor in module.named_buffers()},
+    }
+    saved_keys = set(state)
+    expected_keys = set(targets)
+    missing = sorted(expected_keys - saved_keys)
+    unexpected = sorted(saved_keys - expected_keys, key=repr)
+    if missing or unexpected:
+        raise RuntimeError(
+            f"checkpoint model chunk {chunk_index} schema mismatch: "
+            f"missing={missing}, unexpected={unexpected}"
+        )
+    for key, target in targets.items():
+        source = state[key]
+        if not isinstance(source, torch.Tensor):
+            raise TypeError(
+                f"checkpoint model chunk {chunk_index} tensor {key!r} must be "
+                f"torch.Tensor, got {type(source).__name__}"
+            )
+        local_source = _to_local_tensor(source)
+        local_target = _to_local_tensor(target)
+        if not isinstance(local_source, torch.Tensor):
+            raise TypeError(
+                f"checkpoint model chunk {chunk_index} tensor {key!r} did not "
+                "materialize as torch.Tensor"
+            )
+        if (
+            tuple(local_source.shape) != tuple(local_target.shape)
+            or local_source.dtype != local_target.dtype
+        ):
+            raise RuntimeError(
+                f"checkpoint model chunk {chunk_index} tensor {key!r} "
+                "shape/dtype mismatch: "
+                f"checkpoint={tuple(local_source.shape)}/{local_source.dtype}, "
+                f"target={tuple(local_target.shape)}/{local_target.dtype}"
+            )
+
+
 def _load_chunk_tensor_state(module: nn.Module, state: dict[str, torch.Tensor]) -> None:
-    params = dict(module.named_parameters())
-    buffers = dict(module.named_buffers())
-    missing: list[str] = []
-    for key, src in state.items():
-        kind, name = key.split(".", 1)
-        if kind == "param" and name in params:
-            with torch.no_grad():
-                _copy_tensor_(params[name], src)
-        elif kind == "buffer" and name in buffers:
-            with torch.no_grad():
-                _copy_tensor_(buffers[name], src)
-        else:
-            missing.append(key)
-    if missing:
-        raise RuntimeError(f"checkpoint contains unknown tensor keys: {missing}")
+    targets = {
+        **{f"param.{name}": tensor for name, tensor in module.named_parameters()},
+        **{f"buffer.{name}": tensor for name, tensor in module.named_buffers()},
+    }
+    for key, target in targets.items():
+        with torch.no_grad():
+            _copy_tensor_(target, state[key])
 
 
 def _local_checkpoint_file(path: str | os.PathLike[str]) -> Path:
@@ -351,7 +1934,181 @@ def _local_checkpoint_file(path: str | os.PathLike[str]) -> Path:
 
 
 def _local_optimizer_parameter_state_file(ckpt_file: Path) -> Path:
-    return ckpt_file.with_name(f"{ckpt_file.stem}.optimizer_parameter_state{ckpt_file.suffix}")
+    return ckpt_file.with_name(
+        f"{ckpt_file.stem}.optimizer_parameter_state{ckpt_file.suffix}"
+    )
+
+
+_UNSUPPORTED_PARAMETER_STATE_TEMPLATE = object()
+
+
+def _local_file_fingerprint(path: Path) -> tuple[int, str]:
+    digest = hashlib.sha256()
+    size = 0
+    with open(path, "rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+            size += len(chunk)
+    return size, digest.hexdigest()
+
+
+def _validate_parameter_state_tree(candidate: Any, template: Any, path: str) -> None:
+    if isinstance(template, torch.Tensor):
+        if not isinstance(candidate, torch.Tensor):
+            raise TypeError(
+                f"{path} must be torch.Tensor, got {type(candidate).__name__}"
+            )
+        if candidate.shape != template.shape or candidate.dtype != template.dtype:
+            raise ValueError(
+                f"{path} tensor shape/dtype mismatch: "
+                f"checkpoint={tuple(candidate.shape)}/{candidate.dtype}, "
+                f"target={tuple(template.shape)}/{template.dtype}"
+            )
+        return
+    if isinstance(template, Mapping):
+        if not isinstance(candidate, Mapping):
+            raise TypeError(f"{path} must be a mapping, got {type(candidate).__name__}")
+        if set(candidate) != set(template):
+            raise ValueError(
+                f"{path} mapping keys mismatch: "
+                f"missing={sorted(set(template) - set(candidate), key=repr)}, "
+                f"unexpected={sorted(set(candidate) - set(template), key=repr)}"
+            )
+        for key, expected in template.items():
+            _validate_parameter_state_tree(candidate[key], expected, f"{path}[{key!r}]")
+        return
+    if isinstance(template, (list, tuple)):
+        if type(candidate) is not type(template) or len(candidate) != len(template):
+            raise TypeError(
+                f"{path} must be {type(template).__name__} of length {len(template)}"
+            )
+        for index, (item, expected) in enumerate(zip(candidate, template, strict=True)):
+            _validate_parameter_state_tree(item, expected, f"{path}[{index}]")
+        return
+    if type(candidate) is not type(template) or candidate != template:
+        raise ValueError(
+            f"{path} scalar mismatch: checkpoint={candidate!r}, target={template!r}"
+        )
+
+
+def _optimizer_parameter_state_template(optimizer) -> Any:
+    chained = getattr(optimizer, "chained_optimizers", None)
+    if isinstance(chained, (list, tuple)):
+        if not chained:
+            return None
+        if len(chained) == 1:
+            return _optimizer_parameter_state_template(chained[0])
+        templates = []
+        for child in chained:
+            child_template = _optimizer_parameter_state_template(child)
+            if child_template is not _UNSUPPORTED_PARAMETER_STATE_TEMPLATE:
+                templates.append(child_template)
+        if not templates:
+            return _UNSUPPORTED_PARAMETER_STATE_TEMPLATE
+        return templates if any(item is not None for item in templates) else None
+
+    builder = getattr(optimizer, "get_parameter_state_dp_zero", None)
+    if not callable(builder):
+        return _UNSUPPORTED_PARAMETER_STATE_TEMPLATE
+    return builder(empty_data=True)
+
+
+def _hardlink_parameter_state_for_load(source: Path) -> Path:
+    for counter in range(1000):
+        staged = source.with_name(f".{source.name}.mlite-load-{os.getpid()}-{counter}")
+        try:
+            os.link(source, staged)
+            return staged
+        except FileExistsError:
+            continue
+    raise FileExistsError(
+        f"could not reserve an immutable parameter-state staging link for {source}"
+    )
+
+
+def _atomic_save_optimizer_parameter_state(save_fn, destination: Path) -> None:
+    temporary = destination.with_name(
+        f".{destination.name}.tmp.{os.getpid()}.{os.urandom(8).hex()}"
+    )
+    try:
+        save_fn(str(temporary))
+        if temporary.exists():
+            os.replace(temporary, destination)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _preflight_local_optimizer_parameter_state(
+    optimizer, parameter_state_path: Path, *, update_legacy_format: bool
+) -> tuple[Path, Path | None, tuple[int, str] | None]:
+    staged_path: Path | None = None
+    staged_fingerprint: tuple[int, str] | None = None
+    load_path = parameter_state_path
+    local_error = None
+    try:
+        validator = getattr(optimizer, "validate_parameter_state", None)
+        template = _UNSUPPORTED_PARAMETER_STATE_TEMPLATE
+        if not callable(validator):
+            template = _optimizer_parameter_state_template(optimizer)
+            if template is _UNSUPPORTED_PARAMETER_STATE_TEMPLATE:
+                raise TypeError(
+                    f"Optimizer {type(optimizer).__name__} must implement a pure "
+                    "validate_parameter_state(filename, ...) contract or the MCore "
+                    "get_parameter_state_dp_zero(empty_data=True) schema builder."
+                )
+        if callable(validator) or template is not None:
+            staged_path = _hardlink_parameter_state_for_load(parameter_state_path)
+            load_path = staged_path
+            before_fingerprint = _local_file_fingerprint(staged_path)
+            if callable(validator):
+                validator(str(staged_path), update_legacy_format=update_legacy_format)
+            else:
+                candidate = torch.load(
+                    staged_path, map_location="cpu", weights_only=False
+                )
+                _validate_parameter_state_tree(
+                    candidate, template, "optimizer_parameter_state"
+                )
+            staged_fingerprint = _local_file_fingerprint(staged_path)
+            if staged_fingerprint != before_fingerprint:
+                raise RuntimeError(
+                    "optimizer parameter-state file changed during preflight: "
+                    f"before={before_fingerprint!r}, after={staged_fingerprint!r}"
+                )
+    except Exception as exc:
+        local_error = f"{type(exc).__name__}: {exc}"
+
+    try:
+        _distributed_raise_if_error(
+            local_error, context="local optimizer parameter-state preflight failed"
+        )
+    except Exception:
+        if staged_path is not None:
+            staged_path.unlink(missing_ok=True)
+        raise
+    if staged_path is None:
+        return load_path, None, None
+    assert staged_fingerprint is not None
+    return load_path, staged_path, staged_fingerprint
+
+
+def _revalidate_local_optimizer_parameter_state(
+    staged_path: Path | None, expected_fingerprint: tuple[int, str] | None
+) -> None:
+    local_error = None
+    try:
+        if staged_path is not None:
+            current_fingerprint = _local_file_fingerprint(staged_path)
+            if current_fingerprint != expected_fingerprint:
+                raise RuntimeError(
+                    "optimizer parameter-state staging file changed after preflight: "
+                    f"expected={expected_fingerprint!r}, current={current_fingerprint!r}"
+                )
+    except Exception as exc:
+        local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(
+        local_error, context="local optimizer parameter-state revalidation failed"
+    )
 
 
 def _rank_suffix() -> str:
@@ -386,8 +2143,24 @@ def _get_cuda_rng_tracker_states() -> dict[str, torch.Tensor]:
 
     from megatron.core import tensor_parallel
 
-    states = tensor_parallel.get_cuda_rng_tracker().get_states()
-    return {name: _cpu_clone(state) for name, state in states.items() if state is not None}
+    tracker = tensor_parallel.get_cuda_rng_tracker()
+    states = tracker.get_states()
+    converted = {
+        name: tensor_parallel.convert_cuda_rng_state(state, to_graphable=False)
+        for name, state in states.items()
+        if state is not None
+    }
+    result: dict[str, torch.Tensor] = {}
+    for name, state in converted.items():
+        if not isinstance(state, torch.Tensor):
+            raise TypeError(
+                f"CUDA RNG tracker state {name!r} converted to "
+                f"{type(state).__name__}, expected torch.Tensor"
+            )
+        cloned = _cpu_clone(state)
+        assert cloned is not None
+        result[name] = cloned
+    return result
 
 
 def _get_rng_state() -> dict[str, Any]:
@@ -414,12 +2187,45 @@ def _restore_cuda_rng_tracker_states(states: dict[str, torch.Tensor]) -> None:
         }
         tracker.set_states(restored)
     except Exception as exc:
-        raise RuntimeError("Failed to restore Megatron tensor-parallel RNG tracker state.") from exc
+        raise RuntimeError(
+            "Failed to restore Megatron tensor-parallel RNG tracker state."
+        ) from exc
+
+
+def _validate_rng_state(state: Any) -> dict[str, Any]:
+    if not isinstance(state, dict):
+        raise TypeError(
+            f"RNG checkpoint state must be a dictionary, got {type(state).__name__}"
+        )
+    required = {
+        "random_rng_state",
+        "np_rng_state",
+        "torch_rng_state",
+        "cuda_rng_state",
+        "rng_tracker_states",
+    }
+    missing = sorted(required - set(state))
+    if missing:
+        raise RuntimeError(f"RNG checkpoint state is missing required keys: {missing}")
+    if not isinstance(state["torch_rng_state"], torch.Tensor):
+        raise TypeError("RNG checkpoint torch_rng_state must be a tensor")
+    if state["cuda_rng_state"] is not None and not isinstance(
+        state["cuda_rng_state"], torch.Tensor
+    ):
+        raise TypeError("RNG checkpoint cuda_rng_state must be a tensor or None")
+    tracker_states = state["rng_tracker_states"]
+    if not isinstance(tracker_states, dict) or not all(
+        isinstance(name, str) and isinstance(value, torch.Tensor)
+        for name, value in tracker_states.items()
+    ):
+        raise TypeError("RNG checkpoint rng_tracker_states must map strings to tensors")
+    return state
 
 
 def _restore_rng_state(state: dict[str, Any] | None) -> None:
     if not state:
         return
+    state = _validate_rng_state(state)
     random.setstate(state["random_rng_state"])
     np.random.set_state(state["np_rng_state"])
     torch.set_rng_state(state["torch_rng_state"])
@@ -431,16 +2237,270 @@ def _restore_rng_state(state: dict[str, Any] | None) -> None:
 
 def _save_rng_sidecar(path: str | os.PathLike[str]) -> None:
     rng_file = _rng_sidecar_file(path)
-    rng_file.parent.mkdir(parents=True, exist_ok=True)
-    torch.save(_get_rng_state(), rng_file)
+    _atomic_torch_save(_get_rng_state(), rng_file)
 
 
-def _load_rng_sidecar(path: str | os.PathLike[str]) -> None:
+def _read_rng_sidecar(
+    path: str | os.PathLike[str], *, required: bool = False
+) -> dict[str, Any] | None:
     rng_file = _rng_sidecar_file(path)
     if not rng_file.exists():
+        if required:
+            raise FileNotFoundError(
+                f"RNG sidecar required by completion manifest is missing: {rng_file}"
+            )
         log_rank0(f"RNG sidecar not found at {rng_file}; skipping RNG restore.")
+        return None
+    return _validate_rng_state(
+        torch.load(rng_file, map_location="cpu", weights_only=False)
+    )
+
+
+def _preflight_rng_checkpoint_state(state: dict[str, Any] | None) -> None:
+    if state is None:
         return
-    _restore_rng_state(torch.load(rng_file, map_location="cpu", weights_only=False))
+    state = _validate_rng_state(state)
+    original_state = _get_rng_state()
+    candidate_error: Exception | None = None
+    try:
+        _restore_rng_state(state)
+    except Exception as exc:
+        candidate_error = exc
+    try:
+        _restore_rng_state(original_state)
+    except Exception as exc:
+        detail = f"RNG rollback failed: {type(exc).__name__}: {exc}"
+        if candidate_error is not None:
+            detail = (
+                f"candidate RNG load failed: {type(candidate_error).__name__}: "
+                f"{candidate_error}; {detail}"
+            )
+        raise RuntimeError(detail) from exc
+    if candidate_error is not None:
+        raise RuntimeError(
+            f"RNG checkpoint is incompatible: {type(candidate_error).__name__}: "
+            f"{candidate_error}"
+        ) from candidate_error
+
+
+def _load_rng_sidecar(path: str | os.PathLike[str], *, required: bool = False) -> None:
+    state = _read_rng_sidecar(path, required=required)
+    _preflight_rng_checkpoint_state(state)
+    if state is not None:
+        _restore_rng_state(state)
+
+
+def _extra_state_target_fingerprints(targets: Mapping[str, Any]) -> dict[str, str]:
+    return {
+        filename: repr(targets[filename].fingerprint()) for filename in sorted(targets)
+    }
+
+
+def _assert_extra_state_target_fingerprints_match(
+    fingerprints: Mapping[str, str], *, context: str
+) -> None:
+    if not dist.is_initialized():
+        return
+    gathered: list[dict[str, str] | None] = [None] * dist.get_world_size()
+    local_error = None
+    try:
+        dist.all_gather_object(gathered, dict(fingerprints))
+        reference = gathered[0]
+        if any(fingerprint != reference for fingerprint in gathered[1:]):
+            raise RuntimeError(
+                f"extra-state target fingerprints differ by rank: {gathered}"
+            )
+    except Exception as exc:
+        local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(local_error, context=context)
+
+
+def _restore_extra_state_targets(
+    targets: Mapping[str, Any],
+    snapshots: Mapping[str, Any],
+    baseline_fingerprints: Mapping[str, str],
+) -> str | None:
+    errors: list[str] = []
+    for filename in reversed(sorted(snapshots)):
+        target = targets[filename]
+        try:
+            target.restore(snapshots[filename])
+            restored = repr(target.fingerprint())
+            if restored != baseline_fingerprints[filename]:
+                raise RuntimeError(
+                    f"fingerprint {restored} != baseline "
+                    f"{baseline_fingerprints[filename]}"
+                )
+        except Exception as exc:
+            errors.append(f"{filename}: {type(exc).__name__}: {exc}")
+    return "; ".join(errors) or None
+
+
+def _preflight_extra_state_targets(
+    targets: Mapping[str, Any], extra_state_values: Mapping[str, Any]
+) -> None:
+    if not targets:
+        return
+    snapshots: dict[str, Any] = {}
+    baseline_fingerprints: dict[str, str] = {}
+    candidate_fingerprints: dict[str, str] = {}
+    local_error = None
+    try:
+        for filename in sorted(targets):
+            target = targets[filename]
+            snapshots[filename] = target.snapshot()
+            baseline_fingerprints[filename] = repr(target.fingerprint())
+        for filename in sorted(targets):
+            target = targets[filename]
+            target.apply(extra_state_values[filename])
+            candidate_fingerprints[filename] = repr(target.fingerprint())
+    except Exception as exc:
+        local_error = f"{type(exc).__name__}: {exc}"
+
+    rollback_error = _restore_extra_state_targets(
+        targets, snapshots, baseline_fingerprints
+    )
+    if rollback_error is not None:
+        local_error = (
+            f"{local_error}; target rollback failed: {rollback_error}"
+            if local_error is not None
+            else f"target rollback failed: {rollback_error}"
+        )
+    _distributed_raise_if_error(
+        local_error, context="extra-state target preflight failed"
+    )
+    _assert_extra_state_target_fingerprints_match(
+        candidate_fingerprints,
+        context="extra-state target preflight fingerprint validation failed",
+    )
+
+
+def _commit_extra_state_targets(
+    targets: Mapping[str, Any], extra_state_values: Mapping[str, Any]
+) -> None:
+    if not targets:
+        return
+    snapshots: dict[str, Any] = {}
+    baseline_fingerprints: dict[str, str] = {}
+    candidate_fingerprints: dict[str, str] = {}
+    local_error = None
+    try:
+        for filename in sorted(targets):
+            target = targets[filename]
+            snapshots[filename] = target.snapshot()
+            baseline_fingerprints[filename] = repr(target.fingerprint())
+        for filename in sorted(targets):
+            target = targets[filename]
+            target.apply(extra_state_values[filename])
+            candidate_fingerprints[filename] = repr(target.fingerprint())
+    except Exception as exc:
+        local_error = f"{type(exc).__name__}: {exc}"
+
+    commit_error: Exception | None = None
+    try:
+        _distributed_raise_if_error(
+            local_error, context="extra-state target commit failed"
+        )
+        _assert_extra_state_target_fingerprints_match(
+            candidate_fingerprints,
+            context="extra-state target commit fingerprint validation failed",
+        )
+    except Exception as exc:
+        commit_error = exc
+    if commit_error is None:
+        return
+
+    rollback_error = _restore_extra_state_targets(
+        targets, snapshots, baseline_fingerprints
+    )
+    try:
+        _distributed_raise_if_error(
+            rollback_error, context="extra-state target rollback failed"
+        )
+    except Exception as exc:
+        raise RuntimeError(
+            "extra-state target commit failed after core checkpoint commit; "
+            f"runtime must be poisoned; rollback also failed: {exc}"
+        ) from commit_error
+    raise RuntimeError(
+        "extra-state target commit failed after core checkpoint commit; "
+        f"runtime must be poisoned: {commit_error}"
+    ) from commit_error
+
+
+def _preload_checkpoint_sidecars(
+    checkpoint_path: str,
+    *,
+    optimizer,
+    load_optimizer: bool,
+    allow_legacy_optimizer_state: bool = False,
+    load_rng: bool,
+    rng_required: bool,
+    extra_state_files: Iterable[str],
+    extra_state_validators: Mapping[str, Callable[[Any], None]],
+    extra_state_targets: Mapping[str, Any],
+    checkpoint_step: int | None,
+) -> tuple[Any, dict[str, Any] | None, dict[str, Any]]:
+    """Deserialize and validate all sidecars before any model checkpoint commit."""
+
+    optimizer_state: Any = None
+    rng_state: dict[str, Any] | None = None
+    extra_state_values: dict[str, Any] = {}
+    local_error = None
+    try:
+        if load_optimizer:
+            optimizer_state = _read_optimizer_checkpoint(optimizer, checkpoint_path)
+        if load_rng:
+            rng_state = _read_rng_sidecar(checkpoint_path, required=rng_required)
+        for filename in extra_state_files:
+            extra_state_values[filename] = torch.load(
+                Path(checkpoint_path) / filename, map_location="cpu", weights_only=False
+            )
+
+        if load_optimizer:
+            optimizer_state = _prepare_optimizer_checkpoint_state(
+                optimizer,
+                optimizer_state,
+                allow_legacy_optimizer_state=allow_legacy_optimizer_state,
+            )
+        if load_rng:
+            _preflight_rng_checkpoint_state(rng_state)
+        for filename, validator in extra_state_validators.items():
+            validator(extra_state_values[filename])
+        for filename, target in extra_state_targets.items():
+            validate_step = getattr(target, "validate_step", None)
+            if callable(validate_step):
+                validate_step(extra_state_values[filename], checkpoint_step)
+    except Exception as exc:
+        local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(
+        local_error, context="checkpoint sidecar preflight failed"
+    )
+    _preflight_extra_state_targets(extra_state_targets, extra_state_values)
+    return optimizer_state, rng_state, extra_state_values
+
+
+def _commit_preloaded_sidecars(
+    *,
+    optimizer,
+    optimizer_state: Any,
+    rng_state: dict[str, Any] | None,
+    loaded_extra_states: MutableMapping[str, Any] | None,
+    extra_state_values: Mapping[str, Any],
+    extra_state_targets: Mapping[str, Any],
+) -> None:
+    local_error = None
+    try:
+        if optimizer is not None:
+            _apply_optimizer_checkpoint_state(optimizer, optimizer_state)
+        if rng_state is not None:
+            _restore_rng_state(rng_state)
+    except Exception as exc:
+        local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(local_error, context="checkpoint sidecar commit failed")
+    _commit_extra_state_targets(extra_state_targets, extra_state_values)
+    if loaded_extra_states is not None:
+        loaded_extra_states.update(extra_state_values)
 
 
 def _save_local_training_checkpoint(
@@ -456,7 +2516,9 @@ def _save_local_training_checkpoint(
     ckpt_file.parent.mkdir(parents=True, exist_ok=True)
     save_parameter_state = getattr(optimizer, "save_parameter_state", None)
     optimizer_parameter_state_file = (
-        _local_optimizer_parameter_state_file(ckpt_file) if callable(save_parameter_state) else None
+        _local_optimizer_parameter_state_file(ckpt_file)
+        if callable(save_parameter_state)
+        else None
     )
     state = {
         "format": "megatron_lite.local_training.v1",
@@ -470,9 +2532,11 @@ def _save_local_training_checkpoint(
         ),
         "rng_state": _get_rng_state() if save_rng else None,
     }
-    torch.save(state, ckpt_file)
     if optimizer_parameter_state_file is not None:
-        save_parameter_state(str(optimizer_parameter_state_file))
+        _atomic_save_optimizer_parameter_state(
+            save_parameter_state, optimizer_parameter_state_file
+        )
+    _atomic_torch_save(state, ckpt_file)
     log_rank0(f"Saved local training checkpoint at step {step} to {ckpt_file}")
 
 
@@ -486,30 +2550,119 @@ def _load_local_training_checkpoint(
 ) -> int:
     ckpt_file = _local_checkpoint_file(path)
     state = torch.load(ckpt_file, map_location="cpu", weights_only=False)
+    if not isinstance(state, dict):
+        raise TypeError(
+            f"Local checkpoint root must be a dict, got {type(state).__name__}"
+        )
     if state.get("format") != "megatron_lite.local_training.v1":
         raise RuntimeError(f"Unsupported local checkpoint format in {ckpt_file}")
+    expected_root_keys = {
+        "format",
+        "step",
+        "model",
+        "optimizer",
+        "optimizer_parameter_state",
+        "rng_state",
+    }
+    if set(state) != expected_root_keys:
+        raise RuntimeError(
+            "Local checkpoint root schema mismatch: "
+            f"missing={sorted(expected_root_keys - set(state))}, "
+            f"unexpected={sorted(set(state) - expected_root_keys)}"
+        )
+    step = state["step"]
+    if type(step) is not int or step < 0:
+        raise RuntimeError(
+            f"Local checkpoint step must be a non-negative integer, got {step!r}"
+        )
     chunks = _model_chunks(model)
     chunk_states = state.get("model")
     if not isinstance(chunk_states, list) or len(chunk_states) != len(chunks):
         raise RuntimeError("Checkpoint model chunk count does not match target model.")
-    for chunk, chunk_state in zip(chunks, chunk_states, strict=True):
-        _load_chunk_tensor_state(chunk, chunk_state)
-    if optimizer is not None and state.get("optimizer") is not None:
-        optimizer.load_state_dict(state["optimizer"])
-        parameter_state_name = state.get("optimizer_parameter_state")
-        load_parameter_state = getattr(optimizer, "load_parameter_state", None)
-        if parameter_state_name is not None and callable(load_parameter_state):
-            load_parameter_state(
-                str(ckpt_file.with_name(parameter_state_name)),
-                update_legacy_format=load_parameter_state_update_legacy_format,
+    for chunk_index, (chunk, chunk_state) in enumerate(
+        zip(chunks, chunk_states, strict=True)
+    ):
+        _preflight_chunk_tensor_state(chunk, chunk_state, chunk_index=chunk_index)
+    saved_optimizer_state = state.get("optimizer")
+    saved_has_optimizer = saved_optimizer_state is not None
+    target_has_optimizer = optimizer is not None
+    if saved_has_optimizer != target_has_optimizer:
+        raise RuntimeError(
+            "Local checkpoint optimizer presence does not match the target runtime: "
+            f"saved={saved_has_optimizer}, target={target_has_optimizer}"
+        )
+    parameter_state_name = state.get("optimizer_parameter_state")
+    saved_has_parameter_state = parameter_state_name is not None
+    target_parameter_state_loader = getattr(optimizer, "load_parameter_state", None)
+    target_accepts_parameter_state = callable(target_parameter_state_loader)
+    if saved_has_parameter_state != target_accepts_parameter_state:
+        raise RuntimeError(
+            "Local checkpoint optimizer parameter-state presence does not match "
+            "the target runtime: "
+            f"saved={saved_has_parameter_state}, "
+            f"target={target_accepts_parameter_state}"
+        )
+    parameter_state_path: Path | None = None
+    if parameter_state_name is not None:
+        expected_parameter_state_name = _local_optimizer_parameter_state_file(
+            ckpt_file
+        ).name
+        if (
+            not isinstance(parameter_state_name, str)
+            or Path(parameter_state_name).name != parameter_state_name
+            or parameter_state_name != expected_parameter_state_name
+        ):
+            raise RuntimeError(
+                "Local checkpoint optimizer parameter-state filename is invalid: "
+                f"{parameter_state_name!r}"
             )
-        else:
-            reload_model_params = getattr(optimizer, "reload_model_params", None)
-            if callable(reload_model_params):
-                reload_model_params()
+        parameter_state_path = ckpt_file.with_name(parameter_state_name)
+    if optimizer is not None:
+        _preflight_optimizer_checkpoint_state(optimizer, saved_optimizer_state)
+    saved_rng_state = state.get("rng_state")
     if load_rng:
-        _restore_rng_state(state.get("rng_state"))
-    step = int(state.get("step", 0))
+        if saved_rng_state is None:
+            raise RuntimeError(
+                "Local checkpoint RNG state requested by load_rng=True is missing"
+            )
+        _preflight_rng_checkpoint_state(saved_rng_state)
+    parameter_state_load_path = parameter_state_path
+    staged_parameter_state_path: Path | None = None
+    parameter_state_fingerprint: tuple[int, str] | None = None
+    if parameter_state_path is not None:
+        (
+            parameter_state_load_path,
+            staged_parameter_state_path,
+            parameter_state_fingerprint,
+        ) = _preflight_local_optimizer_parameter_state(
+            optimizer,
+            parameter_state_path,
+            update_legacy_format=load_parameter_state_update_legacy_format,
+        )
+    try:
+        if parameter_state_path is not None:
+            _revalidate_local_optimizer_parameter_state(
+                staged_parameter_state_path, parameter_state_fingerprint
+            )
+        for chunk, chunk_state in zip(chunks, chunk_states, strict=True):
+            _load_chunk_tensor_state(chunk, chunk_state)
+        if optimizer is not None:
+            optimizer.load_state_dict(saved_optimizer_state)
+            if parameter_state_load_path is not None:
+                assert callable(target_parameter_state_loader)
+                target_parameter_state_loader(
+                    str(parameter_state_load_path),
+                    update_legacy_format=load_parameter_state_update_legacy_format,
+                )
+            else:
+                reload_model_params = getattr(optimizer, "reload_model_params", None)
+                if callable(reload_model_params):
+                    reload_model_params()
+        if load_rng:
+            _restore_rng_state(saved_rng_state)
+    finally:
+        if staged_parameter_state_path is not None:
+            staged_parameter_state_path.unlink(missing_ok=True)
     log_rank0(f"Loaded local training checkpoint from {ckpt_file} at step {step}")
     return step
 
@@ -556,7 +2709,9 @@ def _ag(data, size, group, dim=0):
     return allgather_concat(data, size, group, dim)
 
 
-def canonicalize_qkv_for_dcp(model, num_attention_heads, num_key_value_heads, head_dim, ps):
+def canonicalize_qkv_for_dcp(
+    model, num_attention_heads, num_key_value_heads, head_dim, ps
+):
     """Rearrange fused QKV from interleaved-TP to canonical (Q|K|V) for DCP save."""
     if ps.tp_size <= 1:
         return
@@ -579,7 +2734,9 @@ def canonicalize_qkv_for_dcp(model, num_attention_heads, num_key_value_heads, he
         param.data.copy_(canon.chunk(ps.tp_size, dim=0)[ps.tp_rank])
 
 
-def decanon_qkv_after_dcp(model, num_attention_heads, num_key_value_heads, head_dim, ps):
+def decanon_qkv_after_dcp(
+    model, num_attention_heads, num_key_value_heads, head_dim, ps
+):
     """Reverse of canonicalize_qkv_for_dcp."""
     if ps.tp_size <= 1:
         return

--- a/experimental/lite/megatron/lite/primitive/ckpt/distckpt.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/distckpt.py
@@ -208,8 +208,10 @@ def load_dist_opt_checkpoint(
         load_sd,
         model_sd,
         checkpoint_dir,
+        model=model,
         load_model=load_model,
         load_optimizer=load_optimizer,
+        allow_legacy_checkpoint=allow_legacy_checkpoint,
     )
     preloaded_common_state, common_state_fingerprint = _preflight_distckpt_common_state(
         load_sd,
@@ -911,6 +913,32 @@ def _gather_world_metadata_contracts(
     return merged
 
 
+def _gather_world_key_set(local_keys: set[str], *, context: str) -> set[str]:
+    """Union rank-local logical keys after validating their wire representation."""
+
+    if not dist.is_available() or not dist.is_initialized():
+        return set(local_keys)
+    gathered: list[set[str] | None] = [None] * dist.get_world_size()
+    local_error = None
+    try:
+        dist.all_gather_object(gathered, local_keys)
+    except Exception as exc:
+        local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(local_error, context=f"{context} exchange failed")
+
+    merged: set[str] = set()
+    local_error = None
+    for rank, rank_keys in enumerate(gathered):
+        if not isinstance(rank_keys, set) or any(
+            not isinstance(key, str) or not key for key in rank_keys
+        ):
+            local_error = f"rank {rank} reported invalid logical keys: {rank_keys!r}"
+            break
+        merged.update(rank_keys)
+    _distributed_raise_if_error(local_error, context=context)
+    return merged
+
+
 def _validate_requested_checkpoint_contracts(
     requested: Mapping[str, tuple[str, tuple[int, ...], str | None, bool]],
     checkpoint: Mapping[str, tuple[str, tuple[int, ...], str | None, bool]],
@@ -939,8 +967,10 @@ def _preflight_distckpt_checkpoint_metadata(
     model_sd: Mapping[str, Any],
     checkpoint_dir: str,
     *,
+    model: nn.Module | Iterable[nn.Module],
     load_model: bool,
     load_optimizer: bool,
+    allow_legacy_checkpoint: bool,
 ) -> tuple[set[str], set[str]]:
     """Reject component-aware key mismatches before MCore can mutate live tensors."""
 
@@ -971,9 +1001,31 @@ def _preflight_distckpt_checkpoint_metadata(
 
     requested_but_absent = sorted(requested_keys - checkpoint_keys)
     saved_but_unrequested = checkpoint_keys - requested_keys
+    legacy_nonpersistent_buffer_keys: set[str] = set()
+    if allow_legacy_checkpoint and load_model and not load_optimizer:
+        local_nonpersistent_buffer_keys: set[str] = set()
+        local_error = None
+        try:
+            local_nonpersistent_buffer_keys = _model_nonpersistent_buffer_keys(model)
+        except Exception as exc:
+            local_error = f"{type(exc).__name__}: {exc}"
+        _distributed_raise_if_error(
+            local_error,
+            context="distckpt legacy nonpersistent buffer metadata construction failed",
+        )
+        declared_nonpersistent_buffer_keys = _gather_world_key_set(
+            local_nonpersistent_buffer_keys,
+            context="distckpt legacy nonpersistent buffer metadata",
+        )
+        legacy_nonpersistent_buffer_keys = {
+            key
+            for key in declared_nonpersistent_buffer_keys
+            if key in checkpoint_contracts and checkpoint_contracts[key][0] == "tensor"
+        }
     required_saved_but_unrequested = sorted(
         key
         for key in saved_but_unrequested
+        if key not in legacy_nonpersistent_buffer_keys
         if (load_optimizer and key.startswith("optimizer."))
         or (load_model and not key.startswith("optimizer."))
     )
@@ -1384,6 +1436,49 @@ def _model_chunk_sharded_key_prefix(
     if ps is not None and ps.pp_size <= 1 and num_chunks == 1:
         return ""
     return f"{_model_chunk_key(ps, idx, num_chunks)}."
+
+
+def _model_nonpersistent_buffer_keys(
+    model: nn.Module | Iterable[nn.Module],
+) -> set[str]:
+    """Return legacy logical keys backed by currently nonpersistent buffers.
+
+    Older MLite distckpt writers traversed ``named_buffers()`` and therefore
+    serialized runtime-only buffers despite their ``persistent=False``
+    declaration.  Derive the migration allowlist from the live modules rather
+    than from checkpoint-controlled names.
+    """
+
+    chunks = _model_chunks(model)
+    ps = _chunk_parallel_state(chunks[0]) if chunks else None
+    logical_keys: set[str] = set()
+    for idx, chunk in enumerate(chunks):
+        module = _wrapped_module(chunk)
+        sharded_key_prefix = _model_chunk_sharded_key_prefix(ps, idx, len(chunks))
+        tied_keys = getattr(module, "_mlite_tied_checkpoint_keys", {})
+        for name, _buffer in module.named_buffers():
+            module_name, _, local_name = name.rpartition(".")
+            owner = module.get_submodule(module_name) if module_name else module
+            if local_name not in owner._non_persistent_buffers_set:
+                continue
+
+            logical_key = f"{sharded_key_prefix}{name}"
+            # Mirror the legacy path through ``_chunk_sharded_state_dict`` so
+            # PP/VPP checkpoints are matched by their on-disk logical key.
+            if sharded_key_prefix.startswith("model_pp0_vpp") and name in {
+                "embed.embedding.weight",
+                "embed_tokens.embedding.weight",
+            }:
+                logical_key = f"model_pp0.{name}"
+            if name in tied_keys:
+                if not sharded_key_prefix.startswith("model_pp"):
+                    raise RuntimeError(
+                        "PP-tied nonpersistent checkpoint buffer requires a "
+                        f"model_pp prefix; got {sharded_key_prefix!r}."
+                    )
+                logical_key = f"model_pp0.{tied_keys[name]}"
+            logical_keys.add(logical_key)
+    return logical_keys
 
 
 def _chunk_sharded_state_dict(

--- a/experimental/lite/megatron/lite/primitive/ckpt/distckpt.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/distckpt.py
@@ -3,17 +3,26 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
-from collections.abc import Callable, Iterable, MutableMapping
+import struct
+import threading
+from collections.abc import Callable, Iterable, Mapping, MutableMapping
 from dataclasses import replace
 from types import MethodType
 from typing import Any
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
-
 from megatron.core import dist_checkpointing
-from megatron.core.dist_checkpointing.mapping import ShardedTensor
+from megatron.core.dist_checkpointing.mapping import (
+    LocalNonpersistentObject,
+    ShardedBase,
+    ShardedTensor,
+    ShardedTensorFactory,
+)
+from megatron.core.dist_checkpointing.validation import StrictHandling
 from megatron.lite.primitive.ckpt.hf_weights import (
     _distributed_raise_if_error,
     named_persistent_buffers,
@@ -31,6 +40,7 @@ _DISTOPT_METADATA = {
     "distrib_optim_fully_reshardable_mem_efficient": False,
     "chained_optim_avoid_prefix": True,
 }
+_DISTCKPT_COMMON_LOAD_LOCK = threading.RLock()
 
 
 def attach_model_sharded_state_dict(
@@ -77,6 +87,10 @@ def save_dist_opt_checkpoint(
 ) -> None:
     """Save model and DistributedOptimizer state through mcore dist_checkpointing."""
 
+    if type(step) is not int or step < 0:
+        raise TypeError("checkpoint step must be a non-negative integer")
+    if save_optimizer and optimizer is None:
+        raise ValueError("save_optimizer=True requires a non-None sharded optimizer")
     local_error = None
     try:
         os.makedirs(checkpoint_dir, exist_ok=True)
@@ -98,6 +112,7 @@ def save_dist_opt_checkpoint(
     if save_model or save_optimizer:
         try:
             model_sd = _model_sharded_state_dict(model)
+            _validate_model_sharded_key_namespace(model_sd)
         except Exception as exc:
             local_error = f"{type(exc).__name__}: {exc}"
     _distributed_raise_if_error(
@@ -116,6 +131,9 @@ def save_dist_opt_checkpoint(
             try:
                 state_dict["optimizer"] = optimizer.sharded_state_dict(
                     _single_or_all_model_state(model_sd), metadata=_DISTOPT_METADATA
+                )
+                _validate_optimizer_sharded_key_namespace(
+                    state_dict["optimizer"], model_sd
                 )
             finally:
                 _restore_state_dict_patches(patches)
@@ -144,9 +162,13 @@ def load_dist_opt_checkpoint(
     *,
     load_model: bool = True,
     load_optimizer: bool = True,
+    expected_step: int | None = None,
+    allow_legacy_checkpoint: bool = False,
 ) -> int:
     """Load a mcore dist_checkpointing checkpoint into model and DistributedOptimizer."""
 
+    if load_optimizer and optimizer is None:
+        raise ValueError("load_optimizer=True requires a non-None sharded optimizer")
     model_sd: dict[str, Any] = {}
     local_error = None
     if load_model or load_optimizer:
@@ -172,6 +194,9 @@ def load_dist_opt_checkpoint(
                     is_loading=True,
                     metadata=_DISTOPT_METADATA,
                 )
+                _validate_optimizer_sharded_key_namespace(
+                    load_sd["optimizer"], model_sd
+                )
             finally:
                 _restore_state_dict_patches(patches)
         except Exception as exc:
@@ -179,32 +204,58 @@ def load_dist_opt_checkpoint(
     _distributed_raise_if_error(
         local_error, context="distckpt optimizer state construction failed"
     )
-    # torch>=2.6 flips torch.load's weights_only default to True, which rejects the trusted dist_opt
-    # common state (mcore's load_common torch.loads optimizer/scheduler classes like AdamW). We are
-    # loading our OWN checkpoint -> force weights_only=False for the duration of the load.
-    _orig_torch_load = torch.load
-
-    def _trusted_torch_load(*args, **kwargs):
-        kwargs.setdefault("weights_only", False)
-        return _orig_torch_load(*args, **kwargs)
-
-    torch.load = _trusted_torch_load
+    requested_keys, checkpoint_keys = _preflight_distckpt_checkpoint_metadata(
+        load_sd,
+        model_sd,
+        checkpoint_dir,
+        load_model=load_model,
+        load_optimizer=load_optimizer,
+    )
+    preloaded_common_state, common_state_fingerprint = _preflight_distckpt_common_state(
+        load_sd,
+        checkpoint_dir,
+        load_optimizer=load_optimizer,
+        requested_sharded_keys=requested_keys,
+        checkpoint_sharded_keys=checkpoint_keys,
+        expected_step=expected_step,
+        allow_legacy_checkpoint=allow_legacy_checkpoint,
+    )
+    _revalidate_distckpt_common_state_file(checkpoint_dir, common_state_fingerprint)
     state_dict: dict[str, Any] = {}
     local_error = None
     try:
-        try:
-            state_dict = dist_checkpointing.load(
-                load_sd, checkpoint_dir, validate_access_integrity=False
-            )
-        except Exception as exc:
-            local_error = f"{type(exc).__name__}: {exc}"
-    finally:
-        torch.load = _orig_torch_load
+        state_dict = _load_distckpt_with_preloaded_common(
+            load_sd,
+            checkpoint_dir,
+            preloaded_common_state,
+            validate_access_integrity=False,
+            strict=StrictHandling.RAISE_UNEXPECTED,
+        )
+    except Exception as exc:
+        local_error = f"{type(exc).__name__}: {exc}"
     _distributed_raise_if_error(local_error, context="distckpt checkpoint load failed")
+    local_error = None
+    loaded_step = int(state_dict.get("step", 0))
+    if expected_step is not None and loaded_step != expected_step:
+        local_error = (
+            f"checkpoint payload step {loaded_step} does not match completion manifest "
+            f"step {expected_step}"
+        )
+    _distributed_raise_if_error(
+        local_error, context="distckpt checkpoint step validation failed"
+    )
+    local_error = None
+    if load_optimizer and optimizer is not None and "optimizer" not in state_dict:
+        local_error = (
+            "checkpoint is missing optimizer state requested by load_optimizer=True"
+        )
+    _distributed_raise_if_error(
+        local_error, context="distckpt checkpoint completeness validation failed"
+    )
     local_error = None
     if load_model:
         try:
-            _load_model_state_dict(model, state_dict)
+            _load_model_state_dict(model, state_dict, expected_state_dict=model_sd)
         except Exception as exc:
             local_error = f"{type(exc).__name__}: {exc}"
     _distributed_raise_if_error(
@@ -212,7 +263,11 @@ def load_dist_opt_checkpoint(
     )
     local_error = None
     try:
-        if load_optimizer and optimizer is not None and "optimizer" in state_dict:
+        if load_optimizer and optimizer is not None:
+            if "optimizer" not in state_dict:
+                raise RuntimeError(
+                    "checkpoint is missing optimizer state requested by load_optimizer=True"
+                )
             load_patches = _patch_native_optimizer_step_load(optimizer)
             try:
                 optimizer.load_state_dict(state_dict["optimizer"])
@@ -228,7 +283,716 @@ def load_dist_opt_checkpoint(
     _distributed_raise_if_error(
         local_error, context="distckpt optimizer state application failed"
     )
-    return int(state_dict.get("step", 0))
+    return loaded_step
+
+
+def _iter_sharded_bases(value: Any) -> Iterable[ShardedBase]:
+    """Yield effective sharded entries, expanding factories without mutation."""
+
+    if isinstance(value, ShardedTensorFactory):
+        yield from _iter_sharded_bases(value.build())
+    elif isinstance(value, ShardedBase):
+        yield value
+    elif isinstance(value, Mapping):
+        for child in value.values():
+            yield from _iter_sharded_bases(child)
+    elif isinstance(value, (list, tuple)):
+        for child in value:
+            yield from _iter_sharded_bases(child)
+
+
+def _sharded_logical_keys(value: Any) -> set[str]:
+    return set(_sharded_metadata_contracts(value))
+
+
+def _sharded_metadata_contracts(
+    value: Any,
+) -> dict[str, tuple[str, tuple[int, ...], str | None, bool]]:
+    contracts: dict[str, tuple[str, tuple[int, ...], str | None, bool]] = {}
+    for sharded_base in _iter_sharded_bases(value):
+        key = getattr(sharded_base, "key", None)
+        if not isinstance(key, str) or not key:
+            raise RuntimeError(
+                f"distckpt sharded metadata contains an invalid logical key: {key!r}"
+            )
+        global_shape = getattr(sharded_base, "global_shape", None)
+        if not isinstance(global_shape, tuple) or not all(
+            type(dim) is int for dim in global_shape
+        ):
+            raise RuntimeError(
+                f"distckpt sharded metadata for {key!r} has invalid global_shape "
+                f"{global_shape!r}"
+            )
+        if isinstance(sharded_base, ShardedTensor):
+            contract = (
+                "tensor",
+                global_shape,
+                str(sharded_base.dtype),
+                bool(sharded_base.allow_shape_mismatch),
+            )
+        else:
+            contract = ("object", global_shape, None, False)
+        previous = contracts.get(key)
+        if previous is not None and previous != contract:
+            raise RuntimeError(
+                f"distckpt logical key {key!r} has inconsistent metadata contracts: "
+                f"{previous!r} vs {contract!r}"
+            )
+        contracts[key] = contract
+    return contracts
+
+
+def _validate_model_sharded_key_namespace(model_sd: Mapping[str, Any]) -> None:
+    reserved_model_keys = sorted(
+        key for key in _sharded_logical_keys(model_sd) if key.startswith("optimizer.")
+    )
+    if reserved_model_keys:
+        raise RuntimeError(
+            "model checkpoint keys use the reserved 'optimizer.' prefix: "
+            f"{reserved_model_keys}"
+        )
+
+
+def _validate_optimizer_sharded_key_namespace(
+    optimizer_sd: Any, model_sd: Mapping[str, Any]
+) -> None:
+    optimizer_keys = _sharded_logical_keys(optimizer_sd)
+    invalid_optimizer_keys = sorted(
+        key for key in optimizer_keys if not key.startswith("optimizer.")
+    )
+    if invalid_optimizer_keys:
+        raise RuntimeError(
+            "optimizer checkpoint keys must use the reserved 'optimizer.' prefix: "
+            f"{invalid_optimizer_keys}"
+        )
+    overlapping_keys = sorted(optimizer_keys & _sharded_logical_keys(model_sd))
+    if overlapping_keys:
+        raise RuntimeError(
+            f"model and optimizer checkpoint keys overlap: {overlapping_keys}"
+        )
+
+
+def _load_checkpoint_sharded_metadata(checkpoint_dir: str) -> Mapping[str, Any]:
+    # ``load_sharded_metadata`` includes both tensors and ShardedObjects but is
+    # not re-exported from megatron.core.dist_checkpointing.
+    from megatron.core.dist_checkpointing.serialization import load_sharded_metadata
+
+    metadata = load_sharded_metadata(checkpoint_dir)
+    if not isinstance(metadata, Mapping):
+        raise TypeError(
+            "MCore load_sharded_metadata returned "
+            f"{type(metadata).__name__}, expected a mapping"
+        )
+    return metadata
+
+
+def _load_checkpoint_common_state(checkpoint_dir: str) -> Mapping[str, Any]:
+    common_state = dist_checkpointing.load_common_state_dict(checkpoint_dir)
+    if not isinstance(common_state, Mapping):
+        raise TypeError(
+            "MCore load_common_state_dict returned "
+            f"{type(common_state).__name__}, expected a mapping"
+        )
+    return common_state
+
+
+def _common_state_contracts(
+    value: Any, path: tuple[str, ...] = ()
+) -> dict[tuple[str, ...], tuple[str, tuple[int, ...] | None, str | None]]:
+    if isinstance(value, (ShardedBase, LocalNonpersistentObject)):
+        return {}
+
+    def type_name(item: Any) -> str:
+        item_type = type(item)
+        return f"{item_type.__module__}.{item_type.__qualname__}"
+
+    if isinstance(value, Mapping):
+        if not value:
+            return {path + ("<empty>",): (type_name(value), None, None)}
+        contracts = {}
+        for key, child in value.items():
+            segment = f"{type_name(key)}:{key!r}"
+            contracts.update(_common_state_contracts(child, path + (segment,)))
+        if contracts:
+            contracts[path + ("<container>",)] = (type_name(value), None, None)
+        return contracts
+    if isinstance(value, (list, tuple)):
+        if not value:
+            return {path + ("<empty>",): (type_name(value), None, None)}
+        contracts = {}
+        for index, child in enumerate(value):
+            contracts.update(_common_state_contracts(child, path + (f"index:{index}",)))
+        if contracts:
+            contracts[path + ("<container>",)] = (type_name(value), None, None)
+        return contracts
+    if isinstance(value, torch.Tensor):
+        return {path: (type_name(value), tuple(value.shape), str(value.dtype))}
+    return {path: (type_name(value), None, None)}
+
+
+def _common_state_file_fingerprint(checkpoint_dir: str) -> tuple[int, str]:
+    """Hash the exact MCore common-state payload without reserializing it."""
+
+    from megatron.core.msc_utils import MultiStorageClientFeature
+
+    path = os.path.join(checkpoint_dir, "common.pt")
+    if MultiStorageClientFeature.is_enabled():
+        msc = MultiStorageClientFeature.import_package()
+        open_file = msc.open
+    else:
+        open_file = open
+    digest = hashlib.sha256()
+    size = 0
+    with open_file(path, "rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+            size += len(chunk)
+    return size, digest.hexdigest()
+
+
+def _common_state_semantic_fingerprint(value: Any) -> str:
+    """Hash common-state values using a deterministic, pickle-free encoding."""
+
+    digest = hashlib.sha256()
+    active_containers: set[int] = set()
+
+    def type_name(item: Any) -> str:
+        item_type = type(item)
+        return f"{item_type.__module__}.{item_type.__qualname__}"
+
+    def frame_bytes(tag: bytes, payload: bytes) -> bytes:
+        return (
+            len(tag).to_bytes(4, "big")
+            + tag
+            + len(payload).to_bytes(8, "big")
+            + payload
+        )
+
+    def stable_key_bytes(item: Any, path: str) -> bytes:
+        item_type = type_name(item).encode("utf-8")
+        if item is None:
+            payload = b""
+        elif isinstance(item, bool):
+            payload = b"1" if item else b"0"
+        elif isinstance(item, int):
+            payload = str(item).encode("ascii")
+        elif isinstance(item, float):
+            payload = struct.pack(">d", item)
+        elif isinstance(item, complex):
+            payload = struct.pack(">dd", item.real, item.imag)
+        elif isinstance(item, str):
+            payload = item.encode("utf-8")
+        elif isinstance(item, bytes):
+            payload = item
+        elif isinstance(item, tuple):
+            container_id = id(item)
+            if container_id in active_containers:
+                raise ValueError(f"common-state cycle detected at {path}")
+            active_containers.add(container_id)
+            try:
+                children = b"".join(
+                    frame_bytes(b"item", stable_key_bytes(child, f"{path}[{index}]"))
+                    for index, child in enumerate(item)
+                )
+                payload = frame_bytes(
+                    b"length", str(len(item)).encode("ascii")
+                ) + frame_bytes(b"children", children)
+            finally:
+                active_containers.remove(container_id)
+        else:
+            raise TypeError(
+                f"unsupported common-state mapping key at {path}: {type_name(item)}"
+            )
+        return frame_bytes(b"type", item_type) + frame_bytes(b"value", payload)
+
+    def update(tag: bytes, payload: bytes | memoryview = b"") -> None:
+        digest.update(len(tag).to_bytes(4, "big"))
+        digest.update(tag)
+        digest.update(len(payload).to_bytes(8, "big"))
+        digest.update(payload)
+
+    def visit(item: Any, path: str) -> None:
+        if isinstance(item, (ShardedBase, LocalNonpersistentObject)):
+            raise TypeError(
+                f"sharded/nonpersistent object leaked into common state at {path}: "
+                f"{type_name(item)}"
+            )
+        update(b"type", type_name(item).encode("utf-8"))
+        if item is None:
+            update(b"none")
+        elif isinstance(item, bool):
+            update(b"bool", b"1" if item else b"0")
+        elif isinstance(item, int):
+            update(b"int", str(item).encode("ascii"))
+        elif isinstance(item, float):
+            update(b"float64", struct.pack(">d", item))
+        elif isinstance(item, complex):
+            update(b"complex128", struct.pack(">dd", item.real, item.imag))
+        elif isinstance(item, str):
+            update(b"str", item.encode("utf-8"))
+        elif isinstance(item, bytes):
+            update(b"bytes", item)
+        elif isinstance(item, (bytearray, memoryview)):
+            update(b"bytes-like", memoryview(item))
+        elif isinstance(item, torch.Tensor):
+            if item.layout != torch.strided or item.is_quantized:
+                raise TypeError(
+                    f"unsupported common-state tensor at {path}: "
+                    f"layout={item.layout}, quantized={item.is_quantized}"
+                )
+            if item.device.type == "meta":
+                raise TypeError(f"meta tensor is invalid in common state at {path}")
+            cpu = item.detach().resolve_conj().resolve_neg().cpu().contiguous()
+            update(b"tensor.dtype", str(cpu.dtype).encode("ascii"))
+            update(
+                b"tensor.shape",
+                b",".join(str(dim).encode("ascii") for dim in cpu.shape),
+            )
+            raw = cpu.reshape(-1).view(torch.uint8).numpy()
+            update(b"tensor.bytes", memoryview(raw))
+        elif isinstance(item, Mapping):
+            container_id = id(item)
+            if container_id in active_containers:
+                raise ValueError(f"common-state cycle detected at {path}")
+            active_containers.add(container_id)
+            try:
+                encoded_items = sorted(
+                    [
+                        (stable_key_bytes(key, f"{path}.<key>"), key, child)
+                        for key, child in item.items()
+                    ],
+                    key=lambda entry: entry[0],
+                )
+                for previous, current in zip(
+                    encoded_items, encoded_items[1:], strict=False
+                ):
+                    if previous[0] == current[0]:
+                        raise ValueError(
+                            f"common-state mapping has duplicate canonical keys at {path}"
+                        )
+                update(b"mapping.length", str(len(encoded_items)).encode("ascii"))
+                for key_bytes, key, child in encoded_items:
+                    update(b"mapping.key", key_bytes)
+                    visit(child, f"{path}[{key!r}]")
+                update(b"mapping.end")
+            finally:
+                active_containers.remove(container_id)
+        elif isinstance(item, (list, tuple)):
+            container_id = id(item)
+            if container_id in active_containers:
+                raise ValueError(f"common-state cycle detected at {path}")
+            active_containers.add(container_id)
+            try:
+                update(b"sequence.length", str(len(item)).encode("ascii"))
+                for index, child in enumerate(item):
+                    update(b"sequence.index", str(index).encode("ascii"))
+                    visit(child, f"{path}[{index}]")
+                update(b"sequence.end")
+            finally:
+                active_containers.remove(container_id)
+        elif isinstance(item, (set, frozenset)):
+            container_id = id(item)
+            if container_id in active_containers:
+                raise ValueError(f"common-state cycle detected at {path}")
+            active_containers.add(container_id)
+            try:
+                encoded = sorted(
+                    stable_key_bytes(child, f"{path}.<set-item>") for child in item
+                )
+                update(b"set.length", str(len(encoded)).encode("ascii"))
+                for child in encoded:
+                    update(b"set.item", child)
+                update(b"set.end")
+            finally:
+                active_containers.remove(container_id)
+        elif isinstance(item, torch.dtype):
+            update(b"torch.dtype", str(item).encode("ascii"))
+        elif isinstance(item, torch.device):
+            update(b"torch.device", str(item).encode("ascii"))
+        else:
+            raise TypeError(
+                f"unsupported common-state value at {path}: {type_name(item)}"
+            )
+
+    visit(value, "root")
+    return digest.hexdigest()
+
+
+def _validate_distckpt_content_metadata(
+    common_state: Mapping[str, Any],
+    *,
+    load_optimizer: bool,
+    allow_legacy_checkpoint: bool,
+) -> None:
+    """Require the payload format used to build the live load template."""
+
+    if allow_legacy_checkpoint and not load_optimizer:
+        return
+    if "content_metadata" not in common_state:
+        legacy_detail = (
+            "optimizer restore cannot safely infer its sharding format"
+            if load_optimizer
+            else "set allow_legacy_checkpoint=True only for an explicit legacy load"
+        )
+        raise RuntimeError(
+            "checkpoint common state is missing required content_metadata; "
+            f"{legacy_detail}"
+        )
+    metadata = common_state["content_metadata"]
+    if type(metadata) is not dict:
+        raise RuntimeError(
+            "checkpoint content_metadata must be a plain dict, got "
+            f"{type(metadata).__module__}.{type(metadata).__qualname__}"
+        )
+    missing = sorted(set(_DISTOPT_METADATA) - set(metadata))
+    unexpected = sorted(set(metadata) - set(_DISTOPT_METADATA))
+    mismatched = sorted(
+        key
+        for key in set(metadata) & set(_DISTOPT_METADATA)
+        if type(metadata[key]) is not type(_DISTOPT_METADATA[key])
+        or metadata[key] != _DISTOPT_METADATA[key]
+    )
+    if missing or unexpected or mismatched:
+        raise RuntimeError(
+            "checkpoint content_metadata is incompatible with the MLite distckpt "
+            f"format: missing={missing}, unexpected={unexpected}, "
+            f"mismatched={mismatched}"
+        )
+
+
+def _common_state_format_discriminators(
+    value: Any, path: tuple[str, ...] = ()
+) -> dict[tuple[str, ...], tuple[str, Any]]:
+    """Collect exact common-state fields that select optimizer load branches."""
+
+    if isinstance(value, (ShardedBase, LocalNonpersistentObject)):
+        return {}
+
+    def type_name(item: Any) -> str:
+        item_type = type(item)
+        return f"{item_type.__module__}.{item_type.__qualname__}"
+
+    discriminators: dict[tuple[str, ...], tuple[str, Any]] = {}
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            segment = f"{type_name(key)}:{key!r}"
+            child_path = path + (segment,)
+            if key == "param_state_sharding_type":
+                discriminators[child_path] = (type_name(child), child)
+            discriminators.update(
+                _common_state_format_discriminators(child, child_path)
+            )
+    elif isinstance(value, (list, tuple)):
+        for index, child in enumerate(value):
+            discriminators.update(
+                _common_state_format_discriminators(child, path + (f"index:{index}",))
+            )
+    return discriminators
+
+
+def _assert_world_consensus(value: Any, *, context: str) -> None:
+    """Require every WORLD rank to report the same picklable metadata value."""
+
+    if not dist.is_available() or not dist.is_initialized():
+        return
+    gathered: list[Any] = [None] * dist.get_world_size()
+    local_error = None
+    try:
+        dist.all_gather_object(gathered, value, group=dist.group.WORLD)
+    except Exception as exc:
+        local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(local_error, context=f"{context} exchange failed")
+    if any(item != gathered[0] for item in gathered[1:]):
+        raise RuntimeError(f"{context}: rank values={gathered!r}")
+
+
+def _preflight_distckpt_common_state(
+    load_sd: Mapping[str, Any],
+    checkpoint_dir: str,
+    *,
+    load_optimizer: bool,
+    requested_sharded_keys: set[str],
+    checkpoint_sharded_keys: set[str],
+    expected_step: int | None,
+    allow_legacy_checkpoint: bool,
+) -> tuple[dict[str, Any], tuple[int, str]]:
+    common_state: Mapping[str, Any] = {}
+    common_contracts: dict = {}
+    optimizer_contracts: dict = {}
+    common_state_fingerprint: tuple[int, str] | None = None
+    common_state_semantic_fingerprint: str | None = None
+    loaded_step: int | None = None
+    local_error = None
+    try:
+        before_fingerprint = _common_state_file_fingerprint(checkpoint_dir)
+        common_state = _load_checkpoint_common_state(checkpoint_dir)
+        common_state_fingerprint = _common_state_file_fingerprint(checkpoint_dir)
+        if common_state_fingerprint != before_fingerprint:
+            raise RuntimeError(
+                "checkpoint common.pt changed while it was being preflighted: "
+                f"before={before_fingerprint!r}, after={common_state_fingerprint!r}"
+            )
+        _validate_distckpt_content_metadata(
+            common_state,
+            load_optimizer=load_optimizer,
+            allow_legacy_checkpoint=allow_legacy_checkpoint,
+        )
+        common_state_semantic_fingerprint = _common_state_semantic_fingerprint(
+            common_state
+        )
+        common_contracts = _common_state_contracts(common_state)
+        raw_step = common_state.get("step")
+        if type(raw_step) is not int or raw_step < 0:
+            raise RuntimeError(
+                f"checkpoint common step must be a non-negative integer, got {raw_step!r}"
+            )
+        loaded_step = raw_step
+        if expected_step is not None and loaded_step != expected_step:
+            raise RuntimeError(
+                f"checkpoint common step {loaded_step} does not match completion "
+                f"manifest step {expected_step}"
+            )
+        if load_optimizer:
+            expected_optimizer_contracts = _common_state_contracts(
+                load_sd.get("optimizer", {})
+            )
+            optimizer_contracts = _common_state_contracts(
+                common_state["optimizer"] if "optimizer" in common_state else {}
+            )
+            expected_discriminators = _common_state_format_discriminators(
+                load_sd.get("optimizer", {})
+            )
+            saved_discriminators = _common_state_format_discriminators(
+                common_state["optimizer"] if "optimizer" in common_state else {}
+            )
+            requested_optimizer_sharded = any(
+                key.startswith("optimizer.") for key in requested_sharded_keys
+            )
+            checkpoint_optimizer_sharded = any(
+                key.startswith("optimizer.") for key in checkpoint_sharded_keys
+            )
+            if (
+                not expected_optimizer_contracts
+                and requested_optimizer_sharded
+                and ("optimizer" not in common_state or not common_state["optimizer"])
+            ):
+                optimizer_contracts = {}
+            if not checkpoint_optimizer_sharded and "optimizer" not in common_state:
+                raise RuntimeError(
+                    "checkpoint is missing optimizer state requested by "
+                    "load_optimizer=True"
+                )
+            if expected_optimizer_contracts != optimizer_contracts:
+                expected_paths = set(expected_optimizer_contracts)
+                saved_paths = set(optimizer_contracts)
+                mismatched_paths = sorted(
+                    path
+                    for path in expected_paths & saved_paths
+                    if expected_optimizer_contracts[path] != optimizer_contracts[path]
+                )
+                raise RuntimeError(
+                    "checkpoint optimizer common-state schema mismatch: "
+                    f"missing={sorted(expected_paths - saved_paths)}, "
+                    f"unexpected={sorted(saved_paths - expected_paths)}, "
+                    f"mismatched={mismatched_paths}"
+                )
+            if expected_discriminators != saved_discriminators:
+                raise RuntimeError(
+                    "checkpoint optimizer format discriminator mismatch: "
+                    f"expected={expected_discriminators!r}, "
+                    f"saved={saved_discriminators!r}"
+                )
+    except Exception as exc:
+        local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(
+        local_error, context="distckpt common-state preflight failed"
+    )
+    _assert_world_consensus(
+        {
+            "step": loaded_step,
+            "common_state_semantic_sha256": common_state_semantic_fingerprint,
+            "common_contracts": common_contracts,
+            "optimizer_contracts": optimizer_contracts,
+        },
+        context="distckpt common-state metadata differs across ranks",
+    )
+    assert common_state_fingerprint is not None
+    assert common_state_semantic_fingerprint is not None
+    return dict(common_state), common_state_fingerprint
+
+
+def _revalidate_distckpt_common_state_file(
+    checkpoint_dir: str, expected_fingerprint: tuple[int, str]
+) -> None:
+    current_fingerprint: tuple[int, str] | None = None
+    local_error = None
+    try:
+        current_fingerprint = _common_state_file_fingerprint(checkpoint_dir)
+        if current_fingerprint != expected_fingerprint:
+            raise RuntimeError(
+                "checkpoint common.pt changed after preflight: "
+                f"expected={expected_fingerprint!r}, current={current_fingerprint!r}"
+            )
+    except Exception as exc:
+        local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(
+        local_error, context="distckpt common-state revalidation failed"
+    )
+
+
+def _load_distckpt_with_preloaded_common(
+    load_sd: Mapping[str, Any],
+    checkpoint_dir: str,
+    common_state: dict[str, Any],
+    **kwargs,
+) -> dict[str, Any]:
+    """Bind MCore's actual load to the common state validated by preflight."""
+
+    from megatron.core.dist_checkpointing import serialization
+
+    expected_path = os.path.realpath(os.path.abspath(checkpoint_dir))
+    owner_thread = threading.get_ident()
+    with _DISTCKPT_COMMON_LOAD_LOCK:
+        original_load_common = serialization.load_common
+
+        def load_validated_common(actual_checkpoint_dir):
+            actual_path = os.path.realpath(
+                os.path.abspath(os.fspath(actual_checkpoint_dir))
+            )
+            if threading.get_ident() != owner_thread or actual_path != expected_path:
+                return original_load_common(actual_checkpoint_dir)
+            return common_state
+
+        serialization.load_common = load_validated_common
+        try:
+            loaded = dist_checkpointing.load(load_sd, checkpoint_dir, **kwargs)
+        finally:
+            serialization.load_common = original_load_common
+    if not isinstance(loaded, dict):
+        raise TypeError(
+            "MCore dist_checkpointing.load returned "
+            f"{type(loaded).__name__}, expected dict"
+        )
+    return loaded
+
+
+def _gather_world_metadata_contracts(
+    local_contracts: dict[str, tuple[str, tuple[int, ...], str | None, bool]],
+    *,
+    context: str,
+    require_identical: bool,
+) -> dict[str, tuple[str, tuple[int, ...], str | None, bool]]:
+    if not dist.is_available() or not dist.is_initialized():
+        return dict(local_contracts)
+    gathered: list[dict | None] = [None] * dist.get_world_size()
+    local_error = None
+    try:
+        dist.all_gather_object(gathered, local_contracts)
+    except Exception as exc:
+        local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(local_error, context=f"{context} exchange failed")
+    normalized = [dict(contracts or {}) for contracts in gathered]
+    if require_identical and any(
+        contracts != normalized[0] for contracts in normalized[1:]
+    ):
+        local_error = f"rank metadata contracts differ: {normalized!r}"
+        _distributed_raise_if_error(local_error, context=context)
+    merged: dict[str, tuple[str, tuple[int, ...], str | None, bool]] = {}
+    for rank_contracts in normalized:
+        for key, contract in rank_contracts.items():
+            previous = merged.get(key)
+            if previous is not None and previous != contract:
+                local_error = (
+                    f"logical key {key!r} differs across requested ranks: "
+                    f"{previous!r} vs {contract!r}"
+                )
+                _distributed_raise_if_error(local_error, context=context)
+            merged[key] = contract
+    return merged
+
+
+def _validate_requested_checkpoint_contracts(
+    requested: Mapping[str, tuple[str, tuple[int, ...], str | None, bool]],
+    checkpoint: Mapping[str, tuple[str, tuple[int, ...], str | None, bool]],
+) -> list[str]:
+    mismatches: list[str] = []
+    for key in sorted(set(requested) & set(checkpoint)):
+        requested_kind, requested_shape, requested_dtype, allow_shape_mismatch = (
+            requested[key]
+        )
+        checkpoint_kind, checkpoint_shape, checkpoint_dtype, _ = checkpoint[key]
+        if requested_kind != checkpoint_kind:
+            mismatches.append(f"{key}: type {checkpoint_kind!r} != {requested_kind!r}")
+        if requested_dtype != checkpoint_dtype:
+            mismatches.append(
+                f"{key}: dtype {checkpoint_dtype!r} != {requested_dtype!r}"
+            )
+        if not allow_shape_mismatch and requested_shape != checkpoint_shape:
+            mismatches.append(
+                f"{key}: global_shape {checkpoint_shape!r} != {requested_shape!r}"
+            )
+    return mismatches
+
+
+def _preflight_distckpt_checkpoint_metadata(
+    load_sd: Mapping[str, Any],
+    model_sd: Mapping[str, Any],
+    checkpoint_dir: str,
+    *,
+    load_model: bool,
+    load_optimizer: bool,
+) -> tuple[set[str], set[str]]:
+    """Reject component-aware key mismatches before MCore can mutate live tensors."""
+
+    requested_local: dict = {}
+    checkpoint_local: dict = {}
+    local_error = None
+    try:
+        _validate_model_sharded_key_namespace(model_sd)
+        requested_local = _sharded_metadata_contracts(load_sd)
+        checkpoint_metadata = _load_checkpoint_sharded_metadata(checkpoint_dir)
+        checkpoint_local = _sharded_metadata_contracts(checkpoint_metadata)
+    except Exception as exc:
+        local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(
+        local_error, context="distckpt checkpoint metadata read failed"
+    )
+
+    requested_contracts = _gather_world_metadata_contracts(
+        requested_local, context="distckpt requested metadata", require_identical=False
+    )
+    checkpoint_contracts = _gather_world_metadata_contracts(
+        checkpoint_local,
+        context="distckpt on-disk metadata differs across ranks",
+        require_identical=True,
+    )
+    requested_keys = set(requested_contracts)
+    checkpoint_keys = set(checkpoint_contracts)
+
+    requested_but_absent = sorted(requested_keys - checkpoint_keys)
+    saved_but_unrequested = checkpoint_keys - requested_keys
+    required_saved_but_unrequested = sorted(
+        key
+        for key in saved_but_unrequested
+        if (load_optimizer and key.startswith("optimizer."))
+        or (load_model and not key.startswith("optimizer."))
+    )
+    local_error = None
+    contract_mismatches = _validate_requested_checkpoint_contracts(
+        requested_contracts, checkpoint_contracts
+    )
+    if requested_but_absent or required_saved_but_unrequested or contract_mismatches:
+        local_error = (
+            "sharded key mismatch before load: "
+            f"requested_but_absent={requested_but_absent}, "
+            "saved_but_unrequested_for_requested_components="
+            f"{required_saved_but_unrequested}, "
+            f"contract_mismatches={contract_mismatches}"
+        )
+    _distributed_raise_if_error(
+        local_error, context="distckpt checkpoint metadata preflight failed"
+    )
+    return requested_keys, checkpoint_keys
 
 
 def _synchronize_native_optimizer_steps(optimizer: Any) -> None:
@@ -673,22 +1437,85 @@ def _single_or_all_model_state(model_sd: dict[str, Any]) -> dict[str, Any]:
 
 
 def _load_model_state_dict(
-    model: nn.Module | Iterable[nn.Module], state_dict: dict[str, Any]
+    model: nn.Module | Iterable[nn.Module],
+    state_dict: dict[str, Any],
+    *,
+    expected_state_dict: dict[str, Any] | None = None,
 ) -> None:
     chunks = _model_chunks(model)
-    if len(chunks) == 1 and "model" in state_dict:
-        _wrapped_module(chunks[0]).load_state_dict(state_dict["model"], strict=False)
-        return
+    if not chunks:
+        raise RuntimeError("distckpt model load requires at least one model chunk")
     ps = _chunk_parallel_state(chunks[0]) if chunks else None
-    if len(chunks) == 1 and ps is not None and ps.pp_size > 1:
-        key = _model_chunk_key(ps, 0, 1)
-        if key in state_dict:
-            _wrapped_module(chunks[0]).load_state_dict(state_dict[key], strict=False)
-        return
+    expected_state_dict = (
+        _model_sharded_state_dict(model)
+        if expected_state_dict is None
+        else expected_state_dict
+    )
+    assignments: list[tuple[nn.Module, str, dict[str, Any], set[str]]] = []
     for idx, chunk in enumerate(chunks):
         key = _model_chunk_key(ps, idx, len(chunks))
-        if key in state_dict:
-            _wrapped_module(chunk).load_state_dict(state_dict[key], strict=False)
+        if key not in state_dict:
+            raise RuntimeError(
+                f"distckpt checkpoint is missing required model subtree {key!r}"
+            )
+        if key not in expected_state_dict:
+            raise RuntimeError(
+                f"distckpt load template is missing required model subtree {key!r}"
+            )
+        loaded_subtree = state_dict[key]
+        expected_subtree = expected_state_dict[key]
+        if not isinstance(loaded_subtree, dict) or not isinstance(
+            expected_subtree, dict
+        ):
+            raise TypeError(f"distckpt model subtree {key!r} must be a dictionary")
+        loaded_keys = set(loaded_subtree)
+        expected_keys = set(expected_subtree)
+        if loaded_keys != expected_keys:
+            raise RuntimeError(
+                f"distckpt model subtree {key!r} key mismatch: "
+                f"missing={sorted(expected_keys - loaded_keys)}, "
+                f"unexpected={sorted(loaded_keys - expected_keys)}"
+            )
+
+        current_state = _wrapped_module(chunk).state_dict()
+        metadata_errors: list[str] = []
+        for name, loaded_tensor in loaded_subtree.items():
+            current_tensor = current_state.get(name)
+            if not isinstance(current_tensor, torch.Tensor) or not isinstance(
+                loaded_tensor, torch.Tensor
+            ):
+                metadata_errors.append(f"{name}: expected tensor checkpoint entry")
+                continue
+            if current_tensor.shape != loaded_tensor.shape:
+                metadata_errors.append(
+                    f"{name}: shape {tuple(loaded_tensor.shape)} != "
+                    f"{tuple(current_tensor.shape)}"
+                )
+            if current_tensor.dtype != loaded_tensor.dtype:
+                metadata_errors.append(
+                    f"{name}: dtype {loaded_tensor.dtype} != {current_tensor.dtype}"
+                )
+        if metadata_errors:
+            raise RuntimeError(
+                f"distckpt model subtree {key!r} metadata mismatch: {metadata_errors}"
+            )
+        assignments.append((chunk, key, loaded_subtree, expected_keys))
+
+    # Commit only after every chunk passes the read-only preflight. Shared/tied
+    # module aliases are intentionally absent from ``named_parameters`` and thus
+    # from the sharded template, so strict=False is required; missing checkpoint
+    # keys and unexpected loaded keys were already rejected above.
+    for chunk, key, loaded_subtree, expected_keys in assignments:
+        incompatible = _wrapped_module(chunk).load_state_dict(
+            loaded_subtree, strict=False
+        )
+        missing_required = sorted(set(incompatible.missing_keys) & expected_keys)
+        if missing_required or incompatible.unexpected_keys:
+            raise RuntimeError(
+                f"distckpt model subtree {key!r} application mismatch: "
+                f"missing_required={missing_required}, "
+                f"unexpected={sorted(incompatible.unexpected_keys)}"
+            )
 
 
 def _chunk_parallel_state(chunk: nn.Module) -> ParallelState | None:

--- a/experimental/lite/megatron/lite/primitive/ckpt/distckpt.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/distckpt.py
@@ -14,6 +14,10 @@ import torch.nn as nn
 
 from megatron.core import dist_checkpointing
 from megatron.core.dist_checkpointing.mapping import ShardedTensor
+from megatron.lite.primitive.ckpt.hf_weights import (
+    _distributed_raise_if_error,
+    named_persistent_buffers,
+)
 from megatron.lite.primitive.parallel import ParallelState
 from megatron.lite.primitive.protocols import (
     ExpertClassifierFn,
@@ -46,10 +50,14 @@ def attach_model_sharded_state_dict(
         chunk._mlite_dist_opt_parallel_state = ps  # type: ignore[attr-defined]
 
 
-def supports_dist_opt_distckpt(model: nn.Module | Iterable[nn.Module], optimizer: Any) -> bool:
+def supports_dist_opt_distckpt(
+    model: nn.Module | Iterable[nn.Module], optimizer: Any
+) -> bool:
     """Return whether this model/optimizer pair can use mcore dist_checkpointing."""
 
-    if optimizer is not None and not callable(getattr(optimizer, "sharded_state_dict", None)):
+    if optimizer is not None and not callable(
+        getattr(optimizer, "sharded_state_dict", None)
+    ):
         return False
     return all(
         bool(getattr(chunk, "_mlite_dist_opt_sharded_state_dict", False))
@@ -69,26 +77,64 @@ def save_dist_opt_checkpoint(
 ) -> None:
     """Save model and DistributedOptimizer state through mcore dist_checkpointing."""
 
-    os.makedirs(checkpoint_dir, exist_ok=True)
-    model_sd = _model_sharded_state_dict(model) if save_model or save_optimizer else {}
+    local_error = None
+    try:
+        os.makedirs(checkpoint_dir, exist_ok=True)
+    except Exception as exc:
+        local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(
+        local_error, context="distckpt checkpoint directory creation failed"
+    )
+    chunks = _model_chunks(model)
+    ps = _chunk_parallel_state(chunks[0]) if chunks else None
+    if ps is not None and ps.embedding_groups_initialized:
+        from megatron.lite.primitive.parallel import (
+            validate_mtp_embedding_parameter_replicas,
+        )
+
+        validate_mtp_embedding_parameter_replicas(chunks, ps, enabled=True)
+    model_sd: dict[str, Any] = {}
+    local_error = None
+    if save_model or save_optimizer:
+        try:
+            model_sd = _model_sharded_state_dict(model)
+        except Exception as exc:
+            local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(
+        local_error, context="distckpt model state construction failed"
+    )
     state_dict: dict[str, Any] = {"step": int(step)}
     if save_model:
         state_dict.update(model_sd)
+    local_error = None
     if save_optimizer and optimizer is not None:
-        _synchronize_native_optimizer_steps(optimizer)
-        patches = _patch_empty_native_optimizer_state_dicts(optimizer, fallback_step=step)
         try:
-            state_dict["optimizer"] = optimizer.sharded_state_dict(
-                _single_or_all_model_state(model_sd), metadata=_DISTOPT_METADATA
+            _synchronize_native_optimizer_steps(optimizer)
+            patches = _patch_empty_native_optimizer_state_dicts(
+                optimizer, fallback_step=step
             )
-        finally:
-            _restore_state_dict_patches(patches)
-    dist_checkpointing.save(
-        state_dict,
-        checkpoint_dir,
-        validate_access_integrity=False,
-        content_metadata=_DISTOPT_METADATA,
+            try:
+                state_dict["optimizer"] = optimizer.sharded_state_dict(
+                    _single_or_all_model_state(model_sd), metadata=_DISTOPT_METADATA
+                )
+            finally:
+                _restore_state_dict_patches(patches)
+        except Exception as exc:
+            local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(
+        local_error, context="distckpt optimizer state construction failed"
     )
+    local_error = None
+    try:
+        dist_checkpointing.save(
+            state_dict,
+            checkpoint_dir,
+            validate_access_integrity=False,
+            content_metadata=_DISTOPT_METADATA,
+        )
+    except Exception as exc:
+        local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(local_error, context="distckpt checkpoint save failed")
 
 
 def load_dist_opt_checkpoint(
@@ -101,18 +147,38 @@ def load_dist_opt_checkpoint(
 ) -> int:
     """Load a mcore dist_checkpointing checkpoint into model and DistributedOptimizer."""
 
-    model_sd = _model_sharded_state_dict(model) if load_model or load_optimizer else {}
+    model_sd: dict[str, Any] = {}
+    local_error = None
+    if load_model or load_optimizer:
+        try:
+            model_sd = _model_sharded_state_dict(model)
+        except Exception as exc:
+            local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(
+        local_error, context="distckpt model state construction failed"
+    )
     load_sd: dict[str, Any] = {"step": 0}
     if load_model:
         load_sd.update(model_sd)
+    local_error = None
     if load_optimizer and optimizer is not None:
-        patches = _patch_empty_native_optimizer_state_dicts(optimizer, fallback_step=0)
         try:
-            load_sd["optimizer"] = optimizer.sharded_state_dict(
-                _single_or_all_model_state(model_sd), is_loading=True, metadata=_DISTOPT_METADATA
+            patches = _patch_empty_native_optimizer_state_dicts(
+                optimizer, fallback_step=0
             )
-        finally:
-            _restore_state_dict_patches(patches)
+            try:
+                load_sd["optimizer"] = optimizer.sharded_state_dict(
+                    _single_or_all_model_state(model_sd),
+                    is_loading=True,
+                    metadata=_DISTOPT_METADATA,
+                )
+            finally:
+                _restore_state_dict_patches(patches)
+        except Exception as exc:
+            local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(
+        local_error, context="distckpt optimizer state construction failed"
+    )
     # torch>=2.6 flips torch.load's weights_only default to True, which rejects the trusted dist_opt
     # common state (mcore's load_common torch.loads optimizer/scheduler classes like AdamW). We are
     # loading our OWN checkpoint -> force weights_only=False for the duration of the load.
@@ -123,25 +189,45 @@ def load_dist_opt_checkpoint(
         return _orig_torch_load(*args, **kwargs)
 
     torch.load = _trusted_torch_load
+    state_dict: dict[str, Any] = {}
+    local_error = None
     try:
-        state_dict = dist_checkpointing.load(
-            load_sd, checkpoint_dir, validate_access_integrity=False
-        )
+        try:
+            state_dict = dist_checkpointing.load(
+                load_sd, checkpoint_dir, validate_access_integrity=False
+            )
+        except Exception as exc:
+            local_error = f"{type(exc).__name__}: {exc}"
     finally:
         torch.load = _orig_torch_load
+    _distributed_raise_if_error(local_error, context="distckpt checkpoint load failed")
+    local_error = None
     if load_model:
-        _load_model_state_dict(model, state_dict)
-    if load_optimizer and optimizer is not None and "optimizer" in state_dict:
-        load_patches = _patch_native_optimizer_step_load(optimizer)
         try:
-            optimizer.load_state_dict(state_dict["optimizer"])
-        finally:
-            _restore_set_state_patches(load_patches)
-        _synchronize_native_optimizer_steps(optimizer)
-    elif load_model and optimizer is not None:
-        reload_model_params = getattr(optimizer, "reload_model_params", None)
-        if callable(reload_model_params):
-            reload_model_params()
+            _load_model_state_dict(model, state_dict)
+        except Exception as exc:
+            local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(
+        local_error, context="distckpt model state application failed"
+    )
+    local_error = None
+    try:
+        if load_optimizer and optimizer is not None and "optimizer" in state_dict:
+            load_patches = _patch_native_optimizer_step_load(optimizer)
+            try:
+                optimizer.load_state_dict(state_dict["optimizer"])
+            finally:
+                _restore_set_state_patches(load_patches)
+            _synchronize_native_optimizer_steps(optimizer)
+        elif load_model and optimizer is not None:
+            reload_model_params = getattr(optimizer, "reload_model_params", None)
+            if callable(reload_model_params):
+                reload_model_params()
+    except Exception as exc:
+        local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(
+        local_error, context="distckpt optimizer state application failed"
+    )
     return int(state_dict.get("step", 0))
 
 
@@ -178,7 +264,9 @@ def _patch_empty_native_optimizer_state_dicts(
         original_state_dict = dist_opt.state_dict
 
         def patched_state_dict(
-            original_state_dict=original_state_dict, dist_opt=dist_opt, fallback_step=fallback_step
+            original_state_dict=original_state_dict,
+            dist_opt=dist_opt,
+            fallback_step=fallback_step,
         ):
             try:
                 return original_state_dict()
@@ -201,9 +289,14 @@ def _patch_native_optimizer_step_load(optimizer: Any) -> list[tuple[Any, Any]]:
         original_set_state = dist_opt._set_main_param_and_optimizer_states
 
         def patched_set_state(
-            model_param, tensors, dist_opt=dist_opt, original_set_state=original_set_state
+            model_param,
+            tensors,
+            dist_opt=dist_opt,
+            original_set_state=original_set_state,
         ):
-            removed_step = _pop_optimizer_step_for_model_param(dist_opt, model_param, tensors)
+            removed_step = _pop_optimizer_step_for_model_param(
+                dist_opt, model_param, tensors
+            )
             try:
                 return original_set_state(model_param, tensors)
             finally:
@@ -261,7 +354,9 @@ def _iter_distributed_optimizers(optimizer: Any) -> Iterable[Any]:
     yield from visit(optimizer)
 
 
-def _iter_optimizer_children(obj: Any, *, known_inner: Any | None = None) -> Iterable[Any]:
+def _iter_optimizer_children(
+    obj: Any, *, known_inner: Any | None = None
+) -> Iterable[Any]:
     chained = getattr(obj, "chained_optimizers", None)
     if isinstance(chained, Iterable):
         yield from chained
@@ -284,7 +379,9 @@ def _safe_inner_optimizer(obj: Any) -> Any | None:
     return getattr(obj, "optimizer", None)
 
 
-def _empty_native_optimizer_state_dict(dist_opt: Any, fallback_step: int) -> dict[str, Any]:
+def _empty_native_optimizer_state_dict(
+    dist_opt: Any, fallback_step: int
+) -> dict[str, Any]:
     inner_state_dict = dist_opt.optimizer.state_dict()
     optimizer_state = {
         key: ([group.copy() for group in value] if key == "param_groups" else value)
@@ -367,7 +464,12 @@ def _module_sharded_state_dict(
             expert=is_expert(name),
             sharded_offsets=sharded_offsets,
         )
-    for name, buffer in module.named_buffers():
+    # ``named_buffers`` also returns entries registered with
+    # ``persistent=False``. Those are runtime caches and are deliberately absent
+    # from ``state_dict``; putting them into a distributed checkpoint both
+    # violates the PyTorch contract and can make rank-local cache shapes look
+    # like checkpoint corruption on restore.
+    for name, buffer in named_persistent_buffers(module):
         state[f"{prefix}{name}"] = _make_sharded_tensor(
             f"{prefix}{name}",
             buffer,
@@ -388,7 +490,9 @@ def _make_sharded_tensor(
     expert: bool,
     sharded_offsets: tuple[tuple[int, int, int], ...] = (),
 ) -> ShardedTensor:
-    rank_offsets, replica_id = _rank_offsets_and_replica_id(placements, ps, expert=expert)
+    rank_offsets, replica_id = _rank_offsets_and_replica_id(
+        placements, ps, expert=expert
+    )
     return ShardedTensor.from_rank_offsets(
         key, tensor, *sharded_offsets, *rank_offsets, replica_id=replica_id
     )
@@ -403,14 +507,20 @@ def _rank_offsets_and_replica_id(
         if _is_shard_placement(placement):
             dim = _shard_dim(placement)
             if dim is None:
-                raise ValueError(f"Unsupported Shard placement without dim: {placement!r}.")
+                raise ValueError(
+                    f"Unsupported Shard placement without dim: {placement!r}."
+                )
             prev_rank, prev_size = axis_fragments.get(dim, (0, 1))
             axis_fragments[dim] = (prev_rank * size + rank, prev_size * size)
-    rank_offsets = tuple((dim, rank, size) for dim, (rank, size) in axis_fragments.items())
+    rank_offsets = tuple(
+        (dim, rank, size) for dim, (rank, size) in axis_fragments.items()
+    )
     return rank_offsets, _replica_id(placements, ps, expert=expert)
 
 
-def _replica_id(placements: list, ps: ParallelState, *, expert: bool) -> tuple[int, int, int]:
+def _replica_id(
+    placements: list, ps: ParallelState, *, expert: bool
+) -> tuple[int, int, int]:
     # PP stages own different parameters. They are not replicas of one
     # another, so PP rank must not make a shard non-main.
     if expert:
@@ -435,7 +545,9 @@ def _placement_is_sharded(placements: list, axis: int) -> bool:
     return axis < len(placements) and _is_shard_placement(placements[axis])
 
 
-def _mesh_ranks_and_sizes(ps: ParallelState, *, expert: bool) -> tuple[list[int], list[int]]:
+def _mesh_ranks_and_sizes(
+    ps: ParallelState, *, expert: bool
+) -> tuple[list[int], list[int]]:
     if expert:
         return (
             [ps.pp_rank, ps.expert_dp_rank, ps.ep_rank, ps.etp_rank],
@@ -461,12 +573,32 @@ def _shard_dim(placement: Any) -> int | None:
 def _model_sharded_state_dict(model: nn.Module | Iterable[nn.Module]) -> dict[str, Any]:
     chunks = _model_chunks(model)
     ps = _chunk_parallel_state(chunks[0]) if chunks else None
-    return {
-        _model_chunk_key(ps, idx, len(chunks)): _chunk_sharded_state_dict(
+    model_state: dict[str, Any] = {}
+    logical_shard_owners: dict[tuple[str, Any, tuple[int, ...]], str] = {}
+    for idx, chunk in enumerate(chunks):
+        chunk_key = _model_chunk_key(ps, idx, len(chunks))
+        chunk_state = _chunk_sharded_state_dict(
             chunk, _model_chunk_sharded_key_prefix(ps, idx, len(chunks))
         )
-        for idx, chunk in enumerate(chunks)
-    }
+        for local_key, value in chunk_state.items():
+            if not isinstance(value, ShardedTensor):
+                continue
+            replica_id = value.replica_id
+            # The same logical tensor may legitimately have multiple local
+            # fragments on one rank. Only an identical key/replica/offset is a
+            # duplicate shard that would be overwritten during flattening.
+            identity = (value.key, replica_id, value.global_offset)
+            owner = f"{chunk_key}.{local_key}"
+            previous_owner = logical_shard_owners.get(identity)
+            if previous_owner is not None:
+                raise RuntimeError(
+                    "distckpt logical shard collision for "
+                    f"key={value.key!r}, replica_id={replica_id!r}: "
+                    f"{previous_owner} and {owner}"
+                )
+            logical_shard_owners[identity] = owner
+        model_state[chunk_key] = chunk_state
+    return model_state
 
 
 def _model_chunk_key(ps: ParallelState | None, idx: int, num_chunks: int) -> str:
@@ -480,7 +612,9 @@ def _model_chunk_key(ps: ParallelState | None, idx: int, num_chunks: int) -> str
     return f"model{idx}"
 
 
-def _model_chunk_sharded_key_prefix(ps: ParallelState | None, idx: int, num_chunks: int) -> str:
+def _model_chunk_sharded_key_prefix(
+    ps: ParallelState | None, idx: int, num_chunks: int
+) -> str:
     if ps is None and num_chunks == 1:
         return ""
     if ps is not None and ps.pp_size <= 1 and num_chunks == 1:
@@ -488,18 +622,48 @@ def _model_chunk_sharded_key_prefix(ps: ParallelState | None, idx: int, num_chun
     return f"{_model_chunk_key(ps, idx, num_chunks)}."
 
 
-def _chunk_sharded_state_dict(chunk: nn.Module, sharded_key_prefix: str) -> dict[str, Any]:
+def _chunk_sharded_state_dict(
+    chunk: nn.Module, sharded_key_prefix: str
+) -> dict[str, Any]:
     chunk_sd = chunk.sharded_state_dict()  # type: ignore[attr-defined]
     if not sharded_key_prefix:
         return chunk_sd
-    return {
-        key: (
-            replace(value, key=f"{sharded_key_prefix}{value.key}")
-            if isinstance(value, ShardedTensor)
-            else value
+    tied_keys = getattr(_wrapped_module(chunk), "_mlite_tied_checkpoint_keys", {})
+    out: dict[str, Any] = {}
+    seen_tied: set[str] = set()
+    for key, value in chunk_sd.items():
+        if not isinstance(value, ShardedTensor):
+            out[key] = value
+            continue
+        logical_key = f"{sharded_key_prefix}{value.key}"
+        replica_id = value.replica_id
+        # VPP normally includes the local chunk id in every logical checkpoint
+        # key. The canonical input embedding is the exception: an MTP replica
+        # on the last PP stage must point at one stable first-stage key without
+        # knowing which VPP chunk owns the embedding. Normalize that one key to
+        # the existing non-VPP spelling; duplicate ownership is still rejected
+        # by ``_model_sharded_state_dict`` below.
+        if sharded_key_prefix.startswith("model_pp0_vpp") and key in {
+            "embed.embedding.weight",
+            "embed_tokens.embedding.weight",
+        }:
+            logical_key = f"model_pp0.{value.key}"
+        if key in tied_keys:
+            if not sharded_key_prefix.startswith("model_pp"):
+                raise RuntimeError(
+                    "PP-tied MTP embedding checkpoint metadata requires a model_pp prefix; "
+                    f"got {sharded_key_prefix!r}."
+                )
+            logical_key = f"model_pp0.{tied_keys[key]}"
+            replica_id = (1, *tuple(replica_id)[1:])
+            seen_tied.add(key)
+        out[key] = replace(value, key=logical_key, replica_id=replica_id)
+    missing_tied = set(tied_keys) - seen_tied
+    if missing_tied:
+        raise RuntimeError(
+            f"PP-tied checkpoint parameters were not found: {sorted(missing_tied)}"
         )
-        for key, value in chunk_sd.items()
-    }
+    return out
 
 
 def _single_or_all_model_state(model_sd: dict[str, Any]) -> dict[str, Any]:

--- a/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
@@ -20,8 +20,6 @@ from typing import Protocol, runtime_checkable
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-from safetensors import safe_open
-from safetensors.torch import save_file as _safe_save
 
 try:
     from torch.distributed.tensor import DTensor
@@ -104,6 +102,23 @@ class HFWeights(Protocol):
 # ======================================================================
 
 
+def _require_safetensors_io():
+    """Import the optional file-I/O dependency only at an actual I/O boundary.
+
+    Model/config inspection and pure name/shape conversion are useful in CPU
+    build and lint environments that do not install checkpoint codecs.  Real HF
+    reads and writes still fail closed with an actionable dependency error.
+    """
+    try:
+        from safetensors import safe_open
+        from safetensors.torch import save_file
+    except (ImportError, OSError) as exc:
+        raise ImportError(
+            "Hugging Face checkpoint I/O requires the optional 'safetensors' package."
+        ) from exc
+    return safe_open, save_file
+
+
 class SafeTensorReader:
     """Read individual tensors from an HF safetensors directory."""
 
@@ -123,6 +138,7 @@ class SafeTensorReader:
             filepath = self.path / self.index[name]
         else:
             filepath = self.path / "model.safetensors"
+        safe_open, _save_file = _require_safetensors_io()
         with safe_open(str(filepath), framework="pt", device="cpu") as f:
             return f.get_tensor(name)
 
@@ -163,7 +179,8 @@ def save_safetensors(
     tensors: dict[str, torch.Tensor], path: str, filename: str = "model.safetensors"
 ) -> None:
     os.makedirs(path, exist_ok=True)
-    _safe_save(tensors, os.path.join(path, filename))
+    _safe_open, save_file = _require_safetensors_io()
+    save_file(tensors, os.path.join(path, filename))
 
 
 def _distributed_raise_if_error(
@@ -297,9 +314,7 @@ def _copy_tensor_for_hf_load(target: torch.Tensor, source: torch.Tensor) -> None
 
 
 def _distributed_any_error(
-    local_error: str | None,
-    *,
-    participating_group: dist.ProcessGroup | None,
+    local_error: str | None, *, participating_group: dist.ProcessGroup | None
 ) -> bool:
     if not dist.is_initialized():
         return local_error is not None
@@ -396,9 +411,7 @@ def copy_hf_states_atomically(
         for chunk_idx, (model, loaded) in enumerate(model_states):
             try:
                 chunk_prepared = _prepare_hf_state_copy(
-                    model,
-                    loaded,
-                    allow_missing_parameter=allow_missing_parameter,
+                    model, loaded, allow_missing_parameter=allow_missing_parameter
                 )
             except Exception as exc:
                 raise RuntimeError(f"chunk{chunk_idx}: {exc}") from exc
@@ -511,9 +524,7 @@ def load_hf_model_chunks_atomically(
     )
 
 
-def materialize_hf_weights_distributed(
-    weights,
-) -> dict[str, torch.Tensor]:
+def materialize_hf_weights_distributed(weights) -> dict[str, torch.Tensor]:
     """Materialize an export generator with duplicate and WORLD-safe error handling."""
     items: list[tuple[str, torch.Tensor]] = []
     local_error = None
@@ -785,20 +796,36 @@ def gather_gate_up(
 
 
 def load_hf_weights(
-    model: nn.Module,
+    model: nn.Module | list[nn.Module],
     hf_path: str,
     spec: HFWeights,
     ps,
     *,
     vocab_size: int | None = None,
+    participating_group: dist.ProcessGroup | None = None,
 ) -> None:
     """Load HF safetensors into a Megatron Lite model using HFWeights.
 
     Handles PP layer filtering, TP split, EP shard assignment.
     ``ps`` is a ParallelState (lazy import to avoid GPU dep at module level).
+    Materialization and the final copy are one distributed transaction scoped
+    to ``participating_group``; ``None`` retains the historical WORLD scope.
     """
+    load_hf_model_chunks_atomically(
+        model,
+        lambda chunk: _materialize_generic_hf_weights(
+            chunk, hf_path, spec, ps, vocab_size=vocab_size
+        ),
+        context=f"{type(spec).__name__} HF load",
+        participating_group=participating_group,
+    )
+
+
+def _materialize_generic_hf_weights(
+    model: nn.Module, hf_path: str, spec: HFWeights, ps, *, vocab_size: int | None
+) -> dict[str, torch.Tensor]:
+    """Build a complete native state without mutating the target model."""
     from megatron.lite.primitive.parallel import pad_vocab_for_tp
-    from megatron.lite.primitive.utils import log_rank0
 
     base_model = unwrap_model(model)
     reader = SafeTensorReader(hf_path)
@@ -865,20 +892,12 @@ def load_hf_weights(
         actual = _resolve_param_name(mapped, state)
         if actual:
             loaded[actual] = tensor.to(dtype=torch.bfloat16)
-
-    for name, param in base_model.named_parameters():
-        if name in loaded:
-            source = loaded[name]
-            if param.shape != source.shape:
-                raise ValueError(
-                    f"HF load shape mismatch for {name}: "
-                    f"checkpoint={tuple(source.shape)}, model={tuple(param.shape)}"
-                )
-            param.data.copy_(source)
-        elif "lora" in name.lower() or "adapter" in name.lower():
-            continue
-        else:
-            log_rank0(f"WARNING: {name} not loaded from checkpoint")
+        elif re.search(r"(?:^|\.)layers\.\d+\.", mapped):
+            raise KeyError(
+                f"WeightSpec maps local layer tensor {mapped!r}, but the target "
+                "model has no matching parameter"
+            )
+    return loaded
 
 
 def _load_expert_weight(

--- a/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import json
 import os
 import re
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from pathlib import Path
 from typing import Protocol, runtime_checkable
 
@@ -57,7 +57,9 @@ class HFWeights(Protocol):
         """Megatron Lite param name → [HF param names]. Multiple = concat (QKV, gate+up)."""
         ...
 
-    def hf_to_native(self, native_name: str, hf_tensors: list[torch.Tensor]) -> torch.Tensor:
+    def hf_to_native(
+        self, native_name: str, hf_tensors: list[torch.Tensor]
+    ) -> torch.Tensor:
         """Convert HF tensors → single Megatron Lite tensor (e.g. merge QKV)."""
         ...
 
@@ -141,11 +143,497 @@ def unwrap_model(model: nn.Module) -> nn.Module:
     return base_model
 
 
+def named_persistent_buffers(model: nn.Module):
+    """Yield only buffers that PyTorch includes in ``state_dict``.
+
+    ``named_buffers`` also exposes entries explicitly registered as
+    non-persistent. Exporting those implementation caches creates keys that a
+    checkpoint cannot load back and, for hash routing, can misrepresent unused
+    correction bias as model state.
+    """
+    for full_name, buffer in model.named_buffers():
+        module_name, _, local_name = full_name.rpartition(".")
+        owner = model.get_submodule(module_name) if module_name else model
+        if local_name in owner._non_persistent_buffers_set:
+            continue
+        yield full_name, buffer
+
+
 def save_safetensors(
     tensors: dict[str, torch.Tensor], path: str, filename: str = "model.safetensors"
 ) -> None:
     os.makedirs(path, exist_ok=True)
     _safe_save(tensors, os.path.join(path, filename))
+
+
+def _distributed_raise_if_error(
+    local_error: str | None,
+    *,
+    context: str,
+    error_type: type[Exception] = RuntimeError,
+    participating_group: dist.ProcessGroup | None = None,
+) -> None:
+    """Propagate a local failure within the ranks participating in an operation.
+
+    ``participating_group=None`` deliberately means WORLD and is used by the
+    distributed save protocol.  Lower-level exporters must pass their own
+    process group so exporting one model replica does not require unrelated DP
+    replicas to enter a WORLD collective.
+    """
+    if not dist.is_initialized():
+        if local_error is not None:
+            raise error_type(f"{context}: {local_error}")
+        return
+    group = dist.group.WORLD if participating_group is None else participating_group
+    backend = str(
+        dist.get_backend() if participating_group is None else dist.get_backend(group)
+    ).lower()
+    device = (
+        torch.device("cuda", torch.cuda.current_device())
+        if "nccl" in backend
+        else torch.device("cpu")
+    )
+    failed = torch.tensor(
+        [int(local_error is not None)], dtype=torch.int32, device=device
+    )
+    dist.all_reduce(failed, group=group)
+    if not failed.item():
+        return
+    group_size = (
+        dist.get_world_size()
+        if participating_group is None
+        else dist.get_world_size(group)
+    )
+    messages: list[str | None] = [None] * group_size
+    dist.all_gather_object(messages, local_error, group=group)
+    first_error = next((message for message in messages if message is not None), None)
+    raise error_type(f"{context}: {first_error or 'unknown distributed failure'}")
+
+
+def materialize_hf_load_state(
+    builder: Callable[[], dict[str, torch.Tensor]],
+    *,
+    context: str,
+    participating_group: dist.ProcessGroup | None = None,
+) -> dict[str, torch.Tensor]:
+    """Run a read-only HF load builder and propagate every rank-local failure.
+
+    Model-specific loaders can own different PP layers and therefore read
+    different checkpoint keys.  A missing/corrupt key on one stage must not let
+    the other stages proceed to mutation (or to their next collective).  The
+    builder is required to be side-effect free with respect to model state;
+    this function catches its local error and makes every participating rank
+    fail at the same consensus point.
+    """
+    loaded: dict[str, torch.Tensor] = {}
+    local_error = None
+    try:
+        loaded = builder()
+        if not isinstance(loaded, dict):
+            raise TypeError(
+                f"HF load builder returned {type(loaded).__name__}, expected dict"
+            )
+    except Exception as exc:  # every rank still enters the consensus below
+        local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(
+        local_error,
+        context=f"{context} materialization failed",
+        participating_group=participating_group,
+    )
+    return loaded
+
+
+def _resolve_load_target(name: str, targets: dict[str, torch.Tensor]) -> str | None:
+    if name in targets:
+        return name
+    suffix = f".{name}"
+    matches = sorted(key for key in targets if key.endswith(suffix))
+    if not matches:
+        return None
+    if len(matches) > 1:
+        raise RuntimeError(
+            f"Ambiguous wrapped checkpoint target for {name!r}: {matches}"
+        )
+    return matches[0]
+
+
+def _is_adapter_parameter(name: str) -> bool:
+    lowered = name.lower()
+    return "lora" in lowered or "adapter" in lowered
+
+
+def _validate_load_dtype(name: str, source: torch.Tensor, target: torch.Tensor) -> None:
+    """Apply the explicit dtype policy used by native HF checkpoint loads.
+
+    Floating checkpoints may be cast to the model's configured floating dtype.
+    Quantized/integer data may not be copied into floating parameters unless a
+    model-specific loader has already dequantized it.  Persistent integer/bool
+    state is schema data and therefore requires an exact dtype match.
+    """
+    if target.is_floating_point():
+        if not source.is_floating_point():
+            raise RuntimeError(
+                f"checkpoint dtype mismatch for {name}: source={source.dtype}, "
+                f"target={target.dtype}; quantized tensors must be dequantized first"
+            )
+        return
+    if target.is_complex():
+        if not source.is_complex():
+            raise RuntimeError(
+                f"checkpoint dtype mismatch for {name}: source={source.dtype}, "
+                f"target={target.dtype}"
+            )
+        return
+    if source.dtype != target.dtype:
+        raise RuntimeError(
+            f"checkpoint dtype mismatch for {name}: source={source.dtype}, "
+            f"target={target.dtype}; non-floating state requires an exact dtype"
+        )
+
+
+def _copy_tensor_for_hf_load(target: torch.Tensor, source: torch.Tensor) -> None:
+    """Small indirection kept monkeypatchable for transactional-copy tests."""
+    target.copy_(source)
+
+
+def _distributed_any_error(
+    local_error: str | None,
+    *,
+    participating_group: dist.ProcessGroup | None,
+) -> bool:
+    if not dist.is_initialized():
+        return local_error is not None
+    group = dist.group.WORLD if participating_group is None else participating_group
+    backend = str(dist.get_backend(group)).lower()
+    device = (
+        torch.device("cuda", torch.cuda.current_device())
+        if "nccl" in backend
+        else torch.device("cpu")
+    )
+    failed = torch.tensor(
+        [int(local_error is not None)], dtype=torch.int32, device=device
+    )
+    dist.all_reduce(failed, group=group)
+    return bool(failed.item())
+
+
+def _prepare_hf_state_copy(
+    model: nn.Module,
+    loaded: dict[str, torch.Tensor],
+    *,
+    allow_missing_parameter: Callable[[str], bool],
+) -> list[tuple[str, torch.Tensor, torch.Tensor]]:
+    parameters = dict(model.named_parameters())
+    buffers = dict(named_persistent_buffers(model))
+    overlap = sorted(set(parameters).intersection(buffers))
+    if overlap:
+        raise RuntimeError(f"parameter/buffer name collision: {overlap}")
+    targets: dict[str, torch.Tensor] = {**parameters, **buffers}
+    resolved: dict[str, tuple[str, torch.Tensor]] = {}
+    for native_name, source in loaded.items():
+        if not isinstance(native_name, str):
+            raise TypeError(
+                f"checkpoint target name must be str, got {type(native_name).__name__}"
+            )
+        if not isinstance(source, torch.Tensor):
+            raise TypeError(
+                f"checkpoint tensor for {native_name} must be torch.Tensor, "
+                f"got {type(source).__name__}"
+            )
+        actual = _resolve_load_target(native_name, targets)
+        if actual is None:
+            raise RuntimeError(f"checkpoint tensor has no native target: {native_name}")
+        if actual in resolved:
+            previous = resolved[actual][0]
+            raise RuntimeError(
+                f"checkpoint tensors {previous!r} and {native_name!r} both "
+                f"resolve to native target {actual!r}"
+            )
+        target = targets[actual]
+        if source.shape != target.shape:
+            raise RuntimeError(
+                f"checkpoint shape mismatch for {actual}: "
+                f"source={tuple(source.shape)} target={tuple(target.shape)}"
+            )
+        if target.is_meta:
+            raise RuntimeError(
+                f"checkpoint target {actual} is still on the meta device"
+            )
+        _validate_load_dtype(actual, source, target)
+        resolved[actual] = (native_name, source)
+
+    missing_parameters = sorted(
+        name
+        for name in parameters
+        if name not in resolved and not allow_missing_parameter(name)
+    )
+    missing_buffers = sorted(name for name in buffers if name not in resolved)
+    if missing_parameters or missing_buffers:
+        details = []
+        if missing_parameters:
+            details.append(f"parameters={missing_parameters}")
+        if missing_buffers:
+            details.append(f"persistent_buffers={missing_buffers}")
+        raise RuntimeError(
+            "checkpoint does not cover all required native state: " + ", ".join(details)
+        )
+    return [(name, targets[name], resolved[name][1]) for name in sorted(resolved)]
+
+
+def copy_hf_states_atomically(
+    model_states: list[tuple[nn.Module, dict[str, torch.Tensor]]],
+    *,
+    context: str,
+    participating_group: dist.ProcessGroup | None = None,
+    allow_missing_parameter: Callable[[str], bool] = _is_adapter_parameter,
+) -> int:
+    """Preflight and commit every VPP chunk as one distributed transaction."""
+    prepared: list[tuple[str, torch.Tensor, torch.Tensor]] = []
+    local_error = None
+    try:
+        if not model_states:
+            raise ValueError("HF load transaction requires at least one model chunk")
+        for chunk_idx, (model, loaded) in enumerate(model_states):
+            try:
+                chunk_prepared = _prepare_hf_state_copy(
+                    model,
+                    loaded,
+                    allow_missing_parameter=allow_missing_parameter,
+                )
+            except Exception as exc:
+                raise RuntimeError(f"chunk{chunk_idx}: {exc}") from exc
+            prepared.extend(
+                (f"chunk{chunk_idx}.{name}", target, source)
+                for name, target, source in chunk_prepared
+            )
+    except Exception as exc:  # every rank still enters the consensus below
+        local_error = f"{type(exc).__name__}: {exc}"
+
+    _distributed_raise_if_error(
+        local_error,
+        context=f"{context} preflight failed",
+        participating_group=participating_group,
+    )
+
+    # The source dictionaries are private staging state. Releasing their keys
+    # before commit lets rollback snapshots reuse that host-memory envelope.
+    for _model, loaded in model_states:
+        loaded.clear()
+    backups: list[tuple[str, torch.Tensor, torch.Tensor]] = []
+    local_error = None
+    with torch.no_grad():
+        for index, (name, target, source) in enumerate(prepared):
+            try:
+                backup = target.detach().to(device="cpu", copy=True)
+                backups.append((name, target, backup))
+                converted = source.to(device=target.device, dtype=target.dtype)
+                _copy_tensor_for_hf_load(target, converted)
+                # Drop the no-longer-needed source reference.  The rollback
+                # snapshot now occupies its host-memory slot conceptually.
+                prepared[index] = (name, target, backup)
+            except Exception as exc:
+                local_error = f"{type(exc).__name__}: copying {name}: {exc}"
+                break
+
+    if _distributed_any_error(local_error, participating_group=participating_group):
+        rollback_error = None
+        with torch.no_grad():
+            for name, target, backup in backups:
+                try:
+                    restored = backup.to(device=target.device, dtype=target.dtype)
+                    _copy_tensor_for_hf_load(target, restored)
+                except Exception as exc:
+                    rollback_error = rollback_error or (
+                        f"{type(exc).__name__}: restoring {name}: {exc}"
+                    )
+        combined_error = local_error
+        if rollback_error is not None:
+            combined_error = (
+                f"{combined_error}; rollback failed: {rollback_error}"
+                if combined_error is not None
+                else f"rollback failed: {rollback_error}"
+            )
+        _distributed_raise_if_error(
+            combined_error,
+            context=f"{context} atomic copy failed",
+            participating_group=participating_group,
+        )
+        raise AssertionError("unreachable after distributed HF load failure")
+
+    return len(prepared)
+
+
+def copy_hf_state_atomically(
+    model: nn.Module,
+    loaded: dict[str, torch.Tensor],
+    *,
+    context: str,
+    participating_group: dist.ProcessGroup | None = None,
+    allow_missing_parameter: Callable[[str], bool] = _is_adapter_parameter,
+) -> int:
+    """Strictly preflight and transactionally copy one native HF load state.
+
+    The multi-chunk implementation retains CPU rollback snapshots until the
+    complete transaction succeeds, so this wrapper preserves the original
+    single-model API without weakening VPP atomicity.
+    """
+    return copy_hf_states_atomically(
+        [(model, loaded)],
+        context=context,
+        participating_group=participating_group,
+        allow_missing_parameter=allow_missing_parameter,
+    )
+
+
+def load_hf_model_chunks_atomically(
+    models: nn.Module | list[nn.Module],
+    builder: Callable[[nn.Module], dict[str, torch.Tensor]],
+    *,
+    context: str,
+    participating_group: dist.ProcessGroup | None = None,
+    allow_missing_parameter: Callable[[str], bool] = _is_adapter_parameter,
+) -> int:
+    """Materialize all VPP chunks before committing any native model state."""
+    chunks = [models] if isinstance(models, nn.Module) else list(models)
+    staged: list[tuple[nn.Module, dict[str, torch.Tensor]]] = []
+    for chunk_idx, chunk in enumerate(chunks):
+        loaded = materialize_hf_load_state(
+            lambda chunk=chunk: builder(chunk),
+            context=f"{context} chunk {chunk_idx}",
+            participating_group=participating_group,
+        )
+        staged.append((unwrap_model(chunk), loaded))
+    return copy_hf_states_atomically(
+        staged,
+        context=context,
+        participating_group=participating_group,
+        allow_missing_parameter=allow_missing_parameter,
+    )
+
+
+def materialize_hf_weights_distributed(
+    weights,
+) -> dict[str, torch.Tensor]:
+    """Materialize an export generator with duplicate and WORLD-safe error handling."""
+    items: list[tuple[str, torch.Tensor]] = []
+    local_error = None
+    try:
+        items = list(weights)
+        seen: set[str] = set()
+        duplicates: set[str] = set()
+        for name, _tensor in items:
+            if name in seen:
+                duplicates.add(name)
+            seen.add(name)
+        duplicates = sorted(duplicates)
+        if duplicates:
+            raise AssertionError(f"duplicate HF export keys: {duplicates}")
+    except Exception as exc:  # every rank reaches the consensus below
+        local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(local_error, context="HF weight materialization failed")
+    return dict(items)
+
+
+def save_hf_weight_pairs_distributed(weights, hf_path: str) -> None:
+    """Materialize, write on rank 0, and propagate write failures to every rank."""
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    out = materialize_hf_weights_distributed(weights)
+    local_error = None
+    if rank == 0:
+        if not out:
+            local_error = "ValueError: rank 0 materialized no HF weights"
+        else:
+            try:
+                save_safetensors(out, hf_path)
+            except Exception as exc:
+                local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(local_error, context="HF safetensors write failed")
+    if dist.is_initialized():
+        dist.barrier()
+
+
+def gather_pipeline_state_dict(
+    local_state: dict[str, torch.Tensor],
+    ps,
+    *,
+    participating_group: dist.ProcessGroup | None = None,
+) -> dict[str, torch.Tensor]:
+    """Gather small non-parameter export state across a pipeline group.
+
+    The main HF exporter already gathers parameters across PP. Model-specific
+    persistent buffers (router correction bias, hash-routing tables, etc.) must
+    follow the same rule before a ``rank0_only`` writer filters other ranks.
+    Duplicate native names are always rejected. Legal PP ownership is disjoint;
+    accepting identical (often all-zero) buffers would hide a broken global
+    layer remap or duplicated stage.
+    """
+    if ps.pp_size <= 1:
+        return local_state
+    all_states: list[dict[str, torch.Tensor] | None] = [None] * ps.pp_size
+    dist.all_gather_object(all_states, local_state, group=ps.pp_group)
+    gathered: dict[str, torch.Tensor] = {}
+    local_error = None
+    for stage_idx, state in enumerate(all_states):
+        if state is None:
+            local_error = local_error or (
+                f"pipeline export buffer state missing for stage {stage_idx}"
+            )
+            continue
+        for name, tensor in state.items():
+            if name in gathered:
+                local_error = local_error or (
+                    f"pipeline export buffer collision for {name}"
+                )
+                continue
+            gathered[name] = tensor
+    _distributed_raise_if_error(
+        local_error,
+        context="PP buffer export failed",
+        error_type=AssertionError,
+        participating_group=(
+            ps.pp_group if participating_group is None else participating_group
+        ),
+    )
+    return gathered
+
+
+def _validate_mtp_embedding_replica(state: dict[str, torch.Tensor]) -> None:
+    """Refuse to drop a divergent PP MTP embedding during HF export.
+
+    HF formats carry one canonical input embedding.  A PP loss stage may own a
+    physical ``mtp_embed`` replica, but it is legal to omit that duplicate only
+    after proving exact equality with the first-stage tensor.
+    """
+    replica_name = "mtp_embed.embedding.weight"
+    replica = state.get(replica_name)
+    if replica is None:
+        return
+    canonical_names = [
+        name
+        for name in ("embed.embedding.weight", "embed_tokens.embedding.weight")
+        if name in state
+    ]
+    if len(canonical_names) != 1:
+        raise AssertionError(
+            "HF export found an MTP embedding replica without exactly one canonical "
+            f"input embedding: candidates={canonical_names}"
+        )
+    canonical_name = canonical_names[0]
+    canonical = state[canonical_name]
+    if canonical.shape != replica.shape or canonical.dtype != replica.dtype:
+        raise AssertionError(
+            "HF export MTP embedding replica metadata mismatch: "
+            f"{canonical_name} shape={tuple(canonical.shape)} dtype={canonical.dtype}, "
+            f"{replica_name} shape={tuple(replica.shape)} dtype={replica.dtype}"
+        )
+    if not torch.equal(canonical, replica):
+        max_abs = (
+            (canonical.detach().float() - replica.detach().float()).abs().max().item()
+        )
+        raise AssertionError(
+            "HF export refuses to drop a divergent PP MTP embedding replica: "
+            f"canonical={canonical_name}, replica={replica_name}, max_abs={max_abs:.6e}"
+        )
 
 
 def _resolve_export_dtype(export_dtype: str | torch.dtype | None) -> torch.dtype | None:
@@ -169,10 +657,22 @@ def _resolve_export_dtype(export_dtype: str | torch.dtype | None) -> torch.dtype
     return aliases[normalized]
 
 
-def _cast_export_tensor(tensor: torch.Tensor, export_dtype: torch.dtype | None) -> torch.Tensor:
+def _cast_export_tensor(
+    tensor: torch.Tensor, export_dtype: torch.dtype | None
+) -> torch.Tensor:
     if export_dtype is None or not tensor.is_floating_point():
         return tensor
     return tensor.to(dtype=export_dtype)
+
+
+def _is_vocab_parallel_state(name: str) -> bool:
+    return name in {
+        "embed.embedding.weight",
+        "embed_tokens.embedding.weight",
+        "mtp_embed.embedding.weight",
+        "head.col.linear.weight",
+        "lm_head.col.linear.weight",
+    }
 
 
 # ======================================================================
@@ -180,14 +680,21 @@ def _cast_export_tensor(tensor: torch.Tensor, export_dtype: torch.dtype | None) 
 # ======================================================================
 
 
-def split_dim(tensor: torch.Tensor, rank: int, world: int, dim: int = 0) -> torch.Tensor:
+def split_dim(
+    tensor: torch.Tensor, rank: int, world: int, dim: int = 0
+) -> torch.Tensor:
     if world <= 1:
         return tensor
     return tensor.chunk(world, dim=dim)[rank].contiguous()
 
 
 def split_qkv(
-    tensor: torch.Tensor, rank: int, world: int, num_q_heads: int, num_kv_heads: int, head_dim: int
+    tensor: torch.Tensor,
+    rank: int,
+    world: int,
+    num_q_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
 ) -> torch.Tensor:
     """TP-shard a fused [Q, K, V] weight, splitting Q/K/V heads independently.
 
@@ -257,10 +764,15 @@ def to_global_layer_name(name: str, layer_map: dict[int, int]) -> str:
     def _replace(m: re.Match) -> str:
         return f"layers.{layer_map.get(int(m.group(1)), int(m.group(1)))}."
 
-    return re.sub(r"layers\.(\d+)\.", _replace, name)
+    # Only decoder-trunk names use PP-local layer indices. MTP namespaces such
+    # as ``mtp.layers.0`` are already depth-local and must not be remapped to a
+    # trunk stage's first global decoder index.
+    return re.sub(r"^layers\.(\d+)\.", _replace, name)
 
 
-def gather_gate_up(tensor: torch.Tensor, world_size: int, group: dist.ProcessGroup) -> torch.Tensor:
+def gather_gate_up(
+    tensor: torch.Tensor, world_size: int, group: dist.ProcessGroup
+) -> torch.Tensor:
     ffn_local = tensor.shape[0] // 2
     gate_full = allgather_concat(tensor[:ffn_local], world_size, group, dim=0)
     up_full = allgather_concat(tensor[ffn_local:], world_size, group, dim=0)
@@ -273,7 +785,12 @@ def gather_gate_up(tensor: torch.Tensor, world_size: int, group: dist.ProcessGro
 
 
 def load_hf_weights(
-    model: nn.Module, hf_path: str, spec: HFWeights, ps, *, vocab_size: int | None = None
+    model: nn.Module,
+    hf_path: str,
+    spec: HFWeights,
+    ps,
+    *,
+    vocab_size: int | None = None,
 ) -> None:
     """Load HF safetensors into a Megatron Lite model using HFWeights.
 
@@ -328,11 +845,13 @@ def load_hf_weights(
         if tp_info is not None:
             split_d, tp_or_etp = tp_info
             if tp_or_etp == 0:
-                if vocab_size is not None and ("embed" in mapped or "head" in mapped):
+                if vocab_size is not None and _is_vocab_parallel_state(mapped):
                     padded = pad_vocab_for_tp(vocab_size, ps.tp_size)
                     if tensor.size(0) < padded:
                         pad = torch.zeros(
-                            padded - tensor.size(0), *tensor.shape[1:], dtype=tensor.dtype
+                            padded - tensor.size(0),
+                            *tensor.shape[1:],
+                            dtype=tensor.dtype,
                         )
                         tensor = torch.cat([tensor, pad], dim=0)
                 qkv = spec.qkv_spec(mapped) if hasattr(spec, "qkv_spec") else None
@@ -349,16 +868,26 @@ def load_hf_weights(
 
     for name, param in base_model.named_parameters():
         if name in loaded:
-            param.data.copy_(loaded[name])
+            source = loaded[name]
+            if param.shape != source.shape:
+                raise ValueError(
+                    f"HF load shape mismatch for {name}: "
+                    f"checkpoint={tuple(source.shape)}, model={tuple(param.shape)}"
+                )
+            param.data.copy_(source)
         elif "lora" in name.lower() or "adapter" in name.lower():
             continue
         else:
             log_rank0(f"WARNING: {name} not loaded from checkpoint")
 
 
-def _load_expert_weight(native_name, hf_names, reader, spec, ps, loaded, expert_gid, expert_shard):
+def _load_expert_weight(
+    native_name, hf_names, reader, spec, ps, loaded, expert_gid, expert_shard
+):
     if expert_shard is None:
-        raise RuntimeError("Expert weight encountered but expert shard metadata is unavailable.")
+        raise RuntimeError(
+            "Expert weight encountered but expert shard metadata is unavailable."
+        )
     experts_per_rank, local_start = expert_shard
     if expert_gid < local_start or expert_gid >= local_start + experts_per_rank:
         return
@@ -383,10 +912,13 @@ def _load_expert_weight(native_name, hf_names, reader, spec, ps, loaded, expert_
 def _resolve_param_name(name: str, state_dict: dict) -> str | None:
     if name in state_dict:
         return name
-    for key in state_dict:
-        if name in key:
-            return key
-    return None
+    suffix = f".{name}"
+    matches = sorted(key for key in state_dict if key.endswith(suffix))
+    if not matches:
+        return None
+    if len(matches) > 1:
+        raise ValueError(f"ambiguous wrapped parameter match for {name!r}: {matches}")
+    return matches[0]
 
 
 def export_hf_weights(
@@ -398,6 +930,7 @@ def export_hf_weights(
     limit: int | None = None,
     rank0_only: bool = False,
     export_dtype: str | torch.dtype | None = None,
+    participating_group: dist.ProcessGroup | None = None,
 ) -> Generator[tuple[str, torch.Tensor], None, None]:
     """Export model weights as HF-format (name, tensor) pairs.
 
@@ -418,16 +951,25 @@ def export_hf_weights(
 
     if ps.pp_size <= 1:
         exported_params = 0
+        seen_native_names: set[str] = set()
         expert_groups: dict[str, list[tuple[int, str, torch.Tensor]]] = {}
         for chunk in chunks:
             base_chunk = unwrap_model(chunk)
             layer_map = (
-                {i: base_chunk.layer_indices[i] for i in range(len(base_chunk.layer_indices))}
+                {
+                    i: base_chunk.layer_indices[i]
+                    for i in range(len(base_chunk.layer_indices))
+                }
                 if hasattr(base_chunk, "layer_indices")
                 else {}
             )
             for name, param in base_chunk.named_parameters():
                 gname = to_global_layer_name(name, layer_map)
+                if gname in seen_native_names:
+                    raise AssertionError(
+                        f"local export parameter collision for {gname}"
+                    )
+                seen_native_names.add(gname)
                 tensor = _materialize_dtensor(param.data.detach())
 
                 gathered_one: dict[str, torch.Tensor] = {}
@@ -445,12 +987,17 @@ def export_hf_weights(
                 exported_params += 1
                 if not rank0_only or rank == 0:
                     for native_name, gathered_tensor in gathered_one.items():
-                        if vocab_size is not None and (
-                            "embed" in native_name or "head" in native_name
+                        if vocab_size is not None and _is_vocab_parallel_state(
+                            native_name
                         ):
                             gathered_tensor = gathered_tensor[:vocab_size]
-                        for hf_name, hf_tensor in spec.native_to_hf(native_name, gathered_tensor):
-                            yield hf_name, _cast_export_tensor(hf_tensor, resolved_export_dtype)
+                        for hf_name, hf_tensor in spec.native_to_hf(
+                            native_name, gathered_tensor
+                        ):
+                            yield (
+                                hf_name,
+                                _cast_export_tensor(hf_tensor, resolved_export_dtype),
+                            )
 
                 if limit is not None and exported_params >= limit:
                     return
@@ -461,16 +1008,25 @@ def export_hf_weights(
             if not rank0_only or rank == 0:
                 for native_name in sorted(gathered_group, key=parse_expert_idx):
                     gathered_tensor = gathered_group[native_name]
-                    for hf_name, hf_tensor in spec.native_to_hf(native_name, gathered_tensor):
-                        yield hf_name, _cast_export_tensor(hf_tensor, resolved_export_dtype)
+                    for hf_name, hf_tensor in spec.native_to_hf(
+                        native_name, gathered_tensor
+                    ):
+                        yield (
+                            hf_name,
+                            _cast_export_tensor(hf_tensor, resolved_export_dtype),
+                        )
         return
 
     gathered: dict[str, torch.Tensor] = {}
+    local_error = None
     for chunk in chunks:
         base_chunk = unwrap_model(chunk)
         # Map local layer indices to global for PP
         layer_map = (
-            {i: base_chunk.layer_indices[i] for i in range(len(base_chunk.layer_indices))}
+            {
+                i: base_chunk.layer_indices[i]
+                for i in range(len(base_chunk.layer_indices))
+            }
             if hasattr(base_chunk, "layer_indices")
             else {}
         )
@@ -478,19 +1034,63 @@ def export_hf_weights(
             gname = to_global_layer_name(name, layer_map)
             t = _materialize_dtensor(param.data.detach())
 
+            gathered_one: dict[str, torch.Tensor] = {}
             if spec.is_expert(gname):
-                _gather_expert(gname, t, spec, ps, gathered)
+                _gather_expert(gname, t, spec, ps, gathered_one)
             else:
-                gathered[gname] = _gather_dense(gname, t, spec, ps)
+                gathered_one[gname] = _gather_dense(gname, t, spec, ps)
+
+            # Multiple VPP chunks may live on one rank.  Their global native
+            # names must still be disjoint; assigning directly into ``gathered``
+            # would silently keep the last chunk before the PP collision check.
+            for gathered_name, gathered_tensor in gathered_one.items():
+                if gathered_name in gathered:
+                    local_error = local_error or (
+                        f"pipeline export parameter collision for {gathered_name}"
+                    )
+                    continue
+                gathered[gathered_name] = gathered_tensor
 
     # PP gather
     if ps.pp_size > 1:
         all_states: list[dict | None] = [None] * ps.pp_size
         dist.all_gather_object(all_states, gathered, group=ps.pp_group)
         gathered = {}
-        for s in all_states:
-            if s is not None:
-                gathered.update(s)
+        for stage_idx, state in enumerate(all_states):
+            if state is None:
+                local_error = local_error or (
+                    f"pipeline export parameter state missing for stage {stage_idx}"
+                )
+                continue
+            for name, tensor in state.items():
+                if name in gathered:
+                    local_error = local_error or (
+                        f"pipeline export parameter collision for {name}"
+                    )
+                    continue
+                gathered[name] = tensor
+
+    _distributed_raise_if_error(
+        local_error,
+        context="PP parameter export failed",
+        error_type=AssertionError,
+        participating_group=(
+            ps.pp_group if participating_group is None else participating_group
+        ),
+    )
+    local_error = None
+    try:
+        _validate_mtp_embedding_replica(gathered)
+    except Exception as exc:
+        local_error = f"{type(exc).__name__}: {exc}"
+    _distributed_raise_if_error(
+        local_error,
+        context="PP MTP embedding export validation failed",
+        error_type=AssertionError,
+        participating_group=(
+            ps.pp_group if participating_group is None else participating_group
+        ),
+    )
 
     rank = dist.get_rank() if dist.is_initialized() else 0
     if rank0_only and rank != 0:
@@ -499,7 +1099,7 @@ def export_hf_weights(
     # Vocab trim
     if vocab_size is not None:
         for key in list(gathered.keys()):
-            if "embed" in key or "head" in key:
+            if _is_vocab_parallel_state(key):
                 gathered[key] = gathered[key][:vocab_size]
 
     # Convert Megatron Lite names → HF names via spec
@@ -543,7 +1143,9 @@ def _gather_expert(
         out[name] = tensor.cpu()
 
 
-def _gather_expert_etp(name: str, tensor: torch.Tensor, spec: HFWeights, ps) -> torch.Tensor:
+def _gather_expert_etp(
+    name: str, tensor: torch.Tensor, spec: HFWeights, ps
+) -> torch.Tensor:
     # ETP gather
     if ps.etp_size > 1 and ps.etp_group is not None:
         tp_info = spec.tp_spec(name)
@@ -560,7 +1162,10 @@ def _expert_group_key(name: str) -> str:
 
 
 def _gather_expert_group(
-    entries: list[tuple[int, str, torch.Tensor]], spec: HFWeights, ps, out: dict[str, torch.Tensor]
+    entries: list[tuple[int, str, torch.Tensor]],
+    spec: HFWeights,
+    ps,
+    out: dict[str, torch.Tensor],
 ) -> None:
     """Gather local experts in one EP collective per layer/kind."""
     prepared = [
@@ -577,7 +1182,9 @@ def _gather_expert_group(
                 ).cpu()
                 return
 
-            stacked = torch.stack([tensor.contiguous() for _, _, tensor in prepared], dim=0)
+            stacked = torch.stack(
+                [tensor.contiguous() for _, _, tensor in prepared], dim=0
+            )
             ep_gathered = [torch.empty_like(stacked) for _ in range(ps.ep_size)]
             dist.all_gather(ep_gathered, stacked, group=ps.ep_group)
             out[packed_name] = torch.cat(ep_gathered, dim=0).cpu()
@@ -607,9 +1214,7 @@ def save_hf_weights(
     vocab_size: int | None = None,
 ) -> None:
     """Export + write to safetensors."""
-    rank = dist.get_rank() if dist.is_initialized() else 0
-    out = dict(export_hf_weights(model, spec, ps, vocab_size=vocab_size, rank0_only=True))
-    if rank == 0 and out:
-        save_safetensors(out, hf_path)
-    if dist.is_initialized():
-        dist.barrier()
+    save_hf_weight_pairs_distributed(
+        export_hf_weights(model, spec, ps, vocab_size=vocab_size, rank0_only=True),
+        hf_path,
+    )

--- a/experimental/lite/megatron/lite/primitive/kernels/dsa_kernels.py
+++ b/experimental/lite/megatron/lite/primitive/kernels/dsa_kernels.py
@@ -39,6 +39,77 @@ _DSA = None
 _indexer_fwd_sm90: Optional[Callable] = None
 _indexer_fwd_sm100: Optional[Callable] = None
 
+_SCORE_MEMORY_CHECK_THRESHOLD_BYTES = 1024**3
+_SCORE_MEMORY_MAX_FREE_FRACTION = 0.70
+_DENSE_LSE_MAX_SCORE_BYTES = 256 * 1024 * 1024
+_DENSE_KL_MAX_TEMP_BYTES = 256 * 1024 * 1024
+
+
+def _bottom_right_valid_kv_counts(
+    seq_q: int, seq_k: int, ratio: int, device: torch.device
+) -> Tensor:
+    """Return the cuDNN DSA bottom-right causal KV count for every query."""
+
+    if ratio < 1 or seq_q > seq_k * ratio:
+        raise ValueError(
+            "DSA bottom-right causal mask requires ratio >= 1 and "
+            f"seq_q <= seq_k * ratio, got seq_q={seq_q}, seq_k={seq_k}, ratio={ratio}"
+        )
+    q_positions = torch.arange(seq_q, device=device, dtype=torch.int64)
+    q_global_start = seq_k * ratio - seq_q
+    return torch.div(
+        q_global_start + q_positions + 1,
+        ratio,
+        rounding_mode="floor",
+    ).clamp(min=0, max=seq_k)
+
+
+def _estimate_dsa_score_peak_bytes(
+    batch: int,
+    seq_q: int,
+    seq_k: int,
+    *,
+    dense_loss: bool,
+) -> int:
+    """Estimate unavoidable FP32 full-score storage for the current kernels."""
+
+    score_bytes = batch * seq_q * seq_k * torch.float32.itemsize
+    score_matrices = 2 if dense_loss else 1
+    dense_scratch = max(_DENSE_LSE_MAX_SCORE_BYTES, _DENSE_KL_MAX_TEMP_BYTES)
+    return score_matrices * score_bytes + (dense_scratch if dense_loss else 0)
+
+
+def _guard_dsa_score_memory(
+    tensor: Tensor,
+    batch: int,
+    seq_q: int,
+    seq_k: int,
+    *,
+    dense_loss: bool,
+) -> None:
+    """Fail before a predictable full-score OOM with an actionable message."""
+
+    estimated = _estimate_dsa_score_peak_bytes(
+        batch, seq_q, seq_k, dense_loss=dense_loss
+    )
+    if not tensor.is_cuda or estimated < _SCORE_MEMORY_CHECK_THRESHOLD_BYTES:
+        return
+    free_bytes, _total_bytes = torch.cuda.mem_get_info(tensor.device)
+    allowed = int(free_bytes * _SCORE_MEMORY_MAX_FREE_FRACTION)
+    if estimated > allowed:
+        gib = 1024**3
+        mode = "dense auxiliary loss" if dense_loss else "indexer top-k"
+        raise RuntimeError(
+            f"DSA {mode} would materialize full FP32 score tensors with an "
+            f"estimated peak of {estimated / gib:.1f} GiB for "
+            f"(batch={batch}, seq_q={seq_q}, seq_k={seq_k}), but only "
+            f"{free_bytes / gib:.1f} GiB is currently free. Current MLite DSA "
+            "still materializes the full top-k score matrix and, for dense "
+            "KL, two full score matrices plus bounded Q/K-chunk scratch; "
+            "reduce the training sequence length instead of relying on a "
+            "CUDA OOM."
+        )
+
 
 def _ensure_flash_mla():
     """Lazily import the FlashMLA sparse-forward kernel.
@@ -92,9 +163,9 @@ def _dsa_fwd_flash_mla(
     Accepts flat (unbatched) tensors with global indices; pads ``TopK`` to
     the GPU-specific alignment; returns ``(out, lse, lse_indexer)``.
     """
-    assert not (
-        indexer_topk > 0 and topk_length is not None
-    ), "indexer_topk > 0 requires non-compact mode (topk_length must be None)"
+    assert not (indexer_topk > 0 and topk_length is not None), (
+        "indexer_topk > 0 requires non-compact mode (topk_length must be None)"
+    )
     _ensure_flash_mla()
 
     _total_S_q, _H, _D = q.shape
@@ -175,7 +246,9 @@ def _load_indexer_fwd_sm100():
     global _indexer_fwd_sm100
     if _indexer_fwd_sm100 is None:
         try:
-            module = import_module("cudnn.deepseek_sparse_attention.indexer_forward._interface")
+            module = import_module(
+                "cudnn.deepseek_sparse_attention.indexer_forward._interface"
+            )
             _indexer_fwd_sm100 = module.indexer_fwd
         except (AttributeError, ImportError) as exc:
             raise ImportError(
@@ -319,7 +392,9 @@ def build_flat_topk_idxs(
             # CUDA still work. Production callers always go through the CUDA
             # path above.
             valid_mask = global_idxs >= 0
-            sorted_indices = valid_mask.int().argsort(dim=-1, descending=True, stable=True)
+            sorted_indices = valid_mask.int().argsort(
+                dim=-1, descending=True, stable=True
+            )
             global_idxs = global_idxs.gather(-1, sorted_indices)
             topk_length_flat = valid_mask.sum(dim=-1).int()
 
@@ -425,7 +500,14 @@ def dsa_sparse_attn(
     kv_flat = kv.reshape(skv * b, d)
 
     out_flat, _lse, _lse_indexer = SparseAttnFunc.apply(
-        q_flat, kv_flat, attn_sink, topk_idxs, topk_length, softmax_scale, indexer_topk, value_dim
+        q_flat,
+        kv_flat,
+        attn_sink,
+        topk_idxs,
+        topk_length,
+        softmax_scale,
+        indexer_topk,
+        value_dim,
     )
 
     d_v = out_flat.shape[-1]
@@ -469,6 +551,8 @@ def _indexer_topk_bshd(
     b, sq, _idx_nh, _idx_hd = q_bshd.shape
     sk = k_bsd.shape[1]
     device = q_bshd.device
+    valid_per_q = _bottom_right_valid_kv_counts(sq, sk, ratio, device).to(torch.int32)
+    _guard_dsa_score_memory(q_bshd, b, sq, sk, dense_loss=False)
 
     k_bshd = k_bsd.unsqueeze(2)  # (b, sk, 1, idx_hd)
 
@@ -479,8 +563,6 @@ def _indexer_topk_bshd(
     # Top-K selection via the TRT-LLM CuTe-DSL radix kernel.
     n_rows = b * sq
     scores_flat = scores.reshape(n_rows, sk).contiguous()
-    q_idx = torch.arange(sq, device=device)
-    valid_per_q = ((q_idx + 1) // ratio).clamp(max=sk).to(torch.int32)  # (sq,)
     seq_lens = valid_per_q.repeat(b)  # (b*sq,), row-major over (b, sq)
 
     topk_k = min(topk, sk)
@@ -556,7 +638,9 @@ def indexer_topk(
     q_bshd, k_bsd, _w_bsh_raw, w_bsh_scaled = _sbhd_to_bshd_indexer_inputs(
         q_indexer, k_indexer, weights, indexer_softmax_scale
     )
-    topk_indices, topk_length, _ = _indexer_topk_bshd(q_bshd, k_bsd, w_bsh_scaled, topk, ratio)
+    topk_indices, topk_length, _ = _indexer_topk_bshd(
+        q_bshd, k_bsd, w_bsh_scaled, topk, ratio
+    )
     return topk_indices, topk_length
 
 
@@ -565,7 +649,7 @@ def indexer_topk(
 # ---------------------------------------------------------------------------
 
 
-_CLIP_PROB_MIN = torch.finfo(torch.float32).tiny  # kept compatible w/ cudnn kernel
+_CANONICAL_KL_EPS = 1.0e-10
 
 
 def _compute_indexer_predict(
@@ -643,15 +727,57 @@ def _kl_loss_from_target_predict(
     positions. Per-token-loss mode returns a raw local sum so finalize can
     apply the global token divisor.
     """
-    eps = _CLIP_PROB_MIN
-    t = target.clamp(min=eps)
-    p = predict.clamp(min=eps)
-    kl_per_row = (t * (torch.log(t) - torch.log(p))).sum(dim=-1)  # (B, S_q)
+    eps = _CANONICAL_KL_EPS
+    kl_per_row = (target * (torch.log(target + eps) - torch.log(predict + eps))).sum(
+        dim=-1
+    )  # (B, S_q)
 
     row_valid = (topk_indices >= 0).any(dim=-1)  # (B, S_q)
     kl_per_row = torch.where(row_valid, kl_per_row, torch.zeros_like(kl_per_row))
     loss = kl_per_row.sum() if calculate_per_token_loss else kl_per_row.mean()
     return loss_coeff * loss
+
+
+def _scale_target_for_canonical_log_eps_backward_(
+    target: Tensor, predict: Tensor
+) -> Tensor:
+    """Adapt a vendor ``-target`` score-grad to ``-target*P/(P+eps)``."""
+
+    return target.mul_(predict / (predict + _CANONICAL_KL_EPS))
+
+
+def _scale_dense_target_for_canonical_log_eps_backward_(
+    attn_score: Tensor,
+    index_score: Tensor,
+    index_lse: Tensor,
+    ratio: int,
+) -> Tensor:
+    """Apply the canonical log-epsilon score-grad factor in bounded blocks."""
+
+    batch, seq_q, seq_k = index_score.shape
+    valid_kv = _bottom_right_valid_kv_counts(seq_q, seq_k, ratio, index_score.device)
+    queries_per_block, keys_per_block = _dense_kl_block_shape(batch, seq_q, seq_k)
+    for q_start in range(0, seq_q, queries_per_block):
+        q_end = min(q_start + queries_per_block, seq_q)
+        block_valid_kv = valid_kv[q_start:q_end]
+        for k_start in range(0, seq_k, keys_per_block):
+            k_end = min(k_start + keys_per_block, seq_k)
+            k_positions = torch.arange(
+                k_start, k_end, device=index_score.device, dtype=torch.int64
+            )
+            position_valid = k_positions.view(1, -1) < block_valid_kv.view(-1, 1)
+            predict = torch.exp(
+                index_score[:, q_start:q_end, k_start:k_end]
+                - index_lse[:, q_start:q_end].unsqueeze(-1)
+            )
+            factor = predict / (predict + _CANONICAL_KL_EPS)
+            target_block = attn_score[:, q_start:q_end, k_start:k_end]
+            target_block.mul_(
+                torch.where(
+                    position_valid.unsqueeze(0), factor, torch.zeros_like(factor)
+                )
+            )
+    return attn_score
 
 
 # ---------------------------------------------------------------------------
@@ -727,6 +853,140 @@ def _compute_dense_attn_score(
     return result["out"], result["denom"]
 
 
+def _compute_full_causal_attn_lse(
+    q_attn_bshd: Tensor,
+    k_attn_bshd: Tensor,
+    softmax_scale: float,
+    ratio: int,
+    *,
+    max_score_bytes: int = _DENSE_LSE_MAX_SCORE_BYTES,
+) -> Tensor:
+    """Return the full-causal, per-head attention LSE used by dense DSA KL.
+
+    FlashMLA's ``lse_indexer`` only covers the selected sparse indices.  It
+    therefore cannot normalize the canonical dense target, where every
+    attention head first softmaxes over *all* causally valid KV positions.
+    Materializing ``(B, S_q, H_q, S_k)`` is prohibitive, so this helper
+    recomputes the exact FP32 LSE in bounded query blocks.
+
+    The bottom-right ratio mask matches cuDNN DSA score-recompute. Fully
+    masked rows receive FlashMLA's ``+inf`` lonely-query sentinel; the
+    downstream dense score kernel masks every KV entry in those rows and
+    reports a zero L1 norm.
+    """
+
+    if q_attn_bshd.ndim != 4 or k_attn_bshd.ndim != 4:
+        raise ValueError(
+            "dense DSA LSE expects BSHD q/k tensors, got "
+            f"q={tuple(q_attn_bshd.shape)} k={tuple(k_attn_bshd.shape)}"
+        )
+    if max_score_bytes < torch.empty((), dtype=torch.float32).element_size():
+        raise ValueError(f"max_score_bytes must be positive, got {max_score_bytes}")
+
+    batch, seq_q, q_heads, head_dim = q_attn_bshd.shape
+    k_batch, seq_k, kv_heads, k_head_dim = k_attn_bshd.shape
+    if batch != k_batch or head_dim != k_head_dim:
+        raise ValueError(
+            "dense DSA LSE q/k shape mismatch: "
+            f"q={tuple(q_attn_bshd.shape)} k={tuple(k_attn_bshd.shape)}"
+        )
+    if kv_heads <= 0 or q_heads % kv_heads != 0:
+        raise ValueError(
+            f"dense DSA LSE requires q_heads ({q_heads}) divisible by kv_heads ({kv_heads})"
+        )
+    minimum_score_bytes = batch * q_heads * torch.float32.itemsize
+    if max_score_bytes < minimum_score_bytes:
+        raise ValueError(
+            "max_score_bytes cannot hold one KV score for every batch/head, "
+            f"need at least {minimum_score_bytes}, got {max_score_bytes}"
+        )
+    if seq_q == 0:
+        return torch.empty(
+            (batch, 0, q_heads), device=q_attn_bshd.device, dtype=torch.float32
+        )
+    valid_kv_per_query = _bottom_right_valid_kv_counts(
+        seq_q, seq_k, ratio, q_attn_bshd.device
+    )
+
+    fp32_bytes = torch.empty((), dtype=torch.float32).element_size()
+    max_score_elements = max_score_bytes // fp32_bytes
+    score_elements_per_qk = batch * q_heads
+    keys_per_block = max(
+        1,
+        min(seq_k, max_score_elements // score_elements_per_qk),
+    )
+    queries_per_block = max(
+        1,
+        min(
+            seq_q,
+            max_score_elements // (score_elements_per_qk * keys_per_block),
+        ),
+    )
+    qheads_per_kv_head = q_heads // kv_heads
+    k_f32 = k_attn_bshd.detach().float()
+    full_lse = torch.empty(
+        (batch, seq_q, q_heads), device=q_attn_bshd.device, dtype=torch.float32
+    )
+
+    for q_start in range(0, seq_q, queries_per_block):
+        q_end = min(q_start + queries_per_block, seq_q)
+        block_q = (
+            q_attn_bshd[:, q_start:q_end]
+            .detach()
+            .float()
+            .reshape(batch, q_end - q_start, kv_heads, qheads_per_kv_head, head_dim)
+        )
+        valid_kv = valid_kv_per_query[q_start:q_end]
+        block_lse = torch.full(
+            (batch, q_end - q_start, kv_heads, qheads_per_kv_head),
+            -torch.inf,
+            device=q_attn_bshd.device,
+            dtype=torch.float32,
+        )
+        for k_start in range(0, seq_k, keys_per_block):
+            k_end = min(k_start + keys_per_block, seq_k)
+            # (B, Q, H_kv, H_q/H_kv, D) x (B, K, H_kv, D)
+            #   -> (B, Q, H_kv, H_q/H_kv, K)
+            scores = torch.einsum("bqgnd,bkgd->bqgnk", block_q, k_f32[:, k_start:k_end])
+            scores.mul_(float(softmax_scale))
+            key_positions = torch.arange(
+                k_start, k_end, device=q_attn_bshd.device, dtype=torch.int64
+            )
+            causal = key_positions.view(1, -1) < valid_kv.view(-1, 1)
+            scores.masked_fill_(
+                ~causal.view(1, q_end - q_start, 1, 1, k_end - k_start),
+                -torch.inf,
+            )
+            block_lse = torch.logaddexp(block_lse, torch.logsumexp(scores, dim=-1))
+        block_lse = block_lse.reshape(batch, q_end - q_start, q_heads)
+        # Match FlashMLA's lonely-query convention. +inf also prevents an
+        # implementation from exponentiating large QK values before applying
+        # the downstream all-masked-row gate.
+        block_lse = torch.where(
+            valid_kv.view(1, -1, 1) > 0,
+            block_lse,
+            torch.full_like(block_lse, torch.inf),
+        )
+        full_lse[:, q_start:q_end].copy_(block_lse)
+
+    return full_lse
+
+
+def _dense_kl_block_shape(batch: int, seq_q: int, seq_k: int) -> tuple[int, int]:
+    """Choose Q/K blocks that bound canonical dense-KL temporaries."""
+
+    # target, predict, two log operands, KL terms, and masks coexist in the
+    # scalar reduction. Six FP32-equivalent matrices is a conservative bound.
+    max_elements = _DENSE_KL_MAX_TEMP_BYTES // (6 * torch.float32.itemsize)
+    elements_per_qk = max(batch, 1)
+    keys_per_block = max(1, min(seq_k, max_elements // elements_per_qk))
+    queries_per_block = max(
+        1,
+        min(seq_q, max_elements // (elements_per_qk * keys_per_block)),
+    )
+    return queries_per_block, keys_per_block
+
+
 def _kl_loss_from_dense_scores(
     attn_score: Tensor,
     attn_l1norm: Tensor,
@@ -734,6 +994,7 @@ def _kl_loss_from_dense_scores(
     index_lse: Tensor,
     loss_coeff: float,
     calculate_per_token_loss: bool = False,
+    ratio: int = 1,
 ) -> Tensor:
     """KL(target || predict) over the **full** KV axis, averaged over ``(B, S_q)``.
 
@@ -748,35 +1009,96 @@ def _kl_loss_from_dense_scores(
     (LSE); those rows contribute 0 to the loss — the same ``row_valid``
     semantics as the reference ``compute_dsa_indexer_loss``.
     """
-    eps = _CLIP_PROB_MIN
-    # row_valid: rows with at least one un-masked KV position.
-    row_valid = (attn_l1norm > eps) & torch.isfinite(index_lse)
+    if attn_score.shape != index_score.shape or attn_score.ndim != 3:
+        raise ValueError(
+            "dense DSA KL expects matching (B, S_q, S_k) score tensors, got "
+            f"attn={tuple(attn_score.shape)} index={tuple(index_score.shape)}"
+        )
+    batch, seq_q, seq_k = index_score.shape
+    if attn_l1norm.shape != (batch, seq_q) or index_lse.shape != (batch, seq_q):
+        raise ValueError(
+            "dense DSA KL denominator shapes must be (B, S_q), got "
+            f"attn={tuple(attn_l1norm.shape)} index={tuple(index_lse.shape)}"
+        )
+    if batch == 0 or seq_q == 0:
+        return index_score.new_zeros(())
 
-    # Safe denoms: replace invalid rows with a finite value so target /
-    # log-predict don't produce NaN; the row mask zeroes their KL below.
-    safe_l1 = attn_l1norm.clamp(min=eps)
-    safe_lse = torch.where(row_valid, index_lse, torch.zeros_like(index_lse))
+    eps = _CANONICAL_KL_EPS
+    valid_kv = _bottom_right_valid_kv_counts(seq_q, seq_k, ratio, index_score.device)
+    queries_per_block, keys_per_block = _dense_kl_block_shape(batch, seq_q, seq_k)
+    loss_sum = index_score.new_zeros(())
+    for q_start in range(0, seq_q, queries_per_block):
+        q_end = min(q_start + queries_per_block, seq_q)
+        block_valid_kv = valid_kv[q_start:q_end]
+        block_row_valid = (
+            (block_valid_kv.view(1, -1) > 0)
+            & (attn_l1norm[:, q_start:q_end] > eps)
+            & torch.isfinite(index_lse[:, q_start:q_end])
+        )
+        safe_l1 = attn_l1norm[:, q_start:q_end].clamp(min=eps)
+        safe_lse = torch.where(
+            block_row_valid,
+            index_lse[:, q_start:q_end],
+            torch.zeros_like(index_lse[:, q_start:q_end]),
+        )
+        block_kl = index_score.new_zeros((batch, q_end - q_start))
+        for k_start in range(0, seq_k, keys_per_block):
+            k_end = min(k_start + keys_per_block, seq_k)
+            k_positions = torch.arange(
+                k_start, k_end, device=index_score.device, dtype=torch.int64
+            )
+            position_valid = k_positions.view(1, -1) < block_valid_kv.view(-1, 1)
+            position_valid = position_valid.unsqueeze(0)
+            target = attn_score[:, q_start:q_end, k_start:k_end] / safe_l1.unsqueeze(-1)
+            predict = torch.exp(
+                index_score[:, q_start:q_end, k_start:k_end] - safe_lse.unsqueeze(-1)
+            )
+            kl_terms = target * (torch.log(target + eps) - torch.log(predict + eps))
+            block_kl.add_(
+                torch.where(position_valid, kl_terms, torch.zeros_like(kl_terms)).sum(
+                    dim=-1
+                )
+            )
+        loss_sum.add_(
+            torch.where(block_row_valid, block_kl, torch.zeros_like(block_kl)).sum()
+        )
 
-    target = attn_score / safe_l1.unsqueeze(-1)
-    target_clamped = target.clamp(min=eps)
-    # Per-position validity: the indexer-score kernel emits -inf at
-    # ratio-masked positions; those contribute 0 to KL by the
-    # ``0 · log(0/p) = 0`` convention. Without this gate, the eps-clamp
-    # on target makes the term ``eps · (log eps - (-inf)) = +inf``.
-    position_valid = torch.isfinite(index_score)
-    safe_index_score = torch.where(position_valid, index_score, torch.zeros_like(index_score))
-    log_predict = safe_index_score - safe_lse.unsqueeze(-1)
-
-    kl_terms = target_clamped * (torch.log(target_clamped) - log_predict)
-    kl_terms = torch.where(position_valid, kl_terms, torch.zeros_like(kl_terms))
-    kl_per_row = kl_terms.sum(dim=-1)  # (B, S_q)
-    kl_per_row = torch.where(row_valid, kl_per_row, torch.zeros_like(kl_per_row))
-    loss = kl_per_row.sum() if calculate_per_token_loss else kl_per_row.mean()
+    loss = loss_sum if calculate_per_token_loss else loss_sum / (batch * seq_q)
     return loss_coeff * loss
 
 
-class FusedIndexerSparseAttnFunc(torch.autograd.Function):
-    """Path B: fused indexer (+KL loss) + sparse attention in one autograd.
+_MIN_INDEXER_BACKWARD_HEADS = 64
+
+
+def _pad_indexer_heads_for_backward(
+    q_indexer_bshd: Tensor, weights_bsh: Tensor
+) -> Tuple[Tensor, Tensor, int]:
+    """Pad released GLM's 32 heads to the vendor backward minimum of 64.
+
+    Zero-valued query and weight heads contribute exactly zero to the indexer
+    score and its key gradient.  This preserves the released checkpoint math
+    while allowing the current SM90/SM100 cuDNN kernels, which assert
+    ``heads >= 64``, to execute.  Returned query/weight gradients are sliced
+    back to ``original_heads`` immediately after the kernel call.
+    """
+
+    original_heads = q_indexer_bshd.shape[2]
+    if weights_bsh.shape[2] != original_heads:
+        raise ValueError(
+            "indexer query/weight head mismatch: "
+            f"q={original_heads}, weights={weights_bsh.shape[2]}"
+        )
+    if original_heads >= _MIN_INDEXER_BACKWARD_HEADS:
+        return q_indexer_bshd, weights_bsh, original_heads
+
+    pad_heads = _MIN_INDEXER_BACKWARD_HEADS - original_heads
+    q_padded = torch.nn.functional.pad(q_indexer_bshd, (0, 0, 0, pad_heads))
+    weights_padded = torch.nn.functional.pad(weights_bsh, (0, pad_heads))
+    return q_padded.contiguous(), weights_padded.contiguous(), original_heads
+
+
+class _FusedIndexerSparseAttnWithTopKFunc(torch.autograd.Function):
+    """Internal Path B autograd that additionally returns top-k indices.
 
     Differentiable w.r.t. ``query``, ``kv_full``, ``attn_sink``,
     ``q_indexer``, ``k_indexer``, ``weights``.
@@ -823,7 +1145,14 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
         sq, b, np_, d = query.shape
         skv = kv_full.shape[0]
         n_comp = k_indexer.shape[0]
-        idx_nh, idx_hd = q_indexer.shape[2], q_indexer.shape[3]
+
+        _guard_dsa_score_memory(
+            query,
+            b,
+            sq,
+            n_comp,
+            dense_loss=loss_coeff > 0 and not sparse_loss,
+        )
 
         requested_topk = indexer_topk
         effective_topk = min(requested_topk, n_comp)
@@ -839,7 +1168,9 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
         )  # topk_indices_cmp: (b, sq, effective_topk) int32; indexer_scores: (b, sq, n_comp) fp32
 
         # ---- 3. Combine indices (indexer first, then window). --------------
-        compress_topk_idxs = torch.where(topk_indices_cmp >= 0, topk_indices_cmp + kv_offset, -1)
+        compress_topk_idxs = torch.where(
+            topk_indices_cmp >= 0, topk_indices_cmp + kv_offset, -1
+        )
         if requested_topk > effective_topk:
             pad = torch.full(
                 (b, sq, requested_topk - effective_topk),
@@ -854,6 +1185,9 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
         # ---- 4. FlashMLA forward (non-compact, indexer_topk > 0). ---------
         q_flat = query.reshape(sq * b, np_, d)
         kv_flat = kv_full.reshape(skv * b, d)
+        # Sparse KL needs the selected-index LSE. Dense KL must not depend on
+        # top-k at all, so avoid asking FlashMLA for that auxiliary output.
+        flash_indexer_topk = requested_topk if sparse_loss and loss_coeff > 0 else 0
         out_flat, lse, lse_indexer = _dsa_fwd_flash_mla(
             q_flat,
             kv_flat,
@@ -861,17 +1195,23 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
             softmax_scale,
             attn_sink=attn_sink,
             topk_length=None,
-            indexer_topk=requested_topk,
+            indexer_topk=flash_indexer_topk,
             d_v=512 if value_dim is None else value_dim,
         )
 
         # ---- 5. Derive predict from indexer_scores, compute target. --------
         # Attention-path tensors (detached — loss is not differentiable through them).
         q_attn_bshd = query.detach().permute(1, 0, 2, 3).contiguous()
-        k_attn_compressed_bsd = kv_full[kv_offset:].detach().permute(1, 0, 2).contiguous()
-        lse_indexer_bsqh = lse_indexer.reshape(sq, b, np_).permute(1, 0, 2)
+        k_attn_compressed_bsd = (
+            kv_full[kv_offset:].detach().permute(1, 0, 2).contiguous()
+        )
 
-        if sparse_loss:
+        if loss_coeff <= 0:
+            indexer_loss = torch.zeros((), device=query.device, dtype=torch.float32)
+        elif sparse_loss:
+            if lse_indexer is None:
+                raise RuntimeError("FlashMLA did not return the sparse indexer LSE")
+            lse_indexer_bsqh = lse_indexer.reshape(sq, b, np_).permute(1, 0, 2)
             # Derive predict: gather topk scores from indexer_scores → softmax.
             safe_indices = topk_indices_cmp.clamp(min=0).long()
             gathered_scores = torch.gather(indexer_scores, dim=2, index=safe_indices)
@@ -889,37 +1229,51 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
                 qhead_per_kv_head=np_,
             )
 
-            if loss_coeff > 0:
-                indexer_loss = _kl_loss_from_target_predict(
-                    target, predict, topk_indices_cmp, loss_coeff, calculate_per_token_loss
-                )
-            else:
-                indexer_loss = torch.zeros((), device=query.device, dtype=torch.float32)
+            indexer_loss = _kl_loss_from_target_predict(
+                target, predict, topk_indices_cmp, loss_coeff, calculate_per_token_loss
+            )
         else:
-            # Dense: use full indexer_scores directly + logsumexp.
-            index_score = indexer_scores  # (b, sq, n_comp) fp32
-            index_lse = torch.logsumexp(indexer_scores, dim=-1)  # (b, sq) fp32
+            # Dense backward consumes the raw score/denominator pair emitted
+            # by cuDNN's dense recompute kernel. Reusing the top-k path's
+            # BF16-pre-scaled scores would violate that kernel contract.
+            del indexer_scores
+            index_score, index_lse = _compute_dense_indexer_score(
+                q_idx_bshd,
+                k_idx_bsd.unsqueeze(2),
+                w_bsh,
+                qhead_per_kv_head=q_idx_bshd.shape[2],
+                indexer_softmax_scale=indexer_softmax_scale,
+                ratio=ratio,
+            )
+
+            # Canonical dense DSA first normalizes every attention head over
+            # the complete causal KV axis. FlashMLA's sparse/indexer LSE is
+            # selected-top-k-only and would make this target depend on top-k.
+            full_attn_lse = _compute_full_causal_attn_lse(
+                q_attn_bshd,
+                k_attn_compressed_bsd.unsqueeze(2),
+                softmax_scale,
+                ratio,
+            )
 
             attn_score, attn_l1norm = _compute_dense_attn_score(
                 q_attn_bshd,
                 k_attn_compressed_bsd.unsqueeze(2),
-                lse_indexer_bsqh,
+                full_attn_lse,
                 qhead_per_kv_head=np_,
                 softmax_scale=softmax_scale,
                 ratio=ratio,
             )
 
-            if loss_coeff > 0:
-                indexer_loss = _kl_loss_from_dense_scores(
-                    attn_score,
-                    attn_l1norm,
-                    index_score,
-                    index_lse,
-                    loss_coeff,
-                    calculate_per_token_loss,
-                )
-            else:
-                indexer_loss = torch.zeros((), device=query.device, dtype=torch.float32)
+            indexer_loss = _kl_loss_from_dense_scores(
+                attn_score,
+                attn_l1norm,
+                index_score,
+                index_lse,
+                loss_coeff,
+                calculate_per_token_loss,
+                ratio,
+            )
 
         # ---- 6. Eagerly compute indexer backward (grad_loss=1). ------------
         # The actual grad_loss scaling is deferred to backward (when
@@ -931,15 +1285,21 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
         unit_grad_loss = torch.ones((), device=query.device, dtype=torch.float32)
 
         if loss_coeff > 0:
+            q_idx_bwd, w_bwd, original_index_heads = _pad_indexer_heads_for_backward(
+                q_idx_bshd, w_bsh
+            )
             if sparse_loss:
-                attn_score_for_bwd = target.clone()
-                index_score_for_bwd = predict.clone()
+                # Vendor score-grad implements -target followed by the
+                # softmax Jacobian. For canonical log(p + eps), the signal is
+                # -target * p/(p+eps). Apply that factor in-place after the
+                # scalar loss has been materialized.
+                _scale_target_for_canonical_log_eps_backward_(target, predict)
                 ig = _DSA.indexer_backward_wrapper(
-                    q_idx_bshd,
-                    w_bsh,
+                    q_idx_bwd,
+                    w_bwd,
                     k_idx_bsd,
-                    attn_score_for_bwd,
-                    index_score_for_bwd,
+                    target,
+                    predict,
                     topk_indices_cmp,
                     sm_scale=indexer_softmax_scale,
                     loss_coeff=indexer_loss_coeff,
@@ -947,15 +1307,19 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
                     block_I=128,
                 )
             else:
-                attn_score_for_bwd = attn_score.clone()
-                index_score_for_bwd = index_score.clone()
+                _scale_dense_target_for_canonical_log_eps_backward_(
+                    attn_score,
+                    index_score,
+                    index_lse,
+                    ratio,
+                )
                 ig = _DSA.dense_indexer_backward_wrapper(
-                    q_idx_bshd,
-                    w_bsh,
+                    q_idx_bwd,
+                    w_bwd,
                     k_idx_bsd,
-                    attn_score_for_bwd,
+                    attn_score,
                     attn_l1norm,
-                    index_score_for_bwd,
+                    index_score,
                     index_lse,
                     sm_scale=indexer_softmax_scale,
                     loss_coeff=indexer_loss_coeff,
@@ -963,10 +1327,19 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
                     ratio=ratio,
                     block_I=128,
                 )
-            # BSHD -> SBHD (match input layout).
-            precomputed_grad_q_indexer = ig["d_index_q"].permute(1, 0, 2, 3).contiguous()
+            # Remove any compatibility padding, then BSHD -> SBHD to match
+            # the original autograd inputs.  dK already sums across heads.
+            precomputed_grad_q_indexer = (
+                ig["d_index_q"][:, :, :original_index_heads, :]
+                .permute(1, 0, 2, 3)
+                .contiguous()
+            )
             precomputed_grad_k_indexer = ig["d_index_k"].permute(1, 0, 2).contiguous()
-            precomputed_grad_weights = ig["d_weights"].permute(1, 0, 2).contiguous()
+            precomputed_grad_weights = (
+                ig["d_weights"][:, :, :original_index_heads]
+                .permute(1, 0, 2)
+                .contiguous()
+            )
         else:
             precomputed_grad_q_indexer = torch.zeros_like(q_indexer)
             precomputed_grad_k_indexer = torch.zeros_like(k_indexer)
@@ -1062,7 +1435,65 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
         )
 
 
-def _fused_indexer_sparse_attn_apply(
+class FusedIndexerSparseAttnFunc(_FusedIndexerSparseAttnWithTopKFunc):
+    """Legacy two-output fused DSA autograd function.
+
+    Direct callers historically unpacked ``FusedIndexerSparseAttnFunc.apply``
+    as ``(output, indexer_loss)``. Keep that contract stable; IndexShare uses
+    the explicitly named private three-output function instead.
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        query: Tensor,
+        kv_full: Tensor,
+        attn_sink: Tensor,
+        window_idxs: Tensor,
+        q_indexer: Tensor,
+        k_indexer: Tensor,
+        weights: Tensor,
+        indexer_topk: int,
+        ratio: int,
+        softmax_scale: float,
+        indexer_softmax_scale: float,
+        loss_coeff: float,
+        sparse_loss: bool,
+        kv_offset: int,
+        calculate_per_token_loss: bool,
+        value_dim: Optional[int],
+    ) -> Tuple[Tensor, Tensor]:
+        output, indexer_loss, _topk_indices = (
+            _FusedIndexerSparseAttnWithTopKFunc.forward(
+                ctx,
+                query,
+                kv_full,
+                attn_sink,
+                window_idxs,
+                q_indexer,
+                k_indexer,
+                weights,
+                indexer_topk,
+                ratio,
+                softmax_scale,
+                indexer_softmax_scale,
+                loss_coeff,
+                sparse_loss,
+                kv_offset,
+                calculate_per_token_loss,
+                value_dim,
+            )
+        )
+        return output, indexer_loss
+
+    @staticmethod
+    def backward(ctx, grad_output, grad_loss):
+        return _FusedIndexerSparseAttnWithTopKFunc.backward(
+            ctx, grad_output, grad_loss, None
+        )
+
+
+def _fused_indexer_sparse_attn_with_topk_apply(
     query: Tensor,
     kv_full: Tensor,
     attn_sink: Tensor,
@@ -1080,7 +1511,7 @@ def _fused_indexer_sparse_attn_apply(
     calculate_per_token_loss: bool = False,
     value_dim: Optional[int] = None,
 ) -> Tuple[Tensor, Tensor, Tensor]:
-    return FusedIndexerSparseAttnFunc.apply(
+    return _FusedIndexerSparseAttnWithTopKFunc.apply(
         query,
         kv_full,
         attn_sink,
@@ -1156,7 +1587,7 @@ def fused_indexer_sparse_attn(
         ``(output, indexer_loss)`` where ``output`` is ``(sq, b, np * d_v)``
         bf16 and ``indexer_loss`` is a scalar f32.
     """
-    output, indexer_loss, _topk_indices = _fused_indexer_sparse_attn_apply(
+    output, indexer_loss = FusedIndexerSparseAttnFunc.apply(
         query,
         kv_full,
         attn_sink,
@@ -1196,7 +1627,7 @@ def fused_indexer_sparse_attn_with_topk(
     value_dim: Optional[int] = None,
 ) -> Tuple[Tensor, Tensor, Tensor]:
     """Path B plus the fused top-k indices for DSA IndexShare source layers."""
-    return _fused_indexer_sparse_attn_apply(
+    return _fused_indexer_sparse_attn_with_topk_apply(
         query,
         kv_full,
         attn_sink,

--- a/experimental/lite/megatron/lite/primitive/kernels/dsa_kernels.py
+++ b/experimental/lite/megatron/lite/primitive/kernels/dsa_kernels.py
@@ -58,18 +58,12 @@ def _bottom_right_valid_kv_counts(
     q_positions = torch.arange(seq_q, device=device, dtype=torch.int64)
     q_global_start = seq_k * ratio - seq_q
     return torch.div(
-        q_global_start + q_positions + 1,
-        ratio,
-        rounding_mode="floor",
+        q_global_start + q_positions + 1, ratio, rounding_mode="floor"
     ).clamp(min=0, max=seq_k)
 
 
 def _estimate_dsa_score_peak_bytes(
-    batch: int,
-    seq_q: int,
-    seq_k: int,
-    *,
-    dense_loss: bool,
+    batch: int, seq_q: int, seq_k: int, *, dense_loss: bool
 ) -> int:
     """Estimate unavoidable FP32 full-score storage for the current kernels."""
 
@@ -80,12 +74,7 @@ def _estimate_dsa_score_peak_bytes(
 
 
 def _guard_dsa_score_memory(
-    tensor: Tensor,
-    batch: int,
-    seq_q: int,
-    seq_k: int,
-    *,
-    dense_loss: bool,
+    tensor: Tensor, batch: int, seq_q: int, seq_k: int, *, dense_loss: bool
 ) -> None:
     """Fail before a predictable full-score OOM with an actionable message."""
 
@@ -163,9 +152,9 @@ def _dsa_fwd_flash_mla(
     Accepts flat (unbatched) tensors with global indices; pads ``TopK`` to
     the GPU-specific alignment; returns ``(out, lse, lse_indexer)``.
     """
-    assert not (indexer_topk > 0 and topk_length is not None), (
-        "indexer_topk > 0 requires non-compact mode (topk_length must be None)"
-    )
+    assert not (
+        indexer_topk > 0 and topk_length is not None
+    ), "indexer_topk > 0 requires non-compact mode (topk_length must be None)"
     _ensure_flash_mla()
 
     _total_S_q, _H, _D = q.shape
@@ -747,10 +736,7 @@ def _scale_target_for_canonical_log_eps_backward_(
 
 
 def _scale_dense_target_for_canonical_log_eps_backward_(
-    attn_score: Tensor,
-    index_score: Tensor,
-    index_lse: Tensor,
-    ratio: int,
+    attn_score: Tensor, index_score: Tensor, index_lse: Tensor, ratio: int
 ) -> Tensor:
     """Apply the canonical log-epsilon score-grad factor in bounded blocks."""
 
@@ -911,16 +897,9 @@ def _compute_full_causal_attn_lse(
     fp32_bytes = torch.empty((), dtype=torch.float32).element_size()
     max_score_elements = max_score_bytes // fp32_bytes
     score_elements_per_qk = batch * q_heads
-    keys_per_block = max(
-        1,
-        min(seq_k, max_score_elements // score_elements_per_qk),
-    )
+    keys_per_block = max(1, min(seq_k, max_score_elements // score_elements_per_qk))
     queries_per_block = max(
-        1,
-        min(
-            seq_q,
-            max_score_elements // (score_elements_per_qk * keys_per_block),
-        ),
+        1, min(seq_q, max_score_elements // (score_elements_per_qk * keys_per_block))
     )
     qheads_per_kv_head = q_heads // kv_heads
     k_f32 = k_attn_bshd.detach().float()
@@ -954,8 +933,7 @@ def _compute_full_causal_attn_lse(
             )
             causal = key_positions.view(1, -1) < valid_kv.view(-1, 1)
             scores.masked_fill_(
-                ~causal.view(1, q_end - q_start, 1, 1, k_end - k_start),
-                -torch.inf,
+                ~causal.view(1, q_end - q_start, 1, 1, k_end - k_start), -torch.inf
             )
             block_lse = torch.logaddexp(block_lse, torch.logsumexp(scores, dim=-1))
         block_lse = block_lse.reshape(batch, q_end - q_start, q_heads)
@@ -981,8 +959,7 @@ def _dense_kl_block_shape(batch: int, seq_q: int, seq_k: int) -> tuple[int, int]
     elements_per_qk = max(batch, 1)
     keys_per_block = max(1, min(seq_k, max_elements // elements_per_qk))
     queries_per_block = max(
-        1,
-        min(seq_q, max_elements // (elements_per_qk * keys_per_block)),
+        1, min(seq_q, max_elements // (elements_per_qk * keys_per_block))
     )
     return queries_per_block, keys_per_block
 
@@ -1147,11 +1124,7 @@ class _FusedIndexerSparseAttnWithTopKFunc(torch.autograd.Function):
         n_comp = k_indexer.shape[0]
 
         _guard_dsa_score_memory(
-            query,
-            b,
-            sq,
-            n_comp,
-            dense_loss=loss_coeff > 0 and not sparse_loss,
+            query, b, sq, n_comp, dense_loss=loss_coeff > 0 and not sparse_loss
         )
 
         requested_topk = indexer_topk
@@ -1250,10 +1223,7 @@ class _FusedIndexerSparseAttnWithTopKFunc(torch.autograd.Function):
             # the complete causal KV axis. FlashMLA's sparse/indexer LSE is
             # selected-top-k-only and would make this target depend on top-k.
             full_attn_lse = _compute_full_causal_attn_lse(
-                q_attn_bshd,
-                k_attn_compressed_bsd.unsqueeze(2),
-                softmax_scale,
-                ratio,
+                q_attn_bshd, k_attn_compressed_bsd.unsqueeze(2), softmax_scale, ratio
             )
 
             attn_score, attn_l1norm = _compute_dense_attn_score(
@@ -1308,10 +1278,7 @@ class _FusedIndexerSparseAttnWithTopKFunc(torch.autograd.Function):
                 )
             else:
                 _scale_dense_target_for_canonical_log_eps_backward_(
-                    attn_score,
-                    index_score,
-                    index_lse,
-                    ratio,
+                    attn_score, index_score, index_lse, ratio
                 )
                 ig = _DSA.dense_indexer_backward_wrapper(
                     q_idx_bwd,

--- a/experimental/lite/megatron/lite/primitive/modules/attention/csa.py
+++ b/experimental/lite/megatron/lite/primitive/modules/attention/csa.py
@@ -5,11 +5,11 @@ from typing import Any
 import torch
 import torch.nn as nn
 import transformer_engine.pytorch as te
-from megatron.lite.primitive.modules.attention.dsa import rotate_activation
 from megatron.lite.primitive.modules.attention.cp import (
     compress_contiguous_chunks_for_cp,
     iter_cp_sources,
 )
+from megatron.lite.primitive.modules.attention.dsa import rotate_activation
 from megatron.lite.primitive.parallel.state import ParallelState
 from megatron.lite.primitive.utils.rotary import (
     _yarn_find_correction_range,
@@ -28,7 +28,9 @@ class GroupedLinear(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         out_per_group = self.out_features // self.n_groups
-        weight = self.weight.view(self.n_groups, out_per_group, self.in_features_per_group)
+        weight = self.weight.view(
+            self.n_groups, out_per_group, self.in_features_per_group
+        )
         return torch.einsum("...gd,god->...go", x, weight)
 
 
@@ -42,7 +44,10 @@ def build_rope_cos_sin(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     inv_freq = 1.0 / (
         rope_theta
-        ** (torch.arange(0, rope_head_dim, 2, device=device, dtype=torch.float32) / rope_head_dim)
+        ** (
+            torch.arange(0, rope_head_dim, 2, device=device, dtype=torch.float32)
+            / rope_head_dim
+        )
     )
     freqs = torch.einsum("bs,d->bsd", position_ids.to(torch.float32), inv_freq)
     emb = torch.cat([freqs, freqs], dim=-1)
@@ -60,11 +65,13 @@ def build_yarn_rope_cos_sin(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     dim = rope_head_dim
     inv_freq_extra = 1.0 / (
-        rope_theta ** (torch.arange(0, dim, 2, device=device, dtype=torch.float32) / dim)
+        rope_theta
+        ** (torch.arange(0, dim, 2, device=device, dtype=torch.float32) / dim)
     )
     inv_freq_inter = 1.0 / (
         config.rotary_scaling_factor
-        * rope_theta ** (torch.arange(0, dim, 2, device=device, dtype=torch.float32) / dim)
+        * rope_theta
+        ** (torch.arange(0, dim, 2, device=device, dtype=torch.float32) / dim)
     )
     low, high = _yarn_find_correction_range(
         config.beta_fast,
@@ -99,7 +106,9 @@ def build_compressed_rope_cos_sin(
             device=device,
             dtype=dtype,
         )
-    return build_rope_cos_sin(position_ids, rope_head_dim, rope_theta, device=device, dtype=dtype)
+    return build_rope_cos_sin(
+        position_ids, rope_head_dim, rope_theta, device=device, dtype=dtype
+    )
 
 
 def apply_partial_rope(
@@ -123,7 +132,9 @@ def apply_partial_rope(
 
 
 class CompressedSequenceCompressor(nn.Module):
-    def __init__(self, config: Any, compress_ratio: int, head_dim: int, *, rotate: bool = False):
+    def __init__(
+        self, config: Any, compress_ratio: int, head_dim: int, *, rotate: bool = False
+    ):
         super().__init__()
         self.config = config
         self.compress_ratio = compress_ratio
@@ -140,7 +151,9 @@ class CompressedSequenceCompressor(nn.Module):
         self.norm = te.RMSNorm(head_dim, eps=config.rms_norm_eps)
         nn.init.normal_(self.ape, mean=0.0, std=config.initializer_range)
 
-    def _overlap_transform(self, tensor: torch.Tensor, fill_value: float) -> torch.Tensor:
+    def _overlap_transform(
+        self, tensor: torch.Tensor, fill_value: float
+    ) -> torch.Tensor:
         bsz, n_blocks, ratio, _, head_dim = tensor.shape
         out = tensor.new_full((bsz, n_blocks, 2 * ratio, head_dim), fill_value)
         out[:, :, ratio:] = tensor[:, :, :, 1]
@@ -160,7 +173,9 @@ class CompressedSequenceCompressor(nn.Module):
         gate = self.wgate(x[:, :cutoff])
         content = content.view(bsz, n_blocks, ratio, self.coff, self.head_dim)
         gate = gate.view_as(content)
-        gate = gate + self.ape.view(1, 1, ratio, self.coff, self.head_dim).to(gate.device)
+        gate = gate + self.ape.view(1, 1, ratio, self.coff, self.head_dim).to(
+            gate.device
+        )
         if self.overlap:
             content = self._overlap_transform(content, 0.0)
             gate = self._overlap_transform(gate, float("-inf"))
@@ -211,9 +226,7 @@ def _window_topk_indices(
 
 
 def _mask_compressed_scores_with_indexer(
-    compressed_scores: torch.Tensor,
-    index_scores: torch.Tensor,
-    index_topk: int,
+    compressed_scores: torch.Tensor, index_scores: torch.Tensor, index_topk: int
 ) -> torch.Tensor:
     """Apply the Lightning Indexer's selection as a pure block mask.
 
@@ -269,20 +282,16 @@ class CompressedSparseAttentionIndexer(nn.Module):
         self.wq_b = nn.Linear(
             config.q_lora_rank, config.index_n_heads * config.index_head_dim, bias=False
         )
-        self.weights_proj = nn.Linear(config.hidden_size, config.index_n_heads, bias=False)
+        self.weights_proj = nn.Linear(
+            config.hidden_size, config.index_n_heads, bias=False
+        )
         self.compressor = CompressedSequenceCompressor(
             config, compress_ratio, config.index_head_dim, rotate=True
         )
 
 
 class CompressedSparseAttention(nn.Module):
-    def __init__(
-        self,
-        config,
-        *,
-        layer_idx: int,
-        ps: ParallelState,
-    ):
+    def __init__(self, config, *, layer_idx: int, ps: ParallelState):
         super().__init__()
         self.config = config
         self.ps = ps
@@ -301,7 +310,9 @@ class CompressedSparseAttention(nn.Module):
             self.compress_ratio = 0
         self.wq_a = nn.Linear(config.hidden_size, config.q_lora_rank, bias=False)
         self.q_norm = te.RMSNorm(config.q_lora_rank, eps=config.rms_norm_eps)
-        self.wq_b = nn.Linear(config.q_lora_rank, self.num_heads * self.head_dim, bias=False)
+        self.wq_b = nn.Linear(
+            config.q_lora_rank, self.num_heads * self.head_dim, bias=False
+        )
         self.wkv = nn.Linear(config.hidden_size, self.head_dim, bias=False)
         self.kv_norm = te.RMSNorm(config.head_dim, eps=config.rms_norm_eps)
         self.wo_a = GroupedLinear(
@@ -309,7 +320,9 @@ class CompressedSparseAttention(nn.Module):
             config.o_groups * config.o_lora_rank,
             config.o_groups,
         )
-        self.wo_b = nn.Linear(config.o_groups * config.o_lora_rank, config.hidden_size, bias=False)
+        self.wo_b = nn.Linear(
+            config.o_groups * config.o_lora_rank, config.hidden_size, bias=False
+        )
         self.sinks = nn.Parameter(torch.zeros(self.num_heads))
         self.compressor = (
             CompressedSequenceCompressor(config, self.compress_ratio, self.head_dim)
@@ -330,10 +343,14 @@ class CompressedSparseAttention(nn.Module):
         attention_mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
         if self.ps.cp_size > 1 and attention_mask is not None:
-            raise ValueError("CP expects attention_mask=None; masks are derived from position_ids.")
+            raise ValueError(
+                "CP expects attention_mask=None; masks are derived from position_ids."
+            )
         batch, seq_len, _ = x.shape
         attention_rope_theta = (
-            self.config.compress_rope_theta if self.compress_ratio > 1 else self.config.rope_theta
+            self.config.compress_rope_theta
+            if self.compress_ratio > 1
+            else self.config.rope_theta
         )
         cos, sin = build_compressed_rope_cos_sin(
             position_ids,
@@ -345,11 +362,19 @@ class CompressedSparseAttention(nn.Module):
             dtype=x.dtype,
         )
         q_low = self.q_norm(self.wq_a(x))
-        q = self.wq_b(q_low).view(batch, seq_len, self.num_heads, self.head_dim).transpose(1, 2)
+        q = (
+            self.wq_b(q_low)
+            .view(batch, seq_len, self.num_heads, self.head_dim)
+            .transpose(1, 2)
+        )
         q = q * torch.rsqrt(
             q.float().pow(2).mean(dim=-1, keepdim=True) + self.config.rms_norm_eps
         ).to(dtype=q.dtype)
-        kv = self.kv_norm(self.wkv(x)).view(batch, seq_len, 1, self.head_dim).transpose(1, 2)
+        kv = (
+            self.kv_norm(self.wkv(x))
+            .view(batch, seq_len, 1, self.head_dim)
+            .transpose(1, 2)
+        )
         q = apply_partial_rope(q, cos, sin, self.rope_head_dim)
         kv = apply_partial_rope(kv, cos, sin, self.rope_head_dim)
         use_sparse_backend = self.attention_backend not in {"local", "eager", "torch"}
@@ -372,12 +397,7 @@ class CompressedSparseAttention(nn.Module):
             )
         if use_sparse_backend and self.ps.cp_size == 1 and attention_mask is None:
             return self._forward_fused_sparse_no_indexer_cp1(
-                x,
-                q,
-                kv,
-                position_ids=position_ids,
-                cos=cos,
-                sin=sin,
+                x, q, kv, position_ids=position_ids, cos=cos, sin=sin
             )
 
         dense_score_parts = []
@@ -394,9 +414,7 @@ class CompressedSparseAttention(nn.Module):
                 self.head_dim**0.5
             )
             source_mask = _source_scores_mask(
-                position_ids,
-                source_pos,
-                sliding_window=self.config.sliding_window,
+                position_ids, source_pos, sliding_window=self.config.sliding_window
             ).unsqueeze(1)
             scores = scores.masked_fill(~source_mask, -float("inf"))
             dense_score_parts.append(scores)
@@ -429,11 +447,11 @@ class CompressedSparseAttention(nn.Module):
                 q.float(), compressed_values.float().transpose(-1, -2)
             ) / (self.head_dim**0.5)
             compressed_valid = _compressed_scores_mask(
-                position_ids,
-                compressed_pos,
-                ratio=self.compress_ratio,
+                position_ids, compressed_pos, ratio=self.compress_ratio
             ).unsqueeze(1)
-            compressed_scores = compressed_scores.masked_fill(~compressed_valid, -float("inf"))
+            compressed_scores = compressed_scores.masked_fill(
+                ~compressed_valid, -float("inf")
+            )
 
             if self.indexer is not None:
                 index_comp_pack = compress_contiguous_chunks_for_cp(
@@ -462,11 +480,16 @@ class CompressedSparseAttention(nn.Module):
                     q_idx = (
                         self.indexer.wq_b(q_low)
                         .view(
-                            batch, seq_len, self.indexer.index_n_heads, self.indexer.index_head_dim
+                            batch,
+                            seq_len,
+                            self.indexer.index_n_heads,
+                            self.indexer.index_head_dim,
                         )
                         .transpose(1, 2)
                     )
-                    q_idx = apply_partial_rope(q_idx, idx_cos, idx_sin, self.indexer.rope_head_dim)
+                    q_idx = apply_partial_rope(
+                        q_idx, idx_cos, idx_sin, self.indexer.rope_head_dim
+                    )
                     # The indexer compressor stores Hadamard-rotated keys for
                     # the fused kernel.  Rotate the eager query as well: an
                     # orthonormal transform preserves q·k only when applied to
@@ -481,17 +504,15 @@ class CompressedSparseAttention(nn.Module):
                     index_scores = torch.einsum(
                         "bhsd,btd->bsht", q_idx.float(), k_idx.float()
                     ).relu()
-                    index_scores = (index_scores * index_weights.unsqueeze(-1)).sum(dim=2)
+                    index_scores = (index_scores * index_weights.unsqueeze(-1)).sum(
+                        dim=2
+                    )
                     index_valid = _compressed_scores_mask(
-                        position_ids,
-                        index_pos,
-                        ratio=self.compress_ratio,
+                        position_ids, index_pos, ratio=self.compress_ratio
                     )
                     index_scores = index_scores.masked_fill(~index_valid, -float("inf"))
                     compressed_scores = _mask_compressed_scores_with_indexer(
-                        compressed_scores,
-                        index_scores,
-                        self.indexer.index_topk,
+                        compressed_scores, index_scores, self.indexer.index_topk
                     )
             score_parts.append(compressed_scores)
             value_parts.append(compressed_values)
@@ -503,8 +524,12 @@ class CompressedSparseAttention(nn.Module):
             .to(dtype=scores.dtype)
         )
         combined_scores = torch.cat([scores, sink], dim=-1)
-        combined_scores = combined_scores - combined_scores.max(dim=-1, keepdim=True).values
-        probs = torch.softmax(combined_scores, dim=-1, dtype=torch.float32).to(dtype=q.dtype)
+        combined_scores = (
+            combined_scores - combined_scores.max(dim=-1, keepdim=True).values
+        )
+        probs = torch.softmax(combined_scores, dim=-1, dtype=torch.float32).to(
+            dtype=q.dtype
+        )
 
         context = q.new_zeros(batch, self.num_heads, seq_len, self.head_dim)
         offset = 0
@@ -519,10 +544,15 @@ class CompressedSparseAttention(nn.Module):
     def _project_context(
         self, context: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor
     ) -> torch.Tensor:
-        context = apply_partial_rope(context, cos, -sin, self.rope_head_dim).transpose(1, 2)
+        context = apply_partial_rope(context, cos, -sin, self.rope_head_dim).transpose(
+            1, 2
+        )
         batch, seq_len = context.shape[:2]
         grouped = context.reshape(
-            batch, seq_len, self.config.o_groups, self.num_heads_per_group * self.head_dim
+            batch,
+            seq_len,
+            self.config.o_groups,
+            self.num_heads_per_group * self.head_dim,
         )
         return self.wo_b(self.wo_a(grouped).flatten(2))
 
@@ -558,22 +588,19 @@ class CompressedSparseAttention(nn.Module):
         kv_full = kv.squeeze(1)
         kv_full = kv_full.transpose(0, 1).contiguous()
         window_idxs = _window_topk_indices(
-            batch,
-            seq_len,
-            self.config.sliding_window,
-            device=x.device,
+            batch, seq_len, self.config.sliding_window, device=x.device
         )
 
         compressed = None
         if self.compressor is not None and self.compress_ratio > 1:
             compressed = self.compressor(
-                x,
-                position_ids=position_ids,
-                rope_theta=self.config.compress_rope_theta,
+                x, position_ids=position_ids, rope_theta=self.config.compress_rope_theta
             )
             if compressed is not None:
                 compressed_kv = compressed.squeeze(1)
-                kv_full = torch.cat([kv_full, compressed_kv.transpose(0, 1).contiguous()], dim=0)
+                kv_full = torch.cat(
+                    [kv_full, compressed_kv.transpose(0, 1).contiguous()], dim=0
+                )
 
         if compressed is not None:
             n_compressed = compressed.size(2)
@@ -597,20 +624,16 @@ class CompressedSparseAttention(nn.Module):
             )
         else:
             flat_idxs, _flat_tlen = dsa_kernels.build_flat_topk_idxs(
-                window_idxs,
-                batch_size=batch,
-                seqlen_kv=kv_full.size(0),
+                window_idxs, batch_size=batch, seqlen_kv=kv_full.size(0)
             )
 
         out = dsa_kernels.dsa_sparse_attn(
-            query,
-            kv_full,
-            self.sinks.float(),
-            flat_idxs,
-            self.head_dim**-0.5,
+            query, kv_full, self.sinks.float(), flat_idxs, self.head_dim**-0.5
         )
         context = (
-            out.view(seq_len, batch, self.num_heads, self.head_dim).permute(1, 2, 0, 3).contiguous()
+            out.view(seq_len, batch, self.num_heads, self.head_dim)
+            .permute(1, 2, 0, 3)
+            .contiguous()
         )
         return self._project_context(context, cos, sin)
 
@@ -627,7 +650,9 @@ class CompressedSparseAttention(nn.Module):
         attention_mask: torch.Tensor | None,
     ) -> torch.Tensor:
         if self.ps.cp_size != 1:
-            raise NotImplementedError("DeepSeek V4 fused DSA path currently supports CP=1 only.")
+            raise NotImplementedError(
+                "DeepSeek V4 fused DSA path currently supports CP=1 only."
+            )
         if attention_mask is not None:
             raise NotImplementedError(
                 "DeepSeek V4 fused DSA path currently supports causal masking only."
@@ -652,17 +677,15 @@ class CompressedSparseAttention(nn.Module):
             kv = torch.nn.functional.pad(kv, (0, 0, 0, pad))
         batch, seq_len, _ = x.shape
         compressed = self.compressor(
-            x,
-            position_ids=position_ids,
-            rope_theta=self.config.compress_rope_theta,
+            x, position_ids=position_ids, rope_theta=self.config.compress_rope_theta
         )
         index_comp = self.indexer.compressor(
-            x,
-            position_ids=position_ids,
-            rope_theta=self.config.compress_rope_theta,
+            x, position_ids=position_ids, rope_theta=self.config.compress_rope_theta
         )
         if compressed is None or index_comp is None:
-            raise RuntimeError("DeepSeek V4 fused DSA requires at least one compressed KV entry.")
+            raise RuntimeError(
+                "DeepSeek V4 fused DSA requires at least one compressed KV entry."
+            )
         compressed_kv = compressed.squeeze(1)
         index_k = index_comp.squeeze(1).transpose(0, 1).contiguous()
         kv_full = torch.cat([kv.squeeze(1), compressed_kv], dim=1)
@@ -681,11 +704,16 @@ class CompressedSparseAttention(nn.Module):
             batch, seq_len, self.indexer.index_n_heads, self.indexer.index_head_dim
         )
         q_indexer = q_indexer.transpose(1, 2)
-        q_indexer = apply_partial_rope(q_indexer, idx_cos, idx_sin, self.indexer.rope_head_dim)
+        q_indexer = apply_partial_rope(
+            q_indexer, idx_cos, idx_sin, self.indexer.rope_head_dim
+        )
         q_indexer = rotate_activation(q_indexer)
         q_indexer = q_indexer.transpose(1, 2).transpose(0, 1).contiguous()
         weights_indexer = (
-            (self.indexer.weights_proj(x).to(dtype=x.dtype) * (self.indexer.index_n_heads**-0.5))
+            (
+                self.indexer.weights_proj(x).to(dtype=x.dtype)
+                * (self.indexer.index_n_heads**-0.5)
+            )
             .transpose(0, 1)
             .contiguous()
         )
@@ -693,10 +721,7 @@ class CompressedSparseAttention(nn.Module):
         if indexer_topk <= 0:
             raise RuntimeError("DeepSeek V4 fused DSA requires positive indexer_topk.")
         window_idxs = _window_topk_indices(
-            batch,
-            seq_len,
-            self.config.sliding_window,
-            device=x.device,
+            batch, seq_len, self.config.sliding_window, device=x.device
         )
         query = q.transpose(1, 2).transpose(0, 1).contiguous()
         sink = self.sinks.float()
@@ -705,10 +730,7 @@ class CompressedSparseAttention(nn.Module):
             indexer_loss_coeff = 0.0
             fused_q_indexer, fused_index_k, fused_weights_indexer = (
                 _prepare_indexer_inputs_for_fused_loss(
-                    q_indexer,
-                    index_k,
-                    weights_indexer,
-                    loss_coeff=indexer_loss_coeff,
+                    q_indexer, index_k, weights_indexer, loss_coeff=indexer_loss_coeff
                 )
             )
             out, _indexer_loss = dsa_kernels.fused_indexer_sparse_attn(
@@ -738,9 +760,7 @@ class CompressedSparseAttention(nn.Module):
                 indexer_softmax_scale=self.indexer.softmax_scale,
             )
             topk_indices = torch.where(
-                topk_indices >= 0,
-                topk_indices + seq_len,
-                topk_indices,
+                topk_indices >= 0, topk_indices + seq_len, topk_indices
             ).to(torch.int32)
             flat_idxs, flat_tlen = dsa_kernels.build_flat_topk_idxs(
                 window_idxs,
@@ -759,7 +779,9 @@ class CompressedSparseAttention(nn.Module):
             )
 
         context = (
-            out.view(seq_len, batch, self.num_heads, self.head_dim).permute(1, 2, 0, 3).contiguous()
+            out.view(seq_len, batch, self.num_heads, self.head_dim)
+            .permute(1, 2, 0, 3)
+            .contiguous()
         )
         if pad:
             context = context[:, :, :orig_seq_len, :].contiguous()

--- a/experimental/lite/megatron/lite/primitive/modules/attention/csa.py
+++ b/experimental/lite/megatron/lite/primitive/modules/attention/csa.py
@@ -210,6 +210,47 @@ def _window_topk_indices(
     return indices.unsqueeze(0).expand(batch, -1, -1).to(torch.int32)
 
 
+def _mask_compressed_scores_with_indexer(
+    compressed_scores: torch.Tensor,
+    index_scores: torch.Tensor,
+    index_topk: int,
+) -> torch.Tensor:
+    """Apply the Lightning Indexer's selection as a pure block mask.
+
+    The released DSv4 reference uses indexer scores only to select compressed
+    KV blocks. They are not an additive attention bias; selected logits remain
+    the ordinary scaled QK scores.
+    """
+
+    topk = min(int(index_topk), index_scores.size(-1))
+    if topk <= 0:
+        raise ValueError(f"DSv4 index_topk must be positive, got {index_topk}.")
+    topk_indices = index_scores.topk(topk, dim=-1).indices
+    topk_mask = torch.zeros_like(index_scores, dtype=torch.bool)
+    topk_mask.scatter_(-1, topk_indices, True)
+    return compressed_scores.masked_fill(~topk_mask.unsqueeze(1), -float("inf"))
+
+
+def _prepare_indexer_inputs_for_fused_loss(
+    q_indexer: torch.Tensor,
+    k_indexer: torch.Tensor,
+    weights: torch.Tensor,
+    *,
+    loss_coeff: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Keep a zero-loss selector out of autograd and optimizer weight decay.
+
+    Torch ``topk`` is non-differentiable, so the eager CSA path leaves these
+    gradients as ``None``.  The fused autograd wrapper returns explicit zero
+    tensors when ``loss_coeff == 0``; without detaching, AdamW would therefore
+    decay indexer parameters only for the fused backend.
+    """
+
+    if loss_coeff > 0:
+        return q_indexer, k_indexer, weights
+    return q_indexer.detach(), k_indexer.detach(), weights.detach()
+
+
 def _load_dsa_kernels():
     from megatron.lite.primitive.kernels import dsa_kernels
 
@@ -426,6 +467,11 @@ class CompressedSparseAttention(nn.Module):
                         .transpose(1, 2)
                     )
                     q_idx = apply_partial_rope(q_idx, idx_cos, idx_sin, self.indexer.rope_head_dim)
+                    # The indexer compressor stores Hadamard-rotated keys for
+                    # the fused kernel.  Rotate the eager query as well: an
+                    # orthonormal transform preserves q·k only when applied to
+                    # both operands.  The fused path below already does this.
+                    q_idx = rotate_activation(q_idx)
                     index_weights = (
                         self.indexer.weights_proj(x).float()
                         * (self.indexer.index_n_heads**-0.5)
@@ -442,13 +488,10 @@ class CompressedSparseAttention(nn.Module):
                         ratio=self.compress_ratio,
                     )
                     index_scores = index_scores.masked_fill(~index_valid, -float("inf"))
-                    topk = min(self.indexer.index_topk, index_scores.size(-1))
-                    topk_indices = index_scores.topk(topk, dim=-1).indices
-                    topk_mask = torch.zeros_like(index_scores, dtype=torch.bool)
-                    topk_mask.scatter_(-1, topk_indices, True)
-                    compressed_scores = compressed_scores + index_scores.unsqueeze(1)
-                    compressed_scores = compressed_scores.masked_fill(
-                        ~topk_mask.unsqueeze(1), -float("inf")
+                    compressed_scores = _mask_compressed_scores_with_indexer(
+                        compressed_scores,
+                        index_scores,
+                        self.indexer.index_topk,
                     )
             score_parts.append(compressed_scores)
             value_parts.append(compressed_values)
@@ -659,19 +702,28 @@ class CompressedSparseAttention(nn.Module):
         sink = self.sinks.float()
 
         if self.training and torch.is_grad_enabled():
+            indexer_loss_coeff = 0.0
+            fused_q_indexer, fused_index_k, fused_weights_indexer = (
+                _prepare_indexer_inputs_for_fused_loss(
+                    q_indexer,
+                    index_k,
+                    weights_indexer,
+                    loss_coeff=indexer_loss_coeff,
+                )
+            )
             out, _indexer_loss = dsa_kernels.fused_indexer_sparse_attn(
                 query,
                 kv_full,
                 sink,
                 window_idxs,
-                q_indexer,
-                index_k,
-                weights_indexer,
+                fused_q_indexer,
+                fused_index_k,
+                fused_weights_indexer,
                 indexer_topk,
                 self.compress_ratio,
                 self.head_dim**-0.5,
                 self.indexer.softmax_scale,
-                0.0,
+                indexer_loss_coeff,
                 sparse_loss=False,
                 kv_offset=seq_len,
                 calculate_per_token_loss=False,

--- a/experimental/lite/megatron/lite/primitive/modules/attention/dsa.py
+++ b/experimental/lite/megatron/lite/primitive/modules/attention/dsa.py
@@ -7,8 +7,8 @@ keep model config classes out of the primitive layer.
 
 from __future__ import annotations
 
-from collections.abc import Hashable
-from typing import TYPE_CHECKING
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Hashable
 
 import torch
 import torch.nn as nn
@@ -29,7 +29,9 @@ if TYPE_CHECKING:
 
 def _fused_indexer_sparse_attn(*args, value_dim: int | None = None, **kwargs):
     try:
-        return _dsa_kernels.fused_indexer_sparse_attn(*args, value_dim=value_dim, **kwargs)
+        return _dsa_kernels.fused_indexer_sparse_attn(
+            *args, value_dim=value_dim, **kwargs
+        )
     except TypeError as exc:
         if "value_dim" not in str(exc):
             raise
@@ -65,7 +67,9 @@ class DSAIndexerLossAutoScaler(torch.autograd.Function):
                 1.0, device=indexer_loss.device
             )
         indexer_loss_backward_scale = DSAIndexerLossAutoScaler.main_loss_backward_scale
-        scaled_indexer_loss_grad = torch.ones_like(indexer_loss) * indexer_loss_backward_scale
+        scaled_indexer_loss_grad = (
+            torch.ones_like(indexer_loss) * indexer_loss_backward_scale
+        )
         return grad_output, scaled_indexer_loss_grad
 
     @staticmethod
@@ -110,12 +114,19 @@ def rotate_activation(x: torch.Tensor) -> torch.Tensor:
 
 
 def build_rope_cache(
-    *, dim: int, max_position_embeddings: int, rope_theta: float, device: torch.device | None = None
+    *,
+    dim: int,
+    max_position_embeddings: int,
+    rope_theta: float,
+    device: torch.device | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     inv_freq = 1.0 / (
-        rope_theta ** (torch.arange(0, dim, 2, dtype=torch.float32, device=device) / dim)
+        rope_theta
+        ** (torch.arange(0, dim, 2, dtype=torch.float32, device=device) / dim)
     )
-    positions = torch.arange(max_position_embeddings, dtype=torch.float32, device=device)
+    positions = torch.arange(
+        max_position_embeddings, dtype=torch.float32, device=device
+    )
     freqs = torch.outer(positions, inv_freq)
     return freqs.cos(), freqs.sin()
 
@@ -126,13 +137,22 @@ def build_rotary_embeddings(
     device = position_ids.device
     inv_freq = 1.0 / (
         rope_theta
-        ** (torch.arange(0, dim, 2, dtype=torch.int64, device=device).to(torch.float32) / dim)
+        ** (
+            torch.arange(0, dim, 2, dtype=torch.int64, device=device).to(torch.float32)
+            / dim
+        )
     )
-    inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1)
+    inv_freq_expanded = (
+        inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1)
+    )
     position_ids_expanded = position_ids[:, None, :].float()
-    device_type = device.type if isinstance(device.type, str) and device.type != "mps" else "cpu"
+    device_type = (
+        device.type if isinstance(device.type, str) and device.type != "mps" else "cpu"
+    )
     with torch.autocast(device_type=device_type, enabled=False):
-        freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
+        freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(
+            1, 2
+        )
         emb = torch.cat((freqs, freqs), dim=-1)
         cos = emb.cos()
         sin = emb.sin()
@@ -147,10 +167,42 @@ def rotate_half(x: torch.Tensor) -> torch.Tensor:
 
 
 def apply_rotary_pos_emb(
-    x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor, *, unsqueeze_dim: int
+    x: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    *,
+    unsqueeze_dim: int,
+    mla_interleaved: bool = False,
 ) -> torch.Tensor:
+    """Apply half-split or MLA-style interleaved RoPE.
+
+    MLA checkpoints lay each frequency pair out as adjacent even/odd values.
+    The reference implementation rotates those pairs and returns the first
+    value from every pair followed by the second value from every pair.  This
+    is deliberately different from merely applying ``rotate_half`` to the
+    checkpoint layout.
+
+    ``mla_interleaved=False`` retains the original half-split implementation
+    byte-for-byte for GLM-5.1 and other existing callers.
+    """
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
+    if mla_interleaved:
+        if x.shape[-1] % 2:
+            raise ValueError(
+                "MLA-style interleaved RoPE requires an even rotary dimension, "
+                f"got {x.shape[-1]}."
+            )
+        # ``cos``/``sin`` come from cat(freqs, freqs); one angle is shared by
+        # each adjacent even/odd pair in the checkpoint layout.
+        pair_dim = x.shape[-1] // 2
+        cos = cos[..., :pair_dim]
+        sin = sin[..., :pair_dim]
+        x_even = x[..., 0::2]
+        x_odd = x[..., 1::2]
+        return torch.cat(
+            (x_even * cos - x_odd * sin, x_odd * cos + x_even * sin), dim=-1
+        )
     return (x * cos) + (rotate_half(x) * sin)
 
 
@@ -208,7 +260,9 @@ def _rotary_embeddings_from_cache(
     return cos.to(dtype=dtype), sin.to(dtype=dtype)
 
 
-def _all_gather_cp(tensor: torch.Tensor, *, cp_size: int, cp_group) -> list[torch.Tensor]:
+def _all_gather_cp(
+    tensor: torch.Tensor, *, cp_size: int, cp_group
+) -> list[torch.Tensor]:
     if cp_size <= 1:
         return [tensor]
     if cp_group is None:
@@ -218,7 +272,9 @@ def _all_gather_cp(tensor: torch.Tensor, *, cp_size: int, cp_group) -> list[torc
     return list(all_gather(tensor.contiguous(), group=cp_group))
 
 
-def is_dsa_skip_topk_layer(layer_number: int, skip_topk_offset: int, topk_freq: int) -> bool:
+def is_dsa_skip_topk_layer(
+    layer_number: int, skip_topk_offset: int, topk_freq: int
+) -> bool:
     """Return whether a 1-indexed layer reuses a previous DSA indexer top-k."""
     if layer_number < 1:
         raise ValueError(f"layer_number must be >= 1, got {layer_number}")
@@ -231,7 +287,9 @@ def is_dsa_skip_topk_layer(layer_number: int, skip_topk_offset: int, topk_freq: 
     return (max(layer_number - skip_topk_offset, 0) % topk_freq) != 0
 
 
-def source_dsa_compute_layer(layer_number: int, skip_topk_offset: int, topk_freq: int) -> int:
+def source_dsa_compute_layer(
+    layer_number: int, skip_topk_offset: int, topk_freq: int
+) -> int:
     """Return the 1-indexed full/indexer layer used by ``layer_number``."""
     if not is_dsa_skip_topk_layer(layer_number, skip_topk_offset, topk_freq):
         return layer_number
@@ -244,36 +302,61 @@ def source_dsa_compute_layer(layer_number: int, skip_topk_offset: int, topk_freq
     return source_layer
 
 
-def dsa_indexer_type_for_layer(layer_number: int, skip_topk_offset: int, topk_freq: int) -> str:
-    return "shared" if is_dsa_skip_topk_layer(layer_number, skip_topk_offset, topk_freq) else "full"
+def dsa_indexer_type_for_layer(
+    layer_number: int, skip_topk_offset: int, topk_freq: int
+) -> str:
+    return (
+        "shared"
+        if is_dsa_skip_topk_layer(layer_number, skip_topk_offset, topk_freq)
+        else "full"
+    )
 
 
 class DSAIndexShareState:
-    """Per-forward top-k holder for DSA cross-layer IndexShare.
+    """Per-forward, bounded top-k holder for DSA cross-layer IndexShare.
 
-    Only one source layer is resident on GPU at a time.  When activation
-    checkpointing needs old source groups during backward recomputation, they
-    are retained on CPU and paged back one group at a time.  This keeps the GPU
-    working set bounded instead of letting checkpoint closures retain every
-    source layer's ``[B, S, topk]`` tensor.
+    ``consumer_counts`` maps each 1-indexed full/source layer to the number of
+    shared-layer executions that consume its top-k indices. Each packed segment
+    gets an independent cache entry and consumer count. The final consumer
+    removes that segment's entry immediately.
     """
 
-    def __init__(self, *, retain_for_recompute: bool = True):
-        self.retain_for_recompute = retain_for_recompute
-        self._resident_source_layer: int | None = None
-        self._resident_topk_by_layer: dict[
-            tuple[int, Hashable | None], torch.Tensor
-        ] = {}
-        self._cpu_topk_by_layer: dict[
-            tuple[int, Hashable | None], torch.Tensor
-        ] = {}
-        self._sealed = False
+    def __init__(self, consumer_counts: Mapping[int, int] | None = None):
+        consumer_counts = {} if consumer_counts is None else consumer_counts
+        self._consumer_counts: dict[int, int] = {}
+        for layer_number, consumer_count in consumer_counts.items():
+            if layer_number < 1:
+                raise ValueError(
+                    f"DSA IndexShare source layer must be >= 1, got {layer_number}"
+                )
+            if consumer_count < 0:
+                raise ValueError(
+                    "DSA IndexShare consumer count must be non-negative, got "
+                    f"{consumer_count} for source layer {layer_number}"
+                )
+            if consumer_count:
+                self._consumer_counts[layer_number] = consumer_count
+        self._topk_by_layer: dict[tuple[int, Hashable | None], torch.Tensor] = {}
+        self._remaining_consumers: dict[tuple[int, Hashable | None], int] = {}
+        self._completed_sources: set[int] = set()
 
     @staticmethod
     def _key(
         layer_number: int, sequence_key: Hashable | None
     ) -> tuple[int, Hashable | None]:
         return layer_number, sequence_key
+
+    def needs_topk(self, source_layer: int) -> bool:
+        """Return whether ``source_layer`` has any local shared consumers."""
+        return (
+            self._consumer_counts.get(source_layer, 0) > 0
+            and source_layer not in self._completed_sources
+        )
+
+    @property
+    def cached_tensor_count(self) -> int:
+        """Number of currently live top-k tensors."""
+        return len(self._topk_by_layer)
 
     def save_topk(
         self,
@@ -282,40 +365,20 @@ class DSAIndexShareState:
         *,
         sequence_key: Hashable | None = None,
     ) -> None:
-        if self._sealed:
-            # A full source layer is being recomputed in backward.  Its shared
-            # consumers have already run in reverse order, so no later layer
-            # needs the newly produced top-k.
-            if self._resident_source_layer == layer_number:
-                self._resident_topk_by_layer.clear()
-                self._resident_source_layer = None
-            return
-
-        if self._resident_source_layer not in (None, layer_number):
-            self._evict_resident(retain=self.retain_for_recompute)
-        self._resident_source_layer = layer_number
-        self._resident_topk_by_layer[self._key(layer_number, sequence_key)] = (
-            topk_indices.detach()
-        )
-
-    def finish_forward(self) -> None:
-        """Evict the final GPU source group before returning model outputs."""
-        if self._sealed:
-            return
-        self._evict_resident(retain=self.retain_for_recompute)
-        self._sealed = True
-
-    def _evict_resident(self, *, retain: bool) -> None:
-        if retain:
-            for key, topk in self._resident_topk_by_layer.items():
-                self._cpu_topk_by_layer[key] = topk.detach().to(device="cpu")
-        self._resident_topk_by_layer.clear()
-        self._resident_source_layer = None
-
-    @property
-    def _topk_by_layer(self) -> dict[tuple[int, Hashable | None], torch.Tensor]:
-        """Private compatibility view used by focused validation harnesses."""
-        return {**self._cpu_topk_by_layer, **self._resident_topk_by_layer}
+        consumer_count = self._consumer_counts.get(layer_number, 0)
+        if consumer_count == 0:
+            raise AssertionError(
+                "DSA IndexShare attempted to save top-k indices for source layer "
+                f"{layer_number}, but no shared consumer is registered."
+            )
+        key = self._key(layer_number, sequence_key)
+        if key in self._topk_by_layer:
+            raise AssertionError(
+                "DSA IndexShare attempted to overwrite live top-k indices for "
+                f"cache key {key}."
+            )
+        self._topk_by_layer[key] = topk_indices.detach()
+        self._remaining_consumers[key] = consumer_count
 
     def get_topk(
         self,
@@ -323,12 +386,9 @@ class DSAIndexShareState:
         source_layer: int,
         *,
         sequence_key: Hashable | None = None,
-        device: torch.device | None = None,
     ) -> torch.Tensor:
         key = self._key(source_layer, sequence_key)
-        if key in self._resident_topk_by_layer:
-            return self._resident_topk_by_layer[key]
-        if key not in self._cpu_topk_by_layer:
+        if key not in self._topk_by_layer:
             available = sorted(self._topk_by_layer)
             raise AssertionError(
                 "DSA IndexShare shared layer "
@@ -337,18 +397,15 @@ class DSAIndexShareState:
                 "Cross-PP top-k sharing is not supported. "
                 f"Available cache keys: {available}."
             )
-
-        if self._resident_source_layer != source_layer:
-            # During backward, groups are consumed in reverse order.  The CPU
-            # copy already remains authoritative, so dropping the previous GPU
-            # group does not require another device-to-host transfer.
-            self._resident_topk_by_layer.clear()
-            self._resident_source_layer = source_layer
-        topk = self._cpu_topk_by_layer[key]
-        if device is not None and topk.device != device:
-            topk = topk.to(device=device)
-        self._resident_topk_by_layer[key] = topk
-        return topk
+        topk_indices = self._topk_by_layer[key]
+        remaining = self._remaining_consumers[key] - 1
+        if remaining == 0:
+            del self._topk_by_layer[key]
+            del self._remaining_consumers[key]
+            self._completed_sources.add(source_layer)
+        else:
+            self._remaining_consumers[key] = remaining
+        return topk_indices
 
 
 def validate_dsa_index_share_pipeline_split(
@@ -367,11 +424,30 @@ def validate_dsa_index_share_pipeline_split(
         if indexer_types is not None and layer_idx < len(indexer_types):
             indexer_type = indexer_types[layer_idx]
         else:
-            indexer_type = dsa_indexer_type_for_layer(layer_idx + 1, skip_topk_offset, topk_freq)
+            indexer_type = dsa_indexer_type_for_layer(
+                layer_idx + 1, skip_topk_offset, topk_freq
+            )
         if indexer_type != "shared":
             continue
 
-        source_idx = source_dsa_compute_layer(layer_idx + 1, skip_topk_offset, topk_freq) - 1
+        if indexer_types is not None and layer_idx < len(indexer_types):
+            source_idx = next(
+                (
+                    candidate
+                    for candidate in range(layer_idx - 1, -1, -1)
+                    if indexer_types[candidate] == "full"
+                ),
+                None,
+            )
+            if source_idx is None:
+                raise ValueError(
+                    "DSA IndexShare schedule makes layer "
+                    f"{layer_idx} shared before any full source layer."
+                )
+        else:
+            source_idx = (
+                source_dsa_compute_layer(layer_idx + 1, skip_topk_offset, topk_freq) - 1
+            )
         if source_idx not in positions:
             raise ValueError(
                 "DSA IndexShare cannot cross pipeline stages: layer "
@@ -398,7 +474,7 @@ class DSAIndexer(nn.Module):
         index_n_heads: int,
         index_head_dim: int,
         index_topk: int,
-        rope_interleaved: bool = True,
+        rope_interleaved: bool = False,
         layer_norm_eps: float = 1e-5,
         rope_first: bool = False,
         use_hadamard: bool = True,
@@ -438,20 +514,45 @@ class DSAIndexer(nn.Module):
             )
         batch, seq_len, _ = x.shape
         cos, sin = _rotary_embeddings_from_cache(
-            cos, sin, position_ids, device=x.device, dtype=x.dtype, dim=self.qk_rope_head_dim
+            cos,
+            sin,
+            position_ids,
+            device=x.device,
+            dtype=x.dtype,
+            dim=self.qk_rope_head_dim,
         )
 
         q = self.wq_b(q_resid).view(batch, seq_len, self.num_heads, self.head_dim)
 
         k = self.k_norm(self.wk(x))
         if self.rope_first:
-            q_pe, q_nope = torch.split(q, [self.qk_rope_head_dim, self.qk_nope_head_dim], dim=-1)
-            k_pe, k_nope = torch.split(k, [self.qk_rope_head_dim, self.qk_nope_head_dim], dim=-1)
+            q_pe, q_nope = torch.split(
+                q, [self.qk_rope_head_dim, self.qk_nope_head_dim], dim=-1
+            )
+            k_pe, k_nope = torch.split(
+                k, [self.qk_rope_head_dim, self.qk_nope_head_dim], dim=-1
+            )
         else:
-            q_nope, q_pe = torch.split(q, [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
-            k_nope, k_pe = torch.split(k, [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
-        q_pe = apply_rotary_pos_emb(q_pe, cos, sin, unsqueeze_dim=2)
-        k_pe = apply_rotary_pos_emb(k_pe.unsqueeze(2), cos, sin, unsqueeze_dim=2)
+            q_nope, q_pe = torch.split(
+                q, [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1
+            )
+            k_nope, k_pe = torch.split(
+                k, [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1
+            )
+        q_pe = apply_rotary_pos_emb(
+            q_pe,
+            cos,
+            sin,
+            unsqueeze_dim=2,
+            mla_interleaved=self.rope_interleaved,
+        )
+        k_pe = apply_rotary_pos_emb(
+            k_pe.unsqueeze(2),
+            cos,
+            sin,
+            unsqueeze_dim=2,
+            mla_interleaved=self.rope_interleaved,
+        )
         k_pe = k_pe.squeeze(2)
 
         if self.rope_first:
@@ -517,7 +618,7 @@ class DynamicSparseAttention(nn.Module):
         index_head_dim: int,
         index_topk: int,
         rms_norm_eps: float,
-        rope_interleaved: bool = True,
+        rope_interleaved: bool = False,
         latent_rms_norm_eps: float | None = None,
         indexer_layer_norm_eps: float = 1e-5,
         indexer_rope_interleaved: bool | None = None,
@@ -527,6 +628,8 @@ class DynamicSparseAttention(nn.Module):
         index_topk_freq: int = 1,
         index_skip_topk_offset: int = 0,
         indexer_type: str | None = None,
+        index_share_enabled: bool | None = None,
+        index_share_source_layer: int | None = None,
         indexer_loss_coeff: float = 0.0,
         indexer_use_sparse_loss: bool = False,
         calculate_per_token_loss: bool = False,
@@ -559,40 +662,73 @@ class DynamicSparseAttention(nn.Module):
         self.layer_number = 1 if layer_number is None else layer_number
         self.index_topk_freq = index_topk_freq
         self.index_skip_topk_offset = index_skip_topk_offset
-        inferred_indexer_type = dsa_indexer_type_for_layer(
-            self.layer_number, self.index_skip_topk_offset, self.index_topk_freq
-        )
         if indexer_type is None:
-            indexer_type = inferred_indexer_type
+            indexer_type = dsa_indexer_type_for_layer(
+                self.layer_number, self.index_skip_topk_offset, self.index_topk_freq
+            )
         if indexer_type not in {"full", "shared"}:
-            raise ValueError(f"indexer_type must be 'full' or 'shared', got {indexer_type!r}")
-        if indexer_type != inferred_indexer_type:
             raise ValueError(
-                f"indexer_type={indexer_type!r} for layer {self.layer_number} does not match "
-                f"IndexShare schedule {inferred_indexer_type!r}."
+                f"indexer_type must be 'full' or 'shared', got {indexer_type!r}"
             )
         self.indexer_type = indexer_type
-        self.index_share_enabled = self.index_topk_freq > 1
-        self.skip_topk = indexer_type == "shared"
-        self.index_share_source_layer = source_dsa_compute_layer(
-            self.layer_number, self.index_skip_topk_offset, self.index_topk_freq
+        self.index_share_enabled = (
+            self.index_topk_freq > 1 or indexer_type == "shared"
+            if index_share_enabled is None
+            else bool(index_share_enabled)
         )
-        latent_rms_norm_eps = rms_norm_eps if latent_rms_norm_eps is None else latent_rms_norm_eps
+        self.skip_topk = indexer_type == "shared"
+        if self.skip_topk and not self.index_share_enabled:
+            raise ValueError("A shared DSA layer requires index_share_enabled=True")
+        if (
+            not self.skip_topk
+            and self.cp_size > 1
+            and self.calculate_per_token_loss
+            and self.indexer_loss_coeff > 0
+        ):
+            raise NotImplementedError(
+                "GLM5 DSA indexer auxiliary loss with context parallelism and "
+                "calculate_per_token_loss=True is not supported until the global-token "
+                "divisor is wired through the replicated-gradient reduction."
+            )
+        if self.skip_topk:
+            if index_share_source_layer is None:
+                index_share_source_layer = source_dsa_compute_layer(
+                    self.layer_number, self.index_skip_topk_offset, self.index_topk_freq
+                )
+            if not 1 <= index_share_source_layer < self.layer_number:
+                raise ValueError(
+                    "A shared DSA layer requires an earlier 1-indexed source layer, got "
+                    f"source={index_share_source_layer}, layer={self.layer_number}."
+                )
+        else:
+            index_share_source_layer = self.layer_number
+        self.index_share_source_layer = index_share_source_layer
+        latent_rms_norm_eps = (
+            rms_norm_eps if latent_rms_norm_eps is None else latent_rms_norm_eps
+        )
         indexer_rope_interleaved = (
-            rope_interleaved if indexer_rope_interleaved is None else indexer_rope_interleaved
+            rope_interleaved
+            if indexer_rope_interleaved is None
+            else indexer_rope_interleaved
         )
 
         self.q_a_proj = nn.Linear(hidden_size, q_lora_rank, bias=False)
         self.q_a_layernorm = RMSNorm(q_lora_rank, eps=latent_rms_norm_eps)
-        self.q_b_proj = nn.Linear(q_lora_rank, num_attention_heads * self.qk_head_dim, bias=False)
+        self.q_b_proj = nn.Linear(
+            q_lora_rank, num_attention_heads * self.qk_head_dim, bias=False
+        )
         self.kv_a_proj_with_mqa = nn.Linear(
             hidden_size, kv_lora_rank + qk_rope_head_dim, bias=False
         )
         self.kv_a_layernorm = RMSNorm(kv_lora_rank, eps=latent_rms_norm_eps)
         self.kv_b_proj = nn.Linear(
-            kv_lora_rank, num_attention_heads * (qk_nope_head_dim + v_head_dim), bias=False
+            kv_lora_rank,
+            num_attention_heads * (qk_nope_head_dim + v_head_dim),
+            bias=False,
         )
-        self.o_proj = nn.Linear(num_attention_heads * v_head_dim, hidden_size, bias=False)
+        self.o_proj = nn.Linear(
+            num_attention_heads * v_head_dim, hidden_size, bias=False
+        )
         self.indexer: DSAIndexer | None = None
         if not self.skip_topk:
             self.indexer = DSAIndexer(
@@ -631,8 +767,36 @@ class DynamicSparseAttention(nn.Module):
             )
         if packed_seq_params is not None:
             if self.cp_size > 1:
-                x, position_ids = self._gather_packed_cp_inputs(x, position_ids, packed_seq_params)
-                cos, sin = self._gather_packed_cp_rotary(cos, sin, packed_seq_params, x.device)
+                local_seq = x.shape[1]
+                full_seq = int(
+                    self._packed_cu_seqlens(packed_seq_params, x.device)[-1].item()
+                )
+                self._validate_cp_collective_input_metadata(
+                    x,
+                    position_ids,
+                    cos,
+                    sin,
+                    local_seq=local_seq,
+                    full_seq=full_seq,
+                    packed=True,
+                )
+                if local_seq * self.cp_size != full_seq:
+                    raise ValueError(
+                        "GLM5 packed DynamicSparseAttention CP shards must cover "
+                        "the padded packed sequence exactly: "
+                        f"local_seq={local_seq}, cp_size={self.cp_size}, "
+                        f"padded_full_seq={full_seq}."
+                    )
+                x, position_ids = self._gather_packed_cp_inputs(
+                    x, position_ids, packed_seq_params
+                )
+                cos, sin = self._gather_packed_cp_rotary(
+                    cos,
+                    sin,
+                    packed_seq_params,
+                    x.device,
+                    local_seq=local_seq,
+                )
             out = self._forward_packed_full(
                 x,
                 cos,
@@ -644,7 +808,9 @@ class DynamicSparseAttention(nn.Module):
             if self.cp_size > 1:
                 out = split_packed_to_cp_local(
                     out,
-                    cu_seqlens_padded=self._packed_cu_seqlens(packed_seq_params, x.device),
+                    cu_seqlens_padded=self._packed_cu_seqlens(
+                        packed_seq_params, x.device
+                    ),
                     cp_size=self.cp_size,
                     cp_rank=self.cp_rank,
                     dim=1,
@@ -653,8 +819,25 @@ class DynamicSparseAttention(nn.Module):
 
         cp_restore = self.cp_size > 1
         if cp_restore:
+            local_seq = x.shape[1]
+            self._validate_cp_collective_input_metadata(
+                x,
+                position_ids,
+                cos,
+                sin,
+                local_seq=local_seq,
+                full_seq=local_seq * self.cp_size,
+                packed=False,
+            )
             x, position_ids, attention_mask = self._gather_cp_inputs(
                 x, position_ids, attention_mask
+            )
+            cos, sin = self._gather_cp_rotary(
+                cos,
+                sin,
+                local_seq=local_seq,
+                full_seq=x.shape[1],
+                device=x.device,
             )
 
         out = self._forward_dense_full(
@@ -675,6 +858,9 @@ class DynamicSparseAttention(nn.Module):
         index_share_state: DSAIndexShareState | None,
     ) -> torch.Tensor:
         cu_seqlens = self._packed_cu_seqlens(packed_seq_params, x.device)
+        true_cu_seqlens = self._packed_true_cu_seqlens(
+            packed_seq_params, cu_seqlens, x.device
+        )
         if position_ids.dim() == 1:
             position_ids = position_ids.unsqueeze(0)
         if position_ids.shape[-1] != x.shape[1]:
@@ -682,12 +868,51 @@ class DynamicSparseAttention(nn.Module):
                 "GLM5 packed DynamicSparseAttention position_ids must cover the reconstructed packed tokens, "
                 f"got {tuple(position_ids.shape)} for packed length {x.shape[1]}."
             )
+        total_tokens = x.shape[1]
+        packed_tokens = int(cu_seqlens[-1].item())
+        if packed_tokens != total_tokens:
+            raise ValueError(
+                "GLM5 packed DynamicSparseAttention cu_seqlens must cover the reconstructed "
+                f"packed tokens, got cu_seqlens[-1]={packed_tokens} for length {total_tokens}."
+            )
+        padded_lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+        true_lengths = true_cu_seqlens[1:] - true_cu_seqlens[:-1]
+        if (
+            int(cu_seqlens[0].item()) != 0
+            or int(true_cu_seqlens[0].item()) != 0
+            or torch.any(padded_lengths < 0)
+            or torch.any(true_lengths < 0)
+            or torch.any(true_lengths > padded_lengths)
+        ):
+            raise ValueError(
+                "GLM5 packed DynamicSparseAttention cumulative lengths must start at "
+                "zero, be monotonic, and keep every true length no larger than its "
+                "padded length."
+            )
+        has_alignment_padding = bool(torch.any(true_lengths != padded_lengths).item())
+        if has_alignment_padding and not self.skip_topk and self.indexer_loss_coeff > 0:
+            raise NotImplementedError(
+                "GLM5 packed DSA indexer auxiliary loss does not yet support THD "
+                "alignment padding: a query-valid mask must be wired into the fused "
+                "KL forward/backward before padded rows can be excluded safely."
+            )
+        total_true_tokens = int(true_cu_seqlens[-1].item())
         pieces = []
         for idx in range(int(cu_seqlens.numel()) - 1):
             start = int(cu_seqlens[idx].item())
             end = int(cu_seqlens[idx + 1].item())
             if end <= start:
                 continue
+            true_segment_len = int(true_lengths[idx].item())
+            indexer_loss_weight = (
+                1.0
+                if self.calculate_per_token_loss
+                else (
+                    float(true_segment_len) / float(total_true_tokens)
+                    if total_true_tokens > 0
+                    else 0.0
+                )
+            )
             seg_cos, seg_sin = self._slice_rotary_cache(cos, sin, start, end)
             pieces.append(
                 self._forward_dense_full(
@@ -697,6 +922,7 @@ class DynamicSparseAttention(nn.Module):
                     position_ids[:, start:end],
                     index_share_state=index_share_state,
                     index_share_cache_key=idx,
+                    indexer_loss_weight=indexer_loss_weight,
                 )
             )
         if pieces:
@@ -712,26 +938,54 @@ class DynamicSparseAttention(nn.Module):
         *,
         index_share_state: DSAIndexShareState | None = None,
         index_share_cache_key: Hashable | None = None,
+        indexer_loss_weight: float = 1.0,
     ) -> torch.Tensor:
+        if indexer_loss_weight < 0.0:
+            raise ValueError(
+                f"indexer_loss_weight must be non-negative, got {indexer_loss_weight}."
+            )
 
         batch, seq_len, _ = x.shape
         q_resid = self.q_a_layernorm(self.q_a_proj(x))
-        q = self.q_b_proj(q_resid).view(batch, seq_len, self.num_heads, self.qk_head_dim)
-        q_nope, q_pe = torch.split(q, [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
+        q = self.q_b_proj(q_resid).view(
+            batch, seq_len, self.num_heads, self.qk_head_dim
+        )
+        q_nope, q_pe = torch.split(
+            q, [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1
+        )
         cos, sin = _rotary_embeddings_from_cache(
-            cos, sin, position_ids, device=x.device, dtype=x.dtype, dim=self.qk_rope_head_dim
+            cos,
+            sin,
+            position_ids,
+            device=x.device,
+            dtype=x.dtype,
+            dim=self.qk_rope_head_dim,
         )
 
-        q_pe = apply_rotary_pos_emb(q_pe, cos, sin, unsqueeze_dim=2)
+        q_pe = apply_rotary_pos_emb(
+            q_pe,
+            cos,
+            sin,
+            unsqueeze_dim=2,
+            mla_interleaved=self.rope_interleaved,
+        )
         k_up_weight, v_up_weight = self._split_kv_b_weights()
         q_nope = torch.einsum("bshd,hdr->bshr", q_nope, k_up_weight)
         query_states = torch.cat([q_nope, q_pe], dim=-1).transpose(0, 1).contiguous()
 
         kv_latent, k_pe = torch.split(
-            self.kv_a_proj_with_mqa(x), [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1
+            self.kv_a_proj_with_mqa(x),
+            [self.kv_lora_rank, self.qk_rope_head_dim],
+            dim=-1,
         )
         kv_latent = self.kv_a_layernorm(kv_latent)
-        k_pe = apply_rotary_pos_emb(k_pe.unsqueeze(2), cos, sin, unsqueeze_dim=2).squeeze(2)
+        k_pe = apply_rotary_pos_emb(
+            k_pe.unsqueeze(2),
+            cos,
+            sin,
+            unsqueeze_dim=2,
+            mla_interleaved=self.rope_interleaved,
+        ).squeeze(2)
         kv_full = torch.cat([kv_latent, k_pe], dim=-1).transpose(0, 1).contiguous()
 
         topk_indices: torch.Tensor | None = None
@@ -739,13 +993,13 @@ class DynamicSparseAttention(nn.Module):
         if self.skip_topk:
             if index_share_state is None:
                 raise AssertionError(
-                    "DSA IndexShare shared layers require a per-forward " "DSAIndexShareState."
+                    "DSA IndexShare shared layers require a per-forward "
+                    "DSAIndexShareState."
                 )
             topk_indices = index_share_state.get_topk(
                 self.layer_number,
                 self.index_share_source_layer,
                 sequence_key=index_share_cache_key,
-                device=x.device,
             )
         else:
             assert self.indexer is not None
@@ -753,11 +1007,22 @@ class DynamicSparseAttention(nn.Module):
                 x.detach(), q_resid.detach(), cos, sin, position_ids
             )
         effective_indexer_topk = min(self.index_topk, seq_len)
+        share_topk_with_later_layers = (
+            index_share_state is not None
+            and index_share_state.needs_topk(self.layer_number)
+        )
 
         if self.training and torch.is_grad_enabled() and not self.skip_topk:
-            window_idxs = torch.empty(batch, seq_len, 0, device=x.device, dtype=torch.int32)
-            assert q_indexer is not None and k_indexer is not None and weights_indexer is not None
-            if self.index_share_enabled:
+            window_idxs = torch.empty(
+                batch, seq_len, 0, device=x.device, dtype=torch.int32
+            )
+            assert (
+                q_indexer is not None
+                and k_indexer is not None
+                and weights_indexer is not None
+            )
+            if share_topk_with_later_layers:
+                assert index_share_state is not None
                 out, indexer_loss, topk_indices = _fused_indexer_sparse_attn_with_topk(
                     query_states,
                     kv_full,
@@ -776,12 +1041,11 @@ class DynamicSparseAttention(nn.Module):
                     calculate_per_token_loss=self.calculate_per_token_loss,
                     value_dim=self.kv_lora_rank,
                 )
-                if index_share_state is not None:
-                    index_share_state.save_topk(
-                        self.layer_number,
-                        topk_indices,
-                        sequence_key=index_share_cache_key,
-                    )
+                index_share_state.save_topk(
+                    self.layer_number,
+                    topk_indices,
+                    sequence_key=index_share_cache_key,
+                )
             else:
                 out, indexer_loss = _fused_indexer_sparse_attn(
                     query_states,
@@ -802,11 +1066,15 @@ class DynamicSparseAttention(nn.Module):
                     value_dim=self.kv_lora_rank,
                 )
             if self.indexer_loss_coeff > 0:
+                if indexer_loss_weight != 1.0:
+                    indexer_loss = indexer_loss * indexer_loss_weight
                 out = DSAIndexerLossAutoScaler.apply(out, indexer_loss)
         else:
             if topk_indices is None:
                 assert (
-                    q_indexer is not None and k_indexer is not None and weights_indexer is not None
+                    q_indexer is not None
+                    and k_indexer is not None
+                    and weights_indexer is not None
                 )
                 topk_indices, _ = _dsa_kernels.indexer_topk(
                     q_indexer,
@@ -816,7 +1084,8 @@ class DynamicSparseAttention(nn.Module):
                     1,
                     indexer_softmax_scale=self.indexer_softmax_scale,
                 )
-                if self.index_share_enabled and index_share_state is not None:
+                if share_topk_with_later_layers:
+                    assert index_share_state is not None
                     index_share_state.save_topk(
                         self.layer_number,
                         topk_indices,
@@ -845,10 +1114,16 @@ class DynamicSparseAttention(nn.Module):
         kv_b = self.kv_b_proj.weight.view(
             self.num_heads, self.qk_nope_head_dim + self.v_head_dim, self.kv_lora_rank
         )
-        return (kv_b[:, : self.qk_nope_head_dim, :], kv_b[:, self.qk_nope_head_dim :, :])
+        return (
+            kv_b[:, : self.qk_nope_head_dim, :],
+            kv_b[:, self.qk_nope_head_dim :, :],
+        )
 
     def _gather_cp_inputs(
-        self, x: torch.Tensor, position_ids: torch.Tensor, attention_mask: torch.Tensor | None
+        self,
+        x: torch.Tensor,
+        position_ids: torch.Tensor,
+        attention_mask: torch.Tensor | None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
         local_batch, local_seq = x.shape[:2]
         x_parts = _all_gather_cp(x, cp_size=self.cp_size, cp_group=self.cp_group)
@@ -856,7 +1131,11 @@ class DynamicSparseAttention(nn.Module):
         full_seq = full_x.shape[1]
 
         full_position_ids = self._full_cp_position_ids(
-            position_ids, batch=local_batch, local_seq=local_seq, full_seq=full_seq, device=x.device
+            position_ids,
+            batch=local_batch,
+            local_seq=local_seq,
+            full_seq=full_seq,
+            device=x.device,
         )
         if attention_mask is not None:
             expected = (full_seq, full_seq)
@@ -866,6 +1145,66 @@ class DynamicSparseAttention(nn.Module):
                     f"full sequence {expected}, got {tuple(attention_mask.shape)}."
                 )
         return full_x, full_position_ids, attention_mask
+
+    def _validate_cp_collective_input_metadata(
+        self,
+        x: torch.Tensor,
+        position_ids: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        *,
+        local_seq: int,
+        full_seq: int,
+        packed: bool,
+    ) -> None:
+        """Keep rank-local representation choices from splitting CP collectives.
+
+        Position and rank-3 rotary tensors may be supplied in either CP-local or
+        reconstructed full-sequence form.  The later gather helpers necessarily
+        branch on that choice, so every CP rank must make the same choice.  A
+        fixed-size metadata exchange happens before any conditional gather and
+        turns mixed local/full inputs into a deterministic error on every rank
+        instead of leaving only a subset blocked in NCCL.
+        """
+
+        def shape_metadata(tensor: torch.Tensor) -> list[int]:
+            shape = list(tensor.shape)
+            if len(shape) > 4:
+                shape = shape[:4]
+            dtype_code = sum(
+                (index + 1) * ord(character)
+                for index, character in enumerate(str(tensor.dtype))
+            )
+            return [tensor.dim(), dtype_code, *shape, *([-1] * (4 - len(shape)))]
+
+        metadata = torch.tensor(
+            [
+                int(packed),
+                local_seq,
+                full_seq,
+                *shape_metadata(x),
+                *shape_metadata(position_ids),
+                *shape_metadata(cos),
+                *shape_metadata(sin),
+            ],
+            device=x.device,
+            dtype=torch.int64,
+        )
+        metadata_parts = _all_gather_cp(
+            metadata, cp_size=self.cp_size, cp_group=self.cp_group
+        )
+        if len(metadata_parts) != self.cp_size:
+            raise RuntimeError(
+                "GLM5 DynamicSparseAttention CP group size does not match cp_size: "
+                f"group returned {len(metadata_parts)} ranks, configured cp_size={self.cp_size}."
+            )
+        per_rank = [tuple(part.detach().cpu().tolist()) for part in metadata_parts]
+        if any(item != per_rank[0] for item in per_rank[1:]):
+            raise ValueError(
+                "GLM5 DynamicSparseAttention requires every CP rank to use the same "
+                "local/full position and rotary representation and matching tensor "
+                f"shapes; got per-rank metadata {per_rank}."
+            )
 
     def _full_cp_position_ids(
         self,
@@ -901,6 +1240,13 @@ class DynamicSparseAttention(nn.Module):
         local_seq = x.shape[1]
         cu_seqlens = self._packed_cu_seqlens(packed_seq_params, x.device)
         full_seq = int(cu_seqlens[-1].item())
+        if local_seq * self.cp_size != full_seq:
+            raise ValueError(
+                "GLM5 packed DynamicSparseAttention CP shards must cover the "
+                "padded packed sequence exactly: "
+                f"local_seq={local_seq}, cp_size={self.cp_size}, "
+                f"padded_full_seq={full_seq}."
+            )
         x_parts = _all_gather_cp(x, cp_size=self.cp_size, cp_group=self.cp_group)
         full_x = reconstruct_packed_from_cp_parts(
             x_parts, cu_seqlens_padded=cu_seqlens, cp_size=self.cp_size, dim=1
@@ -916,21 +1262,89 @@ class DynamicSparseAttention(nn.Module):
                 "GLM5 packed DynamicSparseAttention CP position_ids must be either local or full packed length, "
                 f"got {tuple(position_ids.shape)} for local_seq={local_seq}, full_seq={full_seq}."
             )
-        pos_parts = _all_gather_cp(position_ids, cp_size=self.cp_size, cp_group=self.cp_group)
+        pos_parts = _all_gather_cp(
+            position_ids, cp_size=self.cp_size, cp_group=self.cp_group
+        )
         full_position_ids = reconstruct_packed_from_cp_parts(
             pos_parts, cu_seqlens_padded=cu_seqlens, cp_size=self.cp_size, dim=1
         )
         return full_x, full_position_ids
 
-    def _gather_packed_cp_rotary(
-        self, cos: torch.Tensor, sin: torch.Tensor, packed_seq_params, device: torch.device
+    def _gather_cp_rotary(
+        self,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        *,
+        local_seq: int,
+        full_seq: int,
+        device: torch.device,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        if cos.dim() != 3 or sin.dim() != 3:
+        """Reconstruct non-packed rank-3 rotary tensors in zigzag CP order."""
+
+        if cos.dim() != sin.dim():
+            raise ValueError(
+                "GLM5 DynamicSparseAttention CP cos/sin ranks must match, "
+                f"got cos={tuple(cos.shape)}, sin={tuple(sin.shape)}."
+            )
+        if cos.dim() != 3:
+            return cos, sin
+        if cos.shape != sin.shape:
+            raise ValueError(
+                "GLM5 DynamicSparseAttention CP rank-3 cos/sin shapes must match, "
+                f"got cos={tuple(cos.shape)}, sin={tuple(sin.shape)}."
+            )
+        if cos.shape[1] == full_seq:
+            return cos, sin
+        if cos.shape[1] != local_seq:
+            raise ValueError(
+                "GLM5 DynamicSparseAttention CP rank-3 rotary tensors must cover "
+                "either the local or reconstructed full sequence, "
+                f"got {tuple(cos.shape)} for local_seq={local_seq}, full_seq={full_seq}."
+            )
+
+        cos_parts = _all_gather_cp(
+            cos.to(device=device), cp_size=self.cp_size, cp_group=self.cp_group
+        )
+        sin_parts = _all_gather_cp(
+            sin.to(device=device), cp_size=self.cp_size, cp_group=self.cp_group
+        )
+        return (
+            zigzag_reconstruct_from_cp_parts(cos_parts, seq_dim=1),
+            zigzag_reconstruct_from_cp_parts(sin_parts, seq_dim=1),
+        )
+
+    def _gather_packed_cp_rotary(
+        self,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        packed_seq_params,
+        device: torch.device,
+        *,
+        local_seq: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if cos.dim() != sin.dim():
+            raise ValueError(
+                "GLM5 packed DynamicSparseAttention CP cos/sin ranks must match, "
+                f"got cos={tuple(cos.shape)}, sin={tuple(sin.shape)}."
+            )
+        if cos.shape != sin.shape:
+            raise ValueError(
+                "GLM5 packed DynamicSparseAttention CP cos/sin shapes must match, "
+                f"got cos={tuple(cos.shape)}, sin={tuple(sin.shape)}."
+            )
+        if cos.dim() != 3:
             return cos, sin
         cu_seqlens = self._packed_cu_seqlens(packed_seq_params, device)
         full_seq = int(cu_seqlens[-1].item())
-        if cos.shape[1] == full_seq and sin.shape[1] == full_seq:
+        if cos.shape[1] == full_seq:
             return cos, sin
+        if cos.shape[1] != local_seq:
+            raise ValueError(
+                "GLM5 packed DynamicSparseAttention CP rank-3 rotary tensors "
+                "must cover either the local or padded full packed sequence, "
+                f"got {tuple(cos.shape)} for local_seq={local_seq}, "
+                f"padded_full_seq={full_seq}."
+            )
         cos_parts = _all_gather_cp(cos, cp_size=self.cp_size, cp_group=self.cp_group)
         sin_parts = _all_gather_cp(sin, cp_size=self.cp_size, cp_group=self.cp_group)
         full_cos = reconstruct_packed_from_cp_parts(
@@ -947,8 +1361,26 @@ class DynamicSparseAttention(nn.Module):
         if cu_seqlens is None:
             cu_seqlens = getattr(packed_seq_params, "cu_seqlens_q", None)
         if cu_seqlens is None:
-            raise ValueError("GLM5 packed DynamicSparseAttention requires packed cu_seqlens.")
+            raise ValueError(
+                "GLM5 packed DynamicSparseAttention requires packed cu_seqlens."
+            )
         return cu_seqlens.to(device=device, dtype=torch.int32)
+
+    @staticmethod
+    def _packed_true_cu_seqlens(
+        packed_seq_params, padded_cu_seqlens: torch.Tensor, device: torch.device
+    ) -> torch.Tensor:
+        true_cu_seqlens = getattr(packed_seq_params, "cu_seqlens_q", None)
+        if true_cu_seqlens is None:
+            return padded_cu_seqlens
+        true_cu_seqlens = true_cu_seqlens.to(device=device, dtype=torch.int32)
+        if true_cu_seqlens.shape != padded_cu_seqlens.shape:
+            raise ValueError(
+                "GLM5 packed DynamicSparseAttention true/padded cu_seqlens must "
+                f"have the same shape, got {tuple(true_cu_seqlens.shape)} and "
+                f"{tuple(padded_cu_seqlens.shape)}."
+            )
+        return true_cu_seqlens
 
     @staticmethod
     def _slice_rotary_cache(

--- a/experimental/lite/megatron/lite/primitive/modules/attention/dsa.py
+++ b/experimental/lite/megatron/lite/primitive/modules/attention/dsa.py
@@ -540,11 +540,7 @@ class DSAIndexer(nn.Module):
                 k, [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1
             )
         q_pe = apply_rotary_pos_emb(
-            q_pe,
-            cos,
-            sin,
-            unsqueeze_dim=2,
-            mla_interleaved=self.rope_interleaved,
+            q_pe, cos, sin, unsqueeze_dim=2, mla_interleaved=self.rope_interleaved
         )
         k_pe = apply_rotary_pos_emb(
             k_pe.unsqueeze(2),
@@ -791,11 +787,7 @@ class DynamicSparseAttention(nn.Module):
                     x, position_ids, packed_seq_params
                 )
                 cos, sin = self._gather_packed_cp_rotary(
-                    cos,
-                    sin,
-                    packed_seq_params,
-                    x.device,
-                    local_seq=local_seq,
+                    cos, sin, packed_seq_params, x.device, local_seq=local_seq
                 )
             out = self._forward_packed_full(
                 x,
@@ -833,11 +825,7 @@ class DynamicSparseAttention(nn.Module):
                 x, position_ids, attention_mask
             )
             cos, sin = self._gather_cp_rotary(
-                cos,
-                sin,
-                local_seq=local_seq,
-                full_seq=x.shape[1],
-                device=x.device,
+                cos, sin, local_seq=local_seq, full_seq=x.shape[1], device=x.device
             )
 
         out = self._forward_dense_full(
@@ -963,11 +951,7 @@ class DynamicSparseAttention(nn.Module):
         )
 
         q_pe = apply_rotary_pos_emb(
-            q_pe,
-            cos,
-            sin,
-            unsqueeze_dim=2,
-            mla_interleaved=self.rope_interleaved,
+            q_pe, cos, sin, unsqueeze_dim=2, mla_interleaved=self.rope_interleaved
         )
         k_up_weight, v_up_weight = self._split_kv_b_weights()
         q_nope = torch.einsum("bshd,hdr->bshr", q_nope, k_up_weight)
@@ -1042,9 +1026,7 @@ class DynamicSparseAttention(nn.Module):
                     value_dim=self.kv_lora_rank,
                 )
                 index_share_state.save_topk(
-                    self.layer_number,
-                    topk_indices,
-                    sequence_key=index_share_cache_key,
+                    self.layer_number, topk_indices, sequence_key=index_share_cache_key
                 )
             else:
                 out, indexer_loss = _fused_indexer_sparse_attn(

--- a/experimental/lite/megatron/lite/primitive/modules/attention/mla.py
+++ b/experimental/lite/megatron/lite/primitive/modules/attention/mla.py
@@ -9,16 +9,6 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import transformer_engine.pytorch as te
-from megatron.lite.primitive.utils.rope import (
-    _apply_rotary_pos_emb_bshd,
-    _apply_rotary_pos_emb_thd,
-)
-from megatron.lite.primitive.utils.rotary import (
-    RotaryEmbedding,
-    YarnRotaryEmbedding,
-    _yarn_get_mscale,
-)
-
 from megatron.lite.primitive.parallel import (
     ColumnParallelLinear,
     ParallelState,
@@ -33,6 +23,15 @@ from megatron.lite.primitive.parallel.thd import (
     reconstruct_packed_from_cp_parts,
     split_packed_to_cp_local,
 )
+from megatron.lite.primitive.utils.rope import (
+    _apply_rotary_pos_emb_bshd,
+    _apply_rotary_pos_emb_thd,
+)
+from megatron.lite.primitive.utils.rotary import (
+    RotaryEmbedding,
+    YarnRotaryEmbedding,
+    _yarn_get_mscale,
+)
 
 _KEPT_PSP_FIELDS = (
     "qkv_format",
@@ -45,7 +44,9 @@ _KEPT_PSP_FIELDS = (
 )
 
 
-def _apply_mla_rope_bshd(t: torch.Tensor, freqs: torch.Tensor, *, mscale: float) -> torch.Tensor:
+def _apply_mla_rope_bshd(
+    t: torch.Tensor, freqs: torch.Tensor, *, mscale: float
+) -> torch.Tensor:
     return _apply_rotary_pos_emb_bshd(
         t, freqs, rotary_interleaved=False, mscale=mscale, mla_rotary_interleaved=True
     )
@@ -93,7 +94,9 @@ class MultiLatentAttention(nn.Module):
     ):
         super().__init__()
         if num_attention_heads % ps.tp_size != 0:
-            raise ValueError("num_attention_heads must be divisible by tensor parallel size")
+            raise ValueError(
+                "num_attention_heads must be divisible by tensor parallel size"
+            )
         self.ps = ps
         self.num_heads_local = num_attention_heads // ps.tp_size
         self.q_lora_rank = q_lora_rank
@@ -104,10 +107,7 @@ class MultiLatentAttention(nn.Module):
         self.q_head_dim = qk_nope_head_dim + qk_rope_head_dim
 
         self.linear_proj = RowParallelLinear(
-            num_attention_heads * v_head_dim,
-            hidden_size,
-            ps,
-            bias=False,
+            num_attention_heads * v_head_dim, hidden_size, ps, bias=False
         )
         self.linear_q_down_proj = nn.Linear(hidden_size, q_lora_rank, bias=False)
         self.linear_q_up_proj = ColumnParallelLinear(
@@ -119,9 +119,7 @@ class MultiLatentAttention(nn.Module):
             eps=rms_norm_eps,
         )
         self.linear_kv_down_proj = nn.Linear(
-            hidden_size,
-            kv_lora_rank + qk_rope_head_dim,
-            bias=False,
+            hidden_size, kv_lora_rank + qk_rope_head_dim, bias=False
         )
         self.linear_kv_up_proj = ColumnParallelLinear(
             kv_lora_rank,
@@ -149,7 +147,9 @@ class MultiLatentAttention(nn.Module):
                 mscale_all_dim=float(rope_scaling.get("mscale_all_dim", 1.0)),
                 cp_group=ps.cp_group if ps.cp_size > 1 else None,
             )
-            attn_mscale = _yarn_get_mscale(factor, float(rope_scaling.get("mscale_all_dim", 1.0)))
+            attn_mscale = _yarn_get_mscale(
+                factor, float(rope_scaling.get("mscale_all_dim", 1.0))
+            )
         elif rope_type == "rope":
             self.rotary = RotaryEmbedding(
                 kv_channels=qk_rope_head_dim,
@@ -177,7 +177,9 @@ class MultiLatentAttention(nn.Module):
         if not self._use_torch_core:
             dpa_kwargs = dict(cp_kwargs, softmax_scale=self._softmax_scale)
             kv_channels = (
-                (self.q_head_dim, v_head_dim) if v_head_dim != self.q_head_dim else self.q_head_dim
+                (self.q_head_dim, v_head_dim)
+                if v_head_dim != self.q_head_dim
+                else self.q_head_dim
             )
             self.core_attn = te.DotProductAttention(
                 num_attention_heads=self.num_heads_local,
@@ -192,18 +194,13 @@ class MultiLatentAttention(nn.Module):
         q_compressed = self.linear_q_down_proj(x)
         kv_combined = self.linear_kv_down_proj(x)
         kv_compressed, k_pos_emb = kv_combined.split(
-            [self.kv_lora_rank, self.qk_rope_head_dim],
-            dim=-1,
+            [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1
         )
         if self.ps.tp_size > 1:
             k_pos_emb = gather_from_sequence_parallel(k_pos_emb, self.ps)
 
         q_proj = self.linear_q_up_proj(q_compressed)
-        q = q_proj.view(
-            *q_proj.shape[:-1],
-            self.num_heads_local,
-            self.q_head_dim,
-        )
+        q = q_proj.view(*q_proj.shape[:-1], self.num_heads_local, self.q_head_dim)
         kv_proj = self.linear_kv_up_proj(kv_compressed)
         kv = kv_proj.view(
             *kv_proj.shape[:-1],
@@ -236,10 +233,7 @@ class MultiLatentAttention(nn.Module):
         if is_thd:
             if self._use_torch_core:
                 out = self._torch_core_attention_thd(
-                    query,
-                    key,
-                    value,
-                    packed_seq_params=packed_seq_params,
+                    query, key, value, packed_seq_params=packed_seq_params
                 ).reshape(query.size(0), 1, -1)
             else:
                 psp_kwargs = {
@@ -261,16 +255,17 @@ class MultiLatentAttention(nn.Module):
                 out = self._torch_core_attention(query, key, value)
             else:
                 assert self.core_attn is not None
-                out = self.core_attn(query, key, value, core_attention_bias_type="no_bias")
+                out = self.core_attn(
+                    query, key, value, core_attention_bias_type="no_bias"
+                )
             if out.dim() > x.dim():
-                out = out.reshape(*out.shape[:-2], self.num_heads_local * self.v_head_dim)
+                out = out.reshape(
+                    *out.shape[:-2], self.num_heads_local * self.v_head_dim
+                )
         return self.linear_proj(out)
 
     def _torch_core_attention(
-        self,
-        query: torch.Tensor,
-        key: torch.Tensor,
-        value: torch.Tensor,
+        self, query: torch.Tensor, key: torch.Tensor, value: torch.Tensor
     ) -> torch.Tensor:
         local_seq = query.size(0)
         if self.ps.cp_size > 1:
@@ -288,18 +283,15 @@ class MultiLatentAttention(nn.Module):
         v = value.permute(1, 2, 0, 3)
         scale = self._softmax_scale if self._query_scale == 1.0 else None
         out = F.scaled_dot_product_attention(
-            q,
-            k,
-            v,
-            dropout_p=0.0,
-            is_causal=True,
-            scale=scale,
+            q, k, v, dropout_p=0.0, is_causal=True, scale=scale
         )
         out = out.permute(2, 0, 1, 3).contiguous()
         if self.ps.cp_size > 1:
             out = zigzag_slice_for_cp(out, self.ps.cp_rank, self.ps.cp_size, seq_dim=0)
             if out.size(0) != local_seq:
-                raise RuntimeError("CP MLA output shard has unexpected sequence length.")
+                raise RuntimeError(
+                    "CP MLA output shard has unexpected sequence length."
+                )
         return out
 
     def _torch_core_attention_thd(
@@ -350,15 +342,12 @@ class MultiLatentAttention(nn.Module):
             k = key[start:end].permute(1, 0, 2).unsqueeze(0)
             v = value[start:end].permute(1, 0, 2).unsqueeze(0)
             out = F.scaled_dot_product_attention(
-                q,
-                k,
-                v,
-                dropout_p=0.0,
-                is_causal=True,
-                scale=scale,
+                q, k, v, dropout_p=0.0, is_causal=True, scale=scale
             )
             outputs.append(out.squeeze(0).permute(1, 0, 2).contiguous())
-        full_out = torch.cat(outputs, dim=0) if outputs else value.new_empty(value.shape)
+        full_out = (
+            torch.cat(outputs, dim=0) if outputs else value.new_empty(value.shape)
+        )
         if self.ps.cp_size <= 1:
             return full_out
         local_out = split_packed_to_cp_local(
@@ -394,18 +383,10 @@ class MultiLatentAttention(nn.Module):
             else:
                 mscale = 1.0
             q_pos = _apply_mla_rope_thd(
-                q_pos,
-                rope_cu_q,
-                freqs,
-                mscale=mscale,
-                cp_group=self.ps.cp_group,
+                q_pos, rope_cu_q, freqs, mscale=mscale, cp_group=self.ps.cp_group
             )
             k_pos = _apply_mla_rope_thd(
-                k_pos,
-                rope_cu_kv,
-                freqs,
-                mscale=mscale,
-                cp_group=self.ps.cp_group,
+                k_pos, rope_cu_kv, freqs, mscale=mscale, cp_group=self.ps.cp_group
             )
             return q_pos, k_pos
 

--- a/experimental/lite/megatron/lite/primitive/modules/attention/mla.py
+++ b/experimental/lite/megatron/lite/primitive/modules/attention/mla.py
@@ -377,10 +377,16 @@ class MultiLatentAttention(nn.Module):
         if is_thd:
             max_q = getattr(packed_seq_params, "max_seqlen_q", None)
             max_kv = getattr(packed_seq_params, "max_seqlen_kv", None)
+            rope_cu_q = getattr(packed_seq_params, "cu_seqlens_q_padded", None)
+            if rope_cu_q is None:
+                rope_cu_q = packed_seq_params.cu_seqlens_q
+            rope_cu_kv = getattr(packed_seq_params, "cu_seqlens_kv_padded", None)
+            if rope_cu_kv is None:
+                rope_cu_kv = packed_seq_params.cu_seqlens_kv
             seq_len = (
                 int(max(max_q, max_kv))
                 if max_q is not None and max_kv is not None
-                else int(packed_seq_params.cu_seqlens_q[-1])
+                else int(rope_cu_q[-1])
             )
             freqs = self.rotary(seq_len, packed_seq=True)
             if isinstance(freqs, tuple):
@@ -389,14 +395,14 @@ class MultiLatentAttention(nn.Module):
                 mscale = 1.0
             q_pos = _apply_mla_rope_thd(
                 q_pos,
-                packed_seq_params.cu_seqlens_q,
+                rope_cu_q,
                 freqs,
                 mscale=mscale,
                 cp_group=self.ps.cp_group,
             )
             k_pos = _apply_mla_rope_thd(
                 k_pos,
-                packed_seq_params.cu_seqlens_kv,
+                rope_cu_kv,
                 freqs,
                 mscale=mscale,
                 cp_group=self.ps.cp_group,

--- a/experimental/lite/megatron/lite/primitive/modules/gqa.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gqa.py
@@ -204,8 +204,14 @@ class GQAttention(nn.Module):
         elif is_thd:
             max_q = getattr(packed_seq_params, "max_seqlen_q", None)
             max_kv = getattr(packed_seq_params, "max_seqlen_kv", None)
+            rope_cu_q = getattr(packed_seq_params, "cu_seqlens_q_padded", None)
+            if rope_cu_q is None:
+                rope_cu_q = packed_seq_params.cu_seqlens_q
+            rope_cu_kv = getattr(packed_seq_params, "cu_seqlens_kv_padded", None)
+            if rope_cu_kv is None:
+                rope_cu_kv = packed_seq_params.cu_seqlens_kv
             if max_q is None or max_kv is None:
-                seq_len_for_rope = int(packed_seq_params.cu_seqlens_q[-1])
+                seq_len_for_rope = int(rope_cu_q[-1])
             else:
                 seq_len_for_rope = int(max(max_q, max_kv))
             # Packed THD uses max per-sequence padded length, not total packed tokens.
@@ -213,7 +219,7 @@ class GQAttention(nn.Module):
             freqs = self.rotary(seq_len_for_rope, packed_seq=True)
             q = _apply_rotary_pos_emb_thd(
                 q,
-                packed_seq_params.cu_seqlens_q,
+                rope_cu_q,
                 freqs,
                 rotary_interleaved=False,
                 mscale=1.0,
@@ -221,7 +227,7 @@ class GQAttention(nn.Module):
             )
             k = _apply_rotary_pos_emb_thd(
                 k,
-                packed_seq_params.cu_seqlens_kv,
+                rope_cu_kv,
                 freqs,
                 rotary_interleaved=False,
                 mscale=1.0,

--- a/experimental/lite/megatron/lite/primitive/modules/gqa.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gqa.py
@@ -10,13 +10,23 @@ from __future__ import annotations
 import torch
 import torch.nn as nn
 import transformer_engine.pytorch as te
-
 from megatron.lite.primitive.modules.gqa_utils import split_grouped_qkvg
-from megatron.lite.primitive.modules.lora import LinearLoRA, LoraConfig, normalize_lora_config
+from megatron.lite.primitive.modules.lora import (
+    LinearLoRA,
+    LoraConfig,
+    normalize_lora_config,
+)
 from megatron.lite.primitive.modules.mrope import MultimodalRotaryEmbedding
-from megatron.lite.primitive.parallel import ColumnParallelLinear, ParallelState, RowParallelLinear
+from megatron.lite.primitive.parallel import (
+    ColumnParallelLinear,
+    ParallelState,
+    RowParallelLinear,
+)
 from megatron.lite.primitive.utils import ensure_divisible
-from megatron.lite.primitive.utils.rope import _apply_rotary_pos_emb_bshd, _apply_rotary_pos_emb_thd
+from megatron.lite.primitive.utils.rope import (
+    _apply_rotary_pos_emb_bshd,
+    _apply_rotary_pos_emb_thd,
+)
 from megatron.lite.primitive.utils.rotary import RotaryEmbedding
 
 # Whitelist of MC PackedSeqParams fields accepted by TE DotProductAttention.forward().
@@ -81,7 +91,9 @@ class GQAttention(nn.Module):
         # Mismatched order would put bucket boundaries in different places,
         # producing different per-rank fp32 master shard layouts and
         # non-bitwise step-1 divergence.
-        self.proj = RowParallelLinear(num_attention_heads * head_dim, hidden_size, ps, bias=False)
+        self.proj = RowParallelLinear(
+            num_attention_heads * head_dim, hidden_size, ps, bias=False
+        )
         q_cols = num_attention_heads * (2 if output_gate else 1)
         qkv_size = (q_cols + 2 * num_key_value_heads) * head_dim
         self.qkv = ColumnParallelLinear(
@@ -171,7 +183,10 @@ class GQAttention(nn.Module):
         )
 
     def forward(
-        self, x: torch.Tensor, position_ids: torch.Tensor | None = None, packed_seq_params=None
+        self,
+        x: torch.Tensor,
+        position_ids: torch.Tensor | None = None,
+        packed_seq_params=None,
     ) -> torch.Tensor:
         qkv = self.qkv(x)
         if self.qkv_lora is not None:
@@ -239,8 +254,12 @@ class GQAttention(nn.Module):
             local_seq_len = q.size(0)
             seq_len_for_rope = local_seq_len * self.ps.cp_size
             freqs = self.rotary(seq_len_for_rope)
-            q = _apply_rotary_pos_emb_bshd(q, freqs, rotary_interleaved=False, mscale=1.0)
-            k = _apply_rotary_pos_emb_bshd(k, freqs, rotary_interleaved=False, mscale=1.0)
+            q = _apply_rotary_pos_emb_bshd(
+                q, freqs, rotary_interleaved=False, mscale=1.0
+            )
+            k = _apply_rotary_pos_emb_bshd(
+                k, freqs, rotary_interleaved=False, mscale=1.0
+            )
         if self._use_fp32_rope:
             q, k = q.to(orig_dtype), k.to(orig_dtype)
 
@@ -263,7 +282,9 @@ class GQAttention(nn.Module):
             attn_out = self.core_attn(q, k, v, core_attention_bias_type="no_bias")
             if attn_out.dim() > x.dim():
                 shape = attn_out.shape
-                attn_out = attn_out.reshape(*shape[:-2], self.num_heads_local * self.head_dim)
+                attn_out = attn_out.reshape(
+                    *shape[:-2], self.num_heads_local * self.head_dim
+                )
 
         if gate is not None:
             gate_fp32 = gate.reshape(attn_out.shape).float().sigmoid()
@@ -290,7 +311,9 @@ class GQAttention(nn.Module):
         if self._qkv_layout == "mcore":
             q_per_group = ensure_divisible(nq, nkv)
             if self._output_gate:
-                return split_grouped_qkvg(qkv, num_heads=nq, num_kv_heads=nkv, head_dim=hd)
+                return split_grouped_qkvg(
+                    qkv, num_heads=nq, num_kv_heads=nkv, head_dim=hd
+                )
 
             qkv = qkv.view(*lead, nkv, (q_per_group + 2) * hd)
             q = qkv[..., : q_per_group * hd].reshape(*lead, nq, hd)

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/adamw.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/adamw.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import inspect
+import math
 from collections.abc import Callable, Iterable
 from typing import Any
 
@@ -28,7 +29,9 @@ def local_grad_sq_sum(
             total = torch.zeros((), device=grad.device, dtype=dtype)
         total += grad.detach().to(dtype).pow(2).sum()
     if total is None:
-        return torch.zeros((), device=default_device or torch.device("cpu"), dtype=dtype)
+        return torch.zeros(
+            (), device=default_device or torch.device("cpu"), dtype=dtype
+        )
     return total
 
 
@@ -60,7 +63,9 @@ def is_dtensor_like(tensor: Any) -> bool:
     )
 
 
-def copy_local_tensor_to_param_(param: nn.Parameter, local_tensor: torch.Tensor) -> None:
+def copy_local_tensor_to_param_(
+    param: nn.Parameter, local_tensor: torch.Tensor
+) -> None:
     if not is_dtensor_like(param):
         param.detach().copy_(local_tensor.to(device=param.device, dtype=param.dtype))
         return
@@ -70,7 +75,9 @@ def copy_local_tensor_to_param_(param: nn.Parameter, local_tensor: torch.Tensor)
     # local * mesh, e.g. a (3,) param over 8 ranks -> 0 or 8), so copy local->local
     # (master is init'd from this same local shard, so shapes match).
     local_param = to_local_tensor(param)
-    local_param.copy_(local_tensor.to(device=local_param.device, dtype=local_param.dtype))
+    local_param.copy_(
+        local_tensor.to(device=local_param.device, dtype=local_param.dtype)
+    )
 
 
 def all_reduce_grad_(grad: torch.Tensor, *, group: dist.ProcessGroup) -> None:
@@ -108,9 +115,13 @@ class ChainedOptimizer:
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
         optimizer_states = state_dict.get("optimizers")
-        if not isinstance(optimizer_states, list) or len(optimizer_states) != len(self.optimizers):
+        if not isinstance(optimizer_states, list) or len(optimizer_states) != len(
+            self.optimizers
+        ):
             raise ValueError("Invalid chained torch optimizer state_dict.")
-        for optimizer, optimizer_state in zip(self.optimizers, optimizer_states, strict=True):
+        for optimizer, optimizer_state in zip(
+            self.optimizers, optimizer_states, strict=True
+        ):
             optimizer.load_state_dict(optimizer_state)
 
 
@@ -128,7 +139,9 @@ class FP32AdamW:
         cpu_update: bool = False,
         model_param_dtypes: dict[int, torch.dtype] | None = None,
     ):
-        self.param_groups = normalize_param_groups(params, default_weight_decay=weight_decay)
+        self.param_groups = normalize_param_groups(
+            params, default_weight_decay=weight_decay
+        )
         self.params: list[nn.Parameter] = []
         self.lr = lr
         self.weight_decay = weight_decay
@@ -215,7 +228,9 @@ class FP32AdamW:
                 exp_avg.mul_(beta1).add_(grad, alpha=1.0 - beta1)
                 exp_avg_sq.mul_(beta2).addcmul_(grad, grad, value=1.0 - beta2)
                 denom = exp_avg_sq.sqrt().div_(bias_correction2_sqrt).add_(self.eps)
-                master.addcdiv_(exp_avg.to(dtype=torch.float32), denom, value=-group_step_size)
+                master.addcdiv_(
+                    exp_avg.to(dtype=torch.float32), denom, value=-group_step_size
+                )
                 self._copy_master_to_param(param, master)
 
     def _prepare_grad(self, grad: torch.Tensor, master: torch.Tensor) -> torch.Tensor:
@@ -236,53 +251,283 @@ class FP32AdamW:
     def state_dict(self) -> dict[str, Any]:
         return {
             "type": "fp32_adamw",
+            "version": 2,
             "step_count": self.step_count,
-            "master_params": [self.state[param]["master_param"] for param in self.params],
+            "config": {
+                "lr": self.lr,
+                "weight_decay": self.weight_decay,
+                "betas": self.betas,
+                "eps": self.eps,
+                "cpu_update": self.cpu_update,
+            },
+            "master_params": [
+                self.state[param]["master_param"] for param in self.params
+            ],
             "exp_avgs": [self.state[param]["exp_avg"] for param in self.params],
             "exp_avg_sqs": [self.state[param]["exp_avg_sq"] for param in self.params],
             "steps": [int(self.state[param]["step"]) for param in self.params],
-            "weight_decays": [
-                float(group.get("weight_decay", self.weight_decay))
+            "param_groups": [
+                {
+                    "param_count": len(group["params"]),
+                    "options": {
+                        key: value for key, value in group.items() if key != "params"
+                    },
+                }
                 for group in self.param_groups
-                for _param in group["params"]
             ],
         }
 
-    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
-        if state_dict.get("type") != "fp32_adamw":
-            raise ValueError("Invalid FP32 AdamW state_dict.")
-        self.step_count = int(state_dict.get("step_count", 0))
+    @staticmethod
+    def _validate_option_value(name: str, value: Any, reference: Any) -> None:
+        if isinstance(reference, torch.Tensor):
+            if not isinstance(value, torch.Tensor):
+                raise TypeError(f"FP32 AdamW option {name} must be a tensor.")
+            if value.shape != reference.shape or value.dtype != reference.dtype:
+                raise ValueError(
+                    f"FP32 AdamW option {name} shape/dtype mismatch: "
+                    f"checkpoint={tuple(value.shape)}/{value.dtype}, "
+                    f"runtime={tuple(reference.shape)}/{reference.dtype}."
+                )
+            if value.is_floating_point() and not torch.isfinite(value).all():
+                raise ValueError(f"FP32 AdamW option {name} must be finite.")
+            return
+        if isinstance(reference, bool):
+            if not isinstance(value, bool):
+                raise TypeError(f"FP32 AdamW option {name} must be bool.")
+            return
+        if isinstance(reference, (int, float)) and not isinstance(reference, bool):
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise TypeError(f"FP32 AdamW option {name} must be numeric.")
+            if not math.isfinite(float(value)):
+                raise ValueError(f"FP32 AdamW option {name} must be finite.")
+            if (
+                name
+                in {
+                    "lr",
+                    "initial_lr",
+                    "weight_decay",
+                    "eps",
+                    "wd_mult",
+                    "lr_mult",
+                    "max_lr",
+                    "min_lr",
+                    "start_wd",
+                    "end_wd",
+                }
+                and value < 0
+            ):
+                raise ValueError(f"FP32 AdamW option {name} must be non-negative.")
+            return
+        if isinstance(reference, tuple):
+            if not isinstance(value, tuple) or len(value) != len(reference):
+                raise TypeError(f"FP32 AdamW option {name} must be a matching tuple.")
+            for index, (item, expected) in enumerate(
+                zip(value, reference, strict=True)
+            ):
+                FP32AdamW._validate_option_value(f"{name}[{index}]", item, expected)
+            return
+        if value is not None and reference is None:
+            raise TypeError(f"FP32 AdamW option {name} must remain None.")
+        if reference is not None and not isinstance(value, type(reference)):
+            raise TypeError(
+                f"FP32 AdamW option {name} must have type {type(reference).__name__}."
+            )
+
+    def validate_state_dict(self, state_dict: dict[str, Any]) -> None:
+        expected_keys = {
+            "type",
+            "version",
+            "step_count",
+            "config",
+            "master_params",
+            "exp_avgs",
+            "exp_avg_sqs",
+            "steps",
+            "param_groups",
+        }
+        if not isinstance(state_dict, dict) or set(state_dict) != expected_keys:
+            raise ValueError("Invalid FP32 AdamW v2 state_dict schema.")
+        if state_dict["type"] != "fp32_adamw" or state_dict["version"] != 2:
+            raise ValueError("Unsupported FP32 AdamW state_dict format.")
+        step_count = state_dict["step_count"]
+        if (
+            isinstance(step_count, bool)
+            or not isinstance(step_count, int)
+            or step_count < 0
+        ):
+            raise ValueError("Invalid FP32 AdamW step_count.")
+        config = state_dict["config"]
+        runtime_config = {
+            "lr": self.lr,
+            "weight_decay": self.weight_decay,
+            "betas": self.betas,
+            "eps": self.eps,
+            "cpu_update": self.cpu_update,
+        }
+        if not isinstance(config, dict) or set(config) != set(runtime_config):
+            raise ValueError("Invalid FP32 AdamW config schema.")
+        for name, reference in runtime_config.items():
+            self._validate_option_value(name, config[name], reference)
+        beta1, beta2 = config["betas"]
+        if not (0.0 <= beta1 < 1.0 and 0.0 <= beta2 < 1.0):
+            raise ValueError("FP32 AdamW betas must lie in [0, 1).")
+        if config["cpu_update"] != self.cpu_update:
+            raise ValueError(
+                "FP32 AdamW cpu_update cannot change across checkpoint resume."
+            )
+
         for target_name, key in (
             ("master_params", "master_param"),
             ("exp_avgs", "exp_avg"),
             ("exp_avg_sqs", "exp_avg_sq"),
         ):
-            loaded = state_dict.get(target_name)
+            loaded = state_dict[target_name]
             if not isinstance(loaded, list) or len(loaded) != len(self.params):
                 raise ValueError(f"Invalid FP32 AdamW {target_name} state.")
-            for param, src in zip(self.params, loaded, strict=True):
-                self.state[param][key].copy_(src)
-        loaded_steps = state_dict.get("steps")
-        if loaded_steps is not None:
-            if not isinstance(loaded_steps, list) or len(loaded_steps) != len(self.params):
-                raise ValueError("Invalid FP32 AdamW steps state.")
-            for param, step in zip(self.params, loaded_steps, strict=True):
-                self.state[param]["step"] = int(step)
-        else:
-            for param in self.params:
-                self.state[param]["step"] = self.step_count
-        loaded_weight_decays = state_dict.get("weight_decays")
-        if loaded_weight_decays is not None:
-            if not isinstance(loaded_weight_decays, list) or len(loaded_weight_decays) != len(
-                self.params
+            for index, (param, src) in enumerate(zip(self.params, loaded, strict=True)):
+                target = self.state[param][key]
+                if not isinstance(src, torch.Tensor):
+                    raise TypeError(
+                        f"FP32 AdamW {target_name}[{index}] must be a tensor."
+                    )
+                if src.shape != target.shape or src.dtype != target.dtype:
+                    raise ValueError(
+                        f"FP32 AdamW {target_name}[{index}] shape/dtype mismatch."
+                    )
+        loaded_steps = state_dict["steps"]
+        if (
+            not isinstance(loaded_steps, list)
+            or len(loaded_steps) != len(self.params)
+            or any(
+                isinstance(step, bool) or not isinstance(step, int) or step < 0
+                for step in loaded_steps
+            )
+        ):
+            raise ValueError("Invalid FP32 AdamW steps state.")
+        if any(step > step_count for step in loaded_steps):
+            raise ValueError("FP32 AdamW parameter step exceeds global step_count.")
+
+        saved_groups = state_dict["param_groups"]
+        if not isinstance(saved_groups, list) or len(saved_groups) != len(
+            self.param_groups
+        ):
+            raise ValueError("Invalid FP32 AdamW param-group count.")
+        for index, (saved_group, runtime_group) in enumerate(
+            zip(saved_groups, self.param_groups, strict=True)
+        ):
+            if not isinstance(saved_group, dict) or set(saved_group) != {
+                "param_count",
+                "options",
+            }:
+                raise ValueError(f"Invalid FP32 AdamW param_groups[{index}] schema.")
+            if saved_group["param_count"] != len(runtime_group["params"]):
+                raise ValueError(
+                    f"FP32 AdamW param_groups[{index}] cardinality mismatch."
+                )
+            options = saved_group["options"]
+            runtime_options = {
+                key: value for key, value in runtime_group.items() if key != "params"
+            }
+            if not isinstance(options, dict) or set(options) != set(runtime_options):
+                raise ValueError(
+                    f"FP32 AdamW param_groups[{index}] option schema mismatch."
+                )
+            for name, reference in runtime_options.items():
+                self._validate_option_value(name, options[name], reference)
+            if options.get("max_lr", self.lr) < options.get("min_lr", 0.0):
+                raise ValueError(
+                    f"FP32 AdamW param_groups[{index}] max_lr must be >= min_lr."
+                )
+            if options.get("end_wd", self.weight_decay) < options.get(
+                "start_wd", self.weight_decay
             ):
-                raise ValueError("Invalid FP32 AdamW weight_decay state.")
-            idx = 0
-            for group in self.param_groups:
-                if not group["params"]:
-                    continue
-                group["weight_decay"] = float(loaded_weight_decays[idx])
-                idx += len(group["params"])
+                raise ValueError(
+                    f"FP32 AdamW param_groups[{index}] end_wd must be >= start_wd."
+                )
+
+    def migrate_legacy_state_dict(self, state_dict: dict[str, Any]) -> dict[str, Any]:
+        """Upgrade the one pre-v2 format using explicitly selected runtime config.
+
+        The legacy payload did not record betas/eps or complete group options, so
+        this is intentionally not part of normal exact resume. The DCP loader may
+        call it only behind its explicit legacy-checkpoint opt-in.
+        """
+
+        legacy_keys = {
+            "type",
+            "step_count",
+            "master_params",
+            "exp_avgs",
+            "exp_avg_sqs",
+            "steps",
+            "weight_decays",
+        }
+        if not isinstance(state_dict, dict) or set(state_dict) != legacy_keys:
+            raise ValueError("Invalid legacy FP32 AdamW state_dict schema.")
+        if state_dict["type"] != "fp32_adamw":
+            raise ValueError("Invalid legacy FP32 AdamW state_dict type.")
+        weight_decays = state_dict["weight_decays"]
+        if not isinstance(weight_decays, list) or len(weight_decays) != len(
+            self.params
+        ):
+            raise ValueError("Invalid legacy FP32 AdamW weight_decays state.")
+
+        migrated = self.state_dict()
+        for name in ("step_count", "master_params", "exp_avgs", "exp_avg_sqs", "steps"):
+            migrated[name] = state_dict[name]
+        offset = 0
+        for group_index, (group, migrated_group) in enumerate(
+            zip(self.param_groups, migrated["param_groups"], strict=True)
+        ):
+            count = len(group["params"])
+            group_weight_decays = weight_decays[offset : offset + count]
+            offset += count
+            if not group_weight_decays:
+                continue
+            first = group_weight_decays[0]
+            if (
+                isinstance(first, bool)
+                or not isinstance(first, (int, float))
+                or not math.isfinite(float(first))
+                or first < 0
+                or any(value != first for value in group_weight_decays[1:])
+            ):
+                raise ValueError(
+                    "Legacy FP32 AdamW weight decay is invalid or inconsistent "
+                    f"within param group {group_index}."
+                )
+            migrated_group["options"]["weight_decay"] = float(first)
+        self.validate_state_dict(migrated)
+        return migrated
+
+    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        self.validate_state_dict(state_dict)
+        self.step_count = state_dict["step_count"]
+        config = state_dict["config"]
+        self.lr = float(config["lr"])
+        self.weight_decay = float(config["weight_decay"])
+        self.betas = tuple(config["betas"])
+        self.eps = float(config["eps"])
+        for target_name, key in (
+            ("master_params", "master_param"),
+            ("exp_avgs", "exp_avg"),
+            ("exp_avg_sqs", "exp_avg_sq"),
+        ):
+            for param, src in zip(self.params, state_dict[target_name], strict=True):
+                self.state[param][key].copy_(src)
+        for param, step in zip(self.params, state_dict["steps"], strict=True):
+            self.state[param]["step"] = step
+        for saved_group, runtime_group in zip(
+            state_dict["param_groups"], self.param_groups, strict=True
+        ):
+            for name, value in saved_group["options"].items():
+                current = runtime_group.get(name)
+                if isinstance(current, torch.Tensor) and isinstance(
+                    value, torch.Tensor
+                ):
+                    current.copy_(value)
+                else:
+                    runtime_group[name] = value
 
 
 def build_adamw_optimizer(
@@ -323,19 +568,33 @@ def build_adamw_optimizer(
             model_param_dtypes=model_param_dtypes,
         )
     if foreach not in {True, False, "auto"}:
-        raise ValueError(f"adamw_foreach must be True, False, or 'auto', got {foreach!r}.")
+        raise ValueError(
+            f"adamw_foreach must be True, False, or 'auto', got {foreach!r}."
+        )
     if foreach is False:
         return torch.optim.AdamW(
-            param_groups, lr=lr, weight_decay=weight_decay, betas=betas, eps=eps, foreach=False
+            param_groups,
+            lr=lr,
+            weight_decay=weight_decay,
+            betas=betas,
+            eps=eps,
+            foreach=False,
         )
 
     dtensor_param_groups, tensor_param_groups = split_dtensor_and_tensor_param_groups(
         param_groups, default_weight_decay=weight_decay
     )
-    split_param_groups = [group for group in (dtensor_param_groups, tensor_param_groups) if group]
+    split_param_groups = [
+        group for group in (dtensor_param_groups, tensor_param_groups) if group
+    ]
     if foreach == "auto" and not dtensor_param_groups:
         return torch.optim.AdamW(
-            param_groups, lr=lr, weight_decay=weight_decay, betas=betas, eps=eps, foreach=False
+            param_groups,
+            lr=lr,
+            weight_decay=weight_decay,
+            betas=betas,
+            eps=eps,
+            foreach=False,
         )
     if len(split_param_groups) <= 1:
         return torch.optim.AdamW(
@@ -371,7 +630,9 @@ def maybe_build_te_fused_adam_optimizer(
 
     all_param_list = list(all_params)
     master_weights = get_bool_opt(
-        opt, "master_weights", default=use_fp32_master and should_use_master_weights(all_param_list)
+        opt,
+        "master_weights",
+        default=use_fp32_master and should_use_master_weights(all_param_list),
     )
     kwargs = dict(
         lr=lr,
@@ -380,15 +641,23 @@ def maybe_build_te_fused_adam_optimizer(
         eps=eps,
         adam_w_mode=True,
         master_weights=master_weights,
-        master_weight_dtype=get_dtype_opt(opt, "master_weight_dtype", default=torch.float32),
-        store_param_remainders=get_bool_opt(opt, "store_param_remainders", default=master_weights),
+        master_weight_dtype=get_dtype_opt(
+            opt, "master_weight_dtype", default=torch.float32
+        ),
+        store_param_remainders=get_bool_opt(
+            opt, "store_param_remainders", default=master_weights
+        ),
         exp_avg_dtype=get_dtype_opt(opt, "exp_avg_dtype", default=torch.float32),
         exp_avg_sq_dtype=get_dtype_opt(opt, "exp_avg_sq_dtype", default=torch.float32),
     )
-    return FusedAdam(param_groups, **filter_supported_kwargs(FusedAdam.__init__, kwargs))
+    return FusedAdam(
+        param_groups, **filter_supported_kwargs(FusedAdam.__init__, kwargs)
+    )
 
 
-def filter_supported_kwargs(fn: Callable[..., Any], kwargs: dict[str, Any]) -> dict[str, Any]:
+def filter_supported_kwargs(
+    fn: Callable[..., Any], kwargs: dict[str, Any]
+) -> dict[str, Any]:
     try:
         params = inspect.signature(fn).parameters
     except (TypeError, ValueError):
@@ -399,7 +668,10 @@ def filter_supported_kwargs(fn: Callable[..., Any], kwargs: dict[str, Any]) -> d
 
 
 def should_use_master_weights(params: Iterable[nn.Parameter]) -> bool:
-    return any(param.is_floating_point() and param.dtype is not torch.float32 for param in params)
+    return any(
+        param.is_floating_point() and param.dtype is not torch.float32
+        for param in params
+    )
 
 
 def get_bool_opt(opt, attr: str, *, default: bool) -> bool:
@@ -443,7 +715,9 @@ def get_opt_value(opt, attr: str):
 
 
 def normalize_param_groups(
-    params: Iterable[nn.Parameter] | Iterable[dict[str, Any]], *, default_weight_decay: float
+    params: Iterable[nn.Parameter] | Iterable[dict[str, Any]],
+    *,
+    default_weight_decay: float,
 ) -> list[dict[str, Any]]:
     items = list(params)
     if not items:

--- a/experimental/lite/megatron/lite/primitive/optimizers/megatron_wrap.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/megatron_wrap.py
@@ -10,7 +10,10 @@ from typing import Any
 import torch  # pyright: ignore[reportMissingImports]
 import torch.nn as nn  # pyright: ignore[reportMissingImports]
 
-from megatron.lite.primitive.protocols import ExpertClassifierFn, default_expert_classifier
+from megatron.lite.primitive.protocols import (
+    ExpertClassifierFn,
+    default_expert_classifier,
+)
 
 
 def validate_dist_opt_config(engine_cfg) -> None:
@@ -123,7 +126,10 @@ def build_dist_opt_stack(
             influences optimizer master-grad sharding, so callers that prewrap
             chunks own the DDP config compatibility.
     """
-    from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig
+    from megatron.core.distributed import (
+        DistributedDataParallel,
+        DistributedDataParallelConfig,
+    )
     from megatron.core.distributed.finalize_model_grads import finalize_model_grads
     from megatron.core.optimizer import get_megatron_optimizer
     from megatron.core.transformer.enums import ModelType
@@ -153,7 +159,9 @@ def build_dist_opt_stack(
         wrapped_chunks = list(model_chunks)
     else:
         ddp_config = DistributedDataParallelConfig(
-            use_distributed_optimizer=True, overlap_grad_reduce=False, grad_reduce_in_fp32=True
+            use_distributed_optimizer=True,
+            overlap_grad_reduce=False,
+            grad_reduce_in_fp32=True,
         )
         wrapped_chunks = []
         for chunk_idx, chunk in enumerate(model_chunks):
@@ -180,7 +188,9 @@ def build_dist_opt_stack(
     # groups. Long term, this primitive should always pass its own
     # `pg_collection`.
     if skip_ddp_wrap or use_mpu_groups:
-        optimizer = get_megatron_optimizer(config=opt_config, model_chunks=wrapped_chunks)
+        optimizer = get_megatron_optimizer(
+            config=opt_config, model_chunks=wrapped_chunks
+        )
         optimizer._dist_opt_pg_collection = None  # pyright: ignore[reportAttributeAccessIssue]
     else:
         optimizer = get_megatron_optimizer(
@@ -189,9 +199,7 @@ def build_dist_opt_stack(
             use_gloo_process_groups=False,
             pg_collection=pg_collection,
         )
-        optimizer._dist_opt_pg_collection = (
-            pg_collection  # pyright: ignore[reportAttributeAccessIssue]
-        )
+        optimizer._dist_opt_pg_collection = pg_collection  # pyright: ignore[reportAttributeAccessIssue]
     return wrapped_chunks, optimizer
 
 
@@ -205,8 +213,11 @@ def build_dist_opt_training_optimizer(
     is_expert: ExpertClassifierFn | None = None,
     skip_ddp_wrap: bool = False,
     deterministic: bool | None = None,
+    mtp_enabled: bool = False,
 ):
     """Build the dist_opt DDP+optimizer stack from a Megatron Lite model ImplConfig."""
+
+    mtp_embedding_sync = bool(ps.pp_size > 1 and mtp_enabled)
 
     opt = impl_cfg.optimizer_config
     if opt is None:
@@ -242,6 +253,12 @@ def build_dist_opt_training_optimizer(
 
     def finalize_grads() -> None:
         finalize_dist_opt_grads(model_chunks, optimizer)
+        if mtp_embedding_sync:
+            from megatron.lite.primitive.parallel.shared_embedding import (
+                allreduce_mtp_embedding_grads,
+            )
+
+            allreduce_mtp_embedding_grads(model_chunks, ps, enabled=True)
 
     return optimizer, finalize_grads
 
@@ -330,7 +347,9 @@ def _build_pg_collection(ps, engine_cfg):
         return ((pp_i * ps.dp_size + dp_i) * ps.cp_size + cp_i) * ps.tp_size + tp_i
 
     def _expert_rank(etp_i: int, ep_i: int, edp_i: int, pp_i: int) -> int:
-        return ((pp_i * ps.expert_dp_size + edp_i) * ps.ep_size + ep_i) * ps.etp_size + etp_i
+        return (
+            (pp_i * ps.expert_dp_size + edp_i) * ps.ep_size + ep_i
+        ) * ps.etp_size + etp_i
 
     rank = dist.get_rank()
     world = dist.get_world_size()
@@ -374,7 +393,9 @@ def _build_pg_collection(ps, engine_cfg):
                 tp_ep_pp_group = group
 
         if mp_group is None or tp_ep_pp_group is None:
-            raise RuntimeError("Failed to construct dist_opt pipeline-aware process groups.")
+            raise RuntimeError(
+                "Failed to construct dist_opt pipeline-aware process groups."
+            )
 
     pg_kwargs = dict(
         tp=ps.tp_group,
@@ -434,7 +455,9 @@ class DistOptBackend:
     def load_state_dict(self, optimizer: Any, state_dict: dict) -> None:
         optimizer.load_state_dict(state_dict)
 
-    def finalize_grads(self, finalize_fn, model_chunks: list[Any], optimizer: Any) -> None:
+    def finalize_grads(
+        self, finalize_fn, model_chunks: list[Any], optimizer: Any
+    ) -> None:
         finalize_fn(model_chunks, optimizer)
 
 

--- a/experimental/lite/megatron/lite/primitive/optimizers/megatron_wrap.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/megatron_wrap.py
@@ -9,7 +9,6 @@ from typing import Any
 
 import torch  # pyright: ignore[reportMissingImports]
 import torch.nn as nn  # pyright: ignore[reportMissingImports]
-
 from megatron.lite.primitive.protocols import (
     ExpertClassifierFn,
     default_expert_classifier,
@@ -33,7 +32,9 @@ def _effective_etp(parallel) -> int:
 def _ensure_dist_opt_mpu_parallel_state(engine_cfg) -> None:
     """Initialize Megatron-Core mpu globals when dist_opt fallback groups are used."""
 
-    from megatron.core import parallel_state as mpu  # pyright: ignore[reportMissingImports]
+    from megatron.core import (
+        parallel_state as mpu,  # pyright: ignore[reportMissingImports]
+    )
 
     p = engine_cfg.parallel
     expected = (int(p.tp), int(p.ep), _effective_etp(p), int(p.pp), int(p.cp))
@@ -191,7 +192,9 @@ def build_dist_opt_stack(
         optimizer = get_megatron_optimizer(
             config=opt_config, model_chunks=wrapped_chunks
         )
-        optimizer._dist_opt_pg_collection = None  # pyright: ignore[reportAttributeAccessIssue]
+        optimizer._dist_opt_pg_collection = (
+            None  # pyright: ignore[reportAttributeAccessIssue]
+        )
     else:
         optimizer = get_megatron_optimizer(
             config=opt_config,
@@ -199,7 +202,9 @@ def build_dist_opt_stack(
             use_gloo_process_groups=False,
             pg_collection=pg_collection,
         )
-        optimizer._dist_opt_pg_collection = pg_collection  # pyright: ignore[reportAttributeAccessIssue]
+        optimizer._dist_opt_pg_collection = (
+            pg_collection  # pyright: ignore[reportAttributeAccessIssue]
+        )
     return wrapped_chunks, optimizer
 
 
@@ -337,7 +342,6 @@ def _mark_dist_opt_parallel_attrs(
 
 def _build_pg_collection(ps, engine_cfg):
     import torch.distributed as dist  # pyright: ignore[reportMissingImports]
-
     from megatron.core.process_groups_config import ProcessGroupCollection
 
     if ps.pp_group is None:

--- a/experimental/lite/megatron/lite/primitive/parallel/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/__init__.py
@@ -17,15 +17,15 @@ from megatron.lite.primitive.parallel.pp import (
     PipelineChunkLayout,
     build_pipeline_chunk_layout,
 )
-from megatron.lite.primitive.parallel.sp import (
-    gather_for_non_sp_head,
-    gather_from_sequence_parallel,
-    scatter_to_sequence_parallel,
-)
 from megatron.lite.primitive.parallel.shared_embedding import (
     allreduce_mtp_embedding_grads,
     synchronize_mtp_embedding_parameters,
     validate_mtp_embedding_parameter_replicas,
+)
+from megatron.lite.primitive.parallel.sp import (
+    gather_for_non_sp_head,
+    gather_from_sequence_parallel,
+    scatter_to_sequence_parallel,
 )
 from megatron.lite.primitive.parallel.state import (
     ParallelState,

--- a/experimental/lite/megatron/lite/primitive/parallel/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/__init__.py
@@ -22,7 +22,16 @@ from megatron.lite.primitive.parallel.sp import (
     gather_from_sequence_parallel,
     scatter_to_sequence_parallel,
 )
-from megatron.lite.primitive.parallel.state import ParallelState, init_parallel
+from megatron.lite.primitive.parallel.shared_embedding import (
+    allreduce_mtp_embedding_grads,
+    synchronize_mtp_embedding_parameters,
+    validate_mtp_embedding_parameter_replicas,
+)
+from megatron.lite.primitive.parallel.state import (
+    ParallelState,
+    init_mtp_embedding_group,
+    init_parallel,
+)
 from megatron.lite.primitive.parallel.thd import (
     PackedSeqParams,
     PackedTHDBatch,
@@ -67,11 +76,13 @@ __all__ = [
     "VocabParallelEmbedding",
     "VocabParallelOutput",
     "build_pipeline_chunk_layout",
+    "allreduce_mtp_embedding_grads",
     "forward_backward_pipelining",
     "gather_for_non_sp_head",
     "gather_from_sequence_parallel",
     "has_packed_thd_params",
     "init_parallel",
+    "init_mtp_embedding_group",
     "pad_vocab_for_tp",
     "pack_nested_thd",
     "parallel_state_from_model",
@@ -82,7 +93,9 @@ __all__ = [
     "scatter_to_sequence_parallel",
     "split_packed_to_cp_local",
     "split_packed_for_cp",
+    "synchronize_mtp_embedding_parameters",
     "unpack_packed_thd_to_nested",
+    "validate_mtp_embedding_parameter_replicas",
     "zigzag_position_ids_for_cp",
     "zigzag_reconstruct_from_cp_parts",
     "zigzag_slice_for_cp",

--- a/experimental/lite/megatron/lite/primitive/parallel/shared_embedding.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/shared_embedding.py
@@ -1,0 +1,648 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Pipeline-replicated input embedding support for MTP.
+
+When MTP is placed on the loss stage, it still consumes the input embedding.
+Under pipeline parallelism that stage owns a physical replica because the
+canonical input embedding lives on the first stage.  The two parameters must
+start equal and must receive the sum of both gradients before every optimizer
+step; otherwise PP changes the model being trained and HF export silently
+discards the MTP-stage value.
+
+Every parameter/gradient data collective is preceded by a fixed-size metadata
+collective.  This is deliberately more strict than relying on the data
+collective to reject incompatible tensors: shape, dtype, or device mismatches
+can otherwise leave one endpoint blocked indefinitely.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+
+_MAX_TENSOR_NDIM = 8
+_METADATA_VERSION = 1
+_METADATA_SIZE = 8 + _MAX_TENSOR_NDIM
+
+_DTYPE_CODES = {
+    dtype: index
+    for index, dtype in enumerate(
+        (
+            torch.bool,
+            torch.uint8,
+            torch.int8,
+            torch.int16,
+            torch.int32,
+            torch.int64,
+            torch.float16,
+            torch.bfloat16,
+            torch.float32,
+            torch.float64,
+            torch.complex64,
+            torch.complex128,
+            getattr(torch, "float8_e4m3fn", None),
+            getattr(torch, "float8_e5m2", None),
+            getattr(torch, "float8_e4m3fnuz", None),
+            getattr(torch, "float8_e5m2fnuz", None),
+        ),
+        start=1,
+    )
+    if dtype is not None
+}
+_DEVICE_CODES = {
+    "cpu": 1,
+    "cuda": 2,
+    "xpu": 3,
+    "npu": 4,
+    "hpu": 5,
+    "mps": 6,
+    "meta": 7,
+    "privateuseone": 8,
+}
+_LAYOUT_CODES = {
+    torch.strided: 1,
+    torch.sparse_coo: 2,
+    torch.sparse_csr: 3,
+    torch.sparse_csc: 4,
+    torch.sparse_bsr: 5,
+    torch.sparse_bsc: 6,
+}
+
+
+@dataclass(frozen=True)
+class _EmbeddingPreflightCache:
+    """Static facts proven before the initialization data collective."""
+
+    boundary: bool
+    model_ids: tuple[int, ...]
+    group: dist.ProcessGroup | None
+    global_ranks: tuple[int, int] | None
+    world_control_device: torch.device
+    pair_control_device: torch.device | None
+    pair_backend: str | None
+    weight: nn.Parameter | None
+    parameter_signature: tuple[object, ...] | None
+    native_name: str | None
+    base: nn.Module | None
+
+
+@dataclass(frozen=True)
+class _GroupContext:
+    boundary: bool
+    group: dist.ProcessGroup | None
+    global_ranks: tuple[int, int] | None
+    world_control_device: torch.device
+    pair_control_device: torch.device | None
+    pair_backend: str | None
+
+
+def _unwrap_model(model: nn.Module) -> nn.Module:
+    base = model
+    seen: set[int] = set()
+    while hasattr(base, "module"):
+        ident = id(base)
+        if ident in seen:
+            break
+        seen.add(ident)
+        candidate = base.module
+        if not isinstance(candidate, nn.Module) or candidate is base:
+            break
+        base = candidate
+    return base
+
+
+def _model_ids(model_chunks: Iterable[nn.Module]) -> tuple[int, ...]:
+    return tuple(id(_unwrap_model(chunk)) for chunk in model_chunks)
+
+
+def _embedding_weight(module: nn.Module | None) -> nn.Parameter | None:
+    if module is None:
+        return None
+    embedding = getattr(module, "embedding", None)
+    weight = getattr(embedding, "weight", None)
+    return weight if isinstance(weight, nn.Parameter) else None
+
+
+def _parameter_signature(parameter: nn.Parameter) -> tuple[object, ...]:
+    return (
+        tuple(parameter.shape),
+        parameter.dtype,
+        parameter.device,
+        parameter.layout,
+    )
+
+
+def _local_shared_embedding_candidates(
+    model_chunks: Iterable[nn.Module], ps
+) -> list[tuple[nn.Parameter, str, nn.Module]]:
+    candidates: list[tuple[nn.Parameter, str, nn.Module]] = []
+    for chunk in model_chunks:
+        base = _unwrap_model(chunk)
+        if ps.pp_is_first:
+            for attr in ("embed", "embed_tokens"):
+                weight = _embedding_weight(getattr(base, attr, None))
+                if weight is not None:
+                    candidates.append((weight, f"{attr}.embedding.weight", base))
+        if ps.pp_is_last:
+            weight = _embedding_weight(getattr(base, "mtp_embed", None))
+            if weight is not None:
+                candidates.append((weight, "mtp_embed.embedding.weight", base))
+    return candidates
+
+
+def _group_backend_name(group: dist.ProcessGroup | None) -> str:
+    # Unit tests exercise the protocol with emulated process groups.  Real
+    # callers always initialize torch.distributed before reaching this module.
+    if not dist.is_initialized():
+        return "gloo"
+    backend = str(dist.get_backend(group)).lower()
+    return backend.rsplit(".", maxsplit=1)[-1]
+
+
+def _control_device_for_group(
+    group: dist.ProcessGroup | None,
+    model_chunks: Iterable[nn.Module] = (),
+) -> torch.device:
+    """Choose a device supported by the process-group backend, not model data."""
+    backend = _group_backend_name(group)
+    if backend == "nccl":
+        if not torch.cuda.is_available():
+            raise RuntimeError(
+                "NCCL metadata consensus requires an available CUDA device."
+            )
+        for chunk in model_chunks:
+            parameter = next(_unwrap_model(chunk).parameters(), None)
+            if parameter is not None and parameter.device.type == "cuda":
+                return parameter.device
+        return torch.device("cuda", torch.cuda.current_device())
+    if backend in {"xccl", "xpu"}:
+        xpu = getattr(torch, "xpu", None)
+        if xpu is None or not xpu.is_available():
+            raise RuntimeError(
+                "XCCL metadata consensus requires an available XPU device."
+            )
+        return torch.device("xpu", xpu.current_device())
+    if backend == "hccl":
+        npu = getattr(torch, "npu", None)
+        if npu is None or not npu.is_available():
+            raise RuntimeError(
+                "HCCL metadata consensus requires an available NPU device."
+            )
+        return torch.device("npu", npu.current_device())
+    # Gloo and MPI require CPU control tensors. UCC supports CPU tensors and
+    # CPU is deterministic across ranks even when model tensors differ.
+    if backend in {"gloo", "mpi", "ucc"}:
+        return torch.device("cpu")
+    raise RuntimeError(f"Unsupported metadata collective backend: {backend!r}.")
+
+
+def _data_device_supported(backend: str, device_type: str) -> bool:
+    if backend == "nccl":
+        return device_type == "cuda"
+    if backend in {"xccl", "xpu"}:
+        return device_type == "xpu"
+    if backend in {"gloo", "mpi"}:
+        return device_type == "cpu"
+    if backend == "hccl":
+        return device_type == "npu"
+    if backend == "ucc":
+        return device_type in {"cpu", "cuda"}
+    # Unknown backends are rejected before a data collective. Supporting a new
+    # backend must be an explicit compatibility decision.
+    return False
+
+
+def _world_error_consensus(local_error: bool, device: torch.device) -> bool:
+    """Make every training rank take the same fail/continue branch."""
+    world_error = torch.tensor([int(local_error)], dtype=torch.int32, device=device)
+    dist.all_reduce(world_error, group=dist.group.WORLD)
+    return bool(world_error.item())
+
+
+def _process_group_global_ranks(
+    group: dist.ProcessGroup, group_size: int
+) -> tuple[int, ...]:
+    """Read actual membership without issuing a collective."""
+    get_ranks = getattr(dist, "get_process_group_ranks", None)
+    if get_ranks is not None:
+        return tuple(int(rank) for rank in get_ranks(group))
+    get_global_rank = getattr(dist, "get_global_rank", None)
+    if get_global_rank is None:
+        raise RuntimeError("torch.distributed cannot inspect process-group membership.")
+    return tuple(int(get_global_rank(group, rank)) for rank in range(group_size))
+
+
+def _tensor_metadata(
+    tensor: torch.Tensor | None,
+    *,
+    count: int,
+    backend: str,
+    control_device: torch.device,
+    locally_valid: bool = True,
+) -> torch.Tensor:
+    """Encode presence and tensor facts into a fixed-size int64 record."""
+    values = [0] * _METADATA_SIZE
+    values[0] = _METADATA_VERSION
+    values[1] = count
+    if tensor is None:
+        values[2] = int(locally_valid and count == 0)
+        return torch.tensor(values, dtype=torch.int64, device=control_device)
+
+    shape = tuple(tensor.shape)
+    dtype_code = _DTYPE_CODES.get(tensor.dtype, 0)
+    device_code = _DEVICE_CODES.get(tensor.device.type, 0)
+    layout_code = _LAYOUT_CODES.get(tensor.layout, 0)
+    data_compatible = _data_device_supported(backend, tensor.device.type)
+    values[2] = int(
+        locally_valid
+        and count == 1
+        and len(shape) <= _MAX_TENSOR_NDIM
+        and dtype_code != 0
+        and device_code != 0
+        and layout_code == _LAYOUT_CODES[torch.strided]
+        and data_compatible
+    )
+    values[3] = len(shape)
+    values[4] = dtype_code
+    values[5] = device_code
+    values[6] = layout_code
+    values[7] = int(data_compatible)
+    for index, size in enumerate(shape[:_MAX_TENSOR_NDIM], start=8):
+        values[index] = size
+    return torch.tensor(values, dtype=torch.int64, device=control_device)
+
+
+def _gather_pair_metadata(
+    local_metadata: torch.Tensor, group: dist.ProcessGroup
+) -> tuple[torch.Tensor, torch.Tensor]:
+    gathered = [torch.empty_like(local_metadata) for _ in range(2)]
+    dist.all_gather(gathered, local_metadata, group=group)
+    return gathered[0], gathered[1]
+
+
+def _metadata_pair_status(
+    gathered: tuple[torch.Tensor, torch.Tensor], *, allow_absent_pair: bool
+) -> tuple[bool, int]:
+    """Return pair validity and total presence with one device synchronization."""
+    first, last = gathered
+    matching_records = torch.all(first == last)
+    version_valid = (first[0] == _METADATA_VERSION) & (last[0] == _METADATA_VERSION)
+    count_valid = (first[1] == 1) & (last[1] == 1)
+    if allow_absent_pair:
+        count_valid |= (first[1] == 0) & (last[1] == 0)
+    records_valid = (first[2] == 1) & (last[2] == 1)
+    success = matching_records & version_valid & count_valid & records_valid
+    summary = torch.stack(
+        (
+            (~success).to(dtype=torch.int64),
+            first[1] + last[1],
+        )
+    )
+    pair_error, total_presence = summary.detach().cpu().tolist()
+    return bool(pair_error), int(total_presence)
+
+
+def _group_context(
+    model_chunks: list[nn.Module], ps, *, operation: str
+) -> _GroupContext:
+    boundary = ps.pp_is_first or ps.pp_is_last
+    try:
+        world_control_device = _control_device_for_group(dist.group.WORLD, model_chunks)
+    except (RuntimeError, ValueError, TypeError) as exc:
+        raise RuntimeError(
+            f"MTP PP embedding {operation} cannot create a WORLD control tensor: {exc}"
+        ) from exc
+
+    group = ps.embedding_group if boundary else None
+    ranks_value = ps.embedding_global_ranks if boundary else None
+    ranks: tuple[int, int] | None = None
+    pair_backend: str | None = None
+    pair_control_device: torch.device | None = None
+    local_error = False
+    if boundary:
+        local_error = not (ps.pp_is_first ^ ps.pp_is_last)
+        if (
+            group is None
+            or ranks_value is None
+            or len(ranks_value) != 2
+            or ranks_value[0] == ranks_value[1]
+        ):
+            local_error = True
+        else:
+            try:
+                ranks = (int(ranks_value[0]), int(ranks_value[1]))
+                if ps.pp_global_ranks is not None:
+                    if len(ps.pp_global_ranks) < 2:
+                        local_error = True
+                    elif ps.pp_is_first:
+                        local_error |= ranks[0] != ps.pp_global_ranks[0]
+                    else:
+                        local_error |= ranks[1] != ps.pp_global_ranks[-1]
+                if dist.is_initialized():
+                    rank = dist.get_rank()
+                    expected_rank = ranks[0] if ps.pp_is_first else ranks[1]
+                    local_error |= rank != expected_rank
+                    group_size = dist.get_world_size(group)
+                    local_error |= group_size != 2
+                    if group_size == 2:
+                        local_error |= (
+                            _process_group_global_ranks(group, group_size) != ranks
+                        )
+            except (IndexError, RuntimeError, ValueError, TypeError):
+                local_error = True
+        if group is not None:
+            try:
+                pair_backend = _group_backend_name(group)
+                pair_control_device = _control_device_for_group(group, model_chunks)
+            except (RuntimeError, ValueError, TypeError):
+                local_error = True
+
+    if _world_error_consensus(local_error, world_control_device):
+        raise RuntimeError(
+            f"MTP PP embedding {operation} group preflight failed on at least one "
+            f"rank; local_pp_rank={ps.pp_rank}, embedding_ranks={ranks_value}."
+        )
+    return _GroupContext(
+        boundary=boundary,
+        group=group,
+        global_ranks=ranks,
+        world_control_device=world_control_device,
+        pair_control_device=pair_control_device,
+        pair_backend=pair_backend,
+    )
+
+
+def _parameter_preflight(
+    model_chunks: list[nn.Module], ps, *, operation: str
+) -> _EmbeddingPreflightCache:
+    """Strictly re-discover and compare both parameter endpoints."""
+    context = _group_context(model_chunks, ps, operation=operation)
+    candidates: list[tuple[nn.Parameter, str, nn.Module]] = []
+    candidate_exception: Exception | None = None
+    pair_error = False
+    if context.boundary:
+        assert context.group is not None
+        assert context.pair_backend is not None
+        assert context.pair_control_device is not None
+        try:
+            candidates = _local_shared_embedding_candidates(model_chunks, ps)
+        except Exception as exc:  # converted into pair + WORLD consensus below
+            candidate_exception = exc
+        weight = candidates[0][0] if len(candidates) == 1 else None
+        local_metadata = _tensor_metadata(
+            weight,
+            count=-1 if candidate_exception is not None else len(candidates),
+            backend=context.pair_backend,
+            control_device=context.pair_control_device,
+            locally_valid=candidate_exception is None and len(candidates) == 1,
+        )
+        gathered = _gather_pair_metadata(local_metadata, context.group)
+        pair_error, _ = _metadata_pair_status(gathered, allow_absent_pair=False)
+
+    if _world_error_consensus(pair_error, context.world_control_device):
+        names = [name for _, name, _ in candidates]
+        local_tensor = candidates[0][0] if len(candidates) == 1 else None
+        local_description = (
+            "none"
+            if local_tensor is None
+            else f"shape={tuple(local_tensor.shape)}, dtype={local_tensor.dtype}, "
+            f"device={local_tensor.device.type}, layout={local_tensor.layout}"
+        )
+        raise RuntimeError(
+            f"MTP PP embedding {operation} parameter metadata preflight failed on "
+            f"at least one pair; local_pp_rank={ps.pp_rank}, "
+            f"local_candidates={names}, local_tensor={local_description}, "
+            f"local_discovery_error={candidate_exception!r}."
+        )
+
+    weight: nn.Parameter | None = None
+    native_name: str | None = None
+    base: nn.Module | None = None
+    if context.boundary:
+        weight, native_name, base = candidates[0]
+    return _EmbeddingPreflightCache(
+        boundary=context.boundary,
+        model_ids=_model_ids(model_chunks),
+        group=context.group,
+        global_ranks=context.global_ranks,
+        world_control_device=context.world_control_device,
+        pair_control_device=context.pair_control_device,
+        pair_backend=context.pair_backend,
+        weight=weight,
+        parameter_signature=(
+            _parameter_signature(weight) if weight is not None else None
+        ),
+        native_name=native_name,
+        base=base,
+    )
+
+
+def _cached_parameter_is_current(
+    cache: _EmbeddingPreflightCache, model_chunks: list[nn.Module], ps
+) -> bool:
+    if _model_ids(model_chunks) != cache.model_ids:
+        return False
+    if not cache.boundary:
+        return not (ps.pp_is_first or ps.pp_is_last)
+    if (
+        cache.group is not ps.embedding_group
+        or cache.global_ranks != tuple(ps.embedding_global_ranks or ())
+        or cache.weight is None
+        or cache.parameter_signature is None
+        or cache.native_name is None
+        or cache.base is None
+    ):
+        return False
+    owner_name = cache.native_name.split(".", maxsplit=1)[0]
+    return (
+        _embedding_weight(getattr(cache.base, owner_name, None)) is cache.weight
+        and _parameter_signature(cache.weight) == cache.parameter_signature
+    )
+
+
+def synchronize_mtp_embedding_parameters(
+    model_chunks: Iterable[nn.Module], ps, *, enabled: bool
+) -> None:
+    """Initialize the MTP-stage replica from the first-stage input embedding."""
+    if not enabled or ps.pp_size <= 1:
+        return
+    chunks = list(model_chunks)
+    cache = _parameter_preflight(chunks, ps, operation="initialization")
+    if not cache.boundary:
+        ps.mtp_embedding_preflight_cache = cache
+        return
+
+    assert cache.weight is not None
+    assert cache.native_name is not None
+    assert cache.base is not None
+    assert cache.group is not None
+    weight, native_name, base = cache.weight, cache.native_name, cache.base
+    canonical_name = native_name
+    if ps.pp_is_last:
+        canonical_name = (
+            "embed_tokens.embedding.weight"
+            if hasattr(base, "embed_tokens")
+            else "embed.embedding.weight"
+        )
+        # SUM(first, zero-replica) broadcasts the canonical initialization while
+        # preserving the same collective on both embedding-group ranks.
+        weight.data.zero_()
+        weight.shared = True
+    weight.shared_embedding = True
+    dist.all_reduce(weight.data, group=cache.group)
+
+    # The dist-checkpoint adapter uses this metadata to store the last-stage
+    # tensor as a replica of the first-stage logical embedding, not as a second
+    # independently named training parameter.
+    if ps.pp_is_last:
+        base._mlite_tied_checkpoint_keys = {
+            "mtp_embed.embedding.weight": canonical_name
+        }
+    # Cache only after the data collective succeeds. The optimizer hot path can
+    # now reuse the proven group/candidate/parameter facts.
+    ps.mtp_embedding_preflight_cache = cache
+
+
+def allreduce_mtp_embedding_grads(
+    model_chunks: Iterable[nn.Module], ps, *, enabled: bool
+) -> None:
+    """Sum first-stage and MTP-stage embedding gradients before optimizer step."""
+    if not enabled or ps.pp_size <= 1:
+        return
+    chunks = list(model_chunks)
+    # Validate the active pair on every rank before any endpoint can enter the
+    # pair metadata collective.  In particular, a boundary rank may have lost
+    # both its cached preflight and ``embedding_group``; raising locally there
+    # would strand the other endpoint in all_gather and middle PP ranks in the
+    # later WORLD consensus.
+    context = _group_context(chunks, ps, operation="gradient")
+    cache_value = getattr(ps, "mtp_embedding_preflight_cache", None)
+    cache = cache_value if isinstance(cache_value, _EmbeddingPreflightCache) else None
+    cache_missing = cache is None
+    boundary = context.boundary
+    world_control_device = context.world_control_device
+    group = context.group
+    pair_backend = context.pair_backend
+    pair_control_device = context.pair_control_device
+    if cache is None:
+        # Join the same pair-metadata -> WORLD sequence as initialized peers so
+        # an asymmetrically missing cache cannot strand them in a collective.
+        weight = None
+        native_name = None
+        pair_error = True
+    else:
+        weight = cache.weight
+        native_name = cache.native_name
+        try:
+            pair_error = not _cached_parameter_is_current(cache, chunks, ps)
+        except Exception:  # converted into pair + WORLD consensus below
+            pair_error = True
+
+    grad: torch.Tensor | None = None
+    present = 0
+    if boundary:
+        assert group is not None
+        assert pair_backend is not None
+        assert pair_control_device is not None
+        if cache is not None:
+            assert weight is not None
+            grad_value = getattr(weight, "main_grad", None)
+            if grad_value is None:
+                grad_value = weight.grad
+            if grad_value is not None:
+                present = 1
+                if isinstance(grad_value, torch.Tensor):
+                    grad = grad_value
+                else:
+                    pair_error = True
+            locally_valid = not pair_error
+            if grad is not None:
+                locally_valid &= tuple(grad.shape) == tuple(weight.shape)
+            metadata_count = present
+        else:
+            # A negative count is a fixed-size invalid record. It can still be
+            # exchanged safely with a peer that has a valid cache.
+            locally_valid = False
+            metadata_count = -1
+        local_metadata = _tensor_metadata(
+            grad,
+            count=metadata_count,
+            backend=pair_backend,
+            control_device=pair_control_device,
+            locally_valid=locally_valid,
+        )
+        gathered = _gather_pair_metadata(local_metadata, group)
+        metadata_error, present = _metadata_pair_status(
+            gathered, allow_absent_pair=True
+        )
+        pair_error |= metadata_error
+
+    if _world_error_consensus(pair_error, world_control_device):
+        local_name = native_name or f"pp_rank={ps.pp_rank}"
+        local_description = (
+            "absent"
+            if grad is None
+            else f"shape={tuple(grad.shape)}, dtype={grad.dtype}, "
+            f"device={grad.device.type}, layout={grad.layout}"
+        )
+        raise RuntimeError(
+            "MTP PP shared embedding gradient metadata preflight failed on at "
+            f"least one pair; local={local_name}, local_pair_presence={present}/2, "
+            f"local_grad={local_description}, local_cache_missing={cache_missing}."
+        )
+    if not boundary or present == 0:
+        # Both copies can be frozen (for example LoRA-only training). With no
+        # optimizer update on either side their already-synchronized values
+        # remain equal, so no data collective is required.
+        return
+    assert grad is not None
+    assert group is not None
+    dist.all_reduce(grad, group=group)
+
+
+def validate_mtp_embedding_parameter_replicas(
+    model_chunks: Iterable[nn.Module], ps, *, enabled: bool
+) -> None:
+    """Prove exact first/MTP embedding equality before a lossy canonical save."""
+    if not enabled or ps.pp_size <= 1:
+        return
+    chunks = list(model_chunks)
+    # Saving deliberately bypasses the optimizer cache: parameters may have
+    # been replaced or reshaped since initialization, and a stale cache must
+    # never authorize a lossy canonical save.
+    cache = _parameter_preflight(chunks, ps, operation="save validation")
+
+    mismatch = False
+    local_max_abs = 0.0
+    if cache.boundary:
+        assert cache.weight is not None
+        assert cache.group is not None
+        assert cache.global_ranks is not None
+        weight = cache.weight
+        canonical = weight.detach().clone()
+        dist.broadcast(
+            canonical,
+            src=cache.global_ranks[0],
+            group=cache.group,
+        )
+        mismatch = not torch.equal(canonical, weight.detach())
+        if mismatch:
+            local_max_abs = (
+                (canonical.float() - weight.detach().float()).abs().max().item()
+            )
+    if _world_error_consensus(mismatch, cache.world_control_device):
+        raise RuntimeError(
+            "Refusing distributed checkpoint save because a PP MTP embedding "
+            f"replica diverged from the canonical parameter; local_pp_rank={ps.pp_rank}, "
+            f"local_max_abs={local_max_abs:.6e}."
+        )
+
+
+__all__ = [
+    "allreduce_mtp_embedding_grads",
+    "synchronize_mtp_embedding_parameters",
+    "validate_mtp_embedding_parameter_replicas",
+]

--- a/experimental/lite/megatron/lite/primitive/parallel/shared_embedding.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/shared_embedding.py
@@ -127,12 +127,7 @@ def _embedding_weight(module: nn.Module | None) -> nn.Parameter | None:
 
 
 def _parameter_signature(parameter: nn.Parameter) -> tuple[object, ...]:
-    return (
-        tuple(parameter.shape),
-        parameter.dtype,
-        parameter.device,
-        parameter.layout,
-    )
+    return (tuple(parameter.shape), parameter.dtype, parameter.device, parameter.layout)
 
 
 def _local_shared_embedding_candidates(
@@ -163,8 +158,7 @@ def _group_backend_name(group: dist.ProcessGroup | None) -> str:
 
 
 def _control_device_for_group(
-    group: dist.ProcessGroup | None,
-    model_chunks: Iterable[nn.Module] = (),
+    group: dist.ProcessGroup | None, model_chunks: Iterable[nn.Module] = ()
 ) -> torch.device:
     """Choose a device supported by the process-group backend, not model data."""
     backend = _group_backend_name(group)
@@ -295,12 +289,7 @@ def _metadata_pair_status(
         count_valid |= (first[1] == 0) & (last[1] == 0)
     records_valid = (first[2] == 1) & (last[2] == 1)
     success = matching_records & version_valid & count_valid & records_valid
-    summary = torch.stack(
-        (
-            (~success).to(dtype=torch.int64),
-            first[1] + last[1],
-        )
-    )
+    summary = torch.stack(((~success).to(dtype=torch.int64), first[1] + last[1]))
     pair_error, total_presence = summary.detach().cpu().tolist()
     return bool(pair_error), int(total_presence)
 
@@ -623,11 +612,7 @@ def validate_mtp_embedding_parameter_replicas(
         assert cache.global_ranks is not None
         weight = cache.weight
         canonical = weight.detach().clone()
-        dist.broadcast(
-            canonical,
-            src=cache.global_ranks[0],
-            group=cache.group,
-        )
+        dist.broadcast(canonical, src=cache.global_ranks[0], group=cache.group)
         mismatch = not torch.equal(canonical, weight.detach())
         if mismatch:
             local_max_abs = (

--- a/experimental/lite/megatron/lite/primitive/parallel/state.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/state.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 import torch.distributed as dist  # pyright: ignore[reportMissingImports]
-
 from megatron.lite.primitive.utils import ensure_divisible
 
 

--- a/experimental/lite/megatron/lite/primitive/parallel/state.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/state.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import torch.distributed as dist  # pyright: ignore[reportMissingImports]
 
@@ -18,12 +18,21 @@ class ParallelState:
     cp_group: dist.ProcessGroup | None = None
     pp_group: dist.ProcessGroup | None = None
     pp_cpu_group: dist.ProcessGroup | None = None
+    embedding_group: dist.ProcessGroup | None = None
     dp_group: dist.ProcessGroup | None = None
     dp_cp_group: dist.ProcessGroup | None = None
     tp_ep_group: dist.ProcessGroup | None = None
     ep_dp_group: dist.ProcessGroup | None = None
     cp_global_ranks: list[int] | None = None
     pp_global_ranks: list[int] | None = None
+    embedding_global_ranks: list[int] | None = None
+    embedding_groups_initialized: bool = False
+    # Populated only after the first/last parameter metadata and initialization
+    # data collective both succeed. Kept opaque here to avoid a state ->
+    # shared_embedding import cycle.
+    mtp_embedding_preflight_cache: object | None = field(
+        default=None, repr=False, compare=False
+    )
 
     tp_size: int = 1
     ep_size: int = 1
@@ -194,4 +203,43 @@ def init_parallel(config) -> ParallelState:
     return ps
 
 
-__all__ = ["ParallelState", "init_parallel"]
+def init_mtp_embedding_group(ps: ParallelState) -> None:
+    """Create first/last PP embedding replica groups only for MTP-enabled models."""
+    if ps.embedding_groups_initialized:
+        return
+    # Any new group generation invalidates a cache tied to the previous group.
+    ps.mtp_embedding_preflight_cache = None
+    if ps.pp_size <= 1:
+        ps.embedding_groups_initialized = True
+        return
+    if not dist.is_initialized():
+        raise RuntimeError(
+            "MTP embedding groups require initialized torch.distributed."
+        )
+
+    expected_world = ps.tp_size * ps.cp_size * ps.pp_size * ps.dp_size
+    if dist.get_world_size() != expected_world:
+        raise RuntimeError(
+            "MTP embedding group rank decomposition does not match world size: "
+            f"world={dist.get_world_size()}, expected={expected_world}."
+        )
+
+    def dense_rank(tp_i: int, cp_i: int, dp_i: int, pp_i: int) -> int:
+        return ((pp_i * ps.dp_size + dp_i) * ps.cp_size + cp_i) * ps.tp_size + tp_i
+
+    rank = dist.get_rank()
+    for dp_i in range(ps.dp_size):
+        for cp_i in range(ps.cp_size):
+            for tp_i in range(ps.tp_size):
+                ranks = [
+                    dense_rank(tp_i, cp_i, dp_i, 0),
+                    dense_rank(tp_i, cp_i, dp_i, ps.pp_size - 1),
+                ]
+                group = dist.new_group(ranks)
+                if rank in ranks:
+                    ps.embedding_group = group
+                    ps.embedding_global_ranks = ranks
+    ps.embedding_groups_initialized = True
+
+
+__all__ = ["ParallelState", "init_mtp_embedding_group", "init_parallel"]

--- a/experimental/lite/megatron/lite/primitive/parallel/thd.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/thd.py
@@ -32,6 +32,7 @@ class PackedTHDBatch:
 
 def _make_packed_seq_params(
     *,
+    cu_seqlens: torch.Tensor,
     cu_seqlens_padded: torch.Tensor,
     max_seqlen: int,
     cp_size: int = 1,
@@ -45,8 +46,8 @@ def _make_packed_seq_params(
             extra_args["cp_group"] = cp_group
     return PackedSeqParams(
         qkv_format="thd",
-        cu_seqlens_q=cu_seqlens_padded,
-        cu_seqlens_kv=cu_seqlens_padded,
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_kv=cu_seqlens,
         max_seqlen_q=max_seqlen,
         max_seqlen_kv=max_seqlen,
         cu_seqlens_q_padded=cu_seqlens_padded,
@@ -385,7 +386,7 @@ def roll_packed_thd_left(
     cp_rank = 0
     cp_group = None
     if packed_seq_params is not None:
-        cu_seqlens_padded = getattr(packed_seq_params, "cu_seqlens_q", None)
+        cu_seqlens_padded = _packed_cu_seqlens(packed_seq_params)
         cp_size = int(getattr(packed_seq_params, "local_cp_size", None) or 1)
         cp_rank = int(getattr(packed_seq_params, "cp_rank", 0) or 0)
         cp_group = getattr(packed_seq_params, "cp_group", None)
@@ -457,6 +458,8 @@ def pack_nested_thd(
 
     cu_seqlens_padded = torch.zeros(lengths.numel() + 1, dtype=torch.int32, device=device)
     cu_seqlens_padded[1:] = torch.cumsum(padded_lengths, dim=0)
+    cu_seqlens = torch.zeros_like(cu_seqlens_padded)
+    cu_seqlens[1:] = torch.cumsum(lengths, dim=0)
     total_padded = int(cu_seqlens_padded[-1].item())
     total_local = total_padded // cp_size if split_cp else total_padded
     max_seqlen = int(padded_lengths.max().item()) if padded_lengths.numel() else 0
@@ -555,6 +558,7 @@ def pack_nested_thd(
         loss_mask=(packed_loss_mask.unsqueeze(0) if packed_loss_mask is not None else None),
         position_ids=position_ids.unsqueeze(0),
         packed_seq_params=_make_packed_seq_params(
+            cu_seqlens=cu_seqlens,
             cu_seqlens_padded=cu_seqlens_padded,
             max_seqlen=max_seqlen,
             cp_size=cp_size if split_cp else 1,

--- a/experimental/lite/megatron/lite/primitive/parallel/thd.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/thd.py
@@ -9,7 +9,6 @@ from typing import Any
 
 import torch
 import torch.distributed as dist
-
 from megatron.lite.primitive.utils.packed_seq import PackedSeqParams
 
 
@@ -57,20 +56,29 @@ def _make_packed_seq_params(
     )
 
 
-def _slice_along_dim(tensor: torch.Tensor, dim: int, start: int, end: int) -> torch.Tensor:
+def _slice_along_dim(
+    tensor: torch.Tensor, dim: int, start: int, end: int
+) -> torch.Tensor:
     index = [slice(None)] * tensor.dim()
     index[dim] = slice(start, end)
     return tensor[tuple(index)]
 
 
-def _assign_along_dim(dst: torch.Tensor, dim: int, start: int, src: torch.Tensor) -> None:
+def _assign_along_dim(
+    dst: torch.Tensor, dim: int, start: int, src: torch.Tensor
+) -> None:
     index = [slice(None)] * dst.dim()
     index[dim] = slice(start, start + src.size(dim))
     dst[tuple(index)] = src
 
 
 def _split_full_to_cp_local(
-    tensor: torch.Tensor, *, cu_seqlens_padded: torch.Tensor, cp_size: int, cp_rank: int, dim: int
+    tensor: torch.Tensor,
+    *,
+    cu_seqlens_padded: torch.Tensor,
+    cp_size: int,
+    cp_rank: int,
+    dim: int,
 ) -> torch.Tensor:
     if cp_size <= 1:
         return tensor
@@ -90,7 +98,10 @@ def _split_full_to_cp_local(
         local_start = full_start // cp_size
 
         first = _slice_along_dim(
-            tensor, dim, full_start + cp_rank * chunk, full_start + (cp_rank + 1) * chunk
+            tensor,
+            dim,
+            full_start + cp_rank * chunk,
+            full_start + (cp_rank + 1) * chunk,
         )
         second = _slice_along_dim(
             tensor, dim, full_end - (cp_rank + 1) * chunk, full_end - cp_rank * chunk
@@ -102,7 +113,11 @@ def _split_full_to_cp_local(
 
 
 def _reconstruct_full_from_cp_parts(
-    parts: list[torch.Tensor], *, cu_seqlens_padded: torch.Tensor, cp_size: int, dim: int
+    parts: list[torch.Tensor],
+    *,
+    cu_seqlens_padded: torch.Tensor,
+    cp_size: int,
+    dim: int,
 ) -> torch.Tensor:
     if cp_size <= 1:
         return parts[0]
@@ -123,7 +138,9 @@ def _reconstruct_full_from_cp_parts(
 
         for rank, part in enumerate(parts):
             first = _slice_along_dim(part, dim, local_start, local_start + chunk)
-            second = _slice_along_dim(part, dim, local_start + chunk, local_start + 2 * chunk)
+            second = _slice_along_dim(
+                part, dim, local_start + chunk, local_start + 2 * chunk
+            )
             _assign_along_dim(full, dim, full_start + rank * chunk, first)
             _assign_along_dim(full, dim, full_end - (rank + 1) * chunk, second)
 
@@ -131,7 +148,11 @@ def _reconstruct_full_from_cp_parts(
 
 
 def reconstruct_packed_from_cp_parts(
-    parts: list[torch.Tensor], *, cu_seqlens_padded: torch.Tensor, cp_size: int, dim: int
+    parts: list[torch.Tensor],
+    *,
+    cu_seqlens_padded: torch.Tensor,
+    cp_size: int,
+    dim: int,
 ) -> torch.Tensor:
     """Reconstruct a full packed THD tensor from CP-local zigzag parts."""
     return _reconstruct_full_from_cp_parts(
@@ -140,11 +161,20 @@ def reconstruct_packed_from_cp_parts(
 
 
 def split_packed_to_cp_local(
-    tensor: torch.Tensor, *, cu_seqlens_padded: torch.Tensor, cp_size: int, cp_rank: int, dim: int
+    tensor: torch.Tensor,
+    *,
+    cu_seqlens_padded: torch.Tensor,
+    cp_size: int,
+    cp_rank: int,
+    dim: int,
 ) -> torch.Tensor:
     """Slice a full packed THD tensor back to one CP rank's zigzag shard."""
     return _split_full_to_cp_local(
-        tensor, cu_seqlens_padded=cu_seqlens_padded, cp_size=cp_size, cp_rank=cp_rank, dim=dim
+        tensor,
+        cu_seqlens_padded=cu_seqlens_padded,
+        cp_size=cp_size,
+        cp_rank=cp_rank,
+        dim=dim,
     )
 
 
@@ -165,7 +195,9 @@ def _sequence_dim(tensor: torch.Tensor) -> int:
     return tensor.dim() - 1 if tensor.dim() > 1 else 0
 
 
-def _with_cp_metadata(packed_seq_params: Any, *, cp_size: int, cp_rank: int, cp_group: Any):
+def _with_cp_metadata(
+    packed_seq_params: Any, *, cp_size: int, cp_rank: int, cp_group: Any
+):
     updated = copy(packed_seq_params)
     updated.local_cp_size = cp_size
     updated.cp_rank = cp_rank
@@ -217,7 +249,11 @@ def prepare_packed_thd_for_context_parallel(
         if tensor is None:
             local_tensors.append(None)
             continue
-        dim = _sequence_dim(tensor) if dims is None or dims[idx] is None else int(dims[idx])
+        dim = (
+            _sequence_dim(tensor)
+            if dims is None or dims[idx] is None
+            else int(dims[idx])
+        )
         local_tensors.append(
             _split_full_to_cp_local(
                 tensor,
@@ -228,7 +264,9 @@ def prepare_packed_thd_for_context_parallel(
             )
         )
     return (
-        _with_cp_metadata(packed_seq_params, cp_size=cp_size, cp_rank=cp_rank, cp_group=cp_group),
+        _with_cp_metadata(
+            packed_seq_params, cp_size=cp_size, cp_rank=cp_rank, cp_group=cp_group
+        ),
         tuple(local_tensors),
     )
 
@@ -314,12 +352,17 @@ def unpack_thd_to_nested(
         flat = output
 
     if meta.cp_size > 1:
-        parts = _all_gather_cp_tensor(flat, cp_size=meta.cp_size, cp_group=meta.cp_group)
+        parts = _all_gather_cp_tensor(
+            flat, cp_size=meta.cp_size, cp_group=meta.cp_group
+        )
         if contiguous:
             flat = torch.cat(parts, dim=0)
         else:
             flat = _reconstruct_full_from_cp_parts(
-                parts, cu_seqlens_padded=meta.cu_seqlens_padded, cp_size=meta.cp_size, dim=0
+                parts,
+                cu_seqlens_padded=meta.cu_seqlens_padded,
+                cp_size=meta.cp_size,
+                dim=0,
             )
 
     pieces = []
@@ -352,7 +395,9 @@ def _roll_packed_thd_left_local(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     dim = dims if dims >= 0 else tensor.dim() + dims
     if dim < 0 or dim >= tensor.dim():
-        raise ValueError(f"Invalid roll dim {dims} for tensor with {tensor.dim()} dims.")
+        raise ValueError(
+            f"Invalid roll dim {dims} for tensor with {tensor.dim()} dims."
+        )
 
     rolled = tensor.clone()
     for idx in range(int(cu_seqlens_padded.numel()) - 1):
@@ -395,7 +440,9 @@ def roll_packed_thd_left(
 
     dim = dims if dims >= 0 else tensor.dim() + dims
     if cp_size <= 1:
-        return _roll_packed_thd_left_local(tensor, cu_seqlens_padded=cu_seqlens_padded, dims=dim)
+        return _roll_packed_thd_left_local(
+            tensor, cu_seqlens_padded=cu_seqlens_padded, dims=dim
+        )
 
     parts = _all_gather_cp_tensor(tensor, cp_size=cp_size, cp_group=cp_group)
     full = _reconstruct_full_from_cp_parts(
@@ -405,7 +452,11 @@ def roll_packed_thd_left(
         full, cu_seqlens_padded=cu_seqlens_padded, dims=dim
     )
     local = _split_full_to_cp_local(
-        rolled_full, cu_seqlens_padded=cu_seqlens_padded, cp_size=cp_size, cp_rank=cp_rank, dim=dim
+        rolled_full,
+        cu_seqlens_padded=cu_seqlens_padded,
+        cp_size=cp_size,
+        cp_rank=cp_rank,
+        dim=dim,
     )
     return local, token_sum
 
@@ -456,7 +507,9 @@ def pack_nested_thd(
     pad_size = (align_size - lengths % align_size) % align_size
     padded_lengths = lengths + pad_size
 
-    cu_seqlens_padded = torch.zeros(lengths.numel() + 1, dtype=torch.int32, device=device)
+    cu_seqlens_padded = torch.zeros(
+        lengths.numel() + 1, dtype=torch.int32, device=device
+    )
     cu_seqlens_padded[1:] = torch.cumsum(padded_lengths, dim=0)
     cu_seqlens = torch.zeros_like(cu_seqlens_padded)
     cu_seqlens[1:] = torch.cumsum(lengths, dim=0)
@@ -466,7 +519,9 @@ def pack_nested_thd(
 
     packed_input = torch.zeros(total_local, dtype=input_ids.dtype, device=device)
     packed_labels = (
-        torch.zeros(total_local, dtype=labels.dtype, device=device) if labels is not None else None
+        torch.zeros(total_local, dtype=labels.dtype, device=device)
+        if labels is not None
+        else None
     )
     packed_loss_mask = (
         torch.zeros(total_local, dtype=loss_mask.dtype, device=device)
@@ -496,10 +551,14 @@ def pack_nested_thd(
         seq_loss_mask = None
         if loss_mask is not None:
             assert packed_loss_mask is not None
-            seq_loss_mask = torch.zeros(padded_length, dtype=loss_mask.dtype, device=device)
+            seq_loss_mask = torch.zeros(
+                padded_length, dtype=loss_mask.dtype, device=device
+            )
             seq_loss_mask[:length] = loss_mask[idx]
             if roll_loss_mask and length > 0:
-                seq_loss_mask[:length] = torch.roll(seq_loss_mask[:length], shifts=-1, dims=0)
+                seq_loss_mask[:length] = torch.roll(
+                    seq_loss_mask[:length], shifts=-1, dims=0
+                )
                 seq_loss_mask[length - 1] = 0
         seq_positions = torch.zeros(padded_length, dtype=torch.long, device=device)
         seq_positions[:length] = torch.arange(length, dtype=torch.long, device=device)
@@ -533,7 +592,9 @@ def pack_nested_thd(
                 else seq_labels
             )
             assert packed_labels is not None
-            packed_labels[local_start : local_start + local_labels.numel()] = local_labels
+            packed_labels[local_start : local_start + local_labels.numel()] = (
+                local_labels
+            )
         if seq_loss_mask is not None:
             local_loss_mask = (
                 _split_full_to_cp_local(
@@ -549,13 +610,17 @@ def pack_nested_thd(
                 else seq_loss_mask
             )
             assert packed_loss_mask is not None
-            packed_loss_mask[local_start : local_start + local_loss_mask.numel()] = local_loss_mask
+            packed_loss_mask[local_start : local_start + local_loss_mask.numel()] = (
+                local_loss_mask
+            )
         position_ids[full_start : full_start + padded_length] = seq_positions
 
     return PackedTHDBatch(
         input_ids=packed_input.unsqueeze(0),
         labels=packed_labels.unsqueeze(0) if packed_labels is not None else None,
-        loss_mask=(packed_loss_mask.unsqueeze(0) if packed_loss_mask is not None else None),
+        loss_mask=(
+            packed_loss_mask.unsqueeze(0) if packed_loss_mask is not None else None
+        ),
         position_ids=position_ids.unsqueeze(0),
         packed_seq_params=_make_packed_seq_params(
             cu_seqlens=cu_seqlens,
@@ -574,7 +639,9 @@ def pack_nested_thd(
     )
 
 
-def unpack_packed_thd_to_nested(output: torch.Tensor, batch: PackedTHDBatch) -> torch.Tensor:
+def unpack_packed_thd_to_nested(
+    output: torch.Tensor, batch: PackedTHDBatch
+) -> torch.Tensor:
     """Unpack ``[1, total_padded, ...]`` THD model output back to jagged form."""
 
     if output.dim() >= 2 and output.shape[0] == 1:
@@ -586,9 +653,14 @@ def unpack_packed_thd_to_nested(output: torch.Tensor, batch: PackedTHDBatch) -> 
 
     if batch.cp_size > 1:
         dim = 0
-        parts = _all_gather_cp_tensor(flat, cp_size=batch.cp_size, cp_group=batch.cp_group)
+        parts = _all_gather_cp_tensor(
+            flat, cp_size=batch.cp_size, cp_group=batch.cp_group
+        )
         flat = _reconstruct_full_from_cp_parts(
-            parts, cu_seqlens_padded=batch.cu_seqlens_padded, cp_size=batch.cp_size, dim=dim
+            parts,
+            cu_seqlens_padded=batch.cu_seqlens_padded,
+            cp_size=batch.cp_size,
+            dim=dim,
         )
 
     pieces = []

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -14,7 +14,11 @@ import torch
 import torch.distributed as dist
 from megatron.lite.runtime.backends import Runtime as RuntimeBase
 from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig
-from megatron.lite.runtime.contracts.data import ForwardResult, ModelOutputs, PackedBatch
+from megatron.lite.runtime.contracts.data import (
+    ForwardResult,
+    ModelOutputs,
+    PackedBatch,
+)
 from megatron.lite.runtime.contracts.handle import ModelHandle
 from megatron.lite.runtime.contracts.loss import split_loss_context
 
@@ -24,14 +28,22 @@ def _build_impl_cfg(proto, rt_cfg: MegatronLiteConfig):
     init_fields = {f.name for f in dc_fields(proto.ImplConfig) if f.init}
     # Only forward impl_cfg keys this model's ImplConfig declares: the connector
     # may pass knobs (e.g. cross_entropy_fusion) that some models don't model.
-    impl_cfg_kwargs = {key: value for key, value in rt_cfg.impl_cfg.items() if key in init_fields}
+    impl_cfg_kwargs = {
+        key: value for key, value in rt_cfg.impl_cfg.items() if key in init_fields
+    }
     impl_cfg_kwargs["parallel"] = rt_cfg.parallel
     if (
         "attention_backend_override" in init_fields
         and impl_cfg_kwargs.get("attention_backend_override") is None
     ):
-        impl_cfg_kwargs["attention_backend_override"] = rt_cfg.attention_backend_override
-    if "hf_path" in init_fields and impl_cfg_kwargs.get("hf_path") in (None, "") and rt_cfg.hf_path:
+        impl_cfg_kwargs["attention_backend_override"] = (
+            rt_cfg.attention_backend_override
+        )
+    if (
+        "hf_path" in init_fields
+        and impl_cfg_kwargs.get("hf_path") in (None, "")
+        and rt_cfg.hf_path
+    ):
         impl_cfg_kwargs["hf_path"] = rt_cfg.hf_path
     # Thread the user-level OptimizerConfig so the protocol can pass it to
     # optimizer primitives without reading runtime internals.
@@ -67,9 +79,13 @@ def _apply_attention_backend_env(backend: str | None, *, tag: str) -> None:
     os.environ["NVTE_UNFUSED_ATTN"] = unfused
 
 
-def _infer_pipeline_tensor_shape(batch: PackedBatch, model_cfg: Any, ps) -> tuple[int, int, int]:
+def _infer_pipeline_tensor_shape(
+    batch: PackedBatch, model_cfg: Any, ps
+) -> tuple[int, int, int]:
     if model_cfg is None or not hasattr(model_cfg, "hidden_size"):
-        raise ValueError("Megatron Lite pipeline runtime requires model_cfg.hidden_size.")
+        raise ValueError(
+            "Megatron Lite pipeline runtime requires model_cfg.hidden_size."
+        )
     if not isinstance(batch, PackedBatch):
         raise TypeError("Megatron Lite pipeline runtime requires PackedBatch inputs.")
 
@@ -81,7 +97,9 @@ def _infer_pipeline_tensor_shape(batch: PackedBatch, model_cfg: Any, ps) -> tupl
         batch_size = int(input_ids.size(0))
         local_seq_len = int(input_ids.size(1))
     else:
-        raise ValueError(f"Unsupported input_ids rank for pipeline runtime: {input_ids.dim()}.")
+        raise ValueError(
+            f"Unsupported input_ids rank for pipeline runtime: {input_ids.dim()}."
+        )
 
     if local_seq_len < 1:
         raise ValueError("Pipeline tensor shape requires non-empty sequence.")
@@ -95,7 +113,11 @@ def _infer_pipeline_tensor_shape(batch: PackedBatch, model_cfg: Any, ps) -> tupl
     # (each sequence padded to align = tp * (2*cp if cp>1 else 1)) then divide by CP*TP.
     seq_lens = getattr(batch, "seq_lens", None)
     if seq_lens is not None and cp_size * tp_size > 1:
-        sl = seq_lens if isinstance(seq_lens, torch.Tensor) else torch.as_tensor(seq_lens)
+        sl = (
+            seq_lens
+            if isinstance(seq_lens, torch.Tensor)
+            else torch.as_tensor(seq_lens)
+        )
         sl = sl.to(torch.int64).reshape(-1)
         align = tp_size * (2 * cp_size if cp_size > 1 else 1)
         padded = sl + (align - sl % align) % align
@@ -133,18 +155,36 @@ def _checkpoint_module(model: Any) -> torch.nn.Module:
     )
 
 
-def _load_hf_chunks(proto, chunks, hf_path: str, model_cfg, ps) -> None:
+def _load_hf_chunks(
+    proto,
+    chunks,
+    hf_path: str,
+    model_cfg,
+    ps,
+    *,
+    participating_group: dist.ProcessGroup | None = None,
+) -> None:
     """Require an all-chunk transaction whenever VPP owns multiple chunks."""
     load_many = getattr(proto, "load_hf_weights_many", None)
     if callable(load_many):
-        load_many(chunks, hf_path, model_cfg, ps)
+        if participating_group is None:
+            load_many(chunks, hf_path, model_cfg, ps)
+        else:
+            load_many(
+                chunks, hf_path, model_cfg, ps, participating_group=participating_group
+            )
         return
     if len(chunks) != 1:
         raise NotImplementedError(
             "VPP HF loading requires the model protocol to implement "
             "load_hf_weights_many; sequential chunk mutation is not atomic."
         )
-    proto.load_hf_weights(chunks[0], hf_path, model_cfg, ps)
+    if participating_group is None:
+        proto.load_hf_weights(chunks[0], hf_path, model_cfg, ps)
+    else:
+        proto.load_hf_weights(
+            chunks[0], hf_path, model_cfg, ps, participating_group=participating_group
+        )
 
 
 class MegatronLiteRuntime(RuntimeBase):
@@ -166,6 +206,7 @@ class MegatronLiteRuntime(RuntimeBase):
         cfg: MegatronLiteConfig | dict[str, Any] | None = None,
         **kwargs,
     ) -> ModelHandle:
+        hf_load_participating_group = kwargs.pop("participating_group", None)
         if cfg is not None and isinstance(cfg, dict):
             rt_cfg = MegatronLiteConfig.from_dict(hf_path or self._hf_path, cfg)
         elif cfg is not None and isinstance(cfg, MegatronLiteConfig):
@@ -188,7 +229,12 @@ class MegatronLiteRuntime(RuntimeBase):
 
         # ── escape hatch: model takes over ──
         if hasattr(proto, "create_runtime"):
-            return proto.create_runtime(rt_cfg.hf_path, rt_cfg).build_model()
+            nested_runtime = proto.create_runtime(rt_cfg.hf_path, rt_cfg)
+            if hf_load_participating_group is None:
+                return nested_runtime.build_model()
+            return nested_runtime.build_model(
+                participating_group=hf_load_participating_group
+            )
 
         # ── construct impl_cfg (parallel injected) ──
         impl_cfg = _build_impl_cfg(proto, rt_cfg)
@@ -203,13 +249,18 @@ class MegatronLiteRuntime(RuntimeBase):
 
         # ── load HF weights (optional) ──
         loaded_hf_weights = False
-        if rt_cfg.load_hf_weights and rt_cfg.hf_path and hasattr(proto, "load_hf_weights"):
+        if (
+            rt_cfg.load_hf_weights
+            and rt_cfg.hf_path
+            and hasattr(proto, "load_hf_weights")
+        ):
             _load_hf_chunks(
                 proto,
                 bundle.chunks,
                 rt_cfg.hf_path,
                 model_cfg,
                 bundle.parallel_state,
+                participating_group=hf_load_participating_group,
             )
             loaded_hf_weights = True
 
@@ -226,7 +277,9 @@ class MegatronLiteRuntime(RuntimeBase):
                 extra_updates = post_load_updates.get("extras")
                 if extra_updates:
                     if not isinstance(extra_updates, dict):
-                        raise TypeError("post_model_load_hook extras update must be a dict.")
+                        raise TypeError(
+                            "post_model_load_hook extras update must be a dict."
+                        )
                     bundle.extras.update(extra_updates)
 
         if loaded_hf_weights and bundle.optimizer is not None:
@@ -235,7 +288,9 @@ class MegatronLiteRuntime(RuntimeBase):
                 reload_model_params()
 
         if bundle.forward_step is None:
-            raise ValueError("Megatron Lite model bundles must provide a typed forward_step.")
+            raise ValueError(
+                "Megatron Lite model bundles must provide a typed forward_step."
+            )
 
         p = rt_cfg.parallel
         model = bundle.chunks[0] if len(bundle.chunks) == 1 else bundle.chunks
@@ -259,7 +314,10 @@ class MegatronLiteRuntime(RuntimeBase):
 
     def _load_protocol(self, rt_cfg: MegatronLiteConfig):
         """Load and return the model protocol module."""
-        from megatron.lite.model.registry import TRAIN_RUNTIME_MODULES, resolve_runtime_model_name
+        from megatron.lite.model.registry import (
+            TRAIN_RUNTIME_MODULES,
+            resolve_runtime_model_name,
+        )
 
         try:
             runtime_key = resolve_runtime_model_name(rt_cfg.model_name, rt_cfg.impl)
@@ -279,7 +337,9 @@ class MegatronLiteRuntime(RuntimeBase):
 
         for fn_name in ("build_model_config", "build_model"):
             if not callable(getattr(proto, fn_name, None)):
-                raise ValueError(f"Protocol module {mod_path} missing required function: {fn_name}")
+                raise ValueError(
+                    f"Protocol module {mod_path} missing required function: {fn_name}"
+                )
         if not hasattr(proto, "ImplConfig"):
             raise ValueError(f"Protocol module {mod_path} missing ImplConfig class")
 
@@ -342,7 +402,9 @@ class MegatronLiteRuntime(RuntimeBase):
             **kwargs,
         )
 
-    def export_weights(self, handle: ModelHandle, **kwargs) -> Iterator[tuple[str, torch.Tensor]]:
+    def export_weights(
+        self, handle: ModelHandle, **kwargs
+    ) -> Iterator[tuple[str, torch.Tensor]]:
         model_chunks = handle._extras.get("model_chunks", [handle._model])
         proto = handle._extras.get("protocol")
         model_cfg = handle._extras.get("model_cfg")
@@ -428,7 +490,9 @@ class MegatronLiteRuntime(RuntimeBase):
         if ps.pp_size > 1:
             from types import SimpleNamespace
 
-            from megatron.lite.primitive.parallel.pipeline import forward_backward_pipelining
+            from megatron.lite.primitive.parallel.pipeline import (
+                forward_backward_pipelining,
+            )
 
             first_item = next(data_iter)
             first_batch, _loss_context = split_loss_context(first_item)
@@ -578,7 +642,10 @@ def _checkpoint_model(handle: ModelHandle, *, use_dcp: bool):
 
 
 def _checkpoint_hooks(handle: ModelHandle):
-    from megatron.lite.primitive.protocols import default_expert_classifier, default_placement_fn
+    from megatron.lite.primitive.protocols import (
+        default_expert_classifier,
+        default_placement_fn,
+    )
 
     proto = handle._extras.get("protocol")
     return (

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -133,6 +133,20 @@ def _checkpoint_module(model: Any) -> torch.nn.Module:
     )
 
 
+def _load_hf_chunks(proto, chunks, hf_path: str, model_cfg, ps) -> None:
+    """Require an all-chunk transaction whenever VPP owns multiple chunks."""
+    load_many = getattr(proto, "load_hf_weights_many", None)
+    if callable(load_many):
+        load_many(chunks, hf_path, model_cfg, ps)
+        return
+    if len(chunks) != 1:
+        raise NotImplementedError(
+            "VPP HF loading requires the model protocol to implement "
+            "load_hf_weights_many; sequential chunk mutation is not atomic."
+        )
+    proto.load_hf_weights(chunks[0], hf_path, model_cfg, ps)
+
+
 class MegatronLiteRuntime(RuntimeBase):
     """Megatron Lite default training backend (Megatron-style 5D parallel)."""
 
@@ -190,8 +204,13 @@ class MegatronLiteRuntime(RuntimeBase):
         # ── load HF weights (optional) ──
         loaded_hf_weights = False
         if rt_cfg.load_hf_weights and rt_cfg.hf_path and hasattr(proto, "load_hf_weights"):
-            for chunk in bundle.chunks:
-                proto.load_hf_weights(chunk, rt_cfg.hf_path, model_cfg, bundle.parallel_state)
+            _load_hf_chunks(
+                proto,
+                bundle.chunks,
+                rt_cfg.hf_path,
+                model_cfg,
+                bundle.parallel_state,
+            )
             loaded_hf_weights = True
 
         post_load_hook = bundle.extras.pop("post_model_load_hook", None)

--- a/experimental/lite/tests/README.md
+++ b/experimental/lite/tests/README.md
@@ -11,6 +11,14 @@ Run unit coverage:
 PYTHONPATH="$(pwd):$(pwd)/experimental/lite" pytest experimental/lite/tests/unit
 ```
 
+Pure config and weight-mapping modules can be imported without `safetensors`.
+Tests or runtime paths that read/write HF checkpoint files require the optional
+`safetensors` package and fail with an explicit dependency error when it is absent.
+Training DCP loads require the completion manifest and model schema emitted by
+the current writer. Pre-manifest checkpoints are rejected by default; a
+one-time migration tool may opt in with `allow_legacy_checkpoint=True`, then
+must re-save in the current format before normal training resumes.
+
 Run smoke coverage on one node:
 
 ```bash
@@ -19,6 +27,24 @@ PYTHONPATH="$(pwd):$(pwd)/experimental/lite" MLITE_RUN_SMOKE=1 MLITE_SMOKE_NPROC
 ```
 
 The smoke suite is skipped by default in regular `pytest` runs. Enable it with `--mlite-smoke` or `MLITE_RUN_SMOKE=1`.
+Release-acceptance commands should also pass `--mlite-fail-on-skip`; this turns
+any selected skip or xfail (including a missing CUDA/kernel dependency) into a
+test failure instead of silently accepting an unexecuted gate.
+
+The pinned GLM-5.2-FP8 real-weight projection gate downloads only the three
+required byte ranges (12,590,080 bytes total), verifies their release hashes,
+and then runs on one GPU:
+
+```bash
+python experimental/lite/tests/fetch_glm52_fp8_projection_authority.py /tmp/glm52-fp8
+GLM52_FP8_PROJECTION_AUTHORITY_DIR=/tmp/glm52-fp8 \
+  pytest --mlite-smoke --mlite-fail-on-skip -q -s \
+  experimental/lite/tests/smoke/model/test_glm52_fp8_real_weight_projection_smoke.py
+```
+
+This is pinned real-checkpoint, dequantized-BF16 q_a projection-level evidence
+through the production `torch.nn.Linear` + Transformer Engine RMSNorm path. It
+is not HF quantized-runtime, full-model, or long-context parity.
 
 Current matrix:
 

--- a/experimental/lite/tests/README.md
+++ b/experimental/lite/tests/README.md
@@ -46,6 +46,22 @@ This is pinned real-checkpoint, dequantized-BF16 q_a projection-level evidence
 through the production `torch.nn.Linear` + Transformer Engine RMSNorm path. It
 is not HF quantized-runtime, full-model, or long-context parity.
 
+The GLM-5.2 indexer-RoPE authority is independent of vanilla Transformers
+5.12, whose indexer ignores the released `indexer_rope_interleave=true` field.
+Fetch the pinned release config and vLLM v0.23.0 sources, verify their exact
+revisions and digests, then run the score/top-k oracle:
+
+```bash
+python experimental/lite/tests/fetch_glm52_rope_layout_authority.py /tmp/glm52-rope
+pytest --mlite-fail-on-skip -q -s \
+  experimental/lite/tests/unit/model/test_glm52_hf_attention_parity.py
+```
+
+The oracle binds MLite's real `DSAIndexer` to the released adjacent-pair
+layout at score/top-k level. The full-model comparison uses an explicitly
+adapted, instance-local HF indexer subclass; it is supporting numerical
+evidence, not a claim of unmodified-Transformers or Megatron-Bridge parity.
+
 Current matrix:
 
 | Surface | Unit | Smoke |
@@ -69,5 +85,7 @@ Current matrix:
 | Optimizer update-state offload fraction | `unit/primitive/test_runtime_config_unit.py` and single-process CUDA coverage in `unit/primitive/test_fsdp2_offload_gpu.py` | multi-rank offloaded grad clipping is checked against the non-offloaded baseline in `smoke/primitive/test_fsdp2_offload_checkpoint_smoke.py` |
 | Qwen3 MoE lite config/build/forward | `unit/model/test_qwen_config_unit.py` | `smoke/model/test_qwen_lite_forward_smoke.py` |
 | Qwen3.5 MoE lite config/build/forward | `unit/model/test_qwen_config_unit.py` | `smoke/model/test_qwen_lite_forward_smoke.py` |
+| GLM-5.2 released RoPE/index-share layout | `unit/model/test_glm52_hf_attention_parity.py`, `unit/model/test_glm5_lite_static.py` | `smoke/model/test_glm52_hf_production_layout_full_model_smoke.py`, `smoke/model/test_glm52_fp8_real_weight_projection_smoke.py` |
+| VERL external-engine registry and THD/CP runtime | `unit/verl/test_mlite_engine_config.py` | `unit/verl/test_mlite_engine_cp_smoke.py` (distributed smoke markers; not Ray worker/trainer E2E) |
 
 Classic FSDP is not a separate MLite primitive in the current source tree; MLite's native sharded optimizer coverage is FSDP2 plus Megatron DDP/distopt.

--- a/experimental/lite/tests/conftest.py
+++ b/experimental/lite/tests/conftest.py
@@ -17,18 +17,34 @@ for root in (REPO_ROOT, LITE_ROOT, VERL_EXAMPLE_ROOT):
 
 
 def pytest_configure(config):
-    config.addinivalue_line("markers", "mlite: mark a test as Megatron Lite validation coverage")
+    config.addinivalue_line(
+        "markers", "mlite: mark a test as Megatron Lite validation coverage"
+    )
     config.addinivalue_line(
         "markers",
         "smoke: mark a Megatron Lite smoke test; skipped unless --mlite-smoke or MLITE_RUN_SMOKE=1 is set",
     )
     config.addinivalue_line("markers", "gpu: mark a test as requiring CUDA")
-    config.addinivalue_line("markers", "distributed: mark a test as requiring torch.distributed")
+    config.addinivalue_line(
+        "markers", "distributed: mark a test as requiring torch.distributed"
+    )
 
 
 def pytest_addoption(parser):
     parser.addoption(
-        "--mlite-smoke", action="store_true", default=False, help="run Megatron Lite smoke tests"
+        "--mlite-smoke",
+        action="store_true",
+        default=False,
+        help="run Megatron Lite smoke tests",
+    )
+    parser.addoption(
+        "--mlite-fail-on-skip",
+        action="store_true",
+        default=False,
+        help=(
+            "fail the test session if any selected test is skipped or xfailed; "
+            "intended for release-acceptance invocations"
+        ),
     )
 
 
@@ -36,10 +52,35 @@ def pytest_collection_modifyitems(config, items):
     run_smoke = config.getoption("--mlite-smoke") or os.getenv("MLITE_RUN_SMOKE") == "1"
     if run_smoke:
         return
-    skip_smoke = pytest.mark.skip(reason="set --mlite-smoke or MLITE_RUN_SMOKE=1 to run")
+    skip_smoke = pytest.mark.skip(
+        reason="set --mlite-smoke or MLITE_RUN_SMOKE=1 to run"
+    )
     for item in items:
         if "smoke" in item.keywords:
             item.add_marker(skip_smoke)
+
+
+def pytest_sessionfinish(session, exitstatus):
+    del exitstatus
+    if not session.config.getoption("--mlite-fail-on-skip"):
+        return
+    reporter = session.config.pluginmanager.get_plugin("terminalreporter")
+    if reporter is None:
+        return
+    nonexecuted = [
+        *reporter.stats.get("skipped", ()),
+        *reporter.stats.get("xfailed", ()),
+    ]
+    if not nonexecuted:
+        return
+    nodeids = sorted({report.nodeid for report in nonexecuted})
+    reporter.write_sep(
+        "=",
+        "MLite acceptance rejected skipped/xfailed selected tests: "
+        + ", ".join(nodeids),
+        red=True,
+    )
+    session.exitstatus = pytest.ExitCode.TESTS_FAILED
 
 
 @pytest.fixture
@@ -58,7 +99,9 @@ def transformer_engine_import_stub(monkeypatch):
 
         class _UnavailableTE:
             def __init__(self, *args, **kwargs):
-                raise RuntimeError("Transformer Engine is not installed in this test environment.")
+                raise RuntimeError(
+                    "Transformer Engine is not installed in this test environment."
+                )
 
         root = types.ModuleType("transformer_engine")
         root.__version__ = "0.0.0"
@@ -93,12 +136,16 @@ def transformer_engine_import_stub(monkeypatch):
         root.pytorch = pytorch
         monkeypatch.setitem(sys.modules, "transformer_engine", root)
         monkeypatch.setitem(sys.modules, "transformer_engine.pytorch", pytorch)
-        monkeypatch.setitem(sys.modules, "transformer_engine.pytorch.permutation", permutation)
+        monkeypatch.setitem(
+            sys.modules, "transformer_engine.pytorch.permutation", permutation
+        )
         monkeypatch.setitem(sys.modules, "transformer_engine.pytorch.router", router)
         monkeypatch.setitem(
             sys.modules, "transformer_engine.pytorch.cpp_extensions", cpp_extensions
         )
         monkeypatch.setitem(sys.modules, "transformer_engine.pytorch.module", module)
-        monkeypatch.setitem(sys.modules, "transformer_engine.pytorch.module.base", module_base)
+        monkeypatch.setitem(
+            sys.modules, "transformer_engine.pytorch.module.base", module_base
+        )
 
     return install

--- a/experimental/lite/tests/fetch_glm52_fp8_projection_authority.py
+++ b/experimental/lite/tests/fetch_glm52_fp8_projection_authority.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Fetch only the pinned GLM-5.2-FP8 q_a projection payload ranges."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import urllib.request
+from pathlib import Path
+
+FIXTURE = Path(__file__).parent / "unit" / "model" / "glm52_fp8_header_authority.json"
+SHARD = "model-00001-of-00141.safetensors"
+OUTPUT_NAMES = {
+    "model.layers.0.self_attn.q_a_proj.weight": "q_a_proj.bin",
+    "model.layers.0.self_attn.q_a_proj.weight_scale_inv": "q_a_proj_scale_inv.bin",
+    "model.layers.0.self_attn.q_a_layernorm.weight": "q_a_layernorm.bin",
+}
+
+
+def _download_range(url: str, start: int, end: int) -> bytes:
+    request = urllib.request.Request(url, headers={"Range": f"bytes={start}-{end}"})
+    with urllib.request.urlopen(request, timeout=120) as response:
+        if response.status != 206:
+            raise RuntimeError(
+                f"range request returned HTTP {response.status}, expected 206; "
+                "refusing a possible full-shard download"
+            )
+        content_range = response.headers.get("Content-Range")
+        expected_prefix = f"bytes {start}-{end}/"
+        if not content_range or not content_range.startswith(expected_prefix):
+            raise RuntimeError(
+                f"range request returned Content-Range={content_range!r}, "
+                f"expected prefix {expected_prefix!r}"
+            )
+        payload = response.read(end - start + 2)
+    expected_bytes = end - start + 1
+    if len(payload) != expected_bytes:
+        raise RuntimeError(
+            f"range request returned {len(payload)} bytes, expected {expected_bytes}"
+        )
+    return payload
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("output_dir", type=Path)
+    args = parser.parse_args()
+
+    authority = json.loads(FIXTURE.read_text())
+    source = authority["source"]
+    shard = source["safetensors"][SHARD]
+    base_url = (
+        f"https://huggingface.co/{source['repo']}/resolve/"
+        f"{source['revision']}/{SHARD}"
+    )
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest = {
+        "repo": source["repo"],
+        "revision": source["revision"],
+        "shard": SHARD,
+        "payloads": {},
+    }
+    for tensor_name, filename in OUTPUT_NAMES.items():
+        contract = shard["payload_ranges"][tensor_name]
+        start, end = contract["file_range"]
+        payload = _download_range(base_url, start, end)
+        digest = hashlib.sha256(payload).hexdigest()
+        if digest != contract["sha256"]:
+            raise RuntimeError(
+                f"payload digest mismatch for {tensor_name}: "
+                f"actual={digest}, expected={contract['sha256']}"
+            )
+
+        destination = args.output_dir / filename
+        temporary = destination.with_name(f".{destination.name}.tmp.{os.getpid()}")
+        try:
+            temporary.write_bytes(payload)
+            os.replace(temporary, destination)
+        finally:
+            temporary.unlink(missing_ok=True)
+        manifest["payloads"][tensor_name] = {
+            "file": filename,
+            "bytes": len(payload),
+            "sha256": digest,
+        }
+
+    manifest_path = args.output_dir / "manifest.json"
+    temporary_manifest = manifest_path.with_name(
+        f".{manifest_path.name}.tmp.{os.getpid()}"
+    )
+    try:
+        temporary_manifest.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+        )
+        os.replace(temporary_manifest, manifest_path)
+    finally:
+        temporary_manifest.unlink(missing_ok=True)
+    print(
+        "GLM52_FP8_PROJECTION_AUTHORITY_READY "
+        f"revision={source['revision']} bytes="
+        f"{sum(item['bytes'] for item in manifest['payloads'].values())} "
+        f"path={args.output_dir}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experimental/lite/tests/fetch_glm52_rope_layout_authority.py
+++ b/experimental/lite/tests/fetch_glm52_rope_layout_authority.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Fetch and verify the small pinned GLM-5.2 RoPE authority files."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+FIXTURE = Path(__file__).parent / "unit" / "model" / "glm52_rope_layout_authority.json"
+MAX_SOURCE_BYTES = 2 * 1024 * 1024
+
+
+def _download(url: str) -> bytes:
+    request = urllib.request.Request(
+        url,
+        headers={"User-Agent": "mlite-glm52-rope-authority/1"},
+    )
+    with urllib.request.urlopen(request, timeout=120) as response:
+        if response.status != 200:
+            raise RuntimeError(
+                f"GET {url} returned HTTP {response.status}, expected 200"
+            )
+        content_length = response.headers.get("Content-Length")
+        if content_length is not None and int(content_length) > MAX_SOURCE_BYTES:
+            raise RuntimeError(
+                f"GET {url} advertised {content_length} bytes; refusing a non-small file"
+            )
+        payload = response.read(MAX_SOURCE_BYTES + 1)
+    if len(payload) > MAX_SOURCE_BYTES:
+        raise RuntimeError(
+            f"GET {url} exceeded the {MAX_SOURCE_BYTES}-byte authority limit"
+        )
+    return payload
+
+
+def _sha256(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _require_digest(*, label: str, payload: bytes, expected: str) -> str:
+    actual = _sha256(payload)
+    if actual != expected:
+        raise RuntimeError(
+            f"digest mismatch for {label}: actual={actual}, expected={expected}"
+        )
+    return actual
+
+
+def _write_atomic(path: Path, payload: bytes) -> None:
+    temporary = path.with_name(f".{path.name}.tmp.{os.getpid()}")
+    try:
+        temporary.write_bytes(payload)
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _validate_release_config(payload: bytes, contract: dict) -> None:
+    try:
+        config = json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise RuntimeError("pinned GLM-5.2 config is not valid UTF-8 JSON") from error
+    for field, expected in contract["required_values"].items():
+        if field not in config:
+            raise RuntimeError(f"pinned GLM-5.2 config is missing {field!r}")
+        actual = config[field]
+        if type(actual) is not type(expected) or actual != expected:
+            raise RuntimeError(
+                f"pinned GLM-5.2 config field {field!r} is {actual!r}, "
+                f"expected {expected!r}"
+            )
+
+
+def _validate_vllm_source(payload: bytes, contract: dict, path: str) -> None:
+    try:
+        source = payload.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise RuntimeError(f"pinned vLLM source {path} is not UTF-8") from error
+    for snippet_contract in contract["required_snippets"]:
+        snippet = snippet_contract["text"]
+        expected_count = snippet_contract["expected_count"]
+        if type(expected_count) is not int or expected_count < 1:
+            raise RuntimeError(
+                f"invalid expected_count for vLLM source {path}: {snippet_contract!r}"
+            )
+        actual_count = source.count(snippet)
+        if actual_count != expected_count:
+            raise RuntimeError(
+                f"pinned vLLM source {path} contains {actual_count} copies of "
+                f"{snippet!r}, expected {expected_count}"
+            )
+
+
+def _validate_remote_revisions(authority: dict) -> None:
+    release = authority["release"]
+    encoded_repo = urllib.parse.quote(release["repo"], safe="/")
+    model_metadata = json.loads(
+        _download(
+            f"https://huggingface.co/api/models/{encoded_repo}/revision/"
+            f"{release['revision']}"
+        )
+    )
+    if model_metadata.get("sha") != release["revision"]:
+        raise RuntimeError(
+            "Hugging Face revision resolution drifted: "
+            f"actual={model_metadata.get('sha')!r}, expected={release['revision']!r}"
+        )
+
+    vllm = authority["vllm"]
+    encoded_tag = urllib.parse.quote(vllm["release"], safe="")
+    tag_metadata = json.loads(
+        _download(
+            f"https://api.github.com/repos/{vllm['repo']}/git/ref/tags/{encoded_tag}"
+        )
+    )
+    tag_object = tag_metadata.get("object", {})
+    if tag_object.get("type") != "commit" or tag_object.get("sha") != vllm["revision"]:
+        raise RuntimeError(
+            f"vLLM tag {vllm['release']} does not resolve to pinned commit "
+            f"{vllm['revision']}: {tag_object!r}"
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("output_dir", type=Path)
+    args = parser.parse_args()
+
+    authority = json.loads(FIXTURE.read_text())
+    _validate_remote_revisions(authority)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    release = authority["release"]
+    config_contract = release["config"]
+    config_url = (
+        f"https://huggingface.co/{release['repo']}/resolve/"
+        f"{release['revision']}/{config_contract['path']}"
+    )
+    config_payload = _download(config_url)
+    config_digest = _require_digest(
+        label=f"{release['repo']}@{release['revision']}/{config_contract['path']}",
+        payload=config_payload,
+        expected=config_contract["sha256"],
+    )
+    _validate_release_config(config_payload, config_contract)
+    config_filename = "glm52-release-config.json"
+    _write_atomic(args.output_dir / config_filename, config_payload)
+
+    manifest = {
+        "release": {
+            "file": config_filename,
+            "repo": release["repo"],
+            "revision": release["revision"],
+            "sha256": config_digest,
+        },
+        "vllm": {
+            "files": {},
+            "release": authority["vllm"]["release"],
+            "repo": authority["vllm"]["repo"],
+            "revision": authority["vllm"]["revision"],
+        },
+    }
+    vllm = authority["vllm"]
+    for source_path, source_contract in vllm["files"].items():
+        source_url = (
+            f"https://raw.githubusercontent.com/{vllm['repo']}/"
+            f"{vllm['revision']}/{source_path}"
+        )
+        source_payload = _download(source_url)
+        source_digest = _require_digest(
+            label=f"{vllm['repo']}@{vllm['revision']}/{source_path}",
+            payload=source_payload,
+            expected=source_contract["sha256"],
+        )
+        _validate_vllm_source(source_payload, source_contract, source_path)
+        filename = "vllm-" + source_path.replace("/", "-")
+        _write_atomic(args.output_dir / filename, source_payload)
+        manifest["vllm"]["files"][source_path] = {
+            "bytes": len(source_payload),
+            "file": filename,
+            "sha256": source_digest,
+        }
+
+    manifest_payload = (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode()
+    _write_atomic(args.output_dir / "manifest.json", manifest_payload)
+    print(
+        "GLM52_ROPE_LAYOUT_AUTHORITY_READY "
+        f"release_revision={release['revision']} "
+        f"vllm_revision={vllm['revision']} path={args.output_dir}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experimental/lite/tests/fetch_glm52_rope_layout_authority.py
+++ b/experimental/lite/tests/fetch_glm52_rope_layout_authority.py
@@ -17,8 +17,7 @@ MAX_SOURCE_BYTES = 2 * 1024 * 1024
 
 def _download(url: str) -> bytes:
     request = urllib.request.Request(
-        url,
-        headers={"User-Agent": "mlite-glm52-rope-authority/1"},
+        url, headers={"User-Agent": "mlite-glm52-rope-authority/1"}
     )
     with urllib.request.urlopen(request, timeout=120) as response:
         if response.status != 200:

--- a/experimental/lite/tests/smoke/model/test_deepseek_v4_hf_ratio4_parity_smoke.py
+++ b/experimental/lite/tests/smoke/model/test_deepseek_v4_hf_ratio4_parity_smoke.py
@@ -1,0 +1,504 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Independent Transformers 5.12 authority for DSv4 ratio-4 CSA attention.
+
+This is deliberately scoped to one *complete attention block*, not advertised
+as whole-model DeepSeek-V4 parity.  It covers the production ratio-4 path end
+to end: query/KV projections, partial YaRN RoPE, sliding KV, overlapping
+compressor, Lightning Indexer top-k, attention sink, inverse RoPE, and grouped
+output projection.  The official HF eager implementation is compared with both
+MLite's Torch oracle and its fused inference path.
+
+Unlike the historical ``ds4_hf_ref`` script, this gate requires exact shapes
+and computes CE against one fixed external label tensor.  It never truncates to
+``min(numel)`` and never derives labels from either implementation's logits.
+
+Excluded by construction: decoder mHC, Hash-MoE, checkpoint dequantization,
+MTP, PP/CP, and optimizer behavior.  Those need separate gates and must not be
+inferred from this test.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+pytestmark = [pytest.mark.mlite, pytest.mark.smoke, pytest.mark.gpu]
+
+_TRANSFORMERS_AUTHORITY = "5.12.0"
+_BATCH = 1
+_SEQ = 512
+_VOCAB = 64
+_COMPRESS_RATIO = 4
+_INDEX_TOPK = 64
+
+
+def _hf_config():
+    import transformers
+    from transformers.models.deepseek_v4.configuration_deepseek_v4 import (
+        DeepseekV4Config,
+    )
+
+    assert transformers.__version__ == _TRANSFORMERS_AUTHORITY, (
+        "DSv4 HF authority is pinned to Transformers "
+        f"{_TRANSFORMERS_AUTHORITY}; got {transformers.__version__}"
+    )
+    config = DeepseekV4Config(
+        vocab_size=_VOCAB,
+        hidden_size=128,
+        moe_intermediate_size=16,
+        num_hidden_layers=1,
+        num_attention_heads=64,
+        num_key_value_heads=1,
+        head_dim=512,
+        q_lora_rank=32,
+        o_lora_rank=32,
+        o_groups=8,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        routed_scaling_factor=1.5,
+        layer_types=["compressed_sparse_attention"],
+        compress_rates={
+            "compressed_sparse_attention": _COMPRESS_RATIO,
+            "heavily_compressed_attention": 128,
+        },
+        mlp_layer_types=["hash_moe"],
+        max_position_embeddings=1_048_576,
+        partial_rotary_factor=64 / 512,
+        rope_theta=10_000.0,
+        compress_rope_theta=160_000.0,
+        rope_parameters={
+            "rope_type": "yarn",
+            "factor": 16.0,
+            "original_max_position_embeddings": 65_536,
+            "beta_fast": 32.0,
+            "beta_slow": 1.0,
+        },
+        sliding_window=128,
+        index_head_dim=128,
+        index_n_heads=64,
+        index_topk=_INDEX_TOPK,
+        hc_mult=2,
+        hc_sinkhorn_iters=4,
+        num_nextn_predict_layers=0,
+        rms_norm_eps=1.0e-6,
+        initializer_range=0.02,
+        use_cache=False,
+        tie_word_embeddings=False,
+    )
+    config._attn_implementation = "eager"
+    assert config.layer_types == ["compressed_sparse_attention"]
+    assert config.compress_rates["compressed_sparse_attention"] == _COMPRESS_RATIO
+    assert config.index_topk == _INDEX_TOPK
+    return config
+
+
+def _lite_config():
+    from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
+
+    return DeepseekV4Config(
+        vocab_size=_VOCAB,
+        hidden_size=128,
+        moe_intermediate_size=16,
+        num_hidden_layers=1,
+        num_attention_heads=64,
+        num_key_value_heads=1,
+        head_dim=512,
+        qk_rope_head_dim=64,
+        q_lora_rank=32,
+        o_lora_rank=32,
+        o_groups=8,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        routed_scaling_factor=1.5,
+        max_position_embeddings=1_048_576,
+        rope_theta=10_000.0,
+        compress_rope_theta=160_000.0,
+        rotary_scaling_factor=16.0,
+        original_max_position_embeddings=65_536,
+        beta_fast=32.0,
+        beta_slow=1.0,
+        compress_ratios=[_COMPRESS_RATIO],
+        sliding_window=128,
+        num_hash_layers=1,
+        hc_mult=2,
+        hc_sinkhorn_iters=4,
+        index_head_dim=128,
+        index_n_heads=64,
+        index_topk=_INDEX_TOPK,
+        num_nextn_predict_layers=0,
+        rms_norm_eps=1.0e-6,
+        initializer_range=0.02,
+    )
+
+
+def _copy_hf_ratio4_attention_weights(hf_attention, lite_attention) -> None:
+    """Copy every MLite attention parameter from its official HF counterpart."""
+    hf_compressor = hf_attention.compressor
+    lite_compressor = lite_attention.compressor
+    assert hf_compressor is not None
+    assert lite_compressor is not None
+    hf_indexer = hf_compressor.indexer
+    lite_indexer = lite_attention.indexer
+    assert hf_indexer is not None
+    assert lite_indexer is not None
+
+    pairs = [
+        ("sinks", lite_attention.sinks, hf_attention.sinks),
+        ("q-a", lite_attention.wq_a.weight, hf_attention.q_a_proj.weight),
+        ("q-a-norm", lite_attention.q_norm.weight, hf_attention.q_a_norm.weight),
+        ("q-b", lite_attention.wq_b.weight, hf_attention.q_b_proj.weight),
+        ("kv", lite_attention.wkv.weight, hf_attention.kv_proj.weight),
+        ("kv-norm", lite_attention.kv_norm.weight, hf_attention.kv_norm.weight),
+        ("o-a", lite_attention.wo_a.weight, hf_attention.o_a_proj.weight),
+        ("o-b", lite_attention.wo_b.weight, hf_attention.o_b_proj.weight),
+        ("compressor-kv", lite_compressor.wkv.weight, hf_compressor.kv_proj.weight),
+        (
+            "compressor-gate",
+            lite_compressor.wgate.weight,
+            hf_compressor.gate_proj.weight,
+        ),
+        ("compressor-position", lite_compressor.ape, hf_compressor.position_bias),
+        ("compressor-norm", lite_compressor.norm.weight, hf_compressor.kv_norm.weight),
+        (
+            "indexer-query",
+            lite_indexer.wq_b.weight,
+            hf_indexer.q_b_proj.weight,
+        ),
+        (
+            "indexer-weights",
+            lite_indexer.weights_proj.weight,
+            hf_indexer.scorer.weights_proj.weight,
+        ),
+        (
+            "indexer-compressor-kv",
+            lite_indexer.compressor.wkv.weight,
+            hf_indexer.kv_proj.weight,
+        ),
+        (
+            "indexer-compressor-gate",
+            lite_indexer.compressor.wgate.weight,
+            hf_indexer.gate_proj.weight,
+        ),
+        (
+            "indexer-compressor-position",
+            lite_indexer.compressor.ape,
+            hf_indexer.position_bias,
+        ),
+        (
+            "indexer-compressor-norm",
+            lite_indexer.compressor.norm.weight,
+            hf_indexer.kv_norm.weight,
+        ),
+    ]
+
+    copied: set[int] = set()
+    with torch.no_grad():
+        for name, destination, source in pairs:
+            assert destination.shape == source.shape, (
+                f"{name}: MLite shape {tuple(destination.shape)} != "
+                f"HF shape {tuple(source.shape)}"
+            )
+            destination.copy_(
+                source.to(device=destination.device, dtype=destination.dtype)
+            )
+            copied.add(id(destination))
+
+    named_parameters = {
+        id(parameter): name for name, parameter in lite_attention.named_parameters()
+    }
+    missing = sorted(
+        name for ident, name in named_parameters.items() if ident not in copied
+    )
+    unexpected = sorted(ident for ident in copied if ident not in named_parameters)
+    assert not missing, f"unmapped MLite attention parameters: {missing}"
+    assert not unexpected, f"copied objects are not MLite parameters: {unexpected}"
+
+
+def _sliding_causal_mask(
+    *, batch: int, seq: int, window: int, device: torch.device, dtype: torch.dtype
+) -> torch.Tensor:
+    query = torch.arange(seq, device=device).view(seq, 1)
+    key = torch.arange(seq, device=device).view(1, seq)
+    allowed = (key <= query) & (key >= query - window + 1)
+    mask = torch.zeros((seq, seq), device=device, dtype=dtype)
+    mask.masked_fill_(~allowed, -float("inf"))
+    return mask.view(1, 1, seq, seq).expand(batch, -1, -1, -1).contiguous()
+
+
+def _metrics(reference: torch.Tensor, candidate: torch.Tensor) -> dict[str, float]:
+    assert candidate.shape == reference.shape, (
+        f"candidate shape {tuple(candidate.shape)} != reference shape {tuple(reference.shape)}"
+    )
+    reference = reference.detach().float()
+    candidate = candidate.detach().float()
+    assert torch.isfinite(reference).all()
+    assert torch.isfinite(candidate).all()
+    reference_flat = reference.reshape(-1)
+    candidate_flat = candidate.reshape(-1)
+    reference_norm = torch.linalg.vector_norm(reference_flat)
+    candidate_norm = torch.linalg.vector_norm(candidate_flat)
+    assert reference_norm > 0 and candidate_norm > 0
+    diff_rms = torch.sqrt(torch.mean((reference - candidate).square()))
+    scale = torch.maximum(
+        torch.sqrt(torch.mean(reference.square())),
+        torch.sqrt(torch.mean(candidate.square())),
+    ).clamp_min(torch.finfo(torch.float32).tiny)
+    return {
+        "cosine": F.cosine_similarity(reference_flat, candidate_flat, dim=0).item(),
+        "rms_relative": (diff_rms / scale).item(),
+        "norm_ratio": (candidate_norm / reference_norm).item(),
+        "max_abs": (reference - candidate).abs().max().item(),
+    }
+
+
+def _assert_hf_parity(
+    name: str, reference: torch.Tensor, candidate: torch.Tensor
+) -> dict[str, float]:
+    values = _metrics(reference, candidate)
+    print(f"[dsv4-hf-ratio4] {name}: shape={tuple(reference.shape)} metrics={values}")
+    assert values["cosine"] >= 0.9985, values
+    assert values["rms_relative"] <= 0.05, values
+    assert 0.99 <= values["norm_ratio"] <= 1.01, values
+    assert values["max_abs"] <= 0.06, values
+    return values
+
+
+def _assert_lite_backend_parity(
+    name: str, reference: torch.Tensor, candidate: torch.Tensor
+) -> dict[str, float]:
+    values = _metrics(reference, candidate)
+    print(f"[dsv4-hf-ratio4] {name}: shape={tuple(reference.shape)} metrics={values}")
+    assert values["cosine"] >= 0.9995, values
+    assert values["rms_relative"] <= 0.02, values
+    assert 0.99 <= values["norm_ratio"] <= 1.01, values
+    assert values["max_abs"] <= 0.03, values
+    return values
+
+
+def _fixed_label_ce(logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+    assert logits.shape[:-1] == labels.shape
+    assert logits.shape[-1] == _VOCAB
+    return F.cross_entropy(logits.float().reshape(-1, _VOCAB), labels.reshape(-1))
+
+
+def _assert_loss_parity(
+    name: str,
+    reference: torch.Tensor,
+    candidate: torch.Tensor,
+    *,
+    abs_max: float,
+    relative_max: float,
+) -> dict[str, float]:
+    reference_value = float(reference.detach().float().item())
+    candidate_value = float(candidate.detach().float().item())
+    absolute = abs(reference_value - candidate_value)
+    relative = absolute / max(abs(reference_value), abs(candidate_value), 1.0e-12)
+    print(
+        f"[dsv4-hf-ratio4] {name}: reference={reference_value:.9f} "
+        f"candidate={candidate_value:.9f} abs={absolute:.9f} relative={relative:.9f}"
+    )
+    assert absolute <= abs_max
+    assert relative <= relative_max
+    return {"absolute": absolute, "relative": relative}
+
+
+def test_dsv4_transformers_512_ratio4_csa_attention_numeric_parity():
+    """HF eager vs MLite Torch/fused for the complete ratio-4 attention block."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for DSv4 ratio-4 HF numeric parity.")
+    pytest.importorskip("transformers")
+    pytest.importorskip("transformer_engine.pytorch")
+    pytest.importorskip("cudnn", reason="MLite fused ratio-4 CSA requires cuDNN DSA.")
+
+    from transformers.models.deepseek_v4.modeling_deepseek_v4 import (
+        DeepseekV4ForCausalLM,
+    )
+
+    from megatron.lite.primitive.modules.attention.csa import (
+        CompressedSparseAttention,
+    )
+    from megatron.lite.primitive.parallel import ParallelState
+
+    device = torch.device("cuda", torch.cuda.current_device())
+    torch.manual_seed(20260627)
+    torch.cuda.manual_seed_all(20260627)
+
+    hf_model = DeepseekV4ForCausalLM(_hf_config())
+    hf_attention = hf_model.model.layers[0].self_attn.to(
+        device=device, dtype=torch.bfloat16
+    )
+    assert type(hf_attention.compressor).__name__ == "DeepseekV4CSACompressor"
+    assert type(hf_attention.compressor.indexer).__name__ == "DeepseekV4Indexer"
+    # Keep inverse frequencies in fp32, matching HF's normal construction.
+    hf_rotary = hf_model.model.rotary_emb.to(device=device)
+    hf_attention.eval()
+
+    lite_config = _lite_config()
+    lite_torch = CompressedSparseAttention(
+        lite_config, layer_idx=0, ps=ParallelState()
+    ).to(device=device, dtype=torch.bfloat16)
+    _copy_hf_ratio4_attention_weights(hf_attention, lite_torch)
+    lite_fused = CompressedSparseAttention(
+        lite_config, layer_idx=0, ps=ParallelState()
+    ).to(device=device, dtype=torch.bfloat16)
+    lite_fused.load_state_dict(lite_torch.state_dict(), strict=True)
+    lite_torch.attention_backend = "torch"
+    lite_fused.attention_backend = "fused"
+    lite_torch.eval()
+    lite_fused.eval()
+
+    assert lite_torch.compress_ratio == _COMPRESS_RATIO
+    assert lite_torch.compressor is not None
+    assert lite_torch.indexer is not None
+    compressed_entries = _SEQ // _COMPRESS_RATIO
+    assert _INDEX_TOPK < compressed_entries, (
+        "the parity batch must make Lightning Indexer selection genuinely sparse"
+    )
+
+    generator = torch.Generator(device="cpu").manual_seed(20260628)
+    hidden_cpu = torch.randn(
+        _BATCH, _SEQ, lite_config.hidden_size, generator=generator, dtype=torch.float32
+    )
+    hidden = hidden_cpu.to(device=device, dtype=torch.bfloat16)
+    hf_hidden = hidden.detach().clone().requires_grad_(True)
+    lite_torch_hidden = hidden.detach().clone().requires_grad_(True)
+    lite_fused_hidden = hidden.detach().clone().requires_grad_(True)
+    position_ids = torch.arange(_SEQ, device=device, dtype=torch.long).unsqueeze(0)
+    attention_mask = _sliding_causal_mask(
+        batch=_BATCH,
+        seq=_SEQ,
+        window=lite_config.sliding_window,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+
+    hf_position_embeddings = {
+        "compress": hf_rotary(
+            hf_hidden, position_ids=position_ids, layer_type="compress"
+        )
+    }
+    hf_output, _hf_attention_weights = hf_attention(
+        hf_hidden,
+        position_embeddings=hf_position_embeddings,
+        position_ids=position_ids,
+        attention_mask=attention_mask,
+        past_key_values=None,
+    )
+    lite_torch_output = lite_torch(lite_torch_hidden, position_ids=position_ids)
+    lite_fused_output = lite_fused(lite_fused_hidden, position_ids=position_ids)
+
+    expected_output_shape = (_BATCH, _SEQ, lite_config.hidden_size)
+    assert tuple(hf_output.shape) == expected_output_shape
+    assert tuple(lite_torch_output.shape) == expected_output_shape
+    assert tuple(lite_fused_output.shape) == expected_output_shape
+    attention_hf_torch = _assert_hf_parity(
+        "attention/hf-vs-lite-torch", hf_output, lite_torch_output
+    )
+    attention_hf_fused = _assert_hf_parity(
+        "attention/hf-vs-lite-fused", hf_output, lite_fused_output
+    )
+    attention_torch_fused = _assert_lite_backend_parity(
+        "attention/lite-torch-vs-fused", lite_torch_output, lite_fused_output
+    )
+
+    head_generator = torch.Generator(device="cpu").manual_seed(20260629)
+    head_weight = torch.randn(
+        _VOCAB,
+        lite_config.hidden_size,
+        generator=head_generator,
+        dtype=torch.float32,
+    ).mul_(lite_config.hidden_size**-0.5)
+    head_weight = head_weight.to(device=device, dtype=torch.bfloat16)
+    hf_logits = F.linear(hf_output, head_weight)
+    lite_torch_logits = F.linear(lite_torch_output, head_weight)
+    lite_fused_logits = F.linear(lite_fused_output, head_weight)
+    expected_logits_shape = (_BATCH, _SEQ, _VOCAB)
+    assert tuple(hf_logits.shape) == expected_logits_shape
+    assert tuple(lite_torch_logits.shape) == expected_logits_shape
+    assert tuple(lite_fused_logits.shape) == expected_logits_shape
+    logits_hf_torch = _assert_hf_parity(
+        "logits/hf-vs-lite-torch", hf_logits, lite_torch_logits
+    )
+    logits_hf_fused = _assert_hf_parity(
+        "logits/hf-vs-lite-fused", hf_logits, lite_fused_logits
+    )
+    logits_torch_fused = _assert_lite_backend_parity(
+        "logits/lite-torch-vs-fused", lite_torch_logits, lite_fused_logits
+    )
+
+    # External deterministic targets: never use either output's argmax/self-CE.
+    labels = ((torch.arange(_SEQ, device=device) * 17 + 3) % _VOCAB).unsqueeze(0)
+    assert tuple(labels.shape) == (_BATCH, _SEQ)
+    assert not torch.equal(labels, hf_logits.argmax(dim=-1))
+    hf_loss = _fixed_label_ce(hf_logits, labels)
+    lite_torch_loss = _fixed_label_ce(lite_torch_logits, labels)
+    lite_fused_loss = _fixed_label_ce(lite_fused_logits, labels)
+    loss_hf_torch = _assert_loss_parity(
+        "fixed-label-CE/hf-vs-lite-torch",
+        hf_loss,
+        lite_torch_loss,
+        abs_max=0.005,
+        relative_max=0.001,
+    )
+    loss_hf_fused = _assert_loss_parity(
+        "fixed-label-CE/hf-vs-lite-fused",
+        hf_loss,
+        lite_fused_loss,
+        abs_max=0.005,
+        relative_max=0.001,
+    )
+    loss_torch_fused = _assert_loss_parity(
+        "fixed-label-CE/lite-torch-vs-fused",
+        lite_torch_loss,
+        lite_fused_loss,
+        abs_max=0.002,
+        relative_max=0.0005,
+    )
+    hf_loss.backward()
+    lite_torch_loss.backward()
+    lite_fused_loss.backward()
+    assert hf_hidden.grad is not None
+    assert lite_torch_hidden.grad is not None
+    assert lite_fused_hidden.grad is not None
+    input_grad_hf_torch = _assert_hf_parity(
+        "input-gradient/hf-vs-lite-torch",
+        hf_hidden.grad,
+        lite_torch_hidden.grad,
+    )
+    input_grad_hf_fused = _assert_hf_parity(
+        "input-gradient/hf-vs-lite-fused",
+        hf_hidden.grad,
+        lite_fused_hidden.grad,
+    )
+    input_grad_torch_fused = _assert_lite_backend_parity(
+        "input-gradient/lite-torch-vs-fused",
+        lite_torch_hidden.grad,
+        lite_fused_hidden.grad,
+    )
+    hf_attention_metrics = (attention_hf_torch, attention_hf_fused)
+    hf_logits_metrics = (logits_hf_torch, logits_hf_fused)
+    hf_input_grad_metrics = (input_grad_hf_torch, input_grad_hf_fused)
+    print(
+        "NON_SKIP_DSV4_TRANSFORMERS_512_RATIO4_CSA_PARITY_PASSED "
+        f"seq={_SEQ} ratio={_COMPRESS_RATIO} compressed={compressed_entries} "
+        f"topk={_INDEX_TOPK} genuine_sparse=True mapped_params=18 "
+        f"attention_min_cosine={min(item['cosine'] for item in hf_attention_metrics):.9f} "
+        f"attention_max_rms_relative="
+        f"{max(item['rms_relative'] for item in hf_attention_metrics):.9f} "
+        f"attention_torch_fused_cosine={attention_torch_fused['cosine']:.9f} "
+        f"logits_min_cosine={min(item['cosine'] for item in hf_logits_metrics):.9f} "
+        f"logits_max_rms_relative="
+        f"{max(item['rms_relative'] for item in hf_logits_metrics):.9f} "
+        f"logits_torch_fused_cosine={logits_torch_fused['cosine']:.9f} "
+        f"loss_hf_torch_abs={loss_hf_torch['absolute']:.9f} "
+        f"loss_hf_fused_abs={loss_hf_fused['absolute']:.9f} "
+        f"loss_torch_fused_abs={loss_torch_fused['absolute']:.9f} "
+        f"input_grad_min_cosine="
+        f"{min(item['cosine'] for item in hf_input_grad_metrics):.9f} "
+        f"input_grad_max_rms_relative="
+        f"{max(item['rms_relative'] for item in hf_input_grad_metrics):.9f} "
+        f"input_grad_torch_fused_cosine={input_grad_torch_fused['cosine']:.9f}"
+    )

--- a/experimental/lite/tests/smoke/model/test_deepseek_v4_hf_ratio4_parity_smoke.py
+++ b/experimental/lite/tests/smoke/model/test_deepseek_v4_hf_ratio4_parity_smoke.py
@@ -162,11 +162,7 @@ def _copy_hf_ratio4_attention_weights(hf_attention, lite_attention) -> None:
         ),
         ("compressor-position", lite_compressor.ape, hf_compressor.position_bias),
         ("compressor-norm", lite_compressor.norm.weight, hf_compressor.kv_norm.weight),
-        (
-            "indexer-query",
-            lite_indexer.wq_b.weight,
-            hf_indexer.q_b_proj.weight,
-        ),
+        ("indexer-query", lite_indexer.wq_b.weight, hf_indexer.q_b_proj.weight),
         (
             "indexer-weights",
             lite_indexer.weights_proj.weight,
@@ -229,9 +225,9 @@ def _sliding_causal_mask(
 
 
 def _metrics(reference: torch.Tensor, candidate: torch.Tensor) -> dict[str, float]:
-    assert candidate.shape == reference.shape, (
-        f"candidate shape {tuple(candidate.shape)} != reference shape {tuple(reference.shape)}"
-    )
+    assert (
+        candidate.shape == reference.shape
+    ), f"candidate shape {tuple(candidate.shape)} != reference shape {tuple(reference.shape)}"
     reference = reference.detach().float()
     candidate = candidate.detach().float()
     assert torch.isfinite(reference).all()
@@ -313,14 +309,11 @@ def test_dsv4_transformers_512_ratio4_csa_attention_numeric_parity():
     pytest.importorskip("transformer_engine.pytorch")
     pytest.importorskip("cudnn", reason="MLite fused ratio-4 CSA requires cuDNN DSA.")
 
+    from megatron.lite.primitive.modules.attention.csa import CompressedSparseAttention
+    from megatron.lite.primitive.parallel import ParallelState
     from transformers.models.deepseek_v4.modeling_deepseek_v4 import (
         DeepseekV4ForCausalLM,
     )
-
-    from megatron.lite.primitive.modules.attention.csa import (
-        CompressedSparseAttention,
-    )
-    from megatron.lite.primitive.parallel import ParallelState
 
     device = torch.device("cuda", torch.cuda.current_device())
     torch.manual_seed(20260627)
@@ -354,9 +347,9 @@ def test_dsv4_transformers_512_ratio4_csa_attention_numeric_parity():
     assert lite_torch.compressor is not None
     assert lite_torch.indexer is not None
     compressed_entries = _SEQ // _COMPRESS_RATIO
-    assert _INDEX_TOPK < compressed_entries, (
-        "the parity batch must make Lightning Indexer selection genuinely sparse"
-    )
+    assert (
+        _INDEX_TOPK < compressed_entries
+    ), "the parity batch must make Lightning Indexer selection genuinely sparse"
 
     generator = torch.Generator(device="cpu").manual_seed(20260628)
     hidden_cpu = torch.randn(
@@ -406,10 +399,7 @@ def test_dsv4_transformers_512_ratio4_csa_attention_numeric_parity():
 
     head_generator = torch.Generator(device="cpu").manual_seed(20260629)
     head_weight = torch.randn(
-        _VOCAB,
-        lite_config.hidden_size,
-        generator=head_generator,
-        dtype=torch.float32,
+        _VOCAB, lite_config.hidden_size, generator=head_generator, dtype=torch.float32
     ).mul_(lite_config.hidden_size**-0.5)
     head_weight = head_weight.to(device=device, dtype=torch.bfloat16)
     hf_logits = F.linear(hf_output, head_weight)
@@ -464,14 +454,10 @@ def test_dsv4_transformers_512_ratio4_csa_attention_numeric_parity():
     assert lite_torch_hidden.grad is not None
     assert lite_fused_hidden.grad is not None
     input_grad_hf_torch = _assert_hf_parity(
-        "input-gradient/hf-vs-lite-torch",
-        hf_hidden.grad,
-        lite_torch_hidden.grad,
+        "input-gradient/hf-vs-lite-torch", hf_hidden.grad, lite_torch_hidden.grad
     )
     input_grad_hf_fused = _assert_hf_parity(
-        "input-gradient/hf-vs-lite-fused",
-        hf_hidden.grad,
-        lite_fused_hidden.grad,
+        "input-gradient/hf-vs-lite-fused", hf_hidden.grad, lite_fused_hidden.grad
     )
     input_grad_torch_fused = _assert_lite_backend_parity(
         "input-gradient/lite-torch-vs-fused",

--- a/experimental/lite/tests/smoke/model/test_glm52_fp8_real_weight_projection_smoke.py
+++ b/experimental/lite/tests/smoke/model/test_glm52_fp8_real_weight_projection_smoke.py
@@ -1,0 +1,249 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Pinned real-weight GLM-5.2-FP8 dequantized-BF16 q_a projection parity.
+
+This gate range-fetches only three tensors from the immutable official HF
+release: layer-0 ``q_a_proj`` FP8 weight, its FP32 block scale, and the BF16
+``q_a_layernorm`` weight. It exercises MLite's production dequantizer plus the
+production ``torch.nn.Linear`` + Transformer Engine RMSNorm path against
+Transformers 5.12's public ``torch.nn.Linear`` + RMSNorm formula and an
+independent FP32 reference. It is deliberately dequantized-BF16,
+projection-level evidence, not HF quantized-runtime, full-model, or
+long-context parity.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+pytestmark = [pytest.mark.mlite, pytest.mark.smoke, pytest.mark.gpu]
+
+_WEIGHT = "model.layers.0.self_attn.q_a_proj.weight"
+_SCALE = f"{_WEIGHT}_scale_inv"
+_NORM = "model.layers.0.self_attn.q_a_layernorm.weight"
+_SHARD = "model-00001-of-00141.safetensors"
+_PAYLOAD_FILES = {
+    _WEIGHT: "q_a_proj.bin",
+    _SCALE: "q_a_proj_scale_inv.bin",
+    _NORM: "q_a_layernorm.bin",
+}
+
+
+def _load_raw_tensor(path: Path, dtype: torch.dtype, shape: list[int]) -> torch.Tensor:
+    payload = bytearray(path.read_bytes())
+    return torch.frombuffer(payload, dtype=dtype).clone().reshape(shape)
+
+
+def _load_and_validate_projection_authority(
+    authority_dir: Path,
+) -> tuple[dict, dict, dict[str, Path], int]:
+    """Bind downloaded payloads back to the immutable in-repo authority."""
+    fixture_path = (
+        Path(__file__).resolve().parents[2]
+        / "unit"
+        / "model"
+        / "glm52_fp8_header_authority.json"
+    )
+    authority = json.loads(fixture_path.read_text())
+    manifest = json.loads((authority_dir / "manifest.json").read_text())
+    source = authority["source"]
+    assert set(manifest) == {"repo", "revision", "shard", "payloads"}
+    assert manifest["repo"] == source["repo"]
+    assert manifest["revision"] == source["revision"]
+    assert manifest["shard"] == _SHARD
+
+    tensors = authority["tensors"]
+    expected_names = {_WEIGHT, _SCALE, _NORM}
+    assert set(tensors) == expected_names
+    assert set(manifest["payloads"]) == expected_names
+    shard_contract = source["safetensors"][_SHARD]
+    paths: dict[str, Path] = {}
+    payload_bytes_total = 0
+    for tensor_name in sorted(expected_names):
+        entry = manifest["payloads"][tensor_name]
+        range_contract = shard_contract["payload_ranges"][tensor_name]
+        range_start, range_end = range_contract["file_range"]
+        expected_bytes = range_end - range_start + 1
+        assert set(entry) == {"file", "bytes", "sha256"}
+        assert entry["file"] == _PAYLOAD_FILES[tensor_name]
+        assert entry["bytes"] == expected_bytes
+        assert entry["sha256"] == range_contract["sha256"]
+        path = authority_dir / entry["file"]
+        payload = path.read_bytes()
+        assert len(payload) == expected_bytes
+        assert hashlib.sha256(payload).hexdigest() == range_contract["sha256"]
+        paths[tensor_name] = path
+        payload_bytes_total += len(payload)
+    assert paths.keys() == expected_names
+    assert payload_bytes_total == 12_590_080
+    return authority, tensors, paths, payload_bytes_total
+
+
+def _metrics(actual: torch.Tensor, expected: torch.Tensor) -> dict[str, float]:
+    actual_f = actual.detach().float().reshape(-1)
+    expected_f = expected.detach().float().reshape(-1)
+    delta = actual_f - expected_f
+    expected_rms = expected_f.square().mean().sqrt().clamp_min(1e-12)
+    actual_norm = actual_f.norm()
+    expected_norm = expected_f.norm().clamp_min(1e-12)
+    return {
+        "cosine": float(F.cosine_similarity(actual_f, expected_f, dim=0).item()),
+        "rms_relative": float(delta.square().mean().sqrt().div(expected_rms).item()),
+        "norm_ratio": float(actual_norm.div(expected_norm).item()),
+        "max_abs": float(delta.abs().max().item()),
+    }
+
+
+def _assert_projection_parity(
+    label: str,
+    actual: torch.Tensor,
+    expected: torch.Tensor,
+    *,
+    cosine_min: float,
+    rms_relative_max: float,
+    max_abs_max: float,
+) -> dict[str, float]:
+    metrics = _metrics(actual, expected)
+    assert metrics["cosine"] >= cosine_min, f"{label}: {metrics}"
+    assert metrics["rms_relative"] <= rms_relative_max, f"{label}: {metrics}"
+    assert 0.99 <= metrics["norm_ratio"] <= 1.01, f"{label}: {metrics}"
+    assert metrics["max_abs"] <= max_abs_max, f"{label}: {metrics}"
+    return metrics
+
+
+def test_glm52_fp8_pinned_real_q_a_projection_matches_transformers() -> None:
+    authority_dir_value = os.getenv("GLM52_FP8_PROJECTION_AUTHORITY_DIR")
+    if not authority_dir_value:
+        pytest.skip(
+            "set GLM52_FP8_PROJECTION_AUTHORITY_DIR after running "
+            "experimental/lite/tests/fetch_glm52_fp8_projection_authority.py"
+        )
+    authority_dir = Path(authority_dir_value)
+    authority, tensors, paths, payload_bytes_total = (
+        _load_and_validate_projection_authority(authority_dir)
+    )
+    source = authority["source"]
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for the GLM-5.2 real-weight projection gate")
+    if not hasattr(torch, "float8_e4m3fn"):
+        pytest.skip("torch float8_e4m3fn is required for the released FP8 weight")
+
+    transformers = pytest.importorskip("transformers")
+    assert transformers.__version__ == "5.12.0"
+    pytest.importorskip("transformer_engine.pytorch")
+    from megatron.lite.model.glm5.lite.checkpoint import _dequant_fp8_weight
+    from megatron.lite.primitive.modules.attention.dsa import RMSNorm
+    from transformers.models.glm_moe_dsa.modeling_glm_moe_dsa import GlmMoeDsaRMSNorm
+
+    raw_weight = _load_raw_tensor(
+        paths[_WEIGHT], torch.float8_e4m3fn, tensors[_WEIGHT]["shape"]
+    )
+    scale = _load_raw_tensor(paths[_SCALE], torch.float32, tensors[_SCALE]["shape"])
+    norm_weight = _load_raw_tensor(
+        paths[_NORM], torch.bfloat16, tensors[_NORM]["shape"]
+    )
+
+    class Reader:
+        index = {_SCALE: "range-payload"}
+
+        @staticmethod
+        def get_tensor(name: str) -> torch.Tensor:
+            assert name == _SCALE
+            return scale
+
+    dequantized = _dequant_fp8_weight(Reader(), _WEIGHT, raw_weight)
+    reference_scale = scale.repeat_interleave(128, 0).repeat_interleave(128, 1)
+    reference_weight = raw_weight.float() * reference_scale
+    torch.testing.assert_close(dequantized, reference_weight, atol=0, rtol=0)
+
+    config_values = source["config_values"]
+    hidden_size = config_values["hidden_size"]
+    q_lora_rank = config_values["q_lora_rank"]
+    eps = config_values["q_a_layernorm_effective_eps"]
+    device = torch.device("cuda", torch.cuda.current_device())
+    bf16_weight = dequantized.to(device=device, dtype=torch.bfloat16)
+    bf16_norm_weight = norm_weight.to(device=device)
+
+    mlite_linear = nn.Linear(
+        hidden_size, q_lora_rank, bias=False, device=device, dtype=torch.bfloat16
+    )
+    mlite_norm = RMSNorm(q_lora_rank, eps=eps).to(device=device, dtype=torch.bfloat16)
+    hf_linear = nn.Linear(
+        hidden_size, q_lora_rank, bias=False, device=device, dtype=torch.bfloat16
+    )
+    hf_norm = GlmMoeDsaRMSNorm(q_lora_rank, eps=eps).to(
+        device=device, dtype=torch.bfloat16
+    )
+    with torch.no_grad():
+        mlite_linear.weight.copy_(bf16_weight)
+        hf_linear.weight.copy_(bf16_weight)
+        mlite_norm.weight.copy_(bf16_norm_weight)
+        hf_norm.weight.copy_(bf16_norm_weight)
+    for module in (mlite_linear, mlite_norm, hf_linear, hf_norm):
+        module.requires_grad_(False)
+
+    generator = torch.Generator(device=device).manual_seed(20260628)
+    source_input = torch.randn(
+        (1, 8, hidden_size), generator=generator, device=device, dtype=torch.bfloat16
+    )
+    mlite_input = source_input.detach().clone().requires_grad_(True)
+    hf_input = source_input.detach().clone().requires_grad_(True)
+    mlite_output = mlite_norm(mlite_linear(mlite_input))
+    hf_output = hf_norm(hf_linear(hf_input))
+
+    reference_linear = F.linear(source_input.float(), dequantized.to(device=device))
+    reference_variance = reference_linear.square().mean(dim=-1, keepdim=True)
+    reference_output = (
+        reference_linear * torch.rsqrt(reference_variance + eps)
+    ) * bf16_norm_weight.float()
+
+    hf_metrics = _assert_projection_parity(
+        "MLite-vs-Transformers dequantized-BF16 real q_a projection",
+        mlite_output,
+        hf_output,
+        cosine_min=0.999,
+        rms_relative_max=0.02,
+        max_abs_max=0.05,
+    )
+    fp32_metrics = _assert_projection_parity(
+        "MLite-vs-FP32 dequantized-BF16 real q_a projection",
+        mlite_output,
+        reference_output,
+        cosine_min=0.999,
+        rms_relative_max=0.02,
+        max_abs_max=0.05,
+    )
+
+    gradient_probe = torch.randn(
+        mlite_output.shape, generator=generator, device=device, dtype=torch.float32
+    )
+    (mlite_output.float() * gradient_probe).mean().backward()
+    (hf_output.float() * gradient_probe).mean().backward()
+    assert mlite_input.grad is not None and hf_input.grad is not None
+    grad_metrics = _assert_projection_parity(
+        "MLite-vs-Transformers dequantized-BF16 real q_a input gradient",
+        mlite_input.grad,
+        hf_input.grad,
+        cosine_min=0.999,
+        rms_relative_max=0.03,
+        max_abs_max=0.005,
+    )
+
+    print(
+        "NON_SKIP_GLM52_FP8_REAL_QA_PROJECTION_PARITY_PASSED "
+        f"revision={source['revision']} real_payload_bytes={payload_bytes_total} "
+        "evidence=dequantized_bf16_projection_level "
+        f"hf_cosine={hf_metrics['cosine']:.9f} "
+        f"hf_rms_relative={hf_metrics['rms_relative']:.9f} "
+        f"fp32_cosine={fp32_metrics['cosine']:.9f} "
+        f"fp32_rms_relative={fp32_metrics['rms_relative']:.9f} "
+        f"grad_cosine={grad_metrics['cosine']:.9f} "
+        f"grad_rms_relative={grad_metrics['rms_relative']:.9f}"
+    )

--- a/experimental/lite/tests/smoke/model/test_glm52_hf_production_layout_full_model_smoke.py
+++ b/experimental/lite/tests/smoke/model/test_glm52_hf_production_layout_full_model_smoke.py
@@ -395,8 +395,7 @@ def _shifted_external_ce(logits: torch.Tensor, labels: torch.Tensor) -> torch.Te
     assert logits.shape == (_BATCH, _SEQ, _VOCAB)
     assert labels.shape == (_BATCH, _SEQ)
     return F.cross_entropy(
-        logits[:, :-1].float().reshape(-1, _VOCAB),
-        labels[:, 1:].reshape(-1),
+        logits[:, :-1].float().reshape(-1, _VOCAB), labels[:, 1:].reshape(-1)
     )
 
 
@@ -588,10 +587,7 @@ def test_glm52_transformers_512_adapted_production_layout_full_model_parity(
             assert attention.indexer is None
 
     input_ids = torch.tensor(
-        [
-            [3, 5, 7, 11, 13, 17, 19, 23, 29, 31],
-            [37, 41, 43, 47, 53, 59, 61, 67, 2, 4],
-        ],
+        [[3, 5, 7, 11, 13, 17, 19, 23, 29, 31], [37, 41, 43, 47, 53, 59, 61, 67, 2, 4]],
         dtype=torch.long,
     )
     labels = torch.tensor(
@@ -647,9 +643,7 @@ def test_glm52_transformers_512_adapted_production_layout_full_model_parity(
             return_dict=True,
         )
         lite_output = lite_model(
-            input_ids=input_ids,
-            position_ids=position_ids,
-            packed_seq_params=None,
+            input_ids=input_ids, position_ids=position_ids, packed_seq_params=None
         )
     finally:
         for handle in [

--- a/experimental/lite/tests/smoke/model/test_glm52_hf_production_layout_full_model_smoke.py
+++ b/experimental/lite/tests/smoke/model/test_glm52_hf_production_layout_full_model_smoke.py
@@ -1,21 +1,23 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-"""Adapted Transformers 5.12 authority for GLM-5.2 production RoPE layout.
+"""ADAPTED Transformers 5.12 full-model check for GLM-5.2 RoPE layout.
 
 Transformers 5.12 already uses its interleaved helper for the main MLA path,
 but ``GlmMoeDsaIndexer.forward`` calls the half-split helper unconditionally
 and ignores the published ``indexer_rope_interleave=true`` checkpoint field.
-The reference below applies one deliberately narrow adapter: within the HF
-modeling module, bind that indexer-only helper name to HF's own interleaved
-helper.  In Transformers 5.12 this symbol has exactly one runtime call site,
-the indexer; the main attention continues to execute the unmodified HF path.
+The reference below applies one deliberately narrow, instance-local adapter:
+only the full layer's indexer is replaced by a test-local subclass whose
+forward calls HF's public interleaved helper. The HF modeling module and its
+globals are never modified; the main attention executes the unmodified path.
 
 The test first proves that vanilla HF and the configured layout choose
 different top-k rows and produce different logits.  It then compares the
-adapted official ``GlmMoeDsaForCausalLM`` with the actual MLite ``Glm5Model``
-through a complete two-layer F/S IndexShare model: dense MLP, MoE, per-layer
-hidden states, logits, fixed external-label shifted CE, and the gradient at the
-embedding output.  Optional production kernels are replaced with explicit
-Torch implementations so this authority lane is deterministic and CPU-only.
+test-locally adapted ``GlmMoeDsaForCausalLM`` with the actual MLite
+``Glm5Model`` through a complete two-layer F/S IndexShare model: dense MLP,
+MoE, per-layer hidden states, logits, fixed external-label shifted CE, and the
+gradient at the embedding output. Optional production kernels are replaced
+with explicit Torch implementations so this supporting comparison is
+deterministic and CPU-only. Release semantics are gated independently by the
+pinned release/vLLM score-and-top-k oracle.
 
 This is not unmodified-Transformers parity, a production sparse-kernel test, or
 coverage for MTP, CP, PP, recompute/offload, or the 202,752-token target.
@@ -23,7 +25,6 @@ coverage for MTP, CP, PP, recompute/offload, or the 202,752-token target.
 
 from __future__ import annotations
 
-import inspect
 import math
 from types import SimpleNamespace
 
@@ -31,7 +32,6 @@ import pytest
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-
 
 pytestmark = [pytest.mark.mlite, pytest.mark.smoke]
 
@@ -227,7 +227,7 @@ def _hf_config():
     import transformers
 
     assert transformers.__version__ == _TRANSFORMERS_AUTHORITY, (
-        "GLM-5.2 HF authority is pinned to Transformers "
+        "GLM-5.2 ADAPTED HF comparison is pinned to Transformers "
         f"{_TRANSFORMERS_AUTHORITY}; got {transformers.__version__}"
     )
     config = transformers.GlmMoeDsaConfig(
@@ -424,10 +424,77 @@ def _capture_first_attention_topk(model, input_ids, position_ids):
     return logits, captured[0]
 
 
+def _make_instance_local_interleaved_indexer(hf_impl, vanilla_indexer):
+    """Replace one HF indexer without changing any HF module-global symbol."""
+
+    class _AdaptedInterleavedGlmMoeDsaIndexer(hf_impl.GlmMoeDsaIndexer):
+        @torch.no_grad()
+        def forward(
+            self,
+            hidden_states,
+            q_resid,
+            position_embeddings,
+            attention_mask,
+            position_ids,
+            past_key_values=None,
+        ):
+            batch_size, seq_len, _ = hidden_states.shape
+            cos, sin = position_embeddings
+            q = self.wq_b(q_resid).view(
+                batch_size, seq_len, self.n_heads, self.head_dim
+            )
+            q_rot, q_pass = torch.split(
+                q,
+                [self.qk_rope_head_dim, self.head_dim - self.qk_rope_head_dim],
+                dim=-1,
+            )
+
+            k = self.k_norm(self.wk(hidden_states)).unsqueeze(2)
+            k_rot, k_pass = torch.split(
+                k,
+                [self.qk_rope_head_dim, self.head_dim - self.qk_rope_head_dim],
+                dim=-1,
+            )
+            q_rot, k_rot = hf_impl.apply_rotary_pos_emb_interleave(
+                q_rot, k_rot, cos, sin, unsqueeze_dim=2
+            )
+            q = torch.cat((q_rot, q_pass), dim=-1)
+            k = torch.cat((k_rot, k_pass), dim=-1).squeeze(2)
+
+            if past_key_values is not None:
+                k = past_key_values.update_indexer(k, self.layer_idx)
+
+            scores = torch.matmul(q.float(), k.transpose(-1, -2).float().unsqueeze(1))
+            scores = F.relu(scores * self.softmax_scale)
+            weights = self.weights_proj(
+                hidden_states.to(self.weights_proj.weight.dtype)
+            ).float() * (self.n_heads**-0.5)
+            index_scores = torch.matmul(weights.unsqueeze(-2), scores).squeeze(-2)
+            if attention_mask is not None:
+                index_scores = index_scores + attention_mask
+            else:
+                key_positions = torch.arange(
+                    index_scores.shape[-1], device=index_scores.device
+                )
+                causal = key_positions[None, None, :] > position_ids[:, :, None]
+                index_scores = index_scores.masked_fill(causal, float("-inf"))
+
+            topk = min(self.index_topk, index_scores.shape[-1])
+            return index_scores.topk(topk, dim=-1).indices.to(torch.int32)
+
+    reference_parameter = next(vanilla_indexer.parameters())
+    adapted = _AdaptedInterleavedGlmMoeDsaIndexer(
+        vanilla_indexer.config, vanilla_indexer.layer_idx
+    ).to(device=reference_parameter.device, dtype=reference_parameter.dtype)
+    adapted.load_state_dict(vanilla_indexer.state_dict(), strict=True)
+    adapted.train(vanilla_indexer.training)
+    return adapted
+
+
 def test_glm52_transformers_512_adapted_production_layout_full_model_parity(
     tmp_path, transformer_engine_import_stub, monkeypatch
 ):
-    """Configured/interleaved F/S GLM-5.2 vs a one-line adapted HF model."""
+    """Configured/interleaved F/S GLM-5.2 vs instance-locally ADAPTED HF."""
 
     transformers = pytest.importorskip("transformers")
     pytest.importorskip("safetensors")
@@ -448,6 +515,11 @@ def test_glm52_transformers_512_adapted_production_layout_full_model_parity(
     # implementation adapters only; the actual MLite model/layer wiring,
     # checkpoint loader, IndexShare state, and autograd graph remain in use.
     monkeypatch.setattr(lite_impl.te, "RMSNorm", _TorchRMSNorm)
+    monkeypatch.setattr(lite_impl.te, "Linear", _TorchLinear)
+    monkeypatch.setattr(lite_impl.te, "LayerNormLinear", _TorchLayerNormLinear)
+    monkeypatch.setattr(
+        lite_impl.te, "GroupedLinear", _TorchGroupedLinear, raising=False
+    )
     monkeypatch.setattr(linear_impl.te, "Linear", _TorchLinear)
     monkeypatch.setattr(linear_impl.te, "LayerNormLinear", _TorchLayerNormLinear)
     monkeypatch.setattr(
@@ -531,37 +603,18 @@ def test_glm52_transformers_512_adapted_production_layout_full_model_parity(
     )
     position_ids = torch.arange(_SEQ, dtype=torch.long).unsqueeze(0).expand(_BATCH, -1)
 
-    # Unmodified Transformers 5.12 is intentionally not the authority for the
-    # published production layout: it ignores indexer_rope_interleave.
+    # Unmodified Transformers 5.12 is the negative control: its indexer ignores
+    # indexer_rope_interleave even though the released GLM-5.2 config enables it.
     vanilla_logits, vanilla_topk = _capture_first_attention_topk(
         hf_model, input_ids, position_ids
     )
-    indexer_forward = inspect.unwrap(hf_impl.GlmMoeDsaIndexer.forward)
-    module_source = inspect.getsource(hf_impl)
-    indexer_source = inspect.getsource(indexer_forward)
-    attention_source = inspect.getsource(
-        inspect.unwrap(hf_impl.GlmMoeDsaAttention.forward)
-    )
-    # One definition plus one call proves that rebinding the module global can
-    # affect no HF runtime path other than this indexer call site.
-    assert module_source.count("apply_rotary_pos_emb(") == 2
-    assert indexer_source.count("apply_rotary_pos_emb(") == 1
-    assert "apply_rotary_pos_emb_interleave(" in attention_source
-    assert indexer_forward.__globals__["apply_rotary_pos_emb"] is (
-        hf_impl.apply_rotary_pos_emb
-    )
-
-    # Minimal production-layout adapter. In Transformers 5.12 the rebound name
-    # is called only by GlmMoeDsaIndexer; main MLA already calls the explicit
-    # interleaved helper and all remaining HF model code stays untouched.
-    monkeypatch.setattr(
-        hf_impl,
-        "apply_rotary_pos_emb",
-        hf_impl.apply_rotary_pos_emb_interleave,
-    )
-    assert indexer_forward.__globals__["apply_rotary_pos_emb"] is (
-        hf_impl.apply_rotary_pos_emb_interleave
-    )
+    vanilla_indexer = hf_model.model.layers[0].self_attn.indexer
+    assert type(vanilla_indexer) is hf_impl.GlmMoeDsaIndexer
+    vanilla_half_split_helper = hf_impl.apply_rotary_pos_emb
+    adapted_indexer = _make_instance_local_interleaved_indexer(hf_impl, vanilla_indexer)
+    assert type(adapted_indexer).__name__ == "_AdaptedInterleavedGlmMoeDsaIndexer"
+    hf_model.model.layers[0].self_attn.indexer = adapted_indexer
+    assert hf_impl.apply_rotary_pos_emb is vanilla_half_split_helper
 
     adapted_topk: list[torch.Tensor] = []
 
@@ -713,7 +766,7 @@ def test_glm52_transformers_512_adapted_production_layout_full_model_parity(
     print(
         "NON_SKIP_GLM52_TRANSFORMERS_512_ADAPTED_PRODUCTION_LAYOUT_"
         "FULL_MODEL_PARITY_PASSED "
-        "adapter=indexer_apply_rotary_pos_emb_interleave_only "
+        "adapter=instance_local_interleaved_indexer_subclass "
         "scope=tiny_full_model_dense_moe_indexshare_F_S "
         "configured_main_rope=true configured_indexer_rope=true "
         f"vanilla_differing_topk_rows={differing_topk_rows} "

--- a/experimental/lite/tests/smoke/model/test_glm52_hf_production_layout_full_model_smoke.py
+++ b/experimental/lite/tests/smoke/model/test_glm52_hf_production_layout_full_model_smoke.py
@@ -1,0 +1,732 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Adapted Transformers 5.12 authority for GLM-5.2 production RoPE layout.
+
+Transformers 5.12 already uses its interleaved helper for the main MLA path,
+but ``GlmMoeDsaIndexer.forward`` calls the half-split helper unconditionally
+and ignores the published ``indexer_rope_interleave=true`` checkpoint field.
+The reference below applies one deliberately narrow adapter: within the HF
+modeling module, bind that indexer-only helper name to HF's own interleaved
+helper.  In Transformers 5.12 this symbol has exactly one runtime call site,
+the indexer; the main attention continues to execute the unmodified HF path.
+
+The test first proves that vanilla HF and the configured layout choose
+different top-k rows and produce different logits.  It then compares the
+adapted official ``GlmMoeDsaForCausalLM`` with the actual MLite ``Glm5Model``
+through a complete two-layer F/S IndexShare model: dense MLP, MoE, per-layer
+hidden states, logits, fixed external-label shifted CE, and the gradient at the
+embedding output.  Optional production kernels are replaced with explicit
+Torch implementations so this authority lane is deterministic and CPU-only.
+
+This is not unmodified-Transformers parity, a production sparse-kernel test, or
+coverage for MTP, CP, PP, recompute/offload, or the 202,752-token target.
+"""
+
+from __future__ import annotations
+
+import inspect
+import math
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+pytestmark = [pytest.mark.mlite, pytest.mark.smoke]
+
+_TRANSFORMERS_AUTHORITY = "5.12.0"
+_BATCH = 2
+_SEQ = 10
+_VOCAB = 71
+_HIDDEN = 32
+_INDEX_TOPK = 3
+
+
+class _TorchRMSNorm(nn.Module):
+    """Torch stand-in for TE RMSNorm with the HF GLM accumulation contract."""
+
+    def __init__(self, hidden_size: int, eps: float = 1.0e-6, **_kwargs):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.eps = eps
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        input_dtype = hidden_states.dtype
+        normalized = hidden_states.float()
+        variance = normalized.square().mean(dim=-1, keepdim=True)
+        normalized = normalized * torch.rsqrt(variance + self.eps)
+        return self.weight * normalized.to(dtype=input_dtype)
+
+
+class _TorchLinear(nn.Module):
+    """Single-rank Torch replacement for the subset of ``te.Linear`` used here."""
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        *,
+        bias: bool = True,
+        params_dtype: torch.dtype = torch.bfloat16,
+        **_kwargs,
+    ):
+        super().__init__()
+        self.weight = nn.Parameter(
+            torch.empty(out_features, in_features, dtype=params_dtype)
+        )
+        self.bias = (
+            nn.Parameter(torch.empty(out_features, dtype=params_dtype))
+            if bias
+            else None
+        )
+        nn.init.kaiming_uniform_(self.weight, a=math.sqrt(5))
+        if self.bias is not None:
+            nn.init.zeros_(self.bias)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return F.linear(hidden_states, self.weight, self.bias)
+
+
+class _TorchLayerNormLinear(_TorchLinear):
+    """Torch RMSNorm+linear replacement for MLite's fused dense-MLP input."""
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        *,
+        normalization: str,
+        eps: float,
+        zero_centered_gamma: bool = False,
+        **kwargs,
+    ):
+        assert normalization == "RMSNorm"
+        assert zero_centered_gamma is False
+        super().__init__(in_features, out_features, **kwargs)
+        self.layer_norm_weight = nn.Parameter(torch.ones(in_features))
+        self.eps = eps
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        input_dtype = hidden_states.dtype
+        normalized = hidden_states.float()
+        variance = normalized.square().mean(dim=-1, keepdim=True)
+        normalized = normalized * torch.rsqrt(variance + self.eps)
+        normalized = self.layer_norm_weight * normalized.to(dtype=input_dtype)
+        return F.linear(normalized, self.weight, self.bias)
+
+
+class _TorchGroupedLinear(nn.Module):
+    """Expert-major Torch replacement preserving TE's ``weightN`` state names."""
+
+    def __init__(
+        self,
+        num_experts: int,
+        in_features: int,
+        out_features: int,
+        *,
+        bias: bool = False,
+        params_dtype: torch.dtype = torch.bfloat16,
+        **_kwargs,
+    ):
+        super().__init__()
+        assert bias is False
+        self.num_experts = num_experts
+        self.out_features = out_features
+        for expert_idx in range(num_experts):
+            weight = nn.Parameter(
+                torch.empty(out_features, in_features, dtype=params_dtype)
+            )
+            nn.init.kaiming_uniform_(weight, a=math.sqrt(5))
+            self.register_parameter(f"weight{expert_idx}", weight)
+
+    def forward(
+        self, hidden_states: torch.Tensor, tokens_per_expert: list[int]
+    ) -> torch.Tensor:
+        assert len(tokens_per_expert) == self.num_experts
+        pieces = hidden_states.split([int(count) for count in tokens_per_expert], dim=0)
+        outputs = [
+            F.linear(piece, getattr(self, f"weight{expert_idx}"))
+            for expert_idx, piece in enumerate(pieces)
+        ]
+        if not outputs:
+            return hidden_states.new_empty((0, self.out_features))
+        return torch.cat(outputs, dim=0)
+
+
+def _torch_indexer_topk(
+    q_indexer: torch.Tensor,
+    k_indexer: torch.Tensor,
+    weights: torch.Tensor,
+    topk: int,
+    ratio: int = 1,
+    indexer_softmax_scale: float = 1.0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """First-principles oracle for MLite's inference indexer contract."""
+
+    q = q_indexer.permute(1, 0, 2, 3).float()
+    k = k_indexer.permute(1, 0, 2).float()
+    w = weights.permute(1, 0, 2).float()
+    scores = torch.relu(torch.einsum("bqhd,bkd->bqhk", q, k))
+    scores = (scores * w.unsqueeze(-1)).sum(dim=2) * indexer_softmax_scale
+    query_positions = torch.arange(scores.shape[1], device=scores.device)
+    key_positions = torch.arange(scores.shape[2], device=scores.device)
+    valid_counts = ((query_positions + 1) // ratio).clamp(max=scores.shape[2])
+    valid = key_positions.unsqueeze(0) < valid_counts.unsqueeze(1)
+    scores = scores.masked_fill(~valid.unsqueeze(0), -torch.inf)
+
+    effective_topk = min(topk, scores.shape[-1])
+    values, indices = torch.topk(scores, effective_topk, dim=-1)
+    indices = torch.where(torch.isfinite(values), indices, -torch.ones_like(indices))
+    if effective_topk < topk:
+        indices = F.pad(indices, (0, topk - effective_topk), value=-1)
+    topk_length = (indices >= 0).sum(dim=-1, dtype=torch.int32)
+    return indices.to(torch.int32), topk_length
+
+
+def _torch_sparse_attention(
+    query: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    softmax_scale: float,
+    topk_length=None,
+    indexer_topk: int = 0,
+    value_dim: int | None = None,
+) -> torch.Tensor:
+    """Differentiable exact sparse attention for MLite's flattened indices."""
+
+    del topk_length, indexer_topk
+    seq, batch, heads, _ = query.shape
+    assert value_dim is not None
+    rows = []
+    for query_idx in range(seq):
+        batches = []
+        for batch_idx in range(batch):
+            flat_row = topk_idxs[query_idx * batch + batch_idx]
+            valid_flat = flat_row[flat_row >= 0].long()
+            assert torch.all(valid_flat % batch == batch_idx)
+            key_indices = valid_flat // batch
+            selected_kv = kv[:, batch_idx][key_indices]
+            scores = (
+                torch.einsum("hd,kd->hk", query[query_idx, batch_idx], selected_kv)
+                * softmax_scale
+            )
+            sink = attn_sink.to(dtype=scores.dtype).view(heads, 1)
+            probabilities = torch.softmax(
+                torch.cat((scores, sink), dim=-1), dim=-1, dtype=torch.float32
+            )[..., :-1].to(dtype=query.dtype)
+            values = selected_kv[:, :value_dim]
+            result = torch.einsum("hk,kv->hv", probabilities, values)
+            batches.append(result.reshape(-1))
+        rows.append(torch.stack(batches, dim=0))
+    return torch.stack(rows, dim=0)
+
+
+def _hf_config():
+    import transformers
+
+    assert transformers.__version__ == _TRANSFORMERS_AUTHORITY, (
+        "GLM-5.2 HF authority is pinned to Transformers "
+        f"{_TRANSFORMERS_AUTHORITY}; got {transformers.__version__}"
+    )
+    config = transformers.GlmMoeDsaConfig(
+        vocab_size=_VOCAB,
+        hidden_size=_HIDDEN,
+        intermediate_size=48,
+        moe_intermediate_size=16,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        q_lora_rank=16,
+        kv_lora_rank=8,
+        qk_nope_head_dim=8,
+        qk_rope_head_dim=4,
+        v_head_dim=8,
+        index_head_dim=8,
+        index_n_heads=4,
+        index_topk=_INDEX_TOPK,
+        indexer_types=["full", "shared"],
+        index_topk_freq=2,
+        index_skip_topk_offset=1,
+        indexer_rope_interleave=True,
+        indexer_rope_first=True,
+        indexer_use_hadamard=False,
+        rope_interleave=True,
+        rope_parameters={"rope_type": "default", "rope_theta": 8_000_000.0},
+        latent_rms_norm_eps=1.0e-6,
+        indexer_layer_norm_eps=1.0e-6,
+        rms_norm_eps=1.0e-5,
+        first_k_dense_replace=1,
+        mlp_layer_types=["dense", "sparse"],
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        n_group=1,
+        topk_group=1,
+        routed_scaling_factor=1.5,
+        norm_topk_prob=True,
+        num_nextn_predict_layers=0,
+        max_position_embeddings=128,
+        attention_bias=False,
+        attention_dropout=0.0,
+        tie_word_embeddings=False,
+        use_cache=False,
+    )
+    config._attn_implementation = "eager"
+    config._experts_implementation = "eager"
+    return config
+
+
+def _checkpoint_state_for_lite(hf_model: nn.Module) -> dict[str, torch.Tensor]:
+    """Expose packed HF experts under the per-expert names accepted by MLite."""
+
+    state = {
+        name: tensor.detach().cpu().contiguous().clone()
+        for name, tensor in hf_model.state_dict().items()
+    }
+    for layer_idx, layer_type in enumerate(hf_model.config.mlp_layer_types):
+        if layer_type != "sparse":
+            continue
+        prefix = f"model.layers.{layer_idx}.mlp.experts"
+        gate_up = state[f"{prefix}.gate_up_proj"]
+        down = state[f"{prefix}.down_proj"]
+        assert gate_up.shape == (
+            hf_model.config.n_routed_experts,
+            2 * hf_model.config.moe_intermediate_size,
+            hf_model.config.hidden_size,
+        )
+        assert down.shape == (
+            hf_model.config.n_routed_experts,
+            hf_model.config.hidden_size,
+            hf_model.config.moe_intermediate_size,
+        )
+        for expert_idx in range(hf_model.config.n_routed_experts):
+            gate, up = gate_up[expert_idx].chunk(2, dim=0)
+            expert_prefix = f"{prefix}.{expert_idx}"
+            state[f"{expert_prefix}.gate_proj.weight"] = gate.contiguous().clone()
+            state[f"{expert_prefix}.up_proj.weight"] = up.contiguous().clone()
+            state[f"{expert_prefix}.down_proj.weight"] = (
+                down[expert_idx].contiguous().clone()
+            )
+    return state
+
+
+def _layer_capture(layers, *, sequence_first: bool):
+    captured: dict[int, torch.Tensor] = {}
+    handles = []
+    for index, layer in enumerate(layers):
+
+        def _hook(_module, _args, output, *, layer_index=index):
+            value = output[0] if isinstance(output, tuple) else output
+            assert isinstance(value, torch.Tensor)
+            if sequence_first:
+                value = value.transpose(0, 1)
+            captured[layer_index] = value.detach().clone()
+
+        handles.append(layer.register_forward_hook(_hook))
+    return captured, handles
+
+
+def _embedding_grad_capture(embedding):
+    captured: list[torch.Tensor] = []
+
+    def _hook(_module, _args, output):
+        assert isinstance(output, torch.Tensor)
+        output.retain_grad()
+        captured.append(output)
+
+    return captured, embedding.register_forward_hook(_hook)
+
+
+def _metrics(reference: torch.Tensor, candidate: torch.Tensor) -> dict[str, float]:
+    assert candidate.shape == reference.shape
+    reference = reference.detach().double()
+    candidate = candidate.detach().double()
+    assert torch.isfinite(reference).all()
+    assert torch.isfinite(candidate).all()
+    reference_flat = reference.reshape(-1)
+    candidate_flat = candidate.reshape(-1)
+    reference_norm = torch.linalg.vector_norm(reference_flat)
+    candidate_norm = torch.linalg.vector_norm(candidate_flat)
+    assert reference_norm > 0 and candidate_norm > 0
+    difference = candidate - reference
+    rms_scale = torch.maximum(
+        torch.sqrt(torch.mean(reference.square())),
+        torch.sqrt(torch.mean(candidate.square())),
+    ).clamp_min(torch.finfo(torch.float64).tiny)
+    return {
+        "cosine": F.cosine_similarity(reference_flat, candidate_flat, dim=0).item(),
+        "rms_relative": (
+            torch.sqrt(torch.mean(difference.square())) / rms_scale
+        ).item(),
+        "norm_ratio": (candidate_norm / reference_norm).item(),
+        "max_abs": difference.abs().max().item(),
+    }
+
+
+def _assert_parity(
+    name: str,
+    reference: torch.Tensor,
+    candidate: torch.Tensor,
+    *,
+    cosine_min: float,
+    rms_relative_max: float,
+    norm_ratio_min: float,
+    norm_ratio_max: float,
+    max_abs_max: float,
+) -> dict[str, float]:
+    values = _metrics(reference, candidate)
+    print(
+        f"[glm52-hf-production-layout] {name}: shape={tuple(reference.shape)} "
+        f"cosine={values['cosine']:.12f} "
+        f"rms_relative={values['rms_relative']:.12e} "
+        f"norm_ratio={values['norm_ratio']:.12f} "
+        f"max_abs={values['max_abs']:.12e}"
+    )
+    assert values["cosine"] >= cosine_min, values
+    assert values["rms_relative"] <= rms_relative_max, values
+    assert norm_ratio_min <= values["norm_ratio"] <= norm_ratio_max, values
+    assert values["max_abs"] <= max_abs_max, values
+    return values
+
+
+def _shifted_external_ce(logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+    assert logits.shape == (_BATCH, _SEQ, _VOCAB)
+    assert labels.shape == (_BATCH, _SEQ)
+    return F.cross_entropy(
+        logits[:, :-1].float().reshape(-1, _VOCAB),
+        labels[:, 1:].reshape(-1),
+    )
+
+
+def _capture_first_attention_topk(model, input_ids, position_ids):
+    captured: list[torch.Tensor] = []
+
+    def _hook(_module, _args, output):
+        assert isinstance(output, tuple) and len(output) == 3
+        assert output[2] is not None
+        captured.append(output[2].detach().clone())
+
+    handle = model.model.layers[0].self_attn.register_forward_hook(_hook)
+    try:
+        with torch.no_grad():
+            logits = model(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                use_cache=False,
+                logits_to_keep=0,
+                return_dict=True,
+            ).logits.detach()
+    finally:
+        handle.remove()
+    assert len(captured) == 1
+    return logits, captured[0]
+
+
+def test_glm52_transformers_512_adapted_production_layout_full_model_parity(
+    tmp_path, transformer_engine_import_stub, monkeypatch
+):
+    """Configured/interleaved F/S GLM-5.2 vs a one-line adapted HF model."""
+
+    transformers = pytest.importorskip("transformers")
+    pytest.importorskip("safetensors")
+    assert transformers.__version__ == _TRANSFORMERS_AUTHORITY
+    from transformers.models.glm_moe_dsa import modeling_glm_moe_dsa as hf_impl
+
+    transformer_engine_import_stub()
+    from megatron.lite.model.glm5.config import Glm5Config
+    from megatron.lite.model.glm5.lite import model as lite_impl
+    from megatron.lite.model.glm5.lite.checkpoint import load_hf_weights
+    from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
+    from megatron.lite.primitive.modules import experts as experts_impl
+    from megatron.lite.primitive.modules.attention import dsa
+    from megatron.lite.primitive.parallel import linear as linear_impl
+    from megatron.lite.primitive.parallel.state import ParallelState
+
+    # Keep this lane independent of TE and fused DSA availability.  These are
+    # implementation adapters only; the actual MLite model/layer wiring,
+    # checkpoint loader, IndexShare state, and autograd graph remain in use.
+    monkeypatch.setattr(lite_impl.te, "RMSNorm", _TorchRMSNorm)
+    monkeypatch.setattr(linear_impl.te, "Linear", _TorchLinear)
+    monkeypatch.setattr(linear_impl.te, "LayerNormLinear", _TorchLayerNormLinear)
+    monkeypatch.setattr(
+        experts_impl.te, "GroupedLinear", _TorchGroupedLinear, raising=False
+    )
+    monkeypatch.setattr(dsa, "RMSNorm", _TorchRMSNorm)
+    recorded_lite_topk: list[torch.Tensor] = []
+
+    def _recording_indexer_topk(*args, **kwargs):
+        indices, lengths = _torch_indexer_topk(*args, **kwargs)
+        recorded_lite_topk.append(indices.detach().clone())
+        return indices, lengths
+
+    monkeypatch.setattr(dsa._dsa_kernels, "indexer_topk", _recording_indexer_topk)
+    monkeypatch.setattr(dsa._dsa_kernels, "dsa_sparse_attn", _torch_sparse_attention)
+
+    torch.manual_seed(20260627)
+    hf_config = _hf_config()
+    hf_model = hf_impl.GlmMoeDsaForCausalLM(hf_config).double().eval()
+    assert type(hf_model.model.layers[1].mlp.experts).__name__ == "GlmMoeDsaNaiveMoe"
+
+    cfg = Glm5Config.from_hf_config(hf_config)
+    assert cfg.resolved_dsa_indexer_types == ("full", "shared")
+    assert cfg.uses_configured_dsa_rope_layout is True
+    assert cfg.rope_interleave is True
+    assert cfg.indexer_rope_interleave is True
+    assert cfg.mlp_layer_types == ["dense", "sparse"]
+    assert hf_config.indexer_rope_interleave is True
+
+    checkpoint_dir = tmp_path / "hf_production_layout"
+    save_safetensors(_checkpoint_state_for_lite(hf_model), str(checkpoint_dir))
+    ps = ParallelState()
+    train_config = SimpleNamespace(
+        tp=1,
+        ep=1,
+        etp=1,
+        pp=1,
+        cp=1,
+        vpp=None,
+        use_deepep=False,
+        fp8=False,
+        recompute_modules=[],
+        offload_modules=[],
+        deterministic=True,
+    )
+    lite_model = (
+        lite_impl.Glm5Model(
+            cfg,
+            train_config,
+            ps,
+            attention_backend_override="unfused",
+            mtp_enable=False,
+        )
+        .double()
+        .eval()
+    )
+    load_hf_weights(lite_model, str(checkpoint_dir), cfg, ps)
+    for layer_idx, layer in enumerate(lite_model.layers):
+        attention = layer.self_attention.self_attention
+        assert attention.rope_interleaved is True
+        if layer_idx == 0:
+            assert attention.indexer is not None
+            assert attention.indexer.rope_interleaved is True
+        else:
+            assert attention.skip_topk is True
+            assert attention.indexer is None
+
+    input_ids = torch.tensor(
+        [
+            [3, 5, 7, 11, 13, 17, 19, 23, 29, 31],
+            [37, 41, 43, 47, 53, 59, 61, 67, 2, 4],
+        ],
+        dtype=torch.long,
+    )
+    labels = torch.tensor(
+        [
+            [6, 10, 14, 18, 22, 26, 30, 34, 38, 42],
+            [46, 50, 54, 58, 62, 66, 70, 1, 9, 15],
+        ],
+        dtype=torch.long,
+    )
+    position_ids = torch.arange(_SEQ, dtype=torch.long).unsqueeze(0).expand(_BATCH, -1)
+
+    # Unmodified Transformers 5.12 is intentionally not the authority for the
+    # published production layout: it ignores indexer_rope_interleave.
+    vanilla_logits, vanilla_topk = _capture_first_attention_topk(
+        hf_model, input_ids, position_ids
+    )
+    indexer_forward = inspect.unwrap(hf_impl.GlmMoeDsaIndexer.forward)
+    module_source = inspect.getsource(hf_impl)
+    indexer_source = inspect.getsource(indexer_forward)
+    attention_source = inspect.getsource(
+        inspect.unwrap(hf_impl.GlmMoeDsaAttention.forward)
+    )
+    # One definition plus one call proves that rebinding the module global can
+    # affect no HF runtime path other than this indexer call site.
+    assert module_source.count("apply_rotary_pos_emb(") == 2
+    assert indexer_source.count("apply_rotary_pos_emb(") == 1
+    assert "apply_rotary_pos_emb_interleave(" in attention_source
+    assert indexer_forward.__globals__["apply_rotary_pos_emb"] is (
+        hf_impl.apply_rotary_pos_emb
+    )
+
+    # Minimal production-layout adapter. In Transformers 5.12 the rebound name
+    # is called only by GlmMoeDsaIndexer; main MLA already calls the explicit
+    # interleaved helper and all remaining HF model code stays untouched.
+    monkeypatch.setattr(
+        hf_impl,
+        "apply_rotary_pos_emb",
+        hf_impl.apply_rotary_pos_emb_interleave,
+    )
+    assert indexer_forward.__globals__["apply_rotary_pos_emb"] is (
+        hf_impl.apply_rotary_pos_emb_interleave
+    )
+
+    adapted_topk: list[torch.Tensor] = []
+
+    def _adapted_topk_hook(_module, _args, output):
+        assert isinstance(output, tuple) and output[2] is not None
+        adapted_topk.append(output[2].detach().clone())
+
+    topk_handle = hf_model.model.layers[0].self_attn.register_forward_hook(
+        _adapted_topk_hook
+    )
+    hf_layers, hf_layer_handles = _layer_capture(
+        hf_model.model.layers, sequence_first=False
+    )
+    lite_layers, lite_layer_handles = _layer_capture(
+        lite_model.layers, sequence_first=True
+    )
+    hf_embeddings, hf_embedding_handle = _embedding_grad_capture(
+        hf_model.model.embed_tokens
+    )
+    assert lite_model.embed is not None
+    lite_embeddings, lite_embedding_handle = _embedding_grad_capture(
+        lite_model.embed.embedding
+    )
+    try:
+        hf_output = hf_model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            use_cache=False,
+            logits_to_keep=0,
+            return_dict=True,
+        )
+        lite_output = lite_model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            packed_seq_params=None,
+        )
+    finally:
+        for handle in [
+            topk_handle,
+            *hf_layer_handles,
+            *lite_layer_handles,
+            hf_embedding_handle,
+            lite_embedding_handle,
+        ]:
+            handle.remove()
+
+    assert len(adapted_topk) == 1
+    assert len(recorded_lite_topk) == 1
+    adapted_topk_tensor = adapted_topk[0]
+    lite_topk_tensor = recorded_lite_topk[0]
+    assert adapted_topk_tensor.shape == (_BATCH, _SEQ, _INDEX_TOPK)
+    assert lite_topk_tensor.shape == (_BATCH, _SEQ, _INDEX_TOPK)
+    for batch_idx in range(_BATCH):
+        for query_idx in range(_SEQ):
+            hf_valid = adapted_topk_tensor[batch_idx, query_idx]
+            hf_valid = hf_valid[hf_valid <= query_idx].sort().values
+            lite_valid = lite_topk_tensor[batch_idx, query_idx]
+            lite_valid = lite_valid[lite_valid >= 0].sort().values
+            assert torch.equal(hf_valid, lite_valid), (
+                f"top-k mismatch at batch={batch_idx}, query={query_idx}: "
+                f"hf={hf_valid.tolist()} lite={lite_valid.tolist()}"
+            )
+
+    fully_valid = slice(_INDEX_TOPK - 1, None)
+    vanilla_valid_rows = vanilla_topk[:, fully_valid].sort(dim=-1).values
+    adapted_valid_rows = adapted_topk_tensor[:, fully_valid].sort(dim=-1).values
+    differing_topk_rows = int(
+        torch.any(vanilla_valid_rows != adapted_valid_rows, dim=-1).sum().item()
+    )
+    assert differing_topk_rows > 0, (
+        "the deterministic batch did not expose the vanilla HF half-split "
+        "indexer layout conflict"
+    )
+
+    hf_logits = hf_output.logits
+    lite_logits = lite_output["logits"]
+    assert hf_logits.shape == (_BATCH, _SEQ, _VOCAB)
+    assert lite_logits.shape == (_BATCH, _SEQ, _VOCAB)
+    vanilla_logit_max_abs = float((vanilla_logits - hf_logits).abs().max().item())
+    assert vanilla_logit_max_abs > 1.0e-6
+
+    assert set(hf_layers) == {0, 1}
+    assert set(lite_layers) == {0, 1}
+    layer_metrics = []
+    for layer_idx, layer_type in enumerate(cfg.mlp_layer_types):
+        assert hf_layers[layer_idx].shape == (_BATCH, _SEQ, _HIDDEN)
+        assert lite_layers[layer_idx].shape == (_BATCH, _SEQ, _HIDDEN)
+        layer_metrics.append(
+            _assert_parity(
+                f"layer-{layer_idx}-{layer_type}",
+                hf_layers[layer_idx],
+                lite_layers[layer_idx],
+                cosine_min=0.999999,
+                rms_relative_max=1.0e-4,
+                norm_ratio_min=0.9999,
+                norm_ratio_max=1.0001,
+                max_abs_max=1.0e-4,
+            )
+        )
+    logits_metrics = _assert_parity(
+        "final-logits",
+        hf_logits,
+        lite_logits,
+        cosine_min=0.999999,
+        rms_relative_max=1.0e-4,
+        norm_ratio_min=0.9999,
+        norm_ratio_max=1.0001,
+        max_abs_max=1.0e-4,
+    )
+
+    hf_loss = _shifted_external_ce(hf_logits, labels)
+    lite_loss = _shifted_external_ce(lite_logits, labels)
+    loss_abs = float((hf_loss - lite_loss).abs().item())
+    loss_relative = loss_abs / max(
+        abs(float(hf_loss.item())), abs(float(lite_loss.item())), 1.0e-12
+    )
+    print(
+        "[glm52-hf-production-layout] shifted-external-CE: "
+        f"hf={float(hf_loss.item()):.12f} lite={float(lite_loss.item()):.12f} "
+        f"abs={loss_abs:.12e} relative={loss_relative:.12e}"
+    )
+    assert loss_abs <= 1.0e-5
+    assert loss_relative <= 3.0e-6
+
+    hf_loss.backward()
+    lite_loss.backward()
+    assert len(hf_embeddings) == 1
+    assert len(lite_embeddings) == 1
+    hf_embedding_grad = hf_embeddings[0].grad
+    lite_embedding_grad = lite_embeddings[0].grad
+    assert hf_embedding_grad is not None
+    assert lite_embedding_grad is not None
+    embedding_grad_metrics = _assert_parity(
+        "embedding-output-gradient",
+        hf_embedding_grad,
+        lite_embedding_grad,
+        cosine_min=0.99999,
+        rms_relative_max=5.0e-4,
+        norm_ratio_min=0.9995,
+        norm_ratio_max=1.0005,
+        max_abs_max=1.0e-5,
+    )
+    hf_grad_norm = float(torch.linalg.vector_norm(hf_embedding_grad.double()).item())
+    lite_grad_norm = float(
+        torch.linalg.vector_norm(lite_embedding_grad.double()).item()
+    )
+    assert hf_grad_norm > 0.0 and lite_grad_norm > 0.0
+
+    print(
+        "NON_SKIP_GLM52_TRANSFORMERS_512_ADAPTED_PRODUCTION_LAYOUT_"
+        "FULL_MODEL_PARITY_PASSED "
+        "adapter=indexer_apply_rotary_pos_emb_interleave_only "
+        "scope=tiny_full_model_dense_moe_indexshare_F_S "
+        "configured_main_rope=true configured_indexer_rope=true "
+        f"vanilla_differing_topk_rows={differing_topk_rows} "
+        f"vanilla_logit_max_abs={vanilla_logit_max_abs:.9e} "
+        f"hidden_min_cosine={min(item['cosine'] for item in layer_metrics):.9f} "
+        f"hidden_max_rms_relative="
+        f"{max(item['rms_relative'] for item in layer_metrics):.9e} "
+        f"logits_cosine={logits_metrics['cosine']:.9f} "
+        f"logits_rms_relative={logits_metrics['rms_relative']:.9e} "
+        f"loss_abs={loss_abs:.9e} loss_relative={loss_relative:.9e} "
+        f"embedding_grad_cosine={embedding_grad_metrics['cosine']:.9f} "
+        f"embedding_grad_rms_relative="
+        f"{embedding_grad_metrics['rms_relative']:.9e} "
+        "excludes=unmodified_hf_vanilla,production_sparse_kernel,mtp,cp,pp,"
+        "recompute_offload,long_context"
+    )

--- a/experimental/lite/tests/smoke/model/test_glm5_dsa_acceptance_smoke.py
+++ b/experimental/lite/tests/smoke/model/test_glm5_dsa_acceptance_smoke.py
@@ -73,16 +73,10 @@ def _make_dsa_pair(*, sparse_loss: bool):
         indexer_use_sparse_loss=sparse_loss,
     )
     source = DynamicSparseAttention(
-        **common,
-        layer_number=1,
-        indexer_type="full",
-        index_share_source_layer=1,
+        **common, layer_number=1, indexer_type="full", index_share_source_layer=1
     )
     shared = DynamicSparseAttention(
-        **common,
-        layer_number=2,
-        indexer_type="shared",
-        index_share_source_layer=1,
+        **common, layer_number=2, indexer_type="shared", index_share_source_layer=1
     )
     assert source.indexer is not None
     assert shared.indexer is None
@@ -171,9 +165,9 @@ def _saved_indexer_loss(output: torch.Tensor) -> torch.Tensor:
             (indexer_loss,) = grad_fn.saved_tensors
             matches.append(indexer_loss)
         stack.extend(parent for parent, _index in grad_fn.next_functions)
-    assert len(matches) == 1, (
-        f"expected exactly one DSAIndexerLossAutoScalerBackward, found {len(matches)}"
-    )
+    assert (
+        len(matches) == 1
+    ), f"expected exactly one DSAIndexerLossAutoScalerBackward, found {len(matches)}"
     indexer_loss = matches[0]
     assert indexer_loss.ndim == 0
     assert torch.isfinite(indexer_loss)
@@ -187,9 +181,7 @@ def _causal_mask(
     k_idx = torch.arange(seq_k, device=device)
     q_global_start = seq_k * ratio - seq_q
     valid_per_q = torch.div(
-        q_global_start + q_idx + 1,
-        ratio,
-        rounding_mode="floor",
+        q_global_start + q_idx + 1, ratio, rounding_mode="floor"
     ).clamp(min=0, max=seq_k)
     return k_idx.unsqueeze(0) < valid_per_q.unsqueeze(1)
 
@@ -326,9 +318,7 @@ def _torch_sparse_indexer_loss(
     )
     attn_probs = torch.softmax(safe_attn_scores, dim=-1)
     attn_probs = torch.where(
-        row_valid.view(*row_valid.shape, 1, 1),
-        attn_probs,
-        torch.zeros_like(attn_probs),
+        row_valid.view(*row_valid.shape, 1, 1), attn_probs, torch.zeros_like(attn_probs)
     )
     target_mass = attn_probs.sum(dim=2)
     target_mass = torch.where(valid, target_mass, torch.zeros_like(target_mass))
@@ -386,9 +376,7 @@ def _torch_dense_indexer_loss(
     )
     attn_probs = torch.softmax(safe_attn_scores, dim=-1)
     attn_probs = torch.where(
-        row_valid.view(*row_valid.shape, 1, 1),
-        attn_probs,
-        torch.zeros_like(attn_probs),
+        row_valid.view(*row_valid.shape, 1, 1), attn_probs, torch.zeros_like(attn_probs)
     )
     target_mass = attn_probs.sum(dim=2)
     target_mass = torch.where(
@@ -434,11 +422,7 @@ def _torch_unfused_dsa_forward(
         dim=module.qk_rope_head_dim,
     )
     q_pe = apply_rotary_pos_emb(
-        q_pe,
-        cos,
-        sin,
-        unsqueeze_dim=2,
-        mla_interleaved=module.rope_interleaved,
+        q_pe, cos, sin, unsqueeze_dim=2, mla_interleaved=module.rope_interleaved
     )
 
     k_up_weight, v_up_weight = module._split_kv_b_weights()
@@ -549,12 +533,7 @@ def _run_once_torch_unfused(
     hidden = local_x + source_out
     shared_out, reused_topk_indices, shared_indexer_loss, shared_indexer_scores = (
         _torch_unfused_dsa_forward(
-            modules["shared"],
-            hidden,
-            cos,
-            sin,
-            position_ids,
-            topk_indices=topk_indices,
+            modules["shared"], hidden, cos, sin, position_ids, topk_indices=topk_indices
         )
     )
     assert shared_indexer_scores is None
@@ -602,12 +581,7 @@ def _tensor_similarity_metrics(
     actual_norm_value = float(actual_norm.item())
     expected_norm_value = float(expected_norm.item())
     if actual_norm_value == 0.0 and expected_norm_value == 0.0:
-        return {
-            "cosine": 1.0,
-            "rms_relative": 0.0,
-            "norm_ratio": 1.0,
-            "max_abs": 0.0,
-        }
+        return {"cosine": 1.0, "rms_relative": 0.0, "norm_ratio": 1.0, "max_abs": 0.0}
     if expected_norm_value == 0.0:
         return {
             "cosine": 0.0,
@@ -633,9 +607,7 @@ def _tensor_similarity_metrics(
     }
 
 
-def _similarity_extrema(
-    comparisons: dict[str, dict[str, float]],
-) -> dict[str, float]:
+def _similarity_extrema(comparisons: dict[str, dict[str, float]]) -> dict[str, float]:
     assert comparisons
     return {
         "min_cosine": min(value["cosine"] for value in comparisons.values()),
@@ -669,8 +641,7 @@ def _canonical_topk_set(topk_indices: torch.Tensor) -> torch.Tensor:
 
 
 def _assert_topk_matches_quantized_scores(
-    actual_indices: torch.Tensor,
-    scores: torch.Tensor,
+    actual_indices: torch.Tensor, scores: torch.Tensor
 ) -> dict[str, float | int]:
     """Validate top-k exactly away from ties and by cutoff at numeric ties."""
 
@@ -739,9 +710,9 @@ def _assert_topk_matches_quantized_scores(
         next_score = probe_values[..., topk]
         margin = cutoff - next_score
         strict_rows = strict_rows | (margin > tolerance)
-    assert torch.all(~strict_rows | exact_rows), (
-        "top-k index multiset differs despite a numerically separated cutoff"
-    )
+    assert torch.all(
+        ~strict_rows | exact_rows
+    ), "top-k index multiset differs despite a numerically separated cutoff"
     ambiguous_rows = (~strict_rows & nonempty).sum()
     return {
         "exact_rows": int(exact_rows.sum().item()),
@@ -806,7 +777,7 @@ def _main_param_grad_similarity(
 
 
 def _assert_main_grad_similarity(
-    comparisons: dict[str, dict[str, float]],
+    comparisons: dict[str, dict[str, float]]
 ) -> dict[str, float]:
     extrema = _similarity_extrema(comparisons)
     assert extrema["min_cosine"] >= _MIN_MAIN_GRAD_COSINE, comparisons
@@ -835,9 +806,9 @@ def _assert_meaningful_indexer_grads(result: dict) -> float:
     grad_max_abs = {
         name: float(grad.abs().max().item()) for name, grad in grads.items()
     }
-    assert all(value > _MIN_INDEXER_GRAD_MAX_ABS for value in grad_max_abs.values()), (
-        grad_max_abs
-    )
+    assert all(
+        value > _MIN_INDEXER_GRAD_MAX_ABS for value in grad_max_abs.values()
+    ), grad_max_abs
     return max(grad_max_abs.values())
 
 
@@ -878,9 +849,7 @@ def test_glm5_dsa_run_to_run_accept_with_proof(sparse_loss: bool, monkeypatch):
         pytest.skip("CUDA is required for GLM5 DSA accept-with-proof smoke.")
 
     from megatron.lite.primitive.modules.attention import build_rope_cache
-    from megatron.lite.primitive.modules.attention.dsa import (
-        DSAIndexerLossAutoScaler,
-    )
+    from megatron.lite.primitive.modules.attention.dsa import DSAIndexerLossAutoScaler
 
     device = torch.device("cuda", int(torch.cuda.current_device()))
     # The runtime loss scaler is process-global.  Pin this standalone oracle to
@@ -899,10 +868,7 @@ def test_glm5_dsa_run_to_run_accept_with_proof(sparse_loss: bool, monkeypatch):
     batch, seq, hidden = 1, _SEQUENCE_LENGTH, 128
     x = torch.randn(batch, seq, hidden, device=device, dtype=torch.bfloat16)
     cos, sin = build_rope_cache(
-        dim=64,
-        max_position_embeddings=seq,
-        rope_theta=1_000_000.0,
-        device=device,
+        dim=64, max_position_embeddings=seq, rope_theta=1_000_000.0, device=device
     )
     position_ids = torch.arange(seq, device=device, dtype=torch.long).unsqueeze(0)
 
@@ -911,20 +877,10 @@ def test_glm5_dsa_run_to_run_accept_with_proof(sparse_loss: bool, monkeypatch):
     unfused_a = _run_once_torch_unfused(unfused, x, cos, sin, position_ids)
     unfused_b = _run_once_torch_unfused(unfused, x, cos, sin, position_ids)
     matched_unfused_a = _run_once_torch_unfused(
-        unfused,
-        x,
-        cos,
-        sin,
-        position_ids,
-        forced_source_topk=fused_a["topk_indices"],
+        unfused, x, cos, sin, position_ids, forced_source_topk=fused_a["topk_indices"]
     )
     matched_unfused_b = _run_once_torch_unfused(
-        unfused,
-        x,
-        cos,
-        sin,
-        position_ids,
-        forced_source_topk=fused_b["topk_indices"],
+        unfused, x, cos, sin, position_ids, forced_source_topk=fused_b["topk_indices"]
     )
 
     fused_r2r_output_similarity = {
@@ -1080,8 +1036,7 @@ def test_glm5_dsa_run_to_run_accept_with_proof(sparse_loss: bool, monkeypatch):
         fused_b["topk_indices"], unfused_a["indexer_scores"]
     )
     topk_ambiguous_rows = max(
-        topk_score_proof_a["ambiguous_rows"],
-        topk_score_proof_b["ambiguous_rows"],
+        topk_score_proof_a["ambiguous_rows"], topk_score_proof_b["ambiguous_rows"]
     )
     topk_max_score_shortfall = max(
         topk_score_proof_a["max_score_shortfall"],
@@ -1137,10 +1092,7 @@ def test_glm5_dsa_run_to_run_accept_with_proof(sparse_loss: bool, monkeypatch):
             if name.startswith("source.indexer.")
         ]
         dense_topk_indexer_grad_diff = max(
-            _max_abs(
-                alternate_topk["param_grads"][name],
-                fused_a["param_grads"][name],
-            )
+            _max_abs(alternate_topk["param_grads"][name], fused_a["param_grads"][name])
             for name in indexer_names
         )
         assert dense_topk_indexer_grad_diff <= 1.0e-6
@@ -1191,8 +1143,7 @@ def test_glm5_dsa_run_to_run_accept_with_proof(sparse_loss: bool, monkeypatch):
         assert fused_r2r_loss <= _MAIN_LOSS_MAX_ABS_DIFF
         assert fused_r2r_loss_symmetric_rel <= _MAX_MAIN_LOSS_SYMMETRIC_REL
         _assert_main_output_similarity(
-            fused_r2r_output_similarity,
-            max_abs=_GLM_FUSED_R2R_OUTPUT_MAX_ABS,
+            fused_r2r_output_similarity, max_abs=_GLM_FUSED_R2R_OUTPUT_MAX_ABS
         )
         _assert_main_grad_similarity(fused_r2r_x_grad_similarity)
         _assert_main_grad_similarity(fused_r2r_param_grad_similarity)
@@ -1219,15 +1170,15 @@ def test_glm5_dsa_run_to_run_accept_with_proof(sparse_loss: bool, monkeypatch):
         rtol=_INDEXER_LOSS_RTOL,
     )
     assert min_indexer_grad_cosine >= _MIN_INDEXER_GRAD_COSINE, indexer_grad_similarity
-    assert max_indexer_grad_rms_relative <= _MAX_INDEXER_GRAD_RMS_REL, (
-        indexer_grad_similarity
-    )
-    assert min_indexer_grad_norm_ratio >= _MIN_INDEXER_GRAD_NORM_RATIO, (
-        indexer_grad_similarity
-    )
-    assert max_indexer_grad_norm_ratio <= _MAX_INDEXER_GRAD_NORM_RATIO, (
-        indexer_grad_similarity
-    )
+    assert (
+        max_indexer_grad_rms_relative <= _MAX_INDEXER_GRAD_RMS_REL
+    ), indexer_grad_similarity
+    assert (
+        min_indexer_grad_norm_ratio >= _MIN_INDEXER_GRAD_NORM_RATIO
+    ), indexer_grad_similarity
+    assert (
+        max_indexer_grad_norm_ratio <= _MAX_INDEXER_GRAD_NORM_RATIO
+    ), indexer_grad_similarity
     valid_topk = (fused_a["topk_indices"] >= 0).sum(dim=-1)
     assert _INDEXER_TOPK < seq
     assert fused_a["topk_indices"].shape[-1] == _INDEXER_TOPK
@@ -1402,34 +1353,20 @@ def test_dsv4_fused_dsa_legacy_two_output_api_real_gpu():
     # legacy fused autograd wrapper and covers the real compressed-KV layout.
     args = make_args()
     topk_indices, topk_length = dsa_kernels.indexer_topk(
-        args[4],
-        args[5],
-        args[6],
-        requested_topk,
-        ratio,
-        indexer_softmax_scale=args[10],
+        args[4], args[5], args[6], requested_topk, ratio, indexer_softmax_scale=args[10]
     )
     assert topk_indices.shape == (batch, seq, requested_topk)
     assert topk_length.shape == (batch, seq)
     assert torch.all(topk_indices[..., n_comp:] == -1)
     independent_indexer_scores = _torch_indexer_scores(
-        args[4],
-        args[5],
-        args[6],
-        ratio=ratio,
-        indexer_softmax_scale=args[10],
+        args[4], args[5], args[6], ratio=ratio, indexer_softmax_scale=args[10]
     )
     padded_topk_score_proof = _assert_topk_matches_quantized_scores(
         topk_indices[..., :n_comp], independent_indexer_scores
     )
     selection_topk = n_comp // 2
     selection_indices, selection_length = dsa_kernels.indexer_topk(
-        args[4],
-        args[5],
-        args[6],
-        selection_topk,
-        ratio,
-        indexer_softmax_scale=args[10],
+        args[4], args[5], args[6], selection_topk, ratio, indexer_softmax_scale=args[10]
     )
     assert selection_indices.shape == (batch, seq, selection_topk)
     assert selection_length.shape == (batch, seq)
@@ -1491,13 +1428,11 @@ def test_dsv4_fused_dsa_legacy_two_output_api_real_gpu():
     direct_public_grad_similarity = {}
     for name in decomposed_main_grads:
         direct_public_grad_similarity[name] = _tensor_similarity_metrics(
-            fused_results[0]["main_grads"][name],
-            fused_results[1]["main_grads"][name],
+            fused_results[0]["main_grads"][name], fused_results[1]["main_grads"][name]
         )
     decomposed_grad_similarity = {
         name: _tensor_similarity_metrics(
-            fused_results[1]["main_grads"][name],
-            decomposed_grad,
+            fused_results[1]["main_grads"][name], decomposed_grad
         )
         for name, decomposed_grad in decomposed_main_grads.items()
     }
@@ -1514,8 +1449,7 @@ def test_dsv4_fused_dsa_legacy_two_output_api_real_gpu():
     )
 
     _assert_main_output_similarity(
-        direct_public_output_similarity,
-        max_abs=_DIRECT_PUBLIC_OUTPUT_ATOL,
+        direct_public_output_similarity, max_abs=_DIRECT_PUBLIC_OUTPUT_ATOL
     )
     torch.testing.assert_close(
         fused_results[0]["output"],
@@ -1581,9 +1515,7 @@ def test_dsv4_csa_torch_fused_module_parity_real_gpu():
     pytest.importorskip("cudnn", reason="DSv4 CSA module parity needs cudnn DSA.")
 
     from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
-    from megatron.lite.primitive.modules.attention.csa import (
-        CompressedSparseAttention,
-    )
+    from megatron.lite.primitive.modules.attention.csa import CompressedSparseAttention
     from megatron.lite.primitive.parallel import ParallelState
 
     device = torch.device("cuda", int(torch.cuda.current_device()))
@@ -1664,10 +1596,7 @@ def test_dsv4_csa_torch_fused_module_parity_real_gpu():
 
     output_comparisons = {}
     gradient_comparisons = {}
-    for name, actual in (
-        ("decomposed", decomposed),
-        ("legacy_fused", legacy_fused),
-    ):
+    for name, actual in (("decomposed", decomposed), ("legacy_fused", legacy_fused)):
         assert set(actual["main_grads"]) == set(reference["main_grads"])
         output_comparisons[name] = _tensor_similarity_metrics(
             actual["output"], reference["output"]
@@ -1691,10 +1620,7 @@ def test_dsv4_csa_torch_fused_module_parity_real_gpu():
         f"gradient_extrema={gradient_extrema}"
     )
 
-    _assert_main_output_similarity(
-        output_comparisons,
-        max_abs=_DSV4_CSA_OUTPUT_MAX_ABS,
-    )
+    _assert_main_output_similarity(output_comparisons, max_abs=_DSV4_CSA_OUTPUT_MAX_ABS)
     assert min(value["cosine"] for value in gradient_comparisons.values()) >= (
         _MIN_MAIN_GRAD_COSINE
     ), gradient_comparisons
@@ -1787,13 +1713,9 @@ def test_glm52_model_preserves_multisegment_positions_through_indexshare_and_mtp
     )
 
     torch.manual_seed(20260627)
-    model = Glm5Model(
-        cfg,
-        train_cfg,
-        ps,
-        mtp_enable=True,
-        mtp_enable_train=False,
-    ).to(device=device, dtype=torch.bfloat16)
+    model = Glm5Model(cfg, train_cfg, ps, mtp_enable=True, mtp_enable_train=False).to(
+        device=device, dtype=torch.bfloat16
+    )
     model.eval()
     assert model.mtp is not None
 

--- a/experimental/lite/tests/smoke/model/test_glm5_dsa_acceptance_smoke.py
+++ b/experimental/lite/tests/smoke/model/test_glm5_dsa_acceptance_smoke.py
@@ -8,12 +8,51 @@ import torch
 
 pytestmark = [pytest.mark.mlite, pytest.mark.smoke, pytest.mark.gpu]
 
+_DIRECT_PUBLIC_OUTPUT_ATOL = 2.0e-3
+_DIRECT_PUBLIC_LOSS_ATOL = 1.0e-6
+_GLM_X_GRAD_MAX_ABS = 1.0e-6
+_GLM_PARAM_GRAD_MAX_ABS = 4.0e-6
+_INDEXER_LOSS_ATOL = 1.0e-6
+_INDEXER_LOSS_RTOL = 5.0e-3
+# Main-attention comparisons use a scale-independent envelope plus a
+# path-specific outlier ceiling. Keep these separate from the stricter
+# indexer-loss oracle above so their tolerances cannot weaken it.
+_MAIN_LOSS_MAX_ABS_DIFF = 1.0e-5
+_MAX_MAIN_LOSS_SYMMETRIC_REL = 1.0e-3
+_GLM_FUSED_R2R_OUTPUT_MAX_ABS = 2.0e-2
+_GLM_FUSED_VS_REFERENCE_OUTPUT_MAX_ABS = 4.0e-2
+_DSV4_FUSED_VS_DECOMPOSED_OUTPUT_MAX_ABS = 2.0e-2
+_DSV4_CSA_OUTPUT_MAX_ABS = 6.0e-3
+_MIN_MAIN_OUTPUT_COSINE = 0.999
+_MAX_MAIN_OUTPUT_RMS_REL = 0.02
+_MIN_MAIN_OUTPUT_NORM_RATIO = 0.99
+_MAX_MAIN_OUTPUT_NORM_RATIO = 1.01
+_INDEXER_TOPK = 512
+_SEQUENCE_LENGTH = 1024
+_INDEXER_LOSS_COEFF = 1.0e-2
+_MIN_INDEXER_GRAD_MAX_ABS = 1.0e-8
+# Four-rank GB300 acceptance high-water marks were 0.999462 cosine, 0.032821
+# RMS-relative, and 0.997976--1.001816 norm ratio for indexer gradients; DSv4
+# main gradients reached 0.999956 cosine, 0.009290 RMS-relative, and
+# 0.998507--1.000822 norm ratio. Keep bounded BF16/kernel headroom without
+# retaining the former 0.99/0.20/0.90--1.10 compatibility envelope.
+_MIN_INDEXER_GRAD_COSINE = 0.999
+_MAX_INDEXER_GRAD_RMS_REL = 0.05
+_MIN_INDEXER_GRAD_NORM_RATIO = 0.995
+_MAX_INDEXER_GRAD_NORM_RATIO = 1.005
+_MIN_MAIN_GRAD_COSINE = 0.9999
+_MAX_MAIN_GRAD_RMS_REL = 0.02
+_MIN_MAIN_GRAD_NORM_RATIO = 0.997
+_MAX_MAIN_GRAD_NORM_RATIO = 1.003
+_TOPK_SCORE_ATOL = 1.0e-5
+_TOPK_SCORE_RTOL = 1.0e-4
 
-def _make_dsa():
+
+def _make_dsa_pair(*, sparse_loss: bool):
     pytest.importorskip("cudnn", reason="GLM5 DSA accept-with-proof needs cudnn DSA.")
     from megatron.lite.primitive.modules.attention import DynamicSparseAttention
 
-    return DynamicSparseAttention(
+    common = dict(
         hidden_size=128,
         num_attention_heads=64,
         q_lora_rank=16,
@@ -23,36 +62,135 @@ def _make_dsa():
         v_head_dim=256,
         index_n_heads=32,
         index_head_dim=128,
-        index_topk=512,
+        index_topk=_INDEXER_TOPK,
         rms_norm_eps=1e-5,
-        layer_number=1,
+        rope_interleaved=True,
+        indexer_rope_interleaved=True,
+        index_topk_freq=2,
+        index_skip_topk_offset=1,
+        index_share_enabled=True,
+        indexer_loss_coeff=_INDEXER_LOSS_COEFF,
+        indexer_use_sparse_loss=sparse_loss,
     )
+    source = DynamicSparseAttention(
+        **common,
+        layer_number=1,
+        indexer_type="full",
+        index_share_source_layer=1,
+    )
+    shared = DynamicSparseAttention(
+        **common,
+        layer_number=2,
+        indexer_type="shared",
+        index_share_source_layer=1,
+    )
+    assert source.indexer is not None
+    assert shared.indexer is None
+    return torch.nn.ModuleDict({"source": source, "shared": shared})
 
 
-def _run_once(module, x, cos, sin, position_ids, *, fused_training: bool):
-    module.zero_grad(set_to_none=True)
-    module.train(fused_training)
+def _run_once(modules, x, cos, sin, position_ids, *, fused_training: bool):
+    from megatron.lite.primitive.modules.attention import DSAIndexShareState
+
+    class RecordingState(DSAIndexShareState):
+        def __init__(self):
+            super().__init__({1: 1})
+            self.saved: list[torch.Tensor] = []
+            self.consumed: list[torch.Tensor] = []
+
+        def save_topk(self, layer_number, topk_indices, *, sequence_key=None):
+            self.saved.append(topk_indices.detach().clone())
+            return super().save_topk(
+                layer_number, topk_indices, sequence_key=sequence_key
+            )
+
+        def get_topk(self, layer_number, source_layer, *, sequence_key=None):
+            topk_indices = super().get_topk(
+                layer_number, source_layer, sequence_key=sequence_key
+            )
+            self.consumed.append(topk_indices.detach().clone())
+            return topk_indices
+
+    modules.zero_grad(set_to_none=True)
+    modules.train(fused_training)
     local_x = x.detach().clone().requires_grad_(True)
-    out = module(local_x, cos=cos, sin=sin, position_ids=position_ids)
+    index_share_state = RecordingState()
+    source_out = modules["source"](
+        local_x,
+        cos=cos,
+        sin=sin,
+        position_ids=position_ids,
+        index_share_state=index_share_state,
+    )
+    indexer_loss = _saved_indexer_loss(source_out)
+    assert index_share_state.cached_tensor_count == 1
+    hidden = local_x + source_out
+    shared_out = modules["shared"](
+        hidden,
+        cos=cos,
+        sin=sin,
+        position_ids=position_ids,
+        index_share_state=index_share_state,
+    )
+    out = hidden + shared_out
+    assert len(index_share_state.saved) == 1
+    assert len(index_share_state.consumed) == 1
+    assert torch.equal(index_share_state.saved[0], index_share_state.consumed[0])
+    assert index_share_state.cached_tensor_count == 0
     loss = out.float().square().mean()
     loss.backward()
     param_grads = {
         name: param.grad.detach().float().clone()
-        for name, param in module.named_parameters()
+        for name, param in modules.named_parameters()
         if param.grad is not None
     }
     return {
         "loss": loss.detach().float().clone(),
+        "indexer_loss": indexer_loss,
         "out": out.detach().float().clone(),
         "x_grad": local_x.grad.detach().float().clone(),
         "param_grads": param_grads,
+        "topk_indices": index_share_state.consumed[0],
     }
 
 
-def _causal_mask(seq_q: int, seq_k: int, *, ratio: int, device: torch.device) -> torch.Tensor:
+def _saved_indexer_loss(output: torch.Tensor) -> torch.Tensor:
+    """Extract the loss attached by DSAIndexerLossAutoScaler before backward."""
+
+    stack = [output.grad_fn]
+    # Keep strong references to visited nodes. Storing only ids permits an
+    # autograd wrapper to be collected and its id reused during traversal.
+    visited: dict[int, object] = {}
+    matches: list[torch.Tensor] = []
+    while stack:
+        grad_fn = stack.pop()
+        if grad_fn is None or id(grad_fn) in visited:
+            continue
+        visited[id(grad_fn)] = grad_fn
+        if type(grad_fn).__name__ == "DSAIndexerLossAutoScalerBackward":
+            (indexer_loss,) = grad_fn.saved_tensors
+            matches.append(indexer_loss)
+        stack.extend(parent for parent, _index in grad_fn.next_functions)
+    assert len(matches) == 1, (
+        f"expected exactly one DSAIndexerLossAutoScalerBackward, found {len(matches)}"
+    )
+    indexer_loss = matches[0]
+    assert indexer_loss.ndim == 0
+    assert torch.isfinite(indexer_loss)
+    return indexer_loss.detach().float().clone()
+
+
+def _causal_mask(
+    seq_q: int, seq_k: int, *, ratio: int, device: torch.device
+) -> torch.Tensor:
     q_idx = torch.arange(seq_q, device=device)
     k_idx = torch.arange(seq_k, device=device)
-    valid_per_q = ((q_idx + 1) // ratio).clamp(max=seq_k)
+    q_global_start = seq_k * ratio - seq_q
+    valid_per_q = torch.div(
+        q_global_start + q_idx + 1,
+        ratio,
+        rounding_mode="floor",
+    ).clamp(min=0, max=seq_k)
     return k_idx.unsqueeze(0) < valid_per_q.unsqueeze(1)
 
 
@@ -66,11 +204,41 @@ def _torch_indexer_scores(
 ) -> torch.Tensor:
     q_bshd = q_indexer.permute(1, 0, 2, 3).float()
     k_bsd = k_indexer.permute(1, 0, 2).float()
+    # Production moves the positive softmax scale onto W, then quantizes the
+    # scaled weights back to BF16 before the indexer GEMM. Reproduce that
+    # boundary so exact top-k checks do not fail on an FP32/BF16 rank flip.
+    w_bsh = (
+        (weights.permute(1, 0, 2).float() * float(indexer_softmax_scale))
+        .to(weights.dtype)
+        .float()
+    )
+    scores = torch.einsum("bqhd,bkd->bqhk", q_bshd, k_bsd)
+    scores = torch.relu(scores).mul(w_bsh.unsqueeze(-1)).sum(dim=2)
+    causal = _causal_mask(
+        scores.shape[1], scores.shape[2], ratio=ratio, device=scores.device
+    )
+    return torch.where(causal.unsqueeze(0), scores, torch.full_like(scores, -torch.inf))
+
+
+def _torch_dense_indexer_scores(
+    q_indexer: torch.Tensor,
+    k_indexer: torch.Tensor,
+    weights: torch.Tensor,
+    *,
+    ratio: int,
+    indexer_softmax_scale: float,
+) -> torch.Tensor:
+    """Canonical full-KV score used by cuDNN dense score/backward."""
+
+    q_bshd = q_indexer.permute(1, 0, 2, 3).float()
+    k_bsd = k_indexer.permute(1, 0, 2).float()
     w_bsh = weights.permute(1, 0, 2).float()
     scores = torch.einsum("bqhd,bkd->bqhk", q_bshd, k_bsd)
     scores = torch.relu(scores).mul(w_bsh.unsqueeze(-1)).sum(dim=2)
     scores = scores * float(indexer_softmax_scale)
-    causal = _causal_mask(scores.shape[1], scores.shape[2], ratio=ratio, device=scores.device)
+    causal = _causal_mask(
+        scores.shape[1], scores.shape[2], ratio=ratio, device=scores.device
+    )
     return torch.where(causal.unsqueeze(0), scores, torch.full_like(scores, -torch.inf))
 
 
@@ -118,7 +286,11 @@ def _torch_sparse_attention(
     scores = torch.where(
         topk_indices.unsqueeze(2) >= 0, scores, torch.full_like(scores, -torch.inf)
     )
-    sink = attn_sink.float().view(1, 1, -1, 1).expand(scores.shape[0], scores.shape[1], -1, -1)
+    sink = (
+        attn_sink.float()
+        .view(1, 1, -1, 1)
+        .expand(scores.shape[0], scores.shape[1], -1, -1)
+    )
     probs = torch.softmax(torch.cat([scores, sink], dim=-1), dim=-1)[..., :-1]
     out = torch.einsum("bqht,bqtr->bqhr", probs, selected_values)
     return out.permute(1, 0, 2, 3).reshape(
@@ -126,7 +298,120 @@ def _torch_sparse_attention(
     )
 
 
-def _torch_unfused_dsa_forward(module, x, cos, sin, position_ids):
+def _torch_sparse_indexer_loss(
+    indexer_scores: torch.Tensor,
+    query_states: torch.Tensor,
+    kv_full: torch.Tensor,
+    topk_indices: torch.Tensor,
+    *,
+    softmax_scale: float,
+    loss_coeff: float,
+) -> torch.Tensor:
+    """Independent sparse KL oracle for the fused indexer-loss backward."""
+
+    valid = topk_indices >= 0
+    query_bshd = query_states.detach().permute(1, 0, 2, 3).float()
+    kv_bsd = kv_full.detach().permute(1, 0, 2).float()
+    selected_keys = _gather_sequence(kv_bsd, topk_indices)
+    attn_scores = torch.einsum("bqhd,bqtd->bqht", query_bshd, selected_keys)
+    attn_scores = attn_scores * float(softmax_scale)
+    attn_scores = torch.where(
+        valid.unsqueeze(2), attn_scores, torch.full_like(attn_scores, -torch.inf)
+    )
+    row_valid = valid.any(dim=-1)
+    safe_attn_scores = torch.where(
+        row_valid.view(*row_valid.shape, 1, 1),
+        attn_scores,
+        torch.zeros_like(attn_scores),
+    )
+    attn_probs = torch.softmax(safe_attn_scores, dim=-1)
+    attn_probs = torch.where(
+        row_valid.view(*row_valid.shape, 1, 1),
+        attn_probs,
+        torch.zeros_like(attn_probs),
+    )
+    target_mass = attn_probs.sum(dim=2)
+    target_mass = torch.where(valid, target_mass, torch.zeros_like(target_mass))
+
+    target_denom = target_mass.sum(dim=-1, keepdim=True).clamp_min(1.0e-10)
+    target = target_mass / target_denom
+
+    safe_indices = topk_indices.clamp(min=0).long()
+    selected_indexer_scores = torch.gather(indexer_scores, dim=-1, index=safe_indices)
+    selected_indexer_scores = torch.where(
+        valid,
+        selected_indexer_scores,
+        torch.full_like(selected_indexer_scores, torch.finfo(torch.float32).min),
+    )
+    predict = torch.softmax(selected_indexer_scores, dim=-1)
+
+    eps = 1.0e-10
+    kl_per_row = (target * (torch.log(target + eps) - torch.log(predict + eps))).sum(
+        dim=-1
+    )
+    kl_per_row = torch.where(row_valid, kl_per_row, torch.zeros_like(kl_per_row))
+    return float(loss_coeff) * kl_per_row.mean()
+
+
+def _torch_dense_indexer_loss(
+    indexer_scores: torch.Tensor,
+    query_states: torch.Tensor,
+    kv_full: torch.Tensor,
+    *,
+    softmax_scale: float,
+    loss_coeff: float,
+) -> torch.Tensor:
+    """Independent full-KV KL oracle for GLM's default dense loss."""
+
+    query_bshd = query_states.detach().permute(1, 0, 2, 3).float()
+    kv_bsd = kv_full.detach().permute(1, 0, 2).float()
+    attn_scores = torch.einsum("bqhd,bkd->bqhk", query_bshd, kv_bsd)
+    attn_scores = attn_scores * float(softmax_scale)
+    causal = _causal_mask(
+        attn_scores.shape[1], attn_scores.shape[-1], ratio=1, device=attn_scores.device
+    )
+    attn_scores = torch.where(
+        causal.view(1, causal.shape[0], 1, causal.shape[1]),
+        attn_scores,
+        torch.full_like(attn_scores, -torch.inf),
+    )
+    # Canonical dense DSA: every attention head independently softmaxes over
+    # the complete causal KV axis, then the head probabilities are summed and
+    # L1-normalized. No top-k tensor or attention sink participates.
+    row_valid = causal.any(dim=-1).unsqueeze(0)
+    safe_attn_scores = torch.where(
+        row_valid.view(*row_valid.shape, 1, 1),
+        attn_scores,
+        torch.zeros_like(attn_scores),
+    )
+    attn_probs = torch.softmax(safe_attn_scores, dim=-1)
+    attn_probs = torch.where(
+        row_valid.view(*row_valid.shape, 1, 1),
+        attn_probs,
+        torch.zeros_like(attn_probs),
+    )
+    target_mass = attn_probs.sum(dim=2)
+    target_mass = torch.where(
+        causal.unsqueeze(0), target_mass, torch.zeros_like(target_mass)
+    )
+    target_denom = target_mass.sum(dim=-1, keepdim=True).clamp_min(1.0e-10)
+    target = target_mass / target_denom
+
+    safe_indexer_scores = torch.where(
+        row_valid.unsqueeze(-1), indexer_scores, torch.zeros_like(indexer_scores)
+    )
+    predict = torch.softmax(safe_indexer_scores, dim=-1)
+    eps = 1.0e-10
+    terms = target * (torch.log(target + eps) - torch.log(predict + eps))
+    terms = torch.where(causal.unsqueeze(0), terms, torch.zeros_like(terms))
+    kl_per_row = terms.sum(dim=-1)
+    kl_per_row = torch.where(row_valid, kl_per_row, torch.zeros_like(kl_per_row))
+    return float(loss_coeff) * kl_per_row.mean()
+
+
+def _torch_unfused_dsa_forward(
+    module, x, cos, sin, position_ids, *, topk_indices: torch.Tensor | None = None
+):
     from megatron.lite.primitive.modules.attention.dsa import (
         _rotary_embeddings_from_cache,
         apply_rotary_pos_emb,
@@ -134,38 +419,96 @@ def _torch_unfused_dsa_forward(module, x, cos, sin, position_ids):
 
     batch, seq_len, _ = x.shape
     q_resid = module.q_a_layernorm(module.q_a_proj(x))
-    q = module.q_b_proj(q_resid).view(batch, seq_len, module.num_heads, module.qk_head_dim)
-    q_nope, q_pe = torch.split(q, [module.qk_nope_head_dim, module.qk_rope_head_dim], dim=-1)
-    cos, sin = _rotary_embeddings_from_cache(
-        cos, sin, position_ids, device=x.device, dtype=x.dtype, dim=module.qk_rope_head_dim
+    q = module.q_b_proj(q_resid).view(
+        batch, seq_len, module.num_heads, module.qk_head_dim
     )
-    q_pe = apply_rotary_pos_emb(q_pe, cos, sin, unsqueeze_dim=2)
+    q_nope, q_pe = torch.split(
+        q, [module.qk_nope_head_dim, module.qk_rope_head_dim], dim=-1
+    )
+    cos, sin = _rotary_embeddings_from_cache(
+        cos,
+        sin,
+        position_ids,
+        device=x.device,
+        dtype=x.dtype,
+        dim=module.qk_rope_head_dim,
+    )
+    q_pe = apply_rotary_pos_emb(
+        q_pe,
+        cos,
+        sin,
+        unsqueeze_dim=2,
+        mla_interleaved=module.rope_interleaved,
+    )
 
     k_up_weight, v_up_weight = module._split_kv_b_weights()
     q_nope = torch.einsum("bshd,hdr->bshr", q_nope, k_up_weight)
     query_states = torch.cat([q_nope, q_pe], dim=-1).transpose(0, 1).contiguous()
 
     kv_latent, k_pe = torch.split(
-        module.kv_a_proj_with_mqa(x), [module.kv_lora_rank, module.qk_rope_head_dim], dim=-1
+        module.kv_a_proj_with_mqa(x),
+        [module.kv_lora_rank, module.qk_rope_head_dim],
+        dim=-1,
     )
     kv_latent = module.kv_a_layernorm(kv_latent)
-    k_pe = apply_rotary_pos_emb(k_pe.unsqueeze(2), cos, sin, unsqueeze_dim=2).squeeze(2)
+    k_pe = apply_rotary_pos_emb(
+        k_pe.unsqueeze(2),
+        cos,
+        sin,
+        unsqueeze_dim=2,
+        mla_interleaved=module.rope_interleaved,
+    ).squeeze(2)
     kv_full = torch.cat([kv_latent, k_pe], dim=-1).transpose(0, 1).contiguous()
 
-    assert module.indexer is not None
-    q_indexer, k_indexer, weights_indexer = module.indexer.forward_before_topk(
-        x, q_resid, cos, sin, position_ids
-    )
-    indexer_scores = _torch_indexer_scores(
-        q_indexer,
-        k_indexer,
-        weights_indexer,
-        ratio=1,
-        indexer_softmax_scale=module.indexer_softmax_scale,
-    )
-    topk_indices = _torch_topk_from_scores(
-        indexer_scores, min(module.index_topk, indexer_scores.shape[-1])
-    )
+    indexer_loss = x.new_zeros((), dtype=torch.float32)
+    indexer_scores = None
+    if module.indexer is not None:
+        q_indexer, k_indexer, weights_indexer = module.indexer.forward_before_topk(
+            x.detach(), q_resid.detach(), cos, sin, position_ids
+        )
+        indexer_scores = _torch_indexer_scores(
+            q_indexer,
+            k_indexer,
+            weights_indexer,
+            ratio=1,
+            indexer_softmax_scale=module.indexer_softmax_scale,
+        )
+        if topk_indices is None:
+            topk_indices = _torch_topk_from_scores(
+                indexer_scores, min(module.index_topk, indexer_scores.shape[-1])
+            )
+        else:
+            # Selection correctness is proved independently from the quantized
+            # indexer scores.  Reusing the vendor-selected indices here makes
+            # the attention/loss/gradient comparison well-defined when several
+            # keys tie at the top-k cutoff but have different attention values.
+            topk_indices = topk_indices.detach()
+        if module.indexer_use_sparse_loss:
+            indexer_loss = _torch_sparse_indexer_loss(
+                indexer_scores,
+                query_states,
+                kv_full,
+                topk_indices,
+                softmax_scale=module.softmax_scale,
+                loss_coeff=module.indexer_loss_coeff,
+            )
+        else:
+            dense_indexer_scores = _torch_dense_indexer_scores(
+                q_indexer,
+                k_indexer,
+                weights_indexer,
+                ratio=1,
+                indexer_softmax_scale=module.indexer_softmax_scale,
+            )
+            indexer_loss = _torch_dense_indexer_loss(
+                dense_indexer_scores,
+                query_states,
+                kv_full,
+                softmax_scale=module.softmax_scale,
+                loss_coeff=module.indexer_loss_coeff,
+            )
+    else:
+        assert topk_indices is not None
     out = _torch_sparse_attention(
         query_states,
         kv_full,
@@ -178,26 +521,61 @@ def _torch_unfused_dsa_forward(module, x, cos, sin, position_ids):
     out = out.permute(1, 0, 2, 3).contiguous()
     out = torch.einsum("bshr,hvr->bshv", out, v_up_weight)
     out = out.reshape(batch, seq_len, module.num_heads * module.v_head_dim)
-    return module.o_proj(out)
+    out = module.o_proj(out)
+    return out, topk_indices, indexer_loss, indexer_scores
 
 
-def _run_once_torch_unfused(module, x, cos, sin, position_ids):
-    module.zero_grad(set_to_none=True)
-    module.train(True)
+def _run_once_torch_unfused(
+    modules,
+    x,
+    cos,
+    sin,
+    position_ids,
+    *,
+    forced_source_topk: torch.Tensor | None = None,
+):
+    modules.zero_grad(set_to_none=True)
+    modules.train(True)
     local_x = x.detach().clone().requires_grad_(True)
-    out = _torch_unfused_dsa_forward(module, local_x, cos, sin, position_ids)
+    source_out, topk_indices, indexer_loss, indexer_scores = _torch_unfused_dsa_forward(
+        modules["source"],
+        local_x,
+        cos,
+        sin,
+        position_ids,
+        topk_indices=forced_source_topk,
+    )
+    assert indexer_scores is not None
+    hidden = local_x + source_out
+    shared_out, reused_topk_indices, shared_indexer_loss, shared_indexer_scores = (
+        _torch_unfused_dsa_forward(
+            modules["shared"],
+            hidden,
+            cos,
+            sin,
+            position_ids,
+            topk_indices=topk_indices,
+        )
+    )
+    assert shared_indexer_scores is None
+    assert torch.equal(reused_topk_indices, topk_indices)
+    assert float(shared_indexer_loss.item()) == 0.0
+    out = hidden + shared_out
     loss = out.float().square().mean()
-    loss.backward()
+    (loss + indexer_loss).backward()
     param_grads = {
         name: param.grad.detach().float().clone()
-        for name, param in module.named_parameters()
+        for name, param in modules.named_parameters()
         if param.grad is not None
     }
     return {
         "loss": loss.detach().float().clone(),
+        "indexer_loss": indexer_loss.detach().float().clone(),
         "out": out.detach().float().clone(),
         "x_grad": local_x.grad.detach().float().clone(),
         "param_grads": param_grads,
+        "topk_indices": topk_indices.detach().clone(),
+        "indexer_scores": indexer_scores.detach().float().clone(),
     }
 
 
@@ -205,25 +583,320 @@ def _max_abs(a: torch.Tensor, b: torch.Tensor) -> float:
     return float((a - b).abs().max().item())
 
 
-def _max_param_grad_abs(a: dict, b: dict) -> float:
-    common = set(a["param_grads"]) & set(b["param_grads"])
-    if not common:
+def _symmetric_relative_difference(actual: float, expected: float) -> float:
+    denominator = abs(actual) + abs(expected)
+    if denominator == 0.0:
         return 0.0
-    return max(_max_abs(a["param_grads"][name], b["param_grads"][name]) for name in common)
+    return 2.0 * abs(actual - expected) / denominator
 
 
-def test_glm5_dsa_run_to_run_accept_with_proof():
+def _tensor_similarity_metrics(
+    actual: torch.Tensor, expected: torch.Tensor
+) -> dict[str, float]:
+    actual_flat = actual.detach().float().reshape(-1)
+    expected_flat = expected.detach().float().reshape(-1)
+    assert torch.isfinite(actual_flat).all()
+    assert torch.isfinite(expected_flat).all()
+    actual_norm = torch.linalg.vector_norm(actual_flat)
+    expected_norm = torch.linalg.vector_norm(expected_flat)
+    actual_norm_value = float(actual_norm.item())
+    expected_norm_value = float(expected_norm.item())
+    if actual_norm_value == 0.0 and expected_norm_value == 0.0:
+        return {
+            "cosine": 1.0,
+            "rms_relative": 0.0,
+            "norm_ratio": 1.0,
+            "max_abs": 0.0,
+        }
+    if expected_norm_value == 0.0:
+        return {
+            "cosine": 0.0,
+            "rms_relative": float("inf"),
+            "norm_ratio": float("inf"),
+            "max_abs": _max_abs(actual_flat, expected_flat),
+        }
+    if actual_norm_value == 0.0:
+        return {
+            "cosine": 0.0,
+            "rms_relative": 1.0,
+            "norm_ratio": 0.0,
+            "max_abs": _max_abs(actual_flat, expected_flat),
+        }
+    cosine = torch.dot(actual_flat, expected_flat) / (actual_norm * expected_norm)
+    rms_diff = torch.sqrt(torch.mean((actual_flat - expected_flat).square()))
+    rms_expected = torch.sqrt(torch.mean(expected_flat.square()))
+    return {
+        "cosine": float(cosine.item()),
+        "rms_relative": float((rms_diff / rms_expected).item()),
+        "norm_ratio": float((actual_norm / expected_norm).item()),
+        "max_abs": _max_abs(actual_flat, expected_flat),
+    }
+
+
+def _similarity_extrema(
+    comparisons: dict[str, dict[str, float]],
+) -> dict[str, float]:
+    assert comparisons
+    return {
+        "min_cosine": min(value["cosine"] for value in comparisons.values()),
+        "max_rms_relative": max(
+            value["rms_relative"] for value in comparisons.values()
+        ),
+        "min_norm_ratio": min(value["norm_ratio"] for value in comparisons.values()),
+        "max_norm_ratio": max(value["norm_ratio"] for value in comparisons.values()),
+        "max_abs": max(value["max_abs"] for value in comparisons.values()),
+    }
+
+
+def _assert_main_output_similarity(
+    comparisons: dict[str, dict[str, float]], *, max_abs: float
+) -> dict[str, float]:
+    """Require both scale-independent agreement and a bounded worst outlier."""
+
+    extrema = _similarity_extrema(comparisons)
+    assert extrema["min_cosine"] >= _MIN_MAIN_OUTPUT_COSINE, comparisons
+    assert extrema["max_rms_relative"] <= _MAX_MAIN_OUTPUT_RMS_REL, comparisons
+    assert extrema["min_norm_ratio"] >= _MIN_MAIN_OUTPUT_NORM_RATIO, comparisons
+    assert extrema["max_norm_ratio"] <= _MAX_MAIN_OUTPUT_NORM_RATIO, comparisons
+    assert extrema["max_abs"] <= max_abs, comparisons
+    return extrema
+
+
+def _canonical_topk_set(topk_indices: torch.Tensor) -> torch.Tensor:
+    """Canonicalize the vendor top-k's intentionally unspecified ordering."""
+
+    return torch.sort(topk_indices, dim=-1).values
+
+
+def _assert_topk_matches_quantized_scores(
+    actual_indices: torch.Tensor,
+    scores: torch.Tensor,
+) -> dict[str, float | int]:
+    """Validate top-k exactly away from ties and by cutoff at numeric ties."""
+
+    assert actual_indices.shape[:2] == scores.shape[:2]
+    topk = actual_indices.shape[-1]
+    seq_k = scores.shape[-1]
+    assert topk <= seq_k
+    actual_valid = actual_indices >= 0
+    valid_count = torch.isfinite(scores).sum(dim=-1)
+    expected_count = valid_count.clamp(max=topk)
+    torch.testing.assert_close(actual_valid.sum(dim=-1), expected_count, atol=0, rtol=0)
+    assert torch.all((actual_indices < seq_k) | ~actual_valid)
+
+    canonical_actual = _canonical_topk_set(actual_indices)
+    duplicate = (canonical_actual[..., 1:] == canonical_actual[..., :-1]) & (
+        canonical_actual[..., 1:] >= 0
+    )
+    assert not torch.any(duplicate), "vendor top-k returned duplicate valid indices"
+
+    expected_indices = _torch_topk_from_scores(scores, topk)
+    exact_rows = torch.all(
+        canonical_actual == _canonical_topk_set(expected_indices), dim=-1
+    )
+
+    probe_k = min(topk + 1, seq_k)
+    probe_values = torch.topk(scores, k=probe_k, dim=-1).values
+    kth_slot = (expected_count - 1).clamp(min=0).unsqueeze(-1)
+    cutoff = torch.gather(probe_values[..., :topk], -1, kth_slot).squeeze(-1)
+    tolerance = _TOPK_SCORE_ATOL + _TOPK_SCORE_RTOL * cutoff.abs()
+
+    safe_indices = actual_indices.clamp(min=0).long()
+    selected_scores = torch.gather(scores, dim=-1, index=safe_indices)
+    selected_scores = torch.where(
+        actual_valid, selected_scores, torch.full_like(selected_scores, torch.inf)
+    )
+    minimum_selected = selected_scores.amin(dim=-1)
+    nonempty = expected_count > 0
+    selected_counts = torch.zeros_like(scores, dtype=torch.int32)
+    selected_counts.scatter_add_(-1, safe_indices, actual_valid.to(torch.int32))
+    selected_mask = selected_counts > 0
+    unselected_scores = torch.where(
+        torch.isfinite(scores) & ~selected_mask,
+        scores,
+        torch.full_like(scores, -torch.inf),
+    )
+    maximum_unselected = unselected_scores.amax(dim=-1)
+    has_unselected = valid_count > expected_count
+    pairwise_tolerance = _TOPK_SCORE_ATOL + _TOPK_SCORE_RTOL * torch.maximum(
+        minimum_selected.abs(), maximum_unselected.abs()
+    )
+    shortfall = torch.where(
+        nonempty & has_unselected,
+        (maximum_unselected - minimum_selected).clamp_min(0),
+        torch.zeros_like(cutoff),
+    )
+    assert torch.all(
+        ~(nonempty & has_unselected)
+        | (minimum_selected >= maximum_unselected - pairwise_tolerance)
+    ), (
+        "top-k omitted a score above the selected boundary: "
+        f"max_shortfall={float(shortfall.max().item())}"
+    )
+
+    strict_rows = valid_count <= topk
+    if probe_k > topk:
+        next_score = probe_values[..., topk]
+        margin = cutoff - next_score
+        strict_rows = strict_rows | (margin > tolerance)
+    assert torch.all(~strict_rows | exact_rows), (
+        "top-k index multiset differs despite a numerically separated cutoff"
+    )
+    ambiguous_rows = (~strict_rows & nonempty).sum()
+    return {
+        "exact_rows": int(exact_rows.sum().item()),
+        "ambiguous_rows": int(ambiguous_rows.item()),
+        "max_score_shortfall": float(shortfall.max().item()),
+    }
+
+
+def test_topk_score_proof_rejects_missing_strict_winner_but_allows_boundary_ties():
+    scores = torch.tensor([[[100.0, 1.0, 1.0]]])
+    with pytest.raises(AssertionError, match="omitted a score"):
+        _assert_topk_matches_quantized_scores(
+            torch.tensor([[[1, 2]]], dtype=torch.int32), scores
+        )
+
+    proof = _assert_topk_matches_quantized_scores(
+        torch.tensor([[[0, 2]]], dtype=torch.int32), scores
+    )
+    assert proof["ambiguous_rows"] == 1
+    assert proof["max_score_shortfall"] == 0.0
+
+
+def _max_param_grad_abs(a: dict, b: dict) -> float:
+    a_keys = set(a["param_grads"])
+    b_keys = set(b["param_grads"])
+    assert a_keys == b_keys, (
+        f"gradient key mismatch: only_a={sorted(a_keys - b_keys)}, "
+        f"only_b={sorted(b_keys - a_keys)}"
+    )
+    if not a_keys:
+        return 0.0
+    return max(
+        _max_abs(a["param_grads"][name], b["param_grads"][name]) for name in a_keys
+    )
+
+
+def _main_param_grad_similarity(
+    actual: dict, expected: dict
+) -> dict[str, dict[str, float]]:
+    """Compare every non-indexer parameter separately so large tensors cannot hide drift."""
+
+    actual_names = {
+        name for name in actual["param_grads"] if not name.startswith("source.indexer.")
+    }
+    expected_names = {
+        name
+        for name in expected["param_grads"]
+        if not name.startswith("source.indexer.")
+    }
+    assert actual_names == expected_names, (
+        "main-gradient key mismatch: "
+        f"only_actual={sorted(actual_names - expected_names)}, "
+        f"only_expected={sorted(expected_names - actual_names)}"
+    )
+    assert actual_names
+    return {
+        name: _tensor_similarity_metrics(
+            actual["param_grads"][name], expected["param_grads"][name]
+        )
+        for name in sorted(actual_names)
+    }
+
+
+def _assert_main_grad_similarity(
+    comparisons: dict[str, dict[str, float]],
+) -> dict[str, float]:
+    extrema = _similarity_extrema(comparisons)
+    assert extrema["min_cosine"] >= _MIN_MAIN_GRAD_COSINE, comparisons
+    assert extrema["max_rms_relative"] <= _MAX_MAIN_GRAD_RMS_REL, comparisons
+    assert extrema["min_norm_ratio"] >= _MIN_MAIN_GRAD_NORM_RATIO, comparisons
+    assert extrema["max_norm_ratio"] <= _MAX_MAIN_GRAD_NORM_RATIO, comparisons
+    return extrema
+
+
+def _assert_meaningful_indexer_grads(result: dict) -> float:
+    expected = {
+        "source.indexer.wq_b.weight",
+        "source.indexer.wk.weight",
+        "source.indexer.k_norm.weight",
+        "source.indexer.k_norm.bias",
+        "source.indexer.weights_proj.weight",
+    }
+    grads = {
+        name: grad
+        for name, grad in result["param_grads"].items()
+        if name.startswith("source.indexer.")
+    }
+    assert set(grads) == expected
+    assert all(torch.isfinite(grad).all() for grad in grads.values())
+    assert all(torch.count_nonzero(grad).item() > 0 for grad in grads.values())
+    grad_max_abs = {
+        name: float(grad.abs().max().item()) for name, grad in grads.items()
+    }
+    assert all(value > _MIN_INDEXER_GRAD_MAX_ABS for value in grad_max_abs.values()), (
+        grad_max_abs
+    )
+    return max(grad_max_abs.values())
+
+
+def _indexer_grad_similarity(
+    actual: dict, expected: dict
+) -> dict[str, tuple[float, float, float]]:
+    names = sorted(
+        name for name in expected["param_grads"] if name.startswith("source.indexer.")
+    )
+    assert names
+    assert set(names) == {
+        name for name in actual["param_grads"] if name.startswith("source.indexer.")
+    }
+    similarities: dict[str, tuple[float, float, float]] = {}
+    for name in names:
+        actual_grad = actual["param_grads"][name].float().reshape(-1)
+        expected_grad = expected["param_grads"][name].float().reshape(-1)
+        actual_norm = torch.linalg.vector_norm(actual_grad)
+        expected_norm = torch.linalg.vector_norm(expected_grad)
+        cosine = torch.dot(actual_grad, expected_grad) / (actual_norm * expected_norm)
+        rms_diff = torch.sqrt(torch.mean((actual_grad - expected_grad).square()))
+        rms_expected = torch.sqrt(torch.mean(expected_grad.square()))
+        rms_relative = rms_diff / rms_expected
+        norm_ratio = actual_norm / expected_norm
+        similarities[name] = (
+            float(cosine.item()),
+            float(rms_relative.item()),
+            float(norm_ratio.item()),
+        )
+    return similarities
+
+
+@pytest.mark.parametrize(
+    "sparse_loss", [True, False], ids=["sparse-loss", "dense-loss"]
+)
+def test_glm5_dsa_run_to_run_accept_with_proof(sparse_loss: bool, monkeypatch):
     if not torch.cuda.is_available():
         pytest.skip("CUDA is required for GLM5 DSA accept-with-proof smoke.")
 
     from megatron.lite.primitive.modules.attention import build_rope_cache
+    from megatron.lite.primitive.modules.attention.dsa import (
+        DSAIndexerLossAutoScaler,
+    )
 
     device = torch.device("cuda", int(torch.cuda.current_device()))
+    # The runtime loss scaler is process-global.  Pin this standalone oracle to
+    # unit scale and let monkeypatch restore any suite-level prior value.
+    monkeypatch.setattr(
+        DSAIndexerLossAutoScaler,
+        "main_loss_backward_scale",
+        torch.ones((), device=device),
+    )
     torch.manual_seed(20260626)
-    fused = _make_dsa().to(device=device, dtype=torch.bfloat16)
+    fused = _make_dsa_pair(sparse_loss=sparse_loss).to(
+        device=device, dtype=torch.bfloat16
+    )
     unfused = copy.deepcopy(fused).to(device=device, dtype=torch.bfloat16)
 
-    batch, seq, hidden = 1, 512, 128
+    batch, seq, hidden = 1, _SEQUENCE_LENGTH, 128
     x = torch.randn(batch, seq, hidden, device=device, dtype=torch.bfloat16)
     cos, sin = build_rope_cache(
         dim=64,
@@ -237,46 +910,941 @@ def test_glm5_dsa_run_to_run_accept_with_proof():
     fused_b = _run_once(fused, x, cos, sin, position_ids, fused_training=True)
     unfused_a = _run_once_torch_unfused(unfused, x, cos, sin, position_ids)
     unfused_b = _run_once_torch_unfused(unfused, x, cos, sin, position_ids)
+    matched_unfused_a = _run_once_torch_unfused(
+        unfused,
+        x,
+        cos,
+        sin,
+        position_ids,
+        forced_source_topk=fused_a["topk_indices"],
+    )
+    matched_unfused_b = _run_once_torch_unfused(
+        unfused,
+        x,
+        cos,
+        sin,
+        position_ids,
+        forced_source_topk=fused_b["topk_indices"],
+    )
 
-    fused_r2r_out = _max_abs(fused_a["out"], fused_b["out"])
+    fused_r2r_output_similarity = {
+        "run_a_vs_run_b": _tensor_similarity_metrics(fused_a["out"], fused_b["out"])
+    }
+    fused_r2r_output_extrema = _similarity_extrema(fused_r2r_output_similarity)
+    fused_r2r_out = fused_r2r_output_extrema["max_abs"]
+    fused_a_loss = float(fused_a["loss"].item())
+    fused_b_loss = float(fused_b["loss"].item())
+    fused_r2r_loss = abs(fused_a_loss - fused_b_loss)
+    fused_r2r_loss_symmetric_rel = _symmetric_relative_difference(
+        fused_a_loss, fused_b_loss
+    )
     fused_r2r_x_grad = _max_abs(fused_a["x_grad"], fused_b["x_grad"])
     fused_r2r_param_grad = _max_param_grad_abs(fused_a, fused_b)
+    fused_r2r_x_grad_similarity = {
+        "input": _tensor_similarity_metrics(fused_a["x_grad"], fused_b["x_grad"])
+    }
+    fused_r2r_param_grad_similarity = _main_param_grad_similarity(fused_a, fused_b)
+    fused_r2r_x_grad_extrema = _similarity_extrema(fused_r2r_x_grad_similarity)
+    fused_r2r_param_grad_extrema = _similarity_extrema(fused_r2r_param_grad_similarity)
     unfused_r2r_out = _max_abs(unfused_a["out"], unfused_b["out"])
+    unfused_r2r_loss = abs(
+        float(unfused_a["loss"].item()) - float(unfused_b["loss"].item())
+    )
     unfused_r2r_x_grad = _max_abs(unfused_a["x_grad"], unfused_b["x_grad"])
     unfused_r2r_param_grad = _max_param_grad_abs(unfused_a, unfused_b)
-    fused_vs_unfused_out = _max_abs(fused_a["out"], unfused_a["out"])
-    fused_vs_unfused_x_grad = _max_abs(fused_a["x_grad"], unfused_a["x_grad"])
-    fused_vs_unfused_param_grad = _max_param_grad_abs(fused_a, unfused_a)
-    loss_diff = abs(float(fused_a["loss"].item()) - float(unfused_a["loss"].item()))
-
-    noise_floor = max(
-        fused_r2r_x_grad,
-        fused_r2r_param_grad,
-        unfused_r2r_x_grad,
-        unfused_r2r_param_grad,
+    fused_vs_unfused_output_similarity = {
+        "run_a": _tensor_similarity_metrics(fused_a["out"], matched_unfused_a["out"]),
+        "run_b": _tensor_similarity_metrics(fused_b["out"], matched_unfused_b["out"]),
+    }
+    fused_vs_unfused_output_extrema = _similarity_extrema(
+        fused_vs_unfused_output_similarity
     )
+    fused_vs_unfused_out = fused_vs_unfused_output_extrema["max_abs"]
+    fused_vs_unfused_x_grad = max(
+        _max_abs(fused_a["x_grad"], matched_unfused_a["x_grad"]),
+        _max_abs(fused_b["x_grad"], matched_unfused_b["x_grad"]),
+    )
+    fused_vs_unfused_param_grad = max(
+        _max_param_grad_abs(fused_a, matched_unfused_a),
+        _max_param_grad_abs(fused_b, matched_unfused_b),
+    )
+    fused_vs_unfused_x_grad_similarity = {
+        "run_a": _tensor_similarity_metrics(
+            fused_a["x_grad"], matched_unfused_a["x_grad"]
+        ),
+        "run_b": _tensor_similarity_metrics(
+            fused_b["x_grad"], matched_unfused_b["x_grad"]
+        ),
+    }
+    fused_vs_unfused_param_grad_similarity = {
+        **{
+            f"run_a:{name}": value
+            for name, value in _main_param_grad_similarity(
+                fused_a, matched_unfused_a
+            ).items()
+        },
+        **{
+            f"run_b:{name}": value
+            for name, value in _main_param_grad_similarity(
+                fused_b, matched_unfused_b
+            ).items()
+        },
+    }
+    fused_vs_unfused_x_grad_extrema = _similarity_extrema(
+        fused_vs_unfused_x_grad_similarity
+    )
+    fused_vs_unfused_param_grad_extrema = _similarity_extrema(
+        fused_vs_unfused_param_grad_similarity
+    )
+    loss_diff = max(
+        abs(fused_a_loss - float(matched_unfused_a["loss"].item())),
+        abs(fused_b_loss - float(matched_unfused_b["loss"].item())),
+    )
+    loss_symmetric_rel = max(
+        _symmetric_relative_difference(
+            fused_a_loss, float(matched_unfused_a["loss"].item())
+        ),
+        _symmetric_relative_difference(
+            fused_b_loss, float(matched_unfused_b["loss"].item())
+        ),
+    )
+    unfused_indexer_loss_diff = abs(
+        float(unfused_a["indexer_loss"].item())
+        - float(unfused_b["indexer_loss"].item())
+    )
+    fused_indexer_grad_max_abs = _assert_meaningful_indexer_grads(fused_a)
+    _assert_meaningful_indexer_grads(fused_b)
+    unfused_indexer_grad_max_abs = _assert_meaningful_indexer_grads(matched_unfused_a)
+    _assert_meaningful_indexer_grads(matched_unfused_b)
+    _assert_meaningful_indexer_grads(unfused_b)
+    indexer_grad_similarity = {
+        **{
+            f"run_a:{name}": value
+            for name, value in _indexer_grad_similarity(
+                fused_a, matched_unfused_a
+            ).items()
+        },
+        **{
+            f"run_b:{name}": value
+            for name, value in _indexer_grad_similarity(
+                fused_b, matched_unfused_b
+            ).items()
+        },
+    }
+    min_indexer_grad_cosine = min(
+        value[0] for value in indexer_grad_similarity.values()
+    )
+    max_indexer_grad_rms_relative = max(
+        value[1] for value in indexer_grad_similarity.values()
+    )
+    min_indexer_grad_norm_ratio = min(
+        value[2] for value in indexer_grad_similarity.values()
+    )
+    max_indexer_grad_norm_ratio = max(
+        value[2] for value in indexer_grad_similarity.values()
+    )
+    fused_indexer_loss_r2r = abs(
+        float(fused_a["indexer_loss"].item()) - float(fused_b["indexer_loss"].item())
+    )
+    fused_vs_unfused_indexer_loss = max(
+        abs(
+            float(fused_a["indexer_loss"].item())
+            - float(matched_unfused_a["indexer_loss"].item())
+        ),
+        abs(
+            float(fused_b["indexer_loss"].item())
+            - float(matched_unfused_b["indexer_loss"].item())
+        ),
+    )
+
     assert torch.isfinite(fused_a["loss"])
+    assert torch.isfinite(fused_a["indexer_loss"])
+    assert float(fused_a["indexer_loss"].item()) > 0.0
+    assert torch.isfinite(fused_b["loss"])
+    assert torch.isfinite(fused_b["indexer_loss"])
+    assert float(fused_b["indexer_loss"].item()) > 0.0
     assert torch.isfinite(unfused_a["loss"])
+    assert torch.isfinite(unfused_a["indexer_loss"])
+    assert float(unfused_a["indexer_loss"].item()) > 0.0
+    fused_a_topk_set = _canonical_topk_set(fused_a["topk_indices"])
+    fused_b_topk_set = _canonical_topk_set(fused_b["topk_indices"])
+    unfused_a_topk_set = _canonical_topk_set(unfused_a["topk_indices"])
+    unfused_b_topk_set = _canonical_topk_set(unfused_b["topk_indices"])
+    fused_topk_set_r2r = torch.equal(fused_a_topk_set, fused_b_topk_set)
+    unfused_topk_set_r2r = torch.equal(unfused_a_topk_set, unfused_b_topk_set)
+    fused_vs_unfused_topk_set = torch.equal(fused_a_topk_set, unfused_a_topk_set)
+    topk_score_proof_a = _assert_topk_matches_quantized_scores(
+        fused_a["topk_indices"], unfused_a["indexer_scores"]
+    )
+    topk_score_proof_b = _assert_topk_matches_quantized_scores(
+        fused_b["topk_indices"], unfused_a["indexer_scores"]
+    )
+    topk_ambiguous_rows = max(
+        topk_score_proof_a["ambiguous_rows"],
+        topk_score_proof_b["ambiguous_rows"],
+    )
+    topk_max_score_shortfall = max(
+        topk_score_proof_a["max_score_shortfall"],
+        topk_score_proof_b["max_score_shortfall"],
+    )
+
+    dense_topk_loss_diff = 0.0
+    dense_topk_indexer_grad_diff = 0.0
+    dense_topk_changed = False
+    if not sparse_loss:
+        from megatron.lite.primitive.kernels import dsa_kernels
+
+        original_topk = dsa_kernels._indexer_topk_bshd
+
+        def lowest_valid_topk(q_bshd, k_bsd, w_bsh, topk, ratio=4):
+            _indices, _length, scores = original_topk(q_bshd, k_bsd, w_bsh, topk, ratio)
+            del _indices, _length
+            low_rank_scores = torch.where(
+                torch.isfinite(scores), scores, torch.full_like(scores, torch.inf)
+            )
+            values, indices = torch.topk(low_rank_scores, k=topk, dim=-1, largest=False)
+            indices = torch.where(
+                torch.isfinite(values), indices, torch.full_like(indices, -1)
+            ).int()
+            lengths = (indices >= 0).sum(dim=-1).int()
+            return indices, lengths, scores
+
+        with monkeypatch.context() as dense_topk_patch:
+            dense_topk_patch.setattr(
+                dsa_kernels, "_indexer_topk_bshd", lowest_valid_topk
+            )
+            alternate_topk = _run_once(
+                fused, x, cos, sin, position_ids, fused_training=True
+            )
+
+        dense_topk_changed = not torch.equal(
+            _canonical_topk_set(alternate_topk["topk_indices"]), fused_a_topk_set
+        )
+        assert dense_topk_changed
+        dense_topk_loss_diff = abs(
+            float(alternate_topk["indexer_loss"].item())
+            - float(fused_a["indexer_loss"].item())
+        )
+        torch.testing.assert_close(
+            alternate_topk["indexer_loss"],
+            fused_a["indexer_loss"],
+            atol=_INDEXER_LOSS_ATOL,
+            rtol=_INDEXER_LOSS_RTOL,
+        )
+        indexer_names = [
+            name
+            for name in fused_a["param_grads"]
+            if name.startswith("source.indexer.")
+        ]
+        dense_topk_indexer_grad_diff = max(
+            _max_abs(
+                alternate_topk["param_grads"][name],
+                fused_a["param_grads"][name],
+            )
+            for name in indexer_names
+        )
+        assert dense_topk_indexer_grad_diff <= 1.0e-6
+    print(
+        "GLM5_DSA_ACCEPTANCE_DIAGNOSTICS "
+        f"sparse_loss={sparse_loss} "
+        f"fused_topk_set_r2r={fused_topk_set_r2r} "
+        f"unfused_topk_set_r2r={unfused_topk_set_r2r} "
+        f"fused_vs_unfused_topk_set={fused_vs_unfused_topk_set} "
+        f"loss_diff={loss_diff:.6e} "
+        f"loss_symmetric_rel={loss_symmetric_rel:.6e} "
+        f"fused_r2r_loss_diff={fused_r2r_loss:.6e} "
+        f"fused_r2r_loss_symmetric_rel={fused_r2r_loss_symmetric_rel:.6e} "
+        f"fused_r2r_out_max_abs={fused_r2r_out:.6e} "
+        f"fused_r2r_out_min_cosine={fused_r2r_output_extrema['min_cosine']:.6e} "
+        f"fused_r2r_out_max_rms_relative={fused_r2r_output_extrema['max_rms_relative']:.6e} "
+        f"fused_r2r_out_min_norm_ratio={fused_r2r_output_extrema['min_norm_ratio']:.6e} "
+        f"fused_r2r_out_max_norm_ratio={fused_r2r_output_extrema['max_norm_ratio']:.6e} "
+        f"fused_r2r_x_grad_max_abs={fused_r2r_x_grad:.6e} "
+        f"fused_r2r_param_grad_max_abs={fused_r2r_param_grad:.6e} "
+        f"fused_r2r_x_grad_similarity={fused_r2r_x_grad_extrema} "
+        f"fused_r2r_param_grad_similarity={fused_r2r_param_grad_extrema} "
+        f"fused_vs_unfused_out_max_abs={fused_vs_unfused_out:.6e} "
+        f"fused_vs_unfused_out_min_cosine={fused_vs_unfused_output_extrema['min_cosine']:.6e} "
+        f"fused_vs_unfused_out_max_rms_relative={fused_vs_unfused_output_extrema['max_rms_relative']:.6e} "
+        f"fused_vs_unfused_out_min_norm_ratio={fused_vs_unfused_output_extrema['min_norm_ratio']:.6e} "
+        f"fused_vs_unfused_out_max_norm_ratio={fused_vs_unfused_output_extrema['max_norm_ratio']:.6e} "
+        f"fused_vs_unfused_x_grad_max_abs={fused_vs_unfused_x_grad:.6e} "
+        f"fused_vs_unfused_param_grad_max_abs={fused_vs_unfused_param_grad:.6e}"
+        f" fused_vs_unfused_x_grad_similarity={fused_vs_unfused_x_grad_extrema}"
+        f" fused_vs_unfused_param_grad_similarity={fused_vs_unfused_param_grad_extrema}"
+        f" fused_indexer_loss_r2r={fused_indexer_loss_r2r:.6e}"
+        f" fused_vs_unfused_indexer_loss={fused_vs_unfused_indexer_loss:.6e}"
+        f" min_indexer_grad_cosine={min_indexer_grad_cosine:.6e}"
+        f" max_indexer_grad_rms_relative={max_indexer_grad_rms_relative:.6e}"
+        f" min_indexer_grad_norm_ratio={min_indexer_grad_norm_ratio:.6e}"
+        f" max_indexer_grad_norm_ratio={max_indexer_grad_norm_ratio:.6e}"
+        f" topk_exact_rows_a={topk_score_proof_a['exact_rows']}"
+        f" topk_exact_rows_b={topk_score_proof_b['exact_rows']}"
+        f" topk_ambiguous_rows={topk_ambiguous_rows}"
+        f" topk_max_score_shortfall={topk_max_score_shortfall:.6e}"
+        f" dense_topk_changed={dense_topk_changed}"
+        f" dense_topk_loss_diff={dense_topk_loss_diff:.6e}"
+        f" dense_topk_indexer_grad_diff={dense_topk_indexer_grad_diff:.6e}"
+    )
+    assert unfused_topk_set_r2r
+    if fused_topk_set_r2r:
+        assert fused_r2r_loss <= _MAIN_LOSS_MAX_ABS_DIFF
+        assert fused_r2r_loss_symmetric_rel <= _MAX_MAIN_LOSS_SYMMETRIC_REL
+        _assert_main_output_similarity(
+            fused_r2r_output_similarity,
+            max_abs=_GLM_FUSED_R2R_OUTPUT_MAX_ABS,
+        )
+        _assert_main_grad_similarity(fused_r2r_x_grad_similarity)
+        _assert_main_grad_similarity(fused_r2r_param_grad_similarity)
+        assert fused_r2r_x_grad <= _GLM_X_GRAD_MAX_ABS
+        assert fused_r2r_param_grad <= _GLM_PARAM_GRAD_MAX_ABS
+        assert fused_indexer_loss_r2r <= _INDEXER_LOSS_ATOL
+    else:
+        # Radix top-k is allowed to choose different members at a quantized
+        # cutoff tie. Each run is checked against its own forced-top-k oracle.
+        assert topk_ambiguous_rows > 0
+        if not sparse_loss:
+            # Canonical dense KL is independent of the selected sparse keys.
+            assert fused_indexer_loss_r2r <= _INDEXER_LOSS_ATOL
+    torch.testing.assert_close(
+        fused_a["indexer_loss"],
+        matched_unfused_a["indexer_loss"],
+        atol=_INDEXER_LOSS_ATOL,
+        rtol=_INDEXER_LOSS_RTOL,
+    )
+    torch.testing.assert_close(
+        fused_b["indexer_loss"],
+        matched_unfused_b["indexer_loss"],
+        atol=_INDEXER_LOSS_ATOL,
+        rtol=_INDEXER_LOSS_RTOL,
+    )
+    assert min_indexer_grad_cosine >= _MIN_INDEXER_GRAD_COSINE, indexer_grad_similarity
+    assert max_indexer_grad_rms_relative <= _MAX_INDEXER_GRAD_RMS_REL, (
+        indexer_grad_similarity
+    )
+    assert min_indexer_grad_norm_ratio >= _MIN_INDEXER_GRAD_NORM_RATIO, (
+        indexer_grad_similarity
+    )
+    assert max_indexer_grad_norm_ratio <= _MAX_INDEXER_GRAD_NORM_RATIO, (
+        indexer_grad_similarity
+    )
+    valid_topk = (fused_a["topk_indices"] >= 0).sum(dim=-1)
+    assert _INDEXER_TOPK < seq
+    assert fused_a["topk_indices"].shape[-1] == _INDEXER_TOPK
+    assert int(valid_topk[0, -1].item()) == _INDEXER_TOPK
+    assert int(valid_topk.max().item()) < seq
+    assert unfused_r2r_loss == 0.0
     assert unfused_r2r_out == 0.0
     assert unfused_r2r_x_grad == 0.0
     assert unfused_r2r_param_grad == 0.0
-    assert fused_vs_unfused_out <= 5.0e-2
-    assert fused_vs_unfused_x_grad <= max(5.0e-1, 16.0 * noise_floor)
-    assert fused_vs_unfused_param_grad <= max(5.0e-1, 16.0 * noise_floor)
+    assert unfused_indexer_loss_diff == 0.0
+    assert loss_diff <= _MAIN_LOSS_MAX_ABS_DIFF
+    assert loss_symmetric_rel <= _MAX_MAIN_LOSS_SYMMETRIC_REL
+    _assert_main_output_similarity(
+        fused_vs_unfused_output_similarity,
+        max_abs=_GLM_FUSED_VS_REFERENCE_OUTPUT_MAX_ABS,
+    )
+    _assert_main_grad_similarity(fused_vs_unfused_x_grad_similarity)
+    _assert_main_grad_similarity(fused_vs_unfused_param_grad_similarity)
+    assert fused_vs_unfused_x_grad <= _GLM_X_GRAD_MAX_ABS
+    assert fused_vs_unfused_param_grad <= _GLM_PARAM_GRAD_MAX_ABS
 
     print(
         "NON_SKIP_GLM5_DSA_RUN_TO_RUN_ACCEPT_WITH_PROOF "
         f"fused_loss={float(fused_a['loss'].item()):.6e} "
         f"unfused_loss={float(unfused_a['loss'].item()):.6e} "
+        f"unfused_indexer_loss={float(unfused_a['indexer_loss'].item()):.6e} "
+        f"fused_indexer_loss={float(fused_a['indexer_loss'].item()):.6e} "
+        f"index_heads=32 sparse_loss={sparse_loss} "
+        f"topk_set_exact={fused_vs_unfused_topk_set} "
+        "topk_score_proof_pass=True "
+        f"topk_ambiguous_rows={topk_ambiguous_rows} "
+        "matched_topk_reference=True "
+        f"dense_topk_independent={not sparse_loss and dense_topk_changed} "
+        f"indexer_topk={_INDEXER_TOPK} seq={seq} "
         f"loss_diff={loss_diff:.6e} "
+        f"loss_symmetric_rel={loss_symmetric_rel:.6e} "
+        f"fused_r2r_loss_diff={fused_r2r_loss:.6e} "
+        f"fused_r2r_loss_symmetric_rel={fused_r2r_loss_symmetric_rel:.6e} "
         f"fused_r2r_out_max_abs={fused_r2r_out:.6e} "
+        f"fused_r2r_out_min_cosine={fused_r2r_output_extrema['min_cosine']:.6e} "
+        f"fused_r2r_out_max_rms_relative={fused_r2r_output_extrema['max_rms_relative']:.6e} "
+        f"fused_r2r_out_min_norm_ratio={fused_r2r_output_extrema['min_norm_ratio']:.6e} "
+        f"fused_r2r_out_max_norm_ratio={fused_r2r_output_extrema['max_norm_ratio']:.6e} "
         f"fused_r2r_x_grad_max_abs={fused_r2r_x_grad:.6e} "
         f"fused_r2r_param_grad_max_abs={fused_r2r_param_grad:.6e} "
+        f"fused_r2r_x_grad_similarity={fused_r2r_x_grad_extrema} "
+        f"fused_r2r_param_grad_similarity={fused_r2r_param_grad_extrema} "
         f"unfused_r2r_out_max_abs={unfused_r2r_out:.6e} "
+        f"unfused_r2r_loss_diff={unfused_r2r_loss:.6e} "
         f"unfused_r2r_x_grad_max_abs={unfused_r2r_x_grad:.6e} "
         f"unfused_r2r_param_grad_max_abs={unfused_r2r_param_grad:.6e} "
         f"fused_vs_unfused_out_max_abs={fused_vs_unfused_out:.6e} "
+        f"fused_vs_unfused_out_min_cosine={fused_vs_unfused_output_extrema['min_cosine']:.6e} "
+        f"fused_vs_unfused_out_max_rms_relative={fused_vs_unfused_output_extrema['max_rms_relative']:.6e} "
+        f"fused_vs_unfused_out_min_norm_ratio={fused_vs_unfused_output_extrema['min_norm_ratio']:.6e} "
+        f"fused_vs_unfused_out_max_norm_ratio={fused_vs_unfused_output_extrema['max_norm_ratio']:.6e} "
         f"fused_vs_unfused_x_grad_max_abs={fused_vs_unfused_x_grad:.6e} "
         f"fused_vs_unfused_param_grad_max_abs={fused_vs_unfused_param_grad:.6e} "
-        f"noise_floor={noise_floor:.6e}"
+        f"fused_vs_unfused_x_grad_similarity={fused_vs_unfused_x_grad_extrema} "
+        f"fused_vs_unfused_param_grad_similarity={fused_vs_unfused_param_grad_extrema} "
+        f"fused_indexer_grad_max_abs={fused_indexer_grad_max_abs:.6e} "
+        f"unfused_indexer_grad_max_abs={unfused_indexer_grad_max_abs:.6e}"
+        f" min_indexer_grad_cosine={min_indexer_grad_cosine:.6e}"
+        f" max_indexer_grad_rms_relative={max_indexer_grad_rms_relative:.6e}"
+        f" min_indexer_grad_norm_ratio={min_indexer_grad_norm_ratio:.6e}"
+        f" max_indexer_grad_norm_ratio={max_indexer_grad_norm_ratio:.6e}"
+        f" dense_topk_loss_diff={dense_topk_loss_diff:.6e}"
+        f" dense_topk_indexer_grad_diff={dense_topk_indexer_grad_diff:.6e}"
+    )
+
+
+def test_dsv4_fused_dsa_legacy_two_output_api_real_gpu():
+    """Prove the legacy DSv4 training API against its decomposed inference path."""
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for the fused DSA API regression smoke.")
+    pytest.importorskip(
+        "cudnn", reason="Fused DSA API smoke needs the cuDNN DSA stack."
+    )
+    from megatron.lite.primitive.kernels import dsa_kernels
+
+    device = torch.device("cuda", int(torch.cuda.current_device()))
+    seq, batch, heads = 512, 1, 64
+    ratio = 4
+    n_comp = seq // ratio
+    kv_offset = seq
+    window_topk = 64
+    query_dim, value_dim = 576, 512
+    index_heads, index_dim = 32, 128
+    requested_topk = n_comp + 64
+
+    query_positions = torch.arange(seq, device=device).view(seq, 1)
+    window_offsets = torch.arange(window_topk, device=device).view(1, window_topk)
+    window = query_positions - (window_topk - 1 - window_offsets)
+    window = torch.where(window >= 0, window, torch.full_like(window, -1))
+    window = window.unsqueeze(0).expand(batch, -1, -1).to(torch.int32)
+
+    def make_args():
+        torch.manual_seed(20260627)
+
+        def leaf(*shape, dtype=torch.bfloat16):
+            return torch.randn(*shape, device=device, dtype=dtype).requires_grad_(True)
+
+        return (
+            leaf(seq, batch, heads, query_dim),
+            leaf(seq + n_comp, batch, query_dim),
+            leaf(heads, dtype=torch.float32),
+            window.clone(),
+            leaf(seq, batch, index_heads, index_dim),
+            leaf(n_comp, batch, index_dim),
+            leaf(seq, batch, index_heads),
+            requested_topk,
+            ratio,
+            query_dim**-0.5,
+            index_dim**-0.5,
+            0.0,
+            False,
+            kv_offset,
+            False,
+            value_dim,
+        )
+
+    fused_results = []
+    for name, call in (
+        ("direct", dsa_kernels.FusedIndexerSparseAttnFunc.apply),
+        ("public", dsa_kernels.fused_indexer_sparse_attn),
+    ):
+        args = make_args()
+        result = call(*args)
+        assert isinstance(result, tuple) and len(result) == 2
+        output, indexer_loss = result
+        assert output.shape == (seq, batch, heads * value_dim)
+        assert indexer_loss.ndim == 0
+        assert float(indexer_loss.item()) == 0.0
+        objective = output.float().square().mean() + indexer_loss
+        objective.backward()
+        main_inputs = {"query": args[0], "kv_full": args[1], "attn_sink": args[2]}
+        indexer_inputs = {
+            "q_indexer": args[4],
+            "k_indexer": args[5],
+            "weights": args[6],
+        }
+        assert all(
+            tensor.grad is not None
+            for tensor in (*main_inputs.values(), *indexer_inputs.values())
+        )
+        assert all(
+            torch.isfinite(tensor.grad).all()
+            for tensor in (*main_inputs.values(), *indexer_inputs.values())
+        )
+        assert all(
+            torch.count_nonzero(tensor.grad).item() == 0
+            for tensor in indexer_inputs.values()
+        )
+        fused_results.append(
+            {
+                "output": output.detach().float(),
+                "objective": objective.detach().float(),
+                "main_grads": {
+                    key: tensor.grad.detach().float()
+                    for key, tensor in main_inputs.items()
+                },
+            }
+        )
+        print(
+            "DSV4_FUSED_DSA_LEGACY_API "
+            f"path={name} loss={float(objective.detach().item()):.8e}"
+        )
+
+    # Reproduce the exact DSv4/CSA inference decomposition: indexer_topk ->
+    # global/compact indices -> dsa_sparse_attn.  This is independent of the
+    # legacy fused autograd wrapper and covers the real compressed-KV layout.
+    args = make_args()
+    topk_indices, topk_length = dsa_kernels.indexer_topk(
+        args[4],
+        args[5],
+        args[6],
+        requested_topk,
+        ratio,
+        indexer_softmax_scale=args[10],
+    )
+    assert topk_indices.shape == (batch, seq, requested_topk)
+    assert topk_length.shape == (batch, seq)
+    assert torch.all(topk_indices[..., n_comp:] == -1)
+    independent_indexer_scores = _torch_indexer_scores(
+        args[4],
+        args[5],
+        args[6],
+        ratio=ratio,
+        indexer_softmax_scale=args[10],
+    )
+    padded_topk_score_proof = _assert_topk_matches_quantized_scores(
+        topk_indices[..., :n_comp], independent_indexer_scores
+    )
+    selection_topk = n_comp // 2
+    selection_indices, selection_length = dsa_kernels.indexer_topk(
+        args[4],
+        args[5],
+        args[6],
+        selection_topk,
+        ratio,
+        indexer_softmax_scale=args[10],
+    )
+    assert selection_indices.shape == (batch, seq, selection_topk)
+    assert selection_length.shape == (batch, seq)
+    assert int(selection_length[0, -1].item()) == selection_topk
+    selection_topk_score_proof = _assert_topk_matches_quantized_scores(
+        selection_indices, independent_indexer_scores
+    )
+    compressed_global = torch.where(
+        topk_indices >= 0, topk_indices + kv_offset, topk_indices
+    ).to(torch.int32)
+    assert torch.all((compressed_global < 0) | (compressed_global >= kv_offset))
+    flat_indices, flat_length = dsa_kernels.build_flat_topk_idxs(
+        args[3],
+        compressed_global,
+        batch_size=batch,
+        seqlen_kv=args[1].shape[0],
+        compact=True,
+    )
+    assert flat_length is not None
+    decomposed_output = dsa_kernels.dsa_sparse_attn(
+        args[0],
+        args[1],
+        args[2],
+        flat_indices,
+        args[9],
+        topk_length=flat_length,
+        value_dim=value_dim,
+    )
+    decomposed_objective = decomposed_output.float().square().mean()
+    decomposed_objective.backward()
+    decomposed_main_grads = {
+        "query": args[0].grad.detach().float(),
+        "kv_full": args[1].grad.detach().float(),
+        "attn_sink": args[2].grad.detach().float(),
+    }
+    assert all(torch.isfinite(grad).all() for grad in decomposed_main_grads.values())
+    assert all(args[index].grad is None for index in (4, 5, 6))
+
+    direct_public_output_similarity = {
+        "direct_vs_public": _tensor_similarity_metrics(
+            fused_results[0]["output"], fused_results[1]["output"]
+        )
+    }
+    direct_public_output_extrema = _similarity_extrema(direct_public_output_similarity)
+    fused_decomposed_output_similarity = {
+        "public_vs_decomposed": _tensor_similarity_metrics(
+            fused_results[1]["output"], decomposed_output.detach().float()
+        )
+    }
+    fused_decomposed_output_extrema = _similarity_extrema(
+        fused_decomposed_output_similarity
+    )
+    public_objective = float(fused_results[1]["objective"].item())
+    decomposed_objective_value = float(decomposed_objective.detach().item())
+    fused_decomposed_loss_diff = abs(public_objective - decomposed_objective_value)
+    fused_decomposed_loss_symmetric_rel = _symmetric_relative_difference(
+        public_objective, decomposed_objective_value
+    )
+    direct_public_grad_similarity = {}
+    for name in decomposed_main_grads:
+        direct_public_grad_similarity[name] = _tensor_similarity_metrics(
+            fused_results[0]["main_grads"][name],
+            fused_results[1]["main_grads"][name],
+        )
+    decomposed_grad_similarity = {
+        name: _tensor_similarity_metrics(
+            fused_results[1]["main_grads"][name],
+            decomposed_grad,
+        )
+        for name, decomposed_grad in decomposed_main_grads.items()
+    }
+    direct_public_grad_extrema = _similarity_extrema(direct_public_grad_similarity)
+    decomposed_grad_extrema = _similarity_extrema(decomposed_grad_similarity)
+    print(
+        "DSV4_FUSED_DSA_DECOMPOSED_DIAGNOSTICS "
+        f"loss_diff={fused_decomposed_loss_diff:.6e} "
+        f"loss_symmetric_rel={fused_decomposed_loss_symmetric_rel:.6e} "
+        f"direct_public_output={direct_public_output_extrema} "
+        f"fused_decomposed_output={fused_decomposed_output_extrema} "
+        f"direct_public_grads={direct_public_grad_extrema} "
+        f"fused_decomposed_grads={decomposed_grad_extrema}"
+    )
+
+    _assert_main_output_similarity(
+        direct_public_output_similarity,
+        max_abs=_DIRECT_PUBLIC_OUTPUT_ATOL,
+    )
+    torch.testing.assert_close(
+        fused_results[0]["output"],
+        fused_results[1]["output"],
+        rtol=0.0,
+        atol=_DIRECT_PUBLIC_OUTPUT_ATOL,
+    )
+    torch.testing.assert_close(
+        fused_results[0]["objective"],
+        fused_results[1]["objective"],
+        rtol=0.0,
+        atol=_DIRECT_PUBLIC_LOSS_ATOL,
+    )
+    _assert_main_output_similarity(
+        fused_decomposed_output_similarity,
+        max_abs=_DSV4_FUSED_VS_DECOMPOSED_OUTPUT_MAX_ABS,
+    )
+    assert fused_decomposed_loss_diff <= _MAIN_LOSS_MAX_ABS_DIFF
+    assert fused_decomposed_loss_symmetric_rel <= _MAX_MAIN_LOSS_SYMMETRIC_REL
+    for similarities in (direct_public_grad_similarity, decomposed_grad_similarity):
+        assert min(value["cosine"] for value in similarities.values()) >= (
+            _MIN_MAIN_GRAD_COSINE
+        ), similarities
+        assert max(value["rms_relative"] for value in similarities.values()) <= (
+            _MAX_MAIN_GRAD_RMS_REL
+        ), similarities
+        assert min(value["norm_ratio"] for value in similarities.values()) >= (
+            _MIN_MAIN_GRAD_NORM_RATIO
+        ), similarities
+        assert max(value["norm_ratio"] for value in similarities.values()) <= (
+            _MAX_MAIN_GRAD_NORM_RATIO
+        ), similarities
+    print(
+        "NON_SKIP_DSV4_FUSED_DSA_DECOMPOSED_PARITY_PASSED "
+        f"ratio={ratio} n_comp={n_comp} requested_topk={requested_topk} "
+        f"window_topk={window_topk} kv_offset={kv_offset} "
+        "topk_padding=True topk_score_proof_pass=True "
+        "nontrivial_topk_score_proof=True "
+        "main_grad_parity=True zero_indexer_grads=True "
+        f"selection_topk={selection_topk} "
+        f"padded_topk_ambiguous_rows={padded_topk_score_proof['ambiguous_rows']} "
+        f"selection_topk_ambiguous_rows={selection_topk_score_proof['ambiguous_rows']} "
+        f"loss_diff={fused_decomposed_loss_diff:.6e} "
+        f"loss_symmetric_rel={fused_decomposed_loss_symmetric_rel:.6e} "
+        f"direct_public_out_max_abs={direct_public_output_extrema['max_abs']:.6e} "
+        f"output_min_cosine={fused_decomposed_output_extrema['min_cosine']:.6e} "
+        f"output_max_rms_relative={fused_decomposed_output_extrema['max_rms_relative']:.6e} "
+        f"output_min_norm_ratio={fused_decomposed_output_extrema['min_norm_ratio']:.6e} "
+        f"output_max_norm_ratio={fused_decomposed_output_extrema['max_norm_ratio']:.6e} "
+        f"output_max_abs={fused_decomposed_output_extrema['max_abs']:.6e} "
+        f"min_main_grad_cosine={decomposed_grad_extrema['min_cosine']:.6e} "
+        f"max_main_grad_rms_relative={decomposed_grad_extrema['max_rms_relative']:.6e} "
+        f"min_main_grad_norm_ratio={decomposed_grad_extrema['min_norm_ratio']:.6e} "
+        f"max_main_grad_norm_ratio={decomposed_grad_extrema['max_norm_ratio']:.6e}"
+    )
+
+
+def test_dsv4_csa_torch_fused_module_parity_real_gpu():
+    """Compare the real CSA module's Torch, decomposed, and legacy fused paths."""
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for the DSv4 CSA module parity smoke.")
+    pytest.importorskip("cudnn", reason="DSv4 CSA module parity needs cudnn DSA.")
+
+    from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
+    from megatron.lite.primitive.modules.attention.csa import (
+        CompressedSparseAttention,
+    )
+    from megatron.lite.primitive.parallel import ParallelState
+
+    device = torch.device("cuda", int(torch.cuda.current_device()))
+    # Keep the released top-k while making the module genuinely sparse:
+    # 2560 / ratio 4 = 640 compressed entries, so topk=512 excludes 128.
+    seq = 2560
+    cfg = DeepseekV4Config(
+        num_hidden_layers=1,
+        hidden_size=128,
+        num_attention_heads=64,
+        num_key_value_heads=1,
+        head_dim=512,
+        qk_rope_head_dim=64,
+        q_lora_rank=32,
+        o_lora_rank=32,
+        o_groups=8,
+        max_position_embeddings=seq,
+        compress_ratios=[4],
+        sliding_window=128,
+        index_head_dim=128,
+        index_n_heads=64,
+        index_topk=512,
+        rms_norm_eps=1.0e-6,
+    )
+    ps = ParallelState()
+
+    torch.manual_seed(20260627)
+    reference_module = CompressedSparseAttention(cfg, layer_idx=0, ps=ps).to(
+        device=device, dtype=torch.bfloat16
+    )
+
+    def clone_reference_module():
+        module = CompressedSparseAttention(cfg, layer_idx=0, ps=ps).to(
+            device=device, dtype=torch.bfloat16
+        )
+        module.load_state_dict(reference_module.state_dict(), strict=True)
+        return module
+
+    decomposed_module = clone_reference_module()
+    legacy_fused_module = clone_reference_module()
+    x = torch.randn(1, seq, cfg.hidden_size, device=device, dtype=torch.bfloat16)
+    position_ids = torch.arange(seq, device=device, dtype=torch.long).unsqueeze(0)
+    grad_output = torch.randn_like(x)
+
+    def run(module, *, backend: str, training: bool):
+        module.zero_grad(set_to_none=True)
+        module.attention_backend = backend
+        module.train(training)
+        local_x = x.detach().clone().requires_grad_(True)
+        output = module(local_x, position_ids=position_ids)
+        assert output.shape == x.shape
+        assert torch.isfinite(output.float()).all()
+        output.backward(grad_output)
+        assert local_x.grad is not None
+        assert torch.isfinite(local_x.grad.float()).all()
+
+        main_grads = {}
+        indexer_grads = {}
+        for name, parameter in module.named_parameters():
+            if name.startswith("indexer."):
+                indexer_grads[name] = parameter.grad
+                continue
+            assert parameter.grad is not None, f"missing main gradient for {name}"
+            assert torch.isfinite(parameter.grad.float()).all(), name
+            main_grads[name] = parameter.grad.detach().float().reshape(-1)
+        assert main_grads
+        assert indexer_grads
+        assert all(grad is None for grad in indexer_grads.values())
+        return {
+            "output": output.detach().float(),
+            "x_grad": local_x.grad.detach().float(),
+            "main_grads": main_grads,
+        }
+
+    reference = run(reference_module, backend="torch", training=True)
+    decomposed = run(decomposed_module, backend="fused", training=False)
+    legacy_fused = run(legacy_fused_module, backend="fused", training=True)
+
+    output_comparisons = {}
+    gradient_comparisons = {}
+    for name, actual in (
+        ("decomposed", decomposed),
+        ("legacy_fused", legacy_fused),
+    ):
+        assert set(actual["main_grads"]) == set(reference["main_grads"])
+        output_comparisons[name] = _tensor_similarity_metrics(
+            actual["output"], reference["output"]
+        )
+        gradient_comparisons[f"{name}:input"] = _tensor_similarity_metrics(
+            actual["x_grad"], reference["x_grad"]
+        )
+        for parameter_name in sorted(reference["main_grads"]):
+            gradient_comparisons[f"{name}:param:{parameter_name}"] = (
+                _tensor_similarity_metrics(
+                    actual["main_grads"][parameter_name],
+                    reference["main_grads"][parameter_name],
+                )
+            )
+
+    output_extrema = _similarity_extrema(output_comparisons)
+    gradient_extrema = _similarity_extrema(gradient_comparisons)
+    print(
+        "DSV4_CSA_TORCH_FUSED_DIAGNOSTICS "
+        f"output_by_path={output_comparisons} "
+        f"gradient_extrema={gradient_extrema}"
+    )
+
+    _assert_main_output_similarity(
+        output_comparisons,
+        max_abs=_DSV4_CSA_OUTPUT_MAX_ABS,
+    )
+    assert min(value["cosine"] for value in gradient_comparisons.values()) >= (
+        _MIN_MAIN_GRAD_COSINE
+    ), gradient_comparisons
+    assert max(value["rms_relative"] for value in gradient_comparisons.values()) <= (
+        _MAX_MAIN_GRAD_RMS_REL
+    ), gradient_comparisons
+    assert min(value["norm_ratio"] for value in gradient_comparisons.values()) >= (
+        _MIN_MAIN_GRAD_NORM_RATIO
+    ), gradient_comparisons
+    assert max(value["norm_ratio"] for value in gradient_comparisons.values()) <= (
+        _MAX_MAIN_GRAD_NORM_RATIO
+    ), gradient_comparisons
+
+    print(
+        "NON_SKIP_DSV4_CSA_TORCH_FUSED_PARITY_PASSED "
+        f"seq={seq} ratio=4 n_comp={seq // 4} indexer_topk={cfg.index_topk} "
+        "nontrivial_sparse_selection=True "
+        "torch_vs_decomposed_output=True torch_vs_legacy_output=True "
+        "main_grad_parity=True indexer_grads_none=True "
+        f"output_min_cosine={output_extrema['min_cosine']:.6e} "
+        f"output_max_rms_relative={output_extrema['max_rms_relative']:.6e} "
+        f"output_min_norm_ratio={output_extrema['min_norm_ratio']:.6e} "
+        f"output_max_norm_ratio={output_extrema['max_norm_ratio']:.6e} "
+        f"output_max_abs={output_extrema['max_abs']:.6e} "
+        f"min_main_grad_cosine={gradient_extrema['min_cosine']:.6e} "
+        f"max_main_grad_rms_relative={gradient_extrema['max_rms_relative']:.6e} "
+        f"min_main_grad_norm_ratio={gradient_extrema['min_norm_ratio']:.6e} "
+        f"max_main_grad_norm_ratio={gradient_extrema['max_norm_ratio']:.6e}"
+    )
+
+
+def test_glm52_model_preserves_multisegment_positions_through_indexshare_and_mtp():
+    """A real packed model must not replace reset positions with flat arange."""
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for the GLM5 packed-position smoke.")
+    pytest.importorskip("cudnn", reason="GLM5 packed-position smoke needs cudnn DSA.")
+
+    from types import SimpleNamespace
+
+    from megatron.lite.model.glm5.config import Glm5Config
+    from megatron.lite.model.glm5.lite.model import Glm5Model
+    from megatron.lite.primitive.parallel import ParallelState
+    from megatron.lite.primitive.utils.packed_seq import PackedSeqParams
+
+    device = torch.device("cuda", int(torch.cuda.current_device()))
+    cfg = Glm5Config(
+        num_hidden_layers=2,
+        hidden_size=128,
+        num_attention_heads=64,
+        num_key_value_heads=64,
+        head_dim=256,
+        vocab_size=32,
+        max_position_embeddings=1024,
+        initializer_range=0.002,
+        q_lora_rank=16,
+        kv_lora_rank=512,
+        qk_head_dim=256,
+        qk_nope_head_dim=192,
+        qk_rope_head_dim=64,
+        v_head_dim=256,
+        index_head_dim=128,
+        index_n_heads=32,
+        index_topk=512,
+        intermediate_size=20,
+        moe_intermediate_size=6,
+        first_k_dense_replace=3,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        num_nextn_predict_layers=1,
+        index_topk_freq=2,
+        index_skip_topk_offset=1,
+        indexer_types=["full", "shared"],
+        rope_interleave=True,
+        indexer_rope_interleave=True,
+    )
+    ps = ParallelState()
+    train_cfg = SimpleNamespace(
+        tp=1,
+        ep=1,
+        etp=1,
+        pp=1,
+        cp=1,
+        vpp=None,
+        use_deepep=False,
+        fp8=False,
+        recompute_modules=[],
+        deterministic=True,
+    )
+
+    torch.manual_seed(20260627)
+    model = Glm5Model(
+        cfg,
+        train_cfg,
+        ps,
+        mtp_enable=True,
+        mtp_enable_train=False,
+    ).to(device=device, dtype=torch.bfloat16)
+    model.eval()
+    assert model.mtp is not None
+
+    segment_length = 512
+    total_tokens = segment_length * 2
+    input_ids = torch.randint(
+        0, cfg.vocab_size, (1, total_tokens), device=device, dtype=torch.long
+    )
+    segment_positions = torch.arange(segment_length, device=device, dtype=torch.long)
+    reset_positions = torch.cat((segment_positions, segment_positions)).unsqueeze(0)
+    cu_seqlens = torch.tensor(
+        [0, segment_length, total_tokens], device=device, dtype=torch.int32
+    )
+    packed_seq_params = PackedSeqParams.from_cu_seqlens(
+        cu_seqlens, max_seqlen=segment_length
+    )
+
+    captured: dict[int, torch.Tensor] = {}
+    handles = []
+
+    def capture_positions(module, _args, kwargs):
+        captured[module.layer_number] = kwargs["position_ids"].detach().clone()
+
+    attention_modules = [
+        layer.self_attention.self_attention for layer in model.layers
+    ] + [model.mtp.layers[0].transformer_layer.self_attention.self_attention]
+    for attention in attention_modules:
+        handles.append(
+            attention.register_forward_pre_hook(capture_positions, with_kwargs=True)
+        )
+
+    try:
+        with torch.no_grad():
+            output = model(
+                input_ids=input_ids,
+                position_ids=reset_positions,
+                packed_seq_params=packed_seq_params,
+            )
+    finally:
+        for handle in handles:
+            handle.remove()
+
+    assert output["logits"].shape == (1, total_tokens, cfg.vocab_size)
+    assert torch.isfinite(output["logits"].float()).all()
+    assert "mtp_logits" in output and len(output["mtp_logits"]) == 1
+    assert torch.equal(captured[1], reset_positions)
+    assert torch.equal(captured[2], reset_positions)
+    assert torch.equal(captured[3], reset_positions)
+    print(
+        "NON_SKIP_GLM52_PACKED_POSITION_IDS_PASSED "
+        f"segments=2 segment_length={segment_length} "
+        f"trunk_reset={torch.equal(captured[2], reset_positions)} "
+        f"mtp_rotary_reused={torch.equal(captured[3], reset_positions)}"
     )

--- a/experimental/lite/tests/smoke/primitive/test_auto_pipeline_layout_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_auto_pipeline_layout_smoke.py
@@ -17,6 +17,7 @@ Run: torchrun --nproc_per_node=8 -m pytest --mlite-smoke, selecting per-env subs
 with -k (qwen3_5 on the qwen3.5 site; the rest on the DSA overlay). Models also
 gate themselves with importorskip.
 """
+
 from __future__ import annotations
 
 import os
@@ -32,7 +33,12 @@ from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
 from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
 from megatron.lite.runtime.contracts.data import PackedBatch
 
-pytestmark = [pytest.mark.mlite, pytest.mark.smoke, pytest.mark.gpu, pytest.mark.distributed]
+pytestmark = [
+    pytest.mark.mlite,
+    pytest.mark.smoke,
+    pytest.mark.gpu,
+    pytest.mark.distributed,
+]
 
 # 9 decoders over pp=4 is non-divisible; 9 is small enough to stay fast yet leaves no
 # empty stage even for the MTP model (deepseek_v4 adds a slot on the last stage).
@@ -87,7 +93,8 @@ def _qwen3_5():
         num_attention_heads=4,
         num_key_value_heads=2,
         head_dim=4,
-        vocab_size=64,
+        # Deliberately not TP-divisible: export must trim padded vocab rows.
+        vocab_size=65,
         num_experts=4,
         num_experts_per_tok=2,
         moe_intermediate_size=8,
@@ -100,6 +107,8 @@ def _qwen3_5():
         layer_types=(["full_attention", "linear_attention"] * ((_NUM_LAYERS + 1) // 2))[
             :_NUM_LAYERS
         ],
+        num_nextn_predict_layers=1,
+        mtp_layer_types=["full_attention"],
         partial_rotary_factor=1.0,
         max_position_embeddings=4096,
     )
@@ -190,12 +199,17 @@ def _glm5():
         index_head_dim=128,
         index_n_heads=32,
         index_topk=512,
+        dsa_indexer_loss_coeff=1.0e-2,
         intermediate_size=20,
         moe_intermediate_size=6,
         first_k_dense_replace=1,
         n_routed_experts=4,
         n_shared_experts=1,
         num_experts_per_tok=2,
+        # GLM-5/5.1 publishes these flags, but without an IndexShare schedule
+        # MLite must preserve its pre-PR half-split behavior.
+        rope_interleave=True,
+        indexer_rope_interleave=True,
     )
     return cfg, protocol
 
@@ -218,7 +232,7 @@ def _glm52_indexshare():
         num_key_value_heads=64,
         head_dim=256,
         vocab_size=32,
-        max_position_embeddings=512,
+        max_position_embeddings=1024,
         initializer_range=0.002,
         q_lora_rank=16,
         kv_lora_rank=512,
@@ -229,6 +243,7 @@ def _glm52_indexshare():
         index_head_dim=128,
         index_n_heads=32,
         index_topk=512,
+        dsa_indexer_loss_coeff=1.0e-2,
         intermediate_size=20,
         moe_intermediate_size=6,
         first_k_dense_replace=1,
@@ -239,13 +254,16 @@ def _glm52_indexshare():
         index_topk_freq=4,
         index_skip_topk_offset=3,
         indexer_types=_glm52_indexer_types(),
-        index_share_for_mtp_iteration=True,
+        rope_interleave=True,
+        indexer_rope_interleave=True,
     )
     return cfg, protocol
 
 
 def _deepseek_v4():
-    pytest.importorskip("cudnn", reason="deepseek_v4 fused DSA needs the cudnn DSA stack.")
+    pytest.importorskip(
+        "cudnn", reason="deepseek_v4 fused DSA needs the cudnn DSA stack."
+    )
     _require_te()
     from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
     from megatron.lite.model.deepseek_v4.lite import protocol
@@ -332,8 +350,17 @@ def _single_node_cuda_dist():
 # teardown can free them (mcore's destroy_model_parallel frees only mcore's groups).
 _BUILT_PARALLEL_STATES: list = []
 _PS_GROUP_ATTRS = (
-    "tp_group", "ep_group", "etp_group", "cp_group", "pp_group", "pp_cpu_group",
-    "dp_group", "dp_cp_group", "tp_ep_group", "ep_dp_group",
+    "tp_group",
+    "ep_group",
+    "etp_group",
+    "cp_group",
+    "pp_group",
+    "pp_cpu_group",
+    "embedding_group",
+    "dp_group",
+    "dp_cp_group",
+    "tp_ep_group",
+    "ep_dp_group",
 )
 
 
@@ -427,12 +454,18 @@ def _build_handle_from_config(
 
 def _build_handle(model_name: str, *, seed: int, pp_layout=None):
     cfg, protocol = MODELS[model_name]()
+    impl_overrides = (
+        {"mtp_enable": True, "mtp_enable_train": True}
+        if model_name in {"qwen3_5", "glm5", "deepseek_v4"}
+        else None
+    )
     return _build_handle_from_config(
         model_name,
         cfg,
         protocol,
         seed=seed,
         pp_layout=pp_layout,
+        impl_overrides=impl_overrides,
     )
 
 
@@ -451,8 +484,828 @@ def _hf_decoder_layer_indices(names) -> set[int]:
     return {int(m.group(1)) for n in names if (m := _HF_LAYER_RE.search(n))}
 
 
+def _named_local_parameters(handle):
+    """Return unique local model parameters with stable chunk-qualified names."""
+    named = []
+    seen: set[int] = set()
+    for chunk_idx, chunk in enumerate(handle._extras["model_chunks"]):
+        for name, parameter in unwrap_model(chunk).named_parameters():
+            if id(parameter) in seen:
+                continue
+            seen.add(id(parameter))
+            named.append((f"chunk{chunk_idx}.{name}", parameter))
+    return named
+
+
+def _parameter_grad(parameter: torch.nn.Parameter) -> torch.Tensor | None:
+    grad = getattr(parameter, "main_grad", None)
+    return parameter.grad if grad is None else grad
+
+
+def _assert_finite_nonzero_gradients(named_parameters, *, label: str) -> list[str]:
+    """Require every selected parameter to have a finite gradient and some signal."""
+    named_parameters = list(named_parameters)
+    assert named_parameters, f"{label}: selected no parameters"
+    nonzero = []
+    for name, parameter in named_parameters:
+        grad = _parameter_grad(parameter)
+        assert grad is not None, f"{label}: missing gradient for {name}"
+        grad = grad.detach().float()
+        assert torch.isfinite(grad).all(), f"{label}: non-finite gradient for {name}"
+        if torch.count_nonzero(grad).item() > 0:
+            nonzero.append(name)
+    assert nonzero, f"{label}: every selected gradient is exactly zero"
+    return nonzero
+
+
+def _assert_finite_nonzero_gradient_signal(
+    named_parameters, *, label: str
+) -> list[str]:
+    """Require finite, nonzero local training signal without banning unused parameters."""
+    named_parameters = list(named_parameters)
+    assert named_parameters, f"{label}: selected no parameters"
+    with_grad = []
+    nonzero = []
+    for name, parameter in named_parameters:
+        grad = _parameter_grad(parameter)
+        if grad is None:
+            continue
+        with_grad.append(name)
+        grad = grad.detach().float()
+        assert torch.isfinite(grad).all(), f"{label}: non-finite gradient for {name}"
+        if torch.count_nonzero(grad).item() > 0:
+            nonzero.append(name)
+    assert with_grad, f"{label}: no local parameter received a gradient"
+    assert nonzero, f"{label}: every local gradient is exactly zero"
+    return nonzero
+
+
+def _snapshot_named_parameters(named_parameters) -> dict[str, torch.Tensor]:
+    return {
+        name: parameter.detach().cpu().clone() for name, parameter in named_parameters
+    }
+
+
+def _assert_snapshot_changed(
+    before: dict[str, torch.Tensor], named_parameters, *, label: str
+) -> list[str]:
+    after = {name: parameter.detach().cpu() for name, parameter in named_parameters}
+    assert before.keys() == after.keys(), (
+        f"{label}: parameter set changed during optimizer step"
+    )
+    changed = [name for name in before if not torch.equal(before[name], after[name])]
+    assert changed, f"{label}: optimizer step did not change any selected parameter"
+    return changed
+
+
+def _optimizer_master_snapshot(handle) -> list[torch.Tensor]:
+    """Snapshot FP32/main parameters owned by the distributed optimizer shard."""
+    parameters = list(handle._optimizer.get_parameters())
+    assert parameters, "distributed optimizer exposes no local main parameters"
+    return [parameter.detach().cpu().clone() for parameter in parameters]
+
+
+def _assert_optimizer_master_changed(handle, before: list[torch.Tensor]) -> int:
+    after = list(handle._optimizer.get_parameters())
+    assert len(before) == len(after), (
+        "optimizer main-parameter count changed during step"
+    )
+    changed = sum(
+        not torch.equal(old, new.detach().cpu())
+        for old, new in zip(before, after, strict=True)
+    )
+    assert changed > 0, "optimizer reported success but no FP32/main parameter changed"
+    return changed
+
+
+def _assert_optimizer_state_initialized(handle) -> int:
+    """Require Adam state with finite, nonzero moving averages after the first step."""
+    from megatron.core.optimizer import ChainedOptimizer
+
+    optimizer = handle._optimizer
+    children = (
+        optimizer.chained_optimizers
+        if isinstance(optimizer, ChainedOptimizer)
+        else [optimizer]
+    )
+    state_tensors = []
+    moving_average_tensors = []
+    for child in children:
+        inner = getattr(child, "optimizer", None)
+        assert inner is not None, "distributed optimizer child has no inner optimizer"
+        for state in inner.state.values():
+            for key, value in state.items():
+                if not isinstance(value, torch.Tensor):
+                    continue
+                assert torch.isfinite(value.float()).all(), (
+                    f"optimizer state {key} contains non-finite values"
+                )
+                state_tensors.append(value)
+                if key in {"exp_avg", "exp_avg_sq"}:
+                    moving_average_tensors.append(value)
+    assert state_tensors, "optimizer step created no tensor state"
+    assert moving_average_tensors, "Adam optimizer state has no moving averages"
+    assert any(
+        torch.count_nonzero(value).item() > 0 for value in moving_average_tensors
+    ), "Adam moving averages are all exactly zero after a nonzero-gradient step"
+    return len(state_tensors)
+
+
+def _assert_successful_optimizer_step(
+    runtime, handle, *, label: str, master_before
+) -> dict:
+    update_successful, grad_norm, num_zeros = runtime.optimizer_step(handle)
+    assert update_successful is True, f"{label}: optimizer rejected/skipped the update"
+    assert torch.isfinite(torch.tensor(grad_norm)), (
+        f"{label}: non-finite grad_norm={grad_norm}"
+    )
+    assert grad_norm > 0.0, f"{label}: zero grad norm permits a no-op optimizer pass"
+    changed_main = _assert_optimizer_master_changed(handle, master_before)
+    optimizer_state_tensors = _assert_optimizer_state_initialized(handle)
+    return {
+        "grad_norm": grad_norm,
+        "num_zeros": num_zeros,
+        "changed_main": changed_main,
+        "optimizer_state_tensors": optimizer_state_tensors,
+    }
+
+
+def _gather_and_validate_pipeline_layout(
+    handle, cfg
+) -> tuple[list[list[int]], list[dict]]:
+    """Prove the global PP layer union and peer ownership, not only local continuity."""
+    ps = handle._parallel_state
+    local = _local_layer_indices(handle)
+    stage = {
+        "global_rank": dist.get_rank(),
+        "pp_rank": ps.pp_rank,
+        "tp_rank": ps.tp_rank,
+        "ep_rank": ps.ep_rank,
+        "layers": local,
+    }
+    gathered = [None for _ in range(dist.get_world_size())]
+    dist.all_gather_object(gathered, stage)
+
+    by_stage: dict[int, list[dict]] = {}
+    for item in gathered:
+        by_stage.setdefault(item["pp_rank"], []).append(item)
+    assert sorted(by_stage) == list(range(ps.pp_size)), (
+        f"PP ranks are incomplete or out of range: {sorted(by_stage)}"
+    )
+    expected_peers = dist.get_world_size() // ps.pp_size
+    splits = []
+    for pp_rank in range(ps.pp_size):
+        peers = by_stage[pp_rank]
+        assert len(peers) == expected_peers, (
+            f"PP stage {pp_rank} has {len(peers)} peers, want {expected_peers}"
+        )
+        ownership = {tuple(item["layers"]) for item in peers}
+        assert len(ownership) == 1, (
+            f"TP/EP/DP peers disagree on PP stage {pp_rank} layer ownership: {ownership}"
+        )
+        splits.append(list(next(iter(ownership))))
+
+    flat = [layer for split in splits for layer in split]
+    expected = list(range(cfg.num_hidden_layers))
+    assert flat == expected, (
+        "global pipeline layout has duplicated, missing, or reordered decoder layers: "
+        f"got {flat}, want {expected}"
+    )
+    return splits, gathered
+
+
+def _is_valid_hf_export_key(key: str, model_name: str) -> bool:
+    if model_name == "deepseek_v4":
+        return key.startswith(("layers.", "mtp.")) or key in {
+            "embed.weight",
+            "head.weight",
+            "norm.weight",
+            "hc_head_base",
+            "hc_head_fn",
+            "hc_head_scale",
+        }
+    if model_name == "qwen3_5":
+        return key.startswith(("model.", "mtp.")) or key == "lm_head.weight"
+    return key.startswith("model.") or key == "lm_head.weight"
+
+
+def _required_hf_roots(model_name: str) -> tuple[str, str, str]:
+    if model_name == "deepseek_v4":
+        return "embed.weight", "norm.weight", "head.weight"
+    if model_name == "qwen3_5":
+        return (
+            "model.language_model.embed_tokens.weight",
+            "model.language_model.norm.weight",
+            "lm_head.weight",
+        )
+    return "model.embed_tokens.weight", "model.norm.weight", "lm_head.weight"
+
+
+def _assert_exact_export_manifest(
+    model_name: str,
+    weights: dict[str, torch.Tensor],
+    expected_shapes: dict[str, tuple[int, ...]],
+) -> None:
+    actual_keys = set(weights)
+    expected_keys = set(expected_shapes)
+    missing = sorted(expected_keys - actual_keys)
+    unexpected = sorted(actual_keys - expected_keys)
+    assert not missing and not unexpected, (
+        f"{model_name}: export schema mismatch; missing={missing}, "
+        f"unexpected={unexpected}"
+    )
+    for key, expected_shape in expected_shapes.items():
+        actual_shape = tuple(weights[key].shape)
+        assert actual_shape == expected_shape, (
+            f"{model_name}: {key} shape={actual_shape}, want {expected_shape}"
+        )
+        if key.endswith(".tid2eid"):
+            assert weights[key].dtype == torch.int64, (
+                f"{model_name}: {key} dtype={weights[key].dtype}, want torch.int64"
+            )
+
+
+def _glm5_expected_export_shapes(cfg) -> dict[str, tuple[int, ...]]:
+    hidden = cfg.hidden_size
+    expected = {
+        "model.embed_tokens.weight": (cfg.vocab_size, hidden),
+        "model.norm.weight": (hidden,),
+        "lm_head.weight": (cfg.vocab_size, hidden),
+    }
+
+    def add_layer(layer_idx: int, *, mtp: bool = False) -> None:
+        prefix = f"model.layers.{layer_idx}."
+        expected.update(
+            {
+                f"{prefix}input_layernorm.weight": (hidden,),
+                f"{prefix}post_attention_layernorm.weight": (hidden,),
+                f"{prefix}self_attn.q_a_proj.weight": (cfg.q_lora_rank, hidden),
+                f"{prefix}self_attn.q_a_layernorm.weight": (cfg.q_lora_rank,),
+                f"{prefix}self_attn.q_b_proj.weight": (
+                    cfg.num_attention_heads * cfg.qk_head_dim,
+                    cfg.q_lora_rank,
+                ),
+                f"{prefix}self_attn.kv_a_proj_with_mqa.weight": (
+                    cfg.kv_lora_rank + cfg.qk_rope_head_dim,
+                    hidden,
+                ),
+                f"{prefix}self_attn.kv_a_layernorm.weight": (cfg.kv_lora_rank,),
+                f"{prefix}self_attn.kv_b_proj.weight": (
+                    cfg.num_attention_heads * (cfg.qk_nope_head_dim + cfg.v_head_dim),
+                    cfg.kv_lora_rank,
+                ),
+                f"{prefix}self_attn.o_proj.weight": (
+                    hidden,
+                    cfg.num_attention_heads * cfg.v_head_dim,
+                ),
+            }
+        )
+        indexer_prefix = f"{prefix}self_attn.indexer."
+        if cfg.builds_dsa_indexer(layer_idx):
+            expected.update(
+                {
+                    f"{indexer_prefix}wq_b.weight": (
+                        cfg.index_n_heads * cfg.index_head_dim,
+                        cfg.q_lora_rank,
+                    ),
+                    f"{indexer_prefix}wk.weight": (cfg.index_head_dim, hidden),
+                    f"{indexer_prefix}k_norm.weight": (cfg.index_head_dim,),
+                    f"{indexer_prefix}k_norm.bias": (cfg.index_head_dim,),
+                    f"{indexer_prefix}weights_proj.weight": (
+                        cfg.index_n_heads,
+                        cfg.index_head_dim,
+                    ),
+                }
+            )
+
+        mlp = f"{prefix}mlp."
+        if cfg.is_moe_layer(layer_idx):
+            shared_intermediate = cfg.n_shared_experts * cfg.moe_intermediate_size
+            expected.update(
+                {
+                    f"{mlp}gate.weight": (cfg.num_experts, hidden),
+                    f"{mlp}gate.e_score_correction_bias": (cfg.num_experts,),
+                    f"{mlp}shared_experts.gate_proj.weight": (
+                        shared_intermediate,
+                        hidden,
+                    ),
+                    f"{mlp}shared_experts.up_proj.weight": (
+                        shared_intermediate,
+                        hidden,
+                    ),
+                    f"{mlp}shared_experts.down_proj.weight": (
+                        hidden,
+                        shared_intermediate,
+                    ),
+                }
+            )
+            for expert_idx in range(cfg.num_experts):
+                expert = f"{mlp}experts.{expert_idx}."
+                expected.update(
+                    {
+                        f"{expert}gate_proj.weight": (
+                            cfg.moe_intermediate_size,
+                            hidden,
+                        ),
+                        f"{expert}up_proj.weight": (
+                            cfg.moe_intermediate_size,
+                            hidden,
+                        ),
+                        f"{expert}down_proj.weight": (
+                            hidden,
+                            cfg.moe_intermediate_size,
+                        ),
+                    }
+                )
+        else:
+            expected.update(
+                {
+                    f"{mlp}gate_proj.weight": (cfg.intermediate_size, hidden),
+                    f"{mlp}up_proj.weight": (cfg.intermediate_size, hidden),
+                    f"{mlp}down_proj.weight": (hidden, cfg.intermediate_size),
+                }
+            )
+        if mtp:
+            expected.update(
+                {
+                    f"{prefix}enorm.weight": (hidden,),
+                    f"{prefix}hnorm.weight": (hidden,),
+                    f"{prefix}eh_proj.weight": (hidden, 2 * hidden),
+                    f"{prefix}shared_head.norm.weight": (hidden,),
+                }
+            )
+
+    for layer_idx in range(cfg.num_hidden_layers):
+        add_layer(layer_idx)
+    for mtp_idx in range(cfg.num_nextn_predict_layers):
+        add_layer(cfg.num_hidden_layers + mtp_idx, mtp=True)
+    return expected
+
+
+def _deepseek_v4_expected_export_shapes(cfg) -> dict[str, tuple[int, ...]]:
+    hidden = cfg.hidden_size
+    expected = {
+        "embed.weight": (cfg.vocab_size, hidden),
+        "norm.weight": (hidden,),
+        "head.weight": (cfg.vocab_size, hidden),
+        "hc_head_fn": (cfg.hc_mult, cfg.hc_mult * hidden),
+        "hc_head_base": (cfg.hc_mult,),
+        "hc_head_scale": (1,),
+    }
+
+    def add_block(prefix: str, layer_idx: int, *, mtp: bool = False) -> None:
+        ratio = (
+            cfg.compress_ratios[min(layer_idx, len(cfg.compress_ratios) - 1)]
+            if cfg.compress_ratios
+            else 0
+        )
+        num_heads_per_group = cfg.num_attention_heads // cfg.o_groups
+        hc_mix = (2 + cfg.hc_mult) * cfg.hc_mult
+        expected.update(
+            {
+                f"{prefix}attn_norm.weight": (hidden,),
+                f"{prefix}ffn_norm.weight": (hidden,),
+                f"{prefix}attn.wq_a.weight": (cfg.q_lora_rank, hidden),
+                f"{prefix}attn.q_norm.weight": (cfg.q_lora_rank,),
+                f"{prefix}attn.wq_b.weight": (
+                    cfg.num_attention_heads * cfg.head_dim,
+                    cfg.q_lora_rank,
+                ),
+                f"{prefix}attn.wkv.weight": (cfg.head_dim, hidden),
+                f"{prefix}attn.kv_norm.weight": (cfg.head_dim,),
+                f"{prefix}attn.wo_a.weight": (
+                    cfg.o_groups * cfg.o_lora_rank,
+                    num_heads_per_group * cfg.head_dim,
+                ),
+                f"{prefix}attn.wo_b.weight": (
+                    hidden,
+                    cfg.o_groups * cfg.o_lora_rank,
+                ),
+                f"{prefix}attn.attn_sink": (cfg.num_attention_heads,),
+                f"{prefix}hc_attn_fn": (hc_mix, cfg.hc_mult * hidden),
+                f"{prefix}hc_attn_base": (hc_mix,),
+                f"{prefix}hc_attn_scale": (3,),
+                f"{prefix}hc_ffn_fn": (hc_mix, cfg.hc_mult * hidden),
+                f"{prefix}hc_ffn_base": (hc_mix,),
+                f"{prefix}hc_ffn_scale": (3,),
+                f"{prefix}ffn.gate.weight": (cfg.num_experts, hidden),
+                f"{prefix}ffn.shared_experts.w1.weight": (
+                    cfg.n_shared_experts * cfg.moe_intermediate_size,
+                    hidden,
+                ),
+                f"{prefix}ffn.shared_experts.w2.weight": (
+                    hidden,
+                    cfg.n_shared_experts * cfg.moe_intermediate_size,
+                ),
+                f"{prefix}ffn.shared_experts.w3.weight": (
+                    cfg.n_shared_experts * cfg.moe_intermediate_size,
+                    hidden,
+                ),
+            }
+        )
+        for expert_idx in range(cfg.num_experts):
+            expert = f"{prefix}ffn.experts.{expert_idx}."
+            expected.update(
+                {
+                    f"{expert}w1.weight": (cfg.moe_intermediate_size, hidden),
+                    f"{expert}w2.weight": (hidden, cfg.moe_intermediate_size),
+                    f"{expert}w3.weight": (cfg.moe_intermediate_size, hidden),
+                }
+            )
+        if layer_idx < cfg.num_hash_layers and not mtp:
+            expected[f"{prefix}ffn.gate.tid2eid"] = (
+                cfg.vocab_size,
+                cfg.num_experts_per_tok,
+            )
+        else:
+            expected[f"{prefix}ffn.gate.bias"] = (cfg.num_experts,)
+
+        if ratio > 1:
+            compressor_width = (2 if ratio == 4 else 1) * cfg.head_dim
+            compressor = f"{prefix}attn.compressor."
+            expected.update(
+                {
+                    f"{compressor}wkv.weight": (compressor_width, hidden),
+                    f"{compressor}wgate.weight": (compressor_width, hidden),
+                    f"{compressor}ape": (ratio, compressor_width),
+                    f"{compressor}norm.weight": (cfg.head_dim,),
+                }
+            )
+        if ratio == 4:
+            indexer = f"{prefix}attn.indexer."
+            indexer_compressor_width = 2 * cfg.index_head_dim
+            expected.update(
+                {
+                    f"{indexer}wq_b.weight": (
+                        cfg.index_n_heads * cfg.index_head_dim,
+                        cfg.q_lora_rank,
+                    ),
+                    f"{indexer}weights_proj.weight": (cfg.index_n_heads, hidden),
+                    f"{indexer}compressor.wkv.weight": (
+                        indexer_compressor_width,
+                        hidden,
+                    ),
+                    f"{indexer}compressor.wgate.weight": (
+                        indexer_compressor_width,
+                        hidden,
+                    ),
+                    f"{indexer}compressor.ape": (
+                        ratio,
+                        indexer_compressor_width,
+                    ),
+                    f"{indexer}compressor.norm.weight": (cfg.index_head_dim,),
+                }
+            )
+        if mtp:
+            expected.update(
+                {
+                    f"{prefix}e_proj.weight": (hidden, hidden),
+                    f"{prefix}h_proj.weight": (hidden, hidden),
+                    f"{prefix}enorm.weight": (hidden,),
+                    f"{prefix}hnorm.weight": (hidden,),
+                    f"{prefix}norm.weight": (hidden,),
+                    f"{prefix}hc_head_fn": (cfg.hc_mult, cfg.hc_mult * hidden),
+                    f"{prefix}hc_head_base": (cfg.hc_mult,),
+                    f"{prefix}hc_head_scale": (1,),
+                }
+            )
+
+    for layer_idx in range(cfg.num_hidden_layers):
+        add_block(f"layers.{layer_idx}.", layer_idx)
+    for mtp_idx in range(cfg.num_nextn_predict_layers):
+        add_block(f"mtp.{mtp_idx}.", cfg.num_hidden_layers + mtp_idx, mtp=True)
+    return expected
+
+
+def _qwen35_expected_export_shapes(cfg) -> dict[str, tuple[int, ...]]:
+    hidden = cfg.hidden_size
+    expected = {
+        "model.language_model.embed_tokens.weight": (cfg.vocab_size, hidden),
+        "model.language_model.norm.weight": (hidden,),
+        "lm_head.weight": (cfg.vocab_size, hidden),
+    }
+    qk_dim = cfg.linear_num_key_heads * cfg.linear_key_head_dim
+    value_dim = cfg.linear_num_value_heads * cfg.linear_value_head_dim
+    for layer_idx in range(cfg.num_hidden_layers):
+        prefix = f"model.language_model.layers.{layer_idx}."
+        expected.update(
+            {
+                f"{prefix}input_layernorm.weight": (hidden,),
+                f"{prefix}post_attention_layernorm.weight": (hidden,),
+                f"{prefix}mlp.gate.weight": (cfg.num_experts, hidden),
+                f"{prefix}mlp.shared_expert.gate_proj.weight": (
+                    cfg.shared_expert_intermediate_size,
+                    hidden,
+                ),
+                f"{prefix}mlp.shared_expert.up_proj.weight": (
+                    cfg.shared_expert_intermediate_size,
+                    hidden,
+                ),
+                f"{prefix}mlp.shared_expert.down_proj.weight": (
+                    hidden,
+                    cfg.shared_expert_intermediate_size,
+                ),
+                f"{prefix}mlp.shared_expert_gate.weight": (1, hidden),
+                f"{prefix}mlp.experts.gate_up_proj": (
+                    cfg.num_experts,
+                    2 * cfg.moe_intermediate_size,
+                    hidden,
+                ),
+                f"{prefix}mlp.experts.down_proj": (
+                    cfg.num_experts,
+                    hidden,
+                    cfg.moe_intermediate_size,
+                ),
+            }
+        )
+        if cfg.layer_type_at(layer_idx) == "full_attention":
+            attn = f"{prefix}self_attn."
+            expected.update(
+                {
+                    f"{attn}q_proj.weight": (
+                        2 * cfg.num_attention_heads * cfg.head_dim,
+                        hidden,
+                    ),
+                    f"{attn}k_proj.weight": (
+                        cfg.num_key_value_heads * cfg.head_dim,
+                        hidden,
+                    ),
+                    f"{attn}v_proj.weight": (
+                        cfg.num_key_value_heads * cfg.head_dim,
+                        hidden,
+                    ),
+                    f"{attn}q_norm.weight": (cfg.head_dim,),
+                    f"{attn}k_norm.weight": (cfg.head_dim,),
+                    f"{attn}o_proj.weight": (
+                        hidden,
+                        cfg.num_attention_heads * cfg.head_dim,
+                    ),
+                }
+            )
+        else:
+            attn = f"{prefix}linear_attn."
+            expected.update(
+                {
+                    f"{attn}in_proj_qkv.weight": (2 * qk_dim + value_dim, hidden),
+                    f"{attn}in_proj_z.weight": (value_dim, hidden),
+                    f"{attn}in_proj_b.weight": (
+                        cfg.linear_num_value_heads,
+                        hidden,
+                    ),
+                    f"{attn}in_proj_a.weight": (
+                        cfg.linear_num_value_heads,
+                        hidden,
+                    ),
+                    f"{attn}conv1d.weight": (
+                        2 * qk_dim + value_dim,
+                        1,
+                        cfg.linear_conv_kernel_dim,
+                    ),
+                    f"{attn}dt_bias": (cfg.linear_num_value_heads,),
+                    f"{attn}A_log": (cfg.linear_num_value_heads,),
+                    f"{attn}norm.weight": (cfg.linear_value_head_dim,),
+                    f"{attn}out_proj.weight": (hidden, value_dim),
+                }
+            )
+    if cfg.num_nextn_predict_layers:
+        assert cfg.num_nextn_predict_layers == 1, (
+            "the released Qwen3.5 checkpoint schema has exactly one physical MTP "
+            f"predictor, got {cfg.num_nextn_predict_layers}"
+        )
+        expected.update(
+            {
+                "mtp.pre_fc_norm_embedding.weight": (hidden,),
+                "mtp.pre_fc_norm_hidden.weight": (hidden,),
+                "mtp.fc.weight": (hidden, 2 * hidden),
+                "mtp.norm.weight": (hidden,),
+            }
+        )
+        for mtp_idx in range(cfg.num_nextn_predict_layers):
+            layer_type = cfg.layer_type_at(cfg.num_hidden_layers + mtp_idx)
+            assert layer_type == "full_attention", (
+                "the released Qwen3.5 MTP predictor must use full attention, got "
+                f"mtp_layer_types[{mtp_idx}]={layer_type!r}"
+            )
+            prefix = f"mtp.layers.{mtp_idx}."
+            expected.update(
+                {
+                    f"{prefix}input_layernorm.weight": (hidden,),
+                    f"{prefix}post_attention_layernorm.weight": (hidden,),
+                    f"{prefix}self_attn.q_proj.weight": (
+                        2 * cfg.num_attention_heads * cfg.head_dim,
+                        hidden,
+                    ),
+                    f"{prefix}self_attn.k_proj.weight": (
+                        cfg.num_key_value_heads * cfg.head_dim,
+                        hidden,
+                    ),
+                    f"{prefix}self_attn.v_proj.weight": (
+                        cfg.num_key_value_heads * cfg.head_dim,
+                        hidden,
+                    ),
+                    f"{prefix}self_attn.q_norm.weight": (cfg.head_dim,),
+                    f"{prefix}self_attn.k_norm.weight": (cfg.head_dim,),
+                    f"{prefix}self_attn.o_proj.weight": (
+                        hidden,
+                        cfg.num_attention_heads * cfg.head_dim,
+                    ),
+                    f"{prefix}mlp.gate.weight": (cfg.num_experts, hidden),
+                    f"{prefix}mlp.shared_expert.gate_proj.weight": (
+                        cfg.shared_expert_intermediate_size,
+                        hidden,
+                    ),
+                    f"{prefix}mlp.shared_expert.up_proj.weight": (
+                        cfg.shared_expert_intermediate_size,
+                        hidden,
+                    ),
+                    f"{prefix}mlp.shared_expert.down_proj.weight": (
+                        hidden,
+                        cfg.shared_expert_intermediate_size,
+                    ),
+                    f"{prefix}mlp.shared_expert_gate.weight": (1, hidden),
+                }
+            )
+            for expert_idx in range(cfg.num_experts):
+                expert = f"{prefix}mlp.experts.{expert_idx}."
+                expected.update(
+                    {
+                        f"{expert}gate_proj.weight": (
+                            cfg.moe_intermediate_size,
+                            hidden,
+                        ),
+                        f"{expert}up_proj.weight": (
+                            cfg.moe_intermediate_size,
+                            hidden,
+                        ),
+                        f"{expert}down_proj.weight": (
+                            hidden,
+                            cfg.moe_intermediate_size,
+                        ),
+                    }
+                )
+    return expected
+
+
+_QWEN35_FP32_CHECKPOINT_SUFFIXES = (
+    ".linear_attn.A_log",
+    ".linear_attn.norm.weight",
+)
+
+
+def _expected_floating_export_dtype(model_name: str, key: str) -> torch.dtype:
+    if model_name == "qwen3_5" and key.endswith(_QWEN35_FP32_CHECKPOINT_SUFFIXES):
+        return torch.float32
+    return torch.bfloat16
+
+
+def _validate_model_specific_hf_keys(
+    model_name: str, cfg, weights: dict[str, torch.Tensor]
+) -> None:
+    keys = set(weights)
+    embed_key, norm_key, head_key = _required_hf_roots(model_name)
+    for required in (embed_key, norm_key, head_key):
+        assert required in keys, (
+            f"{model_name}: HF export is missing required tensor {required}"
+        )
+    assert tuple(weights[embed_key].shape) == (cfg.vocab_size, cfg.hidden_size)
+    assert tuple(weights[norm_key].shape) == (cfg.hidden_size,)
+    assert tuple(weights[head_key].shape) == (cfg.vocab_size, cfg.hidden_size)
+
+    if model_name == "glm5":
+        _assert_exact_export_manifest(
+            model_name, weights, _glm5_expected_export_shapes(cfg)
+        )
+        return
+    if model_name == "deepseek_v4":
+        _assert_exact_export_manifest(
+            "deepseek_v4_v4flash_release",
+            weights,
+            _deepseek_v4_expected_export_shapes(cfg),
+        )
+        return
+    if model_name == "qwen3_5":
+        _assert_exact_export_manifest(
+            model_name, weights, _qwen35_expected_export_shapes(cfg)
+        )
+        mtp_keys = {key for key in keys if key.startswith("mtp.")}
+        assert len(mtp_keys) == 17 + 3 * cfg.num_experts, (
+            f"qwen3_5: incomplete released MTP schema; got {len(mtp_keys)} keys"
+        )
+        return
+
+    if model_name == "kimi_k2":
+        for layer_idx in range(cfg.num_hidden_layers):
+            if not cfg.is_moe_layer(layer_idx):
+                continue
+            bias_key = f"model.layers.{layer_idx}.mlp.gate.e_score_correction_bias"
+            assert bias_key in keys, (
+                f"kimi_k2: PP export is missing router correction buffer {bias_key}"
+            )
+
+
+def _validate_rank0_export_and_reload(exported, cfg, model_name: str, tmp_path) -> int:
+    """Validate and persist the rank-0 materialization; caller synchronizes failures."""
+    names = [name for name, _ in exported]
+    seen: set[str] = set()
+    duplicate_names: set[str] = set()
+    for name in names:
+        if name in seen:
+            duplicate_names.add(name)
+        seen.add(name)
+    duplicates = sorted(duplicate_names)
+    assert not duplicates, f"{model_name}: duplicate HF export keys: {duplicates}"
+    weights = {name: tensor.detach().cpu().contiguous() for name, tensor in exported}
+    assert weights, f"{model_name}: export returned zero tensors"
+    for name, tensor in weights.items():
+        assert _is_valid_hf_export_key(name, model_name), (
+            f"{model_name}: invalid HF key schema {name}"
+        )
+        assert tensor.numel() > 0, f"{model_name}: empty exported tensor {name}"
+        assert torch.isfinite(tensor.float()).all(), (
+            f"{model_name}: non-finite exported tensor {name}"
+        )
+        if tensor.dtype.is_floating_point:
+            expected_dtype = _expected_floating_export_dtype(model_name, name)
+            assert tensor.dtype == expected_dtype, (
+                f"{model_name}: {name} exported as {tensor.dtype}, "
+                f"want {expected_dtype}"
+            )
+        else:
+            assert tensor.dtype in (torch.int64, torch.int32, torch.bool), (
+                f"{model_name}: {name} has unexpected integer dtype {tensor.dtype}"
+            )
+
+    present = _hf_decoder_layer_indices(weights)
+    expected = set(range(cfg.num_hidden_layers))
+    assert expected.issubset(present), (
+        f"{model_name}: uneven-PP export dropped decoder layers {sorted(expected - present)}"
+    )
+    _validate_model_specific_hf_keys(model_name, cfg, weights)
+
+    from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
+    from safetensors import safe_open
+
+    export_dir = os.path.join(str(tmp_path), f"{model_name}-hf-export")
+    save_safetensors(weights, export_dir)
+    reloaded = {}
+    with safe_open(
+        os.path.join(export_dir, "model.safetensors"), framework="pt"
+    ) as reader:
+        for name in reader.keys():
+            reloaded[name] = reader.get_tensor(name)
+    assert reloaded.keys() == weights.keys(), (
+        f"{model_name}: safetensors reload key mismatch"
+    )
+    for name in weights:
+        assert torch.equal(reloaded[name], weights[name]), (
+            f"{model_name}: safetensors reload changed tensor {name}"
+        )
+    return len(weights)
+
+
+def _export_validate_and_reload(
+    handle, cfg, protocol, model_name: str, tmp_path
+) -> int:
+    """Collectively export once and make every rank fail together on validation errors."""
+    exported = list(
+        protocol.export_hf_weights(
+            handle._extras["model_chunks"],
+            cfg,
+            handle._parallel_state,
+            rank0_only=True,
+            # Preserve the official Qwen3.5 mixed-dtype checkpoint contract:
+            # GDN A_log and norm stay FP32 while dt_bias and all other text/MTP
+            # tensors stay BF16. Other proxy models intentionally force BF16.
+            export_dtype=None if model_name == "qwen3_5" else torch.bfloat16,
+        )
+    )
+    rank = dist.get_rank()
+    materialized_counts = [None for _ in range(dist.get_world_size())]
+    dist.all_gather_object(materialized_counts, len(exported))
+
+    outcome: list[object] = [None, 0]
+    if rank == 0:
+        try:
+            assert materialized_counts[0] > 0, "rank 0 materialized no HF tensors"
+            assert all(count == 0 for count in materialized_counts[1:]), (
+                "rank0_only HF export materialized tensors off rank 0: "
+                f"counts={materialized_counts}"
+            )
+            outcome[1] = _validate_rank0_export_and_reload(
+                exported, cfg, model_name, tmp_path
+            )
+        except Exception as exc:  # synchronize expected assertion failures
+            outcome[0] = f"{type(exc).__name__}: {exc}"
+    dist.broadcast_object_list(outcome, src=0)
+    if outcome[0] is not None:
+        raise AssertionError(
+            f"{model_name}: synchronized HF export failure: {outcome[0]}"
+        )
+    return int(outcome[1]) if rank == 0 else 0
+
+
 @pytest.mark.parametrize("model_name", list(MODELS))
-def test_uneven_pp_builds_trains_and_exports(model_name):
+def test_uneven_pp_builds_trains_and_exports(model_name, tmp_path):
     """A non-divisible layer count builds an uneven PP split, trains a step, and
     exports every layer. Build + train + export share one model build (one heavy
     distributed build per test keeps the builds in one torchrun process bounded).
@@ -474,42 +1327,196 @@ def test_uneven_pp_builds_trains_and_exports(model_name):
     handle, cfg = _build_handle(model_name, seed=4242)
     ps = handle._parallel_state
     assert ps.pp_size == _PP
+    assert ps.tp_size == (1 if model_name in _TP1_ONLY else 2)
+    assert ps.ep_size == 2
+    assert ps.cp_size == 1
     assert cfg.num_hidden_layers == _NUM_LAYERS
 
     local = _local_layer_indices(handle)
     assert local == sorted(local) and len(set(local)) == len(local), local
     assert local and all(0 <= i < _NUM_LAYERS for i in local), local
     assert local == list(range(local[0], local[0] + len(local))), local
+    splits, _layout = _gather_and_validate_pipeline_layout(handle, cfg)
+
+    local_model = unwrap_model(handle._extras["model_chunks"][0])
+    if model_name == "glm5":
+        assert cfg.rope_interleave is True
+        assert cfg.indexer_rope_interleave is True
+        assert cfg.dsa_rope_layout_revision == "legacy"
+        assert cfg.uses_configured_dsa_rope_layout is False
+        for layer in local_model.layers:
+            dsa = layer.self_attention.self_attention
+            assert dsa.rope_interleaved is False
+            assert dsa.indexer is not None
+            assert dsa.indexer.rope_interleaved is False
+
+    captured_mtp_losses: list[float] = []
+    mtp_hook = None
+    mtp_enabled_model = model_name in {"qwen3_5", "glm5", "deepseek_v4"}
+    local_has_mtp = mtp_enabled_model and (
+        len(local_model.mtp) > 0
+        if model_name == "deepseek_v4"
+        else local_model.mtp is not None
+    )
+    if local_has_mtp:
+
+        def _capture_mtp_loss(_module, _inputs, output):
+            mtp_loss = output.get("mtp_loss") if isinstance(output, dict) else None
+            if mtp_loss is not None:
+                captured_mtp_losses.append(float(mtp_loss.detach().float().item()))
+
+        mtp_hook = local_model.register_forward_hook(_capture_mtp_loss)
 
     runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
     batch = _random_packed_batch(cfg.vocab_size)
     runtime.zero_grad(handle)
-    result = runtime.forward_backward(handle, iter([batch]), None, num_microbatches=1)
-    runtime.optimizer_step(handle)
+    try:
+        result = runtime.forward_backward(
+            handle, iter([batch]), None, num_microbatches=1
+        )
+    finally:
+        if mtp_hook is not None:
+            mtp_hook.remove()
     loss = result.model_output.loss
     assert loss is not None and torch.isfinite(loss).all(), (
         f"{model_name}: non-finite loss {loss} on uneven PP layout"
     )
-
-    # Export across the uneven PP split (every rank materializes the full HF state).
-    protocol = handle._extras["protocol"]
-    chunks = handle._extras["model_chunks"]
-    exported = list(protocol.export_hf_weights(chunks, cfg, ps))
-    present = _hf_decoder_layer_indices([name for name, _ in exported])
-    expected = set(range(cfg.num_hidden_layers))
-    assert expected.issubset(present), (
-        f"{model_name}: uneven-PP export dropped decoder layers "
-        f"{sorted(expected - present)} (have {sorted(present)}); PP gather lost a stage"
+    named_parameters = _named_local_parameters(handle)
+    nonzero_grads = _assert_finite_nonzero_gradient_signal(
+        named_parameters, label=f"{model_name} uneven-PP model"
     )
-    for name, tensor in exported:
-        assert torch.isfinite(tensor.float()).all(), (
-            f"{model_name}: non-finite exported tensor {name} from uneven PP gather"
+    indexer_parameters = (
+        [
+            (name, parameter)
+            for name, parameter in named_parameters
+            if ".indexer." in name
+        ]
+        if model_name == "glm5"
+        else []
+    )
+    nonzero_indexer_grads = (
+        _assert_finite_nonzero_gradients(
+            indexer_parameters, label=f"{model_name} full indexers"
         )
+        if model_name == "glm5"
+        else []
+    )
+    mtp_parameters = (
+        [
+            (name, parameter)
+            for name, parameter in named_parameters
+            if ".mtp." in name or ".mtp_embed." in name
+        ]
+        if mtp_enabled_model
+        else []
+    )
+    if local_has_mtp:
+        assert captured_mtp_losses, f"{model_name} MTP stage produced no mtp_loss"
+        assert all(
+            torch.isfinite(torch.tensor(value)) and value > 0.0
+            for value in captured_mtp_losses
+        )
+        nonzero_mtp_grads = _assert_finite_nonzero_gradients(
+            mtp_parameters, label=f"{model_name} MTP block"
+        )
+    else:
+        assert not mtp_parameters, (
+            f"non-MTP stage unexpectedly owns {model_name} MTP parameters"
+        )
+        assert not captured_mtp_losses
+        nonzero_mtp_grads = []
+    model_before = _snapshot_named_parameters(named_parameters)
+    indexer_before = _snapshot_named_parameters(indexer_parameters)
+    mtp_before = _snapshot_named_parameters(mtp_parameters)
+    master_before = _optimizer_master_snapshot(handle)
+    optimizer_stats = _assert_successful_optimizer_step(
+        runtime,
+        handle,
+        label=f"{model_name} uneven-PP model",
+        master_before=master_before,
+    )
+    changed_model = _assert_snapshot_changed(
+        model_before, named_parameters, label=f"{model_name} uneven-PP model"
+    )
+    changed_indexers = (
+        _assert_snapshot_changed(
+            indexer_before, indexer_parameters, label=f"{model_name} full indexers"
+        )
+        if indexer_parameters
+        else []
+    )
+    changed_mtp = (
+        _assert_snapshot_changed(
+            mtp_before, mtp_parameters, label=f"{model_name} MTP block"
+        )
+        if mtp_parameters
+        else []
+    )
+    changed_mtp_embedding = [name for name in changed_mtp if ".mtp_embed." in name]
+    if local_has_mtp and ps.pp_size > 1:
+        assert any(".mtp_embed." in name for name in nonzero_mtp_grads), (
+            f"{model_name}: PP MTP embedding replica received no nonzero gradient"
+        )
+        assert changed_mtp_embedding, (
+            f"{model_name}: optimizer did not update the PP MTP embedding replica"
+        )
+    # Export across the uneven PP split, persist it, and exact-reload it. This is
+    # deliberately stronger than merely finding one finite key per decoder layer.
+    protocol = handle._extras["protocol"]
+    exported_key_count = _export_validate_and_reload(
+        handle, cfg, protocol, model_name, tmp_path
+    )
+    local_evidence = {
+        "pp_rank": ps.pp_rank,
+        "has_mtp": local_has_mtp,
+        "mtp_losses": captured_mtp_losses,
+        "nonzero_mtp_grads": len(nonzero_mtp_grads),
+        "changed_mtp": len(changed_mtp),
+        "changed_mtp_embedding": len(changed_mtp_embedding),
+    }
+    gathered_evidence = [None for _ in range(dist.get_world_size())]
+    dist.all_gather_object(gathered_evidence, local_evidence)
+    mtp_peers = [item for item in gathered_evidence if item["has_mtp"]]
+    if mtp_enabled_model:
+        expected_mtp_peers = dist.get_world_size() // ps.pp_size
+        assert len(mtp_peers) == expected_mtp_peers
+        assert {item["pp_rank"] for item in mtp_peers} == {ps.pp_size - 1}
+        assert all(item["mtp_losses"] for item in mtp_peers)
+        assert all(item["nonzero_mtp_grads"] > 0 for item in mtp_peers)
+        assert all(item["changed_mtp"] > 0 for item in mtp_peers)
+        assert all(item["changed_mtp_embedding"] > 0 for item in mtp_peers)
+        min_mtp_loss = min(value for item in mtp_peers for value in item["mtp_losses"])
+        min_mtp_grads = min(item["nonzero_mtp_grads"] for item in mtp_peers)
+        min_changed_mtp = min(item["changed_mtp"] for item in mtp_peers)
+        min_changed_mtp_embedding = min(
+            item["changed_mtp_embedding"] for item in mtp_peers
+        )
+    else:
+        assert not mtp_peers
+        min_mtp_loss = 0.0
+        min_mtp_grads = 0
+        min_changed_mtp = 0
+        min_changed_mtp_embedding = 0
     if dist.get_rank() == 0:
         print(
             "NON_SKIP_UNEVEN_PP_BUILD_TRAIN_EXPORT "
             f"model={model_name} num_layers={cfg.num_hidden_layers} "
-            f"split={local} exported_decoder_layers={len(present & expected)}"
+            f"tp={ps.tp_size} ep={ps.ep_size} pp={ps.pp_size} splits={splits} "
+            f"nonzero_grad_params={len(nonzero_grads)} "
+            f"nonzero_indexer_grad_params={len(nonzero_indexer_grads)} "
+            f"changed_model_params={len(changed_model)} "
+            f"changed_indexer_params={len(changed_indexers)} "
+            f"changed_main_params={optimizer_stats['changed_main']} "
+            f"grad_norm={optimizer_stats['grad_norm']:.6e} "
+            f"optimizer_state_tensors={optimizer_stats['optimizer_state_tensors']} "
+            f"mtp_train_peers={len(mtp_peers)} mtp_loss_min={min_mtp_loss:.6e} "
+            f"mtp_nonzero_grad_params_min={min_mtp_grads} "
+            f"mtp_changed_params_min={min_changed_mtp} "
+            f"mtp_changed_embedding_params_min={min_changed_mtp_embedding} "
+            f"mtp_embedding_export_exact={mtp_enabled_model} "
+            f"qwen_mtp_schema_keys={17 + 3 * cfg.num_experts if model_name == 'qwen3_5' else 0} "
+            f"qwen_mixed_dtype_exact={model_name == 'qwen3_5'} "
+            f"exported_keys={exported_key_count} safetensors_reload_exact=True"
         )
 
 
@@ -527,6 +1534,10 @@ def test_glm52_indexshare_78_layer_uneven_pp_builds_trains_and_keeps_share_group
     set_deterministic(2026)
 
     cfg, protocol = _glm52_indexshare()
+    assert cfg.rope_interleave is True
+    assert cfg.indexer_rope_interleave is True
+    assert cfg.dsa_rope_layout_revision == "configured"
+    assert cfg.uses_configured_dsa_rope_layout is True
     parallel = ParallelConfig(tp=1, ep=1, etp=1, pp=8, cp=1)
     handle, cfg = _build_handle_from_config(
         "glm5",
@@ -541,6 +1552,7 @@ def test_glm52_indexshare_78_layer_uneven_pp_builds_trains_and_keeps_share_group
     assert cfg.num_hidden_layers == 78
     assert cfg.num_nextn_predict_layers == 1
     assert cfg.uses_dsa_index_share is True
+    assert cfg.dsa_indexer_loss_coeff == pytest.approx(1.0e-2)
 
     local = _local_layer_indices(handle)
     assert local == sorted(local) and len(set(local)) == len(local), local
@@ -555,35 +1567,203 @@ def test_glm52_indexshare_78_layer_uneven_pp_builds_trains_and_keeps_share_group
         for layer_idx in local
         if cfg.dsa_indexer_type(layer_idx) == "shared"
     ]
-    assert all(source_idx in local for _, source_idx in local_shared_sources), local_shared_sources
+    assert all(source_idx in local for _, source_idx in local_shared_sources), (
+        local_shared_sources
+    )
+    validated_splits, _layout = _gather_and_validate_pipeline_layout(handle, cfg)
+
+    local_model = unwrap_model(handle._extras["model_chunks"][0])
+    for layer_idx, layer in zip(
+        local_model.layer_indices, local_model.layers, strict=True
+    ):
+        dsa = layer.self_attention.self_attention
+        assert dsa.rope_interleaved is True
+        assert (dsa.indexer is not None) is (cfg.dsa_indexer_type(layer_idx) == "full")
+        if dsa.indexer is not None:
+            assert dsa.indexer.rope_interleaved is True
+    captured_mtp_losses: list[float] = []
+    mtp_hook = None
+    if local_model.mtp is not None:
+        for mtp_layer in local_model.mtp.layers:
+            mtp_dsa = mtp_layer.transformer_layer.self_attention.self_attention
+            assert mtp_dsa.rope_interleaved is True
+            assert mtp_dsa.indexer is not None
+            assert mtp_dsa.indexer.rope_interleaved is True
+
+        def _capture_mtp_loss(_module, _inputs, output):
+            mtp_loss = output.get("mtp_loss") if isinstance(output, dict) else None
+            if mtp_loss is not None:
+                captured_mtp_losses.append(float(mtp_loss.detach().float().item()))
+
+        mtp_hook = local_model.register_forward_hook(_capture_mtp_loss)
 
     runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
-    batch = _random_packed_batch(cfg.vocab_size, num_tokens=512)
+    batch = _random_packed_batch(cfg.vocab_size, num_tokens=1024)
+    assert cfg.index_topk < batch.input_ids.numel()
     runtime.zero_grad(handle)
-    result = runtime.forward_backward(handle, iter([batch]), None, num_microbatches=1)
-    runtime.optimizer_step(handle)
+    try:
+        result = runtime.forward_backward(
+            handle, iter([batch]), None, num_microbatches=1
+        )
+    finally:
+        if mtp_hook is not None:
+            mtp_hook.remove()
     loss = result.model_output.loss
     assert loss is not None and torch.isfinite(loss).all(), (
         f"glm52_indexshare: non-finite loss {loss} on 78-layer uneven PP layout"
     )
 
+    named_parameters = _named_local_parameters(handle)
+    _assert_finite_nonzero_gradient_signal(
+        named_parameters, label="glm52 full local model"
+    )
+    trunk_indexer_parameters = [
+        (name, parameter)
+        for name, parameter in named_parameters
+        if ".indexer." in name and ".mtp." not in name
+    ]
+    nonzero_trunk_indexer_grads = _assert_finite_nonzero_gradients(
+        trunk_indexer_parameters, label="glm52 full trunk indexers"
+    )
+    mtp_parameters = [
+        (name, parameter)
+        for name, parameter in named_parameters
+        if ".mtp." in name or ".mtp_embed." in name
+    ]
+    boundary_embedding = None
+    if ps.pp_is_first:
+        assert local_model.embed is not None
+        boundary_embedding = local_model.embed.embedding.weight
+    elif ps.pp_is_last:
+        assert local_model.mtp_embed is not None
+        boundary_embedding = local_model.mtp_embed.embedding.weight
+    boundary_embedding_before = (
+        boundary_embedding.detach().cpu().clone()
+        if boundary_embedding is not None
+        else None
+    )
+    mtp_indexer_parameters = [
+        (name, parameter) for name, parameter in mtp_parameters if ".indexer." in name
+    ]
+    if local_model.mtp is not None:
+        assert captured_mtp_losses, "glm52 MTP rank did not produce mtp_loss"
+        assert all(
+            torch.isfinite(torch.tensor(value)) and value > 0.0
+            for value in captured_mtp_losses
+        )
+        nonzero_mtp_grads = _assert_finite_nonzero_gradients(
+            mtp_parameters, label="glm52 MTP block"
+        )
+        nonzero_mtp_indexer_grads = _assert_finite_nonzero_gradients(
+            mtp_indexer_parameters, label="glm52 MTP full indexer"
+        )
+    else:
+        assert not mtp_parameters, "non-MTP PP stage unexpectedly owns MTP parameters"
+        assert not captured_mtp_losses
+        nonzero_mtp_grads = []
+        nonzero_mtp_indexer_grads = []
+
+    trunk_indexer_before = _snapshot_named_parameters(trunk_indexer_parameters)
+    mtp_before = _snapshot_named_parameters(mtp_parameters)
+    master_before = _optimizer_master_snapshot(handle)
+    optimizer_stats = _assert_successful_optimizer_step(
+        runtime,
+        handle,
+        label="glm52 IndexShare PP8",
+        master_before=master_before,
+    )
+    changed_trunk_indexers = _assert_snapshot_changed(
+        trunk_indexer_before,
+        trunk_indexer_parameters,
+        label="glm52 full trunk indexers",
+    )
+    changed_mtp = (
+        _assert_snapshot_changed(mtp_before, mtp_parameters, label="glm52 MTP block")
+        if mtp_parameters
+        else []
+    )
+    changed_mtp_embedding = [name for name in changed_mtp if ".mtp_embed." in name]
+    if local_model.mtp is not None and ps.pp_size > 1:
+        assert any(".mtp_embed." in name for name in nonzero_mtp_grads)
+        assert changed_mtp_embedding
+
+    boundary_embedding_after = (
+        boundary_embedding.detach().cpu().clone()
+        if boundary_embedding is not None
+        else None
+    )
+    boundary_embedding_changed = False
+    if boundary_embedding_before is not None:
+        assert boundary_embedding_after is not None
+        boundary_embedding_changed = not torch.equal(
+            boundary_embedding_before, boundary_embedding_after
+        )
+        assert boundary_embedding_changed, (
+            f"GLM5.2 PP boundary embedding did not update on pp_rank={ps.pp_rank}"
+        )
+
     stage_info = {
         "pp_rank": ps.pp_rank,
         "layers": local,
         "shared_sources": local_shared_sources,
-        "has_mtp": bool(unwrap_model(handle._extras["model_chunks"][0]).mtp is not None),
+        "has_mtp": bool(
+            unwrap_model(handle._extras["model_chunks"][0]).mtp is not None
+        ),
+        "mtp_losses": captured_mtp_losses,
+        "nonzero_trunk_indexer_grads": len(nonzero_trunk_indexer_grads),
+        "nonzero_mtp_grads": len(nonzero_mtp_grads),
+        "nonzero_mtp_indexer_grads": len(nonzero_mtp_indexer_grads),
+        "changed_trunk_indexers": len(changed_trunk_indexers),
+        "changed_mtp": len(changed_mtp),
+        "changed_mtp_embedding": len(changed_mtp_embedding),
+        "boundary_embedding": boundary_embedding_after,
+        "boundary_embedding_changed": boundary_embedding_changed,
+        "grad_norm": optimizer_stats["grad_norm"],
     }
     gathered = [None for _ in range(dist.get_world_size())]
     dist.all_gather_object(gathered, stage_info)
+    ordered = sorted(gathered, key=lambda item: item["pp_rank"])
+    splits = [item["layers"] for item in ordered]
+    shared_pairs = sum(len(item["shared_sources"]) for item in ordered)
+    mtp_ranks = [item["pp_rank"] for item in ordered if item["has_mtp"]]
+    mtp_losses = [value for item in ordered for value in item["mtp_losses"]]
+    assert [item["pp_rank"] for item in ordered] == list(range(8))
+    assert splits == validated_splits
+    assert shared_pairs == 57
+    assert mtp_ranks == [7]
+    assert len(mtp_losses) == 1 and mtp_losses[0] > 0.0
+    assert all(item["nonzero_trunk_indexer_grads"] > 0 for item in ordered)
+    assert ordered[7]["nonzero_mtp_grads"] > 0
+    assert ordered[7]["nonzero_mtp_indexer_grads"] > 0
+    assert ordered[7]["changed_mtp"] > 0
+    assert ordered[7]["changed_mtp_embedding"] > 0
+    assert ordered[0]["boundary_embedding_changed"] is True
+    assert ordered[7]["boundary_embedding_changed"] is True
+    assert torch.equal(
+        ordered[0]["boundary_embedding"], ordered[7]["boundary_embedding"]
+    ), "canonical and MTP-stage embedding diverged after the optimizer step"
+    assert all(item["boundary_embedding"] is None for item in ordered[1:7]), (
+        "a middle PP stage unexpectedly reported a shared embedding replica"
+    )
+    assert all(item["changed_trunk_indexers"] > 0 for item in ordered)
     if dist.get_rank() == 0:
-        ordered = sorted(gathered, key=lambda item: item["pp_rank"])
-        splits = [item["layers"] for item in ordered]
-        shared_pairs = sum(len(item["shared_sources"]) for item in ordered)
-        mtp_ranks = [item["pp_rank"] for item in ordered if item["has_mtp"]]
         print(
             "NON_SKIP_GLM52_INDEXSHARE_UNEVEN_PP_PASSED "
             f"pp=8 num_layers=78 mtp_layers=1 splits={splits} "
             f"shared_pairs={shared_pairs} mtp_ranks={mtp_ranks} "
+            f"topk={cfg.index_topk} seq={batch.input_ids.numel()} "
+            f"indexer_loss_coeff={cfg.dsa_indexer_loss_coeff:.1e} "
+            f"mtp_loss={mtp_losses[0]:.6e} "
+            f"min_nonzero_trunk_indexer_grads="
+            f"{min(item['nonzero_trunk_indexer_grads'] for item in ordered)} "
+            f"mtp_nonzero_grads={ordered[7]['nonzero_mtp_grads']} "
+            f"mtp_nonzero_indexer_grads={ordered[7]['nonzero_mtp_indexer_grads']} "
+            f"min_changed_trunk_indexers="
+            f"{min(item['changed_trunk_indexers'] for item in ordered)} "
+            f"mtp_changed_params={ordered[7]['changed_mtp']} "
+            f"mtp_changed_embedding_params={ordered[7]['changed_mtp_embedding']} "
+            "mtp_embedding_pair_updated=True mtp_embedding_pair_exact=True "
+            f"min_grad_norm={min(item['grad_norm'] for item in ordered):.6e} "
             f"loss={float(loss.detach().item()):.6e}"
         )
 

--- a/experimental/lite/tests/smoke/primitive/test_auto_pipeline_layout_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_auto_pipeline_layout_smoke.py
@@ -550,9 +550,9 @@ def _assert_snapshot_changed(
     before: dict[str, torch.Tensor], named_parameters, *, label: str
 ) -> list[str]:
     after = {name: parameter.detach().cpu() for name, parameter in named_parameters}
-    assert before.keys() == after.keys(), (
-        f"{label}: parameter set changed during optimizer step"
-    )
+    assert (
+        before.keys() == after.keys()
+    ), f"{label}: parameter set changed during optimizer step"
     changed = [name for name in before if not torch.equal(before[name], after[name])]
     assert changed, f"{label}: optimizer step did not change any selected parameter"
     return changed
@@ -567,9 +567,9 @@ def _optimizer_master_snapshot(handle) -> list[torch.Tensor]:
 
 def _assert_optimizer_master_changed(handle, before: list[torch.Tensor]) -> int:
     after = list(handle._optimizer.get_parameters())
-    assert len(before) == len(after), (
-        "optimizer main-parameter count changed during step"
-    )
+    assert len(before) == len(
+        after
+    ), "optimizer main-parameter count changed during step"
     changed = sum(
         not torch.equal(old, new.detach().cpu())
         for old, new in zip(before, after, strict=True)
@@ -597,9 +597,9 @@ def _assert_optimizer_state_initialized(handle) -> int:
             for key, value in state.items():
                 if not isinstance(value, torch.Tensor):
                     continue
-                assert torch.isfinite(value.float()).all(), (
-                    f"optimizer state {key} contains non-finite values"
-                )
+                assert torch.isfinite(
+                    value.float()
+                ).all(), f"optimizer state {key} contains non-finite values"
                 state_tensors.append(value)
                 if key in {"exp_avg", "exp_avg_sq"}:
                     moving_average_tensors.append(value)
@@ -616,9 +616,9 @@ def _assert_successful_optimizer_step(
 ) -> dict:
     update_successful, grad_norm, num_zeros = runtime.optimizer_step(handle)
     assert update_successful is True, f"{label}: optimizer rejected/skipped the update"
-    assert torch.isfinite(torch.tensor(grad_norm)), (
-        f"{label}: non-finite grad_norm={grad_norm}"
-    )
+    assert torch.isfinite(
+        torch.tensor(grad_norm)
+    ), f"{label}: non-finite grad_norm={grad_norm}"
     assert grad_norm > 0.0, f"{label}: zero grad norm permits a no-op optimizer pass"
     changed_main = _assert_optimizer_master_changed(handle, master_before)
     optimizer_state_tensors = _assert_optimizer_state_initialized(handle)
@@ -649,20 +649,20 @@ def _gather_and_validate_pipeline_layout(
     by_stage: dict[int, list[dict]] = {}
     for item in gathered:
         by_stage.setdefault(item["pp_rank"], []).append(item)
-    assert sorted(by_stage) == list(range(ps.pp_size)), (
-        f"PP ranks are incomplete or out of range: {sorted(by_stage)}"
-    )
+    assert sorted(by_stage) == list(
+        range(ps.pp_size)
+    ), f"PP ranks are incomplete or out of range: {sorted(by_stage)}"
     expected_peers = dist.get_world_size() // ps.pp_size
     splits = []
     for pp_rank in range(ps.pp_size):
         peers = by_stage[pp_rank]
-        assert len(peers) == expected_peers, (
-            f"PP stage {pp_rank} has {len(peers)} peers, want {expected_peers}"
-        )
+        assert (
+            len(peers) == expected_peers
+        ), f"PP stage {pp_rank} has {len(peers)} peers, want {expected_peers}"
         ownership = {tuple(item["layers"]) for item in peers}
-        assert len(ownership) == 1, (
-            f"TP/EP/DP peers disagree on PP stage {pp_rank} layer ownership: {ownership}"
-        )
+        assert (
+            len(ownership) == 1
+        ), f"TP/EP/DP peers disagree on PP stage {pp_rank} layer ownership: {ownership}"
         splits.append(list(next(iter(ownership))))
 
     flat = [layer for split in splits for layer in split]
@@ -716,13 +716,13 @@ def _assert_exact_export_manifest(
     )
     for key, expected_shape in expected_shapes.items():
         actual_shape = tuple(weights[key].shape)
-        assert actual_shape == expected_shape, (
-            f"{model_name}: {key} shape={actual_shape}, want {expected_shape}"
-        )
+        assert (
+            actual_shape == expected_shape
+        ), f"{model_name}: {key} shape={actual_shape}, want {expected_shape}"
         if key.endswith(".tid2eid"):
-            assert weights[key].dtype == torch.int64, (
-                f"{model_name}: {key} dtype={weights[key].dtype}, want torch.int64"
-            )
+            assert (
+                weights[key].dtype == torch.int64
+            ), f"{model_name}: {key} dtype={weights[key].dtype}, want torch.int64"
 
 
 def _glm5_expected_export_shapes(cfg) -> dict[str, tuple[int, ...]]:
@@ -807,10 +807,7 @@ def _glm5_expected_export_shapes(cfg) -> dict[str, tuple[int, ...]]:
                             cfg.moe_intermediate_size,
                             hidden,
                         ),
-                        f"{expert}up_proj.weight": (
-                            cfg.moe_intermediate_size,
-                            hidden,
-                        ),
+                        f"{expert}up_proj.weight": (cfg.moe_intermediate_size, hidden),
                         f"{expert}down_proj.weight": (
                             hidden,
                             cfg.moe_intermediate_size,
@@ -877,10 +874,7 @@ def _deepseek_v4_expected_export_shapes(cfg) -> dict[str, tuple[int, ...]]:
                     cfg.o_groups * cfg.o_lora_rank,
                     num_heads_per_group * cfg.head_dim,
                 ),
-                f"{prefix}attn.wo_b.weight": (
-                    hidden,
-                    cfg.o_groups * cfg.o_lora_rank,
-                ),
+                f"{prefix}attn.wo_b.weight": (hidden, cfg.o_groups * cfg.o_lora_rank),
                 f"{prefix}attn.attn_sink": (cfg.num_attention_heads,),
                 f"{prefix}hc_attn_fn": (hc_mix, cfg.hc_mult * hidden),
                 f"{prefix}hc_attn_base": (hc_mix,),
@@ -949,10 +943,7 @@ def _deepseek_v4_expected_export_shapes(cfg) -> dict[str, tuple[int, ...]]:
                         indexer_compressor_width,
                         hidden,
                     ),
-                    f"{indexer}compressor.ape": (
-                        ratio,
-                        indexer_compressor_width,
-                    ),
+                    f"{indexer}compressor.ape": (ratio, indexer_compressor_width),
                     f"{indexer}compressor.norm.weight": (cfg.index_head_dim,),
                 }
             )
@@ -1048,14 +1039,8 @@ def _qwen35_expected_export_shapes(cfg) -> dict[str, tuple[int, ...]]:
                 {
                     f"{attn}in_proj_qkv.weight": (2 * qk_dim + value_dim, hidden),
                     f"{attn}in_proj_z.weight": (value_dim, hidden),
-                    f"{attn}in_proj_b.weight": (
-                        cfg.linear_num_value_heads,
-                        hidden,
-                    ),
-                    f"{attn}in_proj_a.weight": (
-                        cfg.linear_num_value_heads,
-                        hidden,
-                    ),
+                    f"{attn}in_proj_b.weight": (cfg.linear_num_value_heads, hidden),
+                    f"{attn}in_proj_a.weight": (cfg.linear_num_value_heads, hidden),
                     f"{attn}conv1d.weight": (
                         2 * qk_dim + value_dim,
                         1,
@@ -1133,10 +1118,7 @@ def _qwen35_expected_export_shapes(cfg) -> dict[str, tuple[int, ...]]:
                             cfg.moe_intermediate_size,
                             hidden,
                         ),
-                        f"{expert}up_proj.weight": (
-                            cfg.moe_intermediate_size,
-                            hidden,
-                        ),
+                        f"{expert}up_proj.weight": (cfg.moe_intermediate_size, hidden),
                         f"{expert}down_proj.weight": (
                             hidden,
                             cfg.moe_intermediate_size,
@@ -1146,10 +1128,7 @@ def _qwen35_expected_export_shapes(cfg) -> dict[str, tuple[int, ...]]:
     return expected
 
 
-_QWEN35_FP32_CHECKPOINT_SUFFIXES = (
-    ".linear_attn.A_log",
-    ".linear_attn.norm.weight",
-)
+_QWEN35_FP32_CHECKPOINT_SUFFIXES = (".linear_attn.A_log", ".linear_attn.norm.weight")
 
 
 def _expected_floating_export_dtype(model_name: str, key: str) -> torch.dtype:
@@ -1164,9 +1143,9 @@ def _validate_model_specific_hf_keys(
     keys = set(weights)
     embed_key, norm_key, head_key = _required_hf_roots(model_name)
     for required in (embed_key, norm_key, head_key):
-        assert required in keys, (
-            f"{model_name}: HF export is missing required tensor {required}"
-        )
+        assert (
+            required in keys
+        ), f"{model_name}: HF export is missing required tensor {required}"
     assert tuple(weights[embed_key].shape) == (cfg.vocab_size, cfg.hidden_size)
     assert tuple(weights[norm_key].shape) == (cfg.hidden_size,)
     assert tuple(weights[head_key].shape) == (cfg.vocab_size, cfg.hidden_size)
@@ -1188,9 +1167,9 @@ def _validate_model_specific_hf_keys(
             model_name, weights, _qwen35_expected_export_shapes(cfg)
         )
         mtp_keys = {key for key in keys if key.startswith("mtp.")}
-        assert len(mtp_keys) == 17 + 3 * cfg.num_experts, (
-            f"qwen3_5: incomplete released MTP schema; got {len(mtp_keys)} keys"
-        )
+        assert (
+            len(mtp_keys) == 17 + 3 * cfg.num_experts
+        ), f"qwen3_5: incomplete released MTP schema; got {len(mtp_keys)} keys"
         return
 
     if model_name == "kimi_k2":
@@ -1198,9 +1177,9 @@ def _validate_model_specific_hf_keys(
             if not cfg.is_moe_layer(layer_idx):
                 continue
             bias_key = f"model.layers.{layer_idx}.mlp.gate.e_score_correction_bias"
-            assert bias_key in keys, (
-                f"kimi_k2: PP export is missing router correction buffer {bias_key}"
-            )
+            assert (
+                bias_key in keys
+            ), f"kimi_k2: PP export is missing router correction buffer {bias_key}"
 
 
 def _validate_rank0_export_and_reload(exported, cfg, model_name: str, tmp_path) -> int:
@@ -1217,13 +1196,13 @@ def _validate_rank0_export_and_reload(exported, cfg, model_name: str, tmp_path) 
     weights = {name: tensor.detach().cpu().contiguous() for name, tensor in exported}
     assert weights, f"{model_name}: export returned zero tensors"
     for name, tensor in weights.items():
-        assert _is_valid_hf_export_key(name, model_name), (
-            f"{model_name}: invalid HF key schema {name}"
-        )
+        assert _is_valid_hf_export_key(
+            name, model_name
+        ), f"{model_name}: invalid HF key schema {name}"
         assert tensor.numel() > 0, f"{model_name}: empty exported tensor {name}"
-        assert torch.isfinite(tensor.float()).all(), (
-            f"{model_name}: non-finite exported tensor {name}"
-        )
+        assert torch.isfinite(
+            tensor.float()
+        ).all(), f"{model_name}: non-finite exported tensor {name}"
         if tensor.dtype.is_floating_point:
             expected_dtype = _expected_floating_export_dtype(model_name, name)
             assert tensor.dtype == expected_dtype, (
@@ -1231,15 +1210,17 @@ def _validate_rank0_export_and_reload(exported, cfg, model_name: str, tmp_path) 
                 f"want {expected_dtype}"
             )
         else:
-            assert tensor.dtype in (torch.int64, torch.int32, torch.bool), (
-                f"{model_name}: {name} has unexpected integer dtype {tensor.dtype}"
-            )
+            assert tensor.dtype in (
+                torch.int64,
+                torch.int32,
+                torch.bool,
+            ), f"{model_name}: {name} has unexpected integer dtype {tensor.dtype}"
 
     present = _hf_decoder_layer_indices(weights)
     expected = set(range(cfg.num_hidden_layers))
-    assert expected.issubset(present), (
-        f"{model_name}: uneven-PP export dropped decoder layers {sorted(expected - present)}"
-    )
+    assert expected.issubset(
+        present
+    ), f"{model_name}: uneven-PP export dropped decoder layers {sorted(expected - present)}"
     _validate_model_specific_hf_keys(model_name, cfg, weights)
 
     from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
@@ -1253,13 +1234,13 @@ def _validate_rank0_export_and_reload(exported, cfg, model_name: str, tmp_path) 
     ) as reader:
         for name in reader.keys():
             reloaded[name] = reader.get_tensor(name)
-    assert reloaded.keys() == weights.keys(), (
-        f"{model_name}: safetensors reload key mismatch"
-    )
+    assert (
+        reloaded.keys() == weights.keys()
+    ), f"{model_name}: safetensors reload key mismatch"
     for name in weights:
-        assert torch.equal(reloaded[name], weights[name]), (
-            f"{model_name}: safetensors reload changed tensor {name}"
-        )
+        assert torch.equal(
+            reloaded[name], weights[name]
+        ), f"{model_name}: safetensors reload changed tensor {name}"
     return len(weights)
 
 
@@ -1378,9 +1359,9 @@ def test_uneven_pp_builds_trains_and_exports(model_name, tmp_path):
         if mtp_hook is not None:
             mtp_hook.remove()
     loss = result.model_output.loss
-    assert loss is not None and torch.isfinite(loss).all(), (
-        f"{model_name}: non-finite loss {loss} on uneven PP layout"
-    )
+    assert (
+        loss is not None and torch.isfinite(loss).all()
+    ), f"{model_name}: non-finite loss {loss} on uneven PP layout"
     named_parameters = _named_local_parameters(handle)
     nonzero_grads = _assert_finite_nonzero_gradient_signal(
         named_parameters, label=f"{model_name} uneven-PP model"
@@ -1420,9 +1401,9 @@ def test_uneven_pp_builds_trains_and_exports(model_name, tmp_path):
             mtp_parameters, label=f"{model_name} MTP block"
         )
     else:
-        assert not mtp_parameters, (
-            f"non-MTP stage unexpectedly owns {model_name} MTP parameters"
-        )
+        assert (
+            not mtp_parameters
+        ), f"non-MTP stage unexpectedly owns {model_name} MTP parameters"
         assert not captured_mtp_losses
         nonzero_mtp_grads = []
     model_before = _snapshot_named_parameters(named_parameters)
@@ -1454,12 +1435,12 @@ def test_uneven_pp_builds_trains_and_exports(model_name, tmp_path):
     )
     changed_mtp_embedding = [name for name in changed_mtp if ".mtp_embed." in name]
     if local_has_mtp and ps.pp_size > 1:
-        assert any(".mtp_embed." in name for name in nonzero_mtp_grads), (
-            f"{model_name}: PP MTP embedding replica received no nonzero gradient"
-        )
-        assert changed_mtp_embedding, (
-            f"{model_name}: optimizer did not update the PP MTP embedding replica"
-        )
+        assert any(
+            ".mtp_embed." in name for name in nonzero_mtp_grads
+        ), f"{model_name}: PP MTP embedding replica received no nonzero gradient"
+        assert (
+            changed_mtp_embedding
+        ), f"{model_name}: optimizer did not update the PP MTP embedding replica"
     # Export across the uneven PP split, persist it, and exact-reload it. This is
     # deliberately stronger than merely finding one finite key per decoder layer.
     protocol = handle._extras["protocol"]
@@ -1567,9 +1548,9 @@ def test_glm52_indexshare_78_layer_uneven_pp_builds_trains_and_keeps_share_group
         for layer_idx in local
         if cfg.dsa_indexer_type(layer_idx) == "shared"
     ]
-    assert all(source_idx in local for _, source_idx in local_shared_sources), (
-        local_shared_sources
-    )
+    assert all(
+        source_idx in local for _, source_idx in local_shared_sources
+    ), local_shared_sources
     validated_splits, _layout = _gather_and_validate_pipeline_layout(handle, cfg)
 
     local_model = unwrap_model(handle._extras["model_chunks"][0])
@@ -1609,9 +1590,9 @@ def test_glm52_indexshare_78_layer_uneven_pp_builds_trains_and_keeps_share_group
         if mtp_hook is not None:
             mtp_hook.remove()
     loss = result.model_output.loss
-    assert loss is not None and torch.isfinite(loss).all(), (
-        f"glm52_indexshare: non-finite loss {loss} on 78-layer uneven PP layout"
-    )
+    assert (
+        loss is not None and torch.isfinite(loss).all()
+    ), f"glm52_indexshare: non-finite loss {loss} on 78-layer uneven PP layout"
 
     named_parameters = _named_local_parameters(handle)
     _assert_finite_nonzero_gradient_signal(
@@ -1667,10 +1648,7 @@ def test_glm52_indexshare_78_layer_uneven_pp_builds_trains_and_keeps_share_group
     mtp_before = _snapshot_named_parameters(mtp_parameters)
     master_before = _optimizer_master_snapshot(handle)
     optimizer_stats = _assert_successful_optimizer_step(
-        runtime,
-        handle,
-        label="glm52 IndexShare PP8",
-        master_before=master_before,
+        runtime, handle, label="glm52 IndexShare PP8", master_before=master_before
     )
     changed_trunk_indexers = _assert_snapshot_changed(
         trunk_indexer_before,
@@ -1698,9 +1676,9 @@ def test_glm52_indexshare_78_layer_uneven_pp_builds_trains_and_keeps_share_group
         boundary_embedding_changed = not torch.equal(
             boundary_embedding_before, boundary_embedding_after
         )
-        assert boundary_embedding_changed, (
-            f"GLM5.2 PP boundary embedding did not update on pp_rank={ps.pp_rank}"
-        )
+        assert (
+            boundary_embedding_changed
+        ), f"GLM5.2 PP boundary embedding did not update on pp_rank={ps.pp_rank}"
 
     stage_info = {
         "pp_rank": ps.pp_rank,
@@ -1742,9 +1720,9 @@ def test_glm52_indexshare_78_layer_uneven_pp_builds_trains_and_keeps_share_group
     assert torch.equal(
         ordered[0]["boundary_embedding"], ordered[7]["boundary_embedding"]
     ), "canonical and MTP-stage embedding diverged after the optimizer step"
-    assert all(item["boundary_embedding"] is None for item in ordered[1:7]), (
-        "a middle PP stage unexpectedly reported a shared embedding replica"
-    )
+    assert all(
+        item["boundary_embedding"] is None for item in ordered[1:7]
+    ), "a middle PP stage unexpectedly reported a shared embedding replica"
     assert all(item["changed_trunk_indexers"] > 0 for item in ordered)
     if dist.get_rank() == 0:
         print(

--- a/experimental/lite/tests/smoke/primitive/test_parallel_topologies_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_parallel_topologies_smoke.py
@@ -11,12 +11,18 @@ import torch.distributed as dist
 from megatron.lite.primitive.parallel import (
     PackedSeqParams,
     contiguous_to_zigzag_chunks,
+    init_mtp_embedding_group,
     init_parallel,
     zigzag_split_for_cp,
     zigzag_to_contiguous_chunks,
 )
 
-pytestmark = [pytest.mark.mlite, pytest.mark.smoke, pytest.mark.gpu, pytest.mark.distributed]
+pytestmark = [
+    pytest.mark.mlite,
+    pytest.mark.smoke,
+    pytest.mark.gpu,
+    pytest.mark.distributed,
+]
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -73,6 +79,8 @@ def test_parallel_state_builds_expected_primitive_groups():
             continue
 
         ps = init_parallel(cfg)
+        if cfg.pp > 1:
+            init_mtp_embedding_group(ps)
         dense_dp = world_size // (cfg.tp * cfg.cp * cfg.pp)
         expert_dp = world_size // (cfg.etp * cfg.ep * cfg.pp)
 
@@ -100,6 +108,15 @@ def test_parallel_state_builds_expected_primitive_groups():
         if cfg.pp > 1:
             assert ps.pp_next_rank in ps.pp_global_ranks
             assert ps.pp_prev_rank in ps.pp_global_ranks
+            if ps.pp_rank in {0, cfg.pp - 1}:
+                _assert_group_size(ps.embedding_group, 2)
+                assert ps.embedding_global_ranks == [
+                    ps.pp_global_ranks[0],
+                    ps.pp_global_ranks[-1],
+                ]
+            else:
+                assert ps.embedding_group is None
+                assert ps.embedding_global_ranks is None
 
 
 def test_cp_zigzag_contiguous_chunk_swap_roundtrip():
@@ -107,7 +124,10 @@ def test_cp_zigzag_contiguous_chunk_swap_roundtrip():
         pytest.skip("CP chunk swap smoke requires at least 2 ranks.")
 
     ps = init_parallel(SimpleNamespace(tp=1, ep=1, etp=1, cp=2, pp=1))
-    full = torch.arange(8, device="cuda", dtype=torch.float32).reshape(1, 8, 1) + 100 * ps.dp_rank
+    full = (
+        torch.arange(8, device="cuda", dtype=torch.float32).reshape(1, 8, 1)
+        + 100 * ps.dp_rank
+    )
     local_zigzag = zigzag_split_for_cp(full, ps.cp_rank, cp_size=2, seq_dim=1)
 
     local_contiguous = zigzag_to_contiguous_chunks(local_zigzag, ps.cp_group, seq_dim=1)

--- a/experimental/lite/tests/smoke/primitive/test_parallel_topologies_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_parallel_topologies_smoke.py
@@ -7,7 +7,6 @@ from types import SimpleNamespace
 import pytest
 import torch
 import torch.distributed as dist
-
 from megatron.lite.primitive.parallel import (
     PackedSeqParams,
     contiguous_to_zigzag_chunks,

--- a/experimental/lite/tests/smoke/primitive/test_qwen35_hf_numeric_roundtrip_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_qwen35_hf_numeric_roundtrip_smoke.py
@@ -13,6 +13,27 @@ wrong vs real HF would pass silently. This smoke closes that blind spot:
     in A, zeroed on reload) and are excluded; the real model has vocab%128==0 so
     no padding exists.
 
+  test_qwen35_transformers_512_checkpoint_ground_truth
+    instantiate the official Transformers 5.12 Qwen3.5 MoE implementation with
+    one full-attention and one linear-attention layer, save its native packed
+    safetensors, load through lite, export, and compare every text tensor.  This
+    is independent ground truth: neither the source checkpoint nor the expected
+    tensors pass through lite's exporter.
+
+  test_qwen35_transformers_512_full_model_numeric_parity
+    reload that official checkpoint into both Transformers and lite, execute the
+    same two-sequence batch through the full text model, and compare per-layer
+    hidden states, final logits, shifted causal-LM CE, and embedding-output
+    gradients under fixed acceptance thresholds.  This closes the semantic gap
+    left by a tensor-only checkpoint round-trip.
+
+  test_qwen35_transformers_512_mtp_decoder_equation_parity
+    Transformers 5.12 intentionally ignores root ``mtp.*`` weights, so construct
+    the released MTP equation explicitly around its independent public
+    Qwen3.5 full-attention decoder layer.  The reference reads official-format
+    tensors directly (never through lite export), then compares predictor hidden
+    states, shared-head logits, shifted CE, and canonical embedding gradients.
+
   test_qwen35_real_hf_load_export_matches_original  [opt-in: QWEN35_HF_DIR]
     GROUND TRUTH against real Qwen3.5 safetensors: load real HF -> export ->
     compare to the ORIGINAL safetensors tensor-by-tensor. Catches HF-file-level
@@ -24,21 +45,31 @@ wrong vs real HF would pass silently. This smoke closes that blind spot:
 Run single GPU:
   torchrun --nproc_per_node=1 -m pytest tests/smoke/primitive/test_qwen35_hf_numeric_roundtrip_smoke.py
 """
+
 from __future__ import annotations
 
 import os
+import re
+import json
 
 import pytest
 import torch
 import torch.distributed as dist
+import torch.nn.functional as F
 
 pytestmark = [pytest.mark.mlite, pytest.mark.smoke, pytest.mark.gpu]
+
+_FP32_CHECKPOINT_SUFFIXES = (
+    ".linear_attn.A_log",
+    ".linear_attn.norm.weight",
+)
 
 
 def _qwen35_tiny_cfg():
     pytest.importorskip("fla", reason="qwen3_5 needs the FLA / GatedDeltaNet stack.")
     pytest.importorskip(
-        "transformer_engine.pytorch", reason="qwen3_5 smoke needs real Transformer Engine."
+        "transformer_engine.pytorch",
+        reason="qwen3_5 smoke needs real Transformer Engine.",
     )
     from megatron.lite.model.qwen3_5.config import Qwen35Config
 
@@ -64,7 +95,7 @@ def _qwen35_tiny_cfg():
     )
 
 
-def _build(cfg, seed):
+def _build(cfg, seed, *, optimizer="dist_opt", mtp_enable=False):
     from megatron.lite.model.qwen3_5.lite import protocol
     from megatron.lite.runtime.contracts.config import ParallelConfig
 
@@ -72,7 +103,11 @@ def _build(cfg, seed):
     torch.cuda.manual_seed_all(seed)
     parallel = ParallelConfig(tp=1, pp=1, cp=1, ep=1, etp=1, vpp=1)
     impl = protocol.ImplConfig(
-        parallel=parallel, optimizer="dist_opt", use_deepep=False, deterministic=True
+        parallel=parallel,
+        optimizer=optimizer,
+        use_deepep=False,
+        deterministic=True,
+        mtp_enable=mtp_enable,
     )
     bundle = protocol.build_model(cfg, impl_cfg=impl)
     return bundle, protocol
@@ -84,6 +119,469 @@ def _named(chunks):
         for name, param in chunk.named_parameters():
             out[f"{i}.{name}"] = param.detach().float().cpu().clone()
     return out
+
+
+def _read_safetensors_dir(path):
+    from safetensors import safe_open
+
+    tensors = {}
+    for filename in sorted(os.listdir(path)):
+        if not filename.endswith(".safetensors"):
+            continue
+        with safe_open(
+            os.path.join(path, filename), framework="pt", device="cpu"
+        ) as handle:
+            for key in handle.keys():
+                assert key not in tensors, f"duplicate safetensors key: {key}"
+                tensors[key] = handle.get_tensor(key)
+    assert tensors, f"no safetensors found under {path}"
+    return tensors
+
+
+def _save_transformers_512_tiny_qwen35(path):
+    """Create an official tiny Qwen3.5 MoE checkpoint with production key layout."""
+    import transformers
+    from transformers import (
+        Qwen3_5MoeConfig,
+        Qwen3_5MoeForConditionalGeneration,
+        Qwen3_5MoeTextConfig,
+        Qwen3_5MoeVisionConfig,
+    )
+
+    assert transformers.__version__ == "5.12.0", (
+        "the Qwen3.5 HF ground-truth contract is pinned to Transformers 5.12.0; "
+        f"got {transformers.__version__}"
+    )
+    text_config = Qwen3_5MoeTextConfig(
+        vocab_size=64,
+        hidden_size=16,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=4,
+        max_position_embeddings=4096,
+        linear_num_key_heads=2,
+        linear_key_head_dim=4,
+        linear_num_value_heads=2,
+        linear_value_head_dim=4,
+        linear_conv_kernel_dim=4,
+        moe_intermediate_size=8,
+        shared_expert_intermediate_size=8,
+        num_experts=4,
+        num_experts_per_tok=2,
+        layer_types=["full_attention", "linear_attention"],
+        partial_rotary_factor=1.0,
+        rope_parameters={"rope_type": "default", "rope_theta": 10_000_000.0},
+        tie_word_embeddings=False,
+    )
+    # The public checkpoint is multimodal, hence its text tensors use the real
+    # `model.language_model.*` namespace consumed by lite.  Keep the unused
+    # vision tower tiny; the comparison below deliberately scopes to text.
+    vision_config = Qwen3_5MoeVisionConfig(
+        depth=1,
+        hidden_size=16,
+        intermediate_size=32,
+        num_heads=4,
+        in_channels=3,
+        patch_size=2,
+        spatial_merge_size=2,
+        temporal_patch_size=2,
+        out_hidden_size=16,
+        num_position_embeddings=16,
+    )
+    config = Qwen3_5MoeConfig(
+        text_config=text_config,
+        vision_config=vision_config,
+        tie_word_embeddings=False,
+    )
+    torch.manual_seed(20260627)
+    model = Qwen3_5MoeForConditionalGeneration(config).to(torch.bfloat16)
+    model.save_pretrained(
+        path,
+        safe_serialization=True,
+        max_shard_size="1GB",
+        # Transformers defaults to a reverse-converted legacy per-expert
+        # representation.  False preserves both its native 5.12 packed layout
+        # and the packed layout of Qwen/Qwen3.5-35B-A3B on the Hub.
+        save_original_format=False,
+    )
+
+    # The strict Transformers 5.12 text-config constructor does not accept the
+    # released checkpoint's auxiliary field, although from_pretrained tolerates
+    # it in serialized Hub configs. Add it through the real config.json shape.
+    config_path = os.path.join(path, "config.json")
+    with open(config_path) as handle:
+        serialized_config = json.load(handle)
+    serialized_config["text_config"]["mtp_num_hidden_layers"] = 1
+    with open(config_path, "w") as handle:
+        json.dump(serialized_config, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+    # Transformers 5.12 intentionally ignores the released checkpoint's
+    # auxiliary `mtp.*` tensors at model load time. Add a deterministic tiny
+    # predictor in the exact Qwen/Qwen3.5-35B-A3B on-disk schema so lite's HF
+    # loader/exporter is still tested against that production contract.
+    from safetensors.torch import save_file
+
+    assert not os.path.exists(os.path.join(path, "model.safetensors.index.json"))
+    tensors = _read_safetensors_dir(path)
+    for key, tensor in list(tensors.items()):
+        if key.endswith(_FP32_CHECKPOINT_SUFFIXES):
+            tensors[key] = tensor.float()
+    layer_prefix = "model.language_model.layers.0"
+    mtp_layer_prefix = "mtp.layers.0"
+    for suffix in (
+        "input_layernorm.weight",
+        "self_attn.q_proj.weight",
+        "self_attn.k_proj.weight",
+        "self_attn.v_proj.weight",
+        "self_attn.q_norm.weight",
+        "self_attn.k_norm.weight",
+        "self_attn.o_proj.weight",
+        "post_attention_layernorm.weight",
+        "mlp.gate.weight",
+        "mlp.shared_expert.gate_proj.weight",
+        "mlp.shared_expert.up_proj.weight",
+        "mlp.shared_expert.down_proj.weight",
+        "mlp.shared_expert_gate.weight",
+    ):
+        tensors[f"{mtp_layer_prefix}.{suffix}"] = tensors[
+            f"{layer_prefix}.{suffix}"
+        ].clone()
+
+    packed_gate_up = tensors[f"{layer_prefix}.mlp.experts.gate_up_proj"]
+    packed_down = tensors[f"{layer_prefix}.mlp.experts.down_proj"]
+    for expert_idx in range(text_config.num_experts):
+        gate, up = packed_gate_up[expert_idx].chunk(2, dim=0)
+        expert_prefix = f"{mtp_layer_prefix}.mlp.experts.{expert_idx}"
+        tensors[f"{expert_prefix}.gate_proj.weight"] = gate.contiguous().clone()
+        tensors[f"{expert_prefix}.up_proj.weight"] = up.contiguous().clone()
+        tensors[f"{expert_prefix}.down_proj.weight"] = (
+            packed_down[expert_idx].contiguous().clone()
+        )
+
+    tensors["mtp.pre_fc_norm_embedding.weight"] = tensors[
+        f"{layer_prefix}.input_layernorm.weight"
+    ].clone()
+    tensors["mtp.pre_fc_norm_hidden.weight"] = tensors[
+        f"{layer_prefix}.post_attention_layernorm.weight"
+    ].clone()
+    tensors["mtp.norm.weight"] = tensors["model.language_model.norm.weight"].clone()
+    tensors["mtp.fc.weight"] = (
+        torch.arange(
+            text_config.hidden_size * 2 * text_config.hidden_size,
+            dtype=torch.float32,
+        )
+        .reshape(text_config.hidden_size, 2 * text_config.hidden_size)
+        .to(torch.bfloat16)
+    )
+    save_file(tensors, os.path.join(path, "model.safetensors"))
+
+
+def _force_hf_torch_reference_kernels(model) -> None:
+    """Use deterministic HF reference kernels instead of optional FLA fast paths."""
+    from transformers.models.qwen3_5_moe import modeling_qwen3_5_moe as hf_impl
+
+    text_model = model.model.language_model
+    text_model.config._attn_implementation = "eager"
+    text_model.config._experts_implementation = "eager"
+    linear_layers = 0
+    for layer in text_model.layers:
+        # The Transformers decorator otherwise dispatches to grouped-mm on GB300.
+        # Keep the authority lane on its explicit per-expert Torch implementation.
+        layer.mlp.experts.config._experts_implementation = "eager"
+        linear_attn = getattr(layer, "linear_attn", None)
+        if linear_attn is None:
+            continue
+        linear_layers += 1
+        linear_attn.causal_conv1d_fn = None
+        linear_attn.chunk_gated_delta_rule = hf_impl.torch_chunk_gated_delta_rule
+        linear_attn.recurrent_gated_delta_rule = (
+            hf_impl.torch_recurrent_gated_delta_rule
+        )
+        # FLA availability is process-global and would otherwise instantiate its
+        # fused gated RMSNorm inside the HF reference model. Replace it with the
+        # Transformers implementation while preserving the checkpoint weight.
+        reference_norm = hf_impl.Qwen3_5MoeRMSNormGated(
+            linear_attn.head_v_dim,
+            eps=linear_attn.layer_norm_epsilon,
+        ).to(
+            device=linear_attn.norm.weight.device,
+            dtype=linear_attn.norm.weight.dtype,
+        )
+        reference_norm.load_state_dict(linear_attn.norm.state_dict(), strict=True)
+        linear_attn.norm = reference_norm
+    assert linear_layers == 1, (
+        f"expected one linear-attention layer, got {linear_layers}"
+    )
+
+
+def _build_transformers_512_mtp_decoder_equation_reference(source_dir: str):
+    """Build the released Qwen3.5 MTP equation from independent HF modules.
+
+    Transformers 5.12 deliberately has no root MTP wrapper and ignores ``mtp.*``
+    while loading a causal LM.  Its Qwen3.5 decoder layer is nevertheless an
+    independent authority for the predictor block.  This helper wires the four
+    released root tensors around that layer and loads every tensor directly from
+    the official on-disk namespace.  No lite checkpoint/export mapping is used.
+    """
+    from transformers import Qwen3_5MoeConfig
+    from transformers.models.qwen3_5_moe import modeling_qwen3_5_moe as hf_impl
+
+    source = _read_safetensors_dir(source_dir)
+    text_config = Qwen3_5MoeConfig.from_pretrained(source_dir).text_config
+    assert text_config.layer_types[0] == "full_attention"
+    text_config._attn_implementation = "eager"
+    text_config._experts_implementation = "eager"
+
+    reference = torch.nn.ModuleDict(
+        {
+            "embedding": torch.nn.Embedding(
+                text_config.vocab_size, text_config.hidden_size
+            ),
+            "enorm": hf_impl.Qwen3_5MoeRMSNorm(
+                text_config.hidden_size, eps=text_config.rms_norm_eps
+            ),
+            "hnorm": hf_impl.Qwen3_5MoeRMSNorm(
+                text_config.hidden_size, eps=text_config.rms_norm_eps
+            ),
+            "fc": torch.nn.Linear(
+                2 * text_config.hidden_size,
+                text_config.hidden_size,
+                bias=False,
+            ),
+            "layer": hf_impl.Qwen3_5MoeDecoderLayer(text_config, layer_idx=0),
+            "final_norm": hf_impl.Qwen3_5MoeRMSNorm(
+                text_config.hidden_size, eps=text_config.rms_norm_eps
+            ),
+            "rotary": hf_impl.Qwen3_5MoeTextRotaryEmbedding(text_config),
+            "head": torch.nn.Linear(
+                text_config.hidden_size, text_config.vocab_size, bias=False
+            ),
+        }
+    ).to(device="cuda", dtype=torch.bfloat16)
+    reference["layer"].mlp.experts.config._experts_implementation = "eager"
+
+    layer_prefix = "mtp.layers.0"
+    direct_layer_suffixes = (
+        "input_layernorm.weight",
+        "self_attn.q_proj.weight",
+        "self_attn.k_proj.weight",
+        "self_attn.v_proj.weight",
+        "self_attn.q_norm.weight",
+        "self_attn.k_norm.weight",
+        "self_attn.o_proj.weight",
+        "post_attention_layernorm.weight",
+        "mlp.gate.weight",
+        "mlp.shared_expert.gate_proj.weight",
+        "mlp.shared_expert.up_proj.weight",
+        "mlp.shared_expert.down_proj.weight",
+        "mlp.shared_expert_gate.weight",
+    )
+    layer_state = {
+        suffix: source[f"{layer_prefix}.{suffix}"] for suffix in direct_layer_suffixes
+    }
+    layer_state["mlp.experts.gate_up_proj"] = torch.stack(
+        [
+            torch.cat(
+                [
+                    source[f"{layer_prefix}.mlp.experts.{expert_idx}.gate_proj.weight"],
+                    source[f"{layer_prefix}.mlp.experts.{expert_idx}.up_proj.weight"],
+                ],
+                dim=0,
+            )
+            for expert_idx in range(text_config.num_experts)
+        ],
+        dim=0,
+    ).contiguous()
+    layer_state["mlp.experts.down_proj"] = torch.stack(
+        [
+            source[f"{layer_prefix}.mlp.experts.{expert_idx}.down_proj.weight"]
+            for expert_idx in range(text_config.num_experts)
+        ],
+        dim=0,
+    ).contiguous()
+    reference["layer"].load_state_dict(layer_state, strict=True)
+
+    root_state = {
+        "embedding": "model.language_model.embed_tokens.weight",
+        "enorm": "mtp.pre_fc_norm_embedding.weight",
+        "hnorm": "mtp.pre_fc_norm_hidden.weight",
+        "fc": "mtp.fc.weight",
+        "final_norm": "mtp.norm.weight",
+        "head": "lm_head.weight",
+    }
+    for module_name, source_name in root_state.items():
+        reference[module_name].load_state_dict(
+            {"weight": source[source_name]}, strict=True
+        )
+    reference.eval()
+    return reference
+
+
+def _forward_transformers_512_mtp_decoder_equation(
+    reference,
+    *,
+    input_ids: torch.Tensor,
+    position_ids: torch.Tensor,
+    encoder_hidden: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Evaluate one released MTP depth in batch-first layout."""
+    shifted_ids = torch.roll(input_ids, shifts=-1, dims=-1)
+    shifted_ids[:, -1] = 0
+
+    decoder_input = reference["enorm"](reference["embedding"](shifted_ids))
+    encoder_input = reference["hnorm"](encoder_hidden)
+    projected = reference["fc"](torch.cat((decoder_input, encoder_input), dim=-1))
+
+    position_embeddings = reference["rotary"](projected, position_ids)
+    sequence_length = projected.shape[1]
+    causal_mask = torch.full(
+        (sequence_length, sequence_length),
+        torch.finfo(projected.dtype).min,
+        dtype=projected.dtype,
+        device=projected.device,
+    )
+    causal_mask = torch.triu(causal_mask, diagonal=1)[None, None, :, :]
+    predictor = reference["layer"](
+        projected,
+        position_embeddings=position_embeddings,
+        attention_mask=causal_mask,
+        position_ids=position_ids[0],
+        use_cache=False,
+    )
+    hidden = reference["final_norm"](predictor)
+    return hidden, reference["head"](hidden), shifted_ids
+
+
+def _shifted_causal_ce(logits: torch.Tensor, input_ids: torch.Tensor) -> torch.Tensor:
+    assert logits.ndim == 3
+    assert input_ids.ndim == 2
+    assert logits.shape[:2] == input_ids.shape
+    assert logits.shape[1] >= 2
+    return F.cross_entropy(
+        logits[:, :-1, :].float().reshape(-1, logits.shape[-1]),
+        input_ids[:, 1:].reshape(-1),
+    )
+
+
+def _roll_left_zero_reference(tensor: torch.Tensor) -> torch.Tensor:
+    """Independent dense equivalent of one MTP left shift."""
+    rolled = torch.roll(tensor, shifts=-1, dims=-1).clone()
+    rolled[..., -1] = 0
+    return rolled
+
+
+def _mtp_depth1_ce_from_raw_tokens(
+    logits: torch.Tensor, raw_input_ids: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Depth-1 MTP CE targets raw token i+2, never the visible i+1 token.
+
+    Main causal labels already target the next raw token.  Qwen MTP rolls those
+    labels and their validity mask once more, matching ``_apply_mtp_loss`` while
+    keeping this reference independent from lite's roll helper.
+    """
+    assert logits.ndim == 3
+    assert raw_input_ids.ndim == 2
+    assert logits.shape[:2] == raw_input_ids.shape
+    assert logits.shape[1] >= 3
+
+    main_labels = _roll_left_zero_reference(raw_input_ids)
+    main_loss_mask = torch.ones_like(raw_input_ids, dtype=torch.float32)
+    main_loss_mask[..., -1] = 0
+    mtp_labels = _roll_left_zero_reference(main_labels)
+    mtp_loss_mask = _roll_left_zero_reference(main_loss_mask)
+    token_loss = F.cross_entropy(
+        logits.float().reshape(-1, logits.shape[-1]),
+        mtp_labels.reshape(-1),
+        reduction="none",
+    ).reshape_as(mtp_loss_mask)
+    loss = (token_loss * mtp_loss_mask).sum() / mtp_loss_mask.sum()
+    return loss, mtp_labels, mtp_loss_mask
+
+
+def _assert_tensor_parity(
+    name: str,
+    hf_value: torch.Tensor,
+    lite_value: torch.Tensor,
+    *,
+    cosine_min: float,
+    rms_relative_max: float,
+    max_abs_max: float,
+    norm_ratio_min: float = 0.99,
+    norm_ratio_max: float = 1.01,
+) -> dict[str, float]:
+    assert lite_value.shape == hf_value.shape, (
+        f"{name}: lite shape {tuple(lite_value.shape)} != HF shape {tuple(hf_value.shape)}"
+    )
+    hf = hf_value.detach().float()
+    lite = lite_value.detach().float()
+    assert torch.isfinite(hf).all(), f"{name}: HF produced non-finite values"
+    assert torch.isfinite(lite).all(), f"{name}: lite produced non-finite values"
+
+    hf_flat = hf.reshape(-1)
+    lite_flat = lite.reshape(-1)
+    hf_norm = torch.linalg.vector_norm(hf_flat)
+    lite_norm = torch.linalg.vector_norm(lite_flat)
+    assert hf_norm > 0 and lite_norm > 0, (
+        f"{name}: zero-norm comparison is not meaningful"
+    )
+    cosine = F.cosine_similarity(hf_flat, lite_flat, dim=0).item()
+    diff_rms = torch.sqrt(torch.mean((hf - lite).square()))
+    symmetric_scale = torch.maximum(
+        torch.sqrt(torch.mean(hf.square())), torch.sqrt(torch.mean(lite.square()))
+    ).clamp_min(torch.finfo(torch.float32).tiny)
+    rms_relative = (diff_rms / symmetric_scale).item()
+    max_abs = (hf - lite).abs().max().item()
+    norm_ratio = (lite_norm / hf_norm).item()
+    print(
+        f"[qwen35-hf-parity] {name}: shape={tuple(hf.shape)} "
+        f"cosine={cosine:.9f} rms_relative={rms_relative:.9f} "
+        f"norm_ratio={norm_ratio:.9f} max_abs={max_abs:.9f}"
+    )
+
+    assert cosine >= cosine_min, f"{name}: cosine {cosine} < {cosine_min}"
+    assert rms_relative <= rms_relative_max, (
+        f"{name}: RMS-relative {rms_relative} > {rms_relative_max}"
+    )
+    assert norm_ratio_min <= norm_ratio <= norm_ratio_max, (
+        f"{name}: norm ratio {norm_ratio} outside [{norm_ratio_min}, {norm_ratio_max}]"
+    )
+    assert max_abs <= max_abs_max, f"{name}: max-abs {max_abs} > {max_abs_max}"
+    return {
+        "cosine": cosine,
+        "rms_relative": rms_relative,
+        "norm_ratio": norm_ratio,
+        "max_abs": max_abs,
+    }
+
+
+def _layer_capture(layers, *, sequence_first: bool):
+    captured: dict[int, torch.Tensor] = {}
+    handles = []
+
+    for index, layer in enumerate(layers):
+
+        def _hook(_module, _args, output, *, layer_index=index):
+            value = output[0] if isinstance(output, tuple) else output
+            assert isinstance(value, torch.Tensor)
+            if sequence_first:
+                value = value.transpose(0, 1)
+            captured[layer_index] = value.detach().float().clone()
+
+        handles.append(layer.register_forward_hook(_hook))
+    return captured, handles
+
+
+def _embedding_grad_capture(embedding):
+    captured: list[torch.Tensor] = []
+
+    def _hook(_module, _args, output):
+        assert isinstance(output, torch.Tensor)
+        output.retain_grad()
+        captured.append(output)
+
+    return captured, embedding.register_forward_hook(_hook)
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -137,6 +635,474 @@ def test_qwen35_save_load_numeric_roundtrip(tmp_path):
         if not torch.allclose(ta, tb, atol=1e-3, rtol=1e-3):
             mism.append(f"{k} (max_abs_diff={(ta - tb).abs().max().item()})")
     assert not mism, "HF save->load not numeric round-trip:\n" + "\n".join(mism)
+
+
+def test_qwen35_transformers_512_checkpoint_ground_truth(tmp_path):
+    """Compare lite load/export directly with official HF-created safetensors."""
+    if dist.get_world_size() != 1:
+        pytest.skip("Transformers ground-truth smoke runs single-rank (tp1).")
+    pytest.importorskip("transformers")
+    pytest.importorskip("safetensors")
+
+    from megatron.lite.model.qwen3_5.config import Qwen35Config
+
+    source_dir = str(tmp_path / "transformers_hf")
+    exported_dir = str(tmp_path / "lite_export")
+    os.makedirs(source_dir)
+    os.makedirs(exported_dir)
+    _save_transformers_512_tiny_qwen35(source_dir)
+
+    source = _read_safetensors_dir(source_dir)
+    expected = {
+        key: tensor
+        for key, tensor in source.items()
+        if key == "lm_head.weight"
+        or key.startswith("model.language_model.")
+        or key.startswith("mtp.")
+    }
+    assert expected
+    assert "model.language_model.layers.0.self_attn.q_proj.weight" in expected
+    assert "model.language_model.layers.1.linear_attn.in_proj_qkv.weight" in expected
+    for layer_idx in range(2):
+        prefix = f"model.language_model.layers.{layer_idx}.mlp.experts"
+        assert f"{prefix}.gate_up_proj" in expected
+        assert f"{prefix}.down_proj" in expected
+    assert not any(
+        re.search(r"\.mlp\.experts\.\d+\.(gate|up|down)_proj\.weight$", key)
+        for key in expected
+        if key.startswith("model.language_model.")
+    ), (
+        "Transformers emitted legacy per-expert tensors instead of the production packed layout"
+    )
+    mtp_expected = {key for key in expected if key.startswith("mtp.")}
+    assert {
+        "mtp.pre_fc_norm_embedding.weight",
+        "mtp.pre_fc_norm_hidden.weight",
+        "mtp.fc.weight",
+        "mtp.norm.weight",
+    } <= mtp_expected
+    expected_fp32 = {key for key in expected if key.endswith(_FP32_CHECKPOINT_SUFFIXES)}
+    assert expected_fp32 == {
+        "model.language_model.layers.1.linear_attn.A_log",
+        "model.language_model.layers.1.linear_attn.norm.weight",
+    }
+    assert all(expected[key].dtype == torch.float32 for key in expected_fp32)
+    assert all(
+        tensor.dtype == torch.bfloat16
+        for key, tensor in expected.items()
+        if key not in expected_fp32
+    )
+    assert (
+        expected["model.language_model.layers.1.linear_attn.dt_bias"].dtype
+        == torch.bfloat16
+    )
+
+    cfg = Qwen35Config.from_hf(source_dir)
+    assert cfg.layer_types == ["full_attention", "linear_attention"]
+    assert cfg.num_nextn_predict_layers == 1
+    assert cfg.mtp_layer_types == ["full_attention"]
+    assert len(mtp_expected) == 17 + 3 * cfg.num_experts
+    for expert_idx in range(cfg.num_experts):
+        prefix = f"mtp.layers.0.mlp.experts.{expert_idx}"
+        assert {
+            f"{prefix}.gate_proj.weight",
+            f"{prefix}.up_proj.weight",
+            f"{prefix}.down_proj.weight",
+        } <= mtp_expected
+    assert "mtp.layers.0.mlp.experts.gate_up_proj" not in mtp_expected
+    assert "mtp.layers.0.mlp.experts.down_proj" not in mtp_expected
+
+    bundle, protocol = _build(cfg, seed=20260628, mtp_enable=True)
+    protocol.load_hf_weights(bundle.chunks[0], source_dir, cfg, bundle.parallel_state)
+    protocol.save_hf_weights(bundle.chunks, exported_dir, cfg, bundle.parallel_state)
+    exported = _read_safetensors_dir(exported_dir)
+
+    assert set(exported) == set(expected), (
+        f"missing={sorted(set(expected) - set(exported))}; "
+        f"unexpected={sorted(set(exported) - set(expected))}"
+    )
+    mismatches = []
+    for key in sorted(expected):
+        want, got = expected[key], exported[key]
+        if want.shape != got.shape:
+            mismatches.append(f"{key}: shape {tuple(got.shape)} != {tuple(want.shape)}")
+        elif want.dtype != got.dtype:
+            mismatches.append(f"{key}: dtype {got.dtype} != {want.dtype}")
+        elif not torch.equal(want, got):
+            max_abs = (want.float() - got.float()).abs().max().item()
+            mismatches.append(f"{key}: values differ (max_abs={max_abs})")
+    assert not mismatches, (
+        "lite does not preserve Transformers 5.12 HF tensors:\n" + "\n".join(mismatches)
+    )
+    print(
+        "QWEN35_HF_MTP_SCHEMA_DTYPE_PARITY "
+        f"mtp_keys={len(mtp_expected)} "
+        "A_log=torch.float32 norm=torch.float32 dt_bias=torch.bfloat16 exact=True"
+    )
+
+
+def test_qwen35_transformers_512_mtp_decoder_equation_parity(tmp_path):
+    """Gate MTP semantics with HF's decoder layer plus the released equation.
+
+    This is intentionally not described as a Transformers MTP-model comparison:
+    Transformers 5.12 drops root ``mtp.*`` weights.  The independent side loads
+    the official-format tensors directly into HF Qwen3.5 primitives and spells
+    out shifted embedding -> pre norms -> fc -> predictor -> final norm -> head.
+    """
+    if dist.get_world_size() != 1:
+        pytest.skip("Transformers MTP equation parity runs single-rank (tp1).")
+    pytest.importorskip("transformers")
+    pytest.importorskip("safetensors")
+
+    import transformers
+
+    from megatron.lite.model.qwen3_5.config import Qwen35Config
+
+    assert transformers.__version__ == "5.12.0", (
+        "the Qwen3.5 MTP decoder authority is pinned to Transformers 5.12.0; "
+        f"got {transformers.__version__}"
+    )
+    torch.manual_seed(20260630)
+    torch.cuda.manual_seed_all(20260630)
+
+    source_dir = str(tmp_path / "transformers_hf_mtp_equation")
+    os.makedirs(source_dir)
+    _save_transformers_512_tiny_qwen35(source_dir)
+    reference = _build_transformers_512_mtp_decoder_equation_reference(source_dir)
+
+    cfg = Qwen35Config.from_hf(source_dir)
+    assert cfg.num_nextn_predict_layers == 1
+    assert cfg.mtp_layer_types == ["full_attention"]
+    lite_bundle, protocol = _build(cfg, seed=20260701, optimizer=None, mtp_enable=True)
+    lite_model = lite_bundle.chunks[0]
+    protocol.load_hf_weights(lite_model, source_dir, cfg, lite_bundle.parallel_state)
+    lite_model.eval()
+    assert lite_model.embed is not None
+    assert lite_model.head is not None
+    assert lite_model.mtp is not None
+    assert len(lite_model.mtp.layers) == 1
+    lite_mtp_layer = lite_model.mtp.layers[0]
+    assert lite_mtp_layer.embedding is lite_model.embed
+
+    input_ids = torch.tensor(
+        [
+            [3, 5, 7, 11, 13, 17, 19, 23],
+            [29, 31, 37, 41, 43, 47, 53, 59],
+        ],
+        dtype=torch.long,
+        device="cuda",
+    )
+    batch_size, sequence_length = input_ids.shape
+    position_ids = (
+        torch.arange(sequence_length, device=input_ids.device)
+        .view(1, 1, -1)
+        .expand(3, batch_size, -1)
+        .contiguous()
+    )
+    encoder_hidden = torch.sin(
+        torch.linspace(
+            -1.25,
+            1.75,
+            steps=batch_size * sequence_length * cfg.hidden_size,
+            dtype=torch.float32,
+            device="cuda",
+        )
+    ).reshape(batch_size, sequence_length, cfg.hidden_size)
+    encoder_hidden = encoder_hidden.to(torch.bfloat16)
+
+    reference.zero_grad(set_to_none=True)
+    lite_model.zero_grad(set_to_none=True)
+    reference_hidden, reference_logits, reference_shifted_ids = (
+        _forward_transformers_512_mtp_decoder_equation(
+            reference,
+            input_ids=input_ids,
+            position_ids=position_ids,
+            encoder_hidden=encoder_hidden,
+        )
+    )
+    lite_hidden_sbh, lite_shifted_ids, lite_shifted_positions = lite_mtp_layer(
+        input_ids=input_ids,
+        position_ids=position_ids,
+        hidden_states=encoder_hidden.transpose(0, 1).contiguous(),
+        rotary_position_ids=position_ids,
+        packed_seq_params=None,
+    )
+    lite_hidden = lite_hidden_sbh.transpose(0, 1).contiguous()
+    lite_logits = lite_model.head.gather(lite_model.head(lite_hidden_sbh))
+    lite_logits = lite_logits.transpose(0, 1).contiguous()
+
+    expected_shifted_positions = torch.roll(position_ids, shifts=-1, dims=-1)
+    expected_shifted_positions[..., -1] = 0
+    assert torch.equal(reference_shifted_ids, lite_shifted_ids)
+    assert lite_shifted_positions is not None
+    assert torch.equal(lite_shifted_positions, expected_shifted_positions)
+    hidden_metrics = _assert_tensor_parity(
+        "mtp-predictor-hidden",
+        reference_hidden,
+        lite_hidden,
+        cosine_min=0.999,
+        rms_relative_max=0.02,
+        max_abs_max=0.05,
+    )
+    logits_metrics = _assert_tensor_parity(
+        "mtp-shared-head-logits",
+        reference_logits,
+        lite_logits,
+        cosine_min=0.999,
+        rms_relative_max=0.02,
+        max_abs_max=0.05,
+    )
+
+    reference_ce, reference_mtp_labels, reference_mtp_mask = (
+        _mtp_depth1_ce_from_raw_tokens(reference_logits, input_ids)
+    )
+    lite_ce, lite_mtp_labels, lite_mtp_mask = _mtp_depth1_ce_from_raw_tokens(
+        lite_logits, input_ids
+    )
+    assert torch.equal(reference_mtp_labels, lite_mtp_labels)
+    assert torch.equal(reference_mtp_mask, lite_mtp_mask)
+    assert torch.equal(reference_mtp_labels[:, :-2], input_ids[:, 2:])
+    assert torch.count_nonzero(reference_mtp_mask[:, -2:]).item() == 0
+    assert reference_mtp_mask.sum().item() == batch_size * (sequence_length - 2)
+    ce_abs = (reference_ce - lite_ce).abs().item()
+    ce_scale = max(abs(reference_ce.item()), abs(lite_ce.item()), 1.0e-12)
+    ce_relative = ce_abs / ce_scale
+    print(
+        "[qwen35-mtp-equation-parity] depth-1 shifted-CE (raw i+2 target): "
+        f"hf_equation={reference_ce.item():.9f} lite={lite_ce.item():.9f} "
+        f"abs={ce_abs:.9f} relative={ce_relative:.9f}"
+    )
+    assert ce_abs <= 0.005, f"MTP shifted CE absolute error {ce_abs} > 0.005"
+    assert ce_relative <= 0.001, f"MTP shifted CE relative error {ce_relative} > 0.001"
+
+    reference_ce.backward()
+    lite_ce.backward()
+    reference_embedding_grad = reference["embedding"].weight.grad
+    lite_embedding_grad = lite_model.embed.embedding.weight.grad
+    assert reference_embedding_grad is not None
+    assert lite_embedding_grad is not None
+    lite_embedding_grad = lite_embedding_grad[: cfg.vocab_size]
+    assert torch.count_nonzero(reference_embedding_grad).item() > 0
+    assert torch.count_nonzero(lite_embedding_grad).item() > 0
+    embedding_grad_metrics = _assert_tensor_parity(
+        "mtp-canonical-embedding-gradient",
+        reference_embedding_grad,
+        lite_embedding_grad,
+        cosine_min=0.999,
+        rms_relative_max=0.02,
+        max_abs_max=0.01,
+    )
+    reference_grad_norm = torch.linalg.vector_norm(
+        reference_embedding_grad.float()
+    ).item()
+    lite_grad_norm = torch.linalg.vector_norm(lite_embedding_grad.float()).item()
+    grad_norm_ratio = lite_grad_norm / reference_grad_norm
+    assert 0.99 <= grad_norm_ratio <= 1.01, (
+        "MTP canonical embedding gradient norm ratio "
+        f"{grad_norm_ratio} is outside [0.99, 1.01]"
+    )
+    print(
+        "NON_SKIP_QWEN35_TRANSFORMERS_512_MTP_DECODER_EQUATION_PARITY_PASSED "
+        "authority=transformers_decoder_plus_released_root_equation "
+        "mtp_layers=1 layer_type=full_attention depth2_target=True batch=2 seq=8 "
+        f"hidden_cosine={hidden_metrics['cosine']:.9f} "
+        f"hidden_rms_relative={hidden_metrics['rms_relative']:.9f} "
+        f"logits_cosine={logits_metrics['cosine']:.9f} "
+        f"logits_rms_relative={logits_metrics['rms_relative']:.9f} "
+        f"ce_abs={ce_abs:.9f} ce_relative={ce_relative:.9f} "
+        f"embedding_grad_cosine={embedding_grad_metrics['cosine']:.9f} "
+        f"embedding_grad_rms_relative="
+        f"{embedding_grad_metrics['rms_relative']:.9f} "
+        f"embedding_grad_norm_ratio={grad_norm_ratio:.9f}"
+    )
+
+
+def test_qwen35_transformers_512_full_model_numeric_parity(tmp_path):
+    """Gate real HF-vs-lite semantics, not merely checkpoint key inversion."""
+    if dist.get_world_size() != 1:
+        pytest.skip("Transformers full-model parity runs single-rank (tp1).")
+    pytest.importorskip("transformers")
+    pytest.importorskip("safetensors")
+
+    import transformers
+    from transformers import Qwen3_5MoeForConditionalGeneration
+
+    from megatron.lite.model.qwen3_5.config import Qwen35Config
+
+    assert transformers.__version__ == "5.12.0", (
+        "the Qwen3.5 HF numeric authority is pinned to Transformers 5.12.0; "
+        f"got {transformers.__version__}"
+    )
+    torch.manual_seed(20260629)
+    torch.cuda.manual_seed_all(20260629)
+
+    source_dir = str(tmp_path / "transformers_hf_numeric")
+    os.makedirs(source_dir)
+    _save_transformers_512_tiny_qwen35(source_dir)
+
+    hf_model = Qwen3_5MoeForConditionalGeneration.from_pretrained(
+        source_dir,
+        dtype=torch.bfloat16,
+        attn_implementation="eager",
+    ).cuda()
+    _force_hf_torch_reference_kernels(hf_model)
+    hf_model.eval()
+
+    cfg = Qwen35Config.from_hf(source_dir)
+    assert cfg.layer_types == ["full_attention", "linear_attention"]
+    lite_bundle, protocol = _build(cfg, seed=20260630, optimizer=None)
+    lite_model = lite_bundle.chunks[0]
+    protocol.load_hf_weights(lite_model, source_dir, cfg, lite_bundle.parallel_state)
+    lite_model.eval()
+
+    # Fixed, non-padding token batch.  Tokens are deliberately unique so the
+    # embedding-output gradient probe is not obscured by repeated-row reduction.
+    input_ids = torch.tensor(
+        [
+            [3, 5, 7, 11, 13, 17, 19, 23],
+            [29, 31, 37, 41, 43, 47, 53, 59],
+        ],
+        dtype=torch.long,
+        device="cuda",
+    )
+    attention_mask = torch.ones_like(input_ids)
+    position_ids = (
+        torch.arange(input_ids.shape[1], device=input_ids.device)
+        .view(1, 1, -1)
+        .expand(3, input_ids.shape[0], -1)
+        .contiguous()
+    )
+    expected_hidden_shape = (2, 8, 16)
+    expected_logits_shape = (2, 8, 64)
+
+    hf_layers, hf_layer_handles = _layer_capture(
+        hf_model.model.language_model.layers, sequence_first=False
+    )
+    lite_layers, lite_layer_handles = _layer_capture(
+        lite_model.layers, sequence_first=True
+    )
+    hf_embeddings, hf_embedding_handle = _embedding_grad_capture(
+        hf_model.model.language_model.embed_tokens
+    )
+    assert lite_model.embed is not None
+    lite_embeddings, lite_embedding_handle = _embedding_grad_capture(
+        lite_model.embed.embedding
+    )
+
+    try:
+        hf_output = hf_model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            labels=input_ids,
+            use_cache=False,
+            output_router_logits=False,
+            logits_to_keep=0,
+            return_dict=True,
+        )
+        lite_output = lite_model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            packed_seq_params=None,
+        )
+    finally:
+        for handle in [
+            *hf_layer_handles,
+            *lite_layer_handles,
+            hf_embedding_handle,
+            lite_embedding_handle,
+        ]:
+            handle.remove()
+
+    hf_logits = hf_output.logits
+    lite_logits = lite_output["logits"]
+    assert tuple(hf_logits.shape) == expected_logits_shape
+    assert tuple(lite_logits.shape) == expected_logits_shape
+    assert set(hf_layers) == {0, 1}
+    assert set(lite_layers) == {0, 1}
+    layer_metrics = []
+    for layer_index, layer_type in enumerate(cfg.layer_types):
+        assert tuple(hf_layers[layer_index].shape) == expected_hidden_shape
+        assert tuple(lite_layers[layer_index].shape) == expected_hidden_shape
+        layer_metrics.append(
+            _assert_tensor_parity(
+                f"layer-{layer_index}-{layer_type}",
+                hf_layers[layer_index],
+                lite_layers[layer_index],
+                cosine_min=0.999,
+                rms_relative_max=0.02,
+                max_abs_max=0.05,
+            )
+        )
+
+    logits_metrics = _assert_tensor_parity(
+        "final-logits",
+        hf_logits,
+        lite_logits,
+        cosine_min=0.999,
+        rms_relative_max=0.02,
+        max_abs_max=0.05,
+    )
+
+    hf_shifted_ce = _shifted_causal_ce(hf_logits, input_ids)
+    lite_shifted_ce = _shifted_causal_ce(lite_logits, input_ids)
+    assert hf_output.loss is not None
+    torch.testing.assert_close(
+        hf_output.loss.float(), hf_shifted_ce, atol=1e-6, rtol=1e-6
+    )
+    loss_abs = (hf_shifted_ce - lite_shifted_ce).abs().item()
+    loss_scale = max(abs(hf_shifted_ce.item()), abs(lite_shifted_ce.item()), 1e-12)
+    loss_relative = loss_abs / loss_scale
+    print(
+        "[qwen35-hf-parity] shifted-CE: "
+        f"hf={hf_shifted_ce.item():.9f} lite={lite_shifted_ce.item():.9f} "
+        f"abs={loss_abs:.9f} relative={loss_relative:.9f}"
+    )
+    assert loss_abs <= 0.005, f"shifted CE absolute error {loss_abs} > 0.005"
+    assert loss_relative <= 0.001, f"shifted CE relative error {loss_relative} > 0.001"
+
+    hf_shifted_ce.backward()
+    lite_shifted_ce.backward()
+    assert len(hf_embeddings) == 1
+    assert len(lite_embeddings) == 1
+    hf_embedding_grad = hf_embeddings[0].grad
+    lite_embedding_grad = lite_embeddings[0].grad
+    assert hf_embedding_grad is not None
+    assert lite_embedding_grad is not None
+    embedding_grad_metrics = _assert_tensor_parity(
+        "embedding-output-gradient",
+        hf_embedding_grad,
+        lite_embedding_grad,
+        cosine_min=0.999,
+        rms_relative_max=0.02,
+        max_abs_max=0.01,
+    )
+    hf_grad_norm = torch.linalg.vector_norm(hf_embedding_grad.float()).item()
+    lite_grad_norm = torch.linalg.vector_norm(lite_embedding_grad.float()).item()
+    grad_norm_ratio = lite_grad_norm / hf_grad_norm
+    print(
+        "[qwen35-hf-parity] embedding-output-gradient norms: "
+        f"hf={hf_grad_norm:.9f} lite={lite_grad_norm:.9f} ratio={grad_norm_ratio:.9f}"
+    )
+    assert 0.99 <= grad_norm_ratio <= 1.01, (
+        f"embedding-output gradient norm ratio {grad_norm_ratio} is outside [0.99, 1.01]"
+    )
+    print(
+        "NON_SKIP_QWEN35_TRANSFORMERS_512_FULL_MODEL_PARITY_PASSED "
+        "layers=2 layer_types=[full_attention,linear_attention] batch=2 seq=8 "
+        f"hidden_min_cosine={min(item['cosine'] for item in layer_metrics):.9f} "
+        f"hidden_max_rms_relative="
+        f"{max(item['rms_relative'] for item in layer_metrics):.9f} "
+        f"hidden_min_norm_ratio={min(item['norm_ratio'] for item in layer_metrics):.9f} "
+        f"hidden_max_norm_ratio={max(item['norm_ratio'] for item in layer_metrics):.9f} "
+        f"logits_cosine={logits_metrics['cosine']:.9f} "
+        f"logits_rms_relative={logits_metrics['rms_relative']:.9f} "
+        f"logits_norm_ratio={logits_metrics['norm_ratio']:.9f} "
+        f"loss_abs={loss_abs:.9f} loss_relative={loss_relative:.9f} "
+        f"embedding_grad_cosine={embedding_grad_metrics['cosine']:.9f} "
+        f"embedding_grad_rms_relative={embedding_grad_metrics['rms_relative']:.9f} "
+        f"embedding_grad_norm_ratio={grad_norm_ratio:.9f}"
+    )
 
 
 @pytest.mark.skipif(
@@ -219,6 +1185,10 @@ def test_qwen35_real_hf_load_export_matches_original(tmp_path):
         o, e = _orig(k), exported[k]
         if o.shape != e.shape:
             mism.append(f"{k} shape {tuple(o.shape)} != {tuple(e.shape)}")
-        elif not torch.allclose(o, e, atol=2e-2, rtol=2e-2):  # bf16-cast export tolerance
+        elif not torch.allclose(
+            o, e, atol=2e-2, rtol=2e-2
+        ):  # bf16-cast export tolerance
             mism.append(f"{k} max_abs_diff={(o - e).abs().max().item()}")
-    assert not mism, "lite export does not match original HF safetensors:\n" + "\n".join(mism)
+    assert not mism, (
+        "lite export does not match original HF safetensors:\n" + "\n".join(mism)
+    )

--- a/experimental/lite/tests/smoke/primitive/test_qwen35_hf_numeric_roundtrip_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_qwen35_hf_numeric_roundtrip_smoke.py
@@ -43,14 +43,15 @@ wrong vs real HF would pass silently. This smoke closes that blind spot:
     decoder layers to bound memory/time.
 
 Run single GPU:
-  torchrun --nproc_per_node=1 -m pytest tests/smoke/primitive/test_qwen35_hf_numeric_roundtrip_smoke.py
+  torchrun --nproc_per_node=1 -m pytest --mlite-smoke --mlite-fail-on-skip \
+    experimental/lite/tests/smoke/primitive/test_qwen35_hf_numeric_roundtrip_smoke.py
 """
 
 from __future__ import annotations
 
+import json
 import os
 import re
-import json
 
 import pytest
 import torch
@@ -59,10 +60,7 @@ import torch.nn.functional as F
 
 pytestmark = [pytest.mark.mlite, pytest.mark.smoke, pytest.mark.gpu]
 
-_FP32_CHECKPOINT_SUFFIXES = (
-    ".linear_attn.A_log",
-    ".linear_attn.norm.weight",
-)
+_FP32_CHECKPOINT_SUFFIXES = (".linear_attn.A_log", ".linear_attn.norm.weight")
 
 
 def _qwen35_tiny_cfg():
@@ -95,7 +93,9 @@ def _qwen35_tiny_cfg():
     )
 
 
-def _build(cfg, seed, *, optimizer="dist_opt", mtp_enable=False):
+def _build(
+    cfg, seed, *, optimizer="dist_opt", mtp_enable=False, mtp_enable_train=False
+):
     from megatron.lite.model.qwen3_5.lite import protocol
     from megatron.lite.runtime.contracts.config import ParallelConfig
 
@@ -108,6 +108,7 @@ def _build(cfg, seed, *, optimizer="dist_opt", mtp_enable=False):
         use_deepep=False,
         deterministic=True,
         mtp_enable=mtp_enable,
+        mtp_enable_train=mtp_enable_train,
     )
     bundle = protocol.build_model(cfg, impl_cfg=impl)
     return bundle, protocol
@@ -190,9 +191,7 @@ def _save_transformers_512_tiny_qwen35(path):
         num_position_embeddings=16,
     )
     config = Qwen3_5MoeConfig(
-        text_config=text_config,
-        vision_config=vision_config,
-        tie_word_embeddings=False,
+        text_config=text_config, vision_config=vision_config, tie_word_embeddings=False
     )
     torch.manual_seed(20260627)
     model = Qwen3_5MoeForConditionalGeneration(config).to(torch.bfloat16)
@@ -269,8 +268,7 @@ def _save_transformers_512_tiny_qwen35(path):
     tensors["mtp.norm.weight"] = tensors["model.language_model.norm.weight"].clone()
     tensors["mtp.fc.weight"] = (
         torch.arange(
-            text_config.hidden_size * 2 * text_config.hidden_size,
-            dtype=torch.float32,
+            text_config.hidden_size * 2 * text_config.hidden_size, dtype=torch.float32
         )
         .reshape(text_config.hidden_size, 2 * text_config.hidden_size)
         .to(torch.bfloat16)
@@ -303,17 +301,13 @@ def _force_hf_torch_reference_kernels(model) -> None:
         # fused gated RMSNorm inside the HF reference model. Replace it with the
         # Transformers implementation while preserving the checkpoint weight.
         reference_norm = hf_impl.Qwen3_5MoeRMSNormGated(
-            linear_attn.head_v_dim,
-            eps=linear_attn.layer_norm_epsilon,
-        ).to(
-            device=linear_attn.norm.weight.device,
-            dtype=linear_attn.norm.weight.dtype,
-        )
+            linear_attn.head_v_dim, eps=linear_attn.layer_norm_epsilon
+        ).to(device=linear_attn.norm.weight.device, dtype=linear_attn.norm.weight.dtype)
         reference_norm.load_state_dict(linear_attn.norm.state_dict(), strict=True)
         linear_attn.norm = reference_norm
-    assert linear_layers == 1, (
-        f"expected one linear-attention layer, got {linear_layers}"
-    )
+    assert (
+        linear_layers == 1
+    ), f"expected one linear-attention layer, got {linear_layers}"
 
 
 def _build_transformers_512_mtp_decoder_equation_reference(source_dir: str):
@@ -346,9 +340,7 @@ def _build_transformers_512_mtp_decoder_equation_reference(source_dir: str):
                 text_config.hidden_size, eps=text_config.rms_norm_eps
             ),
             "fc": torch.nn.Linear(
-                2 * text_config.hidden_size,
-                text_config.hidden_size,
-                bias=False,
+                2 * text_config.hidden_size, text_config.hidden_size, bias=False
             ),
             "layer": hf_impl.Qwen3_5MoeDecoderLayer(text_config, layer_idx=0),
             "final_norm": hf_impl.Qwen3_5MoeRMSNorm(
@@ -511,9 +503,9 @@ def _assert_tensor_parity(
     norm_ratio_min: float = 0.99,
     norm_ratio_max: float = 1.01,
 ) -> dict[str, float]:
-    assert lite_value.shape == hf_value.shape, (
-        f"{name}: lite shape {tuple(lite_value.shape)} != HF shape {tuple(hf_value.shape)}"
-    )
+    assert (
+        lite_value.shape == hf_value.shape
+    ), f"{name}: lite shape {tuple(lite_value.shape)} != HF shape {tuple(hf_value.shape)}"
     hf = hf_value.detach().float()
     lite = lite_value.detach().float()
     assert torch.isfinite(hf).all(), f"{name}: HF produced non-finite values"
@@ -523,9 +515,9 @@ def _assert_tensor_parity(
     lite_flat = lite.reshape(-1)
     hf_norm = torch.linalg.vector_norm(hf_flat)
     lite_norm = torch.linalg.vector_norm(lite_flat)
-    assert hf_norm > 0 and lite_norm > 0, (
-        f"{name}: zero-norm comparison is not meaningful"
-    )
+    assert (
+        hf_norm > 0 and lite_norm > 0
+    ), f"{name}: zero-norm comparison is not meaningful"
     cosine = F.cosine_similarity(hf_flat, lite_flat, dim=0).item()
     diff_rms = torch.sqrt(torch.mean((hf - lite).square()))
     symmetric_scale = torch.maximum(
@@ -541,12 +533,12 @@ def _assert_tensor_parity(
     )
 
     assert cosine >= cosine_min, f"{name}: cosine {cosine} < {cosine_min}"
-    assert rms_relative <= rms_relative_max, (
-        f"{name}: RMS-relative {rms_relative} > {rms_relative_max}"
-    )
-    assert norm_ratio_min <= norm_ratio <= norm_ratio_max, (
-        f"{name}: norm ratio {norm_ratio} outside [{norm_ratio_min}, {norm_ratio_max}]"
-    )
+    assert (
+        rms_relative <= rms_relative_max
+    ), f"{name}: RMS-relative {rms_relative} > {rms_relative_max}"
+    assert (
+        norm_ratio_min <= norm_ratio <= norm_ratio_max
+    ), f"{name}: norm ratio {norm_ratio} outside [{norm_ratio_min}, {norm_ratio_max}]"
     assert max_abs <= max_abs_max, f"{name}: max-abs {max_abs} > {max_abs_max}"
     return {
         "cosine": cosine,
@@ -671,9 +663,7 @@ def test_qwen35_transformers_512_checkpoint_ground_truth(tmp_path):
         re.search(r"\.mlp\.experts\.\d+\.(gate|up|down)_proj\.weight$", key)
         for key in expected
         if key.startswith("model.language_model.")
-    ), (
-        "Transformers emitted legacy per-expert tensors instead of the production packed layout"
-    )
+    ), "Transformers emitted legacy per-expert tensors instead of the production packed layout"
     mtp_expected = {key for key in expected if key.startswith("mtp.")}
     assert {
         "mtp.pre_fc_norm_embedding.weight",
@@ -731,9 +721,9 @@ def test_qwen35_transformers_512_checkpoint_ground_truth(tmp_path):
         elif not torch.equal(want, got):
             max_abs = (want.float() - got.float()).abs().max().item()
             mismatches.append(f"{key}: values differ (max_abs={max_abs})")
-    assert not mismatches, (
-        "lite does not preserve Transformers 5.12 HF tensors:\n" + "\n".join(mismatches)
-    )
+    assert (
+        not mismatches
+    ), "lite does not preserve Transformers 5.12 HF tensors:\n" + "\n".join(mismatches)
     print(
         "QWEN35_HF_MTP_SCHEMA_DTYPE_PARITY "
         f"mtp_keys={len(mtp_expected)} "
@@ -755,7 +745,6 @@ def test_qwen35_transformers_512_mtp_decoder_equation_parity(tmp_path):
     pytest.importorskip("safetensors")
 
     import transformers
-
     from megatron.lite.model.qwen3_5.config import Qwen35Config
 
     assert transformers.__version__ == "5.12.0", (
@@ -773,7 +762,9 @@ def test_qwen35_transformers_512_mtp_decoder_equation_parity(tmp_path):
     cfg = Qwen35Config.from_hf(source_dir)
     assert cfg.num_nextn_predict_layers == 1
     assert cfg.mtp_layer_types == ["full_attention"]
-    lite_bundle, protocol = _build(cfg, seed=20260701, optimizer=None, mtp_enable=True)
+    lite_bundle, protocol = _build(
+        cfg, seed=20260701, optimizer=None, mtp_enable=True, mtp_enable_train=True
+    )
     lite_model = lite_bundle.chunks[0]
     protocol.load_hf_weights(lite_model, source_dir, cfg, lite_bundle.parallel_state)
     lite_model.eval()
@@ -785,10 +776,7 @@ def test_qwen35_transformers_512_mtp_decoder_equation_parity(tmp_path):
     assert lite_mtp_layer.embedding is lite_model.embed
 
     input_ids = torch.tensor(
-        [
-            [3, 5, 7, 11, 13, 17, 19, 23],
-            [29, 31, 37, 41, 43, 47, 53, 59],
-        ],
+        [[3, 5, 7, 11, 13, 17, 19, 23], [29, 31, 37, 41, 43, 47, 53, 59]],
         dtype=torch.long,
         device="cuda",
     )
@@ -901,10 +889,90 @@ def test_qwen35_transformers_512_mtp_decoder_equation_parity(tmp_path):
         "MTP canonical embedding gradient norm ratio "
         f"{grad_norm_ratio} is outside [0.99, 1.01]"
     )
+
+    # Exercise the production route, including the main-label second shift,
+    # rolled validity mask, token-count normalization, and AutoScaler factor.
+    # The MTP-only fc parameter cleanly separates its auxiliary gradient from
+    # the main causal loss, so it must equal an independently computed direct
+    # predictor CE gradient times the configured scale.
+    from megatron.lite.primitive.modules.mtp import MTPLossAutoScaler
+
+    main_labels = _roll_left_zero_reference(input_ids)
+    main_loss_mask = torch.ones_like(input_ids, dtype=torch.float32)
+    main_loss_mask[:, -1] = 0
+    captured_norm_hidden: list[torch.Tensor] = []
+
+    def _capture_norm_hidden(_module, _inputs, output):
+        captured_norm_hidden.append(output.detach().clone())
+
+    lite_model.zero_grad(set_to_none=True)
+    norm_hook = lite_model.norm.register_forward_hook(_capture_norm_hidden)
+    previous_backward_scale = MTPLossAutoScaler.main_loss_backward_scale
+    try:
+        MTPLossAutoScaler.set_loss_scale(1.0)
+        production_output = lite_model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            packed_seq_params=None,
+            labels=main_labels,
+            loss_mask=main_loss_mask,
+            temperature=1.0,
+            use_fused_kernels=False,
+        )
+        assert "mtp_loss" in production_output
+        production_output["loss"].backward()
+    finally:
+        norm_hook.remove()
+        MTPLossAutoScaler.set_loss_scale(previous_backward_scale)
+
+    assert len(captured_norm_hidden) == 1
+    production_mtp_loss = production_output["mtp_loss"]
+    mtp_fc_weight = lite_mtp_layer.eh_proj.linear.weight
+    production_mtp_fc_grad = mtp_fc_weight.grad
+    assert production_mtp_fc_grad is not None
+    production_mtp_fc_grad = production_mtp_fc_grad.detach().clone()
+    assert torch.count_nonzero(production_mtp_fc_grad).item() > 0
+
+    lite_model.zero_grad(set_to_none=True)
+    direct_hidden_sbh, _direct_shifted_ids, _direct_shifted_positions = lite_mtp_layer(
+        input_ids=input_ids,
+        position_ids=position_ids,
+        hidden_states=captured_norm_hidden[0],
+        rotary_position_ids=position_ids,
+        packed_seq_params=None,
+    )
+    direct_logits = lite_model.head.gather(lite_model.head(direct_hidden_sbh))
+    direct_logits = direct_logits.transpose(0, 1).contiguous()
+    direct_ce, direct_labels, direct_mask = _mtp_depth1_ce_from_raw_tokens(
+        direct_logits, input_ids
+    )
+    assert torch.equal(direct_labels, _roll_left_zero_reference(main_labels))
+    assert torch.equal(direct_mask, _roll_left_zero_reference(main_loss_mask))
+    production_loss_abs = abs(production_mtp_loss.item() - direct_ce.item())
+    assert production_loss_abs <= 0.005, (
+        "Qwen3.5 production _apply_mtp_loss disagrees with the independent "
+        f"depth-1 target/mask equation by {production_loss_abs}"
+    )
+
+    direct_ce.backward()
+    direct_mtp_fc_grad = mtp_fc_weight.grad
+    assert direct_mtp_fc_grad is not None
+    expected_scaled_mtp_fc_grad = (
+        direct_mtp_fc_grad.detach().float() * cfg.mtp_loss_scaling_factor
+    )
+    production_scale_grad_metrics = _assert_tensor_parity(
+        "production-mtp-fc-scaled-gradient",
+        expected_scaled_mtp_fc_grad,
+        production_mtp_fc_grad,
+        cosine_min=0.999,
+        rms_relative_max=0.02,
+        max_abs_max=0.01,
+    )
     print(
         "NON_SKIP_QWEN35_TRANSFORMERS_512_MTP_DECODER_EQUATION_PARITY_PASSED "
         "authority=transformers_decoder_plus_released_root_equation "
-        "mtp_layers=1 layer_type=full_attention depth2_target=True batch=2 seq=8 "
+        "mtp_layers=1 layer_type=full_attention depth2_target=True "
+        "production_apply_mtp_loss=True batch=2 seq=8 "
         f"hidden_cosine={hidden_metrics['cosine']:.9f} "
         f"hidden_rms_relative={hidden_metrics['rms_relative']:.9f} "
         f"logits_cosine={logits_metrics['cosine']:.9f} "
@@ -913,7 +981,12 @@ def test_qwen35_transformers_512_mtp_decoder_equation_parity(tmp_path):
         f"embedding_grad_cosine={embedding_grad_metrics['cosine']:.9f} "
         f"embedding_grad_rms_relative="
         f"{embedding_grad_metrics['rms_relative']:.9f} "
-        f"embedding_grad_norm_ratio={grad_norm_ratio:.9f}"
+        f"embedding_grad_norm_ratio={grad_norm_ratio:.9f} "
+        f"production_mtp_loss_abs={production_loss_abs:.9f} "
+        f"production_scale_grad_cosine="
+        f"{production_scale_grad_metrics['cosine']:.9f} "
+        f"production_scale_grad_rms_relative="
+        f"{production_scale_grad_metrics['rms_relative']:.9f}"
     )
 
 
@@ -925,9 +998,8 @@ def test_qwen35_transformers_512_full_model_numeric_parity(tmp_path):
     pytest.importorskip("safetensors")
 
     import transformers
-    from transformers import Qwen3_5MoeForConditionalGeneration
-
     from megatron.lite.model.qwen3_5.config import Qwen35Config
+    from transformers import Qwen3_5MoeForConditionalGeneration
 
     assert transformers.__version__ == "5.12.0", (
         "the Qwen3.5 HF numeric authority is pinned to Transformers 5.12.0; "
@@ -941,9 +1013,7 @@ def test_qwen35_transformers_512_full_model_numeric_parity(tmp_path):
     _save_transformers_512_tiny_qwen35(source_dir)
 
     hf_model = Qwen3_5MoeForConditionalGeneration.from_pretrained(
-        source_dir,
-        dtype=torch.bfloat16,
-        attn_implementation="eager",
+        source_dir, dtype=torch.bfloat16, attn_implementation="eager"
     ).cuda()
     _force_hf_torch_reference_kernels(hf_model)
     hf_model.eval()
@@ -958,10 +1028,7 @@ def test_qwen35_transformers_512_full_model_numeric_parity(tmp_path):
     # Fixed, non-padding token batch.  Tokens are deliberately unique so the
     # embedding-output gradient probe is not obscured by repeated-row reduction.
     input_ids = torch.tensor(
-        [
-            [3, 5, 7, 11, 13, 17, 19, 23],
-            [29, 31, 37, 41, 43, 47, 53, 59],
-        ],
+        [[3, 5, 7, 11, 13, 17, 19, 23], [29, 31, 37, 41, 43, 47, 53, 59]],
         dtype=torch.long,
         device="cuda",
     )
@@ -1001,9 +1068,7 @@ def test_qwen35_transformers_512_full_model_numeric_parity(tmp_path):
             return_dict=True,
         )
         lite_output = lite_model(
-            input_ids=input_ids,
-            position_ids=position_ids,
-            packed_seq_params=None,
+            input_ids=input_ids, position_ids=position_ids, packed_seq_params=None
         )
     finally:
         for handle in [
@@ -1084,9 +1149,9 @@ def test_qwen35_transformers_512_full_model_numeric_parity(tmp_path):
         "[qwen35-hf-parity] embedding-output-gradient norms: "
         f"hf={hf_grad_norm:.9f} lite={lite_grad_norm:.9f} ratio={grad_norm_ratio:.9f}"
     )
-    assert 0.99 <= grad_norm_ratio <= 1.01, (
-        f"embedding-output gradient norm ratio {grad_norm_ratio} is outside [0.99, 1.01]"
-    )
+    assert (
+        0.99 <= grad_norm_ratio <= 1.01
+    ), f"embedding-output gradient norm ratio {grad_norm_ratio} is outside [0.99, 1.01]"
     print(
         "NON_SKIP_QWEN35_TRANSFORMERS_512_FULL_MODEL_PARITY_PASSED "
         "layers=2 layer_types=[full_attention,linear_attention] batch=2 seq=8 "
@@ -1114,11 +1179,10 @@ def test_qwen35_real_hf_load_export_matches_original(tmp_path):
         pytest.skip("ground-truth smoke runs single-rank (tp1).")
     import json
 
-    from safetensors import safe_open
-
     from megatron.lite.model.qwen3_5.config import Qwen35Config
     from megatron.lite.model.qwen3_5.lite import protocol
     from megatron.lite.runtime.contracts.config import ParallelConfig
+    from safetensors import safe_open
 
     model_dir = os.environ["QWEN35_HF_DIR"]
     cfg = Qwen35Config.from_hf(model_dir)
@@ -1189,6 +1253,6 @@ def test_qwen35_real_hf_load_export_matches_original(tmp_path):
             o, e, atol=2e-2, rtol=2e-2
         ):  # bf16-cast export tolerance
             mism.append(f"{k} max_abs_diff={(o - e).abs().max().item()}")
-    assert not mism, (
-        "lite export does not match original HF safetensors:\n" + "\n".join(mism)
-    )
+    assert (
+        not mism
+    ), "lite export does not match original HF safetensors:\n" + "\n".join(mism)

--- a/experimental/lite/tests/smoke/primitive/test_save_load_export_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_save_load_export_smoke.py
@@ -13,7 +13,7 @@ tp2/ep2/pp2 topology (exactly 8 GPUs). fsdp2 cases use torch DCP on a
 pure-DP mesh. Both checkpoint paths are exercised through the unified
 MegatronLiteRuntime so the matrix guards the runtime entry points.
 
-Run with torchrun --nproc_per_node=8 -m pytest, selecting per-env subsets
+Run with torchrun --nproc_per_node=8 -m pytest --mlite-smoke, selecting per-env subsets
 with -k (qwen3_5 needs the qwen3.5 canary site; the four deepseek/qwen3_moe
 models need the DSA overlay). Models gate themselves with importorskip so a
 wrong-env invocation skips rather than errors.
@@ -21,14 +21,15 @@ wrong-env invocation skips rather than errors.
 
 from __future__ import annotations
 
+import copy
 import os
 from datetime import timedelta
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 import torch
 import torch.distributed as dist
-
 from megatron.lite.primitive.deterministic import set_deterministic
 from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
 from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
@@ -176,7 +177,19 @@ def _glm5():
         n_routed_experts=4,
         n_shared_experts=1,
         num_experts_per_tok=2,
+        # Exercise GLM5.2 rather than the legacy all-full GLM5 path in both
+        # exact-resume backends.  The explicit list is the canonical HF
+        # schedule; freq/offset remain present so a future fallback cannot
+        # silently change this fixture's model family.
+        index_topk_freq=2,
+        index_skip_topk_offset=1,
+        indexer_types=["full", "shared"],
+        rope_interleave=True,
+        indexer_rope_interleave=True,
     )
+    assert cfg.resolved_dsa_indexer_types == ("full", "shared")
+    assert cfg.uses_dsa_index_share is True
+    assert cfg.uses_configured_dsa_rope_layout is True
     return cfg, protocol
 
 
@@ -280,19 +293,69 @@ def _single_node_cuda_dist():
             dist.destroy_process_group()
 
 
+# Process groups created by MLite's ``init_parallel`` are independent of
+# MCore's globals and must be destroyed explicitly after every matrix case.  A
+# round-trip builds both a source and a fresh destination model, so retaining
+# these groups across ten parameterized cases exhausts communicators quickly.
+_BUILT_PARALLEL_STATES: list = []
+_PS_GROUP_ATTRS = (
+    "tp_group",
+    "ep_group",
+    "etp_group",
+    "cp_group",
+    "pp_group",
+    "pp_cpu_group",
+    "embedding_group",
+    "dp_group",
+    "dp_cp_group",
+    "tp_ep_group",
+    "ep_dp_group",
+)
+
+
 @pytest.fixture(autouse=True)
 def _reset_parallel_state_between_tests():
-    """Tear down Megatron model-parallel groups after each case.
+    """Tear down MCore and MLite process groups after each case.
 
     The matrix builds models with different topologies (tp2/ep2/pp2 for
-    dist_opt, pure-DP for fsdp2). Leaving a prior case's mpu groups initialized
-    desyncs the next case's collectives, so reset between tests.
+    dist_opt, pp2/dp4 for fsdp2). Leaving a prior case's groups initialized
+    leaks roughly twenty MLite communicators per round-trip and can desync a
+    later case's collectives, so reset both group owners between tests.
     """
     yield
+    import gc
+
     from megatron.core import parallel_state as mpu
 
     if mpu.is_initialized():
         mpu.destroy_model_parallel()
+    gc.collect()
+
+    cleanup_errors: list[str] = []
+    destroyed_groups: list[object] = []
+    for ps in _BUILT_PARALLEL_STATES:
+        for attr in _PS_GROUP_ATTRS:
+            group = getattr(ps, attr, None)
+            if group is None or group is dist.group.WORLD:
+                continue
+            setattr(ps, attr, None)
+            if any(group is destroyed for destroyed in destroyed_groups):
+                continue
+            destroyed_groups.append(group)
+            try:
+                dist.destroy_process_group(group)
+            except Exception as exc:  # report on every rank after best-effort cleanup
+                cleanup_errors.append(f"{attr}: {type(exc).__name__}: {exc}")
+    _BUILT_PARALLEL_STATES.clear()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+    # A rank-local cleanup failure must fail the entire distributed case rather
+    # than letting peers enter the next test with asymmetric group state.
+    gathered_errors: list[list[str] | None] = [None] * dist.get_world_size()
+    dist.all_gather_object(gathered_errors, cleanup_errors)
+    if any(gathered_errors):
+        pytest.fail(f"MLite process-group cleanup failed by rank: {gathered_errors}")
 
 
 # GLM5 / DeepSeek-V4 native lite support TP=ETP=VPP=1 only (EP/PP/CP wired
@@ -364,6 +427,7 @@ def _build_handle(
         mtp_enable_train=train_mtp,
     )
     bundle = protocol.build_model(cfg, impl_cfg=impl_cfg)
+    _BUILT_PARALLEL_STATES.append(bundle.parallel_state)
     chunks = bundle.chunks
 
     if bundle.extras.get("optimizer_backend") == "fsdp2":
@@ -391,6 +455,33 @@ def _build_handle(
         _extras=extras,
     )
     return handle, cfg, protocol
+
+
+def _assert_glm52_index_share_model_contract(handle: ModelHandle, cfg) -> None:
+    """Prove the distributed GLM resume fixture really built full/shared DSA."""
+
+    assert cfg.resolved_dsa_indexer_types == ("full", "shared")
+    assert cfg.uses_dsa_index_share is True
+    assert cfg.uses_configured_dsa_rope_layout is True
+
+    local_full = 0
+    local_shared = 0
+    for chunk in handle._extras["model_chunks"]:
+        for layer_idx, layer in zip(chunk.layer_indices, chunk.layers, strict=True):
+            attention = layer.self_attention.self_attention
+            if cfg.dsa_indexer_type(layer_idx) == "shared":
+                local_shared += 1
+                assert attention.skip_topk is True
+                assert attention.indexer is None
+            else:
+                local_full += 1
+                assert attention.skip_topk is False
+                assert attention.indexer is not None
+
+    counts = torch.tensor([local_full, local_shared], device="cuda", dtype=torch.int64)
+    dist.all_reduce(counts, group=dist.group.WORLD)
+    assert int(counts[0]) > 0, "GLM5.2 resume fixture built no full indexer layer"
+    assert int(counts[1]) > 0, "GLM5.2 resume fixture built no shared indexer layer"
 
 
 def _shared_tmp_path(tmp_path, suffix: str) -> str:
@@ -446,14 +537,106 @@ def _local_named_params(handle: ModelHandle) -> dict[str, torch.Tensor]:
     return params
 
 
-def _assert_params_bitwise_equal(lhs: ModelHandle, rhs: ModelHandle) -> None:
-    lhs_params = _local_named_params(lhs)
-    rhs_params = _local_named_params(rhs)
-    assert lhs_params.keys() == rhs_params.keys()
-    assert lhs_params, "expected at least one local parameter to compare."
+def _local_persistent_buffers(handle: ModelHandle) -> dict[str, torch.Tensor]:
+    from megatron.lite.primitive.ckpt.hf_weights import named_persistent_buffers
+    from megatron.lite.primitive.optimizers.fsdp2.adamw import to_local_tensor
+
+    buffers: dict[str, torch.Tensor] = {}
+    for chunk_idx, chunk in enumerate(handle._extras["model_chunks"]):
+        for name, buffer in named_persistent_buffers(chunk):
+            buffers[f"{chunk_idx}.{name}"] = (
+                to_local_tensor(buffer.detach()).cpu().clone()
+            )
+    return buffers
+
+
+def _local_model_state(handle: ModelHandle) -> dict[str, torch.Tensor]:
+    return {
+        **{
+            f"parameter.{name}": value
+            for name, value in _local_named_params(handle).items()
+        },
+        **{
+            f"persistent_buffer.{name}": value
+            for name, value in _local_persistent_buffers(handle).items()
+        },
+    }
+
+
+def _seed_persistent_buffers(handle: ModelHandle, cfg) -> int:
+    """Make checkpointed buffers non-default so a fresh build cannot fake restore."""
+    from megatron.lite.primitive.ckpt.hf_weights import named_persistent_buffers
+    from megatron.lite.primitive.optimizers.fsdp2.adamw import to_local_tensor
+
+    local_count = 0
+    num_experts = max(
+        int(getattr(cfg, "num_experts", getattr(cfg, "n_routed_experts", 2))), 1
+    )
+    with torch.no_grad():
+        for chunk in handle._extras["model_chunks"]:
+            for _name, buffer in named_persistent_buffers(chunk):
+                local = to_local_tensor(buffer)
+                if local.numel() == 0:
+                    continue
+                values = torch.arange(local.numel(), device=local.device).reshape(
+                    local.shape
+                )
+                if local.dtype == torch.bool:
+                    values = values.remainder(2).bool()
+                elif local.dtype.is_floating_point:
+                    values = values.float().mul_(0.001).add_(0.125).to(local.dtype)
+                else:
+                    values = values.remainder(num_experts).to(local.dtype)
+                local.copy_(values)
+                local_count += 1
+
+    counts: list[int | None] = [None] * dist.get_world_size()
+    dist.all_gather_object(counts, local_count)
+    return sum(int(count or 0) for count in counts)
+
+
+def _assert_rng_state_equal(lhs: dict, rhs: dict, context: str) -> None:
+    assert lhs["random_rng_state"] == rhs["random_rng_state"], context
+    lhs_np, rhs_np = lhs["np_rng_state"], rhs["np_rng_state"]
+    assert lhs_np[0] == rhs_np[0], context
+    np.testing.assert_array_equal(lhs_np[1], rhs_np[1], err_msg=context)
+    assert lhs_np[2:] == rhs_np[2:], context
+    torch.testing.assert_close(
+        lhs["torch_rng_state"], rhs["torch_rng_state"], atol=0, rtol=0, msg=context
+    )
+    for key in ("cuda_rng_state",):
+        if lhs[key] is None or rhs[key] is None:
+            assert lhs[key] is rhs[key], context
+        else:
+            torch.testing.assert_close(lhs[key], rhs[key], atol=0, rtol=0, msg=context)
+    assert lhs["rng_tracker_states"], f"{context}: RNG tracker state is empty"
+    assert rhs["rng_tracker_states"], f"{context}: RNG tracker state is empty"
+    assert lhs["rng_tracker_states"].keys() == rhs["rng_tracker_states"].keys(), context
+    for name in lhs["rng_tracker_states"]:
+        torch.testing.assert_close(
+            lhs["rng_tracker_states"][name],
+            rhs["rng_tracker_states"][name],
+            atol=0,
+            rtol=0,
+            msg=f"{context}: tracker={name}",
+        )
+
+
+def _assert_packed_batch_equal(lhs: PackedBatch, rhs: PackedBatch) -> None:
+    for name in ("input_ids", "labels", "seq_lens"):
+        torch.testing.assert_close(
+            getattr(lhs, name), getattr(rhs, name), atol=0, rtol=0, msg=name
+        )
+
+
+def _assert_model_state_bitwise_equal(lhs: ModelHandle, rhs: ModelHandle) -> None:
+    lhs_state = _local_model_state(lhs)
+    rhs_state = _local_model_state(rhs)
+    assert lhs_state.keys() == rhs_state.keys()
+    assert lhs_state, "expected at least one local model-state tensor to compare."
     mismatches = []
-    for name in lhs_params:
-        lhs_tensor, rhs_tensor = lhs_params[name], rhs_params[name]
+    for name in lhs_state:
+        lhs_tensor, rhs_tensor = lhs_state[name], rhs_state[name]
         if (
             lhs_tensor.shape != rhs_tensor.shape
             or lhs_tensor.dtype != rhs_tensor.dtype
@@ -465,9 +648,9 @@ def _assert_params_bitwise_equal(lhs: ModelHandle, rhs: ModelHandle) -> None:
                 else float("inf")
             )
             mismatches.append(f"{name} (max_abs_diff={diff})")
-    assert not mismatches, "save/load not bitwise; mismatched params:\n" + "\n".join(
-        mismatches
-    )
+    assert (
+        not mismatches
+    ), "save/load not bitwise; mismatched model state:\n" + "\n".join(mismatches)
 
 
 def _is_valid_hf_export_key(key: str, model_name: str) -> bool:
@@ -489,40 +672,10 @@ def _is_valid_hf_export_key(key: str, model_name: str) -> bool:
     return key.startswith("model.") or key in ("lm_head.weight",)
 
 
-def _export_and_reload(
-    handle: ModelHandle, cfg, protocol, out_dir: str, model_name: str
-) -> None:
-    """Export HF weights (bf16) and assert the reloaded shards are valid.
-
-    The integration gate deliberately requests BF16 from the canonical export
-    generator. Materialization uses the production distributed writer so
-    duplicate keys, generator errors, empty rank-0 output, and write failures
-    are propagated to every rank instead of being hidden by ``dict(generator)``.
-    """
-    chunks = handle._extras["model_chunks"]
-    ps = handle._parallel_state
-
-    if not hasattr(protocol, "export_hf_weights"):
-        raise AssertionError(f"{protocol.__name__} exposes no HF export path.")
-    from megatron.lite.primitive.ckpt.hf_weights import (
-        save_hf_weight_pairs_distributed,
-    )
-
-    save_hf_weight_pairs_distributed(
-        protocol.export_hf_weights(
-            chunks,
-            cfg,
-            ps,
-            rank0_only=True,
-            export_dtype=torch.bfloat16,
-        ),
-        out_dir,
-    )
-
-    if dist.get_rank() != 0:
-        dist.barrier()
-        return
-
+def _validate_rank0_hf_export_file(
+    expected: dict[str, torch.Tensor], cfg, out_dir: str, model_name: str
+) -> int:
+    """Require every persisted tensor to equal the canonical source export."""
     from safetensors import safe_open
 
     shards = [f for f in os.listdir(out_dir) if f.endswith(".safetensors")]
@@ -538,22 +691,45 @@ def _export_and_reload(
         with safe_open(os.path.join(out_dir, shard), framework="pt") as fh:
             for key in fh.keys():
                 tensor = fh.get_tensor(key)
+                assert key not in keys, f"duplicate HF export key across files: {key}"
+                assert key in expected, f"file contains unexpected HF export key {key}"
+                source_tensor = expected[key].detach().cpu().contiguous()
+                assert tensor.shape == source_tensor.shape, (
+                    f"{key} file shape={tuple(tensor.shape)}, "
+                    f"canonical export shape={tuple(source_tensor.shape)}"
+                )
+                assert tensor.dtype == source_tensor.dtype, (
+                    f"{key} file dtype={tensor.dtype}, "
+                    f"canonical export dtype={source_tensor.dtype}"
+                )
+                torch.testing.assert_close(
+                    tensor,
+                    source_tensor,
+                    atol=0,
+                    rtol=0,
+                    msg=f"{key}: safetensors differs from canonical source export",
+                )
                 if tensor.dtype.is_floating_point:
-                    assert tensor.dtype == torch.bfloat16, (
-                        f"{key} exported as {tensor.dtype}, want bf16"
-                    )
+                    assert (
+                        tensor.dtype == torch.bfloat16
+                    ), f"{key} exported as {tensor.dtype}, want bf16"
                 else:
-                    assert tensor.dtype in (torch.int64, torch.int32, torch.bool), (
-                        f"{key} exported as unexpected non-float dtype {tensor.dtype}"
-                    )
-                assert torch.isfinite(tensor.float()).all(), (
-                    f"{key} has non-finite values"
-                )
-                assert _is_valid_hf_export_key(key, model_name), (
-                    f"unexpected non-HF export key: {key}"
-                )
+                    assert tensor.dtype in (
+                        torch.int64,
+                        torch.int32,
+                        torch.bool,
+                    ), f"{key} exported as unexpected non-float dtype {tensor.dtype}"
+                assert torch.isfinite(
+                    tensor.float()
+                ).all(), f"{key} has non-finite values"
+                assert _is_valid_hf_export_key(
+                    key, model_name
+                ), f"unexpected non-HF export key: {key}"
                 keys.add(key)
-    assert keys, "exported zero tensors"
+    assert keys == expected.keys() and keys, (
+        "safetensors key set differs from the canonical source export: "
+        f"missing={sorted(expected.keys() - keys)} unexpected={sorted(keys - expected.keys())}"
+    )
     # PP-gather completeness: the rank-0 export must carry EVERY decoder layer's
     # weights (all pipeline stages gathered), not just the first stage's — guards
     # against a pp-blind export silently dropping later stages' layers.
@@ -570,7 +746,161 @@ def _export_and_reload(
         f"export missing decoder layers {missing} (PP gather incomplete); "
         f"sample keys: {sorted(keys)[:6]}"
     )
-    dist.barrier()
+    return len(expected)
+
+
+def _export_and_reload(
+    handle: ModelHandle, cfg, protocol, out_dir: str, model_name: str
+) -> int:
+    """Export HF weights once and verify the persisted key/value state exactly.
+
+    The integration gate deliberately requests BF16 from the canonical export
+    generator. Materialization uses the production distributed writer so
+    duplicate keys, generator errors, empty rank-0 output, and write failures
+    are propagated to every rank instead of being hidden by ``dict(generator)``.
+    """
+    chunks = handle._extras["model_chunks"]
+    ps = handle._parallel_state
+
+    if not hasattr(protocol, "export_hf_weights"):
+        raise AssertionError(f"{protocol.__name__} exposes no HF export path.")
+    from megatron.lite.primitive.ckpt.hf_weights import (
+        materialize_hf_weights_distributed,
+        save_hf_weight_pairs_distributed,
+    )
+
+    # Consume the collective-bearing canonical generator exactly once. Keep
+    # rank 0's materialized key/value oracle, then give the writer only the
+    # side-effect-free dict view so file validation cannot accidentally execute
+    # TP/EP/PP/FSDP collectives a second time.
+    expected = materialize_hf_weights_distributed(
+        protocol.export_hf_weights(
+            chunks, cfg, ps, rank0_only=True, export_dtype=torch.bfloat16
+        )
+    )
+    save_hf_weight_pairs_distributed(expected.items(), out_dir)
+
+    outcome: list[str | int | None] = [None, None]
+    if dist.get_rank() == 0:
+        try:
+            outcome[1] = _validate_rank0_hf_export_file(
+                expected, cfg, out_dir, model_name
+            )
+        except Exception as exc:
+            outcome[0] = f"{type(exc).__name__}: {exc}"
+    # A rank-0 validation failure must release peers instead of stranding them
+    # at a barrier until the external torchrun timeout fires.
+    dist.broadcast_object_list(outcome, src=0)
+    if outcome[0] is not None:
+        raise AssertionError(f"synchronized HF export validation failed: {outcome[0]}")
+    assert isinstance(outcome[1], int) and outcome[1] > 0
+    return outcome[1]
+
+
+def _assert_live_fsdp2_dtensors_materialize_exactly(
+    handle: ModelHandle,
+) -> dict[str, int | bool]:
+    """Prove that live FSDP2 parameters are DTensors and reconstruct exactly.
+
+    ``DTensor.full_tensor()`` is the production HF-export boundary.  Checking
+    only that an export file is finite would let a no-op FSDP wrapper or a
+    duplicated/misordered shard reconstruction pass.  For every live DTensor,
+    independently all-gather its local shards over the DTensor mesh, trim any
+    FSDP padding using the public ``Shard`` metadata, and require bitwise
+    equality with ``full_tensor()``.
+    """
+    from torch.distributed.tensor import DTensor, Shard
+
+    local_dtensor_count = 0
+    local_exact_count = 0
+    for chunk in handle._extras["model_chunks"]:
+        for name, parameter in chunk.named_parameters():
+            if not isinstance(parameter, DTensor):
+                continue
+            local_dtensor_count += 1
+            placements = tuple(parameter.placements)
+            mesh = parameter.device_mesh
+            assert mesh.ndim == 1 and len(placements) == 1, (
+                f"{name}: FSDP2 export expected one-dimensional DTensor sharding, "
+                f"got mesh_ndim={mesh.ndim} placements={placements}"
+            )
+            placement = placements[0]
+            assert isinstance(
+                placement, Shard
+            ), f"{name}: FSDP2 export expected a Shard placement, got {placement}"
+
+            local = parameter.to_local().detach()
+            mesh_size = int(mesh.size())
+            group = mesh.get_group()
+            shard_dim = int(placement.dim)
+            global_dim = int(parameter.shape[shard_dim])
+            # Uneven dim-0 FSDP shards expose their logical (possibly empty)
+            # local shape through DTensor, while the collective itself uses
+            # equal padded chunks. Recreate that neutral padding explicitly so
+            # the independent all-gather also covers dimensions smaller than
+            # the DP mesh.
+            padded_dim = (global_dim + mesh_size - 1) // mesh_size
+            padded_shape = list(local.shape)
+            padded_shape[shard_dim] = padded_dim
+            padded_local = local.new_zeros(padded_shape)
+            if local.numel() > 0:
+                padded_local.narrow(shard_dim, 0, local.shape[shard_dim]).copy_(local)
+            gathered = [torch.empty_like(padded_local) for _ in range(mesh_size)]
+            dist.all_gather(gathered, padded_local.contiguous(), group=group)
+
+            logical_parts = []
+            for mesh_rank, shard in enumerate(gathered):
+                logical_size, _offset = Shard.local_shard_size_and_offset(
+                    global_dim, mesh_size, mesh_rank
+                )
+                logical_parts.append(shard.narrow(shard_dim, 0, int(logical_size)))
+            independently_gathered = torch.cat(logical_parts, dim=shard_dim)
+            materialized = parameter.detach().full_tensor()
+
+            assert not isinstance(
+                materialized, DTensor
+            ), f"{name}: full_tensor() returned another DTensor"
+            assert tuple(materialized.shape) == tuple(parameter.shape), (
+                f"{name}: full_tensor shape={tuple(materialized.shape)}, "
+                f"global shape={tuple(parameter.shape)}"
+            )
+            assert tuple(independently_gathered.shape) == tuple(parameter.shape), (
+                f"{name}: independent shard gather shape="
+                f"{tuple(independently_gathered.shape)}, global shape={tuple(parameter.shape)}"
+            )
+            torch.testing.assert_close(
+                materialized,
+                independently_gathered,
+                atol=0,
+                rtol=0,
+                msg=f"{name}: full_tensor() differs from independently gathered FSDP shards",
+            )
+            local_exact_count += 1
+
+    local_counts: list[tuple[int, int] | None] = [None] * dist.get_world_size()
+    dist.all_gather_object(
+        local_counts, (local_dtensor_count, local_exact_count), group=dist.group.WORLD
+    )
+    assert all(counts is not None and counts[0] > 0 for counts in local_counts), (
+        "FSDP2 export expected every rank to own live DTensor parameters, "
+        f"got per-rank counts={local_counts}"
+    )
+    assert all(
+        counts[0] == counts[1] for counts in local_counts if counts is not None
+    ), (
+        "not every observed FSDP2 DTensor passed exact full-tensor reconstruction: "
+        f"{local_counts}"
+    )
+    global_dtensor_count = sum(
+        counts[0] for counts in local_counts if counts is not None
+    )
+    global_exact_count = sum(counts[1] for counts in local_counts if counts is not None)
+    return {
+        "global_dtensor_count": global_dtensor_count,
+        "global_exact_count": global_exact_count,
+        "materialized_exactly": global_dtensor_count > 0
+        and global_exact_count == global_dtensor_count,
+    }
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
@@ -587,15 +917,33 @@ def test_save_load_roundtrip(model_name, backend, tmp_path):
     set_deterministic(2026)
 
     saved, cfg, _protocol = _build_handle(model_name, backend, seed=4242)
+    if model_name == "glm5":
+        _assert_glm52_index_share_model_contract(saved, cfg)
     _train_step(saved, backend, cfg)
+    seeded_buffer_count = _seed_persistent_buffers(saved, cfg)
+    if model_name in {"kimi_k2", "glm5", "deepseek_v4"}:
+        assert (
+            seeded_buffer_count > 0
+        ), f"{model_name} proxy unexpectedly exposes no persistent checkpoint buffers"
 
     ckpt_dir = _shared_tmp_path(tmp_path, "ckpt")
     runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
     runtime.save_checkpoint(saved, ckpt_dir, step=1)
+    from megatron.lite.primitive.ckpt import dcp as dcp_impl
+
+    checkpoint_rng_state = copy.deepcopy(dcp_impl._get_rng_state())
 
     loaded, _cfg2, _proto2 = _build_handle(model_name, backend, seed=9999)
+    if model_name == "glm5":
+        _assert_glm52_index_share_model_contract(loaded, _cfg2)
     assert runtime.load_checkpoint(loaded, ckpt_dir) == 1
-    _assert_params_bitwise_equal(saved, loaded)
+    _assert_model_state_bitwise_equal(saved, loaded)
+    restored_rng_state = copy.deepcopy(dcp_impl._get_rng_state())
+    _assert_rng_state_equal(
+        checkpoint_rng_state,
+        restored_rng_state,
+        f"{model_name}/{backend} RNG state after load",
+    )
 
     # A checkpoint is not resume-ready merely because model tensors reload.
     # Require non-empty optimizer moments/steps and, where the backend exposes
@@ -618,10 +966,22 @@ def test_save_load_roundtrip(model_name, backend, tmp_path):
     else:
         assert saved_master == loaded_master == {}
         master_weights_evidence = "not_applicable"
-    resume_batch = _random_packed_batch(cfg.vocab_size)
-    _train_step(saved, backend, cfg, batch=resume_batch, seed=20260628)
-    _train_step(loaded, backend, cfg, batch=resume_batch, seed=20260628)
-    _assert_params_bitwise_equal(saved, loaded)
+    dcp_impl._restore_rng_state(copy.deepcopy(restored_rng_state))
+    saved_resume_batch = _random_packed_batch(cfg.vocab_size)
+    _train_step(saved, backend, cfg, batch=saved_resume_batch)
+    saved_post_step_rng = copy.deepcopy(dcp_impl._get_rng_state())
+
+    dcp_impl._restore_rng_state(copy.deepcopy(restored_rng_state))
+    loaded_resume_batch = _random_packed_batch(cfg.vocab_size)
+    _assert_packed_batch_equal(saved_resume_batch, loaded_resume_batch)
+    _train_step(loaded, backend, cfg, batch=loaded_resume_batch)
+    loaded_post_step_rng = copy.deepcopy(dcp_impl._get_rng_state())
+    _assert_rng_state_equal(
+        saved_post_step_rng,
+        loaded_post_step_rng,
+        f"{model_name}/{backend} RNG state after resumed step",
+    )
+    _assert_model_state_bitwise_equal(saved, loaded)
     _assert_nonempty_named_bitwise_equal(
         _opt_state_snapshot(saved, backend),
         _opt_state_snapshot(loaded, backend),
@@ -649,35 +1009,74 @@ def test_save_load_roundtrip(model_name, backend, tmp_path):
             enabled=bool(ps.embedding_groups_initialized),
         )
     if dist.get_rank() == 0:
+        dsa_index_share_evidence = (
+            "full_shared_exact" if model_name == "glm5" else "not_applicable"
+        )
         print(
             "NON_SKIP_DISTRIBUTED_CHECKPOINT_RESUME_EXACT "
-            f"model={model_name} backend={backend} model_params=nonempty_exact "
+            f"model={model_name} backend={backend} model_state=nonempty_exact "
+            f"seeded_persistent_buffers_global={seeded_buffer_count} "
             "optimizer_state=nonempty_exact "
             f"master_weights={master_weights_evidence} next_step=bitwise_exact "
-            "mtp_embedding_replicas=validated_when_enabled"
+            "rng_sidecar=exact resume_batch_from_rng=bitwise_exact "
+            "mtp_embedding_replicas=validated_when_enabled "
+            f"dsa_index_share={dsa_index_share_evidence}"
         )
 
 
-@pytest.mark.parametrize("model_name", list(MODELS))
-def test_export_hf_bf16_reload(model_name, tmp_path):
+_EXPORT_CASES = [
+    *((model_name, "dist_opt") for model_name in MODELS),
+    ("deepseek_v4", "fsdp2"),
+    ("qwen3_5", "fsdp2"),
+]
+
+
+@pytest.mark.parametrize(("model_name", "backend"), _EXPORT_CASES)
+def test_export_hf_bf16_reload(model_name, backend, tmp_path):
     """Export HF weights (bf16) and reload the safetensors shards.
 
-    Export output is backend-agnostic, so this exercises the canonical export
-    path: a dist_opt model whose TP/EP/PP shards are gathered to full HF
-    tensors. NOTE: exporting directly from a live fsdp2 (DTensor-sharded) model
-    is NOT covered here — save_hf_weights' gather is not DTensor-aware and
-    deadlocks; tracked as a known gap.
+    The five dist-opt cases exercise TP/EP/PP gathering. DeepSeek-V4 and
+    Qwen3.5 additionally exercise live FSDP2 DTensor materialization over the
+    PP2 x DP4 topology; these are the release-regression models for PR #66.
     """
     if dist.get_world_size() != 8:
         pytest.skip("export proxy smoke requires exactly 8 GPUs.")
 
     set_deterministic(2026)
 
-    handle, cfg, protocol = _build_handle(model_name, "dist_opt", seed=4242)
-    _train_step(handle, "dist_opt", cfg)
+    handle, cfg, protocol = _build_handle(model_name, backend, seed=4242)
+    _train_step(handle, backend, cfg)
+
+    fsdp_evidence: dict[str, int | bool] | None = None
+    if backend == "fsdp2":
+        fsdp_evidence = _assert_live_fsdp2_dtensors_materialize_exactly(handle)
 
     export_dir = _shared_tmp_path(tmp_path, "hf_export")
-    _export_and_reload(handle, cfg, protocol, export_dir, model_name)
+    exact_exported_tensors = _export_and_reload(
+        handle, cfg, protocol, export_dir, model_name
+    )
+    if dist.get_rank() == 0:
+        observed_dtensors = (
+            int(fsdp_evidence["global_dtensor_count"])
+            if fsdp_evidence is not None
+            else 0
+        )
+        exact_dtensors = (
+            int(fsdp_evidence["global_exact_count"]) if fsdp_evidence is not None else 0
+        )
+        fsdp_materialized = (
+            bool(fsdp_evidence["materialized_exactly"])
+            if fsdp_evidence is not None
+            else False
+        )
+        print(
+            "NON_SKIP_HF_EXPORT_RELOAD "
+            f"model={model_name} backend={backend} pp=2 "
+            f"fsdp_dtensor_materialized={fsdp_materialized} "
+            f"observed_dtensor_params_global={observed_dtensors} "
+            f"full_tensor_exact_params_global={exact_dtensors} "
+            f"canonical_export_file_exact_tensors={exact_exported_tensors}"
+        )
 
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -822,18 +1221,18 @@ def test_offload_onload_roundtrip(model_name, backend, tmp_path):
     assert _opt_state_devices(handle, backend) == {"cuda"}
 
     runtime.to(handle, "cpu", model=True, optimizer=True, grad=True)
-    assert _opt_state_devices(handle, backend) == {"cpu"}, (
-        "optimizer state not offloaded to CPU."
-    )
+    assert _opt_state_devices(handle, backend) == {
+        "cpu"
+    }, "optimizer state not offloaded to CPU."
     if backend == "fsdp2":
         # fsdp2 moves params to CPU directly; dist_opt instead frees the GPU
         # buffer storage (params keep a 0-size cuda handle), so assert only fsdp2.
         assert _local_param_devices(handle) == {"cpu"}, "params not offloaded to CPU."
 
     runtime.to(handle, "cuda", model=True, optimizer=True, grad=True)
-    assert _opt_state_devices(handle, backend) == {"cuda"}, (
-        "optimizer state not back on GPU."
-    )
+    assert _opt_state_devices(handle, backend) == {
+        "cuda"
+    }, "optimizer state not back on GPU."
     assert _local_param_devices(handle) == {"cuda"}, "params not back on GPU."
 
     _assert_named_bitwise_equal(params_before, _local_named_params(handle), "param")
@@ -862,7 +1261,7 @@ def test_offload_fraction_keeps_optimizer_state_on_cpu(model_name, backend, tmp_
         offload_fraction=1.0,
     )
     _train_step(handle, backend, cfg)
-    assert "cpu" in _opt_state_devices(handle, backend), (
-        "offload_fraction=1.0 should keep optimizer update state on CPU."
-    )
+    assert "cpu" in _opt_state_devices(
+        handle, backend
+    ), "offload_fraction=1.0 should keep optimizer update state on CPU."
     _train_step(handle, backend, cfg)  # trains with the offloaded update state

--- a/experimental/lite/tests/smoke/primitive/test_save_load_export_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_save_load_export_smoke.py
@@ -18,6 +18,7 @@ with -k (qwen3_5 needs the qwen3.5 canary site; the four deepseek/qwen3_moe
 models need the DSA overlay). Models gate themselves with importorskip so a
 wrong-env invocation skips rather than errors.
 """
+
 from __future__ import annotations
 
 import os
@@ -34,7 +35,12 @@ from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConf
 from megatron.lite.runtime.contracts.data import PackedBatch
 from megatron.lite.runtime.contracts.handle import ModelHandle
 
-pytestmark = [pytest.mark.mlite, pytest.mark.smoke, pytest.mark.gpu, pytest.mark.distributed]
+pytestmark = [
+    pytest.mark.mlite,
+    pytest.mark.smoke,
+    pytest.mark.gpu,
+    pytest.mark.distributed,
+]
 
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -175,7 +181,9 @@ def _glm5():
 
 
 def _deepseek_v4():
-    pytest.importorskip("cudnn", reason="deepseek_v4 fused DSA needs the cudnn DSA stack.")
+    pytest.importorskip(
+        "cudnn", reason="deepseek_v4 fused DSA needs the cudnn DSA stack."
+    )
     _require_te()
     from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
     from megatron.lite.model.deepseek_v4.lite import protocol
@@ -340,12 +348,20 @@ def _build_handle(
     torch.cuda.manual_seed_all(seed)
 
     parallel = topology or _topology(model_name, backend)
+    # PP-replicated MTP embeddings need first/last-stage gradient summation.
+    # dist_opt provides that protocol; FSDP2 currently does not, so its DS4
+    # checkpoint lane intentionally validates the backbone without mounting
+    # MTP. The dist_opt lane enables and trains DS4 MTP so its parameters,
+    # optimizer state, shared embedding, and resumed next step are all covered.
+    train_mtp = model_name == "deepseek_v4" and backend == "dist_opt"
     impl_cfg = protocol.ImplConfig(
         parallel=parallel,
         optimizer=backend,
         optimizer_config=_optimizer_config(offload_fraction),
         use_deepep=False,
         deterministic=True,
+        mtp_enable=train_mtp,
+        mtp_enable_train=train_mtp,
     )
     bundle = protocol.build_model(cfg, impl_cfg=impl_cfg)
     chunks = bundle.chunks
@@ -395,12 +411,23 @@ def _random_packed_batch(vocab_size: int) -> PackedBatch:
     )
 
 
-def _train_step(handle: ModelHandle, backend: str, cfg) -> None:
+def _train_step(
+    handle: ModelHandle,
+    backend: str,
+    cfg,
+    *,
+    batch: PackedBatch | None = None,
+    seed: int | None = None,
+) -> None:
     # Unified path for both backends: the runtime routes pp>1 through the
     # pipeline schedule regardless of optimizer backend, so fsdp2 also exercises
     # pipeline parallelism here (not just pure DP).
+    if seed is not None:
+        torch.manual_seed(seed)
+        torch.cuda.manual_seed_all(seed)
     runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
-    batch = _random_packed_batch(cfg.vocab_size)
+    if batch is None:
+        batch = _random_packed_batch(cfg.vocab_size)
     runtime.zero_grad(handle)
     runtime.forward_backward(handle, iter([batch]), None, num_microbatches=1)
     runtime.optimizer_step(handle)
@@ -413,7 +440,9 @@ def _local_named_params(handle: ModelHandle) -> dict[str, torch.Tensor]:
     params: dict[str, torch.Tensor] = {}
     for chunk_idx, chunk in enumerate(handle._extras["model_chunks"]):
         for name, param in chunk.named_parameters():
-            params[f"{chunk_idx}.{name}"] = to_local_tensor(param.detach()).cpu().float().clone()
+            params[f"{chunk_idx}.{name}"] = (
+                to_local_tensor(param.detach()).cpu().clone()
+            )
     return params
 
 
@@ -424,10 +453,21 @@ def _assert_params_bitwise_equal(lhs: ModelHandle, rhs: ModelHandle) -> None:
     assert lhs_params, "expected at least one local parameter to compare."
     mismatches = []
     for name in lhs_params:
-        if not torch.equal(lhs_params[name], rhs_params[name]):
-            diff = (lhs_params[name] - rhs_params[name]).abs().max().item()
+        lhs_tensor, rhs_tensor = lhs_params[name], rhs_params[name]
+        if (
+            lhs_tensor.shape != rhs_tensor.shape
+            or lhs_tensor.dtype != rhs_tensor.dtype
+            or not torch.equal(lhs_tensor, rhs_tensor)
+        ):
+            diff = (
+                (lhs_tensor.float() - rhs_tensor.float()).abs().max().item()
+                if lhs_tensor.shape == rhs_tensor.shape
+                else float("inf")
+            )
             mismatches.append(f"{name} (max_abs_diff={diff})")
-    assert not mismatches, "save/load not bitwise; mismatched params:\n" + "\n".join(mismatches)
+    assert not mismatches, "save/load not bitwise; mismatched params:\n" + "\n".join(
+        mismatches
+    )
 
 
 def _is_valid_hf_export_key(key: str, model_name: str) -> bool:
@@ -449,28 +489,35 @@ def _is_valid_hf_export_key(key: str, model_name: str) -> bool:
     return key.startswith("model.") or key in ("lm_head.weight",)
 
 
-def _export_and_reload(handle: ModelHandle, cfg, protocol, out_dir: str, model_name: str) -> None:
+def _export_and_reload(
+    handle: ModelHandle, cfg, protocol, out_dir: str, model_name: str
+) -> None:
     """Export HF weights (bf16) and assert the reloaded shards are valid.
 
-    Prefer the model's ``save_hf_weights`` wrapper; some models only expose the
-    ``export_hf_weights`` generator, so fall back to gathering it and writing
-    the safetensors ourselves (rank 0). Every supported model must offer one of
-    the two — otherwise it has no export path at all, which is a hard failure.
+    The integration gate deliberately requests BF16 from the canonical export
+    generator. Materialization uses the production distributed writer so
+    duplicate keys, generator errors, empty rank-0 output, and write failures
+    are propagated to every rank instead of being hidden by ``dict(generator)``.
     """
     chunks = handle._extras["model_chunks"]
     ps = handle._parallel_state
 
-    if hasattr(protocol, "save_hf_weights"):
-        protocol.save_hf_weights(chunks, out_dir, cfg, ps)
-    elif hasattr(protocol, "export_hf_weights"):
-        from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
-
-        weights = dict(protocol.export_hf_weights(chunks, cfg, ps, rank0_only=True))
-        if dist.get_rank() == 0 and weights:
-            save_safetensors(weights, out_dir)
-    else:
+    if not hasattr(protocol, "export_hf_weights"):
         raise AssertionError(f"{protocol.__name__} exposes no HF export path.")
-    dist.barrier()
+    from megatron.lite.primitive.ckpt.hf_weights import (
+        save_hf_weight_pairs_distributed,
+    )
+
+    save_hf_weight_pairs_distributed(
+        protocol.export_hf_weights(
+            chunks,
+            cfg,
+            ps,
+            rank0_only=True,
+            export_dtype=torch.bfloat16,
+        ),
+        out_dir,
+    )
 
     if dist.get_rank() != 0:
         dist.barrier()
@@ -499,7 +546,9 @@ def _export_and_reload(handle: ModelHandle, cfg, protocol, out_dir: str, model_n
                     assert tensor.dtype in (torch.int64, torch.int32, torch.bool), (
                         f"{key} exported as unexpected non-float dtype {tensor.dtype}"
                     )
-                assert torch.isfinite(tensor.float()).all(), f"{key} has non-finite values"
+                assert torch.isfinite(tensor.float()).all(), (
+                    f"{key} has non-finite values"
+                )
                 assert _is_valid_hf_export_key(key, model_name), (
                     f"unexpected non-HF export key: {key}"
                 )
@@ -547,6 +596,66 @@ def test_save_load_roundtrip(model_name, backend, tmp_path):
     loaded, _cfg2, _proto2 = _build_handle(model_name, backend, seed=9999)
     assert runtime.load_checkpoint(loaded, ckpt_dir) == 1
     _assert_params_bitwise_equal(saved, loaded)
+
+    # A checkpoint is not resume-ready merely because model tensors reload.
+    # Require non-empty optimizer moments/steps and, where the backend exposes
+    # them, non-empty distributed-optimizer master weights to match before the
+    # resumed update. Then prove the exact next batch remains bitwise identical.
+    _assert_nonempty_named_bitwise_equal(
+        _opt_state_snapshot(saved, backend),
+        _opt_state_snapshot(loaded, backend),
+        f"{model_name}/{backend} optimizer state after load",
+    )
+    saved_master = _optimizer_master_snapshot(saved, backend)
+    loaded_master = _optimizer_master_snapshot(loaded, backend)
+    if backend == "dist_opt":
+        _assert_nonempty_named_bitwise_equal(
+            saved_master,
+            loaded_master,
+            f"{model_name}/{backend} optimizer master weights after load",
+        )
+        master_weights_evidence = "nonempty_exact"
+    else:
+        assert saved_master == loaded_master == {}
+        master_weights_evidence = "not_applicable"
+    resume_batch = _random_packed_batch(cfg.vocab_size)
+    _train_step(saved, backend, cfg, batch=resume_batch, seed=20260628)
+    _train_step(loaded, backend, cfg, batch=resume_batch, seed=20260628)
+    _assert_params_bitwise_equal(saved, loaded)
+    _assert_nonempty_named_bitwise_equal(
+        _opt_state_snapshot(saved, backend),
+        _opt_state_snapshot(loaded, backend),
+        f"{model_name}/{backend} optimizer state after resumed step",
+    )
+    resumed_saved_master = _optimizer_master_snapshot(saved, backend)
+    resumed_loaded_master = _optimizer_master_snapshot(loaded, backend)
+    if backend == "dist_opt":
+        _assert_nonempty_named_bitwise_equal(
+            resumed_saved_master,
+            resumed_loaded_master,
+            f"{model_name}/{backend} optimizer master weights after resumed step",
+        )
+    else:
+        assert resumed_saved_master == resumed_loaded_master == {}
+    from megatron.lite.primitive.parallel import (
+        validate_mtp_embedding_parameter_replicas,
+    )
+
+    for handle in (saved, loaded):
+        ps = handle._parallel_state
+        validate_mtp_embedding_parameter_replicas(
+            handle._extras["model_chunks"],
+            ps,
+            enabled=bool(ps.embedding_groups_initialized),
+        )
+    if dist.get_rank() == 0:
+        print(
+            "NON_SKIP_DISTRIBUTED_CHECKPOINT_RESUME_EXACT "
+            f"model={model_name} backend={backend} model_params=nonempty_exact "
+            "optimizer_state=nonempty_exact "
+            f"master_weights={master_weights_evidence} next_step=bitwise_exact "
+            "mtp_embedding_replicas=validated_when_enabled"
+        )
 
 
 @pytest.mark.parametrize("model_name", list(MODELS))
@@ -627,15 +736,31 @@ def _iter_opt_state_tensors(handle: ModelHandle, backend: str):
 def _opt_state_devices(handle: ModelHandle, backend: str) -> set[str]:
     from megatron.lite.primitive.optimizers.fsdp2.adamw import to_local_tensor
 
-    return {to_local_tensor(v).device.type for _, v in _iter_opt_state_tensors(handle, backend)}
+    return {
+        to_local_tensor(v).device.type
+        for _, v in _iter_opt_state_tensors(handle, backend)
+    }
 
 
 def _opt_state_snapshot(handle: ModelHandle, backend: str) -> dict[str, torch.Tensor]:
     from megatron.lite.primitive.optimizers.fsdp2.adamw import to_local_tensor
 
     return {
-        k: to_local_tensor(v.detach()).cpu().float().clone()
+        k: to_local_tensor(v.detach()).cpu().clone()
         for k, v in _iter_opt_state_tensors(handle, backend)
+    }
+
+
+def _optimizer_master_snapshot(
+    handle: ModelHandle, backend: str
+) -> dict[str, torch.Tensor]:
+    if backend != "dist_opt":
+        return {}
+    parameters = list(handle._optimizer.get_parameters())
+    assert parameters, "distributed optimizer exposes no local master parameters"
+    return {
+        str(index): parameter.detach().cpu().clone()
+        for index, parameter in enumerate(parameters)
     }
 
 
@@ -653,10 +778,27 @@ def _assert_named_bitwise_equal(lhs: dict, rhs: dict, label: str) -> None:
     assert lhs.keys() == rhs.keys(), f"{label} keys differ across offload roundtrip."
     mismatches = []
     for name in lhs:
-        if not torch.equal(lhs[name], rhs[name]):
-            diff = (lhs[name] - rhs[name]).abs().max().item()
+        lhs_tensor, rhs_tensor = lhs[name], rhs[name]
+        if (
+            lhs_tensor.shape != rhs_tensor.shape
+            or lhs_tensor.dtype != rhs_tensor.dtype
+            or not torch.equal(lhs_tensor, rhs_tensor)
+        ):
+            diff = (
+                (lhs_tensor.float() - rhs_tensor.float()).abs().max().item()
+                if lhs_tensor.shape == rhs_tensor.shape
+                else float("inf")
+            )
             mismatches.append(f"{name} (max_abs_diff={diff})")
-    assert not mismatches, f"{label} not bitwise after offload/onload:\n" + "\n".join(mismatches)
+    assert not mismatches, f"{label} not bitwise after offload/onload:\n" + "\n".join(
+        mismatches
+    )
+
+
+def _assert_nonempty_named_bitwise_equal(lhs: dict, rhs: dict, label: str) -> None:
+    assert lhs, f"{label} left snapshot is empty; exactness would be vacuous."
+    assert rhs, f"{label} right snapshot is empty; exactness would be vacuous."
+    _assert_named_bitwise_equal(lhs, rhs, label)
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
@@ -680,18 +822,24 @@ def test_offload_onload_roundtrip(model_name, backend, tmp_path):
     assert _opt_state_devices(handle, backend) == {"cuda"}
 
     runtime.to(handle, "cpu", model=True, optimizer=True, grad=True)
-    assert _opt_state_devices(handle, backend) == {"cpu"}, "optimizer state not offloaded to CPU."
+    assert _opt_state_devices(handle, backend) == {"cpu"}, (
+        "optimizer state not offloaded to CPU."
+    )
     if backend == "fsdp2":
         # fsdp2 moves params to CPU directly; dist_opt instead frees the GPU
         # buffer storage (params keep a 0-size cuda handle), so assert only fsdp2.
         assert _local_param_devices(handle) == {"cpu"}, "params not offloaded to CPU."
 
     runtime.to(handle, "cuda", model=True, optimizer=True, grad=True)
-    assert _opt_state_devices(handle, backend) == {"cuda"}, "optimizer state not back on GPU."
+    assert _opt_state_devices(handle, backend) == {"cuda"}, (
+        "optimizer state not back on GPU."
+    )
     assert _local_param_devices(handle) == {"cuda"}, "params not back on GPU."
 
     _assert_named_bitwise_equal(params_before, _local_named_params(handle), "param")
-    _assert_named_bitwise_equal(opt_before, _opt_state_snapshot(handle, backend), "optimizer-state")
+    _assert_named_bitwise_equal(
+        opt_before, _opt_state_snapshot(handle, backend), "optimizer-state"
+    )
 
     _train_step(handle, backend, cfg)  # continues training after onload
 

--- a/experimental/lite/tests/unit/model/glm52_fp8_header_authority.json
+++ b/experimental/lite/tests/unit/model/glm52_fp8_header_authority.json
@@ -1,0 +1,106 @@
+{
+  "canonical_tensor_contract_sha256": "5fbeff826bdf608cb6596de4987d6926df613076ed32ff69803007270183f294",
+  "quantization_config": {
+    "activation_scheme": "dynamic",
+    "fmt": "e4m3",
+    "quant_method": "fp8",
+    "weight_block_size": [
+      128,
+      128
+    ]
+  },
+  "source": {
+    "config_sha256": "d1539d36be7546a1d827fe9cf74c55874695652efb6a5aaa3e60cde1c76ba819",
+    "config_values": {
+      "hidden_size": 6144,
+      "latent_rms_norm_eps": null,
+      "q_a_layernorm_effective_eps": 1e-06,
+      "q_lora_rank": 2048,
+      "rms_norm_eps": 1e-05
+    },
+    "index_sha256": "e0fe7f28c1f853d4824e4d796374e3dacf1fe470988773952c79b063768134bf",
+    "repo": "zai-org/GLM-5.2-FP8",
+    "revision": "31cba24fb749908a485082bdeed6eb1ac6cffc2f",
+    "safetensors": {
+      "model-00001-of-00141.safetensors": {
+        "etag": "dd4d4ca6ff348add79ad2b803c19dce384edb7a7ff72355c30ddb2b8ebcf363a",
+        "file_bytes": 5363940952,
+        "header_bytes": 21840,
+        "header_prefix": [
+          80,
+          85,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0
+        ],
+        "header_range": [
+          8,
+          21847
+        ],
+        "header_sha256": "b438c86e0ba40b96525672d31da75756307c723a3a73efc5ea40bd5893411613",
+        "payload_ranges": {
+          "model.layers.0.self_attn.q_a_layernorm.weight": {
+            "file_range": [
+              3807152216,
+              3807156311
+            ],
+            "sha256": "ccf89a76bc299fd2c5cf8186cc5203a5a1b9e2ea852675372902898f92c6c7f5"
+          },
+          "model.layers.0.self_attn.q_a_proj.weight": {
+            "file_range": [
+              4162141784,
+              4174724695
+            ],
+            "sha256": "235b20da9f5e0351a234cf154a125e648d7a4e397da706fb4ce08d105e2b2198"
+          },
+          "model.layers.0.self_attn.q_a_proj.weight_scale_inv": {
+            "file_range": [
+              108504,
+              111575
+            ],
+            "sha256": "eb1eadbe663c88e51cdd1d276fc41991bb4b25bd21d3fce15af777abacd7eb6d"
+          }
+        }
+      }
+    },
+    "shard_count": 141,
+    "tensor_count": 118629
+  },
+  "tensors": {
+    "model.layers.0.self_attn.q_a_layernorm.weight": {
+      "data_offsets": [
+        3807130368,
+        3807134464
+      ],
+      "dtype": "BF16",
+      "shape": [
+        2048
+      ]
+    },
+    "model.layers.0.self_attn.q_a_proj.weight": {
+      "data_offsets": [
+        4162119936,
+        4174702848
+      ],
+      "dtype": "F8_E4M3",
+      "shape": [
+        2048,
+        6144
+      ]
+    },
+    "model.layers.0.self_attn.q_a_proj.weight_scale_inv": {
+      "data_offsets": [
+        86656,
+        89728
+      ],
+      "dtype": "F32",
+      "shape": [
+        16,
+        48
+      ]
+    }
+  }
+}

--- a/experimental/lite/tests/unit/model/glm52_rope_layout_authority.json
+++ b/experimental/lite/tests/unit/model/glm52_rope_layout_authority.json
@@ -1,0 +1,126 @@
+{
+  "release": {
+    "config": {
+      "path": "config.json",
+      "required_values": {
+        "indexer_rope_interleave": true,
+        "model_type": "glm_moe_dsa",
+        "rope_interleave": true,
+        "transformers_version": "5.12.0"
+      },
+      "sha256": "817f5fb39ca5d4c4b5648de89ca00deaea7537d8c2f130172a459252a05c1073"
+    },
+    "repo": "zai-org/GLM-5.2",
+    "revision": "4d67f66cc64d3219133b767c253b2ad1425c6c88"
+  },
+  "vllm": {
+    "adjacent_pair_contract": {
+      "config_field": "indexer_rope_interleave",
+      "config_value": true,
+      "is_neox_style": false,
+      "layout": "gptj_adjacent_pair"
+    },
+    "files": {
+      "vllm/model_executor/layers/rotary_embedding/common.py": {
+        "required_snippets": [
+          {
+            "expected_count": 2,
+            "text": "if is_neox_style:"
+          },
+          {
+            "expected_count": 2,
+            "text": "x1 = x[..., ::2]"
+          },
+          {
+            "expected_count": 2,
+            "text": "x2 = x[..., 1::2]"
+          },
+          {
+            "expected_count": 1,
+            "text": "output = torch.stack((o1, o2), dim=-1).flatten(-2)"
+          }
+        ],
+        "sha256": "86c9f61904fd3066fd146f0f5b3c5932dd8252841947ffcfd699b18e6a8bde08"
+      },
+      "vllm/model_executor/models/deepseek_v2.py": {
+        "required_snippets": [
+          {
+            "expected_count": 1,
+            "text": "is_neox_style=not getattr(config, \"indexer_rope_interleave\", False)"
+          }
+        ],
+        "sha256": "640b6e60fbacf859f60caff149015dbfc223dff0baf302c507ddd9009b7726a3"
+      }
+    },
+    "gptj_forward_static_golden": {
+      "cos": [
+        [
+          [
+            1.0,
+            1.0
+          ],
+          [
+            0.6,
+            -0.8
+          ]
+        ]
+      ],
+      "dtype": "float64",
+      "output": [
+        [
+          [
+            [
+              1.0,
+              2.0,
+              3.0,
+              4.0
+            ]
+          ],
+          [
+            [
+              -1.5,
+              0.5,
+              0.1,
+              4.3
+            ]
+          ]
+        ]
+      ],
+      "sin": [
+        [
+          [
+            0.0,
+            0.0
+          ],
+          [
+            0.8,
+            0.6
+          ]
+        ]
+      ],
+      "x": [
+        [
+          [
+            [
+              1.0,
+              2.0,
+              3.0,
+              4.0
+            ]
+          ],
+          [
+            [
+              -0.5,
+              1.5,
+              2.5,
+              -3.5
+            ]
+          ]
+        ]
+      ]
+    },
+    "release": "v0.23.0",
+    "repo": "vllm-project/vllm",
+    "revision": "0fc695fc6d1d82e9a5ac6835ac8e4e1c83703665"
+  }
+}

--- a/experimental/lite/tests/unit/model/qwen35_mtp_header_authority.json
+++ b/experimental/lite/tests/unit/model/qwen35_mtp_header_authority.json
@@ -1,0 +1,98 @@
+{
+  "canonical_mtp_schema_sha256": "54a42a904540f171d00a8296f2cd457dcdf4b167290f8a4455ee58c3dcb36871",
+  "dtype": "BF16",
+  "expert_templates": {
+    "mtp.layers.0.mlp.experts.{expert_idx}.down_proj.weight": [
+      2048,
+      512
+    ],
+    "mtp.layers.0.mlp.experts.{expert_idx}.gate_proj.weight": [
+      512,
+      2048
+    ],
+    "mtp.layers.0.mlp.experts.{expert_idx}.up_proj.weight": [
+      512,
+      2048
+    ]
+  },
+  "non_expert_shapes": {
+    "mtp.fc.weight": [
+      2048,
+      4096
+    ],
+    "mtp.layers.0.input_layernorm.weight": [
+      2048
+    ],
+    "mtp.layers.0.mlp.gate.weight": [
+      256,
+      2048
+    ],
+    "mtp.layers.0.mlp.shared_expert.down_proj.weight": [
+      2048,
+      512
+    ],
+    "mtp.layers.0.mlp.shared_expert.gate_proj.weight": [
+      512,
+      2048
+    ],
+    "mtp.layers.0.mlp.shared_expert.up_proj.weight": [
+      512,
+      2048
+    ],
+    "mtp.layers.0.mlp.shared_expert_gate.weight": [
+      1,
+      2048
+    ],
+    "mtp.layers.0.post_attention_layernorm.weight": [
+      2048
+    ],
+    "mtp.layers.0.self_attn.k_norm.weight": [
+      256
+    ],
+    "mtp.layers.0.self_attn.k_proj.weight": [
+      512,
+      2048
+    ],
+    "mtp.layers.0.self_attn.o_proj.weight": [
+      2048,
+      4096
+    ],
+    "mtp.layers.0.self_attn.q_norm.weight": [
+      256
+    ],
+    "mtp.layers.0.self_attn.q_proj.weight": [
+      8192,
+      2048
+    ],
+    "mtp.layers.0.self_attn.v_proj.weight": [
+      512,
+      2048
+    ],
+    "mtp.norm.weight": [
+      2048
+    ],
+    "mtp.pre_fc_norm_embedding.weight": [
+      2048
+    ],
+    "mtp.pre_fc_norm_hidden.weight": [
+      2048
+    ]
+  },
+  "num_experts": 256,
+  "source": {
+    "config_sha256": "5e4d7f74fec2f360eb9cfbfcd6ec0c4c76e684d3a11caaed259d9fd9bfbc7944",
+    "headers": {
+      "model.safetensors-00013-of-00014.safetensors": {
+        "header_bytes": 23344,
+        "header_sha256": "5d7fb10af28ff02acfa88a1e623ccb41b360e442ff2bddeefa131a71235da416"
+      },
+      "model.safetensors-00014-of-00014.safetensors": {
+        "header_bytes": 189072,
+        "header_sha256": "091eaab7a7dd4059a782c2fed3e4c3942546ef4803f9be95ff14bf63bc33c59d"
+      }
+    },
+    "index_sha256": "d8d0b7ca4e61ae107e3e87a3ff21136b3ac7c789e64bb24267227ca804e04205",
+    "repo": "Qwen/Qwen3.5-35B-A3B",
+    "revision": "59d61f3ce65a6d9863b86d2e96597125219dc754"
+  }
+}

--- a/experimental/lite/tests/unit/model/test_deepseek_v4_protocol_activation_controls.py
+++ b/experimental/lite/tests/unit/model/test_deepseek_v4_protocol_activation_controls.py
@@ -1,0 +1,393 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Fail-closed DeepSeek-V4 activation recompute/offload protocol coverage."""
+
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+pytestmark = pytest.mark.mlite
+
+
+class _Unit(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.self_attn = nn.Linear(2, 2)
+        self.mlp = SimpleNamespace(experts=nn.Linear(2, 2), gate=nn.Linear(2, 2))
+        self.input_layernorm = nn.LayerNorm(2)
+        self.post_attention_layernorm = nn.LayerNorm(2)
+
+
+class _BareChunk(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.layers = nn.ModuleDict({"0": _Unit(), "1": _Unit()})
+        self.mtp = nn.ModuleList([_Unit()])
+
+
+class _WrappedChunk(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.model = _BareChunk()
+
+
+class _EmptyPipelineChunk(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.layers = nn.ModuleDict()
+        self.mtp = nn.ModuleList()
+        self.layer_indices = []
+        self.ps = SimpleNamespace(pp_size=2)
+
+
+class _MTPUnit(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.tensor(3.0))
+        self.calls = 0
+
+    def forward(self, hidden_states, *, input_ids, position_ids):
+        self.calls += 1
+        del input_ids, position_ids
+        return hidden_states * self.weight
+
+
+def test_iter_transformer_units_supports_bare_and_legacy_wrapped_chunks() -> None:
+    from megatron.lite.model.deepseek_v4.lite import protocol
+
+    bare = _BareChunk()
+    wrapped = _WrappedChunk()
+
+    assert protocol._iter_transformer_units(bare) == [*bare.layers.values(), *bare.mtp]
+    assert protocol._iter_transformer_units(wrapped) == [
+        *wrapped.model.layers.values(),
+        *wrapped.model.mtp,
+    ]
+
+
+def test_activation_controls_wire_each_nonempty_chunk(monkeypatch) -> None:
+    from megatron.lite.model.deepseek_v4.lite import protocol
+
+    bare = _BareChunk()
+    wrapped = _WrappedChunk()
+    recompute_calls = []
+
+    monkeypatch.setattr(
+        protocol,
+        "apply_recompute",
+        lambda units, names, module_map: recompute_calls.append(
+            (list(units), list(names), module_map)
+        ),
+    )
+
+    protocol._apply_activation_memory_controls(
+        [bare, wrapped], recompute_spec=["core_attn"], offload_spec=[]
+    )
+
+    assert [call[0] for call in recompute_calls] == [
+        protocol._iter_transformer_units(bare),
+        protocol._iter_transformer_units(wrapped),
+    ]
+    assert [call[1] for call in recompute_calls] == [["core_attn"], ["core_attn"]]
+
+
+def test_activation_controls_really_wrap_bare_model_modules() -> None:
+    from megatron.lite.model.deepseek_v4.lite import protocol
+
+    recomputed = _BareChunk()
+    protocol._apply_activation_memory_controls(
+        [recomputed], recompute_spec=["core_attn"], offload_spec=[]
+    )
+    assert {
+        unit.self_attn.forward.__name__
+        for unit in protocol._iter_transformer_units(recomputed)
+    } == {"_checkpointed_forward"}
+
+
+@pytest.mark.parametrize(
+    ("recompute_spec", "offload_spec", "match"),
+    [
+        (["unknown"], [], "Unsupported.*recompute"),
+        ([], ["unknown"], "Unsupported.*offload"),
+        (["moe", "moe"], [], "recompute.*duplicate"),
+        (["full", "moe"], [], "'full' must be used alone"),
+        (["attn", "core_attn"], [], "target the same module"),
+        (["moe", "experts"], [], "parent and child"),
+    ],
+)
+def test_activation_controls_reject_ignored_or_duplicate_selectors(
+    recompute_spec, offload_spec, match
+) -> None:
+    from megatron.lite.model.deepseek_v4.lite import protocol
+
+    with pytest.raises(ValueError, match=match):
+        protocol._apply_activation_memory_controls(
+            [_BareChunk()], recompute_spec=recompute_spec, offload_spec=offload_spec
+        )
+
+
+def test_activation_controls_fail_closed_for_malformed_or_invalid_empty_chunks(
+    monkeypatch,
+) -> None:
+    from megatron.lite.model.deepseek_v4.lite import protocol
+
+    recompute_calls = []
+    monkeypatch.setattr(
+        protocol,
+        "apply_recompute",
+        lambda *args, **kwargs: recompute_calls.append((args, kwargs)),
+    )
+    with pytest.raises(TypeError, match="expose a layers container"):
+        protocol._apply_activation_memory_controls(
+            [nn.Module()], recompute_spec=["full"], offload_spec=[]
+        )
+    with pytest.raises(TypeError, match="expose a layers container"):
+        protocol._apply_activation_memory_controls(
+            [_BareChunk(), nn.Module()], recompute_spec=["full"], offload_spec=[]
+        )
+    assert recompute_calls == []
+    with pytest.raises(RuntimeError, match="non-pipeline-empty"):
+        protocol._apply_activation_memory_controls(
+            [SimpleNamespace(layers=nn.ModuleDict(), mtp=nn.ModuleList())],
+            recompute_spec=["full"],
+            offload_spec=[],
+        )
+    with pytest.raises(RuntimeError, match="no model chunks"):
+        protocol._apply_activation_memory_controls(
+            [], recompute_spec=["full"], offload_spec=[]
+        )
+
+
+def test_activation_controls_allow_explicit_empty_pp_stage(monkeypatch) -> None:
+    from megatron.lite.model.deepseek_v4.lite import protocol
+
+    monkeypatch.setattr(
+        protocol,
+        "apply_recompute",
+        lambda *_args, **_kwargs: pytest.fail("empty PP stage must not be wrapped"),
+    )
+    protocol._apply_activation_memory_controls(
+        [_EmptyPipelineChunk()], recompute_spec=["full"], offload_spec=[]
+    )
+
+
+@pytest.mark.parametrize("offload_spec", [["core_attn"], ["full"]])
+def test_activation_offload_fails_explicitly_before_fake_primitive(
+    offload_spec,
+) -> None:
+    from megatron.lite.model.deepseek_v4.lite import protocol
+
+    with pytest.raises(NotImplementedError, match="performs activation recompute"):
+        protocol._apply_activation_memory_controls(
+            [_BareChunk()], recompute_spec=[], offload_spec=offload_spec
+        )
+
+
+def test_mtp_full_recompute_keeps_hidden_gradient_positional(
+    monkeypatch, transformer_engine_import_stub
+) -> None:
+    from megatron.lite.model.deepseek_v4.lite import protocol
+
+    transformer_engine_import_stub()
+    from megatron.lite.model.deepseek_v4.lite.model import DeepseekV4MTPLayer
+
+    hidden_parameter = inspect.signature(DeepseekV4MTPLayer.forward).parameters[
+        "hidden_states"
+    ]
+    assert hidden_parameter.kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+
+    monkeypatch.setattr(
+        torch.cuda, "get_rng_state", lambda: torch.zeros(1, dtype=torch.uint8)
+    )
+    monkeypatch.setattr(torch.cuda, "set_rng_state", lambda _state: None)
+    mtp = _MTPUnit()
+    chunk = SimpleNamespace(
+        layers=nn.ModuleDict(),
+        mtp=nn.ModuleList([mtp]),
+        layer_indices=[],
+        ps=SimpleNamespace(pp_size=1),
+    )
+    protocol._apply_activation_memory_controls(
+        [chunk], recompute_spec=["full"], offload_spec=[]
+    )
+    hidden_states = torch.tensor([2.0, -4.0], requires_grad=True)
+    mtp(
+        hidden_states,
+        input_ids=torch.ones(2, dtype=torch.long),
+        position_ids=torch.arange(2),
+    ).sum().backward()
+
+    assert mtp.calls == 2
+    torch.testing.assert_close(hidden_states.grad, torch.full_like(hidden_states, 3.0))
+    torch.testing.assert_close(mtp.weight.grad, torch.tensor(-2.0))
+
+
+def test_build_model_rejects_invalid_policy_before_parallel_or_cuda(
+    monkeypatch,
+) -> None:
+    from megatron.lite.model.deepseek_v4.lite import protocol
+
+    monkeypatch.setattr(
+        protocol,
+        "init_parallel",
+        lambda *_args, **_kwargs: pytest.fail("parallel init must not run"),
+    )
+    with pytest.raises(NotImplementedError, match="performs activation recompute"):
+        protocol.build_model(
+            object(),
+            impl_cfg=protocol.ImplConfig(optimizer=None, offload=["core_attn"]),
+        )
+
+
+def test_parallel_scope_rejects_vpp_before_parallel_init() -> None:
+    from megatron.lite.model.deepseek_v4.lite import protocol
+    from megatron.lite.runtime.contracts import ParallelConfig
+
+    with pytest.raises(NotImplementedError, match="virtual pipeline"):
+        protocol._validate_parallel_scope(ParallelConfig(vpp=2))
+
+
+@pytest.mark.smoke
+@pytest.mark.gpu
+@pytest.mark.distributed
+def test_ds4_mtp_full_recompute_matches_real_cuda_backward(tmp_path) -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for the DS4 full-recompute smoke.")
+    pytest.importorskip("cudnn", reason="DS4 model import needs the cuDNN DSA stack.")
+
+    import torch.distributed as dist
+    from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
+    from megatron.lite.model.deepseek_v4.lite import protocol
+    from megatron.lite.runtime.contracts import ParallelConfig
+
+    initialized_here = False
+    if not dist.is_initialized():
+        dist.init_process_group(
+            "nccl", init_method=f"file://{tmp_path / 'nccl-init'}", rank=0, world_size=1
+        )
+        initialized_here = True
+
+    def make_config() -> DeepseekV4Config:
+        return DeepseekV4Config(
+            vocab_size=64,
+            hidden_size=128,
+            moe_intermediate_size=16,
+            num_hidden_layers=1,
+            num_attention_heads=8,
+            num_key_value_heads=1,
+            head_dim=64,
+            qk_rope_head_dim=16,
+            q_lora_rank=32,
+            o_lora_rank=32,
+            o_groups=2,
+            n_routed_experts=4,
+            n_shared_experts=1,
+            num_experts_per_tok=2,
+            routed_scaling_factor=1.5,
+            max_position_embeddings=4096,
+            compress_ratios=[4],
+            sliding_window=16,
+            num_hash_layers=2,
+            hc_mult=2,
+            index_head_dim=64,
+            index_n_heads=8,
+            index_topk=16,
+            num_nextn_predict_layers=1,
+            rms_norm_eps=1.0e-6,
+        )
+
+    def build(recompute: list[str]):
+        torch.manual_seed(20260628)
+        torch.cuda.manual_seed_all(20260628)
+        bundle = protocol.build_model(
+            make_config(),
+            impl_cfg=protocol.ImplConfig(
+                parallel=ParallelConfig(),
+                optimizer=None,
+                recompute=recompute,
+                attention_backend_override="local",
+                mtp_enable=True,
+                mtp_enable_train=True,
+            ),
+        )
+        model = bundle.chunks[0]
+        assert len(model.layers) == 1
+        assert len(model.mtp) == 1
+        assert model.layers["0"].self_attn.self_attn.attention_backend == "local"
+        assert model.mtp[0].self_attn.self_attn.attention_backend == "local"
+        return model
+
+    try:
+        reference = build([])
+        recomputed = build(["full"])
+        recomputed.load_state_dict(reference.state_dict(), strict=True)
+        assert recomputed.layers["0"].forward.__name__ == "_checkpointed_forward"
+        assert recomputed.mtp[0].forward.__name__ == "_checkpointed_forward"
+
+        torch.manual_seed(20260629)
+        input_ids = torch.randint(0, 64, (1, 64), device="cuda")
+        labels = torch.randint(0, 64, (1, 64), device="cuda")
+        loss_mask = torch.ones_like(labels, dtype=torch.float32)
+        position_ids = torch.arange(64, device="cuda").unsqueeze(0)
+
+        def run(model):
+            torch.manual_seed(20260630)
+            torch.cuda.manual_seed_all(20260630)
+            model.zero_grad(set_to_none=True)
+            output = model(
+                input_ids=input_ids,
+                labels=labels,
+                loss_mask=loss_mask,
+                position_ids=position_ids,
+                enable_mtp=True,
+            )
+            loss = output["loss"]
+            assert torch.isfinite(loss)
+            assert torch.isfinite(output["mtp_loss"])
+            loss.backward()
+            gradients = {
+                name: parameter.grad.detach().clone()
+                for name, parameter in model.named_parameters()
+                if parameter.grad is not None
+            }
+            assert gradients
+            assert any(name.startswith("mtp.0.") for name in gradients)
+            assert all(
+                torch.isfinite(gradient).all() for gradient in gradients.values()
+            )
+            return loss.detach(), output["mtp_loss"].detach(), gradients
+
+        reference_loss, reference_mtp_loss, reference_gradients = run(reference)
+        recomputed_loss, recomputed_mtp_loss, recomputed_gradients = run(recomputed)
+        torch.testing.assert_close(
+            recomputed_loss, reference_loss, rtol=1.0e-5, atol=1.0e-6
+        )
+        torch.testing.assert_close(
+            recomputed_mtp_loss, reference_mtp_loss, rtol=1.0e-5, atol=1.0e-6
+        )
+        assert recomputed_gradients.keys() == reference_gradients.keys()
+        for name in reference_gradients:
+            torch.testing.assert_close(
+                recomputed_gradients[name],
+                reference_gradients[name],
+                rtol=1.0e-2,
+                atol=1.0e-5,
+                msg=lambda message, name=name: f"{name}: {message}",
+            )
+        assert any(
+            gradient.abs().max().item() > 0
+            for name, gradient in recomputed_gradients.items()
+            if name.startswith("mtp.0.")
+        )
+        print(
+            "DS4_MTP_FULL_RECOMPUTE_CUDA_PASS "
+            f"loss={float(recomputed_loss):.8f} gradients={len(recomputed_gradients)}",
+            flush=True,
+        )
+    finally:
+        if initialized_here:
+            dist.destroy_process_group()

--- a/experimental/lite/tests/unit/model/test_glm52_hf_attention_parity.py
+++ b/experimental/lite/tests/unit/model/test_glm52_hf_attention_parity.py
@@ -151,11 +151,7 @@ def _torch_indexer_topk(
     k = k_indexer.permute(1, 0, 2).float()
     w = weights.permute(1, 0, 2).float()
     scores = _indexer_score_matrix(
-        q,
-        k,
-        w,
-        ratio=ratio,
-        indexer_softmax_scale=indexer_softmax_scale,
+        q, k, w, ratio=ratio, indexer_softmax_scale=indexer_softmax_scale
     )
     return _topk_from_score_matrix(scores, topk)
 
@@ -358,21 +354,13 @@ def test_glm52_release_vllm_hf_helper_and_mlite_indexer_rope_authority(
         )
         raw_k = indexer.k_norm(indexer.wk(hidden_states)).unsqueeze(2)
         raw_q_rot, raw_q_pass = torch.split(
-            raw_q,
-            [indexer.qk_rope_head_dim, indexer.qk_nope_head_dim],
-            dim=-1,
+            raw_q, [indexer.qk_rope_head_dim, indexer.qk_nope_head_dim], dim=-1
         )
         raw_k_rot, raw_k_pass = torch.split(
-            raw_k,
-            [indexer.qk_rope_head_dim, indexer.qk_nope_head_dim],
-            dim=-1,
+            raw_k, [indexer.qk_rope_head_dim, indexer.qk_nope_head_dim], dim=-1
         )
         hf_q_rot, hf_k_rot = hf_impl.apply_rotary_pos_emb_interleave(
-            raw_q_rot,
-            raw_k_rot,
-            cos,
-            sin,
-            unsqueeze_dim=2,
+            raw_q_rot, raw_k_rot, cos, sin, unsqueeze_dim=2
         )
         hf_q = torch.cat((hf_q_rot, raw_q_pass), dim=-1)
         hf_k = torch.cat((hf_k_rot, raw_k_pass), dim=-1).squeeze(2)
@@ -389,11 +377,7 @@ def test_glm52_release_vllm_hf_helper_and_mlite_indexer_rope_authority(
         vllm_q = torch.cat((vllm_q_rot, raw_q_pass), dim=-1)
         vllm_k = torch.cat((vllm_k_rot, raw_k_pass), dim=-1).squeeze(2)
         vanilla_q_rot, vanilla_k_rot = hf_impl.apply_rotary_pos_emb(
-            raw_q_rot,
-            raw_k_rot,
-            cos,
-            sin,
-            unsqueeze_dim=2,
+            raw_q_rot, raw_k_rot, cos, sin, unsqueeze_dim=2
         )
         vanilla_q = torch.cat((vanilla_q_rot, raw_q_pass), dim=-1)
         vanilla_k = torch.cat((vanilla_k_rot, raw_k_pass), dim=-1).squeeze(2)
@@ -404,11 +388,7 @@ def test_glm52_release_vllm_hf_helper_and_mlite_indexer_rope_authority(
     torch.testing.assert_close(mlite_q, hf_q, rtol=0.0, atol=1.0e-12)
     torch.testing.assert_close(mlite_k, hf_k, rtol=0.0, atol=1.0e-12)
     authority_scores = _indexer_score_matrix(
-        hf_q,
-        hf_k,
-        mlite_weights,
-        ratio=1,
-        indexer_softmax_scale=indexer.softmax_scale,
+        hf_q, hf_k, mlite_weights, ratio=1, indexer_softmax_scale=indexer.softmax_scale
     )
     vllm_scores = _indexer_score_matrix(
         vllm_q,
@@ -440,12 +420,7 @@ def test_glm52_release_vllm_hf_helper_and_mlite_indexer_rope_authority(
     recorded_kernel_scores: list[torch.Tensor] = []
 
     def _recording_indexer_topk(
-        q_indexer,
-        k_indexer,
-        weights,
-        topk,
-        ratio=1,
-        indexer_softmax_scale=1.0,
+        q_indexer, k_indexer, weights, topk, ratio=1, indexer_softmax_scale=1.0
     ):
         scores = _indexer_score_matrix(
             q_indexer.permute(1, 0, 2, 3),

--- a/experimental/lite/tests/unit/model/test_glm52_hf_attention_parity.py
+++ b/experimental/lite/tests/unit/model/test_glm52_hf_attention_parity.py
@@ -1,19 +1,109 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-"""Independent GLM-5.2 attention parity against Transformers v5.12.0.
+"""Independent GLM-5.2 attention and indexer RoPE authorities.
 
 The production sparse kernel is replaced by a first-principles Torch oracle so
-this test can run on CPU.  The HF module supplies the independent projection,
-MLA-style RoPE, sparse-mask, softmax, and value-projection reference.
+this test can run on CPU. The indexer layout authority is pinned to the released
+GLM-5.2 config and vLLM v0.23.0's GPT-J adjacent-pair implementation. The HF
+module supplies its public interleaved helper, projection, sparse-mask, softmax,
+and value-projection references; vanilla HF half-split indexer behavior remains
+an explicit negative control rather than an authority.
 """
 
 from __future__ import annotations
+
+import json
+from pathlib import Path
 
 import pytest
 import torch
 import torch.nn as nn
 
-
 pytestmark = pytest.mark.mlite
+
+_ROPE_AUTHORITY_PATH = Path(__file__).with_name("glm52_rope_layout_authority.json")
+
+
+def _load_rope_authority() -> dict:
+    authority = json.loads(_ROPE_AUTHORITY_PATH.read_text())
+    release = authority["release"]
+    assert release == {
+        "config": {
+            "path": "config.json",
+            "required_values": {
+                "indexer_rope_interleave": True,
+                "model_type": "glm_moe_dsa",
+                "rope_interleave": True,
+                "transformers_version": "5.12.0",
+            },
+            "sha256": (
+                "817f5fb39ca5d4c4b5648de89ca00deaea7537d8c2f130172a459252a05c1073"
+            ),
+        },
+        "repo": "zai-org/GLM-5.2",
+        "revision": "4d67f66cc64d3219133b767c253b2ad1425c6c88",
+    }
+    vllm = authority["vllm"]
+    assert vllm["release"] == "v0.23.0"
+    assert vllm["revision"] == "0fc695fc6d1d82e9a5ac6835ac8e4e1c83703665"
+    assert vllm["files"]["vllm/model_executor/models/deepseek_v2.py"]["sha256"] == (
+        "640b6e60fbacf859f60caff149015dbfc223dff0baf302c507ddd9009b7726a3"
+    )
+    assert vllm["files"]["vllm/model_executor/layers/rotary_embedding/common.py"][
+        "sha256"
+    ] == ("86c9f61904fd3066fd146f0f5b3c5932dd8252841947ffcfd699b18e6a8bde08")
+    assert vllm["adjacent_pair_contract"] == {
+        "config_field": "indexer_rope_interleave",
+        "config_value": True,
+        "is_neox_style": False,
+        "layout": "gptj_adjacent_pair",
+    }
+    return authority
+
+
+def _vllm_gptj_forward_static(
+    x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor
+) -> torch.Tensor:
+    """Pinned vLLM v0.23 ``forward_static(..., is_neox_style=False)`` formula."""
+
+    cos = cos.unsqueeze(-2).to(x.dtype)
+    sin = sin.unsqueeze(-2).to(x.dtype)
+    x1 = x[..., ::2]
+    x2 = x[..., 1::2]
+    o1 = x1 * cos - x2 * sin
+    o2 = x2 * cos + x1 * sin
+    return torch.stack((o1, o2), dim=-1).flatten(-2)
+
+
+def _indexer_score_matrix(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    weights: torch.Tensor,
+    *,
+    ratio: int,
+    indexer_softmax_scale: float,
+) -> torch.Tensor:
+    """Return the complete causal score matrix from batch-first indexer inputs."""
+
+    scores = torch.relu(torch.einsum("bqhd,bkd->bqhk", q.float(), k.float()))
+    scores = (scores * weights.float().unsqueeze(-1)).sum(dim=2)
+    scores = scores * indexer_softmax_scale
+    query_positions = torch.arange(scores.shape[1], device=scores.device)
+    key_positions = torch.arange(scores.shape[2], device=scores.device)
+    valid_counts = ((query_positions + 1) // ratio).clamp(max=scores.shape[2])
+    valid = key_positions.unsqueeze(0) < valid_counts.unsqueeze(1)
+    return scores.masked_fill(~valid.unsqueeze(0), -torch.inf)
+
+
+def _topk_from_score_matrix(
+    scores: torch.Tensor, topk: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    effective_topk = min(topk, scores.shape[-1])
+    values, indices = torch.topk(scores, effective_topk, dim=-1)
+    indices = torch.where(torch.isfinite(values), indices, -torch.ones_like(indices))
+    if effective_topk < topk:
+        indices = torch.nn.functional.pad(indices, (0, topk - effective_topk), value=-1)
+    topk_length = (indices >= 0).sum(dim=-1, dtype=torch.int32)
+    return indices.to(torch.int32), topk_length
 
 
 def _torch_sparse_attention(
@@ -60,21 +150,14 @@ def _torch_indexer_topk(
     q = q_indexer.permute(1, 0, 2, 3).float()
     k = k_indexer.permute(1, 0, 2).float()
     w = weights.permute(1, 0, 2).float()
-    scores = torch.relu(torch.einsum("bqhd,bkd->bqhk", q, k))
-    scores = (scores * w.unsqueeze(-1)).sum(dim=2) * indexer_softmax_scale
-    query_positions = torch.arange(scores.shape[1], device=scores.device)
-    key_positions = torch.arange(scores.shape[2], device=scores.device)
-    valid_counts = ((query_positions + 1) // ratio).clamp(max=scores.shape[2])
-    valid = key_positions.unsqueeze(0) < valid_counts.unsqueeze(1)
-    scores = scores.masked_fill(~valid.unsqueeze(0), -torch.inf)
-
-    effective_topk = min(topk, scores.shape[-1])
-    values, indices = torch.topk(scores, effective_topk, dim=-1)
-    indices = torch.where(torch.isfinite(values), indices, -torch.ones_like(indices))
-    if effective_topk < topk:
-        indices = torch.nn.functional.pad(indices, (0, topk - effective_topk), value=-1)
-    topk_length = (indices >= 0).sum(dim=-1, dtype=torch.int32)
-    return indices.to(torch.int32), topk_length
+    scores = _indexer_score_matrix(
+        q,
+        k,
+        w,
+        ratio=ratio,
+        indexer_softmax_scale=indexer_softmax_scale,
+    )
+    return _topk_from_score_matrix(scores, topk)
 
 
 def test_glm52_shared_attention_matches_transformers_v5_12(
@@ -130,27 +213,31 @@ def test_glm52_shared_attention_matches_transformers_v5_12(
 
     torch.manual_seed(20260627)
     hf_attention = GlmMoeDsaAttention(config, layer_idx=3).double().eval()
-    mlite_attention = dsa.DynamicSparseAttention(
-        hidden_size=16,
-        num_attention_heads=2,
-        q_lora_rank=8,
-        kv_lora_rank=4,
-        qk_nope_head_dim=4,
-        qk_rope_head_dim=4,
-        v_head_dim=4,
-        index_n_heads=2,
-        index_head_dim=8,
-        index_topk=2,
-        rms_norm_eps=1.0e-5,
-        rope_interleaved=True,
-        indexer_rope_interleaved=True,
-        indexer_rope_first=True,
-        indexer_use_hadamard=False,
-        layer_number=4,
-        index_topk_freq=4,
-        index_skip_topk_offset=3,
-        indexer_type="shared",
-    ).double().eval()
+    mlite_attention = (
+        dsa.DynamicSparseAttention(
+            hidden_size=16,
+            num_attention_heads=2,
+            q_lora_rank=8,
+            kv_lora_rank=4,
+            qk_nope_head_dim=4,
+            qk_rope_head_dim=4,
+            v_head_dim=4,
+            index_n_heads=2,
+            index_head_dim=8,
+            index_topk=2,
+            rms_norm_eps=1.0e-5,
+            rope_interleaved=True,
+            indexer_rope_interleaved=True,
+            indexer_rope_first=True,
+            indexer_use_hadamard=False,
+            layer_number=4,
+            index_topk_freq=4,
+            index_skip_topk_offset=3,
+            indexer_type="shared",
+        )
+        .double()
+        .eval()
+    )
     mlite_attention.load_state_dict(hf_attention.state_dict(), strict=True)
 
     hidden_states = torch.randn(1, 4, 16, dtype=torch.float64)
@@ -185,135 +272,218 @@ def test_glm52_shared_attention_matches_transformers_v5_12(
     )
 
 
-def test_glm52_transformers_v5_12_indexer_layout_divergence_is_explicit(
+def test_glm52_release_vllm_hf_helper_and_mlite_indexer_rope_authority(
     transformer_engine_import_stub, monkeypatch
 ):
-    """Prove full HF parity under HF's layout and expose the config conflict.
+    """Bind real MLite indexer scores/top-k to release and vLLM authorities.
 
-    Transformers v5.12 hard-codes half-split indexer RoPE while the published
-    GLM-5.2 checkpoint sets ``indexer_rope_interleave=true``. Megatron, vLLM,
-    and SGLang honor that flag. This test prevents the shared-layer parity gate
-    above from being misreported as end-to-end HF parity.
+    This does not claim that another Megatron implementation or Bridge already
+    maps the release field. It proves the MLite ``DSAIndexer`` behavior directly.
     """
 
     transformers = pytest.importorskip("transformers")
-    version = tuple(int(part) for part in transformers.__version__.split(".")[:2])
-    if version != (5, 12):
-        pytest.skip("This known-divergence contract is pinned to Transformers 5.12.")
-    from transformers.models.glm_moe_dsa.modeling_glm_moe_dsa import (
-        GlmMoeDsaAttention,
-        GlmMoeDsaRotaryEmbedding,
-    )
+    assert transformers.__version__ == "5.12.0"
+    from transformers.models.glm_moe_dsa import modeling_glm_moe_dsa as hf_impl
 
     transformer_engine_import_stub()
     from megatron.lite.primitive.modules.attention import dsa
 
-    monkeypatch.setattr(dsa, "RMSNorm", nn.RMSNorm)
-    monkeypatch.setattr(dsa._dsa_kernels, "dsa_sparse_attn", _torch_sparse_attention)
-    captured_topk: list[torch.Tensor] = []
-
-    def recording_indexer_topk(*args, **kwargs):
-        topk_indices, topk_length = _torch_indexer_topk(*args, **kwargs)
-        captured_topk.append(topk_indices.detach().clone())
-        return topk_indices, topk_length
-
-    monkeypatch.setattr(dsa._dsa_kernels, "indexer_topk", recording_indexer_topk)
-
-    config = transformers.GlmMoeDsaConfig(
-        vocab_size=32,
-        hidden_size=16,
-        intermediate_size=32,
-        moe_intermediate_size=8,
-        num_hidden_layers=4,
-        num_attention_heads=2,
-        num_key_value_heads=2,
-        q_lora_rank=8,
-        kv_lora_rank=4,
-        qk_nope_head_dim=4,
-        qk_rope_head_dim=4,
-        v_head_dim=4,
-        index_head_dim=8,
-        index_n_heads=2,
-        index_topk=2,
-        indexer_types=["full"] * 4,
-        indexer_rope_interleave=True,
-        rope_parameters={"rope_type": "default", "rope_theta": 8_000_000.0},
-        rms_norm_eps=1.0e-5,
+    authority = _load_rope_authority()
+    golden = authority["vllm"]["gptj_forward_static_golden"]
+    assert golden["dtype"] == "float64"
+    golden_x = torch.tensor(golden["x"], dtype=torch.float64)
+    golden_cos = torch.tensor(golden["cos"], dtype=torch.float64)
+    golden_sin = torch.tensor(golden["sin"], dtype=torch.float64)
+    golden_output = torch.tensor(golden["output"], dtype=torch.float64)
+    vllm_golden_output = _vllm_gptj_forward_static(golden_x, golden_cos, golden_sin)
+    torch.testing.assert_close(
+        vllm_golden_output, golden_output, rtol=0.0, atol=1.0e-15
     )
-    config._attn_implementation = "eager"
+    hf_golden_output, _ = hf_impl.apply_rotary_pos_emb_interleave(
+        golden_x,
+        golden_x,
+        torch.cat((golden_cos, golden_cos), dim=-1),
+        torch.cat((golden_sin, golden_sin), dim=-1),
+        unsqueeze_dim=2,
+    )
+    half = hf_golden_output.shape[-1] // 2
+    hf_golden_as_gptj = torch.stack(
+        (hf_golden_output[..., :half], hf_golden_output[..., half:]), dim=-1
+    ).flatten(-2)
+    torch.testing.assert_close(hf_golden_as_gptj, golden_output, rtol=0.0, atol=1.0e-15)
 
-    torch.manual_seed(20260627)
-    hf_attention = GlmMoeDsaAttention(config, layer_idx=2).double().eval()
-
-    def make_mlite(*, indexer_rope_interleaved: bool):
-        module = dsa.DynamicSparseAttention(
-            hidden_size=16,
-            num_attention_heads=2,
-            q_lora_rank=8,
-            kv_lora_rank=4,
-            qk_nope_head_dim=4,
+    indexer = (
+        dsa.DSAIndexer(
+            hidden_size=8,
+            q_lora_rank=6,
             qk_rope_head_dim=4,
-            v_head_dim=4,
-            index_n_heads=2,
-            index_head_dim=8,
-            index_topk=2,
-            rms_norm_eps=1.0e-5,
+            index_n_heads=3,
+            index_head_dim=6,
+            index_topk=3,
             rope_interleaved=True,
-            indexer_rope_interleaved=indexer_rope_interleaved,
-            indexer_rope_first=True,
-            indexer_use_hadamard=False,
-            layer_number=3,
-            indexer_type="full",
-            index_share_enabled=False,
-        ).double().eval()
-        module.load_state_dict(hf_attention.state_dict(), strict=True)
-        return module
+            layer_norm_eps=1.0e-6,
+            rope_first=True,
+            use_hadamard=False,
+        )
+        .double()
+        .eval()
+    )
+    with torch.no_grad():
+        for parameter_index, parameter in enumerate(indexer.parameters()):
+            coordinates = torch.arange(parameter.numel(), dtype=torch.float64)
+            values = torch.sin(coordinates * 0.37 + parameter_index * 0.71)
+            parameter.copy_(values.reshape_as(parameter) * 0.4)
 
-    mlite_hf_layout = make_mlite(indexer_rope_interleaved=False)
-    mlite_checkpoint_layout = make_mlite(indexer_rope_interleaved=True)
-    hidden_states = torch.randn(1, 6, 16, dtype=torch.float64)
-    position_ids = torch.arange(6, dtype=torch.long).unsqueeze(0)
-    rotary = GlmMoeDsaRotaryEmbedding(config)
-    cos, sin = rotary(hidden_states, position_ids)
+    sequence_length = 7
+    hidden_states = torch.sin(
+        torch.arange(sequence_length * 8, dtype=torch.float64) * 0.19 + 0.3
+    ).reshape(1, sequence_length, 8)
+    q_resid = torch.cos(
+        torch.arange(sequence_length * 6, dtype=torch.float64) * 0.23 - 0.2
+    ).reshape(1, sequence_length, 6)
+    position_ids = torch.arange(sequence_length, dtype=torch.long).unsqueeze(0)
+    cos, sin = dsa.build_rotary_embeddings(
+        position_ids=position_ids,
+        dim=indexer.qk_rope_head_dim,
+        rope_theta=97.0,
+        dtype=torch.float64,
+    )
 
     with torch.no_grad():
-        hf_out, _, hf_topk = hf_attention(
-            hidden_states,
-            (cos, sin),
-            None,
-            position_ids=position_ids,
+        mlite_q_sbh, mlite_k_sb, mlite_weights_sb = indexer.forward_before_topk(
+            hidden_states, q_resid, cos, sin, position_ids
         )
-        hf_layout_out = mlite_hf_layout(
-            hidden_states,
-            cos=cos,
-            sin=sin,
-            position_ids=position_ids,
+        raw_q = indexer.wq_b(q_resid).view(
+            1, sequence_length, indexer.num_heads, indexer.head_dim
         )
-        checkpoint_layout_out = mlite_checkpoint_layout(
-            hidden_states,
-            cos=cos,
-            sin=sin,
-            position_ids=position_ids,
+        raw_k = indexer.k_norm(indexer.wk(hidden_states)).unsqueeze(2)
+        raw_q_rot, raw_q_pass = torch.split(
+            raw_q,
+            [indexer.qk_rope_head_dim, indexer.qk_nope_head_dim],
+            dim=-1,
         )
+        raw_k_rot, raw_k_pass = torch.split(
+            raw_k,
+            [indexer.qk_rope_head_dim, indexer.qk_nope_head_dim],
+            dim=-1,
+        )
+        hf_q_rot, hf_k_rot = hf_impl.apply_rotary_pos_emb_interleave(
+            raw_q_rot,
+            raw_k_rot,
+            cos,
+            sin,
+            unsqueeze_dim=2,
+        )
+        hf_q = torch.cat((hf_q_rot, raw_q_pass), dim=-1)
+        hf_k = torch.cat((hf_k_rot, raw_k_pass), dim=-1).squeeze(2)
+        vllm_q_rot = _vllm_gptj_forward_static(
+            raw_q_rot,
+            cos[..., : indexer.qk_rope_head_dim // 2],
+            sin[..., : indexer.qk_rope_head_dim // 2],
+        )
+        vllm_k_rot = _vllm_gptj_forward_static(
+            raw_k_rot,
+            cos[..., : indexer.qk_rope_head_dim // 2],
+            sin[..., : indexer.qk_rope_head_dim // 2],
+        )
+        vllm_q = torch.cat((vllm_q_rot, raw_q_pass), dim=-1)
+        vllm_k = torch.cat((vllm_k_rot, raw_k_pass), dim=-1).squeeze(2)
+        vanilla_q_rot, vanilla_k_rot = hf_impl.apply_rotary_pos_emb(
+            raw_q_rot,
+            raw_k_rot,
+            cos,
+            sin,
+            unsqueeze_dim=2,
+        )
+        vanilla_q = torch.cat((vanilla_q_rot, raw_q_pass), dim=-1)
+        vanilla_k = torch.cat((vanilla_k_rot, raw_k_pass), dim=-1).squeeze(2)
 
-    assert hf_topk is not None
-    mlite_topk = captured_topk[0]
-    for query_idx in range(position_ids.shape[1]):
-        hf_valid = hf_topk[0, query_idx]
-        hf_valid = hf_valid[hf_valid <= query_idx].sort().values
-        mlite_valid = mlite_topk[0, query_idx]
-        mlite_valid = mlite_valid[mlite_valid >= 0].sort().values
-        assert torch.equal(hf_valid, mlite_valid)
-    hf_layout_max_abs = float((hf_layout_out - hf_out).abs().max().item())
-    torch.testing.assert_close(hf_layout_out, hf_out, rtol=5.0e-5, atol=5.0e-5)
+    mlite_q = mlite_q_sbh.transpose(0, 1)
+    mlite_k = mlite_k_sb.transpose(0, 1)
+    mlite_weights = mlite_weights_sb.transpose(0, 1)
+    torch.testing.assert_close(mlite_q, hf_q, rtol=0.0, atol=1.0e-12)
+    torch.testing.assert_close(mlite_k, hf_k, rtol=0.0, atol=1.0e-12)
+    authority_scores = _indexer_score_matrix(
+        hf_q,
+        hf_k,
+        mlite_weights,
+        ratio=1,
+        indexer_softmax_scale=indexer.softmax_scale,
+    )
+    vllm_scores = _indexer_score_matrix(
+        vllm_q,
+        vllm_k,
+        mlite_weights,
+        ratio=1,
+        indexer_softmax_scale=indexer.softmax_scale,
+    )
+    mlite_scores = _indexer_score_matrix(
+        mlite_q,
+        mlite_k,
+        mlite_weights,
+        ratio=1,
+        indexer_softmax_scale=indexer.softmax_scale,
+    )
+    vanilla_scores = _indexer_score_matrix(
+        vanilla_q,
+        vanilla_k,
+        mlite_weights,
+        ratio=1,
+        indexer_softmax_scale=indexer.softmax_scale,
+    )
+    torch.testing.assert_close(mlite_scores, authority_scores, rtol=0.0, atol=1.0e-12)
+    # vLLM keeps adjacent-pair output ordering while HF/MLite group the first
+    # and second pair components. The dot product is permutation-equivalent;
+    # FP32 accumulation order can differ by one ULP.
+    torch.testing.assert_close(vllm_scores, authority_scores, rtol=1.0e-6, atol=1.0e-7)
 
-    # This is the unresolved source-of-truth conflict, not an accepted parity
-    # threshold: the published/configured layout must be gated against the
-    # official Megatron implementation before release.
-    configured_max_abs = float((checkpoint_layout_out - hf_out).abs().max().item())
-    assert configured_max_abs > 1.0e-3
+    recorded_kernel_scores: list[torch.Tensor] = []
+
+    def _recording_indexer_topk(
+        q_indexer,
+        k_indexer,
+        weights,
+        topk,
+        ratio=1,
+        indexer_softmax_scale=1.0,
+    ):
+        scores = _indexer_score_matrix(
+            q_indexer.permute(1, 0, 2, 3),
+            k_indexer.permute(1, 0, 2),
+            weights.permute(1, 0, 2),
+            ratio=ratio,
+            indexer_softmax_scale=indexer_softmax_scale,
+        )
+        recorded_kernel_scores.append(scores.detach().clone())
+        return _topk_from_score_matrix(scores, topk)
+
+    monkeypatch.setattr(dsa._dsa_kernels, "indexer_topk", _recording_indexer_topk)
+    with torch.no_grad():
+        mlite_topk = indexer(hidden_states, q_resid, cos, sin, position_ids)
+    assert len(recorded_kernel_scores) == 1
+    torch.testing.assert_close(
+        recorded_kernel_scores[0], authority_scores, rtol=0.0, atol=1.0e-12
+    )
+    authority_topk, _ = _topk_from_score_matrix(authority_scores, indexer.index_topk)
+    vllm_topk, _ = _topk_from_score_matrix(vllm_scores, indexer.index_topk)
+    assert torch.equal(mlite_topk, authority_topk)
+    assert torch.equal(vllm_topk, authority_topk)
+
+    vanilla_topk, _ = _topk_from_score_matrix(vanilla_scores, indexer.index_topk)
+    finite = torch.isfinite(authority_scores)
+    vanilla_score_max_abs = float(
+        (vanilla_scores[finite] - authority_scores[finite]).abs().max().item()
+    )
+    differing_topk_rows = int(
+        torch.any(vanilla_topk != authority_topk, dim=-1).sum().item()
+    )
+    assert vanilla_score_max_abs > 1.0e-3
+    assert differing_topk_rows > 0
     print(
-        "GLM52_HF_INDEXER_LAYOUT_AUDIT "
-        f"hf_layout_max_abs={hf_layout_max_abs:.8e} "
-        f"checkpoint_layout_max_abs={configured_max_abs:.8e}"
+        "GLM52_RELEASE_VLLM_MLITE_INDEXER_ROPE_AUTHORITY_PASSED "
+        f"release_revision={authority['release']['revision']} "
+        f"vllm_revision={authority['vllm']['revision']} "
+        f"score_shape={tuple(authority_scores.shape)} "
+        f"vanilla_score_max_abs={vanilla_score_max_abs:.8e} "
+        f"vanilla_differing_topk_rows={differing_topk_rows}"
     )

--- a/experimental/lite/tests/unit/model/test_glm52_hf_attention_parity.py
+++ b/experimental/lite/tests/unit/model/test_glm52_hf_attention_parity.py
@@ -1,0 +1,319 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Independent GLM-5.2 attention parity against Transformers v5.12.0.
+
+The production sparse kernel is replaced by a first-principles Torch oracle so
+this test can run on CPU.  The HF module supplies the independent projection,
+MLA-style RoPE, sparse-mask, softmax, and value-projection reference.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+
+
+pytestmark = pytest.mark.mlite
+
+
+def _torch_sparse_attention(
+    query: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    softmax_scale: float,
+    topk_length=None,
+    indexer_topk: int = 0,
+    value_dim: int | None = None,
+) -> torch.Tensor:
+    """Small exact oracle for MLite's flattened sparse-attention contract."""
+    del topk_length, indexer_topk
+    seq, batch, heads, _ = query.shape
+    assert value_dim is not None
+    out = torch.empty(seq, batch, heads * value_dim, dtype=query.dtype)
+    for query_idx in range(seq):
+        for batch_idx in range(batch):
+            flat_row = topk_idxs[query_idx * batch + batch_idx]
+            valid = flat_row >= 0
+            key_indices = flat_row[valid].long() % seq
+            q = query[query_idx, batch_idx].float()
+            selected_kv = kv[:, batch_idx].float()[key_indices]
+            scores = torch.einsum("hd,kd->hk", q, selected_kv) * softmax_scale
+            sink = attn_sink.float().view(heads, 1)
+            probs = torch.softmax(torch.cat((scores, sink), dim=-1), dim=-1)[..., :-1]
+            values = selected_kv[:, :value_dim]
+            result = torch.einsum("hk,kv->hv", probs, values)
+            out[query_idx, batch_idx] = result.to(query.dtype).reshape(-1)
+    return out
+
+
+def _torch_indexer_topk(
+    q_indexer: torch.Tensor,
+    k_indexer: torch.Tensor,
+    weights: torch.Tensor,
+    topk: int,
+    ratio: int = 1,
+    indexer_softmax_scale: float = 1.0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Independent CPU oracle for MLite's inference indexer contract."""
+
+    q = q_indexer.permute(1, 0, 2, 3).float()
+    k = k_indexer.permute(1, 0, 2).float()
+    w = weights.permute(1, 0, 2).float()
+    scores = torch.relu(torch.einsum("bqhd,bkd->bqhk", q, k))
+    scores = (scores * w.unsqueeze(-1)).sum(dim=2) * indexer_softmax_scale
+    query_positions = torch.arange(scores.shape[1], device=scores.device)
+    key_positions = torch.arange(scores.shape[2], device=scores.device)
+    valid_counts = ((query_positions + 1) // ratio).clamp(max=scores.shape[2])
+    valid = key_positions.unsqueeze(0) < valid_counts.unsqueeze(1)
+    scores = scores.masked_fill(~valid.unsqueeze(0), -torch.inf)
+
+    effective_topk = min(topk, scores.shape[-1])
+    values, indices = torch.topk(scores, effective_topk, dim=-1)
+    indices = torch.where(torch.isfinite(values), indices, -torch.ones_like(indices))
+    if effective_topk < topk:
+        indices = torch.nn.functional.pad(indices, (0, topk - effective_topk), value=-1)
+    topk_length = (indices >= 0).sum(dim=-1, dtype=torch.int32)
+    return indices.to(torch.int32), topk_length
+
+
+def test_glm52_shared_attention_matches_transformers_v5_12(
+    transformer_engine_import_stub, monkeypatch
+):
+    """Compare a real HF shared layer with identical MLite weights and top-k.
+
+    A shared layer isolates the main-attention math from the known upstream
+    ambiguity around ``indexer_rope_interleave``.  Sequence length is greater
+    than one and row 1 attends row 0, so an incorrect half-split main RoPE is
+    observable rather than hidden by same-position dot-product invariance.
+    """
+    transformers = pytest.importorskip("transformers")
+    try:
+        from transformers.models.glm_moe_dsa.modeling_glm_moe_dsa import (
+            GlmMoeDsaAttention,
+            GlmMoeDsaRotaryEmbedding,
+        )
+    except ImportError:
+        pytest.skip("Transformers build does not provide GLM-MoE-DSA.")
+
+    version = tuple(int(part) for part in transformers.__version__.split(".")[:2])
+    if version < (5, 12):
+        pytest.skip("GLM-5.2 parity requires Transformers >= 5.12.")
+
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.attention import dsa
+
+    monkeypatch.setattr(dsa, "RMSNorm", nn.RMSNorm)
+    monkeypatch.setattr(dsa._dsa_kernels, "dsa_sparse_attn", _torch_sparse_attention)
+
+    config = transformers.GlmMoeDsaConfig(
+        vocab_size=32,
+        hidden_size=16,
+        intermediate_size=32,
+        moe_intermediate_size=8,
+        num_hidden_layers=4,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        q_lora_rank=8,
+        kv_lora_rank=4,
+        qk_nope_head_dim=4,
+        qk_rope_head_dim=4,
+        v_head_dim=4,
+        index_head_dim=8,
+        index_n_heads=2,
+        index_topk=2,
+        indexer_types=["full", "full", "full", "shared"],
+        rope_parameters={"rope_type": "default", "rope_theta": 8_000_000.0},
+        rms_norm_eps=1.0e-5,
+    )
+    config._attn_implementation = "eager"
+
+    torch.manual_seed(20260627)
+    hf_attention = GlmMoeDsaAttention(config, layer_idx=3).double().eval()
+    mlite_attention = dsa.DynamicSparseAttention(
+        hidden_size=16,
+        num_attention_heads=2,
+        q_lora_rank=8,
+        kv_lora_rank=4,
+        qk_nope_head_dim=4,
+        qk_rope_head_dim=4,
+        v_head_dim=4,
+        index_n_heads=2,
+        index_head_dim=8,
+        index_topk=2,
+        rms_norm_eps=1.0e-5,
+        rope_interleaved=True,
+        indexer_rope_interleaved=True,
+        indexer_rope_first=True,
+        indexer_use_hadamard=False,
+        layer_number=4,
+        index_topk_freq=4,
+        index_skip_topk_offset=3,
+        indexer_type="shared",
+    ).double().eval()
+    mlite_attention.load_state_dict(hf_attention.state_dict(), strict=True)
+
+    hidden_states = torch.randn(1, 4, 16, dtype=torch.float64)
+    position_ids = torch.arange(4, dtype=torch.long).unsqueeze(0)
+    rotary = GlmMoeDsaRotaryEmbedding(config)
+    cos, sin = rotary(hidden_states, position_ids)
+    topk = torch.tensor([[[0, 0], [0, 1], [1, 2], [2, 3]]], dtype=torch.int32)
+
+    with torch.no_grad():
+        hf_out, _, hf_topk = hf_attention(
+            hidden_states,
+            (cos, sin),
+            None,
+            position_ids=position_ids,
+            prev_topk_indices=topk,
+        )
+        state = dsa.DSAIndexShareState({3: 1})
+        state.save_topk(3, topk)
+        mlite_out = mlite_attention(
+            hidden_states,
+            cos=cos,
+            sin=sin,
+            position_ids=position_ids,
+            index_share_state=state,
+        )
+
+    assert torch.equal(hf_topk, topk)
+    torch.testing.assert_close(mlite_out, hf_out, rtol=2.0e-5, atol=2.0e-5)
+    print(
+        "GLM52_HF_SHARED_ATTN_PARITY "
+        f"max_abs={float((mlite_out - hf_out).abs().max().item()):.8e}"
+    )
+
+
+def test_glm52_transformers_v5_12_indexer_layout_divergence_is_explicit(
+    transformer_engine_import_stub, monkeypatch
+):
+    """Prove full HF parity under HF's layout and expose the config conflict.
+
+    Transformers v5.12 hard-codes half-split indexer RoPE while the published
+    GLM-5.2 checkpoint sets ``indexer_rope_interleave=true``. Megatron, vLLM,
+    and SGLang honor that flag. This test prevents the shared-layer parity gate
+    above from being misreported as end-to-end HF parity.
+    """
+
+    transformers = pytest.importorskip("transformers")
+    version = tuple(int(part) for part in transformers.__version__.split(".")[:2])
+    if version != (5, 12):
+        pytest.skip("This known-divergence contract is pinned to Transformers 5.12.")
+    from transformers.models.glm_moe_dsa.modeling_glm_moe_dsa import (
+        GlmMoeDsaAttention,
+        GlmMoeDsaRotaryEmbedding,
+    )
+
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.attention import dsa
+
+    monkeypatch.setattr(dsa, "RMSNorm", nn.RMSNorm)
+    monkeypatch.setattr(dsa._dsa_kernels, "dsa_sparse_attn", _torch_sparse_attention)
+    captured_topk: list[torch.Tensor] = []
+
+    def recording_indexer_topk(*args, **kwargs):
+        topk_indices, topk_length = _torch_indexer_topk(*args, **kwargs)
+        captured_topk.append(topk_indices.detach().clone())
+        return topk_indices, topk_length
+
+    monkeypatch.setattr(dsa._dsa_kernels, "indexer_topk", recording_indexer_topk)
+
+    config = transformers.GlmMoeDsaConfig(
+        vocab_size=32,
+        hidden_size=16,
+        intermediate_size=32,
+        moe_intermediate_size=8,
+        num_hidden_layers=4,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        q_lora_rank=8,
+        kv_lora_rank=4,
+        qk_nope_head_dim=4,
+        qk_rope_head_dim=4,
+        v_head_dim=4,
+        index_head_dim=8,
+        index_n_heads=2,
+        index_topk=2,
+        indexer_types=["full"] * 4,
+        indexer_rope_interleave=True,
+        rope_parameters={"rope_type": "default", "rope_theta": 8_000_000.0},
+        rms_norm_eps=1.0e-5,
+    )
+    config._attn_implementation = "eager"
+
+    torch.manual_seed(20260627)
+    hf_attention = GlmMoeDsaAttention(config, layer_idx=2).double().eval()
+
+    def make_mlite(*, indexer_rope_interleaved: bool):
+        module = dsa.DynamicSparseAttention(
+            hidden_size=16,
+            num_attention_heads=2,
+            q_lora_rank=8,
+            kv_lora_rank=4,
+            qk_nope_head_dim=4,
+            qk_rope_head_dim=4,
+            v_head_dim=4,
+            index_n_heads=2,
+            index_head_dim=8,
+            index_topk=2,
+            rms_norm_eps=1.0e-5,
+            rope_interleaved=True,
+            indexer_rope_interleaved=indexer_rope_interleaved,
+            indexer_rope_first=True,
+            indexer_use_hadamard=False,
+            layer_number=3,
+            indexer_type="full",
+            index_share_enabled=False,
+        ).double().eval()
+        module.load_state_dict(hf_attention.state_dict(), strict=True)
+        return module
+
+    mlite_hf_layout = make_mlite(indexer_rope_interleaved=False)
+    mlite_checkpoint_layout = make_mlite(indexer_rope_interleaved=True)
+    hidden_states = torch.randn(1, 6, 16, dtype=torch.float64)
+    position_ids = torch.arange(6, dtype=torch.long).unsqueeze(0)
+    rotary = GlmMoeDsaRotaryEmbedding(config)
+    cos, sin = rotary(hidden_states, position_ids)
+
+    with torch.no_grad():
+        hf_out, _, hf_topk = hf_attention(
+            hidden_states,
+            (cos, sin),
+            None,
+            position_ids=position_ids,
+        )
+        hf_layout_out = mlite_hf_layout(
+            hidden_states,
+            cos=cos,
+            sin=sin,
+            position_ids=position_ids,
+        )
+        checkpoint_layout_out = mlite_checkpoint_layout(
+            hidden_states,
+            cos=cos,
+            sin=sin,
+            position_ids=position_ids,
+        )
+
+    assert hf_topk is not None
+    mlite_topk = captured_topk[0]
+    for query_idx in range(position_ids.shape[1]):
+        hf_valid = hf_topk[0, query_idx]
+        hf_valid = hf_valid[hf_valid <= query_idx].sort().values
+        mlite_valid = mlite_topk[0, query_idx]
+        mlite_valid = mlite_valid[mlite_valid >= 0].sort().values
+        assert torch.equal(hf_valid, mlite_valid)
+    hf_layout_max_abs = float((hf_layout_out - hf_out).abs().max().item())
+    torch.testing.assert_close(hf_layout_out, hf_out, rtol=5.0e-5, atol=5.0e-5)
+
+    # This is the unresolved source-of-truth conflict, not an accepted parity
+    # threshold: the published/configured layout must be gated against the
+    # official Megatron implementation before release.
+    configured_max_abs = float((checkpoint_layout_out - hf_out).abs().max().item())
+    assert configured_max_abs > 1.0e-3
+    print(
+        "GLM52_HF_INDEXER_LAYOUT_AUDIT "
+        f"hf_layout_max_abs={hf_layout_max_abs:.8e} "
+        f"checkpoint_layout_max_abs={configured_max_abs:.8e}"
+    )

--- a/experimental/lite/tests/unit/model/test_glm5_lite_cp_smoke.py
+++ b/experimental/lite/tests/unit/model/test_glm5_lite_cp_smoke.py
@@ -372,7 +372,8 @@ def test_glm5_tiny_model_cp2_forward_backward_smoke():
     input_ids = zigzag_slice_for_cp(full_ids, rank, world, seq_dim=1).contiguous()
 
     output = model(input_ids=input_ids)
-    assert output["hidden_states"].shape == (batch, seq // world, cfg.hidden_size)
+    # The model contract keeps hidden states in sequence-major (SBH) layout.
+    assert output["hidden_states"].shape == (seq // world, batch, cfg.hidden_size)
     assert torch.isfinite(output["hidden_states"].float()).all()
     loss = output["hidden_states"].float().square().mean()
     assert loss.ndim == 0

--- a/experimental/lite/tests/unit/model/test_glm5_lite_cp_smoke.py
+++ b/experimental/lite/tests/unit/model/test_glm5_lite_cp_smoke.py
@@ -27,8 +27,8 @@ def _make_glm5_model(cfg, ps, **kwargs):
 
 
 def _init_dist_or_skip():
-    from datetime import timedelta
     import os
+    from datetime import timedelta
 
     import torch
     import torch.distributed as dist
@@ -200,7 +200,6 @@ def _make_dsa(
 
 def _wrap_dsa(dsa, ps, *, rope_theta: float = 1_000_000.0):
     import torch.nn as nn
-
     from megatron.lite.model.glm5.lite.model import Glm5DSAAttention
 
     attention = Glm5DSAAttention.__new__(Glm5DSAAttention)
@@ -221,7 +220,6 @@ def test_glm5_dsa_cp2_matches_full_sequence_reference_forward_and_grad(
 ):
     import torch
     import torch.distributed as dist
-
     from megatron.lite.primitive.parallel.cp import zigzag_slice_for_cp
     from megatron.lite.primitive.parallel.state import ParallelState
 
@@ -244,11 +242,7 @@ def test_glm5_dsa_cp2_matches_full_sequence_reference_forward_and_grad(
     torch.manual_seed(2026)
     ref_ps = ParallelState()
     ref_attn = _wrap_dsa(
-        _make_dsa(
-            rope_interleaved=rope_interleaved,
-            indexer_loss_coeff=1.0e-2,
-        ),
-        ref_ps,
+        _make_dsa(rope_interleaved=rope_interleaved, indexer_loss_coeff=1.0e-2), ref_ps
     ).to(device=device, dtype=torch.bfloat16)
 
     batch, seq = 1, _sparse_fused_dsa_seq_len(world)
@@ -311,7 +305,6 @@ def test_glm5_dsa_cp2_matches_full_sequence_reference_forward_and_grad(
 def test_glm5_tiny_model_cp2_matches_full_sequence_reference_forward():
     import torch
     import torch.distributed as dist
-
     from megatron.lite.model.glm5.config import Glm5Config
     from megatron.lite.primitive.parallel.cp import zigzag_slice_for_cp
     from megatron.lite.primitive.parallel.state import ParallelState
@@ -351,7 +344,6 @@ def test_glm5_tiny_model_cp2_matches_full_sequence_reference_forward():
 def test_glm5_tiny_model_cp2_forward_backward_smoke():
     import torch
     import torch.distributed as dist
-
     from megatron.lite.model.glm5.config import Glm5Config
     from megatron.lite.primitive.parallel.cp import zigzag_slice_for_cp
     from megatron.lite.primitive.parallel.state import ParallelState
@@ -391,7 +383,6 @@ def test_glm5_tiny_model_cp2_forward_backward_smoke():
 def test_glm5_packed_thd_variable_sequence_cp2_direct_forward_backward_smoke():
     import torch
     import torch.distributed as dist
-
     from megatron.lite.model.glm5.config import Glm5Config
     from megatron.lite.primitive.parallel.state import ParallelState
     from megatron.lite.primitive.parallel.thd import (
@@ -569,12 +560,12 @@ def test_glm5_packed_thd_protocol_indexshare_mtp_cp2_forward_backward_smoke():
         for name, parameter in parameters:
             assert parameter.grad is not None, f"missing gradient for {label}.{name}"
             gradient = parameter.grad.detach().float()
-            assert torch.isfinite(gradient).all(), (
-                f"non-finite gradient for {label}.{name}"
-            )
-            assert torch.count_nonzero(gradient).item() > 0, (
-                f"zero gradient for {label}.{name}"
-            )
+            assert torch.isfinite(
+                gradient
+            ).all(), f"non-finite gradient for {label}.{name}"
+            assert (
+                torch.count_nonzero(gradient).item() > 0
+            ), f"zero gradient for {label}.{name}"
 
     for layer_idx, indexer in trunk_indexers:
         assert_finite_nonzero_indexer_grads(
@@ -616,15 +607,14 @@ def test_glm5_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
     world = dist.get_world_size()
     rank = dist.get_rank()
 
-    from transformers.models.deepseek_v3.modeling_deepseek_v3 import (
-        DeepseekV3ForCausalLM,
-    )
-
     from megatron.lite.model.glm5.config import Glm5Config
     from megatron.lite.model.glm5.lite.checkpoint import load_hf_weights
     from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
     from megatron.lite.primitive.parallel.cp import zigzag_slice_for_cp
     from megatron.lite.primitive.parallel.state import ParallelState
+    from transformers.models.deepseek_v3.modeling_deepseek_v3 import (
+        DeepseekV3ForCausalLM,
+    )
 
     cfg = Glm5Config(**_tiny_hf_parity_config_kwargs())
 
@@ -682,21 +672,21 @@ def test_glm5_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
                 f"norm_ratio=[{min_norm_ratio},{max_norm_ratio}],"
                 f"max_abs_diff<={max_abs_diff}"
             )
-        assert math.isfinite(cosine) and cosine >= min_cosine, (
-            f"{label} cosine {cosine:.9f} is below {min_cosine}"
-        )
-        assert math.isfinite(rms_relative) and rms_relative <= max_rms_relative, (
-            f"{label} RMS-relative {rms_relative:.9e} exceeds {max_rms_relative}"
-        )
+        assert (
+            math.isfinite(cosine) and cosine >= min_cosine
+        ), f"{label} cosine {cosine:.9f} is below {min_cosine}"
+        assert (
+            math.isfinite(rms_relative) and rms_relative <= max_rms_relative
+        ), f"{label} RMS-relative {rms_relative:.9e} exceeds {max_rms_relative}"
         assert (
             math.isfinite(norm_ratio) and min_norm_ratio <= norm_ratio <= max_norm_ratio
         ), (
             f"{label} norm ratio {norm_ratio:.9f} is outside "
             f"[{min_norm_ratio}, {max_norm_ratio}]"
         )
-        assert math.isfinite(max_abs) and max_abs <= max_abs_diff, (
-            f"{label} max-abs {max_abs:.9e} exceeds {max_abs_diff}"
-        )
+        assert (
+            math.isfinite(max_abs) and max_abs <= max_abs_diff
+        ), f"{label} max-abs {max_abs:.9e} exceeds {max_abs_diff}"
 
     torch.manual_seed(20260611)
     hf_ref = DeepseekV3ForCausalLM(_to_hf_deepseek_v3_config(cfg)).to(
@@ -718,11 +708,7 @@ def test_glm5_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
     label_generator = torch.Generator(device=device)
     label_generator.manual_seed(20260627)
     full_labels = torch.randint(
-        0,
-        cfg.vocab_size,
-        (batch, seq),
-        generator=label_generator,
-        device=device,
+        0, cfg.vocab_size, (batch, seq), generator=label_generator, device=device
     )
     local_labels = zigzag_slice_for_cp(full_labels, rank, world, seq_dim=1).contiguous()
     local_seq = seq // world

--- a/experimental/lite/tests/unit/model/test_glm5_lite_cp_smoke.py
+++ b/experimental/lite/tests/unit/model/test_glm5_lite_cp_smoke.py
@@ -27,6 +27,7 @@ def _make_glm5_model(cfg, ps, **kwargs):
 
 
 def _init_dist_or_skip():
+    from datetime import timedelta
     import os
 
     import torch
@@ -40,7 +41,10 @@ def _init_dist_or_skip():
     local_rank = int(os.environ.get("LOCAL_RANK", "0"))
     torch.cuda.set_device(local_rank)
     if not dist.is_initialized():
-        dist.init_process_group("nccl")
+        timeout_s = int(os.environ.get("MLITE_DIST_TIMEOUT_S", "180"))
+        if timeout_s <= 0:
+            raise ValueError(f"MLITE_DIST_TIMEOUT_S must be positive, got {timeout_s}.")
+        dist.init_process_group("nccl", timeout=timedelta(seconds=timeout_s))
     if dist.get_world_size() < 2:
         pytest.skip("GLM5 CP smoke requires at least 2 ranks.")
     return torch.device("cuda", local_rank)
@@ -83,12 +87,26 @@ def _tiny_hf_parity_config_kwargs():
 def _fused_dsa_seq_len(world: int) -> int:
     seq = 512
     if seq % (2 * world) != 0:
-        pytest.skip(f"GLM5 fused DSA CP smoke requires seq={seq} divisible by 2*world={2 * world}.")
+        pytest.skip(
+            f"GLM5 fused DSA CP smoke requires seq={seq} divisible by 2*world={2 * world}."
+        )
+    return seq
+
+
+def _sparse_fused_dsa_seq_len(world: int) -> int:
+    seq = 1024
+    if seq % (2 * world) != 0:
+        pytest.skip(
+            f"GLM5 sparse fused DSA CP smoke requires seq={seq} "
+            f"divisible by 2*world={2 * world}."
+        )
     return seq
 
 
 def _to_hf_deepseek_v3_config(cfg):
-    from transformers.models.deepseek_v3.configuration_deepseek_v3 import DeepseekV3Config
+    from transformers.models.deepseek_v3.configuration_deepseek_v3 import (
+        DeepseekV3Config,
+    )
 
     return DeepseekV3Config(
         hidden_size=cfg.hidden_size,
@@ -133,7 +151,9 @@ def _distributed_diff_stats(actual, expected) -> tuple[float, float]:
 
     diff = (actual.float() - expected.float()).abs()
     max_abs = diff.max()
-    scale = torch.maximum(actual.float().abs().max(), expected.float().abs().max()).clamp_min(1e-6)
+    scale = torch.maximum(
+        actual.float().abs().max(), expected.float().abs().max()
+    ).clamp_min(1e-6)
     stats = torch.stack([max_abs, scale])
     if dist.is_initialized():
         dist.all_reduce(stats, op=dist.ReduceOp.MAX)
@@ -147,7 +167,14 @@ def _hf_state_dict_for_glm5_loader(model):
     }
 
 
-def _make_dsa(*, cp_size: int = 1, cp_rank: int = 0, cp_group=None):
+def _make_dsa(
+    *,
+    cp_size: int = 1,
+    cp_rank: int = 0,
+    cp_group=None,
+    rope_interleaved: bool = False,
+    indexer_loss_coeff: float = 0.0,
+):
     from megatron.lite.primitive.modules.attention import DynamicSparseAttention
 
     return DynamicSparseAttention(
@@ -162,19 +189,40 @@ def _make_dsa(*, cp_size: int = 1, cp_rank: int = 0, cp_group=None):
         index_head_dim=128,
         index_topk=512,
         rms_norm_eps=1e-5,
+        rope_interleaved=rope_interleaved,
+        indexer_rope_interleaved=rope_interleaved,
+        indexer_loss_coeff=indexer_loss_coeff,
         cp_size=cp_size,
         cp_rank=cp_rank,
         cp_group=cp_group,
     )
 
 
+def _wrap_dsa(dsa, ps, *, rope_theta: float = 1_000_000.0):
+    import torch.nn as nn
+
+    from megatron.lite.model.glm5.lite.model import Glm5DSAAttention
+
+    attention = Glm5DSAAttention.__new__(Glm5DSAAttention)
+    nn.Module.__init__(attention)
+    attention.ps = ps
+    attention.qk_rope_head_dim = dsa.qk_rope_head_dim
+    attention.rope_theta = rope_theta
+    attention.self_attention = dsa
+    return attention
+
+
 @pytest.mark.gpu
-def test_glm5_dsa_cp2_matches_full_sequence_reference_forward_and_grad():
+@pytest.mark.parametrize(
+    "rope_interleaved", [False, True], ids=["half-split", "interleaved"]
+)
+def test_glm5_dsa_cp2_matches_full_sequence_reference_forward_and_grad(
+    rope_interleaved: bool,
+):
     import torch
     import torch.distributed as dist
 
-    from megatron.lite.primitive.modules.attention import build_rope_cache
-    from megatron.lite.primitive.parallel.cp import zigzag_position_ids_for_cp, zigzag_slice_for_cp
+    from megatron.lite.primitive.parallel.cp import zigzag_slice_for_cp
     from megatron.lite.primitive.parallel.state import ParallelState
 
     device = _init_dist_or_skip()
@@ -183,26 +231,41 @@ def test_glm5_dsa_cp2_matches_full_sequence_reference_forward_and_grad():
     ps = ParallelState(cp_group=dist.group.WORLD, cp_size=world, cp_rank=rank)
 
     torch.manual_seed(2026)
-    cp_attn = _make_dsa(cp_size=world, cp_rank=rank, cp_group=ps.cp_group).to(
-        device=device, dtype=torch.bfloat16
-    )
+    cp_attn = _wrap_dsa(
+        _make_dsa(
+            cp_size=world,
+            cp_rank=rank,
+            cp_group=ps.cp_group,
+            rope_interleaved=rope_interleaved,
+            indexer_loss_coeff=1.0e-2,
+        ),
+        ps,
+    ).to(device=device, dtype=torch.bfloat16)
     torch.manual_seed(2026)
-    ref_attn = _make_dsa().to(device=device, dtype=torch.bfloat16)
+    ref_ps = ParallelState()
+    ref_attn = _wrap_dsa(
+        _make_dsa(
+            rope_interleaved=rope_interleaved,
+            indexer_loss_coeff=1.0e-2,
+        ),
+        ref_ps,
+    ).to(device=device, dtype=torch.bfloat16)
 
-    batch, seq = 1, _fused_dsa_seq_len(world)
+    batch, seq = 1, _sparse_fused_dsa_seq_len(world)
+    assert cp_attn.self_attention.index_topk < seq
     torch.manual_seed(99)
     full_x = torch.randn(batch, seq, 128, device=device, dtype=torch.bfloat16)
-    local_x = zigzag_slice_for_cp(full_x, rank, world, seq_dim=1).detach().requires_grad_(True)
+    local_x = (
+        zigzag_slice_for_cp(full_x, rank, world, seq_dim=1)
+        .detach()
+        .requires_grad_(True)
+    )
     ref_x = full_x.detach().clone().requires_grad_(True)
 
-    cos, sin = build_rope_cache(
-        dim=64, max_position_embeddings=seq, rope_theta=1_000_000.0, device=device
-    )
-    local_pos = zigzag_position_ids_for_cp(seq, rank, world, device).expand(batch, -1)
-    full_pos = torch.arange(seq, device=device, dtype=torch.long).unsqueeze(0).expand(batch, -1)
-
-    cp_out = cp_attn(local_x, cos=cos, sin=sin, position_ids=local_pos)
-    ref_out = ref_attn(ref_x, cos=cos, sin=sin, position_ids=full_pos)
+    # Exercise the exported wrapper's position_ids=None fallback, including
+    # global zigzag positions and rank-3 rotary reconstruction inside DSA.
+    cp_out = cp_attn(local_x.transpose(0, 1).contiguous()).transpose(0, 1).contiguous()
+    ref_out = ref_attn(ref_x.transpose(0, 1).contiguous()).transpose(0, 1).contiguous()
     expected = zigzag_slice_for_cp(ref_out, rank, world, seq_dim=1)
     torch.testing.assert_close(cp_out, expected, atol=3e-2, rtol=3e-2)
 
@@ -211,6 +274,37 @@ def test_glm5_dsa_cp2_matches_full_sequence_reference_forward_and_grad():
     expected_grad = zigzag_slice_for_cp(ref_x.grad, rank, world, seq_dim=1)
     assert local_x.grad is not None
     torch.testing.assert_close(local_x.grad, expected_grad, atol=8e-2, rtol=8e-2)
+
+    ref_params = dict(ref_attn.named_parameters())
+    for name, param in cp_attn.named_parameters():
+        assert param.grad is not None, name
+        assert ref_params[name].grad is not None, name
+        cp_grad = param.grad.detach().float().clone()
+        dist.all_reduce(cp_grad, op=dist.ReduceOp.SUM)
+        is_indexer_param = ".indexer." in name
+        if is_indexer_param:
+            # Every CP rank reconstructs the same full sequence, so the
+            # detached indexer auxiliary loss produces replicated gradients.
+            # Runtime replicated-gradient synchronization averages these.
+            cp_grad.div_(world)
+            assert torch.count_nonzero(cp_grad).item() > 0, name
+        torch.testing.assert_close(
+            cp_grad,
+            ref_params[name].grad.detach().float(),
+            atol=8e-2,
+            rtol=8e-2,
+            msg=(
+                f"CP-averaged indexer gradient mismatch for {name}"
+                if is_indexer_param
+                else f"CP-summed parameter gradient mismatch for {name}"
+            ),
+        )
+    if rank == 0:
+        print(
+            "NON_SKIP_GLM5_NONPACKED_CP_RANK3_ROTARY_PASSED "
+            f"cp={world} rope_interleaved={rope_interleaved} "
+            "indexer_loss_coeff=1.0e-2 indexer_topk=512 seq=1024"
+        )
 
 
 @pytest.mark.gpu
@@ -240,7 +334,9 @@ def test_glm5_tiny_model_cp2_matches_full_sequence_reference_forward():
 
     batch, seq = 1, _fused_dsa_seq_len(world)
     torch.manual_seed(100)
-    full_hidden = torch.randn(batch, seq, cfg.hidden_size, device=device, dtype=torch.bfloat16)
+    full_hidden = torch.randn(
+        batch, seq, cfg.hidden_size, device=device, dtype=torch.bfloat16
+    )
     local_hidden = zigzag_slice_for_cp(full_hidden, rank, world, seq_dim=1).contiguous()
 
     with torch.no_grad():
@@ -291,35 +387,24 @@ def test_glm5_tiny_model_cp2_forward_backward_smoke():
 
 
 @pytest.mark.gpu
-def test_glm5_packed_thd_variable_sequence_cp2_forward_backward_smoke():
+def test_glm5_packed_thd_variable_sequence_cp2_direct_forward_backward_smoke():
     import torch
     import torch.distributed as dist
 
     from megatron.lite.model.glm5.config import Glm5Config
-    from megatron.lite.model.glm5.lite.protocol import (
-        _forward_step,
-        unpack_forward_output,
-    )
     from megatron.lite.primitive.parallel.state import ParallelState
-    from megatron.lite.runtime.contracts.data import PackedBatch
+    from megatron.lite.primitive.parallel.thd import (
+        pack_nested_thd,
+        unpack_packed_thd_to_nested,
+    )
 
     device = _init_dist_or_skip()
     world = dist.get_world_size()
     rank = dist.get_rank()
     cfg_kwargs = _tiny_config_kwargs()
-    cfg_kwargs.update(
-        max_position_embeddings=64,
-        num_hidden_layers=6,
-        num_nextn_predict_layers=1,
-    )
-    indexer_types = ["full", "full", "full", "shared", "shared", "shared"]
-    cfg = Glm5Config(
-        **cfg_kwargs,
-        index_topk_freq=4,
-        index_skip_topk_offset=3,
-        indexer_types=indexer_types,
-    )
-    cfg.mlp_layer_types = ["dense"] * 7
+    cfg_kwargs.update(max_position_embeddings=64, num_nextn_predict_layers=1)
+    cfg = Glm5Config(**cfg_kwargs)
+    cfg.mlp_layer_types = ["dense", "dense"]
     ps = ParallelState(cp_group=dist.group.WORLD, cp_size=world, cp_rank=rank)
 
     torch.manual_seed(20260614)
@@ -329,6 +414,109 @@ def test_glm5_packed_thd_variable_sequence_cp2_forward_backward_smoke():
     model.train()
 
     lengths = [16, 20, 24]
+    ids = torch.nested.as_nested_tensor(
+        [
+            torch.randint(0, cfg.vocab_size, (length,), device=device, dtype=torch.long)
+            for length in lengths
+        ],
+        layout=torch.jagged,
+    )
+    labels = torch.nested.as_nested_tensor(
+        [
+            torch.randint(0, cfg.vocab_size, (length,), device=device, dtype=torch.long)
+            for length in lengths
+        ],
+        layout=torch.jagged,
+    )
+    loss_mask = torch.nested.as_nested_tensor(
+        [torch.ones(length, device=device, dtype=torch.float32) for length in lengths],
+        layout=torch.jagged,
+    )
+    packed = pack_nested_thd(
+        ids,
+        cp_size=world,
+        cp_rank=rank,
+        cp_group=ps.cp_group,
+        labels=labels,
+        loss_mask=loss_mask,
+    )
+
+    out = model(
+        input_ids=packed.input_ids,
+        labels=packed.labels,
+        loss_mask=packed.loss_mask,
+        position_ids=packed.position_ids,
+        packed_seq_params=packed.packed_seq_params,
+    )
+    assert torch.isfinite(out["loss"])
+    assert "mtp_loss" in out
+    out["loss"].backward()
+
+    grad_norm = torch.zeros((), device=device)
+    for param in model.parameters():
+        if param.grad is not None:
+            grad_norm = grad_norm + param.grad.detach().float().norm()
+    assert torch.isfinite(grad_norm)
+
+    nested_log_probs = unpack_packed_thd_to_nested(out["log_probs"], packed)
+    assert nested_log_probs.offsets().numel() == len(lengths) + 1
+    assert [int(x) for x in nested_log_probs.offsets().diff().cpu()] == lengths
+
+    if rank == 0:
+        print(
+            "NON_SKIP_GLM5_THD_CP_DIRECT_SMOKE_PASSED "
+            f"world_size={world} lengths={lengths} "
+            f"loss={float(out['loss'].detach().item()):.6e} "
+            f"grad_norm={float(grad_norm.detach().item()):.6e}"
+        )
+
+
+@pytest.mark.gpu
+def test_glm5_packed_thd_protocol_indexshare_mtp_cp2_forward_backward_smoke():
+    import torch
+    import torch.distributed as dist
+
+    device = _init_dist_or_skip()
+    world = dist.get_world_size()
+    rank = dist.get_rank()
+
+    from megatron.lite.model.glm5.config import Glm5Config
+    from megatron.lite.model.glm5.lite.protocol import (
+        _forward_step,
+        unpack_forward_output,
+    )
+    from megatron.lite.primitive.parallel.state import ParallelState
+    from megatron.lite.runtime.contracts.data import PackedBatch
+
+    lengths = [640, 64, 80]
+    cp_alignment = 2 * world
+    assert all(length % cp_alignment == 0 for length in lengths)
+    assert sum(lengths) % world == 0
+
+    cfg_kwargs = _tiny_config_kwargs()
+    cfg_kwargs.update(
+        max_position_embeddings=max(lengths),
+        num_hidden_layers=6,
+        num_nextn_predict_layers=1,
+        dsa_indexer_loss_coeff=1.0e-2,
+    )
+    indexer_types = ["full", "full", "full", "shared", "shared", "shared"]
+    cfg = Glm5Config(
+        **cfg_kwargs,
+        index_topk_freq=4,
+        index_skip_topk_offset=3,
+        indexer_types=indexer_types,
+    )
+    cfg.mlp_layer_types = ["dense"] * 7
+    assert cfg.index_topk < max(lengths)
+    ps = ParallelState(cp_group=dist.group.WORLD, cp_size=world, cp_rank=rank)
+
+    torch.manual_seed(20260614)
+    model = _make_glm5_model(cfg, ps=ps, mtp_enable=True, mtp_enable_train=True).to(
+        device=device, dtype=torch.bfloat16
+    )
+    model.train()
+
     batch = PackedBatch(
         input_ids=torch.cat(
             [
@@ -353,19 +541,52 @@ def test_glm5_packed_thd_variable_sequence_cp2_forward_backward_smoke():
     out = _forward_step(model, batch)
     assert torch.isfinite(out["loss"])
     assert "mtp_loss" in out
-    assert model.layers[3].self_attention.self_attention.skip_topk is True
+    assert torch.isfinite(out["mtp_loss"])
+    assert float(out["mtp_loss"].detach().item()) > 0.0
+
+    trunk_indexers = []
+    for layer_idx, layer in enumerate(model.layers):
+        dsa = layer.self_attention.self_attention
+        if indexer_types[layer_idx] == "full":
+            assert dsa.skip_topk is False
+            assert dsa.indexer is not None
+            trunk_indexers.append((layer_idx, dsa.indexer))
+        else:
+            assert dsa.skip_topk is True
+            assert dsa.indexer is None
+    assert len(trunk_indexers) == indexer_types.count("full")
+
     assert model.mtp is not None
-    assert (
-        model.mtp.layers[0].transformer_layer.self_attention.self_attention.skip_topk
-        is False
-    )
+    mtp_dsa = model.mtp.layers[0].transformer_layer.self_attention.self_attention
+    assert mtp_dsa.skip_topk is False
+    assert mtp_dsa.indexer is not None
     out["loss"].backward()
+
+    def assert_finite_nonzero_indexer_grads(indexer, *, label):
+        parameters = list(indexer.named_parameters())
+        assert parameters, f"{label} has no indexer parameters"
+        for name, parameter in parameters:
+            assert parameter.grad is not None, f"missing gradient for {label}.{name}"
+            gradient = parameter.grad.detach().float()
+            assert torch.isfinite(gradient).all(), (
+                f"non-finite gradient for {label}.{name}"
+            )
+            assert torch.count_nonzero(gradient).item() > 0, (
+                f"zero gradient for {label}.{name}"
+            )
+
+    for layer_idx, indexer in trunk_indexers:
+        assert_finite_nonzero_indexer_grads(
+            indexer, label=f"layers.{layer_idx}.indexer"
+        )
+    assert_finite_nonzero_indexer_grads(mtp_dsa.indexer, label="mtp.layers.0.indexer")
 
     grad_norm = torch.zeros((), device=device)
     for param in model.parameters():
         if param.grad is not None:
             grad_norm = grad_norm + param.grad.detach().float().norm()
     assert torch.isfinite(grad_norm)
+    assert float(grad_norm.item()) > 0.0
 
     nested_log_probs = unpack_forward_output(model, batch, out["log_probs"])
     assert nested_log_probs.offsets().numel() == len(lengths) + 1
@@ -375,16 +596,28 @@ def test_glm5_packed_thd_variable_sequence_cp2_forward_backward_smoke():
         print(
             "NON_SKIP_GLM5_THD_CP_SMOKE_PASSED "
             f"world_size={world} lengths={lengths} index_share=true mtp_indexer=full "
+            "indexer_loss_coeff=1.0e-2 indexer_topk=512 nontrivial_sparse_segment=true "
             f"loss={float(out['loss'].detach().item()):.6e} "
+            f"mtp_loss={float(out['mtp_loss'].detach().item()):.6e} "
             f"grad_norm={float(grad_norm.detach().item()):.6e}"
         )
 
 
 @pytest.mark.gpu
 def test_glm5_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
+    import math
+
     import torch
     import torch.distributed as dist
-    from transformers.models.deepseek_v3.modeling_deepseek_v3 import DeepseekV3ForCausalLM
+    import torch.nn.functional as F
+
+    device = _init_dist_or_skip()
+    world = dist.get_world_size()
+    rank = dist.get_rank()
+
+    from transformers.models.deepseek_v3.modeling_deepseek_v3 import (
+        DeepseekV3ForCausalLM,
+    )
 
     from megatron.lite.model.glm5.config import Glm5Config
     from megatron.lite.model.glm5.lite.checkpoint import load_hf_weights
@@ -392,10 +625,77 @@ def test_glm5_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
     from megatron.lite.primitive.parallel.cp import zigzag_slice_for_cp
     from megatron.lite.primitive.parallel.state import ParallelState
 
-    device = _init_dist_or_skip()
-    world = dist.get_world_size()
-    rank = dist.get_rank()
     cfg = Glm5Config(**_tiny_hf_parity_config_kwargs())
+
+    min_cosine = 0.999
+    max_rms_relative = 0.02
+    min_norm_ratio = 0.99
+    max_norm_ratio = 1.01
+    max_abs_diff = 0.05
+    max_loss_abs_diff = 5.0e-3
+    max_loss_relative_diff = 2.0e-3
+
+    def global_parity_metrics(actual, expected):
+        assert actual.shape == expected.shape
+        actual_fp64 = actual.detach().to(dtype=torch.float64)
+        expected_fp64 = expected.detach().to(dtype=torch.float64)
+        difference = actual_fp64 - expected_fp64
+        sums = torch.stack(
+            [
+                torch.sum(actual_fp64 * expected_fp64),
+                torch.sum(actual_fp64.square()),
+                torch.sum(expected_fp64.square()),
+                torch.sum(difference.square()),
+                torch.tensor(actual_fp64.numel(), device=device, dtype=torch.float64),
+            ]
+        )
+        max_abs = difference.abs().max()
+        dist.all_reduce(sums, op=dist.ReduceOp.SUM)
+        dist.all_reduce(max_abs, op=dist.ReduceOp.MAX)
+
+        dot_product, actual_square, expected_square, diff_square, count = sums
+        cosine = dot_product / torch.sqrt(actual_square * expected_square).clamp_min(
+            1.0e-30
+        )
+        rms_relative = torch.sqrt(diff_square / count) / torch.sqrt(
+            expected_square / count
+        ).clamp_min(1.0e-30)
+        norm_ratio = torch.sqrt(actual_square / expected_square.clamp_min(1.0e-30))
+        return (
+            float(cosine.item()),
+            float(rms_relative.item()),
+            float(norm_ratio.item()),
+            float(max_abs.item()),
+        )
+
+    def assert_fixed_parity_gates(label, actual, expected):
+        cosine, rms_relative, norm_ratio, max_abs = global_parity_metrics(
+            actual, expected
+        )
+        if rank == 0:
+            print(
+                f"glm5_legacy_hf_full_model_parity tensor={label} "
+                f"cosine={cosine:.9f} rms_relative={rms_relative:.9e} "
+                f"norm_ratio={norm_ratio:.9f} max_abs_diff={max_abs:.9e} "
+                f"gates=cosine>={min_cosine},rms_relative<={max_rms_relative},"
+                f"norm_ratio=[{min_norm_ratio},{max_norm_ratio}],"
+                f"max_abs_diff<={max_abs_diff}"
+            )
+        assert math.isfinite(cosine) and cosine >= min_cosine, (
+            f"{label} cosine {cosine:.9f} is below {min_cosine}"
+        )
+        assert math.isfinite(rms_relative) and rms_relative <= max_rms_relative, (
+            f"{label} RMS-relative {rms_relative:.9e} exceeds {max_rms_relative}"
+        )
+        assert (
+            math.isfinite(norm_ratio) and min_norm_ratio <= norm_ratio <= max_norm_ratio
+        ), (
+            f"{label} norm ratio {norm_ratio:.9f} is outside "
+            f"[{min_norm_ratio}, {max_norm_ratio}]"
+        )
+        assert math.isfinite(max_abs) and max_abs <= max_abs_diff, (
+            f"{label} max-abs {max_abs:.9e} exceeds {max_abs_diff}"
+        )
 
     torch.manual_seed(20260611)
     hf_ref = DeepseekV3ForCausalLM(_to_hf_deepseek_v3_config(cfg)).to(
@@ -414,6 +714,21 @@ def test_glm5_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
     torch.manual_seed(311)
     full_ids = torch.randint(0, cfg.vocab_size, (batch, seq), device=device)
     local_ids = zigzag_slice_for_cp(full_ids, rank, world, seq_dim=1).contiguous()
+    label_generator = torch.Generator(device=device)
+    label_generator.manual_seed(20260627)
+    full_labels = torch.randint(
+        0,
+        cfg.vocab_size,
+        (batch, seq),
+        generator=label_generator,
+        device=device,
+    )
+    local_labels = zigzag_slice_for_cp(full_labels, rank, world, seq_dim=1).contiguous()
+    local_seq = seq // world
+    assert full_ids.shape == (batch, seq)
+    assert local_ids.shape == (batch, local_seq)
+    assert full_labels.shape == (batch, seq)
+    assert local_labels.shape == (batch, local_seq)
 
     hf_layer_outputs = []
     native_layer_outputs = []
@@ -438,8 +753,10 @@ def test_glm5_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
     with torch.no_grad():
         if rank == 0:
             print(
-                "glm5_hf_native_parity reference=transformers.DeepseekV3ForCausalLM "
-                "mode=dense_mla_reference_with_full_topk_dsa"
+                "glm5_legacy_hf_full_model_parity "
+                "reference=transformers.DeepseekV3ForCausalLM "
+                "scope=legacy_glm5_glm51_dense_full_topk_deepseek_v3_hf_reference "
+                "excludes=glm52_production_layout"
             )
         hf_logits = hf_ref(full_ids).logits
         native_logits = native(input_ids=local_ids)["logits"]
@@ -449,22 +766,64 @@ def test_glm5_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
 
     assert len(hf_layer_outputs) == cfg.num_hidden_layers
     assert len(native_layer_outputs) == cfg.num_hidden_layers
-    for layer_idx, (actual, full_expected) in enumerate(
+    assert hf_logits.shape == (batch, seq, cfg.vocab_size)
+    assert native_logits.shape == (batch, local_seq, cfg.vocab_size)
+    for layer_idx, (native_sbhd, full_expected) in enumerate(
         zip(native_layer_outputs, hf_layer_outputs, strict=True)
     ):
-        expected = zigzag_slice_for_cp(full_expected, rank, world, seq_dim=1).contiguous()
-        max_abs, max_rel = _distributed_diff_stats(actual, expected)
-        if rank == 0:
-            print(
-                f"glm5_hf_native_parity layer={layer_idx} "
-                f"max_abs_diff={max_abs:.6e} max_rel_diff={max_rel:.6e}"
-            )
-        torch.testing.assert_close(actual.float(), expected.float(), atol=1.5e-1, rtol=1.5e-1)
+        assert full_expected.shape == (batch, seq, cfg.hidden_size)
+        assert native_sbhd.shape == (local_seq, batch, cfg.hidden_size)
+        actual = native_sbhd.transpose(0, 1).contiguous()
+        assert actual.shape == (batch, local_seq, cfg.hidden_size)
+        expected = zigzag_slice_for_cp(
+            full_expected, rank, world, seq_dim=1
+        ).contiguous()
+        assert expected.shape == (batch, local_seq, cfg.hidden_size)
+        assert_fixed_parity_gates(f"layer_{layer_idx}", actual, expected)
 
     expected = zigzag_slice_for_cp(hf_logits, rank, world, seq_dim=1).contiguous()
-    max_abs, max_rel = _distributed_diff_stats(native_logits, expected)
+    assert expected.shape == (batch, local_seq, cfg.vocab_size)
+    assert_fixed_parity_gates("logits", native_logits, expected)
+
+    native_loss_sum = F.cross_entropy(
+        native_logits.float().reshape(-1, cfg.vocab_size),
+        local_labels.reshape(-1),
+        reduction="sum",
+    ).to(dtype=torch.float64)
+    reference_loss_sum = F.cross_entropy(
+        expected.float().reshape(-1, cfg.vocab_size),
+        local_labels.reshape(-1),
+        reduction="sum",
+    ).to(dtype=torch.float64)
+    loss_count = torch.tensor(local_labels.numel(), device=device, dtype=torch.float64)
+    loss_stats = torch.stack([native_loss_sum, reference_loss_sum, loss_count])
+    dist.all_reduce(loss_stats, op=dist.ReduceOp.SUM)
+    native_loss = float((loss_stats[0] / loss_stats[2]).item())
+    reference_loss = float((loss_stats[1] / loss_stats[2]).item())
+    loss_abs_diff = abs(native_loss - reference_loss)
+    loss_relative_diff = loss_abs_diff / max(abs(reference_loss), 1.0e-12)
     if rank == 0:
         print(
-            "glm5_hf_native_parity logits " f"max_abs_diff={max_abs:.6e} max_rel_diff={max_rel:.6e}"
+            "glm5_legacy_hf_full_model_parity external_label_ce "
+            f"native_loss={native_loss:.9e} reference_loss={reference_loss:.9e} "
+            f"abs_diff={loss_abs_diff:.9e} relative_diff={loss_relative_diff:.9e} "
+            f"gates=abs_diff<={max_loss_abs_diff},"
+            f"relative_diff<={max_loss_relative_diff}"
         )
-    torch.testing.assert_close(native_logits.float(), expected.float(), atol=1.5e-1, rtol=1.5e-1)
+    assert math.isfinite(native_loss)
+    assert math.isfinite(reference_loss)
+    assert loss_abs_diff <= max_loss_abs_diff, (
+        f"external-label CE loss abs diff {loss_abs_diff:.9e} exceeds "
+        f"{max_loss_abs_diff}"
+    )
+    assert loss_relative_diff <= max_loss_relative_diff, (
+        f"external-label CE loss relative diff {loss_relative_diff:.9e} exceeds "
+        f"{max_loss_relative_diff}"
+    )
+
+    if rank == 0:
+        print(
+            "NON_SKIP_GLM5_LEGACY_HF_FULL_MODEL_PARITY_PASSED "
+            "scope=legacy_glm5_glm51_dense_full_topk_deepseek_v3_hf_reference "
+            "excludes=glm52_production_layout"
+        )

--- a/experimental/lite/tests/unit/model/test_glm5_lite_static.py
+++ b/experimental/lite/tests/unit/model/test_glm5_lite_static.py
@@ -130,7 +130,23 @@ def test_glm5_config_ignores_null_hf_optional_fields():
     assert cfg.mlp_layer_types is None
 
 
-def test_glm52_config_validates_index_share_schedule():
+def test_glm52_config_fields_append_without_shifting_legacy_positional_slots():
+    from dataclasses import fields
+
+    from megatron.lite.model.glm5.config import Glm5Config
+
+    names = [field.name for field in fields(Glm5Config)]
+    legacy_tail = names.index("mlp_layer_types")
+    assert names[legacy_tail + 1 :] == [
+        "index_topk_freq",
+        "index_skip_topk_offset",
+        "index_topk_pattern",
+        "indexer_types",
+        "dsa_rope_layout_revision",
+    ]
+
+
+def test_glm52_config_uses_explicit_indexer_types_as_canonical_schedule():
     import pytest
 
     from megatron.lite.model.glm5.config import Glm5Config
@@ -145,7 +161,6 @@ def test_glm52_config_validates_index_share_schedule():
         index_topk_freq=4,
         index_skip_topk_offset=3,
         indexer_types=indexer_types,
-        index_share_for_mtp_iteration=True,
     )
 
     assert indexer_types.count("full") == 21
@@ -157,21 +172,396 @@ def test_glm52_config_validates_index_share_schedule():
     assert cfg.dsa_indexer_type(74) == "full"
     assert cfg.dsa_indexer_type(77) == "shared"
     assert cfg.dsa_indexer_source_layer(77) == 74
-    # MTP layer 78 (0-based) is outside trunk indexer_types and is full by
-    # the same global layer-number schedule.
+    # MTP layer 78 (0-based) is outside the backbone-only indexer_types and is
+    # always full.  The serving-only HF index_share_for_mtp_iteration field is
+    # not an architecture schedule input in MLite.
     assert cfg.dsa_indexer_type(78) == "full"
     assert cfg.builds_dsa_indexer(78) is True
-    assert cfg.index_share_for_mtp_iteration is True
 
-    bad_types = list(indexer_types)
-    bad_types[3] = "full"
-    with pytest.raises(ValueError, match="indexer_types\\[3\\]"):
+    custom_types = list(indexer_types)
+    custom_types[3] = "full"
+    custom_cfg = Glm5Config(
+        **{**_tiny_config_kwargs(), "num_hidden_layers": 78},
+        index_topk_freq=4,
+        index_skip_topk_offset=3,
+        indexer_types=custom_types,
+    )
+    assert custom_cfg.dsa_indexer_type(3) == "full"
+    assert custom_cfg.dsa_indexer_source_layer(4) == 3
+
+    with pytest.raises(ValueError, match="shared before any full source"):
         Glm5Config(
-            **{**_tiny_config_kwargs(), "num_hidden_layers": 78},
-            index_topk_freq=4,
-            index_skip_topk_offset=3,
-            indexer_types=bad_types,
+            **{**_tiny_config_kwargs(), "num_hidden_layers": 3},
+            indexer_types=["shared", "full", "shared"],
         )
+
+
+def test_glm52_config_pattern_precedence_groups_and_all_full_override():
+    from megatron.lite.model.glm5.config import Glm5Config
+
+    pattern_cfg = Glm5Config(
+        **{**_tiny_config_kwargs(), "num_hidden_layers": 6},
+        index_topk_freq=1,
+        index_topk_pattern="FSFSSF",
+    )
+    assert pattern_cfg.resolved_dsa_indexer_types == (
+        "full",
+        "shared",
+        "full",
+        "shared",
+        "shared",
+        "full",
+    )
+    assert pattern_cfg.uses_dsa_index_share is True
+    assert pattern_cfg.dsa_indexer_source_layer(4) == 2
+    assert [pattern_cfg.builds_dsa_indexer(idx) for idx in range(6)] == [
+        True,
+        False,
+        True,
+        False,
+        False,
+        True,
+    ]
+    assert pattern_cfg.dsa_index_share_decoder_layer_groups() == [
+        [0, 1],
+        [2, 3, 4],
+        [5],
+    ]
+
+    # Explicit indexer_types overrides both pattern and a contradictory
+    # freq/offset schedule, matching HF's configuration precedence.
+    all_full_cfg = Glm5Config(
+        **{**_tiny_config_kwargs(), "num_hidden_layers": 6},
+        index_topk_freq=4,
+        index_skip_topk_offset=3,
+        index_topk_pattern="SSSSSS",
+        indexer_types=["full"] * 6,
+    )
+    assert all_full_cfg.uses_dsa_index_share is False
+    assert all_full_cfg.has_dsa_index_share_schedule is True
+    assert all_full_cfg.uses_configured_dsa_rope_layout is True
+    assert all_full_cfg.dsa_index_share_decoder_layer_groups() is None
+
+    # The rotary revision is a load-time compatibility decision, not a live
+    # alias of the sharing schedule. Disabling sharing later must not change it.
+    all_full_cfg.indexer_types = None
+    all_full_cfg.index_topk_pattern = None
+    all_full_cfg.index_topk_freq = 1
+    all_full_cfg.index_skip_topk_offset = 0
+    assert all_full_cfg.has_dsa_index_share_schedule is False
+    assert all_full_cfg.uses_configured_dsa_rope_layout is True
+    roundtripped = Glm5Config._from_hf_dict(all_full_cfg.to_dict())
+    assert roundtripped.has_dsa_index_share_schedule is False
+    assert roundtripped.uses_configured_dsa_rope_layout is True
+
+
+def test_glm5_rope_revision_is_inferred_before_schedule_overrides():
+    from megatron.lite.model.glm5.config import Glm5Config
+
+    glm52_source = {
+        **_tiny_config_kwargs(),
+        "index_topk_freq": 2,
+        "index_skip_topk_offset": 1,
+        "indexer_types": ["full", "shared"],
+    }
+    glm52_all_full = Glm5Config._from_hf_dict(
+        glm52_source,
+        index_topk_freq=1,
+        index_skip_topk_offset=0,
+        indexer_types=["full", "full"],
+    )
+    assert glm52_all_full.uses_dsa_index_share is False
+    assert glm52_all_full.uses_configured_dsa_rope_layout is True
+
+    glm51_with_local_all_full = Glm5Config._from_hf_dict(
+        _tiny_config_kwargs(),
+        indexer_types=["full", "full"],
+    )
+    assert glm51_with_local_all_full.uses_dsa_index_share is False
+    assert glm51_with_local_all_full.uses_configured_dsa_rope_layout is False
+
+
+def test_glm51_gate_off_preserves_legacy_rope_layout(
+    transformer_engine_import_stub, monkeypatch
+):
+    import torch.nn as nn
+
+    transformer_engine_import_stub()
+    from megatron.lite.model.glm5.config import Glm5Config
+    from megatron.lite.model.glm5.lite.model import Glm5DSAAttention
+    from megatron.lite.primitive.modules.attention import dsa
+    from megatron.lite.primitive.parallel import ParallelState
+
+    monkeypatch.setattr(dsa, "RMSNorm", nn.RMSNorm)
+
+    published_rope_fields = {
+        "rope_interleave": True,
+        "indexer_rope_interleave": True,
+    }
+    legacy_cfg = Glm5Config(**_tiny_config_kwargs(), **published_rope_fields)
+    glm52_cfg = Glm5Config(
+        **_tiny_config_kwargs(),
+        **published_rope_fields,
+        indexer_types=["full", "shared"],
+    )
+    glm52_all_full_cfg = Glm5Config(
+        **_tiny_config_kwargs(),
+        **published_rope_fields,
+        indexer_types=["full", "full"],
+    )
+
+    assert legacy_cfg.has_dsa_index_share_schedule is False
+    assert legacy_cfg.dsa_rope_layout_revision == "legacy"
+    # The exported wrapper keeps its pre-PR two-argument constructor contract.
+    legacy_dsa = Glm5DSAAttention(legacy_cfg, ParallelState()).self_attention
+    assert legacy_dsa.layer_number == 1
+    assert legacy_dsa.rope_interleaved is False
+    assert legacy_dsa.indexer is not None
+    assert legacy_dsa.indexer.rope_interleaved is False
+
+    assert glm52_cfg.dsa_rope_layout_revision == "configured"
+    glm52_dsa = Glm5DSAAttention(glm52_cfg, ParallelState(), 0).self_attention
+    assert glm52_dsa.rope_interleaved is True
+    assert glm52_dsa.indexer is not None
+    assert glm52_dsa.indexer.rope_interleaved is True
+
+    assert glm52_all_full_cfg.uses_dsa_index_share is False
+    assert glm52_all_full_cfg.uses_configured_dsa_rope_layout is True
+    all_full_dsa = Glm5DSAAttention(
+        glm52_all_full_cfg, ParallelState(), 0
+    ).self_attention
+    assert all_full_dsa.rope_interleaved is True
+    assert all_full_dsa.indexer is not None
+    assert all_full_dsa.indexer.rope_interleaved is True
+
+
+def test_glm5_dsa_attention_preserves_explicit_packed_position_resets(
+    transformer_engine_import_stub,
+):
+    from types import SimpleNamespace
+
+    import pytest
+    import torch
+    import torch.nn as nn
+
+    transformer_engine_import_stub()
+    from megatron.lite.model.glm5.lite.model import Glm5DSAAttention
+    from megatron.lite.primitive.modules.attention import build_rotary_embeddings
+
+    class CaptureDSA(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.calls = []
+
+        def forward(self, x, **kwargs):
+            self.calls.append(
+                {
+                    "position_ids": kwargs["position_ids"].detach().clone(),
+                    "cos": kwargs["cos"].detach().clone(),
+                    "sin": kwargs["sin"].detach().clone(),
+                }
+            )
+            return torch.zeros_like(x)
+
+    attention = Glm5DSAAttention.__new__(Glm5DSAAttention)
+    nn.Module.__init__(attention)
+    attention.ps = SimpleNamespace(cp_size=1, cp_rank=0)
+    attention.qk_rope_head_dim = 4
+    attention.rope_theta = 10_000.0
+    capture = CaptureDSA()
+    attention.self_attention = capture
+
+    x = torch.zeros(6, 1, 8)
+    reset_positions = torch.tensor([[0, 1, 2, 0, 1, 2]], dtype=torch.long)
+    out = attention(
+        x,
+        packed_seq_params=object(),
+        position_ids=reset_positions,
+    )
+
+    assert out.shape == x.shape
+    assert torch.equal(capture.calls[0]["position_ids"], reset_positions)
+    segment_cos, segment_sin = build_rotary_embeddings(
+        position_ids=reset_positions[:, :3],
+        dim=attention.qk_rope_head_dim,
+        rope_theta=attention.rope_theta,
+        dtype=x.dtype,
+    )
+    torch.testing.assert_close(
+        capture.calls[0]["cos"], torch.cat((segment_cos, segment_cos), dim=1)
+    )
+    torch.testing.assert_close(
+        capture.calls[0]["sin"], torch.cat((segment_sin, segment_sin), dim=1)
+    )
+
+    with pytest.raises(
+        ValueError, match="packed sequences require explicit position_ids"
+    ):
+        attention(x, packed_seq_params=object())
+
+    # Direct non-packed legacy callers still get the historical monotonic fallback.
+    attention(x)
+    assert torch.equal(capture.calls[1]["position_ids"], torch.arange(6).unsqueeze(0))
+
+
+def test_glm5_dsa_attention_generates_global_zigzag_positions_for_cp(
+    transformer_engine_import_stub,
+):
+    from types import SimpleNamespace
+
+    import torch
+    import torch.nn as nn
+
+    transformer_engine_import_stub()
+    from megatron.lite.model.glm5.lite.model import Glm5DSAAttention
+    from megatron.lite.primitive.parallel import zigzag_position_ids_for_cp
+
+    class CaptureDSA(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.position_ids = None
+
+        def forward(self, x, **kwargs):
+            self.position_ids = kwargs["position_ids"].detach().clone()
+            return torch.zeros_like(x)
+
+    attention = Glm5DSAAttention.__new__(Glm5DSAAttention)
+    nn.Module.__init__(attention)
+    attention.ps = SimpleNamespace(cp_size=2, cp_rank=1)
+    attention.qk_rope_head_dim = 4
+    attention.rope_theta = 10_000.0
+    capture = CaptureDSA()
+    attention.self_attention = capture
+
+    local_seq = 4
+    x = torch.zeros(local_seq, 1, 8)
+    out = attention(x)
+
+    expected = zigzag_position_ids_for_cp(
+        local_seq * attention.ps.cp_size,
+        attention.ps.cp_rank,
+        attention.ps.cp_size,
+        x.device,
+    )
+    assert out.shape == x.shape
+    assert torch.equal(capture.position_ids, expected)
+
+
+def test_glm5_threads_positions_through_trunk_and_mtp(
+    transformer_engine_import_stub,
+):
+    from types import SimpleNamespace
+
+    import torch
+    import torch.nn as nn
+
+    transformer_engine_import_stub()
+    from megatron.lite.model.glm5.lite.model import Glm5MTPLayer, Glm5Model
+    from megatron.lite.primitive.parallel import ParallelState
+
+    class RecordingLayer(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.position_ids = None
+
+        def forward(
+            self,
+            x,
+            packed_seq_params=None,
+            dsa_index_share_state=None,
+            position_ids=None,
+        ):
+            del packed_seq_params, dsa_index_share_state
+            self.position_ids = (
+                None if position_ids is None else position_ids.detach().clone()
+            )
+            return x
+
+    positions = torch.tensor([[0, 1, 2, 0, 1, 2]], dtype=torch.long)
+    packed = SimpleNamespace(
+        cu_seqlens_q=torch.tensor([0, 3, 6], dtype=torch.int32),
+        local_cp_size=None,
+        cp_rank=0,
+        cp_group=None,
+    )
+
+    # Exercise Glm5Model -> Glm5Layer argument propagation without requiring
+    # Transformer Engine kernels in this CPU unit test.
+    model = Glm5Model.__new__(Glm5Model)
+    nn.Module.__init__(model)
+    trunk = RecordingLayer()
+    model.layers = nn.ModuleList([trunk])
+    model.embed = None
+    model.norm = None
+    model.head = None
+    model.mtp = None
+    model._input_tensor = None
+    model._dsa_index_share_consumer_counts = {}
+    model.train_config = SimpleNamespace(fp8=False)
+    model.ps = ParallelState()
+    hidden = torch.zeros(6, 1, 4)
+    model(hidden_states=hidden, position_ids=positions, packed_seq_params=packed)
+    assert torch.equal(trunk.position_ids, positions)
+
+    class FakeEmbedding(nn.Module):
+        def forward(self, input_ids):
+            return input_ids.transpose(0, 1).unsqueeze(-1).expand(-1, -1, 4).float()
+
+    class KeepHiddenWidth(nn.Module):
+        def forward(self, value):
+            return value[..., :4]
+
+    # MTP rolls token/label positions per packed sequence, while attention
+    # deliberately retains the original rotary coordinates (the same contract
+    # used by MCore's MTP block).
+    mtp = Glm5MTPLayer.__new__(Glm5MTPLayer)
+    nn.Module.__init__(mtp)
+    mtp.ps = ParallelState()
+    mtp.embedding = FakeEmbedding()
+    mtp.detach_encoder = False
+    mtp.enorm = nn.Identity()
+    mtp.hnorm = nn.Identity()
+    mtp.eh_proj = KeepHiddenWidth()
+    mtp.transformer_layer = RecordingLayer()
+    mtp.final_layernorm = nn.Identity()
+    _mtp_hidden, rolled_input_ids, rolled_position_ids = mtp(
+        input_ids=torch.tensor([[3, 4, 5, 6, 7, 8]], dtype=torch.long),
+        position_ids=positions,
+        hidden_states=hidden,
+        packed_seq_params=packed,
+    )
+    assert torch.equal(
+        rolled_input_ids,
+        torch.tensor([[4, 5, 0, 7, 8, 0]], dtype=torch.long),
+    )
+    assert torch.equal(
+        rolled_position_ids,
+        torch.tensor([[1, 2, 0, 1, 2, 0]], dtype=torch.long),
+    )
+    assert torch.equal(mtp.transformer_layer.position_ids, positions)
+
+
+def test_glm52_serving_mtp_share_metadata_is_ignored_and_mtp_is_always_full():
+    from megatron.lite.model.glm5.config import Glm5Config
+
+    cfg = Glm5Config._from_hf_dict(
+        {
+            **_tiny_config_kwargs(),
+            "num_hidden_layers": 4,
+            "num_nextn_predict_layers": 2,
+            "index_topk_freq": 3,
+            "index_skip_topk_offset": 1,
+            "indexer_types": ["full", "shared", "shared", "full"],
+            "index_share_for_mtp_iteration": True,
+        }
+    )
+
+    # The legacy formula would classify global layers 5 and 6 differently;
+    # architecture construction must not apply it to MTP/nextn layers.
+    assert [cfg.dsa_indexer_type(idx) for idx in (4, 5)] == ["full", "full"]
+    assert [cfg.dsa_indexer_source_layer(idx) for idx in (4, 5)] == [4, 5]
+    assert [cfg.builds_dsa_indexer(idx) for idx in (4, 5)] == [True, True]
+    assert "index_share_for_mtp_iteration" not in cfg.to_dict()
 
 
 def test_glm5_config_preserves_mtp_aliases_and_layer_types():
@@ -192,7 +582,14 @@ def test_glm5_config_preserves_mtp_aliases_and_layer_types():
 
 
 def test_glm5_lite_does_not_import_wrappers_or_sibling_models():
-    root = Path(__file__).resolve().parents[3] / "megatron" / "lite" / "model" / "glm5" / "lite"
+    root = (
+        Path(__file__).resolve().parents[3]
+        / "megatron"
+        / "lite"
+        / "model"
+        / "glm5"
+        / "lite"
+    )
     for path in root.glob("*.py"):
         text = path.read_text()
         assert "megatron.lite.model.qwen" not in text
@@ -204,7 +601,9 @@ def test_glm5_lite_does_not_import_wrappers_or_sibling_models():
 def test_glm5_lite_uses_shared_mla_and_dsa_primitive():
     root = Path(__file__).resolve().parents[3] / "megatron" / "lite"
     model_text = (root / "model" / "glm5" / "lite" / "model.py").read_text()
-    primitive_text = (root / "primitive" / "modules" / "attention" / "dsa.py").read_text()
+    primitive_text = (
+        root / "primitive" / "modules" / "attention" / "dsa.py"
+    ).read_text()
     kernel_text = (root / "primitive" / "kernels" / "dsa_kernels.py").read_text()
 
     assert "DynamicSparseAttention" in model_text
@@ -222,7 +621,9 @@ def test_glm5_lite_uses_shared_mla_and_dsa_primitive():
     assert "value_dim" in kernel_text
     assert "from cudnn.deepseek_sparse_attention import DSA" in kernel_text
     assert "from cudnn import DSA" in kernel_text
-    assert "cudnn.deepseek_sparse_attention.indexer_forward._interface_sm90" in kernel_text
+    assert (
+        "cudnn.deepseek_sparse_attention.indexer_forward._interface_sm90" in kernel_text
+    )
     assert "cudnn.deepseek_sparse_attention.indexer_forward._interface" in kernel_text
     assert "torch.cuda.get_device_capability(device)" in kernel_text
     assert "torch.topk" not in primitive_text
@@ -239,13 +640,19 @@ def test_glm5_dsa_kernel_routes_indexer_forward_by_sm(monkeypatch):
     monkeypatch.setattr(dsa_kernels, "_load_indexer_fwd_sm90", lambda: sm90_entry)
     monkeypatch.setattr(dsa_kernels, "_load_indexer_fwd_sm100", lambda: sm100_entry)
 
-    monkeypatch.setattr(dsa_kernels.torch.cuda, "get_device_capability", lambda device: (9, 0))
+    monkeypatch.setattr(
+        dsa_kernels.torch.cuda, "get_device_capability", lambda device: (9, 0)
+    )
     assert dsa_kernels._select_indexer_forward(None) is sm90_entry
 
-    monkeypatch.setattr(dsa_kernels.torch.cuda, "get_device_capability", lambda device: (10, 0))
+    monkeypatch.setattr(
+        dsa_kernels.torch.cuda, "get_device_capability", lambda device: (10, 0)
+    )
     assert dsa_kernels._select_indexer_forward(None) is sm100_entry
 
-    monkeypatch.setattr(dsa_kernels.torch.cuda, "get_device_capability", lambda device: (8, 0))
+    monkeypatch.setattr(
+        dsa_kernels.torch.cuda, "get_device_capability", lambda device: (8, 0)
+    )
     assert dsa_kernels._select_indexer_forward(None) is None
 
 
@@ -254,7 +661,10 @@ def test_glm5_dsa_training_forward_uses_fused_kernel(monkeypatch):
     import torch
 
     from megatron.lite.primitive.modules.attention import dsa
-    from megatron.lite.primitive.modules.attention import DynamicSparseAttention, build_rope_cache
+    from megatron.lite.primitive.modules.attention import (
+        DynamicSparseAttention,
+        build_rope_cache,
+    )
 
     if not torch.cuda.is_available():
         pytest.skip("GLM-5 native attention requires CUDA (Transformer Engine RMSNorm)")
@@ -280,7 +690,14 @@ def test_glm5_dsa_training_forward_uses_fused_kernel(monkeypatch):
         calculate_per_token_loss=False,
         value_dim=None,
     ):
-        del attn_sink, q_indexer, k_indexer, weights, softmax_scale, indexer_softmax_scale
+        del (
+            attn_sink,
+            q_indexer,
+            k_indexer,
+            weights,
+            softmax_scale,
+            indexer_softmax_scale,
+        )
         calls["training"] = {
             "query_shape": tuple(query.shape),
             "kv_shape": tuple(kv_full.shape),
@@ -344,7 +761,10 @@ def test_glm5_dsa_eval_forward_uses_fused_sparse_attention(monkeypatch):
     import torch
 
     from megatron.lite.primitive.modules.attention import dsa
-    from megatron.lite.primitive.modules.attention import DynamicSparseAttention, build_rope_cache
+    from megatron.lite.primitive.modules.attention import (
+        DynamicSparseAttention,
+        build_rope_cache,
+    )
 
     if not torch.cuda.is_available():
         pytest.skip("GLM-5 native attention requires CUDA (Transformer Engine RMSNorm)")
@@ -352,7 +772,9 @@ def test_glm5_dsa_eval_forward_uses_fused_sparse_attention(monkeypatch):
 
     calls = {}
 
-    def fake_indexer_topk(q_indexer, k_indexer, weights, topk, ratio, indexer_softmax_scale=1.0):
+    def fake_indexer_topk(
+        q_indexer, k_indexer, weights, topk, ratio, indexer_softmax_scale=1.0
+    ):
         del q_indexer, k_indexer, weights, indexer_softmax_scale
         calls["indexer"] = {"topk": topk, "ratio": ratio}
         idx = torch.zeros((1, 4, topk), dtype=torch.int32, device=device)
@@ -369,8 +791,13 @@ def test_glm5_dsa_eval_forward_uses_fused_sparse_attention(monkeypatch):
         value_dim=None,
     ):
         del kv_full, attn_sink, topk_idxs, softmax_scale, indexer_topk
-        calls["sparse"] = {"topk_length_is_set": topk_length is not None, "value_dim": value_dim}
-        return query.new_zeros(query.shape[0], query.shape[1], query.shape[2] * value_dim)
+        calls["sparse"] = {
+            "topk_length_is_set": topk_length is not None,
+            "value_dim": value_dim,
+        }
+        return query.new_zeros(
+            query.shape[0], query.shape[1], query.shape[2] * value_dim
+        )
 
     monkeypatch.setattr(dsa._dsa_kernels, "indexer_topk", fake_indexer_topk)
     monkeypatch.setattr(dsa._dsa_kernels, "dsa_sparse_attn", fake_dsa_sparse_attn)
@@ -437,18 +864,20 @@ def test_glm52_index_share_shared_layers_omit_indexer_modules():
         },
         index_topk_freq=4,
         index_skip_topk_offset=3,
-        indexer_types=_glm52_indexer_types(num_layers=6),
+        # Deliberately differs from freq/offset: module construction must obey
+        # the explicit HF list, not the legacy inferred schedule.
+        indexer_types=["full", "shared", "full", "shared", "shared", "full"],
     )
     model = _make_glm5_model(cfg, mtp_enable=True)
     attention_modules = [layer.self_attention.self_attention for layer in model.layers]
 
     assert [module.indexer is not None for module in attention_modules] == [
         True,
+        False,
         True,
+        False,
+        False,
         True,
-        False,
-        False,
-        False,
     ]
     assert model.mtp is not None
     mtp_attention = model.mtp.layers[0].transformer_layer.self_attention.self_attention
@@ -456,10 +885,13 @@ def test_glm52_index_share_shared_layers_omit_indexer_modules():
     assert mtp_attention.indexer is not None
 
     keys = set(model.state_dict())
+    assert "layers.1.self_attention.self_attention.indexer.wq_b.weight" not in keys
     assert "layers.2.self_attention.self_attention.indexer.wq_b.weight" in keys
     assert "layers.3.self_attention.self_attention.indexer.wq_b.weight" not in keys
+    assert "layers.5.self_attention.self_attention.indexer.wq_b.weight" in keys
     assert (
-        "mtp.layers.0.transformer_layer.self_attention.self_attention.indexer.wq_b.weight" in keys
+        "mtp.layers.0.transformer_layer.self_attention.self_attention.indexer.wq_b.weight"
+        in keys
     )
 
 
@@ -484,7 +916,9 @@ def test_glm5_checkpoint_exports_and_saves_hf_style_weights(tmp_path):
 
     assert torch.equal(
         exported["model.layers.1.mlp.experts.2.gate_proj.weight"],
-        state["layers.1.moe.experts.fc1.weight2"][: cfg.moe_intermediate_size].detach().cpu(),
+        state["layers.1.moe.experts.fc1.weight2"][: cfg.moe_intermediate_size]
+        .detach()
+        .cpu(),
     )
     assert torch.equal(
         exported["model.layers.1.mlp.gate.e_score_correction_bias"],
@@ -494,7 +928,9 @@ def test_glm5_checkpoint_exports_and_saves_hf_style_weights(tmp_path):
 
     hf_dir = tmp_path / "hf"
     save_hf_weights(model, str(hf_dir), cfg, ps)
-    with safe_open(str(hf_dir / "model.safetensors"), framework="pt", device="cpu") as handle:
+    with safe_open(
+        str(hf_dir / "model.safetensors"), framework="pt", device="cpu"
+    ) as handle:
         assert torch.equal(
             handle.get_tensor("model.layers.1.mlp.experts.2.down_proj.weight"),
             state["layers.1.moe.experts.fc2.weight2"].detach().cpu(),
@@ -515,7 +951,9 @@ def test_glm5_checkpoint_exports_and_saves_hf_style_weights(tmp_path):
 
     hf_bf16_dir = tmp_path / "hf_bf16"
     save_hf_weights(model, str(hf_bf16_dir), cfg, ps, export_dtype=torch.bfloat16)
-    with safe_open(str(hf_bf16_dir / "model.safetensors"), framework="pt", device="cpu") as handle:
+    with safe_open(
+        str(hf_bf16_dir / "model.safetensors"), framework="pt", device="cpu"
+    ) as handle:
         floating_dtypes = {
             handle.get_tensor(key).dtype
             for key in handle.keys()
@@ -526,7 +964,9 @@ def test_glm5_checkpoint_exports_and_saves_hf_style_weights(tmp_path):
     loaded_bf16 = _make_glm5_model(cfg, ps=ps)
     load_hf_weights(loaded_bf16, str(hf_bf16_dir), cfg, ps)
     assert torch.equal(
-        loaded_bf16.state_dict()["layers.1.moe.experts.fc1.weight2"][cfg.moe_intermediate_size :]
+        loaded_bf16.state_dict()["layers.1.moe.experts.fc1.weight2"][
+            cfg.moe_intermediate_size :
+        ]
         .detach()
         .cpu(),
         state["layers.1.moe.experts.fc1.weight2"][cfg.moe_intermediate_size :]
@@ -541,7 +981,10 @@ def test_glm5_checkpoint_exports_and_loads_mtp_layers(tmp_path):
     import torch
 
     from megatron.lite.model.glm5.config import Glm5Config
-    from megatron.lite.model.glm5.lite.checkpoint import export_hf_weights, load_hf_weights
+    from megatron.lite.model.glm5.lite.checkpoint import (
+        export_hf_weights,
+        load_hf_weights,
+    )
     from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
     from megatron.lite.primitive.parallel import ParallelState
 
@@ -560,6 +1003,7 @@ def test_glm5_checkpoint_exports_and_loads_mtp_layers(tmp_path):
     assert "model.layers.2.shared_head.norm.weight" in exported
     assert "model.layers.2.input_layernorm.weight" in exported
     assert "model.layers.2.mlp.gate.weight" in exported
+    assert "model.layers.2.mlp.gate.e_score_correction_bias" in exported
 
     save_safetensors(exported, str(tmp_path))
     loaded = _make_glm5_model(cfg, ps=ps, mtp_enable=True)
@@ -572,9 +1016,12 @@ def test_glm5_checkpoint_exports_and_loads_mtp_layers(tmp_path):
 
 def test_glm52_checkpoint_mapping_skips_shared_indexer_without_te():
     import importlib.util
+    import pytest
     import torch
 
     from megatron.lite.model.glm5.config import Glm5Config
+
+    pytest.importorskip("safetensors")
 
     checkpoint_path = (
         Path(__file__).resolve().parents[3]
@@ -585,7 +1032,9 @@ def test_glm52_checkpoint_mapping_skips_shared_indexer_without_te():
         / "lite"
         / "checkpoint.py"
     )
-    module_spec = importlib.util.spec_from_file_location("_glm5_checkpoint_test", checkpoint_path)
+    module_spec = importlib.util.spec_from_file_location(
+        "_glm5_checkpoint_test", checkpoint_path
+    )
     assert module_spec is not None and module_spec.loader is not None
     checkpoint_module = importlib.util.module_from_spec(module_spec)
     module_spec.loader.exec_module(checkpoint_module)
@@ -598,8 +1047,9 @@ def test_glm52_checkpoint_mapping_skips_shared_indexer_without_te():
         },
         index_topk_freq=4,
         index_skip_topk_offset=3,
-        indexer_types=_glm52_indexer_types(num_layers=6),
-        index_share_for_mtp_iteration=True,
+        # Deliberately differs from freq/offset: checkpoint presence must obey
+        # the explicit HF list, not the legacy inferred schedule.
+        indexer_types=["full", "shared", "full", "shared", "shared", "full"],
     )
     spec = checkpoint_module.Glm5WeightSpec(cfg)
     tensor = torch.ones(1)
@@ -608,9 +1058,20 @@ def test_glm52_checkpoint_mapping_skips_shared_indexer_without_te():
         "layers.2.self_attention.self_attention.indexer.wq_b.weight", tensor
     ) == [("model.layers.2.self_attn.indexer.wq_b.weight", tensor)]
     assert (
-        spec.native_to_hf("layers.3.self_attention.self_attention.indexer.wq_b.weight", tensor)
+        spec.native_to_hf(
+            "layers.3.self_attention.self_attention.indexer.wq_b.weight", tensor
+        )
         == []
     )
+    assert (
+        spec.native_to_hf(
+            "layers.1.self_attention.self_attention.indexer.wq_b.weight", tensor
+        )
+        == []
+    )
+    assert spec.native_to_hf(
+        "layers.5.self_attention.self_attention.indexer.wq_b.weight", tensor
+    ) == [("model.layers.5.self_attn.indexer.wq_b.weight", tensor)]
     assert spec.native_to_hf(
         "mtp.layers.0.transformer_layer.self_attention.self_attention.indexer.wq_b.weight",
         tensor,
@@ -657,7 +1118,10 @@ def test_glm52_checkpoint_skips_shared_indexer_weights_and_loads_full_layers(tmp
         pytest.skip(f"Transformer Engine is not importable in this environment: {exc}")
 
     from megatron.lite.model.glm5.config import Glm5Config
-    from megatron.lite.model.glm5.lite.checkpoint import export_hf_weights, load_hf_weights
+    from megatron.lite.model.glm5.lite.checkpoint import (
+        export_hf_weights,
+        load_hf_weights,
+    )
     from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
     from megatron.lite.primitive.parallel import ParallelState
 
@@ -670,7 +1134,6 @@ def test_glm52_checkpoint_skips_shared_indexer_weights_and_loads_full_layers(tmp
         index_topk_freq=4,
         index_skip_topk_offset=3,
         indexer_types=_glm52_indexer_types(num_layers=6),
-        index_share_for_mtp_iteration=True,
     )
     ps = ParallelState()
     model = _make_glm5_model(cfg, ps=ps, mtp_enable=True)
@@ -690,12 +1153,16 @@ def test_glm52_checkpoint_skips_shared_indexer_weights_and_loads_full_layers(tmp
         loaded_state["layers.2.self_attention.self_attention.indexer.wq_b.weight"],
         state["layers.2.self_attention.self_attention.indexer.wq_b.weight"],
     )
-    assert "layers.3.self_attention.self_attention.indexer.wq_b.weight" not in loaded_state
+    assert (
+        "layers.3.self_attention.self_attention.indexer.wq_b.weight" not in loaded_state
+    )
     assert torch.equal(
         loaded_state[
             "mtp.layers.0.transformer_layer.self_attention.self_attention.indexer.wq_b.weight"
         ],
-        state["mtp.layers.0.transformer_layer.self_attention.self_attention.indexer.wq_b.weight"],
+        state[
+            "mtp.layers.0.transformer_layer.self_attention.self_attention.indexer.wq_b.weight"
+        ],
     )
 
 
@@ -708,7 +1175,11 @@ def test_glm5_router_modules_use_current_names_and_bias_buffers():
     model = _make_glm5_model(
         Glm5Config(**_tiny_config_kwargs(), num_nextn_predict_layers=1), mtp_enable=True
     )
-    routers = [module for module in model.modules() if isinstance(module, Glm5SigmoidTopKRouter)]
+    routers = [
+        module
+        for module in model.modules()
+        if isinstance(module, Glm5SigmoidTopKRouter)
+    ]
     assert len(routers) == 2
     for router in routers:
         assert hasattr(router, "gate")
@@ -731,6 +1202,34 @@ def test_glm5_protocol_allows_cp_only_parallel_scope():
         _validate_parallel_scope(ParallelConfig(tp=2, ep=1, etp=1, cp=1, pp=1, vpp=1))
     with pytest.raises(NotImplementedError):
         _validate_parallel_scope(ParallelConfig(tp=1, ep=1, etp=2, cp=1, pp=1, vpp=1))
+
+
+def test_glm52_protocol_rejects_attention_replay_before_parallel_init(
+    transformer_engine_import_stub, monkeypatch
+):
+    import pytest
+
+    transformer_engine_import_stub()
+    from megatron.lite.model.glm5.config import Glm5Config
+    from megatron.lite.model.glm5.lite import protocol
+
+    cfg = Glm5Config(
+        **_tiny_config_kwargs(),
+        indexer_types=["full", "shared"],
+    )
+
+    def unexpected_parallel_init(*args, **kwargs):
+        raise AssertionError(
+            "IndexShare activation replay must fail before init_parallel"
+        )
+
+    monkeypatch.setattr(protocol, "init_parallel", unexpected_parallel_init)
+    for impl_cfg in (
+        protocol.ImplConfig(optimizer=None, recompute=["core_attn"]),
+        protocol.ImplConfig(optimizer=None, offload=["dsa"]),
+    ):
+        with pytest.raises(ValueError, match="group-aware"):
+            protocol.build_model(cfg, impl_cfg=impl_cfg)
 
 
 def test_glm5_impl_config_accepts_runtime_mtp_fields():
@@ -830,7 +1329,9 @@ def test_glm5_lite_tiny_forward_backward(monkeypatch):
     assert output["loss"].ndim == 0
     output["loss"].backward()
     grad_norm = sum(
-        param.grad.detach().float().norm() for param in model.parameters() if param.grad is not None
+        param.grad.detach().float().norm()
+        for param in model.parameters()
+        if param.grad is not None
     )
     assert torch.isfinite(grad_norm)
 
@@ -843,16 +1344,26 @@ def test_glm5_lite_tiny_forward_backward(monkeypatch):
     mtp_infer = mtp_model(input_ids=input_ids)
     assert len(mtp_infer["mtp_hidden_states"]) == 1
     assert len(mtp_infer["mtp_logits"]) == 1
-    assert mtp_infer["mtp_hidden_states"][0].shape == (5, 2, mtp_model.config.hidden_size)
+    assert mtp_infer["mtp_hidden_states"][0].shape == (
+        5,
+        2,
+        mtp_model.config.hidden_size,
+    )
     assert mtp_infer["mtp_logits"][0].shape == (2, 5, mtp_model.config.vocab_size)
 
     # Training path (with labels) returns the MTP loss instead of logits.
     mtp_output = mtp_model(
-        input_ids=input_ids, labels=labels, loss_mask=torch.ones_like(labels, dtype=torch.float32)
+        input_ids=input_ids,
+        labels=labels,
+        loss_mask=torch.ones_like(labels, dtype=torch.float32),
     )
 
     assert len(mtp_output["mtp_hidden_states"]) == 1
-    assert mtp_output["mtp_hidden_states"][0].shape == (5, 2, mtp_model.config.hidden_size)
+    assert mtp_output["mtp_hidden_states"][0].shape == (
+        5,
+        2,
+        mtp_model.config.hidden_size,
+    )
     assert mtp_output["mtp_loss"].ndim == 0
     mtp_output["loss"].backward()
     mtp_grad_norm = sum(

--- a/experimental/lite/tests/unit/model/test_glm5_lite_static.py
+++ b/experimental/lite/tests/unit/model/test_glm5_lite_static.py
@@ -130,25 +130,70 @@ def test_glm5_config_ignores_null_hf_optional_fields():
     assert cfg.mlp_layer_types is None
 
 
-def test_glm52_config_fields_append_without_shifting_legacy_positional_slots():
-    from dataclasses import fields
+def test_glm52_config_preserves_public_positional_signature():
+    import inspect
 
     from megatron.lite.model.glm5.config import Glm5Config
 
-    names = [field.name for field in fields(Glm5Config)]
-    legacy_tail = names.index("mlp_layer_types")
-    assert names[legacy_tail + 1 :] == [
+    legacy_names = [
+        "num_hidden_layers",
+        "hidden_size",
+        "num_attention_heads",
+        "num_key_value_heads",
+        "head_dim",
+        "vocab_size",
+        "max_position_embeddings",
+        "rms_norm_eps",
+        "attention_dropout",
+        "initializer_range",
+        "q_lora_rank",
+        "kv_lora_rank",
+        "qk_head_dim",
+        "qk_nope_head_dim",
+        "qk_rope_head_dim",
+        "v_head_dim",
+        "index_head_dim",
+        "index_n_heads",
+        "index_topk",
+        "indexer_layer_norm_eps",
+        "indexer_rope_interleave",
+        "indexer_rope_first",
+        "indexer_use_hadamard",
+        "dsa_indexer_loss_coeff",
+        "dsa_indexer_use_sparse_loss",
+        "calculate_per_token_loss",
+        "rope_interleave",
+        "rope_theta",
+        "latent_rms_norm_eps",
+        "intermediate_size",
+        "moe_intermediate_size",
+        "first_k_dense_replace",
+        "n_routed_experts",
+        "n_shared_experts",
+        "num_experts_per_tok",
+        "n_group",
+        "topk_group",
+        "routed_scaling_factor",
+        "norm_topk_prob",
+        "num_nextn_predict_layers",
+        "mtp_loss_scaling_factor",
+        "mtp_use_repeated_layer",
+        "mlp_layer_types",
+    ]
+    parameter_names = list(inspect.signature(Glm5Config).parameters)
+    assert parameter_names[: len(legacy_names)] == legacy_names
+    assert parameter_names[len(legacy_names) :] == [
         "index_topk_freq",
         "index_skip_topk_offset",
         "index_topk_pattern",
         "indexer_types",
+        "index_share_for_mtp_iteration",
         "dsa_rope_layout_revision",
     ]
 
 
 def test_glm52_config_uses_explicit_indexer_types_as_canonical_schedule():
     import pytest
-
     from megatron.lite.model.glm5.config import Glm5Config
 
     indexer_types = _glm52_indexer_types()
@@ -274,8 +319,7 @@ def test_glm5_rope_revision_is_inferred_before_schedule_overrides():
     assert glm52_all_full.uses_configured_dsa_rope_layout is True
 
     glm51_with_local_all_full = Glm5Config._from_hf_dict(
-        _tiny_config_kwargs(),
-        indexer_types=["full", "full"],
+        _tiny_config_kwargs(), indexer_types=["full", "full"]
     )
     assert glm51_with_local_all_full.uses_dsa_index_share is False
     assert glm51_with_local_all_full.uses_configured_dsa_rope_layout is False
@@ -294,10 +338,7 @@ def test_glm51_gate_off_preserves_legacy_rope_layout(
 
     monkeypatch.setattr(dsa, "RMSNorm", nn.RMSNorm)
 
-    published_rope_fields = {
-        "rope_interleave": True,
-        "indexer_rope_interleave": True,
-    }
+    published_rope_fields = {"rope_interleave": True, "indexer_rope_interleave": True}
     legacy_cfg = Glm5Config(**_tiny_config_kwargs(), **published_rope_fields)
     glm52_cfg = Glm5Config(
         **_tiny_config_kwargs(),
@@ -305,9 +346,7 @@ def test_glm51_gate_off_preserves_legacy_rope_layout(
         indexer_types=["full", "shared"],
     )
     glm52_all_full_cfg = Glm5Config(
-        **_tiny_config_kwargs(),
-        **published_rope_fields,
-        indexer_types=["full", "full"],
+        **_tiny_config_kwargs(), **published_rope_fields, indexer_types=["full", "full"]
     )
 
     assert legacy_cfg.has_dsa_index_share_schedule is False
@@ -373,11 +412,7 @@ def test_glm5_dsa_attention_preserves_explicit_packed_position_resets(
 
     x = torch.zeros(6, 1, 8)
     reset_positions = torch.tensor([[0, 1, 2, 0, 1, 2]], dtype=torch.long)
-    out = attention(
-        x,
-        packed_seq_params=object(),
-        position_ids=reset_positions,
-    )
+    out = attention(x, packed_seq_params=object(), position_ids=reset_positions)
 
     assert out.shape == x.shape
     assert torch.equal(capture.calls[0]["position_ids"], reset_positions)
@@ -447,16 +482,14 @@ def test_glm5_dsa_attention_generates_global_zigzag_positions_for_cp(
     assert torch.equal(capture.position_ids, expected)
 
 
-def test_glm5_threads_positions_through_trunk_and_mtp(
-    transformer_engine_import_stub,
-):
+def test_glm5_threads_positions_through_trunk_and_mtp(transformer_engine_import_stub):
     from types import SimpleNamespace
 
     import torch
     import torch.nn as nn
 
     transformer_engine_import_stub()
-    from megatron.lite.model.glm5.lite.model import Glm5MTPLayer, Glm5Model
+    from megatron.lite.model.glm5.lite.model import Glm5Model, Glm5MTPLayer
     from megatron.lite.primitive.parallel import ParallelState
 
     class RecordingLayer(nn.Module):
@@ -531,17 +564,15 @@ def test_glm5_threads_positions_through_trunk_and_mtp(
         packed_seq_params=packed,
     )
     assert torch.equal(
-        rolled_input_ids,
-        torch.tensor([[4, 5, 0, 7, 8, 0]], dtype=torch.long),
+        rolled_input_ids, torch.tensor([[4, 5, 0, 7, 8, 0]], dtype=torch.long)
     )
     assert torch.equal(
-        rolled_position_ids,
-        torch.tensor([[1, 2, 0, 1, 2, 0]], dtype=torch.long),
+        rolled_position_ids, torch.tensor([[1, 2, 0, 1, 2, 0]], dtype=torch.long)
     )
     assert torch.equal(mtp.transformer_layer.position_ids, positions)
 
 
-def test_glm52_serving_mtp_share_metadata_is_ignored_and_mtp_is_always_full():
+def test_glm52_serving_mtp_share_metadata_is_preserved_but_mtp_is_always_full():
     from megatron.lite.model.glm5.config import Glm5Config
 
     cfg = Glm5Config._from_hf_dict(
@@ -561,7 +592,8 @@ def test_glm52_serving_mtp_share_metadata_is_ignored_and_mtp_is_always_full():
     assert [cfg.dsa_indexer_type(idx) for idx in (4, 5)] == ["full", "full"]
     assert [cfg.dsa_indexer_source_layer(idx) for idx in (4, 5)] == [4, 5]
     assert [cfg.builds_dsa_indexer(idx) for idx in (4, 5)] == [True, True]
-    assert "index_share_for_mtp_iteration" not in cfg.to_dict()
+    assert cfg.index_share_for_mtp_iteration is True
+    assert cfg.to_dict()["index_share_for_mtp_iteration"] is True
 
 
 def test_glm5_config_preserves_mtp_aliases_and_layer_types():
@@ -659,11 +691,10 @@ def test_glm5_dsa_kernel_routes_indexer_forward_by_sm(monkeypatch):
 def test_glm5_dsa_training_forward_uses_fused_kernel(monkeypatch):
     import pytest
     import torch
-
-    from megatron.lite.primitive.modules.attention import dsa
     from megatron.lite.primitive.modules.attention import (
         DynamicSparseAttention,
         build_rope_cache,
+        dsa,
     )
 
     if not torch.cuda.is_available():
@@ -759,11 +790,10 @@ def test_glm5_dsa_training_forward_uses_fused_kernel(monkeypatch):
 def test_glm5_dsa_eval_forward_uses_fused_sparse_attention(monkeypatch):
     import pytest
     import torch
-
-    from megatron.lite.primitive.modules.attention import dsa
     from megatron.lite.primitive.modules.attention import (
         DynamicSparseAttention,
         build_rope_cache,
+        dsa,
     )
 
     if not torch.cuda.is_available():
@@ -897,14 +927,13 @@ def test_glm52_index_share_shared_layers_omit_indexer_modules():
 
 def test_glm5_checkpoint_exports_and_saves_hf_style_weights(tmp_path):
     import torch
-    from safetensors import safe_open
-
     from megatron.lite.model.glm5.config import Glm5Config
     from megatron.lite.model.glm5.lite.checkpoint import (
         export_hf_weights,
         save_hf_weights,
     )
     from megatron.lite.primitive.parallel import ParallelState
+    from safetensors import safe_open
 
     cfg = Glm5Config(**_tiny_config_kwargs())
     ps = ParallelState()
@@ -979,7 +1008,6 @@ def test_glm5_checkpoint_exports_and_saves_hf_style_weights(tmp_path):
 
 def test_glm5_checkpoint_exports_and_loads_mtp_layers(tmp_path):
     import torch
-
     from megatron.lite.model.glm5.config import Glm5Config
     from megatron.lite.model.glm5.lite.checkpoint import (
         export_hf_weights,
@@ -1016,9 +1044,9 @@ def test_glm5_checkpoint_exports_and_loads_mtp_layers(tmp_path):
 
 def test_glm52_checkpoint_mapping_skips_shared_indexer_without_te():
     import importlib.util
+
     import pytest
     import torch
-
     from megatron.lite.model.glm5.config import Glm5Config
 
     pytest.importorskip("safetensors")
@@ -1108,6 +1136,152 @@ def test_glm52_checkpoint_mapping_skips_shared_indexer_without_te():
     assert not any(".indexer." in name for name in out)
 
 
+def test_glm52_fp8_contract_matches_pinned_released_header_authority():
+    """Validate GLM-5.2's production FP8 contract without weight payloads."""
+    import hashlib
+    import json
+    import math
+
+    authority_path = Path(__file__).with_name("glm52_fp8_header_authority.json")
+    authority = json.loads(authority_path.read_text())
+    source = authority["source"]
+
+    assert source["repo"] == "zai-org/GLM-5.2-FP8"
+    assert source["revision"] == "31cba24fb749908a485082bdeed6eb1ac6cffc2f"
+    assert source["config_sha256"] == (
+        "d1539d36be7546a1d827fe9cf74c55874695652efb6a5aaa3e60cde1c76ba819"
+    )
+    assert source["index_sha256"] == (
+        "e0fe7f28c1f853d4824e4d796374e3dacf1fe470988773952c79b063768134bf"
+    )
+    assert source["tensor_count"] == 118629
+    assert source["shard_count"] == 141
+    assert source["config_values"] == {
+        "hidden_size": 6144,
+        "latent_rms_norm_eps": None,
+        "q_a_layernorm_effective_eps": 1e-6,
+        "q_lora_rank": 2048,
+        "rms_norm_eps": 1e-5,
+    }
+
+    shard = source["safetensors"]["model-00001-of-00141.safetensors"]
+    header_prefix = bytes(shard["header_prefix"])
+    assert len(header_prefix) == 8
+    assert int.from_bytes(header_prefix, byteorder="little") == shard["header_bytes"]
+    assert shard["header_bytes"] == 21840
+    assert shard["header_range"] == [8, 21847]
+    assert (
+        shard["header_range"][1] - shard["header_range"][0] + 1 == shard["header_bytes"]
+    )
+    assert shard["header_sha256"] == (
+        "b438c86e0ba40b96525672d31da75756307c723a3a73efc5ea40bd5893411613"
+    )
+
+    tensors = authority["tensors"]
+    canonical = json.dumps(
+        tensors, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode()
+    contract_sha256 = hashlib.sha256(canonical).hexdigest()
+    assert authority["canonical_tensor_contract_sha256"] == (
+        "5fbeff826bdf608cb6596de4987d6926df613076ed32ff69803007270183f294"
+    )
+    assert contract_sha256 == authority["canonical_tensor_contract_sha256"]
+
+    weight_name = "model.layers.0.self_attn.q_a_proj.weight"
+    scale_name = f"{weight_name}_scale_inv"
+    norm_name = "model.layers.0.self_attn.q_a_layernorm.weight"
+    assert set(tensors) == {weight_name, scale_name, norm_name}
+
+    weight = tensors[weight_name]
+    scale = tensors[scale_name]
+    norm = tensors[norm_name]
+    assert weight["dtype"] == "F8_E4M3"
+    assert weight["shape"] == [2048, 6144]
+    assert scale["dtype"] == "F32"
+    assert norm == {
+        "data_offsets": [3807130368, 3807134464],
+        "dtype": "BF16",
+        "shape": [2048],
+    }
+
+    quantization = authority["quantization_config"]
+    assert quantization == {
+        "activation_scheme": "dynamic",
+        "fmt": "e4m3",
+        "quant_method": "fp8",
+        "weight_block_size": [128, 128],
+    }
+    block_rows, block_cols = quantization["weight_block_size"]
+    rows, cols = weight["shape"]
+    expected_scale_shape = [
+        (rows + block_rows - 1) // block_rows,
+        (cols + block_cols - 1) // block_cols,
+    ]
+    assert scale["shape"] == expected_scale_shape == [16, 48]
+
+    dtype_bytes = {"F8_E4M3": 1, "F32": 4, "BF16": 2}
+    payload_ranges = shard["payload_ranges"]
+    assert payload_ranges.keys() == tensors.keys()
+    data_start = 8 + shard["header_bytes"]
+    for name, tensor in tensors.items():
+        start, end = tensor["data_offsets"]
+        assert end > start >= 0
+        assert end - start == math.prod(tensor["shape"]) * dtype_bytes[tensor["dtype"]]
+        # Safetensors offsets are relative to the data section after the
+        # 8-byte length prefix and JSON header.
+        assert data_start + end <= shard["file_bytes"]
+        assert payload_ranges[name]["file_range"] == [
+            data_start + start,
+            data_start + end - 1,
+        ]
+        assert len(payload_ranges[name]["sha256"]) == 64
+
+
+def test_glm52_fp8_dequant_requires_exact_released_block_scale_contract():
+    import pytest
+    import torch
+
+    if not hasattr(torch, "float8_e4m3fn"):
+        pytest.skip("torch float8_e4m3fn is required for the FP8 checkpoint contract")
+
+    from megatron.lite.model.glm5.lite.checkpoint import _dequant_fp8_weight
+
+    weight = torch.ones((129, 130), dtype=torch.float32).to(torch.float8_e4m3fn)
+
+    class Reader:
+        index = {"w_scale_inv": "fake.safetensors"}
+
+        def __init__(self, scale):
+            self.scale = scale
+
+        def get_tensor(self, name):
+            assert name == "w_scale_inv"
+            return self.scale
+
+    scale = torch.tensor([[0.5, 1.0], [1.5, 2.0]], dtype=torch.float32)
+    actual = _dequant_fp8_weight(Reader(scale), "w", weight)
+    expected_scale = scale.repeat_interleave(128, 0).repeat_interleave(128, 1)
+    expected = weight.float() * expected_scale[:129, :130]
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+    class MissingScaleReader:
+        index = {}
+
+    with pytest.raises(KeyError, match="missing required block scale"):
+        _dequant_fp8_weight(MissingScaleReader(), "w", weight)
+    with pytest.raises(ValueError, match=r"expected=\(2, 2\)"):
+        _dequant_fp8_weight(Reader(torch.ones(1, 2)), "w", weight)
+    with pytest.raises(ValueError, match="must be float32"):
+        _dequant_fp8_weight(Reader(torch.ones(2, 2, dtype=torch.bfloat16)), "w", weight)
+    with pytest.raises(ValueError, match="non-finite"):
+        _dequant_fp8_weight(Reader(torch.full((2, 2), float("nan"))), "w", weight)
+    with pytest.raises(ValueError, match="strictly positive"):
+        _dequant_fp8_weight(Reader(torch.zeros(2, 2)), "w", weight)
+
+    int8_weight = torch.ones((2, 2), dtype=torch.int8)
+    assert _dequant_fp8_weight(MissingScaleReader(), "int8", int8_weight) is int8_weight
+
+
 def test_glm52_checkpoint_skips_shared_indexer_weights_and_loads_full_layers(tmp_path):
     import pytest
     import torch
@@ -1168,7 +1342,6 @@ def test_glm52_checkpoint_skips_shared_indexer_weights_and_loads_full_layers(tmp
 
 def test_glm5_router_modules_use_current_names_and_bias_buffers():
     import torch
-
     from megatron.lite.model.glm5.config import Glm5Config
     from megatron.lite.model.glm5.lite.model import Glm5SigmoidTopKRouter
 
@@ -1190,7 +1363,6 @@ def test_glm5_router_modules_use_current_names_and_bias_buffers():
 
 def test_glm5_protocol_allows_cp_only_parallel_scope():
     import pytest
-
     from megatron.lite.model.glm5.lite.protocol import _validate_parallel_scope
     from megatron.lite.runtime.contracts import ParallelConfig
 
@@ -1213,10 +1385,7 @@ def test_glm52_protocol_rejects_attention_replay_before_parallel_init(
     from megatron.lite.model.glm5.config import Glm5Config
     from megatron.lite.model.glm5.lite import protocol
 
-    cfg = Glm5Config(
-        **_tiny_config_kwargs(),
-        indexer_types=["full", "shared"],
-    )
+    cfg = Glm5Config(**_tiny_config_kwargs(), indexer_types=["full", "shared"])
 
     def unexpected_parallel_init(*args, **kwargs):
         raise AssertionError(
@@ -1264,7 +1433,6 @@ def test_glm5_protocol_uses_mlite_optimizer_api():
 def test_glm5_lite_tiny_forward_backward(monkeypatch):
     import pytest
     import torch
-
     from megatron.lite.model.glm5.config import Glm5Config
     from megatron.lite.primitive.modules.attention import dsa
 

--- a/experimental/lite/tests/unit/model/test_glm5_lite_static.py
+++ b/experimental/lite/tests/unit/model/test_glm5_lite_static.py
@@ -300,7 +300,7 @@ def test_glm52_config_pattern_precedence_groups_and_all_full_override():
     assert roundtripped.uses_configured_dsa_rope_layout is True
 
 
-def test_glm5_rope_revision_is_inferred_before_schedule_overrides():
+def test_glm52_rope_revision_is_inferred_before_schedule_overrides():
     from megatron.lite.model.glm5.config import Glm5Config
 
     glm52_source = {
@@ -317,6 +317,10 @@ def test_glm5_rope_revision_is_inferred_before_schedule_overrides():
     )
     assert glm52_all_full.uses_dsa_index_share is False
     assert glm52_all_full.uses_configured_dsa_rope_layout is True
+
+
+def test_glm51_local_all_full_preserves_legacy_rope_revision():
+    from megatron.lite.model.glm5.config import Glm5Config
 
     glm51_with_local_all_full = Glm5Config._from_hf_dict(
         _tiny_config_kwargs(), indexer_types=["full", "full"]
@@ -1434,10 +1438,11 @@ def test_glm5_lite_tiny_forward_backward(monkeypatch):
     import pytest
     import torch
     from megatron.lite.model.glm5.config import Glm5Config
-    from megatron.lite.primitive.modules.attention import dsa
 
     if not torch.cuda.is_available():
         pytest.skip("GLM-5 native model requires CUDA (Transformer Engine RMSNorm)")
+    from megatron.lite.primitive.modules.attention import dsa
+
     device = torch.device("cuda")
 
     def fake_fused_indexer_sparse_attn(
@@ -1483,9 +1488,20 @@ def test_glm5_lite_tiny_forward_backward(monkeypatch):
     )
 
     torch.manual_seed(1234)
-    model = _make_glm5_model(Glm5Config(**_tiny_config_kwargs())).to(
+    glm52_kwargs = {
+        **_tiny_config_kwargs(),
+        "index_topk_freq": 4,
+        "index_skip_topk_offset": 3,
+        "indexer_types": ["full", "shared"],
+        "rope_interleave": True,
+        "indexer_rope_interleave": True,
+    }
+    model = _make_glm5_model(Glm5Config(**glm52_kwargs)).to(
         device=device, dtype=torch.bfloat16
     )
+    assert model.layers[0].self_attention.self_attention.indexer is not None
+    assert model.layers[1].self_attention.self_attention.indexer is None
+    assert model.layers[0].self_attention.self_attention.rope_interleaved is True
     input_ids = torch.randint(0, model.config.vocab_size, (2, 5), device=device)
     labels = torch.randint(0, model.config.vocab_size, (2, 5), device=device)
 
@@ -1504,10 +1520,16 @@ def test_glm5_lite_tiny_forward_backward(monkeypatch):
     assert torch.isfinite(grad_norm)
 
     mtp_model = _make_glm5_model(
-        Glm5Config(**_tiny_config_kwargs(), num_nextn_predict_layers=1),
+        Glm5Config(**glm52_kwargs, num_nextn_predict_layers=1),
         mtp_enable=True,
         mtp_enable_train=True,
     ).to(device=device, dtype=torch.bfloat16)
+    assert mtp_model.mtp is not None
+    mtp_attention = mtp_model.mtp.layers[
+        0
+    ].transformer_layer.self_attention.self_attention
+    assert mtp_attention.indexer is not None
+    assert mtp_attention.rope_interleaved is True
     # Inference path (no labels) exposes the per-MTP-head logits.
     mtp_infer = mtp_model(input_ids=input_ids)
     assert len(mtp_infer["mtp_hidden_states"]) == 1

--- a/experimental/lite/tests/unit/model/test_lite_checkpoint_load_strictness.py
+++ b/experimental/lite/tests/unit/model/test_lite_checkpoint_load_strictness.py
@@ -1,0 +1,492 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from __future__ import annotations
+
+import datetime
+import importlib
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import torch.nn as nn
+
+pytestmark = pytest.mark.mlite
+
+
+def _weight_module(shape: tuple[int, ...]) -> nn.Module:
+    module = nn.Module()
+    module.register_parameter("weight", nn.Parameter(torch.zeros(shape)))
+    return module
+
+
+def _wrapped_target(shape: tuple[int, ...]) -> nn.Module:
+    model = nn.Module()
+    model.wrapper = nn.Module()
+    model.wrapper.shared_gate = _weight_module(shape)
+    return model
+
+
+_COPY_MODULES = (
+    "megatron.lite.model.glm5.lite.checkpoint",
+    "megatron.lite.model.kimi_k2.lite.checkpoint",
+    "megatron.lite.model.deepseek_v4.lite.checkpoint",
+    "megatron.lite.model.qwen3_5.lite.checkpoint",
+)
+
+
+@pytest.mark.parametrize("module_name", _COPY_MODULES)
+def test_model_hf_copy_allows_only_unique_wrapper_suffix(
+    module_name: str, transformer_engine_import_stub
+) -> None:
+    transformer_engine_import_stub()
+    copy_loaded_state = importlib.import_module(module_name)._copy_loaded_state
+    model = _wrapped_target((1, 4))
+    expected = torch.arange(4, dtype=torch.float32).reshape(1, 4)
+
+    copy_loaded_state(model, {"shared_gate.weight": expected})
+
+    torch.testing.assert_close(
+        model.wrapper.shared_gate.weight.detach(), expected, atol=0.0, rtol=0.0
+    )
+
+
+@pytest.mark.parametrize("module_name", _COPY_MODULES)
+def test_model_hf_copy_rejects_broadcastable_shape(
+    module_name: str, transformer_engine_import_stub
+) -> None:
+    transformer_engine_import_stub()
+    copy_loaded_state = importlib.import_module(module_name)._copy_loaded_state
+    model = _wrapped_target((1, 4))
+
+    with pytest.raises(RuntimeError, match=r"checkpoint shape mismatch"):
+        copy_loaded_state(model, {"shared_gate.weight": torch.ones(1)})
+
+
+@pytest.mark.parametrize("module_name", _COPY_MODULES)
+def test_model_hf_copy_rejects_ambiguous_wrapper_suffix(
+    module_name: str, transformer_engine_import_stub
+) -> None:
+    transformer_engine_import_stub()
+    copy_loaded_state = importlib.import_module(module_name)._copy_loaded_state
+    model = nn.Module()
+    model.left = _wrapped_target((1, 4))
+    model.right = _wrapped_target((1, 4))
+
+    with pytest.raises(RuntimeError, match=r"Ambiguous .* checkpoint target"):
+        copy_loaded_state(model, {"shared_gate.weight": torch.ones(1, 4)})
+
+
+def _two_parameter_model() -> nn.Module:
+    model = nn.Module()
+    model.first = _weight_module((2, 2))
+    model.last = _weight_module((2, 2))
+    return model
+
+
+@pytest.mark.parametrize("module_name", _COPY_MODULES)
+def test_model_hf_copy_rejects_missing_native_parameter_without_mutation(
+    module_name: str, transformer_engine_import_stub
+) -> None:
+    transformer_engine_import_stub()
+    copy_loaded_state = importlib.import_module(module_name)._copy_loaded_state
+    model = _two_parameter_model()
+    before = {
+        name: tensor.detach().clone() for name, tensor in model.state_dict().items()
+    }
+
+    with pytest.raises(RuntimeError, match=r"does not cover all required native state"):
+        copy_loaded_state(model, {"first.weight": torch.ones(2, 2)})
+
+    for name, tensor in model.state_dict().items():
+        torch.testing.assert_close(tensor, before[name], atol=0.0, rtol=0.0)
+
+
+@pytest.mark.parametrize("module_name", _COPY_MODULES)
+def test_model_hf_copy_late_shape_mismatch_does_not_partially_write(
+    module_name: str, transformer_engine_import_stub
+) -> None:
+    transformer_engine_import_stub()
+    copy_loaded_state = importlib.import_module(module_name)._copy_loaded_state
+    model = _two_parameter_model()
+
+    with pytest.raises(
+        RuntimeError, match=r"checkpoint shape mismatch for last.weight"
+    ):
+        copy_loaded_state(
+            model,
+            {
+                "first.weight": torch.full((2, 2), 7.0),
+                "last.weight": torch.ones(1),
+            },
+        )
+
+    torch.testing.assert_close(
+        model.first.weight.detach(), torch.zeros(2, 2), atol=0.0, rtol=0.0
+    )
+    torch.testing.assert_close(
+        model.last.weight.detach(), torch.zeros(2, 2), atol=0.0, rtol=0.0
+    )
+
+
+@pytest.mark.parametrize("module_name", _COPY_MODULES)
+def test_model_hf_copy_rejects_unmapped_native_key(
+    module_name: str, transformer_engine_import_stub
+) -> None:
+    transformer_engine_import_stub()
+    copy_loaded_state = importlib.import_module(module_name)._copy_loaded_state
+    model = _weight_module((2, 2))
+
+    with pytest.raises(RuntimeError, match=r"has no native target: stale.weight"):
+        copy_loaded_state(
+            model,
+            {
+                "weight": torch.ones(2, 2),
+                "stale.weight": torch.ones(2, 2),
+            },
+        )
+
+    torch.testing.assert_close(
+        model.weight.detach(), torch.zeros(2, 2), atol=0.0, rtol=0.0
+    )
+
+
+def test_atomic_hf_copy_requires_persistent_but_not_derived_buffers() -> None:
+    from megatron.lite.primitive.ckpt.hf_weights import copy_hf_state_atomically
+
+    model = _weight_module((2, 2))
+    model.register_buffer("schema", torch.zeros(2, dtype=torch.int64), persistent=True)
+    model.register_buffer("cache", torch.ones(2), persistent=False)
+
+    with pytest.raises(RuntimeError, match=r"persistent_buffers=\['schema'\]"):
+        copy_hf_state_atomically(
+            model,
+            {"weight": torch.ones(2, 2)},
+            context="test HF load",
+        )
+
+    copy_hf_state_atomically(
+        model,
+        {
+            "weight": torch.ones(2, 2),
+            "schema": torch.tensor([3, 4], dtype=torch.int64),
+        },
+        context="test HF load",
+    )
+    torch.testing.assert_close(model.cache, torch.ones(2), atol=0.0, rtol=0.0)
+
+
+def test_atomic_hf_copy_rolls_back_on_unexpected_copy_failure(monkeypatch) -> None:
+    from megatron.lite.primitive.ckpt import hf_weights
+
+    model = _two_parameter_model()
+    model.first.weight.data.fill_(11.0)
+    model.last.weight.data.fill_(13.0)
+    before = {
+        name: tensor.detach().clone() for name, tensor in model.state_dict().items()
+    }
+    real_copy = hf_weights._copy_tensor_for_hf_load
+    calls = 0
+
+    def fail_second_copy(target: torch.Tensor, source: torch.Tensor) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise RuntimeError("injected copy failure")
+        real_copy(target, source)
+
+    monkeypatch.setattr(hf_weights, "_copy_tensor_for_hf_load", fail_second_copy)
+    with pytest.raises(
+        RuntimeError, match=r"atomic copy failed.*injected copy failure"
+    ):
+        hf_weights.copy_hf_state_atomically(
+            model,
+            {
+                "first.weight": torch.full((2, 2), 17.0),
+                "last.weight": torch.full((2, 2), 19.0),
+            },
+            context="test HF load",
+        )
+
+    for name, tensor in model.state_dict().items():
+        torch.testing.assert_close(tensor, before[name], atol=0.0, rtol=0.0)
+
+
+def test_atomic_hf_vpp_preflight_rejects_later_chunk_before_any_mutation() -> None:
+    from megatron.lite.primitive.ckpt.hf_weights import copy_hf_states_atomically
+
+    first = _weight_module((2, 2))
+    second = _weight_module((2, 2))
+    first.weight.data.fill_(11.0)
+    second.weight.data.fill_(13.0)
+
+    with pytest.raises(RuntimeError, match=r"preflight failed.*chunk1"):
+        copy_hf_states_atomically(
+            [
+                (first, {"weight": torch.full((2, 2), 17.0)}),
+                (second, {}),
+            ],
+            context="VPP HF load",
+        )
+
+    torch.testing.assert_close(
+        first.weight, torch.full((2, 2), 11.0), atol=0.0, rtol=0.0
+    )
+    torch.testing.assert_close(
+        second.weight, torch.full((2, 2), 13.0), atol=0.0, rtol=0.0
+    )
+
+
+def test_atomic_hf_vpp_copy_failure_rolls_back_earlier_chunks(monkeypatch) -> None:
+    from megatron.lite.primitive.ckpt import hf_weights
+
+    first = _weight_module((2, 2))
+    second = _weight_module((2, 2))
+    first.weight.data.fill_(11.0)
+    second.weight.data.fill_(13.0)
+    real_copy = hf_weights._copy_tensor_for_hf_load
+    calls = 0
+
+    def fail_second_chunk(target: torch.Tensor, source: torch.Tensor) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise RuntimeError("injected VPP copy failure")
+        real_copy(target, source)
+
+    monkeypatch.setattr(hf_weights, "_copy_tensor_for_hf_load", fail_second_chunk)
+    with pytest.raises(RuntimeError, match=r"atomic copy failed.*chunk1.weight"):
+        hf_weights.copy_hf_states_atomically(
+            [
+                (first, {"weight": torch.full((2, 2), 17.0)}),
+                (second, {"weight": torch.full((2, 2), 19.0)}),
+            ],
+            context="VPP HF load",
+        )
+
+    torch.testing.assert_close(
+        first.weight, torch.full((2, 2), 11.0), atol=0.0, rtol=0.0
+    )
+    torch.testing.assert_close(
+        second.weight, torch.full((2, 2), 13.0), atol=0.0, rtol=0.0
+    )
+
+
+def _gloo_corrupt_one_stage_worker(rank: int, init_path: str) -> None:
+    from megatron.lite.primitive.ckpt import hf_weights
+
+    dist.init_process_group(
+        "gloo",
+        init_method=f"file://{init_path}",
+        rank=rank,
+        world_size=2,
+        timeout=datetime.timedelta(seconds=20),
+    )
+    try:
+
+        def build_state() -> dict[str, torch.Tensor]:
+            if rank == 1:
+                raise KeyError("rank-1 checkpoint shard is corrupt")
+            return {"weight": torch.ones(2, 2)}
+
+        try:
+            hf_weights.materialize_hf_load_state(
+                build_state, context="distributed test load"
+            )
+        except RuntimeError as exc:
+            assert "rank-1 checkpoint shard is corrupt" in str(exc)
+        else:
+            raise AssertionError("rank-local materialization error was not propagated")
+
+        model = _weight_module((2, 2))
+        loaded = {
+            "weight": torch.ones(2, 2) if rank == 0 else torch.ones(1),
+        }
+        try:
+            hf_weights.copy_hf_state_atomically(
+                model,
+                loaded,
+                context="distributed test load",
+            )
+        except RuntimeError as exc:
+            assert "checkpoint shape mismatch" in str(exc)
+        else:
+            raise AssertionError("rank-local preflight error was not propagated")
+        torch.testing.assert_close(
+            model.weight.detach(), torch.zeros(2, 2), atol=0.0, rtol=0.0
+        )
+
+        # Both ranks pass preflight. Rank 1 then fails its second physical copy;
+        # rank 0 must learn about that failure and roll back its fully-copied
+        # model rather than keeping a mixed distributed checkpoint state.
+        model = _two_parameter_model()
+        model.first.weight.data.fill_(5.0)
+        model.last.weight.data.fill_(6.0)
+        before = {
+            name: tensor.detach().clone() for name, tensor in model.state_dict().items()
+        }
+        real_copy = hf_weights._copy_tensor_for_hf_load
+        calls = 0
+
+        def fail_rank_one_second_copy(
+            target: torch.Tensor, source: torch.Tensor
+        ) -> None:
+            nonlocal calls
+            calls += 1
+            if rank == 1 and calls == 2:
+                raise RuntimeError("rank-1 injected copy failure")
+            real_copy(target, source)
+
+        hf_weights._copy_tensor_for_hf_load = fail_rank_one_second_copy
+        try:
+            try:
+                hf_weights.copy_hf_state_atomically(
+                    model,
+                    {
+                        "first.weight": torch.full((2, 2), 7.0),
+                        "last.weight": torch.full((2, 2), 8.0),
+                    },
+                    context="distributed test load",
+                )
+            except RuntimeError as exc:
+                assert "rank-1 injected copy failure" in str(exc)
+            else:
+                raise AssertionError("rank-local copy error was not propagated")
+        finally:
+            hf_weights._copy_tensor_for_hf_load = real_copy
+        for name, tensor in model.state_dict().items():
+            torch.testing.assert_close(tensor, before[name], atol=0.0, rtol=0.0)
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.skipif(not dist.is_gloo_available(), reason="Gloo is unavailable")
+def test_atomic_hf_load_corrupt_one_stage_gloo_consensus_no_hang(tmp_path) -> None:
+    init_path = str(tmp_path / "gloo-init")
+    ctx = mp.get_context("spawn")
+    processes = [
+        ctx.Process(target=_gloo_corrupt_one_stage_worker, args=(rank, init_path))
+        for rank in range(2)
+    ]
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=30)
+    alive = [process for process in processes if process.is_alive()]
+    for process in alive:
+        process.terminate()
+        process.join(timeout=5)
+    assert not alive, "distributed HF load consensus hung"
+    assert [process.exitcode for process in processes] == [0, 0]
+
+
+def _gloo_vpp_copy_failure_worker(rank: int, init_path: str) -> None:
+    from megatron.lite.primitive.ckpt import hf_weights
+
+    dist.init_process_group(
+        "gloo",
+        init_method=f"file://{init_path}",
+        rank=rank,
+        world_size=2,
+        timeout=datetime.timedelta(seconds=20),
+    )
+    try:
+        real_copy = hf_weights._copy_tensor_for_hf_load
+
+        # Exercise both possible failing ranks in one process-group lifetime.
+        # The injected failure is in chunk 2, after every rank has already
+        # mutated chunks 0 and 1. The transaction must restore all chunks on
+        # both ranks before it reports the peer failure.
+        for failing_rank in (0, 1):
+            chunks = [_weight_module((2, 2)) for _ in range(3)]
+            before: list[torch.Tensor] = []
+            model_states: list[tuple[nn.Module, dict[str, torch.Tensor]]] = []
+            for chunk_idx, chunk in enumerate(chunks):
+                baseline = float(100 * rank + 10 * failing_rank + chunk_idx)
+                chunk.weight.data.fill_(baseline)
+                before.append(chunk.weight.detach().clone())
+                model_states.append(
+                    (
+                        chunk,
+                        {
+                            "weight": torch.full(
+                                (2, 2), 1000.0 + baseline, dtype=torch.float32
+                            )
+                        },
+                    )
+                )
+
+            calls = 0
+
+            def fail_later_chunk(
+                target: torch.Tensor, source: torch.Tensor
+            ) -> None:
+                nonlocal calls
+                calls += 1
+                if rank == failing_rank and calls == 3:
+                    raise RuntimeError(
+                        f"rank-{failing_rank} injected VPP chunk-2 copy failure"
+                    )
+                real_copy(target, source)
+
+            hf_weights._copy_tensor_for_hf_load = fail_later_chunk
+            try:
+                try:
+                    hf_weights.copy_hf_states_atomically(
+                        model_states,
+                        context=f"distributed VPP test load failing rank {failing_rank}",
+                    )
+                except RuntimeError as exc:
+                    message = str(exc)
+                    assert f"rank-{failing_rank} injected VPP" in message
+                    assert "copying chunk2.weight" in message
+                else:
+                    raise AssertionError(
+                        "rank-local later-chunk copy error was not propagated"
+                    )
+            finally:
+                hf_weights._copy_tensor_for_hf_load = real_copy
+
+            local_restored = []
+            for chunk_idx, chunk in enumerate(chunks):
+                torch.testing.assert_close(
+                    chunk.weight.detach(), before[chunk_idx], atol=0.0, rtol=0.0
+                )
+                local_restored.append(chunk.weight.detach().clone())
+
+            # A collective readback explicitly covers both ranks x all chunks.
+            gathered: list[list[torch.Tensor] | None] = [None, None]
+            dist.all_gather_object(gathered, local_restored)
+            for peer_rank, peer_chunks in enumerate(gathered):
+                assert peer_chunks is not None
+                for chunk_idx, restored in enumerate(peer_chunks):
+                    expected = torch.full(
+                        (2, 2),
+                        float(100 * peer_rank + 10 * failing_rank + chunk_idx),
+                    )
+                    torch.testing.assert_close(
+                        restored, expected, atol=0.0, rtol=0.0
+                    )
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.skipif(not dist.is_gloo_available(), reason="Gloo is unavailable")
+def test_atomic_hf_vpp_copy_failure_gloo_rolls_back_all_chunks_on_all_ranks(
+    tmp_path,
+) -> None:
+    init_path = str(tmp_path / "gloo-vpp-init")
+    ctx = mp.get_context("spawn")
+    processes = [
+        ctx.Process(target=_gloo_vpp_copy_failure_worker, args=(rank, init_path))
+        for rank in range(2)
+    ]
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=30)
+    alive = [process for process in processes if process.is_alive()]
+    for process in alive:
+        process.terminate()
+        process.join(timeout=5)
+    assert not alive, "distributed VPP HF load rollback consensus hung"
+    assert [process.exitcode for process in processes] == [0, 0]

--- a/experimental/lite/tests/unit/model/test_lite_checkpoint_load_strictness.py
+++ b/experimental/lite/tests/unit/model/test_lite_checkpoint_load_strictness.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import datetime
 import importlib
+import time
 
 import pytest
 import torch
@@ -31,6 +32,11 @@ _COPY_MODULES = (
     "megatron.lite.model.kimi_k2.lite.checkpoint",
     "megatron.lite.model.deepseek_v4.lite.checkpoint",
     "megatron.lite.model.qwen3_5.lite.checkpoint",
+)
+
+_PROTOCOL_MODULES = tuple(
+    module_name.removesuffix(".checkpoint") + ".protocol"
+    for module_name in _COPY_MODULES
 )
 
 
@@ -114,10 +120,7 @@ def test_model_hf_copy_late_shape_mismatch_does_not_partially_write(
     ):
         copy_loaded_state(
             model,
-            {
-                "first.weight": torch.full((2, 2), 7.0),
-                "last.weight": torch.ones(1),
-            },
+            {"first.weight": torch.full((2, 2), 7.0), "last.weight": torch.ones(1)},
         )
 
     torch.testing.assert_close(
@@ -138,16 +141,81 @@ def test_model_hf_copy_rejects_unmapped_native_key(
 
     with pytest.raises(RuntimeError, match=r"has no native target: stale.weight"):
         copy_loaded_state(
-            model,
-            {
-                "weight": torch.ones(2, 2),
-                "stale.weight": torch.ones(2, 2),
-            },
+            model, {"weight": torch.ones(2, 2), "stale.weight": torch.ones(2, 2)}
         )
 
     torch.testing.assert_close(
         model.weight.detach(), torch.zeros(2, 2), atol=0.0, rtol=0.0
     )
+
+
+@pytest.mark.parametrize("module_name", _COPY_MODULES)
+def test_model_hf_loader_forwards_explicit_participating_group(
+    module_name: str, monkeypatch, transformer_engine_import_stub
+) -> None:
+    transformer_engine_import_stub()
+    checkpoint = importlib.import_module(module_name)
+    participating_group = object()
+    calls = []
+
+    def fake_load_chunks(
+        models,
+        builder,
+        *,
+        context,
+        participating_group=None,
+        allow_missing_parameter=None,
+    ) -> int:
+        del builder, context, allow_missing_parameter
+        calls.append((models, participating_group))
+        return 0
+
+    monkeypatch.setattr(checkpoint, "load_hf_model_chunks_atomically", fake_load_chunks)
+    model = _weight_module((1,))
+    checkpoint.load_hf_weights(
+        model, "/unused", object(), object(), participating_group=participating_group
+    )
+
+    assert calls == [(model, participating_group)]
+
+
+@pytest.mark.parametrize(
+    ("checkpoint_module_name", "protocol_module_name"),
+    zip(_COPY_MODULES, _PROTOCOL_MODULES, strict=True),
+)
+def test_model_protocol_hf_loaders_forward_explicit_participating_group(
+    checkpoint_module_name: str,
+    protocol_module_name: str,
+    monkeypatch,
+    transformer_engine_import_stub,
+) -> None:
+    transformer_engine_import_stub()
+    checkpoint = importlib.import_module(checkpoint_module_name)
+    protocol = importlib.import_module(protocol_module_name)
+    participating_group = object()
+    calls = []
+
+    def fake_load(models, path, model_cfg, ps, *, participating_group=None) -> None:
+        calls.append((models, path, model_cfg, ps, participating_group))
+
+    monkeypatch.setattr(checkpoint, "load_hf_weights", fake_load)
+    if hasattr(protocol, "_load_hf_weights_impl"):
+        monkeypatch.setattr(protocol, "_load_hf_weights_impl", fake_load)
+
+    chunk = _weight_module((1,))
+    model_cfg = object()
+    ps = object()
+    protocol.load_hf_weights(
+        chunk, "/unused", model_cfg, ps, participating_group=participating_group
+    )
+    protocol.load_hf_weights_many(
+        [chunk], "/unused", model_cfg, ps, participating_group=participating_group
+    )
+
+    assert calls == [
+        (chunk, "/unused", model_cfg, ps, participating_group),
+        ([chunk], "/unused", model_cfg, ps, participating_group),
+    ]
 
 
 def test_atomic_hf_copy_requires_persistent_but_not_derived_buffers() -> None:
@@ -159,17 +227,12 @@ def test_atomic_hf_copy_requires_persistent_but_not_derived_buffers() -> None:
 
     with pytest.raises(RuntimeError, match=r"persistent_buffers=\['schema'\]"):
         copy_hf_state_atomically(
-            model,
-            {"weight": torch.ones(2, 2)},
-            context="test HF load",
+            model, {"weight": torch.ones(2, 2)}, context="test HF load"
         )
 
     copy_hf_state_atomically(
         model,
-        {
-            "weight": torch.ones(2, 2),
-            "schema": torch.tensor([3, 4], dtype=torch.int64),
-        },
+        {"weight": torch.ones(2, 2), "schema": torch.tensor([3, 4], dtype=torch.int64)},
         context="test HF load",
     )
     torch.testing.assert_close(model.cache, torch.ones(2), atol=0.0, rtol=0.0)
@@ -221,10 +284,7 @@ def test_atomic_hf_vpp_preflight_rejects_later_chunk_before_any_mutation() -> No
 
     with pytest.raises(RuntimeError, match=r"preflight failed.*chunk1"):
         copy_hf_states_atomically(
-            [
-                (first, {"weight": torch.full((2, 2), 17.0)}),
-                (second, {}),
-            ],
+            [(first, {"weight": torch.full((2, 2), 17.0)}), (second, {})],
             context="VPP HF load",
         )
 
@@ -298,14 +358,10 @@ def _gloo_corrupt_one_stage_worker(rank: int, init_path: str) -> None:
             raise AssertionError("rank-local materialization error was not propagated")
 
         model = _weight_module((2, 2))
-        loaded = {
-            "weight": torch.ones(2, 2) if rank == 0 else torch.ones(1),
-        }
+        loaded = {"weight": torch.ones(2, 2) if rank == 0 else torch.ones(1)}
         try:
             hf_weights.copy_hf_state_atomically(
-                model,
-                loaded,
-                context="distributed test load",
+                model, loaded, context="distributed test load"
             )
         except RuntimeError as exc:
             assert "checkpoint shape mismatch" in str(exc)
@@ -417,9 +473,7 @@ def _gloo_vpp_copy_failure_worker(rank: int, init_path: str) -> None:
 
             calls = 0
 
-            def fail_later_chunk(
-                target: torch.Tensor, source: torch.Tensor
-            ) -> None:
+            def fail_later_chunk(target: torch.Tensor, source: torch.Tensor) -> None:
                 nonlocal calls
                 calls += 1
                 if rank == failing_rank and calls == 3:
@@ -460,12 +514,9 @@ def _gloo_vpp_copy_failure_worker(rank: int, init_path: str) -> None:
                 assert peer_chunks is not None
                 for chunk_idx, restored in enumerate(peer_chunks):
                     expected = torch.full(
-                        (2, 2),
-                        float(100 * peer_rank + 10 * failing_rank + chunk_idx),
+                        (2, 2), float(100 * peer_rank + 10 * failing_rank + chunk_idx)
                     )
-                    torch.testing.assert_close(
-                        restored, expected, atol=0.0, rtol=0.0
-                    )
+                    torch.testing.assert_close(restored, expected, atol=0.0, rtol=0.0)
     finally:
         dist.destroy_process_group()
 
@@ -490,3 +541,143 @@ def test_atomic_hf_vpp_copy_failure_gloo_rolls_back_all_chunks_on_all_ranks(
         process.join(timeout=5)
     assert not alive, "distributed VPP HF load rollback consensus hung"
     assert [process.exitcode for process in processes] == [0, 0]
+
+
+def _run_four_rank_gloo_worker(worker, init_path: str) -> None:
+    ctx = mp.get_context("spawn")
+    processes = [
+        ctx.Process(target=worker, args=(rank, init_path)) for rank in range(4)
+    ]
+    for process in processes:
+        process.start()
+
+    deadline = time.monotonic() + 30
+    for process in processes:
+        process.join(timeout=max(0.0, deadline - time.monotonic()))
+    alive = [process for process in processes if process.is_alive()]
+    for process in alive:
+        process.terminate()
+        process.join(timeout=5)
+
+    assert not alive, "independent subgroup HF load consensus hung"
+    assert [process.exitcode for process in processes] == [0, 0, 0, 0]
+
+
+def _gloo_independent_success_subgroups_worker(rank: int, init_path: str) -> None:
+    from megatron.lite.primitive.ckpt import hf_weights
+
+    dist.init_process_group(
+        "gloo",
+        init_method=f"file://{init_path}",
+        rank=rank,
+        world_size=4,
+        timeout=datetime.timedelta(seconds=20),
+    )
+    try:
+        # Every WORLD rank must create groups in the same order.  Each rank then
+        # enters collectives only on the subgroup to which it belongs.
+        groups = [dist.new_group([0, 1]), dist.new_group([2, 3])]
+        subgroup_index = rank // 2
+        participating_group = groups[subgroup_index]
+        model = _weight_module((2, 2))
+
+        # The second subgroup performs one extra transaction.  A hidden WORLD
+        # collective would require ranks 0/1 to enter that operation and either
+        # hang or fail when they independently finish after the first load.
+        for step in range(subgroup_index + 1):
+            expected = torch.full((2, 2), float(10 * subgroup_index + step + 1))
+            hf_weights.copy_hf_state_atomically(
+                model,
+                {"weight": expected.clone()},
+                context=f"subgroup {subgroup_index} success load {step}",
+                participating_group=participating_group,
+            )
+            torch.testing.assert_close(
+                model.weight.detach(), expected, atol=0.0, rtol=0.0
+            )
+
+        dist.barrier(group=participating_group)
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.skipif(not dist.is_gloo_available(), reason="Gloo is unavailable")
+def test_atomic_hf_load_independent_success_subgroups_do_not_wait_for_world(
+    tmp_path,
+) -> None:
+    _run_four_rank_gloo_worker(
+        _gloo_independent_success_subgroups_worker,
+        str(tmp_path / "gloo-independent-success-init"),
+    )
+
+
+def _gloo_failure_isolated_from_success_subgroup_worker(
+    rank: int, init_path: str
+) -> None:
+    from megatron.lite.primitive.ckpt import hf_weights
+
+    dist.init_process_group(
+        "gloo",
+        init_method=f"file://{init_path}",
+        rank=rank,
+        world_size=4,
+        timeout=datetime.timedelta(seconds=20),
+    )
+    try:
+        groups = [dist.new_group([0, 1]), dist.new_group([2, 3])]
+        subgroup_index = rank // 2
+        participating_group = groups[subgroup_index]
+        model = _weight_module((2, 2))
+        baseline = torch.full((2, 2), float(rank + 1))
+        model.weight.data.copy_(baseline)
+        expected = torch.full((2, 2), float(rank + 101))
+        real_copy = hf_weights._copy_tensor_for_hf_load
+
+        def fail_on_rank_zero(target: torch.Tensor, source: torch.Tensor) -> None:
+            if rank == 0:
+                raise RuntimeError("rank-0 subgroup-local injected copy failure")
+            real_copy(target, source)
+
+        if subgroup_index == 0:
+            hf_weights._copy_tensor_for_hf_load = fail_on_rank_zero
+        try:
+            if subgroup_index == 0:
+                with pytest.raises(
+                    RuntimeError, match="rank-0 subgroup-local injected copy failure"
+                ):
+                    hf_weights.copy_hf_state_atomically(
+                        model,
+                        {"weight": expected},
+                        context="failing subgroup load",
+                        participating_group=participating_group,
+                    )
+                torch.testing.assert_close(
+                    model.weight.detach(), baseline, atol=0.0, rtol=0.0
+                )
+            else:
+                hf_weights.copy_hf_state_atomically(
+                    model,
+                    {"weight": expected},
+                    context="successful subgroup load",
+                    participating_group=participating_group,
+                )
+                torch.testing.assert_close(
+                    model.weight.detach(), expected, atol=0.0, rtol=0.0
+                )
+        finally:
+            hf_weights._copy_tensor_for_hf_load = real_copy
+
+        # No WORLD synchronization is needed for either subgroup to exit.
+        dist.barrier(group=participating_group)
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.skipif(not dist.is_gloo_available(), reason="Gloo is unavailable")
+def test_atomic_hf_load_failure_consensus_is_isolated_from_success_subgroup(
+    tmp_path,
+) -> None:
+    _run_four_rank_gloo_worker(
+        _gloo_failure_isolated_from_success_subgroup_worker,
+        str(tmp_path / "gloo-failure-isolation-init"),
+    )

--- a/experimental/lite/tests/unit/model/test_qwen35_export.py
+++ b/experimental/lite/tests/unit/model/test_qwen35_export.py
@@ -1,13 +1,15 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 import copy
+import hashlib
+import json
 import math
 import os
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 import torch
 import torch.nn as nn
-
 from megatron.lite.model.qwen3_5.config import Qwen35Config
 from megatron.lite.model.qwen3_5.lite.checkpoint import (
     PLACEMENT_FN,
@@ -23,9 +25,12 @@ from megatron.lite.model.registry import (
     resolve_runtime_model_name,
 )
 
-
 _QWEN35_VISION_EXACT_REQUIRED_ENV = "MLITE_REQUIRE_QWEN35_VISION_EXACT"
 _QWEN35_VISION_EXACT_PASS_MARKER = "QWEN35_VISION_EXACT_PASS"
+_QWEN35_MTP_AUTHORITY_REVISION = "59d61f3ce65a6d9863b86d2e96597125219dc754"
+_QWEN35_MTP_SCHEMA_SHA256 = (
+    "54a42a904540f171d00a8296f2cd457dcdf4b167290f8a4455ee58c3dcb36871"
+)
 
 
 def _transformers_5_12_for_vision_exact():
@@ -120,9 +125,7 @@ class _TinyQwen35MTPModule(nn.Module):
         layer.eh_proj = nn.Module()
         layer.eh_proj.linear = nn.Module()
         parameter(
-            layer.eh_proj.linear,
-            "weight",
-            (config.hidden_size, 2 * config.hidden_size),
+            layer.eh_proj.linear, "weight", (config.hidden_size, 2 * config.hidden_size)
         )
 
         transformer = nn.Module()
@@ -131,18 +134,14 @@ class _TinyQwen35MTPModule(nn.Module):
         transformer.full_attn.qkv = nn.Module()
         transformer.full_attn.qkv.linear = nn.Module()
         parameter(
-            transformer.full_attn.qkv.linear,
-            "layer_norm_weight",
-            (config.hidden_size,),
+            transformer.full_attn.qkv.linear, "layer_norm_weight", (config.hidden_size,)
         )
         q_heads_per_group = config.num_attention_heads // config.num_key_value_heads
         qkv_rows = (
             (2 * q_heads_per_group + 2) * config.head_dim * config.num_key_value_heads
         )
         parameter(
-            transformer.full_attn.qkv.linear,
-            "weight",
-            (qkv_rows, config.hidden_size),
+            transformer.full_attn.qkv.linear, "weight", (qkv_rows, config.hidden_size)
         )
         transformer.full_attn.q_norm = nn.Module()
         parameter(transformer.full_attn.q_norm, "weight", (config.head_dim,))
@@ -153,10 +152,7 @@ class _TinyQwen35MTPModule(nn.Module):
         parameter(
             transformer.full_attn.proj.linear,
             "weight",
-            (
-                config.hidden_size,
-                config.num_attention_heads * config.head_dim,
-            ),
+            (config.hidden_size, config.num_attention_heads * config.head_dim),
         )
 
         transformer.mlp_norm = nn.Module()
@@ -186,9 +182,7 @@ class _TinyQwen35MTPModule(nn.Module):
         )
         transformer.moe.shared_expert.shared_gate = nn.Module()
         parameter(
-            transformer.moe.shared_expert.shared_gate,
-            "weight",
-            (1, config.hidden_size),
+            transformer.moe.shared_expert.shared_gate, "weight", (1, config.hidden_size)
         )
 
         transformer.moe.experts = nn.Module()
@@ -217,10 +211,9 @@ def test_qwen35_protocol_registers_vllm_export_entrypoint() -> None:
 
 def test_qwen35_official_vision_checkpoint_load_export_exact(tmp_path) -> None:
     transformers = _transformers_5_12_for_vision_exact()
+    from megatron.lite.model.qwen3_5.lite import checkpoint
     from safetensors.torch import save_file
     from transformers import Qwen3_5VisionConfig, Qwen3_5VisionModel
-
-    from megatron.lite.model.qwen3_5.lite import checkpoint
 
     vision_cfg = Qwen3_5VisionConfig(
         depth=1,
@@ -423,10 +416,73 @@ def test_qwen35_mtp_hf_schema_exact_and_load_export_roundtrip(monkeypatch) -> No
         )
 
 
-def test_qwen35_mtp_fc_tp2_load_export_shape_roundtrip(monkeypatch) -> None:
-    from torch.distributed.tensor import Replicate, Shard
+def test_qwen35_mtp_schema_matches_pinned_released_header_authority() -> None:
+    """Match production mapping against immutable Hub safetensors headers.
 
+    The compact fixture is an exact expansion of the MTP entries in the two
+    released shards that contain them.  Its canonical digest is pinned here so
+    the authority cannot drift together with test-generated expectations.
+    Meta tensors exercise the real weight mapper at 35B dimensions without
+    allocating the roughly 1.6 GiB predictor payload.
+    """
+    authority_path = Path(__file__).with_name("qwen35_mtp_header_authority.json")
+    authority = json.loads(authority_path.read_text())
+    assert authority["source"]["repo"] == "Qwen/Qwen3.5-35B-A3B"
+    assert authority["source"]["revision"] == _QWEN35_MTP_AUTHORITY_REVISION
+    assert authority["canonical_mtp_schema_sha256"] == _QWEN35_MTP_SCHEMA_SHA256
+
+    dtype = authority["dtype"]
+    expected = {
+        name: {"dtype": dtype, "shape": shape}
+        for name, shape in authority["non_expert_shapes"].items()
+    }
+    for template, shape in authority["expert_templates"].items():
+        for expert_idx in range(authority["num_experts"]):
+            expected[template.format(expert_idx=expert_idx)] = {
+                "dtype": dtype,
+                "shape": shape,
+            }
+    canonical = json.dumps(
+        expected, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode()
+    assert len(expected) == 785
+    assert hashlib.sha256(canonical).hexdigest() == _QWEN35_MTP_SCHEMA_SHA256
+
+    cfg = _tiny_config()
+    cfg.hidden_size = 2048
+    cfg.num_attention_heads = 16
+    cfg.num_key_value_heads = 2
+    cfg.head_dim = 256
+    cfg.num_experts = authority["num_experts"]
+    cfg.moe_intermediate_size = 512
+    cfg.shared_expert_intermediate_size = 512
+    cfg.num_nextn_predict_layers = 1
+    cfg.mtp_layer_types = ["full_attention"]
+    with torch.device("meta"):
+        source = _TinyQwen35MTPModule(cfg).to(dtype=torch.bfloat16)
+
+    spec = Qwen35WeightSpec(cfg)
+    actual: dict[str, dict[str, str | list[int]]] = {}
+    for native_name, tensor in source.named_parameters():
+        for hf_name, hf_tensor in spec.native_to_hf(native_name, tensor):
+            assert hf_name not in actual, f"duplicate mapped MTP key: {hf_name}"
+            assert hf_tensor.dtype == torch.bfloat16
+            actual[hf_name] = {"dtype": "BF16", "shape": list(hf_tensor.shape)}
+
+    assert len(actual) == 785
+    assert actual == expected
+    assert not spec._expert_export_buffers
+    print(
+        "NON_SKIP_QWEN35_PINNED_MTP_HEADER_AUTHORITY_PASSED "
+        f"revision={_QWEN35_MTP_AUTHORITY_REVISION} mtp_keys={len(actual)} "
+        f"dtype={dtype} schema_sha256={_QWEN35_MTP_SCHEMA_SHA256}",
+        flush=True,
+    )
+
+
+def test_qwen35_mtp_fc_tp2_load_export_shape_roundtrip(monkeypatch) -> None:
     from megatron.lite.primitive.ckpt import hf_weights
+    from torch.distributed.tensor import Replicate, Shard
 
     cfg = _tiny_config()
     cfg.num_nextn_predict_layers = 1

--- a/experimental/lite/tests/unit/model/test_qwen35_export.py
+++ b/experimental/lite/tests/unit/model/test_qwen35_export.py
@@ -1,11 +1,16 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+import copy
+import math
+import os
 from types import SimpleNamespace
 
+import pytest
 import torch
 import torch.nn as nn
 
 from megatron.lite.model.qwen3_5.config import Qwen35Config
 from megatron.lite.model.qwen3_5.lite.checkpoint import (
+    PLACEMENT_FN,
     Qwen35WeightSpec,
     _merge_full_attn_qkvg,
     _merge_gate_up_tp_shards,
@@ -13,7 +18,40 @@ from megatron.lite.model.qwen3_5.lite.checkpoint import (
     _merge_linear_attn_in_proj_tp_shards,
     export_hf_weights,
 )
-from megatron.lite.model.registry import TRAIN_RUNTIME_MODULES, resolve_runtime_model_name
+from megatron.lite.model.registry import (
+    TRAIN_RUNTIME_MODULES,
+    resolve_runtime_model_name,
+)
+
+
+_QWEN35_VISION_EXACT_REQUIRED_ENV = "MLITE_REQUIRE_QWEN35_VISION_EXACT"
+_QWEN35_VISION_EXACT_PASS_MARKER = "QWEN35_VISION_EXACT_PASS"
+
+
+def _transformers_5_12_for_vision_exact():
+    required = os.getenv(_QWEN35_VISION_EXACT_REQUIRED_ENV) == "1"
+    try:
+        transformers = __import__("transformers")
+    except (ImportError, OSError) as exc:
+        message = (
+            "Qwen3.5 vision exact parity requires Transformers 5.12.0; "
+            f"import failed: {type(exc).__name__}: {exc}"
+        )
+        if required:
+            pytest.fail(message, pytrace=False)
+        pytest.skip(message)
+
+    version = getattr(transformers, "__version__", "unknown")
+    if version != "5.12.0":
+        message = (
+            "Qwen3.5 vision exact parity is pinned to Transformers 5.12.0; "
+            f"found {version}. Set {_QWEN35_VISION_EXACT_REQUIRED_ENV}=1 in "
+            "Phase A to make this prerequisite fail instead of skip."
+        )
+        if required:
+            pytest.fail(message, pytrace=False)
+        pytest.skip(message)
+    return transformers
 
 
 def _tiny_config() -> Qwen35Config:
@@ -40,8 +78,133 @@ def _tiny_config() -> Qwen35Config:
 
 def _single_rank_parallel_state() -> SimpleNamespace:
     return SimpleNamespace(
-        pp_size=1, tp_size=1, tp_group=None, ep_size=1, ep_group=None, etp_size=1, etp_group=None
+        pp_size=1,
+        pp_rank=0,
+        tp_size=1,
+        tp_rank=0,
+        tp_group=None,
+        ep_size=1,
+        ep_rank=0,
+        ep_group=None,
+        etp_size=1,
+        etp_rank=0,
+        etp_group=None,
     )
+
+
+class _TinyQwen35MTPModule(nn.Module):
+    """CPU-only native MTP head with the same parameter names as Qwen35Model."""
+
+    def __init__(self, config: Qwen35Config) -> None:
+        super().__init__()
+        self.layer_indices: list[int] = []
+        next_value = 1
+
+        def parameter(module: nn.Module, name: str, shape: tuple[int, ...]) -> None:
+            nonlocal next_value
+            numel = math.prod(shape)
+            tensor = torch.arange(
+                next_value, next_value + numel, dtype=torch.float32
+            ).reshape(shape)
+            next_value += numel
+            module.register_parameter(name, nn.Parameter(tensor))
+
+        self.mtp = nn.Module()
+        layer = nn.Module()
+        self.mtp.layers = nn.ModuleList([layer])
+        for name in ("enorm", "hnorm", "final_layernorm"):
+            module = nn.Module()
+            parameter(module, "weight", (config.hidden_size,))
+            setattr(layer, name, module)
+
+        layer.eh_proj = nn.Module()
+        layer.eh_proj.linear = nn.Module()
+        parameter(
+            layer.eh_proj.linear,
+            "weight",
+            (config.hidden_size, 2 * config.hidden_size),
+        )
+
+        transformer = nn.Module()
+        layer.transformer_layer = transformer
+        transformer.full_attn = nn.Module()
+        transformer.full_attn.qkv = nn.Module()
+        transformer.full_attn.qkv.linear = nn.Module()
+        parameter(
+            transformer.full_attn.qkv.linear,
+            "layer_norm_weight",
+            (config.hidden_size,),
+        )
+        q_heads_per_group = config.num_attention_heads // config.num_key_value_heads
+        qkv_rows = (
+            (2 * q_heads_per_group + 2) * config.head_dim * config.num_key_value_heads
+        )
+        parameter(
+            transformer.full_attn.qkv.linear,
+            "weight",
+            (qkv_rows, config.hidden_size),
+        )
+        transformer.full_attn.q_norm = nn.Module()
+        parameter(transformer.full_attn.q_norm, "weight", (config.head_dim,))
+        transformer.full_attn.k_norm = nn.Module()
+        parameter(transformer.full_attn.k_norm, "weight", (config.head_dim,))
+        transformer.full_attn.proj = nn.Module()
+        transformer.full_attn.proj.linear = nn.Module()
+        parameter(
+            transformer.full_attn.proj.linear,
+            "weight",
+            (
+                config.hidden_size,
+                config.num_attention_heads * config.head_dim,
+            ),
+        )
+
+        transformer.mlp_norm = nn.Module()
+        parameter(transformer.mlp_norm, "weight", (config.hidden_size,))
+        transformer.moe = nn.Module()
+        transformer.moe.router = nn.Module()
+        transformer.moe.router.gate = nn.Module()
+        parameter(
+            transformer.moe.router.gate,
+            "weight",
+            (config.num_experts, config.hidden_size),
+        )
+        transformer.moe.shared_expert = nn.Module()
+        transformer.moe.shared_expert.gate_up = nn.Module()
+        transformer.moe.shared_expert.gate_up.linear = nn.Module()
+        parameter(
+            transformer.moe.shared_expert.gate_up.linear,
+            "weight",
+            (2 * config.shared_expert_intermediate_size, config.hidden_size),
+        )
+        transformer.moe.shared_expert.down = nn.Module()
+        transformer.moe.shared_expert.down.linear = nn.Module()
+        parameter(
+            transformer.moe.shared_expert.down.linear,
+            "weight",
+            (config.hidden_size, config.shared_expert_intermediate_size),
+        )
+        transformer.moe.shared_expert.shared_gate = nn.Module()
+        parameter(
+            transformer.moe.shared_expert.shared_gate,
+            "weight",
+            (1, config.hidden_size),
+        )
+
+        transformer.moe.experts = nn.Module()
+        transformer.moe.experts.fc1 = nn.Module()
+        transformer.moe.experts.fc2 = nn.Module()
+        for expert_idx in range(config.num_experts):
+            parameter(
+                transformer.moe.experts.fc1,
+                f"weight{expert_idx}",
+                (2 * config.moe_intermediate_size, config.hidden_size),
+            )
+            parameter(
+                transformer.moe.experts.fc2,
+                f"weight{expert_idx}",
+                (config.hidden_size, config.moe_intermediate_size),
+            )
 
 
 def test_qwen35_protocol_registers_vllm_export_entrypoint() -> None:
@@ -50,6 +213,87 @@ def test_qwen35_protocol_registers_vllm_export_entrypoint() -> None:
 
     assert key == "qwen3_5"
     assert callable(module.export_hf_weights)
+
+
+def test_qwen35_official_vision_checkpoint_load_export_exact(tmp_path) -> None:
+    transformers = _transformers_5_12_for_vision_exact()
+    from safetensors.torch import save_file
+    from transformers import Qwen3_5VisionConfig, Qwen3_5VisionModel
+
+    from megatron.lite.model.qwen3_5.lite import checkpoint
+
+    vision_cfg = Qwen3_5VisionConfig(
+        depth=1,
+        hidden_size=16,
+        intermediate_size=32,
+        num_heads=4,
+        patch_size=2,
+        temporal_patch_size=1,
+        spatial_merge_size=1,
+        out_hidden_size=8,
+        num_position_embeddings=16,
+    )
+    torch.manual_seed(20260628)
+    authority = Qwen3_5VisionModel(vision_cfg)
+    source = {
+        f"model.visual.{name}": tensor.detach().clone()
+        for name, tensor in authority.state_dict().items()
+    }
+    save_file(source, tmp_path / "model.safetensors")
+
+    class VisionOnlyModel(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.layer_indices: list[int] = []
+            self.vision_model = Qwen3_5VisionModel(vision_cfg).to(torch.bfloat16)
+            self.mtp = None
+
+    target = VisionOnlyModel()
+    # Keep this deliberately smaller than the vision patch-embedding output.
+    # Generic vocab trimming must never truncate ``vision_model.patch_embed``.
+    cfg = SimpleNamespace(vocab_size=1)
+    ps = _single_rank_parallel_state()
+    checkpoint.load_hf_weights(target, str(tmp_path), cfg, ps)
+
+    target_state = target.vision_model.state_dict()
+    assert target_state.keys() == authority.state_dict().keys()
+    for name, expected in authority.state_dict().items():
+        torch.testing.assert_close(
+            target_state[name], expected.to(torch.bfloat16), atol=0.0, rtol=0.0
+        )
+
+    exported = dict(checkpoint.export_hf_weights(target, cfg, ps))
+    assert exported.keys() == source.keys()
+    for hf_name, expected in source.items():
+        torch.testing.assert_close(
+            exported[hf_name], expected.to(torch.bfloat16), atol=0.0, rtol=0.0
+        )
+
+    placements = PLACEMENT_FN("vision_model.patch_embed.proj.weight")
+    assert all(type(placement).__name__ == "Replicate" for placement in placements)
+    spec = Qwen35WeightSpec(cfg, target="vllm")
+    with pytest.raises(NotImplementedError, match="vision export"):
+        spec.native_to_hf("vision_model.patch_embed.proj.weight", torch.ones(1))
+    print(f"{_QWEN35_VISION_EXACT_PASS_MARKER} transformers={transformers.__version__}")
+
+
+def test_qwen35_public_vllm_export_rejects_vision_before_first_yield() -> None:
+    class TextThenVisionModel(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.layer_indices: list[int] = []
+            self.embed = nn.Module()
+            self.embed.embedding = nn.Embedding(4, 2)
+            self.vision_model = nn.Linear(2, 2, bias=False)
+
+    generator = export_hf_weights(
+        TextThenVisionModel(),
+        SimpleNamespace(vocab_size=4),
+        _single_rank_parallel_state(),
+        target="vllm",
+    )
+    with pytest.raises(NotImplementedError, match="vision export"):
+        next(generator)
 
 
 def test_qwen35_export_uses_hf_checkpoint_names_without_module_prefix() -> None:
@@ -77,6 +321,147 @@ def test_qwen35_export_uses_hf_checkpoint_names_without_module_prefix() -> None:
     assert all(not name.startswith(("embed.", "norm.", "head.")) for name in exported)
 
 
+def test_qwen35_mtp_hf_schema_exact_and_load_export_roundtrip(monkeypatch) -> None:
+    from megatron.lite.model.qwen3_5.lite import checkpoint
+
+    cfg = _tiny_config()
+    cfg.num_nextn_predict_layers = 1
+    cfg.mtp_layer_types = ["full_attention"]
+    source = _TinyQwen35MTPModule(cfg)
+    ps = _single_rank_parallel_state()
+
+    exported = dict(export_hf_weights(source, cfg, ps))
+    expected_shapes = {
+        "mtp.pre_fc_norm_embedding.weight": (cfg.hidden_size,),
+        "mtp.pre_fc_norm_hidden.weight": (cfg.hidden_size,),
+        "mtp.fc.weight": (cfg.hidden_size, 2 * cfg.hidden_size),
+        "mtp.norm.weight": (cfg.hidden_size,),
+        "mtp.layers.0.input_layernorm.weight": (cfg.hidden_size,),
+        "mtp.layers.0.self_attn.q_proj.weight": (
+            2 * cfg.num_attention_heads * cfg.head_dim,
+            cfg.hidden_size,
+        ),
+        "mtp.layers.0.self_attn.k_proj.weight": (
+            cfg.num_key_value_heads * cfg.head_dim,
+            cfg.hidden_size,
+        ),
+        "mtp.layers.0.self_attn.v_proj.weight": (
+            cfg.num_key_value_heads * cfg.head_dim,
+            cfg.hidden_size,
+        ),
+        "mtp.layers.0.self_attn.q_norm.weight": (cfg.head_dim,),
+        "mtp.layers.0.self_attn.k_norm.weight": (cfg.head_dim,),
+        "mtp.layers.0.self_attn.o_proj.weight": (
+            cfg.hidden_size,
+            cfg.num_attention_heads * cfg.head_dim,
+        ),
+        "mtp.layers.0.post_attention_layernorm.weight": (cfg.hidden_size,),
+        "mtp.layers.0.mlp.gate.weight": (cfg.num_experts, cfg.hidden_size),
+        "mtp.layers.0.mlp.shared_expert.gate_proj.weight": (
+            cfg.shared_expert_intermediate_size,
+            cfg.hidden_size,
+        ),
+        "mtp.layers.0.mlp.shared_expert.up_proj.weight": (
+            cfg.shared_expert_intermediate_size,
+            cfg.hidden_size,
+        ),
+        "mtp.layers.0.mlp.shared_expert.down_proj.weight": (
+            cfg.hidden_size,
+            cfg.shared_expert_intermediate_size,
+        ),
+        # Qwen/Qwen3.5-35B-A3B's published safetensors manifest carries the
+        # shared-expert gate as one row over the hidden dimension.
+        "mtp.layers.0.mlp.shared_expert_gate.weight": (1, cfg.hidden_size),
+    }
+    for expert_idx in range(cfg.num_experts):
+        prefix = f"mtp.layers.0.mlp.experts.{expert_idx}"
+        expected_shapes.update(
+            {
+                f"{prefix}.gate_proj.weight": (
+                    cfg.moe_intermediate_size,
+                    cfg.hidden_size,
+                ),
+                f"{prefix}.up_proj.weight": (
+                    cfg.moe_intermediate_size,
+                    cfg.hidden_size,
+                ),
+                f"{prefix}.down_proj.weight": (
+                    cfg.hidden_size,
+                    cfg.moe_intermediate_size,
+                ),
+            }
+        )
+
+    assert {name: tuple(tensor.shape) for name, tensor in exported.items()} == (
+        expected_shapes
+    )
+    assert all(tensor.dtype == torch.float32 for tensor in exported.values())
+
+    target = copy.deepcopy(source)
+    for parameter in target.parameters():
+        parameter.data.zero_()
+
+    class MemoryReader:
+        index = {name: "memory.safetensors" for name in exported}
+
+        def __init__(self, _path: str) -> None:
+            pass
+
+        @staticmethod
+        def get_tensor(name: str) -> torch.Tensor:
+            return exported[name].clone()
+
+    monkeypatch.setattr(checkpoint, "SafeTensorReader", MemoryReader)
+    checkpoint.load_hf_weights(target, "memory", cfg, ps)
+
+    source_state = source.state_dict()
+    target_state = target.state_dict()
+    assert source_state.keys() == target_state.keys()
+    for name in source_state:
+        torch.testing.assert_close(
+            target_state[name], source_state[name], atol=0.0, rtol=0.0
+        )
+
+
+def test_qwen35_mtp_fc_tp2_load_export_shape_roundtrip(monkeypatch) -> None:
+    from torch.distributed.tensor import Replicate, Shard
+
+    from megatron.lite.primitive.ckpt import hf_weights
+
+    cfg = _tiny_config()
+    cfg.num_nextn_predict_layers = 1
+    cfg.mtp_layer_types = ["full_attention"]
+    spec = Qwen35WeightSpec(cfg)
+    native_name = "mtp.layers.0.eh_proj.linear.weight"
+    full = torch.arange(
+        cfg.hidden_size * 2 * cfg.hidden_size, dtype=torch.float32
+    ).reshape(cfg.hidden_size, 2 * cfg.hidden_size)
+    shards = full.chunk(2, dim=0)
+    tp_group = object()
+    ps = SimpleNamespace(tp_size=2, tp_group=tp_group)
+
+    def fake_allgather_concat(tensor, world_size, group, dim):
+        assert world_size == 2
+        assert group is tp_group
+        assert dim == 0
+        torch.testing.assert_close(tensor, shards[1])
+        return torch.cat(shards, dim=0)
+
+    monkeypatch.setattr(hf_weights, "allgather_concat", fake_allgather_concat)
+
+    assert spec.tp_spec(native_name) == (0, 0)
+    placements = PLACEMENT_FN(native_name)
+    assert all(isinstance(placement, Replicate) for placement in placements[:3])
+    assert isinstance(placements[3], Shard)
+    assert placements[3].dim == 0
+    gathered = hf_weights._gather_dense(native_name, shards[1], spec, ps)
+    exported = dict(spec.native_to_hf(native_name, gathered))
+
+    assert exported.keys() == {"mtp.fc.weight"}
+    assert exported["mtp.fc.weight"].shape == full.shape
+    torch.testing.assert_close(exported["mtp.fc.weight"], full)
+
+
 def test_qwen35_export_dtype_cast_is_opt_in() -> None:
     class TinyQwen35Module(nn.Module):
         def __init__(self, config: Qwen35Config) -> None:
@@ -89,9 +474,9 @@ def test_qwen35_export_dtype_cast_is_opt_in() -> None:
 
             rows = config.moe_intermediate_size * 2
             for expert_idx in range(config.num_experts):
-                tensor = torch.arange(rows * config.hidden_size, dtype=torch.float32).reshape(
-                    rows, config.hidden_size
-                )
+                tensor = torch.arange(
+                    rows * config.hidden_size, dtype=torch.float32
+                ).reshape(rows, config.hidden_size)
                 tensor = tensor + expert_idx * 1000
                 self.layers[0].moe.experts.fc1.register_parameter(
                     f"weight{expert_idx}", nn.Parameter(tensor)
@@ -102,7 +487,9 @@ def test_qwen35_export_dtype_cast_is_opt_in() -> None:
 
     default_export = dict(export_hf_weights(model, cfg, _single_rank_parallel_state()))
     bf16_export = dict(
-        export_hf_weights(model, cfg, _single_rank_parallel_state(), export_dtype="bfloat16")
+        export_hf_weights(
+            model, cfg, _single_rank_parallel_state(), export_dtype="bfloat16"
+        )
     )
 
     assert default_export["model.language_model.norm.weight"].dtype == torch.float32
@@ -129,9 +516,9 @@ def test_qwen35_export_preserves_runtime_parameter_dtype_by_default() -> None:
 
             rows = config.moe_intermediate_size * 2
             for expert_idx in range(config.num_experts):
-                tensor = torch.arange(rows * config.hidden_size, dtype=torch.bfloat16).reshape(
-                    rows, config.hidden_size
-                )
+                tensor = torch.arange(
+                    rows * config.hidden_size, dtype=torch.bfloat16
+                ).reshape(rows, config.hidden_size)
                 tensor = tensor + expert_idx * 1000
                 self.layers[0].moe.experts.fc1.register_parameter(
                     f"weight{expert_idx}", nn.Parameter(tensor)
@@ -144,7 +531,8 @@ def test_qwen35_export_preserves_runtime_parameter_dtype_by_default() -> None:
 
     assert exported["model.language_model.norm.weight"].dtype == torch.bfloat16
     assert (
-        exported["model.language_model.layers.0.mlp.experts.gate_up_proj"].dtype == torch.bfloat16
+        exported["model.language_model.layers.0.mlp.experts.gate_up_proj"].dtype
+        == torch.bfloat16
     )
 
 
@@ -159,9 +547,9 @@ def test_qwen35_export_batches_ep_expert_gather(monkeypatch) -> None:
 
             rows = config.moe_intermediate_size * 2
             for local_idx in range(config.num_experts // 2):
-                tensor = torch.arange(rows * config.hidden_size, dtype=torch.bfloat16).reshape(
-                    rows, config.hidden_size
-                )
+                tensor = torch.arange(
+                    rows * config.hidden_size, dtype=torch.bfloat16
+                ).reshape(rows, config.hidden_size)
                 tensor = tensor + local_idx * 1000
                 self.layers[0].moe.experts.fc1.register_parameter(
                     f"weight{local_idx}", nn.Parameter(tensor)
@@ -186,7 +574,9 @@ def test_qwen35_export_batches_ep_expert_gather(monkeypatch) -> None:
         outputs[0].copy_(tensor)
         outputs[1].copy_(tensor + 2000)
 
-    monkeypatch.setattr("megatron.lite.primitive.ckpt.hf_weights.dist.all_gather", fake_all_gather)
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.hf_weights.dist.all_gather", fake_all_gather
+    )
 
     exported = dict(export_hf_weights(model, cfg, ps))
 
@@ -197,10 +587,17 @@ def test_qwen35_export_batches_ep_expert_gather(monkeypatch) -> None:
         model.layers[0].moe.experts.fc1.weight1.detach(),
     ]
     expected = torch.stack(
-        [local_tensors[0], local_tensors[1], local_tensors[0] + 2000, local_tensors[1] + 2000],
+        [
+            local_tensors[0],
+            local_tensors[1],
+            local_tensors[0] + 2000,
+            local_tensors[1] + 2000,
+        ],
         dim=0,
     )
-    assert torch.equal(exported["model.language_model.layers.0.mlp.experts.gate_up_proj"], expected)
+    assert torch.equal(
+        exported["model.language_model.layers.0.mlp.experts.gate_up_proj"], expected
+    )
 
 
 def test_qwen35_export_uses_packed_expert_group_names(monkeypatch) -> None:
@@ -214,9 +611,9 @@ def test_qwen35_export_uses_packed_expert_group_names(monkeypatch) -> None:
 
             rows = config.moe_intermediate_size * 2
             for expert_idx in range(config.num_experts):
-                tensor = torch.arange(rows * config.hidden_size, dtype=torch.bfloat16).reshape(
-                    rows, config.hidden_size
-                )
+                tensor = torch.arange(
+                    rows * config.hidden_size, dtype=torch.bfloat16
+                ).reshape(rows, config.hidden_size)
                 tensor = tensor + expert_idx * 1000
                 self.layers[0].moe.experts.fc1.register_parameter(
                     f"weight{expert_idx}", nn.Parameter(tensor)
@@ -232,7 +629,9 @@ def test_qwen35_export_uses_packed_expert_group_names(monkeypatch) -> None:
 
     monkeypatch.setattr(Qwen35WeightSpec, "native_to_hf", spy_native_to_hf)
 
-    exported = dict(export_hf_weights(TinyQwen35Module(cfg), cfg, _single_rank_parallel_state()))
+    exported = dict(
+        export_hf_weights(TinyQwen35Module(cfg), cfg, _single_rank_parallel_state())
+    )
 
     assert seen_native_names == ["layers.0.moe.experts.fc1.packed"]
     assert set(exported) == {"model.language_model.layers.0.mlp.experts.gate_up_proj"}
@@ -249,7 +648,10 @@ def test_qwen35_export_rank0_only_still_participates_in_ep_gather(monkeypatch) -
 
             rows = config.moe_intermediate_size * 2
             for local_idx in range(config.num_experts // 2):
-                tensor = torch.zeros(rows, config.hidden_size, dtype=torch.bfloat16) + local_idx
+                tensor = (
+                    torch.zeros(rows, config.hidden_size, dtype=torch.bfloat16)
+                    + local_idx
+                )
                 self.layers[0].moe.experts.fc1.register_parameter(
                     f"weight{local_idx}", nn.Parameter(tensor)
                 )
@@ -272,9 +674,15 @@ def test_qwen35_export_rank0_only_still_participates_in_ep_gather(monkeypatch) -
         outputs[0].copy_(tensor)
         outputs[1].copy_(tensor + 2)
 
-    monkeypatch.setattr("megatron.lite.primitive.ckpt.hf_weights.dist.is_initialized", lambda: True)
-    monkeypatch.setattr("megatron.lite.primitive.ckpt.hf_weights.dist.get_rank", lambda: 1)
-    monkeypatch.setattr("megatron.lite.primitive.ckpt.hf_weights.dist.all_gather", fake_all_gather)
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.hf_weights.dist.is_initialized", lambda: True
+    )
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.hf_weights.dist.get_rank", lambda: 1
+    )
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.hf_weights.dist.all_gather", fake_all_gather
+    )
 
     exported = list(export_hf_weights(TinyQwen35Module(cfg), cfg, ps, rank0_only=True))
 
@@ -307,12 +715,15 @@ def test_qwen35_export_unpacks_full_attention_q_gate() -> None:
     cfg = _tiny_config()
     spec = Qwen35WeightSpec(cfg)
     hidden = cfg.hidden_size
-    q_gate = torch.arange(cfg.num_attention_heads * 2 * cfg.head_dim * hidden).reshape(-1, hidden)
+    q_gate = torch.arange(cfg.num_attention_heads * 2 * cfg.head_dim * hidden).reshape(
+        -1, hidden
+    )
     key = torch.arange(
         q_gate.numel(), q_gate.numel() + cfg.num_key_value_heads * cfg.head_dim * hidden
     ).reshape(-1, hidden)
     value = torch.arange(
-        key[-1, -1] + 1, key[-1, -1] + 1 + cfg.num_key_value_heads * cfg.head_dim * hidden
+        key[-1, -1] + 1,
+        key[-1, -1] + 1 + cfg.num_key_value_heads * cfg.head_dim * hidden,
     ).reshape(-1, hidden)
 
     packed = _merge_full_attn_qkvg(q_gate, key, value, cfg=cfg)
@@ -323,9 +734,15 @@ def test_qwen35_export_unpacks_full_attention_q_gate() -> None:
         "model.language_model.layers.0.self_attn.k_proj.weight",
         "model.language_model.layers.0.self_attn.v_proj.weight",
     }
-    assert torch.equal(exported["model.language_model.layers.0.self_attn.q_proj.weight"], q_gate)
-    assert torch.equal(exported["model.language_model.layers.0.self_attn.k_proj.weight"], key)
-    assert torch.equal(exported["model.language_model.layers.0.self_attn.v_proj.weight"], value)
+    assert torch.equal(
+        exported["model.language_model.layers.0.self_attn.q_proj.weight"], q_gate
+    )
+    assert torch.equal(
+        exported["model.language_model.layers.0.self_attn.k_proj.weight"], key
+    )
+    assert torch.equal(
+        exported["model.language_model.layers.0.self_attn.v_proj.weight"], value
+    )
 
 
 def test_qwen35_export_maps_linear_attention_to_hf_checkpoint_names() -> None:
@@ -336,7 +753,9 @@ def test_qwen35_export_maps_linear_attention_to_hf_checkpoint_names() -> None:
     rows = qk_dim * 2 + v_dim * 2 + cfg.linear_num_value_heads * 2
     tensor = torch.arange(rows * cfg.hidden_size).reshape(rows, cfg.hidden_size)
 
-    exported = dict(spec.native_to_hf("layers.0.linear_attn.in_proj.linear.weight", tensor))
+    exported = dict(
+        spec.native_to_hf("layers.0.linear_attn.in_proj.linear.weight", tensor)
+    )
 
     assert set(exported) == {
         "model.language_model.layers.0.linear_attn.in_proj_qkv.weight",
@@ -345,10 +764,15 @@ def test_qwen35_export_maps_linear_attention_to_hf_checkpoint_names() -> None:
         "model.language_model.layers.0.linear_attn.in_proj_a.weight",
     }
     assert (
-        exported["model.language_model.layers.0.linear_attn.in_proj_qkv.weight"].shape[0]
+        exported["model.language_model.layers.0.linear_attn.in_proj_qkv.weight"].shape[
+            0
+        ]
         == qk_dim * 2 + v_dim
     )
-    assert exported["model.language_model.layers.0.linear_attn.in_proj_z.weight"].shape[0] == v_dim
+    assert (
+        exported["model.language_model.layers.0.linear_attn.in_proj_z.weight"].shape[0]
+        == v_dim
+    )
     assert (
         exported["model.language_model.layers.0.linear_attn.in_proj_b.weight"].shape[0]
         == cfg.linear_num_value_heads
@@ -377,7 +801,10 @@ def test_qwen35_export_reorders_linear_attention_tp_shards_before_hf_split() -> 
         ),
     ]
     full = torch.cat(parts, dim=0)
-    shards = [torch.cat([part.chunk(2, dim=0)[rank] for part in parts], dim=0) for rank in range(2)]
+    shards = [
+        torch.cat([part.chunk(2, dim=0)[rank] for part in parts], dim=0)
+        for rank in range(2)
+    ]
 
     merged = _merge_linear_attn_in_proj_tp_shards(shards, cfg=cfg)
 
@@ -390,18 +817,21 @@ def test_qwen35_export_reorders_linear_attention_conv1d_tp_shards() -> None:
     v_dim = cfg.linear_num_value_heads * cfg.linear_value_head_dim
     trailing = (1, cfg.linear_conv_kernel_dim)
     parts = [
-        torch.arange(0, qk_dim * trailing[0] * trailing[1], dtype=torch.float32).reshape(
-            qk_dim, *trailing
-        ),
-        torch.arange(100, 100 + qk_dim * trailing[0] * trailing[1], dtype=torch.float32).reshape(
-            qk_dim, *trailing
-        ),
-        torch.arange(200, 200 + v_dim * trailing[0] * trailing[1], dtype=torch.float32).reshape(
-            v_dim, *trailing
-        ),
+        torch.arange(
+            0, qk_dim * trailing[0] * trailing[1], dtype=torch.float32
+        ).reshape(qk_dim, *trailing),
+        torch.arange(
+            100, 100 + qk_dim * trailing[0] * trailing[1], dtype=torch.float32
+        ).reshape(qk_dim, *trailing),
+        torch.arange(
+            200, 200 + v_dim * trailing[0] * trailing[1], dtype=torch.float32
+        ).reshape(v_dim, *trailing),
     ]
     full = torch.cat(parts, dim=0)
-    shards = [torch.cat([part.chunk(2, dim=0)[rank] for part in parts], dim=0) for rank in range(2)]
+    shards = [
+        torch.cat([part.chunk(2, dim=0)[rank] for part in parts], dim=0)
+        for rank in range(2)
+    ]
 
     merged = _merge_linear_attn_conv1d_tp_shards(shards, cfg=cfg)
 
@@ -424,18 +854,21 @@ def test_qwen35_export_uses_mbridge_conv1d_tp_gather(monkeypatch) -> None:
     v_dim = cfg.linear_num_value_heads * cfg.linear_value_head_dim
     trailing = (1, cfg.linear_conv_kernel_dim)
     parts = [
-        torch.arange(0, qk_dim * trailing[0] * trailing[1], dtype=torch.float32).reshape(
-            qk_dim, *trailing
-        ),
-        torch.arange(100, 100 + qk_dim * trailing[0] * trailing[1], dtype=torch.float32).reshape(
-            qk_dim, *trailing
-        ),
-        torch.arange(200, 200 + v_dim * trailing[0] * trailing[1], dtype=torch.float32).reshape(
-            v_dim, *trailing
-        ),
+        torch.arange(
+            0, qk_dim * trailing[0] * trailing[1], dtype=torch.float32
+        ).reshape(qk_dim, *trailing),
+        torch.arange(
+            100, 100 + qk_dim * trailing[0] * trailing[1], dtype=torch.float32
+        ).reshape(qk_dim, *trailing),
+        torch.arange(
+            200, 200 + v_dim * trailing[0] * trailing[1], dtype=torch.float32
+        ).reshape(v_dim, *trailing),
     ]
     full = torch.cat(parts, dim=0)
-    shards = [torch.cat([part.chunk(2, dim=0)[rank] for part in parts], dim=0) for rank in range(2)]
+    shards = [
+        torch.cat([part.chunk(2, dim=0)[rank] for part in parts], dim=0)
+        for rank in range(2)
+    ]
     ps = SimpleNamespace(
         pp_size=1,
         tp_size=2,
@@ -461,7 +894,9 @@ def test_qwen35_export_uses_mbridge_conv1d_tp_gather(monkeypatch) -> None:
 
     assert len(gather_calls) == 1
     assert torch.equal(gather_calls[0], shards[0])
-    assert torch.equal(exported["model.language_model.layers.0.linear_attn.conv1d.weight"], full)
+    assert torch.equal(
+        exported["model.language_model.layers.0.linear_attn.conv1d.weight"], full
+    )
 
 
 def test_qwen35_export_reorders_shared_expert_gate_up_tp_shards() -> None:
@@ -491,14 +926,35 @@ def test_qwen35_export_restores_zero_centered_linear_attention_norm() -> None:
     )
 
 
+def test_qwen35_export_preserves_official_gdn_mixed_dtypes() -> None:
+    spec = Qwen35WeightSpec(_tiny_config())
+    prefix = "layers.0.linear_attn"
+
+    a_log = dict(
+        spec.native_to_hf(f"{prefix}.A_log", torch.ones(2, dtype=torch.float32))
+    )
+    norm = dict(
+        spec.native_to_hf(f"{prefix}.norm.weight", torch.ones(2, dtype=torch.float32))
+    )
+    dt_bias = dict(
+        spec.native_to_hf(f"{prefix}.dt_bias", torch.ones(2, dtype=torch.bfloat16))
+    )
+
+    assert next(iter(a_log.values())).dtype == torch.float32
+    assert next(iter(norm.values())).dtype == torch.float32
+    assert next(iter(dt_bias.values())).dtype == torch.bfloat16
+
+
 def test_qwen35_export_maps_shared_expert_to_hf_checkpoint_names() -> None:
     cfg = _tiny_config()
     spec = Qwen35WeightSpec(cfg)
-    tensor = torch.arange(cfg.shared_expert_intermediate_size * 2 * cfg.hidden_size).reshape(
-        -1, cfg.hidden_size
-    )
+    tensor = torch.arange(
+        cfg.shared_expert_intermediate_size * 2 * cfg.hidden_size
+    ).reshape(-1, cfg.hidden_size)
 
-    exported = dict(spec.native_to_hf("layers.0.moe.shared_expert.gate_up.linear.weight", tensor))
+    exported = dict(
+        spec.native_to_hf("layers.0.moe.shared_expert.gate_up.linear.weight", tensor)
+    )
 
     assert set(exported) == {
         "model.language_model.layers.0.mlp.shared_expert.gate_proj.weight",
@@ -506,7 +962,8 @@ def test_qwen35_export_maps_shared_expert_to_hf_checkpoint_names() -> None:
     }
     gate, up = tensor.chunk(2, dim=0)
     assert torch.equal(
-        exported["model.language_model.layers.0.mlp.shared_expert.gate_proj.weight"], gate
+        exported["model.language_model.layers.0.mlp.shared_expert.gate_proj.weight"],
+        gate,
     )
     assert torch.equal(
         exported["model.language_model.layers.0.mlp.shared_expert.up_proj.weight"], up
@@ -526,7 +983,11 @@ def test_qwen35_export_packs_base_expert_fc1_to_hf_gate_up_proj() -> None:
         tensor = base + expert_idx * 1000
         expert_tensors.append(tensor)
         exported.update(
-            dict(spec.native_to_hf(f"layers.0.moe.experts.fc1.weight{expert_idx}", tensor))
+            dict(
+                spec.native_to_hf(
+                    f"layers.0.moe.experts.fc1.weight{expert_idx}", tensor
+                )
+            )
         )
 
     assert set(exported) == {"model.language_model.layers.0.mlp.experts.gate_up_proj"}
@@ -541,14 +1002,16 @@ def test_qwen35_export_matches_mbridge_qwen35_moe_packed_expert_contract() -> No
     spec = Qwen35WeightSpec(cfg)
     rows = cfg.moe_intermediate_size * 2
     fc1_tensors = [
-        torch.arange(rows * cfg.hidden_size, dtype=torch.bfloat16).reshape(rows, cfg.hidden_size)
+        torch.arange(rows * cfg.hidden_size, dtype=torch.bfloat16).reshape(
+            rows, cfg.hidden_size
+        )
         + expert_idx * 1000
         for expert_idx in range(cfg.num_experts)
     ]
     fc2_tensors = [
-        torch.arange(cfg.hidden_size * cfg.moe_intermediate_size, dtype=torch.bfloat16).reshape(
-            cfg.hidden_size, cfg.moe_intermediate_size
-        )
+        torch.arange(
+            cfg.hidden_size * cfg.moe_intermediate_size, dtype=torch.bfloat16
+        ).reshape(cfg.hidden_size, cfg.moe_intermediate_size)
         + expert_idx * 1000
         for expert_idx in range(cfg.num_experts)
     ]
@@ -563,7 +1026,9 @@ def test_qwen35_export_matches_mbridge_qwen35_moe_packed_expert_contract() -> No
             dict(spec.native_to_hf(f"layers.0.moe.experts.fc2.weight{expert_idx}", fc2))
         )
 
-    assert set(fc1_exported) == {"model.language_model.layers.0.mlp.experts.gate_up_proj"}
+    assert set(fc1_exported) == {
+        "model.language_model.layers.0.mlp.experts.gate_up_proj"
+    }
     assert set(fc2_exported) == {"model.language_model.layers.0.mlp.experts.down_proj"}
     assert torch.equal(
         fc1_exported["model.language_model.layers.0.mlp.experts.gate_up_proj"],
@@ -575,7 +1040,9 @@ def test_qwen35_export_matches_mbridge_qwen35_moe_packed_expert_contract() -> No
     )
 
 
-def test_qwen35_export_vllm_target_uses_runtime_prefix_and_packed_expert_names() -> None:
+def test_qwen35_export_vllm_target_uses_runtime_prefix_and_packed_expert_names() -> (
+    None
+):
     cfg = _tiny_config()
     spec = Qwen35WeightSpec(cfg, target="vllm")
     dense = torch.arange(cfg.hidden_size)
@@ -590,24 +1057,29 @@ def test_qwen35_export_vllm_target_uses_runtime_prefix_and_packed_expert_names()
     assert set(exported_mlp_norm) == {
         "language_model.model.layers.0.post_attention_layernorm.weight"
     }
-    assert torch.equal(exported_embed["language_model.model.embed_tokens.weight"], dense)
+    assert torch.equal(
+        exported_embed["language_model.model.embed_tokens.weight"], dense
+    )
     assert torch.equal(exported_norm["language_model.model.norm.weight"], dense)
     assert torch.equal(exported_head["language_model.lm_head.weight"], dense)
     assert torch.equal(
-        exported_mlp_norm["language_model.model.layers.0.post_attention_layernorm.weight"], dense
+        exported_mlp_norm[
+            "language_model.model.layers.0.post_attention_layernorm.weight"
+        ],
+        dense,
     )
 
     fc1_tensors = [
-        torch.arange(cfg.moe_intermediate_size * 2 * cfg.hidden_size, dtype=torch.bfloat16).reshape(
-            -1, cfg.hidden_size
-        )
+        torch.arange(
+            cfg.moe_intermediate_size * 2 * cfg.hidden_size, dtype=torch.bfloat16
+        ).reshape(-1, cfg.hidden_size)
         + expert_idx * 1000
         for expert_idx in range(cfg.num_experts)
     ]
     fc2_tensors = [
-        torch.arange(cfg.hidden_size * cfg.moe_intermediate_size, dtype=torch.bfloat16).reshape(
-            cfg.hidden_size, cfg.moe_intermediate_size
-        )
+        torch.arange(
+            cfg.hidden_size * cfg.moe_intermediate_size, dtype=torch.bfloat16
+        ).reshape(cfg.hidden_size, cfg.moe_intermediate_size)
         + expert_idx * 2000
         for expert_idx in range(cfg.num_experts)
     ]
@@ -622,7 +1094,9 @@ def test_qwen35_export_vllm_target_uses_runtime_prefix_and_packed_expert_names()
             dict(spec.native_to_hf(f"layers.0.moe.experts.fc2.weight{expert_idx}", fc2))
         )
 
-    assert set(fc1_exported) == {"language_model.model.layers.0.mlp.experts.gate_up_proj"}
+    assert set(fc1_exported) == {
+        "language_model.model.layers.0.mlp.experts.gate_up_proj"
+    }
     assert set(fc2_exported) == {"language_model.model.layers.0.mlp.experts.down_proj"}
     assert torch.equal(
         fc1_exported["language_model.model.layers.0.mlp.experts.gate_up_proj"],
@@ -646,12 +1120,13 @@ def test_qwen35_export_vllm_target_packs_experts_with_runtime_prefix() -> None:
 
             rows = config.moe_intermediate_size * 2
             for expert_idx in range(config.num_experts):
-                fc1 = torch.arange(rows * config.hidden_size, dtype=torch.bfloat16).reshape(
-                    rows, config.hidden_size
-                )
+                fc1 = torch.arange(
+                    rows * config.hidden_size, dtype=torch.bfloat16
+                ).reshape(rows, config.hidden_size)
                 fc1 = fc1 + expert_idx * 1000
                 fc2 = torch.arange(
-                    config.hidden_size * config.moe_intermediate_size, dtype=torch.bfloat16
+                    config.hidden_size * config.moe_intermediate_size,
+                    dtype=torch.bfloat16,
                 ).reshape(config.hidden_size, config.moe_intermediate_size)
                 fc2 = fc2 + expert_idx * 2000
                 self.layers[0].moe.experts.fc1.register_parameter(
@@ -664,12 +1139,18 @@ def test_qwen35_export_vllm_target_packs_experts_with_runtime_prefix() -> None:
     cfg = _tiny_config()
     model = TinyQwen35Module(cfg)
 
-    exported = dict(export_hf_weights(model, cfg, _single_rank_parallel_state(), target="vllm"))
+    exported = dict(
+        export_hf_weights(model, cfg, _single_rank_parallel_state(), target="vllm")
+    )
 
     assert "model.language_model.layers.0.mlp.experts.gate_up_proj" not in exported
     assert "model.language_model.layers.0.mlp.experts.down_proj" not in exported
-    assert "language_model.model.layers.0.mlp.experts.0.gate_proj.weight" not in exported
-    assert "language_model.model.layers.0.mlp.experts.0.down_proj.weight" not in exported
+    assert (
+        "language_model.model.layers.0.mlp.experts.0.gate_proj.weight" not in exported
+    )
+    assert (
+        "language_model.model.layers.0.mlp.experts.0.down_proj.weight" not in exported
+    )
     assert set(exported) == {
         "language_model.model.layers.0.mlp.experts.gate_up_proj",
         "language_model.model.layers.0.mlp.experts.down_proj",
@@ -707,7 +1188,11 @@ def test_qwen35_export_packs_base_expert_fc2_and_expert_metadata() -> None:
         tensor = base + expert_idx * 1000
         expert_tensors.append(tensor)
         exported.update(
-            dict(spec.native_to_hf(f"layers.0.moe.experts.fc2.weight{expert_idx}", tensor))
+            dict(
+                spec.native_to_hf(
+                    f"layers.0.moe.experts.fc2.weight{expert_idx}", tensor
+                )
+            )
         )
 
     assert set(exported) == {"model.language_model.layers.0.mlp.experts.down_proj"}

--- a/experimental/lite/tests/unit/model/test_qwen_config_unit.py
+++ b/experimental/lite/tests/unit/model/test_qwen_config_unit.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import pytest
 import torch
 import torch.nn as nn
-
 from megatron.lite.model.qwen3_5.config import Qwen35Config
 from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
 from megatron.lite.model.registry import (
@@ -124,9 +123,7 @@ def test_qwen35_protocol_rejects_noncanonical_multi_layer_mtp_before_parallel_in
         protocol.build_model(
             cfg,
             impl_cfg=protocol.ImplConfig(
-                parallel=ParallelConfig(),
-                optimizer=None,
-                mtp_enable=True,
+                parallel=ParallelConfig(), optimizer=None, mtp_enable=True
             ),
         )
 
@@ -219,6 +216,31 @@ def test_qwen_lite_protocols_reexport_checkpoint_hook_names():
         assert "PLACEMENT_FN" in exported
         assert "EXPERT_CLASSIFIER" in checkpoint_imports
         assert "PLACEMENT_FN" in checkpoint_imports
+
+
+def test_qwen3_moe_protocol_bulk_loader_is_atomic_group_aware(
+    monkeypatch, transformer_engine_import_stub
+):
+    transformer_engine_import_stub()
+    from megatron.lite.model.qwen3_moe.lite import protocol
+
+    calls = []
+    participating_group = object()
+
+    def fake_load(chunks, path, model_cfg, ps, *, participating_group=None):
+        calls.append((chunks, path, model_cfg, ps, participating_group))
+
+    monkeypatch.setattr(protocol, "_load_hf_weights_impl", fake_load)
+    chunks = [nn.Linear(1, 1), nn.Linear(1, 1)]
+    model_cfg = object()
+    ps = object()
+
+    protocol.load_hf_weights_many(
+        chunks, "/unused", model_cfg, ps, participating_group=participating_group
+    )
+
+    assert calls == [(chunks, "/unused", model_cfg, ps, participating_group)]
+    assert "load_hf_weights_many" in protocol.__all__
 
 
 def _string_list_assignment(tree: ast.Module, name: str) -> set[str]:

--- a/experimental/lite/tests/unit/model/test_qwen_config_unit.py
+++ b/experimental/lite/tests/unit/model/test_qwen_config_unit.py
@@ -5,10 +5,15 @@ import ast
 from pathlib import Path
 
 import pytest
+import torch
+import torch.nn as nn
 
 from megatron.lite.model.qwen3_5.config import Qwen35Config
 from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
-from megatron.lite.model.registry import resolve_model_type_from_hf, resolve_runtime_model_name
+from megatron.lite.model.registry import (
+    resolve_model_type_from_hf,
+    resolve_runtime_model_name,
+)
 
 pytestmark = pytest.mark.mlite
 
@@ -89,7 +94,99 @@ def test_qwen35_config_from_text_config_splits_mtp_layer_types():
     assert cfg.mrope_section == [1, 1, 0]
 
 
-def test_qwen_lite_protocols_build_configs_from_hf_dicts(transformer_engine_import_stub):
+def test_qwen35_protocol_rejects_noncanonical_multi_layer_mtp_before_parallel_init(
+    transformer_engine_import_stub, monkeypatch
+):
+    transformer_engine_import_stub()
+
+    from megatron.lite.model.qwen3_5.lite import protocol
+    from megatron.lite.runtime.contracts import ParallelConfig
+
+    hf = _tiny_qwen35_text_config()
+    hf["num_nextn_predict_layers"] = 2
+    hf["layer_types"] = [
+        "linear_attention",
+        "full_attention",
+        "full_attention",
+        "full_attention",
+    ]
+    cfg = Qwen35Config._from_hf_dict(hf)
+    assert cfg.mtp_layer_types == ["full_attention", "full_attention"]
+
+    def unexpected_init_parallel(_parallel):
+        raise AssertionError("multi-layer MTP must fail before init_parallel")
+
+    monkeypatch.setattr(protocol, "init_parallel", unexpected_init_parallel)
+    with pytest.raises(
+        NotImplementedError,
+        match=r"released Qwen3\.5 HF MTP schema supports exactly one predictor layer",
+    ):
+        protocol.build_model(
+            cfg,
+            impl_cfg=protocol.ImplConfig(
+                parallel=ParallelConfig(),
+                optimizer=None,
+                mtp_enable=True,
+            ),
+        )
+
+
+def test_qwen35_protocol_restores_official_gdn_checkpoint_dtypes(
+    transformer_engine_import_stub,
+):
+    transformer_engine_import_stub()
+
+    from megatron.lite.model.qwen3_5.lite import protocol
+
+    model = nn.Module()
+    model.layers = nn.ModuleList([nn.Module()])
+    linear_attn = nn.Module()
+    model.layers[0].linear_attn = linear_attn
+    linear_attn.register_parameter(
+        "A_log", nn.Parameter(torch.ones(2, dtype=torch.bfloat16))
+    )
+    linear_attn.register_parameter(
+        "dt_bias", nn.Parameter(torch.ones(2, dtype=torch.bfloat16))
+    )
+    linear_attn.norm = nn.Module()
+    linear_attn.norm.register_parameter(
+        "weight", nn.Parameter(torch.ones(2, dtype=torch.bfloat16))
+    )
+
+    protocol._restore_checkpoint_parameter_dtypes([model])
+
+    assert linear_attn.A_log.dtype == torch.float32
+    assert linear_attn.norm.weight.dtype == torch.float32
+    assert linear_attn.dt_bias.dtype == torch.bfloat16
+
+    protocol_path = LITE_ROOT / "megatron/lite/model/qwen3_5/lite/protocol.py"
+    tree = ast.parse(protocol_path.read_text())
+    build_model = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "build_model"
+    )
+    restore_calls = [
+        node.lineno
+        for node in ast.walk(build_model)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_restore_checkpoint_parameter_dtypes"
+    ]
+    cuda_calls = [
+        node.lineno
+        for node in ast.walk(build_model)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "cuda"
+    ]
+    assert len(restore_calls) == 1
+    assert cuda_calls and restore_calls[0] > max(cuda_calls)
+
+
+def test_qwen_lite_protocols_build_configs_from_hf_dicts(
+    transformer_engine_import_stub,
+):
     transformer_engine_import_stub()
 
     from megatron.lite.model.qwen3_5.lite import protocol as qwen35_protocol
@@ -97,7 +194,8 @@ def test_qwen_lite_protocols_build_configs_from_hf_dicts(transformer_engine_impo
 
     qwen3_cfg = qwen3_protocol.build_model_config(_tiny_qwen3_hf_dict(), vocab_size=128)
     qwen35_cfg = qwen35_protocol.build_model_config(
-        {"model_type": "qwen3_5_moe", "text_config": _tiny_qwen35_text_config()}, vocab_size=128
+        {"model_type": "qwen3_5_moe", "text_config": _tiny_qwen35_text_config()},
+        vocab_size=128,
     )
 
     assert qwen3_cfg.vocab_size == 128
@@ -127,11 +225,16 @@ def _string_list_assignment(tree: ast.Module, name: str) -> set[str]:
     for node in tree.body:
         if not isinstance(node, ast.Assign):
             continue
-        if not any(isinstance(target, ast.Name) and target.id == name for target in node.targets):
+        if not any(
+            isinstance(target, ast.Name) and target.id == name
+            for target in node.targets
+        ):
             continue
         if not isinstance(node.value, (ast.List, ast.Tuple)):
             return set()
-        return {item.value for item in node.value.elts if isinstance(item, ast.Constant)}
+        return {
+            item.value for item in node.value.elts if isinstance(item, ast.Constant)
+        }
     return set()
 
 

--- a/experimental/lite/tests/unit/primitive/test_attention_moe_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_attention_moe_unit.py
@@ -507,10 +507,7 @@ def test_glm5_cp_per_token_indexer_loss_fails_until_global_divisor_is_wired(
 
 @pytest.mark.parametrize(
     ("calculate_per_token_loss", "expected_weights"),
-    [
-        (False, [0.2, 0.3, 0.5]),
-        (True, [1.0, 1.0, 1.0]),
-    ],
+    [(False, [0.2, 0.3, 0.5]), (True, [1.0, 1.0, 1.0])],
     ids=["mean-kl-token-weighted", "per-token-kl-sum"],
 )
 def test_glm5_packed_dsa_weights_segment_indexer_losses(
@@ -553,12 +550,7 @@ def test_glm5_packed_dsa_weights_segment_indexer_losses(
     )
 
     actual = attention._forward_packed_full(
-        x,
-        cos,
-        sin,
-        positions,
-        packed_seq_params,
-        index_share_state=None,
+        x, cos, sin, positions, packed_seq_params, index_share_state=None
     )
 
     torch.testing.assert_close(actual, x)
@@ -607,12 +599,7 @@ def test_glm5_packed_dsa_rejects_padded_indexer_aux_until_query_mask_exists():
 
     with pytest.raises(NotImplementedError, match="query-valid mask"):
         attention._forward_packed_full(
-            x,
-            cos,
-            sin,
-            positions,
-            packed_seq_params,
-            index_share_state=None,
+            x, cos, sin, positions, packed_seq_params, index_share_state=None
         )
 
 
@@ -630,18 +617,10 @@ def test_dense_dsa_full_causal_lse_is_chunked_and_topk_independent():
     # block loop rather than accidentally validating one monolithic einsum.
     max_score_bytes = 2 * batch * q_heads * seq_k * 4
     actual = dsa_kernels._compute_full_causal_attn_lse(
-        q,
-        k,
-        scale,
-        ratio,
-        max_score_bytes=max_score_bytes,
+        q, k, scale, ratio, max_score_bytes=max_score_bytes
     )
     key_chunked = dsa_kernels._compute_full_causal_attn_lse(
-        q,
-        k,
-        scale,
-        ratio,
-        max_score_bytes=2 * batch * q_heads * 4,
+        q, k, scale, ratio, max_score_bytes=2 * batch * q_heads * 4
     )
 
     expanded_k = k.float().repeat_interleave(q_heads // kv_heads, dim=2)
@@ -650,19 +629,14 @@ def test_dense_dsa_full_causal_lse_is_chunked_and_topk_independent():
     q_pos = torch.arange(seq_q)
     k_pos = torch.arange(seq_k)
     valid_kv = torch.div(
-        q_global_start + q_pos + 1,
-        ratio,
-        rounding_mode="floor",
+        q_global_start + q_pos + 1, ratio, rounding_mode="floor"
     ).clamp(min=0, max=seq_k)
     causal = k_pos.view(1, seq_k) < valid_kv.view(seq_q, 1)
     expected = torch.logsumexp(
-        scores.masked_fill(~causal.view(1, seq_q, 1, seq_k), -torch.inf),
-        dim=-1,
+        scores.masked_fill(~causal.view(1, seq_q, 1, seq_k), -torch.inf), dim=-1
     )
     expected = torch.where(
-        valid_kv.view(1, seq_q, 1) > 0,
-        expected,
-        torch.full_like(expected, torch.inf),
+        valid_kv.view(1, seq_q, 1) > 0, expected, torch.full_like(expected, torch.inf)
     )
 
     torch.testing.assert_close(actual, expected, atol=1.0e-6, rtol=1.0e-6)
@@ -692,26 +666,16 @@ def test_dsa_score_memory_guard_raises_before_predictable_cuda_oom(monkeypatch):
     from megatron.lite.primitive.kernels import dsa_kernels
 
     gib = 1024**3
-    fake_cuda_tensor = SimpleNamespace(
-        is_cuda=True,
-        device=torch.device("cuda", 0),
-    )
+    fake_cuda_tensor = SimpleNamespace(is_cuda=True, device=torch.device("cuda", 0))
     monkeypatch.setattr(
-        torch.cuda,
-        "mem_get_info",
-        lambda _device: (80 * gib, 288 * gib),
+        torch.cuda, "mem_get_info", lambda _device: (80 * gib, 288 * gib)
     )
 
     with pytest.raises(
-        RuntimeError,
-        match=r"DSA indexer top-k.*estimated peak of 153\.[0-9] GiB",
+        RuntimeError, match=r"DSA indexer top-k.*estimated peak of 153\.[0-9] GiB"
     ):
         dsa_kernels._guard_dsa_score_memory(
-            fake_cuda_tensor,
-            1,
-            202_752,
-            202_752,
-            dense_loss=False,
+            fake_cuda_tensor, 1, 202_752, 202_752, dense_loss=False
         )
 
 
@@ -795,11 +759,7 @@ def test_dense_dsa_kl_matches_canonical_epsilon_placement():
     coeff = 0.25
 
     actual = dsa_kernels._kl_loss_from_dense_scores(
-        attn_score,
-        attn_l1norm,
-        index_logits,
-        index_lse,
-        coeff,
+        attn_score, attn_l1norm, index_logits, index_lse, coeff
     )
 
     target = attn_score[0, 0] / attn_l1norm[0, 0]
@@ -853,11 +813,7 @@ def test_glm5_nonpacked_cp_reconstructs_rank3_rotary_in_zigzag_order(monkeypatch
     attention.cp_group = "cp-group"
 
     gathered_cos, gathered_sin = attention._gather_cp_rotary(
-        cos_parts[0],
-        sin_parts[0],
-        local_seq=4,
-        full_seq=8,
-        device=torch.device("cpu"),
+        cos_parts[0], sin_parts[0], local_seq=4, full_seq=8, device=torch.device("cpu")
     )
     torch.testing.assert_close(gathered_cos, full_cos)
     torch.testing.assert_close(gathered_sin, full_sin)
@@ -865,11 +821,7 @@ def test_glm5_nonpacked_cp_reconstructs_rank3_rotary_in_zigzag_order(monkeypatch
     cache_cos = torch.ones(8, 2)
     cache_sin = torch.zeros(8, 2)
     same_cos, same_sin = attention._gather_cp_rotary(
-        cache_cos,
-        cache_sin,
-        local_seq=4,
-        full_seq=8,
-        device=torch.device("cpu"),
+        cache_cos, cache_sin, local_seq=4, full_seq=8, device=torch.device("cpu")
     )
     assert same_cos is cache_cos
     assert same_sin is cache_sin
@@ -888,9 +840,7 @@ def test_glm5_packed_cp_rejects_inconsistent_padded_extent():
 
     with pytest.raises(ValueError, match="padded packed sequence exactly"):
         attention._gather_packed_cp_inputs(
-            torch.zeros(1, 3, 8),
-            torch.arange(3).unsqueeze(0),
-            packed,
+            torch.zeros(1, 3, 8), torch.arange(3).unsqueeze(0), packed
         )
 
 
@@ -920,11 +870,7 @@ def test_glm5_packed_cp_rejects_invalid_rotary_representations(cos, sin, match):
 
     with pytest.raises(ValueError, match=match):
         attention._gather_packed_cp_rotary(
-            cos,
-            sin,
-            packed,
-            torch.device("cpu"),
-            local_seq=4,
+            cos, sin, packed, torch.device("cpu"), local_seq=4
         )
 
 
@@ -937,21 +883,13 @@ def test_glm5_packed_cp_reconstructs_rank3_rotary(monkeypatch):
     full_sin = full_cos + 100.0
     cos_parts = [
         split_packed_to_cp_local(
-            full_cos,
-            cu_seqlens_padded=cu_seqlens,
-            cp_size=2,
-            cp_rank=rank,
-            dim=1,
+            full_cos, cu_seqlens_padded=cu_seqlens, cp_size=2, cp_rank=rank, dim=1
         )
         for rank in range(2)
     ]
     sin_parts = [
         split_packed_to_cp_local(
-            full_sin,
-            cu_seqlens_padded=cu_seqlens,
-            cp_size=2,
-            cp_rank=rank,
-            dim=1,
+            full_sin, cu_seqlens_padded=cu_seqlens, cp_size=2, cp_rank=rank, dim=1
         )
         for rank in range(2)
     ]
@@ -969,20 +907,14 @@ def test_glm5_packed_cp_reconstructs_rank3_rotary(monkeypatch):
     packed = SimpleNamespace(cu_seqlens_q_padded=cu_seqlens)
 
     gathered_cos, gathered_sin = attention._gather_packed_cp_rotary(
-        cos_parts[0],
-        sin_parts[0],
-        packed,
-        torch.device("cpu"),
-        local_seq=4,
+        cos_parts[0], sin_parts[0], packed, torch.device("cpu"), local_seq=4
     )
     torch.testing.assert_close(gathered_cos, full_cos)
     torch.testing.assert_close(gathered_sin, full_sin)
 
 
 @pytest.mark.parametrize(
-    "metadata_index",
-    [12, 18],
-    ids=["position-local-vs-full", "rotary-local-vs-full"],
+    "metadata_index", [12, 18], ids=["position-local-vs-full", "rotary-local-vs-full"]
 )
 def test_glm5_cp_rejects_mixed_collective_input_representations(
     monkeypatch, metadata_index
@@ -1025,22 +957,14 @@ def test_dsa_index_share_pipeline_guard_rejects_cross_stage_sources():
     )
 
     validate_dsa_index_share_pipeline_split(
-        [0, 1, 2, 3],
-        topk_freq=4,
-        skip_topk_offset=3,
+        [0, 1, 2, 3], topk_freq=4, skip_topk_offset=3
     )
     with pytest.raises(ValueError, match="cannot cross pipeline stages"):
         validate_dsa_index_share_pipeline_split(
-            [3, 4, 5],
-            topk_freq=4,
-            skip_topk_offset=3,
+            [3, 4, 5], topk_freq=4, skip_topk_offset=3
         )
     with pytest.raises(ValueError, match="must execute before"):
-        validate_dsa_index_share_pipeline_split(
-            [3, 2],
-            topk_freq=4,
-            skip_topk_offset=3,
-        )
+        validate_dsa_index_share_pipeline_split([3, 2], topk_freq=4, skip_topk_offset=3)
 
 
 def test_dsa_index_share_pipeline_guard_uses_explicit_nearest_full_source(monkeypatch):
@@ -1053,17 +977,11 @@ def test_dsa_index_share_pipeline_guard_uses_explicit_nearest_full_source(monkey
 
     indexer_types = ["full", "shared", "full", "shared", "shared", "full"]
     validate_dsa_index_share_pipeline_split(
-        [2, 3, 4],
-        topk_freq=1,
-        skip_topk_offset=0,
-        indexer_types=indexer_types,
+        [2, 3, 4], topk_freq=1, skip_topk_offset=0, indexer_types=indexer_types
     )
     with pytest.raises(ValueError, match="cannot cross pipeline stages"):
         validate_dsa_index_share_pipeline_split(
-            [3, 4],
-            topk_freq=1,
-            skip_topk_offset=0,
-            indexer_types=indexer_types,
+            [3, 4], topk_freq=1, skip_topk_offset=0, indexer_types=indexer_types
         )
 
     # A canonical explicit schedule may intentionally contradict freq/offset.

--- a/experimental/lite/tests/unit/primitive/test_attention_moe_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_attention_moe_unit.py
@@ -85,7 +85,9 @@ def test_gqa_split_grouped_qkvg_preserves_q_gate_kv_order():
     split_grouped_qkvg = _split_grouped_qkvg()
     qkv = torch.arange(24).reshape(1, 24)
 
-    query, gate, key, value = split_grouped_qkvg(qkv, num_heads=4, num_kv_heads=2, head_dim=2)
+    query, gate, key, value = split_grouped_qkvg(
+        qkv, num_heads=4, num_kv_heads=2, head_dim=2
+    )
 
     assert query.shape == (1, 4, 2)
     assert gate.shape == (1, 4, 2)
@@ -154,6 +156,102 @@ def test_topk_router_does_not_attach_aux_scaler_in_eval(monkeypatch):
     assert not any("MoEAuxLoss" in name for name in _walk_grad_fn_names(scores))
 
 
+def test_dsv4_indexer_is_a_pure_topk_mask_not_an_attention_bias():
+    from megatron.lite.primitive.modules.attention.csa import (
+        _mask_compressed_scores_with_indexer,
+    )
+
+    compressed_scores = torch.tensor(
+        [
+            [
+                [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]],
+                [[9.0, 10.0, 11.0, 12.0], [13.0, 14.0, 15.0, 16.0]],
+            ]
+        ]
+    )
+    index_scores = torch.tensor([[[100.0, -4.0, 3.0, 2.0], [1.0, 8.0, 7.0, 0.0]]])
+    actual = _mask_compressed_scores_with_indexer(
+        compressed_scores, index_scores, index_topk=2
+    )
+
+    selected = torch.zeros_like(index_scores, dtype=torch.bool)
+    selected.scatter_(-1, index_scores.topk(2, dim=-1).indices, True)
+    selected = selected.unsqueeze(1).expand_as(compressed_scores)
+    torch.testing.assert_close(actual[selected], compressed_scores[selected])
+    assert torch.isneginf(actual[~selected]).all()
+    with pytest.raises(ValueError, match="must be positive"):
+        _mask_compressed_scores_with_indexer(
+            compressed_scores, index_scores, index_topk=0
+        )
+
+
+def test_dsv4_zero_loss_fused_selector_does_not_create_optimizer_grads():
+    from megatron.lite.primitive.modules.attention.csa import (
+        _prepare_indexer_inputs_for_fused_loss,
+    )
+
+    inputs = tuple(torch.nn.Parameter(torch.randn(2, 3)) for _ in range(3))
+    detached = _prepare_indexer_inputs_for_fused_loss(*inputs, loss_coeff=0.0)
+    assert all(
+        not tensor.requires_grad and tensor.grad_fn is None for tensor in detached
+    )
+    assert all(
+        actual.data_ptr() == source.data_ptr()
+        for actual, source in zip(detached, inputs)
+    )
+
+    before_step = tuple(parameter.detach().clone() for parameter in inputs)
+    optimizer = torch.optim.AdamW(inputs, lr=0.1, weight_decay=0.5)
+    optimizer.step()
+    for actual, expected in zip(inputs, before_step):
+        torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+    differentiable = _prepare_indexer_inputs_for_fused_loss(*inputs, loss_coeff=1.0e-2)
+    assert all(actual is source for actual, source in zip(differentiable, inputs))
+
+
+def test_dsv4_torch_indexer_rotates_query_and_compressed_key(monkeypatch):
+    from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
+    from megatron.lite.primitive.modules.attention import csa
+    from megatron.lite.primitive.parallel import ParallelState
+
+    monkeypatch.setattr(csa.te, "RMSNorm", torch.nn.RMSNorm)
+    rotated_shapes = []
+
+    def record_rotation(tensor):
+        rotated_shapes.append(tuple(tensor.shape))
+        return tensor
+
+    monkeypatch.setattr(csa, "rotate_activation", record_rotation)
+    cfg = DeepseekV4Config(
+        hidden_size=8,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=4,
+        qk_rope_head_dim=2,
+        q_lora_rank=4,
+        o_lora_rank=4,
+        o_groups=1,
+        compress_ratios=[4],
+        sliding_window=4,
+        index_head_dim=4,
+        index_n_heads=2,
+        index_topk=1,
+    )
+    module = csa.CompressedSparseAttention(cfg, layer_idx=0, ps=ParallelState())
+    hidden = torch.randn(1, 8, cfg.hidden_size)
+    position_ids = torch.arange(8).unsqueeze(0)
+
+    output = module(hidden, position_ids=position_ids)
+
+    assert output.shape == hidden.shape
+    assert rotated_shapes == [
+        (1, 1, 2, cfg.index_head_dim),
+        (1, cfg.index_n_heads, 8, cfg.index_head_dim),
+    ]
+
+
 def test_topk_router_aux_loss_contributes_gate_gradient(monkeypatch):
     TopKRouter, ParallelState = _router_and_parallel_state(monkeypatch)
     config = _router_config()
@@ -191,32 +289,14 @@ def test_dsa_index_share_schedule_and_state():
     assert dsa_indexer_type_for_layer(7, skip_topk_offset=3, topk_freq=4) == "full"
     assert source_dsa_compute_layer(6, skip_topk_offset=3, topk_freq=4) == 3
 
-    state = DSAIndexShareState()
+    state = DSAIndexShareState({3: 1})
     topk = torch.tensor([[[0, 1], [1, 2]]], dtype=torch.int32)
     state.save_topk(3, topk, sequence_key=0)
+    assert state.cached_tensor_count == 1
     assert torch.equal(state.get_topk(6, 3, sequence_key=0), topk)
+    assert state.cached_tensor_count == 0
     with pytest.raises(AssertionError, match="source layer 3"):
         state.get_topk(5, 3, sequence_key=1)
-
-    state.save_topk(7, topk + 1, sequence_key=0)
-    assert state._resident_source_layer == 7
-    assert state._topk_by_layer[(3, 0)].device.type == "cpu"
-    state.finish_forward()
-    assert state._resident_source_layer is None
-    assert all(value.device.type == "cpu" for value in state._topk_by_layer.values())
-
-
-def test_dsa_index_share_state_drops_old_groups_without_recompute():
-    from megatron.lite.primitive.modules.attention.dsa import DSAIndexShareState
-
-    state = DSAIndexShareState(retain_for_recompute=False)
-    topk = torch.tensor([[[0, 1], [1, 2]]], dtype=torch.int32)
-    state.save_topk(3, topk)
-    state.save_topk(7, topk)
-    with pytest.raises(AssertionError, match="source layer 3"):
-        state.get_topk(4, 3)
-    state.finish_forward()
-    assert state._topk_by_layer == {}
 
 
 def test_glm5_dsa_wrapper_forwards_explicit_position_ids():
@@ -244,6 +324,699 @@ def test_glm5_dsa_wrapper_forwards_explicit_position_ids():
 
     assert output.shape == hidden.shape
     assert torch.equal(wrapper.self_attention.position_ids, position_ids)
+    with pytest.raises(ValueError, match="batch dimension"):
+        wrapper(hidden, position_ids=torch.zeros(3, 5, dtype=torch.long))
+
+
+def test_dsa_index_share_state_releases_final_packed_consumer():
+    from megatron.lite.primitive.modules.attention.dsa import DSAIndexShareState
+
+    state = DSAIndexShareState({3: 2})
+    segment_0 = torch.tensor([[[0, 1]]], dtype=torch.int32)
+    segment_1 = torch.tensor([[[1, 0]]], dtype=torch.int32)
+    state.save_topk(3, segment_0, sequence_key=0)
+    state.save_topk(3, segment_1, sequence_key=1)
+    assert state.cached_tensor_count == 2
+
+    assert torch.equal(state.get_topk(4, 3, sequence_key=0), segment_0)
+    assert torch.equal(state.get_topk(4, 3, sequence_key=1), segment_1)
+    assert state.cached_tensor_count == 2
+    assert torch.equal(state.get_topk(5, 3, sequence_key=0), segment_0)
+    assert state.cached_tensor_count == 1
+    assert torch.equal(state.get_topk(5, 3, sequence_key=1), segment_1)
+    assert state.cached_tensor_count == 0
+
+
+def test_dsa_index_share_state_rejects_unconsumed_source_save():
+    from megatron.lite.primitive.modules.attention.dsa import DSAIndexShareState
+
+    state = DSAIndexShareState()
+    assert state.needs_topk(3) is False
+    with pytest.raises(AssertionError, match="no shared consumer"):
+        state.save_topk(3, torch.zeros(1, 1, 1, dtype=torch.int32))
+
+
+def test_glm5_counts_local_index_share_consumers_and_rejects_activation_replay():
+    from megatron.lite.model.glm5.lite.model import (
+        _local_dsa_index_share_consumer_counts,
+        _validate_dsa_index_share_activation_replay,
+    )
+
+    def layer(*, shared: bool, source_layer: int):
+        dsa = SimpleNamespace(skip_topk=shared, index_share_source_layer=source_layer)
+        return SimpleNamespace(self_attention=SimpleNamespace(self_attention=dsa))
+
+    trunk_layers = [
+        layer(shared=False, source_layer=3),
+        layer(shared=True, source_layer=3),
+        layer(shared=True, source_layer=3),
+    ]
+    mtp = SimpleNamespace(
+        layers=[SimpleNamespace(transformer_layer=layer(shared=False, source_layer=7))],
+        repeated_layer=True,
+        num_layers=3,
+    )
+
+    consumer_counts = _local_dsa_index_share_consumer_counts(trunk_layers, mtp)
+    assert consumer_counts == {3: 2}
+    _validate_dsa_index_share_activation_replay(
+        True,
+        recompute_modules=["moe", "attn_proj"],
+        offload_modules=["mlp", "attn_proj"],
+    )
+    _validate_dsa_index_share_activation_replay(
+        False,
+        recompute_modules=["full", "core_attn", "self_attn", "dsa"],
+        offload_modules=["full", "core_attn", "self_attn", "dsa"],
+    )
+    for replay_kind in ("recompute", "offload"):
+        for unsafe_mode in ("full", "core_attn", "self_attn", "dsa"):
+            kwargs = {"recompute_modules": [], "offload_modules": []}
+            kwargs[f"{replay_kind}_modules"] = [unsafe_mode]
+            with pytest.raises(ValueError, match="group-aware"):
+                _validate_dsa_index_share_activation_replay(True, **kwargs)
+
+
+def test_dsv4_fused_dsa_legacy_two_output_api_cpu_mock(monkeypatch):
+    """DSv4's public fused wrapper and direct Function keep two outputs."""
+    from megatron.lite.primitive.kernels import dsa_kernels
+
+    def fake_forward(ctx, *args):
+        query = args[0]
+        ctx.input_count = len(args)
+        output = query * 2.0
+        loss = query.float().sum() * 0.0
+        topk = torch.zeros(query.shape[:2] + (1,), dtype=torch.int32)
+        return output, loss, topk
+
+    def fake_backward(ctx, grad_output, grad_loss, grad_topk=None):
+        del grad_loss, grad_topk
+        grads = [None] * ctx.input_count
+        grads[0] = grad_output * 2.0
+        return tuple(grads)
+
+    with_topk_func = dsa_kernels._FusedIndexerSparseAttnWithTopKFunc
+    monkeypatch.setattr(with_topk_func, "forward", staticmethod(fake_forward))
+    monkeypatch.setattr(with_topk_func, "backward", staticmethod(fake_backward))
+
+    query = torch.ones(2, 1, 1, 2, requires_grad=True)
+    args = (
+        query,
+        torch.ones(2, 1, 2),
+        torch.zeros(1),
+        torch.empty(1, 2, 0, dtype=torch.int32),
+        torch.ones(2, 1, 1, 2),
+        torch.ones(2, 1, 2),
+        torch.ones(2, 1, 1),
+        1,
+        1,
+        0.5,
+        1.0,
+        0.0,
+        False,
+        0,
+        False,
+        2,
+    )
+
+    direct_result = dsa_kernels.FusedIndexerSparseAttnFunc.apply(*args)
+    assert isinstance(direct_result, tuple)
+    assert len(direct_result) == 2
+
+    output, indexer_loss = dsa_kernels.fused_indexer_sparse_attn(*args)
+    assert output.shape == query.shape
+    assert indexer_loss.ndim == 0
+    (output.sum() + indexer_loss).backward()
+    torch.testing.assert_close(query.grad, torch.full_like(query, 2.0))
+
+    with_topk_result = dsa_kernels.fused_indexer_sparse_attn_with_topk(*args)
+    assert len(with_topk_result) == 3
+    assert with_topk_result[2].dtype == torch.int32
+
+
+def test_glm32_indexer_backward_padding_is_zero_and_reversible():
+    from megatron.lite.primitive.kernels import dsa_kernels
+
+    query = torch.arange(2 * 3 * 32 * 4, dtype=torch.float32).view(2, 3, 32, 4)
+    weights = torch.arange(2 * 3 * 32, dtype=torch.float32).view(2, 3, 32)
+    padded_query, padded_weights, original_heads = (
+        dsa_kernels._pad_indexer_heads_for_backward(query, weights)
+    )
+
+    assert original_heads == 32
+    assert padded_query.shape == (2, 3, 64, 4)
+    assert padded_weights.shape == (2, 3, 64)
+    torch.testing.assert_close(padded_query[:, :, :32], query)
+    torch.testing.assert_close(padded_weights[:, :, :32], weights)
+    assert torch.count_nonzero(padded_query[:, :, 32:]).item() == 0
+    assert torch.count_nonzero(padded_weights[:, :, 32:]).item() == 0
+
+    unchanged_query, unchanged_weights, original_heads = (
+        dsa_kernels._pad_indexer_heads_for_backward(padded_query, padded_weights)
+    )
+    assert original_heads == 64
+    assert unchanged_query is padded_query
+    assert unchanged_weights is padded_weights
+
+
+def test_glm5_cp_per_token_indexer_loss_fails_until_global_divisor_is_wired(
+    monkeypatch,
+):
+    from megatron.lite.primitive.modules.attention import dsa
+
+    monkeypatch.setattr(dsa, "RMSNorm", torch.nn.LayerNorm)
+    with pytest.raises(NotImplementedError, match="global-token divisor"):
+        dsa.DynamicSparseAttention(
+            hidden_size=16,
+            num_attention_heads=2,
+            q_lora_rank=8,
+            kv_lora_rank=4,
+            qk_nope_head_dim=4,
+            qk_rope_head_dim=4,
+            v_head_dim=4,
+            index_n_heads=2,
+            index_head_dim=8,
+            index_topk=2,
+            rms_norm_eps=1.0e-5,
+            indexer_loss_coeff=1.0e-2,
+            calculate_per_token_loss=True,
+            cp_size=2,
+            cp_rank=0,
+        )
+
+
+@pytest.mark.parametrize(
+    ("calculate_per_token_loss", "expected_weights"),
+    [
+        (False, [0.2, 0.3, 0.5]),
+        (True, [1.0, 1.0, 1.0]),
+    ],
+    ids=["mean-kl-token-weighted", "per-token-kl-sum"],
+)
+def test_glm5_packed_dsa_weights_segment_indexer_losses(
+    calculate_per_token_loss, expected_weights
+):
+    from types import MethodType
+
+    from megatron.lite.primitive.modules.attention import dsa
+
+    attention = dsa.DynamicSparseAttention.__new__(dsa.DynamicSparseAttention)
+    torch.nn.Module.__init__(attention)
+    attention.calculate_per_token_loss = calculate_per_token_loss
+    attention.skip_topk = False
+    attention.indexer_loss_coeff = 0.0
+
+    calls = []
+
+    def fake_forward_dense_full(
+        self,
+        x,
+        cos,
+        sin,
+        position_ids,
+        *,
+        index_share_state=None,
+        index_share_cache_key=None,
+        indexer_loss_weight=1.0,
+    ):
+        del self, cos, sin, position_ids, index_share_state
+        calls.append((x.shape[1], index_share_cache_key, indexer_loss_weight))
+        return x
+
+    attention._forward_dense_full = MethodType(fake_forward_dense_full, attention)
+    x = torch.arange(40, dtype=torch.float32).view(1, 10, 4)
+    positions = torch.tensor([[0, 1, 0, 1, 2, 0, 1, 2, 3, 4]])
+    cos = torch.zeros(1, 10, 2)
+    sin = torch.zeros_like(cos)
+    packed_seq_params = SimpleNamespace(
+        cu_seqlens_q_padded=torch.tensor([0, 2, 5, 10], dtype=torch.int32)
+    )
+
+    actual = attention._forward_packed_full(
+        x,
+        cos,
+        sin,
+        positions,
+        packed_seq_params,
+        index_share_state=None,
+    )
+
+    torch.testing.assert_close(actual, x)
+    assert [length for length, _key, _weight in calls] == [2, 3, 5]
+    assert [key for _length, key, _weight in calls] == [0, 1, 2]
+    assert [weight for _length, _key, weight in calls] == pytest.approx(
+        expected_weights
+    )
+    segment_losses = [1.0, 3.0, 5.0]
+    aggregated = sum(
+        loss * weight
+        for loss, (_length, _key, weight) in zip(segment_losses, calls, strict=True)
+    )
+    expected_aggregate = (
+        sum(segment_losses)
+        if calculate_per_token_loss
+        else (1.0 * 2 + 3.0 * 3 + 5.0 * 5) / 10
+    )
+    assert aggregated == pytest.approx(expected_aggregate)
+
+
+def test_glm5_packed_dsa_rejects_padded_indexer_aux_until_query_mask_exists():
+    from types import MethodType
+
+    from megatron.lite.primitive.modules.attention import dsa
+
+    attention = dsa.DynamicSparseAttention.__new__(dsa.DynamicSparseAttention)
+    torch.nn.Module.__init__(attention)
+    attention.calculate_per_token_loss = False
+    attention.skip_topk = False
+    attention.indexer_loss_coeff = 1.0e-2
+
+    def must_not_run(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError("padded indexer auxiliary path must fail before DSA")
+
+    attention._forward_dense_full = MethodType(must_not_run, attention)
+    x = torch.zeros(1, 8, 4)
+    positions = torch.tensor([[0, 1, 0, 0, 0, 1, 2, 0]])
+    cos = torch.zeros(1, 8, 2)
+    sin = torch.zeros_like(cos)
+    packed_seq_params = SimpleNamespace(
+        cu_seqlens_q=torch.tensor([0, 2, 5], dtype=torch.int32),
+        cu_seqlens_q_padded=torch.tensor([0, 4, 8], dtype=torch.int32),
+    )
+
+    with pytest.raises(NotImplementedError, match="query-valid mask"):
+        attention._forward_packed_full(
+            x,
+            cos,
+            sin,
+            positions,
+            packed_seq_params,
+            index_share_state=None,
+        )
+
+
+def test_dense_dsa_full_causal_lse_is_chunked_and_topk_independent():
+    from megatron.lite.primitive.kernels import dsa_kernels
+
+    torch.manual_seed(123)
+    batch, seq_q, seq_k, q_heads, kv_heads, head_dim = 2, 10, 5, 4, 2, 3
+    ratio = 2
+    scale = 0.37
+    q = torch.randn(batch, seq_q, q_heads, head_dim, dtype=torch.bfloat16)
+    k = torch.randn(batch, seq_k, kv_heads, head_dim, dtype=torch.bfloat16)
+
+    # Limit the temporary to two query rows so this exercises the bounded
+    # block loop rather than accidentally validating one monolithic einsum.
+    max_score_bytes = 2 * batch * q_heads * seq_k * 4
+    actual = dsa_kernels._compute_full_causal_attn_lse(
+        q,
+        k,
+        scale,
+        ratio,
+        max_score_bytes=max_score_bytes,
+    )
+    key_chunked = dsa_kernels._compute_full_causal_attn_lse(
+        q,
+        k,
+        scale,
+        ratio,
+        max_score_bytes=2 * batch * q_heads * 4,
+    )
+
+    expanded_k = k.float().repeat_interleave(q_heads // kv_heads, dim=2)
+    scores = torch.einsum("bqhd,bkhd->bqhk", q.float(), expanded_k) * scale
+    q_global_start = seq_k * ratio - seq_q
+    q_pos = torch.arange(seq_q)
+    k_pos = torch.arange(seq_k)
+    valid_kv = torch.div(
+        q_global_start + q_pos + 1,
+        ratio,
+        rounding_mode="floor",
+    ).clamp(min=0, max=seq_k)
+    causal = k_pos.view(1, seq_k) < valid_kv.view(seq_q, 1)
+    expected = torch.logsumexp(
+        scores.masked_fill(~causal.view(1, seq_q, 1, seq_k), -torch.inf),
+        dim=-1,
+    )
+    expected = torch.where(
+        valid_kv.view(1, seq_q, 1) > 0,
+        expected,
+        torch.full_like(expected, torch.inf),
+    )
+
+    torch.testing.assert_close(actual, expected, atol=1.0e-6, rtol=1.0e-6)
+    torch.testing.assert_close(key_chunked, expected, atol=1.0e-6, rtol=1.0e-6)
+    assert actual.shape == (batch, seq_q, q_heads)
+    assert torch.isposinf(actual[:, :1]).all()
+    assert torch.isfinite(actual[:, 1:]).all()
+
+
+def test_dsa_score_memory_estimate_exposes_202k_training_boundary():
+    from megatron.lite.primitive.kernels import dsa_kernels
+
+    seq = 202_752
+    sparse_bytes = dsa_kernels._estimate_dsa_score_peak_bytes(
+        1, seq, seq, dense_loss=False
+    )
+    dense_bytes = dsa_kernels._estimate_dsa_score_peak_bytes(
+        1, seq, seq, dense_loss=True
+    )
+    gib = 1024**3
+    assert sparse_bytes / gib > 150.0
+    assert dense_bytes / gib > 300.0
+    assert dense_bytes > 2 * sparse_bytes
+
+
+def test_dsa_score_memory_guard_raises_before_predictable_cuda_oom(monkeypatch):
+    from megatron.lite.primitive.kernels import dsa_kernels
+
+    gib = 1024**3
+    fake_cuda_tensor = SimpleNamespace(
+        is_cuda=True,
+        device=torch.device("cuda", 0),
+    )
+    monkeypatch.setattr(
+        torch.cuda,
+        "mem_get_info",
+        lambda _device: (80 * gib, 288 * gib),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"DSA indexer top-k.*estimated peak of 153\.[0-9] GiB",
+    ):
+        dsa_kernels._guard_dsa_score_memory(
+            fake_cuda_tensor,
+            1,
+            202_752,
+            202_752,
+            dense_loss=False,
+        )
+
+
+def test_dsa_score_memory_guard_is_wired_to_indexer_and_fused_paths(monkeypatch):
+    from megatron.lite.primitive.kernels import dsa_kernels
+
+    calls = []
+
+    def fail_from_guard(_tensor, batch, seq_q, seq_k, *, dense_loss):
+        calls.append((batch, seq_q, seq_k, dense_loss))
+        raise RuntimeError("score-memory guard wired")
+
+    monkeypatch.setattr(dsa_kernels, "_ensure_dsa_namespace", lambda: None)
+    monkeypatch.setattr(dsa_kernels, "_guard_dsa_score_memory", fail_from_guard)
+
+    q_bshd = torch.zeros(1, 4, 2, 8)
+    k_bsd = torch.zeros(1, 1, 8)
+    w_bsh = torch.zeros(1, 4, 2)
+    with pytest.raises(RuntimeError, match="score-memory guard wired"):
+        dsa_kernels._indexer_topk_bshd(q_bshd, k_bsd, w_bsh, 1, ratio=4)
+
+    query = torch.zeros(4, 1, 2, 8)
+    kv_full = torch.zeros(5, 1, 8)
+    attn_sink = torch.zeros(2)
+    window_idxs = torch.zeros(1, 4, 1, dtype=torch.int32)
+    q_indexer = torch.zeros(4, 1, 2, 8)
+    k_indexer = torch.zeros(1, 1, 8)
+    weights = torch.zeros(4, 1, 2)
+    with pytest.raises(RuntimeError, match="score-memory guard wired"):
+        dsa_kernels.FusedIndexerSparseAttnFunc.apply(
+            query,
+            kv_full,
+            attn_sink,
+            window_idxs,
+            q_indexer,
+            k_indexer,
+            weights,
+            1,
+            4,
+            8**-0.5,
+            8**-0.5,
+            1.0,
+            False,
+            4,
+            False,
+            8,
+        )
+
+    assert calls == [(1, 4, 1, False), (1, 4, 1, True)]
+
+
+def test_dsa_bottom_right_topk_lengths_cover_non_square_valid_keys():
+    from megatron.lite.primitive.kernels import dsa_kernels
+
+    ratio1 = dsa_kernels._bottom_right_valid_kv_counts(
+        seq_q=2, seq_k=4, ratio=1, device=torch.device("cpu")
+    )
+    assert ratio1.tolist() == [3, 4]
+
+    ratio4 = dsa_kernels._bottom_right_valid_kv_counts(
+        seq_q=5, seq_k=2, ratio=4, device=torch.device("cpu")
+    )
+    assert ratio4.tolist() == [1, 1, 1, 1, 2]
+
+    with pytest.raises(ValueError, match="seq_q <= seq_k"):
+        dsa_kernels._bottom_right_valid_kv_counts(
+            seq_q=9, seq_k=2, ratio=4, device=torch.device("cpu")
+        )
+
+
+def test_dense_dsa_kl_matches_canonical_epsilon_placement():
+    from megatron.lite.primitive.kernels import dsa_kernels
+
+    attn_score = torch.tensor([[[0.7, 0.3, 0.0], [0.0, 0.0, 0.0]]], dtype=torch.float32)
+    attn_l1norm = attn_score.sum(dim=-1)
+    index_logits = torch.tensor(
+        [[[1.2, -0.4, -torch.inf], [-torch.inf, -torch.inf, -torch.inf]]],
+        dtype=torch.float32,
+    )
+    index_lse = torch.logsumexp(index_logits, dim=-1)
+    coeff = 0.25
+
+    actual = dsa_kernels._kl_loss_from_dense_scores(
+        attn_score,
+        attn_l1norm,
+        index_logits,
+        index_lse,
+        coeff,
+    )
+
+    target = attn_score[0, 0] / attn_l1norm[0, 0]
+    predict = torch.softmax(index_logits[0, 0, :2], dim=-1)
+    expected_row = (
+        target[:2] * (torch.log(target[:2] + 1.0e-10) - torch.log(predict + 1.0e-10))
+    ).sum()
+    expected = coeff * expected_row / 2
+    torch.testing.assert_close(actual, expected, atol=1.0e-7, rtol=1.0e-7)
+
+
+def test_dsa_vendor_score_grad_is_adjusted_for_canonical_log_epsilon():
+    from megatron.lite.primitive.kernels import dsa_kernels
+
+    logits = torch.tensor([2.0, -30.0, -50.0], dtype=torch.float64, requires_grad=True)
+    target = torch.tensor([0.2, 0.3, 0.5], dtype=torch.float64)
+    predict = torch.softmax(logits, dim=-1)
+    loss = -(target * torch.log(predict + 1.0e-10)).sum()
+    (autograd_grad,) = torch.autograd.grad(loss, logits)
+
+    adjusted_target = dsa_kernels._scale_target_for_canonical_log_eps_backward_(
+        target.clone(), predict.detach()
+    )
+    vendor_equivalent = -adjusted_target + predict.detach() * adjusted_target.sum()
+    torch.testing.assert_close(
+        vendor_equivalent, autograd_grad, atol=1.0e-12, rtol=1.0e-12
+    )
+    # The tiny-probability entries must be attenuated; plain -target would be
+    # the wrong gradient for log(P + 1e-10).
+    assert adjusted_target[-1] < target[-1] * 1.0e-8
+
+
+def test_glm5_nonpacked_cp_reconstructs_rank3_rotary_in_zigzag_order(monkeypatch):
+    from megatron.lite.primitive.modules.attention import dsa
+    from megatron.lite.primitive.parallel.cp import zigzag_slice_for_cp
+
+    full_cos = torch.arange(1 * 8 * 4, dtype=torch.float32).view(1, 8, 4)
+    full_sin = full_cos + 100.0
+    cos_parts = [zigzag_slice_for_cp(full_cos, rank, 2, seq_dim=1) for rank in range(2)]
+    sin_parts = [zigzag_slice_for_cp(full_sin, rank, 2, seq_dim=1) for rank in range(2)]
+
+    def fake_all_gather(tensor, *, cp_size, cp_group):
+        assert cp_size == 2
+        assert cp_group == "cp-group"
+        return cos_parts if torch.equal(tensor, cos_parts[0]) else sin_parts
+
+    monkeypatch.setattr(dsa, "_all_gather_cp", fake_all_gather)
+    attention = dsa.DynamicSparseAttention.__new__(dsa.DynamicSparseAttention)
+    torch.nn.Module.__init__(attention)
+    attention.cp_size = 2
+    attention.cp_group = "cp-group"
+
+    gathered_cos, gathered_sin = attention._gather_cp_rotary(
+        cos_parts[0],
+        sin_parts[0],
+        local_seq=4,
+        full_seq=8,
+        device=torch.device("cpu"),
+    )
+    torch.testing.assert_close(gathered_cos, full_cos)
+    torch.testing.assert_close(gathered_sin, full_sin)
+
+    cache_cos = torch.ones(8, 2)
+    cache_sin = torch.zeros(8, 2)
+    same_cos, same_sin = attention._gather_cp_rotary(
+        cache_cos,
+        cache_sin,
+        local_seq=4,
+        full_seq=8,
+        device=torch.device("cpu"),
+    )
+    assert same_cos is cache_cos
+    assert same_sin is cache_sin
+
+
+def test_glm5_packed_cp_rejects_inconsistent_padded_extent():
+    from megatron.lite.primitive.modules.attention import dsa
+
+    attention = dsa.DynamicSparseAttention.__new__(dsa.DynamicSparseAttention)
+    torch.nn.Module.__init__(attention)
+    attention.cp_size = 2
+    attention.cp_group = "cp-group"
+    packed = SimpleNamespace(
+        cu_seqlens_q_padded=torch.tensor([0, 8], dtype=torch.int32)
+    )
+
+    with pytest.raises(ValueError, match="padded packed sequence exactly"):
+        attention._gather_packed_cp_inputs(
+            torch.zeros(1, 3, 8),
+            torch.arange(3).unsqueeze(0),
+            packed,
+        )
+
+
+@pytest.mark.parametrize(
+    ("cos", "sin", "match"),
+    [
+        (torch.zeros(1, 4, 4), torch.zeros(8, 2), "ranks must match"),
+        (torch.zeros(1, 4, 4), torch.zeros(1, 4, 2), "shapes must match"),
+        (
+            torch.zeros(1, 5, 4),
+            torch.zeros(1, 5, 4),
+            "local or padded full packed sequence",
+        ),
+    ],
+    ids=["rank", "shape", "coverage"],
+)
+def test_glm5_packed_cp_rejects_invalid_rotary_representations(cos, sin, match):
+    from megatron.lite.primitive.modules.attention import dsa
+
+    attention = dsa.DynamicSparseAttention.__new__(dsa.DynamicSparseAttention)
+    torch.nn.Module.__init__(attention)
+    attention.cp_size = 2
+    attention.cp_group = "cp-group"
+    packed = SimpleNamespace(
+        cu_seqlens_q_padded=torch.tensor([0, 8], dtype=torch.int32)
+    )
+
+    with pytest.raises(ValueError, match=match):
+        attention._gather_packed_cp_rotary(
+            cos,
+            sin,
+            packed,
+            torch.device("cpu"),
+            local_seq=4,
+        )
+
+
+def test_glm5_packed_cp_reconstructs_rank3_rotary(monkeypatch):
+    from megatron.lite.primitive.modules.attention import dsa
+    from megatron.lite.primitive.parallel.thd import split_packed_to_cp_local
+
+    cu_seqlens = torch.tensor([0, 8], dtype=torch.int32)
+    full_cos = torch.arange(1 * 8 * 4, dtype=torch.float32).view(1, 8, 4)
+    full_sin = full_cos + 100.0
+    cos_parts = [
+        split_packed_to_cp_local(
+            full_cos,
+            cu_seqlens_padded=cu_seqlens,
+            cp_size=2,
+            cp_rank=rank,
+            dim=1,
+        )
+        for rank in range(2)
+    ]
+    sin_parts = [
+        split_packed_to_cp_local(
+            full_sin,
+            cu_seqlens_padded=cu_seqlens,
+            cp_size=2,
+            cp_rank=rank,
+            dim=1,
+        )
+        for rank in range(2)
+    ]
+
+    def fake_all_gather(tensor, *, cp_size, cp_group):
+        assert cp_size == 2
+        assert cp_group == "cp-group"
+        return cos_parts if torch.equal(tensor, cos_parts[0]) else sin_parts
+
+    monkeypatch.setattr(dsa, "_all_gather_cp", fake_all_gather)
+    attention = dsa.DynamicSparseAttention.__new__(dsa.DynamicSparseAttention)
+    torch.nn.Module.__init__(attention)
+    attention.cp_size = 2
+    attention.cp_group = "cp-group"
+    packed = SimpleNamespace(cu_seqlens_q_padded=cu_seqlens)
+
+    gathered_cos, gathered_sin = attention._gather_packed_cp_rotary(
+        cos_parts[0],
+        sin_parts[0],
+        packed,
+        torch.device("cpu"),
+        local_seq=4,
+    )
+    torch.testing.assert_close(gathered_cos, full_cos)
+    torch.testing.assert_close(gathered_sin, full_sin)
+
+
+@pytest.mark.parametrize(
+    "metadata_index",
+    [12, 18],
+    ids=["position-local-vs-full", "rotary-local-vs-full"],
+)
+def test_glm5_cp_rejects_mixed_collective_input_representations(
+    monkeypatch, metadata_index
+):
+    from megatron.lite.primitive.modules.attention import dsa
+
+    attention = dsa.DynamicSparseAttention.__new__(dsa.DynamicSparseAttention)
+    torch.nn.Module.__init__(attention)
+    attention.cp_size = 2
+    attention.cp_group = "cp-group"
+
+    def fake_all_gather(metadata, *, cp_size, cp_group):
+        assert cp_size == 2
+        assert cp_group == "cp-group"
+        peer_metadata = metadata.clone()
+        # Metadata layout is header(3), followed by fixed-size shape/dtype
+        # records for x, position, cos, and sin. Change one rank's selected
+        # sequence axis from local length 4 to full length 8.
+        peer_metadata[metadata_index] = 8
+        return [metadata, peer_metadata]
+
+    monkeypatch.setattr(dsa, "_all_gather_cp", fake_all_gather)
+    with pytest.raises(
+        ValueError, match="same local/full position and rotary representation"
+    ):
+        attention._validate_cp_collective_input_metadata(
+            torch.zeros(1, 4, 8),
+            torch.arange(4).unsqueeze(0),
+            torch.zeros(1, 4, 4),
+            torch.zeros(1, 4, 4),
+            local_seq=4,
+            full_seq=8,
+            packed=False,
+        )
 
 
 def test_dsa_index_share_pipeline_guard_rejects_cross_stage_sources():
@@ -268,17 +1041,52 @@ def test_dsa_index_share_pipeline_guard_rejects_cross_stage_sources():
             topk_freq=4,
             skip_topk_offset=3,
         )
-    # Global layer index 3 is the first MTP layer for a 3-layer trunk in this
-    # configuration.  It is shared from trunk layer 2 and must not sit alone on
-    # the final pipeline stage.
+
+
+def test_dsa_index_share_pipeline_guard_uses_explicit_nearest_full_source(monkeypatch):
+    from megatron.lite.primitive.modules.attention import dsa
+
+    DynamicSparseAttention = dsa.DynamicSparseAttention
+    validate_dsa_index_share_pipeline_split = (
+        dsa.validate_dsa_index_share_pipeline_split
+    )
+
+    indexer_types = ["full", "shared", "full", "shared", "shared", "full"]
+    validate_dsa_index_share_pipeline_split(
+        [2, 3, 4],
+        topk_freq=1,
+        skip_topk_offset=0,
+        indexer_types=indexer_types,
+    )
     with pytest.raises(ValueError, match="cannot cross pipeline stages"):
         validate_dsa_index_share_pipeline_split(
-            [3],
-            topk_freq=4,
-            skip_topk_offset=3,
+            [3, 4],
+            topk_freq=1,
+            skip_topk_offset=0,
+            indexer_types=indexer_types,
         )
-    validate_dsa_index_share_pipeline_split(
-        [2, 3],
-        topk_freq=4,
-        skip_topk_offset=3,
+
+    # A canonical explicit schedule may intentionally contradict freq/offset.
+    # The primitive accepts the caller-provided type and source instead of
+    # silently recomputing a different schedule.
+    monkeypatch.setattr(dsa, "RMSNorm", torch.nn.LayerNorm)
+    shared = DynamicSparseAttention(
+        hidden_size=16,
+        num_attention_heads=2,
+        q_lora_rank=8,
+        kv_lora_rank=4,
+        qk_nope_head_dim=4,
+        qk_rope_head_dim=4,
+        v_head_dim=4,
+        index_n_heads=2,
+        index_head_dim=8,
+        index_topk=2,
+        rms_norm_eps=1e-5,
+        layer_number=5,
+        index_topk_freq=1,
+        indexer_type="shared",
+        index_share_enabled=True,
+        index_share_source_layer=3,
     )
+    assert shared.indexer is None
+    assert shared.index_share_source_layer == 3

--- a/experimental/lite/tests/unit/primitive/test_checkpoint_runtime.py
+++ b/experimental/lite/tests/unit/primitive/test_checkpoint_runtime.py
@@ -28,6 +28,18 @@ class TinyMLP(nn.Module):
         return self.layers(x)
 
 
+class BufferedModule(nn.Module):
+    def __init__(self, cache_size: int):
+        super().__init__()
+        self.weight = nn.Parameter(torch.arange(4, dtype=torch.float32))
+        self.register_buffer("persistent_scale", torch.tensor([1.0, 2.0]))
+        self.register_buffer(
+            "runtime_cache",
+            torch.arange(cache_size, dtype=torch.float32),
+            persistent=False,
+        )
+
+
 def _step(
     model: nn.Module, optimizer: torch.optim.Optimizer, x: torch.Tensor, y: torch.Tensor
 ):
@@ -266,6 +278,147 @@ def test_primitive_local_checkpoint_keeps_optimizer_checkpoints_local(tmp_path):
 
     dcp_save_mock.assert_not_called()
     assert (tmp_path / "training_state.pt").exists()
+
+
+def test_local_checkpoint_v2_excludes_nonpersistent_buffers(tmp_path):
+    source = BufferedModule(cache_size=3)
+
+    save_training_checkpoint(
+        source, None, 12, str(tmp_path), use_dcp=False, save_rng=False
+    )
+
+    state = torch.load(tmp_path / "training_state.pt", weights_only=False)
+    assert state["format"] == "megatron_lite.local_training.v2"
+    assert set(state["model"][0]) == {"param.weight", "buffer.persistent_scale"}
+
+
+def test_local_checkpoint_v2_preserves_different_nonpersistent_cache_on_load(tmp_path):
+    source = BufferedModule(cache_size=3)
+    with torch.no_grad():
+        source.weight.add_(10.0)
+        source.persistent_scale.add_(20.0)
+    save_training_checkpoint(
+        source, None, 13, str(tmp_path), use_dcp=False, save_rng=False
+    )
+
+    target = BufferedModule(cache_size=7)
+    with torch.no_grad():
+        target.runtime_cache.add_(100.0)
+    cache_before = target.runtime_cache.clone()
+
+    assert (
+        load_training_checkpoint(
+            target, None, str(tmp_path), use_dcp=False, load_rng=False
+        )
+        == 13
+    )
+    torch.testing.assert_close(target.weight, source.weight, atol=0, rtol=0)
+    torch.testing.assert_close(
+        target.persistent_scale, source.persistent_scale, atol=0, rtol=0
+    )
+    torch.testing.assert_close(target.runtime_cache, cache_before, atol=0, rtol=0)
+
+
+def test_local_checkpoint_v2_rejects_nonpersistent_buffer_before_mutation(tmp_path):
+    source = BufferedModule(cache_size=3)
+    save_training_checkpoint(
+        source, None, 14, str(tmp_path), use_dcp=False, save_rng=False
+    )
+    checkpoint_file = tmp_path / "training_state.pt"
+    state = torch.load(checkpoint_file, weights_only=False)
+    state["model"][0]["buffer.runtime_cache"] = source.runtime_cache.clone()
+    torch.save(state, checkpoint_file)
+
+    target = BufferedModule(cache_size=5)
+    before = copy.deepcopy(target.state_dict())
+    cache_before = target.runtime_cache.clone()
+    with pytest.raises(RuntimeError, match="schema mismatch.*buffer.runtime_cache"):
+        load_training_checkpoint(
+            target, None, str(tmp_path), use_dcp=False, load_rng=False
+        )
+
+    _assert_model_state_unchanged(target, before)
+    torch.testing.assert_close(target.runtime_cache, cache_before, atol=0, rtol=0)
+
+
+def test_local_checkpoint_v1_ignores_matching_nonpersistent_buffer(tmp_path):
+    source = BufferedModule(cache_size=3)
+    with torch.no_grad():
+        source.weight.add_(10.0)
+        source.persistent_scale.add_(20.0)
+    save_training_checkpoint(
+        source, None, 14, str(tmp_path), use_dcp=False, save_rng=False
+    )
+    checkpoint_file = tmp_path / "training_state.pt"
+    state = torch.load(checkpoint_file, weights_only=False)
+    state["format"] = "megatron_lite.local_training.v1"
+    state["model"][0]["buffer.runtime_cache"] = torch.arange(11, dtype=torch.float64)
+    torch.save(state, checkpoint_file)
+
+    target = BufferedModule(cache_size=5)
+    with torch.no_grad():
+        target.runtime_cache.add_(100.0)
+    cache_before = target.runtime_cache.clone()
+
+    assert (
+        load_training_checkpoint(
+            target, None, str(tmp_path), use_dcp=False, load_rng=False
+        )
+        == 14
+    )
+    torch.testing.assert_close(target.weight, source.weight, atol=0, rtol=0)
+    torch.testing.assert_close(
+        target.persistent_scale, source.persistent_scale, atol=0, rtol=0
+    )
+    torch.testing.assert_close(target.runtime_cache, cache_before, atol=0, rtol=0)
+
+
+def test_local_checkpoint_v1_rejects_nontensor_nonpersistent_buffer_before_mutation(
+    tmp_path,
+):
+    source = BufferedModule(cache_size=3)
+    save_training_checkpoint(
+        source, None, 15, str(tmp_path), use_dcp=False, save_rng=False
+    )
+    checkpoint_file = tmp_path / "training_state.pt"
+    state = torch.load(checkpoint_file, weights_only=False)
+    state["format"] = "megatron_lite.local_training.v1"
+    state["model"][0]["buffer.runtime_cache"] = "not-a-tensor"
+    torch.save(state, checkpoint_file)
+
+    target = BufferedModule(cache_size=5)
+    before = copy.deepcopy(target.state_dict())
+    cache_before = target.runtime_cache.clone()
+    with pytest.raises(TypeError, match="non-persistent buffer.*must be torch.Tensor"):
+        load_training_checkpoint(
+            target, None, str(tmp_path), use_dcp=False, load_rng=False
+        )
+
+    _assert_model_state_unchanged(target, before)
+    torch.testing.assert_close(target.runtime_cache, cache_before, atol=0, rtol=0)
+
+
+def test_local_checkpoint_v1_rejects_unknown_buffer_before_mutation(tmp_path):
+    source = BufferedModule(cache_size=3)
+    save_training_checkpoint(
+        source, None, 15, str(tmp_path), use_dcp=False, save_rng=False
+    )
+    checkpoint_file = tmp_path / "training_state.pt"
+    state = torch.load(checkpoint_file, weights_only=False)
+    state["format"] = "megatron_lite.local_training.v1"
+    state["model"][0]["buffer.removed_cache"] = torch.ones(2)
+    torch.save(state, checkpoint_file)
+
+    target = BufferedModule(cache_size=5)
+    before = copy.deepcopy(target.state_dict())
+    cache_before = target.runtime_cache.clone()
+    with pytest.raises(RuntimeError, match="schema mismatch.*buffer.removed_cache"):
+        load_training_checkpoint(
+            target, None, str(tmp_path), use_dcp=False, load_rng=False
+        )
+
+    _assert_model_state_unchanged(target, before)
+    torch.testing.assert_close(target.runtime_cache, cache_before, atol=0, rtol=0)
 
 
 @pytest.mark.parametrize(

--- a/experimental/lite/tests/unit/primitive/test_checkpoint_runtime.py
+++ b/experimental/lite/tests/unit/primitive/test_checkpoint_runtime.py
@@ -7,10 +7,13 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import numpy as np
+import pytest
 import torch
 import torch.nn as nn
-
-from megatron.lite.primitive.ckpt import save_training_checkpoint
+from megatron.lite.primitive.ckpt import (
+    load_training_checkpoint,
+    save_training_checkpoint,
+)
 from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
 from megatron.lite.runtime.contracts.config import ParallelConfig
 from megatron.lite.runtime.contracts.handle import ModelHandle
@@ -25,7 +28,9 @@ class TinyMLP(nn.Module):
         return self.layers(x)
 
 
-def _step(model: nn.Module, optimizer: torch.optim.Optimizer, x: torch.Tensor, y: torch.Tensor):
+def _step(
+    model: nn.Module, optimizer: torch.optim.Optimizer, x: torch.Tensor, y: torch.Tensor
+):
     optimizer.zero_grad(set_to_none=True)
     loss = torch.nn.functional.mse_loss(model(x), y)
     loss.backward()
@@ -45,6 +50,12 @@ def _assert_model_close(lhs: nn.Module, rhs: nn.Module):
     ):
         assert lhs_name == rhs_name
         torch.testing.assert_close(lhs_param, rhs_param, atol=0.0, rtol=0.0)
+
+
+def _assert_model_state_unchanged(model: nn.Module, before: dict[str, torch.Tensor]):
+    assert model.state_dict().keys() == before.keys()
+    for name, tensor in model.state_dict().items():
+        torch.testing.assert_close(tensor, before[name], atol=0.0, rtol=0.0)
 
 
 def test_runtime_local_checkpoint_load_matches_uninterrupted_training(tmp_path):
@@ -109,14 +120,45 @@ class DistOptLike:
         self.load_calls = int(marker["load_calls"]) + 1
         self.optimizer.load_state_dict(state)
 
+    def validate_state_dict(self, state):
+        from megatron.lite.primitive.ckpt import dcp
+
+        if not isinstance(state, dict) or set(state) != {
+            "state",
+            "param_groups",
+            "dist_opt_like_marker",
+        }:
+            raise ValueError("invalid DistOptLike state schema")
+        marker = state["dist_opt_like_marker"]
+        if not isinstance(marker, dict) or type(marker.get("load_calls")) is not int:
+            raise TypeError("invalid DistOptLike marker")
+        inner_state = {
+            key: value for key, value in state.items() if key != "dist_opt_like_marker"
+        }
+        dcp._validate_torch_optimizer_checkpoint_state(self.optimizer, inner_state)
+
     def save_parameter_state(self, filename: str):
         self.parameter_save_calls += 1
         torch.save({"parameter_save_calls": self.parameter_save_calls}, filename)
 
-    def load_parameter_state(self, filename: str, *, update_legacy_format: bool = False):
+    def load_parameter_state(
+        self, filename: str, *, update_legacy_format: bool = False
+    ):
         state = torch.load(filename, weights_only=False)
         self.parameter_load_calls = int(state["parameter_save_calls"])
         self.update_legacy_format = update_legacy_format
+
+    @staticmethod
+    def validate_parameter_state(filename: str, *, update_legacy_format: bool = False):
+        del update_legacy_format
+        state = torch.load(filename, map_location="cpu", weights_only=False)
+        if (
+            not isinstance(state, dict)
+            or set(state) != {"parameter_save_calls"}
+            or type(state["parameter_save_calls"]) is not int
+            or state["parameter_save_calls"] < 1
+        ):
+            raise ValueError("invalid DistOptLike parameter state")
 
 
 def test_runtime_local_checkpoint_uses_optimizer_parameter_state_contract(tmp_path):
@@ -130,11 +172,16 @@ def test_runtime_local_checkpoint_uses_optimizer_parameter_state_contract(tmp_pa
 
     runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
     runtime.save_checkpoint(
-        ModelHandle(model=model, optimizer=optimizer), str(tmp_path), step=7, use_dcp=False
+        ModelHandle(model=model, optimizer=optimizer),
+        str(tmp_path),
+        step=7,
+        use_dcp=False,
     )
 
     loaded_model = TinyMLP()
-    loaded_optimizer = DistOptLike(torch.optim.AdamW(loaded_model.parameters(), lr=1.0e-3))
+    loaded_optimizer = DistOptLike(
+        torch.optim.AdamW(loaded_model.parameters(), lr=1.0e-3)
+    )
 
     assert (
         runtime.load_checkpoint(
@@ -189,11 +236,16 @@ def test_runtime_local_checkpoint_uses_rank_specific_files_when_distributed(tmp_
 
     with (
         patch("megatron.lite.primitive.ckpt.dcp.dist.is_available", return_value=True),
-        patch("megatron.lite.primitive.ckpt.dcp.dist.is_initialized", return_value=True),
+        patch(
+            "megatron.lite.primitive.ckpt.dcp.dist.is_initialized", return_value=True
+        ),
         patch("megatron.lite.primitive.ckpt.dcp.dist.get_rank", return_value=3),
     ):
         runtime.save_checkpoint(
-            ModelHandle(model=model, optimizer=None), str(tmp_path), step=11, use_dcp=False
+            ModelHandle(model=model, optimizer=None),
+            str(tmp_path),
+            step=11,
+            use_dcp=False,
         )
         assert (tmp_path / "training_state_rank_00003.pt").exists()
         assert not (tmp_path / "training_state.pt").exists()
@@ -216,13 +268,375 @@ def test_primitive_local_checkpoint_keeps_optimizer_checkpoints_local(tmp_path):
     assert (tmp_path / "training_state.pt").exists()
 
 
+@pytest.mark.parametrize(
+    ("save_model", "save_optimizer"), ((False, True), (True, False), (False, False))
+)
+def test_local_checkpoint_save_rejects_partial_component_selection(
+    tmp_path, save_model: bool, save_optimizer: bool
+):
+    model = TinyMLP()
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1.0e-3)
+
+    with pytest.raises(
+        ValueError, match="Local-format checkpoints do not support partial"
+    ):
+        save_training_checkpoint(
+            model,
+            optimizer,
+            12,
+            str(tmp_path),
+            use_dcp=False,
+            save_model=save_model,
+            save_optimizer=save_optimizer,
+        )
+
+    assert not (tmp_path / "training_state.pt").exists()
+
+
+@pytest.mark.parametrize(
+    ("load_model", "load_optimizer"), ((False, True), (True, False), (False, False))
+)
+def test_local_checkpoint_load_rejects_partial_component_selection_before_mutation(
+    tmp_path, load_model: bool, load_optimizer: bool
+):
+    source = TinyMLP()
+    source_optimizer = torch.optim.AdamW(source.parameters(), lr=1.0e-3)
+    save_training_checkpoint(source, source_optimizer, 13, str(tmp_path), use_dcp=False)
+    target = TinyMLP()
+    target_optimizer = torch.optim.AdamW(target.parameters(), lr=1.0e-3)
+    before = copy.deepcopy(target.state_dict())
+
+    with pytest.raises(
+        ValueError, match="Local-format checkpoints do not support partial"
+    ):
+        load_training_checkpoint(
+            target,
+            target_optimizer,
+            str(tmp_path),
+            use_dcp=False,
+            load_model=load_model,
+            load_optimizer=load_optimizer,
+        )
+
+    for name, tensor in target.state_dict().items():
+        torch.testing.assert_close(tensor, before[name], atol=0.0, rtol=0.0)
+
+
+def test_local_checkpoint_rejects_invalid_step_before_any_mutation(tmp_path):
+    source = TinyMLP()
+    save_training_checkpoint(source, None, 14, str(tmp_path), use_dcp=False)
+    checkpoint_file = tmp_path / "training_state.pt"
+    state = torch.load(checkpoint_file, weights_only=False)
+    state["step"] = "14"
+    torch.save(state, checkpoint_file)
+
+    target = TinyMLP()
+    before = copy.deepcopy(target.state_dict())
+    rng_before = torch.get_rng_state().clone()
+    with pytest.raises(RuntimeError, match="step must be a non-negative integer"):
+        load_training_checkpoint(target, None, str(tmp_path), use_dcp=False)
+
+    _assert_model_state_unchanged(target, before)
+    torch.testing.assert_close(torch.get_rng_state(), rng_before, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("corruption", ["missing", "unexpected", "shape", "dtype"])
+def test_local_checkpoint_preflights_every_chunk_before_copy(tmp_path, corruption):
+    source_chunks = [nn.Linear(3, 3), nn.Linear(3, 2)]
+    save_training_checkpoint(
+        source_chunks, None, 15, str(tmp_path), use_dcp=False, save_rng=False
+    )
+    checkpoint_file = tmp_path / "training_state.pt"
+    state = torch.load(checkpoint_file, weights_only=False)
+    second_chunk = state["model"][1]
+    if corruption == "missing":
+        second_chunk.pop("param.weight")
+    elif corruption == "unexpected":
+        second_chunk["param.removed"] = torch.zeros(1)
+    elif corruption == "shape":
+        second_chunk["param.weight"] = torch.zeros(1, 3)
+    else:
+        second_chunk["param.weight"] = second_chunk["param.weight"].double()
+    torch.save(state, checkpoint_file)
+
+    target_chunks = [nn.Linear(3, 3), nn.Linear(3, 2)]
+    before = [copy.deepcopy(chunk.state_dict()) for chunk in target_chunks]
+    with pytest.raises(RuntimeError, match="model chunk 1"):
+        load_training_checkpoint(
+            target_chunks, None, str(tmp_path), use_dcp=False, load_rng=False
+        )
+
+    for chunk, chunk_before in zip(target_chunks, before, strict=True):
+        _assert_model_state_unchanged(chunk, chunk_before)
+
+
+def test_local_checkpoint_rejects_optimizer_state_before_model_copy(tmp_path):
+    source = TinyMLP()
+    source_optimizer = torch.optim.AdamW(source.parameters(), lr=1.0e-3)
+    _step(source, source_optimizer, torch.randn(2, 4), torch.randn(2, 2))
+    save_training_checkpoint(source, source_optimizer, 16, str(tmp_path), use_dcp=False)
+    checkpoint_file = tmp_path / "training_state.pt"
+    state = torch.load(checkpoint_file, weights_only=False)
+    state["optimizer"]["param_groups"][0]["lr"] = "corrupt"
+    torch.save(state, checkpoint_file)
+
+    target = TinyMLP()
+    target_optimizer = torch.optim.AdamW(target.parameters(), lr=1.0e-3)
+    before = copy.deepcopy(target.state_dict())
+    with pytest.raises(RuntimeError, match="optimizer checkpoint is incompatible"):
+        load_training_checkpoint(target, target_optimizer, str(tmp_path), use_dcp=False)
+
+    _assert_model_state_unchanged(target, before)
+    assert not target_optimizer.state
+
+
+def test_local_checkpoint_rejects_incompatible_rng_before_model_copy(tmp_path):
+    source = TinyMLP()
+    save_training_checkpoint(source, None, 17, str(tmp_path), use_dcp=False)
+    checkpoint_file = tmp_path / "training_state.pt"
+    state = torch.load(checkpoint_file, weights_only=False)
+    state["rng_state"]["torch_rng_state"] = torch.zeros(1, dtype=torch.uint8)
+    torch.save(state, checkpoint_file)
+
+    target = TinyMLP()
+    before = copy.deepcopy(target.state_dict())
+    rng_before = torch.get_rng_state().clone()
+    with pytest.raises(RuntimeError, match="RNG checkpoint is incompatible"):
+        load_training_checkpoint(target, None, str(tmp_path), use_dcp=False)
+
+    _assert_model_state_unchanged(target, before)
+    torch.testing.assert_close(torch.get_rng_state(), rng_before, atol=0, rtol=0)
+
+
+def test_local_checkpoint_rejects_missing_requested_rng_before_model_copy(tmp_path):
+    source = TinyMLP()
+    save_training_checkpoint(
+        source, None, 17, str(tmp_path), use_dcp=False, save_rng=False
+    )
+    target = TinyMLP()
+    before = copy.deepcopy(target.state_dict())
+    rng_before = torch.get_rng_state().clone()
+
+    with pytest.raises(RuntimeError, match="RNG state .* is missing"):
+        load_training_checkpoint(target, None, str(tmp_path), use_dcp=False)
+
+    _assert_model_state_unchanged(target, before)
+    torch.testing.assert_close(torch.get_rng_state(), rng_before, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("saved_has_optimizer", [False, True])
+def test_local_checkpoint_rejects_optimizer_presence_mismatch_before_model_copy(
+    tmp_path, saved_has_optimizer
+):
+    source = TinyMLP()
+    source_optimizer = (
+        torch.optim.AdamW(source.parameters(), lr=1.0e-3)
+        if saved_has_optimizer
+        else None
+    )
+    save_training_checkpoint(source, source_optimizer, 18, str(tmp_path), use_dcp=False)
+    target = TinyMLP()
+    target_optimizer = (
+        None
+        if saved_has_optimizer
+        else torch.optim.AdamW(target.parameters(), lr=1.0e-3)
+    )
+    before = copy.deepcopy(target.state_dict())
+
+    with pytest.raises(RuntimeError, match="optimizer presence does not match"):
+        load_training_checkpoint(target, target_optimizer, str(tmp_path), use_dcp=False)
+
+    _assert_model_state_unchanged(target, before)
+
+
+def test_local_checkpoint_requires_parameter_state_file_before_model_copy(tmp_path):
+    source = TinyMLP()
+    source_optimizer = DistOptLike(torch.optim.AdamW(source.parameters(), lr=1.0e-3))
+    save_training_checkpoint(source, source_optimizer, 19, str(tmp_path), use_dcp=False)
+    (tmp_path / "training_state.optimizer_parameter_state.pt").unlink()
+
+    target = TinyMLP()
+    target_optimizer = DistOptLike(torch.optim.AdamW(target.parameters(), lr=1.0e-3))
+    before = copy.deepcopy(target.state_dict())
+    with pytest.raises(
+        RuntimeError,
+        match="optimizer parameter-state preflight failed.*FileNotFoundError",
+    ):
+        load_training_checkpoint(target, target_optimizer, str(tmp_path), use_dcp=False)
+
+    _assert_model_state_unchanged(target, before)
+    assert target_optimizer.load_calls == 0
+    assert target_optimizer.parameter_load_calls == 0
+
+
+def test_local_checkpoint_rejects_corrupt_parameter_state_before_any_commit(tmp_path):
+    source = TinyMLP()
+    source_optimizer = DistOptLike(torch.optim.AdamW(source.parameters(), lr=1.0e-3))
+    save_training_checkpoint(source, source_optimizer, 19, str(tmp_path), use_dcp=False)
+    parameter_state_path = tmp_path / "training_state.optimizer_parameter_state.pt"
+    torch.save({"wrong": 1}, parameter_state_path)
+
+    target = TinyMLP()
+    target_optimizer = DistOptLike(torch.optim.AdamW(target.parameters(), lr=1.0e-3))
+    before = copy.deepcopy(target.state_dict())
+    with pytest.raises(
+        RuntimeError, match="optimizer parameter-state preflight failed"
+    ):
+        load_training_checkpoint(target, target_optimizer, str(tmp_path), use_dcp=False)
+
+    _assert_model_state_unchanged(target, before)
+    assert target_optimizer.load_calls == 0
+    assert target_optimizer.parameter_load_calls == 0
+    assert not list(tmp_path.glob(".*.mlite-load-*"))
+
+
+def test_local_checkpoint_supports_mcore_parameter_state_schema_adapter(tmp_path):
+    class MCoreParameterStateLike:
+        def __init__(self):
+            self.load_calls = 0
+            self.parameter_load_calls = 0
+            self.grad_scaler = None
+            self.optimizer = SimpleNamespace(
+                param_groups=[
+                    {
+                        "params": [],
+                        "lr": 1.0e-3,
+                        "wd_mult": 1.0,
+                        "lr_mult": 1.0,
+                        "is_expert_parallel": False,
+                        "is_decoupled_lr": False,
+                    }
+                ]
+            )
+
+        @staticmethod
+        def _parameter_state(fill: float):
+            tensors = {
+                name: torch.full((3,), fill, dtype=torch.float32)
+                for name in ("param", "exp_avg", "exp_avg_sq")
+            }
+            tensors["numel_unpadded"] = 3
+            return {
+                "buckets_coalesced": True,
+                0: {(torch.float32, torch.float32): tensors},
+            }
+
+        def state_dict(self):
+            return {
+                "optimizer": {
+                    "param_groups": [
+                        {
+                            "lr": 1.0e-3,
+                            "step": 4,
+                            "wd_mult": 1.0,
+                            "lr_mult": 1.0,
+                            "is_expert_parallel": False,
+                            "is_decoupled_lr": False,
+                        }
+                    ]
+                }
+            }
+
+        def load_state_dict(self, state):
+            assert "optimizer" in state
+            self.load_calls += 1
+
+        def save_parameter_state(self, filename):
+            torch.save(self._parameter_state(7.0), filename)
+
+        def get_parameter_state_dp_zero(self, *, empty_data=False):
+            assert empty_data is True
+            return self._parameter_state(0.0)
+
+        def load_parameter_state(self, filename, *, update_legacy_format=False):
+            assert update_legacy_format is False
+            state = torch.load(filename, map_location="cpu", weights_only=False)
+            assert state[0][(torch.float32, torch.float32)]["param"].shape == (3,)
+            self.parameter_load_calls += 1
+
+    source = TinyMLP()
+    source_optimizer = MCoreParameterStateLike()
+    save_training_checkpoint(source, source_optimizer, 20, str(tmp_path), use_dcp=False)
+    target = TinyMLP()
+    target_optimizer = MCoreParameterStateLike()
+
+    assert (
+        load_training_checkpoint(target, target_optimizer, str(tmp_path), use_dcp=False)
+        == 20
+    )
+    assert target_optimizer.load_calls == 1
+    assert target_optimizer.parameter_load_calls == 1
+    assert not list(tmp_path.glob(".*.mlite-load-*"))
+
+
+def test_local_parameter_state_preflight_binds_staged_inode_across_replace(tmp_path):
+    from megatron.lite.primitive.ckpt import dcp
+
+    model = TinyMLP()
+    optimizer = DistOptLike(torch.optim.AdamW(model.parameters(), lr=1.0e-3))
+    source = tmp_path / "parameter_state.pt"
+    torch.save({"parameter_save_calls": 1}, source)
+    load_path, staged_path, fingerprint = (
+        dcp._preflight_local_optimizer_parameter_state(
+            optimizer, source, update_legacy_format=False
+        )
+    )
+    assert staged_path is not None
+    replacement = tmp_path / "replacement.pt"
+    torch.save({"parameter_save_calls": 99}, replacement)
+    replacement.replace(source)
+
+    try:
+        dcp._revalidate_local_optimizer_parameter_state(staged_path, fingerprint)
+        optimizer.load_parameter_state(str(load_path))
+        assert optimizer.parameter_load_calls == 1
+    finally:
+        staged_path.unlink(missing_ok=True)
+
+
+def test_local_checkpoint_requires_exact_parameter_state_capability_before_copy(
+    tmp_path,
+):
+    source = TinyMLP()
+    source_optimizer = torch.optim.AdamW(source.parameters(), lr=1.0e-3)
+    save_training_checkpoint(source, source_optimizer, 20, str(tmp_path), use_dcp=False)
+
+    target = TinyMLP()
+    target_optimizer = DistOptLike(torch.optim.AdamW(target.parameters(), lr=1.0e-3))
+    before = copy.deepcopy(target.state_dict())
+    with pytest.raises(RuntimeError, match="parameter-state presence does not match"):
+        load_training_checkpoint(target, target_optimizer, str(tmp_path), use_dcp=False)
+
+    _assert_model_state_unchanged(target, before)
+
+
+def test_local_checkpoint_requires_outer_optimizer_apply_contract_before_copy(tmp_path):
+    class NoLoadOptimizer:
+        pass
+
+    source = TinyMLP()
+    source_optimizer = torch.optim.AdamW(source.parameters(), lr=1.0e-3)
+    save_training_checkpoint(source, source_optimizer, 21, str(tmp_path), use_dcp=False)
+    target = TinyMLP()
+    before = copy.deepcopy(target.state_dict())
+
+    with pytest.raises(RuntimeError, match="does not provide load_state_dict"):
+        load_training_checkpoint(
+            target, NoLoadOptimizer(), str(tmp_path), use_dcp=False
+        )
+
+    _assert_model_state_unchanged(target, before)
+
+
 def test_primitive_explicit_dcp_saves_optimizer_rank_sidecar(tmp_path):
     model = TinyMLP()
     optimizer = torch.optim.AdamW(model.parameters(), lr=1.0e-3)
     parallel = ParallelConfig(tp=1, ep=1, pp=1, cp=1)
 
     with (
-        patch("megatron.lite.primitive.ckpt.dcp._build_meshes", return_value=(None, None)),
+        patch(
+            "megatron.lite.primitive.ckpt.dcp._build_meshes", return_value=(None, None)
+        ),
         patch(
             "megatron.lite.primitive.ckpt.dcp.DTensor.from_local",
             side_effect=lambda tensor, *args, **kwargs: tensor,
@@ -230,7 +644,13 @@ def test_primitive_explicit_dcp_saves_optimizer_rank_sidecar(tmp_path):
         patch("megatron.lite.primitive.ckpt.dcp.dcp.save") as dcp_save_mock,
     ):
         save_training_checkpoint(
-            model, optimizer, 12, str(tmp_path), parallel, object(), use_dcp=True
+            model,
+            optimizer,
+            12,
+            str(tmp_path),
+            parallel,
+            SimpleNamespace(pp_size=1, pp_rank=0),
+            use_dcp=True,
         )
 
     dcp_save_mock.assert_called_once()
@@ -248,7 +668,9 @@ def test_runtime_dcp_checkpoint_threads_parallel_config_and_protocol_hooks(tmp_p
     def expert_classifier(name: str):
         return name.endswith("expert")
 
-    proto = SimpleNamespace(PLACEMENT_FN=placement_fn, EXPERT_CLASSIFIER=expert_classifier)
+    proto = SimpleNamespace(
+        PLACEMENT_FN=placement_fn, EXPERT_CLASSIFIER=expert_classifier
+    )
     handle = ModelHandle(
         model=[model],
         optimizer=None,

--- a/experimental/lite/tests/unit/primitive/test_checkpoint_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_checkpoint_unit.py
@@ -1,16 +1,1749 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from __future__ import annotations
 
+import builtins
 import copy
+import datetime
+import importlib
+import json
+import multiprocessing as mp
+import random
+import sys
+import types
 
+import numpy as np
 import pytest
 import torch
 import torch.nn as nn
-
 from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
 from megatron.lite.runtime.contracts.handle import ModelHandle
 
 pytestmark = pytest.mark.mlite
+
+
+def _gloo_extra_state_target_commit_failure_worker(rank: int, init_path: str) -> None:
+    import torch.distributed as dist
+    from megatron.lite.primitive.ckpt import dcp
+
+    dist.init_process_group(
+        "gloo",
+        init_method=f"file://{init_path}",
+        rank=rank,
+        world_size=2,
+        timeout=datetime.timedelta(seconds=20),
+    )
+    try:
+
+        class Target:
+            def __init__(self):
+                self.value = rank + 10
+                self.apply_calls = 0
+
+            def snapshot(self):
+                return self.value
+
+            def apply(self, state):
+                self.apply_calls += 1
+                self.value = state["value"]
+                if self.apply_calls == 2 and rank == 1:
+                    raise RuntimeError("rank-1 injected scheduler commit failure")
+
+            def restore(self, snapshot):
+                self.value = snapshot
+
+            def fingerprint(self):
+                return self.value
+
+        target = Target()
+        targets = {"lr_scheduler.pt": target}
+        values = {"lr_scheduler.pt": {"value": 99}}
+        dcp._preflight_extra_state_targets(targets, values)
+        assert target.value == rank + 10
+
+        with pytest.raises(RuntimeError, match="runtime must be poisoned"):
+            dcp._commit_extra_state_targets(targets, values)
+        assert target.value == rank + 10
+
+        restored: list[int | None] = [None, None]
+        dist.all_gather_object(restored, target.value)
+        assert restored == [10, 11]
+        dist.barrier()
+    finally:
+        dist.destroy_process_group()
+
+
+def _checkpoint_transaction_race_worker(
+    checkpoint_path: str, start_event, results
+) -> None:
+    from megatron.lite.primitive.ckpt import dcp
+
+    start_event.wait(timeout=20)
+    try:
+        dcp._begin_checkpoint_transaction(
+            checkpoint_path,
+            step=77,
+            save_model=True,
+            save_optimizer=False,
+            save_rng=False,
+            payload_format="dcp",
+            optimizer_storage="none",
+        )
+    except Exception as exc:
+        results.put(("error", type(exc).__name__, str(exc)))
+    else:
+        results.put(("ok", None, None))
+
+
+def _gloo_checkpoint_reservation_failure_worker(
+    rank: int, init_path: str, checkpoint_path: str
+) -> None:
+    import torch.distributed as dist
+    from megatron.lite.primitive.ckpt import dcp
+
+    dist.init_process_group(
+        "gloo",
+        init_method=f"file://{init_path}",
+        rank=rank,
+        world_size=2,
+        timeout=datetime.timedelta(seconds=20),
+    )
+    try:
+        with pytest.raises(RuntimeError, match="atomic reservation failed"):
+            dcp._begin_checkpoint_transaction(
+                checkpoint_path,
+                step=78,
+                save_model=True,
+                save_optimizer=False,
+                save_rng=False,
+                payload_format="dcp",
+                optimizer_storage="none",
+            )
+        dist.barrier()
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.skipif(
+    not torch.distributed.is_gloo_available(), reason="Gloo is unavailable"
+)
+def test_extra_state_target_rank_failure_gloo_rolls_back_without_hang(tmp_path):
+    init_path = str(tmp_path / "gloo-extra-state-target-init")
+    ctx = mp.get_context("spawn")
+    processes = [
+        ctx.Process(
+            target=_gloo_extra_state_target_commit_failure_worker,
+            args=(rank, init_path),
+        )
+        for rank in range(2)
+    ]
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=30)
+    alive = [process for process in processes if process.is_alive()]
+    for process in alive:
+        process.terminate()
+        process.join(timeout=5)
+    assert not alive, "extra-state target commit consensus hung"
+    assert [process.exitcode for process in processes] == [0, 0]
+
+
+def test_hf_weight_mapping_import_is_independent_of_safetensors_io(monkeypatch):
+    from megatron.lite.primitive.ckpt import hf_weights
+
+    real_import = builtins.__import__
+
+    def import_without_safetensors(
+        name, globals=None, locals=None, fromlist=(), level=0
+    ):
+        if name == "safetensors" or name.startswith("safetensors."):
+            raise ModuleNotFoundError("blocked optional dependency", name="safetensors")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_safetensors)
+    with pytest.raises(
+        ImportError, match="checkpoint I/O requires the optional 'safetensors' package"
+    ):
+        hf_weights._require_safetensors_io()
+
+
+def test_checkpoint_resolver_ignores_incomplete_latest_transaction(tmp_path):
+    from megatron.lite.primitive.ckpt import dcp
+
+    step1 = tmp_path / "step_1"
+    manifest1 = dcp._begin_checkpoint_transaction(
+        str(step1),
+        step=1,
+        save_model=True,
+        save_optimizer=False,
+        save_rng=False,
+        payload_format="dcp",
+        optimizer_storage="none",
+    )
+    dcp._complete_checkpoint_transaction(str(step1), manifest1)
+    step2 = tmp_path / "step_2"
+    dcp._begin_checkpoint_transaction(
+        str(step2),
+        step=2,
+        save_model=True,
+        save_optimizer=False,
+        save_rng=False,
+        payload_format="dcp",
+        optimizer_storage="none",
+    )
+
+    assert dcp._resolve_step_checkpoint_path(str(tmp_path)) == str(step1)
+    with pytest.raises(
+        RuntimeError,
+        match="checkpoint completion manifest validation failed: RuntimeError: "
+        "checkpoint status is 'incomplete'",
+    ):
+        dcp._validate_checkpoint_manifest(
+            str(step2), load_model=True, load_optimizer=False, load_rng=False
+        )
+
+
+def test_same_step_retry_preserves_existing_complete_checkpoint_bytes(tmp_path):
+    from megatron.lite.primitive.ckpt import dcp
+
+    step = tmp_path / "step_2"
+    manifest = dcp._begin_checkpoint_transaction(
+        str(step),
+        step=2,
+        save_model=True,
+        save_optimizer=False,
+        save_rng=False,
+        payload_format="dcp",
+        optimizer_storage="none",
+    )
+    payload_path = step / "payload.distcp"
+    payload_path.write_bytes(b"immutable-complete-payload")
+    dcp._complete_checkpoint_transaction(str(step), manifest)
+    manifest_path = step / dcp._CHECKPOINT_MANIFEST
+    before = {
+        entry.name: entry.read_bytes() for entry in step.iterdir() if entry.is_file()
+    }
+
+    with pytest.raises(
+        RuntimeError,
+        match="checkpoint destination is non-empty and will not be overwritten",
+    ):
+        dcp._begin_checkpoint_transaction(
+            str(step),
+            step=2,
+            save_model=True,
+            save_optimizer=False,
+            save_rng=False,
+            payload_format="dcp",
+            optimizer_storage="none",
+        )
+
+    assert json.loads(manifest_path.read_text())["status"] == "complete"
+    assert {
+        entry.name: entry.read_bytes() for entry in step.iterdir() if entry.is_file()
+    } == before
+
+
+def test_checkpoint_transaction_atomically_reserves_one_same_step_writer(tmp_path):
+    checkpoint_path = str(tmp_path / "step_77")
+    ctx = mp.get_context("spawn")
+    start_event = ctx.Event()
+    results = ctx.Queue()
+    processes = [
+        ctx.Process(
+            target=_checkpoint_transaction_race_worker,
+            args=(checkpoint_path, start_event, results),
+        )
+        for _ in range(2)
+    ]
+    for process in processes:
+        process.start()
+    start_event.set()
+    for process in processes:
+        process.join(timeout=30)
+    alive = [process for process in processes if process.is_alive()]
+    for process in alive:
+        process.terminate()
+        process.join(timeout=5)
+    assert not alive, "same-step checkpoint reservation race hung"
+    assert [process.exitcode for process in processes] == [0, 0]
+    outcomes = [results.get(timeout=5) for _ in processes]
+    assert [outcome[0] for outcome in outcomes].count("ok") == 1
+    assert [outcome[0] for outcome in outcomes].count("error") == 1
+    error = next(outcome[2] for outcome in outcomes if outcome[0] == "error")
+    assert "atomically reserved" in error or "will not be overwritten" in error
+
+
+@pytest.mark.parametrize("existing_kind", ["file", "malformed-manifest"])
+@pytest.mark.skipif(
+    not torch.distributed.is_gloo_available(), reason="Gloo is unavailable"
+)
+def test_checkpoint_atomic_reservation_rank0_failure_propagates_without_hang(
+    tmp_path, existing_kind
+):
+    checkpoint_path = tmp_path / "step_78"
+    if existing_kind == "file":
+        checkpoint_path.write_text("not-a-directory")
+    else:
+        checkpoint_path.mkdir()
+        (checkpoint_path / "mlite_checkpoint_manifest.json").write_text("{broken")
+    init_path = str(tmp_path / f"gloo-reservation-{existing_kind}")
+    ctx = mp.get_context("spawn")
+    processes = [
+        ctx.Process(
+            target=_gloo_checkpoint_reservation_failure_worker,
+            args=(rank, init_path, str(checkpoint_path)),
+        )
+        for rank in range(2)
+    ]
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=30)
+    alive = [process for process in processes if process.is_alive()]
+    for process in alive:
+        process.terminate()
+        process.join(timeout=5)
+    assert not alive, f"{existing_kind} reservation failure propagation hung"
+    assert [process.exitcode for process in processes] == [0, 0]
+
+
+def test_legacy_dcp_checkpoint_requires_explicit_migration_opt_in(tmp_path):
+    from megatron.lite.primitive.ckpt import dcp
+
+    legacy = tmp_path / "step_4"
+    legacy.mkdir()
+
+    with pytest.raises(
+        RuntimeError, match="Legacy DCP checkpoints are rejected by default"
+    ):
+        dcp._validate_checkpoint_manifest(
+            str(legacy), load_model=True, load_optimizer=False, load_rng=False
+        )
+
+    assert (
+        dcp._validate_checkpoint_manifest(
+            str(legacy),
+            load_model=True,
+            load_optimizer=False,
+            load_rng=False,
+            allow_legacy_checkpoint=True,
+        )
+        is None
+    )
+
+
+def test_checkpoint_resolver_ignores_newer_legacy_directory_by_default(tmp_path):
+    from megatron.lite.primitive.ckpt import dcp
+
+    current = tmp_path / "step_3"
+    manifest = dcp._begin_checkpoint_transaction(
+        str(current),
+        step=3,
+        save_model=True,
+        save_optimizer=False,
+        save_rng=False,
+        payload_format="dcp",
+        optimizer_storage="none",
+    )
+    dcp._complete_checkpoint_transaction(str(current), manifest)
+    legacy = tmp_path / "step_9"
+    legacy.mkdir()
+
+    assert dcp._resolve_step_checkpoint_path(str(tmp_path)) == str(current)
+    assert dcp._resolve_step_checkpoint_path(
+        str(tmp_path), allow_legacy_checkpoint=True
+    ) == str(legacy)
+
+
+def test_completed_checkpoint_manifest_requires_declared_rank_sidecars(tmp_path):
+    from megatron.lite.primitive.ckpt import dcp
+
+    step = tmp_path / "step_3"
+    manifest = dcp._begin_checkpoint_transaction(
+        str(step),
+        step=3,
+        save_model=True,
+        save_optimizer=True,
+        save_rng=True,
+        payload_format="dcp",
+        optimizer_storage="rank_sidecar",
+    )
+    dcp._complete_checkpoint_transaction(str(step), manifest)
+
+    with pytest.raises(
+        RuntimeError, match="completed checkpoint is missing rank-local RNG sidecar"
+    ):
+        dcp._validate_checkpoint_manifest(
+            str(step), load_model=True, load_optimizer=True, load_rng=True
+        )
+
+
+@pytest.mark.parametrize(
+    ("mutation", "match"),
+    [
+        (
+            lambda manifest: manifest.__setitem__("unknown", 1),
+            "top-level schema mismatch",
+        ),
+        (lambda manifest: manifest.pop("world_size"), "top-level schema mismatch"),
+        (lambda manifest: manifest.__setitem__("step", -1), "non-negative integer"),
+        (lambda manifest: manifest.__setitem__("world_size", 0), "positive integer"),
+        (
+            lambda manifest: manifest["components"].__setitem__("model", 1),
+            "component values must be booleans",
+        ),
+        (
+            lambda manifest: manifest["components"].__setitem__("unknown", False),
+            "components schema mismatch",
+        ),
+        (
+            lambda manifest: manifest.__setitem__("optimizer_storage", "rank_sidecar"),
+            "optimizer component does not match optimizer_storage",
+        ),
+        (
+            lambda manifest: manifest["components"].__setitem__("extra_states", True),
+            "extra_states component does not match extra_state_files",
+        ),
+    ],
+)
+def test_checkpoint_manifest_v2_uses_exact_schema(mutation, match):
+    from megatron.lite.primitive.ckpt import dcp
+
+    manifest = {
+        "format": dcp._CHECKPOINT_MANIFEST_FORMAT,
+        "status": "complete",
+        "step": 3,
+        "world_size": 1,
+        "components": {
+            "model": True,
+            "optimizer": False,
+            "rng": False,
+            "extra_states": False,
+        },
+        "payload_format": "dcp",
+        "optimizer_storage": "none",
+        "extra_state_files": [],
+    }
+    mutation(manifest)
+
+    with pytest.raises(RuntimeError, match=match):
+        dcp._validate_checkpoint_manifest_schema(manifest, expected_status="complete")
+
+
+def test_checkpoint_resolver_rejects_rank_path_disagreement(monkeypatch, tmp_path):
+    from megatron.lite.primitive.ckpt import dcp
+
+    step = tmp_path / "step_3"
+    manifest = dcp._begin_checkpoint_transaction(
+        str(step),
+        step=3,
+        save_model=True,
+        save_optimizer=False,
+        save_rng=False,
+        payload_format="dcp",
+        optimizer_storage="none",
+    )
+    dcp._complete_checkpoint_transaction(str(step), manifest)
+
+    def disagree(value):
+        other = copy.deepcopy(value)
+        other["selected_path"] = f"{other['selected_path']}.rank1"
+        return [value, other]
+
+    monkeypatch.setattr(dcp, "_gather_world_objects", disagree)
+    with pytest.raises(
+        RuntimeError, match="checkpoint step resolution differs across ranks"
+    ):
+        dcp._resolve_step_checkpoint_path(str(tmp_path))
+
+
+def test_checkpoint_manifest_rejects_rank_content_disagreement(monkeypatch, tmp_path):
+    from megatron.lite.primitive.ckpt import dcp
+
+    step = tmp_path / "step_4"
+    manifest = dcp._begin_checkpoint_transaction(
+        str(step),
+        step=4,
+        save_model=True,
+        save_optimizer=False,
+        save_rng=False,
+        payload_format="dcp",
+        optimizer_storage="none",
+    )
+    dcp._complete_checkpoint_transaction(str(step), manifest)
+
+    def disagree(value):
+        other = copy.deepcopy(value)
+        other["manifest"]["step"] = 5
+        return [value, other]
+
+    monkeypatch.setattr(dcp, "_gather_world_objects", disagree)
+    with pytest.raises(RuntimeError, match="checkpoint manifest differs across ranks"):
+        dcp._validate_checkpoint_manifest(
+            str(step), load_model=True, load_optimizer=False, load_rng=False
+        )
+
+
+def test_checkpoint_manifest_rejects_rank_presence_disagreement(monkeypatch, tmp_path):
+    from megatron.lite.primitive.ckpt import dcp
+
+    step = tmp_path / "step_5"
+    manifest = dcp._begin_checkpoint_transaction(
+        str(step),
+        step=5,
+        save_model=True,
+        save_optimizer=False,
+        save_rng=False,
+        payload_format="dcp",
+        optimizer_storage="none",
+    )
+    dcp._complete_checkpoint_transaction(str(step), manifest)
+
+    def disagree(value):
+        other = copy.deepcopy(value)
+        other["manifest_present"] = False
+        other["manifest"] = None
+        return [value, other]
+
+    monkeypatch.setattr(dcp, "_gather_world_objects", disagree)
+    with pytest.raises(RuntimeError, match="checkpoint manifest differs across ranks"):
+        dcp._validate_checkpoint_manifest(
+            str(step), load_model=True, load_optimizer=False, load_rng=False
+        )
+
+
+def test_checkpoint_resolver_wraps_local_directory_read_error(monkeypatch, tmp_path):
+    from megatron.lite.primitive.ckpt import dcp
+
+    def fail_listdir(_path):
+        raise PermissionError("injected directory read denial")
+
+    monkeypatch.setattr(dcp.os, "listdir", fail_listdir)
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "checkpoint step resolution failed: PermissionError: "
+            "injected directory read denial"
+        ),
+    ):
+        dcp._resolve_step_checkpoint_path(str(tmp_path))
+
+
+def test_dcp_tensor_contract_includes_only_persistent_buffers():
+    from megatron.lite.primitive.ckpt import dcp
+
+    class BufferedModule(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.weight = nn.Parameter(torch.ones(2))
+            self.register_buffer("router_bias", torch.arange(2), persistent=True)
+            self.register_buffer("workspace", torch.zeros(4), persistent=False)
+
+    items = dict(dcp._named_model_checkpoint_tensors(BufferedModule()))
+
+    assert set(items) == {"weight", "router_bias"}
+
+
+def test_dcp_model_metadata_rejects_unexpected_current_stage_tensor():
+    from megatron.lite.primitive.ckpt import dcp
+
+    model = nn.Linear(2, 2)
+    parameters = list(model.named_parameters())
+    metadata_keys = {
+        dcp._DCP_MODEL_SCHEMA_KEY,
+        "model_pp1.weight",
+        "model_pp1.bias",
+        "model_pp1.removed_parameter",
+        # A different pipeline stage owns a disjoint namespace and must not be
+        # mistaken for an unexpected tensor on this rank.
+        "model_pp0.weight",
+    }
+
+    with pytest.raises(
+        RuntimeError, match=r"unexpected model tensors.*model_pp1\.removed_parameter"
+    ):
+        dcp._validate_dcp_model_metadata(
+            metadata_keys,
+            model_prefix="model_pp1",
+            parameter_items=parameters,
+            buffer_items=[],
+            require_schema=True,
+        )
+
+
+def test_completed_dcp_model_metadata_requires_schema_key():
+    from megatron.lite.primitive.ckpt import dcp
+
+    model = nn.Linear(2, 2)
+    with pytest.raises(RuntimeError, match="missing the required model schema key"):
+        dcp._validate_dcp_model_metadata(
+            {"model.weight", "model.bias"},
+            model_prefix="model",
+            parameter_items=list(model.named_parameters()),
+            buffer_items=[],
+            require_schema=True,
+        )
+
+
+def test_requested_rank_local_optimizer_checkpoint_must_exist(tmp_path):
+    from megatron.lite.primitive.ckpt import dcp
+
+    optimizer = torch.optim.AdamW(nn.Linear(2, 2).parameters(), lr=0.01)
+
+    with pytest.raises(
+        FileNotFoundError,
+        match="optimizer checkpoint requested by load_optimizer=True is missing",
+    ):
+        dcp._load_optimizer_checkpoint(optimizer, str(tmp_path))
+
+
+def test_dcp_load_optimizer_request_requires_optimizer_object(tmp_path):
+    from megatron.lite.primitive.ckpt import dcp
+
+    with pytest.raises(
+        ValueError, match="load_optimizer=True requires a non-None optimizer"
+    ):
+        dcp.load_training_checkpoint(
+            nn.Linear(2, 2), None, str(tmp_path), use_dcp=True, load_optimizer=True
+        )
+
+
+def test_rng_tracker_save_converts_graph_safe_generator_to_tensor(monkeypatch):
+    from megatron.lite.primitive.ckpt import dcp
+
+    generator = torch.Generator().manual_seed(20260628)
+
+    class Tracker:
+        @staticmethod
+        def get_states():
+            return {"model-parallel-rng": generator}
+
+    tensor_parallel = types.SimpleNamespace(
+        get_cuda_rng_tracker=lambda: Tracker(),
+        convert_cuda_rng_state=lambda state, *, to_graphable: (
+            state
+            if to_graphable or isinstance(state, torch.Tensor)
+            else state.get_state()
+        ),
+    )
+    core = types.ModuleType("megatron.core")
+    core.tensor_parallel = tensor_parallel
+    monkeypatch.setitem(sys.modules, "megatron.core", core)
+    monkeypatch.setattr(torch.cuda, "is_initialized", lambda: True)
+
+    states = dcp._get_cuda_rng_tracker_states()
+
+    assert states.keys() == {"model-parallel-rng"}
+    assert isinstance(states["model-parallel-rng"], torch.Tensor)
+    torch.testing.assert_close(
+        states["model-parallel-rng"], generator.get_state(), atol=0, rtol=0
+    )
+
+
+def _assert_nested_state_equal(actual, expected):
+    if torch.is_tensor(expected):
+        torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+    elif isinstance(expected, dict):
+        assert actual.keys() == expected.keys()
+        for key, value in expected.items():
+            _assert_nested_state_equal(actual[key], value)
+    elif isinstance(expected, (list, tuple)):
+        assert len(actual) == len(expected)
+        for actual_value, expected_value in zip(actual, expected, strict=True):
+            _assert_nested_state_equal(actual_value, expected_value)
+    else:
+        assert actual == expected
+
+
+def _initialized_adam(model):
+    optimizer = torch.optim.AdamW(model.parameters(), lr=0.01)
+    model(torch.ones(2, model.in_features)).sum().backward()
+    optimizer.step()
+    optimizer.zero_grad(set_to_none=True)
+    return optimizer
+
+
+def _initialized_fp32_adamw():
+    from megatron.lite.primitive.optimizers.fsdp2.adamw import FP32AdamW
+
+    param = nn.Parameter(torch.tensor([1.0, -2.0], dtype=torch.float32))
+    optimizer = FP32AdamW(
+        [param], lr=0.05, weight_decay=0.1, betas=(0.8, 0.95), eps=1e-6
+    )
+    param.grad = torch.tensor([0.25, -0.5])
+    optimizer.step()
+    param.grad = None
+    return param, optimizer
+
+
+def _legacy_fp32_adamw_state(optimizer):
+    current = copy.deepcopy(optimizer.state_dict())
+    return {
+        "type": "fp32_adamw",
+        "step_count": current["step_count"],
+        "master_params": current["master_params"],
+        "exp_avgs": current["exp_avgs"],
+        "exp_avg_sqs": current["exp_avg_sqs"],
+        "steps": current["steps"],
+        "weight_decays": [
+            float(optimizer.state[param].get("weight_decay", optimizer.weight_decay))
+            for param in optimizer.params
+        ],
+    }
+
+
+def test_fp32_adamw_preflight_is_non_mutating_and_never_calls_load(monkeypatch):
+    from megatron.lite.primitive.ckpt import dcp
+
+    _param, optimizer = _initialized_fp32_adamw()
+    candidate = copy.deepcopy(optimizer.state_dict())
+    candidate["master_params"][0].add_(7.0)
+    candidate["exp_avgs"][0].add_(3.0)
+    candidate["exp_avg_sqs"][0].add_(2.0)
+    live_before = {
+        name: optimizer.state[optimizer.params[0]][name].clone()
+        for name in ("master_param", "exp_avg", "exp_avg_sq")
+    }
+    monkeypatch.setattr(
+        optimizer,
+        "load_state_dict",
+        lambda _state: pytest.fail("preflight must not call load_state_dict"),
+    )
+
+    dcp._preflight_optimizer_checkpoint_state(optimizer, candidate)
+
+    for name, expected in live_before.items():
+        torch.testing.assert_close(
+            optimizer.state[optimizer.params[0]][name], expected, atol=0, rtol=0
+        )
+
+
+@pytest.mark.parametrize("corruption", ["shape", "dtype"])
+def test_fp32_adamw_preflight_rejects_tensor_contract_mismatch(corruption):
+    from megatron.lite.primitive.ckpt import dcp
+
+    _param, optimizer = _initialized_fp32_adamw()
+    candidate = copy.deepcopy(optimizer.state_dict())
+    if corruption == "shape":
+        candidate["master_params"][0] = torch.zeros(3, dtype=torch.float32)
+    else:
+        candidate["master_params"][0] = candidate["master_params"][0].double()
+
+    with pytest.raises(RuntimeError, match="optimizer checkpoint is incompatible"):
+        dcp._preflight_optimizer_checkpoint_state(optimizer, candidate)
+
+
+def test_fp32_adamw_checkpoint_restores_complete_optimizer_configuration():
+    _param, source = _initialized_fp32_adamw()
+    state = copy.deepcopy(source.state_dict())
+    target_param = nn.Parameter(torch.tensor([3.0, 4.0], dtype=torch.float32))
+    from megatron.lite.primitive.optimizers.fsdp2.adamw import FP32AdamW
+
+    target = FP32AdamW(
+        [target_param], lr=0.2, weight_decay=0.0, betas=(0.9, 0.999), eps=1e-8
+    )
+
+    target.load_state_dict(state)
+
+    assert target.lr == source.lr
+    assert target.weight_decay == source.weight_decay
+    assert target.betas == source.betas
+    assert target.eps == source.eps
+    assert target.step_count == source.step_count
+    assert target.param_groups[0]["lr"] == source.param_groups[0]["lr"]
+    assert (
+        target.param_groups[0]["weight_decay"] == source.param_groups[0]["weight_decay"]
+    )
+
+
+def test_fp32_adamw_explicit_legacy_migration_upgrades_to_strict_v2():
+    _param, optimizer = _initialized_fp32_adamw()
+    legacy = _legacy_fp32_adamw_state(optimizer)
+    legacy["weight_decays"] = [0.125 for _param in optimizer.params]
+
+    migrated = optimizer.migrate_legacy_state_dict(legacy)
+
+    assert migrated["version"] == 2
+    assert migrated["config"]["betas"] == optimizer.betas
+    assert migrated["param_groups"][0]["options"]["weight_decay"] == 0.125
+    optimizer.validate_state_dict(migrated)
+
+
+@pytest.mark.parametrize("wrapper_kind", ["fsdp2", "chained"])
+def test_legacy_optimizer_sidecar_migrates_only_on_explicit_unmanifested_load(
+    monkeypatch, tmp_path, wrapper_kind
+):
+    from megatron.lite.primitive.ckpt import dcp
+    from megatron.lite.primitive.optimizers.fsdp2.adamw import ChainedOptimizer
+
+    _param, fp32_optimizer = _initialized_fp32_adamw()
+    legacy = _legacy_fp32_adamw_state(fp32_optimizer)
+    expected_master = legacy["master_params"][0].clone()
+    expected_step = legacy["steps"][0]
+
+    class FSDP2Like:
+        def __init__(self, optimizer):
+            self.optimizer = optimizer
+
+        def state_dict(self):
+            return self.optimizer.state_dict()
+
+        def load_state_dict(self, state):
+            self.optimizer.load_state_dict(state)
+
+    if wrapper_kind == "fsdp2":
+        optimizer = FSDP2Like(fp32_optimizer)
+        sidecar_state = legacy
+    else:
+        optimizer = ChainedOptimizer([fp32_optimizer])
+        sidecar_state = {"type": "chained_torch_optimizer", "optimizers": [legacy]}
+
+    fp32_optimizer.step_count = 0
+    for state in fp32_optimizer.state.values():
+        state["master_param"].zero_()
+        state["exp_avg"].zero_()
+        state["exp_avg_sq"].zero_()
+        state["step"] = 0
+
+    step = tmp_path / "step_31"
+    step.mkdir()
+    torch.save(sidecar_state, step / "optimizer_rank_0.pt")
+    monkeypatch.setattr(dcp, "_supports_dist_opt_distckpt", lambda *_args: False)
+    monkeypatch.setattr(dcp, "_build_meshes", lambda _config: (None, None))
+
+    def fake_dcp_load(state_dict, *, checkpoint_id):
+        assert checkpoint_id == str(step)
+        state_dict["step"] = 31
+
+    monkeypatch.setattr(dcp.dcp, "load", fake_dcp_load)
+
+    with pytest.raises(RuntimeError, match="Legacy DCP checkpoints are rejected"):
+        dcp.load_training_checkpoint(
+            nn.Linear(2, 2),
+            optimizer,
+            str(step),
+            config=object(),
+            ps=types.SimpleNamespace(pp_size=1, pp_rank=0),
+            use_dcp=True,
+            load_model=False,
+            load_optimizer=True,
+            load_rng=False,
+        )
+
+    assert (
+        dcp.load_training_checkpoint(
+            nn.Linear(2, 2),
+            optimizer,
+            str(step),
+            config=object(),
+            ps=types.SimpleNamespace(pp_size=1, pp_rank=0),
+            use_dcp=True,
+            load_model=False,
+            load_optimizer=True,
+            load_rng=False,
+            allow_legacy_checkpoint=True,
+        )
+        == 31
+    )
+    assert fp32_optimizer.step_count == legacy["step_count"]
+    assert fp32_optimizer.state[fp32_optimizer.params[0]]["step"] == expected_step
+    torch.testing.assert_close(
+        fp32_optimizer.state[fp32_optimizer.params[0]]["master_param"],
+        expected_master,
+        atol=0,
+        rtol=0,
+    )
+
+
+def test_manifested_checkpoint_never_enables_legacy_optimizer_migration(
+    monkeypatch, tmp_path
+):
+    from megatron.lite.primitive.ckpt import dcp
+
+    _param, optimizer = _initialized_fp32_adamw()
+    legacy = _legacy_fp32_adamw_state(optimizer)
+    step = tmp_path / "step_32"
+    _complete_manifest(dcp, step, save_optimizer=True, optimizer_storage="rank_sidecar")
+    torch.save(legacy, step / "optimizer_rank_0.pt")
+    monkeypatch.setattr(dcp, "_supports_dist_opt_distckpt", lambda *_args: False)
+
+    with pytest.raises(RuntimeError, match="optimizer checkpoint is incompatible"):
+        dcp.load_training_checkpoint(
+            nn.Linear(2, 2),
+            optimizer,
+            str(step),
+            config=object(),
+            ps=types.SimpleNamespace(pp_size=1, pp_rank=0),
+            use_dcp=True,
+            load_model=False,
+            load_optimizer=True,
+            load_rng=False,
+            allow_legacy_checkpoint=True,
+        )
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda state: state["config"].__setitem__("weight_decay", float("nan")),
+        lambda state: state["config"].pop("betas"),
+        lambda state: state["config"].__setitem__("betas", "bad"),
+    ],
+)
+def test_fp32_adamw_preflight_rejects_invalid_hyperparameters(mutate):
+    from megatron.lite.primitive.ckpt import dcp
+
+    _param, optimizer = _initialized_fp32_adamw()
+    candidate = copy.deepcopy(optimizer.state_dict())
+    mutate(candidate)
+
+    with pytest.raises(RuntimeError, match="optimizer checkpoint is incompatible"):
+        dcp._preflight_optimizer_checkpoint_state(optimizer, candidate)
+
+
+def test_torch_adamw_preflight_rejects_missing_initialized_moment_key():
+    from megatron.lite.primitive.ckpt import dcp
+
+    model = nn.Linear(2, 2)
+    optimizer = _initialized_adam(model)
+    candidate = copy.deepcopy(optimizer.state_dict())
+    first_state = next(iter(candidate["state"].values()))
+    first_state.pop("exp_avg")
+
+    with pytest.raises(RuntimeError, match="Optimizer state key mismatch"):
+        dcp._preflight_optimizer_checkpoint_state(optimizer, candidate)
+
+
+def test_torch_adamw_preflight_rejects_missing_moment_with_fresh_runtime():
+    from megatron.lite.primitive.ckpt import dcp
+
+    source_model = nn.Linear(2, 2)
+    source_optimizer = _initialized_adam(source_model)
+    candidate = copy.deepcopy(source_optimizer.state_dict())
+    next(iter(candidate["state"].values())).pop("exp_avg")
+    target_model = nn.Linear(2, 2)
+    target_optimizer = torch.optim.AdamW(target_model.parameters(), lr=0.01)
+    assert target_optimizer.state == {}
+
+    with pytest.raises(RuntimeError, match="Optimizer state key mismatch"):
+        dcp._preflight_optimizer_checkpoint_state(target_optimizer, candidate)
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda state: state["param_groups"][0].pop("betas"),
+        lambda state: state["param_groups"][0].__setitem__("betas", "bad"),
+        lambda state: state["param_groups"][0].__setitem__("lr", float("nan")),
+    ],
+)
+def test_torch_adamw_preflight_rejects_invalid_group_schema_or_values(mutate):
+    from megatron.lite.primitive.ckpt import dcp
+
+    model = nn.Linear(2, 2)
+    optimizer = _initialized_adam(model)
+    candidate = copy.deepcopy(optimizer.state_dict())
+    mutate(candidate)
+
+    with pytest.raises(RuntimeError, match="optimizer checkpoint is incompatible"):
+        dcp._preflight_optimizer_checkpoint_state(optimizer, candidate)
+
+
+def test_fresh_mcore_chained_optimizer_preflight_uses_pure_inner_schema():
+    from megatron.lite.primitive.ckpt import dcp
+
+    class FreshMCoreDistOpt:
+        def __init__(self, lr_mult):
+            self.grad_scaler = None
+            self.optimizer = types.SimpleNamespace(
+                param_groups=[
+                    {
+                        "params": [],
+                        "lr": 1.0e-3,
+                        "wd_mult": 1.0,
+                        "lr_mult": lr_mult,
+                        "is_expert_parallel": False,
+                        "is_decoupled_lr": False,
+                    }
+                ]
+            )
+            self.lr_mult = lr_mult
+
+        def state_dict(self):
+            raise AssertionError("fresh MCore outer state_dict must not be called")
+
+        def get_parameter_state_dp_zero(self, *, empty_data=False):
+            assert empty_data is True
+            return {
+                "buckets_coalesced": True,
+                0: {
+                    (torch.float32, torch.float32): {
+                        "param": torch.empty(2),
+                        "exp_avg": torch.empty(2),
+                        "exp_avg_sq": torch.empty(2),
+                        "numel_unpadded": 2,
+                    }
+                },
+            }
+
+    children = [FreshMCoreDistOpt(1.0), FreshMCoreDistOpt(2.0)]
+
+    class FreshMCoreChain:
+        chained_optimizers = children
+
+        @staticmethod
+        def load_state_dict(_state):
+            raise AssertionError("preflight must not apply optimizer state")
+
+    def saved_state(child):
+        group = {
+            key: value
+            for key, value in child.optimizer.param_groups[0].items()
+            if key != "params"
+        }
+        group["step"] = 8
+        return {"optimizer": {"param_groups": [group]}}
+
+    candidate = [saved_state(child) for child in children]
+    dcp._preflight_optimizer_checkpoint_state(FreshMCoreChain(), candidate)
+    templates = dcp._optimizer_parameter_state_template(FreshMCoreChain())
+    assert isinstance(templates, list) and len(templates) == 2
+    assert templates[0][0][(torch.float32, torch.float32)]["param"].shape == (2,)
+
+    candidate[1]["optimizer"]["param_groups"][0]["lr_mult"] = 3.0
+    with pytest.raises(RuntimeError, match="group identifier 'lr_mult' mismatch"):
+        dcp._preflight_optimizer_checkpoint_state(FreshMCoreChain(), candidate)
+
+
+def _complete_manifest(
+    dcp,
+    step,
+    *,
+    save_optimizer=False,
+    save_rng=False,
+    optimizer_storage="none",
+    payload_format="dcp",
+    extra_state_files=(),
+):
+    manifest = dcp._begin_checkpoint_transaction(
+        str(step),
+        step=int(step.name.removeprefix("step_")),
+        save_model=True,
+        save_optimizer=save_optimizer,
+        save_rng=save_rng,
+        payload_format=payload_format,
+        optimizer_storage=optimizer_storage,
+        extra_state_files=extra_state_files,
+    )
+    dcp._complete_checkpoint_transaction(str(step), manifest)
+    return manifest
+
+
+def test_manifest_routes_model_only_distckpt_without_optimizer(monkeypatch, tmp_path):
+    from megatron.lite.primitive.ckpt import dcp
+
+    step = tmp_path / "step_33"
+    _complete_manifest(dcp, step, payload_format="distckpt")
+    calls = []
+    monkeypatch.setattr(
+        dcp, "_supports_dist_opt_distckpt", lambda _model, optimizer: optimizer is None
+    )
+
+    def load_dist(*_args, **kwargs):
+        assert kwargs["load_model"] is True
+        assert kwargs["load_optimizer"] is False
+        calls.append("distckpt")
+        return 33
+
+    monkeypatch.setattr(dcp, "_load_dist_opt_checkpoint", load_dist)
+    monkeypatch.setattr(
+        dcp.dcp,
+        "load",
+        lambda *_args, **_kwargs: pytest.fail("generic DCP must not run"),
+    )
+
+    assert (
+        dcp.load_training_checkpoint(
+            nn.Linear(2, 2),
+            None,
+            str(step),
+            use_dcp=True,
+            load_model=True,
+            load_optimizer=False,
+            load_rng=False,
+        )
+        == 33
+    )
+    assert calls == ["distckpt"]
+
+
+def test_manifest_routes_dcp_even_with_current_dist_optimizer_unrequested(
+    monkeypatch, tmp_path
+):
+    from megatron.lite.primitive.ckpt import dcp
+
+    step = tmp_path / "step_34"
+    _complete_manifest(dcp, step, payload_format="dcp")
+    optimizer = types.SimpleNamespace(sharded_state_dict=lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(
+        dcp,
+        "_supports_dist_opt_distckpt",
+        lambda *_args: pytest.fail(
+            "strict DCP routing must not use current heuristics"
+        ),
+    )
+    monkeypatch.setattr(
+        dcp,
+        "_load_dist_opt_checkpoint",
+        lambda *_args, **_kwargs: pytest.fail("distckpt must not run"),
+    )
+
+    def load_dcp(state_dict, *, checkpoint_id):
+        assert checkpoint_id == str(step)
+        state_dict["step"] = 34
+
+    monkeypatch.setattr(dcp.dcp, "load", load_dcp)
+
+    assert (
+        dcp.load_training_checkpoint(
+            nn.Linear(2, 2),
+            optimizer,
+            str(step),
+            use_dcp=True,
+            load_model=False,
+            load_optimizer=False,
+            load_rng=False,
+        )
+        == 34
+    )
+
+
+@pytest.mark.parametrize("payload_format", ["dcp", "distckpt"])
+def test_manifest_extra_only_load_needs_no_model_backend_config(
+    monkeypatch, tmp_path, payload_format
+):
+    from megatron.lite.primitive.ckpt import dcp
+
+    step = tmp_path / "step_35"
+    _complete_manifest(
+        dcp, step, payload_format=payload_format, extra_state_files=("scheduler.pt",)
+    )
+    torch.save({"cursor": 9}, step / "scheduler.pt")
+    loaded = {}
+    monkeypatch.setattr(
+        dcp,
+        "_supports_dist_opt_distckpt",
+        lambda *_args: pytest.fail("extra-only strict routing needs no heuristic"),
+    )
+    if payload_format == "distckpt":
+        monkeypatch.setattr(
+            dcp, "_load_dist_opt_checkpoint", lambda *_args, **_kwargs: 35
+        )
+        monkeypatch.setattr(
+            dcp.dcp,
+            "load",
+            lambda *_args, **_kwargs: pytest.fail("generic DCP must not run"),
+        )
+    else:
+
+        def load_dcp(state_dict, *, checkpoint_id):
+            assert checkpoint_id == str(step)
+            state_dict["step"] = 35
+
+        monkeypatch.setattr(dcp.dcp, "load", load_dcp)
+        monkeypatch.setattr(
+            dcp,
+            "_load_dist_opt_checkpoint",
+            lambda *_args, **_kwargs: pytest.fail("distckpt must not run"),
+        )
+
+    assert (
+        dcp.load_training_checkpoint(
+            nn.Linear(2, 2),
+            None,
+            str(step),
+            use_dcp=True,
+            load_model=False,
+            load_optimizer=False,
+            load_rng=False,
+            load_extra_state_files=("scheduler.pt",),
+            loaded_extra_states=loaded,
+        )
+        == 35
+    )
+    assert loaded == {"scheduler.pt": {"cursor": 9}}
+
+
+def test_corrupt_optimizer_sidecar_fails_before_dcp_model_load(monkeypatch, tmp_path):
+    from megatron.lite.primitive.ckpt import dcp
+
+    model = nn.Linear(2, 2)
+    optimizer = _initialized_adam(model)
+    model_before = copy.deepcopy(model.state_dict())
+    optimizer_before = copy.deepcopy(optimizer.state_dict())
+    rng_before = torch.get_rng_state().clone()
+    step = tmp_path / "step_3"
+    _complete_manifest(dcp, step, save_optimizer=True, optimizer_storage="rank_sidecar")
+    (step / "optimizer_rank_0.pt").write_bytes(b"not-a-torch-checkpoint")
+    monkeypatch.setattr(dcp, "_supports_dist_opt_distckpt", lambda *_args: False)
+    monkeypatch.setattr(
+        dcp.dcp,
+        "load",
+        lambda *_args, **_kwargs: pytest.fail("DCP model load must not run"),
+    )
+
+    with pytest.raises(RuntimeError, match="checkpoint sidecar preflight failed"):
+        dcp.load_training_checkpoint(
+            model, optimizer, str(step), use_dcp=True, load_rng=False
+        )
+
+    _assert_nested_state_equal(model.state_dict(), model_before)
+    _assert_nested_state_equal(optimizer.state_dict(), optimizer_before)
+    torch.testing.assert_close(torch.get_rng_state(), rng_before, atol=0, rtol=0)
+
+
+def test_incompatible_optimizer_sidecar_rolls_back_preflight(monkeypatch, tmp_path):
+    from megatron.lite.primitive.ckpt import dcp
+
+    model = nn.Linear(2, 2)
+    optimizer = _initialized_adam(model)
+    model_before = copy.deepcopy(model.state_dict())
+    optimizer_before = copy.deepcopy(optimizer.state_dict())
+    rng_before = torch.get_rng_state().clone()
+    incompatible = copy.deepcopy(optimizer_before)
+    incompatible["param_groups"][0]["params"] = []
+    step = tmp_path / "step_4"
+    _complete_manifest(dcp, step, save_optimizer=True, optimizer_storage="rank_sidecar")
+    torch.save(incompatible, step / "optimizer_rank_0.pt")
+    monkeypatch.setattr(dcp, "_supports_dist_opt_distckpt", lambda *_args: False)
+
+    with pytest.raises(RuntimeError, match="optimizer checkpoint is incompatible"):
+        dcp.load_training_checkpoint(
+            model, optimizer, str(step), use_dcp=True, load_rng=False
+        )
+
+    _assert_nested_state_equal(model.state_dict(), model_before)
+    _assert_nested_state_equal(optimizer.state_dict(), optimizer_before)
+    torch.testing.assert_close(torch.get_rng_state(), rng_before, atol=0, rtol=0)
+
+
+def test_optimizer_sidecar_validator_rejects_without_mutating_live_state(
+    monkeypatch, tmp_path
+):
+    from megatron.lite.primitive.ckpt import dcp
+
+    class PartialOptimizer:
+        def __init__(self):
+            self.value = 0
+
+        def state_dict(self):
+            return {"value": self.value}
+
+        def load_state_dict(self, state):
+            self.value = state["value"]
+
+        @staticmethod
+        def validate_state_dict(state):
+            if state.get("fail"):
+                raise RuntimeError("incompatible optimizer state")
+
+    model = nn.Linear(2, 2)
+    optimizer = PartialOptimizer()
+    model_before = copy.deepcopy(model.state_dict())
+    rng_before = torch.get_rng_state().clone()
+    step = tmp_path / "step_41"
+    _complete_manifest(dcp, step, save_optimizer=True, optimizer_storage="rank_sidecar")
+    torch.save({"value": 9, "fail": True}, step / "optimizer_rank_0.pt")
+    monkeypatch.setattr(dcp, "_supports_dist_opt_distckpt", lambda *_args: False)
+
+    with pytest.raises(RuntimeError, match="incompatible optimizer state"):
+        dcp.load_training_checkpoint(
+            model, optimizer, str(step), use_dcp=True, load_rng=False
+        )
+
+    _assert_nested_state_equal(model.state_dict(), model_before)
+    assert optimizer.value == 0
+    torch.testing.assert_close(torch.get_rng_state(), rng_before, atol=0, rtol=0)
+
+
+def test_sidecar_preflight_never_snapshots_model_or_deepcopies_optimizer(
+    monkeypatch, tmp_path
+):
+    from megatron.lite.primitive.ckpt import dcp
+
+    class NoDeepcopyState(dict):
+        def __deepcopy__(self, _memo):
+            raise AssertionError("optimizer state must not be deep-copied")
+
+    class Optimizer:
+        def __init__(self):
+            self.value = 0
+
+        def state_dict(self):
+            return NoDeepcopyState(value=self.value)
+
+        def load_state_dict(self, state):
+            self.value = state["value"]
+
+        @staticmethod
+        def validate_state_dict(state):
+            if not isinstance(state.get("value"), int):
+                raise TypeError("value must be int")
+
+    optimizer = Optimizer()
+    torch.save({"value": 7}, tmp_path / "optimizer_rank_0.pt")
+    monkeypatch.setattr(
+        dcp,
+        "_chunk_tensor_state",
+        lambda *_args, **_kwargs: pytest.fail("model snapshot must not run"),
+    )
+
+    optimizer_state, rng_state, extra_states = dcp._preload_checkpoint_sidecars(
+        str(tmp_path),
+        optimizer=optimizer,
+        load_optimizer=True,
+        load_rng=False,
+        rng_required=False,
+        extra_state_files=(),
+        extra_state_validators={},
+        extra_state_targets={},
+        checkpoint_step=None,
+    )
+
+    assert optimizer.value == 0
+    assert optimizer_state == {"value": 7}
+    assert rng_state is None
+    assert extra_states == {}
+
+
+def test_distopt_corrupt_rng_sidecar_is_preloaded_before_payload(monkeypatch, tmp_path):
+    from megatron.lite.primitive.ckpt import dcp
+
+    model = nn.Linear(2, 2)
+    model_before = copy.deepcopy(model.state_dict())
+    rng_before = torch.get_rng_state().clone()
+    step = tmp_path / "step_5"
+    _complete_manifest(dcp, step, save_rng=True, payload_format="distckpt")
+    (step / "rng_state_rank_00000.pt").write_bytes(b"corrupt-rng")
+    monkeypatch.setattr(dcp, "_supports_dist_opt_distckpt", lambda *_args: True)
+    monkeypatch.setattr(
+        dcp,
+        "_load_dist_opt_checkpoint",
+        lambda *_args, **_kwargs: pytest.fail("distckpt payload load must not run"),
+    )
+
+    with pytest.raises(RuntimeError, match="checkpoint sidecar preflight failed"):
+        dcp.load_training_checkpoint(
+            model, None, str(step), use_dcp=True, load_optimizer=False, load_rng=True
+        )
+
+    _assert_nested_state_equal(model.state_dict(), model_before)
+    torch.testing.assert_close(torch.get_rng_state(), rng_before, atol=0, rtol=0)
+
+
+def test_partially_applied_rng_preflight_restores_every_rng(monkeypatch, tmp_path):
+    from megatron.lite.primitive.ckpt import dcp
+
+    original = copy.deepcopy(dcp._get_rng_state())
+    random.seed(991)
+    np.random.seed(991)
+    candidate = copy.deepcopy(dcp._get_rng_state())
+    dcp._restore_rng_state(original)
+    candidate["torch_rng_state"] = torch.zeros(1, dtype=torch.uint8)
+    model = nn.Linear(2, 2)
+    model_before = copy.deepcopy(model.state_dict())
+    rng_before = copy.deepcopy(dcp._get_rng_state())
+    step = tmp_path / "step_51"
+    _complete_manifest(dcp, step, save_rng=True, payload_format="distckpt")
+    torch.save(candidate, step / "rng_state_rank_00000.pt")
+    monkeypatch.setattr(dcp, "_supports_dist_opt_distckpt", lambda *_args: True)
+    monkeypatch.setattr(
+        dcp,
+        "_load_dist_opt_checkpoint",
+        lambda *_args, **_kwargs: pytest.fail("distckpt payload load must not run"),
+    )
+
+    with pytest.raises(RuntimeError, match="RNG checkpoint is incompatible"):
+        dcp.load_training_checkpoint(
+            model, None, str(step), use_dcp=True, load_optimizer=False, load_rng=True
+        )
+
+    restored = dcp._get_rng_state()
+    assert restored["random_rng_state"] == rng_before["random_rng_state"]
+    assert restored["np_rng_state"][0] == rng_before["np_rng_state"][0]
+    np.testing.assert_array_equal(
+        restored["np_rng_state"][1], rng_before["np_rng_state"][1]
+    )
+    assert restored["np_rng_state"][2:] == rng_before["np_rng_state"][2:]
+    torch.testing.assert_close(
+        restored["torch_rng_state"], rng_before["torch_rng_state"], atol=0, rtol=0
+    )
+    _assert_nested_state_equal(model.state_dict(), model_before)
+
+
+def test_rank0_extra_state_is_in_completion_manifest(monkeypatch, tmp_path):
+    from megatron.lite.primitive.ckpt import dcp
+
+    model = nn.Linear(2, 2)
+    monkeypatch.setattr(dcp, "_supports_dist_opt_distckpt", lambda *_args: True)
+    monkeypatch.setattr(
+        dcp, "_save_dist_opt_checkpoint", lambda *_args, **_kwargs: None
+    )
+
+    dcp.save_training_checkpoint(
+        model,
+        None,
+        6,
+        str(tmp_path),
+        use_dcp=True,
+        save_optimizer=False,
+        save_rng=False,
+        extra_states={"lr_scheduler.pt": {"num_steps": 11}},
+    )
+
+    step = tmp_path / "step_6"
+    manifest = json.loads((step / dcp._CHECKPOINT_MANIFEST).read_text())
+    assert manifest["status"] == "complete"
+    assert manifest["components"]["extra_states"] is True
+    assert manifest["extra_state_files"] == ["lr_scheduler.pt"]
+    assert torch.load(step / "lr_scheduler.pt", weights_only=False) == {"num_steps": 11}
+
+
+def test_completed_manifest_requires_every_declared_extra_state(tmp_path):
+    from megatron.lite.primitive.ckpt import dcp
+
+    step = tmp_path / "step_61"
+    _complete_manifest(
+        dcp, step, payload_format="distckpt", extra_state_files=("lr_scheduler.pt",)
+    )
+
+    with pytest.raises(
+        RuntimeError, match="completed checkpoint is missing declared extra-state file"
+    ):
+        dcp._validate_checkpoint_manifest(
+            str(step),
+            load_model=True,
+            load_optimizer=False,
+            load_rng=False,
+            load_extra_state_files=("lr_scheduler.pt",),
+        )
+
+
+def test_extra_state_validator_fails_before_distopt_payload(monkeypatch, tmp_path):
+    from megatron.lite.primitive.ckpt import dcp
+
+    model = nn.Linear(2, 2)
+    model_before = copy.deepcopy(model.state_dict())
+    rng_before = torch.get_rng_state().clone()
+    loaded = {"existing": "preserve"}
+    step = tmp_path / "step_7"
+    _complete_manifest(
+        dcp, step, payload_format="distckpt", extra_state_files=("lr_scheduler.pt",)
+    )
+    torch.save({"num_steps": "bad"}, step / "lr_scheduler.pt")
+    monkeypatch.setattr(dcp, "_supports_dist_opt_distckpt", lambda *_args: True)
+    monkeypatch.setattr(
+        dcp,
+        "_load_dist_opt_checkpoint",
+        lambda *_args, **_kwargs: pytest.fail("distckpt payload load must not run"),
+    )
+
+    def validate_scheduler(state):
+        if not isinstance(state.get("num_steps"), int):
+            raise TypeError("num_steps must be int")
+
+    with pytest.raises(RuntimeError, match="num_steps must be int"):
+        dcp.load_training_checkpoint(
+            model,
+            None,
+            str(step),
+            use_dcp=True,
+            load_optimizer=False,
+            load_rng=False,
+            load_extra_state_files=("lr_scheduler.pt",),
+            loaded_extra_states=loaded,
+            extra_state_validators={"lr_scheduler.pt": validate_scheduler},
+        )
+
+    _assert_nested_state_equal(model.state_dict(), model_before)
+    assert loaded == {"existing": "preserve"}
+    torch.testing.assert_close(torch.get_rng_state(), rng_before, atol=0, rtol=0)
+
+
+def test_requested_extra_state_is_published_only_after_core_commit(
+    monkeypatch, tmp_path
+):
+    from megatron.lite.primitive.ckpt import dcp
+
+    events = []
+
+    class Target:
+        def __init__(self):
+            self.value = 3
+
+        def snapshot(self):
+            return self.value
+
+        def apply(self, state):
+            events.append("target_apply")
+            self.value = state["num_steps"]
+
+        def restore(self, snapshot):
+            events.append("target_restore")
+            self.value = snapshot
+
+        def fingerprint(self):
+            return self.value
+
+        @staticmethod
+        def validate_step(state, expected_step):
+            events.append(("validate_step", expected_step))
+            assert state["checkpoint_step"] == expected_step
+
+    model = nn.Linear(2, 2)
+    step = tmp_path / "step_71"
+    _complete_manifest(
+        dcp, step, payload_format="distckpt", extra_state_files=("lr_scheduler.pt",)
+    )
+    torch.save({"num_steps": 17, "checkpoint_step": 71}, step / "lr_scheduler.pt")
+    loaded = {}
+    target = Target()
+    monkeypatch.setattr(dcp, "_supports_dist_opt_distckpt", lambda *_args: True)
+
+    def load_core(*_args, **_kwargs):
+        events.append("core")
+        return 71
+
+    monkeypatch.setattr(dcp, "_load_dist_opt_checkpoint", load_core)
+
+    def validate_scheduler(state):
+        assert state["num_steps"] == 17
+
+    restored_step = dcp.load_training_checkpoint(
+        model,
+        None,
+        str(step),
+        use_dcp=True,
+        load_optimizer=False,
+        load_rng=False,
+        load_extra_state_files=("lr_scheduler.pt",),
+        loaded_extra_states=loaded,
+        extra_state_validators={"lr_scheduler.pt": validate_scheduler},
+        extra_state_targets={"lr_scheduler.pt": target},
+    )
+
+    assert restored_step == 71
+    assert loaded == {"lr_scheduler.pt": {"num_steps": 17, "checkpoint_step": 71}}
+    assert target.value == 17
+    assert [event for event in events if isinstance(event, str)] == [
+        "target_apply",
+        "target_restore",
+        "core",
+        "target_apply",
+    ]
+    assert ("validate_step", 71) in events
+
+
+def test_extra_state_target_commit_failure_rolls_back_target_and_poison_fails(
+    monkeypatch, tmp_path
+):
+    from megatron.lite.primitive.ckpt import dcp
+
+    class Target:
+        def __init__(self):
+            self.value = 4
+            self.apply_calls = 0
+
+        def snapshot(self):
+            return self.value
+
+        def apply(self, state):
+            self.apply_calls += 1
+            self.value = state["num_steps"]
+            if self.apply_calls == 2:
+                raise RuntimeError("injected target commit failure")
+
+        def restore(self, snapshot):
+            self.value = snapshot
+
+        def fingerprint(self):
+            return self.value
+
+    model = nn.Linear(2, 2)
+    step = tmp_path / "step_72"
+    _complete_manifest(
+        dcp, step, payload_format="distckpt", extra_state_files=("lr_scheduler.pt",)
+    )
+    torch.save({"num_steps": 18}, step / "lr_scheduler.pt")
+    loaded = {}
+    target = Target()
+    core_called = []
+    monkeypatch.setattr(dcp, "_supports_dist_opt_distckpt", lambda *_args: True)
+
+    def load_core(*_args, **_kwargs):
+        core_called.append(True)
+        return 72
+
+    monkeypatch.setattr(dcp, "_load_dist_opt_checkpoint", load_core)
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"runtime must be poisoned: .*injected target commit failure",
+    ):
+        dcp.load_training_checkpoint(
+            model,
+            None,
+            str(step),
+            use_dcp=True,
+            load_optimizer=False,
+            load_rng=False,
+            load_extra_state_files=("lr_scheduler.pt",),
+            loaded_extra_states=loaded,
+            extra_state_targets={"lr_scheduler.pt": target},
+        )
+
+    assert core_called == [True]
+    assert target.value == 4
+    assert loaded == {}
+
+
+def test_extra_state_target_commit_runs_after_optimizer_and_rng():
+    from megatron.lite.primitive.ckpt import dcp
+
+    events = []
+
+    class Optimizer:
+        @staticmethod
+        def load_state_dict(_state):
+            events.append("optimizer")
+
+    class Target:
+        value = 0
+
+        def snapshot(self):
+            return self.value
+
+        def apply(self, state):
+            events.append("target")
+            self.value = state["num_steps"]
+
+        def restore(self, snapshot):
+            self.value = snapshot
+
+        def fingerprint(self):
+            return self.value
+
+    target = Target()
+    loaded = {}
+    dcp._commit_preloaded_sidecars(
+        optimizer=Optimizer(),
+        optimizer_state={"state": "ready"},
+        rng_state=None,
+        loaded_extra_states=loaded,
+        extra_state_values={"lr_scheduler.pt": {"num_steps": 19}},
+        extra_state_targets={"lr_scheduler.pt": target},
+    )
+
+    assert events == ["optimizer", "target"]
+    assert target.value == 19
+    assert loaded == {"lr_scheduler.pt": {"num_steps": 19}}
+
+
+def test_distckpt_preflights_on_disk_keys_before_mcore_load_can_mutate_model(
+    monkeypatch, tmp_path
+):
+    target_module = "megatron.lite.primitive.ckpt.distckpt"
+    parent_module = importlib.import_module("megatron.lite.primitive.ckpt")
+    missing_parent_attr = object()
+    previous_parent_attr = parent_module.__dict__.get("distckpt", missing_parent_attr)
+    monkeypatch.delitem(sys.modules, target_module, raising=False)
+
+    strict_sentinel = object()
+
+    class StrictHandling:
+        RAISE_UNEXPECTED = strict_sentinel
+
+    class ShardedBase:
+        def __init__(self, key):
+            self.key = key
+
+    class ShardedTensor(ShardedBase):
+        def __init__(self, key):
+            super().__init__(key)
+            self.global_shape = (1,)
+            self.dtype = torch.float32
+            self.allow_shape_mismatch = False
+
+    class ShardedTensorFactory(ShardedBase):
+        def build(self):
+            raise AssertionError("factory expansion is not expected in this test")
+
+    class LocalNonpersistentObject:
+        pass
+
+    dist_checkpointing = types.ModuleType("megatron.core.dist_checkpointing")
+
+    def unexpected_load(*_args, **_kwargs):
+        raise AssertionError("MCore load must not run after metadata mismatch")
+
+    dist_checkpointing.load = unexpected_load
+    mapping = types.ModuleType("megatron.core.dist_checkpointing.mapping")
+    mapping.LocalNonpersistentObject = LocalNonpersistentObject
+    mapping.ShardedBase = ShardedBase
+    mapping.ShardedTensor = ShardedTensor
+    mapping.ShardedTensorFactory = ShardedTensorFactory
+    validation = types.ModuleType("megatron.core.dist_checkpointing.validation")
+    validation.StrictHandling = StrictHandling
+    core = types.ModuleType("megatron.core")
+    core.dist_checkpointing = dist_checkpointing
+    monkeypatch.setitem(sys.modules, "megatron.core", core)
+    monkeypatch.setitem(
+        sys.modules, "megatron.core.dist_checkpointing", dist_checkpointing
+    )
+    monkeypatch.setitem(
+        sys.modules, "megatron.core.dist_checkpointing.mapping", mapping
+    )
+    monkeypatch.setitem(
+        sys.modules, "megatron.core.dist_checkpointing.validation", validation
+    )
+
+    distckpt = importlib.import_module(target_module)
+    model = nn.Linear(2, 2)
+    before = copy.deepcopy(model.state_dict())
+    monkeypatch.setattr(
+        distckpt,
+        "_model_sharded_state_dict",
+        lambda _model: {
+            "model": {"weight": ShardedTensor("weight"), "bias": ShardedTensor("bias")}
+        },
+    )
+    monkeypatch.setattr(
+        distckpt,
+        "_load_checkpoint_sharded_metadata",
+        lambda _path: {
+            "weight": ShardedTensor("weight"),
+            "bias": ShardedTensor("bias"),
+            "removed": ShardedTensor("removed_parameter"),
+        },
+    )
+    monkeypatch.setattr(
+        distckpt, "_load_checkpoint_common_state", lambda _path: {"step": 0}
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"distckpt checkpoint metadata preflight failed: .*removed_parameter",
+    ):
+        distckpt.load_dist_opt_checkpoint(
+            model, None, str(tmp_path), load_model=True, load_optimizer=False
+        )
+
+    _assert_nested_state_equal(model.state_dict(), before)
+    if previous_parent_attr is missing_parent_attr:
+        parent_module.__dict__.pop("distckpt", None)
+    else:
+        parent_module.distckpt = previous_parent_attr
 
 
 class TinyMLP(nn.Module):
@@ -105,6 +1838,23 @@ class DistOptLike:
         self.load_calls = int(marker["load_calls"]) + 1
         self.optimizer.load_state_dict(state)
 
+    def validate_state_dict(self, state):
+        from megatron.lite.primitive.ckpt import dcp
+
+        if not isinstance(state, dict) or set(state) != {
+            "state",
+            "param_groups",
+            "dist_opt_like_marker",
+        }:
+            raise ValueError("invalid DistOptLike state schema")
+        marker = state["dist_opt_like_marker"]
+        if not isinstance(marker, dict) or type(marker.get("load_calls")) is not int:
+            raise TypeError("invalid DistOptLike marker")
+        inner_state = {
+            key: value for key, value in state.items() if key != "dist_opt_like_marker"
+        }
+        dcp._validate_torch_optimizer_checkpoint_state(self.optimizer, inner_state)
+
     def save_parameter_state(self, filename: str):
         self.parameter_save_calls += 1
         torch.save({"parameter_save_calls": self.parameter_save_calls}, filename)
@@ -114,6 +1864,18 @@ class DistOptLike:
     ):
         state = torch.load(filename)
         self.parameter_load_calls = int(state["parameter_save_calls"])
+
+    @staticmethod
+    def validate_parameter_state(filename: str, *, update_legacy_format: bool = False):
+        del update_legacy_format
+        state = torch.load(filename, map_location="cpu", weights_only=False)
+        if (
+            not isinstance(state, dict)
+            or set(state) != {"parameter_save_calls"}
+            or type(state["parameter_save_calls"]) is not int
+            or state["parameter_save_calls"] < 1
+        ):
+            raise ValueError("invalid DistOptLike parameter state")
 
 
 def test_runtime_checkpoint_uses_optimizer_state_dict_contract(tmp_path):
@@ -438,8 +2200,7 @@ def test_non_pipeline_export_rejects_local_vpp_name_collision(expert):
     chunks = [nn.Linear(2, 2, bias=False), nn.Linear(2, 2, bias=False)]
 
     with pytest.raises(
-        AssertionError,
-        match=r"^local export parameter collision for weight$",
+        AssertionError, match=r"^local export parameter collision for weight$"
     ):
         list(hf_weights.export_hf_weights(chunks, WeightSpec(), ps))
 
@@ -476,10 +2237,7 @@ def test_resolve_param_name_only_accepts_unique_wrapper_suffix():
 def test_resolve_param_name_rejects_ambiguous_wrapper_suffixes():
     from megatron.lite.primitive.ckpt.hf_weights import _resolve_param_name
 
-    state = {
-        "module.layers.0.weight": object(),
-        "_orig_mod.layers.0.weight": object(),
-    }
+    state = {"module.layers.0.weight": object(), "_orig_mod.layers.0.weight": object()}
 
     with pytest.raises(
         ValueError,
@@ -494,8 +2252,8 @@ def test_resolve_param_name_rejects_ambiguous_wrapper_suffixes():
 def test_load_hf_weights_rejects_broadcastable_shape_mismatch(monkeypatch):
     from types import SimpleNamespace
 
-    from megatron.lite.primitive.ckpt import hf_weights
     import megatron.lite.primitive.parallel as parallel
+    from megatron.lite.primitive.ckpt import hf_weights
 
     class Reader:
         def __init__(self, _path):
@@ -529,13 +2287,101 @@ def test_load_hf_weights_rejects_broadcastable_shape_mismatch(monkeypatch):
     monkeypatch.setitem(parallel.__dict__, "pad_vocab_for_tp", lambda size, _tp: size)
 
     with pytest.raises(
-        ValueError,
+        RuntimeError,
         match=(
-            r"^HF load shape mismatch for weight: "
-            r"checkpoint=\(1, 2\), model=\(2, 2\)$"
+            r"WeightSpec HF load preflight failed: RuntimeError: chunk0: "
+            r"checkpoint shape mismatch for weight: source=\(1, 2\) target=\(2, 2\)"
         ),
     ):
         hf_weights.load_hf_weights(model, "/unused", WeightSpec(), ps)
+
+
+def test_generic_hf_loader_scopes_atomic_transaction_to_explicit_group(monkeypatch):
+    from types import SimpleNamespace
+
+    from megatron.lite.primitive.ckpt import hf_weights
+
+    calls = []
+    participating_group = object()
+
+    def fake_atomic_load(
+        model,
+        builder,
+        *,
+        context,
+        participating_group=None,
+        allow_missing_parameter=None,
+    ):
+        del builder, allow_missing_parameter
+        calls.append((model, context, participating_group))
+
+    class WeightSpec:
+        pass
+
+    model = nn.Linear(2, 2, bias=False)
+    monkeypatch.setattr(hf_weights, "load_hf_model_chunks_atomically", fake_atomic_load)
+
+    hf_weights.load_hf_weights(
+        model,
+        "/unused",
+        WeightSpec(),
+        SimpleNamespace(),
+        participating_group=participating_group,
+    )
+
+    assert calls == [(model, "WeightSpec HF load", participating_group)]
+
+
+def test_generic_hf_loader_rejects_stale_local_layer_mapping(monkeypatch):
+    from types import SimpleNamespace
+
+    import megatron.lite.primitive.parallel as parallel
+    from megatron.lite.primitive.ckpt import hf_weights
+
+    class Reader:
+        def __init__(self, _path):
+            pass
+
+        @staticmethod
+        def get_tensor(_name):
+            return torch.ones(2, 2)
+
+    class WeightSpec:
+        @staticmethod
+        def weight_map():
+            return {
+                "layers.0.weight": ["hf.weight"],
+                "layers.0.removed_weight": ["hf.removed_weight"],
+            }
+
+        @staticmethod
+        def expert_global_id(_name):
+            return None
+
+        @staticmethod
+        def hf_to_native(_name, tensors):
+            return tensors[0]
+
+        @staticmethod
+        def tp_spec(_name):
+            return None
+
+    class LocalStage(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layer_indices = [0]
+            self.layers = nn.ModuleList([nn.Linear(2, 2, bias=False)])
+
+    monkeypatch.setattr(hf_weights, "SafeTensorReader", Reader)
+    monkeypatch.setitem(parallel.__dict__, "pad_vocab_for_tp", lambda size, _tp: size)
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"maps local layer tensor 'layers\.0\.removed_weight'.*no matching",
+    ):
+        hf_weights.load_hf_weights(
+            LocalStage(), "/unused", WeightSpec(), SimpleNamespace(ep_size=1, ep_rank=0)
+        )
 
 
 def test_to_global_layer_name_never_remaps_mtp_namespace():
@@ -723,8 +2569,7 @@ def test_save_hf_weight_pairs_propagates_rank0_write_error_before_barrier(
     monkeypatch.setattr(hf_weights, "save_safetensors", fake_save)
 
     with pytest.raises(
-        RuntimeError,
-        match=r"^HF safetensors write failed: OSError: disk full$",
+        RuntimeError, match=r"^HF safetensors write failed: OSError: disk full$"
     ):
         hf_weights.save_hf_weight_pairs_distributed(
             iter([("model.weight", torch.ones(1))]), str(tmp_path)

--- a/experimental/lite/tests/unit/primitive/test_checkpoint_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_checkpoint_unit.py
@@ -22,7 +22,9 @@ class TinyMLP(nn.Module):
         return self.layers(x)
 
 
-def _step(model: nn.Module, optimizer: torch.optim.Optimizer, x: torch.Tensor, y: torch.Tensor):
+def _step(
+    model: nn.Module, optimizer: torch.optim.Optimizer, x: torch.Tensor, y: torch.Tensor
+):
     optimizer.zero_grad(set_to_none=True)
     loss = torch.nn.functional.mse_loss(model(x), y)
     loss.backward()
@@ -58,12 +60,16 @@ def test_runtime_checkpoint_load_matches_uninterrupted_training(tmp_path):
 
     runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
     ckpt_handle = ModelHandle(
-        model=ckpt_model, optimizer=ckpt_optimizer, _extras={"model_chunks": [ckpt_model]}
+        model=ckpt_model,
+        optimizer=ckpt_optimizer,
+        _extras={"model_chunks": [ckpt_model]},
     )
     runtime.save_checkpoint(ckpt_handle, str(tmp_path), step=1, use_dcp=False)
 
     loaded_handle = ModelHandle(
-        model=loaded_model, optimizer=loaded_optimizer, _extras={"model_chunks": [loaded_model]}
+        model=loaded_model,
+        optimizer=loaded_optimizer,
+        _extras={"model_chunks": [loaded_model]},
     )
     assert runtime.load_checkpoint(loaded_handle, str(tmp_path), use_dcp=False) == 1
 
@@ -103,7 +109,9 @@ class DistOptLike:
         self.parameter_save_calls += 1
         torch.save({"parameter_save_calls": self.parameter_save_calls}, filename)
 
-    def load_parameter_state(self, filename: str, *, update_legacy_format: bool = False):
+    def load_parameter_state(
+        self, filename: str, *, update_legacy_format: bool = False
+    ):
         state = torch.load(filename)
         self.parameter_load_calls = int(state["parameter_save_calls"])
 
@@ -119,16 +127,22 @@ def test_runtime_checkpoint_uses_optimizer_state_dict_contract(tmp_path):
 
     runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
     runtime.save_checkpoint(
-        ModelHandle(model=model, optimizer=optimizer, _extras={"model_chunks": [model]}),
+        ModelHandle(
+            model=model, optimizer=optimizer, _extras={"model_chunks": [model]}
+        ),
         str(tmp_path),
         step=7,
         use_dcp=False,
     )
 
     loaded_model = TinyMLP()
-    loaded_optimizer = DistOptLike(torch.optim.AdamW(loaded_model.parameters(), lr=1.0e-3))
+    loaded_optimizer = DistOptLike(
+        torch.optim.AdamW(loaded_model.parameters(), lr=1.0e-3)
+    )
     loaded_handle = ModelHandle(
-        model=loaded_model, optimizer=loaded_optimizer, _extras={"model_chunks": [loaded_model]}
+        model=loaded_model,
+        optimizer=loaded_optimizer,
+        _extras={"model_chunks": [loaded_model]},
     )
 
     assert runtime.load_checkpoint(loaded_handle, str(tmp_path), use_dcp=False) == 7
@@ -136,3 +150,628 @@ def test_runtime_checkpoint_uses_optimizer_state_dict_contract(tmp_path):
     assert loaded_optimizer.parameter_load_calls == 1
     assert (tmp_path / "training_state.optimizer_parameter_state.pt").exists()
     _assert_model_close(model, loaded_model)
+
+
+def test_gather_pipeline_state_dict_collects_later_stage_buffers(monkeypatch):
+    from types import SimpleNamespace
+
+    from megatron.lite.primitive.ckpt.hf_weights import gather_pipeline_state_dict
+
+    group = object()
+    ps = SimpleNamespace(pp_size=2, pp_group=group)
+    local = {"layers.0.router_bias": torch.tensor([1.0])}
+    later = {"layers.1.router_bias": torch.tensor([2.0])}
+
+    def fake_all_gather_object(output, value, *, group):
+        assert value is local
+        assert group is ps.pp_group
+        output[:] = [local, later]
+
+    monkeypatch.setattr(torch.distributed, "all_gather_object", fake_all_gather_object)
+    gathered = gather_pipeline_state_dict(local, ps)
+    assert gathered.keys() == local.keys() | later.keys()
+    assert torch.equal(gathered["layers.1.router_bias"], later["layers.1.router_bias"])
+
+
+def test_distributed_error_consensus_uses_explicit_participating_group(monkeypatch):
+    from megatron.lite.primitive.ckpt import hf_weights
+
+    participating_group = object()
+    events: list[str] = []
+
+    monkeypatch.setattr(hf_weights.dist, "is_initialized", lambda: True)
+
+    def fake_get_backend(group):
+        assert group is participating_group
+        return "gloo"
+
+    def fake_all_reduce(failed, *, group):
+        assert group is participating_group
+        assert failed.item() == 1
+        events.append("all_reduce")
+
+    def fake_get_world_size(group):
+        assert group is participating_group
+        return 2
+
+    def fake_all_gather_object(messages, local_error, *, group):
+        assert group is participating_group
+        assert local_error == "local failure"
+        messages[:] = ["local failure", None]
+        events.append("all_gather_object")
+
+    monkeypatch.setattr(hf_weights.dist, "get_backend", fake_get_backend)
+    monkeypatch.setattr(hf_weights.dist, "all_reduce", fake_all_reduce)
+    monkeypatch.setattr(hf_weights.dist, "get_world_size", fake_get_world_size)
+    monkeypatch.setattr(hf_weights.dist, "all_gather_object", fake_all_gather_object)
+
+    with pytest.raises(RuntimeError, match=r"^test export: local failure$"):
+        hf_weights._distributed_raise_if_error(
+            "local failure",
+            context="test export",
+            participating_group=participating_group,
+        )
+
+    assert events == ["all_reduce", "all_gather_object"]
+
+
+def test_pipeline_buffer_error_consensus_defaults_to_pp_group(monkeypatch):
+    from types import SimpleNamespace
+
+    from megatron.lite.primitive.ckpt import hf_weights
+
+    pp_group = object()
+    ps = SimpleNamespace(pp_size=2, pp_group=pp_group)
+    local = {"layers.0.router_bias": torch.tensor([1.0])}
+    later = {"layers.1.router_bias": torch.tensor([2.0])}
+    consensus_groups = []
+
+    def fake_all_gather_object(output, value, *, group):
+        assert value is local
+        assert group is pp_group
+        output[:] = [local, later]
+
+    def fake_consensus(
+        local_error, *, context, error_type=RuntimeError, participating_group=None
+    ):
+        assert local_error is None
+        assert context == "PP buffer export failed"
+        assert error_type is AssertionError
+        consensus_groups.append(participating_group)
+
+    monkeypatch.setattr(hf_weights.dist, "all_gather_object", fake_all_gather_object)
+    monkeypatch.setattr(hf_weights, "_distributed_raise_if_error", fake_consensus)
+
+    gathered = hf_weights.gather_pipeline_state_dict(local, ps)
+
+    assert gathered.keys() == local.keys() | later.keys()
+    assert consensus_groups == [pp_group]
+
+
+def test_pipeline_buffer_export_rejects_missing_stage_state(monkeypatch):
+    from types import SimpleNamespace
+
+    from megatron.lite.primitive.ckpt.hf_weights import gather_pipeline_state_dict
+
+    ps = SimpleNamespace(pp_size=2, pp_group=object())
+    local = {"layers.0.router_bias": torch.tensor([1.0])}
+
+    def fake_all_gather_object(output, value, *, group):
+        assert value is local
+        assert group is ps.pp_group
+        output[:] = [local, None]
+
+    monkeypatch.setattr(torch.distributed, "all_gather_object", fake_all_gather_object)
+
+    with pytest.raises(
+        AssertionError,
+        match=(
+            r"^PP buffer export failed: pipeline export buffer state missing "
+            r"for stage 1$"
+        ),
+    ):
+        gather_pipeline_state_dict(local, ps)
+
+
+def test_pipeline_parameter_error_consensus_defaults_to_pp_group(monkeypatch):
+    from types import SimpleNamespace
+
+    from megatron.lite.primitive.ckpt import hf_weights
+
+    class WeightSpec:
+        num_experts = 0
+
+        @staticmethod
+        def is_expert(_name):
+            return False
+
+        @staticmethod
+        def tp_spec(_name):
+            return None
+
+        @staticmethod
+        def native_to_hf(name, tensor):
+            return [(name, tensor)]
+
+    model = nn.Linear(2, 2, bias=False)
+    pp_group = object()
+    ps = SimpleNamespace(pp_size=2, pp_group=pp_group, tp_size=1)
+    consensus_groups = []
+
+    def fake_all_gather_object(output, local_state, *, group):
+        assert group is pp_group
+        output[:] = [local_state, {"remote.weight": torch.ones(1)}]
+
+    def fake_consensus(
+        local_error, *, context, error_type=RuntimeError, participating_group=None
+    ):
+        assert local_error is None
+        assert error_type is AssertionError
+        consensus_groups.append((context, participating_group))
+
+    monkeypatch.setattr(hf_weights.dist, "is_initialized", lambda: False)
+    monkeypatch.setattr(hf_weights.dist, "all_gather_object", fake_all_gather_object)
+    monkeypatch.setattr(hf_weights, "_distributed_raise_if_error", fake_consensus)
+
+    exported = dict(hf_weights.export_hf_weights(model, WeightSpec(), ps))
+
+    assert exported.keys() == {"weight", "remote.weight"}
+    assert consensus_groups == [
+        ("PP parameter export failed", pp_group),
+        ("PP MTP embedding export validation failed", pp_group),
+    ]
+
+
+def test_pipeline_parameter_export_rejects_local_vpp_name_collision(monkeypatch):
+    from types import SimpleNamespace
+
+    from megatron.lite.primitive.ckpt import hf_weights
+
+    class WeightSpec:
+        num_experts = 0
+
+        @staticmethod
+        def is_expert(_name):
+            return False
+
+        @staticmethod
+        def tp_spec(_name):
+            return None
+
+        @staticmethod
+        def native_to_hf(name, tensor):
+            return [(name, tensor)]
+
+    first_chunk = nn.Linear(2, 2, bias=False)
+    second_chunk = nn.Linear(2, 2, bias=False)
+    with torch.no_grad():
+        first_chunk.weight.fill_(1.0)
+        second_chunk.weight.fill_(2.0)
+
+    pp_group = object()
+    ps = SimpleNamespace(pp_size=2, pp_group=pp_group, tp_size=1)
+
+    def fake_all_gather_object(output, local_state, *, group):
+        assert group is pp_group
+        # The first chunk remains canonical while the duplicate is reported;
+        # the old direct assignment silently replaced it with the second chunk.
+        torch.testing.assert_close(local_state["weight"], torch.ones(2, 2))
+        output[:] = [local_state, {"remote.weight": torch.ones(1)}]
+
+    monkeypatch.setattr(hf_weights.dist, "is_initialized", lambda: False)
+    monkeypatch.setattr(hf_weights.dist, "all_gather_object", fake_all_gather_object)
+
+    with pytest.raises(
+        AssertionError,
+        match=(
+            r"^PP parameter export failed: pipeline export parameter collision "
+            r"for weight$"
+        ),
+    ):
+        list(
+            hf_weights.export_hf_weights([first_chunk, second_chunk], WeightSpec(), ps)
+        )
+
+
+def test_pipeline_parameter_export_rejects_missing_stage_state(monkeypatch):
+    from types import SimpleNamespace
+
+    from megatron.lite.primitive.ckpt import hf_weights
+
+    class WeightSpec:
+        num_experts = 0
+
+        @staticmethod
+        def is_expert(_name):
+            return False
+
+        @staticmethod
+        def tp_spec(_name):
+            return None
+
+        @staticmethod
+        def native_to_hf(name, tensor):
+            return [(name, tensor)]
+
+    model = nn.Linear(2, 2, bias=False)
+    ps = SimpleNamespace(pp_size=2, pp_group=object(), tp_size=1)
+
+    def fake_all_gather_object(output, local_state, *, group):
+        assert group is ps.pp_group
+        output[:] = [local_state, None]
+
+    monkeypatch.setattr(hf_weights.dist, "is_initialized", lambda: False)
+    monkeypatch.setattr(hf_weights.dist, "all_gather_object", fake_all_gather_object)
+
+    with pytest.raises(
+        AssertionError,
+        match=(
+            r"^PP parameter export failed: pipeline export parameter state missing "
+            r"for stage 1$"
+        ),
+    ):
+        list(hf_weights.export_hf_weights(model, WeightSpec(), ps))
+
+
+@pytest.mark.parametrize("expert", [False, True], ids=["dense", "batched-expert"])
+def test_non_pipeline_export_rejects_local_vpp_name_collision(expert):
+    from types import SimpleNamespace
+
+    from megatron.lite.primitive.ckpt import hf_weights
+
+    class WeightSpec:
+        num_experts = 1
+
+        @staticmethod
+        def is_expert(_name):
+            return expert
+
+        @staticmethod
+        def tp_spec(_name):
+            return None
+
+        @staticmethod
+        def native_to_hf(name, tensor):
+            return [(name, tensor)]
+
+    ps = SimpleNamespace(pp_size=1, tp_size=1)
+    chunks = [nn.Linear(2, 2, bias=False), nn.Linear(2, 2, bias=False)]
+
+    with pytest.raises(
+        AssertionError,
+        match=r"^local export parameter collision for weight$",
+    ):
+        list(hf_weights.export_hf_weights(chunks, WeightSpec(), ps))
+
+
+def test_named_persistent_buffers_excludes_runtime_caches():
+    from megatron.lite.primitive.ckpt.hf_weights import named_persistent_buffers
+
+    model = nn.Module()
+    model.register_buffer("root_cache", torch.zeros(1), persistent=False)
+    model.child = nn.Module()
+    model.child.register_buffer("router_bias", torch.ones(2), persistent=True)
+    model.child.register_buffer("workspace", torch.zeros(3), persistent=False)
+
+    buffers = dict(named_persistent_buffers(model))
+
+    assert buffers.keys() == {"child.router_bias"}
+    assert buffers["child.router_bias"] is model.child.router_bias
+
+
+def test_resolve_param_name_only_accepts_unique_wrapper_suffix():
+    from megatron.lite.primitive.ckpt.hf_weights import _resolve_param_name
+
+    state = {
+        "layers.0.weight": object(),
+        "module.layers.1.weight": object(),
+        "prefix.layers.2.weight.suffix": object(),
+    }
+
+    assert _resolve_param_name("layers.0.weight", state) == "layers.0.weight"
+    assert _resolve_param_name("layers.1.weight", state) == "module.layers.1.weight"
+    assert _resolve_param_name("layers.2.weight", state) is None
+
+
+def test_resolve_param_name_rejects_ambiguous_wrapper_suffixes():
+    from megatron.lite.primitive.ckpt.hf_weights import _resolve_param_name
+
+    state = {
+        "module.layers.0.weight": object(),
+        "_orig_mod.layers.0.weight": object(),
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"^ambiguous wrapped parameter match for 'layers\.0\.weight': "
+            r"\['_orig_mod\.layers\.0\.weight', 'module\.layers\.0\.weight'\]$"
+        ),
+    ):
+        _resolve_param_name("layers.0.weight", state)
+
+
+def test_load_hf_weights_rejects_broadcastable_shape_mismatch(monkeypatch):
+    from types import SimpleNamespace
+
+    from megatron.lite.primitive.ckpt import hf_weights
+    import megatron.lite.primitive.parallel as parallel
+
+    class Reader:
+        def __init__(self, _path):
+            pass
+
+        @staticmethod
+        def get_tensor(name):
+            assert name == "hf.weight"
+            return torch.ones(1, 2)
+
+    class WeightSpec:
+        @staticmethod
+        def weight_map():
+            return {"weight": ["hf.weight"]}
+
+        @staticmethod
+        def expert_global_id(_name):
+            return None
+
+        @staticmethod
+        def hf_to_native(_name, tensors):
+            return tensors[0]
+
+        @staticmethod
+        def tp_spec(_name):
+            return None
+
+    model = nn.Linear(2, 2, bias=False)
+    ps = SimpleNamespace(ep_size=1, ep_rank=0)
+    monkeypatch.setattr(hf_weights, "SafeTensorReader", Reader)
+    monkeypatch.setitem(parallel.__dict__, "pad_vocab_for_tp", lambda size, _tp: size)
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"^HF load shape mismatch for weight: "
+            r"checkpoint=\(1, 2\), model=\(2, 2\)$"
+        ),
+    ):
+        hf_weights.load_hf_weights(model, "/unused", WeightSpec(), ps)
+
+
+def test_to_global_layer_name_never_remaps_mtp_namespace():
+    from megatron.lite.primitive.ckpt.hf_weights import to_global_layer_name
+
+    layer_map = {0: 8, 1: 9}
+    assert to_global_layer_name("layers.0.attn.weight", layer_map) == (
+        "layers.8.attn.weight"
+    )
+    assert to_global_layer_name("mtp.layers.0.attn.weight", layer_map) == (
+        "mtp.layers.0.attn.weight"
+    )
+
+
+def test_gather_pipeline_state_dict_rejects_conflicting_stage_names(monkeypatch):
+    from types import SimpleNamespace
+
+    from megatron.lite.primitive.ckpt.hf_weights import gather_pipeline_state_dict
+
+    ps = SimpleNamespace(pp_size=2, pp_group=object())
+    local = {"layers.0.router_bias": torch.tensor([1.0])}
+
+    def fake_all_gather_object(output, _value, *, group):
+        assert group is ps.pp_group
+        output[:] = [local, {"layers.0.router_bias": torch.tensor([9.0])}]
+
+    monkeypatch.setattr(torch.distributed, "all_gather_object", fake_all_gather_object)
+    with pytest.raises(
+        AssertionError,
+        match=(
+            r"^PP buffer export failed: pipeline export buffer collision for "
+            r"layers\.0\.router_bias$"
+        ),
+    ):
+        gather_pipeline_state_dict(local, ps)
+
+
+def test_gather_pipeline_state_dict_rejects_identical_zero_stage_names(monkeypatch):
+    from types import SimpleNamespace
+
+    from megatron.lite.primitive.ckpt.hf_weights import gather_pipeline_state_dict
+
+    ps = SimpleNamespace(pp_size=2, pp_group=object())
+    local = {"layers.0.router_bias": torch.zeros(2)}
+
+    def fake_all_gather_object(output, _value, *, group):
+        assert group is ps.pp_group
+        output[:] = [local, {"layers.0.router_bias": torch.zeros(2)}]
+
+    monkeypatch.setattr(torch.distributed, "all_gather_object", fake_all_gather_object)
+    with pytest.raises(
+        AssertionError,
+        match=(
+            r"^PP buffer export failed: pipeline export buffer collision for "
+            r"layers\.0\.router_bias$"
+        ),
+    ):
+        gather_pipeline_state_dict(local, ps)
+
+
+@pytest.mark.parametrize("rank", [0, 1], ids=["failing-lane", "peer-lane"])
+def test_materialize_hf_weights_propagates_generator_error_to_world(monkeypatch, rank):
+    from megatron.lite.primitive.ckpt import hf_weights
+
+    shared_error = "ValueError: lane 0 generator exploded"
+
+    monkeypatch.setattr(hf_weights.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(hf_weights.dist, "get_backend", lambda: "gloo")
+    monkeypatch.setattr(hf_weights.dist, "get_world_size", lambda: 2)
+
+    def fake_all_reduce(failed, *, group):
+        assert group is hf_weights.dist.group.WORLD
+        assert failed.device.type == "cpu"
+        assert failed.item() == int(rank == 0)
+        failed.fill_(1)
+
+    def fake_all_gather_object(messages, local_error, *, group):
+        assert group is hf_weights.dist.group.WORLD
+        assert local_error == (shared_error if rank == 0 else None)
+        messages[:] = [shared_error, None]
+
+    monkeypatch.setattr(hf_weights.dist, "all_reduce", fake_all_reduce)
+    monkeypatch.setattr(hf_weights.dist, "all_gather_object", fake_all_gather_object)
+
+    def weights():
+        if rank == 0:
+            raise ValueError("lane 0 generator exploded")
+        yield "model.weight", torch.ones(1)
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            r"^HF weight materialization failed: ValueError: "
+            r"lane 0 generator exploded$"
+        ),
+    ):
+        hf_weights.materialize_hf_weights_distributed(weights())
+
+
+def test_materialize_hf_weights_rejects_duplicate_keys(monkeypatch):
+    from megatron.lite.primitive.ckpt import hf_weights
+
+    monkeypatch.setattr(hf_weights.dist, "is_initialized", lambda: False)
+    weights = [
+        ("model.weight", torch.tensor([1.0])),
+        ("model.weight", torch.tensor([2.0])),
+    ]
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            r"^HF weight materialization failed: AssertionError: "
+            r"duplicate HF export keys: \['model\.weight'\]$"
+        ),
+    ):
+        hf_weights.materialize_hf_weights_distributed(iter(weights))
+
+
+def test_save_hf_weight_pairs_rejects_empty_rank0_export(monkeypatch, tmp_path):
+    from megatron.lite.primitive.ckpt import hf_weights
+
+    monkeypatch.setattr(hf_weights.dist, "is_initialized", lambda: False)
+
+    def unexpected_save(*_args, **_kwargs):
+        raise AssertionError("an empty export must not create a safetensors file")
+
+    monkeypatch.setattr(hf_weights, "save_safetensors", unexpected_save)
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            r"^HF safetensors write failed: ValueError: "
+            r"rank 0 materialized no HF weights$"
+        ),
+    ):
+        hf_weights.save_hf_weight_pairs_distributed(iter(()), str(tmp_path))
+
+
+@pytest.mark.parametrize("rank", [0, 1], ids=["writer-lane", "peer-lane"])
+def test_save_hf_weight_pairs_propagates_rank0_write_error_before_barrier(
+    monkeypatch, tmp_path, rank
+):
+    from megatron.lite.primitive.ckpt import hf_weights
+
+    events = []
+    write_error = "OSError: disk full"
+    consensus_round = 0
+
+    monkeypatch.setattr(hf_weights.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(hf_weights.dist, "get_backend", lambda: "gloo")
+    monkeypatch.setattr(hf_weights.dist, "get_world_size", lambda: 2)
+    monkeypatch.setattr(hf_weights.dist, "get_rank", lambda: rank)
+
+    def fake_all_reduce(failed, *, group):
+        nonlocal consensus_round
+        assert group is hf_weights.dist.group.WORLD
+        assert failed.device.type == "cpu"
+        consensus_round += 1
+        events.append(f"all_reduce_{consensus_round}")
+        if consensus_round == 1:
+            assert failed.item() == 0
+            return
+        assert consensus_round == 2
+        assert failed.item() == int(rank == 0)
+        failed.fill_(1)
+
+    def fake_all_gather_object(messages, local_error, *, group):
+        assert group is hf_weights.dist.group.WORLD
+        assert consensus_round == 2
+        assert local_error == (write_error if rank == 0 else None)
+        events.append("all_gather_error")
+        messages[:] = [write_error, None]
+
+    def fake_save(_out, _path):
+        assert rank == 0
+        events.append("write")
+        raise OSError("disk full")
+
+    def fake_barrier():
+        events.append("barrier")
+
+    monkeypatch.setattr(hf_weights.dist, "all_reduce", fake_all_reduce)
+    monkeypatch.setattr(hf_weights.dist, "all_gather_object", fake_all_gather_object)
+    monkeypatch.setattr(hf_weights.dist, "barrier", fake_barrier)
+    monkeypatch.setattr(hf_weights, "save_safetensors", fake_save)
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"^HF safetensors write failed: OSError: disk full$",
+    ):
+        hf_weights.save_hf_weight_pairs_distributed(
+            iter([("model.weight", torch.ones(1))]), str(tmp_path)
+        )
+
+    assert events[-1] == "all_gather_error"
+    assert "barrier" not in events
+    assert events.count("write") == int(rank == 0)
+
+
+def test_save_hf_weight_pairs_writes_before_success_barrier(monkeypatch, tmp_path):
+    from megatron.lite.primitive.ckpt import hf_weights
+
+    events = []
+
+    monkeypatch.setattr(hf_weights.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(hf_weights.dist, "get_backend", lambda: "gloo")
+    monkeypatch.setattr(hf_weights.dist, "get_world_size", lambda: 2)
+    monkeypatch.setattr(hf_weights.dist, "get_rank", lambda: 0)
+
+    def fake_all_reduce(failed, *, group):
+        assert group is hf_weights.dist.group.WORLD
+        assert failed.device.type == "cpu"
+        assert failed.item() == 0
+        events.append("all_reduce")
+
+    def unexpected_all_gather_object(*_args, **_kwargs):
+        raise AssertionError("a successful consensus must not gather error strings")
+
+    def fake_save(out, path):
+        assert path == str(tmp_path)
+        assert list(out) == ["model.weight"]
+        torch.testing.assert_close(out["model.weight"], torch.tensor([3.0]))
+        events.append("write")
+
+    def fake_barrier():
+        events.append("barrier")
+
+    monkeypatch.setattr(hf_weights.dist, "all_reduce", fake_all_reduce)
+    monkeypatch.setattr(
+        hf_weights.dist, "all_gather_object", unexpected_all_gather_object
+    )
+    monkeypatch.setattr(hf_weights.dist, "barrier", fake_barrier)
+    monkeypatch.setattr(hf_weights, "save_safetensors", fake_save)
+
+    hf_weights.save_hf_weight_pairs_distributed(
+        iter([("model.weight", torch.tensor([3.0]))]), str(tmp_path)
+    )
+
+    assert events == ["all_reduce", "write", "all_reduce", "barrier"]

--- a/experimental/lite/tests/unit/primitive/test_glm5_dsa_rope.py
+++ b/experimental/lite/tests/unit/primitive/test_glm5_dsa_rope.py
@@ -7,7 +7,6 @@ import pytest
 import torch
 import torch.nn as nn
 
-
 pytestmark = pytest.mark.mlite
 
 
@@ -36,10 +35,7 @@ def _half_split_reference(
 def _rotary_inputs(dsa, *, dtype: torch.dtype = torch.float64):
     position_ids = torch.tensor([[0, 3, 11, 29]], dtype=torch.long)
     cos, sin = dsa.build_rotary_embeddings(
-        position_ids=position_ids,
-        dim=8,
-        rope_theta=8_000_000.0,
-        dtype=dtype,
+        position_ids=position_ids, dim=8, rope_theta=8_000_000.0, dtype=dtype
     )
     values = torch.linspace(-2.5, 3.5, 2 * 4 * 3 * 8, dtype=dtype).reshape(2, 4, 3, 8)
     return values, cos.expand(2, -1, -1), sin.expand(2, -1, -1), position_ids
@@ -148,10 +144,7 @@ def test_dynamic_sparse_attention_main_rope_matches_independent_reference(
     )
     position_ids = torch.tensor([[0, 3, 11, 29]], dtype=torch.long)
     cos, sin = dsa.build_rotary_embeddings(
-        position_ids=position_ids,
-        dim=8,
-        rope_theta=8_000_000.0,
-        dtype=torch.float32,
+        position_ids=position_ids, dim=8, rope_theta=8_000_000.0, dtype=torch.float32
     )
     x = torch.linspace(-1.5, 2.0, 4 * 16, dtype=torch.float32).reshape(1, 4, 16)
 
@@ -200,10 +193,7 @@ def test_dsa_indexer_honors_its_independent_rope_layout_flag(
     )
     position_ids = torch.tensor([[0, 3, 11, 29]], dtype=torch.long)
     cos, sin = dsa.build_rotary_embeddings(
-        position_ids=position_ids,
-        dim=8,
-        rope_theta=8_000_000.0,
-        dtype=torch.float32,
+        position_ids=position_ids, dim=8, rope_theta=8_000_000.0, dtype=torch.float32
     )
     x = torch.linspace(-1.0, 1.0, 4 * 16, dtype=torch.float32).reshape(1, 4, 16)
     q_resid = torch.linspace(-0.5, 0.75, 4 * 8, dtype=torch.float32).reshape(1, 4, 8)

--- a/experimental/lite/tests/unit/primitive/test_glm5_dsa_rope.py
+++ b/experimental/lite/tests/unit/primitive/test_glm5_dsa_rope.py
@@ -1,0 +1,226 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""CPU precision tests for the two GLM-5 DSA RoPE layouts."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+
+
+pytestmark = pytest.mark.mlite
+
+
+def _hf_mla_interleaved_reference(
+    x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor, *, unsqueeze_dim: int = 2
+) -> torch.Tensor:
+    """Transformers v5.12.0 ``apply_rotary_pos_emb_interleave`` for one tensor.
+
+    Vendored from transformers commit e0e7504bca2bfd1b85bb0eedb148f7b250226f06
+    so this CPU gate does not require transformers as a test dependency.
+    """
+    cos = cos[..., : cos.shape[-1] // 2].unsqueeze(unsqueeze_dim)
+    sin = sin[..., : sin.shape[-1] // 2].unsqueeze(unsqueeze_dim)
+    x_even, x_odd = x[..., 0::2], x[..., 1::2]
+    return torch.cat((x_even * cos - x_odd * sin, x_odd * cos + x_even * sin), dim=-1)
+
+
+def _half_split_reference(
+    x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor, *, unsqueeze_dim: int = 2
+) -> torch.Tensor:
+    half = x.shape[-1] // 2
+    rotated = torch.cat((-x[..., half:], x[..., :half]), dim=-1)
+    return x * cos.unsqueeze(unsqueeze_dim) + rotated * sin.unsqueeze(unsqueeze_dim)
+
+
+def _rotary_inputs(dsa, *, dtype: torch.dtype = torch.float64):
+    position_ids = torch.tensor([[0, 3, 11, 29]], dtype=torch.long)
+    cos, sin = dsa.build_rotary_embeddings(
+        position_ids=position_ids,
+        dim=8,
+        rope_theta=8_000_000.0,
+        dtype=dtype,
+    )
+    values = torch.linspace(-2.5, 3.5, 2 * 4 * 3 * 8, dtype=dtype).reshape(2, 4, 3, 8)
+    return values, cos.expand(2, -1, -1), sin.expand(2, -1, -1), position_ids
+
+
+def test_mla_interleaved_rope_matches_transformers_v5_12_at_distinct_positions(
+    transformer_engine_import_stub,
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.attention import dsa
+
+    x, cos, sin, _ = _rotary_inputs(dsa)
+
+    actual = dsa.apply_rotary_pos_emb(
+        x, cos, sin, unsqueeze_dim=2, mla_interleaved=True
+    )
+    expected = _hf_mla_interleaved_reference(x, cos, sin)
+    legacy = _half_split_reference(x, cos, sin)
+
+    torch.testing.assert_close(actual, expected, rtol=0.0, atol=0.0)
+    # Position zero is intentionally present, but non-zero positions must make
+    # the incorrect half-split interpretation observable.
+    assert not torch.allclose(actual[:, 1:], legacy[:, 1:])
+
+
+def test_non_interleaved_rope_keeps_the_glm51_formula_bitwise(
+    transformer_engine_import_stub,
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.attention import dsa
+
+    x, cos, sin, _ = _rotary_inputs(dsa)
+
+    actual = dsa.apply_rotary_pos_emb(
+        x, cos, sin, unsqueeze_dim=2, mla_interleaved=False
+    )
+    expected = _half_split_reference(x, cos, sin)
+
+    assert torch.equal(actual, expected)
+
+
+def test_public_dsa_primitive_defaults_preserve_legacy_half_split(
+    transformer_engine_import_stub, monkeypatch
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.attention import dsa
+
+    monkeypatch.setattr(dsa, "RMSNorm", nn.RMSNorm)
+    attention = dsa.DynamicSparseAttention(
+        hidden_size=16,
+        num_attention_heads=2,
+        q_lora_rank=8,
+        kv_lora_rank=4,
+        qk_nope_head_dim=4,
+        qk_rope_head_dim=8,
+        v_head_dim=4,
+        index_n_heads=2,
+        index_head_dim=12,
+        index_topk=2,
+        rms_norm_eps=1e-6,
+    )
+
+    assert attention.rope_interleaved is False
+    assert attention.indexer is not None
+    assert attention.indexer.rope_interleaved is False
+
+
+@pytest.mark.parametrize("mla_interleaved", [False, True])
+def test_dynamic_sparse_attention_main_rope_matches_independent_reference(
+    transformer_engine_import_stub, monkeypatch, mla_interleaved
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.attention import dsa
+
+    # The production class uses TE RMSNorm; nn.RMSNorm lets this precision
+    # contract run on CPU without changing the projections under test.
+    monkeypatch.setattr(dsa, "RMSNorm", nn.RMSNorm)
+    captured = {}
+
+    def _capture_fused(query, kv_full, *args, value_dim=None, **kwargs):
+        del args, kwargs
+        captured["query"] = query.detach().clone()
+        captured["kv_full"] = kv_full.detach().clone()
+        output = query.new_zeros(
+            query.shape[0], query.shape[1], query.shape[2] * value_dim
+        )
+        return output, query.new_zeros((), dtype=torch.float32)
+
+    monkeypatch.setattr(dsa, "_fused_indexer_sparse_attn", _capture_fused)
+    attention = dsa.DynamicSparseAttention(
+        hidden_size=16,
+        num_attention_heads=2,
+        q_lora_rank=8,
+        kv_lora_rank=4,
+        qk_nope_head_dim=4,
+        qk_rope_head_dim=8,
+        v_head_dim=4,
+        index_n_heads=2,
+        index_head_dim=12,
+        index_topk=2,
+        rms_norm_eps=1e-6,
+        rope_interleaved=mla_interleaved,
+        indexer_rope_interleaved=False,
+        indexer_rope_first=True,
+        indexer_use_hadamard=False,
+    )
+    position_ids = torch.tensor([[0, 3, 11, 29]], dtype=torch.long)
+    cos, sin = dsa.build_rotary_embeddings(
+        position_ids=position_ids,
+        dim=8,
+        rope_theta=8_000_000.0,
+        dtype=torch.float32,
+    )
+    x = torch.linspace(-1.5, 2.0, 4 * 16, dtype=torch.float32).reshape(1, 4, 16)
+
+    attention(x, cos=cos, sin=sin, position_ids=position_ids)
+
+    with torch.no_grad():
+        q_resid = attention.q_a_layernorm(attention.q_a_proj(x))
+        q = attention.q_b_proj(q_resid).view(1, 4, 2, 12)
+        q_pe = q[..., -8:]
+        k_pe = attention.kv_a_proj_with_mqa(x)[..., -8:].unsqueeze(2)
+        reference = (
+            _hf_mla_interleaved_reference if mla_interleaved else _half_split_reference
+        )
+        expected_q_pe = reference(q_pe, cos, sin)
+        expected_k_pe = reference(k_pe, cos, sin).squeeze(2)
+
+    torch.testing.assert_close(
+        captured["query"].transpose(0, 1)[..., -8:], expected_q_pe
+    )
+    torch.testing.assert_close(
+        captured["kv_full"].transpose(0, 1)[..., -8:], expected_k_pe
+    )
+
+
+@pytest.mark.parametrize("mla_interleaved", [False, True])
+def test_dsa_indexer_honors_its_independent_rope_layout_flag(
+    transformer_engine_import_stub, mla_interleaved
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.attention import dsa
+
+    # HF v5.12.0 currently hard-codes half-split RoPE in its indexer despite
+    # the checkpoint flag. Megatron and vLLM honor indexer_rope_interleave, so
+    # this test covers the explicit MLite configuration contract independently
+    # from the main-attention HF oracle above.
+    indexer = dsa.DSAIndexer(
+        hidden_size=16,
+        q_lora_rank=8,
+        qk_rope_head_dim=8,
+        index_n_heads=2,
+        index_head_dim=12,
+        index_topk=2,
+        rope_interleaved=mla_interleaved,
+        rope_first=True,
+        use_hadamard=False,
+    )
+    position_ids = torch.tensor([[0, 3, 11, 29]], dtype=torch.long)
+    cos, sin = dsa.build_rotary_embeddings(
+        position_ids=position_ids,
+        dim=8,
+        rope_theta=8_000_000.0,
+        dtype=torch.float32,
+    )
+    x = torch.linspace(-1.0, 1.0, 4 * 16, dtype=torch.float32).reshape(1, 4, 16)
+    q_resid = torch.linspace(-0.5, 0.75, 4 * 8, dtype=torch.float32).reshape(1, 4, 8)
+
+    q_out, k_out, _ = indexer.forward_before_topk(x, q_resid, cos, sin, position_ids)
+
+    with torch.no_grad():
+        q = indexer.wq_b(q_resid).view(1, 4, 2, 12)
+        k = indexer.k_norm(indexer.wk(x))
+        reference = (
+            _hf_mla_interleaved_reference if mla_interleaved else _half_split_reference
+        )
+        expected_q = torch.cat([reference(q[..., :8], cos, sin), q[..., 8:]], dim=-1)
+        expected_k = torch.cat(
+            [reference(k[..., :8].unsqueeze(2), cos, sin).squeeze(2), k[..., 8:]],
+            dim=-1,
+        )
+
+    torch.testing.assert_close(q_out.transpose(0, 1), expected_q)
+    torch.testing.assert_close(k_out.transpose(0, 1), expected_k)

--- a/experimental/lite/tests/unit/primitive/test_mtp_protocol_failfast_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_mtp_protocol_failfast_unit.py
@@ -8,16 +8,9 @@ from pathlib import Path
 
 import pytest
 
-
 pytestmark = [pytest.mark.mlite]
 
-_PROTOCOLS = (
-    "glm5",
-    "deepseek_v4",
-    "kimi_k2",
-    "qwen3_5",
-    "qwen3_moe",
-)
+_PROTOCOLS = ("glm5", "deepseek_v4", "kimi_k2", "qwen3_5", "qwen3_moe")
 
 
 def _protocol_path(model_name: str) -> Path:
@@ -93,18 +86,18 @@ def test_fsdp2_pp_mtp_gate_precedes_parallel_and_cuda_initialization(
 
     init_parallel_lines = _call_lines(function, "init_parallel")
     cuda_lines = _call_lines(function, "cuda")
-    assert init_parallel_lines, (
-        f"{model_name}: build_model does not initialize parallel state"
-    )
-    assert cuda_lines, (
-        f"{model_name}: build_model does not materialize CUDA model chunks"
-    )
-    assert gate.lineno < min(init_parallel_lines), (
-        f"{model_name}: FSDP2 PP+MTP gate runs after init_parallel"
-    )
-    assert gate.lineno < min(cuda_lines), (
-        f"{model_name}: FSDP2 PP+MTP gate runs after CUDA construction"
-    )
+    assert (
+        init_parallel_lines
+    ), f"{model_name}: build_model does not initialize parallel state"
+    assert (
+        cuda_lines
+    ), f"{model_name}: build_model does not materialize CUDA model chunks"
+    assert gate.lineno < min(
+        init_parallel_lines
+    ), f"{model_name}: FSDP2 PP+MTP gate runs after init_parallel"
+    assert gate.lineno < min(
+        cuda_lines
+    ), f"{model_name}: FSDP2 PP+MTP gate runs after CUDA construction"
 
 
 def test_deepseek_v4_packed_mtp_requires_single_sequence_without_cp() -> None:

--- a/experimental/lite/tests/unit/primitive/test_mtp_protocol_failfast_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_mtp_protocol_failfast_unit.py
@@ -1,0 +1,192 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Static contract tests for PP-replicated MTP embedding protocol gates."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = [pytest.mark.mlite]
+
+_PROTOCOLS = (
+    "glm5",
+    "deepseek_v4",
+    "kimi_k2",
+    "qwen3_5",
+    "qwen3_moe",
+)
+
+
+def _protocol_path(model_name: str) -> Path:
+    lite_root = Path(__file__).resolve().parents[3] / "megatron" / "lite"
+    return lite_root / "model" / model_name / "lite" / "protocol.py"
+
+
+def _model_path(model_name: str) -> Path:
+    lite_root = Path(__file__).resolve().parents[3] / "megatron" / "lite"
+    return lite_root / "model" / model_name / "lite" / "model.py"
+
+
+def _call_lines(function: ast.FunctionDef, name: str) -> list[int]:
+    return sorted(
+        node.lineno
+        for node in ast.walk(function)
+        if isinstance(node, ast.Call)
+        and (
+            (isinstance(node.func, ast.Name) and node.func.id == name)
+            or (isinstance(node.func, ast.Attribute) and node.func.attr == name)
+        )
+    )
+
+
+@pytest.mark.parametrize("model_name", _PROTOCOLS)
+def test_fsdp2_pp_mtp_gate_precedes_parallel_and_cuda_initialization(
+    model_name: str,
+) -> None:
+    """Reject every FSDP2+PP+MTP model before allocating parallel/CUDA state.
+
+    Even when MTP loss is disabled, the first-stage input embedding still
+    receives the trunk gradient. FSDP2 has no first/last-stage replica sync, so
+    allowing that configuration would silently diverge ``mtp_embed`` after the
+    first optimizer step. Pure load/export remains available with
+    ``optimizer=None`` because the gate is explicitly scoped to FSDP2.
+    """
+
+    path = _protocol_path(model_name)
+    tree = ast.parse(path.read_text(), filename=str(path))
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "build_model"
+    )
+
+    gates: list[tuple[ast.If, ast.Raise]] = []
+    for node in ast.walk(function):
+        if not isinstance(node, ast.If):
+            continue
+        for child in node.body:
+            if not isinstance(child, ast.Raise) or child.exc is None:
+                continue
+            if not isinstance(child.exc, ast.Call):
+                continue
+            if not isinstance(child.exc.func, ast.Name):
+                continue
+            if child.exc.func.id != "NotImplementedError":
+                continue
+            message = ast.unparse(child.exc)
+            if "PP-replicated MTP input embedding" in message:
+                gates.append((node, child))
+
+    assert len(gates) == 1, f"{model_name}: expected one FSDP2 PP+MTP gate"
+    gate, _raise = gates[0]
+    condition = ast.unparse(gate.test)
+    condition_names = {
+        node.id for node in ast.walk(gate.test) if isinstance(node, ast.Name)
+    }
+    assert "fsdp2" in condition
+    assert "mtp_enable" in condition_names
+    assert "mtp_enable_train" not in condition_names
+    assert ".pp" in condition and "> 1" in condition
+
+    init_parallel_lines = _call_lines(function, "init_parallel")
+    cuda_lines = _call_lines(function, "cuda")
+    assert init_parallel_lines, (
+        f"{model_name}: build_model does not initialize parallel state"
+    )
+    assert cuda_lines, (
+        f"{model_name}: build_model does not materialize CUDA model chunks"
+    )
+    assert gate.lineno < min(init_parallel_lines), (
+        f"{model_name}: FSDP2 PP+MTP gate runs after init_parallel"
+    )
+    assert gate.lineno < min(cuda_lines), (
+        f"{model_name}: FSDP2 PP+MTP gate runs after CUDA construction"
+    )
+
+
+def test_deepseek_v4_packed_mtp_requires_single_sequence_without_cp() -> None:
+    path = _protocol_path("deepseek_v4")
+    tree = ast.parse(path.read_text(), filename=str(path))
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_prepare_packed_batch_kwargs"
+    )
+
+    enable_mtp_values = [
+        value
+        for node in ast.walk(function)
+        if isinstance(node, ast.Dict)
+        for key, value in zip(node.keys, node.values)
+        if isinstance(key, ast.Constant) and key.value == "enable_mtp"
+    ]
+    assert len(enable_mtp_values) == 1
+
+    gate = enable_mtp_values[0]
+    assert isinstance(gate, ast.BoolOp) and isinstance(gate.op, ast.And)
+    assert {ast.unparse(term) for term in gate.values} == {
+        "ps.cp_size == 1",
+        "seq_lens.numel() == 1",
+    }
+
+
+@pytest.mark.parametrize(
+    ("model_name", "class_name"),
+    (("qwen3_5", "Qwen35Model"), ("qwen3_moe", "Qwen3MoEModel")),
+)
+def test_qwen_models_pass_mtp_slots_to_pipeline_layout_and_honor_layout_gate(
+    model_name: str, class_name: str
+) -> None:
+    path = _model_path(model_name)
+    tree = ast.parse(path.read_text(), filename=str(path))
+    model_class = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == class_name
+    )
+    constructor = next(
+        node
+        for node in model_class.body
+        if isinstance(node, ast.FunctionDef) and node.name == "__init__"
+    )
+
+    layout_calls = [
+        node
+        for node in ast.walk(constructor)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "build_pipeline_chunk_layout"
+    ]
+    assert len(layout_calls) == 1
+    keyword = next(
+        (item for item in layout_calls[0].keywords if item.arg == "num_mtp_layers"),
+        None,
+    )
+    assert keyword is not None
+    expression = ast.unparse(keyword.value)
+    assert "config.num_nextn_predict_layers" in expression
+    assert "mtp_enable" in expression
+
+    mtp_gates = []
+    for node in ast.walk(constructor):
+        if not isinstance(node, ast.If):
+            continue
+        assigns_mtp = any(
+            isinstance(child, ast.Assign)
+            and any(
+                isinstance(target, ast.Attribute)
+                and isinstance(target.value, ast.Name)
+                and target.value.id == "self"
+                and target.attr == "mtp"
+                for target in child.targets
+            )
+            for child in ast.walk(node)
+        )
+        if assigns_mtp:
+            mtp_gates.append(ast.unparse(node.test))
+
+    assert any("layout.has_mtp" in condition for condition in mtp_gates)

--- a/experimental/lite/tests/unit/primitive/test_parallel_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_parallel_unit.py
@@ -219,6 +219,55 @@ def test_grouped_pp_layout_keeps_glm52_indexshare_groups_inside_stage():
         )
 
 
+def test_grouped_pp_layout_uses_explicit_custom_indexer_schedule():
+    from megatron.lite.model.glm5.config import Glm5Config
+    from megatron.lite.primitive.modules.attention.dsa import (
+        validate_dsa_index_share_pipeline_split,
+    )
+
+    cfg = Glm5Config(
+        num_hidden_layers=6,
+        hidden_size=16,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        q_lora_rank=8,
+        kv_lora_rank=4,
+        qk_head_dim=8,
+        qk_nope_head_dim=4,
+        qk_rope_head_dim=4,
+        v_head_dim=4,
+        index_head_dim=8,
+        index_n_heads=2,
+        index_topk_freq=1,
+        indexer_types=["full", "shared", "full", "shared", "shared", "full"],
+        n_routed_experts=3,
+        num_experts_per_tok=2,
+    )
+    groups = cfg.dsa_index_share_decoder_layer_groups()
+    assert groups == [[0, 1], [2, 3, 4], [5]]
+
+    chunks = [
+        build_pipeline_chunk_layout(
+            cfg.num_hidden_layers,
+            ps,
+            num_mtp_layers=1,
+            decoder_layer_groups=groups,
+        )
+        for ps in _ranks(2)
+    ]
+    indices = [chunk.layer_indices for chunk in chunks]
+    _assert_full_contiguous_cover(indices, cfg.num_hidden_layers)
+    owner = {layer_idx: stage for stage, layers in enumerate(indices) for layer_idx in layers}
+    assert all(len({owner[layer_idx] for layer_idx in group}) == 1 for group in groups)
+    for stage_indices in indices:
+        validate_dsa_index_share_pipeline_split(
+            stage_indices,
+            topk_freq=cfg.index_topk_freq,
+            skip_topk_offset=cfg.index_skip_topk_offset,
+            indexer_types=list(cfg.resolved_dsa_indexer_types),
+        )
+
+
 def test_ungrouped_glm52_auto_layout_would_trip_indexshare_guard():
     from megatron.lite.primitive.modules.attention.dsa import (
         validate_dsa_index_share_pipeline_split,
@@ -366,6 +415,14 @@ def test_plain_thd_batch_is_split_by_protocol_context_parallel_helper():
     assert packed.input_ids.shape == (1, 16)
     assert packed.cp_size == 2
     assert packed.packed_seq_params.local_cp_size is None
+    assert torch.equal(
+        packed.packed_seq_params.cu_seqlens_q,
+        torch.tensor([0, 5, 12], dtype=torch.int32),
+    )
+    assert torch.equal(
+        packed.packed_seq_params.cu_seqlens_q_padded,
+        torch.tensor([0, 8, 16], dtype=torch.int32),
+    )
 
     local_params, local_tensors = prepare_packed_thd_for_context_parallel(
         packed.packed_seq_params,

--- a/experimental/lite/tests/unit/primitive/test_parallel_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_parallel_unit.py
@@ -23,7 +23,9 @@ pytestmark = pytest.mark.mlite
 
 def test_cp_zigzag_split_slice_and_reconstruct_match():
     tensor = torch.arange(16).reshape(1, 8, 2)
-    parts = [zigzag_split_for_cp(tensor, rank, cp_size=2, seq_dim=1) for rank in range(2)]
+    parts = [
+        zigzag_split_for_cp(tensor, rank, cp_size=2, seq_dim=1) for rank in range(2)
+    ]
 
     assert torch.equal(parts[0], tensor[:, [0, 1, 6, 7], :])
     assert torch.equal(parts[1], tensor[:, [2, 3, 4, 5], :])
@@ -63,7 +65,9 @@ def _ranks(pp_size: int, pp_layout=None) -> list[ParallelState]:
     ]
 
 
-def _layout_indices(num_layers: int, pp_size: int, *, pp_layout=None, **kw) -> list[list[int]]:
+def _layout_indices(
+    num_layers: int, pp_size: int, *, pp_layout=None, **kw
+) -> list[list[int]]:
     return [
         build_pipeline_chunk_layout(num_layers, ps, **kw).layer_indices
         for ps in _ranks(pp_size, pp_layout)
@@ -121,7 +125,9 @@ def test_pp_layout_accounts_for_head_tail_even_when_divisible():
 
 # --- Correctness matrix: real delivery counts x MTP{off,on} x PP{2,4,8} ---
 _REAL_LAYERS = {"deepseek_v4": 43, "kimi_k2": 61, "glm5": 78}
-_CORRECTNESS_CASES = [(m, pp, mtp) for m in _REAL_LAYERS for pp in (2, 4, 8) for mtp in (0, 1)]
+_CORRECTNESS_CASES = [
+    (m, pp, mtp) for m in _REAL_LAYERS for pp in (2, 4, 8) for mtp in (0, 1)
+]
 
 
 def _mcore_reference_decoder_ids(num_layers: int, pp: int, mtp: int) -> list[list[int]]:
@@ -139,7 +145,10 @@ def _mcore_reference_decoder_ids(num_layers: int, pp: int, mtp: int) -> list[lis
         rows.append(units[pos : pos + size])
         pos += size
     ref = PipelineParallelLayerLayout(rows, pipeline_model_parallel_size=pp)
-    return [ref.get_layer_id_list(LayerType.decoder, vp_stage=0, pp_rank=r) for r in range(pp)]
+    return [
+        ref.get_layer_id_list(LayerType.decoder, vp_stage=0, pp_rank=r)
+        for r in range(pp)
+    ]
 
 
 @pytest.mark.parametrize("model, pp, mtp", _CORRECTNESS_CASES)
@@ -147,13 +156,17 @@ def test_auto_layout_is_bit_equal_to_mcore(model, pp, mtp):
     # Faithful reuse: the glue's per-stage decoder ids are exactly mcore's for the same
     # canonical layout, so correctness is inherited from mcore (not re-derived).
     n = _REAL_LAYERS[model]
-    assert _layout_indices(n, pp, num_mtp_layers=mtp) == _mcore_reference_decoder_ids(n, pp, mtp)
+    assert _layout_indices(n, pp, num_mtp_layers=mtp) == _mcore_reference_decoder_ids(
+        n, pp, mtp
+    )
 
 
 @pytest.mark.parametrize("model, pp, mtp", _CORRECTNESS_CASES)
 def test_auto_layout_is_legal_and_balanced(model, pp, mtp):
     n = _REAL_LAYERS[model]
-    chunks = [build_pipeline_chunk_layout(n, ps, num_mtp_layers=mtp) for ps in _ranks(pp)]
+    chunks = [
+        build_pipeline_chunk_layout(n, ps, num_mtp_layers=mtp) for ps in _ranks(pp)
+    ]
     # complete + ordered, no missing/dup decoder -> sum == num_layers
     assert [i for c in chunks for i in c.layer_indices] == list(range(n))
     # embedding only on stage 0; loss/head only on the last stage
@@ -162,7 +175,10 @@ def test_auto_layout_is_legal_and_balanced(model, pp, mtp):
     # MTP placed exactly `mtp` times, on the final (head) stage
     assert sum(c.has_mtp for c in chunks) == mtp and chunks[-1].has_mtp == bool(mtp)
     # balanced: per-stage unit cells (decoders + embedding/loss/mtp slots) differ by <=1
-    cells = [len(c.layer_indices) + c.has_embed + c.has_head + (mtp if c.has_mtp else 0) for c in chunks]
+    cells = [
+        len(c.layer_indices) + c.has_embed + c.has_head + (mtp if c.has_mtp else 0)
+        for c in chunks
+    ]
     assert max(cells) - min(cells) <= 1
 
 
@@ -177,8 +193,14 @@ def _glm52_index_share_groups(num_layers: int = 78) -> list[list[int]]:
     current_source: int | None = None
     for layer_idx in range(num_layers):
         layer_number = layer_idx + 1
-        if dsa_indexer_type_for_layer(layer_number, skip_topk_offset=3, topk_freq=4) == "shared":
-            source_idx = source_dsa_compute_layer(layer_number, skip_topk_offset=3, topk_freq=4) - 1
+        if (
+            dsa_indexer_type_for_layer(layer_number, skip_topk_offset=3, topk_freq=4)
+            == "shared"
+        ):
+            source_idx = (
+                source_dsa_compute_layer(layer_number, skip_topk_offset=3, topk_freq=4)
+                - 1
+            )
         else:
             source_idx = layer_idx
         if current and source_idx != current_source:
@@ -198,10 +220,7 @@ def test_grouped_pp_layout_keeps_glm52_indexshare_groups_inside_stage():
 
     chunks = [
         build_pipeline_chunk_layout(
-            78,
-            ps,
-            num_mtp_layers=1,
-            decoder_layer_groups=_glm52_index_share_groups(),
+            78, ps, num_mtp_layers=1, decoder_layer_groups=_glm52_index_share_groups()
         )
         for ps in _ranks(8)
     ]
@@ -212,10 +231,7 @@ def test_grouped_pp_layout_keeps_glm52_indexshare_groups_inside_stage():
     assert [chunk.has_mtp for chunk in chunks[:-1]] == [False] * 7
     for stage_indices in indices:
         validate_dsa_index_share_pipeline_split(
-            stage_indices,
-            topk_freq=4,
-            skip_topk_offset=3,
-            indexer_types=None,
+            stage_indices, topk_freq=4, skip_topk_offset=3, indexer_types=None
         )
 
 
@@ -248,16 +264,15 @@ def test_grouped_pp_layout_uses_explicit_custom_indexer_schedule():
 
     chunks = [
         build_pipeline_chunk_layout(
-            cfg.num_hidden_layers,
-            ps,
-            num_mtp_layers=1,
-            decoder_layer_groups=groups,
+            cfg.num_hidden_layers, ps, num_mtp_layers=1, decoder_layer_groups=groups
         )
         for ps in _ranks(2)
     ]
     indices = [chunk.layer_indices for chunk in chunks]
     _assert_full_contiguous_cover(indices, cfg.num_hidden_layers)
-    owner = {layer_idx: stage for stage, layers in enumerate(indices) for layer_idx in layers}
+    owner = {
+        layer_idx: stage for stage, layers in enumerate(indices) for layer_idx in layers
+    }
     assert all(len({owner[layer_idx] for layer_idx in group}) == 1 for group in groups)
     for stage_indices in indices:
         validate_dsa_index_share_pipeline_split(
@@ -277,10 +292,7 @@ def test_ungrouped_glm52_auto_layout_would_trip_indexshare_guard():
     with pytest.raises(ValueError, match="DSA IndexShare cannot cross pipeline stages"):
         for stage_indices in bad_indices:
             validate_dsa_index_share_pipeline_split(
-                stage_indices,
-                topk_freq=4,
-                skip_topk_offset=3,
-                indexer_types=None,
+                stage_indices, topk_freq=4, skip_topk_offset=3, indexer_types=None
             )
 
 
@@ -313,9 +325,14 @@ def test_pp_layout_marks_mtp_stage_from_the_layout_not_a_fixed_rank():
     # no MTP requested -> no stage owns MTP.
     assert _mtp_flags(6, 4) == [False, False, False, False]
     # single stage owns the MTP too.
-    assert build_pipeline_chunk_layout(
-        5, ParallelState(pp_size=1, pp_rank=0, pp_is_first=True, pp_is_last=True), num_mtp_layers=1
-    ).has_mtp is True
+    assert (
+        build_pipeline_chunk_layout(
+            5,
+            ParallelState(pp_size=1, pp_rank=0, pp_is_first=True, pp_is_last=True),
+            num_mtp_layers=1,
+        ).has_mtp
+        is True
+    )
 
 
 def test_pp_layout_custom_string_mtp_lands_on_the_designated_stage():
@@ -324,7 +341,10 @@ def test_pp_layout_custom_string_mtp_lands_on_the_designated_stage():
     flags = _mtp_flags(6, 4, pp_layout="Ett|tt|t|tmL", num_mtp_layers=1)
     assert flags == [False, False, False, True]
     assert _layout_indices(6, 4, pp_layout="Ett|tt|t|tmL", num_mtp_layers=1) == [
-        [0, 1], [2, 3], [4], [5]
+        [0, 1],
+        [2, 3],
+        [4],
+        [5],
     ]
 
 
@@ -339,7 +359,11 @@ def test_pp_layout_custom_string_mtp_lands_on_the_designated_stage():
 def test_pp_layout_custom_string_standalone_mtp_builds_on_designated_stage():
     # DESIRED (follow-up): `m` on a non-final stage builds MTP on that stage.
     # "E|ttttttm|L" over pp3 -> [E], [t*6, m], [L]; MTP belongs on the middle stage.
-    assert _mtp_flags(6, 3, pp_layout="E|ttttttm|L", num_mtp_layers=1) == [False, True, False]
+    assert _mtp_flags(6, 3, pp_layout="E|ttttttm|L", num_mtp_layers=1) == [
+        False,
+        True,
+        False,
+    ]
 
 
 def test_pp_layout_single_stage_owns_all_layers():
@@ -367,7 +391,9 @@ def test_virtual_pipeline_rank_is_tracked_on_lite_parallel_state():
 
 def test_thd_roll_keeps_sequence_boundaries():
     cu_seqlens = torch.tensor([0, 4, 8], dtype=torch.int32)
-    rolled, token_sum = roll_packed_thd_left(torch.arange(8), cu_seqlens_padded=cu_seqlens, dims=0)
+    rolled, token_sum = roll_packed_thd_left(
+        torch.arange(8), cu_seqlens_padded=cu_seqlens, dims=0
+    )
 
     assert torch.equal(rolled, torch.tensor([1, 2, 3, 0, 5, 6, 7, 0]))
     assert token_sum.item() == 24
@@ -386,30 +412,25 @@ def test_thd_cp_split_and_reconstruct_roundtrip():
     assert torch.equal(parts[0], torch.tensor([0, 1, 6, 7]))
     assert torch.equal(parts[1], torch.tensor([2, 3, 4, 5]))
     assert torch.equal(
-        reconstruct_packed_from_cp_parts(parts, cu_seqlens_padded=cu_seqlens, cp_size=2, dim=0),
+        reconstruct_packed_from_cp_parts(
+            parts, cu_seqlens_padded=cu_seqlens, cp_size=2, dim=0
+        ),
         tensor,
     )
 
 
 def test_plain_thd_batch_is_split_by_protocol_context_parallel_helper():
     ids = torch.nested.as_nested_tensor(
-        [torch.arange(1, 6), torch.arange(11, 18)],
-        layout=torch.jagged,
+        [torch.arange(1, 6), torch.arange(11, 18)], layout=torch.jagged
     )
     labels = torch.nested.as_nested_tensor(
-        [torch.arange(101, 106), torch.arange(111, 118)],
-        layout=torch.jagged,
+        [torch.arange(101, 106), torch.arange(111, 118)], layout=torch.jagged
     )
     loss_mask = torch.nested.as_nested_tensor(
-        [torch.ones(5), torch.ones(7)],
-        layout=torch.jagged,
+        [torch.ones(5), torch.ones(7)], layout=torch.jagged
     )
     packed = pack_nested_thd(
-        ids,
-        cp_size=2,
-        split_cp=False,
-        labels=labels,
-        loss_mask=loss_mask,
+        ids, cp_size=2, split_cp=False, labels=labels, loss_mask=loss_mask
     )
 
     assert packed.input_ids.shape == (1, 16)
@@ -484,10 +505,7 @@ def test_protocol_context_parallel_helper_is_noop_without_packed_thd_params():
     tensor = torch.arange(8)
 
     local_params, local_tensors = prepare_packed_thd_for_context_parallel(
-        None,
-        (tensor,),
-        cp_size=2,
-        cp_rank=0,
+        None, (tensor,), cp_size=2, cp_rank=0
     )
 
     assert local_params is None

--- a/experimental/lite/tests/unit/primitive/test_shared_embedding_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_shared_embedding_unit.py
@@ -1,0 +1,1352 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from __future__ import annotations
+
+import datetime
+import time
+import traceback
+import uuid
+from collections.abc import Callable
+from queue import Empty
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import torch.nn as nn
+
+import megatron.lite.primitive.parallel.shared_embedding as shared_embedding
+from megatron.lite.primitive.parallel.shared_embedding import (
+    allreduce_mtp_embedding_grads,
+    synchronize_mtp_embedding_parameters,
+    validate_mtp_embedding_parameter_replicas,
+)
+from megatron.lite.primitive.parallel.state import (
+    ParallelState,
+    init_mtp_embedding_group,
+    init_parallel,
+)
+
+pytestmark = pytest.mark.mlite
+
+
+@pytest.fixture(autouse=True)
+def _mock_collective_tests_start_uninitialized(monkeypatch) -> None:
+    # Phase-A may invoke this unit file from an already-initialized outer rank.
+    # Mock process groups must still use the deterministic emulated-Gloo path.
+    # Tests that exercise real initialization override this locally or spawn a
+    # clean child interpreter.
+    monkeypatch.setattr(dist, "is_initialized", lambda: False)
+
+
+class _EmbeddingOwner(nn.Module):
+    def __init__(
+        self,
+        *,
+        canonical_attr: str | None = None,
+        canonical_weight: torch.Tensor | None = None,
+        mtp_weight: torch.Tensor | None = None,
+    ) -> None:
+        super().__init__()
+        if canonical_attr is not None:
+            if canonical_weight is None:
+                # Last-stage models retain the canonical attribute name even
+                # though they do not own the first-stage parameter.
+                setattr(self, canonical_attr, None)
+            else:
+                setattr(self, canonical_attr, _Embedding(canonical_weight))
+        if mtp_weight is not None:
+            self.mtp_embed = _Embedding(mtp_weight)
+
+
+class _Embedding(nn.Module):
+    def __init__(self, weight: torch.Tensor) -> None:
+        super().__init__()
+        self.embedding = nn.Embedding(
+            weight.shape[0],
+            weight.shape[1],
+            device=weight.device,
+            dtype=weight.dtype,
+        )
+        with torch.no_grad():
+            self.embedding.weight.copy_(weight)
+
+
+def _boundary_states(group: object) -> tuple[ParallelState, ParallelState]:
+    common = {
+        "pp_size": 2,
+        "embedding_group": group,
+        "embedding_global_ranks": [3, 11],
+    }
+    return (
+        ParallelState(
+            **common,
+            pp_rank=0,
+            pp_is_first=True,
+            pp_is_last=False,
+        ),
+        ParallelState(
+            **common,
+            pp_rank=1,
+            pp_is_first=False,
+            pp_is_last=True,
+        ),
+    )
+
+
+def _run_for_both_boundaries(
+    fn: Callable,
+    first: nn.Module,
+    last: nn.Module,
+    first_ps: ParallelState,
+    last_ps: ParallelState,
+) -> None:
+    fn([first], first_ps, enabled=True)
+    fn([last], last_ps, enabled=True)
+
+
+def _prime_shared_embedding_cache(
+    monkeypatch,
+    first: nn.Module,
+    last: nn.Module,
+    first_ps: ParallelState,
+    last_ps: ParallelState,
+) -> None:
+    """Run the real initialization protocol with an emulated matching pair."""
+    reduced: list[torch.Tensor] = []
+
+    def fake_all_gather(
+        outputs: list[torch.Tensor], tensor: torch.Tensor, *, group: object
+    ) -> None:
+        assert group is first_ps.embedding_group
+        assert tensor.dtype == torch.int64
+        for output in outputs:
+            output.copy_(tensor)
+
+    def fake_all_reduce(tensor: torch.Tensor, *, group: object) -> None:
+        if group is torch.distributed.group.WORLD:
+            assert tensor.dtype == torch.int32
+            tensor.zero_()
+            return
+        assert group is first_ps.embedding_group
+        reduced.append(tensor)
+        if len(reduced) == 2:
+            total = sum((item.clone() for item in reduced), torch.zeros_like(tensor))
+            for item in reduced:
+                item.copy_(total)
+
+    monkeypatch.setattr(torch.distributed, "all_gather", fake_all_gather)
+    monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
+    _run_for_both_boundaries(
+        synchronize_mtp_embedding_parameters,
+        first,
+        last,
+        first_ps,
+        last_ps,
+    )
+    assert first_ps.mtp_embedding_preflight_cache is not None
+    assert last_ps.mtp_embedding_preflight_cache is not None
+
+
+def _distributed_shared_embedding_worker(
+    rank: int,
+    world_size: int,
+    init_method: str,
+    case: str,
+    results,
+) -> None:
+    """Real Gloo endpoint used by the no-hang metadata regression test."""
+    try:
+        dist.init_process_group(
+            backend="gloo",
+            init_method=init_method,
+            rank=rank,
+            world_size=world_size,
+            timeout=datetime.timedelta(seconds=20),
+        )
+        first_rank = 0
+        last_rank = world_size - 1
+        boundary = rank in {first_rank, last_rank}
+        pair_group = (
+            dist.new_group(ranks=[first_rank, last_rank])
+            if world_size > 2
+            else dist.group.WORLD
+        )
+        if case == "shape":
+            weight = torch.zeros(3 + rank, 2, dtype=torch.float32)
+        elif case == "dtype":
+            dtype = torch.float32 if rank == 0 else torch.float64
+            weight = torch.zeros(3, 2, dtype=dtype)
+        else:
+            assert case in {
+                "missing_cache",
+                "asymmetric_cache",
+                "missing_group",
+                "missing_group_pp4",
+            }
+            weight = torch.zeros(3, 2, dtype=torch.float32)
+        if rank == first_rank:
+            model = _EmbeddingOwner(canonical_attr="embed", canonical_weight=weight)
+        elif rank == last_rank:
+            model = _EmbeddingOwner(mtp_weight=weight)
+        else:
+            model = _EmbeddingOwner()
+        missing_group_rank = (
+            case in {"missing_group", "missing_group_pp4"} and rank == last_rank
+        )
+        ps = ParallelState(
+            pp_size=world_size,
+            pp_rank=rank,
+            pp_is_first=rank == first_rank,
+            pp_is_last=rank == last_rank,
+            pp_global_ranks=list(range(world_size)),
+            embedding_group=(
+                None if missing_group_rank or not boundary else pair_group
+            ),
+            embedding_global_ranks=([first_rank, last_rank] if boundary else None),
+            embedding_groups_initialized=True,
+        )
+        try:
+            if case in {"missing_cache", "missing_group", "missing_group_pp4"}:
+                allreduce_mtp_embedding_grads([model], ps, enabled=True)
+            elif case == "asymmetric_cache":
+                synchronize_mtp_embedding_parameters([model], ps, enabled=True)
+                local_weight = (
+                    model.embed.embedding.weight
+                    if rank == 0
+                    else model.mtp_embed.embedding.weight
+                )
+                local_weight.grad = torch.ones_like(local_weight)
+                if rank == 1:
+                    ps.mtp_embedding_preflight_cache = None
+                allreduce_mtp_embedding_grads([model], ps, enabled=True)
+            else:
+                synchronize_mtp_embedding_parameters([model], ps, enabled=True)
+        except RuntimeError as exc:
+            results.put((rank, "runtime_error", str(exc)))
+        else:
+            results.put((rank, "unexpected_success", ""))
+    except BaseException:  # pragma: no cover - surfaced with the remote traceback
+        results.put((rank, "worker_error", traceback.format_exc()))
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+def _run_real_gloo_case(
+    tmp_path, case: str, *, world_size: int = 2
+) -> dict[int, tuple[str, str]]:
+    init_method = (tmp_path / f"gloo-{case}-{uuid.uuid4().hex}").as_uri()
+    context = mp.get_context("spawn")
+    results = context.Queue()
+    processes = [
+        context.Process(
+            target=_distributed_shared_embedding_worker,
+            args=(rank, world_size, init_method, case, results),
+        )
+        for rank in range(world_size)
+    ]
+    for process in processes:
+        process.start()
+
+    deadline = time.monotonic() + 30
+    for process in processes:
+        process.join(max(0.0, deadline - time.monotonic()))
+    hung = [process.pid for process in processes if process.is_alive()]
+    for process in processes:
+        if process.is_alive():
+            process.terminate()
+            process.join(5)
+    if hung:
+        pytest.fail(f"Gloo metadata preflight hung worker processes: {hung}")
+
+    payloads = []
+    try:
+        for _ in range(world_size):
+            payloads.append(results.get(timeout=5))
+    except Empty:
+        pytest.fail(
+            "Gloo metadata preflight workers exited without both rank results; "
+            f"exitcodes={[process.exitcode for process in processes]}"
+        )
+    finally:
+        results.close()
+        results.join_thread()
+
+    assert [process.exitcode for process in processes] == [0] * world_size
+    by_rank = {rank: (status, message) for rank, status, message in payloads}
+    assert set(by_rank) == set(range(world_size))
+    return by_rank
+
+
+@pytest.mark.parametrize("canonical_attr", ["embed", "embed_tokens"])
+def test_shared_embedding_initialization_broadcasts_first_stage_and_marks_replica(
+    monkeypatch, canonical_attr: str
+) -> None:
+    embedding_group = object()
+    first_ps, last_ps = _boundary_states(embedding_group)
+    canonical = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+    first = _EmbeddingOwner(
+        canonical_attr=canonical_attr,
+        canonical_weight=canonical,
+    )
+    last = _EmbeddingOwner(
+        canonical_attr=canonical_attr,
+        mtp_weight=torch.full_like(canonical, -9.0),
+    )
+    reduced: list[torch.Tensor] = []
+    collective_order: list[str] = []
+
+    def fake_all_gather(
+        outputs: list[torch.Tensor], tensor: torch.Tensor, *, group: object
+    ) -> None:
+        assert group is embedding_group
+        assert tensor.dtype == torch.int64
+        collective_order.append("pair_parameter_metadata")
+        for output in outputs:
+            output.copy_(tensor)
+
+    def fake_all_reduce(tensor: torch.Tensor, *, group: object) -> None:
+        if group is torch.distributed.group.WORLD:
+            assert tensor.dtype == torch.int32
+            collective_order.append("world")
+            return
+        assert group is embedding_group
+        collective_order.append("pair_data")
+        reduced.append(tensor)
+        if len(reduced) == 2:
+            total = sum((item.clone() for item in reduced), torch.zeros_like(tensor))
+            for item in reduced:
+                item.copy_(total)
+
+    monkeypatch.setattr(torch.distributed, "all_gather", fake_all_gather)
+    monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
+
+    _run_for_both_boundaries(
+        synchronize_mtp_embedding_parameters,
+        first,
+        last,
+        first_ps,
+        last_ps,
+    )
+
+    assert (
+        collective_order
+        == [
+            "world",
+            "pair_parameter_metadata",
+            "world",
+            "pair_data",
+        ]
+        * 2
+    )
+    first_weight = getattr(first, canonical_attr).embedding.weight
+    last_weight = last.mtp_embed.embedding.weight
+    torch.testing.assert_close(first_weight, canonical, atol=0.0, rtol=0.0)
+    torch.testing.assert_close(last_weight, canonical, atol=0.0, rtol=0.0)
+    assert first_weight.shared_embedding is True
+    assert last_weight.shared_embedding is True
+    assert not getattr(first_weight, "shared", False)
+    assert last_weight.shared is True
+    assert last._mlite_tied_checkpoint_keys == {
+        "mtp_embed.embedding.weight": f"{canonical_attr}.embedding.weight"
+    }
+    assert first_ps.mtp_embedding_preflight_cache is not None
+    assert last_ps.mtp_embedding_preflight_cache is not None
+
+
+def test_shared_embedding_gradient_allreduce_sums_main_and_parameter_grads(
+    monkeypatch,
+) -> None:
+    embedding_group = object()
+    first_ps, last_ps = _boundary_states(embedding_group)
+    zeros = torch.zeros(3, 2)
+    first = _EmbeddingOwner(canonical_attr="embed", canonical_weight=zeros)
+    last = _EmbeddingOwner(mtp_weight=zeros)
+    _prime_shared_embedding_cache(
+        monkeypatch,
+        first,
+        last,
+        first_ps,
+        last_ps,
+    )
+    first_weight = first.embed.embedding.weight
+    last_weight = last.mtp_embed.embedding.weight
+    first_weight.grad = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+    last_weight.main_grad = torch.tensor([[10.0, 20.0], [30.0, 40.0], [50.0, 60.0]])
+    last_weight.grad = torch.full_like(last_weight, -99.0)
+    expected = first_weight.grad.clone() + last_weight.main_grad.clone()
+    collective_order: list[str] = []
+
+    def fake_all_gather(
+        outputs: list[torch.Tensor], tensor: torch.Tensor, *, group: object
+    ) -> None:
+        assert group is embedding_group
+        assert tensor.dtype == torch.int64
+        collective_order.append("pair_gradient_metadata")
+        for output in outputs:
+            output.copy_(tensor)
+
+    def fake_all_reduce(tensor: torch.Tensor, *, group: object) -> None:
+        if group is torch.distributed.group.WORLD:
+            assert tensor.dtype == torch.int32
+            collective_order.append("world")
+            return
+        assert group is embedding_group
+        collective_order.append("pair_data")
+        tensor.copy_(expected)
+
+    monkeypatch.setattr(torch.distributed, "all_gather", fake_all_gather)
+    monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
+
+    _run_for_both_boundaries(
+        allreduce_mtp_embedding_grads,
+        first,
+        last,
+        first_ps,
+        last_ps,
+    )
+
+    assert (
+        collective_order
+        == [
+            "world",
+            "pair_gradient_metadata",
+            "world",
+            "pair_data",
+        ]
+        * 2
+    )
+    torch.testing.assert_close(first_weight.grad, expected, atol=0.0, rtol=0.0)
+    torch.testing.assert_close(last_weight.main_grad, expected, atol=0.0, rtol=0.0)
+    torch.testing.assert_close(
+        last_weight.grad,
+        torch.full_like(last_weight, -99.0),
+        atol=0.0,
+        rtol=0.0,
+    )
+
+
+def test_incomplete_shared_embedding_grads_fail_both_ranks_before_data_allreduce(
+    monkeypatch,
+) -> None:
+    embedding_group = object()
+    first_ps, last_ps = _boundary_states(embedding_group)
+    zeros = torch.zeros(3, 2)
+    first = _EmbeddingOwner(canonical_attr="embed", canonical_weight=zeros)
+    last = _EmbeddingOwner(mtp_weight=zeros)
+    _prime_shared_embedding_cache(
+        monkeypatch,
+        first,
+        last,
+        first_ps,
+        last_ps,
+    )
+    first.embed.embedding.weight.grad = torch.ones_like(first.embed.embedding.weight)
+    collective_order: list[str] = []
+
+    def fake_all_gather(
+        outputs: list[torch.Tensor], tensor: torch.Tensor, *, group: object
+    ) -> None:
+        assert group is embedding_group
+        assert tensor.dtype == torch.int64
+        collective_order.append("pair_gradient_metadata")
+        for output in outputs:
+            output.copy_(tensor)
+        # Always expose the real 1/2 pair state to both emulated endpoints.
+        outputs[0][1] = 1
+        outputs[1].zero_()
+        outputs[1][0] = tensor[0]
+        outputs[1][2] = 1
+
+    def fake_all_reduce(tensor: torch.Tensor, *, group: object) -> None:
+        if group is torch.distributed.group.WORLD:
+            assert tensor.dtype == torch.int32
+            collective_order.append("world")
+            return
+        raise AssertionError("gradient data collective must not run")
+
+    monkeypatch.setattr(torch.distributed, "all_gather", fake_all_gather)
+    monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
+
+    for model, ps in ((first, first_ps), (last, last_ps)):
+        with pytest.raises(
+            RuntimeError,
+            match=r"gradient metadata preflight failed.*local_pair_presence=1/2",
+        ):
+            allreduce_mtp_embedding_grads([model], ps, enabled=True)
+
+    assert (
+        collective_order
+        == [
+            "world",
+            "pair_gradient_metadata",
+            "world",
+        ]
+        * 2
+    )
+
+
+def test_absent_shared_embedding_grads_return_after_presence_collective(
+    monkeypatch,
+) -> None:
+    embedding_group = object()
+    first_ps, last_ps = _boundary_states(embedding_group)
+    zeros = torch.zeros(3, 2)
+    first = _EmbeddingOwner(canonical_attr="embed", canonical_weight=zeros)
+    last = _EmbeddingOwner(mtp_weight=zeros)
+    _prime_shared_embedding_cache(
+        monkeypatch,
+        first,
+        last,
+        first_ps,
+        last_ps,
+    )
+    collective_order: list[str] = []
+
+    def fake_all_gather(
+        outputs: list[torch.Tensor], tensor: torch.Tensor, *, group: object
+    ) -> None:
+        assert group is embedding_group
+        assert tensor.dtype == torch.int64
+        collective_order.append("pair_gradient_metadata")
+        for output in outputs:
+            output.copy_(tensor)
+
+    def fake_all_reduce(tensor: torch.Tensor, *, group: object) -> None:
+        if group is torch.distributed.group.WORLD:
+            assert tensor.dtype == torch.int32
+            collective_order.append("world")
+            return
+        raise AssertionError("gradient data collective must not run")
+
+    monkeypatch.setattr(torch.distributed, "all_gather", fake_all_gather)
+    monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
+
+    _run_for_both_boundaries(
+        allreduce_mtp_embedding_grads,
+        first,
+        last,
+        first_ps,
+        last_ps,
+    )
+
+    # A layer can legitimately be unused on both endpoints. Both ranks still
+    # compare fixed-size metadata and reach WORLD consensus, then skip data.
+    assert (
+        collective_order
+        == [
+            "world",
+            "pair_gradient_metadata",
+            "world",
+        ]
+        * 2
+    )
+
+
+@pytest.mark.parametrize(
+    ("mismatch", "first_weight", "last_weight"),
+    [
+        ("shape", torch.zeros(3, 2), torch.zeros(4, 2)),
+        (
+            "dtype",
+            torch.zeros(3, 2, dtype=torch.float32),
+            torch.zeros(3, 2, dtype=torch.float64),
+        ),
+    ],
+)
+def test_parameter_metadata_mismatch_fails_both_endpoints_before_data_collective(
+    monkeypatch,
+    mismatch: str,
+    first_weight: torch.Tensor,
+    last_weight: torch.Tensor,
+) -> None:
+    embedding_group = object()
+    first_ps, last_ps = _boundary_states(embedding_group)
+    first = _EmbeddingOwner(canonical_attr="embed", canonical_weight=first_weight)
+    last = _EmbeddingOwner(mtp_weight=last_weight)
+    collective_order: list[str] = []
+
+    def fake_all_gather(
+        outputs: list[torch.Tensor], tensor: torch.Tensor, *, group: object
+    ) -> None:
+        assert group is embedding_group
+        assert tensor.dtype == torch.int64
+        collective_order.append("pair_parameter_metadata")
+        for output in outputs:
+            output.copy_(tensor)
+        # Return the same deterministic first/last records to both emulated
+        # callers so both observe the cross-rank mismatch.
+        outputs[0][2] = 1
+        outputs[1][2] = 1
+        if mismatch == "shape":
+            outputs[0][3] = outputs[1][3] = 2
+            outputs[0][8:10] = torch.tensor([3, 2])
+            outputs[1][8:10] = torch.tensor([4, 2])
+        else:
+            outputs[0][4] = 8
+            outputs[1][4] = 9
+
+    def fake_all_reduce(tensor: torch.Tensor, *, group: object) -> None:
+        assert group is torch.distributed.group.WORLD
+        assert tensor.dtype == torch.int32
+        collective_order.append("world")
+
+    monkeypatch.setattr(torch.distributed, "all_gather", fake_all_gather)
+    monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
+
+    for model, ps in ((first, first_ps), (last, last_ps)):
+        with pytest.raises(RuntimeError, match="parameter metadata preflight failed"):
+            synchronize_mtp_embedding_parameters([model], ps, enabled=True)
+
+    assert (
+        collective_order
+        == [
+            "world",
+            "pair_parameter_metadata",
+            "world",
+        ]
+        * 2
+    )
+    assert first_ps.mtp_embedding_preflight_cache is None
+    assert last_ps.mtp_embedding_preflight_cache is None
+
+
+@pytest.mark.parametrize("mismatch", ["shape", "dtype"])
+def test_real_gloo_parameter_metadata_mismatch_fails_both_ranks_without_hang(
+    tmp_path,
+    mismatch: str,
+) -> None:
+    # Each outer Phase-A pytest rank receives its own tmp_path. UUID also keeps
+    # repeated parameter cases from sharing a FileStore rendezvous path.
+    by_rank = _run_real_gloo_case(tmp_path, mismatch)
+    for rank in (0, 1):
+        status, message = by_rank[rank]
+        assert status == "runtime_error", message
+        assert "parameter metadata preflight failed" in message
+
+
+def test_real_gloo_missing_cache_fails_both_ranks_without_hang(tmp_path) -> None:
+    by_rank = _run_real_gloo_case(tmp_path, "missing_cache")
+    for rank in (0, 1):
+        status, message = by_rank[rank]
+        assert status == "runtime_error", message
+        assert "gradient metadata preflight failed" in message
+        assert "local_cache_missing=True" in message
+
+
+def test_real_gloo_missing_group_fails_all_ranks_before_pair_collective(
+    tmp_path,
+) -> None:
+    by_rank = _run_real_gloo_case(tmp_path, "missing_group_pp4", world_size=4)
+    for rank in range(4):
+        status, message = by_rank[rank]
+        assert status == "runtime_error", message
+        assert "gradient group preflight failed" in message
+
+
+def test_real_gloo_asymmetric_cache_invalidation_fails_without_hang(tmp_path) -> None:
+    by_rank = _run_real_gloo_case(tmp_path, "asymmetric_cache")
+    for rank in (0, 1):
+        status, message = by_rank[rank]
+        assert status == "runtime_error", message
+        assert "gradient metadata preflight failed" in message
+    assert "local_cache_missing=False" in by_rank[0][1]
+    assert "local_cache_missing=True" in by_rank[1][1]
+
+
+def test_gradient_shape_mismatch_fails_both_endpoints_before_data_collective(
+    monkeypatch,
+) -> None:
+    embedding_group = object()
+    first_ps, last_ps = _boundary_states(embedding_group)
+    zeros = torch.zeros(3, 2)
+    first = _EmbeddingOwner(canonical_attr="embed", canonical_weight=zeros)
+    last = _EmbeddingOwner(mtp_weight=zeros)
+    _prime_shared_embedding_cache(
+        monkeypatch,
+        first,
+        last,
+        first_ps,
+        last_ps,
+    )
+    first.embed.embedding.weight.main_grad = torch.ones(3, 2)
+    last.mtp_embed.embedding.weight.main_grad = torch.ones(4, 2)
+    collective_order: list[str] = []
+
+    def fake_all_gather(
+        outputs: list[torch.Tensor], tensor: torch.Tensor, *, group: object
+    ) -> None:
+        assert group is embedding_group
+        assert tensor.dtype == torch.int64
+        collective_order.append("pair_gradient_metadata")
+        for output in outputs:
+            output.copy_(tensor)
+            output[1] = 1
+            output[2] = 1
+            output[3] = 2
+        outputs[0][8:10] = torch.tensor([3, 2])
+        outputs[1][8:10] = torch.tensor([4, 2])
+
+    def fake_all_reduce(tensor: torch.Tensor, *, group: object) -> None:
+        if group is torch.distributed.group.WORLD:
+            assert tensor.dtype == torch.int32
+            collective_order.append("world")
+            return
+        raise AssertionError("gradient data collective must not run")
+
+    monkeypatch.setattr(torch.distributed, "all_gather", fake_all_gather)
+    monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
+
+    for model, ps in ((first, first_ps), (last, last_ps)):
+        with pytest.raises(
+            RuntimeError,
+            match=r"gradient metadata preflight failed.*local_pair_presence=2/2",
+        ):
+            allreduce_mtp_embedding_grads([model], ps, enabled=True)
+
+    assert collective_order == ["world", "pair_gradient_metadata", "world"] * 2
+
+
+def test_cached_parameter_signature_change_fails_before_gradient_data_collective(
+    monkeypatch,
+) -> None:
+    embedding_group = object()
+    first_ps, last_ps = _boundary_states(embedding_group)
+    zeros = torch.zeros(3, 2)
+    first = _EmbeddingOwner(canonical_attr="embed", canonical_weight=zeros)
+    last = _EmbeddingOwner(mtp_weight=zeros)
+    _prime_shared_embedding_cache(
+        monkeypatch,
+        first,
+        last,
+        first_ps,
+        last_ps,
+    )
+    # Preserve Parameter identity while changing the facts proven at init. Both
+    # endpoints use the same new metadata so only the cached fingerprint can
+    # catch this stale-preflight condition.
+    first_weight = first.embed.embedding.weight
+    last_weight = last.mtp_embed.embedding.weight
+    first_weight.data = torch.zeros(4, 2)
+    last_weight.data = torch.zeros(4, 2)
+    first_weight.main_grad = torch.ones(4, 2)
+    last_weight.main_grad = torch.ones(4, 2)
+    collective_order: list[str] = []
+
+    def fake_all_gather(
+        outputs: list[torch.Tensor], tensor: torch.Tensor, *, group: object
+    ) -> None:
+        assert group is embedding_group
+        collective_order.append("pair_gradient_metadata")
+        for output in outputs:
+            output.copy_(tensor)
+
+    def fake_all_reduce(tensor: torch.Tensor, *, group: object) -> None:
+        if group is dist.group.WORLD:
+            collective_order.append("world")
+            return
+        raise AssertionError("gradient data collective must not run")
+
+    monkeypatch.setattr(dist, "all_gather", fake_all_gather)
+    monkeypatch.setattr(dist, "all_reduce", fake_all_reduce)
+
+    for model, ps in ((first, first_ps), (last, last_ps)):
+        with pytest.raises(RuntimeError, match="gradient metadata preflight failed"):
+            allreduce_mtp_embedding_grads([model], ps, enabled=True)
+
+    assert collective_order == ["world", "pair_gradient_metadata", "world"] * 2
+
+
+def test_nccl_cpu_parameter_fails_metadata_preflight_before_data_collective(
+    monkeypatch,
+) -> None:
+    embedding_group = object()
+    first_ps, last_ps = _boundary_states(embedding_group)
+    zeros = torch.zeros(3, 2)
+    first = _EmbeddingOwner(canonical_attr="embed", canonical_weight=zeros)
+    last = _EmbeddingOwner(mtp_weight=zeros)
+    collective_order: list[str] = []
+
+    def fake_backend(group: object) -> str:
+        return "gloo" if group is torch.distributed.group.WORLD else "nccl"
+
+    def fake_all_gather(
+        outputs: list[torch.Tensor], tensor: torch.Tensor, *, group: object
+    ) -> None:
+        assert group is embedding_group
+        collective_order.append("pair_parameter_metadata")
+        for output in outputs:
+            output.copy_(tensor)
+
+    def fake_all_reduce(tensor: torch.Tensor, *, group: object) -> None:
+        assert group is torch.distributed.group.WORLD
+        collective_order.append("world")
+
+    monkeypatch.setattr(shared_embedding, "_group_backend_name", fake_backend)
+    # The collectives are emulated on this CPU-only unit-test host. Production
+    # chooses CUDA for NCCL control metadata; only the data tensor stays CPU and
+    # must therefore be rejected by the encoded compatibility bit.
+    monkeypatch.setattr(
+        shared_embedding,
+        "_control_device_for_group",
+        lambda group, model_chunks=(): torch.device("cpu"),
+    )
+    monkeypatch.setattr(torch.distributed, "all_gather", fake_all_gather)
+    monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
+
+    for model, ps in ((first, first_ps), (last, last_ps)):
+        with pytest.raises(RuntimeError, match="parameter metadata preflight failed"):
+            synchronize_mtp_embedding_parameters([model], ps, enabled=True)
+
+    assert (
+        collective_order
+        == [
+            "world",
+            "pair_parameter_metadata",
+            "world",
+        ]
+        * 2
+    )
+
+
+def test_declared_embedding_ranks_must_match_actual_group_membership(
+    monkeypatch,
+) -> None:
+    embedding_group = object()
+    first_ps, last_ps = _boundary_states(embedding_group)
+    zeros = torch.zeros(3, 2)
+    first = _EmbeddingOwner(canonical_attr="embed", canonical_weight=zeros)
+    last = _EmbeddingOwner(mtp_weight=zeros)
+    current_rank = 3
+    collective_order: list[str] = []
+
+    monkeypatch.setattr(dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(dist, "get_backend", lambda group: "gloo")
+    monkeypatch.setattr(dist, "get_rank", lambda: current_rank)
+    monkeypatch.setattr(dist, "get_world_size", lambda group=None: 2)
+    monkeypatch.setattr(
+        dist,
+        "get_process_group_ranks",
+        lambda group: [3, 12],
+    )
+
+    def fake_all_reduce(tensor: torch.Tensor, *, group: object) -> None:
+        assert group is dist.group.WORLD
+        collective_order.append("world")
+
+    def forbidden_all_gather(*args, **kwargs) -> None:
+        raise AssertionError("pair metadata must not run for invalid membership")
+
+    monkeypatch.setattr(dist, "all_reduce", fake_all_reduce)
+    monkeypatch.setattr(dist, "all_gather", forbidden_all_gather)
+
+    for rank, model, ps in (
+        (3, first, first_ps),
+        (11, last, last_ps),
+    ):
+        current_rank = rank
+        with pytest.raises(RuntimeError, match="group preflight failed"):
+            synchronize_mtp_embedding_parameters([model], ps, enabled=True)
+
+    assert collective_order == ["world", "world"]
+
+
+@pytest.mark.parametrize(
+    ("fn", "expected_world_collectives"),
+    [
+        (synchronize_mtp_embedding_parameters, 2),
+        (allreduce_mtp_embedding_grads, 2),
+        (validate_mtp_embedding_parameter_replicas, 3),
+    ],
+)
+def test_middle_pipeline_rank_participates_only_in_world_consensus(
+    monkeypatch,
+    fn: Callable,
+    expected_world_collectives: int,
+) -> None:
+    middle = _EmbeddingOwner()
+    ps = ParallelState(
+        pp_size=4,
+        pp_rank=1,
+        pp_is_first=False,
+        pp_is_last=False,
+        embedding_group=None,
+        embedding_global_ranks=None,
+    )
+    collective_order: list[str] = []
+
+    def fake_all_reduce(tensor: torch.Tensor, *, group: object) -> None:
+        assert group is torch.distributed.group.WORLD
+        assert tensor.dtype == torch.int32
+        collective_order.append("world")
+
+    monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
+
+    if fn is allreduce_mtp_embedding_grads:
+        # Initialization caches static parameter facts on every rank. The
+        # optimizer hot path revalidates the active group through WORLD before
+        # its dynamic pair-metadata -> WORLD sequence.
+        synchronize_mtp_embedding_parameters([middle], ps, enabled=True)
+        collective_order.clear()
+
+    fn([middle], ps, enabled=True)
+
+    assert collective_order == ["world"] * expected_world_collectives
+
+
+def test_mtp_embedding_parameter_replica_validation_accepts_exact_equality(
+    monkeypatch,
+) -> None:
+    embedding_group = object()
+    first_ps, last_ps = _boundary_states(embedding_group)
+    canonical = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+    first = _EmbeddingOwner(canonical_attr="embed", canonical_weight=canonical)
+    last = _EmbeddingOwner(mtp_weight=canonical.clone())
+    collective_order: list[str] = []
+
+    def fake_all_gather(
+        outputs: list[torch.Tensor], tensor: torch.Tensor, *, group: object
+    ) -> None:
+        assert group is embedding_group
+        assert tensor.dtype == torch.int64
+        collective_order.append("pair_parameter_metadata")
+        for output in outputs:
+            output.copy_(tensor)
+
+    def fake_all_reduce(tensor: torch.Tensor, *, group: object) -> None:
+        assert tensor.dtype == torch.int32
+        assert group is torch.distributed.group.WORLD
+        collective_order.append("world")
+        tensor.zero_()
+
+    def fake_broadcast(
+        tensor: torch.Tensor,
+        *,
+        src: int,
+        group: object,
+    ) -> None:
+        assert src == first_ps.embedding_global_ranks[0]
+        assert group is embedding_group
+        collective_order.append("pair_broadcast")
+        tensor.copy_(canonical)
+
+    monkeypatch.setattr(torch.distributed, "all_gather", fake_all_gather)
+    monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
+    monkeypatch.setattr(torch.distributed, "broadcast", fake_broadcast)
+
+    _run_for_both_boundaries(
+        validate_mtp_embedding_parameter_replicas,
+        first,
+        last,
+        first_ps,
+        last_ps,
+    )
+
+    assert (
+        collective_order
+        == [
+            "world",
+            "pair_parameter_metadata",
+            "world",
+            "pair_broadcast",
+            "world",
+        ]
+        * 2
+    )
+
+
+def test_save_validation_rechecks_parameters_instead_of_trusting_init_cache(
+    monkeypatch,
+) -> None:
+    embedding_group = object()
+    first_ps, last_ps = _boundary_states(embedding_group)
+    canonical = torch.zeros(3, 2)
+    first = _EmbeddingOwner(canonical_attr="embed", canonical_weight=canonical)
+    last = _EmbeddingOwner(mtp_weight=canonical)
+    _prime_shared_embedding_cache(
+        monkeypatch,
+        first,
+        last,
+        first_ps,
+        last_ps,
+    )
+    # Replace the registered parameter after initialization. A validator that
+    # trusted only the static optimizer cache would miss this incompatible
+    # replica and could hang in broadcast.
+    last.mtp_embed = _Embedding(torch.zeros(4, 2))
+    collective_order: list[str] = []
+
+    def fake_all_gather(
+        outputs: list[torch.Tensor], tensor: torch.Tensor, *, group: object
+    ) -> None:
+        assert group is embedding_group
+        collective_order.append("pair_parameter_metadata")
+        for output in outputs:
+            output.copy_(tensor)
+            output[2] = 1
+            output[3] = 2
+        outputs[0][8:10] = torch.tensor([3, 2])
+        outputs[1][8:10] = torch.tensor([4, 2])
+
+    def fake_all_reduce(tensor: torch.Tensor, *, group: object) -> None:
+        assert group is torch.distributed.group.WORLD
+        collective_order.append("world")
+
+    def forbidden_broadcast(*args, **kwargs) -> None:
+        raise AssertionError("parameter broadcast must not run")
+
+    monkeypatch.setattr(torch.distributed, "all_gather", fake_all_gather)
+    monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
+    monkeypatch.setattr(torch.distributed, "broadcast", forbidden_broadcast)
+
+    for model, ps in ((first, first_ps), (last, last_ps)):
+        with pytest.raises(RuntimeError, match="parameter metadata preflight failed"):
+            validate_mtp_embedding_parameter_replicas([model], ps, enabled=True)
+
+    assert (
+        collective_order
+        == [
+            "world",
+            "pair_parameter_metadata",
+            "world",
+        ]
+        * 2
+    )
+
+
+def test_mtp_embedding_parameter_replica_divergence_fails_all_ranks_via_world(
+    monkeypatch,
+) -> None:
+    embedding_group = object()
+    first_ps, last_ps = _boundary_states(embedding_group)
+    canonical = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+    first = _EmbeddingOwner(canonical_attr="embed", canonical_weight=canonical)
+    perturbed = canonical.clone()
+    perturbed[1, 0] += 0.25
+    last = _EmbeddingOwner(mtp_weight=perturbed)
+    collective_order: list[str] = []
+    world_calls = 0
+
+    def fake_all_gather(
+        outputs: list[torch.Tensor], tensor: torch.Tensor, *, group: object
+    ) -> None:
+        assert group is embedding_group
+        assert tensor.dtype == torch.int64
+        collective_order.append("pair_parameter_metadata")
+        for output in outputs:
+            output.copy_(tensor)
+
+    def fake_all_reduce(tensor: torch.Tensor, *, group: object) -> None:
+        nonlocal world_calls
+        assert tensor.dtype == torch.int32
+        if group is torch.distributed.group.WORLD:
+            phase = world_calls % 3
+            collective_order.append("world")
+            # The final WORLD consensus carries the last-stage mismatch to
+            # every rank, including the locally-equal canonical owner.
+            tensor.fill_(int(phase == 2))
+            world_calls += 1
+            return
+        raise AssertionError("only WORLD error consensus uses all_reduce")
+
+    def fake_broadcast(
+        tensor: torch.Tensor,
+        *,
+        src: int,
+        group: object,
+    ) -> None:
+        assert src == first_ps.embedding_global_ranks[0]
+        assert group is embedding_group
+        collective_order.append("pair_broadcast")
+        tensor.copy_(canonical)
+
+    monkeypatch.setattr(torch.distributed, "all_gather", fake_all_gather)
+    monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
+    monkeypatch.setattr(torch.distributed, "broadcast", fake_broadcast)
+
+    errors: list[str] = []
+    for model, ps in ((first, first_ps), (last, last_ps)):
+        with pytest.raises(RuntimeError, match="replica diverged") as exc_info:
+            validate_mtp_embedding_parameter_replicas([model], ps, enabled=True)
+        errors.append(str(exc_info.value))
+
+    assert "local_max_abs=0.000000e+00" in errors[0]
+    assert "local_max_abs=2.500000e-01" in errors[1]
+    assert (
+        collective_order
+        == [
+            "world",
+            "pair_parameter_metadata",
+            "world",
+            "pair_broadcast",
+            "world",
+        ]
+        * 2
+    )
+
+
+def test_dist_opt_finalize_runs_dp_sync_before_mtp_pair_sync(monkeypatch) -> None:
+    import megatron.lite.primitive.optimizers.megatron_wrap as megatron_wrap
+
+    original = _EmbeddingOwner(
+        canonical_attr="embed", canonical_weight=torch.zeros(3, 2)
+    )
+    wrapped = nn.Module()
+    chunks = [original]
+    ps = ParallelState(pp_size=2)
+    optimizer = object()
+    call_order: list[str] = []
+
+    def fake_build_dist_opt_stack(actual_chunks, **kwargs):
+        assert actual_chunks == [original]
+        return [wrapped], optimizer
+
+    def fake_finalize_dist_opt_grads(actual_chunks, actual_optimizer) -> None:
+        assert actual_chunks == [wrapped]
+        assert actual_optimizer is optimizer
+        call_order.append("dp_finalize")
+
+    def fake_allreduce_mtp_embedding_grads(
+        actual_chunks, actual_ps, *, enabled
+    ) -> None:
+        assert actual_chunks == [wrapped]
+        assert actual_ps is ps
+        assert enabled is True
+        call_order.append("mtp_pair")
+
+    monkeypatch.setattr(
+        megatron_wrap,
+        "build_dist_opt_stack",
+        fake_build_dist_opt_stack,
+    )
+    monkeypatch.setattr(
+        megatron_wrap,
+        "finalize_dist_opt_grads",
+        fake_finalize_dist_opt_grads,
+    )
+    monkeypatch.setattr(
+        shared_embedding,
+        "allreduce_mtp_embedding_grads",
+        fake_allreduce_mtp_embedding_grads,
+    )
+
+    actual_optimizer, finalize_grads = megatron_wrap.build_dist_opt_training_optimizer(
+        chunks,
+        model_cfg=SimpleNamespace(),
+        impl_cfg=SimpleNamespace(
+            optimizer_config=SimpleNamespace(),
+            parallel=SimpleNamespace(),
+        ),
+        ps=ps,
+        model_name="unit",
+        mtp_enabled=True,
+    )
+    assert actual_optimizer is optimizer
+    assert chunks == [wrapped]
+
+    finalize_grads()
+
+    assert call_order == ["dp_finalize", "mtp_pair"]
+
+
+@pytest.mark.parametrize("rank", [0, 1, 3])
+def test_init_parallel_defers_mtp_embedding_pair_until_lazy_init(
+    monkeypatch,
+    rank: int,
+) -> None:
+    config = SimpleNamespace(tp=1, ep=1, etp=1, cp=1, pp=4)
+    created_groups: list[tuple[tuple[int, ...], str | None, object]] = []
+
+    def fake_new_group(ranks, backend=None):
+        marker = object()
+        created_groups.append((tuple(ranks), backend, marker))
+        return marker
+
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda group=None: 4)
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: rank)
+    monkeypatch.setattr(torch.distributed, "new_group", fake_new_group)
+
+    ps = init_parallel(config)
+
+    assert ps.embedding_groups_initialized is False
+    assert ps.embedding_group is None
+    assert ps.embedding_global_ranks is None
+    assert not [entry for entry in created_groups if entry[0] == (0, 3)]
+
+    before_lazy_init = len(created_groups)
+    init_mtp_embedding_group(ps)
+    lazy_groups = created_groups[before_lazy_init:]
+
+    assert len(lazy_groups) == 1
+    pair_ranks, backend, pair_group = lazy_groups[0]
+    assert pair_ranks == (0, 3)
+    assert backend is None
+    assert ps.embedding_groups_initialized is True
+    if rank in pair_ranks:
+        assert ps.embedding_group is pair_group
+        assert ps.embedding_global_ranks == [0, 3]
+    else:
+        assert ps.embedding_group is None
+        assert ps.embedding_global_ranks is None
+
+    # Lazy initialization is idempotent and never creates a second pair.
+    init_mtp_embedding_group(ps)
+    assert len(created_groups) == before_lazy_init + 1
+
+
+def test_distckpt_tied_embedding_uses_canonical_logical_key_and_replica_id() -> None:
+    pytest.importorskip("megatron.core.dist_checkpointing")
+    from megatron.lite.primitive.ckpt.distckpt import (
+        _model_sharded_state_dict,
+        attach_model_sharded_state_dict,
+    )
+
+    weight = torch.arange(6, dtype=torch.float32).reshape(3, 2)
+    first = _EmbeddingOwner(
+        canonical_attr="embed_tokens",
+        canonical_weight=weight,
+    )
+    last = _EmbeddingOwner(mtp_weight=weight)
+    last._mlite_tied_checkpoint_keys = {
+        "mtp_embed.embedding.weight": "embed_tokens.embedding.weight"
+    }
+    first_ps = ParallelState(
+        pp_size=2,
+        pp_rank=0,
+        pp_is_first=True,
+        pp_is_last=False,
+        tp_size=4,
+        tp_rank=2,
+        dp_cp_rank=3,
+    )
+    last_ps = ParallelState(
+        pp_size=2,
+        pp_rank=1,
+        pp_is_first=False,
+        pp_is_last=True,
+        tp_size=4,
+        tp_rank=2,
+        dp_cp_rank=3,
+    )
+    attach_model_sharded_state_dict([first], first_ps)
+    attach_model_sharded_state_dict([last], last_ps)
+
+    first_state = _model_sharded_state_dict(first)["model_pp0"]
+    last_state = _model_sharded_state_dict(last)["model_pp1"]
+    canonical = first_state["embed_tokens.embedding.weight"]
+    replica = last_state["mtp_embed.embedding.weight"]
+
+    assert canonical.key == replica.key == "model_pp0.embed_tokens.embedding.weight"
+    assert canonical.replica_id == (0, 2, 3)
+    assert replica.replica_id == (1, 2, 3)
+
+
+def test_distckpt_save_validates_tied_embedding_before_logical_collapse(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    pytest.importorskip("megatron.core.dist_checkpointing")
+    import megatron.lite.primitive.ckpt.distckpt as distckpt
+    import megatron.lite.primitive.parallel as parallel
+
+    model = _EmbeddingOwner(mtp_weight=torch.zeros(3, 2))
+    ps = ParallelState(
+        pp_size=2,
+        pp_rank=1,
+        pp_is_first=False,
+        pp_is_last=True,
+        embedding_groups_initialized=True,
+    )
+    model._mlite_dist_opt_parallel_state = ps
+    model._mlite_tied_checkpoint_keys = {
+        "mtp_embed.embedding.weight": "embed.embedding.weight"
+    }
+    call_order: list[str] = []
+
+    def fake_validate(chunks, actual_ps, *, enabled: bool) -> None:
+        assert chunks == [model]
+        assert actual_ps is ps
+        assert enabled is True
+        call_order.append("validate")
+
+    def fake_model_sharded_state_dict(actual_model):
+        assert actual_model is model
+        call_order.append("logical_collapse")
+        return {"model_pp1": {}}
+
+    def fake_save(state_dict, checkpoint_dir, **kwargs) -> None:
+        assert state_dict == {"step": 7, "model_pp1": {}}
+        assert checkpoint_dir == str(tmp_path)
+        call_order.append("save")
+
+    monkeypatch.setattr(
+        parallel,
+        "validate_mtp_embedding_parameter_replicas",
+        fake_validate,
+    )
+    monkeypatch.setattr(
+        distckpt,
+        "_model_sharded_state_dict",
+        fake_model_sharded_state_dict,
+    )
+    monkeypatch.setattr(distckpt.dist_checkpointing, "save", fake_save)
+
+    distckpt.save_dist_opt_checkpoint(
+        model,
+        optimizer=None,
+        step=7,
+        checkpoint_dir=str(tmp_path),
+        save_model=True,
+        save_optimizer=False,
+    )
+
+    assert call_order == ["validate", "logical_collapse", "save"]
+
+
+@pytest.mark.parametrize(
+    "canonical_name",
+    ["embed.embedding.weight", "embed_tokens.embedding.weight"],
+)
+def test_hf_export_accepts_equal_mtp_embedding_replica(canonical_name: str) -> None:
+    from megatron.lite.primitive.ckpt.hf_weights import (
+        _validate_mtp_embedding_replica,
+    )
+
+    canonical = torch.arange(6, dtype=torch.float32).reshape(3, 2)
+    _validate_mtp_embedding_replica(
+        {
+            canonical_name: canonical,
+            "mtp_embed.embedding.weight": canonical.clone(),
+        }
+    )
+
+
+def test_hf_export_rejects_perturbed_mtp_embedding_replica() -> None:
+    from megatron.lite.primitive.ckpt.hf_weights import (
+        _validate_mtp_embedding_replica,
+    )
+
+    canonical = torch.arange(6, dtype=torch.float32).reshape(3, 2)
+    replica = canonical.clone()
+    replica[1, 0] += 0.25
+
+    with pytest.raises(AssertionError, match="divergent PP MTP embedding replica"):
+        _validate_mtp_embedding_replica(
+            {
+                "embed.embedding.weight": canonical,
+                "mtp_embed.embedding.weight": replica,
+            }
+        )
+
+
+def test_hf_export_rejects_mtp_embedding_replica_without_canonical() -> None:
+    from megatron.lite.primitive.ckpt.hf_weights import (
+        _validate_mtp_embedding_replica,
+    )
+
+    with pytest.raises(AssertionError, match="without exactly one canonical"):
+        _validate_mtp_embedding_replica(
+            {"mtp_embed.embedding.weight": torch.zeros(3, 2)}
+        )

--- a/experimental/lite/tests/unit/primitive/test_shared_embedding_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_shared_embedding_unit.py
@@ -9,13 +9,12 @@ from collections.abc import Callable
 from queue import Empty
 from types import SimpleNamespace
 
+import megatron.lite.primitive.parallel.shared_embedding as shared_embedding
 import pytest
 import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
 import torch.nn as nn
-
-import megatron.lite.primitive.parallel.shared_embedding as shared_embedding
 from megatron.lite.primitive.parallel.shared_embedding import (
     allreduce_mtp_embedding_grads,
     synchronize_mtp_embedding_parameters,
@@ -63,34 +62,17 @@ class _Embedding(nn.Module):
     def __init__(self, weight: torch.Tensor) -> None:
         super().__init__()
         self.embedding = nn.Embedding(
-            weight.shape[0],
-            weight.shape[1],
-            device=weight.device,
-            dtype=weight.dtype,
+            weight.shape[0], weight.shape[1], device=weight.device, dtype=weight.dtype
         )
         with torch.no_grad():
             self.embedding.weight.copy_(weight)
 
 
 def _boundary_states(group: object) -> tuple[ParallelState, ParallelState]:
-    common = {
-        "pp_size": 2,
-        "embedding_group": group,
-        "embedding_global_ranks": [3, 11],
-    }
+    common = {"pp_size": 2, "embedding_group": group, "embedding_global_ranks": [3, 11]}
     return (
-        ParallelState(
-            **common,
-            pp_rank=0,
-            pp_is_first=True,
-            pp_is_last=False,
-        ),
-        ParallelState(
-            **common,
-            pp_rank=1,
-            pp_is_first=False,
-            pp_is_last=True,
-        ),
+        ParallelState(**common, pp_rank=0, pp_is_first=True, pp_is_last=False),
+        ParallelState(**common, pp_rank=1, pp_is_first=False, pp_is_last=True),
     )
 
 
@@ -138,22 +120,14 @@ def _prime_shared_embedding_cache(
     monkeypatch.setattr(torch.distributed, "all_gather", fake_all_gather)
     monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
     _run_for_both_boundaries(
-        synchronize_mtp_embedding_parameters,
-        first,
-        last,
-        first_ps,
-        last_ps,
+        synchronize_mtp_embedding_parameters, first, last, first_ps, last_ps
     )
     assert first_ps.mtp_embedding_preflight_cache is not None
     assert last_ps.mtp_embedding_preflight_cache is not None
 
 
 def _distributed_shared_embedding_worker(
-    rank: int,
-    world_size: int,
-    init_method: str,
-    case: str,
-    results,
+    rank: int, world_size: int, init_method: str, case: str, results
 ) -> None:
     """Real Gloo endpoint used by the no-hang metadata regression test."""
     try:
@@ -286,13 +260,9 @@ def test_shared_embedding_initialization_broadcasts_first_stage_and_marks_replic
     embedding_group = object()
     first_ps, last_ps = _boundary_states(embedding_group)
     canonical = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
-    first = _EmbeddingOwner(
-        canonical_attr=canonical_attr,
-        canonical_weight=canonical,
-    )
+    first = _EmbeddingOwner(canonical_attr=canonical_attr, canonical_weight=canonical)
     last = _EmbeddingOwner(
-        canonical_attr=canonical_attr,
-        mtp_weight=torch.full_like(canonical, -9.0),
+        canonical_attr=canonical_attr, mtp_weight=torch.full_like(canonical, -9.0)
     )
     reduced: list[torch.Tensor] = []
     collective_order: list[str] = []
@@ -323,22 +293,12 @@ def test_shared_embedding_initialization_broadcasts_first_stage_and_marks_replic
     monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
 
     _run_for_both_boundaries(
-        synchronize_mtp_embedding_parameters,
-        first,
-        last,
-        first_ps,
-        last_ps,
+        synchronize_mtp_embedding_parameters, first, last, first_ps, last_ps
     )
 
     assert (
         collective_order
-        == [
-            "world",
-            "pair_parameter_metadata",
-            "world",
-            "pair_data",
-        ]
-        * 2
+        == ["world", "pair_parameter_metadata", "world", "pair_data"] * 2
     )
     first_weight = getattr(first, canonical_attr).embedding.weight
     last_weight = last.mtp_embed.embedding.weight
@@ -363,13 +323,7 @@ def test_shared_embedding_gradient_allreduce_sums_main_and_parameter_grads(
     zeros = torch.zeros(3, 2)
     first = _EmbeddingOwner(canonical_attr="embed", canonical_weight=zeros)
     last = _EmbeddingOwner(mtp_weight=zeros)
-    _prime_shared_embedding_cache(
-        monkeypatch,
-        first,
-        last,
-        first_ps,
-        last_ps,
-    )
+    _prime_shared_embedding_cache(monkeypatch, first, last, first_ps, last_ps)
     first_weight = first.embed.embedding.weight
     last_weight = last.mtp_embed.embedding.weight
     first_weight.grad = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
@@ -400,30 +354,17 @@ def test_shared_embedding_gradient_allreduce_sums_main_and_parameter_grads(
     monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
 
     _run_for_both_boundaries(
-        allreduce_mtp_embedding_grads,
-        first,
-        last,
-        first_ps,
-        last_ps,
+        allreduce_mtp_embedding_grads, first, last, first_ps, last_ps
     )
 
     assert (
         collective_order
-        == [
-            "world",
-            "pair_gradient_metadata",
-            "world",
-            "pair_data",
-        ]
-        * 2
+        == ["world", "pair_gradient_metadata", "world", "pair_data"] * 2
     )
     torch.testing.assert_close(first_weight.grad, expected, atol=0.0, rtol=0.0)
     torch.testing.assert_close(last_weight.main_grad, expected, atol=0.0, rtol=0.0)
     torch.testing.assert_close(
-        last_weight.grad,
-        torch.full_like(last_weight, -99.0),
-        atol=0.0,
-        rtol=0.0,
+        last_weight.grad, torch.full_like(last_weight, -99.0), atol=0.0, rtol=0.0
     )
 
 
@@ -435,13 +376,7 @@ def test_incomplete_shared_embedding_grads_fail_both_ranks_before_data_allreduce
     zeros = torch.zeros(3, 2)
     first = _EmbeddingOwner(canonical_attr="embed", canonical_weight=zeros)
     last = _EmbeddingOwner(mtp_weight=zeros)
-    _prime_shared_embedding_cache(
-        monkeypatch,
-        first,
-        last,
-        first_ps,
-        last_ps,
-    )
+    _prime_shared_embedding_cache(monkeypatch, first, last, first_ps, last_ps)
     first.embed.embedding.weight.grad = torch.ones_like(first.embed.embedding.weight)
     collective_order: list[str] = []
 
@@ -476,15 +411,7 @@ def test_incomplete_shared_embedding_grads_fail_both_ranks_before_data_allreduce
         ):
             allreduce_mtp_embedding_grads([model], ps, enabled=True)
 
-    assert (
-        collective_order
-        == [
-            "world",
-            "pair_gradient_metadata",
-            "world",
-        ]
-        * 2
-    )
+    assert collective_order == ["world", "pair_gradient_metadata", "world"] * 2
 
 
 def test_absent_shared_embedding_grads_return_after_presence_collective(
@@ -495,13 +422,7 @@ def test_absent_shared_embedding_grads_return_after_presence_collective(
     zeros = torch.zeros(3, 2)
     first = _EmbeddingOwner(canonical_attr="embed", canonical_weight=zeros)
     last = _EmbeddingOwner(mtp_weight=zeros)
-    _prime_shared_embedding_cache(
-        monkeypatch,
-        first,
-        last,
-        first_ps,
-        last_ps,
-    )
+    _prime_shared_embedding_cache(monkeypatch, first, last, first_ps, last_ps)
     collective_order: list[str] = []
 
     def fake_all_gather(
@@ -524,24 +445,12 @@ def test_absent_shared_embedding_grads_return_after_presence_collective(
     monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
 
     _run_for_both_boundaries(
-        allreduce_mtp_embedding_grads,
-        first,
-        last,
-        first_ps,
-        last_ps,
+        allreduce_mtp_embedding_grads, first, last, first_ps, last_ps
     )
 
     # A layer can legitimately be unused on both endpoints. Both ranks still
     # compare fixed-size metadata and reach WORLD consensus, then skip data.
-    assert (
-        collective_order
-        == [
-            "world",
-            "pair_gradient_metadata",
-            "world",
-        ]
-        * 2
-    )
+    assert collective_order == ["world", "pair_gradient_metadata", "world"] * 2
 
 
 @pytest.mark.parametrize(
@@ -556,10 +465,7 @@ def test_absent_shared_embedding_grads_return_after_presence_collective(
     ],
 )
 def test_parameter_metadata_mismatch_fails_both_endpoints_before_data_collective(
-    monkeypatch,
-    mismatch: str,
-    first_weight: torch.Tensor,
-    last_weight: torch.Tensor,
+    monkeypatch, mismatch: str, first_weight: torch.Tensor, last_weight: torch.Tensor
 ) -> None:
     embedding_group = object()
     first_ps, last_ps = _boundary_states(embedding_group)
@@ -599,23 +505,14 @@ def test_parameter_metadata_mismatch_fails_both_endpoints_before_data_collective
         with pytest.raises(RuntimeError, match="parameter metadata preflight failed"):
             synchronize_mtp_embedding_parameters([model], ps, enabled=True)
 
-    assert (
-        collective_order
-        == [
-            "world",
-            "pair_parameter_metadata",
-            "world",
-        ]
-        * 2
-    )
+    assert collective_order == ["world", "pair_parameter_metadata", "world"] * 2
     assert first_ps.mtp_embedding_preflight_cache is None
     assert last_ps.mtp_embedding_preflight_cache is None
 
 
 @pytest.mark.parametrize("mismatch", ["shape", "dtype"])
 def test_real_gloo_parameter_metadata_mismatch_fails_both_ranks_without_hang(
-    tmp_path,
-    mismatch: str,
+    tmp_path, mismatch: str
 ) -> None:
     # Each outer Phase-A pytest rank receives its own tmp_path. UUID also keeps
     # repeated parameter cases from sharing a FileStore rendezvous path.
@@ -663,13 +560,7 @@ def test_gradient_shape_mismatch_fails_both_endpoints_before_data_collective(
     zeros = torch.zeros(3, 2)
     first = _EmbeddingOwner(canonical_attr="embed", canonical_weight=zeros)
     last = _EmbeddingOwner(mtp_weight=zeros)
-    _prime_shared_embedding_cache(
-        monkeypatch,
-        first,
-        last,
-        first_ps,
-        last_ps,
-    )
+    _prime_shared_embedding_cache(monkeypatch, first, last, first_ps, last_ps)
     first.embed.embedding.weight.main_grad = torch.ones(3, 2)
     last.mtp_embed.embedding.weight.main_grad = torch.ones(4, 2)
     collective_order: list[str] = []
@@ -716,13 +607,7 @@ def test_cached_parameter_signature_change_fails_before_gradient_data_collective
     zeros = torch.zeros(3, 2)
     first = _EmbeddingOwner(canonical_attr="embed", canonical_weight=zeros)
     last = _EmbeddingOwner(mtp_weight=zeros)
-    _prime_shared_embedding_cache(
-        monkeypatch,
-        first,
-        last,
-        first_ps,
-        last_ps,
-    )
+    _prime_shared_embedding_cache(monkeypatch, first, last, first_ps, last_ps)
     # Preserve Parameter identity while changing the facts proven at init. Both
     # endpoints use the same new metadata so only the cached fingerprint can
     # catch this stale-preflight condition.
@@ -799,15 +684,7 @@ def test_nccl_cpu_parameter_fails_metadata_preflight_before_data_collective(
         with pytest.raises(RuntimeError, match="parameter metadata preflight failed"):
             synchronize_mtp_embedding_parameters([model], ps, enabled=True)
 
-    assert (
-        collective_order
-        == [
-            "world",
-            "pair_parameter_metadata",
-            "world",
-        ]
-        * 2
-    )
+    assert collective_order == ["world", "pair_parameter_metadata", "world"] * 2
 
 
 def test_declared_embedding_ranks_must_match_actual_group_membership(
@@ -825,11 +702,7 @@ def test_declared_embedding_ranks_must_match_actual_group_membership(
     monkeypatch.setattr(dist, "get_backend", lambda group: "gloo")
     monkeypatch.setattr(dist, "get_rank", lambda: current_rank)
     monkeypatch.setattr(dist, "get_world_size", lambda group=None: 2)
-    monkeypatch.setattr(
-        dist,
-        "get_process_group_ranks",
-        lambda group: [3, 12],
-    )
+    monkeypatch.setattr(dist, "get_process_group_ranks", lambda group: [3, 12])
 
     def fake_all_reduce(tensor: torch.Tensor, *, group: object) -> None:
         assert group is dist.group.WORLD
@@ -841,10 +714,7 @@ def test_declared_embedding_ranks_must_match_actual_group_membership(
     monkeypatch.setattr(dist, "all_reduce", fake_all_reduce)
     monkeypatch.setattr(dist, "all_gather", forbidden_all_gather)
 
-    for rank, model, ps in (
-        (3, first, first_ps),
-        (11, last, last_ps),
-    ):
+    for rank, model, ps in ((3, first, first_ps), (11, last, last_ps)):
         current_rank = rank
         with pytest.raises(RuntimeError, match="group preflight failed"):
             synchronize_mtp_embedding_parameters([model], ps, enabled=True)
@@ -861,9 +731,7 @@ def test_declared_embedding_ranks_must_match_actual_group_membership(
     ],
 )
 def test_middle_pipeline_rank_participates_only_in_world_consensus(
-    monkeypatch,
-    fn: Callable,
-    expected_world_collectives: int,
+    monkeypatch, fn: Callable, expected_world_collectives: int
 ) -> None:
     middle = _EmbeddingOwner()
     ps = ParallelState(
@@ -920,12 +788,7 @@ def test_mtp_embedding_parameter_replica_validation_accepts_exact_equality(
         collective_order.append("world")
         tensor.zero_()
 
-    def fake_broadcast(
-        tensor: torch.Tensor,
-        *,
-        src: int,
-        group: object,
-    ) -> None:
+    def fake_broadcast(tensor: torch.Tensor, *, src: int, group: object) -> None:
         assert src == first_ps.embedding_global_ranks[0]
         assert group is embedding_group
         collective_order.append("pair_broadcast")
@@ -936,23 +799,12 @@ def test_mtp_embedding_parameter_replica_validation_accepts_exact_equality(
     monkeypatch.setattr(torch.distributed, "broadcast", fake_broadcast)
 
     _run_for_both_boundaries(
-        validate_mtp_embedding_parameter_replicas,
-        first,
-        last,
-        first_ps,
-        last_ps,
+        validate_mtp_embedding_parameter_replicas, first, last, first_ps, last_ps
     )
 
     assert (
         collective_order
-        == [
-            "world",
-            "pair_parameter_metadata",
-            "world",
-            "pair_broadcast",
-            "world",
-        ]
-        * 2
+        == ["world", "pair_parameter_metadata", "world", "pair_broadcast", "world"] * 2
     )
 
 
@@ -964,13 +816,7 @@ def test_save_validation_rechecks_parameters_instead_of_trusting_init_cache(
     canonical = torch.zeros(3, 2)
     first = _EmbeddingOwner(canonical_attr="embed", canonical_weight=canonical)
     last = _EmbeddingOwner(mtp_weight=canonical)
-    _prime_shared_embedding_cache(
-        monkeypatch,
-        first,
-        last,
-        first_ps,
-        last_ps,
-    )
+    _prime_shared_embedding_cache(monkeypatch, first, last, first_ps, last_ps)
     # Replace the registered parameter after initialization. A validator that
     # trusted only the static optimizer cache would miss this incompatible
     # replica and could hang in broadcast.
@@ -1004,15 +850,7 @@ def test_save_validation_rechecks_parameters_instead_of_trusting_init_cache(
         with pytest.raises(RuntimeError, match="parameter metadata preflight failed"):
             validate_mtp_embedding_parameter_replicas([model], ps, enabled=True)
 
-    assert (
-        collective_order
-        == [
-            "world",
-            "pair_parameter_metadata",
-            "world",
-        ]
-        * 2
-    )
+    assert collective_order == ["world", "pair_parameter_metadata", "world"] * 2
 
 
 def test_mtp_embedding_parameter_replica_divergence_fails_all_ranks_via_world(
@@ -1050,12 +888,7 @@ def test_mtp_embedding_parameter_replica_divergence_fails_all_ranks_via_world(
             return
         raise AssertionError("only WORLD error consensus uses all_reduce")
 
-    def fake_broadcast(
-        tensor: torch.Tensor,
-        *,
-        src: int,
-        group: object,
-    ) -> None:
+    def fake_broadcast(tensor: torch.Tensor, *, src: int, group: object) -> None:
         assert src == first_ps.embedding_global_ranks[0]
         assert group is embedding_group
         collective_order.append("pair_broadcast")
@@ -1075,14 +908,7 @@ def test_mtp_embedding_parameter_replica_divergence_fails_all_ranks_via_world(
     assert "local_max_abs=2.500000e-01" in errors[1]
     assert (
         collective_order
-        == [
-            "world",
-            "pair_parameter_metadata",
-            "world",
-            "pair_broadcast",
-            "world",
-        ]
-        * 2
+        == ["world", "pair_parameter_metadata", "world", "pair_broadcast", "world"] * 2
     )
 
 
@@ -1116,14 +942,10 @@ def test_dist_opt_finalize_runs_dp_sync_before_mtp_pair_sync(monkeypatch) -> Non
         call_order.append("mtp_pair")
 
     monkeypatch.setattr(
-        megatron_wrap,
-        "build_dist_opt_stack",
-        fake_build_dist_opt_stack,
+        megatron_wrap, "build_dist_opt_stack", fake_build_dist_opt_stack
     )
     monkeypatch.setattr(
-        megatron_wrap,
-        "finalize_dist_opt_grads",
-        fake_finalize_dist_opt_grads,
+        megatron_wrap, "finalize_dist_opt_grads", fake_finalize_dist_opt_grads
     )
     monkeypatch.setattr(
         shared_embedding,
@@ -1135,8 +957,7 @@ def test_dist_opt_finalize_runs_dp_sync_before_mtp_pair_sync(monkeypatch) -> Non
         chunks,
         model_cfg=SimpleNamespace(),
         impl_cfg=SimpleNamespace(
-            optimizer_config=SimpleNamespace(),
-            parallel=SimpleNamespace(),
+            optimizer_config=SimpleNamespace(), parallel=SimpleNamespace()
         ),
         ps=ps,
         model_name="unit",
@@ -1152,8 +973,7 @@ def test_dist_opt_finalize_runs_dp_sync_before_mtp_pair_sync(monkeypatch) -> Non
 
 @pytest.mark.parametrize("rank", [0, 1, 3])
 def test_init_parallel_defers_mtp_embedding_pair_until_lazy_init(
-    monkeypatch,
-    rank: int,
+    monkeypatch, rank: int
 ) -> None:
     config = SimpleNamespace(tp=1, ep=1, etp=1, cp=1, pp=4)
     created_groups: list[tuple[tuple[int, ...], str | None, object]] = []
@@ -1204,10 +1024,7 @@ def test_distckpt_tied_embedding_uses_canonical_logical_key_and_replica_id() -> 
     )
 
     weight = torch.arange(6, dtype=torch.float32).reshape(3, 2)
-    first = _EmbeddingOwner(
-        canonical_attr="embed_tokens",
-        canonical_weight=weight,
-    )
+    first = _EmbeddingOwner(canonical_attr="embed_tokens", canonical_weight=weight)
     last = _EmbeddingOwner(mtp_weight=weight)
     last._mlite_tied_checkpoint_keys = {
         "mtp_embed.embedding.weight": "embed_tokens.embedding.weight"
@@ -1244,8 +1061,7 @@ def test_distckpt_tied_embedding_uses_canonical_logical_key_and_replica_id() -> 
 
 
 def test_distckpt_save_validates_tied_embedding_before_logical_collapse(
-    monkeypatch,
-    tmp_path,
+    monkeypatch, tmp_path
 ) -> None:
     pytest.importorskip("megatron.core.dist_checkpointing")
     import megatron.lite.primitive.ckpt.distckpt as distckpt
@@ -1282,14 +1098,10 @@ def test_distckpt_save_validates_tied_embedding_before_logical_collapse(
         call_order.append("save")
 
     monkeypatch.setattr(
-        parallel,
-        "validate_mtp_embedding_parameter_replicas",
-        fake_validate,
+        parallel, "validate_mtp_embedding_parameter_replicas", fake_validate
     )
     monkeypatch.setattr(
-        distckpt,
-        "_model_sharded_state_dict",
-        fake_model_sharded_state_dict,
+        distckpt, "_model_sharded_state_dict", fake_model_sharded_state_dict
     )
     monkeypatch.setattr(distckpt.dist_checkpointing, "save", fake_save)
 
@@ -1306,27 +1118,19 @@ def test_distckpt_save_validates_tied_embedding_before_logical_collapse(
 
 
 @pytest.mark.parametrize(
-    "canonical_name",
-    ["embed.embedding.weight", "embed_tokens.embedding.weight"],
+    "canonical_name", ["embed.embedding.weight", "embed_tokens.embedding.weight"]
 )
 def test_hf_export_accepts_equal_mtp_embedding_replica(canonical_name: str) -> None:
-    from megatron.lite.primitive.ckpt.hf_weights import (
-        _validate_mtp_embedding_replica,
-    )
+    from megatron.lite.primitive.ckpt.hf_weights import _validate_mtp_embedding_replica
 
     canonical = torch.arange(6, dtype=torch.float32).reshape(3, 2)
     _validate_mtp_embedding_replica(
-        {
-            canonical_name: canonical,
-            "mtp_embed.embedding.weight": canonical.clone(),
-        }
+        {canonical_name: canonical, "mtp_embed.embedding.weight": canonical.clone()}
     )
 
 
 def test_hf_export_rejects_perturbed_mtp_embedding_replica() -> None:
-    from megatron.lite.primitive.ckpt.hf_weights import (
-        _validate_mtp_embedding_replica,
-    )
+    from megatron.lite.primitive.ckpt.hf_weights import _validate_mtp_embedding_replica
 
     canonical = torch.arange(6, dtype=torch.float32).reshape(3, 2)
     replica = canonical.clone()
@@ -1334,17 +1138,12 @@ def test_hf_export_rejects_perturbed_mtp_embedding_replica() -> None:
 
     with pytest.raises(AssertionError, match="divergent PP MTP embedding replica"):
         _validate_mtp_embedding_replica(
-            {
-                "embed.embedding.weight": canonical,
-                "mtp_embed.embedding.weight": replica,
-            }
+            {"embed.embedding.weight": canonical, "mtp_embed.embedding.weight": replica}
         )
 
 
 def test_hf_export_rejects_mtp_embedding_replica_without_canonical() -> None:
-    from megatron.lite.primitive.ckpt.hf_weights import (
-        _validate_mtp_embedding_replica,
-    )
+    from megatron.lite.primitive.ckpt.hf_weights import _validate_mtp_embedding_replica
 
     with pytest.raises(AssertionError, match="without exactly one canonical"):
         _validate_mtp_embedding_replica(

--- a/experimental/lite/tests/unit/primitive/test_training_checkpoint.py
+++ b/experimental/lite/tests/unit/primitive/test_training_checkpoint.py
@@ -2,10 +2,16 @@
 from __future__ import annotations
 
 import copy
+import datetime
+import hashlib
+import multiprocessing as mp
+import threading
+from dataclasses import replace
 from types import SimpleNamespace
 
 import pytest
 import torch
+import torch.distributed as dist
 from torch.distributed.tensor import Replicate, Shard
 
 pytest.importorskip("megatron.core.dist_checkpointing")
@@ -15,11 +21,16 @@ from megatron.core.dist_checkpointing.strategies.torch import (
 )
 from megatron.lite.primitive.ckpt import dcp
 from megatron.lite.primitive.ckpt.distckpt import (
+    _iter_sharded_bases,
+    _load_model_state_dict,
     _model_sharded_state_dict,
     _rank_offsets_and_replica_id,
+    _sharded_logical_keys,
     _single_or_all_model_state,
     _synchronize_native_optimizer_steps,
     attach_model_sharded_state_dict,
+    load_dist_opt_checkpoint,
+    save_dist_opt_checkpoint,
 )
 from megatron.lite.primitive.parallel import ParallelState
 from megatron.lite.primitive.protocols import (
@@ -45,6 +56,41 @@ def _assert_state_equal(actual, expected) -> None:
         assert actual == expected
 
 
+def _gloo_common_state_semantic_consensus_worker(rank: int, init_path: str) -> None:
+    import megatron.lite.primitive.ckpt.distckpt as distckpt
+    import torch.distributed as worker_dist
+
+    worker_dist.init_process_group(
+        "gloo",
+        init_method=f"file://{init_path}",
+        rank=rank,
+        world_size=2,
+        timeout=datetime.timedelta(seconds=20),
+    )
+    try:
+        tensor = torch.arange(6, dtype=torch.bfloat16).reshape(2, 3).t()
+        if rank == 0:
+            common = {"step": 3, "nested": {"tensor": tensor, "flag": True}}
+        else:
+            common = {"nested": {"flag": True, "tensor": tensor.clone()}, "step": 3}
+        distckpt._assert_world_consensus(
+            distckpt._common_state_semantic_fingerprint(common),
+            context="semantic common state differs",
+        )
+        worker_dist.barrier()
+
+        if rank == 1:
+            common["nested"]["tensor"][0, 0] += 1
+        with pytest.raises(RuntimeError, match="semantic common state differs"):
+            distckpt._assert_world_consensus(
+                distckpt._common_state_semantic_fingerprint(common),
+                context="semantic common state differs",
+            )
+        worker_dist.barrier()
+    finally:
+        worker_dist.destroy_process_group()
+
+
 def test_optimizer_checkpoint_roundtrips_rank_local_state(tmp_path) -> None:
     model = torch.nn.Linear(4, 2)
     optimizer = torch.optim.AdamW(model.parameters(), lr=0.01)
@@ -67,6 +113,31 @@ def test_optimizer_checkpoint_roundtrips_rank_local_state(tmp_path) -> None:
     _assert_state_equal(optimizer.state_dict(), expected)
 
 
+def test_optimizer_checkpoint_load_fails_when_requested_state_is_missing(
+    tmp_path,
+) -> None:
+    optimizer = torch.optim.AdamW(torch.nn.Linear(2, 2).parameters(), lr=0.01)
+
+    with pytest.raises(
+        FileNotFoundError,
+        match="optimizer checkpoint requested by load_optimizer=True is missing",
+    ):
+        dcp._load_optimizer_checkpoint(optimizer, str(tmp_path))
+
+
+def test_dcp_model_tensor_contract_includes_only_persistent_buffers() -> None:
+    class BufferedModule(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.ones(2))
+            self.register_buffer("router_bias", torch.arange(2), persistent=True)
+            self.register_buffer("workspace", torch.zeros(4), persistent=False)
+
+    items = dict(dcp._named_model_checkpoint_tensors(BufferedModule()))
+
+    assert set(items) == {"weight", "router_bias"}
+
+
 class FakeDistOpt:
     def __init__(self):
         self.save_model_sd = None
@@ -82,7 +153,12 @@ class FakeDistOpt:
         return {"is_loading": is_loading}
 
     def load_state_dict(self, state):
-        self.loaded_state = state
+        self.loaded_state = (
+            state["loaded_state"] if set(state) == {"loaded_state"} else state
+        )
+
+    def state_dict(self):
+        return {"loaded_state": copy.deepcopy(self.loaded_state)}
 
 
 class FakeWrapper(torch.nn.Module):
@@ -104,6 +180,24 @@ DISTOPT_METADATA = {
     "distrib_optim_fully_reshardable_mem_efficient": False,
     "chained_optim_avoid_prefix": True,
 }
+
+
+def _fake_checkpoint_metadata(*trees):
+    entries = [entry for tree in trees for entry in _iter_sharded_bases(tree)]
+    return {
+        f"entry_{index}": entry.without_data() for index, entry in enumerate(entries)
+    }
+
+
+def _mock_distckpt_common_state(monkeypatch, state) -> None:
+    import megatron.lite.primitive.ckpt.distckpt as distckpt
+
+    monkeypatch.setattr(distckpt, "_load_checkpoint_common_state", lambda _path: state)
+    monkeypatch.setattr(
+        distckpt,
+        "_common_state_file_fingerprint",
+        lambda _path: (4096, "fixture-common-state-sha256"),
+    )
 
 
 def test_dist_opt_checkpoint_dispatches_to_mcore_distckpt(
@@ -254,6 +348,71 @@ def test_dist_opt_model_state_keys_are_pp_and_vpp_aware() -> None:
     assert _single_or_all_model_state(vpp_sd) is vpp_sd
 
 
+def test_dist_opt_model_load_rejects_missing_pp_subtree_before_mutation() -> None:
+    ps = ParallelState(pp_size=2, pp_rank=1, pp_is_first=False, pp_is_last=True)
+    model = torch.nn.Linear(2, 2)
+    attach_model_sharded_state_dict([model], ps)
+    before = copy.deepcopy(model.state_dict())
+
+    with pytest.raises(
+        RuntimeError, match=r"missing required model subtree 'model_pp1'"
+    ):
+        _load_model_state_dict(model, {"step": 7, "model_pp0": {}})
+
+    _assert_state_equal(model.state_dict(), before)
+
+
+def test_dist_opt_vpp_load_preflights_every_chunk_before_mutation() -> None:
+    ps = ParallelState(pp_size=2, pp_rank=1, pp_is_first=False, pp_is_last=True)
+    chunks = [torch.nn.Linear(2, 2), torch.nn.Linear(2, 2)]
+    attach_model_sharded_state_dict(chunks, ps)
+    before = [copy.deepcopy(chunk.state_dict()) for chunk in chunks]
+    first_state = {
+        name: torch.full_like(tensor, 17)
+        for name, tensor in chunks[0].state_dict().items()
+    }
+
+    with pytest.raises(
+        RuntimeError, match=r"missing required model subtree 'model_pp1_vpp1'"
+    ):
+        _load_model_state_dict(chunks, {"step": 7, "model_pp1_vpp0": first_state})
+
+    for chunk, expected in zip(chunks, before, strict=True):
+        _assert_state_equal(chunk.state_dict(), expected)
+
+
+def test_dist_opt_model_load_allows_only_tied_aliases_outside_sharded_template() -> (
+    None
+):
+    class TiedModule(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.canonical = torch.nn.Parameter(torch.zeros(2))
+            self.alias = self.canonical
+
+    model = TiedModule()
+    attach_model_sharded_state_dict([model], ParallelState())
+    loaded = torch.tensor([3.0, 5.0])
+
+    _load_model_state_dict(model, {"model": {"canonical": loaded}})
+
+    assert model.canonical is model.alias
+    torch.testing.assert_close(model.canonical, loaded)
+
+
+def test_dist_opt_model_load_rejects_incomplete_subtree_before_mutation() -> None:
+    model = torch.nn.Linear(2, 2)
+    attach_model_sharded_state_dict([model], ParallelState())
+    before = copy.deepcopy(model.state_dict())
+
+    with pytest.raises(RuntimeError, match=r"key mismatch: missing=\['bias'\]"):
+        _load_model_state_dict(
+            model, {"model": {"weight": torch.full_like(model.weight, 9)}}
+        )
+
+    _assert_state_equal(model.state_dict(), before)
+
+
 def test_dist_opt_vpp_rejects_duplicate_logical_shards() -> None:
     ps = ParallelState(pp_size=2, pp_rank=1, pp_is_first=False, pp_is_last=True)
     chunks = [torch.nn.Linear(2, 2, bias=False), torch.nn.Linear(2, 2, bias=False)]
@@ -283,23 +442,13 @@ def test_dist_opt_vpp_mtp_embedding_replica_uses_canonical_first_stage_key() -> 
             super().__init__()
             setattr(self, attr, Embedding())
 
-    first_ps = ParallelState(
-        pp_size=2,
-        pp_rank=0,
-        pp_is_first=True,
-        pp_is_last=False,
-    )
+    first_ps = ParallelState(pp_size=2, pp_rank=0, pp_is_first=True, pp_is_last=False)
     first_chunks = [torch.nn.Linear(4, 4), EmbeddingOwner("embed")]
     attach_model_sharded_state_dict(first_chunks, first_ps)
     first_state = _model_sharded_state_dict(first_chunks)
     canonical = first_state["model_pp0_vpp1"]["embed.embedding.weight"]
 
-    last_ps = ParallelState(
-        pp_size=2,
-        pp_rank=1,
-        pp_is_first=False,
-        pp_is_last=True,
-    )
+    last_ps = ParallelState(pp_size=2, pp_rank=1, pp_is_first=False, pp_is_last=True)
     last_chunks = [torch.nn.Linear(4, 4), EmbeddingOwner("mtp_embed")]
     last_chunks[1]._mlite_tied_checkpoint_keys = {
         "mtp_embed.embedding.weight": "embed.embedding.weight"
@@ -402,20 +551,388 @@ def test_dist_opt_save_consensus_wraps_checkpoint_directory_failure(
         )
 
 
+def test_distckpt_world_consensus_rejects_rank_metadata_disagreement(
+    monkeypatch,
+) -> None:
+    import megatron.lite.primitive.ckpt.distckpt as distckpt
+
+    monkeypatch.setattr(distckpt.dist, "is_available", lambda: True)
+    monkeypatch.setattr(distckpt.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(distckpt.dist, "get_world_size", lambda: 2)
+
+    def fake_distributed_raise_if_error(local_error, *, context):
+        assert local_error is None
+        assert context.endswith(" exchange failed")
+
+    monkeypatch.setattr(
+        distckpt, "_distributed_raise_if_error", fake_distributed_raise_if_error
+    )
+
+    def fake_all_gather_object(output, value, *, group):
+        assert group is distckpt.dist.group.WORLD
+        output[:] = [value, {"step": 8}]
+
+    monkeypatch.setattr(distckpt.dist, "all_gather_object", fake_all_gather_object)
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            r"^distckpt common-state metadata differs across ranks: "
+            r"rank values=\[\{'step': 7\}, \{'step': 8\}\]$"
+        ),
+    ):
+        distckpt._assert_world_consensus(
+            {"step": 7}, context="distckpt common-state metadata differs across ranks"
+        )
+
+
+def test_distckpt_common_state_fingerprint_hashes_exact_file_bytes(tmp_path) -> None:
+    import megatron.lite.primitive.ckpt.distckpt as distckpt
+
+    payload = b"common-state\x00with-bf16-and-nested-payload\xff"
+    (tmp_path / "common.pt").write_bytes(payload)
+
+    assert distckpt._common_state_file_fingerprint(str(tmp_path)) == (
+        len(payload),
+        hashlib.sha256(payload).hexdigest(),
+    )
+
+
+def test_distckpt_common_state_semantic_fingerprint_is_canonical_and_exact() -> None:
+    import megatron.lite.primitive.ckpt.distckpt as distckpt
+
+    tensor = torch.arange(6, dtype=torch.bfloat16).reshape(2, 3).t()
+    left = {
+        "step": 7,
+        "nested": {
+            "tensor": tensor,
+            "empty": torch.empty(0, dtype=torch.bfloat16),
+            "scalar": torch.tensor(2, dtype=torch.int64),
+            "values": [True, 1, 1.0, -0.0],
+        },
+    }
+    right = {
+        "nested": {
+            "values": [True, 1, 1.0, -0.0],
+            "scalar": torch.tensor(2, dtype=torch.int64),
+            "empty": torch.empty(0, dtype=torch.bfloat16),
+            "tensor": tensor.clone(),
+        },
+        "step": 7,
+    }
+    fingerprint = distckpt._common_state_semantic_fingerprint(left)
+    assert distckpt._common_state_semantic_fingerprint(right) == fingerprint
+
+    right["nested"]["tensor"][0, 0] += 1
+    assert distckpt._common_state_semantic_fingerprint(right) != fingerprint
+    right["nested"]["tensor"][0, 0] -= 1
+    right["nested"]["values"][-1] = 0.0
+    assert distckpt._common_state_semantic_fingerprint(right) != fingerprint
+    right["nested"]["values"][-1] = -0.0
+    right["nested"]["values"] = tuple(right["nested"]["values"])
+    assert distckpt._common_state_semantic_fingerprint(right) != fingerprint
+
+
+def test_distckpt_common_state_semantic_fingerprint_fails_closed() -> None:
+    import megatron.lite.primitive.ckpt.distckpt as distckpt
+
+    cycle = []
+    cycle.append(cycle)
+    with pytest.raises(ValueError, match="cycle detected"):
+        distckpt._common_state_semantic_fingerprint(cycle)
+    with pytest.raises(TypeError, match="unsupported common-state value"):
+        distckpt._common_state_semantic_fingerprint({"bad": object()})
+    with pytest.raises(TypeError, match="unsupported common-state mapping key"):
+        distckpt._common_state_semantic_fingerprint({object(): 1})
+    sparse = torch.ones(1, 1).to_sparse()
+    with pytest.raises(TypeError, match="unsupported common-state tensor"):
+        distckpt._common_state_semantic_fingerprint({"sparse": sparse})
+
+
+@pytest.mark.skipif(
+    not torch.distributed.is_gloo_available(), reason="Gloo is unavailable"
+)
+def test_distckpt_common_state_semantic_world_consensus_gloo(tmp_path) -> None:
+    init_path = str(tmp_path / "gloo-common-semantic-init")
+    ctx = mp.get_context("spawn")
+    processes = [
+        ctx.Process(
+            target=_gloo_common_state_semantic_consensus_worker, args=(rank, init_path)
+        )
+        for rank in range(2)
+    ]
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=30)
+    alive = [process for process in processes if process.is_alive()]
+    for process in alive:
+        process.terminate()
+        process.join(timeout=5)
+    assert not alive, "common-state semantic WORLD consensus hung"
+    assert [process.exitcode for process in processes] == [0, 0]
+
+
+def test_distckpt_common_state_preflight_detects_file_change_during_read(
+    monkeypatch,
+) -> None:
+    import megatron.lite.primitive.ckpt.distckpt as distckpt
+
+    fingerprints = iter([(10, "before"), (11, "after")])
+    monkeypatch.setattr(
+        distckpt, "_common_state_file_fingerprint", lambda _path: next(fingerprints)
+    )
+    monkeypatch.setattr(
+        distckpt,
+        "_load_checkpoint_common_state",
+        lambda _path: {"step": 1, "content_metadata": DISTOPT_METADATA},
+    )
+
+    with pytest.raises(
+        RuntimeError, match="common.pt changed while it was being preflighted"
+    ):
+        distckpt._preflight_distckpt_common_state(
+            {"step": 0},
+            "/checkpoint",
+            load_optimizer=False,
+            requested_sharded_keys=set(),
+            checkpoint_sharded_keys=set(),
+            expected_step=1,
+            allow_legacy_checkpoint=False,
+        )
+
+
+def test_distckpt_common_state_revalidation_detects_post_preflight_change(
+    monkeypatch,
+) -> None:
+    import megatron.lite.primitive.ckpt.distckpt as distckpt
+
+    monkeypatch.setattr(
+        distckpt, "_common_state_file_fingerprint", lambda _path: (12, "changed")
+    )
+    with pytest.raises(RuntimeError, match="common.pt changed after preflight"):
+        distckpt._revalidate_distckpt_common_state_file("/checkpoint", (12, "original"))
+
+
+def test_distckpt_mcore_load_binds_only_owner_to_prevalidated_common(
+    monkeypatch, tmp_path
+) -> None:
+    import megatron.lite.primitive.ckpt.distckpt as distckpt
+    from megatron.core.dist_checkpointing import serialization
+
+    checkpoint_path = str(tmp_path / "target")
+    other_path = str(tmp_path / "other")
+    common_state = {"step": 9, "content_metadata": DISTOPT_METADATA}
+    original_calls = []
+
+    def original_load_common(path):
+        original_calls.append(str(path))
+        return {"source": str(path)}
+
+    monkeypatch.setattr(serialization, "load_common", original_load_common)
+
+    def fake_distckpt_load(load_sd, actual_path, **kwargs):
+        assert load_sd == {"step": 0}
+        assert actual_path == checkpoint_path
+        assert kwargs["validate_access_integrity"] is False
+        assert serialization.load_common(actual_path) is common_state
+        assert serialization.load_common(other_path) == {"source": other_path}
+        other_thread_result = []
+        thread = threading.Thread(
+            target=lambda: other_thread_result.append(
+                serialization.load_common(actual_path)
+            )
+        )
+        thread.start()
+        thread.join(timeout=5)
+        assert not thread.is_alive()
+        assert other_thread_result == [{"source": actual_path}]
+        return {"step": 9}
+
+    monkeypatch.setattr(distckpt.dist_checkpointing, "load", fake_distckpt_load)
+    assert distckpt._load_distckpt_with_preloaded_common(
+        {"step": 0}, checkpoint_path, common_state, validate_access_integrity=False
+    ) == {"step": 9}
+    assert serialization.load_common is original_load_common
+    assert original_calls == [other_path, checkpoint_path]
+
+
+def test_distckpt_legacy_model_only_ignores_optimizer_format_metadata() -> None:
+    import megatron.lite.primitive.ckpt.distckpt as distckpt
+
+    legacy_metadata = {
+        **DISTOPT_METADATA,
+        "distrib_optim_sharding_type": "dp_reshardable",
+    }
+    distckpt._validate_distckpt_content_metadata(
+        {"content_metadata": legacy_metadata},
+        load_optimizer=False,
+        allow_legacy_checkpoint=True,
+    )
+    with pytest.raises(RuntimeError, match="incompatible with the MLite distckpt"):
+        distckpt._validate_distckpt_content_metadata(
+            {"content_metadata": legacy_metadata},
+            load_optimizer=True,
+            allow_legacy_checkpoint=True,
+        )
+    with pytest.raises(RuntimeError, match="cannot safely infer its sharding format"):
+        distckpt._validate_distckpt_content_metadata(
+            {}, load_optimizer=True, allow_legacy_checkpoint=True
+        )
+
+
+@pytest.mark.parametrize(
+    ("metadata", "message"),
+    [
+        (None, "missing required content_metadata"),
+        (
+            {**DISTOPT_METADATA, "distrib_optim_sharding_type": "dp_reshardable"},
+            "mismatched=\\['distrib_optim_sharding_type'\\]",
+        ),
+        (
+            {**DISTOPT_METADATA, "distrib_optim_fully_reshardable_mem_efficient": 0},
+            "mismatched=\\['distrib_optim_fully_reshardable_mem_efficient'\\]",
+        ),
+        (
+            {**DISTOPT_METADATA, "unknown_format_flag": True},
+            "unexpected=\\['unknown_format_flag'\\]",
+        ),
+    ],
+)
+def test_dist_opt_load_rejects_incompatible_content_metadata_before_mcore_load(
+    monkeypatch, tmp_path, metadata, message
+) -> None:
+    import megatron.lite.primitive.ckpt.distckpt as distckpt
+
+    model = torch.nn.Linear(2, 2)
+    attach_model_sharded_state_dict([model], ParallelState())
+    before = copy.deepcopy(model.state_dict())
+    checkpoint_metadata = _fake_checkpoint_metadata(_model_sharded_state_dict(model))
+    common_state = {"step": 4}
+    if metadata is not None:
+        common_state["content_metadata"] = metadata
+    monkeypatch.setattr(
+        distckpt, "_load_checkpoint_sharded_metadata", lambda _path: checkpoint_metadata
+    )
+    _mock_distckpt_common_state(monkeypatch, common_state)
+
+    def unexpected_load(*_args, **_kwargs):
+        with torch.no_grad():
+            model.weight.fill_(99)
+        raise AssertionError("MCore load must not run after metadata mismatch")
+
+    monkeypatch.setattr(distckpt.dist_checkpointing, "load", unexpected_load)
+
+    with pytest.raises(RuntimeError, match=message):
+        load_dist_opt_checkpoint(
+            model, None, str(tmp_path), load_model=True, load_optimizer=False
+        )
+
+    _assert_state_equal(model.state_dict(), before)
+
+
+def test_dist_opt_load_rejects_optimizer_format_discriminator_before_mcore_load(
+    monkeypatch, tmp_path
+) -> None:
+    import megatron.lite.primitive.ckpt.distckpt as distckpt
+
+    class FormatDistOpt(FakeDistOpt):
+        def sharded_state_dict(self, model_sd, is_loading=False, metadata=None):
+            super().sharded_state_dict(
+                model_sd, is_loading=is_loading, metadata=metadata
+            )
+            source = next(iter(_iter_sharded_bases(model_sd)))
+            return {
+                "param_state": replace(
+                    source,
+                    key=f"optimizer.exp_avg.{source.key}",
+                    data=torch.zeros_like(source.data),
+                ),
+                "param_state_sharding_type": "fully_reshardable",
+            }
+
+    model = torch.nn.Linear(2, 2)
+    optimizer = FormatDistOpt()
+    attach_model_sharded_state_dict([model], ParallelState())
+    before = copy.deepcopy(model.state_dict())
+    model_sd = _model_sharded_state_dict(model)
+    optimizer_sd = optimizer.sharded_state_dict(
+        _single_or_all_model_state(model_sd), is_loading=True, metadata=DISTOPT_METADATA
+    )
+    monkeypatch.setattr(
+        distckpt,
+        "_load_checkpoint_sharded_metadata",
+        lambda _path: _fake_checkpoint_metadata(model_sd, optimizer_sd),
+    )
+    _mock_distckpt_common_state(
+        monkeypatch,
+        {
+            "step": 4,
+            "optimizer": {"param_state_sharding_type": "dp_reshardable"},
+            "content_metadata": DISTOPT_METADATA,
+        },
+    )
+    monkeypatch.setattr(
+        distckpt.dist_checkpointing,
+        "load",
+        lambda *_args, **_kwargs: pytest.fail("MCore load must not run"),
+    )
+
+    with pytest.raises(
+        RuntimeError, match="checkpoint optimizer format discriminator mismatch"
+    ):
+        load_dist_opt_checkpoint(
+            model, optimizer, str(tmp_path), load_model=True, load_optimizer=True
+        )
+
+    _assert_state_equal(model.state_dict(), before)
+
+
+def test_dist_opt_save_rejects_model_keys_in_reserved_optimizer_namespace(
+    monkeypatch, tmp_path
+) -> None:
+    class AmbiguousModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.optimizer = torch.nn.Linear(2, 2, bias=False)
+
+    model = AmbiguousModel()
+    attach_model_sharded_state_dict([model], ParallelState())
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.distckpt.dist_checkpointing.save",
+        lambda *_args, **_kwargs: pytest.fail("MCore save must not run"),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            r"distckpt model state construction failed: RuntimeError: model "
+            r"checkpoint keys use the reserved 'optimizer\.' prefix"
+        ),
+    ):
+        save_dist_opt_checkpoint(
+            model, None, 3, str(tmp_path), save_model=True, save_optimizer=False
+        )
+
+
 def test_dist_opt_checkpoint_loads_from_mcore_distckpt(monkeypatch, tmp_path) -> None:
     wrapped_module = torch.nn.Linear(4, 2)
     model = FakeWrapper(wrapped_module)
     optimizer = FakeDistOpt()
     attach_model_sharded_state_dict([model], ParallelState())
+    checkpoint_metadata = _fake_checkpoint_metadata(_model_sharded_state_dict(model))
     expected_weight = torch.full_like(wrapped_module.weight, 3.0)
     expected_bias = torch.full_like(wrapped_module.bias, -2.0)
 
     def fake_load(sharded_state_dict, checkpoint_dir, **kwargs):
+        from megatron.core.dist_checkpointing.validation import StrictHandling
+
         assert set(sharded_state_dict["model"]) == {"weight", "bias"}
         assert optimizer.load_model_sd is sharded_state_dict["model"]
         assert sharded_state_dict["optimizer"] == {"is_loading": True}
         assert checkpoint_dir == str(tmp_path / "step_5")
         assert kwargs["validate_access_integrity"] is False
+        assert kwargs["strict"] is StrictHandling.RAISE_UNEXPECTED
         return {
             "step": 5,
             "model": {"weight": expected_weight, "bias": expected_bias},
@@ -425,9 +942,25 @@ def test_dist_opt_checkpoint_loads_from_mcore_distckpt(monkeypatch, tmp_path) ->
     monkeypatch.setattr(
         "megatron.lite.primitive.ckpt.distckpt.dist_checkpointing.load", fake_load
     )
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.distckpt._load_checkpoint_sharded_metadata",
+        lambda _path: checkpoint_metadata,
+    )
+    _mock_distckpt_common_state(
+        monkeypatch,
+        {
+            "step": 5,
+            "optimizer": {"is_loading": False},
+            "content_metadata": DISTOPT_METADATA,
+        },
+    )
 
     step = dcp.load_training_checkpoint(
-        model, optimizer, str(tmp_path / "step_5"), use_dcp=True
+        model,
+        optimizer,
+        str(tmp_path / "step_5"),
+        use_dcp=True,
+        allow_legacy_checkpoint=True,
     )
 
     assert step == 5
@@ -435,6 +968,314 @@ def test_dist_opt_checkpoint_loads_from_mcore_distckpt(monkeypatch, tmp_path) ->
     torch.testing.assert_close(wrapped_module.weight, expected_weight)
     torch.testing.assert_close(wrapped_module.bias, expected_bias)
     assert optimizer.loaded_state == {"loaded": True}
+
+
+@pytest.mark.parametrize(
+    ("load_model", "load_optimizer"),
+    ((True, True), (True, False), (False, True), (False, False)),
+)
+def test_dist_opt_full_checkpoint_supports_component_partial_loads(
+    monkeypatch, tmp_path, load_model: bool, load_optimizer: bool
+) -> None:
+    from megatron.core.dist_checkpointing.validation import StrictHandling
+
+    class ShardedFakeDistOpt(FakeDistOpt):
+        def sharded_state_dict(self, model_sd, is_loading: bool = False, metadata=None):
+            super().sharded_state_dict(
+                model_sd, is_loading=is_loading, metadata=metadata
+            )
+            source = next(iter(_iter_sharded_bases(model_sd)))
+            return {
+                "exp_avg": replace(
+                    source,
+                    key=f"optimizer.exp_avg.{source.key}",
+                    data=torch.zeros_like(source.data),
+                )
+            }
+
+    model = torch.nn.Linear(2, 2)
+    optimizer = ShardedFakeDistOpt()
+    attach_model_sharded_state_dict([model], ParallelState())
+    model_sd = _model_sharded_state_dict(model)
+    optimizer_sd = optimizer.sharded_state_dict(
+        _single_or_all_model_state(model_sd), is_loading=True, metadata=DISTOPT_METADATA
+    )
+    checkpoint_metadata = _fake_checkpoint_metadata(model_sd, optimizer_sd)
+    expected_weight = torch.full_like(model.weight, 7)
+    expected_bias = torch.full_like(model.bias, -3)
+    load_calls = []
+
+    def fake_load(load_sd, _checkpoint_dir, **kwargs):
+        assert kwargs["strict"] is StrictHandling.RAISE_UNEXPECTED
+        assert _sharded_logical_keys(load_sd) == (
+            ({"weight", "bias"} if load_model else set())
+            | ({"optimizer.exp_avg.weight"} if load_optimizer else set())
+        )
+        load_calls.append(True)
+        loaded = {"step": 11}
+        if load_model:
+            loaded["model"] = {"weight": expected_weight, "bias": expected_bias}
+        if load_optimizer:
+            loaded["optimizer"] = {"loaded": True}
+        return loaded
+
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.distckpt._load_checkpoint_sharded_metadata",
+        lambda _path: checkpoint_metadata,
+    )
+    _mock_distckpt_common_state(
+        monkeypatch, {"step": 11, "content_metadata": DISTOPT_METADATA}
+    )
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.distckpt.dist_checkpointing.load", fake_load
+    )
+    before = copy.deepcopy(model.state_dict())
+
+    step = load_dist_opt_checkpoint(
+        model,
+        optimizer,
+        str(tmp_path),
+        load_model=load_model,
+        load_optimizer=load_optimizer,
+    )
+
+    assert step == 11
+    assert load_calls == [True]
+    if load_model:
+        torch.testing.assert_close(model.weight, expected_weight)
+        torch.testing.assert_close(model.bias, expected_bias)
+    else:
+        _assert_state_equal(model.state_dict(), before)
+    if load_optimizer:
+        assert optimizer.loaded_state == {"loaded": True}
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="MCore distckpt requires CUDA"
+)
+def test_real_mcore_full_checkpoint_roundtrips_all_partial_component_loads(
+    tmp_path,
+) -> None:
+    class TinyShardedOptimizer:
+        def __init__(self, model: torch.nn.Linear, value: float):
+            self.exp_avg = torch.full_like(model.weight, value)
+
+        def sharded_state_dict(self, model_sd, is_loading: bool = False, metadata=None):
+            del is_loading
+            assert metadata == DISTOPT_METADATA
+            source = next(iter(_iter_sharded_bases(model_sd)))
+            return {
+                "exp_avg": replace(
+                    source, key=f"optimizer.exp_avg.{source.key}", data=self.exp_avg
+                )
+            }
+
+        def load_state_dict(self, state):
+            self.exp_avg.copy_(state["exp_avg"])
+
+    initialized_here = False
+    if not dist.is_initialized():
+        dist.init_process_group(
+            "nccl", init_method=f"file://{tmp_path / 'nccl-init'}", rank=0, world_size=1
+        )
+        initialized_here = True
+    try:
+        source = torch.nn.Linear(2, 2, device="cuda")
+        with torch.no_grad():
+            source.weight.fill_(5)
+            source.bias.fill_(-2)
+        source_optimizer = TinyShardedOptimizer(source, 7)
+        attach_model_sharded_state_dict([source], ParallelState())
+        checkpoint_dir = str(tmp_path / "distckpt")
+        save_dist_opt_checkpoint(
+            source,
+            source_optimizer,
+            23,
+            checkpoint_dir,
+            save_model=True,
+            save_optimizer=True,
+        )
+
+        for load_model, load_optimizer in (
+            (True, True),
+            (True, False),
+            (False, True),
+            (False, False),
+        ):
+            target = torch.nn.Linear(2, 2, device="cuda")
+            with torch.no_grad():
+                target.weight.zero_()
+                target.bias.zero_()
+            target_optimizer = TinyShardedOptimizer(target, -4)
+            attach_model_sharded_state_dict([target], ParallelState())
+
+            assert (
+                load_dist_opt_checkpoint(
+                    target,
+                    target_optimizer,
+                    checkpoint_dir,
+                    load_model=load_model,
+                    load_optimizer=load_optimizer,
+                )
+                == 23
+            )
+            expected_weight = (
+                source.weight if load_model else torch.zeros_like(source.weight)
+            )
+            expected_bias = source.bias if load_model else torch.zeros_like(source.bias)
+            expected_exp_avg = (
+                source_optimizer.exp_avg
+                if load_optimizer
+                else torch.full_like(source_optimizer.exp_avg, -4)
+            )
+            torch.testing.assert_close(target.weight, expected_weight)
+            torch.testing.assert_close(target.bias, expected_bias)
+            torch.testing.assert_close(target_optimizer.exp_avg, expected_exp_avg)
+    finally:
+        if initialized_here:
+            dist.destroy_process_group()
+
+
+def test_dist_opt_saved_stale_model_key_fails_metadata_preflight_before_load(
+    monkeypatch, tmp_path
+) -> None:
+    wrapped_module = torch.nn.Linear(2, 2)
+    model = FakeWrapper(wrapped_module)
+    optimizer = FakeDistOpt()
+    attach_model_sharded_state_dict([model], ParallelState())
+    model_before = copy.deepcopy(wrapped_module.state_dict())
+    optimizer_before = copy.deepcopy(optimizer.state_dict())
+    model_sd = _model_sharded_state_dict(model)
+    checkpoint_metadata = _fake_checkpoint_metadata(model_sd)
+    first_entry = next(iter(checkpoint_metadata.values()))
+    checkpoint_metadata["stale"] = replace(first_entry, key="removed_parameter")
+
+    def unexpected_load(*_args, **_kwargs):
+        raise AssertionError("MCore load must not run after metadata mismatch")
+
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.distckpt.dist_checkpointing.load", unexpected_load
+    )
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.distckpt._load_checkpoint_sharded_metadata",
+        lambda _path: checkpoint_metadata,
+    )
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.distckpt._load_checkpoint_common_state",
+        lambda _path: {"step": 8, "optimizer": {"is_loading": False}},
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            r"distckpt checkpoint metadata preflight failed: sharded key mismatch "
+            r"before load: .*removed_parameter"
+        ),
+    ):
+        dcp.load_training_checkpoint(
+            model,
+            optimizer,
+            str(tmp_path / "step_8"),
+            use_dcp=True,
+            load_rng=False,
+            allow_legacy_checkpoint=True,
+        )
+
+    _assert_state_equal(wrapped_module.state_dict(), model_before)
+    _assert_state_equal(optimizer.state_dict(), optimizer_before)
+
+
+def test_dist_opt_requested_stale_model_key_fails_before_mcore_load_or_mutation(
+    monkeypatch, tmp_path
+) -> None:
+    model = torch.nn.Linear(2, 2)
+    attach_model_sharded_state_dict([model], ParallelState())
+    before = copy.deepcopy(model.state_dict())
+    model_sd = _model_sharded_state_dict(model)
+    checkpoint_metadata = _fake_checkpoint_metadata(model_sd)
+    checkpoint_metadata = {
+        metadata_key: entry
+        for metadata_key, entry in checkpoint_metadata.items()
+        if entry.key != "weight"
+    }
+
+    def unexpected_load(*_args, **_kwargs):
+        with torch.no_grad():
+            model.weight.fill_(99)
+        raise AssertionError("MCore load must not run after metadata mismatch")
+
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.distckpt._load_checkpoint_sharded_metadata",
+        lambda _path: checkpoint_metadata,
+    )
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.distckpt._load_checkpoint_common_state",
+        lambda _path: {"step": 0},
+    )
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.distckpt.dist_checkpointing.load", unexpected_load
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            r"distckpt checkpoint metadata preflight failed: sharded key mismatch "
+            r"before load: requested_but_absent=\['weight'\]"
+        ),
+    ):
+        load_dist_opt_checkpoint(
+            model, None, str(tmp_path), load_model=True, load_optimizer=False
+        )
+
+    _assert_state_equal(model.state_dict(), before)
+
+
+def test_dist_opt_checkpoint_load_rejects_missing_optimizer_before_model_mutation(
+    monkeypatch, tmp_path
+) -> None:
+    model = torch.nn.Linear(2, 2)
+    optimizer = FakeDistOpt()
+    attach_model_sharded_state_dict([model], ParallelState())
+    before = copy.deepcopy(model.state_dict())
+    checkpoint_metadata = _fake_checkpoint_metadata(_model_sharded_state_dict(model))
+
+    def fake_load(_sharded_state_dict, _checkpoint_dir, **_kwargs):
+        return {
+            "step": 5,
+            "model": {
+                "weight": torch.full_like(model.weight, 9),
+                "bias": torch.full_like(model.bias, -4),
+            },
+        }
+
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.distckpt.dist_checkpointing.load", fake_load
+    )
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.distckpt._load_checkpoint_sharded_metadata",
+        lambda _path: checkpoint_metadata,
+    )
+    _mock_distckpt_common_state(
+        monkeypatch, {"step": 5, "content_metadata": DISTOPT_METADATA}
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "distckpt common-state preflight failed: RuntimeError: checkpoint is missing "
+            "optimizer state requested by load_optimizer=True"
+        ),
+    ):
+        dcp.load_training_checkpoint(
+            model,
+            optimizer,
+            str(tmp_path / "step_5"),
+            use_dcp=True,
+            allow_legacy_checkpoint=True,
+        )
+
+    _assert_state_equal(model.state_dict(), before)
 
 
 def test_dist_opt_step_sync_traverses_multi_optimizer_chain_without_optimizer_property() -> (
@@ -505,7 +1346,11 @@ def test_runtime_checkpoint_api_passes_current_training_checkpoint_signature(
         handle, str(tmp_path), global_step=7, save_model=True, save_optimizer=False
     )
     loaded_step = runtime.load_checkpoint(
-        handle, str(tmp_path), load_model=False, load_optimizer=True
+        handle,
+        str(tmp_path),
+        load_model=False,
+        load_optimizer=True,
+        allow_legacy_checkpoint=True,
     )
 
     assert calls["save"] == (
@@ -538,6 +1383,7 @@ def test_runtime_checkpoint_api_passes_current_training_checkpoint_signature(
             "load_parameter_state_update_legacy_format": False,
             "load_model": False,
             "load_optimizer": True,
+            "allow_legacy_checkpoint": True,
         },
     )
     assert loaded_step == 7

--- a/experimental/lite/tests/unit/primitive/test_training_checkpoint.py
+++ b/experimental/lite/tests/unit/primitive/test_training_checkpoint.py
@@ -1137,6 +1137,239 @@ def test_real_mcore_full_checkpoint_roundtrips_all_partial_component_loads(
             dist.destroy_process_group()
 
 
+@pytest.mark.gpu
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="MCore distckpt requires CUDA"
+)
+def test_real_mcore_legacy_model_only_ignores_nonpersistent_buffer(tmp_path) -> None:
+    from megatron.core import dist_checkpointing
+
+    class BufferedModule(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.tensor([1.0, 2.0], device="cuda"))
+            self.register_buffer(
+                "router_bias", torch.tensor([3.0, 4.0], device="cuda"), persistent=True
+            )
+            self.register_buffer(
+                "workspace", torch.tensor([5.0, 6.0], device="cuda"), persistent=False
+            )
+
+    initialized_here = False
+    if not dist.is_initialized():
+        dist.init_process_group(
+            "nccl", init_method=f"file://{tmp_path / 'nccl-init'}", rank=0, world_size=1
+        )
+        initialized_here = True
+    try:
+        model = BufferedModule()
+        attach_model_sharded_state_dict([model], ParallelState())
+        current = _model_sharded_state_dict(model)
+        source = next(
+            entry for entry in _iter_sharded_bases(current) if entry.key == "weight"
+        )
+        legacy_model = dict(current["model"])
+        legacy_model["workspace"] = replace(
+            source, key="workspace", data=model.workspace
+        )
+        checkpoint_dir = tmp_path / "legacy-distckpt"
+        checkpoint_dir.mkdir()
+        dist_checkpointing.save(
+            {"step": 31, "model": legacy_model},
+            str(checkpoint_dir),
+            validate_access_integrity=False,
+        )
+
+        with torch.no_grad():
+            model.weight.zero_()
+            model.router_bias.zero_()
+            model.workspace.fill_(99)
+
+        assert (
+            load_dist_opt_checkpoint(
+                model,
+                None,
+                str(checkpoint_dir),
+                load_model=True,
+                load_optimizer=False,
+                allow_legacy_checkpoint=True,
+            )
+            == 31
+        )
+        torch.testing.assert_close(
+            model.weight, torch.tensor([1.0, 2.0], device="cuda")
+        )
+        torch.testing.assert_close(
+            model.router_bias, torch.tensor([3.0, 4.0], device="cuda")
+        )
+        torch.testing.assert_close(
+            model.workspace, torch.tensor([99.0, 99.0], device="cuda")
+        )
+    finally:
+        if initialized_here:
+            dist.destroy_process_group()
+
+
+@pytest.fixture
+def legacy_dist_opt_nonpersistent_fixture():
+    class BufferedModule(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.ones(2))
+            self.register_buffer("router_bias", torch.arange(2.0), persistent=True)
+            self.register_buffer("workspace", torch.full((2,), -7.0), persistent=False)
+
+    model = BufferedModule()
+    attach_model_sharded_state_dict([model], ParallelState())
+    model_sd = _model_sharded_state_dict(model)
+    checkpoint_metadata = _fake_checkpoint_metadata(model_sd)
+    source = next(
+        entry for entry in checkpoint_metadata.values() if entry.key == "weight"
+    )
+    # This is the metadata shape emitted by the pre-fix writer, which traversed
+    # all named_buffers() instead of honoring persistent=False.
+    checkpoint_metadata["legacy_workspace"] = replace(source, key="workspace")
+    return model, checkpoint_metadata
+
+
+def test_mcore_raise_unexpected_ignores_checkpoint_only_legacy_buffer(
+    legacy_dist_opt_nonpersistent_fixture,
+) -> None:
+    from megatron.core.dist_checkpointing.validation import (
+        StrictHandling,
+        validate_integrity_and_strict_load,
+    )
+
+    model, checkpoint_metadata = legacy_dist_opt_nonpersistent_fixture
+    load_sd = _model_sharded_state_dict(model)
+
+    validated, missing, unexpected = validate_integrity_and_strict_load(
+        load_sd,
+        StrictHandling.RAISE_UNEXPECTED,
+        validate_access_integrity=False,
+        ckpt_sharded_metadata=checkpoint_metadata,
+    )
+
+    assert _sharded_logical_keys(validated) == {"weight", "router_bias"}
+    assert missing == set()
+    assert unexpected == set()
+
+
+def test_dist_opt_legacy_model_only_allows_declared_nonpersistent_buffer_preflight(
+    monkeypatch, tmp_path, legacy_dist_opt_nonpersistent_fixture
+) -> None:
+    import megatron.lite.primitive.ckpt.distckpt as distckpt
+    from megatron.core.dist_checkpointing.validation import StrictHandling
+
+    model, checkpoint_metadata = legacy_dist_opt_nonpersistent_fixture
+    expected_weight = torch.full_like(model.weight, 5)
+    expected_router_bias = torch.full_like(model.router_bias, 3)
+    workspace_before = model.workspace.clone()
+
+    monkeypatch.setattr(
+        distckpt, "_load_checkpoint_sharded_metadata", lambda _path: checkpoint_metadata
+    )
+    _mock_distckpt_common_state(monkeypatch, {"step": 8})
+
+    def fake_load(load_sd, _checkpoint_dir, **kwargs):
+        assert _sharded_logical_keys(load_sd) == {"weight", "router_bias"}
+        assert kwargs["strict"] is StrictHandling.RAISE_UNEXPECTED
+        return {
+            "step": 8,
+            "model": {"weight": expected_weight, "router_bias": expected_router_bias},
+        }
+
+    monkeypatch.setattr(distckpt.dist_checkpointing, "load", fake_load)
+
+    assert (
+        load_dist_opt_checkpoint(
+            model,
+            None,
+            str(tmp_path),
+            load_model=True,
+            load_optimizer=False,
+            allow_legacy_checkpoint=True,
+        )
+        == 8
+    )
+    torch.testing.assert_close(model.weight, expected_weight)
+    torch.testing.assert_close(model.router_bias, expected_router_bias)
+    torch.testing.assert_close(model.workspace, workspace_before)
+
+
+def test_dist_opt_nonpersistent_legacy_key_requires_explicit_opt_in(
+    monkeypatch, tmp_path, legacy_dist_opt_nonpersistent_fixture
+) -> None:
+    import megatron.lite.primitive.ckpt.distckpt as distckpt
+
+    model, checkpoint_metadata = legacy_dist_opt_nonpersistent_fixture
+    before = copy.deepcopy(model.state_dict())
+    workspace_before = model.workspace.clone()
+    monkeypatch.setattr(
+        distckpt, "_load_checkpoint_sharded_metadata", lambda _path: checkpoint_metadata
+    )
+    monkeypatch.setattr(
+        distckpt.dist_checkpointing,
+        "load",
+        lambda *_args, **_kwargs: pytest.fail("MCore load must not run"),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"saved_but_unrequested_for_requested_components=\['workspace'\]",
+    ):
+        load_dist_opt_checkpoint(
+            model,
+            None,
+            str(tmp_path),
+            load_model=True,
+            load_optimizer=False,
+            allow_legacy_checkpoint=False,
+        )
+
+    _assert_state_equal(model.state_dict(), before)
+    torch.testing.assert_close(model.workspace, workspace_before)
+
+
+def test_dist_opt_legacy_model_only_rejects_unknown_model_tensor_before_mcore_load(
+    monkeypatch, tmp_path, legacy_dist_opt_nonpersistent_fixture
+) -> None:
+    import megatron.lite.primitive.ckpt.distckpt as distckpt
+
+    model, checkpoint_metadata = legacy_dist_opt_nonpersistent_fixture
+    source = next(iter(checkpoint_metadata.values()))
+    checkpoint_metadata["unknown"] = replace(source, key="removed_parameter")
+    before = copy.deepcopy(model.state_dict())
+    workspace_before = model.workspace.clone()
+    monkeypatch.setattr(
+        distckpt, "_load_checkpoint_sharded_metadata", lambda _path: checkpoint_metadata
+    )
+    monkeypatch.setattr(
+        distckpt.dist_checkpointing,
+        "load",
+        lambda *_args, **_kwargs: pytest.fail("MCore load must not run"),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            r"saved_but_unrequested_for_requested_components="
+            r"\['removed_parameter'\]"
+        ),
+    ):
+        load_dist_opt_checkpoint(
+            model,
+            None,
+            str(tmp_path),
+            load_model=True,
+            load_optimizer=False,
+            allow_legacy_checkpoint=True,
+        )
+
+    _assert_state_equal(model.state_dict(), before)
+    torch.testing.assert_close(model.workspace, workspace_before)
+
+
 def test_dist_opt_saved_stale_model_key_fails_metadata_preflight_before_load(
     monkeypatch, tmp_path
 ) -> None:

--- a/experimental/lite/tests/unit/primitive/test_training_checkpoint.py
+++ b/experimental/lite/tests/unit/primitive/test_training_checkpoint.py
@@ -22,7 +22,10 @@ from megatron.lite.primitive.ckpt.distckpt import (
     attach_model_sharded_state_dict,
 )
 from megatron.lite.primitive.parallel import ParallelState
-from megatron.lite.primitive.protocols import default_expert_classifier, default_placement_fn
+from megatron.lite.primitive.protocols import (
+    default_expert_classifier,
+    default_placement_fn,
+)
 from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
 from megatron.lite.runtime.contracts.handle import ModelHandle
 
@@ -103,7 +106,9 @@ DISTOPT_METADATA = {
 }
 
 
-def test_dist_opt_checkpoint_dispatches_to_mcore_distckpt(monkeypatch, tmp_path) -> None:
+def test_dist_opt_checkpoint_dispatches_to_mcore_distckpt(
+    monkeypatch, tmp_path
+) -> None:
     model = torch.nn.Linear(4, 2)
     optimizer = FakeDistOpt()
     ps = ParallelState(pp_rank=1, tp_rank=2, dp_cp_rank=3)
@@ -115,7 +120,9 @@ def test_dist_opt_checkpoint_dispatches_to_mcore_distckpt(monkeypatch, tmp_path)
         saved["checkpoint_dir"] = checkpoint_dir
         saved["kwargs"] = kwargs
 
-    monkeypatch.setattr("megatron.lite.primitive.ckpt.distckpt.dist_checkpointing.save", fake_save)
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.distckpt.dist_checkpointing.save", fake_save
+    )
 
     dcp.save_training_checkpoint(model, optimizer, 5, str(tmp_path), use_dcp=True)
 
@@ -205,14 +212,18 @@ def test_dist_opt_replica_id_does_not_treat_pp_as_a_replica_axis() -> None:
     assert replica_id == (0, 0, 0)
 
 
-def test_dist_opt_pp_rank_one_model_keys_survive_torch_dist_main_replica_filter() -> None:
+def test_dist_opt_pp_rank_one_model_keys_survive_torch_dist_main_replica_filter() -> (
+    None
+):
     ps = ParallelState(pp_size=2, pp_rank=1, pp_is_first=False, pp_is_last=True)
     model = torch.nn.Linear(4, 2)
     attach_model_sharded_state_dict([model], ps)
 
     model_sd = _model_sharded_state_dict(model)
-    filtered_sd, _flat_mapping, _rename_mapping = _replace_state_dict_keys_with_sharded_keys(
-        model_sd, keep_only_main_replica=True
+    filtered_sd, _flat_mapping, _rename_mapping = (
+        _replace_state_dict_keys_with_sharded_keys(
+            model_sd, keep_only_main_replica=True
+        )
     )
 
     assert set(filtered_sd) == {"model_pp1.weight", "model_pp1.bias"}
@@ -243,6 +254,154 @@ def test_dist_opt_model_state_keys_are_pp_and_vpp_aware() -> None:
     assert _single_or_all_model_state(vpp_sd) is vpp_sd
 
 
+def test_dist_opt_vpp_rejects_duplicate_logical_shards() -> None:
+    ps = ParallelState(pp_size=2, pp_rank=1, pp_is_first=False, pp_is_last=True)
+    chunks = [torch.nn.Linear(2, 2, bias=False), torch.nn.Linear(2, 2, bias=False)]
+    for chunk in chunks:
+        chunk._mlite_tied_checkpoint_keys = {"weight": "embed.embedding.weight"}
+    attach_model_sharded_state_dict(chunks, ps)
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            r"^distckpt logical shard collision for "
+            r"key='model_pp0\.embed\.embedding\.weight', replica_id=\(1, 0, 0\): "
+            r"model_pp1_vpp0\.weight and model_pp1_vpp1\.weight$"
+        ),
+    ):
+        _model_sharded_state_dict(chunks)
+
+
+def test_dist_opt_vpp_mtp_embedding_replica_uses_canonical_first_stage_key() -> None:
+    class Embedding(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.embedding = torch.nn.Embedding(8, 4)
+
+    class EmbeddingOwner(torch.nn.Module):
+        def __init__(self, attr: str) -> None:
+            super().__init__()
+            setattr(self, attr, Embedding())
+
+    first_ps = ParallelState(
+        pp_size=2,
+        pp_rank=0,
+        pp_is_first=True,
+        pp_is_last=False,
+    )
+    first_chunks = [torch.nn.Linear(4, 4), EmbeddingOwner("embed")]
+    attach_model_sharded_state_dict(first_chunks, first_ps)
+    first_state = _model_sharded_state_dict(first_chunks)
+    canonical = first_state["model_pp0_vpp1"]["embed.embedding.weight"]
+
+    last_ps = ParallelState(
+        pp_size=2,
+        pp_rank=1,
+        pp_is_first=False,
+        pp_is_last=True,
+    )
+    last_chunks = [torch.nn.Linear(4, 4), EmbeddingOwner("mtp_embed")]
+    last_chunks[1]._mlite_tied_checkpoint_keys = {
+        "mtp_embed.embedding.weight": "embed.embedding.weight"
+    }
+    attach_model_sharded_state_dict(last_chunks, last_ps)
+    last_state = _model_sharded_state_dict(last_chunks)
+    replica = last_state["model_pp1_vpp1"]["mtp_embed.embedding.weight"]
+
+    assert canonical.key == replica.key == "model_pp0.embed.embedding.weight"
+    assert canonical.replica_id[0] == 0
+    assert replica.replica_id[0] == 1
+
+
+def test_dist_opt_sharded_state_excludes_nonpersistent_buffers() -> None:
+    class BufferedModule(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.ones(2))
+            self.register_buffer("router_bias", torch.arange(2), persistent=True)
+            self.register_buffer("workspace", torch.zeros(4), persistent=False)
+
+    model = BufferedModule()
+    attach_model_sharded_state_dict([model], ParallelState())
+
+    model_sd = _model_sharded_state_dict(model)["model"]
+
+    assert set(model_sd) == {"weight", "router_bias"}
+    assert "workspace" not in model_sd
+
+
+def test_dist_opt_save_wraps_model_preflight_failure_before_mcore(
+    monkeypatch, tmp_path
+) -> None:
+    import megatron.lite.primitive.ckpt.distckpt as distckpt
+
+    model = torch.nn.Linear(2, 2, bias=False)
+    attach_model_sharded_state_dict([model], ParallelState())
+
+    def fail_model_state(_model):
+        raise ValueError("broken VPP metadata")
+
+    def unexpected_save(*_args, **_kwargs):
+        raise AssertionError("MCore save must not run after a preflight failure")
+
+    monkeypatch.setattr(distckpt, "_model_sharded_state_dict", fail_model_state)
+    monkeypatch.setattr(distckpt.dist_checkpointing, "save", unexpected_save)
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            r"^distckpt model state construction failed: ValueError: "
+            r"broken VPP metadata$"
+        ),
+    ):
+        distckpt.save_dist_opt_checkpoint(
+            model,
+            optimizer=None,
+            step=3,
+            checkpoint_dir=str(tmp_path),
+            save_model=True,
+            save_optimizer=False,
+        )
+
+
+def test_dist_opt_save_consensus_wraps_checkpoint_directory_failure(
+    monkeypatch, tmp_path
+) -> None:
+    import megatron.lite.primitive.ckpt.distckpt as distckpt
+
+    model = torch.nn.Linear(2, 2, bias=False)
+    attach_model_sharded_state_dict([model], ParallelState())
+
+    def fail_makedirs(*_args, **_kwargs):
+        raise PermissionError("read-only checkpoint root")
+
+    def unexpected_model_state(*_args, **_kwargs):
+        raise AssertionError("model state construction must not run")
+
+    def unexpected_save(*_args, **_kwargs):
+        raise AssertionError("MCore save must not run")
+
+    monkeypatch.setattr(distckpt.os, "makedirs", fail_makedirs)
+    monkeypatch.setattr(distckpt, "_model_sharded_state_dict", unexpected_model_state)
+    monkeypatch.setattr(distckpt.dist_checkpointing, "save", unexpected_save)
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            r"^distckpt checkpoint directory creation failed: PermissionError: "
+            r"read-only checkpoint root$"
+        ),
+    ):
+        distckpt.save_dist_opt_checkpoint(
+            model,
+            optimizer=None,
+            step=3,
+            checkpoint_dir=str(tmp_path),
+            save_model=True,
+            save_optimizer=False,
+        )
+
+
 def test_dist_opt_checkpoint_loads_from_mcore_distckpt(monkeypatch, tmp_path) -> None:
     wrapped_module = torch.nn.Linear(4, 2)
     model = FakeWrapper(wrapped_module)
@@ -263,9 +422,13 @@ def test_dist_opt_checkpoint_loads_from_mcore_distckpt(monkeypatch, tmp_path) ->
             "optimizer": {"loaded": True},
         }
 
-    monkeypatch.setattr("megatron.lite.primitive.ckpt.distckpt.dist_checkpointing.load", fake_load)
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.distckpt.dist_checkpointing.load", fake_load
+    )
 
-    step = dcp.load_training_checkpoint(model, optimizer, str(tmp_path / "step_5"), use_dcp=True)
+    step = dcp.load_training_checkpoint(
+        model, optimizer, str(tmp_path / "step_5"), use_dcp=True
+    )
 
     assert step == 5
     assert not model.wrapper_load_called
@@ -274,11 +437,14 @@ def test_dist_opt_checkpoint_loads_from_mcore_distckpt(monkeypatch, tmp_path) ->
     assert optimizer.loaded_state == {"loaded": True}
 
 
-def test_dist_opt_step_sync_traverses_multi_optimizer_chain_without_optimizer_property() -> None:
+def test_dist_opt_step_sync_traverses_multi_optimizer_chain_without_optimizer_property() -> (
+    None
+):
     class FakeTorchOptimizer:
         def __init__(self, steps):
             self.state = {
-                object(): {"step": torch.tensor(step, dtype=torch.int64)} for step in steps
+                object(): {"step": torch.tensor(step, dtype=torch.int64)}
+                for step in steps
             }
 
     class FakeDistOpt:
@@ -316,8 +482,12 @@ def test_runtime_checkpoint_api_passes_current_training_checkpoint_signature(
         calls["load"] = (model, optimizer, path, config, ps, kwargs)
         return 7
 
-    monkeypatch.setattr("megatron.lite.primitive.ckpt.save_training_checkpoint", fake_save)
-    monkeypatch.setattr("megatron.lite.primitive.ckpt.load_training_checkpoint", fake_load)
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.save_training_checkpoint", fake_save
+    )
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.load_training_checkpoint", fake_load
+    )
 
     runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
     model = torch.nn.Linear(1, 1)

--- a/experimental/lite/tests/unit/runtime/test_packed_batch_bridge.py
+++ b/experimental/lite/tests/unit/runtime/test_packed_batch_bridge.py
@@ -112,8 +112,10 @@ def test_bridge_forward_kwargs_are_context_parallel_correct() -> None:
         assert local["input_ids"].shape == (1, full_padded // 2)
         assert local["position_ids"].shape == (1, full_padded // 2)
         psp = local["packed_seq_params"]
-        # cu_seqlens stays full (CP-aligned), not the unpadded [0, 3, 8].
-        assert torch.equal(psp.cu_seqlens_q, ref.cu_seqlens_padded)
+        assert torch.equal(
+            psp.cu_seqlens_q, torch.tensor([0, 3, 8], dtype=torch.int32)
+        )
+        assert torch.equal(psp.cu_seqlens_q_padded, ref.cu_seqlens_padded)
         assert int(getattr(psp, "local_cp_size", 1)) == 2
 
     # The two rank-local zigzag shards reconstruct the full padded sequence.

--- a/experimental/lite/tests/unit/runtime/test_packed_batch_bridge.py
+++ b/experimental/lite/tests/unit/runtime/test_packed_batch_bridge.py
@@ -61,12 +61,10 @@ def test_bridge_forward_kwargs_are_transient_bridge_metadata() -> None:
     # like the native pack_thd_forward_kwargs path, so both backends train on the
     # same shifted targets.
     assert torch.equal(
-        out["labels"].reshape(-1),
-        torch.tensor([101, 102, 0, 104, 105, 106, 107, 0]),
+        out["labels"].reshape(-1), torch.tensor([101, 102, 0, 104, 105, 106, 107, 0])
     )
     assert torch.equal(
-        out["position_ids"].reshape(-1),
-        torch.tensor([0, 1, 2, 0, 1, 2, 3, 4]),
+        out["position_ids"].reshape(-1), torch.tensor([0, 1, 2, 0, 1, 2, 3, 4])
     )
 
     psp = out["packed_seq_params"]
@@ -82,8 +80,7 @@ def test_bridge_forward_kwargs_carry_loss_mask_only_inside_bridge() -> None:
     assert "loss_mask" in out
     # loss_mask is rolled with the labels so it masks the shifted targets.
     assert torch.equal(
-        out["loss_mask"].reshape(-1),
-        torch.tensor([1, 0, 0, 1, 1, 0, 1, 0]),
+        out["loss_mask"].reshape(-1), torch.tensor([1, 0, 0, 1, 1, 0, 1, 0])
     )
 
 
@@ -112,9 +109,7 @@ def test_bridge_forward_kwargs_are_context_parallel_correct() -> None:
         assert local["input_ids"].shape == (1, full_padded // 2)
         assert local["position_ids"].shape == (1, full_padded // 2)
         psp = local["packed_seq_params"]
-        assert torch.equal(
-            psp.cu_seqlens_q, torch.tensor([0, 3, 8], dtype=torch.int32)
-        )
+        assert torch.equal(psp.cu_seqlens_q, torch.tensor([0, 3, 8], dtype=torch.int32))
         assert torch.equal(psp.cu_seqlens_q_padded, ref.cu_seqlens_padded)
         assert int(getattr(psp, "local_cp_size", 1)) == 2
 

--- a/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
+++ b/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
@@ -11,7 +11,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import torch.nn as nn
-
 from megatron.lite.runtime import create_runtime
 from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig
 from megatron.lite.runtime.backends.mlite.runtime import (
@@ -20,7 +19,11 @@ from megatron.lite.runtime.backends.mlite.runtime import (
     _build_impl_cfg,
     _load_hf_chunks,
 )
-from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig, RuntimeConfig
+from megatron.lite.runtime.contracts.config import (
+    OptimizerConfig,
+    ParallelConfig,
+    RuntimeConfig,
+)
 from megatron.lite.runtime.contracts.handle import ModelHandle
 
 pytestmark = pytest.mark.mlite
@@ -48,7 +51,8 @@ def test_runtime_config_accepts_mlite_backend_cfg():
 
 def test_mlite_config_defaults_and_parallel_fields():
     cfg = MegatronLiteConfig(
-        model_name="qwen3_moe", parallel=ParallelConfig(tp=4, etp=1, ep=8, pp=2, vpp=2, cp=2)
+        model_name="qwen3_moe",
+        parallel=ParallelConfig(tp=4, etp=1, ep=8, pp=2, vpp=2, cp=2),
     )
 
     assert cfg.model_name == "qwen3_moe"
@@ -174,6 +178,39 @@ def test_runtime_allows_single_chunk_protocol_without_bulk_loader() -> None:
     assert calls == [(chunks[0], "/models/single", model_cfg, ps)]
 
 
+@pytest.mark.parametrize("with_bulk_loader", [False, True])
+def test_runtime_forwards_explicit_hf_load_participating_group(
+    with_bulk_loader: bool,
+) -> None:
+    calls = []
+    participating_group = object()
+
+    class Proto:
+        @staticmethod
+        def load_hf_weights(chunk, path, model_cfg, ps, *, participating_group=None):
+            calls.append(("single", participating_group))
+
+    if with_bulk_loader:
+
+        def load_many(chunks, path, model_cfg, ps, *, participating_group=None):
+            calls.append(("many", participating_group))
+
+        Proto.load_hf_weights_many = staticmethod(load_many)
+
+    chunks = [object(), object()] if with_bulk_loader else [object()]
+    _load_hf_chunks(
+        Proto,
+        chunks,
+        "/models/subgroup",
+        object(),
+        object(),
+        participating_group=participating_group,
+    )
+
+    expected_loader = "many" if with_bulk_loader else "single"
+    assert calls == [(expected_loader, participating_group)]
+
+
 def test_runtime_rejects_nonatomic_vpp_loader_without_bulk_contract() -> None:
     class Proto:
         @staticmethod
@@ -184,6 +221,85 @@ def test_runtime_rejects_nonatomic_vpp_loader_without_bulk_contract() -> None:
         NotImplementedError, match="sequential chunk mutation is not atomic"
     ):
         _load_hf_chunks(Proto, [object(), object()], "/models/vpp", object(), object())
+
+
+def _runtime_with_escape_protocol(monkeypatch, proto) -> MegatronLiteRuntime:
+    runtime = MegatronLiteRuntime(
+        "/models/escape",
+        MegatronLiteConfig(model_name="qwen3", hf_path="/models/escape"),
+    )
+    monkeypatch.setattr(runtime, "_load_protocol", lambda _cfg: proto)
+    monkeypatch.setattr(
+        "megatron.lite.runtime.backends.mlite.runtime.dist.is_initialized", lambda: True
+    )
+    monkeypatch.setattr(
+        "megatron.lite.runtime.backends.mlite.runtime.dist.get_rank", lambda: 0
+    )
+    monkeypatch.setattr(
+        "megatron.lite.runtime.backends.mlite.runtime.torch.cuda.device_count",
+        lambda: 1,
+    )
+    monkeypatch.setattr(
+        "megatron.lite.runtime.backends.mlite.runtime.torch.cuda.set_device",
+        lambda _device: None,
+    )
+    monkeypatch.setattr(
+        "megatron.lite.runtime.backends.mlite.runtime.torch.cuda.manual_seed",
+        lambda _seed: None,
+    )
+    return runtime
+
+
+def test_runtime_escape_hatch_preserves_legacy_build_model_abi(monkeypatch) -> None:
+    expected = object()
+    calls = []
+
+    class NestedRuntime:
+        def build_model(self):
+            calls.append("build")
+            return expected
+
+    nested_runtime = NestedRuntime()
+
+    class Proto:
+        @staticmethod
+        def create_runtime(hf_path, cfg):
+            calls.append((hf_path, cfg))
+            return nested_runtime
+
+    runtime = _runtime_with_escape_protocol(monkeypatch, Proto)
+
+    result = runtime.build_model()
+
+    assert result is expected
+    assert calls == [("/models/escape", runtime._cfg), "build"]
+
+
+def test_runtime_escape_hatch_forwards_explicit_participating_group(
+    monkeypatch,
+) -> None:
+    expected = object()
+    participating_group = object()
+    calls = []
+
+    class NestedRuntime:
+        def build_model(self, *, participating_group):
+            calls.append(participating_group)
+            return expected
+
+    nested_runtime = NestedRuntime()
+
+    class Proto:
+        @staticmethod
+        def create_runtime(_hf_path, _cfg):
+            return nested_runtime
+
+    runtime = _runtime_with_escape_protocol(monkeypatch, Proto)
+
+    result = runtime.build_model(participating_group=participating_group)
+
+    assert result is expected
+    assert calls == [participating_group]
 
 
 @pytest.mark.parametrize(
@@ -227,7 +343,9 @@ class HookedOptimizer:
 
 def test_runtime_to_prefers_optimizer_specific_offload_hooks():
     optimizer = HookedOptimizer()
-    handle = ModelHandle(model=nn.Linear(2, 2), optimizer=optimizer, _extras={"model_chunks": []})
+    handle = ModelHandle(
+        model=nn.Linear(2, 2), optimizer=optimizer, _extras={"model_chunks": []}
+    )
     runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
 
     runtime.to(handle, "cpu", model=False, optimizer=True, grad=False)
@@ -342,7 +460,10 @@ def test_megatron_ddp_detection_accepts_ddp_and_subclasses(monkeypatch):
 
 @pytest.mark.parametrize("model_cls", [_FakeMegatronDDP, _FakeMegatronDDPSubclass])
 def test_megatron_ddp_model_move_helpers_use_buffer_path(monkeypatch, model_cls):
-    from megatron.lite.runtime.megatron_utils import load_model_to_gpu, offload_model_to_cpu
+    from megatron.lite.runtime.megatron_utils import (
+        load_model_to_gpu,
+        offload_model_to_cpu,
+    )
 
     _install_fake_megatron_ddp(monkeypatch)
     model = model_cls()
@@ -369,7 +490,10 @@ def test_megatron_ddp_model_move_helpers_use_buffer_path(monkeypatch, model_cls)
 
 
 def test_native_model_move_helpers_do_not_require_megatron_core(monkeypatch):
-    from megatron.lite.runtime.megatron_utils import load_model_to_gpu, offload_model_to_cpu
+    from megatron.lite.runtime.megatron_utils import (
+        load_model_to_gpu,
+        offload_model_to_cpu,
+    )
 
     monkeypatch.setitem(sys.modules, "megatron.core", None)
     monkeypatch.setitem(sys.modules, "megatron.core.distributed", None)
@@ -405,7 +529,9 @@ def test_model_handle_dp_from_parallel_state():
 def test_model_handle_cp_range_and_config_properties():
     cfg = {"tp": 8, "ep": 4}
     default_handle = ModelHandle(model=MagicMock())
-    configured_handle = ModelHandle(model=MagicMock(), config=cfg, _extras={"cp_range": (1, 8)})
+    configured_handle = ModelHandle(
+        model=MagicMock(), config=cfg, _extras={"cp_range": (1, 8)}
+    )
 
     assert default_handle.cp_range == (1, 1)
     assert configured_handle.cp_range == (1, 8)
@@ -419,7 +545,9 @@ def test_runtime_dispatch_creates_mlite_backend():
 
         runtime = create_runtime(
             RuntimeConfig(
-                backend="mlite", hf_path="/models/test", backend_cfg={"model_name": "qwen3"}
+                backend="mlite",
+                hf_path="/models/test",
+                backend_cfg={"model_name": "qwen3"},
             )
         )
 
@@ -448,7 +576,9 @@ def _run_verl_sft_dry_run(script: Path, tmp_path: Path, **env_overrides: str) ->
         "ETP_SIZE": "1",
         **env_overrides,
     }
-    completed = subprocess.run([str(script)], env=env, text=True, capture_output=True, check=True)
+    completed = subprocess.run(
+        [str(script)], env=env, text=True, capture_output=True, check=True
+    )
     return completed.stdout
 
 
@@ -472,7 +602,9 @@ def test_verl_sft_script_maps_offload_env_to_backend_args(tmp_path):
     assert "engine.param_offload=True" in command
     assert "engine.optimizer_offload=True" in command
     assert "+optim.override_optimizer_config.offload_fraction=0.75" in command
-    assert "+optim.override_optimizer_config.use_precision_aware_optimizer=True" in command
+    assert (
+        "+optim.override_optimizer_config.use_precision_aware_optimizer=True" in command
+    )
 
 
 def test_verl_sft_script_does_not_emit_optimizer_state_offload_when_disabled(tmp_path):

--- a/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
+++ b/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
@@ -18,6 +18,7 @@ from megatron.lite.runtime.backends.mlite.runtime import (
     MegatronLiteRuntime,
     _apply_attention_backend_env,
     _build_impl_cfg,
+    _load_hf_chunks,
 )
 from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig, RuntimeConfig
 from megatron.lite.runtime.contracts.handle import ModelHandle
@@ -133,6 +134,56 @@ def test_build_impl_cfg_preserves_explicit_impl_hf_path():
     impl_cfg = _build_impl_cfg(proto, cfg)
 
     assert impl_cfg.hf_path == "/models/impl"
+
+
+def test_runtime_prefers_atomic_bulk_hf_loader_for_vpp_chunks() -> None:
+    calls = []
+
+    class Proto:
+        @staticmethod
+        def load_hf_weights_many(chunks, path, model_cfg, ps):
+            calls.append(("many", chunks, path, model_cfg, ps))
+
+        @staticmethod
+        def load_hf_weights(*_args):
+            raise AssertionError(
+                "sequential loader must not run when bulk loader exists"
+            )
+
+    chunks = [object(), object()]
+    model_cfg = object()
+    ps = object()
+    _load_hf_chunks(Proto, chunks, "/models/vpp", model_cfg, ps)
+
+    assert calls == [("many", chunks, "/models/vpp", model_cfg, ps)]
+
+
+def test_runtime_allows_single_chunk_protocol_without_bulk_loader() -> None:
+    calls = []
+
+    class Proto:
+        @staticmethod
+        def load_hf_weights(chunk, path, model_cfg, ps):
+            calls.append((chunk, path, model_cfg, ps))
+
+    chunks = [object()]
+    model_cfg = object()
+    ps = object()
+    _load_hf_chunks(Proto, chunks, "/models/single", model_cfg, ps)
+
+    assert calls == [(chunks[0], "/models/single", model_cfg, ps)]
+
+
+def test_runtime_rejects_nonatomic_vpp_loader_without_bulk_contract() -> None:
+    class Proto:
+        @staticmethod
+        def load_hf_weights(*_args):
+            raise AssertionError("must fail before mutating the first VPP chunk")
+
+    with pytest.raises(
+        NotImplementedError, match="sequential chunk mutation is not atomic"
+    ):
+        _load_hf_chunks(Proto, [object(), object()], "/models/vpp", object(), object())
 
 
 @pytest.mark.parametrize(

--- a/experimental/lite/tests/unit/verl/test_mlite_engine_checkpoint.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_engine_checkpoint.py
@@ -1,26 +1,124 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+import copy
+import math
 from types import SimpleNamespace
 
 import pytest
 import torch
 from verl_mlite.engine.config import MegatronLiteEngineConfig
-from verl_mlite.engine.mlite_engine import MegatronLiteEngine
+from verl_mlite.engine.mlite_engine import (
+    _LR_SCHEDULER_CONFIG_FIELDS,
+    _LR_SCHEDULER_FORMAT,
+    _LR_SCHEDULER_PAYLOAD_FORMAT,
+    _LR_SCHEDULER_STATE,
+    MegatronLiteEngine,
+    _checkpoint_components_with_consensus,
+    _content_set,
+    _LRSchedulerCheckpointTarget,
+    _MegatronLiteLRScheduler,
+    _scheduler_payload,
+    _scheduler_state_with_consensus,
+    _validate_lr_scheduler_payload,
+    _validate_lr_scheduler_state,
+)
+
+
+def _scheduler_state(*, num_steps=7, max_lr=0.25):
+    config = {
+        "init_lr": 0.0,
+        "max_lr": max_lr,
+        "min_lr": 0.0,
+        "lr_warmup_steps": 0,
+        "lr_decay_steps": 10,
+        "lr_decay_style": "constant",
+        "start_wd": 0.1,
+        "end_wd": 0.1,
+        "wd_incr_steps": 10,
+        "wd_incr_style": "constant",
+        "wsd_decay_steps": None,
+        "lr_wsd_decay_style": "exponential",
+    }
+    assert set(config) == set(_LR_SCHEDULER_CONFIG_FIELDS)
+    return {"format": _LR_SCHEDULER_FORMAT, "num_steps": num_steps, "config": config}
+
+
+def _scheduler_payload_state(*, checkpoint_step=13, num_steps=None, max_lr=0.25):
+    if num_steps is None:
+        num_steps = checkpoint_step
+    return {
+        "format": _LR_SCHEDULER_PAYLOAD_FORMAT,
+        "checkpoint_step": checkpoint_step,
+        "scheduler_state": _scheduler_state(num_steps=num_steps, max_lr=max_lr),
+    }
 
 
 class _Scheduler:
-    def __init__(self):
+    def __init__(self, optimizer):
+        self.optimizer = optimizer
+        self._state = _scheduler_state()
         self.loaded_state = None
 
     def state_dict(self):
-        return {"step": 7, "lr": 0.25}
+        return copy.deepcopy(self._state)
 
     def load_state_dict(self, state):
-        self.loaded_state = state
+        _validate_lr_scheduler_state(state)
+        self._state = copy.deepcopy(state)
+        self.loaded_state = copy.deepcopy(state)
+        for group in self.optimizer.param_groups:
+            group["lr"] = state["config"]["max_lr"]
+            group["weight_decay"] = state["config"]["end_wd"]
+
+
+def _real_scheduler(*, max_lr=0.25, use_checkpoint_config=False):
+    optimizer = SimpleNamespace(
+        param_groups=[{"lr": max_lr, "weight_decay": 0.1, "min_lr": 0.0}]
+    )
+    scheduler = _MegatronLiteLRScheduler(
+        optimizer,
+        init_lr=0.0,
+        max_lr=max_lr,
+        min_lr=0.0,
+        lr_warmup_steps=0,
+        lr_decay_steps=10,
+        lr_decay_style="constant",
+        start_wd=0.1,
+        end_wd=0.1,
+        wd_incr_steps=10,
+        wd_incr_style="constant",
+        wsd_decay_steps=None,
+        lr_wsd_decay_style="exponential",
+        use_checkpoint_config=use_checkpoint_config,
+    )
+    return scheduler, optimizer
+
+
+def _group_scheduler(param_groups, *, use_checkpoint_config=False):
+    optimizer = SimpleNamespace(param_groups=param_groups)
+    scheduler = _MegatronLiteLRScheduler(
+        optimizer,
+        init_lr=0.01,
+        max_lr=0.2,
+        min_lr=0.02,
+        lr_warmup_steps=2,
+        lr_decay_steps=6,
+        lr_decay_style="linear",
+        start_wd=0.1,
+        end_wd=0.2,
+        wd_incr_steps=4,
+        wd_incr_style="linear",
+        wsd_decay_steps=None,
+        lr_wsd_decay_style="exponential",
+        use_checkpoint_config=use_checkpoint_config,
+    )
+    return scheduler, optimizer
 
 
 @pytest.fixture(autouse=True)
 def _single_process_dist(monkeypatch):
-    monkeypatch.setattr("verl_mlite.engine.mlite_engine.dist.is_initialized", lambda: False)
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.dist.is_initialized", lambda: False
+    )
 
 
 def _optimizer_config() -> SimpleNamespace:
@@ -63,8 +161,10 @@ def _initialized_engine(*, checkpoint_config=None, param_offload=False):
     parallel = SimpleNamespace(tp=1, cp=1, pp=1)
     parallel_state = SimpleNamespace(dp_rank=0)
     module = torch.nn.Linear(2, 2)
-    optimizer = object()
-    scheduler = _Scheduler()
+    optimizer = SimpleNamespace(
+        param_groups=[{"lr": 0.25, "weight_decay": 0.1, "min_lr": 0.0}]
+    )
+    scheduler = _Scheduler(optimizer)
     engine.module = module
     engine.handle = SimpleNamespace(
         _optimizer=optimizer,
@@ -90,6 +190,17 @@ def _initialized_engine(*, checkpoint_config=None, param_offload=False):
     )
 
 
+def test_checkpoint_content_set_uses_exact_keys_and_rejects_unknown_values():
+    assert _content_set(None) == set()
+    assert _content_set("model") == {"model"}
+    assert _content_set("[model, optimizer, extra]") == {"model", "optimizer", "extra"}
+    assert _content_set((" 'model' ", '"extra"')) == {"model", "extra"}
+    with pytest.raises(ValueError, match="unsupported entries"):
+        _content_set("not_model", key="checkpoint_config.save_contents")
+    with pytest.raises(TypeError, match="entries must be strings"):
+        _content_set(["model", 7], key="checkpoint_config.save_contents")
+
+
 def test_save_checkpoint_forwards_contents_scheduler_and_param_offload_reload(
     tmp_path, monkeypatch
 ):
@@ -102,7 +213,9 @@ def test_save_checkpoint_forwards_contents_scheduler_and_param_offload_reload(
         parallel_state,
         placement_fn,
         expert_classifier,
-    ) = _initialized_engine(checkpoint_config={"save_contents": ["model"]}, param_offload=True)
+    ) = _initialized_engine(
+        checkpoint_config={"save_contents": ["model", "extra"]}, param_offload=True
+    )
     to_calls = []
     save_calls = []
     sync_calls = []
@@ -112,6 +225,7 @@ def test_save_checkpoint_forwards_contents_scheduler_and_param_offload_reload(
         "verl_mlite.engine.mlite_engine.save_training_checkpoint",
         lambda *args, **kwargs: save_calls.append((args, kwargs)),
     )
+    scheduler._state["num_steps"] = 13
 
     engine.save_checkpoint(str(tmp_path), global_step=13)
 
@@ -127,14 +241,17 @@ def test_save_checkpoint_forwards_contents_scheduler_and_param_offload_reload(
     assert save_kwargs["is_expert"] is expert_classifier
     assert save_kwargs["save_model"] is True
     assert save_kwargs["save_optimizer"] is False
-    assert (
-        torch.load(tmp_path / "lr_scheduler.pt", map_location="cpu", weights_only=False)
-        == scheduler.state_dict()
-    )
+    assert save_kwargs["save_rng"] is True
+    assert save_kwargs["extra_states"] == {
+        _LR_SCHEDULER_STATE: _scheduler_payload_state(checkpoint_step=13)
+    }
+    assert not (tmp_path / _LR_SCHEDULER_STATE).exists()
 
 
-def test_save_checkpoint_skips_when_contents_exclude_model_and_optimizer(tmp_path, monkeypatch):
-    engine, *_ = _initialized_engine(checkpoint_config={"save_contents": ["extra"]})
+def test_save_checkpoint_skips_when_contents_exclude_model_and_optimizer(
+    tmp_path, monkeypatch
+):
+    engine, *_ = _initialized_engine(checkpoint_config={"save_contents": []})
     checkpoint_path = tmp_path / "ckpt"
     save_calls = []
     monkeypatch.setattr(
@@ -148,7 +265,151 @@ def test_save_checkpoint_skips_when_contents_exclude_model_and_optimizer(tmp_pat
     assert not checkpoint_path.exists()
 
 
-def test_load_checkpoint_restores_scheduler_and_param_offload_reload(tmp_path, monkeypatch):
+def test_save_setup_failure_reaches_consensus_before_checkpoint_collectives(
+    tmp_path, monkeypatch
+):
+    engine, _module, _optimizer, scheduler, *_ = _initialized_engine()
+    scheduler._state["num_steps"] = 3
+    monkeypatch.setattr(
+        engine, "_checkpoint_hooks", lambda: (_ for _ in ()).throw(OSError("hook boom"))
+    )
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.save_training_checkpoint",
+        lambda *args, **kwargs: pytest.fail("checkpoint save must not run"),
+    )
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.dist.is_initialized", lambda: True
+    )
+    monkeypatch.setattr("verl_mlite.engine.mlite_engine.dist.get_world_size", lambda: 2)
+    gathered_errors = []
+
+    def fake_all_gather_object(output, value):
+        if isinstance(value, str):
+            gathered_errors.append(value)
+            output[:] = [value, None]
+        else:
+            output[:] = [copy.deepcopy(value), copy.deepcopy(value)]
+
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.dist.all_gather_object", fake_all_gather_object
+    )
+
+    with pytest.raises(RuntimeError, match="checkpoint save setup failed.*hook boom"):
+        engine.save_checkpoint(str(tmp_path), global_step=3)
+
+    assert any("hook boom" in error for error in gathered_errors)
+
+
+def test_save_offload_cleanup_failure_is_not_silently_ignored(tmp_path, monkeypatch):
+    engine, _module, _optimizer, scheduler, *_ = _initialized_engine(param_offload=True)
+    scheduler._state["num_steps"] = 3
+
+    def fake_to(**kwargs):
+        if kwargs["device"] == "cpu":
+            raise RuntimeError("offload cleanup boom")
+
+    monkeypatch.setattr(engine, "to", fake_to)
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda: None)
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.save_training_checkpoint",
+        lambda *args, **kwargs: None,
+    )
+
+    with pytest.raises(RuntimeError, match="offload cleanup.*offload cleanup boom"):
+        engine.save_checkpoint(str(tmp_path), global_step=3)
+
+
+def test_save_checkpoint_treats_rng_and_scheduler_as_extra(tmp_path, monkeypatch):
+    engine, _module, _optimizer, scheduler, *_ = _initialized_engine(
+        checkpoint_config={"save_contents": ["extra"]}
+    )
+    save_calls = []
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.save_training_checkpoint",
+        lambda *args, **kwargs: save_calls.append((args, kwargs)),
+    )
+    scheduler._state["num_steps"] = 9
+
+    engine.save_checkpoint(str(tmp_path), global_step=9)
+
+    assert len(save_calls) == 1
+    _args, kwargs = save_calls[0]
+    assert kwargs["save_model"] is False
+    assert kwargs["save_optimizer"] is False
+    assert kwargs["save_rng"] is True
+    assert kwargs["extra_states"] == {
+        _LR_SCHEDULER_STATE: {
+            "format": _LR_SCHEDULER_PAYLOAD_FORMAT,
+            "checkpoint_step": 9,
+            "scheduler_state": scheduler.state_dict(),
+        }
+    }
+
+
+def test_save_checkpoint_model_only_does_not_write_rng_or_scheduler(
+    tmp_path, monkeypatch
+):
+    engine, *_ = _initialized_engine(checkpoint_config={"save_contents": ["model"]})
+    save_calls = []
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.save_training_checkpoint",
+        lambda *args, **kwargs: save_calls.append((args, kwargs)),
+    )
+
+    engine.save_checkpoint(str(tmp_path), global_step=9)
+
+    _args, kwargs = save_calls[0]
+    assert kwargs["save_model"] is True
+    assert kwargs["save_optimizer"] is False
+    assert kwargs["save_rng"] is False
+    assert kwargs["extra_states"] is None
+
+
+@pytest.mark.parametrize(
+    "contents",
+    [
+        [],
+        ["model"],
+        ["optimizer"],
+        ["extra"],
+        ["model", "optimizer"],
+        ["model", "extra"],
+        ["optimizer", "extra"],
+        ["model", "optimizer", "extra"],
+    ],
+)
+def test_save_checkpoint_all_component_combinations(tmp_path, monkeypatch, contents):
+    engine, _module, _optimizer, scheduler, *_ = _initialized_engine(
+        checkpoint_config={"save_contents": contents}
+    )
+    calls = []
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.save_training_checkpoint",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    scheduler._state["num_steps"] = 6
+    if "optimizer" in contents and "extra" not in contents:
+        with pytest.raises(ValueError, match="exact-resume checkpoint"):
+            engine.save_checkpoint(str(tmp_path / "ckpt"), global_step=6)
+        assert calls == []
+        return
+
+    engine.save_checkpoint(str(tmp_path / "ckpt"), global_step=6)
+
+    if not contents:
+        assert calls == []
+        return
+    _args, kwargs = calls[0]
+    assert kwargs["save_model"] is ("model" in contents)
+    assert kwargs["save_optimizer"] is ("optimizer" in contents)
+    assert kwargs["save_rng"] is ("extra" in contents)
+    assert bool(kwargs["extra_states"]) is ("extra" in contents)
+
+
+def test_load_checkpoint_restores_scheduler_and_param_offload_reload(
+    tmp_path, monkeypatch
+):
     (
         engine,
         module,
@@ -159,15 +420,31 @@ def test_load_checkpoint_restores_scheduler_and_param_offload_reload(tmp_path, m
         placement_fn,
         expert_classifier,
     ) = _initialized_engine(param_offload=True)
-    torch.save({"step": 23, "lr": 0.125}, tmp_path / "lr_scheduler.pt")
+    saved_scheduler_payload = _scheduler_payload_state(
+        checkpoint_step=23, num_steps=23, max_lr=0.125
+    )
     to_calls = []
     load_calls = []
     sync_calls = []
     monkeypatch.setattr(engine, "to", lambda **kwargs: to_calls.append(kwargs))
     monkeypatch.setattr(torch.cuda, "synchronize", lambda: sync_calls.append(True))
+
+    def fake_load(*args, **kwargs):
+        load_calls.append((args, kwargs))
+        kwargs["extra_state_validators"][_LR_SCHEDULER_STATE](saved_scheduler_payload)
+        target = kwargs["extra_state_targets"][_LR_SCHEDULER_STATE]
+        target.validate_step(saved_scheduler_payload, 23)
+        snapshot = target.snapshot()
+        target.apply(saved_scheduler_payload)
+        assert target.fingerprint()["checkpoint_step"] == 23
+        target.restore(snapshot)
+        optimizer.param_groups[0]["lr"] = 999.0  # core optimizer commit happens first
+        target.apply(saved_scheduler_payload)
+        kwargs["loaded_extra_states"][_LR_SCHEDULER_STATE] = saved_scheduler_payload
+        return 23
+
     monkeypatch.setattr(
-        "verl_mlite.engine.mlite_engine.load_training_checkpoint",
-        lambda *args, **kwargs: load_calls.append((args, kwargs)),
+        "verl_mlite.engine.mlite_engine.load_training_checkpoint", fake_load
     )
 
     engine.load_checkpoint(str(tmp_path))
@@ -177,7 +454,8 @@ def test_load_checkpoint_restores_scheduler_and_param_offload_reload(tmp_path, m
         {"device": "cpu", "model": True, "optimizer": False, "grad": False},
     ]
     assert sync_calls == [True]
-    assert scheduler.loaded_state == {"step": 23, "lr": 0.125}
+    assert scheduler.loaded_state == saved_scheduler_payload["scheduler_state"]
+    assert optimizer.param_groups[0]["lr"] == 0.125
     assert len(load_calls) == 1
     load_args, load_kwargs = load_calls[0]
     assert load_args == (module, optimizer, str(tmp_path), parallel, parallel_state)
@@ -185,3 +463,718 @@ def test_load_checkpoint_restores_scheduler_and_param_offload_reload(tmp_path, m
     assert load_kwargs["is_expert"] is expert_classifier
     assert load_kwargs["load_model"] is True
     assert load_kwargs["load_optimizer"] is True
+    assert load_kwargs["load_rng"] is True
+    assert load_kwargs["allow_legacy_checkpoint"] is False
+    assert load_kwargs["load_extra_state_files"] == (_LR_SCHEDULER_STATE,)
+    assert load_kwargs["loaded_extra_states"] == {
+        _LR_SCHEDULER_STATE: saved_scheduler_payload
+    }
+    assert load_kwargs["extra_state_validators"] == {
+        _LR_SCHEDULER_STATE: _validate_lr_scheduler_payload
+    }
+    assert isinstance(
+        load_kwargs["extra_state_targets"][_LR_SCHEDULER_STATE],
+        _LRSchedulerCheckpointTarget,
+    )
+
+
+@pytest.mark.parametrize(
+    ("load_contents", "expected"),
+    [
+        ([], (False, False, False, False)),
+        (["model"], (True, False, False, False)),
+        (["optimizer"], (False, True, False, False)),
+        (["extra"], (False, False, True, True)),
+        (["model", "optimizer"], (True, True, False, False)),
+        (["model", "extra"], (True, False, True, True)),
+        (["optimizer", "extra"], (False, True, True, True)),
+        (["model", "optimizer", "extra"], (True, True, True, True)),
+    ],
+)
+def test_load_checkpoint_component_policy_is_symmetric(
+    tmp_path, monkeypatch, load_contents, expected
+):
+    engine, *_ = _initialized_engine(checkpoint_config={"load_contents": load_contents})
+    payload = _scheduler_payload_state(checkpoint_step=5, num_steps=5)
+    calls = []
+
+    def fake_load(*args, **kwargs):
+        calls.append((args, kwargs))
+        target_map = kwargs.get("extra_state_targets")
+        if target_map:
+            target = target_map[_LR_SCHEDULER_STATE]
+            target.validate_step(payload, 5)
+            target.apply(payload)
+            kwargs["loaded_extra_states"][_LR_SCHEDULER_STATE] = payload
+        return 5
+
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.load_training_checkpoint", fake_load
+    )
+
+    load_model, load_optimizer, load_rng, has_scheduler_target = expected
+    if load_optimizer and not load_rng:
+        with pytest.raises(ValueError, match="matching LR scheduler progress"):
+            engine.load_checkpoint(str(tmp_path))
+        assert calls == []
+        return
+
+    engine.load_checkpoint(str(tmp_path))
+
+    if not any(expected):
+        assert calls == []
+        return
+    _args, kwargs = calls[0]
+    assert kwargs["load_model"] is load_model
+    assert kwargs["load_optimizer"] is load_optimizer
+    assert kwargs["load_rng"] is load_rng
+    assert bool(kwargs["extra_state_targets"]) is has_scheduler_target
+
+
+def test_load_contents_defaults_to_saved_partial_component_policy(
+    tmp_path, monkeypatch
+):
+    engine, *_ = _initialized_engine(checkpoint_config={"save_contents": ["model"]})
+    calls = []
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.load_training_checkpoint",
+        lambda *args, **kwargs: calls.append((args, kwargs)) or 3,
+    )
+
+    engine.load_checkpoint(str(tmp_path))
+
+    _args, kwargs = calls[0]
+    assert kwargs["load_model"] is True
+    assert kwargs["load_optimizer"] is False
+    assert kwargs["load_rng"] is False
+    assert kwargs["extra_state_targets"] is None
+
+
+def test_load_setup_failure_reaches_consensus_before_checkpoint_collectives(
+    tmp_path, monkeypatch
+):
+    engine, *_ = _initialized_engine()
+    monkeypatch.setattr(
+        engine, "_checkpoint_hooks", lambda: (_ for _ in ()).throw(OSError("hook boom"))
+    )
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.load_training_checkpoint",
+        lambda *args, **kwargs: pytest.fail("checkpoint load must not run"),
+    )
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.dist.is_initialized", lambda: True
+    )
+    monkeypatch.setattr("verl_mlite.engine.mlite_engine.dist.get_world_size", lambda: 2)
+    gathered_errors = []
+
+    def fake_all_gather_object(output, value):
+        if isinstance(value, str):
+            gathered_errors.append(value)
+            output[:] = [value, None]
+        else:
+            output[:] = [copy.deepcopy(value), copy.deepcopy(value)]
+
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.dist.all_gather_object", fake_all_gather_object
+    )
+
+    with pytest.raises(RuntimeError, match="checkpoint load setup failed.*hook boom"):
+        engine.load_checkpoint(str(tmp_path))
+
+    assert any("hook boom" in error for error in gathered_errors)
+    assert engine._checkpoint_load_poisoned is True
+
+
+@pytest.mark.parametrize(
+    "state, error",
+    [
+        (None, TypeError),
+        ({}, ValueError),
+        ({**_scheduler_state(), "format": "unsupported"}, ValueError),
+        ({**_scheduler_state(), "num_steps": True}, TypeError),
+        ({**_scheduler_state(), "num_steps": 1.5}, TypeError),
+        ({**_scheduler_state(), "num_steps": -1}, ValueError),
+        (
+            {
+                **_scheduler_state(),
+                "config": {**_scheduler_state()["config"], "max_lr": float("nan")},
+            },
+            ValueError,
+        ),
+        (
+            {
+                **_scheduler_state(),
+                "config": {**_scheduler_state()["config"], "min_lr": -0.1},
+            },
+            ValueError,
+        ),
+        (
+            {
+                **_scheduler_state(),
+                "config": {
+                    **_scheduler_state()["config"],
+                    "min_lr": 0.5,
+                    "max_lr": 0.25,
+                },
+            },
+            ValueError,
+        ),
+        (
+            {
+                **_scheduler_state(),
+                "config": {
+                    **_scheduler_state()["config"],
+                    "wd_incr_style": "exponential",
+                },
+            },
+            ValueError,
+        ),
+        (
+            {
+                **_scheduler_state(),
+                "config": {**_scheduler_state()["config"], "init_lr": 0.5},
+            },
+            ValueError,
+        ),
+        (
+            {
+                **_scheduler_state(),
+                "config": {
+                    **_scheduler_state()["config"],
+                    "start_wd": 0.2,
+                    "end_wd": 0.1,
+                },
+            },
+            ValueError,
+        ),
+    ],
+)
+def test_lr_scheduler_state_validation_rejects_incompatible_sidecars(state, error):
+    with pytest.raises(error):
+        _validate_lr_scheduler_state(state)
+
+
+def test_lr_scheduler_payload_binds_core_checkpoint_step():
+    payload = _scheduler_payload_state(checkpoint_step=12)
+
+    _validate_lr_scheduler_payload(payload, expected_step=12)
+    with pytest.raises(RuntimeError, match="sidecar/core step mismatch"):
+        _validate_lr_scheduler_payload(payload, expected_step=13)
+    with pytest.raises(RuntimeError, match="progress/core step mismatch"):
+        _validate_lr_scheduler_payload(
+            _scheduler_payload_state(checkpoint_step=12, num_steps=11), expected_step=12
+        )
+
+
+def test_lr_scheduler_runtime_config_override_matches_verl_wrapper_policy():
+    scheduler, _optimizer = _real_scheduler(max_lr=0.25)
+    checkpoint_state = _scheduler_state(num_steps=4, max_lr=0.125)
+
+    scheduler.load_state_dict(checkpoint_state)
+
+    assert scheduler.max_lr == 0.25
+    assert scheduler.num_steps == 4
+
+
+def test_lr_scheduler_checkpoint_config_policy_is_explicit():
+    scheduler, optimizer = _real_scheduler(max_lr=0.25, use_checkpoint_config=True)
+    checkpoint_state = _scheduler_state(num_steps=4, max_lr=0.125)
+
+    scheduler.load_state_dict(checkpoint_state)
+
+    assert scheduler.max_lr == 0.125
+    assert optimizer.param_groups[0]["lr"] == 0.125
+
+
+def test_lr_scheduler_preserves_group_lr_wd_and_tensor_lr_across_resume():
+    lr_tensor = torch.tensor(-1.0)
+    direct, direct_optimizer = _group_scheduler(
+        [
+            {
+                "lr": lr_tensor,
+                "weight_decay": -1.0,
+                "max_lr": 0.2,
+                "min_lr": 0.02,
+                "wd_mult": 1.0,
+            },
+            {
+                "lr": -1.0,
+                "weight_decay": -1.0,
+                "max_lr": 0.05,
+                "min_lr": 0.005,
+                "wd_mult": 0.0,
+            },
+        ]
+    )
+
+    assert direct_optimizer.param_groups[0]["lr"] is lr_tensor
+    assert lr_tensor.item() == pytest.approx(0.01)
+    assert direct_optimizer.param_groups[0]["weight_decay"] == pytest.approx(0.1)
+    assert direct_optimizer.param_groups[1]["lr"] == pytest.approx(0.01)
+    assert direct_optimizer.param_groups[1]["weight_decay"] == 0.0
+
+    direct.step(2)
+    assert lr_tensor.item() == pytest.approx(0.2)
+    assert direct_optimizer.param_groups[1]["lr"] == pytest.approx(0.05)
+    assert direct_optimizer.param_groups[0]["weight_decay"] == pytest.approx(0.15)
+    assert direct_optimizer.param_groups[1]["weight_decay"] == 0.0
+    checkpoint_state = direct.state_dict()
+
+    resumed_lr_tensor = torch.tensor(-1.0)
+    resumed, resumed_optimizer = _group_scheduler(
+        [
+            {
+                "lr": resumed_lr_tensor,
+                "weight_decay": -1.0,
+                "max_lr": 0.2,
+                "min_lr": 0.02,
+                "wd_mult": 1.0,
+            },
+            {
+                "lr": -1.0,
+                "weight_decay": -1.0,
+                "max_lr": 0.05,
+                "min_lr": 0.005,
+                "wd_mult": 0.0,
+            },
+        ]
+    )
+    resumed.load_state_dict(checkpoint_state)
+
+    assert resumed_optimizer.param_groups[0]["lr"] is resumed_lr_tensor
+    for _ in range(3):
+        direct.step()
+        resumed.step()
+        assert resumed.state_dict() == direct.state_dict()
+        for direct_group, resumed_group in zip(
+            direct_optimizer.param_groups, resumed_optimizer.param_groups, strict=True
+        ):
+            assert float(resumed_group["lr"]) == pytest.approx(
+                float(direct_group["lr"])
+            )
+            assert resumed_group["weight_decay"] == pytest.approx(
+                direct_group["weight_decay"]
+            )
+
+
+def test_lr_scheduler_supports_unambiguous_legacy_lr_multiplier():
+    scheduler, optimizer = _group_scheduler(
+        [{"lr": -1.0, "weight_decay": 0.1, "lr_mult": 0.5, "wd_mult": 1.0}]
+    )
+
+    assert optimizer.param_groups[0]["lr"] == pytest.approx(0.005)
+    scheduler.step(2)
+    assert optimizer.param_groups[0]["lr"] == pytest.approx(0.1)
+
+
+def test_lr_scheduler_rejects_ambiguous_explicit_bounds_and_lr_multiplier():
+    with pytest.raises(ValueError, match="mixes explicit max_lr/min_lr"):
+        _group_scheduler(
+            [
+                {
+                    "lr": 0.0,
+                    "weight_decay": 0.1,
+                    "max_lr": 0.1,
+                    "min_lr": 0.01,
+                    "lr_mult": 0.5,
+                }
+            ]
+        )
+
+
+@pytest.mark.parametrize(
+    ("style", "expected"),
+    [
+        ("linear", 0.5),
+        ("cosine", 0.5),
+        ("exponential", 2.0 * math.sqrt(0.5) - 1.0),
+        ("minus_sqrt", 1.0 - math.sqrt(0.5)),
+    ],
+)
+def test_wsd_lr_decay_matches_mcore_coefficients(style, expected):
+    optimizer = SimpleNamespace(param_groups=[{"lr": 0.0, "weight_decay": 0.1}])
+    scheduler = _MegatronLiteLRScheduler(
+        optimizer,
+        init_lr=0.0,
+        max_lr=1.0,
+        min_lr=0.0,
+        lr_warmup_steps=0,
+        lr_decay_steps=4,
+        lr_decay_style="wsd",
+        start_wd=0.1,
+        end_wd=0.1,
+        wd_incr_steps=4,
+        wd_incr_style="constant",
+        wsd_decay_steps=4,
+        lr_wsd_decay_style=style,
+        use_checkpoint_config=False,
+    )
+
+    scheduler.step(2)
+
+    assert optimizer.param_groups[0]["lr"] == pytest.approx(expected)
+
+
+def test_inverse_square_root_pins_min_lr_after_decay_horizon():
+    optimizer = SimpleNamespace(param_groups=[{"lr": 0.0, "weight_decay": 0.1}])
+    scheduler = _MegatronLiteLRScheduler(
+        optimizer,
+        init_lr=0.0,
+        max_lr=1.0,
+        min_lr=0.1,
+        lr_warmup_steps=1,
+        lr_decay_steps=4,
+        lr_decay_style="inverse-square-root",
+        start_wd=0.1,
+        end_wd=0.1,
+        wd_incr_steps=4,
+        wd_incr_style="constant",
+        wsd_decay_steps=None,
+        lr_wsd_decay_style="exponential",
+        use_checkpoint_config=False,
+    )
+
+    scheduler.step(5)
+
+    assert optimizer.param_groups[0]["lr"] == pytest.approx(0.1)
+
+
+@pytest.mark.parametrize("wsd_decay_steps", [None, 0, 5])
+def test_wsd_scheduler_rejects_invalid_decay_span(wsd_decay_steps):
+    optimizer = SimpleNamespace(param_groups=[{"lr": 0.0, "weight_decay": 0.1}])
+    with pytest.raises(ValueError, match="requires 1 <= wsd_decay_steps"):
+        _MegatronLiteLRScheduler(
+            optimizer,
+            init_lr=0.0,
+            max_lr=1.0,
+            min_lr=0.0,
+            lr_warmup_steps=0,
+            lr_decay_steps=4,
+            lr_decay_style="wsd",
+            start_wd=0.1,
+            end_wd=0.1,
+            wd_incr_steps=4,
+            wd_incr_style="constant",
+            wsd_decay_steps=wsd_decay_steps,
+            lr_wsd_decay_style="exponential",
+            use_checkpoint_config=False,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("lr_warmup_steps", -1),
+        ("lr_warmup_steps", 1.5),
+        ("lr_decay_steps", 0),
+        ("wd_incr_steps", 0),
+    ],
+)
+def test_lr_scheduler_constructor_rejects_instead_of_coercing(field, value):
+    kwargs = {
+        "init_lr": 0.0,
+        "max_lr": 1.0,
+        "min_lr": 0.0,
+        "lr_warmup_steps": 0,
+        "lr_decay_steps": 4,
+        "lr_decay_style": "linear",
+        "start_wd": 0.1,
+        "end_wd": 0.1,
+        "wd_incr_steps": 4,
+        "wd_incr_style": "constant",
+        "wsd_decay_steps": None,
+        "lr_wsd_decay_style": "exponential",
+        "use_checkpoint_config": False,
+    }
+    kwargs[field] = value
+    optimizer = SimpleNamespace(param_groups=[{"lr": 0.0, "weight_decay": 0.1}])
+
+    with pytest.raises((TypeError, ValueError)):
+        _MegatronLiteLRScheduler(optimizer, **kwargs)
+
+
+@pytest.mark.parametrize("increment", [-1, 1.5, True])
+def test_lr_scheduler_step_rejects_invalid_increment(increment):
+    scheduler, _optimizer = _real_scheduler()
+
+    with pytest.raises(ValueError, match="non-negative integer"):
+        scheduler.step(increment)
+
+
+def test_lr_scheduler_target_restores_tensor_lr_identity_after_preflight():
+    lr_tensor = torch.tensor(0.0)
+    scheduler, optimizer = _group_scheduler(
+        [{"lr": lr_tensor, "weight_decay": 0.1, "max_lr": 0.2, "min_lr": 0.02}],
+        use_checkpoint_config=True,
+    )
+    target = _LRSchedulerCheckpointTarget(scheduler)
+    baseline = target.snapshot()
+    candidate = _scheduler_payload_state(checkpoint_step=2, num_steps=2, max_lr=0.1)
+
+    target.apply(candidate)
+    target.restore(baseline)
+
+    assert optimizer.param_groups[0]["lr"] is lr_tensor
+    assert lr_tensor.item() == pytest.approx(0.01)
+
+
+def test_lr_scheduler_resume_preserves_future_lr_and_weight_decay_sequence():
+    direct, direct_optimizer = _real_scheduler(max_lr=0.25)
+    for _ in range(4):
+        direct.step()
+    checkpoint_state = direct.state_dict()
+
+    resumed, resumed_optimizer = _real_scheduler(max_lr=0.25)
+    resumed.load_state_dict(checkpoint_state)
+
+    for _ in range(5):
+        direct.step()
+        resumed.step()
+        assert resumed.state_dict() == direct.state_dict()
+        assert (
+            resumed_optimizer.param_groups[0]["lr"]
+            == direct_optimizer.param_groups[0]["lr"]
+        )
+        assert resumed_optimizer.param_groups[0]["weight_decay"] == (
+            direct_optimizer.param_groups[0]["weight_decay"]
+        )
+
+
+def test_lr_scheduler_target_preflight_can_restore_small_state():
+    scheduler, optimizer = _real_scheduler(max_lr=0.25, use_checkpoint_config=True)
+    target = _LRSchedulerCheckpointTarget(scheduler)
+    baseline = target.snapshot()
+    payload = _scheduler_payload_state(checkpoint_step=8, num_steps=8, max_lr=0.125)
+
+    target.validate_step(payload, 8)
+    target.apply(payload)
+    assert optimizer.param_groups[0]["lr"] == 0.125
+    assert target.fingerprint()["checkpoint_step"] == 8
+    target.restore(baseline)
+
+    assert optimizer.param_groups[0]["lr"] == 0.25
+    assert target.fingerprint() == _LRSchedulerCheckpointTarget(scheduler).fingerprint()
+
+
+def test_scheduler_save_rejects_cross_rank_step_mismatch(monkeypatch):
+    optimizer = SimpleNamespace(
+        param_groups=[{"lr": 0.25, "weight_decay": 0.1, "min_lr": 0.0}]
+    )
+    scheduler = _Scheduler(optimizer)
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.dist.is_initialized", lambda: True
+    )
+    monkeypatch.setattr("verl_mlite.engine.mlite_engine.dist.get_world_size", lambda: 2)
+
+    def fake_all_gather_object(output, value):
+        if value is None:
+            output[:] = [None, None]
+        else:
+            other = copy.deepcopy(value)
+            other["num_steps"] += 1
+            output[:] = [value, other]
+
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.dist.all_gather_object", fake_all_gather_object
+    )
+
+    with pytest.raises(RuntimeError, match="differs across ranks"):
+        _scheduler_state_with_consensus(scheduler)
+
+
+def test_scheduler_payload_validation_reaches_error_consensus_before_payload_gather(
+    monkeypatch,
+):
+    scheduler, _optimizer = _real_scheduler()
+    state = scheduler.state_dict()
+    state["num_steps"] = 7
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine._scheduler_state_with_consensus",
+        lambda _scheduler: state,
+    )
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.dist.is_initialized", lambda: True
+    )
+    monkeypatch.setattr("verl_mlite.engine.mlite_engine.dist.get_world_size", lambda: 2)
+    gathered = []
+
+    def fake_all_gather_object(output, value):
+        gathered.append(value)
+        if isinstance(value, str):
+            output[:] = [value, None]
+        else:
+            pytest.fail("payload gather must not run after local validation failure")
+
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.dist.all_gather_object", fake_all_gather_object
+    )
+
+    with pytest.raises(RuntimeError, match="progress/core step mismatch"):
+        _scheduler_payload(scheduler, checkpoint_step=8)
+
+    assert len(gathered) == 1
+
+
+def test_checkpoint_component_presence_mismatch_fails_before_branch(monkeypatch):
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.dist.is_initialized", lambda: True
+    )
+    monkeypatch.setattr("verl_mlite.engine.mlite_engine.dist.get_world_size", lambda: 2)
+
+    def fake_all_gather_object(output, value):
+        output[:] = [value, (*value[:3], not value[3])]
+
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.dist.all_gather_object", fake_all_gather_object
+    )
+
+    with pytest.raises(RuntimeError, match="component policy differs across ranks"):
+        _checkpoint_components_with_consensus(
+            model=True,
+            optimizer=True,
+            extra=True,
+            scheduler_present=True,
+            context="checkpoint save",
+        )
+
+
+def test_load_checkpoint_rejects_missing_required_scheduler_extra_state(
+    tmp_path, monkeypatch
+):
+    engine, *_ = _initialized_engine()
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.load_training_checkpoint",
+        lambda *args, **kwargs: 17,
+    )
+
+    with pytest.raises(RuntimeError, match="required lr_scheduler.pt extra state"):
+        engine.load_checkpoint(str(tmp_path))
+
+    assert engine._checkpoint_load_poisoned is True
+    with pytest.raises(RuntimeError, match="poisoned by a failed checkpoint load"):
+        engine.optimizer_step()
+
+
+def test_post_load_validation_reaches_error_consensus_before_barrier(
+    tmp_path, monkeypatch
+):
+    engine, *_ = _initialized_engine()
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.load_training_checkpoint",
+        lambda *args, **kwargs: 17,
+    )
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.dist.is_initialized", lambda: True
+    )
+    monkeypatch.setattr("verl_mlite.engine.mlite_engine.dist.get_world_size", lambda: 2)
+    gathered_errors = []
+
+    def fake_all_gather_object(output, value):
+        if isinstance(value, str):
+            gathered_errors.append(value)
+        output[:] = [copy.deepcopy(value), copy.deepcopy(value)]
+
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.dist.all_gather_object", fake_all_gather_object
+    )
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.dist.barrier",
+        lambda: pytest.fail("barrier must not run after post-load validation failure"),
+    )
+
+    with pytest.raises(RuntimeError, match="required lr_scheduler.pt extra state"):
+        engine.load_checkpoint(str(tmp_path))
+
+    assert any(
+        "required lr_scheduler.pt extra state" in error for error in gathered_errors
+    )
+    assert engine._checkpoint_load_poisoned is True
+
+
+def test_legacy_step_validation_reaches_consensus_before_scheduler_commit(
+    tmp_path, monkeypatch
+):
+    from megatron.lite.primitive.ckpt import dcp as dcp_impl
+
+    engine, *_ = _initialized_engine()
+    payload = _scheduler_payload_state(checkpoint_step=8, num_steps=8)
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine._legacy_scheduler_payload_with_consensus",
+        lambda *_args, **_kwargs: payload,
+    )
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.load_training_checkpoint",
+        lambda *args, **kwargs: 9,
+    )
+    monkeypatch.setattr(dcp_impl, "_preflight_extra_state_targets", lambda *_args: None)
+    monkeypatch.setattr(
+        dcp_impl,
+        "_commit_extra_state_targets",
+        lambda *_args: pytest.fail(
+            "legacy target commit must not run on step mismatch"
+        ),
+    )
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.dist.is_initialized", lambda: True
+    )
+    monkeypatch.setattr("verl_mlite.engine.mlite_engine.dist.get_world_size", lambda: 2)
+    gathered_errors = []
+
+    def fake_all_gather_object(output, value):
+        if isinstance(value, str):
+            gathered_errors.append(value)
+        output[:] = [copy.deepcopy(value), copy.deepcopy(value)]
+
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.dist.all_gather_object", fake_all_gather_object
+    )
+
+    with pytest.raises(RuntimeError, match="sidecar/core step mismatch"):
+        engine.load_checkpoint(str(tmp_path), allow_legacy_checkpoint=True)
+
+    assert any("sidecar/core step mismatch" in error for error in gathered_errors)
+    assert engine._checkpoint_load_poisoned is True
+
+
+def test_explicit_legacy_scheduler_migration_reads_root_sidecar(tmp_path, monkeypatch):
+    engine, _module, _optimizer, scheduler, *_ = _initialized_engine()
+    (tmp_path / "step_4").mkdir()
+    torch.save({"num_steps": 4}, tmp_path / _LR_SCHEDULER_STATE)
+    load_calls = []
+
+    def fake_load(*args, **kwargs):
+        load_calls.append((args, kwargs))
+        return 4
+
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.load_training_checkpoint", fake_load
+    )
+
+    engine.load_checkpoint(str(tmp_path), allow_legacy_checkpoint=True)
+
+    assert scheduler.state_dict()["num_steps"] == 4
+    _args, kwargs = load_calls[0]
+    assert kwargs["load_extra_state_files"] is None
+    assert kwargs["extra_state_targets"] is None
+    assert kwargs["allow_legacy_checkpoint"] is True
+
+
+def test_legacy_scheduler_migration_rejects_root_and_step_sidecars(
+    tmp_path, monkeypatch
+):
+    engine, *_ = _initialized_engine()
+    step = tmp_path / "step_4"
+    step.mkdir()
+    torch.save({"num_steps": 4}, tmp_path / _LR_SCHEDULER_STATE)
+    torch.save({"num_steps": 4}, step / _LR_SCHEDULER_STATE)
+    core_called = []
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.load_training_checkpoint",
+        lambda *args, **kwargs: core_called.append(True) or 4,
+    )
+
+    with pytest.raises(RuntimeError, match="requires exactly one recognized"):
+        engine.load_checkpoint(str(tmp_path), allow_legacy_checkpoint=True)
+
+    assert core_called == []
+    assert engine._checkpoint_load_poisoned is True

--- a/experimental/lite/tests/unit/verl/test_mlite_engine_config.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_engine_config.py
@@ -2,7 +2,6 @@
 from types import SimpleNamespace
 
 import pytest
-
 from verl_mlite.engine.config import MegatronLiteEngineConfig
 from verl_mlite.engine.mlite_engine import MegatronLiteEngine, _build_lr_scheduler
 
@@ -31,7 +30,9 @@ def _optimizer_config(**override_optimizer_config) -> SimpleNamespace:
 
 
 def _engine(
-    *, engine_config: MegatronLiteEngineConfig, optimizer_config: SimpleNamespace | None = None
+    *,
+    engine_config: MegatronLiteEngineConfig,
+    optimizer_config: SimpleNamespace | None = None
 ) -> MegatronLiteEngine:
     return MegatronLiteEngine(
         model_config=SimpleNamespace(
@@ -130,6 +131,7 @@ def test_local_lr_scheduler_warmup_decay_and_state_roundtrip() -> None:
         weight_decay_incr_style="constant",
         lr_wsd_decay_steps=None,
         lr_wsd_decay_style="exponential",
+        use_checkpoint_opt_param_scheduler=False,
     )
 
     scheduler = _build_lr_scheduler(optimizer, opt)

--- a/experimental/lite/tests/unit/verl/test_mlite_engine_config.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_engine_config.py
@@ -159,6 +159,35 @@ def test_mlite_config_threads_rl_parallel_and_impl_settings() -> None:
     assert config.impl_cfg["deterministic"] is False
 
 
+def test_auto_qwen35_weight_sync_uses_resolved_vllm_export_target() -> None:
+    engine = _engine(engine_config=_engine_config())
+    assert engine.engine_config.model_name == "auto"
+    engine._mlite_config = engine._build_mlite_config()
+    assert engine._mlite_config.model_name == "qwen3_5"
+
+    captured = {}
+
+    def export_weights(handle, **kwargs):
+        captured["handle"] = handle
+        captured["kwargs"] = kwargs
+        return ["weight-payload"]
+
+    handle = object()
+    engine.runtime = SimpleNamespace(export_weights=export_weights)
+    engine.handle = handle
+
+    payload, metadata = engine.get_per_tensor_param(limit=3)
+
+    assert payload == ["weight-payload"]
+    assert metadata is None
+    assert captured["handle"] is handle
+    assert captured["kwargs"] == {
+        "limit": 3,
+        "target": "vllm",
+        "export_dtype": "bfloat16",
+    }
+
+
 def test_local_lr_scheduler_warmup_decay_and_state_roundtrip() -> None:
     optimizer = SimpleNamespace(param_groups=[{"lr": 0.0, "weight_decay": 0.1}])
     opt = SimpleNamespace(

--- a/experimental/lite/tests/unit/verl/test_mlite_engine_config.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_engine_config.py
@@ -1,4 +1,7 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+import os
+import subprocess
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -32,7 +35,7 @@ def _optimizer_config(**override_optimizer_config) -> SimpleNamespace:
 def _engine(
     *,
     engine_config: MegatronLiteEngineConfig,
-    optimizer_config: SimpleNamespace | None = None
+    optimizer_config: SimpleNamespace | None = None,
 ) -> MegatronLiteEngine:
     return MegatronLiteEngine(
         model_config=SimpleNamespace(
@@ -48,6 +51,46 @@ def _engine_config(**kwargs) -> MegatronLiteEngineConfig:
     values = {"custom_backend_module": None, "impl_cfg": {"use_thd": True}}
     values.update(kwargs)
     return MegatronLiteEngineConfig(**values)
+
+
+def test_canonical_config_target_import_registers_default_mlite_backend() -> None:
+    """Exercise the fresh-process import path used by VERL/Hydra configs."""
+
+    script = r"""
+import importlib
+import sys
+
+from verl.workers.engine.base import EngineRegistry
+
+assert "verl_mlite.engine.mlite_engine" not in sys.modules
+config_module = importlib.import_module("verl_mlite.engine.config")
+config = config_module.MegatronLiteEngineConfig(impl_cfg={"use_thd": True})
+assert config.custom_backend_module == "verl_mlite.engine.mlite_engine"
+assert config.strategy == "mlite"
+engine_cls = EngineRegistry.get_engine_cls(
+    model_type="language_model", backend="mlite"
+)
+assert engine_cls.__module__ == config.custom_backend_module
+assert engine_cls.__name__ == "MegatronLiteEngine"
+print("CANONICAL_VERL_MLITE_REGISTRY_PASS")
+"""
+    env = dict(os.environ)
+    env["VERL_ENGINE_DEVICE"] = "cuda"
+    env.pop("VERL_ENGINE_VENDOR", None)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+        timeout=60,
+    )
+
+    assert result.returncode == 0, (
+        f"fresh VERL registry process failed\nstdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+    assert result.stdout.strip() == "CANONICAL_VERL_MLITE_REGISTRY_PASS"
 
 
 def test_optimizer_offload_enables_full_optimizer_state_offload_by_default() -> None:

--- a/experimental/lite/tests/unit/verl/test_mlite_engine_cp_smoke.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_engine_cp_smoke.py
@@ -71,7 +71,7 @@ def _write_kimi_config(path) -> None:
     (path / "config.json").write_text(json.dumps(config), encoding="utf-8")
 
 
-def _write_glm5_config(path) -> None:
+def _write_glm52_config(path) -> None:
     config = {
         "model_type": "glm_moe_dsa",
         "num_hidden_layers": 2,
@@ -80,7 +80,7 @@ def _write_glm5_config(path) -> None:
         "num_key_value_heads": 64,
         "head_dim": 256,
         "vocab_size": 32,
-        "max_position_embeddings": 64,
+        "max_position_embeddings": 1024,
         "initializer_range": 0.002,
         "q_lora_rank": 16,
         "kv_lora_rank": 512,
@@ -91,14 +91,22 @@ def _write_glm5_config(path) -> None:
         "index_head_dim": 128,
         "index_n_heads": 32,
         "index_topk": 512,
+        "index_topk_freq": 2,
+        "index_skip_topk_offset": 1,
+        "indexer_types": ["full", "shared"],
+        "rope_interleave": True,
+        "indexer_rope_interleave": True,
+        "dsa_indexer_loss_coeff": 1.0e-2,
         "intermediate_size": 20,
         "moe_intermediate_size": 6,
         "first_k_dense_replace": 1,
-        "n_routed_experts": 3,
+        "n_routed_experts": 4,
         "n_shared_experts": 1,
-        "num_experts_per_tok": 3,
+        "num_experts_per_tok": 2,
+        "n_group": 1,
+        "topk_group": 1,
         "num_nextn_predict_layers": 1,
-        "mlp_layer_types": ["dense", "dense"],
+        "mlp_layer_types": ["dense", "sparse"],
     }
     path.mkdir(parents=True, exist_ok=True)
     (path / "config.json").write_text(json.dumps(config), encoding="utf-8")
@@ -146,6 +154,252 @@ def _write_deepseek_v4_config(path) -> None:
     (path / "config.json").write_text(json.dumps(config), encoding="utf-8")
 
 
+def _write_qwen35_config(path) -> None:
+    # Keep the released nested text-config shape while making both Qwen3.5
+    # attention families small enough for an 8-rank CP integration smoke.
+    config = {
+        "model_type": "qwen3_5_moe",
+        "text_config": {
+            "model_type": "qwen3_5_moe",
+            "num_hidden_layers": 2,
+            "hidden_size": 32,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "head_dim": 8,
+            "vocab_size": 128,
+            "rms_norm_eps": 1.0e-6,
+            "max_position_embeddings": 128,
+            "num_experts": 4,
+            "num_experts_per_tok": 2,
+            "moe_intermediate_size": 16,
+            "shared_expert_intermediate_size": 16,
+            "linear_num_key_heads": 4,
+            "linear_key_head_dim": 8,
+            "linear_num_value_heads": 4,
+            "linear_value_head_dim": 8,
+            "linear_conv_kernel_dim": 2,
+            "layer_types": ["linear_attention", "full_attention"],
+            "partial_rotary_factor": 1.0,
+            "mrope_section": [1, 1, 2],
+            "num_nextn_predict_layers": 0,
+            "rope_parameters": {
+                "rope_theta": 10_000_000.0,
+                "partial_rotary_factor": 1.0,
+                "mrope_section": [1, 1, 2],
+            },
+        },
+    }
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+
+
+def _assert_built_model_contract(engine, model_name: str) -> str:
+    """Prove the requested release path was built, not only serialized."""
+
+    assert engine._mlite_config.model_name == model_name
+    model = _unwrap_primary_model(engine)
+    config = model.config
+    assert model.ps.cp_size == engine.engine_config.cp
+    assert model.ps.cp_size > 1
+
+    if model_name == "glm5":
+        assert config.resolved_dsa_indexer_types == ("full", "shared")
+        assert config.uses_configured_dsa_rope_layout is True
+        assert config.rope_interleave is True
+        assert config.indexer_rope_interleave is True
+        assert config.dsa_indexer_loss_coeff == pytest.approx(1.0e-2)
+        assert config.mlp_layer_types == ["dense", "sparse"]
+        full_dsa = model.layers[0].self_attention.self_attention
+        shared_dsa = model.layers[1].self_attention.self_attention
+        assert full_dsa.skip_topk is False
+        assert full_dsa.indexer is not None
+        assert full_dsa.rope_interleaved is True
+        assert full_dsa.indexer.rope_interleaved is True
+        assert shared_dsa.skip_topk is True
+        assert shared_dsa.indexer is None
+        assert shared_dsa.rope_interleaved is True
+        return "variant=glm52 dsa_schedule=full,shared rope_layout=interleaved"
+
+    if model_name == "qwen3_5":
+        assert config.layer_types == ["linear_attention", "full_attention"]
+        assert config.mrope_section == [1, 1, 2]
+        assert model.layers[0].linear_attn is not None
+        assert model.layers[0].full_attn is None
+        assert model.layers[0].linear_attn.cp_mode == "fla_allgather"
+        assert model.layers[1].linear_attn is None
+        assert model.layers[1].full_attn is not None
+        return "variant=qwen3.5 attention_schedule=linear,full"
+
+    if model_name == "deepseek_v4":
+        import torch
+        from megatron.lite.model.deepseek_v4.lite.model import DeepseekV4CSAAttention
+        from megatron.lite.primitive.modules.attention.csa import (
+            CompressedSparseAttention,
+        )
+
+        first_layer = model.layers["0"]
+        assert isinstance(first_layer.self_attn, DeepseekV4CSAAttention)
+        csa = first_layer.self_attn.self_attn
+        assert isinstance(csa, CompressedSparseAttention)
+        assert csa.compress_ratio == config.compress_ratios[0] == 4
+        assert csa.compressor is not None
+        assert csa.indexer is not None
+        assert first_layer.attn_hc is not None
+        assert first_layer.ffn_hc is not None
+        assert first_layer.attn_hc.hc_mult == config.hc_mult
+        assert first_layer.ffn_hc.hc_mult == config.hc_mult
+        assert model.hc_mult == config.hc_mult
+        assert first_layer.mlp.is_hash_layer is True
+        tid2eid = first_layer.mlp.gate.get_buffer("tid2eid")
+        assert tid2eid.shape == (config.vocab_size, config.num_experts_per_tok)
+        assert tid2eid.dtype == torch.int64
+        return "variant=deepseek-v4 csa=true mhc=true hash_moe=true"
+    return "variant=kimi-k2 optional=true"
+
+
+def _unwrap_primary_model(engine):
+    model = engine.module
+    while not all(hasattr(model, name) for name in ("config", "layers", "ps")):
+        wrapped = getattr(model, "module", None)
+        if wrapped is None or wrapped is model:
+            raise AssertionError(
+                f"Cannot resolve primary model through {type(model).__name__}."
+            )
+        model = wrapped
+    return model
+
+
+def _parameter_gradient(parameter):
+    # Megatron-Core DDP accumulates the optimizer-facing gradient in
+    # ``main_grad``; fall back to the ordinary autograd slot for unwrapped
+    # implementations.
+    gradient = getattr(parameter, "main_grad", None)
+    if gradient is None:
+        gradient = parameter.grad
+    return gradient
+
+
+def _optimizer_master_snapshot(engine) -> list:
+    """Snapshot the FP32/main parameters owned by this dist-opt rank."""
+
+    parameters = list(engine.handle._optimizer.get_parameters())
+    assert parameters, "distributed optimizer exposes no local main parameters"
+    return [parameter.detach().cpu().clone() for parameter in parameters]
+
+
+def _assert_optimizer_master_changed(engine, before: list) -> tuple[int, float]:
+    """Reject a successful return code when no optimizer-owned value changed."""
+
+    import torch
+
+    after = list(engine.handle._optimizer.get_parameters())
+    assert len(before) == len(
+        after
+    ), "optimizer main-parameter count changed during step"
+    deltas = [
+        (old - new.detach().cpu()).abs().max().float()
+        for old, new in zip(before, after, strict=True)
+    ]
+    assert deltas, "distributed optimizer exposes no post-step main parameters"
+    max_abs_delta = torch.stack(deltas).max()
+    assert torch.isfinite(max_abs_delta), "optimizer master delta is non-finite"
+    changed = sum(delta.item() > 0.0 for delta in deltas)
+    assert changed > 0, "optimizer reported success but no FP32/main parameter changed"
+    assert max_abs_delta.item() > 0.0
+    return changed, float(max_abs_delta.item())
+
+
+def _assert_optimizer_state_initialized(engine) -> int:
+    """Require finite, nonzero Adam moving averages after the first step."""
+
+    import torch
+    from megatron.core.optimizer import ChainedOptimizer
+
+    optimizer = engine.handle._optimizer
+    children = (
+        optimizer.chained_optimizers
+        if isinstance(optimizer, ChainedOptimizer)
+        else [optimizer]
+    )
+    state_tensors = []
+    moving_average_tensors = []
+    for child in children:
+        inner = getattr(child, "optimizer", None)
+        assert inner is not None, "distributed optimizer child has no inner optimizer"
+        for state in inner.state.values():
+            for key, value in state.items():
+                if not isinstance(value, torch.Tensor):
+                    continue
+                assert torch.isfinite(
+                    value.float()
+                ).all(), f"optimizer state {key} contains non-finite values"
+                state_tensors.append(value)
+                if key in {"exp_avg", "exp_avg_sq"}:
+                    moving_average_tensors.append(value)
+    assert state_tensors, "optimizer step created no tensor state"
+    assert moving_average_tensors, "Adam optimizer state has no moving averages"
+    assert any(
+        torch.count_nonzero(value).item() > 0 for value in moving_average_tensors
+    ), "Adam moving averages are all exactly zero after a nonzero-gradient step"
+    return len(state_tensors)
+
+
+def _assert_model_specific_grad_contract(engine, model_name: str) -> str:
+    """Require gradients through the model-specific path on every CP rank."""
+
+    import torch
+
+    def assert_module_has_nonzero_grads(module, *, label: str) -> None:
+        gradients = [
+            gradient.detach().float()
+            for parameter in module.parameters()
+            if (gradient := _parameter_gradient(parameter)) is not None
+        ]
+        assert gradients, f"{label} has no gradients"
+        grad_norm = sum(gradient.norm() for gradient in gradients)
+        assert torch.isfinite(grad_norm), f"{label} has non-finite gradients"
+        assert grad_norm.item() > 0.0, f"{label} has only zero gradients"
+
+    model = _unwrap_primary_model(engine)
+    if model_name == "glm5":
+        indexer = model.layers[0].self_attention.self_attention.indexer
+        assert indexer is not None
+        assert_module_has_nonzero_grads(indexer, label="GLM-5.2 full DSA indexer")
+        return "indexer_grad=nonzero"
+
+    if model_name == "qwen3_5":
+        linear_attention = model.layers[0].linear_attn
+        full_attention = model.layers[1].full_attn
+        assert linear_attention is not None
+        assert full_attention is not None
+        assert_module_has_nonzero_grads(
+            linear_attention, label="Qwen3.5 linear attention"
+        )
+        assert_module_has_nonzero_grads(full_attention, label="Qwen3.5 full attention")
+        return "linear_grad=nonzero full_grad=nonzero"
+
+    if model_name == "deepseek_v4":
+        first_layer = model.layers["0"]
+        csa = first_layer.self_attn.self_attn
+        assert_module_has_nonzero_grads(csa, label="DeepSeek-V4 CSA")
+        assert_module_has_nonzero_grads(
+            csa.compressor, label="DeepSeek-V4 ratio-4 CSA compressor"
+        )
+        assert_module_has_nonzero_grads(
+            first_layer.attn_hc, label="DeepSeek-V4 attention mHC"
+        )
+        assert_module_has_nonzero_grads(first_layer.ffn_hc, label="DeepSeek-V4 FFN mHC")
+        assert_module_has_nonzero_grads(
+            first_layer.mlp.experts, label="DeepSeek-V4 hash-MoE experts"
+        )
+        return (
+            "csa_grad=nonzero compressor_grad=nonzero "
+            "mhc_grad=nonzero hash_moe_grad=nonzero"
+        )
+
+    return "model_grad=nonzero"
+
+
 def _optimizer_config() -> SimpleNamespace:
     return SimpleNamespace(
         optimizer="adam",
@@ -172,29 +426,76 @@ def _optimizer_config() -> SimpleNamespace:
 @pytest.mark.parametrize(
     ("model_name", "model_type", "write_config", "vocab_size", "lengths"),
     [
-        ("kimi_k2", "deepseek_v3", _write_kimi_config, 128, [5, 7, 9]),
-        ("glm5", "glm_moe_dsa", _write_glm5_config, 32, [16, 20, 24]),
-        ("deepseek_v4", "deepseek_v4", _write_deepseek_v4_config, 128, [16, 20, 24]),
+        pytest.param(
+            "deepseek_v4",
+            "deepseek_v4",
+            _write_deepseek_v4_config,
+            128,
+            [16, 20, 24],
+            id="deepseek-v4-release-gate",
+        ),
+        pytest.param(
+            "glm5",
+            "glm_moe_dsa",
+            _write_glm52_config,
+            32,
+            [640, 64, 80],
+            id="glm-5.2-release-gate",
+        ),
+        pytest.param(
+            "qwen3_5",
+            "qwen3_5_moe",
+            _write_qwen35_config,
+            128,
+            [16, 20, 24],
+            id="qwen-3.5-linear-full-release-gate",
+        ),
+        # Retain Kimi coverage, but release manifests should select only the
+        # three explicit release-gate nodeids above.
+        pytest.param(
+            "kimi_k2",
+            "deepseek_v3",
+            _write_kimi_config,
+            128,
+            [5, 7, 9],
+            id="kimi-k2-optional",
+        ),
     ],
 )
 def test_mlite_engine_runtime_thd_cp_uses_typed_packed_batch(
     tmp_path, model_name, model_type, write_config, vocab_size, lengths
 ):
+    """Validate the external-engine runtime+optimizer atom, not a Ray worker E2E."""
+
     torch = pytest.importorskip("torch")
     dist = pytest.importorskip("torch.distributed")
     TensorDict = pytest.importorskip("tensordict").TensorDict
     from verl_mlite.compat import apply_runtime_patches
 
     apply_runtime_patches()
+    from megatron.lite.runtime.contracts import PackedBatch
     from verl_mlite.engine.config import MegatronLiteEngineConfig
     from verl_mlite.engine.mlite_engine import MegatronLiteEngine
-    from megatron.lite.runtime.contracts import PackedBatch
 
     device = _init_dist_or_skip()
     world = dist.get_world_size()
     rank = dist.get_rank()
-    hf_path = tmp_path / f"tiny-{model_name}"
+    case_seed = {
+        "deepseek_v4": 20260401,
+        "glm5": 20260502,
+        "qwen3_5": 20260305,
+        "kimi_k2": 20260201,
+    }[model_name]
+    # CP ranks must start from identical model parameters and the same global
+    # packed batch. Rank-local RNG streams would create a meaningless mixture
+    # of unrelated sequences after the model protocol performs the CP split.
+    torch.manual_seed(case_seed)
+    torch.cuda.manual_seed_all(case_seed)
+    # torchrun ranks can share pytest's TMPDIR. Give each writer a private
+    # config directory, then synchronize before any rank starts model build.
+    hf_path = tmp_path / f"rank-{rank}" / f"tiny-{model_name}"
     write_config(hf_path)
+    dist.barrier()
 
     engine = MegatronLiteEngine(
         model_config=SimpleNamespace(
@@ -207,7 +508,6 @@ def test_mlite_engine_runtime_thd_cp_uses_typed_packed_batch(
             cp=world,
             impl_cfg={
                 "use_thd": True,
-                "optimizer": None,
                 "deterministic": False,
                 "mtp_enable": False,
             },
@@ -223,10 +523,27 @@ def test_mlite_engine_runtime_thd_cp_uses_typed_packed_batch(
         config.load_hf_weights = False
         return config
 
-    engine._build_mlite_config = MethodType(_build_config_without_loading_weights, engine)
+    engine._build_mlite_config = MethodType(
+        _build_config_without_loading_weights, engine
+    )
     engine.initialize()
     engine.optimizer_zero_grad()
+    assert engine.handle._optimizer is not None
+    assert engine.handle._lr_scheduler is not None
+    built_contract = _assert_built_model_contract(engine, model_name)
+    parameter_probe_name, parameter_probe_parameter = next(
+        engine.module.named_parameters()
+    )
+    parameter_probe = parameter_probe_parameter.detach().contiguous()
+    parameter_replicas = [torch.empty_like(parameter_probe) for _ in range(world)]
+    dist.all_gather(parameter_replicas, parameter_probe)
+    assert all(
+        torch.equal(replica, parameter_replicas[0])
+        for replica in parameter_replicas[1:]
+    )
 
+    torch.manual_seed(case_seed + 1)
+    torch.cuda.manual_seed_all(case_seed + 1)
     input_ids = torch.nested.as_nested_tensor(
         [
             torch.randint(0, vocab_size, (length,), device=device, dtype=torch.long)
@@ -251,6 +568,11 @@ def test_mlite_engine_runtime_thd_cp_uses_typed_packed_batch(
     assert runtime_batch.seq_lens.tolist() == lengths
     assert int(runtime_batch.input_ids.numel()) == sum(lengths)
     assert not runtime_batch.extras
+    input_replicas = [torch.empty_like(runtime_batch.input_ids) for _ in range(world)]
+    dist.all_gather(input_replicas, runtime_batch.input_ids)
+    assert all(
+        torch.equal(replica, input_replicas[0]) for replica in input_replicas[1:]
+    )
 
     with engine.train_mode():
         result = engine.runtime.forward_backward(
@@ -263,13 +585,18 @@ def test_mlite_engine_runtime_thd_cp_uses_typed_packed_batch(
 
     assert torch.isfinite(result.model_output.loss)
     assert result.model_output.log_probs is not None
-    grad_norm = torch.zeros((), dtype=torch.float32, device=device)
+    local_grad_norm = torch.zeros((), dtype=torch.float32, device=device)
     for param in engine.module.parameters():
-        if param.grad is not None:
-            grad_norm = grad_norm + param.grad.detach().float().norm()
-    dist.all_reduce(grad_norm, op=dist.ReduceOp.SUM)
-    assert torch.isfinite(grad_norm)
-    assert grad_norm.item() > 0.0
+        gradient = _parameter_gradient(param)
+        if gradient is not None:
+            local_grad_norm = local_grad_norm + gradient.detach().float().norm()
+    grad_norm_min = local_grad_norm.clone()
+    grad_norm_sum = local_grad_norm.clone()
+    dist.all_reduce(grad_norm_min, op=dist.ReduceOp.MIN)
+    dist.all_reduce(grad_norm_sum, op=dist.ReduceOp.SUM)
+    assert torch.isfinite(grad_norm_min)
+    assert torch.isfinite(grad_norm_sum)
+    assert grad_norm_min.item() > 0.0
 
     verl_output = engine._build_verl_model_output(
         raw_output={"log_probs": result.model_output.log_probs},
@@ -277,12 +604,104 @@ def test_mlite_engine_runtime_thd_cp_uses_typed_packed_batch(
     )
     nested_log_probs = verl_output["log_probs"]
     assert [int(x) for x in nested_log_probs.offsets().diff().cpu()] == lengths
+    grad_contract = _assert_model_specific_grad_contract(engine, model_name)
+
+    optimizer_master_before = _optimizer_master_snapshot(engine)
+    scheduler_steps_before = int(engine.handle._lr_scheduler.state_dict()["num_steps"])
+    optimizer_step_receipt = {}
+    runtime_optimizer_step = engine.runtime.optimizer_step
+
+    def _recording_runtime_optimizer_step(self, handle):
+        del self
+        receipt = runtime_optimizer_step(handle)
+        optimizer_step_receipt["value"] = receipt
+        return receipt
+
+    engine.runtime.optimizer_step = MethodType(
+        _recording_runtime_optimizer_step, engine.runtime
+    )
+    public_optimizer_grad_norm = float(engine.optimizer_step())
+    update_successful, runtime_grad_norm, _num_zeros = optimizer_step_receipt["value"]
+    assert update_successful is True
+    assert public_optimizer_grad_norm == pytest.approx(float(runtime_grad_norm))
+    changed_master_params, master_max_abs_delta = _assert_optimizer_master_changed(
+        engine, optimizer_master_before
+    )
+    optimizer_state_tensors = _assert_optimizer_state_initialized(engine)
+    optimizer_grad_norm = torch.tensor(
+        public_optimizer_grad_norm, dtype=torch.float32, device=device
+    )
+    optimizer_grad_norm_min = optimizer_grad_norm.clone()
+    optimizer_grad_norm_sum = optimizer_grad_norm.clone()
+    dist.all_reduce(optimizer_grad_norm_min, op=dist.ReduceOp.MIN)
+    dist.all_reduce(optimizer_grad_norm_sum, op=dist.ReduceOp.SUM)
+    assert torch.isfinite(optimizer_grad_norm_min)
+    assert torch.isfinite(optimizer_grad_norm_sum)
+    assert optimizer_grad_norm_min.item() > 0.0
+
+    changed_master_count = torch.tensor(
+        changed_master_params, dtype=torch.int64, device=device
+    )
+    changed_master_count_min = changed_master_count.clone()
+    dist.all_reduce(changed_master_count_min, op=dist.ReduceOp.MIN)
+    assert changed_master_count_min.item() > 0
+    master_delta = torch.tensor(
+        master_max_abs_delta, dtype=torch.float32, device=device
+    )
+    master_delta_min = master_delta.clone()
+    master_delta_max = master_delta.clone()
+    dist.all_reduce(master_delta_min, op=dist.ReduceOp.MIN)
+    dist.all_reduce(master_delta_max, op=dist.ReduceOp.MAX)
+    assert torch.isfinite(master_delta_min)
+    assert torch.isfinite(master_delta_max)
+    assert master_delta_min.item() > 0.0
+
+    post_step_probe_name, post_step_probe_parameter = next(
+        engine.module.named_parameters()
+    )
+    assert post_step_probe_name == parameter_probe_name
+    post_step_probe = post_step_probe_parameter.detach().contiguous()
+    post_step_replicas = [torch.empty_like(post_step_probe) for _ in range(world)]
+    dist.all_gather(post_step_replicas, post_step_probe)
+    assert all(
+        torch.equal(replica, post_step_replicas[0])
+        for replica in post_step_replicas[1:]
+    )
+
+    learning_rate = torch.tensor(
+        float(engine.lr_scheduler_step()), dtype=torch.float32, device=device
+    )
+    learning_rate_min = learning_rate.clone()
+    learning_rate_max = learning_rate.clone()
+    dist.all_reduce(learning_rate_min, op=dist.ReduceOp.MIN)
+    dist.all_reduce(learning_rate_max, op=dist.ReduceOp.MAX)
+    assert torch.isfinite(learning_rate_min)
+    assert torch.isfinite(learning_rate_max)
+    assert learning_rate_min.item() > 0.0
+    assert learning_rate_min.item() == pytest.approx(learning_rate_max.item())
+    scheduler_steps_after = int(engine.handle._lr_scheduler.state_dict()["num_steps"])
+    assert scheduler_steps_after == scheduler_steps_before + 1
 
     if rank == 0:
         print(
             "NON_SKIP_VERL_MLITE_RUNTIME_THD_CP_SMOKE_PASSED "
+            "scope=external-engine-runtime-optimizer ray_worker_e2e=false "
             f"model={model_name} "
+            f"{built_contract} "
+            f"{grad_contract} "
+            "cp_parameter_probe_replicated_pre_post=true cp_inputs=replicated "
+            "optimizer_step=true optimizer_update_successful=true "
+            "optimizer_master_changed=true optimizer_state_initialized=true "
+            "lr_scheduler_step=true scheduler_step_delta=1 "
             f"world_size={world} lengths={lengths} "
             f"loss={float(result.model_output.loss.detach().item()):.6e} "
-            f"grad_norm_sum={float(grad_norm.item()):.6e}"
+            f"grad_norm_min={float(grad_norm_min.item()):.6e} "
+            f"grad_norm_sum={float(grad_norm_sum.item()):.6e} "
+            f"optimizer_grad_norm_min={float(optimizer_grad_norm_min.item()):.6e} "
+            f"optimizer_grad_norm_sum={float(optimizer_grad_norm_sum.item()):.6e} "
+            f"changed_master_params_min={int(changed_master_count_min.item())} "
+            f"master_delta_min={float(master_delta_min.item()):.6e} "
+            f"master_delta_max={float(master_delta_max.item()):.6e} "
+            f"optimizer_state_tensors={optimizer_state_tensors} "
+            f"lr={float(learning_rate_min.item()):.6e}"
         )

--- a/experimental/lite/tests/unit/verl/test_mlite_engine_cp_smoke.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_engine_cp_smoke.py
@@ -499,18 +499,12 @@ def test_mlite_engine_runtime_thd_cp_uses_typed_packed_batch(
 
     engine = MegatronLiteEngine(
         model_config=SimpleNamespace(
-            local_path=str(hf_path),
-            hf_config={"model_type": model_type},
-            mtp=None,
+            local_path=str(hf_path), hf_config={"model_type": model_type}, mtp=None
         ),
         engine_config=MegatronLiteEngineConfig(
             model_name=model_name,
             cp=world,
-            impl_cfg={
-                "use_thd": True,
-                "deterministic": False,
-                "mtp_enable": False,
-            },
+            impl_cfg={"use_thd": True, "deterministic": False, "mtp_enable": False},
             use_fused_kernels=False,
         ),
         optimizer_config=_optimizer_config(),


### PR DESCRIPTION
This is a stacked follow-up to #66. It targets the PR branch rather than
`main` because the original branch has `maintainerCanModify=false` and cannot
be updated directly by this account.

Status: **draft; frozen-head GPU acceptance is still pending**. Phase A
attempt 12 ended in preparation/collection before any numerical rank ran.
Attempt 13 was never submitted and is invalidated after its post-staging audit
found missing checkpoint coverage. Replacement source
`de17918b42f868e3e26076dcd38d120fada2d56d` is frozen and published. Attempt
14 was never submitted and is invalidated after authoritative pre-commit found
required source changes. Attempt 15 was never submitted and is now invalidated
after DS4 activation-control and strict legacy MCore checkpoint audits required
source changes. Attempt 16 is staged and test-only verified but is not
submitted or authorized.

## What changed

- Make the released GLM-5.2 RoPE and IndexShare schedule authoritative,
  including explicit precedence and full-only MTP layers.
- Add a pinned GLM-5.2 release/vLLM score-and-top-k authority plus an explicitly
  adapted Transformers 5.12 supporting full-model comparison for hidden
  states, logits, CE loss, and embedding gradients.
- Keep the DSA top-k cache bounded and fail closed for replay/offload modes.
- Wire DeepSeek-V4 activation recompute to bare model chunks, cover MTP
  backward on real CUDA, and fail closed for unsupported activation offload or
  virtual pipeline parallelism.
- Preserve the DeepSeek-V4 fused public two-output ABI while separating the
  decomposed diagnostic API.
- Harden local, DCP, and MCore dist-checkpoint save/load so corrupt or
  incompatible sidecars/common state fail before live model, optimizer, or RNG
  mutation.
- Write local checkpoints as v2 with only parameters and persistent buffers;
  load v1 by ignoring only exact current `persistent=False` cache keys while
  rejecting unknown keys, v2 cache keys, and non-Tensor legacy cache values.
- Apply the same narrow declared-nonpersistent legacy migration to MCore
  dist-checkpoint metadata, with real-CUDA model-only restore coverage.
- Pin and test the real VERL source integration and retain independent
  DeepSeek-V4 and Qwen3.5 non-regression gates.
- Route VERL `model_name=auto` Qwen3.5 weight sync through the resolved model
  identity so it emits the required vLLM export keyspace.
- Align the repository's pinned isort with Black and apply the resulting
  authoritative formatting without semantic AST changes outside import order.
- Add pinned Qwen3.5 MTP and GLM-5.2 FP8 authority fixtures plus real-weight
  projection validation.

GLM readiness scope is GLM-5.2 only. GLM-5.0/5.1 are not release blockers;
DeepSeek-V4 and Qwen3.5 remain independent gates.

## Root cause

The original change had several paths where metadata or legacy-compatible
behavior could look supported without proving the actual released GLM-5.2
layout, and checkpoint validation could occur after mutable load paths had
already started. The acceptance suite also lacked a strict full-model HF
oracle and exact pinned dependency/authority checks. Local checkpointing also
treated dynamic non-persistent caches as training state, and Qwen3.5 auto model
resolution happened after the export-target decision. DeepSeek-V4 also built
bare model chunks while its activation-control iterator only inspected a
legacy `.model` wrapper, silently turning configured recompute into a no-op;
the MCore legacy checkpoint path lacked the same exact declared-cache boundary
already enforced by local v1 loading.

## Current validation on frozen head

Frozen head / live PR #67 head:
`de17918b42f868e3e26076dcd38d120fada2d56d`

- final-head broad non-MCore run: `396 passed, 22 skipped, 4 Transformer
  Engine import failures`; two skips are Mac-only MCore/Triton import
  limitations. A pinned-MCore single-session rerun excludes exactly the 24
  deferred compute cases and passes all 398 Mac-executable nodeids with zero
  skip/xfail; the 24 deferred cases remain mandatory in Phase A
- checkpoint strict gate: `167 passed`, zero skip
- exact VERL gate: `77 passed`, zero skip/deselect, with Ray 2.55.1,
  TensorDict 0.10.0, Transformers 5.12.0, Datasets 5.0.0, PEFT 0.19.1, and
  Accelerate 1.14.0
- Phase A replacement harness: `471` nodeids, including independent 35-case
  local-runtime checkpoint, 49-case MCore checkpoint, 17-case DS4 activation
  control, and 77-case VERL groups. Attempt 15 is invalidated; attempt 16 is
  staged but not submitted. Phase B manifest is exact collect `20`
- targeted final-head authority fetch PASS; selected GLM-5.2, adapted-HF, and
  VERL registry evidence remains in the manifest; ordered Phase A collect is
  `422/422` after excluding only the MCore file, with static checkpoint
  authority `35/35 + 49/49`; a separate MCore run is `47 passed, 2 skipped`
  (the two real-CUDA cases remain pending); Phase B exact collect `20/20`
- canonical isort 5.13.2 then Black 24.4.2; Ruff and `git diff --check` pass;
  launchers pin the validated local Python and Pytest 8.4.2 before collection
- launch, staged-submit, and receipt paths pin both live #66 and #67 refs;
  submission-lock and receipt transitions recheck invalidation markers and
  immutable artifact hashes
- frozen-head attempt 12 / job `701975`: **prepare/collection FAILED**,
  **0/4 rank PASS**, no acceptance receipt
- frozen-head attempt 13: packet integrity passed, but the attempt is
  **invalidated and must not be submitted** because its manifest omitted all
  29 `test_checkpoint_runtime.py` and all 44 `test_training_checkpoint.py`
  nodeids that cover final checkpoint blockers
- attempt-13 source SHA-256:
  `2b120c5b7ac7777b75937917748501effd600219d6c48dcd62ba5fab8c070b6e`
- attempt-13 artifact-ledger SHA-256:
  `172f806c344f58bc720a4327547e31308bcfb723cd13df5b153e73680ff208d7`
- invalidated attempt 14 source SHA-256:
  `f8547d3fe2427d75271bcca37aa1af241c5c7960f918c6e4dfee99f06a387af3`
- invalidated attempt 14 source-manifest SHA-256:
  `8b9c22bf7c51cdccee962281f13e82dd72e2ea1532a2375b0eaa610c8721ef34`
- invalidated attempt 14 17-entry artifact-ledger SHA-256:
  `b40df0e8503bf3196db4cc1f236834473b2fa9a1b763dc80be87f26f0401b565`
- attempt 14 initial/recovery `sbatch --test-only` projected tokens: `702775`,
  `702776`; neither exists in `squeue` or `sacct`, and no job ID or submit lock
  exists. Its invalidation guard prevents submission or receipt creation
- invalidated attempt 15 source SHA-256:
  `657181e7ab163aaa48c3162c02fb02932e15e78e1c29d10ef66a7c6258346b5f`
- invalidated attempt 15 source-manifest SHA-256:
  `e24a268a74f50f91c3ef6397424f8ebefd02c27060fa849b8abe5d842f6c8925`
- invalidated attempt 15 17-entry artifact-ledger SHA-256:
  `5b26f48c0f9b3741ea06afce6158d11e74c432e76d1750c59064458c8b94a542`
- attempt 15 initial/recovery `sbatch --test-only` projected tokens: `703084`,
  `703091`; neither exists in `squeue` or `sacct`, and local plus remote audits
  found no job ID, submit lock, terminal marker, or PASS receipt
- attempt 15 now has local and remote invalidation markers; the staged-submit
  guard rejects it with rc 6 before any SSH or scheduler action
- staged attempt 16: `phase-a-16-head-de17918`; source SHA-256 `087e2cf031fc`,
  source-manifest SHA-256 `ca8922acc3db`, artifact-ledger SHA-256
  `b48c539a88b1`; initial/recovery test-only tokens `703705` and `703706` are
  absent from `squeue`/`sacct`, and no job ID, lock, terminal marker, receipt,
  or authorization exists

Attempt 12 failed while collecting the pinned VERL suites: the prepared
dependency overlay exposed an incompatible Torch/torchvision import graph,
`torchvision::nms` was unavailable, and two VERL modules failed collection.
The four numerical acceptance ranks never started. This is a harness
dependency-isolation/collection failure, not a GLM-5.2, DeepSeek-V4, Qwen3.5,
GPU-kernel, or model numerical failure.

Attempt 13 was never submitted and produced no GPU result. Its post-staging
audit found that packet integrity did not imply sufficient coverage: the
manifest omitted the local parameter-state binding regressions and the MCore
`common.pt`/PP/VPP/real-round-trip checkpoint regressions. It is therefore not
eligible to create a Phase A receipt.

The replacement harness now keeps those omitted suites independent as
`checkpoint_runtime_state=35`, `training_checkpoint_mcore=49`, and
`dsv4_activation_controls=17`. Local
validation pins Pytest 8.4.2 and derives their parameter IDs with a fail-closed
AST + Pytest `IdMaker` path; the NGC preparation step must still perform exact
ordered real collection of the complete final manifest. Every acceptance rank
must report all tests passed with zero skip, xfail, or xpass. The replacement
source is frozen, the attempt 15 packet is invalidated, and the immutable
attempt 16 packet is staged. No real job or immutable PASS receipt has been
created from this baseline.

The final authority lane independently fetches the released GLM-5.2 config at
`4d67f66cc64d3219133b767c253b2ad1425c6c88` and the two pinned RoPE sources
from vLLM v0.23.0 at `0fc695fc6d1d82e9a5ac6835ac8e4e1c83703665`.
An immutable run validator requires the exact file manifest, digests, released
`indexer_rope_interleave=true` field, and adjacent-pair layout before pytest
collection. The 77-case VERL group also includes a fresh-subprocess import of
the canonical Hydra target and must observe default MLite backend registration.

Phase B adds three independent two-node/world-size-8 VERL external-engine
THD/CP runtime+optimizer cases for GLM-5.2, DeepSeek-V4, and Qwen3.5. Every
model starts a fresh `torchrun`. The gates require the released model-specific
paths and nonzero gradients—GLM-5.2 full/shared interleaved IndexShare,
DeepSeek-V4 ratio-4 CSA compressor/mHC/hash-MoE, and Qwen3.5 linear/full
attention—followed by a changed local FP32 optimizer master parameter,
initialized finite nonzero Adam state, a model-visible CP replica probe before
and after the step, and one LR-scheduler step. Prepare uses the same
pinned real VERL source/dependencies as Phase A and proves the NGC
Torch/torchvision `nms` ABI, canonical registry, and FLA CP import on both
nodes. This is not Ray worker/trainer end-to-end evidence.

The Phase A `hf_full_model_parity` bucket must also be read narrowly: it
contains one tiny GLM-5.2 adapted-HF full-model comparison and one DeepSeek-V4
ratio-4 CSA attention-block comparison. It does not establish DeepSeek-V4
whole-model HF parity.

Adapted-HF GLM-5.2 full-model metrics:

- hidden RMS relative: `7.211e-09`
- logits RMS relative: `4.887e-08`
- CE absolute difference: `0`
- embedding-gradient RMS relative: `4.532e-08`

## Remaining acceptance before ready-for-review

- Submit exact attempt 16 only after a new explicit confirmation naming that
  immutable packet.
- After Phase A passes, run the separately approved two-node Phase B gate.
- Attach immutable receipts and re-check that the reviewed tree equals the
  receipt-bound tree.

## Integration note

The #66 head `da86fe54304bc13ec9012134e084b8342654f24d` is an ancestor of frozen
head `de17918b42f868e3e26076dcd38d120fada2d56d`. The preferred final
integration is a no-force fast-forward of the
original PR branch to the receipt-bound commit. Squash/rebase/merge-button
integration creates a different SHA and therefore requires receipts to be
rebound or rerun.
