### PR TITLE
Fix MLite DAPO loss and forward-only microbatch contracts

### DIFF
--- a/experimental/lite/examples/verl/README.md
+++ b/experimental/lite/examples/verl/README.md
@@ -18,6 +18,12 @@ backend as `mlite`, while Megatron Lite model implementations still use
 - `scripts/run_qwen3moe_gsm8k_sft.sh`: GSM8K wrapper around the SFT launcher.
 - `scripts/run_qwen3moe_gsm8k_grpo.sh`: GSM8K GRPO launcher with MLite actor
   training and a standard VERL rollout backend.
+- `scripts/run_qwen3moe_gsm8k_dapo.sh`: GSM8K DAPO launcher. Same MLite actor +
+  VERL rollout path as GRPO, with the DAPO recipe enabled through
+  `verl.trainer.main_ppo`: decoupled clip (`clip_ratio_low`/`clip_ratio_high`),
+  token-level loss (`loss_agg_mode=token-mean`), dynamic sampling
+  (`algorithm.filter_groups` over an oversampled `data.gen_batch_size`), no KL,
+  and the `dapo` reward manager with optional overlong reward shaping.
 
 ## Prerequisites
 

--- a/experimental/lite/examples/verl/scripts/run_qwen3moe_gsm8k_dapo.sh
+++ b/experimental/lite/examples/verl/scripts/run_qwen3moe_gsm8k_dapo.sh
@@ -193,16 +193,16 @@ ALGORITHM=(
   "algorithm.kl_ctrl.kl_coef=0.0"
   "algorithm.rollout_correction.bypass_mode=True"
   "algorithm.norm_adv_by_std_in_grpo=False"
-  "algorithm.filter_groups.enable=${FILTER_GROUPS_ENABLE}"
-  "algorithm.filter_groups.metric=${FILTER_GROUPS_METRIC}"
-  "algorithm.filter_groups.max_num_gen_batches=${FILTER_GROUPS_MAX_NUM_GEN_BATCHES}"
+  "+algorithm.filter_groups.enable=${FILTER_GROUPS_ENABLE}"
+  "+algorithm.filter_groups.metric=${FILTER_GROUPS_METRIC}"
+  "+algorithm.filter_groups.max_num_gen_batches=${FILTER_GROUPS_MAX_NUM_GEN_BATCHES}"
 )
 
 DATA=(
   "data.train_files=${TRAIN_FILES}"
   "data.val_files=${VAL_FILES}"
   "data.train_batch_size=${TRAIN_BATCH_SIZE}"
-  "data.gen_batch_size=${GEN_BATCH_SIZE}"
+  "+data.gen_batch_size=${GEN_BATCH_SIZE}"
   "data.prompt_key=prompt"
   "data.return_raw_chat=True"
   "data.max_prompt_length=${MAX_PROMPT_LENGTH}"

--- a/experimental/lite/examples/verl/scripts/run_qwen3moe_gsm8k_dapo.sh
+++ b/experimental/lite/examples/verl/scripts/run_qwen3moe_gsm8k_dapo.sh
@@ -138,7 +138,6 @@ RESUME_MODE="${RESUME_MODE:-auto}"
 RESUME_FROM_PATH="${RESUME_FROM_PATH:-null}"
 LOG_VAL_GENERATIONS="${LOG_VAL_GENERATIONS:-10}"
 LOGGER="${LOGGER:-[console,file]}"
-USE_LEGACY_WORKER_IMPL="${USE_LEGACY_WORKER_IMPL:-disable}"
 DRY_RUN="${DRY_RUN:-0}"
 EXTRA_ARGS=("$@")
 
@@ -325,7 +324,6 @@ TRAINER=(
   "trainer.default_local_dir=${CKPT_DIR}"
   "trainer.val_before_train=False"
   "trainer.log_val_generations=${LOG_VAL_GENERATIONS}"
-  "trainer.use_legacy_worker_impl=${USE_LEGACY_WORKER_IMPL}"
 )
 
 COMMAND=(

--- a/experimental/lite/examples/verl/scripts/run_qwen3moe_gsm8k_dapo.sh
+++ b/experimental/lite/examples/verl/scripts/run_qwen3moe_gsm8k_dapo.sh
@@ -1,0 +1,366 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${VERBOSE:-0}" == "1" ]]; then
+  set -x
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -L)"
+EXAMPLE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd -L)"
+LITE_ROOT="$(cd "${EXAMPLE_ROOT}/../.." && pwd -L)"
+REPO_ROOT="$(cd "${LITE_ROOT}/../.." && pwd -L)"
+
+add_pythonpath() {
+  local path="${1:-}"
+  if [[ -n "${path}" ]]; then
+    export PYTHONPATH="${path}:${PYTHONPATH:-}"
+  fi
+}
+
+add_pythonpath "${EXAMPLE_ROOT}"
+add_pythonpath "${LITE_ROOT}"
+add_pythonpath "${REPO_ROOT}"
+add_pythonpath "${VERL_ROOT:-}"
+add_pythonpath "${MEGATRON_ROOT:-}"
+
+export CUDA_DEVICE_MAX_CONNECTIONS="${CUDA_DEVICE_MAX_CONNECTIONS:-1}"
+if [[ -n "${CUDA_VISIBLE_DEVICES:-}" ]]; then
+  unset ROCR_VISIBLE_DEVICES
+  unset HIP_VISIBLE_DEVICES
+fi
+
+DATASET_DIR="${DATASET_DIR:-${HOME}/data/gsm8k}"
+MODEL_PATH="${MODEL_PATH:-Qwen/Qwen3.5-35B-A3B}"
+TRAIN_FILES="${TRAIN_FILES:-${DATASET_DIR}/train.parquet}"
+VAL_FILES="${VAL_FILES:-${DATASET_DIR}/test.parquet}"
+
+OUTPUT_ROOT="${OUTPUT_ROOT:-${EXAMPLE_ROOT}/outputs/qwen35_gsm8k_dapo}"
+PROJECT_NAME="${PROJECT_NAME:-verl-mlite-qwen35-gsm8k-dapo}"
+INFER_BACKEND="${INFER_BACKEND:-vllm}"
+
+NNODES="${NNODES:-1}"
+NGPUS_PER_NODE="${NGPUS_PER_NODE:-${NPROC_PER_NODE:-8}}"
+
+# DAPO oversamples the generation batch (gen_batch_size > train_batch_size) and
+# keeps drawing generation batches until train_batch_size groups survive dynamic
+# sampling (filter groups). Defaults follow the upstream DAPO recipe ratio.
+TRAIN_BATCH_SIZE="${TRAIN_BATCH_SIZE:-128}"
+GEN_BATCH_SIZE="${GEN_BATCH_SIZE:-$((TRAIN_BATCH_SIZE * 3))}"
+PPO_MINI_BATCH_SIZE="${PPO_MINI_BATCH_SIZE:-32}"
+ACTOR_PPO_MICRO_BATCH_SIZE_PER_GPU="${ACTOR_PPO_MICRO_BATCH_SIZE_PER_GPU:-1}"
+MAX_PROMPT_LENGTH="${MAX_PROMPT_LENGTH:-512}"
+MAX_RESPONSE_LENGTH="${MAX_RESPONSE_LENGTH:-1024}"
+PPO_MAX_TOKEN_LEN_PER_GPU="${PPO_MAX_TOKEN_LEN_PER_GPU:-8192}"
+
+ROLLOUT_N="${ROLLOUT_N:-16}"
+ROLLOUT_MODE="${ROLLOUT_MODE:-async}"
+ROLLOUT_TP="${ROLLOUT_TP:-2}"
+ROLLOUT_GPU_MEMORY_UTILIZATION="${ROLLOUT_GPU_MEMORY_UTILIZATION:-0.6}"
+ROLLOUT_LOG_PROB_MICRO_BATCH_SIZE_PER_GPU="${ROLLOUT_LOG_PROB_MICRO_BATCH_SIZE_PER_GPU:-1}"
+ROLLOUT_LOG_PROB_MAX_TOKEN_LEN_PER_GPU="${ROLLOUT_LOG_PROB_MAX_TOKEN_LEN_PER_GPU:-${PPO_MAX_TOKEN_LEN_PER_GPU}}"
+ROLLOUT_MAX_MODEL_LEN="${ROLLOUT_MAX_MODEL_LEN:-$((MAX_PROMPT_LENGTH + MAX_RESPONSE_LENGTH))}"
+ROLLOUT_MAX_NUM_SEQS="${ROLLOUT_MAX_NUM_SEQS:-1024}"
+ROLLOUT_DEFAULT_MAX_NUM_BATCHED_TOKENS="$((MAX_PROMPT_LENGTH + MAX_RESPONSE_LENGTH))"
+if (( ROLLOUT_DEFAULT_MAX_NUM_BATCHED_TOKENS < ROLLOUT_MAX_NUM_SEQS )); then
+  ROLLOUT_DEFAULT_MAX_NUM_BATCHED_TOKENS="${ROLLOUT_MAX_NUM_SEQS}"
+fi
+ROLLOUT_MAX_NUM_BATCHED_TOKENS="${ROLLOUT_MAX_NUM_BATCHED_TOKENS:-${ROLLOUT_DEFAULT_MAX_NUM_BATCHED_TOKENS}}"
+if (( ROLLOUT_MAX_NUM_BATCHED_TOKENS < ROLLOUT_MAX_NUM_SEQS )); then
+  ROLLOUT_MAX_NUM_BATCHED_TOKENS="${ROLLOUT_MAX_NUM_SEQS}"
+fi
+# DAPO rollout sampling: high temperature, top-p 1.0 (full DAPO uses 1.0 / 0.7-1.0).
+ROLLOUT_TEMPERATURE="${ROLLOUT_TEMPERATURE:-1.0}"
+ROLLOUT_TOP_P="${ROLLOUT_TOP_P:-1.0}"
+ROLLOUT_TOP_K="${ROLLOUT_TOP_K:--1}"
+ROLLOUT_LIMIT_IMAGES="${ROLLOUT_LIMIT_IMAGES:-0}"
+ROLLOUT_LIMIT_VIDEOS="${ROLLOUT_LIMIT_VIDEOS:-0}"
+VAL_TEMPERATURE="${VAL_TEMPERATURE:-0.0}"
+VAL_TOP_P="${VAL_TOP_P:-1.0}"
+VAL_DO_SAMPLE="${VAL_DO_SAMPLE:-False}"
+VAL_N="${VAL_N:-1}"
+
+ACTOR_TP="${ACTOR_TP:-2}"
+ACTOR_PP="${ACTOR_PP:-1}"
+ACTOR_VPP="${ACTOR_VPP:-null}"
+ACTOR_CP="${ACTOR_CP:-1}"
+ACTOR_EP="${ACTOR_EP:-8}"
+ACTOR_ETP="${ACTOR_ETP:-1}"
+DTYPE="${DTYPE:-bfloat16}"
+MLITE_MODEL_NAME="${MLITE_MODEL_NAME:-auto}"
+MLITE_IMPL="${MLITE_IMPL:-lite}"
+ATTENTION_BACKEND="${ATTENTION_BACKEND:-flash}"
+# Optimizer backend:
+# - dist_opt (default): Megatron-Core DDP + distributed optimizer.
+# - fsdp2: Megatron Lite FSDP2 wrapper + optimizer.
+MLITE_OPTIMIZER_BACKEND="${MLITE_OPTIMIZER_BACKEND:-dist_opt}"
+
+ACTOR_LR="${ACTOR_LR:-1e-6}"
+# DAPO uses the clip-higher (decoupled clip) trick: separate low/high PPO clip
+# bounds plus a dual-clip constant. loss_agg_mode is token-mean (token-level loss).
+POLICY_LOSS_MODE="${POLICY_LOSS_MODE:-vanilla}"
+CLIP_RATIO_LOW="${CLIP_RATIO_LOW:-0.2}"
+CLIP_RATIO_HIGH="${CLIP_RATIO_HIGH:-0.28}"
+CLIP_RATIO_C="${CLIP_RATIO_C:-10.0}"
+LOSS_AGG_MODE="${LOSS_AGG_MODE:-token-mean}"
+WEIGHT_DECAY="${WEIGHT_DECAY:-0.1}"
+BETAS="${BETAS:-[0.9,0.95]}"
+CLIP_GRAD="${CLIP_GRAD:-1.0}"
+LR_WARMUP_STEPS="${LR_WARMUP_STEPS:-0}"
+LR_DECAY_STYLE="${LR_DECAY_STYLE:-constant}"
+ENTROPY_COEFF="${ENTROPY_COEFF:-0}"
+USE_DYNAMIC_BSZ="${USE_DYNAMIC_BSZ:-True}"
+PARAM_OFFLOAD="${PARAM_OFFLOAD:-False}"
+OPTIMIZER_OFFLOAD="${OPTIMIZER_OFFLOAD:-True}"
+GRAD_OFFLOAD="${GRAD_OFFLOAD:-False}"
+OPTIMIZER_STATE_OFFLOAD_FRACTION="${OPTIMIZER_STATE_OFFLOAD_FRACTION:-1.0}"
+USE_PRECISION_AWARE_OPTIMIZER="${USE_PRECISION_AWARE_OPTIMIZER:-True}"
+DECOUPLED_WEIGHT_DECAY="${DECOUPLED_WEIGHT_DECAY:-True}"
+
+# DAPO dynamic sampling (filter groups): keep only prompt groups whose rollouts
+# are not uniformly correct/incorrect, drawing up to MAX_NUM_GEN_BATCHES batches.
+FILTER_GROUPS_ENABLE="${FILTER_GROUPS_ENABLE:-True}"
+FILTER_GROUPS_METRIC="${FILTER_GROUPS_METRIC:-acc}"
+FILTER_GROUPS_MAX_NUM_GEN_BATCHES="${FILTER_GROUPS_MAX_NUM_GEN_BATCHES:-10}"
+
+# DAPO overlong reward shaping: soft length penalty over the last OVERLONG_BUFFER_LEN
+# tokens of the allowed response window.
+REWARD_MANAGER="${REWARD_MANAGER:-dapo}"
+OVERLONG_BUFFER_ENABLE="${OVERLONG_BUFFER_ENABLE:-True}"
+OVERLONG_BUFFER_LEN="${OVERLONG_BUFFER_LEN:-256}"
+OVERLONG_BUFFER_PENALTY_FACTOR="${OVERLONG_BUFFER_PENALTY_FACTOR:-1.0}"
+OVERLONG_BUFFER_LOG="${OVERLONG_BUFFER_LOG:-False}"
+
+TOTAL_EPOCHS="${TOTAL_EPOCHS:-15}"
+TOTAL_TRAINING_STEPS="${TOTAL_TRAINING_STEPS:-null}"
+SAVE_FREQ="${SAVE_FREQ:-20}"
+TEST_FREQ="${TEST_FREQ:-5}"
+RESUME_MODE="${RESUME_MODE:-auto}"
+RESUME_FROM_PATH="${RESUME_FROM_PATH:-null}"
+LOG_VAL_GENERATIONS="${LOG_VAL_GENERATIONS:-10}"
+LOGGER="${LOGGER:-[console,file]}"
+USE_LEGACY_WORKER_IMPL="${USE_LEGACY_WORKER_IMPL:-disable}"
+DRY_RUN="${DRY_RUN:-0}"
+EXTRA_ARGS=("$@")
+
+if [[ "${INFER_BACKEND}" != "vllm" && "${INFER_BACKEND}" != "sglang" && "${INFER_BACKEND}" != "trtllm" ]]; then
+  echo "Unsupported INFER_BACKEND=${INFER_BACKEND}. Expected vllm, sglang, or trtllm." >&2
+  exit 1
+fi
+
+case "${MLITE_OPTIMIZER_BACKEND}" in
+  dist_opt)
+    MLITE_IMPL_OPTIMIZER="dist_opt"
+    ;;
+  fsdp2)
+    MLITE_IMPL_OPTIMIZER="fsdp2"
+    ;;
+  *)
+    echo "Unsupported MLITE_OPTIMIZER_BACKEND=${MLITE_OPTIMIZER_BACKEND}. Expected dist_opt or fsdp2." >&2
+    exit 1
+    ;;
+esac
+
+if [[ "${INFER_BACKEND}" == "vllm" ]]; then
+  export VLLM_USE_V1="${VLLM_USE_V1:-1}"
+  export VLLM_ALLREDUCE_USE_SYMM_MEM="${VLLM_ALLREDUCE_USE_SYMM_MEM:-0}"
+fi
+
+MLITE_VPP_SIZE="${ACTOR_VPP}"
+if [[ "${MLITE_VPP_SIZE}" == "null" ]]; then
+  MLITE_VPP_SIZE=1
+fi
+
+RUN_NAME="${RUN_NAME:-qwen35_gsm8k_dapo_mlite_${INFER_BACKEND}_tp${ACTOR_TP}_pp${ACTOR_PP}_cp${ACTOR_CP}_ep${ACTOR_EP}}"
+CKPT_DIR="${CKPT_DIR:-${OUTPUT_ROOT}/checkpoints/${RUN_NAME}}"
+LOG_FILE="${LOG_FILE:-${OUTPUT_ROOT}/${RUN_NAME}.log}"
+JSONL_FILE="${JSONL_FILE:-${OUTPUT_ROOT}/${RUN_NAME}.jsonl}"
+CMD_FILE="${CMD_FILE:-${OUTPUT_ROOT}/${RUN_NAME}.cmd.sh}"
+
+mkdir -p "${OUTPUT_ROOT}" "${CKPT_DIR}" "$(dirname "${LOG_FILE}")" "$(dirname "${JSONL_FILE}")" "$(dirname "${CMD_FILE}")"
+export VERL_FILE_LOGGER_PATH="${JSONL_FILE}"
+
+CACHE_ROOT="${VERL_MLITE_CACHE_ROOT:-${TMPDIR:-/tmp}/verl_mlite}"
+mkdir -p "${CACHE_ROOT}/pycache_${USER:-user}" "${CACHE_ROOT}/torchinductor_${USER:-user}" "${CACHE_ROOT}/triton_${USER:-user}"
+export PYTHONPYCACHEPREFIX="${PYTHONPYCACHEPREFIX:-${CACHE_ROOT}/pycache_${USER:-user}}"
+export TORCHINDUCTOR_CACHE_DIR="${TORCHINDUCTOR_CACHE_DIR:-${CACHE_ROOT}/torchinductor_${USER:-user}}"
+export TRITON_CACHE_DIR="${TRITON_CACHE_DIR:-${CACHE_ROOT}/triton_${USER:-user}}"
+
+# DAPO = GRPO-style group advantage (no std normalization) without KL, plus
+# decoupled clipping + dynamic sampling + overlong reward shaping configured below.
+ALGORITHM=(
+  "algorithm.adv_estimator=grpo"
+  "algorithm.use_kl_in_reward=False"
+  "algorithm.kl_ctrl.kl_coef=0.0"
+  "algorithm.rollout_correction.bypass_mode=True"
+  "algorithm.norm_adv_by_std_in_grpo=False"
+  "algorithm.filter_groups.enable=${FILTER_GROUPS_ENABLE}"
+  "algorithm.filter_groups.metric=${FILTER_GROUPS_METRIC}"
+  "algorithm.filter_groups.max_num_gen_batches=${FILTER_GROUPS_MAX_NUM_GEN_BATCHES}"
+)
+
+DATA=(
+  "data.train_files=${TRAIN_FILES}"
+  "data.val_files=${VAL_FILES}"
+  "data.train_batch_size=${TRAIN_BATCH_SIZE}"
+  "data.gen_batch_size=${GEN_BATCH_SIZE}"
+  "data.prompt_key=prompt"
+  "data.return_raw_chat=True"
+  "data.max_prompt_length=${MAX_PROMPT_LENGTH}"
+  "data.max_response_length=${MAX_RESPONSE_LENGTH}"
+  "data.filter_overlong_prompts=True"
+  "data.truncation=error"
+)
+
+MODEL=(
+  "actor_rollout_ref.model.path=${MODEL_PATH}"
+  "actor_rollout_ref.model.trust_remote_code=True"
+  "actor_rollout_ref.model.use_fused_kernels=False"
+)
+
+ACTOR=(
+  "actor@actor_rollout_ref.actor=mlite_actor"
+  "actor_rollout_ref.actor.optim.lr=${ACTOR_LR}"
+  "actor_rollout_ref.actor.optim.weight_decay=${WEIGHT_DECAY}"
+  "actor_rollout_ref.actor.optim.betas=${BETAS}"
+  "actor_rollout_ref.actor.optim.clip_grad=${CLIP_GRAD}"
+  "actor_rollout_ref.actor.optim.lr_warmup_steps=${LR_WARMUP_STEPS}"
+  "actor_rollout_ref.actor.optim.lr_warmup_init=0"
+  "actor_rollout_ref.actor.optim.lr_decay_style=${LR_DECAY_STYLE}"
+  "actor_rollout_ref.actor.ppo_mini_batch_size=${PPO_MINI_BATCH_SIZE}"
+  "actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=${ACTOR_PPO_MICRO_BATCH_SIZE_PER_GPU}"
+  "actor_rollout_ref.actor.use_dynamic_bsz=${USE_DYNAMIC_BSZ}"
+  "actor_rollout_ref.actor.ppo_max_token_len_per_gpu=${PPO_MAX_TOKEN_LEN_PER_GPU}"
+  "actor_rollout_ref.actor.use_kl_loss=False"
+  "actor_rollout_ref.actor.kl_loss_coef=0.0"
+  "actor_rollout_ref.actor.entropy_coeff=${ENTROPY_COEFF}"
+  "actor_rollout_ref.actor.clip_ratio_low=${CLIP_RATIO_LOW}"
+  "actor_rollout_ref.actor.clip_ratio_high=${CLIP_RATIO_HIGH}"
+  "actor_rollout_ref.actor.clip_ratio_c=${CLIP_RATIO_C}"
+  "actor_rollout_ref.actor.policy_loss.loss_mode=${POLICY_LOSS_MODE}"
+  "actor_rollout_ref.actor.loss_agg_mode=${LOSS_AGG_MODE}"
+  "actor_rollout_ref.actor.engine.dtype=${DTYPE}"
+  "actor_rollout_ref.actor.engine.model_name=${MLITE_MODEL_NAME}"
+  "actor_rollout_ref.actor.engine.impl=${MLITE_IMPL}"
+  "actor_rollout_ref.actor.engine.tp=${ACTOR_TP}"
+  "actor_rollout_ref.actor.engine.pp=${ACTOR_PP}"
+  "actor_rollout_ref.actor.engine.vpp=${MLITE_VPP_SIZE}"
+  "actor_rollout_ref.actor.engine.cp=${ACTOR_CP}"
+  "actor_rollout_ref.actor.engine.ep=${ACTOR_EP}"
+  "actor_rollout_ref.actor.engine.etp=${ACTOR_ETP}"
+  "actor_rollout_ref.actor.engine.param_offload=${PARAM_OFFLOAD}"
+  "actor_rollout_ref.actor.engine.optimizer_offload=${OPTIMIZER_OFFLOAD}"
+  "actor_rollout_ref.actor.engine.grad_offload=${GRAD_OFFLOAD}"
+  "actor_rollout_ref.actor.engine.attention_backend_override=${ATTENTION_BACKEND}"
+  "actor_rollout_ref.actor.engine.impl_cfg.use_thd=True"
+  "+actor_rollout_ref.actor.engine.impl_cfg.optimizer=${MLITE_IMPL_OPTIMIZER}"
+)
+
+if [[ "${OPTIMIZER_OFFLOAD}" == "True" || "${OPTIMIZER_OFFLOAD}" == "true" || "${OPTIMIZER_OFFLOAD}" == "1" ]]; then
+  ACTOR+=(
+    "+actor_rollout_ref.actor.optim.override_optimizer_config.offload_fraction=${OPTIMIZER_STATE_OFFLOAD_FRACTION}"
+    "+actor_rollout_ref.actor.optim.override_optimizer_config.use_precision_aware_optimizer=${USE_PRECISION_AWARE_OPTIMIZER}"
+    "+actor_rollout_ref.actor.optim.override_optimizer_config.decoupled_weight_decay=${DECOUPLED_WEIGHT_DECAY}"
+  )
+fi
+
+ROLLOUT=(
+  "actor_rollout_ref.rollout.name=${INFER_BACKEND}"
+  "actor_rollout_ref.rollout.mode=${ROLLOUT_MODE}"
+  "actor_rollout_ref.rollout.tensor_model_parallel_size=${ROLLOUT_TP}"
+  "actor_rollout_ref.rollout.gpu_memory_utilization=${ROLLOUT_GPU_MEMORY_UTILIZATION}"
+  "actor_rollout_ref.rollout.n=${ROLLOUT_N}"
+  "actor_rollout_ref.rollout.calculate_log_probs=True"
+  "actor_rollout_ref.rollout.log_prob_use_dynamic_bsz=${USE_DYNAMIC_BSZ}"
+  "actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=${ROLLOUT_LOG_PROB_MAX_TOKEN_LEN_PER_GPU}"
+  "actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=${ROLLOUT_LOG_PROB_MICRO_BATCH_SIZE_PER_GPU}"
+  "actor_rollout_ref.rollout.prompt_length=${MAX_PROMPT_LENGTH}"
+  "actor_rollout_ref.rollout.response_length=${MAX_RESPONSE_LENGTH}"
+  "actor_rollout_ref.rollout.max_model_len=${ROLLOUT_MAX_MODEL_LEN}"
+  "actor_rollout_ref.rollout.max_num_seqs=${ROLLOUT_MAX_NUM_SEQS}"
+  "actor_rollout_ref.rollout.max_num_batched_tokens=${ROLLOUT_MAX_NUM_BATCHED_TOKENS}"
+  "actor_rollout_ref.rollout.temperature=${ROLLOUT_TEMPERATURE}"
+  "actor_rollout_ref.rollout.top_p=${ROLLOUT_TOP_P}"
+  "actor_rollout_ref.rollout.top_k=${ROLLOUT_TOP_K}"
+  "actor_rollout_ref.rollout.val_kwargs.temperature=${VAL_TEMPERATURE}"
+  "actor_rollout_ref.rollout.val_kwargs.top_p=${VAL_TOP_P}"
+  "actor_rollout_ref.rollout.val_kwargs.do_sample=${VAL_DO_SAMPLE}"
+  "actor_rollout_ref.rollout.val_kwargs.n=${VAL_N}"
+  "actor_rollout_ref.rollout.free_cache_engine=True"
+)
+
+if [[ "${INFER_BACKEND}" == "vllm" ]]; then
+  ROLLOUT+=(
+    "+actor_rollout_ref.rollout.engine_kwargs.vllm.limit_mm_per_prompt.image=${ROLLOUT_LIMIT_IMAGES}"
+    "+actor_rollout_ref.rollout.engine_kwargs.vllm.limit_mm_per_prompt.video=${ROLLOUT_LIMIT_VIDEOS}"
+  )
+fi
+
+REWARD=(
+  "reward_model.reward_manager=${REWARD_MANAGER}"
+)
+if [[ "${REWARD_MANAGER}" == "dapo" ]]; then
+  REWARD+=(
+    "+reward_model.reward_kwargs.overlong_buffer_cfg.enable=${OVERLONG_BUFFER_ENABLE}"
+    "+reward_model.reward_kwargs.overlong_buffer_cfg.len=${OVERLONG_BUFFER_LEN}"
+    "+reward_model.reward_kwargs.overlong_buffer_cfg.penalty_factor=${OVERLONG_BUFFER_PENALTY_FACTOR}"
+    "+reward_model.reward_kwargs.overlong_buffer_cfg.log=${OVERLONG_BUFFER_LOG}"
+    "+reward_model.reward_kwargs.max_resp_len=${MAX_RESPONSE_LENGTH}"
+  )
+fi
+
+TRAINER=(
+  "critic.enable=False"
+  "trainer.balance_batch=True"
+  "trainer.logger=${LOGGER}"
+  "trainer.project_name=${PROJECT_NAME}"
+  "trainer.experiment_name=${RUN_NAME}"
+  "trainer.n_gpus_per_node=${NGPUS_PER_NODE}"
+  "trainer.nnodes=${NNODES}"
+  "trainer.save_freq=${SAVE_FREQ}"
+  "trainer.test_freq=${TEST_FREQ}"
+  "trainer.total_epochs=${TOTAL_EPOCHS}"
+  "trainer.total_training_steps=${TOTAL_TRAINING_STEPS}"
+  "trainer.resume_mode=${RESUME_MODE}"
+  "trainer.resume_from_path=${RESUME_FROM_PATH}"
+  "trainer.default_local_dir=${CKPT_DIR}"
+  "trainer.val_before_train=False"
+  "trainer.log_val_generations=${LOG_VAL_GENERATIONS}"
+  "trainer.use_legacy_worker_impl=${USE_LEGACY_WORKER_IMPL}"
+)
+
+COMMAND=(
+  python3
+  -m
+  verl.trainer.main_ppo
+  "hydra.searchpath=[pkg://verl_mlite.config]"
+  "${ALGORITHM[@]}"
+  "${DATA[@]}"
+  "${MODEL[@]}"
+  "${ACTOR[@]}"
+  "${ROLLOUT[@]}"
+  "${REWARD[@]}"
+  "${TRAINER[@]}"
+  "${EXTRA_ARGS[@]}"
+)
+
+printf '%q ' "${COMMAND[@]}" > "${CMD_FILE}"
+printf '\n' >> "${CMD_FILE}"
+
+if [[ "${DRY_RUN}" == "1" ]]; then
+  printf '%q ' "${COMMAND[@]}"
+  printf '\n'
+  exit 0
+fi
+
+echo "[mlite] output_root=${OUTPUT_ROOT}"
+echo "[mlite] log=${LOG_FILE}"
+echo "[mlite] jsonl=${JSONL_FILE}"
+echo "[mlite] cmd=${CMD_FILE}"
+echo "[mlite] optimizer_backend=${MLITE_OPTIMIZER_BACKEND} impl_cfg.optimizer=${MLITE_IMPL_OPTIMIZER}"
+echo "[mlite] dapo: clip_low=${CLIP_RATIO_LOW} clip_high=${CLIP_RATIO_HIGH} loss_agg=${LOSS_AGG_MODE} filter_groups=${FILTER_GROUPS_ENABLE} gen_batch=${GEN_BATCH_SIZE}"
+
+set +e
+"${COMMAND[@]}" 2>&1 | tee "${LOG_FILE}"
+cmd_rc="${PIPESTATUS[0]}"
+set -e
+exit "${cmd_rc}"

--- a/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
@@ -678,20 +678,26 @@ class MegatronLiteEngine(BaseEngine):
             loss_fn=runtime_loss_fn,
             num_microbatches=num_micro_batches,
             forward_only=forward_only,
+            # VERL's PPO/SFT loss is already normalized with the logical
+            # batch's global token count. Each micro loss is a contribution
+            # that must be summed, not averaged again by the runtime.
+            loss_fn_already_normalized=runtime_loss_fn is not None,
         )
         metrics = dict(result.metrics)
         micro_outputs = metrics.pop("_micro_outputs", None)
         if micro_outputs is not None and self.is_mp_src_rank_with_outputs():
             return postprocess_batch_func(output_lst=micro_outputs, indices=indices, data=data)
-        loss = float(metrics.get("loss", 0.0))
+        loss = metrics.get("loss", 0.0)
+        losses = [float(value) for value in loss] if isinstance(loss, list) else [float(loss)]
         return {
             "model_output": {},
-            "loss": [loss],
+            "loss": losses,
             # Pass Metric aggregators through unchanged (reduce_metrics folds them);
             # list-wrap plain scalars as the legacy contract expects.
             "metrics": {
                 key: value
-                if (_VerlMetric is not None and isinstance(value, _VerlMetric))
+                if isinstance(value, list)
+                or (_VerlMetric is not None and isinstance(value, _VerlMetric))
                 else [value]
                 for key, value in metrics.items()
             },

--- a/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
@@ -669,8 +669,19 @@ class MegatronLiteEngine(BaseEngine):
             )
 
         runtime_loss_fn = None
+        pp1_forward_outputs = (
+            []
+            if forward_only
+            and self.engine_config.pp == 1
+            and self.is_mp_src_rank_with_outputs()
+            else None
+        )
         if loss_function is not None or forward_only:
-            runtime_loss_fn = self._make_runtime_loss_fn(loss_function, forward_only=forward_only)
+            runtime_loss_fn = self._make_runtime_loss_fn(
+                loss_function,
+                forward_only=forward_only,
+                output_lst=pp1_forward_outputs,
+            )
 
         result = self.runtime.forward_backward(
             self.handle,
@@ -683,6 +694,12 @@ class MegatronLiteEngine(BaseEngine):
             # that must be summed, not averaged again by the runtime.
             loss_fn_already_normalized=runtime_loss_fn is not None,
         )
+        if pp1_forward_outputs is not None:
+            if result.model_output.log_probs is None:
+                raise ValueError("Megatron Lite forward-only result must contain token log_probs.")
+            return postprocess_batch_func(
+                output_lst=pp1_forward_outputs, indices=indices, data=data
+            )
         metrics = dict(result.metrics)
         micro_outputs = metrics.pop("_micro_outputs", None)
         if micro_outputs is not None and self.is_mp_src_rank_with_outputs():
@@ -785,7 +802,13 @@ class MegatronLiteEngine(BaseEngine):
             output["entropy"] = unpack(self.module, runtime_batch, entropy)
         return output
 
-    def _make_runtime_loss_fn(self, loss_function, *, forward_only: bool):
+    def _make_runtime_loss_fn(
+        self,
+        loss_function,
+        *,
+        forward_only: bool,
+        output_lst: list[dict[str, Any]] | None = None,
+    ):
         def _loss_fn(
             raw_output: dict[str, torch.Tensor],
             runtime_batch: PackedBatch,
@@ -814,6 +837,14 @@ class MegatronLiteEngine(BaseEngine):
                 )
 
             raw_output["_verl_metrics"] = metrics
+            if output_lst is not None:
+                output_lst.append(
+                    {
+                        "model_output": model_output,
+                        "loss": float(loss.detach().item()),
+                        "metrics": metrics,
+                    }
+                )
             return loss, metrics
 
         return _loss_fn

--- a/experimental/lite/megatron/lite/primitive/parallel/pipeline.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/pipeline.py
@@ -28,6 +28,7 @@ def forward_backward_pipelining(
     pre_forward_hook: Callable[[torch.Tensor], None] | None = None,
     loss_fn: Callable | None = None,
     forward_only: bool = False,
+    loss_fn_already_normalized: bool = False,
 ) -> list[dict]:
     """
     Run forward and backward passes with pipeline parallelism.
@@ -45,6 +46,9 @@ def forward_backward_pipelining(
     Returns:
         List of output dicts from forward passes.
     """
+    if loss_fn_already_normalized and loss_fn is None:
+        raise ValueError("loss_fn_already_normalized requires an external loss_fn")
+
     if ps.pp_size <= 1:
         if forward_only:
             return _forward_only_no_pipeline(
@@ -65,6 +69,7 @@ def forward_backward_pipelining(
             grad_sync_fn=grad_sync_fn,
             pre_forward_hook=pre_forward_hook,
             loss_fn=loss_fn,
+            loss_fn_already_normalized=loss_fn_already_normalized,
         )
 
     if tensor_shape is None:
@@ -96,6 +101,7 @@ def forward_backward_pipelining(
             grad_sync_fn=grad_sync_fn,
             pre_forward_hook=pre_forward_hook,
             loss_fn=loss_fn,
+            loss_fn_already_normalized=loss_fn_already_normalized,
         )
 
     return _1f1b_schedule(
@@ -109,6 +115,7 @@ def forward_backward_pipelining(
         grad_sync_fn=grad_sync_fn,
         pre_forward_hook=pre_forward_hook,
         loss_fn=loss_fn,
+        loss_fn_already_normalized=loss_fn_already_normalized,
     )
 
 
@@ -126,6 +133,18 @@ def _set_aux_loss_scale(pre_forward_hook, num_microbatches: int) -> None:
     if pre_forward_hook is not None:
         scale = torch.tensor(1.0 / num_microbatches, device="cuda")
         pre_forward_hook(scale)
+
+
+def _loss_for_backward(
+    loss: torch.Tensor,
+    num_microbatches: int,
+    *,
+    loss_fn_already_normalized: bool,
+) -> torch.Tensor:
+    """Scale a main loss without changing the independent auxiliary-loss scale."""
+    if loss_fn_already_normalized:
+        return loss
+    return loss / num_microbatches
 
 
 def _batch_get(batch, key: str):
@@ -175,6 +194,7 @@ def _no_pipeline(
     grad_sync_fn=None,
     pre_forward_hook=None,
     loss_fn=None,
+    loss_fn_already_normalized=False,
 ):
     num_microbatches = _num_microbatches_from_config(config, ps)
     outputs = []
@@ -189,8 +209,11 @@ def _no_pipeline(
             assert loss is not None
         else:
             loss = output["loss"]
-        loss = loss / num_microbatches
-        loss.backward()
+        _loss_for_backward(
+            loss,
+            num_microbatches,
+            loss_fn_already_normalized=loss_fn is not None and loss_fn_already_normalized,
+        ).backward()
         outputs.append(_compact_pipeline_output(output))
     return outputs
 
@@ -225,6 +248,7 @@ def _1f1b_schedule(
     grad_sync_fn=None,
     pre_forward_hook=None,
     loss_fn=None,
+    loss_fn_already_normalized=False,
 ):
     """
     1-Forward-1-Backward pipeline schedule using batch_isend_irecv.
@@ -301,7 +325,15 @@ def _1f1b_schedule(
         current_input = fwd_input
         out = _run_forward(fwd_input, batch, loss_ctx)
         hidden = out.get("hidden_states")
-        loss_s = out["loss"] / num_microbatches if "loss" in out and ps.pp_is_last else None
+        loss_s = (
+            _loss_for_backward(
+                out["loss"],
+                num_microbatches,
+                loss_fn_already_normalized=loss_fn is not None and loss_fn_already_normalized,
+            )
+            if "loss" in out and ps.pp_is_last
+            else None
+        )
 
         need_recv_next = not ps.pp_is_first and k < num_warmup - 1
         if not ps.pp_is_last:
@@ -327,7 +359,15 @@ def _1f1b_schedule(
         mb_idx += 1
         out = _run_forward(fwd_input, batch, loss_ctx)
         hidden = out.get("hidden_states")
-        loss_s = out["loss"] / num_microbatches if "loss" in out and ps.pp_is_last else None
+        loss_s = (
+            _loss_for_backward(
+                out["loss"],
+                num_microbatches,
+                loss_fn_already_normalized=loss_fn is not None and loss_fn_already_normalized,
+            )
+            if "loss" in out and ps.pp_is_last
+            else None
+        )
 
         input_tensors.append(fwd_input if not ps.pp_is_first else None)
         output_hiddens.append(hidden)
@@ -602,6 +642,7 @@ def _interleaved_1f1b_schedule(
     grad_sync_fn=None,
     pre_forward_hook=None,
     loss_fn=None,
+    loss_fn_already_normalized=False,
 ):
     """
     Correct non-overlapped schedule for Virtual Pipeline Parallelism (VPP).
@@ -676,7 +717,17 @@ def _interleaved_1f1b_schedule(
                         f"chunk={chunk_id} hidden_shape={hidden_shape}",
                         flush=True,
                     )
-                loss = out["loss"] / num_microbatches if is_last_stage and "loss" in out else None
+                loss = (
+                    _loss_for_backward(
+                        out["loss"],
+                        num_microbatches,
+                        loss_fn_already_normalized=(
+                            loss_fn is not None and loss_fn_already_normalized
+                        ),
+                    )
+                    if is_last_stage and "loss" in out
+                    else None
+                )
                 saved[stage_id] = (activation, hidden, loss, out)
 
                 if is_last_stage:

--- a/experimental/lite/megatron/lite/primitive/parallel/pipeline.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/pipeline.py
@@ -201,11 +201,12 @@ def _no_pipeline(
     for i in range(num_microbatches):
         if grad_sync_fn and i == num_microbatches - 1:
             grad_sync_fn()
-        batch = next(data_iter)
+        batch, loss_context = split_loss_context(next(data_iter))
         _set_aux_loss_scale(pre_forward_hook, num_microbatches)
-        output = forward_step_fn(model, batch)
+        with use_loss_context(loss_context):
+            output = forward_step_fn(model, batch)
         if loss_fn is not None:
-            loss, _metrics = _apply_external_loss(output, batch, loss_fn)
+            loss, _metrics = _apply_external_loss(output, batch, loss_fn, loss_context)
             assert loss is not None
         else:
             loss = output["loss"]
@@ -225,10 +226,11 @@ def _forward_only_no_pipeline(
     del ps
     outputs = []
     for _ in range(num_microbatches):
-        batch = next(data_iter)
+        batch, loss_context = split_loss_context(next(data_iter))
         _set_aux_loss_scale(pre_forward_hook, num_microbatches)
-        output = forward_step_fn(model, batch)
-        _apply_external_loss(output, batch, loss_fn)
+        with use_loss_context(loss_context):
+            output = forward_step_fn(model, batch)
+        _apply_external_loss(output, batch, loss_fn, loss_context)
         outputs.append(_compact_pipeline_output(output))
     return outputs
 
@@ -549,13 +551,15 @@ def _run_pipeline_chunk_forward(
     num_microbatches: int,
     pre_forward_hook=None,
     loss_fn=None,
+    loss_context=None,
 ) -> dict:
     _set_aux_loss_scale(pre_forward_hook, num_microbatches)
     if not is_first_stage:
         model.set_input_tensor(input_tensor)
-    out = forward_step_fn(model, batch)
+    with use_loss_context(loss_context):
+        out = forward_step_fn(model, batch)
     if is_last_stage:
-        _apply_external_loss(out, batch, loss_fn)
+        _apply_external_loss(out, batch, loss_fn, loss_context)
     return out
 
 
@@ -576,7 +580,7 @@ def _forward_only_pipeline_schedule(
     outputs: list[dict] = []
 
     for _mb in range(num_microbatches):
-        batch = next(data_iter)
+        batch, loss_context = split_loss_context(next(data_iter))
         _set_aux_loss_scale(pre_forward_hook, num_microbatches)
         pending_activation: torch.Tensor | None = None
         last_output: dict | None = None
@@ -602,6 +606,7 @@ def _forward_only_pipeline_schedule(
                     num_microbatches=num_microbatches,
                     pre_forward_hook=None,
                     loss_fn=loss_fn,
+                    loss_context=loss_context,
                 )
                 if is_last_stage:
                     last_output = out
@@ -669,7 +674,7 @@ def _interleaved_1f1b_schedule(
         )
 
     for mb_id in range(num_microbatches):
-        batch = next(data_iter)
+        batch, loss_context = split_loss_context(next(data_iter))
         _set_aux_loss_scale(pre_forward_hook, num_microbatches)
         saved: dict[
             int, tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None, dict]
@@ -707,6 +712,7 @@ def _interleaved_1f1b_schedule(
                     num_microbatches=num_microbatches,
                     pre_forward_hook=None,
                     loss_fn=loss_fn,
+                    loss_context=loss_context,
                 )
 
                 hidden = out.get("hidden_states")

--- a/experimental/lite/megatron/lite/primitive/train_step.py
+++ b/experimental/lite/megatron/lite/primitive/train_step.py
@@ -22,6 +22,7 @@ def run_microbatch_loop(
     pre_forward_hook: Callable[[torch.Tensor], None] | None = None,
     loss_fn: Callable | None = None,
     forward_only: bool = False,
+    loss_fn_already_normalized: bool = False,
 ):
     """Run forward-backward over microbatches with loss accumulation.
 
@@ -45,8 +46,18 @@ def run_microbatch_loop(
             ``infer_batch``). The caller (verl) runs the forward under ``no_grad`` so the
             loss has no ``grad_fn``; calling ``.backward()`` then raises. Mirrors the
             pipeline path, which already threads ``forward_only`` to skip backward.
+        loss_fn_already_normalized: If True, each external loss is already a
+            contribution to the logical batch loss and is not divided by the
+            number of microbatches again. The default averages ordinary
+            per-microbatch losses. This does not change the independent
+            ``1 / num_microbatches`` scale used for auxiliary losses.
     """
+    if loss_fn_already_normalized and loss_fn is None:
+        raise ValueError("loss_fn_already_normalized requires an external loss_fn")
+
+    external_loss_scale = 1.0 if loss_fn_already_normalized else 1.0 / num_microbatches
     last_out = None
+    all_losses: list[torch.Tensor] = []
     all_metrics: list[dict] = []
     for mb in range(num_microbatches):
         batch, loss_context = split_loss_context(next(data_iter))
@@ -63,13 +74,15 @@ def run_microbatch_loop(
             else:
                 loss, metrics = loss_fn(out, batch, loss_context)
             if not forward_only:
-                (loss / num_microbatches).backward()
+                (loss * external_loss_scale).backward()
             out["loss"] = loss.detach()
+            all_losses.append(loss.detach())
             all_metrics.append(metrics)
         elif not forward_only:
             (out["loss"] / num_microbatches).backward()
         last_out = out
     if last_out is not None and all_metrics:
+        last_out["_loss_fn_losses"] = all_losses
         last_out["_loss_fn_metrics"] = all_metrics
     return last_out
 

--- a/experimental/lite/megatron/lite/runtime/backends/__init__.py
+++ b/experimental/lite/megatron/lite/runtime/backends/__init__.py
@@ -79,12 +79,18 @@ class Runtime(ABC):
         *,
         num_microbatches: int = 1,
         forward_only: bool = False,
+        loss_fn_already_normalized: bool = False,
     ) -> ForwardResult:
         """Forward + backward pass over data.
 
         Args:
             num_microbatches: Number of microbatches to accumulate inside one
                 logical training step.
+            loss_fn_already_normalized: Whether each external ``loss_fn`` result
+                is already a contribution to the logical batch loss (for example,
+                a VERL PPO loss divided by the global token count). Such losses
+                are summed across microbatches during backward. The default keeps
+                ordinary per-microbatch losses averaged by ``num_microbatches``.
             loss_fn: Optional external loss function with signature::
 
                 loss_fn(model_output: dict, batch) -> (loss: Tensor, metrics: dict)

--- a/experimental/lite/megatron/lite/runtime/backends/bridge/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/bridge/runtime.py
@@ -694,12 +694,15 @@ class BridgeRuntime(RuntimeBase):
         *,
         num_microbatches: int = 1,
         forward_only: bool = False,
+        loss_fn_already_normalized: bool = False,
     ) -> ForwardResult:
         from megatron.core import parallel_state as mpu
         from megatron.core.pipeline_parallel.schedules import get_forward_backward_func
 
         if num_microbatches < 1:
             raise ValueError("num_microbatches must be >= 1")
+        if loss_fn_already_normalized and loss_fn is None:
+            raise ValueError("loss_fn_already_normalized requires an external loss_fn")
 
         model_list = handle._extras["model_list"]
         data_iter = _as_data_iter(data)
@@ -765,7 +768,8 @@ class BridgeRuntime(RuntimeBase):
                 else:
                     loss = output_tensor.mean()
                 last_loss[0] = float(loss.detach().item())
-                return loss, {}
+                backward_loss = loss * num_microbatches if loss_fn_already_normalized else loss
+                return backward_loss, {}
 
             return output_tensor, _bridge_loss_fn
 

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -133,6 +133,25 @@ def _checkpoint_module(model: Any) -> torch.nn.Module:
     )
 
 
+def _merge_microbatch_metrics(metrics_by_microbatch: list[dict]) -> dict:
+    """Preserve every microbatch value while honoring metric accumulator objects."""
+    merged: dict = {}
+    for micro_metrics in metrics_by_microbatch:
+        for key, value in micro_metrics.items():
+            if key not in merged:
+                init_list = getattr(value, "init_list", None)
+                if callable(init_list):
+                    accumulator = init_list()
+                    accumulator.append(value)
+                    merged[key] = accumulator
+                else:
+                    merged[key] = [value]
+                continue
+            accumulator = merged[key]
+            accumulator.append(value)
+    return merged
+
+
 class MegatronLiteRuntime(RuntimeBase):
     """Megatron Lite default training backend (Megatron-style 5D parallel)."""
 
@@ -391,12 +410,15 @@ class MegatronLiteRuntime(RuntimeBase):
         *,
         num_microbatches: int = 1,
         forward_only: bool = False,
+        loss_fn_already_normalized: bool = False,
     ) -> ForwardResult:
         from megatron.lite.primitive.train_step import run_microbatch_loop
 
         forward_step = handle._extras["forward_step"]
         if num_microbatches < 1:
             raise ValueError("num_microbatches must be >= 1")
+        if loss_fn_already_normalized and loss_fn is None:
+            raise ValueError("loss_fn_already_normalized requires an external loss_fn")
 
         if hasattr(data, "__next__"):
             data_iter = data
@@ -427,6 +449,7 @@ class MegatronLiteRuntime(RuntimeBase):
                 pre_forward_hook=handle._extras.get("pre_forward_hook"),
                 loss_fn=loss_fn,
                 forward_only=forward_only,
+                loss_fn_already_normalized=loss_fn_already_normalized,
             )
             out = _last_loss_output(outputs)
             loss_obj = out.get("loss") if out else None
@@ -451,6 +474,7 @@ class MegatronLiteRuntime(RuntimeBase):
                 pre_forward_hook=handle._extras.get("pre_forward_hook"),
                 loss_fn=loss_fn,
                 forward_only=forward_only,
+                loss_fn_already_normalized=loss_fn_already_normalized,
             )
 
         if not forward_only:
@@ -459,21 +483,32 @@ class MegatronLiteRuntime(RuntimeBase):
                 finalize_grads()
 
         loss_tensor = out.get("loss") if out else None
-        loss_val = (
-            loss_tensor.item()
-            if isinstance(loss_tensor, torch.Tensor)
-            else float(loss_tensor or 0.0)
-        )
-        metrics: dict = {"loss": loss_val}
-        for m in out.get("_loss_fn_metrics", []) if out else []:
-            for k, v in m.items():
-                if k not in metrics:
-                    metrics[k] = v
+        loss_values = out.get("_loss_fn_losses", []) if out else []
+        if loss_values:
+            micro_losses = [
+                value.item() if isinstance(value, torch.Tensor) else float(value)
+                for value in loss_values
+            ]
+            loss_metric: float | list[float] = (
+                micro_losses
+                if loss_fn_already_normalized
+                else sum(micro_losses) / num_microbatches
+            )
+        else:
+            loss_metric = (
+                loss_tensor.item()
+                if isinstance(loss_tensor, torch.Tensor)
+                else float(loss_tensor or 0.0)
+            )
+        metrics: dict = {"loss": loss_metric}
+        all_loss_fn_metrics = out.get("_loss_fn_metrics", []) if out else []
+        metrics.update(_merge_microbatch_metrics(all_loss_fn_metrics))
         if ps.pp_size > 1:
-            for item in outputs:
-                for k, v in item.get("metrics", {}).items():
-                    if k not in metrics:
-                        metrics[k] = v
+            metrics.update(
+                _merge_microbatch_metrics(
+                    [item["metrics"] for item in outputs if item.get("metrics")]
+                )
+            )
             metrics["_micro_outputs"] = outputs
 
         return ForwardResult(

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -451,6 +451,7 @@ class MegatronLiteRuntime(RuntimeBase):
                 forward_only=forward_only,
                 loss_fn_already_normalized=loss_fn_already_normalized,
             )
+            pipeline_loss_values = [item["loss"] for item in outputs if "loss" in item]
             out = _last_loss_output(outputs)
             loss_obj = out.get("loss") if out else None
             if isinstance(loss_obj, torch.Tensor):
@@ -464,6 +465,7 @@ class MegatronLiteRuntime(RuntimeBase):
                 dist.broadcast(loss_t, src=ps.pp_global_ranks[-1], group=ps.pp_group)
             out = {"loss": loss_t.squeeze(0)}
         else:
+            pipeline_loss_values = []
             out = run_microbatch_loop(
                 handle._model,
                 data_iter,
@@ -483,7 +485,7 @@ class MegatronLiteRuntime(RuntimeBase):
                 finalize_grads()
 
         loss_tensor = out.get("loss") if out else None
-        loss_values = out.get("_loss_fn_losses", []) if out else []
+        loss_values = pipeline_loss_values or (out.get("_loss_fn_losses", []) if out else [])
         if loss_values:
             micro_losses = [
                 value.item() if isinstance(value, torch.Tensor) else float(value)

--- a/experimental/lite/tests/unit/primitive/test_loss_microbatch_contract.py
+++ b/experimental/lite/tests/unit/primitive/test_loss_microbatch_contract.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from megatron.lite.primitive import parallel as parallel_primitives
+from megatron.lite.primitive.parallel import pipeline
+from megatron.lite.primitive.train_step import run_microbatch_loop
+from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
+from megatron.lite.runtime.contracts.handle import ModelHandle
+
+
+pytestmark = pytest.mark.mlite
+
+
+class _Metric:
+    """Small stand-in for VERL's Metric without importing the connector dependency."""
+
+    def __init__(self, aggregation: str, value: float | None = None):
+        self.aggregation = aggregation
+        self.values: list[float] = []
+        if value is not None:
+            self.values.append(value)
+
+    def init_list(self):
+        return _Metric(self.aggregation)
+
+    def append(self, value):
+        if isinstance(value, _Metric):
+            assert value.aggregation == self.aggregation
+            self.values.extend(value.values)
+        else:
+            self.values.append(value)
+
+    def aggregate(self):
+        if self.aggregation == "sum":
+            return sum(self.values)
+        return sum(self.values) / len(self.values)
+
+
+class _ScalarModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = nn.Parameter(torch.tensor(1.0))
+
+
+@pytest.mark.parametrize("num_microbatches", [1, 4])
+@pytest.mark.parametrize("loss_kind", ["internal", "external", "external_normalized"])
+def test_run_microbatch_loop_loss_contract_is_microbatch_invariant(
+    num_microbatches,
+    loss_kind,
+):
+    model = _ScalarModel()
+    batches = iter([{"value": 3.0, "micro": index} for index in range(num_microbatches)])
+    normalized = loss_kind == "external_normalized"
+
+    def forward_fn(module, batch):
+        value = module.weight * batch["value"]
+        return {"value": value, "loss": value}
+
+    def loss_fn(output, batch):
+        loss = output["value"] / num_microbatches if normalized else output["value"]
+        return loss, {"metric": _Metric("sum", float(batch["micro"] + 1))}
+
+    output = run_microbatch_loop(
+        model,
+        batches,
+        num_microbatches,
+        forward_fn,
+        loss_fn=None if loss_kind == "internal" else loss_fn,
+        loss_fn_already_normalized=normalized,
+    )
+
+    torch.testing.assert_close(model.weight.grad, torch.tensor(3.0))
+    if loss_kind == "internal":
+        assert "_loss_fn_metrics" not in output
+    else:
+        assert len(output["_loss_fn_metrics"]) == num_microbatches
+
+
+@pytest.mark.parametrize("num_microbatches", [1, 4])
+def test_runtime_aggregates_every_external_loss_metric(num_microbatches):
+    model = _ScalarModel()
+    handle = ModelHandle(
+        model=model,
+        parallel_state=SimpleNamespace(pp_size=1),
+        _extras={
+            "forward_step": lambda module, batch: {"value": module.weight * batch["value"]},
+        },
+    )
+    runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
+    batches = iter([{"value": 0.0, "micro": index} for index in range(num_microbatches)])
+
+    def loss_fn(output, batch):
+        return output["value"] + batch["micro"] + 1, {
+            "sum_metric": _Metric("sum", float(batch["micro"] + 1)),
+            "plain_metric": batch["micro"] + 1,
+        }
+
+    result = runtime.forward_backward(
+        handle,
+        batches,
+        loss_fn,
+        num_microbatches=num_microbatches,
+        loss_fn_already_normalized=True,
+    )
+
+    assert result.metrics["sum_metric"].values == list(
+        map(float, range(1, num_microbatches + 1))
+    )
+    assert result.metrics["sum_metric"].aggregate() == sum(range(1, num_microbatches + 1))
+    assert result.metrics["plain_metric"] == list(range(1, num_microbatches + 1))
+    assert result.metrics["loss"] == list(map(float, range(1, num_microbatches + 1)))
+
+
+class _PipelineLastStageModel(_ScalarModel):
+    def __init__(self):
+        super().__init__()
+        self.input_tensor = None
+
+    def set_input_tensor(self, input_tensor):
+        self.input_tensor = input_tensor
+
+    def forward(self, *, hidden_states=None, **_kwargs):
+        hidden_states = self.input_tensor if hidden_states is None else hidden_states
+        return {"value": self.weight * hidden_states.sum()}
+
+
+@pytest.mark.parametrize("num_microbatches", [1, 4])
+@pytest.mark.parametrize("normalized", [False, True])
+def test_pipeline_schedule_honors_external_loss_contract(
+    monkeypatch,
+    num_microbatches,
+    normalized,
+):
+    model = _PipelineLastStageModel()
+    sent_input_grads = []
+    original_empty = torch.empty
+
+    def cpu_empty(*args, **kwargs):
+        if kwargs.get("device") == "cuda":
+            kwargs["device"] = "cpu"
+        return original_empty(*args, **kwargs)
+
+    def fake_send_recv(
+        send_fwd,
+        send_bwd,
+        recv_fwd,
+        recv_bwd,
+        _ps,
+        tensor_shape,
+        **_kwargs,
+    ):
+        assert not recv_bwd
+        if send_bwd is not None:
+            sent_input_grads.append(send_bwd.detach().clone())
+        activation = (
+            torch.full(tensor_shape, 3.0, requires_grad=True) if recv_fwd else None
+        )
+        return activation, None
+
+    monkeypatch.setattr(pipeline.torch, "empty", cpu_empty)
+    monkeypatch.setattr(pipeline, "_send_recv_pipeline", fake_send_recv)
+    ps = SimpleNamespace(
+        pp_size=2,
+        pp_rank=1,
+        pp_is_first=False,
+        pp_is_last=True,
+        dp_size=1,
+    )
+
+    def loss_fn(output, batch):
+        loss = output["value"] / num_microbatches if normalized else output["value"]
+        return loss, {"metric": _Metric("sum", float(batch["micro"] + 1))}
+
+    outputs = parallel_primitives.forward_backward_pipelining(
+        lambda module, _batch: module(),
+        [model],
+        iter([{"micro": index} for index in range(num_microbatches)]),
+        SimpleNamespace(num_microbatches=num_microbatches),
+        ps,
+        tensor_shape=(1,),
+        loss_fn=loss_fn,
+        loss_fn_already_normalized=normalized,
+    )
+
+    torch.testing.assert_close(model.weight.grad, torch.tensor(3.0))
+    torch.testing.assert_close(torch.stack(sent_input_grads).sum(), torch.tensor(1.0))
+    assert len(outputs) == num_microbatches
+    assert [item["metrics"]["metric"].values for item in outputs] == [
+        [float(index)] for index in range(1, num_microbatches + 1)
+    ]
+
+
+def test_normalized_flag_requires_external_loss():
+    model = _ScalarModel()
+    with pytest.raises(ValueError, match="requires an external loss_fn"):
+        run_microbatch_loop(
+            model,
+            iter([{"value": 1.0}]),
+            1,
+            lambda module, batch: {"loss": module.weight * batch["value"]},
+            loss_fn_already_normalized=True,
+        )

--- a/experimental/lite/tests/unit/primitive/test_loss_microbatch_contract.py
+++ b/experimental/lite/tests/unit/primitive/test_loss_microbatch_contract.py
@@ -9,8 +9,11 @@ from torch import nn
 from megatron.lite.primitive import parallel as parallel_primitives
 from megatron.lite.primitive.parallel import pipeline
 from megatron.lite.primitive.train_step import run_microbatch_loop
+from megatron.lite.runtime.backends.mlite import runtime as runtime_module
 from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
+from megatron.lite.runtime.contracts.data import PackedBatch
 from megatron.lite.runtime.contracts.handle import ModelHandle
+from megatron.lite.runtime.contracts.loss import LossContext, get_loss_context
 
 
 pytestmark = pytest.mark.mlite
@@ -116,6 +119,53 @@ def test_runtime_aggregates_every_external_loss_metric(num_microbatches):
     assert result.metrics["loss"] == list(map(float, range(1, num_microbatches + 1)))
 
 
+@pytest.mark.parametrize("normalized", [False, True])
+def test_pipeline_runtime_aggregates_every_external_loss(monkeypatch, normalized):
+    micro_losses = [1.0, 2.0, 3.0, 4.0]
+    outputs = [
+        {
+            "loss": value,
+            "metrics": {"plain_metric": index},
+        }
+        for index, value in enumerate(micro_losses, start=1)
+    ]
+    monkeypatch.setattr(
+        pipeline,
+        "forward_backward_pipelining",
+        lambda *_args, **_kwargs: outputs,
+    )
+    monkeypatch.setattr(
+        runtime_module,
+        "_infer_pipeline_tensor_shape",
+        lambda *_args, **_kwargs: (1,),
+    )
+    handle = ModelHandle(
+        model=_ScalarModel(),
+        parallel_state=SimpleNamespace(
+            pp_size=2,
+            pp_group=None,
+            pp_global_ranks=None,
+        ),
+        _extras={
+            "forward_step": lambda _module, _batch: {},
+            "model_cfg": SimpleNamespace(hidden_size=1),
+        },
+    )
+    runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
+
+    result = runtime.forward_backward(
+        handle,
+        iter([{"value": 0.0}] * len(micro_losses)),
+        lambda *_args: (torch.tensor(0.0), {}),
+        num_microbatches=len(micro_losses),
+        loss_fn_already_normalized=normalized,
+    )
+
+    expected_loss = micro_losses if normalized else sum(micro_losses) / len(micro_losses)
+    assert result.metrics["loss"] == expected_loss
+    assert result.metrics["plain_metric"] == list(range(1, len(micro_losses) + 1))
+
+
 class _PipelineLastStageModel(_ScalarModel):
     def __init__(self):
         super().__init__()
@@ -193,6 +243,70 @@ def test_pipeline_schedule_honors_external_loss_contract(
     assert [item["metrics"]["metric"].values for item in outputs] == [
         [float(index)] for index in range(1, num_microbatches + 1)
     ]
+
+
+def test_pipeline_forward_only_preserves_loss_context(monkeypatch):
+    model = _PipelineLastStageModel()
+    original_empty = torch.empty
+    seen_contexts = []
+
+    def cpu_empty(*args, **kwargs):
+        if kwargs.get("device") == "cuda":
+            kwargs["device"] = "cpu"
+        return original_empty(*args, **kwargs)
+
+    def fake_send_recv(
+        _send_fwd,
+        _send_bwd,
+        recv_fwd,
+        _recv_bwd,
+        _ps,
+        tensor_shape,
+        **_kwargs,
+    ):
+        activation = torch.full(tensor_shape, 3.0) if recv_fwd else None
+        return activation, None
+
+    monkeypatch.setattr(pipeline.torch, "empty", cpu_empty)
+    monkeypatch.setattr(pipeline, "_send_recv_pipeline", fake_send_recv)
+    ps = SimpleNamespace(
+        pp_size=2,
+        pp_rank=1,
+        pp_is_first=False,
+        pp_is_last=True,
+        pp_cpu_group=None,
+        dp_size=1,
+    )
+    runtime_batch = PackedBatch(
+        input_ids=torch.tensor([1]),
+        labels=torch.tensor([1]),
+        seq_lens=torch.tensor([1]),
+    )
+    loss_context = LossContext(source_batch={"micro": 1})
+
+    def forward_fn(module, batch):
+        assert batch is runtime_batch
+        seen_contexts.append(get_loss_context())
+        return module()
+
+    def loss_fn(output, batch, context):
+        assert batch is runtime_batch
+        assert context is loss_context
+        return output["value"], {"micro": context.source_batch["micro"]}
+
+    outputs = parallel_primitives.forward_backward_pipelining(
+        forward_fn,
+        [model],
+        iter([(runtime_batch, loss_context)]),
+        SimpleNamespace(num_microbatches=1),
+        ps,
+        tensor_shape=(1,),
+        loss_fn=loss_fn,
+        forward_only=True,
+    )
+
+    assert seen_contexts == [loss_context]
+    assert outputs == [{"loss": 3.0, "metrics": {"micro": 1}}]
 
 
 def test_normalized_flag_requires_external_loss():

--- a/experimental/lite/tests/unit/verl/test_mlite_engine_forward_only.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_engine_forward_only.py
@@ -1,0 +1,155 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from __future__ import annotations
+
+from types import MethodType, SimpleNamespace
+
+import pytest
+import torch
+from verl_mlite.engine.config import MegatronLiteEngineConfig
+from verl_mlite.engine.mlite_engine import MegatronLiteEngine
+from megatron.lite.runtime.contracts import ForwardResult, LossContext, ModelOutputs
+
+
+class _MicroBatch:
+    def __init__(self, index: int):
+        self.index = index
+
+    def to(self, _device):
+        return self
+
+
+class _ForwardOnlyRuntime:
+    def __init__(self, raw_outputs: list[dict[str, torch.Tensor]]):
+        self.raw_outputs = raw_outputs
+
+    def forward_backward(self, _handle, data, loss_fn, **kwargs):
+        assert kwargs["forward_only"] is True
+        assert kwargs["num_microbatches"] == len(self.raw_outputs)
+        assert loss_fn is not None
+        for raw_output, (runtime_batch, loss_context) in zip(
+            self.raw_outputs, data, strict=True
+        ):
+            loss_fn(raw_output, runtime_batch, loss_context)
+        return ForwardResult(
+            model_output=ModelOutputs(log_probs=self.raw_outputs[-1]["log_probs"]),
+            metrics={"loss": 0.0},
+        )
+
+
+def _engine(raw_outputs: list[dict[str, torch.Tensor]]) -> MegatronLiteEngine:
+    engine = MegatronLiteEngine(
+        model_config=SimpleNamespace(
+            local_path="/tmp/qwen35", hf_config={"model_type": "qwen3_5_moe"}, mtp=None
+        ),
+        engine_config=MegatronLiteEngineConfig(
+            custom_backend_module=None,
+            pp=1,
+            impl_cfg={"use_thd": True},
+        ),
+        optimizer_config=SimpleNamespace(),
+        checkpoint_config={},
+    )
+    engine.handle = object()
+    engine.runtime = _ForwardOnlyRuntime(raw_outputs)
+    engine._make_runtime_batch = MethodType(lambda _self, batch: batch, engine)
+    engine._make_runtime_loss_context = MethodType(
+        lambda _self, batch, *, loss_scale: LossContext(
+            loss_scale=loss_scale, source_batch=batch
+        ),
+        engine,
+    )
+    engine._build_verl_model_output = MethodType(
+        lambda _self, *, raw_output, runtime_batch: {
+            key: value
+            for key, value in raw_output.items()
+            if key in {"log_probs", "entropy"} and value is not None
+        },
+        engine,
+    )
+    engine.get_data_parallel_size = MethodType(lambda _self: 1, engine)
+    engine.is_mp_src_rank_with_outputs = MethodType(lambda _self: True, engine)
+    return engine
+
+
+@pytest.mark.parametrize("with_entropy", [False, True])
+def test_pp1_forward_only_preserves_all_log_probs_and_optional_entropy(
+    monkeypatch, with_entropy
+):
+    raw_outputs = []
+    for index in range(2):
+        output = {"log_probs": torch.tensor([float(index + 1)])}
+        if with_entropy:
+            output["entropy"] = torch.tensor([float(index + 11)])
+        raw_outputs.append(output)
+    engine = _engine(raw_outputs)
+    captured = {}
+
+    def postprocess_batch_func(*, output_lst, indices, data):
+        captured["outputs"] = output_lst
+        assert indices == [1, 0]
+        assert data is logical_batch
+        model_output = {
+            key: torch.cat([item["model_output"][key] for item in output_lst])
+            for key in output_lst[0]["model_output"]
+        }
+        return {"model_output": model_output}
+
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.postprocess_batch_func", postprocess_batch_func
+    )
+    monkeypatch.setattr("verl_mlite.engine.mlite_engine.get_device_id", lambda: "cpu")
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.tu.get_non_tensor_data",
+        lambda **_kwargs: 2,
+    )
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.tu.assign_non_tensor", lambda *_args, **_kwargs: None
+    )
+    logical_batch = object()
+
+    result = engine._forward_backward_batch_with_runtime(
+        data=logical_batch,
+        micro_batches=[_MicroBatch(0), _MicroBatch(1)],
+        indices=[1, 0],
+        loss_function=None,
+        forward_only=True,
+    )
+
+    torch.testing.assert_close(result["model_output"]["log_probs"], torch.tensor([1.0, 2.0]))
+    assert len(captured["outputs"]) == 2
+    if with_entropy:
+        torch.testing.assert_close(
+            result["model_output"]["entropy"], torch.tensor([11.0, 12.0])
+        )
+    else:
+        assert "entropy" not in result["model_output"]
+
+
+def test_pp1_forward_only_requires_result_log_probs(monkeypatch):
+    raw_outputs = [{"log_probs": torch.tensor([1.0])}]
+    engine = _engine(raw_outputs)
+
+    class _MissingLogProbRuntime(_ForwardOnlyRuntime):
+        def forward_backward(self, *args, **kwargs):
+            result = super().forward_backward(*args, **kwargs)
+            result.model_output.log_probs = None
+            return result
+
+    engine.runtime = _MissingLogProbRuntime(raw_outputs)
+    monkeypatch.setattr("verl_mlite.engine.mlite_engine.get_device_id", lambda: "cpu")
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.tu.get_non_tensor_data",
+        lambda **_kwargs: 1,
+    )
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.tu.assign_non_tensor", lambda *_args, **_kwargs: None
+    )
+
+    with pytest.raises(ValueError, match="must contain token log_probs"):
+        engine._forward_backward_batch_with_runtime(
+            data=object(),
+            micro_batches=[_MicroBatch(0)],
+            indices=None,
+            loss_function=None,
+            forward_only=True,
+        )


### PR DESCRIPTION
## Summary

- add a runnable Qwen3.5 DAPO launcher for the current VERL integration
- preserve the contract for externally normalized PPO losses so MLite does not divide gradients by the microbatch count a second time
- aggregate loss, policy-loss, KL, entropy, and related metrics across every microbatch while propagating `LossContext` through PP/VPP paths
- preserve all PP=1 forward-only outputs so old/new log-prob and entropy computation receives every microbatch result

## Validated candidate mapping

The running experiment uses these source commits; this review branch contains tree-equivalent changes rebased onto current `ISEEKYAN/Megatron-LM:main`:

- `254f82577` -> `b994ecc63` (normalized external-loss scaling)
- `58410e33c` -> `824b40b38` (pipeline/microbatch metric contract)
- `758d2ddf6` -> `655847f89` (PP1 forward-only outputs)

The DAPO launcher prerequisites are included as the first three commits. Internal-only identifiers were removed from their commit messages.

## Validation

- candidate-touched files are byte-equivalent to the tree used by the experiment
- `bash -n experimental/lite/examples/verl/scripts/run_qwen3moe_gsm8k_dapo.sh`
- PR hygiene guards: no internal task identifiers in commit messages or diff
- targeted CPU-only pytest invocation: 17 passed; 2 pipeline-runtime cases reached the CUDA reduction path and could not run on a host without an NVIDIA driver
- real 4-node / 32-GPU DAPO validation is in progress; clean AIME checkpoints currently show 10.21% -> 21.25% -> 37.29% -> 42.92% through step 15

## Experiment-only workaround

`actor_rollout_ref.rollout.engine_kwargs.vllm.async_scheduling=False` is being used to avoid a vLLM SHM rollout timeout. It is a launch-time vLLM setting and is intentionally not part of the MLite algorithm changes in this PR.

This PR remains draft until the step-25 run and final metric/checkpoint audit complete.