### PR TITLE
Fix expert gradient scaling and enable VERL SFT support

### DIFF
--- a/experimental/lite/examples/verl/scripts/run_qwen3moe_sft.sh
+++ b/experimental/lite/examples/verl/scripts/run_qwen3moe_sft.sh
@@ -72,6 +72,7 @@ ATTENTION_BACKEND="${ATTENTION_BACKEND:-flash}"
 # Optimizer backend:
 # - distopt (default): Megatron-Core DDP + distributed optimizer.
 # - fsdp2: Megatron Lite FSDP2 wrapper + optimizer.
+# - mfsdp: Megatron-FSDP wrapper + optimizer.
 MLITE_OPTIMIZER_BACKEND="${MLITE_OPTIMIZER_BACKEND:-distopt}"
 
 LR="${LR:-1e-5}"
@@ -108,8 +109,11 @@ case "${MLITE_OPTIMIZER_BACKEND}" in
   fsdp2)
     MLITE_IMPL_OPTIMIZER="fsdp2"
     ;;
+  mfsdp)
+    MLITE_IMPL_OPTIMIZER="mfsdp"
+    ;;
   *)
-    echo "Unsupported MLITE_OPTIMIZER_BACKEND=${MLITE_OPTIMIZER_BACKEND}. Expected distopt or fsdp2." >&2
+    echo "Unsupported MLITE_OPTIMIZER_BACKEND=${MLITE_OPTIMIZER_BACKEND}. Expected distopt, fsdp2, or mfsdp." >&2
     exit 1
     ;;
 esac

--- a/experimental/lite/examples/verl/verl_mlite/config/engine/mlite.yaml
+++ b/experimental/lite/examples/verl/verl_mlite/config/engine/mlite.yaml
@@ -8,6 +8,8 @@ grad_offload: false
 forward_only: false
 dtype: bfloat16
 export_dtype: bfloat16
+seed: 42
+full_determinism: false
 
 model_name: auto
 impl: lite

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/grad_norm.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/grad_norm.py
@@ -135,7 +135,7 @@ class CanonicalGradNormMegatronFSDPOptimizer:
             _phase_debug("mcore_get_grad_norm:start")
             mcore_norm_before_scale = self._inner_optimizer.get_grad_norm()
             _phase_debug("mcore_get_grad_norm:end")
-        expert_scale = _expert_grad_scale(self.ps)
+        expert_scale = _expert_grad_scale(self.ps, self._inner_optimizer)
         _phase_debug("expert_grad_scale:start")
         _scale_mfsdp_expert_grads(
             self._inner_optimizer,
@@ -680,10 +680,18 @@ def _scale_mfsdp_expert_grads(
                     _scale_grad_in_place(grad, scale)
 
 
-def _expert_grad_scale(ps: ParallelState) -> float:
+def _expert_grad_scale(ps: ParallelState, optimizer: Any = None) -> float:
     override = os.environ.get("MLITE_MFSDP_EXPERT_GRAD_SCALE")
     if override is not None:
         return float(override)
+    if optimizer is not None:
+        # When the unsharded expert grad buffers had their per-microbatch
+        # gradient_scaling_factor neutralized at build time (see
+        # optimizer._defer_expert_grad_microbatch_scaling), re-apply that factor
+        # exactly once here so the expert grad becomes scale*(g_mb0 + g_mb1).
+        deferred = getattr(optimizer, "_mlite_mfsdp_expert_deferred_scale", None)
+        if deferred is not None:
+            return float(deferred)
     return 1.0
 
 

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/optimizer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/optimizer.py
@@ -94,6 +94,7 @@ def build_mfsdp_stack(
 
     if skip_fsdp_wrap:
         wrapped_chunks = list(model_chunks)
+        expert_deferred_scale = None
     else:
         ddp_config = build_mfsdp_ddp_config(DistributedDataParallelConfig, ddp_overrides)
         wrapped_chunks = []
@@ -117,6 +118,9 @@ def build_mfsdp_stack(
                     pg_collection=pg_collection,
                 )
             )
+        expert_deferred_scale = _defer_expert_grad_microbatch_scaling(
+            wrapped_chunks, ddp_config
+        )
 
     opt_config = build_mc_optimizer_config(
         opt,
@@ -140,6 +144,11 @@ def build_mfsdp_stack(
         if not hasattr(optimizer_owner, "model_chunks"):
             optimizer_owner.model_chunks = wrapped_chunks  # pyright: ignore[reportAttributeAccessIssue]
     attach_mfsdp_checkpoint_metadata(optimizer, ps=ps, is_expert=is_expert_param)
+    if expert_deferred_scale is not None:
+        # The per-microbatch scaling was neutralized on the unsharded expert grad
+        # buffers (see _defer_expert_grad_microbatch_scaling); re-apply it exactly
+        # once per step in grad_norm._scale_mfsdp_expert_grads via _expert_grad_scale.
+        optimizer._mlite_mfsdp_expert_deferred_scale = expert_deferred_scale
     param_is_expert, param_names = _build_wrapped_param_metadata(wrapped_chunks, is_expert_param)
     optimizer = CanonicalGradNormMegatronFSDPOptimizer(
         optimizer,
@@ -210,6 +219,61 @@ def finalize_mfsdp_grads(model_chunks: list[nn.Module], optimizer) -> None:
     )
 
     finalize_model_grads(model_chunks, pg_collection=optimizer._mc_pg_collection)
+
+
+def _defer_expert_grad_microbatch_scaling(model_chunks, ddp_config) -> float | None:
+    """Work around a Megatron-FSDP multi-microbatch bug for unsharded expert grads.
+
+    For expert params whose grad buffer is *unsharded* (expert-DP size == 1), the
+    Megatron-FSDP grad-reduce pipeline pre-scales the *entire* accumulator by
+    ``gradient_scaling_factor`` on every microbatch's reduce
+    (``gradient_reduce_preprocessing`` -> ``grad_data.mul_(scaling_factor)``).
+    Because an unsharded buffer accumulates across microbatches in place
+    (``main_grad.add_``), each earlier microbatch is re-scaled once per subsequent
+    microbatch, yielding ``0.5*g_mb0 + g_mb1`` instead of ``0.5*(g_mb0 + g_mb1)``
+    for NUM_MB=2. Sharded (dense) buffers are unaffected because each microbatch's
+    contribution is reduce-scattered into a separate persistent shard.
+
+    Fix (contained in the M-FSDP primitive): null the per-microbatch scaling on
+    these buffers so they accumulate an unscaled SUM (the size-1 collective is a
+    no-op anyway), and re-apply the factor exactly once per step in
+    ``grad_norm._scale_mfsdp_expert_grads`` via ``_expert_grad_scale``. Returns the
+    (single, shared) deferred factor, or ``None`` if nothing needed neutralizing.
+    """
+    if getattr(ddp_config, "average_in_collective", False):
+        # ReduceOp.AVG path does not use the in-place pre-scale; not affected.
+        return None
+    deferred: float | None = None
+    for chunk in model_chunks:
+        buffer = getattr(chunk, "param_and_grad_buffer", None)
+        if buffer is None:
+            continue
+        for group in getattr(buffer, "parameter_groups", ()):
+            if not getattr(group, "is_expert_param", False):
+                continue
+            gbuf = getattr(group, "main_grad_buffer", None)
+            if gbuf is None or getattr(gbuf, "is_data_distributed", False):
+                # Sharded expert buffers reduce-scatter correctly; leave them alone.
+                continue
+            stashed = getattr(gbuf, "_mlite_deferred_grad_scale", None)
+            if stashed is not None:
+                factor = stashed  # Idempotent: already neutralized on a prior build.
+            else:
+                factor = getattr(gbuf, "gradient_scaling_factor", None)
+                if factor is None or factor == 1.0:
+                    # No scaling applied per microbatch -> nothing to defer.
+                    continue
+                gbuf._mlite_deferred_grad_scale = float(factor)
+                gbuf.gradient_scaling_factor = None
+            if deferred is None:
+                deferred = float(factor)
+            elif abs(deferred - float(factor)) > 1e-12:
+                raise ValueError(
+                    "Megatron-FSDP expert grad buffers have inconsistent "
+                    f"gradient_scaling_factor ({deferred} vs {factor}); "
+                    "deferred expert grad scaling assumes a single shared factor."
+                )
+    return deferred
 
 
 def _build_wrapped_param_metadata(


### PR DESCRIPTION
 ## Summary

  This PR ports the M-FSDP and VERL fixes authored by `conver334` onto the `mlite-mfsdp` branch.

  - adds M-FSDP optimizer support to the VERL Qwen3-MoE SFT launcher;
  - exposes `seed` and `full_determinism` in the MLite engine configuration;
  - fixes expert-gradient scaling across multiple microbatches when the expert gradient buffer is unsharded.

  ## M-FSDP gradient scaling fix

  For unsharded expert gradient buffers, applying `gradient_scaling_factor` during every microbatch reduction repeatedly rescales contributions from earlier microbatches.

  For two microbatches, this can produce:

  ```text
  0.5 * grad_mb0 + grad_mb1

  instead of:

  0.5 * (grad_mb0 + grad_mb1)

  This change defers scaling for affected expert buffers and applies the factor exactly once after all microbatch gradients have accumulated. Sharded expert buffers and the ReduceOp.AVG path are unchanged.

  ## VERL changes

  - Accept MLITE_OPTIMIZER_BACKEND=mfsdp in run_qwen3moe_sft.sh.
  - Map it to the MLite mfsdp optimizer implementation.
  - Add default engine configuration values:

  seed: 42
  full_determinism: false

  ## Validation

  - experimental/lite/tests/unit/primitive/test_mfsdp.py: 5 passed
  - bash -n experimental/lite/examples/verl/scripts/run_qwen3moe_sft.sh: passed
  - git diff --check: passed


