### PR TITLE
Fuse RoPE across MLite attention implementations

### DIFF
--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/model.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/model.py
@@ -95,10 +95,12 @@ class DeepseekV4CSAAttention(nn.Module):
     observes the batch-first interior.
     """
 
-    def __init__(self, config: DeepseekV4Config, *, layer_idx: int, ps: ParallelState):
+    def __init__(self, config: DeepseekV4Config, *, layer_idx: int, ps: ParallelState,
+        apply_rope_fusion: bool = True):
         super().__init__()
         self.ps = ps
-        self.self_attn = CompressedSparseAttention(config, layer_idx=layer_idx, ps=ps)
+        self.self_attn = CompressedSparseAttention(config, layer_idx=layer_idx, ps=ps,
+            apply_rope_fusion=apply_rope_fusion)
 
     def forward(self, x: torch.Tensor, *, position_ids: torch.Tensor) -> torch.Tensor:
         # Skeleton feeds SBHD [S, B, H]; CSA needs batch-first [B, S, H].
@@ -127,6 +129,7 @@ class DeepseekV4Layer(nn.Module):
         layer_idx: int,
         *,
         use_deepep: bool = False,
+        apply_rope_fusion: bool = True,
     ):
         super().__init__()
         self.layer_idx = layer_idx
@@ -134,7 +137,8 @@ class DeepseekV4Layer(nn.Module):
         self.input_layernorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.post_attention_layernorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         # DS4 ONLY: CSA attention behind the SBHD shim (Kimi builds MLA here).
-        self.self_attn = DeepseekV4CSAAttention(config, layer_idx=layer_idx, ps=ps)
+        self.self_attn = DeepseekV4CSAAttention(config, layer_idx=layer_idx, ps=ps,
+            apply_rope_fusion=apply_rope_fusion)
         # DS4 ONLY: hash-routed MoE family (shared Experts/Router/dispatcher).
         self.mlp = DeepseekV4MoE(config, ps, layer_idx=layer_idx, use_deepep=use_deepep)
         # DS4 ONLY: per-layer multi-head hyper-connections wrapping attn + ffn.
@@ -191,8 +195,10 @@ class DeepseekV4MTPLayer(DeepseekV4Layer):
         embedding: VocabParallelEmbedding,
         use_deepep: bool,
         detach_encoder: bool,
+        apply_rope_fusion: bool,
     ):
-        super().__init__(config, ps, layer_idx, use_deepep=use_deepep)
+        super().__init__(config, ps, layer_idx, use_deepep=use_deepep,
+            apply_rope_fusion=apply_rope_fusion)
         self.config = config
         object.__setattr__(self, "embedding", embedding)
         self.detach_encoder = detach_encoder
@@ -286,6 +292,7 @@ class DeepseekV4Model(nn.Module):
         mtp_enable_train: bool = False,
         mtp_detach_encoder: bool = False,
         use_deepep: bool = False,
+        apply_rope_fusion: bool = True,
     ):
         super().__init__()
         del hf_path, use_thd  # DS4 CSA derives its own masking from position_ids.
@@ -327,7 +334,8 @@ class DeepseekV4Model(nn.Module):
         # for its dense-vs-MoE / per-layer logic.
         self.layers = nn.ModuleDict(
             {
-                str(local): DeepseekV4Layer(config, ps, global_idx, use_deepep=use_deepep)
+                str(local): DeepseekV4Layer(config, ps, global_idx, use_deepep=use_deepep,
+                    apply_rope_fusion=apply_rope_fusion)
                 for local, global_idx in enumerate(self.layer_indices)
             }
         )
@@ -358,6 +366,7 @@ class DeepseekV4Model(nn.Module):
                         embedding=mtp_embedding,
                         use_deepep=use_deepep,
                         detach_encoder=mtp_detach_encoder,
+                        apply_rope_fusion=apply_rope_fusion,
                     )
                     for idx in range(config.num_nextn_predict_layers)
                 ]

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
@@ -47,6 +47,7 @@ class ImplConfig:
     recompute: list[str] = field(default_factory=list)
     offload: list[str] = field(default_factory=list)
     use_thd: bool = False
+    apply_rope_fusion: bool = True
     use_deepep: bool = False
     attention_backend_override: str | None = None
     deterministic: bool = True
@@ -381,6 +382,7 @@ def build_model(model_cfg: DeepseekV4Config, *, impl_cfg: ImplConfig) -> ModelBu
                 mtp_enable=mtp_enable,
                 mtp_enable_train=mtp_enable_train,
                 mtp_detach_encoder=impl_cfg.mtp_detach_encoder,
+                apply_rope_fusion=impl_cfg.apply_rope_fusion,
             )
             .to(torch.bfloat16)
             .cuda()

--- a/experimental/lite/megatron/lite/model/glm5/lite/model.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/model.py
@@ -159,7 +159,7 @@ class Glm5DSAAttention(nn.Module):
     The Kimi skeleton therefore never observes the batch-first interior.
     """
 
-    def __init__(self, config: Glm5Config, ps: ParallelState):
+    def __init__(self, config: Glm5Config, ps: ParallelState, *, apply_rope_fusion: bool = True):
         super().__init__()
         self.ps = ps
         self.qk_rope_head_dim = config.qk_rope_head_dim
@@ -188,6 +188,8 @@ class Glm5DSAAttention(nn.Module):
             cp_size=ps.cp_size,
             cp_rank=ps.cp_rank,
             cp_group=ps.cp_group,
+            rope_theta=config.rope_theta,
+            apply_rope_fusion=apply_rope_fusion,
         )
 
     def forward(self, x: torch.Tensor, packed_seq_params=None) -> torch.Tensor:
@@ -446,6 +448,7 @@ class Glm5Layer(nn.Module):
         fp8: bool = False,
         moe_act_recompute: bool = False,
         use_thd: bool = False,
+        apply_rope_fusion: bool = True,
     ):
         super().__init__()
         self.layer_idx = layer_idx
@@ -454,7 +457,7 @@ class Glm5Layer(nn.Module):
         # The wrapper preserves the SBHD self_attention(x, packed_seq_params=)
         # contract so this layer's forward stays identical to Kimi's.
         del use_thd  # DSA derives its own THD handling from packed_seq_params.
-        self.self_attention = Glm5DSAAttention(config, ps)
+        self.self_attention = Glm5DSAAttention(config, ps, apply_rope_fusion=apply_rope_fusion)
         if config.is_moe_layer(layer_idx):
             self.mlp_norm: nn.Module | None = te.RMSNorm(
                 config.hidden_size, eps=config.rms_norm_eps
@@ -511,6 +514,7 @@ class Glm5MTPLayer(nn.Module):
         moe_act_recompute: bool,
         use_thd: bool,
         detach_encoder: bool,
+        apply_rope_fusion: bool,
     ):
         super().__init__()
         self.ps = ps
@@ -534,6 +538,7 @@ class Glm5MTPLayer(nn.Module):
             fp8=fp8,
             moe_act_recompute=moe_act_recompute,
             use_thd=use_thd,
+            apply_rope_fusion=apply_rope_fusion,
         )
         self.final_layernorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 
@@ -583,6 +588,7 @@ class Glm5MTPBlock(nn.Module):
         use_thd: bool,
         detach_encoder: bool,
         repeated_layer: bool,
+        apply_rope_fusion: bool,
     ):
         super().__init__()
         self.num_layers = config.num_nextn_predict_layers
@@ -601,6 +607,7 @@ class Glm5MTPBlock(nn.Module):
                     moe_act_recompute=moe_act_recompute,
                     use_thd=use_thd,
                     detach_encoder=detach_encoder,
+                    apply_rope_fusion=apply_rope_fusion,
                 )
                 for idx in range(layers_to_build)
             ]
@@ -674,6 +681,7 @@ class Glm5Model(nn.Module):
         mtp_enable: bool = False,
         mtp_enable_train: bool = False,
         mtp_detach_encoder: bool = False,
+        apply_rope_fusion: bool = True,
     ):
         super().__init__()
         del hf_path
@@ -719,6 +727,7 @@ class Glm5Model(nn.Module):
                     fp8=train_config.fp8,
                     moe_act_recompute=moe_act_recompute,
                     use_thd=use_thd,
+                    apply_rope_fusion=apply_rope_fusion,
                 )
                 for idx in self.layer_indices
             ]
@@ -748,6 +757,7 @@ class Glm5Model(nn.Module):
                 use_thd=use_thd,
                 detach_encoder=mtp_detach_encoder,
                 repeated_layer=config.mtp_use_repeated_layer,
+                apply_rope_fusion=apply_rope_fusion,
             )
 
         self.sp_params: list[nn.Parameter] = []

--- a/experimental/lite/megatron/lite/model/glm5/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/protocol.py
@@ -91,6 +91,7 @@ class ImplConfig:
     offload: list[str] = field(default_factory=list)
     use_deepep: bool = False
     use_thd: bool = False
+    apply_rope_fusion: bool = True
     cross_entropy_fusion: bool = False
     hf_path: str = ""
     attention_backend_override: str | None = None
@@ -220,6 +221,7 @@ def build_model(model_cfg: Glm5Config, *, impl_cfg: ImplConfig) -> ModelBundle:
         mtp_enable=mtp_enable,
         mtp_enable_train=mtp_enable_train,
         mtp_detach_encoder=impl_cfg.mtp_detach_encoder,
+        apply_rope_fusion=impl_cfg.apply_rope_fusion,
     )
 
     if vpp is None:

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/model.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/model.py
@@ -331,6 +331,7 @@ class KimiK2Layer(nn.Module):
         fp8: bool = False,
         moe_act_recompute: bool = False,
         use_thd: bool = False,
+        apply_rope_fusion: bool = True,
     ):
         super().__init__()
         self.layer_idx = layer_idx
@@ -348,6 +349,7 @@ class KimiK2Layer(nn.Module):
             rope_theta=config.rope_theta,
             rope_scaling=config.rope_scaling,
             use_thd=use_thd,
+            apply_rope_fusion=apply_rope_fusion,
         )
         if config.is_moe_layer(layer_idx):
             self.mlp_norm: nn.Module | None = te.RMSNorm(
@@ -405,6 +407,7 @@ class KimiK2MTPLayer(nn.Module):
         moe_act_recompute: bool,
         use_thd: bool,
         detach_encoder: bool,
+        apply_rope_fusion: bool,
     ):
         super().__init__()
         self.ps = ps
@@ -428,6 +431,7 @@ class KimiK2MTPLayer(nn.Module):
             fp8=fp8,
             moe_act_recompute=moe_act_recompute,
             use_thd=use_thd,
+            apply_rope_fusion=apply_rope_fusion,
         )
         self.final_layernorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 
@@ -477,6 +481,7 @@ class KimiK2MTPBlock(nn.Module):
         use_thd: bool,
         detach_encoder: bool,
         repeated_layer: bool,
+        apply_rope_fusion: bool,
     ):
         super().__init__()
         self.num_layers = config.num_nextn_predict_layers
@@ -495,6 +500,7 @@ class KimiK2MTPBlock(nn.Module):
                     moe_act_recompute=moe_act_recompute,
                     use_thd=use_thd,
                     detach_encoder=detach_encoder,
+                    apply_rope_fusion=apply_rope_fusion,
                 )
                 for idx in range(layers_to_build)
             ]
@@ -568,6 +574,7 @@ class KimiK2Model(nn.Module):
         mtp_enable: bool = False,
         mtp_enable_train: bool = False,
         mtp_detach_encoder: bool = False,
+        apply_rope_fusion: bool = True,
     ):
         super().__init__()
         del hf_path
@@ -609,6 +616,7 @@ class KimiK2Model(nn.Module):
                     fp8=train_config.fp8,
                     moe_act_recompute=moe_act_recompute,
                     use_thd=use_thd,
+                    apply_rope_fusion=apply_rope_fusion,
                 )
                 for idx in self.layer_indices
             ]
@@ -638,6 +646,7 @@ class KimiK2Model(nn.Module):
                 use_thd=use_thd,
                 detach_encoder=mtp_detach_encoder,
                 repeated_layer=config.mtp_use_repeated_layer,
+                apply_rope_fusion=apply_rope_fusion,
             )
 
         self.sp_params: list[nn.Parameter] = []

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/protocol.py
@@ -75,6 +75,7 @@ class ImplConfig:
     offload: list[str] = field(default_factory=list)
     use_deepep: bool = False
     use_thd: bool = False
+    apply_rope_fusion: bool = True
     cross_entropy_fusion: bool = False
     hf_path: str = ""
     attention_backend_override: str | None = None
@@ -180,6 +181,7 @@ def build_model(model_cfg: KimiK2Config, *, impl_cfg: ImplConfig) -> ModelBundle
         mtp_enable=mtp_enable,
         mtp_enable_train=mtp_enable_train,
         mtp_detach_encoder=impl_cfg.mtp_detach_encoder,
+        apply_rope_fusion=impl_cfg.apply_rope_fusion,
     )
 
     if vpp is None:

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
@@ -233,6 +233,7 @@ class Qwen35Layer(nn.Module):
         use_thd: bool = False,
         deterministic: bool = False,
         gdn_cp_mode: str = "replicated",
+        apply_rope_fusion: bool = True,
     ):
         super().__init__()
         self.layer_idx = layer_idx
@@ -254,6 +255,7 @@ class Qwen35Layer(nn.Module):
                 zero_centered_gamma=True,
                 qkv_layout="mcore",
                 mrope_section=_qwen_mrope_section(config),
+                apply_rope_fusion=apply_rope_fusion,
             )
         else:
             self.linear_attn = GatedDeltaNet(
@@ -336,6 +338,7 @@ class Qwen35Model(nn.Module):
         mtp_detach_encoder: bool = False,
         mount_vision_model: bool = False,
         gdn_cp_mode: str = "replicated",
+        apply_rope_fusion: bool = True,
     ):
         super().__init__()
         del attention_backend_override
@@ -378,6 +381,7 @@ class Qwen35Model(nn.Module):
                     use_thd=use_thd,
                     deterministic=getattr(train_config, "deterministic", False),
                     gdn_cp_mode=gdn_cp_mode,
+                    apply_rope_fusion=apply_rope_fusion,
                 )
                 for idx in self.layer_indices
             ]
@@ -416,6 +420,7 @@ class Qwen35Model(nn.Module):
                         use_thd=use_thd,
                         deterministic=getattr(train_config, "deterministic", False),
                         gdn_cp_mode=gdn_cp_mode,
+                        apply_rope_fusion=apply_rope_fusion,
                     ),
                     detach_encoder=mtp_detach_encoder,
                 )

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
@@ -53,6 +53,7 @@ class ImplConfig:
     offload: list[str] = field(default_factory=list)
     use_deepep: bool = False
     use_thd: bool = False
+    apply_rope_fusion: bool = True
     cross_entropy_fusion: bool = False
     hf_path: str = ""
     attention_backend_override: str | None = None
@@ -200,6 +201,7 @@ def build_model(model_cfg: Qwen35Config, *, impl_cfg: ImplConfig) -> ModelBundle
         mtp_detach_encoder=impl_cfg.mtp_detach_encoder,
         mount_vision_model=impl_cfg.mount_vision_model,
         gdn_cp_mode=impl_cfg.gdn_cp_mode,
+        apply_rope_fusion=impl_cfg.apply_rope_fusion,
     )
 
     if vpp is None:

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
@@ -51,6 +51,7 @@ class MoELayer(nn.Module):
         fp8: bool = False,
         moe_act_recompute: bool = False,
         lora_config: LoraConfig | dict | None = None,
+        apply_rope_fusion: bool = True,
     ):
         super().__init__()
         # Match Qwen3-MoE's `load_balancing_type="none"` setting: no aux loss.
@@ -126,6 +127,7 @@ class TransformerLayer(nn.Module):
         moe_act_recompute: bool = False,
         use_thd: bool = False,
         lora_config: LoraConfig | dict | None = None,
+        apply_rope_fusion: bool = True,
     ):
         super().__init__()
         self.layer_idx = layer_idx
@@ -146,6 +148,7 @@ class TransformerLayer(nn.Module):
             use_thd=use_thd,
             qkv_layout="mcore",
             lora_config=lora_config,
+            apply_rope_fusion=apply_rope_fusion,
         )
         self.mlp_norm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.moe = MoELayer(
@@ -213,6 +216,7 @@ class MultiTokenPredictionLayer(nn.Module):
         use_thd: bool,
         detach_encoder: bool,
         lora_config: LoraConfig | dict | None,
+        apply_rope_fusion: bool,
     ):
         super().__init__()
         self.ps = ps
@@ -233,6 +237,7 @@ class MultiTokenPredictionLayer(nn.Module):
             moe_act_recompute=moe_act_recompute,
             use_thd=use_thd,
             lora_config=lora_config,
+            apply_rope_fusion=apply_rope_fusion,
         )
         self.final_layernorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 
@@ -287,6 +292,7 @@ class MultiTokenPredictionBlock(nn.Module):
         detach_encoder: bool,
         repeated_layer: bool,
         lora_config: LoraConfig | dict | None,
+        apply_rope_fusion: bool,
     ):
         super().__init__()
         self.num_layers = config.num_nextn_predict_layers
@@ -306,6 +312,7 @@ class MultiTokenPredictionBlock(nn.Module):
                     use_thd=use_thd,
                     detach_encoder=detach_encoder,
                     lora_config=lora_config,
+                    apply_rope_fusion=apply_rope_fusion,
                 )
                 for idx in range(layers_to_build)
             ]
@@ -361,6 +368,7 @@ class Qwen3MoEModel(nn.Module):
         mtp_enable_train: bool = False,
         mtp_detach_encoder: bool = False,
         lora_config: LoraConfig | dict | None = None,
+        apply_rope_fusion: bool = True,
     ):
         super().__init__()
         self.config = config
@@ -395,6 +403,7 @@ class Qwen3MoEModel(nn.Module):
                     moe_act_recompute=moe_act_recompute,
                     use_thd=use_thd,
                     lora_config=lora_config,
+                    apply_rope_fusion=apply_rope_fusion,
                 )
                 for idx in self.layer_indices
             ]
@@ -425,6 +434,7 @@ class Qwen3MoEModel(nn.Module):
                 detach_encoder=mtp_detach_encoder,
                 repeated_layer=config.mtp_use_repeated_layer,
                 lora_config=lora_config,
+                apply_rope_fusion=apply_rope_fusion,
             )
 
         self.sp_params: list[nn.Parameter] = []

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
@@ -75,6 +75,7 @@ class ImplConfig:
     offload: list[str] = field(default_factory=list)
     use_deepep: bool = False
     use_thd: bool = False
+    apply_rope_fusion: bool = True
     cross_entropy_fusion: bool = False
     router_aux_loss_coef: float | None = None
     router_bias_rate: float = 0.0
@@ -179,6 +180,7 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
         recompute_modules=recompute_spec,
         router_bias_rate=impl_cfg.router_bias_rate,
         use_thd=impl_cfg.use_thd,
+        apply_rope_fusion=impl_cfg.apply_rope_fusion,
         mtp_enable=mtp_enable,
         mtp_enable_train=mtp_enable_train,
         mtp_detach_encoder=impl_cfg.mtp_detach_encoder,

--- a/experimental/lite/megatron/lite/primitive/kernels/rope.py
+++ b/experimental/lite/megatron/lite/primitive/kernels/rope.py
@@ -1,0 +1,146 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Fused RoPE kernel boundary for MLite attention primitives."""
+
+from __future__ import annotations
+
+from importlib import import_module
+
+import torch
+
+
+def _require_contiguous_last_dim(tensor: torch.Tensor, name: str) -> None:
+    if tensor.stride(-1) != 1:
+        raise ValueError(f"{name} must have a contiguous last dimension")
+
+
+def _load_generic_kernels():
+    try:
+        module = import_module("megatron.core.extensions.transformer_engine")
+        return module.fused_apply_rotary_pos_emb, module.fused_apply_rotary_pos_emb_thd
+    except (ImportError, AttributeError) as exc:
+        raise RuntimeError(
+            "Fused generic RoPE requires Megatron-Core's Transformer Engine RoPE kernels"
+        ) from exc
+
+
+def _load_mla_kernels():
+    try:
+        module = import_module("megatron.core.fusions.fused_mla_yarn_rope_apply")
+        return module.fused_mla_rope_inplace, module.fused_mla_rope_kv_split
+    except (ImportError, AttributeError) as exc:
+        raise RuntimeError("Fused MLA RoPE kernels are unavailable") from exc
+
+
+def apply_fused_rotary(
+    tensor: torch.Tensor,
+    freqs: torch.Tensor,
+    *,
+    cu_seqlens: torch.Tensor | None = None,
+    cp_rank: int = 0,
+    cp_size: int = 1,
+    rotary_interleaved: bool = False,
+) -> torch.Tensor:
+    """Apply the upstream TE-backed fused SBHD or THD RoPE kernel."""
+    _require_contiguous_last_dim(tensor, "tensor")
+    if cu_seqlens is None:
+        if tensor.ndim != 4:
+            raise ValueError("Fused SBHD RoPE expects a 4-D [S,B,H,D] tensor")
+        if cp_size != 1 or cp_rank != 0:
+            raise ValueError("SBHD frequencies must already be CP-local")
+        fused_sbhd, _ = _load_generic_kernels()
+        return fused_sbhd(tensor, freqs, interleaved=rotary_interleaved)
+    if tensor.ndim != 3:
+        raise ValueError("Fused THD RoPE expects a 3-D [T,H,D] tensor")
+    if cp_size < 1 or not 0 <= cp_rank < cp_size:
+        raise ValueError(f"Invalid CP coordinates rank={cp_rank}, size={cp_size}")
+    _, fused_thd = _load_generic_kernels()
+    return fused_thd(
+        tensor,
+        cu_seqlens,
+        freqs,
+        cp_size=cp_size,
+        cp_rank=cp_rank,
+        interleaved=rotary_interleaved,
+    )
+
+
+def apply_fused_mla_rotary_for_q(
+    tensor: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    *,
+    nope_dim: int,
+    rope_dim: int,
+    cu_seqlens: torch.Tensor | None = None,
+    cp_rank: int = 0,
+    cp_size: int = 1,
+    inverse: bool = False,
+    remove_interleaving: bool = False,
+) -> torch.Tensor:
+    """Apply upstream in-place MLA Q RoPE; callers own any required clone."""
+    _require_contiguous_last_dim(tensor, "tensor")
+    if tensor.shape[-1] != nope_dim + rope_dim:
+        raise ValueError("MLA Q last dimension does not match NoPE + RoPE dimensions")
+    if rope_dim % 4:
+        raise ValueError("MLA fused RoPE dimension must be divisible by 4")
+    fused_q, _ = _load_mla_kernels()
+    return fused_q(
+        tensor,
+        cos,
+        sin,
+        nope_dim,
+        rope_dim,
+        cu_seqlens,
+        cp_rank,
+        cp_size,
+        False,
+        inverse,
+        remove_interleaving,
+    )
+
+
+def apply_fused_mla_rotary_for_kv(
+    kv: torch.Tensor,
+    k_pos_emb: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    *,
+    rope_dim: int,
+    key_nope_dim: int,
+    value_dim: int,
+    cu_seqlens_kv: torch.Tensor | None = None,
+    cp_rank: int = 0,
+    cp_size: int = 1,
+    remove_interleaving: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Split compressed KV and apply upstream fused MLA KV RoPE."""
+    _require_contiguous_last_dim(kv, "kv")
+    _require_contiguous_last_dim(k_pos_emb, "k_pos_emb")
+    if kv.shape[-1] != key_nope_dim + value_dim:
+        raise ValueError(
+            "MLA KV last dimension does not match key NoPE + value dimensions"
+        )
+    if rope_dim % 4:
+        raise ValueError("MLA fused RoPE dimension must be divisible by 4")
+    _, fused_kv = _load_mla_kernels()
+    return fused_kv(
+        kv,
+        k_pos_emb,
+        cos,
+        sin,
+        rope_dim,
+        key_nope_dim,
+        value_dim,
+        cu_seqlens_kv,
+        cp_rank,
+        cp_size,
+        False,
+        remove_interleaving,
+    )
+
+
+__all__ = [
+    "apply_fused_mla_rotary_for_kv",
+    "apply_fused_mla_rotary_for_q",
+    "apply_fused_rotary",
+]

--- a/experimental/lite/megatron/lite/primitive/modules/attention/csa.py
+++ b/experimental/lite/megatron/lite/primitive/modules/attention/csa.py
@@ -5,6 +5,7 @@ from typing import Any
 import torch
 import torch.nn as nn
 import transformer_engine.pytorch as te
+from megatron.lite.primitive.kernels.rope import apply_fused_mla_rotary_for_q
 from megatron.lite.primitive.modules.attention.dsa import rotate_activation
 from megatron.lite.primitive.modules.attention.cp import (
     compress_contiguous_chunks_for_cp,
@@ -122,8 +123,29 @@ def apply_partial_rope(
     return torch.cat([tail, rope_out], dim=-1)
 
 
+def _apply_partial_rope_dispatch(x, cos, sin, rope_head_dim, *, fused, inverse=False):
+    if not fused:
+        return apply_partial_rope(x, cos, -sin if inverse else sin, rope_head_dim)
+    if rope_head_dim == 0:
+        return x
+    if x.ndim != 4 or cos.ndim != 3 or sin.ndim != 3:
+        raise ValueError("Fused CSA RoPE expects BHSD tensors and BSD cosine/sine tables")
+    if cos.size(0) != 1 and not torch.equal(cos, cos[:1].expand_as(cos)):
+        raise ValueError("Fused CSA RoPE requires identical positions across the batch")
+    if sin.size(0) != 1 and not torch.equal(sin, sin[:1].expand_as(sin)):
+        raise ValueError("Fused CSA RoPE requires identical positions across the batch")
+    sbhd = x.permute(2, 0, 1, 3).contiguous().clone()
+    cos = cos[0].view(cos.size(1), 1, 1, cos.size(2)).contiguous()
+    sin = sin[0].view(sin.size(1), 1, 1, sin.size(2)).contiguous()
+    out = apply_fused_mla_rotary_for_q(sbhd, cos, sin,
+        nope_dim=x.size(-1) - rope_head_dim, rope_dim=rope_head_dim,
+        inverse=inverse, remove_interleaving=True)
+    return out.permute(1, 2, 0, 3).contiguous()
+
+
 class CompressedSequenceCompressor(nn.Module):
-    def __init__(self, config: Any, compress_ratio: int, head_dim: int, *, rotate: bool = False):
+    def __init__(self, config: Any, compress_ratio: int, head_dim: int, *,
+        rotate: bool = False, apply_rope_fusion: bool = True):
         super().__init__()
         self.config = config
         self.compress_ratio = compress_ratio
@@ -132,6 +154,7 @@ class CompressedSequenceCompressor(nn.Module):
         self.overlap = compress_ratio == 4
         self.coff = 2 if self.overlap else 1
         self.rotate = rotate
+        self.apply_rope_fusion = apply_rope_fusion
         self.wkv = nn.Linear(config.hidden_size, self.coff * head_dim, bias=False)
         self.wgate = nn.Linear(config.hidden_size, self.coff * head_dim, bias=False)
         self.ape = nn.Parameter(
@@ -179,7 +202,8 @@ class CompressedSequenceCompressor(nn.Module):
             device=x.device,
             dtype=compressed.dtype,
         )
-        compressed = apply_partial_rope(compressed, cos, sin, self.rope_head_dim)
+        compressed = _apply_partial_rope_dispatch(compressed, cos, sin,
+            self.rope_head_dim, fused=self.apply_rope_fusion)
         return rotate_activation(compressed) if self.rotate else compressed
 
 
@@ -217,7 +241,7 @@ def _load_dsa_kernels():
 
 
 class CompressedSparseAttentionIndexer(nn.Module):
-    def __init__(self, config, compress_ratio: int):
+    def __init__(self, config, compress_ratio: int, *, apply_rope_fusion: bool = True):
         super().__init__()
         self.config = config
         self.index_n_heads = config.index_n_heads
@@ -225,12 +249,14 @@ class CompressedSparseAttentionIndexer(nn.Module):
         self.index_topk = config.index_topk
         self.rope_head_dim = min(config.qk_rope_head_dim, config.index_head_dim)
         self.softmax_scale = self.index_head_dim**-0.5
+        self.apply_rope_fusion = apply_rope_fusion
         self.wq_b = nn.Linear(
             config.q_lora_rank, config.index_n_heads * config.index_head_dim, bias=False
         )
         self.weights_proj = nn.Linear(config.hidden_size, config.index_n_heads, bias=False)
         self.compressor = CompressedSequenceCompressor(
-            config, compress_ratio, config.index_head_dim, rotate=True
+            config, compress_ratio, config.index_head_dim, rotate=True,
+            apply_rope_fusion=apply_rope_fusion
         )
 
 
@@ -241,6 +267,7 @@ class CompressedSparseAttention(nn.Module):
         *,
         layer_idx: int,
         ps: ParallelState,
+        apply_rope_fusion: bool = True,
     ):
         super().__init__()
         self.config = config
@@ -249,6 +276,7 @@ class CompressedSparseAttention(nn.Module):
         self.num_heads = config.num_attention_heads
         self.head_dim = config.head_dim
         self.rope_head_dim = config.qk_rope_head_dim
+        self.apply_rope_fusion = apply_rope_fusion
         self.num_heads_per_group = config.num_attention_heads // config.o_groups
         # MTP layers use layer_idx == num_hidden_layers (+i), which is past the
         # per-decoder-layer compress_ratios list (length num_hidden_layers); fall
@@ -271,12 +299,14 @@ class CompressedSparseAttention(nn.Module):
         self.wo_b = nn.Linear(config.o_groups * config.o_lora_rank, config.hidden_size, bias=False)
         self.sinks = nn.Parameter(torch.zeros(self.num_heads))
         self.compressor = (
-            CompressedSequenceCompressor(config, self.compress_ratio, self.head_dim)
+            CompressedSequenceCompressor(config, self.compress_ratio, self.head_dim,
+                apply_rope_fusion=apply_rope_fusion)
             if self.compress_ratio > 1
             else None
         )
         self.indexer = (
-            CompressedSparseAttentionIndexer(config, self.compress_ratio)
+            CompressedSparseAttentionIndexer(config, self.compress_ratio,
+                apply_rope_fusion=apply_rope_fusion)
             if self.compress_ratio == 4
             else None
         )
@@ -309,8 +339,10 @@ class CompressedSparseAttention(nn.Module):
             q.float().pow(2).mean(dim=-1, keepdim=True) + self.config.rms_norm_eps
         ).to(dtype=q.dtype)
         kv = self.kv_norm(self.wkv(x)).view(batch, seq_len, 1, self.head_dim).transpose(1, 2)
-        q = apply_partial_rope(q, cos, sin, self.rope_head_dim)
-        kv = apply_partial_rope(kv, cos, sin, self.rope_head_dim)
+        q = _apply_partial_rope_dispatch(q, cos, sin, self.rope_head_dim,
+            fused=self.apply_rope_fusion)
+        kv = _apply_partial_rope_dispatch(kv, cos, sin, self.rope_head_dim,
+            fused=self.apply_rope_fusion)
         use_sparse_backend = self.attention_backend not in {"local", "eager", "torch"}
         if (
             use_sparse_backend
@@ -425,7 +457,8 @@ class CompressedSparseAttention(nn.Module):
                         )
                         .transpose(1, 2)
                     )
-                    q_idx = apply_partial_rope(q_idx, idx_cos, idx_sin, self.indexer.rope_head_dim)
+                    q_idx = _apply_partial_rope_dispatch(q_idx, idx_cos, idx_sin,
+                        self.indexer.rope_head_dim, fused=self.apply_rope_fusion)
                     index_weights = (
                         self.indexer.weights_proj(x).float()
                         * (self.indexer.index_n_heads**-0.5)
@@ -476,7 +509,8 @@ class CompressedSparseAttention(nn.Module):
     def _project_context(
         self, context: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor
     ) -> torch.Tensor:
-        context = apply_partial_rope(context, cos, -sin, self.rope_head_dim).transpose(1, 2)
+        context = _apply_partial_rope_dispatch(context, cos, sin, self.rope_head_dim,
+            fused=self.apply_rope_fusion, inverse=True).transpose(1, 2)
         batch, seq_len = context.shape[:2]
         grouped = context.reshape(
             batch, seq_len, self.config.o_groups, self.num_heads_per_group * self.head_dim
@@ -638,7 +672,8 @@ class CompressedSparseAttention(nn.Module):
             batch, seq_len, self.indexer.index_n_heads, self.indexer.index_head_dim
         )
         q_indexer = q_indexer.transpose(1, 2)
-        q_indexer = apply_partial_rope(q_indexer, idx_cos, idx_sin, self.indexer.rope_head_dim)
+        q_indexer = _apply_partial_rope_dispatch(q_indexer, idx_cos, idx_sin,
+            self.indexer.rope_head_dim, fused=self.apply_rope_fusion)
         q_indexer = rotate_activation(q_indexer)
         q_indexer = q_indexer.transpose(1, 2).transpose(0, 1).contiguous()
         weights_indexer = (

--- a/experimental/lite/megatron/lite/primitive/modules/attention/dsa.py
+++ b/experimental/lite/megatron/lite/primitive/modules/attention/dsa.py
@@ -23,6 +23,7 @@ from megatron.lite.primitive.parallel.thd import (
 )
 
 from megatron.lite.primitive.kernels import dsa_kernels as _dsa_kernels
+from megatron.lite.primitive.kernels.rope import apply_fused_rotary
 
 if TYPE_CHECKING:
     from megatron.lite.primitive.modules.attention.mla import MultiLatentAttention
@@ -111,8 +112,9 @@ def build_rope_cache(
 
 
 def build_rotary_embeddings(
-    *, position_ids: torch.Tensor, dim: int, rope_theta: float, dtype: torch.dtype
-) -> tuple[torch.Tensor, torch.Tensor]:
+    *, position_ids: torch.Tensor, dim: int, rope_theta: float, dtype: torch.dtype,
+    return_freqs: bool = False,
+) -> tuple[torch.Tensor, ...]:
     device = position_ids.device
     inv_freq = 1.0 / (
         rope_theta
@@ -126,7 +128,17 @@ def build_rotary_embeddings(
         emb = torch.cat((freqs, freqs), dim=-1)
         cos = emb.cos()
         sin = emb.sin()
-    return cos.to(dtype=dtype), sin.to(dtype=dtype)
+    result = (cos.to(dtype=dtype), sin.to(dtype=dtype))
+    return (*result, emb) if return_freqs else result
+
+
+def _apply_fused_dsa_rope(x: torch.Tensor, freqs: torch.Tensor) -> torch.Tensor:
+    if x.ndim != 4 or freqs.ndim != 3:
+        raise ValueError("Fused DSA RoPE expects BSHD tensors and BSD phase tables")
+    if freqs.size(0) != 1 and not torch.equal(freqs, freqs[:1].expand_as(freqs)):
+        raise ValueError("Fused DSA RoPE requires identical positions across the batch")
+    phase = freqs[0].view(freqs.size(1), 1, 1, freqs.size(2)).contiguous()
+    return apply_fused_rotary(x.permute(1, 0, 2, 3).contiguous(), phase).permute(1, 0, 2, 3).contiguous()
 
 
 def rotate_half(x: torch.Tensor) -> torch.Tensor:
@@ -224,6 +236,7 @@ class DSAIndexer(nn.Module):
         layer_norm_eps: float = 1e-5,
         rope_first: bool = False,
         use_hadamard: bool = True,
+        apply_rope_fusion: bool = True,
     ):
         super().__init__()
         if index_head_dim < qk_rope_head_dim:
@@ -236,6 +249,7 @@ class DSAIndexer(nn.Module):
         self.rope_interleaved = rope_interleaved
         self.rope_first = rope_first
         self.use_hadamard = use_hadamard
+        self.apply_rope_fusion = apply_rope_fusion
 
         self.wq_b = nn.Linear(q_lora_rank, index_n_heads * index_head_dim, bias=False)
         self.wk = nn.Linear(hidden_size, index_head_dim, bias=False)
@@ -250,6 +264,7 @@ class DSAIndexer(nn.Module):
         cos: torch.Tensor,
         sin: torch.Tensor,
         position_ids: torch.Tensor,
+        freqs: torch.Tensor | None = None,
         attention_mask: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Project GLM5 indexer inputs for Megatron's fused DSA kernels."""
@@ -272,8 +287,14 @@ class DSAIndexer(nn.Module):
         else:
             q_nope, q_pe = torch.split(q, [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
             k_nope, k_pe = torch.split(k, [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
-        q_pe = apply_rotary_pos_emb(q_pe, cos, sin, unsqueeze_dim=2)
-        k_pe = apply_rotary_pos_emb(k_pe.unsqueeze(2), cos, sin, unsqueeze_dim=2)
+        if self.apply_rope_fusion:
+            if freqs is None:
+                raise ValueError("Fused DSA indexer RoPE requires phase frequencies")
+            q_pe = _apply_fused_dsa_rope(q_pe, freqs)
+            k_pe = _apply_fused_dsa_rope(k_pe.unsqueeze(2), freqs)
+        else:
+            q_pe = apply_rotary_pos_emb(q_pe, cos, sin, unsqueeze_dim=2)
+            k_pe = apply_rotary_pos_emb(k_pe.unsqueeze(2), cos, sin, unsqueeze_dim=2)
         k_pe = k_pe.squeeze(2)
 
         if self.rope_first:
@@ -300,10 +321,11 @@ class DSAIndexer(nn.Module):
         cos: torch.Tensor,
         sin: torch.Tensor,
         position_ids: torch.Tensor,
+        freqs: torch.Tensor | None = None,
         attention_mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
         q, k, weights = self.forward_before_topk(
-            x, q_resid, cos, sin, position_ids, attention_mask=attention_mask
+            x, q_resid, cos, sin, position_ids, freqs, attention_mask=attention_mask
         )
         topk_indices, _ = _dsa_kernels.indexer_topk(
             q,
@@ -351,6 +373,8 @@ class DynamicSparseAttention(nn.Module):
         cp_size: int = 1,
         cp_rank: int = 0,
         cp_group=None,
+        rope_theta: float = 10_000.0,
+        apply_rope_fusion: bool = True,
     ):
         super().__init__()
         if cp_size < 1:
@@ -372,6 +396,8 @@ class DynamicSparseAttention(nn.Module):
         self.cp_size = cp_size
         self.cp_rank = cp_rank
         self.cp_group = cp_group
+        self.rope_theta = rope_theta
+        self.apply_rope_fusion = apply_rope_fusion
         latent_rms_norm_eps = rms_norm_eps if latent_rms_norm_eps is None else latent_rms_norm_eps
         indexer_rope_interleaved = (
             rope_interleaved if indexer_rope_interleaved is None else indexer_rope_interleaved
@@ -399,6 +425,7 @@ class DynamicSparseAttention(nn.Module):
             layer_norm_eps=indexer_layer_norm_eps,
             rope_first=indexer_rope_first,
             use_hadamard=indexer_use_hadamard,
+            apply_rope_fusion=apply_rope_fusion,
         )
         self.register_buffer(
             "attn_sink",
@@ -494,11 +521,16 @@ class DynamicSparseAttention(nn.Module):
         q_resid = self.q_a_layernorm(self.q_a_proj(x))
         q = self.q_b_proj(q_resid).view(batch, seq_len, self.num_heads, self.qk_head_dim)
         q_nope, q_pe = torch.split(q, [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
-        cos, sin = _rotary_embeddings_from_cache(
-            cos, sin, position_ids, device=x.device, dtype=x.dtype, dim=self.qk_rope_head_dim
-        )
+        if self.apply_rope_fusion:
+            cos, sin, freqs = build_rotary_embeddings(position_ids=position_ids,
+                dim=self.qk_rope_head_dim, rope_theta=self.rope_theta,
+                dtype=x.dtype, return_freqs=True)
+        else:
+            cos, sin = _rotary_embeddings_from_cache(cos, sin, position_ids,
+                device=x.device, dtype=x.dtype, dim=self.qk_rope_head_dim)
+            freqs = None
 
-        q_pe = apply_rotary_pos_emb(q_pe, cos, sin, unsqueeze_dim=2)
+        q_pe = _apply_fused_dsa_rope(q_pe, freqs) if self.apply_rope_fusion else apply_rotary_pos_emb(q_pe, cos, sin, unsqueeze_dim=2)
         k_up_weight, v_up_weight = self._split_kv_b_weights()
         q_nope = torch.einsum("bshd,hdr->bshr", q_nope, k_up_weight)
         query_states = torch.cat([q_nope, q_pe], dim=-1).transpose(0, 1).contiguous()
@@ -507,11 +539,12 @@ class DynamicSparseAttention(nn.Module):
             self.kv_a_proj_with_mqa(x), [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1
         )
         kv_latent = self.kv_a_layernorm(kv_latent)
-        k_pe = apply_rotary_pos_emb(k_pe.unsqueeze(2), cos, sin, unsqueeze_dim=2).squeeze(2)
+        k_pe = (_apply_fused_dsa_rope(k_pe.unsqueeze(2), freqs) if self.apply_rope_fusion
+            else apply_rotary_pos_emb(k_pe.unsqueeze(2), cos, sin, unsqueeze_dim=2)).squeeze(2)
         kv_full = torch.cat([kv_latent, k_pe], dim=-1).transpose(0, 1).contiguous()
 
         q_indexer, k_indexer, weights_indexer = self.indexer.forward_before_topk(
-            x.detach(), q_resid.detach(), cos, sin, position_ids
+            x.detach(), q_resid.detach(), cos, sin, position_ids, freqs
         )
         effective_indexer_topk = min(self.indexer.index_topk, seq_len)
 

--- a/experimental/lite/megatron/lite/primitive/modules/attention/mla.py
+++ b/experimental/lite/megatron/lite/primitive/modules/attention/mla.py
@@ -9,6 +9,9 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import transformer_engine.pytorch as te
+from megatron.lite.primitive.kernels.rope import (
+    apply_fused_mla_rotary_for_kv, apply_fused_mla_rotary_for_q,
+)
 from megatron.lite.primitive.utils.rope import (
     _apply_rotary_pos_emb_bshd,
     _apply_rotary_pos_emb_thd,
@@ -90,6 +93,7 @@ class MultiLatentAttention(nn.Module):
         rope_theta: float = 10_000.0,
         rope_scaling: dict | None = None,
         use_thd: bool = False,
+        apply_rope_fusion: bool = True,
     ):
         super().__init__()
         if num_attention_heads % ps.tp_size != 0:
@@ -102,6 +106,7 @@ class MultiLatentAttention(nn.Module):
         self.qk_rope_head_dim = qk_rope_head_dim
         self.v_head_dim = v_head_dim
         self.q_head_dim = qk_nope_head_dim + qk_rope_head_dim
+        self.apply_rope_fusion = apply_rope_fusion
 
         self.linear_proj = RowParallelLinear(
             num_attention_heads * v_head_dim,
@@ -210,26 +215,27 @@ class MultiLatentAttention(nn.Module):
             self.num_heads_local,
             self.qk_nope_head_dim + self.v_head_dim,
         )
-        q_nope, q_pos = q.split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
-        k_nope, value = kv.split([self.qk_nope_head_dim, self.v_head_dim], dim=-1)
         k_pos = k_pos_emb.unsqueeze(-2)
 
         is_thd = packed_seq_params is not None
         if is_thd:
-            q_nope = q_nope.squeeze(1)
-            q_pos = q_pos.squeeze(1)
-            k_nope = k_nope.squeeze(1)
-            value = value.squeeze(1)
+            q = q.squeeze(1)
+            kv = kv.squeeze(1)
             k_pos = k_pos.squeeze(1)
 
-        q_pos, k_pos = self._apply_rope(q_pos, k_pos, packed_seq_params)
-        if k_pos.dim() == q_nope.dim():
-            k_pos = k_pos.expand(*q_nope.shape[:-1], self.qk_rope_head_dim)
+        if self.apply_rope_fusion:
+            query, key, value = self._apply_fused_rope(q, kv, k_pos, packed_seq_params)
         else:
-            k_pos = k_pos.expand(-1, -1, self.num_heads_local, -1)
-        query = torch.cat([q_nope, q_pos], dim=-1).contiguous()
-        key = torch.cat([k_nope, k_pos], dim=-1).contiguous()
-        value = value.contiguous()
+            q_nope, q_pos = q.split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
+            k_nope, value = kv.split([self.qk_nope_head_dim, self.v_head_dim], dim=-1)
+            q_pos, k_pos = self._apply_rope(q_pos, k_pos, packed_seq_params)
+            if k_pos.dim() == q_nope.dim():
+                k_pos = k_pos.expand(*q_nope.shape[:-1], self.qk_rope_head_dim)
+            else:
+                k_pos = k_pos.expand(-1, -1, self.num_heads_local, -1)
+            query = torch.cat([q_nope, q_pos], dim=-1).contiguous()
+            key = torch.cat([k_nope, k_pos], dim=-1).contiguous()
+            value = value.contiguous()
         if self._query_scale != 1.0:
             query = query * self._query_scale
 
@@ -413,6 +419,38 @@ class MultiLatentAttention(nn.Module):
             _apply_mla_rope_bshd(q_pos, freqs, mscale=mscale),
             _apply_mla_rope_bshd(k_pos, freqs, mscale=mscale),
         )
+
+    def _apply_fused_rope(self, q, kv, k_pos, packed_seq_params):
+        is_thd = packed_seq_params is not None
+        if is_thd:
+            max_q = getattr(packed_seq_params, "max_seqlen_q", None)
+            max_kv = getattr(packed_seq_params, "max_seqlen_kv", None)
+            seq_len = int(max(max_q, max_kv)) if max_q is not None and max_kv is not None else int(packed_seq_params.cu_seqlens_q[-1])
+            freqs = self.rotary(seq_len, packed_seq=True)
+        else:
+            freqs = self.rotary(q.size(0) * self.ps.cp_size)
+        if isinstance(freqs, tuple):
+            freqs, mscale = freqs
+        else:
+            mscale = 1.0
+        cos = (freqs.cos() * mscale).to(dtype=q.dtype).contiguous()
+        sin = (freqs.sin() * mscale).to(dtype=q.dtype).contiguous()
+        q_cu = kv_cu = None
+        cp_rank, cp_size = 0, 1
+        if is_thd:
+            q_cu = getattr(packed_seq_params, "cu_seqlens_q_padded", None)
+            q_cu = packed_seq_params.cu_seqlens_q if q_cu is None else q_cu
+            kv_cu = getattr(packed_seq_params, "cu_seqlens_kv_padded", None)
+            kv_cu = packed_seq_params.cu_seqlens_kv if kv_cu is None else kv_cu
+            cp_rank, cp_size = self.ps.cp_rank, self.ps.cp_size
+        query = apply_fused_mla_rotary_for_q(q.contiguous().clone(), cos, sin,
+            nope_dim=self.qk_nope_head_dim, rope_dim=self.qk_rope_head_dim,
+            cu_seqlens=q_cu, cp_rank=cp_rank, cp_size=cp_size)
+        key, value = apply_fused_mla_rotary_for_kv(kv.contiguous(), k_pos.contiguous(), cos, sin,
+            rope_dim=self.qk_rope_head_dim, key_nope_dim=self.qk_nope_head_dim,
+            value_dim=self.v_head_dim, cu_seqlens_kv=kv_cu,
+            cp_rank=cp_rank, cp_size=cp_size)
+        return query, key, value
 
 
 __all__ = ["MultiLatentAttention"]

--- a/experimental/lite/megatron/lite/primitive/modules/gqa.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gqa.py
@@ -14,6 +14,7 @@ import transformer_engine.pytorch as te
 from megatron.lite.primitive.modules.gqa_utils import split_grouped_qkvg
 from megatron.lite.primitive.modules.lora import LinearLoRA, LoraConfig, normalize_lora_config
 from megatron.lite.primitive.modules.mrope import MultimodalRotaryEmbedding
+from megatron.lite.primitive.kernels.rope import apply_fused_rotary
 from megatron.lite.primitive.parallel import ColumnParallelLinear, ParallelState, RowParallelLinear
 from megatron.lite.primitive.utils import ensure_divisible
 from megatron.lite.primitive.utils.rope import _apply_rotary_pos_emb_bshd, _apply_rotary_pos_emb_thd
@@ -59,6 +60,7 @@ class GQAttention(nn.Module):
         qkv_layout: str = "flat",
         lora_config: LoraConfig | dict | None = None,
         mrope_section: list[int] | None = None,
+        apply_rope_fusion: bool = True,
     ):
         super().__init__()
         self.num_heads_local = ensure_divisible(num_attention_heads, ps.tp_size)
@@ -73,6 +75,7 @@ class GQAttention(nn.Module):
             raise ValueError(f"Unsupported qkv_layout={qkv_layout!r}")
         self._qkv_layout = qkv_layout
         self._mrope_section = list(mrope_section) if mrope_section is not None else None
+        self.apply_rope_fusion = apply_rope_fusion
 
         # Declaration order follows MC's `SelfAttention` submodule order
         # (linear_proj → linear_qkv → q_layernorm → k_layernorm). `named_
@@ -195,7 +198,19 @@ class GQAttention(nn.Module):
             # Packed THD position_ids are already CP-local after protocol.forward
             # prepares the VERL batch; avoid slicing MRoPE frequencies twice.
             freqs = self.rotary(position_ids, self._mrope_section, packed_seq=is_thd)
-            if is_thd:
+            if self.apply_rope_fusion and is_thd:
+                cu = getattr(packed_seq_params, "cu_seqlens_q_padded", None)
+                cu = packed_seq_params.cu_seqlens_q if cu is None else cu
+                q = apply_fused_rotary(q.contiguous(), freqs, cu_seqlens=cu,
+                    cp_rank=self.ps.cp_rank, cp_size=self.ps.cp_size)
+                k = apply_fused_rotary(k.contiguous(), freqs, cu_seqlens=cu,
+                    cp_rank=self.ps.cp_rank, cp_size=self.ps.cp_size)
+            elif self.apply_rope_fusion:
+                if q.size(1) != 1:
+                    raise ValueError("Fused SBHD MRoPE supports batch size 1 only")
+                q = apply_fused_rotary(q.contiguous(), freqs)
+                k = apply_fused_rotary(k.contiguous(), freqs)
+            elif is_thd:
                 q = _apply_rotary_pos_emb_bshd(q[:, None], freqs).squeeze(1)
                 k = _apply_rotary_pos_emb_bshd(k[:, None], freqs).squeeze(1)
             else:
@@ -211,7 +226,17 @@ class GQAttention(nn.Module):
             # Packed THD uses max per-sequence padded length, not total packed tokens.
             # The THD apply helper handles CP-zigzag frequency slicing per sequence.
             freqs = self.rotary(seq_len_for_rope, packed_seq=True)
-            q = _apply_rotary_pos_emb_thd(
+            q_cu = getattr(packed_seq_params, "cu_seqlens_q_padded", None)
+            q_cu = packed_seq_params.cu_seqlens_q if q_cu is None else q_cu
+            kv_cu = getattr(packed_seq_params, "cu_seqlens_kv_padded", None)
+            kv_cu = packed_seq_params.cu_seqlens_kv if kv_cu is None else kv_cu
+            if self.apply_rope_fusion:
+                q = apply_fused_rotary(q.contiguous(), freqs, cu_seqlens=q_cu,
+                    cp_rank=self.ps.cp_rank, cp_size=self.ps.cp_size)
+                k = apply_fused_rotary(k.contiguous(), freqs, cu_seqlens=kv_cu,
+                    cp_rank=self.ps.cp_rank, cp_size=self.ps.cp_size)
+            else:
+                q = _apply_rotary_pos_emb_thd(
                 q,
                 packed_seq_params.cu_seqlens_q,
                 freqs,
@@ -219,22 +244,20 @@ class GQAttention(nn.Module):
                 mscale=1.0,
                 cp_group=self.ps.cp_group,
             )
-            k = _apply_rotary_pos_emb_thd(
-                k,
-                packed_seq_params.cu_seqlens_kv,
-                freqs,
-                rotary_interleaved=False,
-                mscale=1.0,
-                cp_group=self.ps.cp_group,
-            )
+                k = _apply_rotary_pos_emb_thd(k, packed_seq_params.cu_seqlens_kv, freqs,
+                    rotary_interleaved=False, mscale=1.0, cp_group=self.ps.cp_group)
         else:
             # q is CP-zigzag pre-sliced; rotary needs FULL seq len,
             # its internal get_pos_emb_on_this_cp_rank re-slices to local len.
             local_seq_len = q.size(0)
             seq_len_for_rope = local_seq_len * self.ps.cp_size
             freqs = self.rotary(seq_len_for_rope)
-            q = _apply_rotary_pos_emb_bshd(q, freqs, rotary_interleaved=False, mscale=1.0)
-            k = _apply_rotary_pos_emb_bshd(k, freqs, rotary_interleaved=False, mscale=1.0)
+            if self.apply_rope_fusion:
+                q = apply_fused_rotary(q.contiguous(), freqs)
+                k = apply_fused_rotary(k.contiguous(), freqs)
+            else:
+                q = _apply_rotary_pos_emb_bshd(q, freqs, rotary_interleaved=False, mscale=1.0)
+                k = _apply_rotary_pos_emb_bshd(k, freqs, rotary_interleaved=False, mscale=1.0)
         if self._use_fp32_rope:
             q, k = q.to(orig_dtype), k.to(orig_dtype)
 

--- a/experimental/lite/tests/smoke/primitive/test_rope_fusion_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_rope_fusion_smoke.py
@@ -1,0 +1,166 @@
+import pytest
+import torch
+
+from megatron.lite.primitive.kernels.rope import (
+    apply_fused_mla_rotary_for_kv,
+    apply_fused_mla_rotary_for_q,
+    apply_fused_rotary,
+)
+from megatron.lite.primitive.utils.rope import (
+    _apply_rotary_pos_emb_bshd,
+    _apply_rotary_pos_emb_thd,
+)
+
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA is required"
+)
+
+
+class _CP1:
+    @staticmethod
+    def size():
+        return 1
+
+    @staticmethod
+    def rank():
+        return 0
+
+
+def _freqs(seq: int, dim: int) -> torch.Tensor:
+    inv = 1.0 / (10_000 ** (torch.arange(0, dim, 2, device="cuda").float() / dim))
+    phase = torch.outer(torch.arange(seq, device="cuda").float(), inv)
+    return torch.cat([phase, phase], dim=-1)[:, None, None, :]
+
+
+@pytest.mark.parametrize("packed", [False, True])
+def test_generic_fused_rope_forward_backward(packed):
+    torch.manual_seed(7)
+    freqs = _freqs(4 if packed else 8, 16)
+    if packed:
+        cu = torch.tensor([0, 4, 8], device="cuda", dtype=torch.int32)
+        source = torch.randn(8, 3, 16, device="cuda", dtype=torch.bfloat16)
+        ref_input = source.detach().clone().requires_grad_(True)
+        fused_input = source.detach().clone().requires_grad_(True)
+        ref = _apply_rotary_pos_emb_thd(ref_input, cu, freqs, cp_group=_CP1())
+        fused = apply_fused_rotary(fused_input, freqs, cu_seqlens=cu)
+    else:
+        source = torch.randn(8, 1, 3, 16, device="cuda", dtype=torch.bfloat16)
+        ref_input = source.detach().clone().requires_grad_(True)
+        fused_input = source.detach().clone().requires_grad_(True)
+        ref = _apply_rotary_pos_emb_bshd(ref_input, freqs)
+        fused = apply_fused_rotary(fused_input, freqs)
+    torch.testing.assert_close(fused, ref, rtol=0, atol=2e-2)
+    grad = torch.randn_like(ref)
+    ref.backward(grad)
+    fused.backward(grad)
+    torch.testing.assert_close(fused_input.grad, ref_input.grad, rtol=0, atol=2e-2)
+
+
+def test_mla_q_and_kv_fused_rope_forward_backward():
+    torch.manual_seed(11)
+    seq, heads, nope, rope, value = 8, 4, 8, 8, 16
+    phase = _freqs(seq, rope)
+    cos, sin = phase.cos().contiguous(), phase.sin().contiguous()
+    q = torch.randn(seq, 1, heads, nope + rope, device="cuda", dtype=torch.bfloat16)
+    kv = torch.randn(seq, 1, heads, nope + value, device="cuda", dtype=torch.bfloat16)
+    k_pos = torch.randn(seq, 1, 1, rope, device="cuda", dtype=torch.bfloat16)
+    q_ref = q.detach().clone().requires_grad_(True)
+    q_fused = q.detach().clone().requires_grad_(True)
+    kv_ref = kv.detach().clone().requires_grad_(True)
+    kv_fused = kv.detach().clone().requires_grad_(True)
+    kp_ref = k_pos.detach().clone().requires_grad_(True)
+    kp_fused = k_pos.detach().clone().requires_grad_(True)
+
+    q_nope, q_pos = q_ref.split([nope, rope], dim=-1)
+    q_pos = _apply_rotary_pos_emb_bshd(q_pos, phase, mla_rotary_interleaved=True)
+    expected_q = torch.cat([q_nope, q_pos], dim=-1)
+    expected_k = torch.cat(
+        [
+            kv_ref[..., :nope],
+            _apply_rotary_pos_emb_bshd(
+                kp_ref, phase, mla_rotary_interleaved=True
+            ).expand(seq, 1, heads, rope),
+        ],
+        dim=-1,
+    )
+    expected_v = kv_ref[..., nope:]
+
+    actual_q = apply_fused_mla_rotary_for_q(
+        q_fused.clone(), cos, sin, nope_dim=nope, rope_dim=rope
+    )
+    actual_k, actual_v = apply_fused_mla_rotary_for_kv(
+        kv_fused,
+        kp_fused,
+        cos,
+        sin,
+        rope_dim=rope,
+        key_nope_dim=nope,
+        value_dim=value,
+    )
+    torch.testing.assert_close(actual_q, expected_q, rtol=0, atol=2e-2)
+    torch.testing.assert_close(actual_k, expected_k, rtol=0, atol=2e-2)
+    torch.testing.assert_close(actual_v, expected_v, rtol=0, atol=2e-2)
+    (expected_q.sum() + expected_k.sum() + expected_v.sum()).backward()
+    (actual_q.sum() + actual_k.sum() + actual_v.sum()).backward()
+    torch.testing.assert_close(q_fused.grad, q_ref.grad, rtol=0, atol=2e-2)
+    torch.testing.assert_close(kv_fused.grad, kv_ref.grad, rtol=0, atol=2e-2)
+    # The fused kernel reduces this shared positional gradient across heads in
+    # BF16; allow the corresponding reduction-order rounding while retaining
+    # the same absolute bound used by the other MLA checks.
+    torch.testing.assert_close(kp_fused.grad, kp_ref.grad, rtol=1e-2, atol=2e-2)
+
+
+def test_mla_inverse_remove_interleaving_round_trip():
+    seq, heads, dim = 8, 2, 8
+    phase = _freqs(seq, dim)
+    cos, sin = phase.cos().contiguous(), phase.sin().contiguous()
+    source = torch.randn(seq, 1, heads, dim, device="cuda", dtype=torch.bfloat16)
+    rotated = apply_fused_mla_rotary_for_q(
+        source.clone(), cos, sin, nope_dim=0, rope_dim=dim, remove_interleaving=True
+    )
+    restored = apply_fused_mla_rotary_for_q(
+        rotated.clone(),
+        cos,
+        sin,
+        nope_dim=0,
+        rope_dim=dim,
+        inverse=True,
+        remove_interleaving=True,
+    )
+    torch.testing.assert_close(restored, source, rtol=0, atol=3e-2)
+
+
+def test_dsa_and_csa_site_adapters_forward_backward():
+    from megatron.lite.primitive.modules.attention.csa import (
+        _apply_partial_rope_dispatch,
+        apply_partial_rope,
+    )
+    from megatron.lite.primitive.modules.attention.dsa import (
+        _apply_fused_dsa_rope,
+        apply_rotary_pos_emb,
+    )
+
+    phase = _freqs(8, 8).squeeze(1).squeeze(1).unsqueeze(0)
+    cos, sin = phase.cos().to(torch.bfloat16), phase.sin().to(torch.bfloat16)
+    source = torch.randn(1, 8, 3, 8, device="cuda", dtype=torch.bfloat16)
+    dsa_ref_input = source.detach().clone().requires_grad_(True)
+    dsa_fused_input = source.detach().clone().requires_grad_(True)
+    dsa_ref = apply_rotary_pos_emb(dsa_ref_input, cos, sin, unsqueeze_dim=2)
+    dsa_fused = _apply_fused_dsa_rope(dsa_fused_input, phase)
+    torch.testing.assert_close(dsa_fused, dsa_ref, rtol=0, atol=2e-2)
+    dsa_ref.sum().backward()
+    dsa_fused.sum().backward()
+    torch.testing.assert_close(dsa_fused_input.grad, dsa_ref_input.grad, rtol=0, atol=2e-2)
+
+    csa_source = source.transpose(1, 2).detach()
+    csa_ref_input = csa_source.clone().requires_grad_(True)
+    csa_fused_input = csa_source.clone().requires_grad_(True)
+    csa_ref = apply_partial_rope(csa_ref_input, cos, sin, 8)
+    csa_fused = _apply_partial_rope_dispatch(
+        csa_fused_input, cos, sin, 8, fused=True
+    )
+    torch.testing.assert_close(csa_fused, csa_ref, rtol=0, atol=2e-2)
+    csa_ref.sum().backward()
+    csa_fused.sum().backward()
+    torch.testing.assert_close(csa_fused_input.grad, csa_ref_input.grad, rtol=0, atol=2e-2)

--- a/experimental/lite/tests/unit/primitive/test_rope_kernel_adapter.py
+++ b/experimental/lite/tests/unit/primitive/test_rope_kernel_adapter.py
@@ -1,0 +1,80 @@
+from unittest import mock
+from pathlib import Path
+
+import pytest
+import torch
+
+from megatron.lite.primitive.kernels import rope
+
+
+LITE_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_generic_sbhd_dispatches_to_mcore_te_kernel():
+    tensor = torch.randn(4, 1, 2, 8)
+    freqs = torch.randn(4, 1, 1, 8)
+    sbhd = mock.Mock(return_value=tensor + 1)
+    with mock.patch.object(
+        rope, "_load_generic_kernels", return_value=(sbhd, mock.Mock())
+    ):
+        out = rope.apply_fused_rotary(tensor, freqs)
+    assert torch.equal(out, tensor + 1)
+    sbhd.assert_called_once_with(tensor, freqs, interleaved=False)
+
+
+def test_generic_thd_forwards_cp_coordinates():
+    tensor = torch.randn(4, 2, 8)
+    freqs = torch.randn(8, 1, 1, 8)
+    cu = torch.tensor([0, 8], dtype=torch.int32)
+    thd = mock.Mock(return_value=tensor)
+    with mock.patch.object(
+        rope, "_load_generic_kernels", return_value=(mock.Mock(), thd)
+    ):
+        rope.apply_fused_rotary(tensor, freqs, cu_seqlens=cu, cp_rank=1, cp_size=2)
+    thd.assert_called_once_with(
+        tensor, cu, freqs, cp_size=2, cp_rank=1, interleaved=False
+    )
+
+
+def test_mla_q_adapter_does_not_hide_inplace_semantics():
+    tensor = torch.randn(4, 1, 2, 12)
+    cos = sin = torch.randn(4, 1, 1, 4)
+    fused = mock.Mock(return_value=tensor)
+    with mock.patch.object(
+        rope, "_load_mla_kernels", return_value=(fused, mock.Mock())
+    ):
+        out = rope.apply_fused_mla_rotary_for_q(
+            tensor, cos, sin, nope_dim=8, rope_dim=4
+        )
+    assert out is tensor
+    assert fused.call_args.args[0] is tensor
+
+
+def test_invalid_layout_fails_closed_before_loading_kernel():
+    tensor = torch.randn(4, 1, 2, 8).transpose(-1, -2)
+    with pytest.raises(ValueError, match="contiguous last dimension"):
+        rope.apply_fused_rotary(tensor, torch.randn(4, 1, 1, 8))
+
+
+def test_all_model_impl_configs_default_rope_fusion_on():
+    for family in ("qwen3_moe", "qwen3_5", "kimi_k2", "glm5", "deepseek_v4"):
+        source = (
+            LITE_ROOT / "megatron/lite/model" / family / "lite/protocol.py"
+        ).read_text()
+        assert "apply_rope_fusion: bool = True" in source
+
+
+def test_rope_provider_references_are_confined_to_kernel_boundary():
+    provider_terms = (
+        "megatron.core.extensions.transformer_engine",
+        "megatron.core.fusions.fused_mla_yarn_rope_apply",
+    )
+    violations = []
+    boundary = LITE_ROOT / "megatron/lite/primitive/kernels/rope.py"
+    for path in (LITE_ROOT / "megatron/lite").rglob("*.py"):
+        if path == boundary:
+            continue
+        text = path.read_text(encoding="utf-8")
+        if any(term in text for term in provider_terms):
+            violations.append(str(path.relative_to(LITE_ROOT)))
+    assert violations == []

--- a/experimental/lite/tests/unit/runtime/test_layering_contracts.py
+++ b/experimental/lite/tests/unit/runtime/test_layering_contracts.py
@@ -29,6 +29,18 @@ RUNTIME_ROOT = LITE_ROOT / "megatron" / "lite" / "runtime"
 MODEL_ROOT = LITE_ROOT / "megatron" / "lite" / "model"
 PRIMITIVE_ROOT = LITE_ROOT / "megatron" / "lite" / "primitive"
 BRIDGE_RUNTIME = RUNTIME_ROOT / "backends" / "bridge" / "runtime.py"
+ROPE_KERNEL = PRIMITIVE_ROOT / "kernels" / "rope.py"
+
+ROPE_PROVIDER_MODULES = {
+    "megatron.core.extensions.transformer_engine": {
+        "fused_apply_rotary_pos_emb",
+        "fused_apply_rotary_pos_emb_thd",
+    },
+    "megatron.core.fusions.fused_mla_yarn_rope_apply": {
+        "fused_mla_rope_inplace",
+        "fused_mla_rope_kv_split",
+    },
+}
 
 ALLOW_BEGIN = "MLITE_LAYERING_ALLOW_BRIDGE_FORWARD_METADATA_BEGIN"
 ALLOW_END = "MLITE_LAYERING_ALLOW_BRIDGE_FORWARD_METADATA_END"
@@ -103,6 +115,37 @@ def _imported_modules(path: Path) -> list[tuple[int, str]]:
         elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
             imports.append((node.lineno, node.module))
     return imports
+
+
+def _rope_provider_imports(path: Path) -> list[tuple[int, str]]:
+    """Return static and lazy mcore RoPE provider imports."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imports = _imported_modules(path)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not node.args:
+            continue
+        if isinstance(node.func, ast.Name):
+            is_import_module = node.func.id == "import_module"
+        else:
+            is_import_module = (
+                isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "importlib"
+                and node.func.attr == "import_module"
+            )
+        if is_import_module and isinstance(node.args[0], ast.Constant):
+            module = node.args[0].value
+            if isinstance(module, str):
+                imports.append((node.lineno, module))
+    return [
+        (lineno, module)
+        for lineno, module in imports
+        if module == "megatron.core.extensions.transformer_engine"
+        or (
+            module.startswith("megatron.core")
+            and ("rope" in module.lower() or "rotary" in module.lower())
+        )
+    ]
 
 
 def _code_lines(path: Path) -> list[str]:
@@ -233,3 +276,30 @@ def test_runtime_packed_seq_params_is_bridge_forward_transient_only() -> None:
 def test_primitive_layer_is_model_name_agnostic() -> None:
     violations = _violations(_python_files(PRIMITIVE_ROOT), MODEL_NAME_TERMS)
     assert violations == []
+
+
+def test_rope_providers_are_isolated_to_kernel_adapter() -> None:
+    violations: list[str] = []
+    for path in _python_files(LITE_ROOT / "megatron" / "lite"):
+        for lineno, module in _rope_provider_imports(path):
+            if path != ROPE_KERNEL or module not in ROPE_PROVIDER_MODULES:
+                rel = path.relative_to(LITE_ROOT)
+                violations.append(f"{rel}:{lineno}: disallowed RoPE provider {module}")
+    assert violations == []
+
+
+def test_rope_kernel_uses_only_canonical_fused_symbols() -> None:
+    tree = ast.parse(ROPE_KERNEL.read_text(encoding="utf-8"))
+    provider_imports = {module for _, module in _rope_provider_imports(ROPE_KERNEL)}
+    fused_symbols = {
+        node.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute)
+        and (
+            node.attr.startswith("fused_apply_rotary_pos_emb")
+            or node.attr.startswith("fused_mla_rope_")
+        )
+    }
+
+    assert provider_imports == set(ROPE_PROVIDER_MODULES)
+    assert fused_symbols == set().union(*ROPE_PROVIDER_MODULES.values())

--- a/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
+++ b/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
@@ -148,6 +148,7 @@ class _FakeImplConfig:
     hf_path: str = ""
     optimizer_config: object = None
     attention_backend_override: str | None = None
+    apply_rope_fusion: bool = True
 
 
 def test_build_impl_cfg_backfills_top_level_hf_path_and_runtime_fields():
@@ -173,6 +174,19 @@ def test_build_impl_cfg_preserves_explicit_impl_hf_path():
     impl_cfg = _build_impl_cfg(proto, cfg)
 
     assert impl_cfg.hf_path == "/models/impl"
+
+
+def test_build_impl_cfg_defaults_and_forwards_typed_rope_fusion():
+    proto = type("Proto", (), {"ImplConfig": _FakeImplConfig})
+
+    default_cfg = _build_impl_cfg(proto, MegatronLiteConfig(model_name="qwen3"))
+    disabled_cfg = _build_impl_cfg(
+        proto,
+        MegatronLiteConfig(model_name="qwen3", impl_cfg={"apply_rope_fusion": False}),
+    )
+
+    assert default_cfg.apply_rope_fusion is True
+    assert disabled_cfg.apply_rope_fusion is False
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- add a single MLite kernel boundary for TE-backed generic and MLA fused RoPE providers
- route dense/MRoPE, MLA, DSA, and CSA RoPE sites through the fused path while preserving the unfused reference path
- enable RoPE fusion by default in the relevant typed implementation configs
- add adapter, routing, runtime-config, and AST layering contract coverage

## Validation

- focused CPU suite: 43 passed
- ruff and diff checks passed
- eos Slurm 5538097: COMPLETED 0:0, 5 passed, 0 skipped (forward and backward coverage)
