### PR TITLE
[lite] verl launcher: make rollout_correction bypass_mode configurable (default off)

### DIFF
--- a/experimental/lite/examples/verl/scripts/run_qwen3moe_gsm8k_grpo.sh
+++ b/experimental/lite/examples/verl/scripts/run_qwen3moe_gsm8k_grpo.sh
@@ -89,6 +89,15 @@ ATTENTION_BACKEND="${ATTENTION_BACKEND:-flash}"
 # - fsdp2: Megatron Lite FSDP2 wrapper + optimizer.
 MLITE_OPTIMIZER_BACKEND="${MLITE_OPTIMIZER_BACKEND:-dist_opt}"
 
+# Rollout-correction bypass takes old_log_probs from the vLLM rollout instead
+# of recomputing them with the actor. The rollout-vs-actor divergence grows
+# with sequence length (measured on identical weights: ppo_kl ~0.22 at ~460
+# tokens, 1.2-1.4 at ~3400 tokens), which distorts every importance ratio in
+# the PPO loss. An A/B ablation on DAPO-Math-17k showed ppo_kl dropping from
+# 1.3 to 0.023 and val accuracy going from decline to hold when bypass is
+# disabled, so it defaults to False here.
+ROLLOUT_CORRECTION_BYPASS="${ROLLOUT_CORRECTION_BYPASS:-False}"
+
 ACTOR_LR="${ACTOR_LR:-1e-6}"
 POLICY_LOSS_MODE="${POLICY_LOSS_MODE:-vanilla}"
 LOSS_AGG_MODE="${LOSS_AGG_MODE:-seq-mean-token-sum-norm}"
@@ -166,7 +175,7 @@ ALGORITHM=(
   "algorithm.adv_estimator=grpo"
   "algorithm.use_kl_in_reward=${USE_KL_IN_REWARD:-False}"
   "algorithm.kl_ctrl.kl_coef=${KL_COEF:-0.0}"
-  "algorithm.rollout_correction.bypass_mode=True"
+  "algorithm.rollout_correction.bypass_mode=${ROLLOUT_CORRECTION_BYPASS}"
   "algorithm.norm_adv_by_std_in_grpo=False"
 )
 


### PR DESCRIPTION
## What

Makes `algorithm.rollout_correction.bypass_mode` configurable in the verl GRPO example launcher (`experimental/lite/examples/verl/scripts/run_qwen3moe_gsm8k_grpo.sh`) instead of hardcoded `True`.

- New env `ROLLOUT_CORRECTION_BYPASS` (default `False`), wired into the `ALGORITHM` array; inline comment documents the rationale.
- Opt back in with `ROLLOUT_CORRECTION_BYPASS=True` — the previous behavior stays one env var away.
- No new dependencies, no config-schema changes; +10/−1 in one script.

## Why

`bypass_mode=True` takes `old_log_probs` directly from the vLLM rollout instead of recomputing them with the actor engine. (`ppo_kl` below = verl's mean per-token log-prob gap between those two sources on identical weights — the standard train/inference-mismatch gauge; see the rollout-correction discussion referenced in verl's `RolloutCorrectionConfig`, https://richardli.xyz/rl-collapse.) The rollout and actor are numerically different implementations, and their divergence grows with sequence length — measured on identical weights: ppo_kl ~0.22 at ~460 tokens vs 1.2–1.4 at ~3400 tokens. Since `old_log_probs` sits in the denominator of the PPO importance ratio, this distorts every ratio in the loss, and the effect compounds exactly in the long-response regime GRPO training moves toward. A launcher example should default to the numerically safe setting; bypass is a throughput optimization the user should choose knowingly.

## Experiments

**Divergence vs sequence length** (DS-R1-Distill-Qwen-1.5B, verl + vLLM 0.23 async rollout, identical weights, rollout log-probs vs actor-engine recompute over full sampled batches):

| mean response length | ppo_kl |
|---|---|
| ~460 tokens | ~0.22 |
| ~3400 tokens | 1.2–1.4 |

**A/B ablation on DAPO-Math-17k** (DS-R1-Distill-Qwen-1.5B, GRPO, LoRA r16/α32, LR 1e-5, batch 32 prompts × 8 rollouts, response cap 4096, 100 steps, 4×B100 — identical recipe and seeds, only `bypass_mode` flipped):

| metric | bypass=True | bypass=False |
|---|---|---|
| ppo_kl | 1.3 | 0.023 |
| val accuracy trend | declining | holds |

## Asks

Single decision: is flipping the **example launcher's** default to the
numerically-safe setting acceptable, given it costs the old-log-prob recompute
pass in throughput? Existing users get the old behavior back with
`ROLLOUT_CORRECTION_BYPASS=True`. Independent of the #72-#79 stack; merges
directly on `main` (single script, +10/−1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

