### PR TITLE
Fix globally normalized microbatch loss accumulation

### DIFF
--- a/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
@@ -589,6 +589,7 @@ class MegatronLiteEngine(BaseEngine):
             loss_fn=runtime_loss_fn,
             num_microbatches=num_micro_batches,
             forward_only=forward_only,
+            loss_is_global_batch_normalized=loss_function is not None,
         )
         metrics = dict(result.metrics)
         micro_outputs = metrics.pop("_micro_outputs", None)

--- a/experimental/lite/megatron/lite/primitive/parallel/pipeline.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/pipeline.py
@@ -26,6 +26,7 @@ def forward_backward_pipelining(
     pre_forward_hook: Callable[[torch.Tensor], None] | None = None,
     loss_fn: Callable | None = None,
     forward_only: bool = False,
+    loss_is_global_batch_normalized: bool = False,
 ) -> list[dict]:
     """
     Run forward and backward passes with pipeline parallelism.
@@ -63,6 +64,7 @@ def forward_backward_pipelining(
             grad_sync_fn=grad_sync_fn,
             pre_forward_hook=pre_forward_hook,
             loss_fn=loss_fn,
+            loss_is_global_batch_normalized=loss_is_global_batch_normalized,
         )
 
     if tensor_shape is None:
@@ -94,6 +96,7 @@ def forward_backward_pipelining(
             grad_sync_fn=grad_sync_fn,
             pre_forward_hook=pre_forward_hook,
             loss_fn=loss_fn,
+            loss_is_global_batch_normalized=loss_is_global_batch_normalized,
         )
 
     return _1f1b_schedule(
@@ -107,6 +110,7 @@ def forward_backward_pipelining(
         grad_sync_fn=grad_sync_fn,
         pre_forward_hook=pre_forward_hook,
         loss_fn=loss_fn,
+        loss_is_global_batch_normalized=loss_is_global_batch_normalized,
     )
 
 
@@ -148,6 +152,17 @@ def _apply_external_loss(out: dict, batch, loss_fn) -> tuple[torch.Tensor, dict]
     return loss, metrics
 
 
+def _loss_for_backward(
+    loss: torch.Tensor,
+    num_microbatches: int,
+    loss_fn,
+    loss_is_global_batch_normalized: bool,
+) -> torch.Tensor:
+    if loss_fn is not None and loss_is_global_batch_normalized:
+        return loss
+    return loss / num_microbatches
+
+
 def _compact_pipeline_output(out: dict | None) -> dict:
     if not out:
         return {}
@@ -174,6 +189,7 @@ def _no_pipeline(
     grad_sync_fn=None,
     pre_forward_hook=None,
     loss_fn=None,
+    loss_is_global_batch_normalized: bool = False,
 ):
     num_microbatches = _num_microbatches_from_config(config, ps)
     outputs = []
@@ -188,7 +204,12 @@ def _no_pipeline(
             assert loss is not None
         else:
             loss = output["loss"]
-        loss = loss / num_microbatches
+        loss = _loss_for_backward(
+            loss,
+            num_microbatches,
+            loss_fn,
+            loss_is_global_batch_normalized,
+        )
         loss.backward()
         outputs.append(_compact_pipeline_output(output))
     return outputs
@@ -231,6 +252,7 @@ def _1f1b_schedule(
     grad_sync_fn=None,
     pre_forward_hook=None,
     loss_fn=None,
+    loss_is_global_batch_normalized: bool = False,
 ):
     """
     1-Forward-1-Backward pipeline schedule using batch_isend_irecv.
@@ -318,7 +340,16 @@ def _1f1b_schedule(
         current_input = fwd_input
         out = _run_forward(fwd_input, batch)
         hidden = out.get("hidden_states")
-        loss_s = out["loss"] / num_microbatches if "loss" in out and ps.pp_is_last else None
+        loss_s = (
+            _loss_for_backward(
+                out["loss"],
+                num_microbatches,
+                loss_fn,
+                loss_is_global_batch_normalized,
+            )
+            if "loss" in out and ps.pp_is_last
+            else None
+        )
 
         need_recv_next = not ps.pp_is_first and k < num_warmup - 1
         if not ps.pp_is_last:
@@ -344,7 +375,16 @@ def _1f1b_schedule(
         mb_idx += 1
         out = _run_forward(fwd_input, batch)
         hidden = out.get("hidden_states")
-        loss_s = out["loss"] / num_microbatches if "loss" in out and ps.pp_is_last else None
+        loss_s = (
+            _loss_for_backward(
+                out["loss"],
+                num_microbatches,
+                loss_fn,
+                loss_is_global_batch_normalized,
+            )
+            if "loss" in out and ps.pp_is_last
+            else None
+        )
 
         input_tensors.append(fwd_input if not ps.pp_is_first else None)
         output_hiddens.append(hidden)
@@ -642,6 +682,7 @@ def _interleaved_1f1b_schedule(
     grad_sync_fn=None,
     pre_forward_hook=None,
     loss_fn=None,
+    loss_is_global_batch_normalized: bool = False,
 ):
     """
     Correct non-overlapped schedule for Virtual Pipeline Parallelism (VPP).
@@ -714,7 +755,16 @@ def _interleaved_1f1b_schedule(
                         f"chunk={chunk_id} hidden_shape={hidden_shape}",
                         flush=True,
                     )
-                loss = out["loss"] / num_microbatches if is_last_stage and "loss" in out else None
+                loss = (
+                    _loss_for_backward(
+                        out["loss"],
+                        num_microbatches,
+                        loss_fn,
+                        loss_is_global_batch_normalized,
+                    )
+                    if is_last_stage and "loss" in out
+                    else None
+                )
                 saved[stage_id] = (activation, hidden, loss, out)
 
                 if is_last_stage:

--- a/experimental/lite/megatron/lite/primitive/train_step.py
+++ b/experimental/lite/megatron/lite/primitive/train_step.py
@@ -20,6 +20,7 @@ def run_microbatch_loop(
     dist_opt: bool = False,
     pre_forward_hook: Callable[[torch.Tensor], None] | None = None,
     loss_fn: Callable | None = None,
+    loss_is_global_batch_normalized: bool = False,
 ):
     """Run forward-backward over microbatches with loss accumulation.
 
@@ -39,9 +40,14 @@ def run_microbatch_loop(
             ``loss_fn(model_output: dict, batch) -> (loss: Tensor, metrics: dict)``.
             When provided, ``forward_fn`` output is passed to ``loss_fn`` instead of
             reading ``out["loss"]`` directly. This enables RLHF policy/value losses.
+        loss_is_global_batch_normalized: The external loss already uses the logical
+            batch's global denominator. Such per-microbatch contributions are summed
+            for backward instead of averaged again. Ignored when ``loss_fn`` is None.
     """
     last_out = None
     all_metrics: list[dict] = []
+    micro_outputs: list[dict] = []
+    accumulated_loss: torch.Tensor | None = None
     for mb in range(num_microbatches):
         batch = next(data_iter)
         if pre_forward_hook is not None:
@@ -52,14 +58,32 @@ def run_microbatch_loop(
             optimizer.grad_sync_enabled = True
         if loss_fn is not None:
             loss, metrics = loss_fn(out, batch)
-            (loss / num_microbatches).backward()
+            backward_loss = loss if loss_is_global_batch_normalized else loss / num_microbatches
+            backward_loss.backward()
             out["loss"] = loss.detach()
             all_metrics.append(metrics)
+            compact_output = {
+                "model_output": out.get("_verl_model_output", {}),
+                "loss": loss.detach().item(),
+                "metrics": metrics,
+            }
+            micro_outputs.append(compact_output)
         else:
-            (out["loss"] / num_microbatches).backward()
+            backward_loss = out["loss"] / num_microbatches
+            backward_loss.backward()
+        detached_backward_loss = backward_loss.detach()
+        accumulated_loss = (
+            detached_backward_loss
+            if accumulated_loss is None
+            else accumulated_loss + detached_backward_loss
+        )
         last_out = out
-    if last_out is not None and all_metrics:
-        last_out["_loss_fn_metrics"] = all_metrics
+    if last_out is not None:
+        if accumulated_loss is not None:
+            last_out["loss"] = accumulated_loss
+        if all_metrics:
+            last_out["_loss_fn_metrics"] = all_metrics
+            last_out["_micro_outputs"] = micro_outputs
     return last_out
 
 

--- a/experimental/lite/megatron/lite/runtime/backends/__init__.py
+++ b/experimental/lite/megatron/lite/runtime/backends/__init__.py
@@ -83,12 +83,16 @@ class Runtime(ABC):
         *,
         num_microbatches: int = 1,
         forward_only: bool = False,
+        loss_is_global_batch_normalized: bool = False,
     ) -> ForwardResult:
         """Forward + backward pass over data.
 
         Args:
             num_microbatches: Number of microbatches to accumulate inside one
                 logical training step.
+            loss_is_global_batch_normalized: Whether each external loss is an
+                already globally normalized contribution to the logical batch.
+                When true, contributions are summed instead of averaged again.
             loss_fn: Optional external loss function with signature::
 
                 loss_fn(model_output: dict, batch) -> (loss: Tensor, metrics: dict)

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -344,6 +344,7 @@ class MegatronLiteRuntime(RuntimeBase):
     def forward_backward(
         self, handle: ModelHandle, data: Any, loss_fn: Callable | None,
         *, num_microbatches: int = 1, forward_only: bool = False,
+        loss_is_global_batch_normalized: bool = False,
     ) -> ForwardResult:
         from megatron.lite.primitive.train_step import run_microbatch_loop
 
@@ -381,6 +382,7 @@ class MegatronLiteRuntime(RuntimeBase):
                 pre_forward_hook=handle._extras.get("pre_forward_hook"),
                 loss_fn=loss_fn,
                 forward_only=forward_only,
+                loss_is_global_batch_normalized=loss_is_global_batch_normalized,
             )
             out = _last_loss_output(outputs)
             loss_obj = out.get("loss") if out else None
@@ -405,6 +407,7 @@ class MegatronLiteRuntime(RuntimeBase):
                 dist_opt=not forward_only,
                 pre_forward_hook=handle._extras.get("pre_forward_hook"),
                 loss_fn=loss_fn,
+                loss_is_global_batch_normalized=loss_is_global_batch_normalized,
             )
 
         if not forward_only:
@@ -419,6 +422,8 @@ class MegatronLiteRuntime(RuntimeBase):
             for k, v in m.items():
                 if k not in metrics:
                     metrics[k] = v
+        if out and out.get("_micro_outputs") is not None:
+            metrics["_micro_outputs"] = out["_micro_outputs"]
         if ps.pp_size > 1:
             for item in outputs:
                 for k, v in item.get("metrics", {}).items():

--- a/experimental/lite/tests/unit/primitive/test_train_step_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_train_step_unit.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from megatron.lite.primitive.parallel.pipeline import forward_backward_pipelining
+from megatron.lite.primitive.train_step import run_microbatch_loop
+
+
+pytestmark = pytest.mark.mlite
+
+
+class _ScalarModel(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.tensor(1.0))
+
+
+def _forward(model: _ScalarModel, batch: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+    return {"weighted_tokens": model.weight * batch["tokens"]}
+
+
+def _globally_normalized_loss(output, batch):
+    loss = output["weighted_tokens"] / batch["global_tokens"]
+    return loss, {"pg_loss": loss.detach()}
+
+
+def test_external_globally_normalized_loss_sums_microbatch_gradients():
+    model = _ScalarModel()
+    batches = iter(
+        [
+            {"tokens": torch.tensor(2.0), "global_tokens": torch.tensor(8.0)},
+            {"tokens": torch.tensor(6.0), "global_tokens": torch.tensor(8.0)},
+        ]
+    )
+
+    output = run_microbatch_loop(
+        model,
+        batches,
+        num_microbatches=2,
+        forward_fn=_forward,
+        loss_fn=_globally_normalized_loss,
+        loss_is_global_batch_normalized=True,
+    )
+
+    assert model.weight.grad.item() == pytest.approx(1.0)
+    assert output["loss"].item() == pytest.approx(1.0)
+    assert [item["loss"] for item in output["_micro_outputs"]] == pytest.approx([0.25, 0.75])
+    assert [item["metrics"]["pg_loss"].item() for item in output["_micro_outputs"]] == pytest.approx(
+        [0.25, 0.75]
+    )
+
+
+def test_external_loss_keeps_microbatch_mean_as_default():
+    model = _ScalarModel()
+    batches = iter(
+        [
+            {"tokens": torch.tensor(2.0), "global_tokens": torch.tensor(8.0)},
+            {"tokens": torch.tensor(6.0), "global_tokens": torch.tensor(8.0)},
+        ]
+    )
+
+    output = run_microbatch_loop(
+        model,
+        batches,
+        num_microbatches=2,
+        forward_fn=_forward,
+        loss_fn=_globally_normalized_loss,
+    )
+
+    assert model.weight.grad.item() == pytest.approx(0.5)
+    assert output["loss"].item() == pytest.approx(0.5)
+
+
+def test_pipeline_contract_sums_globally_normalized_external_loss():
+    model = _ScalarModel()
+    batches = iter(
+        [
+            {"tokens": torch.tensor(2.0), "global_tokens": torch.tensor(8.0)},
+            {"tokens": torch.tensor(6.0), "global_tokens": torch.tensor(8.0)},
+        ]
+    )
+    parallel_state = SimpleNamespace(pp_size=1, dp_size=1)
+    config = SimpleNamespace(num_microbatches=2)
+
+    outputs = forward_backward_pipelining(
+        _forward,
+        [model],
+        batches,
+        config,
+        parallel_state,
+        loss_fn=_globally_normalized_loss,
+        loss_is_global_batch_normalized=True,
+    )
+
+    assert model.weight.grad.item() == pytest.approx(1.0)
+    assert [item["loss"] for item in outputs] == pytest.approx([0.25, 0.75])
+    assert [item["metrics"]["pg_loss"].item() for item in outputs] == pytest.approx([0.25, 0.75])

--- a/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
+++ b/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
@@ -4,9 +4,11 @@ from dataclasses import dataclass
 import os
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+import torch
 import torch.nn as nn
 
 from megatron.lite.runtime import create_runtime
@@ -261,6 +263,41 @@ def test_runtime_dispatch_creates_mlite_backend():
 def test_runtime_dispatch_unknown_backend_raises():
     with pytest.raises(KeyError):
         create_runtime(RuntimeConfig(backend="nonexistent"))
+
+
+def test_runtime_preserves_all_micro_outputs_for_external_loss_aggregation():
+    model = nn.Linear(1, 1, bias=False)
+    model.weight.data.fill_(1.0)
+    handle = ModelHandle(
+        model=model,
+        parallel_state=SimpleNamespace(pp_size=1),
+        _extras={"forward_step": lambda module, batch: {"value": module(batch["tokens"])}},
+    )
+    batches = iter(
+        [
+            {"tokens": torch.tensor([[2.0]]), "global_tokens": torch.tensor(8.0)},
+            {"tokens": torch.tensor([[6.0]]), "global_tokens": torch.tensor(8.0)},
+        ]
+    )
+
+    def loss_fn(output, batch):
+        loss = output["value"].sum() / batch["global_tokens"]
+        return loss, {"pg_loss": loss.detach()}
+
+    result = MegatronLiteRuntime.__new__(MegatronLiteRuntime).forward_backward(
+        handle,
+        batches,
+        loss_fn,
+        num_microbatches=2,
+        loss_is_global_batch_normalized=True,
+    )
+
+    assert model.weight.grad.item() == pytest.approx(1.0)
+    assert result.model_output.loss.item() == pytest.approx(1.0)
+    assert [item["loss"] for item in result.metrics["_micro_outputs"]] == pytest.approx([0.25, 0.75])
+    assert [
+        item["metrics"]["pg_loss"].item() for item in result.metrics["_micro_outputs"]
+    ] == pytest.approx([0.25, 0.75])
 
 
 def _run_verl_sft_dry_run(script: Path, tmp_path: Path, **env_overrides: str) -> str:


### PR DESCRIPTION
## Summary
- distinguish external losses that are already normalized over the logical global batch
- sum those microbatch contributions for backward while preserving the default mean-loss behavior
- return every microbatch output for the existing VERL postprocessing and metric reduction contract
- cover primitive, pipeline, and runtime behavior with CPU regression tests

## Tests
- `PYTHONPATH=experimental/lite pytest -q experimental/lite/tests/unit/primitive/test_train_step_unit.py experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py` (26 passed)
- `python -m py_compile experimental/lite/megatron/lite/primitive/train_step.py experimental/lite/megatron/lite/primitive/parallel/pipeline.py experimental/lite/megatron/lite/runtime/backends/__init__.py experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py`
- four-node fused same-rollout-batch replay completed one optimizer step with the runtime fix