### PR TITLE
[lite] fix(export): keep router expert_bias fp32 under export_dtype casts

### DIFF
--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
@@ -34,8 +34,6 @@ import torch.nn as nn
 from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
 from megatron.lite.primitive.ckpt.hf_weights import (
     SafeTensorReader,
-    _cast_export_tensor,
-    _resolve_export_dtype,
     parse_expert_idx,
     to_global_layer_name,
     unwrap_model,
@@ -473,7 +471,6 @@ def export_hf_weights(model, config: DeepseekV4Config, ps: ParallelState, **kwar
 
     spec = DeepseekV4WeightSpec(config)
     rank0_only = bool(kwargs.get("rank0_only", False))
-    export_dtype = _resolve_export_dtype(kwargs.get("export_dtype"))
     yield from _export(model, spec, ps, vocab_size=config.vocab_size, **kwargs)
 
     rank = dist.get_rank() if dist.is_initialized() else 0
@@ -490,11 +487,14 @@ def export_hf_weights(model, config: DeepseekV4Config, ps: ParallelState, **kwar
         for name, buffer in base_chunk.named_buffers():
             # Persistent router buffers carried into HF: hash-layer ``tid2eid``
             # and the (made-persistent for non-hash layers) ``expert_bias``.
+            # Both bypass the export_dtype cast: tid2eid is integral, and
+            # expert_bias steers top-k selection — hub layout and the load
+            # path keep it fp32 regardless of export_dtype.
             if not (name.endswith(".mlp.gate.tid2eid") or name.endswith(".mlp.gate.expert_bias")):
                 continue
             global_name = to_global_layer_name(name, layer_map)
             for hf_name, hf_tensor in spec.native_to_hf(global_name, buffer.detach().cpu()):
-                yield hf_name, _cast_export_tensor(hf_tensor, export_dtype)
+                yield hf_name, hf_tensor
 
 
 def save_hf_weights(model, path: str, config: DeepseekV4Config, ps: ParallelState, **kwargs) -> None:

--- a/experimental/lite/megatron/lite/model/glm5/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/checkpoint.py
@@ -31,8 +31,6 @@ from torch.distributed.tensor import Replicate, Shard
 from megatron.lite.model.glm5.config import Glm5Config
 from megatron.lite.primitive.ckpt.hf_weights import (
     SafeTensorReader,
-    _cast_export_tensor,
-    _resolve_export_dtype,
     parse_expert_idx,
     to_global_layer_name,
     unwrap_model,
@@ -628,7 +626,6 @@ def export_hf_weights(model, config: Glm5Config, ps: ParallelState, **kwargs):
 
     spec = Glm5WeightSpec(config)
     rank0_only = bool(kwargs.get("rank0_only", False))
-    export_dtype = _resolve_export_dtype(kwargs.get("export_dtype"))
     yield from _export(model, spec, ps, vocab_size=config.vocab_size, **kwargs)
     rank = dist.get_rank() if dist.is_initialized() else 0
     if rank0_only and rank != 0:
@@ -645,8 +642,10 @@ def export_hf_weights(model, config: Glm5Config, ps: ParallelState, **kwargs):
             if not name.endswith(".moe.router.expert_bias"):
                 continue
             global_name = to_global_layer_name(name, layer_map)
+            # expert_bias steers top-k selection; hub layout and the load path
+            # keep it fp32 regardless of export_dtype, so it bypasses the cast.
             for hf_name, hf_tensor in spec.native_to_hf(global_name, buffer.detach().cpu()):
-                yield hf_name, _cast_export_tensor(hf_tensor, export_dtype)
+                yield hf_name, hf_tensor
 
 
 def save_hf_weights(model, path: str, config: Glm5Config, ps: ParallelState, **kwargs) -> None:

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/checkpoint.py
@@ -11,8 +11,6 @@ from torch.distributed.tensor import Replicate, Shard
 from megatron.lite.model.kimi_k2.config import KimiK2Config
 from megatron.lite.primitive.ckpt.hf_weights import (
     SafeTensorReader,
-    _cast_export_tensor,
-    _resolve_export_dtype,
     parse_expert_idx,
     to_global_layer_name,
     unwrap_model,
@@ -618,7 +616,6 @@ def export_hf_weights(model, config: KimiK2Config, ps: ParallelState, **kwargs):
 
     spec = KimiK2WeightSpec(config)
     rank0_only = bool(kwargs.get("rank0_only", False))
-    export_dtype = _resolve_export_dtype(kwargs.get("export_dtype"))
     yield from _export(model, spec, ps, vocab_size=config.vocab_size, **kwargs)
     rank = dist.get_rank() if dist.is_initialized() else 0
     if rank0_only and rank != 0:
@@ -635,8 +632,10 @@ def export_hf_weights(model, config: KimiK2Config, ps: ParallelState, **kwargs):
             if not name.endswith(".moe.router.expert_bias"):
                 continue
             global_name = to_global_layer_name(name, layer_map)
+            # expert_bias steers top-k selection; hub layout and the load path
+            # keep it fp32 regardless of export_dtype, so it bypasses the cast.
             for hf_name, hf_tensor in spec.native_to_hf(global_name, buffer.detach().cpu()):
-                yield hf_name, _cast_export_tensor(hf_tensor, export_dtype)
+                yield hf_name, hf_tensor
 
 
 def save_hf_weights(model, path: str, config: KimiK2Config, ps: ParallelState) -> None:

--- a/experimental/lite/tests/smoke/primitive/test_save_load_export_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_save_load_export_smoke.py
@@ -21,6 +21,7 @@ wrong-env invocation skips rather than errors.
 from __future__ import annotations
 
 import os
+import re
 from datetime import timedelta
 from types import SimpleNamespace
 
@@ -28,6 +29,7 @@ import pytest
 import torch
 import torch.distributed as dist
 
+from megatron.lite.primitive.ckpt.hf_weights import to_global_layer_name, unwrap_model
 from megatron.lite.primitive.deterministic import set_deterministic
 from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
 from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
@@ -449,6 +451,39 @@ def _is_valid_hf_export_key(key: str, model_name: str) -> bool:
     return key.startswith("model.") or key in ("lm_head.weight",)
 
 
+# Router correction bias keys: ``model.``-rooted kimi/glm5 layout and the bare
+# DS4-Flash layout. The bias steers top-k expert selection, so the export must
+# pass it through bit-identical to the live buffer (never silently cast it).
+_ROUTER_BIAS_KEY_RE = re.compile(
+    r"(?:model\.)?layers\.(\d+)\.(?:mlp\.gate\.e_score_correction_bias|ffn\.gate\.bias)"
+)
+
+
+def _live_router_biases(handle: ModelHandle, num_layers: int) -> dict[int, torch.Tensor]:
+    """Global layer idx -> live router bias buffer (this rank's stages only —
+    exactly the buffers the per-model export bias loop yields)."""
+    biases: dict[int, torch.Tensor] = {}
+    for chunk in handle._extras["model_chunks"]:
+        base_chunk = unwrap_model(chunk)
+        layer_map = (
+            {i: base_chunk.layer_indices[i] for i in range(len(base_chunk.layer_indices))}
+            if hasattr(base_chunk, "layer_indices")
+            else {}
+        )
+        for name, buffer in base_chunk.named_buffers():
+            if not name.endswith((".moe.router.expert_bias", ".mlp.gate.expert_bias")):
+                continue
+            gname = to_global_layer_name(name, layer_map)
+            if gname.startswith("layers."):
+                idx = int(gname.split(".")[1])
+            elif gname.startswith("mtp.layers."):
+                idx = num_layers + int(gname.split(".")[2])
+            else:
+                continue
+            biases[idx] = buffer.detach().cpu()
+    return biases
+
+
 def _export_and_reload(handle: ModelHandle, cfg, protocol, out_dir: str, model_name: str) -> None:
     """Export HF weights (bf16) and assert the reloaded shards are valid.
 
@@ -481,9 +516,12 @@ def _export_and_reload(handle: ModelHandle, cfg, protocol, out_dir: str, model_n
     shards = [f for f in os.listdir(out_dir) if f.endswith(".safetensors")]
     assert shards, f"no safetensors exported to {out_dir}"
     keys: set[str] = set()
-    # The shared exporter casts EVERY floating tensor to bf16 (``_cast_export_tensor``
-    # with export_dtype=bf16) and leaves integers untouched.  So every float weight
-    # — including the router correction bias — must be bf16, while integer auxiliary
+    live_biases = _live_router_biases(handle, int(getattr(cfg, "num_hidden_layers")))
+    # The exporter casts floating tensors to bf16 and leaves integers untouched,
+    # with ONE floating exemption: the router correction bias steers top-k
+    # expert selection, so hub layouts and the load path keep it fp32 (HF
+    # ``_keep_in_fp32_modules_strict``) and the export passes it through
+    # bit-identical to the live buffer instead of casting it.  Integer auxiliary
     # buffers (e.g. DS4 hash-routing ``tid2eid`` index tables; casting them would
     # corrupt the indices) keep their native integral dtype.  Excluding such buffers
     # from the export would be a de-scope; we keep them and check their dtype.
@@ -491,7 +529,19 @@ def _export_and_reload(handle: ModelHandle, cfg, protocol, out_dir: str, model_n
         with safe_open(os.path.join(out_dir, shard), framework="pt") as fh:
             for key in fh.keys():
                 tensor = fh.get_tensor(key)
-                if tensor.dtype.is_floating_point:
+                bias_match = _ROUTER_BIAS_KEY_RE.fullmatch(key)
+                if bias_match is not None:
+                    source = live_biases.get(int(bias_match.group(1)))
+                    assert source is not None, f"{key} has no live router bias source"
+                    if key.endswith(".mlp.gate.e_score_correction_bias"):
+                        assert tensor.dtype == torch.float32, (
+                            f"{key} exported as {tensor.dtype}, want fp32"
+                        )
+                    assert tensor.dtype == source.dtype, (
+                        f"{key} exported as {tensor.dtype}, want untouched {source.dtype}"
+                    )
+                    assert torch.equal(tensor, source), f"{key} altered by export"
+                elif tensor.dtype.is_floating_point:
                     assert tensor.dtype == torch.bfloat16, (
                         f"{key} exported as {tensor.dtype}, want bf16"
                     )

--- a/experimental/lite/tests/unit/model/test_export_expert_bias_fp32.py
+++ b/experimental/lite/tests/unit/model/test_export_expert_bias_fp32.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Exported router ``expert_bias`` must bypass the opt-in ``export_dtype`` cast.
+
+The bias steers top-k expert selection: hub checkpoints for these families
+store it as the only fp32 tensor (HF ``_keep_in_fp32_modules_strict``) and the
+load path deliberately restores it fp32, so bf16-rounding it on export flips
+routing. Every other floating tensor must still honor the opt-in cast.
+
+The glm5/deepseek_v4 cases install the shared ``transformer_engine_import_stub``
+fixture (their ``lite`` package eagerly imports the TE-backed model on import);
+kimi_k2 imports TE-free and runs without it.
+"""
+from types import SimpleNamespace
+
+import torch
+import torch.nn as nn
+
+
+def _single_rank_parallel_state() -> SimpleNamespace:
+    return SimpleNamespace(
+        pp_size=1, tp_size=1, tp_group=None, ep_size=1, ep_group=None, etp_size=1, etp_group=None
+    )
+
+
+def _bias_pattern(num_experts: int) -> torch.Tensor:
+    # Distinctive fp32 values that do NOT survive a bf16 round-trip bitwise.
+    return torch.arange(num_experts, dtype=torch.float32) * 1e-3 + 0.05
+
+
+class _TinyRoutedModule(nn.Module):
+    """Exactly what the bias-export loop consumes: a ``layers.0`` submodule
+    holding the fp32 router bias buffer, plus a ``norm.weight`` parameter so
+    the shared exporter has one ordinary float tensor to cast (the positive
+    half of the opt-in cast contract)."""
+
+    def __init__(self, bias_parent_path: str, num_experts: int) -> None:
+        super().__init__()
+        self.norm = nn.LayerNorm(8)
+        self.layers = nn.ModuleList([nn.Module()])
+        parent = self.layers[0]
+        for part in bias_parent_path.split("."):
+            child = nn.Module()
+            setattr(parent, part, child)
+            parent = child
+        parent.register_buffer("expert_bias", _bias_pattern(num_experts))
+
+
+def _assert_bias_fp32_and_norm_cast(
+    exported: dict[str, torch.Tensor],
+    source_bias: torch.Tensor,
+    bias_key: str,
+    norm_key: str,
+) -> None:
+    assert bias_key in exported
+    bias = exported[bias_key]
+    assert bias.dtype == torch.float32
+    assert torch.equal(bias, source_bias)
+    # The opt-in cast contract must stay intact for every non-bias float.
+    assert exported[norm_key].dtype == torch.bfloat16
+
+
+def test_kimi_k2_export_keeps_expert_bias_fp32_under_bf16_cast() -> None:
+    from megatron.lite.model.kimi_k2.config import KimiK2Config
+    from megatron.lite.model.kimi_k2.lite.checkpoint import export_hf_weights
+
+    cfg = KimiK2Config(
+        num_hidden_layers=1, n_routed_experts=4, num_experts_per_tok=2, first_k_dense_replace=0
+    )
+    model = _TinyRoutedModule("moe.router", cfg.num_experts)
+
+    exported = dict(
+        export_hf_weights(model, cfg, _single_rank_parallel_state(), export_dtype="bfloat16")
+    )
+
+    _assert_bias_fp32_and_norm_cast(
+        exported,
+        model.layers[0].moe.router.expert_bias,
+        "model.layers.0.mlp.gate.e_score_correction_bias",
+        "model.norm.weight",
+    )
+
+
+def test_glm5_export_keeps_expert_bias_fp32_under_bf16_cast(
+    transformer_engine_import_stub,
+) -> None:
+    transformer_engine_import_stub()
+    from megatron.lite.model.glm5.config import Glm5Config
+    from megatron.lite.model.glm5.lite.checkpoint import export_hf_weights
+
+    cfg = Glm5Config(
+        num_hidden_layers=1,
+        n_routed_experts=4,
+        num_experts_per_tok=2,
+        first_k_dense_replace=0,
+        num_nextn_predict_layers=0,
+    )
+    model = _TinyRoutedModule("moe.router", cfg.num_experts)
+
+    exported = dict(
+        export_hf_weights(model, cfg, _single_rank_parallel_state(), export_dtype="bfloat16")
+    )
+
+    _assert_bias_fp32_and_norm_cast(
+        exported,
+        model.layers[0].moe.router.expert_bias,
+        "model.layers.0.mlp.gate.e_score_correction_bias",
+        "model.norm.weight",
+    )
+
+
+def test_deepseek_v4_export_keeps_expert_bias_fp32_under_bf16_cast(
+    transformer_engine_import_stub,
+) -> None:
+    transformer_engine_import_stub()
+    from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
+    from megatron.lite.model.deepseek_v4.lite.checkpoint import export_hf_weights
+
+    cfg = DeepseekV4Config(
+        num_hidden_layers=1,
+        n_routed_experts=4,
+        num_experts_per_tok=2,
+        num_hash_layers=0,
+        num_nextn_predict_layers=0,
+    )
+    # Synthetic fp32 buffer pins the exporter contract (never cast the bias); real
+    # DS4 runtime buffers are bf16 today (SigmoidTopKRouter lacks the _apply fp32 pin).
+    model = _TinyRoutedModule("mlp.gate", cfg.num_experts)
+
+    exported = dict(
+        export_hf_weights(model, cfg, _single_rank_parallel_state(), export_dtype="bfloat16")
+    )
+
+    _assert_bias_fp32_and_norm_cast(
+        exported,
+        model.layers[0].mlp.gate.expert_bias,
+        "layers.0.ffn.gate.bias",
+        "norm.weight",
+    )

--- a/experimental/lite/tests/unit/model/test_glm5_lite_static.py
+++ b/experimental/lite/tests/unit/model/test_glm5_lite_static.py
@@ -384,7 +384,8 @@ def test_glm5_checkpoint_exports_and_saves_hf_style_weights(tmp_path):
     cfg = Glm5Config(**_tiny_config_kwargs())
     ps = ParallelState()
     model = _make_glm5_model(cfg, ps=ps)
-    model.layers[1].moe.router.expert_bias.copy_(torch.tensor([0.25, -0.5, 1.0]))
+    # Deliberately not bf16-representable so the fp32 pin below is non-vacuous.
+    model.layers[1].moe.router.expert_bias.copy_(torch.tensor([0.05, -0.51, 1.01]))
 
     exported = dict(export_hf_weights(model, cfg, ps))
     state = model.state_dict()
@@ -421,14 +422,22 @@ def test_glm5_checkpoint_exports_and_saves_hf_style_weights(tmp_path):
     )
 
     hf_bf16_dir = tmp_path / "hf_bf16"
+    bias_key = "model.layers.1.mlp.gate.e_score_correction_bias"
     save_hf_weights(model, str(hf_bf16_dir), cfg, ps, export_dtype=torch.bfloat16)
     with safe_open(str(hf_bf16_dir / "model.safetensors"), framework="pt", device="cpu") as handle:
         floating_dtypes = {
             handle.get_tensor(key).dtype
             for key in handle.keys()
-            if handle.get_tensor(key).is_floating_point()
+            if key != bias_key and handle.get_tensor(key).is_floating_point()
         }
         assert floating_dtypes == {torch.bfloat16}
+        # expert_bias steers top-k selection; hub layout and the load path keep
+        # it fp32 regardless of export_dtype.
+        assert handle.get_tensor(bias_key).dtype == torch.float32
+        assert torch.equal(
+            handle.get_tensor(bias_key),
+            state["layers.1.moe.router.expert_bias"].detach().cpu(),
+        )
 
     loaded_bf16 = _make_glm5_model(cfg, ps=ps)
     load_hf_weights(loaded_bf16, str(hf_bf16_dir), cfg, ps)
@@ -443,6 +452,12 @@ def test_glm5_checkpoint_exports_and_saves_hf_style_weights(tmp_path):
         .cpu()
         .to(torch.bfloat16)
         .to(torch.float32),
+    )
+    # Roundtrip idempotency restored by the fp32 exemption: the bias survives a
+    # bf16 export -> reload bitwise-intact.
+    assert torch.equal(
+        loaded_bf16.state_dict()["layers.1.moe.router.expert_bias"].detach().cpu(),
+        state["layers.1.moe.router.expert_bias"].detach().cpu(),
     )
 
 


### PR DESCRIPTION
## Summary

`export_hf_weights` blanket-casts the fp32 router `expert_bias` buffer whenever `export_dtype` is set (kimi_k2 / glm5 / deepseek_v4), while the load path deliberately preserves it in fp32. Since `expert_bias` is the one tensor whose exact bits steer top-k expert selection, `export(bf16) → load` is silently non-idempotent for exactly the tensor the rest of the codebase protects — and the verl engine defaults `export_dtype="bfloat16"` (`examples/verl/verl_mlite/engine/config.py:40`), so rollout weight pushes hit this by default.

## Why this is a defect, not a dtype preference

- **Export/load asymmetry.** The load side keeps the bias fp32 through cooperating mechanisms: fp32 `register_buffer` + `_apply` re-float override (kimi `model.py:157-161`, glm5 `model.py:270-272`) + fp32 router GEMM + explicit `reader...float()` on load (kimi `checkpoint.py:529,587`, glm5 `checkpoint.py:539,597`). The export side threw those bits away with no warning; `SafeTensorReader` has no dtype validation, so re-loading a degraded checkpoint is silent.
- **Hub layout fidelity.** For these families the faithful HF layout is bf16-everything-except-bias-fp32: HF transformers declares `_keep_in_fp32_modules_strict = ["e_score_correction_bias"]` for the deepseek_v3 and hy_v3 model families, and e.g. the `tencent/Hy3` checkpoint stores `mlp.expert_bias` as the only F32 key type among 47k tensors. A "bf16 export" that casts the bias does not reproduce hub format — it deviates in the single behavior-relevant place. (Upcasting at load heals the dtype, never the discarded mantissa.)
- **Measured routing impact** (synthetic, reproducible): with 4096 tokens x 192 experts, top-8, sigmoid scoring, casting the bias fp32->bf16->fp32 flips the selected expert set for 50/4096 tokens at bias scale 0.05, 48/4096 at 0.01, 32/4096 at 0.005 — nonzero two-digit counts across an order of magnitude of assumed scale. On the default verl path this becomes a systematic train/rollout routing mismatch.

## Changes

- `kimi_k2/glm5/deepseek_v4 lite/checkpoint.py`: the bias export loop yields the tensor uncast; now-dead `_resolve_export_dtype` locals/imports removed (the generic exporter still resolves, validates, and applies `export_dtype` to all other tensors — the opt-in cast contract is unchanged, cf. `test_qwen35_export.py`).
- **New** `tests/unit/model/test_export_expert_bias_fp32.py` (CPU-only, TDD red->green): for each of the three models, asserts the exported bias stays fp32 and bitwise-equal to the source while other floating tensors do cast to bf16.
- `tests/unit/model/test_glm5_lite_static.py` and `tests/smoke/primitive/test_save_load_export_smoke.py` had codified the uniform cast (the smoke comment explicitly said the correction bias must be bf16); both now assert the bias is left untouched and bitwise-intact instead. The glm5 static bias seed values were changed to non-bf16-representable ones so the new assertions are non-vacuous.

## Scope note on deepseek_v4

This PR fixes the export-function contract for all three models, but ds4's *runtime* bias buffer is currently bf16 in a bf16 model: the shared `SigmoidTopKRouter` lacks the `_apply` fp32 pin that the kimi/glm5 model-local routers have. So ds4's exported bias is bitwise-faithful to its (bf16) runtime buffer after this PR, while true fp32 end-to-end for ds4 additionally needs that router pin — a separate pre-existing issue, intentionally not bundled here.

## Verification

- New test file: 3 failing before the fix (bias exported as bf16) -> 3 passing after; runs CPU-only via the existing `transformer_engine_import_stub` conftest fixture.
- `test_qwen35_export.py`: 22/22 passing (opt-in cast contract intact).
- Full `tests/unit` A/B (stash-based): failure set identical before/after (pre-existing environment failures only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
