### PR TITLE
Enable streaming weight export for miles

### DIFF
--- a/experimental/lite/examples/miles/miles_mlite/weight_update.py
+++ b/experimental/lite/examples/miles/miles_mlite/weight_update.py
@@ -184,7 +184,7 @@ class RawHFWeightUpdater:
         chunk = []
         chunk_bytes = 0
         limit = int(getattr(self.args, "update_weight_buffer_size", 2**30))
-        export_kwargs = {}
+        export_kwargs = {"cpu": False}
         if getattr(self.args, "mlite_export_dtype", None):
             export_kwargs["export_dtype"] = self.args.mlite_export_dtype
         for name, tensor in self._iter_local_hf_weights(**export_kwargs):

--- a/experimental/lite/tests/unit/miles/test_weight_update.py
+++ b/experimental/lite/tests/unit/miles/test_weight_update.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+
+
+def _load_weight_update_module(monkeypatch):
+    monkeypatch.setitem(sys.modules, "ray", types.ModuleType("ray"))
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "examples"
+        / "miles"
+        / "miles_mlite"
+        / "weight_update.py"
+    )
+    spec = importlib.util.spec_from_file_location("miles_mlite_weight_update", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_online_weight_export_requests_gpu_resident_fast_path(monkeypatch) -> None:
+    weight_update = _load_weight_update_module(monkeypatch)
+    captured = {}
+
+    class NoPayloadUpdater(weight_update.RawHFWeightUpdater):
+        @property
+        def _needs_weight_payload(self) -> bool:
+            return False
+
+        def _iter_local_hf_weights(self, **export_kwargs):
+            captured.update(export_kwargs)
+            yield "weight", torch.ones(1)
+
+    updater = object.__new__(NoPayloadUpdater)
+    updater.args = SimpleNamespace(
+        mlite_export_dtype="bfloat16",
+        update_weight_buffer_size=4 * 1024**3,
+    )
+
+    assert list(updater._export_weight_chunks()) == []
+    assert captured == {"cpu": False, "export_dtype": "bfloat16"}


### PR DESCRIPTION
This stacks on #85 and enables its GPU-resident bounded streaming export path for miles/SGLang online weight updates by requesting GPU-resident exports. Hugging Face checkpoint saves retain the default CPU path. Validation: focused unit tests passed (11 passed, 1 CUDA-only skip); Slurm job 13571590 completed all steps with rc=0, ran one Qwen3 MoE GRPO rollout plus both weight updates, and reduced the steady-state pause-to-continue window from a 13-second historical median to 2 seconds.