### PR TITLE
MLite M-FSDP: fully standalone optimizer (follow-up to #26; no vendoring / mcore / fsdp2 deps)

### DIFF
--- a/experimental/lite/docs/architecture.md
+++ b/experimental/lite/docs/architecture.md
@@ -37,6 +37,16 @@ The model protocol owns:
 - Model-specific optimizer construction.
 - HF checkpoint load/export mapping.
 
+## M-FSDP Optimizer Algorithm Seam
+
+The M-FSDP primitive owns parameter, gradient, and optimizer-state sharding;
+the optimizer algorithm is an orthogonal injection point. Adam is the default,
+and SGD is built in. A caller may pass `optimizer_factory` to
+`build_mfsdp_training_optimizer` for an optional algorithm such as Muon. The
+factory receives the sharded main-parameter groups and optimizer config and
+must return a `torch.optim.Optimizer`-compatible object. It must not wrap the
+model or replace the M-FSDP all-gather/reduce-scatter lifecycle.
+
 ## Current Deliberate Omissions
 
 This package currently includes only the lite model implementation path. It

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
@@ -20,9 +20,15 @@ from megatron.lite.model.protocol_utils import (
 )
 from megatron.lite.model.qwen3_5.config import Qwen35Config
 from megatron.lite.model.qwen3_5.lite.checkpoint import EXPERT_CLASSIFIER, PLACEMENT_FN
-from megatron.lite.model.qwen3_5.lite.checkpoint import export_hf_weights as _export_hf_weights_impl
-from megatron.lite.model.qwen3_5.lite.checkpoint import load_hf_weights as _load_hf_weights_impl
-from megatron.lite.model.qwen3_5.lite.checkpoint import save_hf_weights as _save_hf_weights_impl
+from megatron.lite.model.qwen3_5.lite.checkpoint import (
+    export_hf_weights as _export_hf_weights_impl,
+)
+from megatron.lite.model.qwen3_5.lite.checkpoint import (
+    load_hf_weights as _load_hf_weights_impl,
+)
+from megatron.lite.model.qwen3_5.lite.checkpoint import (
+    save_hf_weights as _save_hf_weights_impl,
+)
 from megatron.lite.primitive.bundle import ModelBundle
 from megatron.lite.primitive.parallel import ParallelState, init_parallel
 from megatron.lite.primitive.quantization import (
@@ -125,7 +131,11 @@ def _forward_step_bshd(model: nn.Module, batch: PackedBatch) -> dict:
     """
     input_ids = batch.input_ids.reshape(1, -1)
     labels = batch.labels.reshape(1, -1) if batch.labels is not None else None
-    kwargs: dict[str, Any] = {"input_ids": input_ids, "labels": labels, "packed_seq_params": None}
+    kwargs: dict[str, Any] = {
+        "input_ids": input_ids,
+        "labels": labels,
+        "packed_seq_params": None,
+    }
     add_cross_entropy_fusion(kwargs, model)
     return model(**kwargs)
 
@@ -178,7 +188,9 @@ def build_model(model_cfg: Qwen35Config, *, impl_cfg: ImplConfig) -> ModelBundle
     mtp_enable_train = mtp_enable and bool(impl_cfg.mtp_enable_train)
     if mtp_enable:
         if model_cfg.num_nextn_predict_layers <= 0:
-            raise ValueError("mtp_enable=True but HF config has no num_nextn_predict_layers.")
+            raise ValueError(
+                "mtp_enable=True but HF config has no num_nextn_predict_layers."
+            )
         model_cfg.mtp_loss_scaling_factor = impl_cfg.mtp_loss_scaling_factor
         if impl_cfg.mtp_use_repeated_layer is not None:
             model_cfg.mtp_use_repeated_layer = impl_cfg.mtp_use_repeated_layer
@@ -189,7 +201,11 @@ def build_model(model_cfg: Qwen35Config, *, impl_cfg: ImplConfig) -> ModelBundle
     recompute_spec = parse_recompute_spec(impl_cfg.recompute)
     vpp = None if p.vpp == 1 else p.vpp
     deterministic = impl_cfg.deterministic
-    if impl_cfg.use_thd and deterministic and "linear_attention" in model_cfg.layer_types:
+    if (
+        impl_cfg.use_thd
+        and deterministic
+        and "linear_attention" in model_cfg.layer_types
+    ):
         deterministic = False
     train_cfg = SimpleNamespace(
         tp=ps.tp_size,
@@ -216,7 +232,11 @@ def build_model(model_cfg: Qwen35Config, *, impl_cfg: ImplConfig) -> ModelBundle
     )
 
     if vpp is None:
-        chunks = [Qwen35Model(model_cfg, train_cfg, ps, **model_kwargs).to(torch.bfloat16).cuda()]
+        chunks = [
+            Qwen35Model(model_cfg, train_cfg, ps, **model_kwargs)
+            .to(torch.bfloat16)
+            .cuda()
+        ]
     else:
         chunks = [
             Qwen35Model(model_cfg, train_cfg, ps, vpp_chunk_id=i, **model_kwargs)
@@ -252,7 +272,9 @@ def build_model(model_cfg: Qwen35Config, *, impl_cfg: ImplConfig) -> ModelBundle
     post_model_load_hook = None
     optimizer_backend = "none"
     if impl_cfg.optimizer == "dist_opt":
-        optimizer, finalize_grads = _build_dist_opt_optimizer(chunks, model_cfg, impl_cfg, ps)
+        optimizer, finalize_grads = _build_dist_opt_optimizer(
+            chunks, model_cfg, impl_cfg, ps
+        )
         from megatron.lite.primitive.ckpt import attach_model_sharded_state_dict
         from megatron.lite.runtime.megatron_utils import register_training_hooks
 
@@ -293,7 +315,9 @@ def build_model(model_cfg: Qwen35Config, *, impl_cfg: ImplConfig) -> ModelBundle
 
         def _post_model_load_hook():
             from megatron.lite.model.qwen3_5.lite.model import Qwen35Layer
-            from megatron.lite.primitive.optimizers.fsdp2 import build_fsdp2_training_optimizer
+            from megatron.lite.primitive.optimizers.fsdp2 import (
+                build_fsdp2_training_optimizer,
+            )
 
             return {
                 "optimizer": build_fsdp2_training_optimizer(

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
@@ -261,6 +261,33 @@ def build_model(model_cfg: Qwen35Config, *, impl_cfg: ImplConfig) -> ModelBundle
         )
         register_training_hooks(chunks, optimizer)
         optimizer_backend = "dist_opt"
+    elif impl_cfg.optimizer == "mfsdp":
+        # build_model is the per-model optimizer dispatch/wiring point (dist_opt
+        # and fsdp2 branch here too). This branch is symmetric with the fsdp2
+        # branch below and cannot be collapsed into optimizers/mfsdp/: the wrap
+        # granularity is architecture-specific -- the model must name its own
+        # transformer-layer class (fsdp_unit_modules) -- and that fact only lives
+        # in the model protocol. The optimizer *construction* is delegated to
+        # build_mfsdp_training_optimizer under optimizers/mfsdp/; only this
+        # model-specific wiring stays here.
+        optimizer_backend = "mfsdp"
+
+        def _post_model_load_hook():
+            from megatron.lite.model.qwen3_5.lite.model import Qwen35Layer
+            from megatron.lite.primitive.optimizers.mfsdp import (
+                build_mfsdp_training_optimizer,
+            )
+
+            optimizer, finalize = build_mfsdp_training_optimizer(
+                chunks,
+                impl_cfg=impl_cfg,
+                ps=ps,
+                is_expert=is_expert_param,
+                fsdp_unit_modules=(Qwen35Layer,),
+            )
+            return {"optimizer": optimizer, "finalize_grads": finalize}
+
+        post_model_load_hook = _post_model_load_hook
     elif impl_cfg.optimizer == "fsdp2":
         optimizer_backend = "fsdp2"
 

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
@@ -257,6 +257,32 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
             chunks, ps, get_placements=PLACEMENT_FN, is_expert=is_expert_param
         )
         optimizer_backend = "dist_opt"
+    elif impl_cfg.optimizer == "mfsdp":
+        # build_model is the per-model optimizer dispatch/wiring point (dist_opt
+        # and fsdp2 branch here too). Symmetric with the fsdp2 branch below and
+        # not collapsible into optimizers/mfsdp/: the wrap granularity is
+        # architecture-specific -- the model must name its own transformer-layer
+        # class (fsdp_unit_modules), which only the model protocol knows. The
+        # optimizer construction is delegated to build_mfsdp_training_optimizer
+        # under optimizers/mfsdp/; only this model-specific wiring stays here.
+        optimizer_backend = "mfsdp"
+
+        def _post_model_load_hook():
+            from megatron.lite.model.qwen3_moe.lite.model import TransformerLayer
+            from megatron.lite.primitive.optimizers.mfsdp import (
+                build_mfsdp_training_optimizer,
+            )
+
+            optimizer, finalize = build_mfsdp_training_optimizer(
+                chunks,
+                impl_cfg=impl_cfg,
+                ps=ps,
+                is_expert=is_expert_param,
+                fsdp_unit_modules=(TransformerLayer,),
+            )
+            return {"optimizer": optimizer, "finalize_grads": finalize}
+
+        post_model_load_hook = _post_model_load_hook
     elif impl_cfg.optimizer == "fsdp2":
         optimizer_backend = "fsdp2"
 

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
@@ -36,8 +36,13 @@ from megatron.lite.model.protocol_utils import (
 )
 from megatron.lite.model.qwen3_moe.common import is_expert_param
 from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
-from megatron.lite.model.qwen3_moe.lite.checkpoint import EXPERT_CLASSIFIER, PLACEMENT_FN
-from megatron.lite.model.qwen3_moe.lite.checkpoint import load_hf_weights as _load_hf_weights_impl
+from megatron.lite.model.qwen3_moe.lite.checkpoint import (
+    EXPERT_CLASSIFIER,
+    PLACEMENT_FN,
+)
+from megatron.lite.model.qwen3_moe.lite.checkpoint import (
+    load_hf_weights as _load_hf_weights_impl,
+)
 from megatron.lite.model.qwen3_moe.lite.model import MTPLossAutoScaler, Qwen3MoEModel
 from megatron.lite.primitive.bundle import ModelBundle
 from megatron.lite.primitive.modules.lora import (
@@ -144,7 +149,9 @@ def _forward_step(model: nn.Module, batch: PackedBatch) -> dict:
 
 def _forward_step_bshd(model: nn.Module, batch: PackedBatch) -> dict:
     labels = batch.labels.reshape(1, -1) if batch.labels is not None else None
-    return model(input_ids=batch.input_ids.reshape(1, -1), labels=labels, packed_seq_params=None)
+    return model(
+        input_ids=batch.input_ids.reshape(1, -1), labels=labels, packed_seq_params=None
+    )
 
 
 def unpack_forward_output(model: nn.Module, batch: PackedBatch, output) -> Any:
@@ -170,7 +177,9 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
     mtp_enable_train = mtp_enable and bool(impl_cfg.mtp_enable_train)
     if mtp_enable:
         if model_cfg.num_nextn_predict_layers <= 0:
-            raise ValueError("mtp_enable=True but HF config has no num_nextn_predict_layers.")
+            raise ValueError(
+                "mtp_enable=True but HF config has no num_nextn_predict_layers."
+            )
         model_cfg.mtp_loss_scaling_factor = impl_cfg.mtp_loss_scaling_factor
         if impl_cfg.mtp_use_repeated_layer is not None:
             model_cfg.mtp_use_repeated_layer = impl_cfg.mtp_use_repeated_layer
@@ -197,7 +206,9 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
 
     vpp = None if p.vpp == 1 else p.vpp
     if vpp is None:
-        chunks = [Qwen3MoEModel(model_cfg, ps, **model_kwargs).to(torch.bfloat16).cuda()]
+        chunks = [
+            Qwen3MoEModel(model_cfg, ps, **model_kwargs).to(torch.bfloat16).cuda()
+        ]
     else:
         chunks = []
         for i in range(vpp):
@@ -288,7 +299,9 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
 
         def _post_model_load_hook():
             from megatron.lite.model.qwen3_moe.lite.model import TransformerLayer
-            from megatron.lite.primitive.optimizers.fsdp2 import build_fsdp2_training_optimizer
+            from megatron.lite.primitive.optimizers.fsdp2 import (
+                build_fsdp2_training_optimizer,
+            )
 
             return {
                 "optimizer": build_fsdp2_training_optimizer(
@@ -355,7 +368,9 @@ def export_hf_weights(
     chunks: list[nn.Module], model_cfg: Qwen3MoEConfig, ps: ParallelState, **kwargs
 ):
     """Export HF weights from model chunks."""
-    from megatron.lite.model.qwen3_moe.lite.checkpoint import export_hf_weights as _export
+    from megatron.lite.model.qwen3_moe.lite.checkpoint import (
+        export_hf_weights as _export,
+    )
 
     for chunk in chunks:
         yield from _export(chunk, model_cfg, ps, **kwargs)

--- a/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
@@ -22,6 +22,7 @@ import torch.nn as nn  # pyright: ignore[reportMissingImports]
 from torch.distributed.device_mesh import DeviceMesh  # pyright: ignore[reportMissingImports]
 from torch.distributed.tensor import DTensor  # pyright: ignore[reportMissingImports]
 
+from megatron.lite.primitive.optimizers.mfsdp.wrapper import MFSdpModule
 from megatron.lite.primitive.parallel import ParallelState
 from megatron.lite.primitive.protocols import (
     ExpertClassifierFn,
@@ -159,7 +160,8 @@ def load_training_checkpoint(
                 t = state_dict[key]
                 with torch.no_grad():
                     _copy_tensor_(param, t)
-        _copy_full_parameters_to_shards_if_available(model)
+        if isinstance(model, MFSdpModule):
+            model.install_optimized_model_weights()
 
     if load_optimizer:
         _load_optimizer_checkpoint(optimizer, ckpt_path)
@@ -262,20 +264,6 @@ def _model_chunks(model: nn.Module | Iterable[nn.Module]) -> list[nn.Module]:
     if not all(isinstance(chunk, nn.Module) for chunk in chunks):
         raise TypeError("checkpoint model chunks must be nn.Module instances.")
     return chunks
-
-
-def _copy_full_parameters_to_shards_if_available(
-    model: nn.Module | Iterable[nn.Module],
-) -> None:
-    for chunk in _model_chunks(model):
-        for module in chunk.modules():
-            copy_fn = getattr(
-                getattr(module, "param_sync", None),
-                "copy_full_parameters_to_shards",
-                None,
-            )
-            if callable(copy_fn):
-                copy_fn()
 
 
 def _to_local_tensor(tensor: Any) -> torch.Tensor:

--- a/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
@@ -159,6 +159,7 @@ def load_training_checkpoint(
                 t = state_dict[key]
                 with torch.no_grad():
                     _copy_tensor_(param, t)
+        _copy_full_parameters_to_shards_if_available(model)
 
     if load_optimizer:
         _load_optimizer_checkpoint(optimizer, ckpt_path)
@@ -261,6 +262,20 @@ def _model_chunks(model: nn.Module | Iterable[nn.Module]) -> list[nn.Module]:
     if not all(isinstance(chunk, nn.Module) for chunk in chunks):
         raise TypeError("checkpoint model chunks must be nn.Module instances.")
     return chunks
+
+
+def _copy_full_parameters_to_shards_if_available(
+    model: nn.Module | Iterable[nn.Module],
+) -> None:
+    for chunk in _model_chunks(model):
+        for module in chunk.modules():
+            copy_fn = getattr(
+                getattr(module, "param_sync", None),
+                "copy_full_parameters_to_shards",
+                None,
+            )
+            if callable(copy_fn):
+                copy_fn()
 
 
 def _to_local_tensor(tensor: Any) -> torch.Tensor:

--- a/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
@@ -39,7 +39,9 @@ def _tensor_nbytes(tensor: torch.Tensor) -> int:
 def _to_cpu(tensor: torch.Tensor) -> torch.Tensor:
     if tensor.device.type == "cpu":
         return tensor
-    with get_weight_sync_probe().measure("d2h", nbytes=_tensor_nbytes(tensor), device=tensor.device):
+    with get_weight_sync_probe().measure(
+        "d2h", nbytes=_tensor_nbytes(tensor), device=tensor.device
+    ):
         return tensor.cpu()
 
 
@@ -47,7 +49,9 @@ def _copy_to_cpu(dst: torch.Tensor, src: torch.Tensor) -> None:
     if src.device.type == "cpu":
         dst.copy_(src)
         return
-    with get_weight_sync_probe().measure("d2h", nbytes=_tensor_nbytes(src), device=src.device):
+    with get_weight_sync_probe().measure(
+        "d2h", nbytes=_tensor_nbytes(src), device=src.device
+    ):
         dst.copy_(src)
 
 
@@ -83,7 +87,9 @@ def _materialize_dtensor(tensor: torch.Tensor) -> torch.Tensor:
     params (dist_opt backend) pass through untouched.
     """
     if DTensor is not None and isinstance(tensor, DTensor):
-        with get_weight_sync_probe().measure("fsdp_gather", device=tensor.device) as sample:
+        with get_weight_sync_probe().measure(
+            "fsdp_gather", device=tensor.device
+        ) as sample:
             result = tensor.full_tensor()
             sample.nbytes = _tensor_nbytes(result)
             return result
@@ -101,7 +107,9 @@ class HFWeights(Protocol):
         """Megatron Lite param name → [HF param names]. Multiple = concat (QKV, gate+up)."""
         ...
 
-    def hf_to_native(self, native_name: str, hf_tensors: list[torch.Tensor]) -> torch.Tensor:
+    def hf_to_native(
+        self, native_name: str, hf_tensors: list[torch.Tensor]
+    ) -> torch.Tensor:
         """Convert HF tensors → single Megatron Lite tensor (e.g. merge QKV)."""
         ...
 
@@ -244,7 +252,9 @@ def _resolve_export_dtype(export_dtype: str | torch.dtype | None) -> torch.dtype
     return aliases[normalized]
 
 
-def _cast_export_tensor(tensor: torch.Tensor, export_dtype: torch.dtype | None) -> torch.Tensor:
+def _cast_export_tensor(
+    tensor: torch.Tensor, export_dtype: torch.dtype | None
+) -> torch.Tensor:
     if export_dtype is None or not tensor.is_floating_point():
         return tensor
     return tensor.to(dtype=export_dtype)
@@ -255,14 +265,21 @@ def _cast_export_tensor(tensor: torch.Tensor, export_dtype: torch.dtype | None) 
 # ======================================================================
 
 
-def split_dim(tensor: torch.Tensor, rank: int, world: int, dim: int = 0) -> torch.Tensor:
+def split_dim(
+    tensor: torch.Tensor, rank: int, world: int, dim: int = 0
+) -> torch.Tensor:
     if world <= 1:
         return tensor
     return tensor.chunk(world, dim=dim)[rank].contiguous()
 
 
 def split_qkv(
-    tensor: torch.Tensor, rank: int, world: int, num_q_heads: int, num_kv_heads: int, head_dim: int
+    tensor: torch.Tensor,
+    rank: int,
+    world: int,
+    num_q_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
 ) -> torch.Tensor:
     """TP-shard a fused [Q, K, V] weight, splitting Q/K/V heads independently.
 
@@ -363,7 +380,8 @@ def bucketed_all_gather_into_tensor(
         [torch.empty_like(tensor) for _, tensor in bucket] for _ in range(group_size)
     ]
     gathered_flat_views = [
-        [tensor.view(-1) for tensor in rank_shards] for rank_shards in gathered_shards_by_rank
+        [tensor.view(-1) for tensor in rank_shards]
+        for rank_shards in gathered_shards_by_rank
     ]
 
     send_buffer = torch.empty(max_chunk_numel, dtype=dtype, device=device)
@@ -636,7 +654,9 @@ def to_global_layer_name(name: str, layer_map: dict[int, int]) -> str:
     return re.sub(r"layers\.(\d+)\.", _replace, name)
 
 
-def gather_gate_up(tensor: torch.Tensor, world_size: int, group: dist.ProcessGroup) -> torch.Tensor:
+def gather_gate_up(
+    tensor: torch.Tensor, world_size: int, group: dist.ProcessGroup
+) -> torch.Tensor:
     ffn_local = tensor.shape[0] // 2
     gate_full = allgather_concat(tensor[:ffn_local], world_size, group, dim=0)
     up_full = allgather_concat(tensor[ffn_local:], world_size, group, dim=0)
@@ -649,7 +669,12 @@ def gather_gate_up(tensor: torch.Tensor, world_size: int, group: dist.ProcessGro
 
 
 def load_hf_weights(
-    model: nn.Module, hf_path: str, spec: HFWeights, ps, *, vocab_size: int | None = None
+    model: nn.Module,
+    hf_path: str,
+    spec: HFWeights,
+    ps,
+    *,
+    vocab_size: int | None = None,
 ) -> None:
     """Load HF safetensors into a Megatron Lite model using HFWeights.
 
@@ -708,7 +733,9 @@ def load_hf_weights(
                     padded = pad_vocab_for_tp(vocab_size, ps.tp_size)
                     if tensor.size(0) < padded:
                         pad = torch.zeros(
-                            padded - tensor.size(0), *tensor.shape[1:], dtype=tensor.dtype
+                            padded - tensor.size(0),
+                            *tensor.shape[1:],
+                            dtype=tensor.dtype,
                         )
                         tensor = torch.cat([tensor, pad], dim=0)
                 qkv = spec.qkv_spec(mapped) if hasattr(spec, "qkv_spec") else None
@@ -732,9 +759,13 @@ def load_hf_weights(
             log_rank0(f"WARNING: {name} not loaded from checkpoint")
 
 
-def _load_expert_weight(native_name, hf_names, reader, spec, ps, loaded, expert_gid, expert_shard):
+def _load_expert_weight(
+    native_name, hf_names, reader, spec, ps, loaded, expert_gid, expert_shard
+):
     if expert_shard is None:
-        raise RuntimeError("Expert weight encountered but expert shard metadata is unavailable.")
+        raise RuntimeError(
+            "Expert weight encountered but expert shard metadata is unavailable."
+        )
     experts_per_rank, local_start = expert_shard
     if expert_gid < local_start or expert_gid >= local_start + experts_per_rank:
         return
@@ -906,9 +937,13 @@ def export_hf_weights(
             if rank0_only and rank != 0:
                 return
             for native_name, gathered_tensor in gathered_tensors.items():
-                if vocab_size is not None and ("embed" in native_name or "head" in native_name):
+                if vocab_size is not None and (
+                    "embed" in native_name or "head" in native_name
+                ):
                     gathered_tensor = gathered_tensor[:vocab_size]
-                for hf_name, hf_tensor in _native_to_hf(spec, native_name, gathered_tensor):
+                for hf_name, hf_tensor in _native_to_hf(
+                    spec, native_name, gathered_tensor
+                ):
                     yield hf_name, _cast_export_tensor(hf_tensor, resolved_export_dtype)
 
         def _flush_dense_bucket():
@@ -955,9 +990,9 @@ def export_hf_weights(
                     if packed_name is None:
                         yield from _iter_mapped({global_name: export_shard})
                         continue
-                    packed_expert_buffers.setdefault(packed_name, {})[
-                        global_idx
-                    ] = export_shard
+                    packed_expert_buffers.setdefault(packed_name, {})[global_idx] = (
+                        export_shard
+                    )
                 if packed_name is not None:
                     packed = packed_expert_buffers[packed_name]
                     if len(packed) == spec.num_experts:
@@ -989,7 +1024,8 @@ def export_hf_weights(
                     tensor_bytes = tensor.numel() * tensor.element_size()
                     should_flush = bool(expert_bucket) and (
                         tensor.dtype != expert_bucket[0][1].dtype
-                        or expert_bucket_bytes + tensor_bytes > expert_bucket_limit_bytes
+                        or expert_bucket_bytes + tensor_bytes
+                        > expert_bucket_limit_bytes
                     )
                     if should_flush:
                         yield from _flush_expert_bucket()
@@ -1090,7 +1126,10 @@ def export_hf_weights(
                     if bucket_bytes >= buffer_max_size_bytes:
                         break
                 header: list[Any] = [
-                    [(name, tuple(tensor.shape), tensor.dtype) for name, tensor in bucket]
+                    [
+                        (name, tuple(tensor.shape), tensor.dtype)
+                        for name, tensor in bucket
+                    ]
                 ]
             else:
                 header = [None]
@@ -1156,7 +1195,9 @@ def _gather_expert(
         out[name] = _maybe_cpu(tensor, cpu=cpu)
 
 
-def _gather_expert_etp(name: str, tensor: torch.Tensor, spec: HFWeights, ps) -> torch.Tensor:
+def _gather_expert_etp(
+    name: str, tensor: torch.Tensor, spec: HFWeights, ps
+) -> torch.Tensor:
     # ETP gather
     if ps.etp_size > 1 and ps.etp_group is not None:
         tp_info = spec.tp_spec(name)

--- a/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
@@ -786,6 +786,50 @@ def _merge_dense_shards(
     return torch.cat(shards, dim=split_dim)
 
 
+def _iter_export_named_parameters(chunk: nn.Module, base_chunk: nn.Module):
+    """Source ``(name, full_param)`` pairs for export, bounded when possible.
+
+    Backends whose wrapper exposes ``stream_full_parameters`` (the mfsdp backend)
+    gather the unsharded parameters one bucket at a time, capping the transient
+    export footprint at a single bucket instead of the whole model. Everything
+    else -- FSDP2 ``DTensor`` params (gathered lazily by ``_materialize_dtensor``)
+    and plain manually-sharded params -- falls back to ``named_parameters``.
+
+    The streaming path is guarded for completeness. Its bucket walk emits a
+    param only when it can match the bucket's shard identity back to a name; a
+    param whose identity fails to match would otherwise fall through the bucket
+    loop and never be yielded (a silently truncated shard on resync). So the set
+    of streamed names is checked against the full ``named_parameters`` set on the
+    unwrapped chunk and any drift fails loud instead of shipping partial weights.
+    """
+    streamer = getattr(chunk, "stream_full_parameters", None)
+    if not callable(streamer):
+        yield from base_chunk.named_parameters()
+        return
+
+    from megatron.lite.primitive.utils import log_rank0
+
+    log_rank0(
+        "[export] bounded stream_full_parameters path active "
+        "(per-bucket materialization)"
+    )
+    # Cheap reference set: the unwrapped chunk's sharded named_parameters (no
+    # all-gather). Names align with the streamer, which resolves against the same
+    # (currently-installed, sharded) module params.
+    expected = {name for name, _ in base_chunk.named_parameters()}
+    streamed: set[str] = set()
+    for name, param in streamer():
+        streamed.add(name)
+        yield name, param
+    if streamed != expected:
+        missing = sorted(expected - streamed)
+        unexpected = sorted(streamed - expected)
+        raise RuntimeError(
+            "bounded parameter export is incomplete: refusing to ship a "
+            f"truncated weight shard (missing={missing}, unexpected={unexpected})"
+        )
+
+
 def export_hf_weights(
     model: nn.Module | list[nn.Module],
     spec: HFWeights,
@@ -828,7 +872,11 @@ def export_hf_weights(
                 if hasattr(base_chunk, "layer_indices")
                 else {}
             )
-            for name, param in base_chunk.named_parameters():
+            # M-FSDP backends stream unsharded params one bounded bucket at a
+            # time via ``stream_full_parameters`` (capping the export peak);
+            # FSDP2 / manual shards fall back to ``named_parameters`` and are
+            # gathered lazily downstream by ``_materialize_dtensor``.
+            for name, param in _iter_export_named_parameters(chunk, base_chunk):
                 yield to_global_layer_name(name, layer_map), param.data.detach()
             if callable(is_export_buffer):
                 for name, buffer in base_chunk.named_buffers():

--- a/experimental/lite/megatron/lite/primitive/optimizers/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/__init__.py
@@ -5,9 +5,15 @@ from __future__ import annotations
 
 import importlib
 
+# One entry per selectable optimizer backend. Registering "mfsdp" here (the
+# minimal wiring the standalone M-FSDP optimizer needs) is what makes it
+# selectable by name via ``get_optimizer_backend`` on the same footing as the
+# existing dist_opt / fsdp2 backends; the implementation lives entirely under
+# ``optimizers/mfsdp/``.
 BACKENDS = {
     "dist_opt": "megatron.lite.primitive.optimizers.megatron_wrap",
     "fsdp2": "megatron.lite.primitive.optimizers.fsdp2",
+    "mfsdp": "megatron.lite.primitive.optimizers.mfsdp.backend",
 }
 
 

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/__init__.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Megatron-FSDP optimizer primitive package."""
+
+from __future__ import annotations
+
+from megatron.lite.primitive.optimizers.mfsdp.fused_ops import OptimizerFactory
+from megatron.lite.primitive.optimizers.mfsdp.optimizer import (
+    build_mfsdp_training_optimizer,
+)
+
+__all__ = [
+    "OptimizerFactory",
+    "build_mfsdp_training_optimizer",
+]

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/backend.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/backend.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Runtime backend contract for standalone M-FSDP."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+
+import torch.distributed as dist
+from torch.distributed.checkpoint.metadata import (
+    ChunkStorageMetadata,
+    MetadataIndex,
+    TensorProperties,
+)
+from torch.distributed.checkpoint.planner import (
+    TensorWriteData,
+    WriteItem,
+    WriteItemType,
+)
+from torch.distributed.tensor import DTensor
+from torch.distributed.tensor.placement_types import Replicate, Shard, _StridedShard
+
+
+def gather_chunk_metadata(dtensor: DTensor) -> ChunkStorageMetadata:
+    """Compute this rank's global offset from the actual uneven local sizes."""
+    local_shape = list(dtensor.to_local().shape)
+    cumulative_shape = list(local_shape)
+    offsets = [0] * len(local_shape)
+    placements = list(dtensor.placements)
+    shard_order = getattr(dtensor.device_mesh, "_shard_order", None)
+    if shard_order is None:
+        strided = [
+            i
+            for i, placement in enumerate(placements)
+            if isinstance(placement, _StridedShard)
+        ]
+        if len(strided) > 1:
+            raise ValueError(
+                "M-FSDP DCP supports at most one strided DTensor placement."
+            )
+        ordinary = [i for i in range(len(placements)) if i not in strided]
+        shard_order = list(reversed(strided + ordinary))
+
+    for mesh_dim in reversed(shard_order):
+        placement = placements[mesh_dim]
+        if isinstance(placement, Replicate):
+            continue
+        if not isinstance(placement, (Shard, _StridedShard)):
+            raise ValueError(f"Unsupported DTensor placement: {placement!r}")
+        shard_dim = int(placement.dim)
+        group = dtensor.device_mesh.get_group(mesh_dim)
+        shapes: list[list[int] | None] = [None] * dist.get_world_size(group)
+        dist.all_gather_object(shapes, list(cumulative_shape), group=group)
+        resolved = [shape for shape in shapes if shape is not None]
+        rank = dist.get_rank(group)
+        offsets[shard_dim] += sum(shape[shard_dim] for shape in resolved[:rank])
+        cumulative_shape[shard_dim] = sum(shape[shard_dim] for shape in resolved)
+    return ChunkStorageMetadata(offsets=tuple(offsets), sizes=tuple(local_shape))
+
+
+def update_uneven_dtensor_chunk_metadata(dtensor: DTensor) -> None:
+    chunk = gather_chunk_metadata(dtensor)
+
+    def create_chunk_list():
+        return [chunk]
+
+    def create_write_items(fqn: str, tensor: DTensor) -> list[WriteItem]:
+        local = tensor.to_local()
+        if local.numel() == 0:
+            return []
+        return [
+            WriteItem(
+                type=WriteItemType.SHARD,
+                index=MetadataIndex(fqn, chunk.offsets),
+                tensor_data=TensorWriteData(
+                    chunk=chunk,
+                    properties=TensorProperties.create_from_tensor(local),
+                    size=tensor.size(),
+                ),
+            )
+        ]
+
+    local = dtensor.to_local()
+    local.__create_chunk_list__ = create_chunk_list
+    local.__create_write_items__ = create_write_items
+
+
+def preprocess_state_dict_for_uneven_dtensor(
+    state_dict: dict[str, Any],
+) -> dict[str, Any]:
+    """Attach DCP planner closures to every nested DTensor, in stable key order."""
+    for _path, value in sorted(_walk_state(state_dict), key=lambda item: item[0]):
+        if isinstance(value, DTensor):
+            update_uneven_dtensor_chunk_metadata(value)
+    return state_dict
+
+
+def _walk_state(
+    value: Any, path: tuple[str, ...] = ()
+) -> Iterator[tuple[tuple[str, ...], Any]]:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            yield from _walk_state(child, (*path, str(key)))
+    elif isinstance(value, (list, tuple)):
+        for index, child in enumerate(value):
+            yield from _walk_state(child, (*path, str(index)))
+    else:
+        yield path, value
+
+
+@dataclass(frozen=True, slots=True)
+class MegatronFSDPBackend:
+    name: str = "mfsdp"
+    runtime_backend: str = "megatron_fsdp"
+
+    def zero_grad(self, optimizer: Any) -> None:
+        optimizer.zero_grad()
+
+    def finish_grad_sync(self, optimizer: Any) -> None:
+        optimizer.finish_grad_sync()
+
+    def clip_grad_norm(self, optimizer: Any):
+        return optimizer.clip_grad_norm()
+
+    def step(self, optimizer: Any):
+        return optimizer.step()
+
+    def state_dict(self, optimizer: Any) -> dict[str, Any]:
+        return optimizer.state_dict()
+
+    def dcp_state_dict(self, optimizer: Any, *, is_loading: bool) -> dict[str, Any]:
+        state = optimizer.state_dict()
+        return preprocess_state_dict_for_uneven_dtensor(state)
+
+    def load_state_dict(self, optimizer: Any, state_dict: dict[str, Any]) -> None:
+        optimizer.load_state_dict(state_dict)
+
+    def sync_model_weights_to_main_weights(self, optimizer: Any) -> bool:
+        for chunk in optimizer._model_chunks:
+            chunk.param_sync.copy_full_parameters_to_shards()
+        return True
+
+    def finalize_grads(
+        self, finalize_fn, model_chunks: list[Any], optimizer: Any
+    ) -> None:
+        finalize_fn()
+
+
+BACKEND = MegatronFSDPBackend()
+
+
+__all__ = [
+    "BACKEND",
+    "MegatronFSDPBackend",
+    "gather_chunk_metadata",
+    "preprocess_state_dict_for_uneven_dtensor",
+    "update_uneven_dtensor_chunk_metadata",
+]

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
@@ -379,7 +379,13 @@ class ParamBucket:
             )
         )
         self.full_buffer = torch.empty(0, dtype=compute_dtype, device=self.device)
+        self.full_main_grad_buffer = torch.empty(
+            0,
+            dtype=self.policy.main_grads_dtype,
+            device=self.device,
+        )
         self._full_lease: BufferLease | None = None
+        self._full_main_grad_lease: BufferLease | None = None
         self._grad_lease: BufferLease | None = None
         self._param_gather_work: Any | None = None
         self._grad_reduce_work: Any | None = None
@@ -412,6 +418,9 @@ class ParamBucket:
                 _copy_parameter_metadata(spec.full_param, shard_param)
                 shard_param._mfsdp_original_ndim = spec.full_param.ndim
                 spec.shard_param = shard_param
+                # TE returns a dummy ``.grad`` when its wgrad GEMM writes the
+                # real gradient directly into ``main_grad``.
+                spec.full_param.grad_added_to_main_grad = False
                 spec.full_param.register_post_accumulate_grad_hook(
                     self._make_grad_ready_hook(spec)
                 )
@@ -431,6 +440,39 @@ class ParamBucket:
             spec.full_param.data = view
             for binding in spec.bindings:
                 setattr(binding.module, binding.attribute, spec.full_param)
+
+    def prepare_main_grads(self) -> None:
+        """Attach bounded FP32 views for fused wgrad accumulation."""
+        if self._full_main_grad_lease is None:
+            self._full_main_grad_lease = self.allocator.allocate(
+                self.full_numel,
+                dtype=self.policy.main_grads_dtype,
+                device=self.device,
+                group=self.process_group,
+                key=(
+                    "main_grad",
+                    id(self.process_group),
+                    self.allocator_layout_key,
+                ),
+            )
+            self.full_main_grad_buffer = self._full_main_grad_lease.tensor
+            self.full_main_grad_buffer.zero_()
+        for spec in self.specs:
+            spec.full_param.main_grad = self.full_main_grad_buffer.narrow(
+                0, spec.full_offset, spec.numel
+            ).view(spec.shape)
+
+    def _release_full_main_grads(self) -> None:
+        if self._full_main_grad_lease is not None:
+            self._full_main_grad_lease.release()
+            self._full_main_grad_lease = None
+        self.full_main_grad_buffer = torch.empty(
+            0,
+            dtype=self.policy.main_grads_dtype,
+            device=self.device,
+        )
+        for spec in self.specs:
+            spec.full_param.main_grad = self.full_main_grad_buffer
 
     def prepare_param_gather(self) -> tuple[torch.Tensor, torch.Tensor]:
         if self._full_lease is None:
@@ -505,6 +547,8 @@ class ParamBucket:
         self.discard_full_parameter_views()
         if self._grad_reduce_launched:
             self.wait_grad_reduce()
+        else:
+            self._release_full_main_grads()
         self.allocator.release_cached()
 
         grad_present = {
@@ -525,6 +569,11 @@ class ParamBucket:
         self.full_buffer = torch.empty(
             0,
             dtype=self.policy.compute_dtype,
+            device=device,
+        )
+        self.full_main_grad_buffer = torch.empty(
+            0,
+            dtype=self.policy.main_grads_dtype,
             device=device,
         )
 
@@ -563,6 +612,8 @@ class ParamBucket:
         self.discard_full_parameter_views()
         if self._grad_reduce_launched:
             self.wait_grad_reduce()
+        else:
+            self._release_full_main_grads()
         self.allocator.release_cached()
 
     def prepare_grad_reduce(
@@ -573,23 +624,27 @@ class ParamBucket:
         if not force and len(self._grad_ready_ids) != len(self.specs):
             return None
         self._grad_reduce_launched = True
-        self._grad_lease = self.allocator.allocate(
-            self.full_numel,
-            dtype=self.policy.grad_comm_dtype,
-            device=self.device,
-            group=self.process_group,
-            key=(
-                "grad",
-                id(self.process_group),
-                self.allocator_layout_key,
-            ),
-        )
-        grad_input = self._grad_lease.tensor
-        grad_input.zero_()
+        self.prepare_main_grads()
+        if self.policy.grad_comm_dtype == self.policy.main_grads_dtype:
+            grad_input = self.full_main_grad_buffer
+        else:
+            self._grad_lease = self.allocator.allocate(
+                self.full_numel,
+                dtype=self.policy.grad_comm_dtype,
+                device=self.device,
+                group=self.process_group,
+                key=(
+                    "grad",
+                    id(self.process_group),
+                    self.allocator_layout_key,
+                ),
+            )
+            grad_input = self._grad_lease.tensor
+            grad_input.copy_(self.full_main_grad_buffer)
         with torch.no_grad():
             for spec in self.specs:
                 grad = spec.full_param.grad
-                if grad is not None:
+                if grad is not None and not spec.full_param.grad_added_to_main_grad:
                     grad_input.narrow(0, spec.full_offset, spec.numel).copy_(
                         grad.reshape(-1)
                     )
@@ -628,6 +683,7 @@ class ParamBucket:
         if self._grad_lease is not None:
             self._grad_lease.release()
             self._grad_lease = None
+        self._release_full_main_grads()
 
     def copy_full_parameters_to_shards(self) -> None:
         self.wait_param_gather()
@@ -646,8 +702,10 @@ class ParamBucket:
         self.main_grad_buffer.zero_()
         for spec in self.specs:
             spec.full_param.grad = None
+            spec.full_param.grad_added_to_main_grad = False
             if spec.shard_param is not None:
                 spec.shard_param.grad = None
+        self._release_full_main_grads()
 
     def set_grad_sync_enabled(self, enabled: bool) -> None:
         enabled = bool(enabled)
@@ -982,6 +1040,7 @@ class AllGatherPipeline:
         bucket_id = bucket.bucket_id
         self.wait_bucket_ready(bucket_id, bwd=True)
         bucket.install_full_parameters()
+        bucket.prepare_main_grads()
         self._backward_cursor = min(self._backward_cursor, bucket_id - 1)
         if self.overlap and self._backward_cursor >= 0:
             self.async_bucket_gather(self._backward_cursor, bwd=True)

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
@@ -939,7 +939,11 @@ class AllGatherPipeline:
 
     def wait_bucket_ready(self, bucket_id: int, bwd: bool = False) -> None:
         bucket = self.buckets[bucket_id]
-        if self.overlap and not bucket._full_ready and bucket._param_gather_work is None:
+        if (
+            self.overlap
+            and not bucket._full_ready
+            and bucket._param_gather_work is None
+        ):
             # Prefetch/overlap path: launch the dense all-gather ahead of use on the
             # dedicated priority communication stream.
             self.async_bucket_gather(bucket_id, bwd=bwd)

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
@@ -625,6 +625,12 @@ class ParamBucket:
             return None
         self._grad_reduce_launched = True
         self.prepare_main_grads()
+        with torch.no_grad():
+            for spec in self.specs:
+                grad = spec.full_param.grad
+                if grad is not None and not spec.full_param.grad_added_to_main_grad:
+                    spec.full_param.main_grad.add_(grad)
+                spec.full_param.grad = None
         if self.policy.grad_comm_dtype == self.policy.main_grads_dtype:
             grad_input = self.full_main_grad_buffer
         else:
@@ -641,14 +647,6 @@ class ParamBucket:
             )
             grad_input = self._grad_lease.tensor
             grad_input.copy_(self.full_main_grad_buffer)
-        with torch.no_grad():
-            for spec in self.specs:
-                grad = spec.full_param.grad
-                if grad is not None and not spec.full_param.grad_added_to_main_grad:
-                    grad_input.narrow(0, spec.full_offset, spec.numel).copy_(
-                        grad.reshape(-1)
-                    )
-                spec.full_param.grad = None
         return self.local_grad_comm_buffer, grad_input
 
     def mark_grad_reduce_launched(self, work: Any | None) -> None:
@@ -740,6 +738,10 @@ class ParamBucket:
                 return
             self._grad_ready_ids.add(id(spec))
             if param.grad_added_to_main_grad:
+                param.grad = None
+            else:
+                with torch.no_grad():
+                    param.main_grad.add_(param.grad)
                 param.grad = None
             if len(self._grad_ready_ids) != len(self.specs):
                 return

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
@@ -1,0 +1,1189 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Bucketed parameter and gradient storage for standalone M-FSDP.
+
+The layout follows the useful core of MCore's ParamAndGradBuffer: parameters
+are concatenated once, the global flat buffer is padded once per bucket, and
+each rank owns one contiguous shard.  An all-gather therefore reconstructs the
+global flat layout directly; compute parameters are zero-copy views into the
+collective output and optimizer parameters/gradients are zero-copy views into
+persistent local main buffers.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import math
+from collections import defaultdict
+from collections.abc import Callable, Iterable, Iterator
+from contextlib import nullcontext
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+
+from megatron.lite.primitive.optimizers.mfsdp.config import (
+    MFSDPConfig,
+    MFSDPProcessGroups,
+    MixedPrecisionPolicy,
+    group_rank,
+    group_size,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class NCCLUserBuffer:
+    """Best-effort Apex NCCL memory-pool adapter."""
+
+    def __init__(
+        self,
+        *,
+        enabled: bool,
+        groups: tuple[dist.ProcessGroup, ...],
+        symmetric: bool,
+    ) -> None:
+        self.enabled = bool(enabled and torch.cuda.is_available())
+        self.groups = groups
+        self.symmetric = symmetric
+        self.module: Any | None = None
+        self.pool: Any | None = None
+        self._warned = False
+        if self.enabled:
+            self._initialize()
+
+    @property
+    def active(self) -> bool:
+        return self.module is not None and self.pool is not None
+
+    def _initialize(self) -> None:
+        try:
+            module = importlib.import_module("apex.contrib.nccl_allocator")
+            module.init()
+            try:
+                pool = module.create_nccl_mem_pool(symmetric=self.symmetric)
+            except TypeError:
+                pool = module.create_nccl_mem_pool()
+            self.module = module
+            self.pool = pool
+        except (ImportError, AttributeError, RuntimeError, TypeError) as error:
+            self._disable(f"NCCL user-buffer allocation unavailable: {error}")
+
+    def allocation_context(self, group: dist.ProcessGroup | None):
+        if not self.active or group is None:
+            return nullcontext()
+        try:
+            return self.module.nccl_mem(self.pool, group=group)
+        except (AttributeError, RuntimeError, TypeError) as error:
+            self._disable(f"NCCL user-buffer context failed: {error}")
+            return nullcontext()
+
+    def register_additional_groups(self) -> None:
+        if not self.active or len(self.groups) < 2:
+            return
+        for group in self.groups[1:]:
+            try:
+                backend = group._get_backend(
+                    torch.device("cuda", torch.cuda.current_device())
+                )
+                backend.register_mem_pool(self.pool)
+            except (AttributeError, RuntimeError, TypeError) as error:
+                self._disable(f"NCCL user-buffer group registration failed: {error}")
+                return
+
+    def _disable(self, reason: str) -> None:
+        self.module = None
+        self.pool = None
+        if not self._warned:
+            logger.warning("%s; using Torch communication buffers.", reason)
+            self._warned = True
+
+
+@dataclass(slots=True)
+class BufferLease:
+    tensor: torch.Tensor
+    owner: "TemporaryBufferAllocator"
+    key: tuple[Any, ...]
+    slot: int | None = None
+    registered: bool = False
+    _released: bool = False
+
+    def release(self) -> None:
+        if not self._released:
+            self.owner.release(self)
+            self._released = True
+
+
+class TemporaryBufferAllocator:
+    """Allocate communication storage and release it at the pipeline boundary."""
+
+    def __init__(self, user_buffer: NCCLUserBuffer | None = None) -> None:
+        self.user_buffer = user_buffer
+
+    def allocate(
+        self,
+        numel: int,
+        *,
+        dtype: torch.dtype,
+        device: torch.device,
+        group: dist.ProcessGroup | None,
+        key: tuple[Any, ...],
+    ) -> BufferLease:
+        context = (
+            self.user_buffer.allocation_context(group)
+            if self.user_buffer is not None
+            else nullcontext()
+        )
+        registered = bool(self.user_buffer is not None and self.user_buffer.active)
+        try:
+            with context:
+                tensor = torch.empty(numel, dtype=dtype, device=device)
+            if registered:
+                self.user_buffer.register_additional_groups()
+        except (RuntimeError, TypeError) as error:
+            if self.user_buffer is not None:
+                self.user_buffer._disable(f"Registered allocation failed: {error}")
+            tensor = torch.empty(numel, dtype=dtype, device=device)
+            registered = False
+        return BufferLease(tensor=tensor, owner=self, key=key, registered=registered)
+
+    def release(self, lease: BufferLease) -> None:
+        # Dynamic storage is reclaimed when the lease drops its final reference.
+        return None
+
+    def release_cached(self, *, force: bool = False) -> None:
+        """Drop allocator-owned communication storage before a device move."""
+
+
+class DoubleBufferAllocator(TemporaryBufferAllocator):
+    """Two persistent communication slots per dtype/device/group key."""
+
+    def __init__(self, user_buffer: NCCLUserBuffer | None = None) -> None:
+        super().__init__(user_buffer)
+        self._slots: dict[tuple[Any, ...], list[torch.Tensor | None]] = {}
+        self._busy: dict[tuple[Any, ...], set[int]] = {}
+        self._reuse_events: dict[tuple[Any, ...], list[Any | None]] = {}
+
+    def allocate(
+        self,
+        numel: int,
+        *,
+        dtype: torch.dtype,
+        device: torch.device,
+        group: dist.ProcessGroup | None,
+        key: tuple[Any, ...],
+    ) -> BufferLease:
+        pool_key = (*key, dtype, device)
+        slots = self._slots.setdefault(pool_key, [None, None])
+        busy = self._busy.setdefault(pool_key, set())
+        reuse_events = self._reuse_events.setdefault(pool_key, [None, None])
+        for slot in range(2):
+            if slot in busy:
+                continue
+            tensor = slots[slot]
+            if tensor is None or tensor.numel() < numel:
+                lease = super().allocate(
+                    numel,
+                    dtype=dtype,
+                    device=device,
+                    group=group,
+                    key=pool_key,
+                )
+                tensor = lease.tensor
+                slots[slot] = tensor
+                registered = lease.registered
+            else:
+                registered = bool(
+                    self.user_buffer is not None and self.user_buffer.active
+                )
+            _wait_for_reuse_event(reuse_events[slot], tensor)
+            reuse_events[slot] = None
+            busy.add(slot)
+            return BufferLease(
+                tensor=tensor.narrow(0, 0, numel),
+                owner=self,
+                key=pool_key,
+                slot=slot,
+                registered=registered,
+            )
+        return super().allocate(
+            numel,
+            dtype=dtype,
+            device=device,
+            group=group,
+            key=pool_key,
+        )
+
+    def release(self, lease: BufferLease) -> None:
+        if lease.slot is not None:
+            events = self._reuse_events.setdefault(lease.key, [None, None])
+            events[lease.slot] = _record_reuse_event(lease.tensor)
+            self._busy.get(lease.key, set()).discard(lease.slot)
+
+    def release_cached(self, *, force: bool = False) -> None:
+        # The busy check catches genuine misuse — releasing the cache while a
+        # collective is legitimately in flight — on the normal path. On an
+        # exception-driven teardown (``force=True``) a slot may be left busy by
+        # an aborted collective; raising here would replace the primary error
+        # (e.g. the OOM that triggered the teardown) with a misleading
+        # "active buffers" RuntimeError, so force-drop the cache instead.
+        if not force and any(self._busy.values()):
+            raise RuntimeError("Cannot release active M-FSDP communication buffers.")
+        self._slots.clear()
+        self._busy.clear()
+        self._reuse_events.clear()
+
+
+def _record_reuse_event(tensor: torch.Tensor) -> Any | None:
+    if tensor.device.type != "cuda":
+        return None
+    event = torch.cuda.Event()
+    event.record(torch.cuda.current_stream(tensor.device))
+    return event
+
+
+def _wait_for_reuse_event(event: Any | None, tensor: torch.Tensor) -> None:
+    if event is not None:
+        torch.cuda.current_stream(tensor.device).wait_event(event)
+
+
+def build_temporary_allocator(
+    config: MFSDPConfig,
+    groups: tuple[dist.ProcessGroup, ...],
+) -> TemporaryBufferAllocator:
+    user_buffer = NCCLUserBuffer(
+        enabled=config.nccl_ub,
+        groups=groups,
+        symmetric=not config.disable_symmetric_registration,
+    )
+    allocator_type = (
+        DoubleBufferAllocator if config.fsdp_double_buffer else TemporaryBufferAllocator
+    )
+    return allocator_type(user_buffer)
+
+
+@dataclass(frozen=True, slots=True)
+class ParamBinding:
+    module: nn.Module
+    attribute: str
+
+
+@dataclass(slots=True)
+class ParamSpec:
+    name: str
+    full_param: nn.Parameter
+    bindings: list[ParamBinding]
+    shape: torch.Size
+    numel: int
+    full_offset: int = 0
+    shard_numel: int = 0
+    local_offset: int = 0
+    param_offset: int = 0
+    shard_param: nn.Parameter | None = None
+    retain_full_storage_through_backward: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class SavedParamView:
+    bucket: "ParamBucket"
+    size: tuple[int, ...]
+    stride: tuple[int, ...]
+    storage_offset: int
+
+
+class ParamBucket:
+    """One communication bucket with persistent optimizer shard storage."""
+
+    def __init__(
+        self,
+        bucket_id: int,
+        specs: list[ParamSpec],
+        *,
+        process_group: dist.ProcessGroup | None,
+        gather_group: dist.ProcessGroup | None,
+        config: MFSDPConfig,
+        allocator: TemporaryBufferAllocator,
+        allocator_layout_key: tuple[Any, ...],
+    ) -> None:
+        if not specs:
+            raise ValueError("An M-FSDP parameter bucket cannot be empty.")
+        self.bucket_id = int(bucket_id)
+        self.specs = specs
+        self.process_group = process_group
+        self.gather_group = gather_group or process_group
+        self.world_size = group_size(process_group)
+        self.rank = group_rank(process_group)
+        self.config = config
+        self.allocator = allocator
+        self.allocator_layout_key = allocator_layout_key
+        self.retain_full_storage_through_backward = all(
+            spec.retain_full_storage_through_backward for spec in specs
+        )
+        self.device = specs[0].full_param.device
+        compute_dtype = specs[0].full_param.dtype
+        self.policy = MixedPrecisionPolicy(
+            compute_dtype=compute_dtype,
+            main_params_dtype=config.main_params_dtype,
+            main_grads_dtype=config.main_grads_dtype,
+            grad_comm_dtype=config.grad_comm_dtype,
+        )
+
+        unpadded_numel = sum(spec.numel for spec in specs)
+        self.local_numel = math.ceil(unpadded_numel / self.world_size)
+        self.full_numel = self.local_numel * self.world_size
+        offset = 0
+        local_begin = self.rank * self.local_numel
+        local_end = local_begin + self.local_numel
+        for spec in specs:
+            spec.full_offset = offset
+            spec_begin = offset
+            spec_end = offset + spec.numel
+            intersection_begin = max(spec_begin, local_begin)
+            intersection_end = min(spec_end, local_end)
+            spec.shard_numel = max(0, intersection_end - intersection_begin)
+            spec.local_offset = min(
+                self.local_numel,
+                max(0, intersection_begin - local_begin),
+            )
+            spec.param_offset = min(
+                spec.numel,
+                max(0, intersection_begin - spec_begin),
+            )
+            offset = spec_end
+
+        self.main_param_buffer = torch.zeros(
+            self.local_numel,
+            dtype=self.policy.main_params_dtype,
+            device=self.device,
+        )
+        self.main_grad_buffer = torch.zeros(
+            self.local_numel,
+            dtype=self.policy.main_grads_dtype,
+            device=self.device,
+        )
+        self.grad_shard_buffer = self.main_grad_buffer
+        self.local_compute_buffer = torch.empty(
+            self.local_numel,
+            dtype=self.policy.compute_dtype,
+            device=self.device,
+        )
+        self.local_grad_comm_buffer = (
+            self.main_grad_buffer
+            if self.policy.grad_comm_dtype == self.policy.main_grads_dtype
+            else torch.empty(
+                self.local_numel,
+                dtype=self.policy.grad_comm_dtype,
+                device=self.device,
+            )
+        )
+        self.full_buffer = torch.empty(0, dtype=compute_dtype, device=self.device)
+        self._full_lease: BufferLease | None = None
+        self._grad_lease: BufferLease | None = None
+        self._param_gather_work: Any | None = None
+        self._grad_reduce_work: Any | None = None
+        self._grad_reduce_launched = False
+        self._full_ready = True
+        self.grad_sync_enabled = False
+        self.grad_ready_callback: Callable[["ParamBucket"], None] | None = None
+        self._grad_ready_ids: set[int] = set()
+        self._initialize_parameters()
+
+    def _initialize_parameters(self) -> None:
+        with torch.no_grad():
+            for spec in self.specs:
+                if spec.shard_numel:
+                    source = (
+                        spec.full_param.detach()
+                        .reshape(-1)
+                        .narrow(0, spec.param_offset, spec.shard_numel)
+                    )
+                    self.main_param_buffer.narrow(
+                        0, spec.local_offset, spec.shard_numel
+                    ).copy_(source)
+                shard_view = self.main_param_buffer.narrow(
+                    0, spec.local_offset, spec.shard_numel
+                )
+                shard_param = nn.Parameter(
+                    shard_view,
+                    requires_grad=spec.full_param.requires_grad,
+                )
+                _copy_parameter_metadata(spec.full_param, shard_param)
+                shard_param._mfsdp_original_ndim = spec.full_param.ndim
+                spec.shard_param = shard_param
+                spec.full_param.register_post_accumulate_grad_hook(
+                    self._make_grad_ready_hook(spec)
+                )
+
+    def install_sharded_parameters(self) -> None:
+        for spec in self.specs:
+            assert spec.shard_param is not None
+            for binding in spec.bindings:
+                setattr(binding.module, binding.attribute, spec.shard_param)
+
+    def install_full_parameters(self) -> None:
+        self.wait_param_gather()
+        for spec in self.specs:
+            view = self.full_buffer.narrow(0, spec.full_offset, spec.numel).view(
+                spec.shape
+            )
+            spec.full_param.data = view
+            for binding in spec.bindings:
+                setattr(binding.module, binding.attribute, spec.full_param)
+
+    def prepare_param_gather(self) -> tuple[torch.Tensor, torch.Tensor]:
+        if self._full_lease is None:
+            self._full_lease = self.allocator.allocate(
+                self.full_numel,
+                dtype=self.policy.compute_dtype,
+                device=self.device,
+                group=self.gather_group,
+                key=(
+                    "param",
+                    id(self.gather_group),
+                    self.allocator_layout_key,
+                ),
+            )
+            self.full_buffer = self._full_lease.tensor
+        self.local_compute_buffer.copy_(self.main_param_buffer)
+        return self.full_buffer, self.local_compute_buffer
+
+    def mark_param_gather_launched(self, work: Any | None) -> None:
+        self._param_gather_work = work
+
+    def wait_param_gather(self) -> None:
+        if self._full_ready:
+            return
+        if self._param_gather_work is None:
+            output, local = self.prepare_param_gather()
+            if self.world_size == 1:
+                output.copy_(local)
+            else:
+                self._param_gather_work = dist.all_gather_into_tensor(
+                    output,
+                    local,
+                    group=self.gather_group,
+                    async_op=True,
+                )
+        if self._param_gather_work is not None:
+            self._param_gather_work.wait()
+            self._param_gather_work = None
+        self._full_ready = True
+
+    def release_full_parameters(self) -> None:
+        self.install_sharded_parameters()
+        if self._param_gather_work is not None:
+            self._param_gather_work.wait()
+            self._param_gather_work = None
+        if self._full_lease is not None:
+            self._full_lease.release()
+            self._full_lease = None
+        self.full_buffer = torch.empty(
+            0,
+            dtype=self.policy.compute_dtype,
+            device=self.device,
+        )
+
+        self._full_ready = False
+
+    def discard_full_parameter_views(self) -> None:
+        """Release full-parameter references after autograd no longer needs them."""
+        empty = torch.empty(
+            0,
+            dtype=self.policy.compute_dtype,
+            device=self.device,
+        )
+        with torch.no_grad():
+            for spec in self.specs:
+                spec.full_param.data = empty
+
+    def move_model_state(self, device: torch.device, *, load_grad: bool) -> None:
+        """Move persistent sharded storage without breaking optimizer aliases."""
+        device = torch.device(device)
+        self.release_full_parameters()
+        self.discard_full_parameter_views()
+        if self._grad_reduce_launched:
+            self.wait_grad_reduce()
+        self.allocator.release_cached()
+
+        grad_present = {
+            id(spec): spec.shard_param is not None and spec.shard_param.grad is not None
+            for spec in self.specs
+        }
+        self.main_param_buffer = self.main_param_buffer.to(device)
+        grad_comm_shares_main = self.local_grad_comm_buffer is self.main_grad_buffer
+        self.main_grad_buffer = self.main_grad_buffer.to(device)
+        self.grad_shard_buffer = self.main_grad_buffer
+        self.local_compute_buffer = self.local_compute_buffer.to(device)
+        self.local_grad_comm_buffer = (
+            self.main_grad_buffer
+            if grad_comm_shares_main
+            else self.local_grad_comm_buffer.to(device)
+        )
+        self.device = device
+        self.full_buffer = torch.empty(
+            0,
+            dtype=self.policy.compute_dtype,
+            device=device,
+        )
+
+        with torch.no_grad():
+            for spec in self.specs:
+                assert spec.shard_param is not None
+                spec.shard_param.data = self.main_param_buffer.narrow(
+                    0,
+                    spec.local_offset,
+                    spec.shard_numel,
+                )
+                if load_grad and grad_present[id(spec)]:
+                    spec.shard_param.grad = self.main_grad_buffer.narrow(
+                        0,
+                        spec.local_offset,
+                        spec.shard_numel,
+                    ).view_as(spec.shard_param)
+                else:
+                    spec.shard_param.grad = None
+                spec.full_param.data = self.full_buffer
+
+    def release_scratch_keep_weights(self) -> None:
+        """Drop the all-gather scratch while leaving the sharded weights resident.
+
+        This is ``move_model_state``'s scratch-release prologue without the
+        device move: release the full-parameter all-gather buffer, discard the
+        full-parameter views, drain any in-flight grad reduce, and hand the
+        allocator's cached double-buffer slots back to the driver -- but keep
+        ``main_param_buffer`` (and the optimizer-aliased shard views installed by
+        ``release_full_parameters``) on their current device. A colocated vLLM
+        weight-pool wake needs the transient full-model scratch back before it
+        can ``create_and_map``; the export that follows the wake gathers from the
+        resident shards, so the persistent weights must not move.
+        """
+        self.release_full_parameters()
+        self.discard_full_parameter_views()
+        if self._grad_reduce_launched:
+            self.wait_grad_reduce()
+        self.allocator.release_cached()
+
+    def prepare_grad_reduce(
+        self, *, force: bool = False
+    ) -> tuple[torch.Tensor, torch.Tensor] | None:
+        if self._grad_reduce_launched:
+            return None
+        if not force and len(self._grad_ready_ids) != len(self.specs):
+            return None
+        self._grad_reduce_launched = True
+        self._grad_lease = self.allocator.allocate(
+            self.full_numel,
+            dtype=self.policy.grad_comm_dtype,
+            device=self.device,
+            group=self.process_group,
+            key=(
+                "grad",
+                id(self.process_group),
+                self.allocator_layout_key,
+            ),
+        )
+        grad_input = self._grad_lease.tensor
+        grad_input.zero_()
+        with torch.no_grad():
+            for spec in self.specs:
+                grad = spec.full_param.grad
+                if grad is not None:
+                    grad_input.narrow(0, spec.full_offset, spec.numel).copy_(
+                        grad.reshape(-1)
+                    )
+                spec.full_param.grad = None
+        return self.local_grad_comm_buffer, grad_input
+
+    def mark_grad_reduce_launched(self, work: Any | None) -> None:
+        self._grad_reduce_work = work
+
+    def wait_grad_reduce(self) -> None:
+        if not self._grad_reduce_launched:
+            tensors = self.prepare_grad_reduce(force=True)
+            assert tensors is not None
+            output, grad_input = tensors
+            if self.world_size == 1:
+                output.copy_(grad_input)
+            else:
+                self._grad_reduce_work = dist.reduce_scatter_tensor(
+                    output,
+                    grad_input,
+                    op=dist.ReduceOp.SUM,
+                    group=self.process_group,
+                    async_op=True,
+                )
+        if self._grad_reduce_work is not None:
+            self._grad_reduce_work.wait()
+            self._grad_reduce_work = None
+        self.main_grad_buffer.copy_(self.local_grad_comm_buffer)
+        if self.config.average_gradients and self.world_size > 1:
+            self.main_grad_buffer.div_(self.world_size)
+        for spec in self.specs:
+            assert spec.shard_param is not None
+            spec.shard_param.grad = self.main_grad_buffer.narrow(
+                0, spec.local_offset, spec.shard_numel
+            ).view_as(spec.shard_param)
+        if self._grad_lease is not None:
+            self._grad_lease.release()
+            self._grad_lease = None
+
+    def copy_full_parameters_to_shards(self) -> None:
+        self.wait_param_gather()
+        local_begin = self.rank * self.local_numel
+        self.main_param_buffer.copy_(
+            self.full_buffer.narrow(0, local_begin, self.local_numel)
+        )
+
+    def reset_grad_state(self) -> None:
+        if self._grad_reduce_work is not None:
+            self._grad_reduce_work.wait()
+        self._grad_reduce_work = None
+        self._grad_reduce_launched = False
+        self.grad_sync_enabled = False
+        self._grad_ready_ids.clear()
+        self.main_grad_buffer.zero_()
+        for spec in self.specs:
+            spec.full_param.grad = None
+            if spec.shard_param is not None:
+                spec.shard_param.grad = None
+
+    def set_grad_sync_enabled(self, enabled: bool) -> None:
+        enabled = bool(enabled)
+        if enabled and not self.grad_sync_enabled:
+            self._grad_ready_ids.clear()
+        self.grad_sync_enabled = enabled
+
+    def saved_view(self, tensor: torch.Tensor) -> SavedParamView | None:
+        if not self._full_ready or tensor.numel() == 0:
+            return None
+        if _storage_pointer(tensor) != _storage_pointer(self.full_buffer):
+            return None
+        return SavedParamView(
+            bucket=self,
+            size=tuple(tensor.size()),
+            stride=tuple(tensor.stride()),
+            storage_offset=int(tensor.storage_offset()),
+        )
+
+    def restore_saved_view(self, view: SavedParamView) -> torch.Tensor:
+        self.wait_param_gather()
+        return torch.as_strided(
+            self.full_buffer,
+            size=view.size,
+            stride=view.stride,
+            storage_offset=view.storage_offset,
+        )
+
+    def _make_grad_ready_hook(self, spec: ParamSpec) -> Callable[[nn.Parameter], None]:
+        def grad_ready(param: nn.Parameter) -> None:
+            if param.grad is None:
+                return
+            self._grad_ready_ids.add(id(spec))
+            if len(self._grad_ready_ids) != len(self.specs):
+                return
+            if self.grad_sync_enabled and self.grad_ready_callback is not None:
+                self.grad_ready_callback(self)
+            self.release_full_parameters()
+            self.discard_full_parameter_views()
+            if not self.grad_sync_enabled:
+                self._grad_ready_ids.clear()
+
+        return grad_ready
+
+
+class ParamAndGradBuffer:
+    """Build dense/expert buckets and expose their owning module boundaries."""
+
+    def __init__(
+        self,
+        module: nn.Module,
+        *,
+        groups: MFSDPProcessGroups,
+        config: MFSDPConfig,
+        is_expert: Callable[[str], bool],
+        unit_modules: Iterable[type[nn.Module] | str] | None,
+    ) -> None:
+        self.module = module
+        self.groups = groups
+        self.config = config
+        self.allocator = build_temporary_allocator(
+            config,
+            groups.registration_groups(),
+        )
+        self.buckets, self.owners = self._build(
+            is_expert=is_expert,
+            unit_modules=unit_modules or (),
+        )
+
+    def _build(
+        self,
+        *,
+        is_expert: Callable[[str], bool],
+        unit_modules: Iterable[type[nn.Module] | str],
+    ) -> tuple[list[ParamBucket], dict[int, list[int]]]:
+        module_by_name = dict(self.module.named_modules())
+        module_order = {
+            id(value): index for index, value in enumerate(module_by_name.values())
+        }
+        unit_types = _resolve_module_types(unit_modules)
+        specs_by_id: dict[int, ParamSpec] = {}
+        owner_by_param_id: dict[int, nn.Module] = {}
+        expert_by_param_id: dict[int, bool] = {}
+
+        for name, param in self.module.named_parameters(remove_duplicate=False):
+            if not param.requires_grad:
+                continue
+            parent_name, _, attribute = name.rpartition(".")
+            parent = module_by_name[parent_name]
+            spec = specs_by_id.get(id(param))
+            if spec is None:
+                spec = ParamSpec(
+                    name=name,
+                    full_param=param,
+                    bindings=[],
+                    shape=param.shape,
+                    numel=param.numel(),
+                )
+                specs_by_id[id(param)] = spec
+                owner_by_param_id[id(param)] = _parameter_owner(
+                    parent_name,
+                    parent,
+                    module_by_name,
+                    unit_types,
+                )
+                expert_by_param_id[id(param)] = bool(is_expert(name))
+            spec.bindings.append(ParamBinding(parent, attribute))
+
+        grouped: dict[
+            tuple[int, bool, bool, torch.dtype, torch.device], list[ParamSpec]
+        ] = defaultdict(list)
+        owner_for_key: dict[
+            tuple[int, bool, bool, torch.dtype, torch.device], nn.Module
+        ] = {}
+        for param_id, spec in specs_by_id.items():
+            owner = owner_by_param_id[param_id]
+            expert = expert_by_param_id[param_id]
+            retain_full_storage = len(spec.shape) == 1
+            spec.retain_full_storage_through_backward = retain_full_storage
+            key = (
+                module_order[id(owner)],
+                expert,
+                retain_full_storage,
+                spec.full_param.dtype,
+                spec.full_param.device,
+            )
+            grouped[key].append(spec)
+            owner_for_key[key] = owner
+
+        buckets: list[ParamBucket] = []
+        owners: dict[int, list[int]] = defaultdict(list)
+        for key in sorted(grouped, key=lambda item: item[0]):
+            _owner_order, expert, _retain_full_storage, _dtype, _device = key
+            owner = owner_for_key[key]
+            partitions = _split_specs(grouped[key], self.config.bucket_size)
+            owner_type = type(owner)
+            owner_layout = f"{owner_type.__module__}.{owner_type.__qualname__}"
+            for partition_index, partition in enumerate(partitions):
+                bucket_id = len(buckets)
+                buckets.append(
+                    ParamBucket(
+                        bucket_id,
+                        partition,
+                        process_group=self.groups.data_group(expert=expert),
+                        gather_group=self.groups.gather_group(expert=expert),
+                        config=self.config,
+                        allocator=self.allocator,
+                        allocator_layout_key=(
+                            owner_layout,
+                            expert,
+                            _retain_full_storage,
+                            partition_index,
+                            len(partitions),
+                            sum(spec.numel for spec in partition),
+                        ),
+                    )
+                )
+                owners[id(owner)].append(bucket_id)
+        return buckets, dict(owners)
+
+
+def _split_specs(
+    specs: list[ParamSpec], bucket_size: int | None
+) -> list[list[ParamSpec]]:
+    if bucket_size is None:
+        return [specs]
+    result: list[list[ParamSpec]] = []
+    current: list[ParamSpec] = []
+    current_numel = 0
+    for spec in specs:
+        if current and current_numel + spec.numel > bucket_size:
+            result.append(current)
+            current = []
+            current_numel = 0
+        current.append(spec)
+        current_numel += spec.numel
+    if current:
+        result.append(current)
+    return result
+
+
+def _parameter_owner(
+    parent_name: str,
+    parent: nn.Module,
+    module_by_name: dict[str, nn.Module],
+    unit_types: tuple[type[nn.Module], ...],
+) -> nn.Module:
+    if not unit_types:
+        return parent
+    parts = parent_name.split(".") if parent_name else []
+    for end in range(len(parts), -1, -1):
+        candidate = module_by_name[".".join(parts[:end])]
+        if isinstance(candidate, unit_types):
+            return candidate
+    return module_by_name[""]
+
+
+def _resolve_module_types(
+    module_types: Iterable[type[nn.Module] | str],
+) -> tuple[type[nn.Module], ...]:
+    resolved: list[type[nn.Module]] = []
+    for value in module_types:
+        if isinstance(value, type) and issubclass(value, nn.Module):
+            resolved.append(value)
+            continue
+        if not isinstance(value, str) or "." not in value:
+            raise TypeError(f"Invalid M-FSDP unit module: {value!r}")
+        module_name, _, attribute = value.rpartition(".")
+        module_type = getattr(importlib.import_module(module_name), attribute)
+        if not isinstance(module_type, type) or not issubclass(module_type, nn.Module):
+            raise TypeError(f"M-FSDP unit is not an nn.Module type: {value!r}")
+        resolved.append(module_type)
+    return tuple(resolved)
+
+
+def _copy_parameter_metadata(source: nn.Parameter, target: nn.Parameter) -> None:
+    for name, value in source.__dict__.items():
+        if name not in {"grad", "_grad"}:
+            setattr(target, name, value)
+
+
+def _storage_pointer(tensor: torch.Tensor) -> int:
+    try:
+        return int(tensor.untyped_storage().data_ptr())
+    except RuntimeError:
+        return 0
+
+
+class CommunicationStream:
+    """Launch collectives on a dedicated CUDA stream when CUDA is available."""
+
+    def __init__(self, device: torch.device) -> None:
+        self.device = device
+        self.stream: torch.cuda.Stream | None = None
+        if device.type == "cuda":
+            with torch.cuda.device(device):
+                self.stream = torch.cuda.Stream(device=device, priority=-1)
+
+    def launch(
+        self,
+        callback: Callable[[], Any | None],
+        tensors: Iterable[torch.Tensor],
+    ) -> Any | None:
+        if self.stream is None:
+            return callback()
+        current = torch.cuda.current_stream(self.device)
+        self.stream.wait_stream(current)
+        with torch.cuda.stream(self.stream):
+            work = callback()
+            for tensor in tensors:
+                tensor.record_stream(self.stream)
+        return work
+
+    def wait_for_current(self) -> None:
+        if self.stream is not None:
+            torch.cuda.current_stream(self.device).wait_stream(self.stream)
+
+
+class AllGatherPipeline:
+    """Prefetch parameter buckets in forward and reverse-backward order."""
+
+    def __init__(self, buckets: list[ParamBucket]) -> None:
+        self.buckets = buckets
+        self.overlap = bool(buckets and buckets[0].config.overlap_param_gather)
+        device = buckets[0].device if buckets else torch.device("cpu")
+        self.comm_stream = CommunicationStream(device)
+        self._forward_cursor = 0
+        self._backward_cursor = len(buckets) - 1
+
+    def async_bucket_gather(self, bucket_id: int, bwd: bool = False) -> None:
+        bucket = self.buckets[bucket_id]
+        if bucket._full_ready or bucket._param_gather_work is not None:
+            return
+        output, local = bucket.prepare_param_gather()
+
+        def collective():
+            if bucket.world_size == 1:
+                output.copy_(local)
+                return None
+            return dist.all_gather_into_tensor(
+                output,
+                local,
+                group=bucket.gather_group,
+                async_op=True,
+            )
+
+        work = self.comm_stream.launch(collective, (output, local))
+        bucket.mark_param_gather_launched(work)
+
+    def wait_bucket_ready(self, bucket_id: int, bwd: bool = False) -> None:
+        bucket = self.buckets[bucket_id]
+        if self.overlap and not bucket._full_ready and bucket._param_gather_work is None:
+            # Prefetch/overlap path: launch the dense all-gather ahead of use on the
+            # dedicated priority communication stream.
+            self.async_bucket_gather(bucket_id, bwd=bwd)
+        self.comm_stream.wait_for_current()
+        # When overlap is disabled (the guard forces this for any CP>=2 + DP-sharded
+        # config, see optimizer._order_param_gathers_for_parallel_collectives), do NOT
+        # launch on the side comm stream. Let wait_param_gather issue the all-gather on
+        # the current compute stream instead, so dense_ag (gather_group == dp_cp_ag_group)
+        # is enqueued in program order alongside the model's CP collectives (cp_group).
+        # Those two process groups intersect; launching them from different streams lets
+        # their NCCL enqueue order diverge across ranks on multi-node runs -> collective
+        # deadlock (invisible on single-node NVLink proxies). Program-order serialization
+        # on one stream mirrors how FSDP2 avoids the same hazard.
+        bucket.wait_param_gather()
+
+    def begin_forward(self) -> None:
+        self.release_all()
+        self._forward_cursor = 0
+        if self.buckets and self.overlap:
+            self.async_bucket_gather(0)
+
+    def acquire_forward(self, bucket_ids: Iterable[int]) -> None:
+        for bucket_id in bucket_ids:
+            self.wait_bucket_ready(bucket_id)
+            self.buckets[bucket_id].install_full_parameters()
+            self._forward_cursor = max(self._forward_cursor, bucket_id + 1)
+            if self.overlap and self._forward_cursor < len(self.buckets):
+                self.async_bucket_gather(self._forward_cursor)
+
+    def begin_backward(self) -> None:
+        self._backward_cursor = len(self.buckets) - 1
+        if self.buckets and self.overlap:
+            self.async_bucket_gather(self._backward_cursor, bwd=True)
+
+    def acquire_backward(self, bucket: ParamBucket) -> None:
+        bucket_id = bucket.bucket_id
+        self.wait_bucket_ready(bucket_id, bwd=True)
+        bucket.install_full_parameters()
+        self._backward_cursor = min(self._backward_cursor, bucket_id - 1)
+        if self.overlap and self._backward_cursor >= 0:
+            self.async_bucket_gather(self._backward_cursor, bwd=True)
+
+    def materialize_all(self) -> None:
+        for bucket in self.buckets:
+            self.async_bucket_gather(bucket.bucket_id)
+        for bucket in self.buckets:
+            self.wait_bucket_ready(bucket.bucket_id)
+            bucket.install_full_parameters()
+
+    def release_all(self) -> None:
+        for bucket in self.buckets:
+            bucket.release_full_parameters()
+
+    def reset_device(self, device: torch.device) -> None:
+        self.comm_stream = CommunicationStream(device)
+
+
+class GradReducePipeline:
+    """Launch ready reduce-scatter buckets on a communication stream."""
+
+    def __init__(self, buckets: list[ParamBucket]) -> None:
+        self.buckets = buckets
+        device = buckets[0].device if buckets else torch.device("cpu")
+        self.comm_stream = CommunicationStream(device)
+        for bucket in buckets:
+            if bucket.config.overlap_grad_reduce:
+                bucket.grad_ready_callback = self.reduce_gradients
+
+    def reduce_gradients(self, bucket: ParamBucket, *, force: bool = False) -> None:
+        tensors = bucket.prepare_grad_reduce(force=force)
+        if tensors is None:
+            return
+        output, grad_input = tensors
+
+        def collective():
+            if bucket.world_size == 1:
+                output.copy_(grad_input)
+                return None
+            return dist.reduce_scatter_tensor(
+                output,
+                grad_input,
+                op=dist.ReduceOp.SUM,
+                group=bucket.process_group,
+                async_op=True,
+            )
+
+        work = self.comm_stream.launch(collective, (output, grad_input))
+        bucket.mark_grad_reduce_launched(work)
+
+    def finish(self) -> None:
+        for bucket in reversed(self.buckets):
+            self.reduce_gradients(bucket, force=True)
+        self.comm_stream.wait_for_current()
+        for bucket in self.buckets:
+            bucket.wait_grad_reduce()
+
+    def reset(self) -> None:
+        for bucket in self.buckets:
+            bucket.reset_grad_state()
+
+    def set_enabled(self, enabled: bool) -> None:
+        for bucket in self.buckets:
+            bucket.set_grad_sync_enabled(enabled)
+
+    def reset_device(self, device: torch.device) -> None:
+        self.comm_stream = CommunicationStream(device)
+
+
+class CommunicationPipelines:
+    """Join parameter all-gather and gradient reduce-scatter pipelines."""
+
+    def __init__(self, buckets: list[ParamBucket]) -> None:
+        self.buckets = buckets
+        self.all_gather = AllGatherPipeline(buckets)
+        self.grad_reduce = GradReducePipeline(buckets)
+
+    def begin_forward(self) -> None:
+        self.all_gather.begin_forward()
+
+    def acquire_forward(self, bucket_ids: Iterable[int]) -> None:
+        self.all_gather.acquire_forward(bucket_ids)
+
+    def begin_backward(self) -> None:
+        self.all_gather.begin_backward()
+
+    def acquire_backward(self, bucket: ParamBucket) -> None:
+        self.all_gather.acquire_backward(bucket)
+
+    def acquire_backward_ids(self, bucket_ids: Iterable[int]) -> None:
+        for bucket_id in reversed(tuple(bucket_ids)):
+            self.all_gather.acquire_backward(self.buckets[bucket_id])
+
+    def release_backward_ids(self, bucket_ids: Iterable[int]) -> None:
+        for bucket_id in bucket_ids:
+            bucket = self.buckets[bucket_id]
+            bucket.release_full_parameters()
+            bucket.discard_full_parameter_views()
+
+    def release_forward_ids(self, bucket_ids: Iterable[int]) -> None:
+        for bucket_id in bucket_ids:
+            bucket = self.buckets[bucket_id]
+            if not bucket.retain_full_storage_through_backward:
+                bucket.release_full_parameters()
+                bucket.discard_full_parameter_views()
+
+    def end_forward(self) -> None:
+        for bucket in self.buckets:
+            if not bucket.retain_full_storage_through_backward:
+                bucket.release_full_parameters()
+                bucket.discard_full_parameter_views()
+
+    def materialize_all(self) -> None:
+        self.all_gather.materialize_all()
+
+    def stream_materialize_buckets(self) -> Iterator["ParamBucket"]:
+        """Materialize one bucket at a time, releasing each before the next.
+
+        ``materialize_all`` all-gathers *every* bucket into the persistent
+        double-buffer simultaneously, so the whole unsharded model is resident
+        at once -- a transient full-model peak (tens of GiB/rank) that lands on
+        top of steady-state and drives the colocated resync OOM. A
+        full-parameter *export* only ever reads one
+        parameter at a time, so it does not need the whole model resident; this
+        generator bounds the transient footprint to a single bucket by
+        gather → install → yield → release per bucket, mirroring FSDP2's
+        per-parameter ``full_tensor`` path (which retains no whole-model buffer
+        and shows no export peak). Consumers MUST finish reading a bucket's
+        parameters before requesting the next (plain iteration guarantees this).
+        """
+        for bucket in self.buckets:
+            self.all_gather.async_bucket_gather(bucket.bucket_id)
+            self.all_gather.wait_bucket_ready(bucket.bucket_id)
+            bucket.install_full_parameters()
+            try:
+                yield bucket
+            finally:
+                bucket.release_full_parameters()
+                bucket.discard_full_parameter_views()
+
+    def release_all(self) -> None:
+        self.all_gather.release_all()
+
+    def discard_full_parameter_views(self) -> None:
+        for bucket in self.buckets:
+            bucket.discard_full_parameter_views()
+
+    def move_model_state(self, device: torch.device, *, load_grad: bool) -> None:
+        device = torch.device(device)
+        for bucket in self.buckets:
+            bucket.move_model_state(device, load_grad=load_grad)
+        self.all_gather.reset_device(device)
+        self.grad_reduce.reset_device(device)
+
+    def release_scratch_keep_weights(self) -> None:
+        """Reclaim every bucket's all-gather scratch, keeping weights resident.
+
+        Per-bucket counterpart to ``move_model_state`` that stops short of the
+        device move: it hands the retained double-buffer slots back to the driver
+        (what a colocated vLLM wake needs) but leaves the sharded weights and
+        their optimizer aliases in place as the export gather source. See
+        ``ParamBucket.release_scratch_keep_weights``.
+        """
+        for bucket in self.buckets:
+            bucket.release_scratch_keep_weights()
+
+    def finish_grad_sync(self) -> None:
+        self.grad_reduce.finish()
+
+    def reset_grad_state(self) -> None:
+        self.grad_reduce.reset()
+
+    def set_grad_sync_enabled(self, enabled: bool) -> None:
+        self.grad_reduce.set_enabled(enabled)
+
+    def copy_full_parameters_to_shards(self) -> None:
+        for bucket in self.buckets:
+            bucket.copy_full_parameters_to_shards()
+        self.release_all()
+
+    def pack_saved_tensor(self, tensor: torch.Tensor) -> torch.Tensor | SavedParamView:
+        for bucket in self.buckets:
+            view = bucket.saved_view(tensor)
+            if view is not None:
+                return view
+        return tensor
+
+    def unpack_saved_tensor(self, value: torch.Tensor | SavedParamView) -> torch.Tensor:
+        if isinstance(value, SavedParamView):
+            self.acquire_backward(value.bucket)
+            return value.bucket.restore_saved_view(value)
+        return value
+
+
+__all__ = [
+    "AllGatherPipeline",
+    "BufferLease",
+    "CommunicationPipelines",
+    "CommunicationStream",
+    "DoubleBufferAllocator",
+    "GradReducePipeline",
+    "NCCLUserBuffer",
+    "ParamAndGradBuffer",
+    "ParamBucket",
+    "ParamSpec",
+    "SavedParamView",
+    "TemporaryBufferAllocator",
+]

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
@@ -323,9 +323,12 @@ class ParamBucket:
         )
         self.device = specs[0].full_param.device
         compute_dtype = specs[0].full_param.dtype
+        main_params_dtype = (
+            compute_dtype if config.full_optimizer_offload else config.main_params_dtype
+        )
         self.policy = MixedPrecisionPolicy(
             compute_dtype=compute_dtype,
-            main_params_dtype=config.main_params_dtype,
+            main_params_dtype=main_params_dtype,
             main_grads_dtype=config.main_grads_dtype,
             grad_comm_dtype=config.grad_comm_dtype,
         )
@@ -364,10 +367,14 @@ class ParamBucket:
             device=self.device,
         )
         self.grad_shard_buffer = self.main_grad_buffer
-        self.local_compute_buffer = torch.empty(
-            self.local_numel,
-            dtype=self.policy.compute_dtype,
-            device=self.device,
+        self.local_compute_buffer = (
+            self.main_param_buffer
+            if self.policy.main_params_dtype == self.policy.compute_dtype
+            else torch.empty(
+                self.local_numel,
+                dtype=self.policy.compute_dtype,
+                device=self.device,
+            )
         )
         self.local_grad_comm_buffer = (
             self.main_grad_buffer
@@ -411,6 +418,8 @@ class ParamBucket:
                 )
                 _copy_parameter_metadata(spec.full_param, shard_param)
                 shard_param._mfsdp_original_ndim = spec.full_param.ndim
+                if shard_param.dtype != self.policy.main_grads_dtype:
+                    shard_param.grad_dtype = self.policy.main_grads_dtype
                 spec.shard_param = shard_param
                 spec.full_param.register_post_accumulate_grad_hook(
                     self._make_grad_ready_hook(spec)
@@ -446,7 +455,8 @@ class ParamBucket:
                 ),
             )
             self.full_buffer = self._full_lease.tensor
-        self.local_compute_buffer.copy_(self.main_param_buffer)
+        if self.local_compute_buffer is not self.main_param_buffer:
+            self.local_compute_buffer.copy_(self.main_param_buffer)
         return self.full_buffer, self.local_compute_buffer
 
     def mark_param_gather_launched(self, work: Any | None) -> None:
@@ -511,11 +521,16 @@ class ParamBucket:
             id(spec): spec.shard_param is not None and spec.shard_param.grad is not None
             for spec in self.specs
         }
+        compute_shares_main = self.local_compute_buffer is self.main_param_buffer
         self.main_param_buffer = self.main_param_buffer.to(device)
         grad_comm_shares_main = self.local_grad_comm_buffer is self.main_grad_buffer
         self.main_grad_buffer = self.main_grad_buffer.to(device)
         self.grad_shard_buffer = self.main_grad_buffer
-        self.local_compute_buffer = self.local_compute_buffer.to(device)
+        self.local_compute_buffer = (
+            self.main_param_buffer
+            if compute_shares_main
+            else self.local_compute_buffer.to(device)
+        )
         self.local_grad_comm_buffer = (
             self.main_grad_buffer
             if grad_comm_shares_main

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
@@ -739,6 +739,8 @@ class ParamBucket:
             if param.grad is None:
                 return
             self._grad_ready_ids.add(id(spec))
+            if param.grad_added_to_main_grad:
+                param.grad = None
             if len(self._grad_ready_ids) != len(self.specs):
                 return
             if self.grad_sync_enabled and self.grad_ready_callback is not None:

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/config.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/config.py
@@ -1,0 +1,395 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Standalone Megatron-FSDP config lowering and validation."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+
+_SUPPORTED_OPTIMIZERS = {"adam", "sgd"}
+_REQUIRED_DDP_KNOB_VALUES = {
+    "use_distributed_optimizer": True,
+    "use_megatron_fsdp": True,
+}
+_UNSUPPORTED_OPTIMIZATION_KNOBS = {
+    "use_hsdp",
+    "hsdp",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class MFSDPConfig:
+    """Narrow configuration owned by the standalone M-FSDP primitive.
+
+    The fields are the subset of Megatron-FSDP that MLite exercises.  Keeping
+    this contract local avoids importing the much broader MCore DDP config and
+    makes unsupported sharding modes fail before any buffers are allocated.
+    """
+
+    sharding_strategy: str = "optim_grads_params"
+    bucket_size: int | None = 40_000_000
+    overlap_grad_reduce: bool = True
+    overlap_param_gather: bool = True
+    average_gradients: bool = True
+    main_params_dtype: torch.dtype = torch.float32
+    main_grads_dtype: torch.dtype = torch.float32
+    grad_comm_dtype: torch.dtype = torch.float32
+    nccl_ub: bool = False
+    fsdp_double_buffer: bool = True
+    disable_symmetric_registration: bool = False
+    all_gather_in_start_param_sync: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class MixedPrecisionPolicy:
+    """Dtype policy for compute, persistent main parameters, and gradients."""
+
+    compute_dtype: torch.dtype
+    main_params_dtype: torch.dtype = torch.float32
+    main_grads_dtype: torch.dtype = torch.float32
+    grad_comm_dtype: torch.dtype = torch.float32
+
+    def __post_init__(self) -> None:
+        for name in (
+            "compute_dtype",
+            "main_params_dtype",
+            "main_grads_dtype",
+            "grad_comm_dtype",
+        ):
+            dtype = getattr(self, name)
+            if not torch.empty((), dtype=dtype).is_floating_point():
+                raise ValueError(f"M-FSDP {name} must be floating point, got {dtype}.")
+
+
+@dataclass(frozen=True, slots=True)
+class MFSDPProcessGroups:
+    """Process groups explicitly supplied by MLite composition."""
+
+    dense_dp: dist.ProcessGroup | None
+    expert_dp: dist.ProcessGroup | None
+    dense_ag: dist.ProcessGroup | None
+    expert_ag: dist.ProcessGroup | None
+    tp: dist.ProcessGroup | None
+    etp: dist.ProcessGroup | None
+    ep: dist.ProcessGroup | None
+    pp: dist.ProcessGroup | None
+
+    def data_group(self, *, expert: bool) -> dist.ProcessGroup | None:
+        return self.expert_dp if expert else self.dense_dp
+
+    def gather_group(self, *, expert: bool) -> dist.ProcessGroup | None:
+        return self.expert_ag if expert else self.dense_ag
+
+    def registration_groups(self) -> tuple[dist.ProcessGroup, ...]:
+        groups: list[dist.ProcessGroup] = []
+        for group in (self.dense_dp, self.expert_dp, self.dense_ag, self.expert_ag):
+            if group is not None and all(group is not existing for existing in groups):
+                groups.append(group)
+        return tuple(groups)
+
+
+def build_mfsdp_process_groups(ps: Any) -> MFSDPProcessGroups:
+    """Read groups already owned by MLite; never initialize global MCore state."""
+    dense_dp = getattr(ps, "dp_cp_group", None) or getattr(ps, "dp_group", None)
+    expert_dp = getattr(ps, "ep_dp_group", None) or dense_dp
+    dense_ag = getattr(ps, "dp_cp_ag_group", None) or getattr(ps, "dp_ag_group", None)
+    expert_ag = getattr(ps, "ep_dp_ag_group", None)
+    return MFSDPProcessGroups(
+        dense_dp=dense_dp,
+        expert_dp=expert_dp,
+        dense_ag=dense_ag or dense_dp,
+        expert_ag=expert_ag or expert_dp,
+        tp=getattr(ps, "tp_group", None),
+        etp=getattr(ps, "etp_group", None),
+        ep=getattr(ps, "ep_group", None),
+        pp=getattr(ps, "pp_group", None),
+    )
+
+
+def group_size(group: dist.ProcessGroup | None) -> int:
+    if group is None or not dist.is_available() or not dist.is_initialized():
+        return 1
+    return dist.get_world_size(group)
+
+
+def group_rank(group: dist.ProcessGroup | None) -> int:
+    if group is None or not dist.is_available() or not dist.is_initialized():
+        return 0
+    return dist.get_rank(group)
+
+
+SKIP_TP_DUPLICATE_SYNC_ATTR = "_mlite_mfsdp_skip_tp_duplicate_sync"
+PARAM_NAME_ATTR = "_mlite_mfsdp_param_name"
+
+
+def annotate_parallel_parameters(
+    module: nn.Module,
+    is_expert: Callable[[str], bool],
+    *,
+    tp_size: int,
+    etp_size: int,
+) -> None:
+    """Normalize parameter ownership from topology and explicit attributes."""
+    sequence_parallel_ids = {id(param) for param in getattr(module, "sp_params", ())}
+    for name, param in module.named_parameters():
+        setattr(param, PARAM_NAME_ATTR, name)
+        expert = bool(is_expert(name))
+        param._mfsdp_is_expert = expert
+        if not hasattr(param, "allreduce"):
+            param.allreduce = not expert
+
+        replicated = bool(
+            id(param) in sequence_parallel_ids
+            or getattr(param, "sequence_parallel", False)
+            or getattr(param, "average_gradients_across_tp_domain", False)
+            or getattr(param, "shared", False)
+        )
+        if id(param) in sequence_parallel_ids:
+            param.sequence_parallel = True
+        active_tp_size = max(int(etp_size if expert else tp_size), 1)
+        explicitly_sharded = bool(getattr(param, "tensor_model_parallel", False))
+        sharded = (
+            not replicated
+            and param.ndim > 1
+            and (explicitly_sharded or active_tp_size > 1)
+        )
+        param.tensor_model_parallel = sharded
+        if sharded:
+            setattr(param, SKIP_TP_DUPLICATE_SYNC_ATTR, True)
+        elif hasattr(param, SKIP_TP_DUPLICATE_SYNC_ATTR):
+            delattr(param, SKIP_TP_DUPLICATE_SYNC_ATTR)
+
+
+def build_mfsdp_config(opt: Any) -> MFSDPConfig:
+    """Lower runtime optimizer options into the supported M-FSDP surface."""
+    values = dict(getattr(opt, "override_optimizer_config", None) or {})
+
+    def option(name: str, default: Any, *aliases: str) -> Any:
+        for key in (name, *aliases):
+            if key in values:
+                return values[key]
+            if hasattr(opt, key):
+                value = getattr(opt, key)
+                if value is not None:
+                    return value
+        return default
+
+    strategy = str(
+        option(
+            "mfsdp_sharding_strategy",
+            "optim_grads_params",
+            "data_parallel_sharding_strategy",
+            "megatron_fsdp_sharding_strategy",
+        )
+    )
+    if strategy != "optim_grads_params":
+        raise ValueError(
+            "The standalone M-FSDP path supports only "
+            "data_parallel_sharding_strategy='optim_grads_params'."
+        )
+    raw_bucket_size = option(
+        "bucket_size", 40_000_000, "suggested_communication_unit_size"
+    )
+    bucket_size = None if raw_bucket_size is None else int(raw_bucket_size)
+    if bucket_size is not None and bucket_size <= 0:
+        raise ValueError("M-FSDP bucket_size must be a positive element count or None.")
+
+    main_params_dtype = _coerce_dtype(
+        option("megatron_fsdp_main_params_dtype", torch.float32),
+        name="megatron_fsdp_main_params_dtype",
+    )
+    main_grads_dtype = _coerce_dtype(
+        option("megatron_fsdp_main_grads_dtype", torch.float32),
+        name="megatron_fsdp_main_grads_dtype",
+    )
+    grad_comm_dtype = _coerce_dtype(
+        option("megatron_fsdp_grad_comm_dtype", main_grads_dtype),
+        name="megatron_fsdp_grad_comm_dtype",
+    )
+    nccl_ub = bool(option("nccl_ub", False))
+    return MFSDPConfig(
+        sharding_strategy=strategy,
+        bucket_size=bucket_size,
+        overlap_grad_reduce=bool(option("overlap_grad_reduce", True)),
+        overlap_param_gather=bool(option("overlap_param_gather", True)),
+        average_gradients=bool(option("average_in_collective", True)),
+        main_params_dtype=main_params_dtype,
+        main_grads_dtype=main_grads_dtype,
+        grad_comm_dtype=grad_comm_dtype,
+        nccl_ub=nccl_ub,
+        fsdp_double_buffer=bool(option("fsdp_double_buffer", True)) or nccl_ub,
+        disable_symmetric_registration=bool(
+            option("disable_symmetric_registration", False)
+        ),
+        all_gather_in_start_param_sync=bool(
+            option("fsdp_all_gather_in_start_param_sync", True)
+        ),
+    )
+
+
+def _coerce_dtype(value: Any, *, name: str) -> torch.dtype:
+    if isinstance(value, torch.dtype):
+        return value
+    if value is None:
+        return torch.float32
+    normalized = str(value).lower().removeprefix("torch.")
+    mapping = {
+        "fp32": torch.float32,
+        "float32": torch.float32,
+        "bf16": torch.bfloat16,
+        "bfloat16": torch.bfloat16,
+        "fp16": torch.float16,
+        "float16": torch.float16,
+    }
+    if normalized not in mapping:
+        raise ValueError(f"{name} has unsupported dtype {value!r}.")
+    return mapping[normalized]
+
+
+def validate_mfsdp_config(
+    engine_cfg,
+    *,
+    has_optimizer_factory: bool = False,
+) -> None:
+    """Validate the supported surface for optimizer='megatron_fsdp'."""
+    validate_mfsdp_topology(engine_cfg.parallel)
+    opt = engine_cfg.optimizer
+    validate_optimizer_name(
+        getattr(opt, "optimizer", "adam"),
+        has_optimizer_factory=has_optimizer_factory,
+    )
+    validate_optimization_knobs(opt)
+    if os.environ.get("CUDA_DEVICE_MAX_CONNECTIONS") == "1":
+        raise ValueError(
+            "Megatron-FSDP requires CUDA_DEVICE_MAX_CONNECTIONS > 1 or unset."
+        )
+
+
+def validate_mfsdp_topology(parallel_cfg) -> None:
+    """Validate supported topology surfaces for Megatron-FSDP."""
+    pp = int(getattr(parallel_cfg, "pp", 1) or 1)
+    vpp = int(getattr(parallel_cfg, "vpp", 1) or 1)
+
+    if vpp > 1 and pp <= 1:
+        raise ValueError("optimizer_impl='megatron_fsdp' requires pp>1 when vpp>1.")
+
+
+def validate_optimizer_name(
+    optimizer_name: str,
+    *,
+    has_optimizer_factory: bool = False,
+) -> None:
+    if optimizer_name not in _SUPPORTED_OPTIMIZERS and not has_optimizer_factory:
+        raise ValueError(
+            "optimizer_impl='megatron_fsdp' supports only adam/sgd, "
+            f"got {optimizer_name!r}; provide optimizer_factory for an optional "
+            "algorithm such as Muon."
+        )
+
+
+def validate_precision_aware_disabled(opt) -> None:
+    precision_aware = getattr(opt, "use_precision_aware_optimizer", None)
+    raw_overrides = dict(getattr(opt, "override_optimizer_config", None) or {})
+    if "use_precision_aware_optimizer" in raw_overrides:
+        precision_aware = raw_overrides["use_precision_aware_optimizer"]
+    if precision_aware not in {None, True, False}:
+        raise ValueError("use_precision_aware_optimizer must be a boolean when set.")
+    if precision_aware is True:
+        raise ValueError(
+            "optimizer_impl='megatron_fsdp' does not support "
+            "use_precision_aware_optimizer=True in this image; Slurm smoke hit "
+            "transformer_engine::multi_tensor_scale_cuda segfault."
+        )
+
+
+def validate_optimization_knobs(opt) -> None:
+    """Validate optimizer and communication knobs before construction."""
+    values = dict(getattr(opt, "override_optimizer_config", None) or {})
+    for key in _UNSUPPORTED_OPTIMIZATION_KNOBS:
+        value = values.get(key, getattr(opt, key, None))
+        if _truthy_feature_value(value):
+            raise ValueError(
+                "optimizer_impl='megatron_fsdp' does not accept hsdp/use_hsdp aliases; "
+                "set num_distributed_optimizer_instances explicitly."
+            )
+    instances = values.get(
+        "num_distributed_optimizer_instances",
+        getattr(opt, "num_distributed_optimizer_instances", None),
+    )
+    if _invalid_distributed_optimizer_instances(instances):
+        raise ValueError(
+            "optimizer_impl='megatron_fsdp' requires "
+            "num_distributed_optimizer_instances to be a positive integer."
+        )
+    if instances is not None and str(instances).lower() not in {"", "none", "null"}:
+        if int(instances) > 1:
+            raise ValueError(
+                "optimizer_impl='megatron_fsdp' does not support "
+                "num_distributed_optimizer_instances>1."
+            )
+    nccl_ub = values.get("nccl_ub", getattr(opt, "nccl_ub", None))
+    if _truthy_feature_value(nccl_ub) and _cuda_alloc_conf_expands_segments():
+        raise ValueError(
+            "optimizer_impl='megatron_fsdp' requires PYTORCH_CUDA_ALLOC_CONF without "
+            "expandable_segments:True when nccl_ub=True; unset it before enabling UBR."
+        )
+    for key, required_value in _REQUIRED_DDP_KNOB_VALUES.items():
+        value = values.get(key, getattr(opt, key, required_value))
+        if value != required_value:
+            raise ValueError(
+                f"optimizer_impl='megatron_fsdp' requires {key}={required_value!r}."
+            )
+    validate_precision_aware_disabled(opt)
+
+
+def _truthy_feature_value(value: Any) -> bool:
+    if value is None or value is False:
+        return False
+    if isinstance(value, int | float) and value == 0:
+        return False
+    if isinstance(value, str) and value.lower() in {
+        "",
+        "0",
+        "false",
+        "none",
+        "null",
+        "off",
+    }:
+        return False
+    return True
+
+
+def _cuda_alloc_conf_expands_segments() -> bool:
+    value = os.environ.get("PYTORCH_CUDA_ALLOC_CONF", "")
+    for item in value.split(","):
+        key, _, raw = item.strip().partition(":")
+        if key.lower() == "expandable_segments" and raw.lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }:
+            return True
+    return False
+
+
+def _invalid_distributed_optimizer_instances(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, int | float):
+        return int(value) != value or value < 1
+    if isinstance(value, str):
+        normalized = value.lower()
+        if normalized in {"", "none", "null"}:
+            return False
+        try:
+            return int(normalized) < 1
+        except ValueError:
+            return True
+    return True

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/config.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/config.py
@@ -40,6 +40,7 @@ class MFSDPConfig:
     main_params_dtype: torch.dtype = torch.float32
     main_grads_dtype: torch.dtype = torch.float32
     grad_comm_dtype: torch.dtype = torch.float32
+    full_optimizer_offload: bool = False
     nccl_ub: bool = False
     fsdp_double_buffer: bool = True
     disable_symmetric_registration: bool = False

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/cpu_offload.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/cpu_offload.py
@@ -97,9 +97,33 @@ class CpuAdamGroup:
             cpu_param.grad = None
 
     def state_dict(self) -> dict[str, Any]:
-        return self._cpu_optimizer.state_dict()
+        return {
+            "optimizer": self._cpu_optimizer.state_dict(),
+            "master_params": [param.detach().clone() for param in self._cpu_params],
+        }
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
-        self._cpu_optimizer.load_state_dict(state_dict)
-        for gpu_param, cpu_param in zip(self._gpu_params, self._cpu_params):
-            cpu_param.data.copy_(gpu_param.data.view(-1).cpu())
+        optimizer_state = state_dict.get("optimizer", state_dict)
+        self._cpu_optimizer.load_state_dict(optimizer_state)
+        master_params = state_dict.get("master_params")
+        if master_params is not None and len(master_params) != len(self._cpu_params):
+            raise ValueError(
+                "M-FSDP CPU optimizer checkpoint master parameter count does not "
+                f"match: expected {len(self._cpu_params)}, got {len(master_params)}."
+            )
+        with torch.no_grad():
+            for index, (gpu_param, cpu_param) in enumerate(
+                zip(self._gpu_params, self._cpu_params)
+            ):
+                if master_params is None:
+                    cpu_param.copy_(gpu_param.detach().view(-1).cpu())
+                else:
+                    saved = master_params[index]
+                    if saved.shape != cpu_param.shape:
+                        raise ValueError(
+                            "M-FSDP CPU optimizer checkpoint master parameter shape "
+                            f"does not match at index {index}: expected "
+                            f"{tuple(cpu_param.shape)}, got {tuple(saved.shape)}."
+                        )
+                    cpu_param.copy_(saved)
+                gpu_param.view(-1).copy_(cpu_param.to(dtype=gpu_param.dtype))

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/cpu_offload.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/cpu_offload.py
@@ -12,8 +12,9 @@ import torch.nn as nn
 class CpuAdamGroup:
     """Adam momentum state on CPU for a subset of M-FSDP shard parameters.
 
-    Memory savings: exp_avg + exp_avg_sq moved off GPU (2 × 4B × numel).
-    Hard constraint: shard_param.data (fp32 master) stays on GPU for all-gather.
+    Memory savings: the authoritative fp32 master plus exp_avg and exp_avg_sq
+    live on CPU. ``shard_param.data`` is the GPU compute/all-gather mirror and
+    is refreshed after each CPU update.
 
     Per-step flow (synchronous):
       1. D2H — copy GPU gradient → pinned CPU grad buffer  (blocking)

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/cpu_offload.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/cpu_offload.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""CPU Adam momentum offload for M-FSDP shard parameters."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+
+class CpuAdamGroup:
+    """Adam momentum state on CPU for a subset of M-FSDP shard parameters.
+
+    Memory savings: exp_avg + exp_avg_sq moved off GPU (2 × 4B × numel).
+    Hard constraint: shard_param.data (fp32 master) stays on GPU for all-gather.
+
+    Per-step flow (synchronous):
+      1. D2H — copy GPU gradient → pinned CPU grad buffer  (blocking)
+      2. CPU AdamW step updates cpu_param
+      3. H2D — copy updated cpu_param → GPU shard_param.data  (blocking)
+    """
+
+    def __init__(
+        self,
+        gpu_param_groups: list[dict[str, Any]],
+        *,
+        lr: float,
+        betas: tuple[float, float],
+        eps: float,
+    ) -> None:
+        use_pinned = torch.cuda.is_available()
+        self._use_pinned = use_pinned
+        self._gpu_params: list[nn.Parameter] = []
+        self._cpu_params: list[torch.Tensor] = []
+        self._cpu_grad_bufs: list[torch.Tensor | None] = []
+        cpu_groups: list[dict[str, Any]] = []
+
+        for group in gpu_param_groups:
+            cpu_group_params: list[torch.Tensor] = []
+            for gpu_param in group["params"]:
+                flat = gpu_param.detach().cpu().float().contiguous()
+                if use_pinned:
+                    pinned = torch.empty_like(flat, pin_memory=True)
+                    pinned.copy_(flat)
+                    flat = pinned
+                # Wrap as leaf tensor with grad support so AdamW can update it.
+                cpu_p = flat.detach().requires_grad_(True)
+                self._gpu_params.append(gpu_param)
+                self._cpu_params.append(cpu_p)
+                self._cpu_grad_bufs.append(None)
+                cpu_group_params.append(cpu_p)
+
+            cpu_group = {k: v for k, v in group.items() if k != "params"}
+            cpu_group["params"] = cpu_group_params
+            cpu_groups.append(cpu_group)
+
+        self._cpu_optimizer = torch.optim.AdamW(
+            cpu_groups,
+            lr=lr,
+            betas=betas,
+            eps=eps,
+            foreach=False,
+        )
+
+    @property
+    def param_groups(self) -> list[dict[str, Any]]:
+        return self._cpu_optimizer.param_groups
+
+    def step(self) -> None:
+        for i, (gpu_param, cpu_param) in enumerate(
+            zip(self._gpu_params, self._cpu_params)
+        ):
+            if gpu_param.grad is None:
+                cpu_param.grad = None
+                continue
+
+            flat_gpu_grad = gpu_param.grad.detach().view(-1)
+
+            buf = self._cpu_grad_bufs[i]
+            if buf is None or buf.shape != flat_gpu_grad.shape:
+                buf = torch.zeros(
+                    flat_gpu_grad.shape, dtype=torch.float32, device="cpu"
+                )
+                if self._use_pinned:
+                    buf = buf.pin_memory()
+                self._cpu_grad_bufs[i] = buf
+
+            buf.copy_(flat_gpu_grad)
+            cpu_param.grad = buf
+
+        self._cpu_optimizer.step()
+
+        for gpu_param, cpu_param in zip(self._gpu_params, self._cpu_params):
+            gpu_param.data.view(-1).copy_(cpu_param.data)
+            cpu_param.grad = None
+
+    def state_dict(self) -> dict[str, Any]:
+        return self._cpu_optimizer.state_dict()
+
+    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        self._cpu_optimizer.load_state_dict(state_dict)
+        for gpu_param, cpu_param in zip(self._gpu_params, self._cpu_params):
+            cpu_param.data.copy_(gpu_param.data.view(-1).cpu())

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/fully_shard.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/fully_shard.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Narrow ``optim_grads_params`` construction API for M-FSDP."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+
+import torch.nn as nn
+
+from megatron.lite.primitive.optimizers.mfsdp.config import (
+    MFSDPConfig,
+    MFSDPProcessGroups,
+)
+from megatron.lite.primitive.optimizers.mfsdp.wrapper import MegatronFSDP
+
+
+def fully_shard_model(
+    module: nn.Module,
+    *,
+    groups: MFSDPProcessGroups,
+    config: MFSDPConfig,
+    is_expert: Callable[[str], bool],
+    unit_modules: Iterable[type[nn.Module] | str] | None,
+) -> MegatronFSDP:
+    if config.sharding_strategy != "optim_grads_params":
+        raise ValueError(
+            "MLite M-FSDP only implements the optim_grads_params strategy."
+        )
+    return MegatronFSDP(
+        module,
+        groups=groups,
+        config=config,
+        is_expert=is_expert,
+        unit_modules=unit_modules,
+    )
+
+
+__all__ = ["fully_shard_model"]

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/fused_ops.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/fused_ops.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Optional fused optimizer construction with a Torch reference fallback."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from collections.abc import Callable
+from typing import Any
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+OptimizerFactory = Callable[
+    [list[dict[str, Any]], Any],
+    torch.optim.Optimizer,
+]
+
+
+def build_optimizer(
+    param_groups: list[dict[str, Any]],
+    opt: Any,
+    *,
+    optimizer_factory: OptimizerFactory | None = None,
+) -> torch.optim.Optimizer:
+    """Build the optimizer algorithm independently from M-FSDP sharding.
+
+    ``optimizer_factory`` receives already-sharded main parameter groups (FP32
+    by default) plus the original optimizer config. Optional algorithms such as
+    Muon can regroup them without changing the M-FSDP communication path.
+    """
+    if optimizer_factory is not None:
+        return optimizer_factory(param_groups, opt)
+
+    optimizer_name = str(getattr(opt, "optimizer", "adam"))
+    lr = float(getattr(opt, "lr", 1.0e-4))
+    weight_decay = float(getattr(opt, "weight_decay", 0.01))
+    values = dict(getattr(opt, "override_optimizer_config", None) or {})
+    use_fused = bool(values.get("use_fused_optimizer", True)) and _has_cuda_params(
+        param_groups
+    )
+    if use_fused and _has_shared_param_storage(param_groups):
+        logger.warning(
+            "Apex fused optimizer is unsafe for M-FSDP parameters that share "
+            "flat storage; using the Torch optimizer fallback."
+        )
+        use_fused = False
+    if use_fused:
+        fused = _build_apex_optimizer(
+            optimizer_name,
+            param_groups,
+            opt,
+            lr=lr,
+            weight_decay=weight_decay,
+        )
+        if fused is not None:
+            return fused
+
+    if optimizer_name == "adam":
+        beta1 = getattr(opt, "adam_beta1", None)
+        beta2 = getattr(opt, "adam_beta2", None)
+        eps = getattr(opt, "adam_eps", None)
+        return torch.optim.AdamW(
+            param_groups,
+            lr=lr,
+            weight_decay=weight_decay,
+            betas=(0.9 if beta1 is None else beta1, 0.999 if beta2 is None else beta2),
+            eps=1.0e-8 if eps is None else eps,
+            foreach=False,
+        )
+    if optimizer_name == "sgd":
+        return torch.optim.SGD(
+            param_groups,
+            lr=lr,
+            weight_decay=weight_decay,
+            momentum=float(getattr(opt, "sgd_momentum", 0.9)),
+        )
+    raise ValueError(f"Unsupported M-FSDP optimizer: {optimizer_name!r}.")
+
+
+def _build_apex_optimizer(
+    optimizer_name: str,
+    param_groups: list[dict[str, Any]],
+    opt: Any,
+    *,
+    lr: float,
+    weight_decay: float,
+) -> torch.optim.Optimizer | None:
+    try:
+        apex_optimizers = importlib.import_module("apex.optimizers")
+        if optimizer_name == "adam":
+            beta1 = getattr(opt, "adam_beta1", None)
+            beta2 = getattr(opt, "adam_beta2", None)
+            eps = getattr(opt, "adam_eps", None)
+            return apex_optimizers.FusedAdam(
+                param_groups,
+                lr=lr,
+                betas=(
+                    0.9 if beta1 is None else beta1,
+                    0.999 if beta2 is None else beta2,
+                ),
+                eps=1.0e-8 if eps is None else eps,
+                weight_decay=weight_decay,
+                adam_w_mode=True,
+            )
+        if optimizer_name == "sgd":
+            return apex_optimizers.FusedSGD(
+                param_groups,
+                lr=lr,
+                weight_decay=weight_decay,
+                momentum=float(getattr(opt, "sgd_momentum", 0.9)),
+            )
+    except (ImportError, AttributeError, RuntimeError, TypeError) as error:
+        logger.warning(
+            "Fused optimizer unavailable (%s); using Torch optimizer.", error
+        )
+    return None
+
+
+def _has_cuda_params(param_groups: list[dict[str, Any]]) -> bool:
+    return any(
+        isinstance(param, torch.Tensor) and param.device.type == "cuda"
+        for group in param_groups
+        for param in group["params"]
+    )
+
+
+def _has_shared_param_storage(param_groups: list[dict[str, Any]]) -> bool:
+    """Return whether distinct optimizer parameters alias one flat storage."""
+    storages: set[tuple[str, int | None, int]] = set()
+    for group in param_groups:
+        for param in group["params"]:
+            if not isinstance(param, torch.Tensor):
+                continue
+            key = (
+                param.device.type,
+                param.device.index,
+                param.untyped_storage().data_ptr(),
+            )
+            if key in storages:
+                return True
+            storages.add(key)
+    return False
+
+
+__all__ = ["OptimizerFactory", "build_optimizer"]

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/grad_norm.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/grad_norm.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Standalone gradient norm and clipping helpers for M-FSDP shards."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+import torch
+import torch.distributed as dist
+
+
+def local_grad_sq_sum(
+    params: Iterable[torch.nn.Parameter],
+    *,
+    dtype: str | torch.dtype,
+    default_device: torch.device | None = None,
+) -> torch.Tensor:
+    """Accumulate the squared L2 norm of local Tensor or DTensor-like grads."""
+    resolved_dtype = resolve_torch_dtype(dtype)
+    total: torch.Tensor | None = None
+    for param in params:
+        grad = param.grad
+        if grad is None:
+            continue
+        local_grad = to_local_tensor(grad)
+        if total is None:
+            total = torch.zeros((), device=local_grad.device, dtype=resolved_dtype)
+        total.add_(local_grad.detach().to(resolved_dtype).pow(2).sum())
+    if total is None:
+        total = torch.zeros(
+            (), device=default_device or torch.device("cpu"), dtype=resolved_dtype
+        )
+    return total
+
+
+def to_local_tensor(tensor: Any) -> torch.Tensor:
+    """Return local storage for DTensor-like values and tensors unchanged."""
+    local = getattr(tensor, "_local_tensor", None)
+    if isinstance(local, torch.Tensor):
+        return local
+    to_local = getattr(tensor, "to_local", None)
+    if callable(to_local):
+        return to_local()
+    if not isinstance(tensor, torch.Tensor):
+        raise TypeError(
+            f"Expected a Tensor or DTensor-like value, got {type(tensor)!r}."
+        )
+    return tensor
+
+
+def resolve_torch_dtype(dtype: str | torch.dtype) -> torch.dtype:
+    if isinstance(dtype, torch.dtype):
+        resolved = dtype
+    else:
+        resolved = getattr(torch, dtype.removeprefix("torch."), None)
+    if (
+        not isinstance(resolved, torch.dtype)
+        or not torch.empty((), dtype=resolved).is_floating_point()
+    ):
+        raise ValueError(
+            f"Gradient norm accumulation dtype must be floating point: {dtype!r}."
+        )
+    return resolved
+
+
+def all_reduce_scalar_(
+    value: torch.Tensor, *, op: dist.ReduceOp, group: dist.ProcessGroup
+) -> None:
+    """All-reduce a scalar on a device accepted by the process-group backend."""
+    reduced = value
+    try:
+        backend = str(dist.get_backend(group)).lower()
+    except (RuntimeError, TypeError, ValueError):
+        backend = ""
+    if "nccl" in backend and value.device.type != "cuda":
+        if not torch.cuda.is_available():
+            raise RuntimeError("NCCL scalar all-reduce requires a CUDA tensor.")
+        reduced = value.to(torch.device("cuda", torch.cuda.current_device()))
+    elif "gloo" in backend and value.device.type != "cpu":
+        reduced = value.cpu()
+    dist.all_reduce(reduced, op=op, group=group)
+    if reduced is not value:
+        value.copy_(reduced.to(device=value.device, dtype=value.dtype))

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/optimizer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/optimizer.py
@@ -356,7 +356,14 @@ def build_mfsdp_stack(
     )
     opt = engine_cfg.optimizer
     classifier = is_expert or (lambda _name: False)
+    offload_fraction = float(getattr(opt, "offload_fraction", 0.0) or 0.0)
+    if not math.isfinite(offload_fraction) or not 0.0 <= offload_fraction <= 1.0:
+        raise ValueError(
+            f"M-FSDP offload_fraction must be in [0, 1], got {offload_fraction}."
+        )
     config = build_mfsdp_config(opt)
+    if offload_fraction == 1.0:
+        config = replace(config, full_optimizer_offload=True)
     config = _order_param_gathers_for_parallel_collectives(config, ps)
     groups = build_mfsdp_process_groups(ps)
 
@@ -384,12 +391,6 @@ def build_mfsdp_stack(
         weight_decay=float(getattr(opt, "weight_decay", 0.01)),
         apply_wd_to_qk_layernorm=bool(getattr(opt, "apply_wd_to_qk_layernorm", False)),
     )
-    offload_fraction = float(getattr(opt, "offload_fraction", 0.0) or 0.0)
-    if not math.isfinite(offload_fraction) or not 0.0 <= offload_fraction <= 1.0:
-        raise ValueError(
-            f"M-FSDP offload_fraction must be in [0, 1], got {offload_fraction}."
-        )
-
     if offload_fraction > 0.0:
         optimizer_name = str(getattr(opt, "optimizer", "adam")).lower()
         if optimizer_name != "adam":
@@ -420,7 +421,7 @@ def build_mfsdp_stack(
             total_numel = sum(p.numel() for p in params)
             logger.info(
                 "M-FSDP CPU optimizer offload: %.1f%% of parameter elements "
-                "(%d / %d) use CPU Adam; exp_avg + exp_avg_sq moved off GPU.",
+                "(%d / %d) use CPU Adam; FP32 master and Adam moments live on CPU.",
                 100.0 * cpu_numel / max(total_numel, 1),
                 cpu_numel,
                 total_numel,

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/optimizer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/optimizer.py
@@ -1,0 +1,658 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Self-contained Megatron-FSDP construction for Megatron Lite."""
+
+from __future__ import annotations
+
+import logging
+import math
+from collections.abc import Callable, Iterable
+from dataclasses import replace
+from types import SimpleNamespace
+from typing import Any
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+
+from megatron.lite.primitive.optimizers.mfsdp.config import (
+    MFSDPConfig,
+    annotate_parallel_parameters,
+    build_mfsdp_config,
+    build_mfsdp_process_groups,
+    validate_mfsdp_config,
+)
+from megatron.lite.primitive.optimizers.mfsdp.fully_shard import fully_shard_model
+from megatron.lite.primitive.optimizers.mfsdp.fused_ops import (
+    OptimizerFactory,
+    build_optimizer,
+)
+from megatron.lite.primitive.optimizers.mfsdp.grad_norm import (
+    all_reduce_scalar_,
+    local_grad_sq_sum,
+    resolve_torch_dtype,
+)
+from megatron.lite.primitive.optimizers.mfsdp.cpu_offload import CpuAdamGroup
+from megatron.lite.primitive.optimizers.mfsdp.wrapper import (
+    MFSdpModule,
+    mark_optimizer_built,
+)
+
+ExpertClassifierFn = Callable[[str], bool]
+
+logger = logging.getLogger(__name__)
+
+
+def _override(opt: Any, name: str, default: Any) -> Any:
+    values = dict(getattr(opt, "override_optimizer_config", None) or {})
+    return values.get(name, getattr(opt, name, default))
+
+
+class _NullOptimizer:
+    """No-op GPU optimizer used when all parameters are CPU-offloaded."""
+
+    def __init__(self) -> None:
+        self.param_groups: list = []
+        self.state: dict = {}
+
+    def step(self) -> None:
+        pass
+
+    def zero_grad(self, *, set_to_none: bool = True) -> None:
+        pass
+
+    def state_dict(self) -> dict[str, Any]:
+        return {"state": {}, "param_groups": []}
+
+    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        pass
+
+
+class _StandaloneOptimizer:
+    """Torch optimizer adapter with M-FSDP-aware norm and state movement."""
+
+    def __init__(
+        self,
+        optimizer: torch.optim.Optimizer,
+        params: list[nn.Parameter],
+        *,
+        ps: Any,
+        clip_grad: float,
+        grad_norm_accum_dtype: str | torch.dtype,
+        expert_params: Iterable[nn.Parameter],
+        expert_grad_scale: float,
+        cpu_group: CpuAdamGroup | None = None,
+    ) -> None:
+        self.optimizer = optimizer
+        self.params = params
+        self.ps = ps
+        self.clip_grad = float(clip_grad)
+        self.grad_norm_accum_dtype = resolve_torch_dtype(grad_norm_accum_dtype)
+        self.expert_params = list(expert_params)
+        self._expert_param_ids = {id(param) for param in self.expert_params}
+        self.tp_replicated_params = [
+            param
+            for param in self.params
+            if id(param) not in self._expert_param_ids
+            and (
+                bool(getattr(param, "sequence_parallel", False))
+                or bool(getattr(param, "average_gradients_across_tp_domain", False))
+            )
+            and not bool(getattr(param, "shared", False))
+        ]
+        self._tp_replicated_param_ids = {
+            id(param) for param in self.tp_replicated_params
+        }
+        self.expert_grad_scale = float(expert_grad_scale)
+        self._expert_grads_scaled = False
+        self._tp_replicated_grads_synced = False
+        self._offloaded_state_devices: dict[tuple[int, str], torch.device] = {}
+        self.cpu_group = cpu_group
+
+    @property
+    def param_groups(self) -> list[dict[str, Any]]:
+        groups = list(self.optimizer.param_groups)
+        if self.cpu_group is not None:
+            groups += list(self.cpu_group.param_groups)
+        return groups
+
+    def zero_grad(self) -> None:
+        self.optimizer.zero_grad()
+        self._expert_grads_scaled = False
+        self._tp_replicated_grads_synced = False
+
+    def step(self) -> tuple[bool, float, int]:
+        self._sync_tp_replicated_grads_once()
+        self._scale_expert_grads_once()
+        grad_norm = self.clip_grad_norm()
+        if not math.isfinite(grad_norm):
+            return False, grad_norm, 0
+        self.optimizer.step()
+        if self.cpu_group is not None:
+            self.cpu_group.step()
+        return True, grad_norm, 0
+
+    def clip_grad_norm(self) -> float:
+        self._sync_tp_replicated_grads_once()
+        self._scale_expert_grads_once()
+        dense_params = [
+            param
+            for param in self.params
+            if id(param) not in self._expert_param_ids
+            and id(param) not in self._tp_replicated_param_ids
+            and _include_dense_param_in_norm(param, getattr(self.ps, "tp_group", None))
+        ]
+        default_device = self.params[0].device if self.params else torch.device("cpu")
+        dense_sq = local_grad_sq_sum(
+            dense_params,
+            dtype=self.grad_norm_accum_dtype,
+            default_device=default_device,
+        )
+        dense_dp_group = getattr(self.ps, "dp_cp_group", None) or getattr(
+            self.ps, "dp_group", None
+        )
+        _sum_if_distributed(
+            dense_sq,
+            dense_dp_group,
+        )
+        _sum_if_distributed(dense_sq, getattr(self.ps, "tp_group", None))
+
+        tp_replicated_sq = local_grad_sq_sum(
+            self.tp_replicated_params,
+            dtype=self.grad_norm_accum_dtype,
+            default_device=dense_sq.device,
+        )
+        _sum_if_distributed(tp_replicated_sq, dense_dp_group)
+
+        expert_sq = local_grad_sq_sum(
+            self.expert_params,
+            dtype=self.grad_norm_accum_dtype,
+            default_device=dense_sq.device,
+        )
+        _sum_if_distributed(expert_sq, getattr(self.ps, "ep_dp_group", None))
+        _sum_if_distributed(expert_sq, getattr(self.ps, "etp_group", None))
+        _sum_if_distributed(expert_sq, getattr(self.ps, "ep_group", None))
+        total_sq = (
+            dense_sq
+            + tp_replicated_sq.to(dense_sq.device)
+            + expert_sq.to(dense_sq.device)
+        )
+        _sum_if_distributed(total_sq, getattr(self.ps, "pp_group", None))
+        total_norm = total_sq.sqrt()
+        if bool(torch.isfinite(total_norm).item()) and self.clip_grad > 0.0:
+            coefficient = min(1.0, self.clip_grad / (float(total_norm.item()) + 1.0e-6))
+            if coefficient < 1.0:
+                for param in self.params:
+                    if param.grad is not None:
+                        param.grad.mul_(coefficient)
+        return float(total_norm.float().item())
+
+    def state_dict(self) -> dict[str, Any]:
+        if self.cpu_group is None:
+            return self.optimizer.state_dict()
+        return {
+            "gpu": self.optimizer.state_dict(),
+            "cpu": self.cpu_group.state_dict(),
+        }
+
+    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        if self.cpu_group is None:
+            gpu_state = state_dict.get("gpu", state_dict)
+            self.optimizer.load_state_dict(gpu_state)
+            return
+        if "gpu" not in state_dict or "cpu" not in state_dict:
+            raise ValueError(
+                "M-FSDP CPU-offloaded optimizer requires a checkpoint with "
+                "both 'gpu' and 'cpu' optimizer states."
+            )
+        self.optimizer.load_state_dict(state_dict["gpu"])
+        self.cpu_group.load_state_dict(state_dict["cpu"])
+
+    def offload_state_to_cpu(self) -> None:
+        self._offloaded_state_devices.clear()
+        for param, state in self.optimizer.state.items():
+            for key, value in tuple(state.items()):
+                if not isinstance(value, torch.Tensor) or value.device.type == "cpu":
+                    continue
+                self._offloaded_state_devices[(id(param), str(key))] = value.device
+                state[key] = value.cpu()
+        # cpu_group state is already on CPU; nothing to move.
+
+    def load_state_to_device(self) -> None:
+        for param, state in self.optimizer.state.items():
+            for key, value in tuple(state.items()):
+                device = self._offloaded_state_devices.get((id(param), str(key)))
+                if device is not None and isinstance(value, torch.Tensor):
+                    state[key] = value.to(device)
+        self._offloaded_state_devices.clear()
+        # cpu_group state remains on CPU.
+
+    def _scale_expert_grads_once(self) -> None:
+        if self._expert_grads_scaled:
+            return
+        if self.expert_grad_scale != 1.0:
+            for param in self.expert_params:
+                if param.grad is not None:
+                    param.grad.mul_(self.expert_grad_scale)
+        self._expert_grads_scaled = True
+
+    def _sync_tp_replicated_grads_once(self) -> None:
+        if self._tp_replicated_grads_synced:
+            return
+        group = getattr(self.ps, "tp_group", None)
+        for param in self.tp_replicated_params:
+            if param.grad is not None:
+                _all_reduce_grad_if_distributed(
+                    param.grad,
+                    group,
+                    average=bool(
+                        getattr(param, "average_gradients_across_tp_domain", False)
+                    ),
+                )
+        self._tp_replicated_grads_synced = True
+
+
+def _sum_if_distributed(value: torch.Tensor, group: dist.ProcessGroup | None) -> None:
+    if group is None or not dist.is_initialized() or dist.get_world_size(group) <= 1:
+        return
+    all_reduce_scalar_(value, op=dist.ReduceOp.SUM, group=group)
+
+
+def _all_reduce_grad_if_distributed(
+    grad: torch.Tensor,
+    group: dist.ProcessGroup | None,
+    *,
+    average: bool = False,
+) -> None:
+    if group is None or not dist.is_initialized() or dist.get_world_size(group) <= 1:
+        return
+    dist.all_reduce(grad, op=dist.ReduceOp.SUM, group=group)
+    if average:
+        grad.div_(dist.get_world_size(group))
+
+
+def _include_dense_param_in_norm(
+    param: nn.Parameter, tp_group: dist.ProcessGroup | None
+) -> bool:
+    if bool(getattr(param, "shared", False)):
+        return False
+    if bool(getattr(param, "tensor_model_parallel", False)):
+        return True
+    if tp_group is None or not dist.is_initialized():
+        return True
+    return dist.get_rank(tp_group) == 0
+
+
+class MFSdpOptimizer:
+    """Join the standalone optimizer and M-FSDP communication lifecycle."""
+
+    name = "megatron_fsdp"
+
+    def __init__(self, optimizer: Any, model_chunks: list[MFSdpModule]) -> None:
+        self._inner_optimizer = optimizer
+        self._model_chunks = model_chunks
+        self._grad_sync_enabled = False
+
+    @property
+    def grad_sync_enabled(self) -> bool:
+        return self._grad_sync_enabled
+
+    @grad_sync_enabled.setter
+    def grad_sync_enabled(self, enabled: bool) -> None:
+        self._grad_sync_enabled = bool(enabled)
+        for chunk in self._model_chunks:
+            chunk.param_sync.set_grad_sync_enabled(self._grad_sync_enabled)
+
+    @property
+    def param_groups(self):
+        return self._inner_optimizer.param_groups
+
+    def zero_grad(self) -> None:
+        self.grad_sync_enabled = False
+        self._inner_optimizer.zero_grad()
+        for chunk in self._model_chunks:
+            chunk.zero_grad_buffer()
+
+    def finish_grad_sync(self) -> None:
+        for chunk in self._model_chunks:
+            chunk.finish_grad_sync()
+
+    def clip_grad_norm(self) -> float:
+        return self._inner_optimizer.clip_grad_norm()
+
+    def step(self) -> tuple[bool, float, int]:
+        result = self._inner_optimizer.step()
+        for chunk in self._model_chunks:
+            chunk.param_sync.release_all()
+            chunk.param_sync.discard_full_parameter_views()
+        self.grad_sync_enabled = False
+        return result
+
+    def state_dict(self) -> dict[str, Any]:
+        return self._inner_optimizer.state_dict()
+
+    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        self._inner_optimizer.load_state_dict(state_dict)
+
+    def offload_state_to_cpu(self) -> None:
+        self._inner_optimizer.offload_state_to_cpu()
+
+    def load_state_to_device(self) -> None:
+        self._inner_optimizer.load_state_to_device()
+
+
+def build_mfsdp_stack(
+    model_chunks: list[nn.Module],
+    *,
+    engine_cfg,
+    ps,
+    is_expert: ExpertClassifierFn | None = None,
+    fsdp_unit_modules: tuple[type[nn.Module] | str, ...] | None = None,
+    optimizer_factory: OptimizerFactory | None = None,
+):
+    """Wrap chunks with the native M-FSDP path and build its local optimizer."""
+    validate_mfsdp_config(
+        engine_cfg,
+        has_optimizer_factory=optimizer_factory is not None,
+    )
+    opt = engine_cfg.optimizer
+    classifier = is_expert or (lambda _name: False)
+    config = build_mfsdp_config(opt)
+    config = _order_param_gathers_for_parallel_collectives(config, ps)
+    groups = build_mfsdp_process_groups(ps)
+
+    wrapped_chunks = []
+    for chunk in model_chunks:
+        _mark_mfsdp_parallel_attrs(
+            chunk,
+            classifier,
+            tp_size=int(getattr(engine_cfg.parallel, "tp", 1) or 1),
+            etp_size=int(getattr(engine_cfg.parallel, "etp", 1) or 1),
+        )
+        wrapped_chunks.append(
+            fully_shard_model(
+                chunk,
+                groups=groups,
+                config=config,
+                is_expert=classifier,
+                unit_modules=fsdp_unit_modules,
+            )
+        )
+
+    params, param_groups, expert_params = _build_param_groups(
+        wrapped_chunks,
+        classifier=classifier,
+        weight_decay=float(getattr(opt, "weight_decay", 0.01)),
+        apply_wd_to_qk_layernorm=bool(getattr(opt, "apply_wd_to_qk_layernorm", False)),
+    )
+    offload_fraction = float(getattr(opt, "offload_fraction", 0.0) or 0.0)
+    if not math.isfinite(offload_fraction) or not 0.0 <= offload_fraction <= 1.0:
+        raise ValueError(
+            f"M-FSDP offload_fraction must be in [0, 1], got {offload_fraction}."
+        )
+
+    if offload_fraction > 0.0:
+        optimizer_name = str(getattr(opt, "optimizer", "adam")).lower()
+        if optimizer_name != "adam":
+            raise ValueError(
+                "M-FSDP CPU optimizer offload currently only supports Adam; "
+                f"got {optimizer_name!r}."
+            )
+        if optimizer_factory is not None:
+            raise ValueError(
+                "M-FSDP CPU optimizer offload does not support optimizer_factory; "
+                "a CPU update implementation must preserve the selected algorithm."
+            )
+        gpu_param_groups, cpu_param_groups = _split_param_groups_by_fraction(
+            param_groups, offload_fraction
+        )
+        torch_optimizer = (
+            _build_optimizer_algorithm(
+                gpu_param_groups,
+                opt,
+                optimizer_factory=optimizer_factory,
+            )
+            if gpu_param_groups
+            else _NullOptimizer()
+        )
+        cpu_group = _build_cpu_adam_group(cpu_param_groups, opt)
+        if not dist.is_initialized() or dist.get_rank() == 0:
+            cpu_numel = sum(p.numel() for g in cpu_param_groups for p in g["params"])
+            total_numel = sum(p.numel() for p in params)
+            logger.info(
+                "M-FSDP CPU optimizer offload: %.1f%% of parameter elements "
+                "(%d / %d) use CPU Adam; exp_avg + exp_avg_sq moved off GPU.",
+                100.0 * cpu_numel / max(total_numel, 1),
+                cpu_numel,
+                total_numel,
+            )
+    else:
+        torch_optimizer = _build_optimizer_algorithm(
+            param_groups,
+            opt,
+            optimizer_factory=optimizer_factory,
+        )
+        cpu_group = None
+
+    standalone_optimizer = _StandaloneOptimizer(
+        torch_optimizer,
+        params,
+        ps=ps,
+        clip_grad=float(getattr(opt, "clip_grad", 1.0)),
+        grad_norm_accum_dtype=_override(opt, "grad_norm_accum_dtype", "float32"),
+        expert_params=expert_params,
+        expert_grad_scale=(
+            float(getattr(ps, "expert_dp_size", 1))
+            / float(getattr(ps, "dp_cp_size", 1))
+            if expert_params
+            else 1.0
+        ),
+        cpu_group=cpu_group,
+    )
+    for chunk in wrapped_chunks:
+        mark_optimizer_built(chunk)
+    optimizer = MFSdpOptimizer(standalone_optimizer, wrapped_chunks)
+    return wrapped_chunks, optimizer
+
+
+def _order_param_gathers_for_parallel_collectives(
+    config: MFSDPConfig,
+    ps: Any,
+) -> MFSDPConfig:
+    """Avoid unordered async collectives across intersecting process groups.
+
+    The standalone overlap pipeline has no dependency handshake with model-side
+    TP/CP/EP/ETP collectives.  When parameter shards and model-parallel groups
+    both span ranks, prefetching the next bucket can enqueue collectives on
+    intersecting process groups in different orders.  Keep overlap for pure
+    data parallelism, but make multidimensional compositions use ordered bucket
+    gathers until that cross-group handshake exists.
+    """
+    if not config.overlap_param_gather:
+        return config
+
+    model_parallel_size = math.prod(
+        max(int(getattr(ps, name, 1) or 1), 1)
+        for name in ("tp_size", "cp_size", "ep_size", "etp_size")
+    )
+    sharded_group_size = max(
+        int(getattr(ps, "dp_cp_size", 1) or 1),
+        int(getattr(ps, "expert_dp_size", 1) or 1),
+    )
+    if model_parallel_size == 1 or sharded_group_size == 1:
+        return config
+
+    if not dist.is_initialized() or dist.get_rank() == 0:
+        logger.warning(
+            "Disabling M-FSDP parameter-gather overlap because parameter shards "
+            "and model-parallel collectives span intersecting process groups."
+        )
+    return replace(config, overlap_param_gather=False)
+
+
+def _mark_mfsdp_parallel_attrs(
+    model: nn.Module,
+    classifier: ExpertClassifierFn,
+    *,
+    tp_size: int,
+    etp_size: int,
+) -> None:
+    """Compatibility entry point for the active metadata normalization pass."""
+    annotate_parallel_parameters(
+        model,
+        classifier,
+        tp_size=tp_size,
+        etp_size=etp_size,
+    )
+
+
+def build_mfsdp_training_optimizer(
+    model_chunks: list[nn.Module],
+    *,
+    impl_cfg,
+    ps,
+    is_expert: ExpertClassifierFn | None = None,
+    fsdp_unit_modules: tuple[type[nn.Module] | str, ...] | None = None,
+    optimizer_factory: OptimizerFactory | None = None,
+):
+    """Build M-FSDP with Adam by default or an injected optimizer algorithm."""
+    opt = impl_cfg.optimizer_config
+    if opt is None:
+        opt = SimpleNamespace(
+            optimizer="adam",
+            lr=1e-4,
+            min_lr=0.0,
+            weight_decay=0.01,
+            clip_grad=1.0,
+            offload_fraction=None,
+            adam_beta1=None,
+            adam_beta2=None,
+            adam_eps=None,
+            override_optimizer_config={},
+        )
+    engine_cfg = SimpleNamespace(
+        parallel=impl_cfg.parallel,
+        optimizer=opt,
+    )
+    model_chunks[:], optimizer = build_mfsdp_stack(
+        model_chunks,
+        engine_cfg=engine_cfg,
+        ps=ps,
+        is_expert=is_expert,
+        fsdp_unit_modules=fsdp_unit_modules,
+        optimizer_factory=optimizer_factory,
+    )
+
+    def finalize_grads() -> None:
+        optimizer.finish_grad_sync()
+
+    return optimizer, finalize_grads
+
+
+def _split_param_groups_by_fraction(
+    param_groups: list[dict[str, Any]],
+    offload_fraction: float,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Split param groups so the first *offload_fraction* of numel goes to CPU."""
+    total_numel = sum(p.numel() for g in param_groups for p in g["params"])
+    cpu_numel_target = int(total_numel * offload_fraction)
+
+    gpu_groups: list[dict[str, Any]] = []
+    cpu_groups: list[dict[str, Any]] = []
+    cpu_numel_so_far = 0
+
+    for group in param_groups:
+        gpu_params: list[nn.Parameter] = []
+        cpu_params: list[nn.Parameter] = []
+        for param in group["params"]:
+            if cpu_numel_so_far < cpu_numel_target:
+                cpu_params.append(param)
+                cpu_numel_so_far += param.numel()
+            else:
+                gpu_params.append(param)
+        if gpu_params:
+            g = dict(group)
+            g["params"] = gpu_params
+            gpu_groups.append(g)
+        if cpu_params:
+            g = dict(group)
+            g["params"] = cpu_params
+            cpu_groups.append(g)
+
+    return gpu_groups, cpu_groups
+
+
+def _build_cpu_adam_group(
+    cpu_param_groups: list[dict[str, Any]],
+    opt: Any,
+) -> CpuAdamGroup:
+    lr = float(getattr(opt, "lr", 1.0e-4))
+    beta1 = getattr(opt, "adam_beta1", None)
+    beta2 = getattr(opt, "adam_beta2", None)
+    eps = getattr(opt, "adam_eps", None)
+    return CpuAdamGroup(
+        cpu_param_groups,
+        lr=lr,
+        betas=(0.9 if beta1 is None else beta1, 0.999 if beta2 is None else beta2),
+        eps=1.0e-8 if eps is None else eps,
+    )
+
+
+def _build_param_groups(
+    model_chunks: Iterable[nn.Module],
+    *,
+    classifier: ExpertClassifierFn,
+    weight_decay: float,
+    apply_wd_to_qk_layernorm: bool,
+) -> tuple[
+    list[nn.Parameter],
+    list[dict[str, Any]],
+    list[nn.Parameter],
+]:
+    params: list[nn.Parameter] = []
+    decay_params: list[nn.Parameter] = []
+    no_decay_params: list[nn.Parameter] = []
+    expert_params: list[nn.Parameter] = []
+    seen: set[int] = set()
+    for chunk in model_chunks:
+        for name, param in chunk.named_parameters():
+            if not param.requires_grad or id(param) in seen:
+                continue
+            seen.add(id(param))
+            params.append(param)
+            normalized_name = name.removeprefix("module.")
+            if classifier(normalized_name):
+                expert_params.append(param)
+            original_ndim = int(getattr(param, "_mfsdp_original_ndim", param.ndim))
+            no_weight_decay = original_ndim == 1 or normalized_name.endswith(".bias")
+            if apply_wd_to_qk_layernorm and any(
+                marker in normalized_name
+                for marker in ("q_layernorm.", "k_layernorm.", "q_norm.", "k_norm.")
+            ):
+                no_weight_decay = False
+            (no_decay_params if no_weight_decay else decay_params).append(param)
+
+    param_groups: list[dict[str, Any]] = []
+    if decay_params:
+        param_groups.append(
+            {"params": decay_params, "weight_decay": weight_decay, "wd_mult": 1.0}
+        )
+    if no_decay_params:
+        param_groups.append(
+            {"params": no_decay_params, "weight_decay": 0.0, "wd_mult": 0.0}
+        )
+    if not param_groups:
+        raise ValueError("M-FSDP found no trainable parameters.")
+    return params, param_groups, expert_params
+
+
+def _build_optimizer_algorithm(
+    param_groups: list[dict[str, Any]],
+    opt: Any,
+    *,
+    optimizer_factory: OptimizerFactory | None = None,
+) -> torch.optim.Optimizer:
+    return build_optimizer(
+        param_groups,
+        opt,
+        optimizer_factory=optimizer_factory,
+    )

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/optimizer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/optimizer.py
@@ -38,6 +38,7 @@ from megatron.lite.primitive.optimizers.mfsdp.wrapper import (
 )
 
 ExpertClassifierFn = Callable[[str], bool]
+_MFSDP_PARAM_VALUES_KEY = "_mfsdp_param_values"
 
 logger = logging.getLogger(__name__)
 
@@ -188,24 +189,41 @@ class _StandaloneOptimizer:
 
     def state_dict(self) -> dict[str, Any]:
         if self.cpu_group is None:
-            return self.optimizer.state_dict()
-        return {
-            "gpu": self.optimizer.state_dict(),
-            "cpu": self.cpu_group.state_dict(),
-        }
+            state = self.optimizer.state_dict()
+        else:
+            state = {
+                "gpu": self.optimizer.state_dict(),
+                "cpu": self.cpu_group.state_dict(),
+            }
+        state[_MFSDP_PARAM_VALUES_KEY] = [
+            [param.detach().cpu().clone() for param in group["params"]]
+            for group in self.optimizer.param_groups
+        ]
+        return state
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        state = dict(state_dict)
+        param_values = state.pop(_MFSDP_PARAM_VALUES_KEY, None)
         if self.cpu_group is None:
-            gpu_state = state_dict.get("gpu", state_dict)
+            gpu_state = state.get("gpu", state)
             self.optimizer.load_state_dict(gpu_state)
-            return
-        if "gpu" not in state_dict or "cpu" not in state_dict:
+        elif "gpu" not in state or "cpu" not in state:
             raise ValueError(
                 "M-FSDP CPU-offloaded optimizer requires a checkpoint with "
                 "both 'gpu' and 'cpu' optimizer states."
             )
-        self.optimizer.load_state_dict(state_dict["gpu"])
-        self.cpu_group.load_state_dict(state_dict["cpu"])
+        else:
+            self.optimizer.load_state_dict(state["gpu"])
+            self.cpu_group.load_state_dict(state["cpu"])
+        if param_values is not None:
+            with torch.no_grad():
+                for group, group_values in zip(
+                    self.optimizer.param_groups, param_values, strict=True
+                ):
+                    for param, value in zip(
+                        group["params"], group_values, strict=True
+                    ):
+                        param.copy_(value.to(device=param.device, dtype=param.dtype))
 
     def offload_state_to_cpu(self) -> None:
         self._offloaded_state_devices.clear()

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/wrapper.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/wrapper.py
@@ -1,0 +1,275 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""MLite-owned Megatron-FSDP module wrapper."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Iterator
+
+import torch
+import torch.nn as nn
+from torch.autograd.graph import saved_tensors_hooks
+from torch.utils._pytree import tree_map_only
+
+from megatron.lite.primitive.optimizers.mfsdp.buffer import (
+    AllGatherPipeline,
+    CommunicationPipelines,
+    GradReducePipeline,
+    ParamAndGradBuffer,
+)
+from megatron.lite.primitive.optimizers.mfsdp.config import (
+    MFSDPConfig,
+    MFSDPProcessGroups,
+)
+
+
+class _BeginBackward(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        tensor: torch.Tensor,
+        pipeline: CommunicationPipelines,
+    ) -> torch.Tensor:
+        ctx.pipeline = pipeline
+        return tensor
+
+    @staticmethod
+    def backward(ctx, grad: torch.Tensor) -> tuple[torch.Tensor, None]:
+        ctx.pipeline.begin_backward()
+        return grad, None
+
+
+class _AcquireBackward(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        tensor: torch.Tensor,
+        pipeline: CommunicationPipelines,
+        bucket_ids: tuple[int, ...],
+    ) -> torch.Tensor:
+        ctx.pipeline = pipeline
+        ctx.bucket_ids = bucket_ids
+        return tensor
+
+    @staticmethod
+    def backward(ctx, grad: torch.Tensor) -> tuple[torch.Tensor, None, None]:
+        ctx.pipeline.acquire_backward_ids(ctx.bucket_ids)
+        return grad, None, None
+
+
+class _ReleaseBackward(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        tensor: torch.Tensor,
+        pipeline: CommunicationPipelines,
+        bucket_ids: tuple[int, ...],
+    ) -> torch.Tensor:
+        ctx.pipeline = pipeline
+        ctx.bucket_ids = bucket_ids
+        return tensor
+
+    @staticmethod
+    def backward(ctx, grad: torch.Tensor) -> tuple[torch.Tensor, None, None]:
+        ctx.pipeline.release_backward_ids(ctx.bucket_ids)
+        return grad, None, None
+
+
+class MegatronFSDP(nn.Module):
+    """Wrap a module with bucketed sharding and communication overlap."""
+
+    def __init__(
+        self,
+        module: nn.Module,
+        *,
+        groups: MFSDPProcessGroups,
+        config: MFSDPConfig,
+        is_expert: Callable[[str], bool],
+        unit_modules: Iterable[type[nn.Module] | str] | None,
+    ) -> None:
+        super().__init__()
+        self.module = module
+        self.mfsdp_config = config
+        self._expose_sharded_parameters = True
+        self.param_and_grad_buffer = ParamAndGradBuffer(
+            module,
+            groups=groups,
+            config=config,
+            is_expert=is_expert,
+            unit_modules=unit_modules,
+        )
+        self.param_sync = CommunicationPipelines(self.param_and_grad_buffer.buckets)
+        self.all_gather_pipeline: AllGatherPipeline = self.param_sync.all_gather
+        self.grad_reduce_pipeline: GradReducePipeline = self.param_sync.grad_reduce
+        for owner_id, bucket_ids in self.param_and_grad_buffer.owners.items():
+            owner = _module_by_id(module, owner_id)
+            ids = tuple(bucket_ids)
+
+            def prepare_forward(_module, args, ids=ids):
+                self.param_sync.acquire_forward(ids)
+                return tree_map_only(
+                    torch.Tensor,
+                    lambda tensor: (
+                        _ReleaseBackward.apply(tensor, self.param_sync, ids)
+                        if tensor.requires_grad
+                        else tensor
+                    ),
+                    args,
+                )
+
+            def finish_forward(_module, _args, output, ids=ids):
+                output = tree_map_only(
+                    torch.Tensor,
+                    lambda tensor: (
+                        _AcquireBackward.apply(tensor, self.param_sync, ids)
+                        if tensor.requires_grad
+                        else tensor
+                    ),
+                    output,
+                )
+                self.param_sync.release_forward_ids(ids)
+                return output
+
+            owner.register_forward_pre_hook(prepare_forward)
+            owner.register_forward_hook(finish_forward)
+        self.param_sync.release_all()
+        self.param_sync.discard_full_parameter_views()
+
+    def forward(self, *args, **kwargs):
+        self.param_sync.begin_forward()
+
+        def attach_backward(tensor: torch.Tensor) -> torch.Tensor:
+            if not tensor.requires_grad:
+                return tensor
+            return _BeginBackward.apply(tensor, self.param_sync)
+
+        try:
+            with saved_tensors_hooks(
+                self.param_sync.pack_saved_tensor,
+                self.param_sync.unpack_saved_tensor,
+            ):
+                output = self.module(*args, **kwargs)
+                output = tree_map_only(
+                    torch.Tensor,
+                    attach_backward,
+                    output,
+                )
+        finally:
+            self.param_sync.end_forward()
+        return output
+
+    def start_param_sync(self, *_args, force_sync: bool = False, **_kwargs) -> None:
+        if force_sync:
+            self.param_sync.materialize_all()
+        elif (
+            self.mfsdp_config.all_gather_in_start_param_sync and self.param_sync.buckets
+        ):
+            self.all_gather_pipeline.async_bucket_gather(0)
+
+    def start_grad_sync(self, *_args) -> None:
+        for bucket in reversed(self.param_sync.buckets):
+            self.grad_reduce_pipeline.reduce_gradients(bucket, force=True)
+
+    def finish_grad_sync(self, *_args) -> None:
+        self.param_sync.finish_grad_sync()
+
+    def zero_grad_buffer(self) -> None:
+        self.param_sync.reset_grad_state()
+
+    def move_model_state(
+        self,
+        device: torch.device | str,
+        *,
+        load_grad: bool = True,
+    ) -> None:
+        """Move M-FSDP-owned storage while preserving optimizer parameter aliases."""
+        self.param_sync.move_model_state(
+            torch.device(device),
+            load_grad=load_grad,
+        )
+
+    def release_export_scratch(self) -> None:
+        """Reclaim the training step's all-gather scratch before a colocated wake.
+
+        verl's ``update_weights`` wakes the sleeping vLLM weight pool
+        (``resume(['weights'])``) *before* exporting M-FSDP weights. At that
+        point the trainer still pins the training step's transient all-gather
+        scratch -- the persistent double-buffer slots plus any full-parameter
+        views -- on top of the sharded weights and optimizer state, and vLLM's
+        cumem ``create_and_map`` OOMs. Hand that scratch back to the driver
+        (keeping the sharded weights resident as the export gather source) and
+        drain the caching allocator so the wake has room.
+        """
+        self.param_sync.release_scratch_keep_weights()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+    def stream_full_parameters(self) -> Iterator[tuple[str, nn.Parameter]]:
+        """Yield ``(name, full_param)`` one bucket at a time for export.
+
+        The bounded-bucket counterpart to ``materialize_all``: an exporter that
+        walks parameters one at a time (see the shared HF exporter's
+        ``export_hf_weights``) can consume this stream instead of pre-gathering
+        the whole model, capping the transient full-parameter footprint at a
+        single bucket rather than the whole unsharded model. This is the
+        materialization side of the DS4 resync bounded-export protocol and
+        mirrors FSDP2's per-parameter ``full_tensor`` gather, which shows no
+        export memory peak.
+
+        Each yielded parameter's ``.data`` is cloned off the bucket's gather
+        buffer before the bucket is released, so a consumer that retains the
+        tensor past the bucket's lifetime (e.g. the exporter buffers expert
+        shards for a per-layer EP collective) keeps a private allocation and
+        never aliases storage that the release has handed back to the allocator.
+        """
+        # Names are resolved against the currently-installed (sharded) params,
+        # which is the module state on entry and after each bucket release.
+        name_by_shard_id = {
+            id(param): name for name, param in self.module.named_parameters()
+        }
+        covered: set[str] = set()
+        for bucket in self.param_sync.stream_materialize_buckets():
+            for spec in bucket.specs:
+                name = name_by_shard_id.get(id(spec.shard_param))
+                if name is None:
+                    continue
+                covered.add(name)
+                full_param = spec.full_param
+                full_param.data = full_param.data.clone()
+                yield name, full_param
+        # Parameters (and any params not owned by an M-FSDP bucket) that the
+        # bucket walk did not cover -- emit them from the restored sharded view.
+        for name, param in self.module.named_parameters():
+            if name not in covered:
+                yield name, param
+
+    def named_parameters(self, *args, **kwargs) -> Iterator[tuple[str, nn.Parameter]]:
+        if not self._expose_sharded_parameters:
+            self.param_sync.materialize_all()
+        return super().named_parameters(*args, **kwargs)
+
+    def state_dict(self, *args, **kwargs):
+        self.param_sync.materialize_all()
+        return super().state_dict(*args, **kwargs)
+
+    def load_state_dict(self, state_dict, strict: bool = True, assign: bool = False):
+        self.param_sync.materialize_all()
+        result = super().load_state_dict(state_dict, strict=strict, assign=assign)
+        self.param_sync.copy_full_parameters_to_shards()
+        return result
+
+
+MFSdpModule = MegatronFSDP
+
+
+def mark_optimizer_built(module: MegatronFSDP) -> None:
+    module._expose_sharded_parameters = False
+
+
+def _module_by_id(root: nn.Module, module_id: int) -> nn.Module:
+    for module in root.modules():
+        if id(module) == module_id:
+            return module
+    raise RuntimeError("M-FSDP bucket owner is no longer part of the wrapped module.")
+
+
+__all__ = ["MFSdpModule", "MegatronFSDP", "mark_optimizer_built"]

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/wrapper.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/wrapper.py
@@ -97,6 +97,7 @@ class MegatronFSDP(nn.Module):
             is_expert=is_expert,
             unit_modules=unit_modules,
         )
+        _enable_fused_wgrad_accumulation(module)
         self.param_sync = CommunicationPipelines(self.param_and_grad_buffer.buckets)
         self.all_gather_pipeline: AllGatherPipeline = self.param_sync.all_gather
         self.grad_reduce_pipeline: GradReducePipeline = self.param_sync.grad_reduce
@@ -270,6 +271,13 @@ def _module_by_id(root: nn.Module, module_id: int) -> nn.Module:
         if id(module) == module_id:
             return module
     raise RuntimeError("M-FSDP bucket owner is no longer part of the wrapped module.")
+
+
+def _enable_fused_wgrad_accumulation(module: nn.Module) -> None:
+    """Enable TE-style fused wgrad only inside the M-FSDP ownership boundary."""
+    for child in module.modules():
+        if hasattr(child, "fuse_wgrad_accumulation"):
+            child.fuse_wgrad_accumulation = True
 
 
 __all__ = ["MFSdpModule", "MegatronFSDP", "mark_optimizer_built"]

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/wrapper.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/wrapper.py
@@ -252,10 +252,13 @@ class MegatronFSDP(nn.Module):
         self.param_sync.materialize_all()
         return super().state_dict(*args, **kwargs)
 
+    def install_optimized_model_weights(self) -> None:
+        self.param_sync.copy_full_parameters_to_shards()
+
     def load_state_dict(self, state_dict, strict: bool = True, assign: bool = False):
         self.param_sync.materialize_all()
         result = super().load_state_dict(state_dict, strict=strict, assign=assign)
-        self.param_sync.copy_full_parameters_to_shards()
+        self.install_optimized_model_weights()
         return result
 
 

--- a/experimental/lite/megatron/lite/primitive/recompute.py
+++ b/experimental/lite/megatron/lite/primitive/recompute.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
 import torch  # pyright: ignore[reportMissingImports]
@@ -65,7 +66,9 @@ class _CheckpointWithoutOutputFn(torch.autograd.Function):
             ctx.cpu_rng_state = torch.get_rng_state()
             ctx.cuda_rng_state = torch.cuda.get_rng_state()
 
-        ctx.tensor_indices = [i for i, a in enumerate(args) if isinstance(a, torch.Tensor)]
+        ctx.tensor_indices = [
+            i for i, a in enumerate(args) if isinstance(a, torch.Tensor)
+        ]
         ctx.non_tensor_args = [
             (i, a) for i, a in enumerate(args) if not isinstance(a, torch.Tensor)
         ]
@@ -87,7 +90,9 @@ class _CheckpointWithoutOutputFn(torch.autograd.Function):
         torch.autograd.backward(outputs, grad_outputs)
         ctx.outputs = None
         ctx.inputs = None
-        grads = tuple(inp.grad if isinstance(inp, torch.Tensor) else None for inp in inputs)
+        grads = tuple(
+            inp.grad if isinstance(inp, torch.Tensor) else None for inp in inputs
+        )
         return (None, None) + grads
 
 
@@ -124,7 +129,9 @@ class CheckpointWithoutOutput:
             self._cuda_rng = torch.cuda.get_rng_state()
 
         outputs = _CheckpointWithoutOutputFn.apply(run_function, self, *args)
-        self.outputs = (outputs,) if isinstance(outputs, torch.Tensor) else tuple(outputs)
+        self.outputs = (
+            (outputs,) if isinstance(outputs, torch.Tensor) else tuple(outputs)
+        )
         return outputs
 
     def _recompute(self, _) -> None:
@@ -189,6 +196,16 @@ ModuleMap = dict[str, Callable[[nn.Module], nn.Module | None]]
 """Maps module name → lambda that extracts a sub-module from a layer."""
 
 
+@dataclass(frozen=True)
+class ActivationOffloadApplication:
+    """Observable result of applying an activation-offload request."""
+
+    requested: tuple[str, ...]
+    units: int
+    matched: int
+    wrapped: int
+
+
 def apply_recompute(
     layers: nn.ModuleList,
     module_names: list[str],
@@ -207,24 +224,52 @@ def apply_recompute(
                 if mod_name in module_map:
                     submod = module_map[mod_name](layer)
                     if submod is not None:
-                        wrap_checkpoint(submod, preserve_rng_state=mod_name not in no_rng)
+                        wrap_checkpoint(
+                            submod, preserve_rng_state=mod_name not in no_rng
+                        )
 
 
-def apply_offload(layers: nn.ModuleList, module_names: list[str], module_map: ModuleMap) -> None:
-    """Wrap specified sub-modules with activation offloading to CPU."""
+def apply_offload(
+    layers: nn.ModuleList,
+    module_names: list[str],
+    module_map: ModuleMap,
+) -> ActivationOffloadApplication:
+    """Offload tensors saved for backward by the selected modules to CPU."""
     if not module_names:
-        return
-    try:
-        from torch.utils.checkpoint import CheckpointPolicy  # noqa: F401
-    except ImportError:
-        log_rank0("WARNING: torch.utils.checkpoint policy_fn not available, skipping offload")
-        return
+        return ActivationOffloadApplication((), len(layers), 0, 0)
+    if not layers:
+        raise ValueError(
+            f"activation offload requested for {module_names!r}, but received "
+            "0 transformer units. Check transformer-unit enumeration."
+        )
+
+    matched = 0
+    wrapped = 0
     for layer in layers:
-        for mod_name in module_names:
-            if mod_name in module_map:
-                submod = module_map[mod_name](layer)
-                if submod is not None:
-                    wrap_offload(submod)
+        if "full" in module_names:
+            matched += 1
+            wrapped += wrap_offload(layer)
+            continue
+        for module_name in module_names:
+            selector = module_map.get(module_name)
+            if selector is None:
+                continue
+            submodule = selector(layer)
+            if submodule is not None:
+                matched += 1
+                wrapped += wrap_offload(submodule)
+
+    if matched == 0:
+        raise ValueError(
+            f"activation offload requested for {module_names!r}, but matched "
+            "0 modules. Check transformer-unit enumeration and the model module map."
+        )
+    return ActivationOffloadApplication(
+        requested=tuple(module_names),
+        units=len(layers),
+        matched=matched,
+        wrapped=wrapped,
+    )
 
 
 class CheckpointFunction(torch.autograd.Function):
@@ -274,7 +319,9 @@ class CheckpointFunction(torch.autograd.Function):
 
         # Recompute forward pass with gradients enabled.
         detached = tuple(
-            t.detach().requires_grad_(t.requires_grad) if isinstance(t, torch.Tensor) else t
+            t.detach().requires_grad_(t.requires_grad)
+            if isinstance(t, torch.Tensor)
+            else t
             for t in inputs
         )
         with torch.enable_grad():
@@ -299,13 +346,21 @@ class CheckpointFunction(torch.autograd.Function):
         if outputs_with_grad:
             torch.autograd.backward(outputs_with_grad, grad_for_outputs)
 
-        grads = tuple(inp.grad if isinstance(inp, torch.Tensor) else None for inp in detached)
+        grads = tuple(
+            inp.grad if isinstance(inp, torch.Tensor) else None for inp in detached
+        )
         # None for run_function, None for preserve_rng_state, then grads for each input.
         return (None, None) + grads
 
 
 def wrap_checkpoint(module: nn.Module, *, preserve_rng_state: bool = True) -> None:
     """Wrap a module's forward with reentrant activation checkpointing."""
+    if getattr(module, "_megatron_lite_recompute_wrapped", False):
+        return
+    if getattr(module, "_megatron_lite_offload_wrapped", False):
+        raise ValueError(
+            "activation recompute and activation offload cannot wrap the same module"
+        )
     original_forward = module.forward
     _routers = [m for m in module.modules() if hasattr(m, "expert_bias")]
 
@@ -339,18 +394,29 @@ def wrap_checkpoint(module: nn.Module, *, preserve_rng_state: bool = True) -> No
         return CheckpointFunction.apply(_fn, preserve_rng_state, *args)
 
     module.forward = _checkpointed_forward
+    module._megatron_lite_recompute_wrapped = True
 
 
-def wrap_offload(module: nn.Module) -> None:
-    """Wrap a module's forward with activation offloading."""
+def wrap_offload(module: nn.Module) -> int:
+    """Wrap a module once so tensors saved for backward live on CPU."""
+    if getattr(module, "_megatron_lite_offload_wrapped", False):
+        return 0
+    if getattr(module, "_megatron_lite_recompute_wrapped", False):
+        raise ValueError(
+            "activation offload and activation recompute cannot wrap the same module"
+        )
     original_forward = module.forward
 
     def _offloaded_forward(*args, **kwargs):
-        return torch.utils.checkpoint.checkpoint(
-            original_forward, *args, use_reentrant=False, **kwargs
-        )
+        with torch.autograd.graph.save_on_cpu(
+            pin_memory=torch.cuda.is_available(),
+            device_type="cuda",
+        ):
+            return original_forward(*args, **kwargs)
 
     module.forward = _offloaded_forward
+    module._megatron_lite_offload_wrapped = True
+    return 1
 
 
 def log_rank0(msg: str) -> None:
@@ -370,6 +436,7 @@ def parse_recompute_spec(recompute: str | list[str] | None) -> list[str]:
 
 
 __all__ = [
+    "ActivationOffloadApplication",
     "CheckpointFunction",
     "CheckpointWithoutOutput",
     "ModuleMap",

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -15,9 +15,17 @@ import torch
 import torch.distributed as dist
 from megatron.lite.runtime.backends import Runtime as RuntimeBase
 from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig
-from megatron.lite.runtime.contracts.data import ForwardResult, ModelOutputs, PackedBatch
+from megatron.lite.runtime.contracts.data import (
+    ForwardResult,
+    ModelOutputs,
+    PackedBatch,
+)
 from megatron.lite.runtime.contracts.handle import ModelHandle
-from megatron.lite.runtime.contracts.loss import get_loss_context, split_loss_context, use_loss_context
+from megatron.lite.runtime.contracts.loss import (
+    get_loss_context,
+    split_loss_context,
+    use_loss_context,
+)
 
 
 def _build_impl_cfg(proto, rt_cfg: MegatronLiteConfig):
@@ -25,20 +33,28 @@ def _build_impl_cfg(proto, rt_cfg: MegatronLiteConfig):
     init_fields = {f.name for f in dc_fields(proto.ImplConfig) if f.init}
     # Only forward impl_cfg keys this model's ImplConfig declares: the connector
     # may pass knobs (e.g. cross_entropy_fusion) that some models don't model.
-    impl_cfg_kwargs = {key: value for key, value in rt_cfg.impl_cfg.items() if key in init_fields}
+    impl_cfg_kwargs = {
+        key: value for key, value in rt_cfg.impl_cfg.items() if key in init_fields
+    }
     impl_cfg_kwargs["parallel"] = rt_cfg.parallel
     if (
         "attention_backend_override" in init_fields
         and impl_cfg_kwargs.get("attention_backend_override") is None
     ):
-        impl_cfg_kwargs["attention_backend_override"] = rt_cfg.attention_backend_override
+        impl_cfg_kwargs["attention_backend_override"] = (
+            rt_cfg.attention_backend_override
+        )
     if (
         "router_aux_loss_coef" in init_fields
         and impl_cfg_kwargs.get("router_aux_loss_coef") is None
         and rt_cfg.router_aux_loss_coef is not None
     ):
         impl_cfg_kwargs["router_aux_loss_coef"] = rt_cfg.router_aux_loss_coef
-    if "hf_path" in init_fields and impl_cfg_kwargs.get("hf_path") in (None, "") and rt_cfg.hf_path:
+    if (
+        "hf_path" in init_fields
+        and impl_cfg_kwargs.get("hf_path") in (None, "")
+        and rt_cfg.hf_path
+    ):
         impl_cfg_kwargs["hf_path"] = rt_cfg.hf_path
     # Thread the user-level OptimizerConfig so the protocol can pass it to
     # optimizer primitives without reading runtime internals.
@@ -74,9 +90,13 @@ def _apply_attention_backend_env(backend: str | None, *, tag: str) -> None:
     os.environ["NVTE_UNFUSED_ATTN"] = unfused
 
 
-def _infer_pipeline_tensor_shape(batch: PackedBatch, model_cfg: Any, ps) -> tuple[int, int, int]:
+def _infer_pipeline_tensor_shape(
+    batch: PackedBatch, model_cfg: Any, ps
+) -> tuple[int, int, int]:
     if model_cfg is None or not hasattr(model_cfg, "hidden_size"):
-        raise ValueError("Megatron Lite pipeline runtime requires model_cfg.hidden_size.")
+        raise ValueError(
+            "Megatron Lite pipeline runtime requires model_cfg.hidden_size."
+        )
     if not isinstance(batch, PackedBatch):
         raise TypeError("Megatron Lite pipeline runtime requires PackedBatch inputs.")
 
@@ -88,7 +108,9 @@ def _infer_pipeline_tensor_shape(batch: PackedBatch, model_cfg: Any, ps) -> tupl
         batch_size = int(input_ids.size(0))
         local_seq_len = int(input_ids.size(1))
     else:
-        raise ValueError(f"Unsupported input_ids rank for pipeline runtime: {input_ids.dim()}.")
+        raise ValueError(
+            f"Unsupported input_ids rank for pipeline runtime: {input_ids.dim()}."
+        )
 
     if local_seq_len < 1:
         raise ValueError("Pipeline tensor shape requires non-empty sequence.")
@@ -102,7 +124,11 @@ def _infer_pipeline_tensor_shape(batch: PackedBatch, model_cfg: Any, ps) -> tupl
     # (each sequence padded to align = tp * (2*cp if cp>1 else 1)) then divide by CP*TP.
     seq_lens = getattr(batch, "seq_lens", None)
     if seq_lens is not None and cp_size * tp_size > 1:
-        sl = seq_lens if isinstance(seq_lens, torch.Tensor) else torch.as_tensor(seq_lens)
+        sl = (
+            seq_lens
+            if isinstance(seq_lens, torch.Tensor)
+            else torch.as_tensor(seq_lens)
+        )
         sl = sl.to(torch.int64).reshape(-1)
         align = tp_size * (2 * cp_size if cp_size > 1 else 1)
         padded = sl + (align - sl % align) % align
@@ -217,9 +243,15 @@ class MegatronLiteRuntime(RuntimeBase):
 
         # ── load HF weights (optional) ──
         loaded_hf_weights = False
-        if rt_cfg.load_hf_weights and rt_cfg.hf_path and hasattr(proto, "load_hf_weights"):
+        if (
+            rt_cfg.load_hf_weights
+            and rt_cfg.hf_path
+            and hasattr(proto, "load_hf_weights")
+        ):
             for chunk in bundle.chunks:
-                proto.load_hf_weights(chunk, rt_cfg.hf_path, model_cfg, bundle.parallel_state)
+                proto.load_hf_weights(
+                    chunk, rt_cfg.hf_path, model_cfg, bundle.parallel_state
+                )
             loaded_hf_weights = True
 
         post_load_hook = bundle.extras.pop("post_model_load_hook", None)
@@ -235,7 +267,9 @@ class MegatronLiteRuntime(RuntimeBase):
                 extra_updates = post_load_updates.get("extras")
                 if extra_updates:
                     if not isinstance(extra_updates, dict):
-                        raise TypeError("post_model_load_hook extras update must be a dict.")
+                        raise TypeError(
+                            "post_model_load_hook extras update must be a dict."
+                        )
                     bundle.extras.update(extra_updates)
 
         if loaded_hf_weights and bundle.optimizer is not None:
@@ -244,7 +278,9 @@ class MegatronLiteRuntime(RuntimeBase):
                 reload_model_params()
 
         if bundle.forward_step is None:
-            raise ValueError("Megatron Lite model bundles must provide a typed forward_step.")
+            raise ValueError(
+                "Megatron Lite model bundles must provide a typed forward_step."
+            )
 
         p = rt_cfg.parallel
         model = bundle.chunks[0] if len(bundle.chunks) == 1 else bundle.chunks
@@ -268,7 +304,10 @@ class MegatronLiteRuntime(RuntimeBase):
 
     def _load_protocol(self, rt_cfg: MegatronLiteConfig):
         """Load and return the model protocol module."""
-        from megatron.lite.model.registry import TRAIN_RUNTIME_MODULES, resolve_runtime_model_name
+        from megatron.lite.model.registry import (
+            TRAIN_RUNTIME_MODULES,
+            resolve_runtime_model_name,
+        )
 
         try:
             runtime_key = resolve_runtime_model_name(rt_cfg.model_name, rt_cfg.impl)
@@ -288,7 +327,9 @@ class MegatronLiteRuntime(RuntimeBase):
 
         for fn_name in ("build_model_config", "build_model"):
             if not callable(getattr(proto, fn_name, None)):
-                raise ValueError(f"Protocol module {mod_path} missing required function: {fn_name}")
+                raise ValueError(
+                    f"Protocol module {mod_path} missing required function: {fn_name}"
+                )
         if not hasattr(proto, "ImplConfig"):
             raise ValueError(f"Protocol module {mod_path} missing ImplConfig class")
 
@@ -351,7 +392,9 @@ class MegatronLiteRuntime(RuntimeBase):
             **kwargs,
         )
 
-    def export_weights(self, handle: ModelHandle, **kwargs) -> Iterator[tuple[str, torch.Tensor]]:
+    def export_weights(
+        self, handle: ModelHandle, **kwargs
+    ) -> Iterator[tuple[str, torch.Tensor]]:
         model_chunks = handle._extras.get("model_chunks", [handle._model])
         proto = handle._extras.get("protocol")
         model_cfg = handle._extras.get("model_cfg")
@@ -447,7 +490,9 @@ class MegatronLiteRuntime(RuntimeBase):
         router_replay: Any = None,
     ) -> ForwardResult:
         from megatron.lite.primitive.train_step import run_microbatch_loop
-        from megatron.lite.runtime.backends.mlite.router_replay import RouterReplayDriver
+        from megatron.lite.runtime.backends.mlite.router_replay import (
+            RouterReplayDriver,
+        )
 
         forward_step = handle._extras["forward_step"]
         if num_microbatches < 1:
@@ -470,7 +515,9 @@ class MegatronLiteRuntime(RuntimeBase):
             from types import SimpleNamespace
 
             from megatron.lite.primitive.ckpt.hf_weights import unwrap_model
-            from megatron.lite.primitive.parallel.pipeline import forward_backward_pipelining
+            from megatron.lite.primitive.parallel.pipeline import (
+                forward_backward_pipelining,
+            )
 
             first_item = next(data_iter)
             first_batch, _loss_context = split_loss_context(first_item)
@@ -484,7 +531,9 @@ class MegatronLiteRuntime(RuntimeBase):
 
             model_chunks = handle._extras.get("model_chunks", [handle._model])
             pipeline_chunks = [unwrap_model(chunk) for chunk in model_chunks]
-            pipeline_forward_step, pipeline_loss_fn = _pipeline_callbacks(forward_step, loss_fn)
+            pipeline_forward_step, pipeline_loss_fn = _pipeline_callbacks(
+                forward_step, loss_fn
+            )
 
             # Backend wiring (minimal): the 1F1B schedule calls grad_sync_fn at the
             # point it should start reducing gradients (after the last microbatch's
@@ -502,7 +551,9 @@ class MegatronLiteRuntime(RuntimeBase):
                     ps,
                     tensor_shape=tensor_shape,
                     grad_sync_fn=(
-                        enable_optimizer_grad_sync if handle._optimizer is not None else None
+                        enable_optimizer_grad_sync
+                        if handle._optimizer is not None
+                        else None
                     ),
                     pre_forward_hook=handle._extras.get("pre_forward_hook"),
                     loss_fn=pipeline_loss_fn,
@@ -523,7 +574,9 @@ class MegatronLiteRuntime(RuntimeBase):
                 dtype=torch.float32,
             )
             if ps.pp_group is not None and ps.pp_global_ranks is not None:
-                dist.broadcast(loss_payload, src=ps.pp_global_ranks[-1], group=ps.pp_group)
+                dist.broadcast(
+                    loss_payload, src=ps.pp_global_ranks[-1], group=ps.pp_group
+                )
             out = {"loss": loss_payload[1]} if bool(loss_payload[0].item()) else {}
         else:
             try:
@@ -639,7 +692,10 @@ def _checkpoint_model(handle: ModelHandle, *, use_dcp: bool):
 
 
 def _checkpoint_hooks(handle: ModelHandle):
-    from megatron.lite.primitive.protocols import default_expert_classifier, default_placement_fn
+    from megatron.lite.primitive.protocols import (
+        default_expert_classifier,
+        default_placement_fn,
+    )
 
     proto = handle._extras.get("protocol")
     return (

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -485,6 +485,14 @@ class MegatronLiteRuntime(RuntimeBase):
             model_chunks = handle._extras.get("model_chunks", [handle._model])
             pipeline_chunks = [unwrap_model(chunk) for chunk in model_chunks]
             pipeline_forward_step, pipeline_loss_fn = _pipeline_callbacks(forward_step, loss_fn)
+
+            # Backend wiring (minimal): the 1F1B schedule calls grad_sync_fn at the
+            # point it should start reducing gradients (after the last microbatch's
+            # backward), letting an overlap-capable optimizer arm its DP grad
+            # reduction. Passed only when an optimizer is attached; None otherwise.
+            def enable_optimizer_grad_sync() -> None:
+                handle._optimizer.grad_sync_enabled = True
+
             try:
                 outputs = forward_backward_pipelining(
                     pipeline_forward_step,
@@ -493,6 +501,9 @@ class MegatronLiteRuntime(RuntimeBase):
                     SimpleNamespace(num_microbatches=num_microbatches),
                     ps,
                     tensor_shape=tensor_shape,
+                    grad_sync_fn=(
+                        enable_optimizer_grad_sync if handle._optimizer is not None else None
+                    ),
                     pre_forward_hook=handle._extras.get("pre_forward_hook"),
                     loss_fn=pipeline_loss_fn,
                     forward_only=forward_only,

--- a/experimental/lite/megatron/lite/runtime/megatron_utils.py
+++ b/experimental/lite/megatron/lite/runtime/megatron_utils.py
@@ -59,7 +59,9 @@ def register_training_hooks(model_list: list, optimizer) -> None:
 
         optimizer_config = getattr(optimizer, "config", None)
         overlap_param_gather = getattr(optimizer_config, "overlap_param_gather", False)
-        overlap_grad_reduce = getattr(one_model.ddp_config, "overlap_grad_reduce", False)
+        overlap_grad_reduce = getattr(
+            one_model.ddp_config, "overlap_grad_reduce", False
+        )
         align_grad_reduce = True
         align_param_gather = getattr(one_model.ddp_config, "align_param_gather", False)
 
@@ -137,7 +139,9 @@ def offload_model_to_cpu(model_list: list) -> None:
             for buffers in all_buffers:
                 for buffer in buffers:
                     if buffer.param_data.storage().size() > 0:
-                        buffer.param_data.cpu_data = buffer.param_data.data.cpu().pin_memory()
+                        buffer.param_data.cpu_data = (
+                            buffer.param_data.data.cpu().pin_memory()
+                        )
                         buffer.param_data_size = buffer.param_data.storage().size()
                         buffer.param_data.storage().resize_(0)
 
@@ -180,7 +184,9 @@ def load_model_to_gpu(model_list: list, load_grad: bool = True) -> None:
 
                     if buffer.param_data.storage().size() == 0:
                         buffer.param_data.storage().resize_(buffer.param_data_size)
-                        buffer.param_data.copy_(buffer.param_data.cpu_data, non_blocking=True)
+                        buffer.param_data.copy_(
+                            buffer.param_data.cpu_data, non_blocking=True
+                        )
 
             for param in model_chunk.module.parameters():
                 if not param.requires_grad and param.device.type == "cpu":
@@ -202,7 +208,8 @@ def offload_optimizer(optimizer) -> None:
         if _opt.optimizer is not None:
             hdo = _opt.optimizer
             if all(
-                hasattr(hdo, a) for a in ("sub_optimizers", "inner_param_to_orig_param", "state")
+                hasattr(hdo, a)
+                for a in ("sub_optimizers", "inner_param_to_orig_param", "state")
             ):
                 for sub_opt in hdo.sub_optimizers:
                     for param, state in sub_opt.state.items():
@@ -267,7 +274,9 @@ def build_sharded_state_dict(
         sharded_state_dict.update(chunk_sd)
 
     if optimizer is not None:
-        opt_sd = optimizer.sharded_state_dict(model_sharded_state_dict=sharded_state_dict)
+        opt_sd = optimizer.sharded_state_dict(
+            model_sharded_state_dict=sharded_state_dict
+        )
         sharded_state_dict.update(opt_sd)
 
     if lr_scheduler is not None:

--- a/experimental/lite/megatron/lite/runtime/megatron_utils.py
+++ b/experimental/lite/megatron/lite/runtime/megatron_utils.py
@@ -121,9 +121,18 @@ def _reshard_fsdp2_modules(model_chunk: Any) -> None:
 
 
 def offload_model_to_cpu(model_list: list) -> None:
-    """Offload DDP model to CPU via buffer-resize (zero-copy on GPU side)."""
+    """Offload model to CPU (buffer-resize for DDP; wrapper hook otherwise)."""
     for model_chunk in model_list:
-        if _is_megatron_ddp(model_chunk):
+        # Extension point: any wrapper that self-manages its parameter/grad state
+        # storage (and therefore cannot be offloaded by the generic DDP
+        # buffer-resize or fsdp2 reshard paths below) opts in by exposing a
+        # ``move_model_state(device, load_grad=...)`` method. This is duck-typed,
+        # not an ``if backend == ...`` special-case; the mfsdp optimizer is the
+        # first consumer, and any future self-managed wrapper routes here for free.
+        move_model_state = getattr(model_chunk, "move_model_state", None)
+        if callable(move_model_state):
+            move_model_state(torch.device("cpu"), load_grad=True)
+        elif _is_megatron_ddp(model_chunk):
             all_buffers = [model_chunk.buffers, model_chunk.expert_parallel_buffers]
             for buffers in all_buffers:
                 for buffer in buffers:
@@ -145,9 +154,19 @@ def offload_model_to_cpu(model_list: list) -> None:
 
 
 def load_model_to_gpu(model_list: list, load_grad: bool = True) -> None:
-    """Load DDP model back to GPU from pinned CPU copy."""
+    """Load model back to GPU (pinned-copy for DDP; wrapper hook otherwise)."""
     for model_chunk in model_list:
-        if _is_megatron_ddp(model_chunk):
+        # Mirror of offload_model_to_cpu: the same duck-typed extension point.
+        # A self-managing wrapper's move_model_state handles its own restore;
+        # mfsdp is the first consumer, everything else falls through to the
+        # generic DDP / fsdp2 reload below.
+        move_model_state = getattr(model_chunk, "move_model_state", None)
+        if callable(move_model_state):
+            move_model_state(
+                torch.device("cuda"),
+                load_grad=load_grad,
+            )
+        elif _is_megatron_ddp(model_chunk):
             all_buffers = [model_chunk.buffers, model_chunk.expert_parallel_buffers]
             for buffers in all_buffers:
                 for buffer in buffers:

--- a/experimental/lite/tests/README.md
+++ b/experimental/lite/tests/README.md
@@ -3,7 +3,7 @@
 `experimental/lite/tests` separates MLite validation into two layers:
 
 - Unit tests: CPU/single-process contract tests for primitive, model, runtime, checkpoint sentinels, config, and helper behavior. Pure helper tests stub optional imports when no Transformer Engine runtime path is exercised; tests that need the real package explicitly skip when unavailable.
-- Smoke tests: real `torch.distributed` tests for TP/EP/PP/CP/FSDP2/offload/checkpoint/distopt and tiny Qwen lite forward/backward behavior. Smoke runs are capped at one node and at most 8 GPUs.
+- Smoke tests: real `torch.distributed` tests for TP/EP/PP/CP/FSDP2/M-FSDP/offload/checkpoint/distopt and tiny Qwen lite forward/backward behavior. Regular smoke runs and the dedicated M-FSDP full-parallel signoff are capped at one node and at most 8 GPUs.
 
 Run unit coverage:
 
@@ -36,6 +36,7 @@ Current matrix:
 | Data/recompute/train-step primitives | `unit/primitive/test_ops_data_trainstep_unit.py` | model/runtime smoke exercises training loop integration |
 | DDP + distributed optimizer | `unit/primitive/test_checkpoint_unit.py`, `unit/primitive/test_checkpoint_runtime.py` | `smoke/primitive/test_distopt_checkpoint_smoke.py` |
 | FSDP2 config/wrap/offload | `unit/primitive/test_fsdp2_unit.py` | `smoke/primitive/test_fsdp2_offload_checkpoint_smoke.py` |
+| M-FSDP precision/performance | `unit/primitive/test_mfsdp.py`, `unit/runtime/test_runtime_backend_unit.py` | `smoke/primitive/test_mfsdp_parity_smoke.py` via `run_mfsdp_hopper_validation.sh` (8-GPU throughput; 8-GPU TP2/EP2/ETP1/PP2/CP2 50-step precision curve) |
 | FSDP2 save/load resume | `unit/primitive/test_checkpoint_unit.py`, `unit/primitive/test_checkpoint_runtime.py` | `smoke/primitive/test_fsdp2_offload_checkpoint_smoke.py` |
 | Checkpoint restore vs direct training | `unit/primitive/test_checkpoint_unit.py`, `unit/primitive/test_checkpoint_runtime.py` | FSDP2 and distopt checkpoint smokes cover distributed restore paths |
 | Runtime backend registry/config | `unit/primitive/test_runtime_config_unit.py`, `unit/runtime/test_runtime_backend_unit.py` | covered through checkpoint/model handles |

--- a/experimental/lite/tests/run_mfsdp_hopper_validation.sh
+++ b/experimental/lite/tests/run_mfsdp_hopper_validation.sh
@@ -36,7 +36,7 @@ case "${MODE}" in
       echo "cpu-offload mode requires NNODES=1 and NPROC_PER_NODE=8." >&2
       exit 2
     fi
-    TEST_EXPR="cpu_optimizer_offload_reduces_memory_and_preserves_update"
+    TEST_EXPR="offload_matrix_matches_fsdp2_precision_speed_and_memory"
     ;;
   *)
     echo "usage: $0 {throughput|full-parallel|cpu-offload}" >&2

--- a/experimental/lite/tests/run_mfsdp_hopper_validation.sh
+++ b/experimental/lite/tests/run_mfsdp_hopper_validation.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "${ROOT}"
+
+if [[ -z "${SLURM_JOB_ID:-}" ]]; then
+  echo "M-FSDP Hopper validation must run inside a Slurm allocation." >&2
+  exit 2
+fi
+
+MODE="${1:-}"
+NPROC_PER_NODE="${NPROC_PER_NODE:-8}"
+NNODES="${NNODES:-${SLURM_NNODES:-1}}"
+export PYTHONPATH="${ROOT}/experimental/lite:${PYTHONPATH:-}"
+export MLITE_RUN_SMOKE=1
+export PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
+
+case "${MODE}" in
+  throughput)
+    if [[ "${NNODES}" != "1" || "${NPROC_PER_NODE}" != "8" ]]; then
+      echo "throughput mode requires NNODES=1 and NPROC_PER_NODE=8." >&2
+      exit 2
+    fi
+    TEST_EXPR="throughput_exceeds_fsdp2"
+    ;;
+  full-parallel)
+    if [[ "${NNODES}" != "1" || "${NPROC_PER_NODE}" != "8" ]]; then
+      echo "full-parallel mode requires NNODES=1 and NPROC_PER_NODE=8." >&2
+      exit 2
+    fi
+    TEST_EXPR="full_parallel_precision_curve"
+    ;;
+  cpu-offload)
+    if [[ "${NNODES}" != "1" || "${NPROC_PER_NODE}" != "8" ]]; then
+      echo "cpu-offload mode requires NNODES=1 and NPROC_PER_NODE=8." >&2
+      exit 2
+    fi
+    TEST_EXPR="cpu_optimizer_offload_reduces_memory_and_preserves_update"
+    ;;
+  *)
+    echo "usage: $0 {throughput|full-parallel|cpu-offload}" >&2
+    exit 2
+    ;;
+esac
+
+DIST_ARGS=(--nproc_per_node="${NPROC_PER_NODE}")
+if [[ "${NNODES}" == "1" ]]; then
+  DIST_ARGS+=(--standalone)
+else
+  NODE_RANK="${NODE_RANK:-${SLURM_NODEID:-}}"
+  : "${NODE_RANK:?set NODE_RANK or launch one Slurm task per node}"
+  : "${MASTER_ADDR:?set MASTER_ADDR to the first allocated node}"
+  MASTER_PORT="${MASTER_PORT:-29571}"
+  DIST_ARGS+=(
+    --nnodes="${NNODES}"
+    --node_rank="${NODE_RANK}"
+    --master_addr="${MASTER_ADDR}"
+    --master_port="${MASTER_PORT}"
+  )
+fi
+
+python -m torch.distributed.run "${DIST_ARGS[@]}" \
+  -m pytest \
+  -c /dev/null \
+  --rootdir="${ROOT}" \
+  --confcutdir="${ROOT}" \
+  -q -s -rs \
+  experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py \
+  -k "${TEST_EXPR}"

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -1024,6 +1024,7 @@ def test_mfsdp_non_fused_wgrad_accumulates_in_fp32_per_microbatch():
     assert not hasattr(model.linear, "fuse_wgrad_accumulation")
     chunks = [model]
     optimizer_config = _optimizer_cfg(use_fused_optimizer=False)
+    optimizer_config.clip_grad = 10000.0
     impl_cfg = SimpleNamespace(
         parallel=parallel,
         optimizer_config=optimizer_config,

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -624,6 +624,29 @@ def _assert_tensor_sets_close(
     return max_abs, max_rel
 
 
+def _tensor_set_metrics(
+    lhs: dict[str, torch.Tensor], rhs: dict[str, torch.Tensor]
+) -> dict[str, float]:
+    assert lhs.keys() == rhs.keys()
+    max_abs = 0.0
+    max_rel = 0.0
+    min_cosine = 1.0
+    for name in lhs:
+        left = lhs[name].double().reshape(-1)
+        right = rhs[name].double().reshape(-1)
+        diff = (left - right).abs()
+        max_abs = max(max_abs, float(diff.max().item()))
+        denominator = torch.maximum(left.abs(), right.abs()).clamp_min(_TENSOR_ATOL)
+        max_rel = max(max_rel, float((diff / denominator).max().item()))
+        cosine = torch.nn.functional.cosine_similarity(left, right, dim=0, eps=1.0e-12)
+        min_cosine = min(min_cosine, float(cosine.item()))
+    return {
+        "max_param_abs_diff": max_abs,
+        "max_param_rel_diff": max_rel,
+        "min_param_cosine": min_cosine,
+    }
+
+
 def _dense_parallel_config() -> ParallelConfig:
     return ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1)
 
@@ -851,7 +874,33 @@ def test_mfsdp_offload_matrix_matches_fsdp2_precision_speed_and_memory():
                     target=target,
                 )
 
+    if dist.get_rank() == 0:
+        for (backend, optimizer_offload, activation_offload), result in matrix.items():
+            name = (
+                f"{backend}_optimizer_{int(optimizer_offload)}"
+                f"_activation_{int(activation_offload)}"
+            )
+            raw = {key: value for key, value in result.items() if key != "params"}
+            print(
+                "[MFSDP_OFFLOAD_RAW] "
+                + json.dumps({"commit": commit, "arm": name, **raw}, sort_keys=True),
+                flush=True,
+            )
+            wandb_run.log(
+                {
+                    f"{name}/step_ms": raw["step_ms"],
+                    f"{name}/tokens_per_s_per_gpu": raw["tokens_per_s_per_gpu"],
+                    f"{name}/loss_final": raw["losses"][-1],
+                    **{
+                        f"{name}/{side}/{metric}": value
+                        for side in ("training_memory", "optimizer_memory")
+                        for metric, value in raw[side].items()
+                    },
+                }
+            )
+
     comparisons = {}
+    offload_effects = {}
     for optimizer_offload in (False, True):
         for activation_offload in (False, True):
             fsdp2 = matrix[("fsdp2", optimizer_offload, activation_offload)]
@@ -861,20 +910,31 @@ def test_mfsdp_offload_matrix_matches_fsdp2_precision_speed_and_memory():
                 rel=_LOSS_REL_TOL,
                 abs=_TENSOR_ATOL,
             )
-            max_abs, max_rel = _assert_tensor_sets_close(
-                fsdp2["params"],
-                mfsdp["params"],
-            )
             comparisons[(optimizer_offload, activation_offload)] = {
-                "max_param_abs_diff": max_abs,
-                "max_param_rel_diff": max_rel,
                 "max_loss_rel_diff": _max_relative_difference(
                     fsdp2["losses"],
                     mfsdp["losses"],
                 ),
+                **_tensor_set_metrics(fsdp2["params"], mfsdp["params"]),
             }
 
     for backend in ("fsdp2", "mfsdp"):
+        baseline = matrix[(backend, False, False)]
+        for optimizer_offload in (False, True):
+            for activation_offload in (False, True):
+                arm = matrix[(backend, optimizer_offload, activation_offload)]
+                assert arm["losses"] == pytest.approx(
+                    baseline["losses"],
+                    rel=_LOSS_REL_TOL,
+                    abs=_TENSOR_ATOL,
+                )
+                offload_effects[(backend, optimizer_offload, activation_offload)] = {
+                    "max_loss_rel_diff": _max_relative_difference(
+                        baseline["losses"],
+                        arm["losses"],
+                    ),
+                    **_tensor_set_metrics(baseline["params"], arm["params"]),
+                }
         for activation_offload in (False, True):
             optimizer_off = matrix[(backend, False, activation_offload)]
             optimizer_on = matrix[(backend, True, activation_offload)]
@@ -911,7 +971,12 @@ def test_mfsdp_offload_matrix_matches_fsdp2_precision_speed_and_memory():
                         "commit": commit,
                         "arm": name,
                         **serializable_matrix[name],
-                        **comparisons[(optimizer_offload, activation_offload)],
+                        "vs_fsdp2": comparisons[
+                            (optimizer_offload, activation_offload)
+                        ],
+                        "vs_backend_no_offload": offload_effects[
+                            (backend, optimizer_offload, activation_offload)
+                        ],
                     },
                     sort_keys=True,
                 ),

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -1,0 +1,1176 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from __future__ import annotations
+
+import gc
+import os
+import statistics
+import sys
+import time
+from contextlib import contextmanager
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.utils._python_dispatch import TorchDispatchMode
+
+from megatron.lite.primitive.optimizers.fsdp2 import (
+    build_fsdp2_training_optimizer,
+    fsdp2_available,
+)
+from megatron.lite.primitive.optimizers.mfsdp import build_mfsdp_training_optimizer
+from megatron.lite.primitive.parallel import init_parallel
+from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
+from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
+from megatron.lite.runtime.contracts.data import PackedBatch
+from megatron.lite.runtime.contracts.handle import ModelHandle
+
+pytestmark = [
+    pytest.mark.mlite,
+    pytest.mark.smoke,
+    pytest.mark.gpu,
+    pytest.mark.distributed,
+]
+
+_MFSDP_SHARDING_STRATEGY = "optim_grads_params"
+_PRECISION_STEPS = 50
+_LOSS_REL_TOL = 1.0e-2
+_TENSOR_RTOL = 1.0e-2
+_TENSOR_ATOL = 1.0e-5
+_BENCH_WARMUP_STEPS = 5
+_BENCH_MEASURE_STEPS = 20
+_BENCH_TOKENS_PER_RANK = 1024
+_MIN_SPEEDUP = 1.0
+_FULL_PARALLEL_WORLD_SIZE = 8
+_FULL_PARALLEL_STEPS = 50
+_FULL_PARALLEL_CURVE_INTERVAL = 10
+_FULL_PARALLEL_MICROBATCHES = 2
+_FULL_PARALLEL_SEQ_LEN = 64
+
+
+class TinyUnit(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(8, 8, bias=False)
+        self.act = nn.GELU()
+
+    def forward(self, x):
+        return self.act(self.linear(x))
+
+
+class TinyDenseModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.unit0 = TinyUnit()
+        self.unit1 = TinyUnit()
+        self.out = nn.Linear(8, 4, bias=False)
+
+    def forward(self, x):
+        return self.out(self.unit1(self.unit0(x)))
+
+
+class TinyExperts(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(8, 8, bias=False)
+
+    def forward(self, x):
+        return torch.nn.functional.gelu(self.linear(x))
+
+
+class TinyParallelModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.unit = TinyUnit()
+        self.experts = TinyExperts()
+        self.tp_bias = nn.Parameter(torch.zeros(8))
+        self.sp_params = [self.tp_bias]
+        self.out = nn.Linear(8, 4, bias=False)
+        self.unit.linear.weight.tensor_model_parallel = True
+        self.unit.linear.weight.partition_dim = 0
+        self.out.weight.tensor_model_parallel = True
+        self.out.weight.partition_dim = 1
+
+    def forward(self, x):
+        hidden = self.unit(x) + self.tp_bias
+        return self.out(self.experts(hidden))
+
+
+class BenchmarkUnit(nn.Module):
+    def __init__(self, hidden_size: int):
+        super().__init__()
+        self.up = nn.Linear(hidden_size, hidden_size * 2, bias=False)
+        self.down = nn.Linear(hidden_size * 2, hidden_size, bias=False)
+
+    def forward(self, x):
+        return x + self.down(torch.nn.functional.gelu(self.up(x)))
+
+
+class BenchmarkModel(nn.Module):
+    hidden_size = 1024
+    num_layers = 12
+
+    def __init__(self):
+        super().__init__()
+        self.layers = nn.ModuleList(
+            BenchmarkUnit(self.hidden_size) for _ in range(self.num_layers)
+        )
+
+    def forward(self, x):
+        for layer in self.layers:
+            x = layer(x)
+        return x
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _cuda_dist():
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    if not torch.cuda.is_available():
+        if world_size > 1:
+            pytest.fail(
+                "Distributed M-FSDP parity was launched without visible CUDA devices."
+            )
+        pytest.skip("CUDA is required for M-FSDP parity smoke tests.")
+    if not fsdp2_available():
+        if world_size > 1:
+            pytest.fail("Distributed M-FSDP parity requires PyTorch FSDP2 fully_shard.")
+        pytest.skip("Installed PyTorch does not expose FSDP2 fully_shard.")
+    if world_size < 2:
+        pytest.skip(
+            "M-FSDP sharding parity smoke requires at least 2 distributed ranks."
+        )
+    if world_size > _FULL_PARALLEL_WORLD_SIZE:
+        pytest.skip(
+            "M-FSDP smoke tests support at most the dedicated 8-rank full-parallel signoff."
+        )
+
+    os.environ.setdefault("RANK", "0")
+    os.environ.setdefault("WORLD_SIZE", "1")
+    os.environ.setdefault("LOCAL_RANK", "0")
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29571")
+    os.environ.setdefault("CUBLAS_WORKSPACE_CONFIG", ":4096:8")
+    os.environ.setdefault("NVTE_ALLOW_NONDETERMINISTIC_ALGO", "0")
+
+    torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
+    if int(os.environ["RANK"]) == 0:
+        print(
+            "[MFSDP_ENV] "
+            f"torch={torch.__version__} "
+            f"world_size={world_size} "
+            f"slurm_nnodes={os.environ.get('SLURM_NNODES', '1')} "
+            f"cuda_devices={torch.cuda.device_count()} "
+            f"fsdp2_available={fsdp2_available()}",
+            flush=True,
+        )
+    _install_transformer_engine_import_stub_if_needed()
+    created_pg = False
+    if not dist.is_initialized():
+        dist.init_process_group(backend="nccl", init_method="env://")
+        created_pg = True
+    yield
+    if created_pg and dist.is_initialized():
+        dist.destroy_process_group()
+
+
+def _install_transformer_engine_import_stub_if_needed() -> None:
+    try:
+        import transformer_engine  # noqa: F401
+
+        return
+    except (ImportError, OSError):
+        pass
+
+    for name in list(sys.modules):
+        if name == "transformer_engine" or name.startswith("transformer_engine."):
+            sys.modules.pop(name, None)
+        if name == "transformer_engine_torch" or name.startswith(
+            "transformer_engine_torch."
+        ):
+            sys.modules.pop(name, None)
+
+    sys.modules["transformer_engine"] = None
+    sys.modules["transformer_engine_torch"] = None
+
+
+def _model_cfg() -> SimpleNamespace:
+    return SimpleNamespace(
+        num_hidden_layers=2,
+        hidden_size=8,
+        num_attention_heads=1,
+        add_bias_linear=False,
+    )
+
+
+def _optimizer_cfg(*, use_fused_optimizer: bool = True) -> OptimizerConfig:
+    cfg = OptimizerConfig(
+        optimizer="adam",
+        lr=1.0e-3,
+        min_lr=0.0,
+        weight_decay=0.0,
+        clip_grad=1000.0,
+        adam_beta1=0.9,
+        adam_beta2=0.999,
+        adam_eps=1.0e-8,
+    )
+    cfg.override_optimizer_config = {
+        "mfsdp_sharding_strategy": _MFSDP_SHARDING_STRATEGY,
+        "use_fused_optimizer": use_fused_optimizer,
+    }
+    return cfg
+
+
+def _new_model(seed: int, model_type: type[nn.Module]) -> nn.Module:
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    return model_type().cuda().to(torch.bfloat16)
+
+
+def _parallel_state(config: ParallelConfig) -> Any:
+    return init_parallel(config)
+
+
+def _build_fsdp2_pair(
+    seed: int,
+    *,
+    parallel: ParallelConfig,
+    model_type: type[nn.Module] = TinyDenseModel,
+    expert_classifier=None,
+    unit_modules: tuple[type[nn.Module], ...] = (TinyUnit,),
+):
+    ps = _parallel_state(parallel)
+    chunks = [_new_model(seed, model_type)]
+    optimizer = build_fsdp2_training_optimizer(
+        chunks,
+        _optimizer_cfg(),
+        ps,
+        unit_modules=unit_modules,
+        expert_classifier=expert_classifier,
+        deterministic=True,
+        use_fp32_master=True,
+    )
+    return chunks, optimizer, None
+
+
+def _build_mfsdp_pair(
+    seed: int,
+    *,
+    parallel: ParallelConfig,
+    model_type: type[nn.Module] = TinyDenseModel,
+    expert_classifier=None,
+    unit_modules: tuple[type[nn.Module], ...] = (TinyUnit,),
+    offload_fraction: float = 0.0,
+    use_fused_optimizer: bool = True,
+):
+    ps = _parallel_state(parallel)
+    chunks = [_new_model(seed, model_type)]
+    optimizer_config = _optimizer_cfg(use_fused_optimizer=use_fused_optimizer)
+    optimizer_config.offload_fraction = offload_fraction
+    impl_cfg = SimpleNamespace(
+        parallel=parallel,
+        optimizer_config=optimizer_config,
+    )
+    optimizer, finalize = build_mfsdp_training_optimizer(
+        chunks,
+        impl_cfg=impl_cfg,
+        ps=ps,
+        is_expert=expert_classifier or (lambda _name: False),
+        fsdp_unit_modules=unit_modules,
+    )
+    return chunks, optimizer, finalize
+
+
+def _run_mfsdp_offload_arm(
+    *,
+    offload_fraction: float,
+    x: torch.Tensor,
+    target: torch.Tensor,
+) -> tuple[list[float], list[float], float, dict[str, torch.Tensor]]:
+    torch.cuda.empty_cache()
+    chunks, optimizer, finalize = _build_mfsdp_pair(
+        seed=4567,
+        parallel=_dense_parallel_config(),
+        model_type=BenchmarkModel,
+        unit_modules=(BenchmarkUnit,),
+        offload_fraction=offload_fraction,
+        use_fused_optimizer=False,
+    )
+    losses = []
+    for _ in range(2):
+        success, loss, _grad_norm = _train_step(chunks, optimizer, finalize, x, target)
+        assert success
+        losses.append(loss)
+
+    torch.cuda.synchronize()
+    torch.cuda.reset_peak_memory_stats()
+    step_times = [
+        _timed_train_step(chunks, optimizer, finalize, x, target) for _ in range(3)
+    ]
+    peak_bytes = torch.tensor(
+        torch.cuda.max_memory_allocated(), device="cuda", dtype=torch.float64
+    )
+    dist.all_reduce(peak_bytes, op=dist.ReduceOp.MAX)
+    params = _named_model_tensors(chunks)
+    del optimizer, chunks
+    gc.collect()
+    torch.cuda.empty_cache()
+    return losses, step_times, float(peak_bytes), params
+
+
+def _qualified_type(value: Any) -> str:
+    value_type = type(value)
+    return f"{value_type.__module__}.{value_type.__qualname__}"
+
+
+def _optimizer_chain(optimizer: Any) -> tuple[str, ...]:
+    chain = []
+    seen = set()
+    current = optimizer
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        chain.append(_qualified_type(current))
+        current = getattr(current, "_inner_optimizer", None) or getattr(
+            current, "optimizer", None
+        )
+    return tuple(chain)
+
+
+def _assert_distinct_backend_identities(
+    fsdp2_optimizer: Any, mfsdp_optimizer: Any
+) -> None:
+    fsdp2_chain = _optimizer_chain(fsdp2_optimizer)
+    mfsdp_chain = _optimizer_chain(mfsdp_optimizer)
+    assert fsdp2_chain[0].startswith("megatron.lite.primitive.optimizers.fsdp2."), (
+        fsdp2_chain
+    )
+    assert mfsdp_chain[0].startswith("megatron.lite.primitive.optimizers.mfsdp."), (
+        mfsdp_chain
+    )
+    assert fsdp2_chain[0] != mfsdp_chain[0]
+    if dist.get_rank() == 0:
+        print(
+            "[MFSDP_BACKEND] "
+            f"configured=fsdp2 optimizer_chain={' > '.join(fsdp2_chain)}",
+            flush=True,
+        )
+        print(
+            "[MFSDP_BACKEND] "
+            f"configured=mfsdp optimizer_chain={' > '.join(mfsdp_chain)}",
+            flush=True,
+        )
+
+
+def _train_once(chunks, optimizer, finalize, x: torch.Tensor, target: torch.Tensor):
+    optimizer.zero_grad()
+    output = chunks[0](x)
+    loss = torch.nn.functional.mse_loss(output.float(), target.float())
+    loss.backward()
+    if finalize is not None:
+        finalize()
+    success, grad_norm, _num_zeros = optimizer.step()
+    grads = _named_optimizer_grads(optimizer)
+    optimizer.zero_grad()
+    return bool(success), float(loss.detach().cpu()), float(grad_norm), grads
+
+
+def _train_step(chunks, optimizer, finalize, x: torch.Tensor, target: torch.Tensor):
+    optimizer.zero_grad()
+    output = chunks[0](x)
+    loss = torch.nn.functional.mse_loss(output.float(), target.float())
+    loss.backward()
+    if finalize is not None:
+        finalize()
+    success, grad_norm, _num_zeros = optimizer.step()
+    return bool(success), float(loss.detach()), float(grad_norm)
+
+
+def _timed_train_step(chunks, optimizer, finalize, x, target) -> float:
+    torch.cuda.synchronize()
+    started = time.perf_counter()
+    success, _loss, _grad_norm = _train_step(chunks, optimizer, finalize, x, target)
+    torch.cuda.synchronize()
+    assert success
+    elapsed = torch.tensor(time.perf_counter() - started, device="cuda")
+    dist.all_reduce(elapsed, op=dist.ReduceOp.MAX)
+    return float(elapsed)
+
+
+def _relative_difference_curve(lhs: list[float], rhs: list[float]) -> list[float]:
+    assert len(lhs) == len(rhs)
+    assert lhs
+    return [
+        abs(left - right) / max(abs(left), abs(right), 1.0e-12)
+        for left, right in zip(lhs, rhs)
+    ]
+
+
+def _max_relative_difference(lhs: list[float], rhs: list[float]) -> float:
+    return max(_relative_difference_curve(lhs, rhs))
+
+
+def _full_tensor(tensor: torch.Tensor) -> torch.Tensor:
+    full_tensor = getattr(tensor, "full_tensor", None)
+    if callable(full_tensor):
+        return full_tensor()
+    return tensor
+
+
+def _named_model_tensors(chunks) -> dict[str, torch.Tensor]:
+    params: dict[str, torch.Tensor] = {}
+    for chunk_idx, chunk in enumerate(chunks):
+        for name, param in chunk.named_parameters():
+            if not param.requires_grad:
+                continue
+            canonical_name = name.replace("_orig_mod.", "").replace("module.", "")
+            full = _full_tensor(param.detach())
+            params[f"{chunk_idx}.{canonical_name}"] = full.cpu().float().clone()
+    return params
+
+
+def _canonical_optimizer_name(name: str) -> str:
+    chunk_name, separator, remainder = name.partition(".")
+    if separator and chunk_name.startswith("chunk") and chunk_name[5:].isdigit():
+        chunk_index = chunk_name[5:]
+        name = f"{chunk_index}.{remainder}"
+    return name.replace("_orig_mod.", "").replace("module.", "")
+
+
+def _named_optimizer_grads(optimizer) -> dict[str, torch.Tensor]:
+    model_chunks = getattr(optimizer, "_model_chunks", None)
+    if model_chunks is not None:
+        return _named_mfsdp_optimizer_grads(model_chunks)
+
+    grads: dict[str, torch.Tensor] = {}
+    for param in optimizer.params:
+        if param.grad is None:
+            continue
+        name = _canonical_optimizer_name(optimizer.param_names[id(param)])
+        grads[name] = _full_tensor(param.grad.detach()).cpu().float().clone()
+    return grads
+
+
+def _named_mfsdp_optimizer_grads(model_chunks) -> dict[str, torch.Tensor]:
+    grads: dict[str, torch.Tensor] = {}
+    for chunk_index, chunk in enumerate(model_chunks):
+        for bucket in chunk.param_sync.buckets:
+            rank_major = torch.empty(
+                bucket.full_numel,
+                dtype=bucket.main_grad_buffer.dtype,
+                device=bucket.device,
+            )
+            if bucket.world_size == 1:
+                rank_major.copy_(bucket.grad_shard_buffer)
+            else:
+                dist.all_gather_into_tensor(
+                    rank_major,
+                    bucket.grad_shard_buffer,
+                    group=bucket.process_group,
+                )
+            for spec in bucket.specs:
+                grads[f"{chunk_index}.{spec.name}"] = (
+                    rank_major.narrow(0, spec.full_offset, spec.numel)
+                    .view(spec.shape)
+                    .cpu()
+                    .float()
+                    .clone()
+                )
+    return grads
+
+
+def _assert_tensor_sets_close(
+    lhs: dict[str, torch.Tensor], rhs: dict[str, torch.Tensor]
+) -> tuple[float, float]:
+    assert lhs.keys() == rhs.keys()
+    max_abs = 0.0
+    max_rel = 0.0
+    for name in lhs:
+        diff = (lhs[name] - rhs[name]).abs()
+        max_abs = max(max_abs, float(diff.max().item()))
+        denominator = torch.maximum(lhs[name].abs(), rhs[name].abs()).clamp_min(
+            _TENSOR_ATOL
+        )
+        max_rel = max(max_rel, float((diff / denominator).max().item()))
+        torch.testing.assert_close(
+            lhs[name],
+            rhs[name],
+            rtol=_TENSOR_RTOL,
+            atol=_TENSOR_ATOL,
+            msg=lambda message: f"{name}: {message}",
+        )
+    return max_abs, max_rel
+
+
+def _dense_parallel_config() -> ParallelConfig:
+    return ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1)
+
+
+def _tp_ep_parallel_config() -> ParallelConfig:
+    return ParallelConfig(tp=2, ep=2, etp=1, pp=1, vpp=1, cp=1)
+
+
+def _is_tiny_expert(name: str) -> bool:
+    return name.startswith("experts.")
+
+
+def test_mfsdp_precision_curve_matches_fsdp2():
+    torch.manual_seed(4026 + dist.get_rank())
+    torch.cuda.manual_seed_all(4026 + dist.get_rank())
+    x = torch.randn(32, 8, device="cuda", dtype=torch.bfloat16)
+    target = torch.randn(32, 4, device="cuda", dtype=torch.bfloat16)
+    parallel = _dense_parallel_config()
+
+    fsdp2_chunks, fsdp2_optimizer, fsdp2_finalize = _build_fsdp2_pair(
+        seed=3456, parallel=parallel
+    )
+    mfsdp_chunks, mfsdp_optimizer, mfsdp_finalize = _build_mfsdp_pair(
+        seed=3456, parallel=parallel
+    )
+    _assert_distinct_backend_identities(fsdp2_optimizer, mfsdp_optimizer)
+
+    fsdp2_losses = []
+    mfsdp_losses = []
+    for _step in range(_PRECISION_STEPS):
+        fsdp2_success, fsdp2_loss, _ = _train_step(
+            fsdp2_chunks, fsdp2_optimizer, fsdp2_finalize, x, target
+        )
+        mfsdp_success, mfsdp_loss, _ = _train_step(
+            mfsdp_chunks, mfsdp_optimizer, mfsdp_finalize, x, target
+        )
+        assert fsdp2_success
+        assert mfsdp_success
+        fsdp2_losses.append(fsdp2_loss)
+        mfsdp_losses.append(mfsdp_loss)
+
+    max_loss_rel_diff = torch.tensor(
+        _max_relative_difference(fsdp2_losses, mfsdp_losses), device="cuda"
+    )
+    dist.all_reduce(max_loss_rel_diff, op=dist.ReduceOp.MAX)
+    first_window_fsdp2 = statistics.mean(fsdp2_losses[:10])
+    final_window_fsdp2 = statistics.mean(fsdp2_losses[-10:])
+    first_window_mfsdp = statistics.mean(mfsdp_losses[:10])
+    final_window_mfsdp = statistics.mean(mfsdp_losses[-10:])
+
+    if dist.get_rank() == 0:
+        print(
+            "[MFSDP_PRECISION] "
+            f"world_size={dist.get_world_size()} "
+            f"steps={_PRECISION_STEPS} "
+            f"loss_rel_tol={_LOSS_REL_TOL:.3e} "
+            f"max_loss_rel_diff={float(max_loss_rel_diff):.8e} "
+            f"first_loss_fsdp2={first_window_fsdp2:.8f} "
+            f"final_loss_fsdp2={final_window_fsdp2:.8f} "
+            f"first_loss_mfsdp={first_window_mfsdp:.8f} "
+            f"final_loss_mfsdp={final_window_mfsdp:.8f}",
+            flush=True,
+        )
+
+    assert torch.isfinite(max_loss_rel_diff)
+    assert float(max_loss_rel_diff) <= _LOSS_REL_TOL
+    assert final_window_fsdp2 < first_window_fsdp2
+    assert final_window_mfsdp < first_window_mfsdp
+
+
+def test_mfsdp_throughput_exceeds_fsdp2():
+    torch.manual_seed(5026 + dist.get_rank())
+    torch.cuda.manual_seed_all(5026 + dist.get_rank())
+    x = torch.randn(
+        _BENCH_TOKENS_PER_RANK,
+        BenchmarkModel.hidden_size,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    target = torch.zeros_like(x)
+    parallel = _dense_parallel_config()
+
+    fsdp2_chunks, fsdp2_optimizer, fsdp2_finalize = _build_fsdp2_pair(
+        seed=4567,
+        parallel=parallel,
+        model_type=BenchmarkModel,
+        unit_modules=(BenchmarkUnit,),
+    )
+    mfsdp_chunks, mfsdp_optimizer, mfsdp_finalize = _build_mfsdp_pair(
+        seed=4567,
+        parallel=parallel,
+        model_type=BenchmarkModel,
+        unit_modules=(BenchmarkUnit,),
+    )
+    _assert_distinct_backend_identities(fsdp2_optimizer, mfsdp_optimizer)
+
+    for step in range(_BENCH_WARMUP_STEPS):
+        pairs = (
+            (
+                fsdp2_chunks,
+                fsdp2_optimizer,
+                fsdp2_finalize,
+            ),
+            (
+                mfsdp_chunks,
+                mfsdp_optimizer,
+                mfsdp_finalize,
+            ),
+        )
+        if step % 2:
+            pairs = tuple(reversed(pairs))
+        for chunks, optimizer, finalize in pairs:
+            _train_step(chunks, optimizer, finalize, x, target)
+
+    torch.cuda.synchronize()
+    torch.cuda.reset_peak_memory_stats()
+    fsdp2_times = []
+    mfsdp_times = []
+    for step in range(_BENCH_MEASURE_STEPS):
+        pairs = [
+            (
+                "fsdp2",
+                fsdp2_chunks,
+                fsdp2_optimizer,
+                fsdp2_finalize,
+                fsdp2_times,
+            ),
+            (
+                "mfsdp",
+                mfsdp_chunks,
+                mfsdp_optimizer,
+                mfsdp_finalize,
+                mfsdp_times,
+            ),
+        ]
+        if step % 2:
+            pairs.reverse()
+        for _name, chunks, optimizer, finalize, samples in pairs:
+            samples.append(_timed_train_step(chunks, optimizer, finalize, x, target))
+
+    fsdp2_step_s = statistics.median(fsdp2_times)
+    mfsdp_step_s = statistics.median(mfsdp_times)
+    global_tokens = _BENCH_TOKENS_PER_RANK * dist.get_world_size()
+    fsdp2_tokens_per_s = global_tokens / fsdp2_step_s
+    mfsdp_tokens_per_s = global_tokens / mfsdp_step_s
+    speedup = mfsdp_tokens_per_s / fsdp2_tokens_per_s
+    peak_memory_bytes = torch.tensor(
+        torch.cuda.max_memory_allocated(), device="cuda", dtype=torch.float64
+    )
+    dist.all_reduce(peak_memory_bytes, op=dist.ReduceOp.MAX)
+    peak_memory_gib = float(peak_memory_bytes) / (1024**3)
+
+    if dist.get_rank() == 0:
+        print(
+            "[MFSDP_THROUGHPUT] "
+            f"world_size={dist.get_world_size()} "
+            f"warmup_steps={_BENCH_WARMUP_STEPS} "
+            f"measure_steps={_BENCH_MEASURE_STEPS} "
+            f"tokens_per_rank={_BENCH_TOKENS_PER_RANK} "
+            f"fsdp2_step_ms={fsdp2_step_s * 1000.0:.4f} "
+            f"mfsdp_step_ms={mfsdp_step_s * 1000.0:.4f} "
+            f"fsdp2_tokens_per_s={fsdp2_tokens_per_s:.2f} "
+            f"mfsdp_tokens_per_s={mfsdp_tokens_per_s:.2f} "
+            f"mfsdp_speedup={speedup:.4f} "
+            f"peak_memory_gib={peak_memory_gib:.4f}",
+            flush=True,
+        )
+
+    assert speedup > _MIN_SPEEDUP
+
+
+def test_mfsdp_cpu_optimizer_offload_reduces_memory_and_preserves_update():
+    torch.manual_seed(6060 + dist.get_rank())
+    torch.cuda.manual_seed_all(6060 + dist.get_rank())
+    x = torch.randn(
+        128,
+        BenchmarkModel.hidden_size,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    target = torch.zeros_like(x)
+
+    baseline_losses, baseline_times, baseline_peak, baseline_params = (
+        _run_mfsdp_offload_arm(
+            offload_fraction=0.0,
+            x=x,
+            target=target,
+        )
+    )
+    offload_losses, offload_times, offload_peak, offload_params = (
+        _run_mfsdp_offload_arm(
+            offload_fraction=1.0,
+            x=x,
+            target=target,
+        )
+    )
+
+    max_param_abs, max_param_rel = _assert_tensor_sets_close(
+        baseline_params, offload_params
+    )
+    baseline_step_s = statistics.median(baseline_times)
+    offload_step_s = statistics.median(offload_times)
+    assert offload_losses == pytest.approx(
+        baseline_losses, rel=_LOSS_REL_TOL, abs=_TENSOR_ATOL
+    )
+    assert offload_peak < baseline_peak
+
+    if dist.get_rank() == 0:
+        print(
+            "[MFSDP_CPU_OFFLOAD] "
+            f"world_size={dist.get_world_size()} "
+            f"baseline_peak_gib={baseline_peak / (1024**3):.4f} "
+            f"offload_peak_gib={offload_peak / (1024**3):.4f} "
+            f"saved_gib={(baseline_peak - offload_peak) / (1024**3):.4f} "
+            f"baseline_step_ms={baseline_step_s * 1000.0:.4f} "
+            f"offload_step_ms={offload_step_s * 1000.0:.4f} "
+            f"slowdown={offload_step_s / baseline_step_s:.4f} "
+            f"max_param_abs_diff={max_param_abs:.8e} "
+            f"max_param_rel_diff={max_param_rel:.8e}",
+            flush=True,
+        )
+
+
+def test_mfsdp_matches_fsdp2_tiny_dense_single_step():
+    torch.manual_seed(2026 + dist.get_rank())
+    torch.cuda.manual_seed_all(2026 + dist.get_rank())
+    x = torch.randn(4, 8, device="cuda", dtype=torch.bfloat16)
+    target = torch.randn(4, 4, device="cuda", dtype=torch.bfloat16)
+
+    parallel = _dense_parallel_config()
+    fsdp2_chunks, fsdp2_optimizer, fsdp2_finalize = _build_fsdp2_pair(
+        seed=1234, parallel=parallel
+    )
+    mfsdp_chunks, mfsdp_optimizer, mfsdp_finalize = _build_mfsdp_pair(
+        seed=1234, parallel=parallel
+    )
+
+    fsdp2_success, fsdp2_loss, fsdp2_grad_norm, fsdp2_grads = _train_once(
+        fsdp2_chunks, fsdp2_optimizer, fsdp2_finalize, x, target
+    )
+    mfsdp_success, mfsdp_loss, mfsdp_grad_norm, mfsdp_grads = _train_once(
+        mfsdp_chunks, mfsdp_optimizer, mfsdp_finalize, x, target
+    )
+
+    assert fsdp2_success
+    assert mfsdp_success
+    assert fsdp2_loss == pytest.approx(mfsdp_loss, rel=_LOSS_REL_TOL)
+    assert fsdp2_grad_norm == pytest.approx(mfsdp_grad_norm, rel=_LOSS_REL_TOL)
+    max_grad_abs, max_grad_rel = _assert_tensor_sets_close(fsdp2_grads, mfsdp_grads)
+    max_param_abs, max_param_rel = _assert_tensor_sets_close(
+        _named_model_tensors(fsdp2_chunks), _named_model_tensors(mfsdp_chunks)
+    )
+
+    if dist.get_rank() == 0:
+        print(
+            "[MFSDP_COMPOSITION] "
+            f"world_size={dist.get_world_size()} "
+            f"strategy={_MFSDP_SHARDING_STRATEGY} "
+            f"loss_fsdp2={fsdp2_loss:.8f} "
+            f"loss_mfsdp={mfsdp_loss:.8f} "
+            f"grad_norm_fsdp2={fsdp2_grad_norm:.8f} "
+            f"grad_norm_mfsdp={mfsdp_grad_norm:.8f} "
+            f"max_grad_abs_diff={max_grad_abs:.8e} "
+            f"max_grad_rel_diff={max_grad_rel:.8e} "
+            f"max_param_abs_diff={max_param_abs:.8e} "
+            f"max_param_rel_diff={max_param_rel:.8e}",
+            flush=True,
+        )
+
+
+def test_mfsdp_matches_fsdp2_tp_ep_single_step():
+    torch.manual_seed(3026 + dist.get_rank())
+    torch.cuda.manual_seed_all(3026 + dist.get_rank())
+    x = torch.randn(4, 8, device="cuda", dtype=torch.bfloat16)
+    target = torch.randn(4, 4, device="cuda", dtype=torch.bfloat16)
+    parallel = _tp_ep_parallel_config()
+
+    fsdp2_chunks, fsdp2_optimizer, fsdp2_finalize = _build_fsdp2_pair(
+        seed=2345,
+        parallel=parallel,
+        model_type=TinyParallelModel,
+        expert_classifier=_is_tiny_expert,
+    )
+    mfsdp_chunks, mfsdp_optimizer, mfsdp_finalize = _build_mfsdp_pair(
+        seed=2345,
+        parallel=parallel,
+        model_type=TinyParallelModel,
+        expert_classifier=_is_tiny_expert,
+    )
+
+    fsdp2_success, fsdp2_loss, fsdp2_grad_norm, fsdp2_grads = _train_once(
+        fsdp2_chunks, fsdp2_optimizer, fsdp2_finalize, x, target
+    )
+    mfsdp_success, mfsdp_loss, mfsdp_grad_norm, mfsdp_grads = _train_once(
+        mfsdp_chunks, mfsdp_optimizer, mfsdp_finalize, x, target
+    )
+
+    assert fsdp2_success
+    assert mfsdp_success
+    assert fsdp2_loss == pytest.approx(mfsdp_loss, rel=_LOSS_REL_TOL)
+    assert fsdp2_grad_norm == pytest.approx(mfsdp_grad_norm, rel=_LOSS_REL_TOL)
+    max_grad_abs, max_grad_rel = _assert_tensor_sets_close(fsdp2_grads, mfsdp_grads)
+    max_param_abs, max_param_rel = _assert_tensor_sets_close(
+        _named_model_tensors(fsdp2_chunks), _named_model_tensors(mfsdp_chunks)
+    )
+
+    if dist.get_rank() == 0:
+        print(
+            "[MFSDP_COMPOSITION] "
+            f"world_size={dist.get_world_size()} "
+            "topology=tp2_ep2 "
+            f"strategy={_MFSDP_SHARDING_STRATEGY} "
+            f"loss_fsdp2={fsdp2_loss:.8f} "
+            f"loss_mfsdp={mfsdp_loss:.8f} "
+            f"grad_norm_fsdp2={fsdp2_grad_norm:.8f} "
+            f"grad_norm_mfsdp={mfsdp_grad_norm:.8f} "
+            f"max_grad_abs_diff={max_grad_abs:.8e} "
+            f"max_grad_rel_diff={max_grad_rel:.8e} "
+            f"max_param_abs_diff={max_param_abs:.8e} "
+            f"max_param_rel_diff={max_param_rel:.8e}",
+            flush=True,
+        )
+
+
+def _full_parallel_config() -> ParallelConfig:
+    return ParallelConfig(tp=2, ep=2, etp=1, pp=2, vpp=1, cp=2)
+
+
+def _tiny_qwen3_moe_config():
+    from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
+
+    return Qwen3MoEConfig(
+        num_hidden_layers=2,
+        hidden_size=256,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=64,
+        vocab_size=64,
+        num_experts=4,
+        num_experts_per_tok=1,
+        moe_intermediate_size=64,
+        max_position_embeddings=4096,
+        layer_types=["full_attention", "full_attention"],
+    )
+
+
+def _build_full_parallel_handle(backend: str, *, seed: int):
+    from megatron.lite.model.qwen3_moe.lite import protocol
+
+    parallel = _full_parallel_config()
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    impl_cfg = protocol.ImplConfig(
+        parallel=parallel,
+        optimizer=backend,
+        optimizer_config=_optimizer_cfg(use_fused_optimizer=False),
+        use_deepep=False,
+        use_thd=True,
+        deterministic=True,
+    )
+    model_cfg = _tiny_qwen3_moe_config()
+    bundle = protocol.build_model(model_cfg, impl_cfg=impl_cfg)
+    initial_params = _named_model_tensors(bundle.chunks)
+    assert bundle.extras.get("optimizer_backend") == backend
+    post_load_hook = bundle.extras.get("post_model_load_hook")
+    assert callable(post_load_hook), (
+        f"{backend} did not expose its production post-load hook."
+    )
+    updates = post_load_hook()
+    assert isinstance(updates, dict)
+    optimizer = updates.get("optimizer", bundle.optimizer)
+    finalize_grads = updates.get("finalize_grads", bundle.finalize_grads)
+    assert optimizer is not None
+
+    extras = dict(bundle.extras)
+    extras.update(
+        {
+            "model_chunks": bundle.chunks,
+            "model_cfg": model_cfg,
+            "forward_step": bundle.forward_step,
+            "finalize_grads": finalize_grads,
+        }
+    )
+    handle = ModelHandle(
+        model=bundle.chunks,
+        optimizer=optimizer,
+        parallel_state=bundle.parallel_state,
+        config=SimpleNamespace(parallel=parallel),
+        _extras=extras,
+    )
+    return handle, initial_params
+
+
+def _fixed_packed_batches(vocab_size: int, *, seed: int) -> list[PackedBatch]:
+    batches = []
+    for microbatch in range(_FULL_PARALLEL_MICROBATCHES):
+        generator = torch.Generator(device="cuda").manual_seed(seed + microbatch)
+        batches.append(
+            PackedBatch(
+                input_ids=torch.randint(
+                    0,
+                    vocab_size,
+                    (_FULL_PARALLEL_SEQ_LEN,),
+                    device="cuda",
+                    generator=generator,
+                ),
+                labels=torch.randint(
+                    0,
+                    vocab_size,
+                    (_FULL_PARALLEL_SEQ_LEN,),
+                    device="cuda",
+                    generator=generator,
+                ),
+                seq_lens=torch.tensor(
+                    [_FULL_PARALLEL_SEQ_LEN], dtype=torch.int64, device="cuda"
+                ),
+            )
+        )
+    return batches
+
+
+_COMM_TOKENS = (
+    "all_gather",
+    "allgather",
+    "reduce_scatter",
+    "reducescatter",
+    "all_reduce",
+    "allreduce",
+    "all_to_all",
+    "alltoall",
+    "broadcast",
+    "send",
+    "recv",
+)
+
+
+class _CollectiveDispatchTap(TorchDispatchMode):
+    def __init__(self, sequence: list[str]):
+        super().__init__()
+        self.sequence = sequence
+
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+        del types
+        name = str(func)
+        if any(token in name.lower() for token in _COMM_TOKENS):
+            self.sequence.append(f"dispatch::{name}")
+        return func(*args, **(kwargs or {}))
+
+
+@contextmanager
+def _record_collectives():
+    sequence = []
+    originals = {}
+    api_names = (
+        "all_gather",
+        "all_gather_into_tensor",
+        "_all_gather_base",
+        "reduce_scatter",
+        "reduce_scatter_tensor",
+        "_reduce_scatter_base",
+        "all_reduce",
+        "all_to_all",
+        "all_to_all_single",
+        "broadcast",
+        "batch_isend_irecv",
+        "send",
+        "recv",
+    )
+    for name in api_names:
+        original = getattr(dist, name, None)
+        if original is None:
+            continue
+        originals[name] = original
+
+        def wrapped(*args, _name=name, _original=original, **kwargs):
+            sequence.append(f"python::torch.distributed.{_name}")
+            return _original(*args, **kwargs)
+
+        setattr(dist, name, wrapped)
+
+    try:
+        with _CollectiveDispatchTap(sequence):
+            yield sequence
+    finally:
+        for name, original in originals.items():
+            setattr(dist, name, original)
+
+
+def _contains_collective(sequence: tuple[str, ...], *tokens: str) -> bool:
+    return any(any(token in name.lower() for token in tokens) for name in sequence)
+
+
+def _run_full_parallel_step(
+    handle: ModelHandle, *, batch_seed: int, record_collectives: bool
+) -> tuple[float, float, tuple[str, ...]]:
+    runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
+    runtime.zero_grad(handle)
+    batches = _fixed_packed_batches(64, seed=batch_seed)
+    sequence = []
+    if record_collectives:
+        with _record_collectives() as sequence:
+            result = runtime.forward_backward(
+                handle,
+                iter(batches),
+                None,
+                num_microbatches=_FULL_PARALLEL_MICROBATCHES,
+            )
+        torch.cuda.synchronize()
+    else:
+        result = runtime.forward_backward(
+            handle, iter(batches), None, num_microbatches=_FULL_PARALLEL_MICROBATCHES
+        )
+
+    success, grad_norm, _num_zeros = runtime.optimizer_step(handle)
+    assert success
+    loss = result.model_output.loss
+    assert loss is not None
+    return float(loss.detach().float().cpu()), float(grad_norm), tuple(sequence)
+
+
+def _max_snapshot_abs_diff(
+    lhs: dict[str, torch.Tensor], rhs: dict[str, torch.Tensor]
+) -> float:
+    assert lhs.keys() == rhs.keys()
+    assert lhs
+    return max(float((lhs[name] - rhs[name]).abs().max()) for name in lhs)
+
+
+def test_mfsdp_matches_fsdp2_full_parallel_precision_curve(monkeypatch):
+    if dist.get_world_size() != _FULL_PARALLEL_WORLD_SIZE:
+        pytest.skip("M-FSDP TP2/EP2/ETP1/PP2/CP2 signoff requires exactly 8 ranks.")
+
+    if int(os.environ.get("SLURM_NNODES", "0")) != 1:
+        pytest.fail("M-FSDP full-parallel signoff requires exactly one Slurm node.")
+
+    try:
+        import transformer_engine.pytorch as te
+    except (ImportError, OSError) as exc:
+        pytest.fail(
+            f"full-parallel M-FSDP signoff requires real Transformer Engine: {exc}"
+        )
+    assert hasattr(te, "Linear"), "full-parallel signoff requires real TE Linear."
+
+    from megatron.lite.model import protocol_utils
+
+    cp_splits = []
+    original_prepare_cp = protocol_utils.prepare_packed_thd_kwargs_for_context_parallel
+
+    def record_cp_split(model, kwargs):
+        full_tokens = int(kwargs["input_ids"].numel())
+        result = original_prepare_cp(model, kwargs)
+        local_tokens = int(kwargs["input_ids"].numel())
+        cp_splits.append((full_tokens, local_tokens))
+        return result
+
+    monkeypatch.setattr(
+        protocol_utils,
+        "prepare_packed_thd_kwargs_for_context_parallel",
+        record_cp_split,
+    )
+
+    fsdp2_handle, fsdp2_initial = _build_full_parallel_handle("fsdp2", seed=7345)
+    mfsdp_handle, mfsdp_initial = _build_full_parallel_handle("mfsdp", seed=7345)
+    _assert_distinct_backend_identities(
+        fsdp2_handle._optimizer, mfsdp_handle._optimizer
+    )
+
+    for handle in (fsdp2_handle, mfsdp_handle):
+        ps = handle._parallel_state
+        assert (ps.tp_size, ps.ep_size, ps.etp_size, ps.pp_size, ps.cp_size) == (
+            2,
+            2,
+            1,
+            2,
+            2,
+        )
+
+    initial_max_abs = torch.tensor(
+        _max_snapshot_abs_diff(fsdp2_initial, mfsdp_initial), device="cuda"
+    )
+    dist.all_reduce(initial_max_abs, op=dist.ReduceOp.MAX)
+    assert float(initial_max_abs) == 0.0
+
+    losses = {"fsdp2": [], "mfsdp": []}
+    grad_norms = {"fsdp2": [], "mfsdp": []}
+    traces = {}
+    for step in range(_FULL_PARALLEL_STEPS):
+        for backend, handle in (("fsdp2", fsdp2_handle), ("mfsdp", mfsdp_handle)):
+            dist.barrier()
+            loss, grad_norm, trace = _run_full_parallel_step(
+                handle,
+                batch_seed=8345 + step,
+                record_collectives=step == 0,
+            )
+            losses[backend].append(loss)
+            grad_norms[backend].append(grad_norm)
+            if trace:
+                traces[backend] = trace
+
+    for backend in ("fsdp2", "mfsdp"):
+        trace = traces.get(backend, ())
+        assert trace, f"{backend} tap recorded no distributed collectives."
+        assert _contains_collective(trace, "all_gather", "allgather")
+        assert _contains_collective(trace, "reduce_scatter", "reducescatter")
+
+    assert cp_splits
+    assert all(
+        full_tokens == 2 * local_tokens for full_tokens, local_tokens in cp_splits
+    )
+
+    loss_rel_curve = torch.tensor(
+        _relative_difference_curve(losses["fsdp2"], losses["mfsdp"]),
+        device="cuda",
+    )
+    grad_norm_rel_curve = torch.tensor(
+        _relative_difference_curve(grad_norms["fsdp2"], grad_norms["mfsdp"]),
+        device="cuda",
+    )
+    dist.all_reduce(loss_rel_curve, op=dist.ReduceOp.MAX)
+    dist.all_reduce(grad_norm_rel_curve, op=dist.ReduceOp.MAX)
+    max_loss_rel_diff = loss_rel_curve.max()
+    max_grad_norm_rel_diff = grad_norm_rel_curve.max()
+
+    if dist.get_rank() == 0:
+        ps = fsdp2_handle._parallel_state
+        print(
+            "[MFSDP_FULL_PARALLEL] "
+            "topology=tp2_ep2_etp1_pp2_cp2 "
+            f"world_size={dist.get_world_size()} "
+            f"dp_cp_size={ps.dp_cp_size} "
+            f"microbatches={_FULL_PARALLEL_MICROBATCHES} "
+            f"steps={_FULL_PARALLEL_STEPS} "
+            f"initial_max_abs_diff={float(initial_max_abs):.8e} "
+            f"max_loss_rel_diff={float(max_loss_rel_diff):.8e} "
+            f"max_grad_norm_rel_diff={float(max_grad_norm_rel_diff):.8e} "
+            f"fsdp2_losses={','.join(f'{value:.8f}' for value in losses['fsdp2'])} "
+            f"mfsdp_losses={','.join(f'{value:.8f}' for value in losses['mfsdp'])} "
+            f"cp_split={cp_splits[0][0]}->{cp_splits[0][1]} "
+            f"cp_split_calls={len(cp_splits)}",
+            flush=True,
+        )
+        for curve_index in range(
+            _FULL_PARALLEL_CURVE_INTERVAL - 1,
+            _FULL_PARALLEL_STEPS,
+            _FULL_PARALLEL_CURVE_INTERVAL,
+        ):
+            print(
+                "[MFSDP_FULL_PARALLEL_CURVE] "
+                f"step={curve_index + 1} "
+                f"loss_rel_diff={float(loss_rel_curve[curve_index]):.8e} "
+                f"grad_norm_rel_diff={float(grad_norm_rel_curve[curve_index]):.8e} "
+                f"loss_fsdp2={losses['fsdp2'][curve_index]:.8f} "
+                f"loss_mfsdp={losses['mfsdp'][curve_index]:.8f} "
+                f"grad_norm_fsdp2={grad_norms['fsdp2'][curve_index]:.8f} "
+                f"grad_norm_mfsdp={grad_norms['mfsdp'][curve_index]:.8f}",
+                flush=True,
+            )
+        for backend in ("fsdp2", "mfsdp"):
+            trace = traces[backend]
+            print(
+                "[MFSDP_COMM_TRACE] "
+                f"backend={backend} phase=forward_backward events={len(trace)} "
+                f"sequence={' > '.join(trace[:96])}",
+                flush=True,
+            )
+
+    assert torch.isfinite(loss_rel_curve).all()
+    assert torch.isfinite(grad_norm_rel_curve).all()
+    assert float(max_loss_rel_diff) <= _LOSS_REL_TOL
+    assert float(max_grad_norm_rel_diff) <= _LOSS_REL_TOL
+    assert losses["fsdp2"][-1] < losses["fsdp2"][0]
+    assert losses["mfsdp"][-1] < losses["mfsdp"][0]

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import gc
+import json
 import os
 import statistics
 import sys
@@ -22,6 +23,7 @@ from megatron.lite.primitive.optimizers.fsdp2 import (
 )
 from megatron.lite.primitive.optimizers.mfsdp import build_mfsdp_training_optimizer
 from megatron.lite.primitive.parallel import init_parallel
+from megatron.lite.primitive.recompute import apply_offload
 from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
 from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
 from megatron.lite.runtime.contracts.data import PackedBatch
@@ -239,12 +241,18 @@ def _build_fsdp2_pair(
     model_type: type[nn.Module] = TinyDenseModel,
     expert_classifier=None,
     unit_modules: tuple[type[nn.Module], ...] = (TinyUnit,),
+    offload_fraction: float = 0.0,
+    activation_offload: bool = False,
 ):
     ps = _parallel_state(parallel)
     chunks = [_new_model(seed, model_type)]
+    if activation_offload:
+        apply_offload(chunks[0].layers, ["full"], {})
+    optimizer_config = _optimizer_cfg(use_fused_optimizer=False)
+    optimizer_config.offload_fraction = offload_fraction
     optimizer = build_fsdp2_training_optimizer(
         chunks,
-        _optimizer_cfg(),
+        optimizer_config,
         ps,
         unit_modules=unit_modules,
         expert_classifier=expert_classifier,
@@ -262,10 +270,13 @@ def _build_mfsdp_pair(
     expert_classifier=None,
     unit_modules: tuple[type[nn.Module], ...] = (TinyUnit,),
     offload_fraction: float = 0.0,
+    activation_offload: bool = False,
     use_fused_optimizer: bool = True,
 ):
     ps = _parallel_state(parallel)
     chunks = [_new_model(seed, model_type)]
+    if activation_offload:
+        apply_offload(chunks[0].layers, ["full"], {})
     optimizer_config = _optimizer_cfg(use_fused_optimizer=use_fused_optimizer)
     optimizer_config.offload_fraction = offload_fraction
     impl_cfg = SimpleNamespace(
@@ -282,21 +293,113 @@ def _build_mfsdp_pair(
     return chunks, optimizer, finalize
 
 
-def _run_mfsdp_offload_arm(
+def _memory_triple() -> dict[str, float]:
+    allocated = torch.cuda.memory_allocated()
+    reserved = torch.cuda.memory_reserved()
+    values = torch.tensor(
+        [allocated, reserved, reserved - allocated],
+        device="cuda",
+        dtype=torch.float64,
+    )
+    dist.all_reduce(values, op=dist.ReduceOp.MAX)
+    return dict(
+        zip(
+            ("allocated_gib", "reserved_gib", "scratch_gib"),
+            (float(value) / (1024**3) for value in values),
+            strict=True,
+        )
+    )
+
+
+def _optimizer_tensor_devices(optimizer: Any) -> list[str]:
+    devices: set[str] = set()
+    seen: set[int] = set()
+
+    def visit(value: Any, depth: int = 0) -> None:
+        if value is None or depth > 8 or id(value) in seen:
+            return
+        seen.add(id(value))
+        if isinstance(value, torch.Tensor):
+            devices.add(value.device.type)
+            return
+        if isinstance(value, dict):
+            for item in value.values():
+                visit(item, depth + 1)
+            return
+        if isinstance(value, (list, tuple)):
+            for item in value:
+                visit(item, depth + 1)
+            return
+        for attribute in (
+            "state",
+            "optimizer",
+            "_inner_optimizer",
+            "_cpu_optimizer",
+            "cpu_group",
+            "_cpu_params",
+        ):
+            visit(getattr(value, attribute, None), depth + 1)
+
+    visit(optimizer)
+    return sorted(devices)
+
+
+def _mfsdp_cpu_master_devices(optimizer: Any) -> list[str]:
+    inner = getattr(optimizer, "_inner_optimizer", None)
+    cpu_group = getattr(inner, "cpu_group", None)
+    cpu_params = getattr(cpu_group, "_cpu_params", ())
+    return sorted({param.device.type for param in cpu_params})
+
+
+def _profiled_train_step(chunks, optimizer, finalize, x, target):
+    optimizer.zero_grad()
+    torch.cuda.synchronize()
+    started = time.perf_counter()
+    output = chunks[0](x)
+    loss = torch.nn.functional.mse_loss(output.float(), target.float())
+    torch.cuda.synchronize()
+    training_memory = _memory_triple()
+    loss.backward()
+    if finalize is not None:
+        finalize()
+    success, grad_norm, _num_zeros = optimizer.step()
+    torch.cuda.synchronize()
+    optimizer_memory = _memory_triple()
+    elapsed = torch.tensor(time.perf_counter() - started, device="cuda")
+    dist.all_reduce(elapsed, op=dist.ReduceOp.MAX)
+    return (
+        bool(success),
+        float(loss.detach()),
+        float(grad_norm),
+        float(elapsed),
+        training_memory,
+        optimizer_memory,
+    )
+
+
+def _run_offload_arm(
     *,
+    backend: str,
     offload_fraction: float,
+    activation_offload: bool,
     x: torch.Tensor,
     target: torch.Tensor,
-) -> tuple[list[float], list[float], float, dict[str, torch.Tensor]]:
+) -> dict[str, Any]:
+    gc.collect()
     torch.cuda.empty_cache()
-    chunks, optimizer, finalize = _build_mfsdp_pair(
+    builder = _build_mfsdp_pair if backend == "mfsdp" else _build_fsdp2_pair
+    kwargs = dict(
         seed=4567,
         parallel=_dense_parallel_config(),
         model_type=BenchmarkModel,
         unit_modules=(BenchmarkUnit,),
         offload_fraction=offload_fraction,
-        use_fused_optimizer=False,
+        activation_offload=activation_offload,
     )
+    if backend == "mfsdp":
+        kwargs["use_fused_optimizer"] = False
+    chunks, optimizer, finalize = builder(**kwargs)
+
     losses = []
     for _ in range(2):
         success, loss, _grad_norm = _train_step(chunks, optimizer, finalize, x, target)
@@ -305,18 +408,37 @@ def _run_mfsdp_offload_arm(
 
     torch.cuda.synchronize()
     torch.cuda.reset_peak_memory_stats()
-    step_times = [
-        _timed_train_step(chunks, optimizer, finalize, x, target) for _ in range(3)
-    ]
-    peak_bytes = torch.tensor(
-        torch.cuda.max_memory_allocated(), device="cuda", dtype=torch.float64
-    )
-    dist.all_reduce(peak_bytes, op=dist.ReduceOp.MAX)
+    step_times = []
+    training_memory = []
+    optimizer_memory = []
+    for _ in range(5):
+        success, loss, _grad_norm, step_s, training, optimizer_side = (
+            _profiled_train_step(chunks, optimizer, finalize, x, target)
+        )
+        assert success
+        losses.append(loss)
+        step_times.append(step_s)
+        training_memory.append(training)
+        optimizer_memory.append(optimizer_side)
+
     params = _named_model_tensors(chunks)
+    result = {
+        "backend": backend,
+        "optimizer_offload": bool(offload_fraction),
+        "activation_offload": activation_offload,
+        "losses": losses,
+        "step_ms": statistics.median(step_times) * 1000.0,
+        "tokens_per_s_per_gpu": x.shape[0] / statistics.median(step_times),
+        "training_memory": training_memory[-1],
+        "optimizer_memory": optimizer_memory[-1],
+        "optimizer_tensor_devices": _optimizer_tensor_devices(optimizer),
+        "cpu_master_devices": _mfsdp_cpu_master_devices(optimizer),
+        "params": params,
+    }
     del optimizer, chunks
     gc.collect()
     torch.cuda.empty_cache()
-    return losses, step_times, float(peak_bytes), params
+    return result
 
 
 def _qualified_type(value: Any) -> str:
@@ -673,7 +795,7 @@ def test_mfsdp_throughput_exceeds_fsdp2():
     assert speedup > _MIN_SPEEDUP
 
 
-def test_mfsdp_cpu_optimizer_offload_reduces_memory_and_preserves_update():
+def test_mfsdp_offload_matrix_matches_fsdp2_precision_speed_and_memory():
     torch.manual_seed(6060 + dist.get_rank())
     torch.cuda.manual_seed_all(6060 + dist.get_rank())
     x = torch.randn(
@@ -684,45 +806,133 @@ def test_mfsdp_cpu_optimizer_offload_reduces_memory_and_preserves_update():
     )
     target = torch.zeros_like(x)
 
-    baseline_losses, baseline_times, baseline_peak, baseline_params = (
-        _run_mfsdp_offload_arm(
-            offload_fraction=0.0,
-            x=x,
-            target=target,
+    commit = os.environ.get("MLITE_VALIDATION_COMMIT")
+    wandb_project = os.environ.get("WANDB_PROJECT")
+    if not commit:
+        pytest.fail("offload matrix requires MLITE_VALIDATION_COMMIT provenance")
+    if not wandb_project:
+        pytest.fail(
+            "offload matrix requires WANDB_PROJECT; offline fallback is not accepted"
         )
-    )
-    offload_losses, offload_times, offload_peak, offload_params = (
-        _run_mfsdp_offload_arm(
-            offload_fraction=1.0,
-            x=x,
-            target=target,
-        )
-    )
 
-    max_param_abs, max_param_rel = _assert_tensor_sets_close(
-        baseline_params, offload_params
-    )
-    baseline_step_s = statistics.median(baseline_times)
-    offload_step_s = statistics.median(offload_times)
-    assert offload_losses == pytest.approx(
-        baseline_losses, rel=_LOSS_REL_TOL, abs=_TENSOR_ATOL
-    )
-    assert offload_peak < baseline_peak
-
+    wandb_run = None
     if dist.get_rank() == 0:
-        print(
-            "[MFSDP_CPU_OFFLOAD] "
-            f"world_size={dist.get_world_size()} "
-            f"baseline_peak_gib={baseline_peak / (1024**3):.4f} "
-            f"offload_peak_gib={offload_peak / (1024**3):.4f} "
-            f"saved_gib={(baseline_peak - offload_peak) / (1024**3):.4f} "
-            f"baseline_step_ms={baseline_step_s * 1000.0:.4f} "
-            f"offload_step_ms={offload_step_s * 1000.0:.4f} "
-            f"slowdown={offload_step_s / baseline_step_s:.4f} "
-            f"max_param_abs_diff={max_param_abs:.8e} "
-            f"max_param_rel_diff={max_param_rel:.8e}",
-            flush=True,
+        try:
+            import wandb
+
+            wandb_run = wandb.init(
+                project=wandb_project,
+                entity=os.environ.get("WANDB_ENTITY"),
+                name=os.environ.get("WANDB_NAME", f"mfsdp-offload-{commit[:10]}"),
+                config={
+                    "commit": commit,
+                    "world_size": dist.get_world_size(),
+                    "optimizer_offload_values": [False, True],
+                    "activation_offload_values": [False, True],
+                    "reference": "fsdp2",
+                },
+            )
+            if wandb_run is None:
+                pytest.fail("wandb.init returned no run")
+            print(f"[MFSDP_WANDB] url={wandb_run.url}", flush=True)
+        except Exception as exc:
+            pytest.fail(f"mandatory W&B initialization failed: {exc}")
+
+    matrix = {}
+    for backend in ("fsdp2", "mfsdp"):
+        for optimizer_offload in (False, True):
+            for activation_offload in (False, True):
+                key = (backend, optimizer_offload, activation_offload)
+                matrix[key] = _run_offload_arm(
+                    backend=backend,
+                    offload_fraction=float(optimizer_offload),
+                    activation_offload=activation_offload,
+                    x=x,
+                    target=target,
+                )
+
+    comparisons = {}
+    for optimizer_offload in (False, True):
+        for activation_offload in (False, True):
+            fsdp2 = matrix[("fsdp2", optimizer_offload, activation_offload)]
+            mfsdp = matrix[("mfsdp", optimizer_offload, activation_offload)]
+            assert mfsdp["losses"] == pytest.approx(
+                fsdp2["losses"],
+                rel=_LOSS_REL_TOL,
+                abs=_TENSOR_ATOL,
+            )
+            max_abs, max_rel = _assert_tensor_sets_close(
+                fsdp2["params"],
+                mfsdp["params"],
+            )
+            comparisons[(optimizer_offload, activation_offload)] = {
+                "max_param_abs_diff": max_abs,
+                "max_param_rel_diff": max_rel,
+                "max_loss_rel_diff": _max_relative_difference(
+                    fsdp2["losses"],
+                    mfsdp["losses"],
+                ),
+            }
+
+    for backend in ("fsdp2", "mfsdp"):
+        for activation_offload in (False, True):
+            optimizer_off = matrix[(backend, False, activation_offload)]
+            optimizer_on = matrix[(backend, True, activation_offload)]
+            assert (
+                optimizer_on["optimizer_memory"]["allocated_gib"]
+                < optimizer_off["optimizer_memory"]["allocated_gib"]
+            )
+            assert "cpu" in optimizer_on["optimizer_tensor_devices"]
+            if backend == "mfsdp":
+                assert optimizer_off["cpu_master_devices"] == []
+                assert optimizer_on["cpu_master_devices"] == ["cpu"]
+        for optimizer_offload in (False, True):
+            activation_off = matrix[(backend, optimizer_offload, False)]
+            activation_on = matrix[(backend, optimizer_offload, True)]
+            assert (
+                activation_on["training_memory"]["allocated_gib"]
+                < activation_off["training_memory"]["allocated_gib"]
+            )
+
+    serializable_matrix = {}
+    for (backend, optimizer_offload, activation_offload), result in matrix.items():
+        name = (
+            f"{backend}_optimizer_{int(optimizer_offload)}"
+            f"_activation_{int(activation_offload)}"
         )
+        serializable_matrix[name] = {
+            key: value for key, value in result.items() if key != "params"
+        }
+        if dist.get_rank() == 0:
+            print(
+                "[MFSDP_OFFLOAD_MATRIX] "
+                + json.dumps(
+                    {
+                        "commit": commit,
+                        "arm": name,
+                        **serializable_matrix[name],
+                        **comparisons[(optimizer_offload, activation_offload)],
+                    },
+                    sort_keys=True,
+                ),
+                flush=True,
+            )
+
+    if wandb_run is not None:
+        try:
+            for arm, result in serializable_matrix.items():
+                payload = {
+                    f"{arm}/step_ms": result["step_ms"],
+                    f"{arm}/tokens_per_s_per_gpu": result["tokens_per_s_per_gpu"],
+                    f"{arm}/loss_final": result["losses"][-1],
+                }
+                for side in ("training_memory", "optimizer_memory"):
+                    for metric, value in result[side].items():
+                        payload[f"{arm}/{side}/{metric}"] = value
+                wandb_run.log(payload)
+            wandb_run.finish()
+        except Exception as exc:
+            pytest.fail(f"mandatory W&B logging failed: {exc}")
 
 
 def test_mfsdp_matches_fsdp2_tiny_dense_single_step():

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -100,6 +100,63 @@ class TinyParallelModel(nn.Module):
         return self.out(self.experts(hidden))
 
 
+class TinyTELinear(nn.Module):
+    def __init__(self, in_features: int, out_features: int):
+        super().__init__()
+        import transformer_engine.pytorch as te
+
+        self.linear = te.Linear(
+            in_features,
+            out_features,
+            bias=False,
+            params_dtype=torch.bfloat16,
+        )
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+class TinyTETransformerLayer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.dense = TinyTELinear(8, 8)
+        self.expert = TinyTELinear(8, 8)
+
+    def forward(self, x):
+        return torch.tanh(self.dense(x) + self.expert(x))
+
+
+class TinyTEQwen3MoE(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layers = nn.ModuleList(
+            [TinyTETransformerLayer(), TinyTETransformerLayer()]
+        )
+        self.out = TinyTELinear(8, 4)
+
+    def forward(self, x):
+        for layer in self.layers:
+            x = layer(x)
+        return self.out(x)
+
+
+class RecordingSGD(torch.optim.SGD):
+    def __init__(self, param_groups):
+        super().__init__(param_groups, lr=0.0)
+        self.consumed_grad_groups: list[list[torch.Tensor]] = []
+
+    def step(self, closure=None):
+        self.consumed_grad_groups = [
+            [
+                param.grad.detach().clone()
+                for param in group["params"]
+                if param.grad is not None
+            ]
+            for group in self.param_groups
+        ]
+        return super().step(closure)
+
+
 class BenchmarkUnit(nn.Module):
     def __init__(self, hidden_size: int):
         super().__init__()
@@ -309,6 +366,14 @@ def _memory_triple() -> dict[str, float]:
             strict=True,
         )
     )
+
+
+def _bf16_roundtrip_difference_fraction(tensors: list[torch.Tensor]) -> float:
+    values = torch.cat([tensor.detach().float().reshape(-1) for tensor in tensors])
+    assert values.numel() > 0
+    rounded = values.to(torch.bfloat16).to(torch.float32)
+    assert not torch.equal(values, rounded)
+    return float((values != rounded).float().mean().item())
 
 
 def _memory_delta(
@@ -674,6 +739,102 @@ def _tp_ep_parallel_config() -> ParallelConfig:
 
 def _is_tiny_expert(name: str) -> bool:
     return name.startswith("experts.")
+
+
+def test_mfsdp_native_fp32_fused_wgrad_reaches_optimizer_groups():
+    parallel = _dense_parallel_config()
+    ps = _parallel_state(parallel)
+    chunks = [_new_model(7319, TinyTEQwen3MoE)]
+    optimizer_config = _optimizer_cfg(use_fused_optimizer=False)
+    impl_cfg = SimpleNamespace(
+        parallel=parallel,
+        optimizer_config=optimizer_config,
+    )
+
+    def build_recording_optimizer(param_groups, _optimizer_config):
+        params = [param for group in param_groups for param in group["params"]]
+        assert len(params) == 5
+        return RecordingSGD(
+            [
+                {"params": params[::2], "weight_decay": 0.0},
+                {"params": params[1::2], "weight_decay": 0.0},
+            ]
+        )
+
+    optimizer, finalize = build_mfsdp_training_optimizer(
+        chunks,
+        impl_cfg=impl_cfg,
+        ps=ps,
+        is_expert=lambda name: ".expert." in name,
+        fsdp_unit_modules=(TinyTETransformerLayer,),
+        optimizer_factory=build_recording_optimizer,
+    )
+    chunk = chunks[0]
+    assert len(chunk.param_sync.buckets) == 5
+    assert len(optimizer.param_groups) == 2
+
+    optimizer.zero_grad()
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(8107 + dist.get_rank())
+    value = torch.randn(
+        64,
+        8,
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    chunk(value).float().square().mean().backward()
+
+    main_grad_by_shard = {}
+    for bucket in chunk.param_sync.buckets:
+        for spec in bucket.specs:
+            assert spec.shard_param is not None
+            assert spec.full_param.grad_added_to_main_grad is True
+            assert spec.full_param.main_grad.dtype is torch.float32
+            main_grad_by_shard[id(spec.shard_param)] = (
+                spec.full_param.main_grad.detach().clone()
+            )
+    main_grad_fractions = [
+        _bf16_roundtrip_difference_fraction(
+            [main_grad_by_shard[id(param)] for param in group["params"]]
+        )
+        for group in optimizer.param_groups
+    ]
+
+    finalize()
+    optimizer_grad_fractions = [
+        _bf16_roundtrip_difference_fraction(
+            [param.grad for param in group["params"] if param.grad is not None]
+        )
+        for group in optimizer.param_groups
+    ]
+    success, _grad_norm, _num_zeros = optimizer.step()
+    recording_optimizer = optimizer._inner_optimizer.optimizer
+    consumed_grad_fractions = [
+        _bf16_roundtrip_difference_fraction(group)
+        for group in recording_optimizer.consumed_grad_groups
+    ]
+
+    assert success
+    assert all(fraction > 0.0 for fraction in main_grad_fractions)
+    assert all(fraction > 0.0 for fraction in optimizer_grad_fractions)
+    assert all(fraction > 0.0 for fraction in consumed_grad_fractions)
+    if dist.get_rank() == 0:
+        print(
+            "[MFSDP_NATIVE_FP32_WGRAD] "
+            + json.dumps(
+                {
+                    "world_size": dist.get_world_size(),
+                    "bucket_count": len(chunk.param_sync.buckets),
+                    "optimizer_group_count": len(optimizer.param_groups),
+                    "main_grad_low_bit_fractions": main_grad_fractions,
+                    "optimizer_grad_low_bit_fractions": optimizer_grad_fractions,
+                    "consumed_grad_low_bit_fractions": consumed_grad_fractions,
+                },
+                sort_keys=True,
+            ),
+            flush=True,
+        )
 
 
 def test_mfsdp_precision_curve_matches_fsdp2():

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -311,6 +311,12 @@ def _memory_triple() -> dict[str, float]:
     )
 
 
+def _memory_delta(
+    current: dict[str, float], baseline: dict[str, float]
+) -> dict[str, float]:
+    return {name: current[name] - baseline[name] for name in current}
+
+
 def _optimizer_tensor_devices(optimizer: Any) -> list[str]:
     devices: set[str] = set()
     seen: set[int] = set()
@@ -387,6 +393,10 @@ def _run_offload_arm(
 ) -> dict[str, Any]:
     gc.collect()
     torch.cuda.empty_cache()
+    # Composable FSDP keeps process-lifetime bookkeeping across models. Preserve
+    # the absolute allocator snapshot, but compare each arm using its isolated
+    # increment so earlier arms cannot contaminate later arms.
+    arm_baseline_memory = _memory_triple()
     builder = _build_mfsdp_pair if backend == "mfsdp" else _build_fsdp2_pair
     kwargs = dict(
         seed=4567,
@@ -429,8 +439,15 @@ def _run_offload_arm(
         "losses": losses,
         "step_ms": statistics.median(step_times) * 1000.0,
         "tokens_per_s_per_gpu": x.shape[0] / statistics.median(step_times),
+        "arm_baseline_memory": arm_baseline_memory,
         "training_memory": training_memory[-1],
+        "training_incremental_memory": _memory_delta(
+            training_memory[-1], arm_baseline_memory
+        ),
         "optimizer_memory": optimizer_memory[-1],
+        "optimizer_incremental_memory": _memory_delta(
+            optimizer_memory[-1], arm_baseline_memory
+        ),
         "optimizer_tensor_devices": _optimizer_tensor_devices(optimizer),
         "cpu_master_devices": _mfsdp_cpu_master_devices(optimizer),
         "params": params,
@@ -893,7 +910,12 @@ def test_mfsdp_offload_matrix_matches_fsdp2_precision_speed_and_memory():
                     f"{name}/loss_final": raw["losses"][-1],
                     **{
                         f"{name}/{side}/{metric}": value
-                        for side in ("training_memory", "optimizer_memory")
+                        for side in (
+                            "training_memory",
+                            "training_incremental_memory",
+                            "optimizer_memory",
+                            "optimizer_incremental_memory",
+                        )
                         for metric, value in raw[side].items()
                     },
                 }
@@ -939,8 +961,8 @@ def test_mfsdp_offload_matrix_matches_fsdp2_precision_speed_and_memory():
             optimizer_off = matrix[(backend, False, activation_offload)]
             optimizer_on = matrix[(backend, True, activation_offload)]
             assert (
-                optimizer_on["optimizer_memory"]["allocated_gib"]
-                < optimizer_off["optimizer_memory"]["allocated_gib"]
+                optimizer_on["optimizer_incremental_memory"]["allocated_gib"]
+                < optimizer_off["optimizer_incremental_memory"]["allocated_gib"]
             )
             assert "cpu" in optimizer_on["optimizer_tensor_devices"]
             if backend == "mfsdp":
@@ -950,8 +972,8 @@ def test_mfsdp_offload_matrix_matches_fsdp2_precision_speed_and_memory():
             activation_off = matrix[(backend, optimizer_offload, False)]
             activation_on = matrix[(backend, optimizer_offload, True)]
             assert (
-                activation_on["training_memory"]["allocated_gib"]
-                < activation_off["training_memory"]["allocated_gib"]
+                activation_on["training_incremental_memory"]["allocated_gib"]
+                < activation_off["training_incremental_memory"]["allocated_gib"]
             )
 
     serializable_matrix = {}
@@ -991,7 +1013,12 @@ def test_mfsdp_offload_matrix_matches_fsdp2_precision_speed_and_memory():
                     f"{arm}/tokens_per_s_per_gpu": result["tokens_per_s_per_gpu"],
                     f"{arm}/loss_final": result["losses"][-1],
                 }
-                for side in ("training_memory", "optimizer_memory"):
+                for side in (
+                    "training_memory",
+                    "training_incremental_memory",
+                    "optimizer_memory",
+                    "optimizer_incremental_memory",
+                ):
                     for metric, value in result[side].items():
                         payload[f"{arm}/{side}/{metric}"] = value
                 wandb_run.log(payload)

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -176,6 +176,17 @@ class TinyTEGroupedMoE(nn.Module):
         return self.out(x)
 
 
+class TinyNonFusedLinear(nn.Module):
+    """Regular autograd linear covering M-FSDP's non-TE gradient path."""
+
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(4, 4, bias=False, dtype=torch.bfloat16)
+
+    def forward(self, x):
+        return self.linear(x)
+
+
 class RecordingSGD(torch.optim.SGD):
     def __init__(self, param_groups):
         super().__init__(param_groups, lr=0.0)
@@ -417,6 +428,11 @@ def _bf16_roundtrip_difference_fraction(tensors: list[torch.Tensor]) -> float:
     rounded = values.to(torch.bfloat16).to(torch.float32)
     assert not torch.equal(values, rounded)
     return float((values != rounded).float().mean().item())
+
+
+def _is_bf16_roundtrip_exact(tensor: torch.Tensor) -> bool:
+    values = tensor.detach().float()
+    return torch.equal(values, values.to(torch.bfloat16).to(torch.float32))
 
 
 def _memory_delta(
@@ -843,6 +859,7 @@ def test_mfsdp_native_fp32_fused_wgrad_reaches_optimizer_groups():
         for spec in bucket.specs:
             assert spec.shard_param is not None
             assert spec.full_param.grad_added_to_main_grad is True
+            assert spec.full_param.grad is None
             assert spec.full_param.main_grad.dtype is torch.float32
             main_grad_by_shard[id(spec.shard_param)] = (
                 spec.full_param.main_grad.detach().clone()
@@ -991,6 +1008,87 @@ def test_mfsdp_native_fp32_grouped_expert_wgrad_reaches_optimizer():
                     "main_grad_low_bit_fractions": main_grad_fractions,
                     "optimizer_grad_low_bit_fractions": optimizer_grad_fractions,
                     "consumed_grad_low_bit_fractions": consumed_grad_fractions,
+                },
+                sort_keys=True,
+            ),
+            flush=True,
+        )
+
+
+def test_mfsdp_non_fused_wgrad_accumulates_in_fp32_per_microbatch():
+    parallel = _dense_parallel_config()
+    ps = _parallel_state(parallel)
+    torch.manual_seed(10103)
+    torch.cuda.manual_seed_all(10103)
+    chunks = [TinyNonFusedLinear().cuda()]
+    optimizer_config = _optimizer_cfg(use_fused_optimizer=False)
+    impl_cfg = SimpleNamespace(
+        parallel=parallel,
+        optimizer_config=optimizer_config,
+    )
+
+    def build_recording_optimizer(param_groups, _optimizer_config):
+        return RecordingSGD(param_groups)
+
+    optimizer, finalize = build_mfsdp_training_optimizer(
+        chunks,
+        impl_cfg=impl_cfg,
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(TinyNonFusedLinear,),
+        optimizer_factory=build_recording_optimizer,
+    )
+    chunk = chunks[0]
+    assert not hasattr(chunk.linear, "fuse_wgrad_accumulation")
+    assert len(chunk.param_sync.buckets) == 1
+    spec = chunk.param_sync.buckets[0].specs[0]
+    assert spec.shard_param is not None
+    assert spec.full_param.grad_added_to_main_grad is False
+
+    optimizer.zero_grad()
+    chunk(torch.ones(1, 4, device="cuda", dtype=torch.bfloat16)).sum().backward()
+    single_backward_grad = spec.full_param.main_grad.detach().clone()
+    assert spec.full_param.grad is None
+    assert spec.full_param.main_grad.dtype is torch.float32
+    assert torch.equal(single_backward_grad, torch.ones(4, 4, device="cuda"))
+    assert _is_bf16_roundtrip_exact(single_backward_grad)
+
+    optimizer.zero_grad()
+    chunk(
+        torch.full((1, 4), 256.0, device="cuda", dtype=torch.bfloat16)
+    ).sum().backward()
+    assert spec.full_param.grad is None
+    assert torch.equal(
+        spec.full_param.main_grad,
+        torch.full((4, 4), 256.0, device="cuda"),
+    )
+    assert _is_bf16_roundtrip_exact(spec.full_param.main_grad)
+
+    chunk(torch.ones(1, 4, device="cuda", dtype=torch.bfloat16)).sum().backward()
+    expected = torch.full((4, 4), 257.0, device="cuda")
+    assert spec.full_param.grad is None
+    assert torch.equal(spec.full_param.main_grad, expected)
+    assert not _is_bf16_roundtrip_exact(spec.full_param.main_grad)
+
+    finalize()
+    expected_shard = expected.reshape(-1).chunk(dist.get_world_size())[dist.get_rank()]
+    assert spec.shard_param.grad is not None
+    assert spec.shard_param.grad.dtype is torch.float32
+    assert torch.equal(spec.shard_param.grad, expected_shard)
+    success, _grad_norm, _num_zeros = optimizer.step()
+    recording_optimizer = optimizer._inner_optimizer.optimizer
+    consumed_grad = recording_optimizer.consumed_grad_by_param[id(spec.shard_param)]
+    assert success
+    assert torch.equal(consumed_grad, expected_shard)
+    if dist.get_rank() == 0:
+        print(
+            "[MFSDP_NON_FUSED_FP32_ACCUMULATION] "
+            + json.dumps(
+                {
+                    "world_size": dist.get_world_size(),
+                    "single_backward_bf16_roundtrip_exact": True,
+                    "multi_microbatch_value": float(consumed_grad[0]),
+                    "multi_microbatch_bf16_roundtrip_exact": False,
                 },
                 sort_keys=True,
             ),

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -17,6 +17,7 @@ import torch.distributed as dist
 import torch.nn as nn
 from torch.utils._python_dispatch import TorchDispatchMode
 
+from megatron.lite.primitive.modules.experts import Experts
 from megatron.lite.primitive.optimizers.fsdp2 import (
     build_fsdp2_training_optimizer,
     fsdp2_available,
@@ -140,10 +141,46 @@ class TinyTEQwen3MoE(nn.Module):
         return self.out(x)
 
 
+class TinyTEGroupedExpertLayer(nn.Module):
+    def __init__(self, ps):
+        super().__init__()
+        config = SimpleNamespace(
+            num_experts=2,
+            hidden_size=8,
+            moe_intermediate_size=16,
+            swiglu_limit=0.0,
+        )
+        self.experts = Experts(config, ps)
+
+    def forward(self, x):
+        first_expert_tokens = x.shape[0] // 2
+        tokens_per_expert = torch.tensor(
+            [first_expert_tokens, x.shape[0] - first_expert_tokens],
+            device=x.device,
+            dtype=torch.int64,
+        )
+        return torch.tanh(self.experts(x, tokens_per_expert))
+
+
+class TinyTEGroupedMoE(nn.Module):
+    def __init__(self, ps):
+        super().__init__()
+        self.layers = nn.ModuleList(
+            [TinyTEGroupedExpertLayer(ps), TinyTEGroupedExpertLayer(ps)]
+        )
+        self.out = TinyTELinear(8, 4)
+
+    def forward(self, x):
+        for layer in self.layers:
+            x = layer(x)
+        return self.out(x)
+
+
 class RecordingSGD(torch.optim.SGD):
     def __init__(self, param_groups):
         super().__init__(param_groups, lr=0.0)
         self.consumed_grad_groups: list[list[torch.Tensor]] = []
+        self.consumed_grad_by_param: dict[int, torch.Tensor] = {}
 
     def step(self, closure=None):
         self.consumed_grad_groups = [
@@ -154,6 +191,12 @@ class RecordingSGD(torch.optim.SGD):
             ]
             for group in self.param_groups
         ]
+        self.consumed_grad_by_param = {
+            id(param): param.grad.detach().clone()
+            for group in self.param_groups
+            for param in group["params"]
+            if param.grad is not None
+        }
         return super().step(closure)
 
 
@@ -741,6 +784,16 @@ def _is_tiny_expert(name: str) -> bool:
     return name.startswith("experts.")
 
 
+def _grouped_expert_key(name: str) -> str | None:
+    layer_name, marker, parameter_name = name.partition("experts.")
+    if not marker:
+        return None
+    weight_name = parameter_name.rsplit(".", 1)[-1]
+    if not weight_name.startswith("weight") or not weight_name[6:].isdigit():
+        return None
+    return f"{layer_name}expert{weight_name[6:]}"
+
+
 def test_mfsdp_native_fp32_fused_wgrad_reaches_optimizer_groups():
     parallel = _dense_parallel_config()
     ps = _parallel_state(parallel)
@@ -827,6 +880,114 @@ def test_mfsdp_native_fp32_fused_wgrad_reaches_optimizer_groups():
                     "world_size": dist.get_world_size(),
                     "bucket_count": len(chunk.param_sync.buckets),
                     "optimizer_group_count": len(optimizer.param_groups),
+                    "main_grad_low_bit_fractions": main_grad_fractions,
+                    "optimizer_grad_low_bit_fractions": optimizer_grad_fractions,
+                    "consumed_grad_low_bit_fractions": consumed_grad_fractions,
+                },
+                sort_keys=True,
+            ),
+            flush=True,
+        )
+
+
+def test_mfsdp_native_fp32_grouped_expert_wgrad_reaches_optimizer():
+    parallel = _dense_parallel_config()
+    ps = _parallel_state(parallel)
+    torch.manual_seed(9127)
+    torch.cuda.manual_seed_all(9127)
+    chunks = [TinyTEGroupedMoE(ps).cuda().to(torch.bfloat16)]
+    optimizer_config = _optimizer_cfg(use_fused_optimizer=False)
+    impl_cfg = SimpleNamespace(
+        parallel=parallel,
+        optimizer_config=optimizer_config,
+    )
+
+    def build_recording_optimizer(param_groups, _optimizer_config):
+        params = [param for group in param_groups for param in group["params"]]
+        return RecordingSGD(
+            [{"params": [param], "weight_decay": 0.0} for param in params]
+        )
+
+    optimizer, finalize = build_mfsdp_training_optimizer(
+        chunks,
+        impl_cfg=impl_cfg,
+        ps=ps,
+        is_expert=lambda name: "experts." in name,
+        fsdp_unit_modules=(TinyTEGroupedExpertLayer,),
+        optimizer_factory=build_recording_optimizer,
+    )
+    chunk = chunks[0]
+    grouped_linear_modules = [
+        module for module in chunk.modules() if type(module).__name__ == "GroupedLinear"
+    ]
+    assert len(grouped_linear_modules) == 4
+    assert all(module.fuse_wgrad_accumulation for module in grouped_linear_modules)
+
+    expert_specs = {}
+    for bucket in chunk.param_sync.buckets:
+        for spec in bucket.specs:
+            expert_key = _grouped_expert_key(spec.name)
+            if expert_key is not None:
+                expert_specs.setdefault(expert_key, []).append(spec)
+    assert len(expert_specs) == 4
+    assert all(len(specs) == 2 for specs in expert_specs.values())
+
+    optimizer.zero_grad()
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(9131 + dist.get_rank())
+    value = torch.randn(
+        64,
+        8,
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    chunk(value).float().square().mean().backward()
+
+    main_grad_fractions = {}
+    for expert_key, specs in expert_specs.items():
+        main_grads = []
+        for spec in specs:
+            assert spec.shard_param is not None
+            assert spec.full_param.grad_added_to_main_grad is True
+            assert spec.full_param.main_grad.dtype is torch.float32
+            assert spec.full_param.grad is None
+            main_grads.append(spec.full_param.main_grad)
+        main_grad_fractions[expert_key] = _bf16_roundtrip_difference_fraction(
+            main_grads
+        )
+
+    finalize()
+    optimizer_grad_fractions = {
+        expert_key: _bf16_roundtrip_difference_fraction(
+            [spec.shard_param.grad for spec in specs]
+        )
+        for expert_key, specs in expert_specs.items()
+    }
+    success, _grad_norm, _num_zeros = optimizer.step()
+    recording_optimizer = optimizer._inner_optimizer.optimizer
+    consumed_grad_fractions = {
+        expert_key: _bf16_roundtrip_difference_fraction(
+            [
+                recording_optimizer.consumed_grad_by_param[id(spec.shard_param)]
+                for spec in specs
+            ]
+        )
+        for expert_key, specs in expert_specs.items()
+    }
+
+    assert success
+    assert all(fraction > 0.0 for fraction in main_grad_fractions.values())
+    assert all(fraction > 0.0 for fraction in optimizer_grad_fractions.values())
+    assert all(fraction > 0.0 for fraction in consumed_grad_fractions.values())
+    if dist.get_rank() == 0:
+        print(
+            "[MFSDP_NATIVE_FP32_GROUPED_EXPERT_WGRAD] "
+            + json.dumps(
+                {
+                    "world_size": dist.get_world_size(),
+                    "expert_group_count": len(expert_specs),
+                    "grouped_linear_count": len(grouped_linear_modules),
                     "main_grad_low_bit_fractions": main_grad_fractions,
                     "optimizer_grad_low_bit_fractions": optimizer_grad_fractions,
                     "consumed_grad_low_bit_fractions": consumed_grad_fractions,

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -40,6 +40,7 @@ pytestmark = [
 _MFSDP_SHARDING_STRATEGY = "optim_grads_params"
 _PRECISION_STEPS = 50
 _LOSS_REL_TOL = 1.0e-2
+_E2E_SFT_LOSS_REL_TOL = 5.09e-3
 _TENSOR_RTOL = 1.0e-2
 _TENSOR_ATOL = 1.0e-5
 _BENCH_WARMUP_STEPS = 5
@@ -1754,7 +1755,10 @@ def _max_snapshot_abs_diff(
     return max(float((lhs[name] - rhs[name]).abs().max()) for name in lhs)
 
 
-def test_mfsdp_matches_fsdp2_full_parallel_precision_curve(monkeypatch):
+@pytest.mark.parametrize("reference_backend", ("dist_opt", "fsdp2"))
+def test_mfsdp_matches_reference_full_parallel_precision_curve(
+    monkeypatch, reference_backend
+):
     if dist.get_world_size() != _FULL_PARALLEL_WORLD_SIZE:
         pytest.skip("M-FSDP TP2/EP2/ETP1/PP2/CP2 signoff requires exactly 8 ranks.")
 
@@ -1787,13 +1791,15 @@ def test_mfsdp_matches_fsdp2_full_parallel_precision_curve(monkeypatch):
         record_cp_split,
     )
 
-    fsdp2_handle, fsdp2_initial = _build_full_parallel_handle("fsdp2", seed=7345)
+    reference_handle, reference_initial = _build_full_parallel_handle(
+        reference_backend, seed=7345
+    )
     mfsdp_handle, mfsdp_initial = _build_full_parallel_handle("mfsdp", seed=7345)
     _assert_distinct_backend_identities(
-        fsdp2_handle._optimizer, mfsdp_handle._optimizer
+        reference_handle._optimizer, mfsdp_handle._optimizer
     )
 
-    for handle in (fsdp2_handle, mfsdp_handle):
+    for handle in (reference_handle, mfsdp_handle):
         ps = handle._parallel_state
         assert (ps.tp_size, ps.ep_size, ps.etp_size, ps.pp_size, ps.cp_size) == (
             2,
@@ -1804,16 +1810,37 @@ def test_mfsdp_matches_fsdp2_full_parallel_precision_curve(monkeypatch):
         )
 
     initial_max_abs = torch.tensor(
-        _max_snapshot_abs_diff(fsdp2_initial, mfsdp_initial), device="cuda"
+        _max_snapshot_abs_diff(reference_initial, mfsdp_initial), device="cuda"
     )
     dist.all_reduce(initial_max_abs, op=dist.ReduceOp.MAX)
     assert float(initial_max_abs) == 0.0
 
-    losses = {"fsdp2": [], "mfsdp": []}
-    grad_norms = {"fsdp2": [], "mfsdp": []}
+    losses = {reference_backend: [], "mfsdp": []}
+    grad_norms = {reference_backend: [], "mfsdp": []}
+    wandb_run = None
+    if dist.get_rank() == 0:
+        import wandb
+
+        wandb_run = wandb.init(
+            project=os.environ.get("WANDB_PROJECT", "mlite-mfsdp-precision"),
+            entity=os.environ.get("WANDB_ENTITY", "megatron-core-moe-dev"),
+            name=os.environ.get("WANDB_NAME", f"mfsdp-sft-curve-{reference_backend}"),
+            config={
+                "reference_backend": reference_backend,
+                "target_backend": "mfsdp",
+                "seed": 7345,
+                "steps": _FULL_PARALLEL_STEPS,
+                "microbatches": _FULL_PARALLEL_MICROBATCHES,
+                "same_input_sft": True,
+            },
+        )
+        print(f"[MFSDP_WANDB] url={wandb_run.url}", flush=True)
     traces = {}
     for step in range(_FULL_PARALLEL_STEPS):
-        for backend, handle in (("fsdp2", fsdp2_handle), ("mfsdp", mfsdp_handle)):
+        for backend, handle in (
+            (reference_backend, reference_handle),
+            ("mfsdp", mfsdp_handle),
+        ):
             dist.barrier()
             loss, grad_norm, trace = _run_full_parallel_step(
                 handle,
@@ -1824,8 +1851,19 @@ def test_mfsdp_matches_fsdp2_full_parallel_precision_curve(monkeypatch):
             grad_norms[backend].append(grad_norm)
             if trace:
                 traces[backend] = trace
+        if wandb_run is not None:
+            wandb_run.log(
+                {
+                    "step": step + 1,
+                    f"{reference_backend}/sft_loss": losses[reference_backend][-1],
+                    "mfsdp/sft_loss": losses["mfsdp"][-1],
+                    f"{reference_backend}/grad_norm": grad_norms[reference_backend][-1],
+                    "mfsdp/grad_norm": grad_norms["mfsdp"][-1],
+                },
+                step=step + 1,
+            )
 
-    for backend in ("fsdp2", "mfsdp"):
+    for backend in (reference_backend, "mfsdp"):
         trace = traces.get(backend, ())
         assert trace, f"{backend} tap recorded no distributed collectives."
         assert _contains_collective(trace, "all_gather", "allgather")
@@ -1837,11 +1875,11 @@ def test_mfsdp_matches_fsdp2_full_parallel_precision_curve(monkeypatch):
     )
 
     loss_rel_curve = torch.tensor(
-        _relative_difference_curve(losses["fsdp2"], losses["mfsdp"]),
+        _relative_difference_curve(losses[reference_backend], losses["mfsdp"]),
         device="cuda",
     )
     grad_norm_rel_curve = torch.tensor(
-        _relative_difference_curve(grad_norms["fsdp2"], grad_norms["mfsdp"]),
+        _relative_difference_curve(grad_norms[reference_backend], grad_norms["mfsdp"]),
         device="cuda",
     )
     dist.all_reduce(loss_rel_curve, op=dist.ReduceOp.MAX)
@@ -1850,7 +1888,7 @@ def test_mfsdp_matches_fsdp2_full_parallel_precision_curve(monkeypatch):
     max_grad_norm_rel_diff = grad_norm_rel_curve.max()
 
     if dist.get_rank() == 0:
-        ps = fsdp2_handle._parallel_state
+        ps = reference_handle._parallel_state
         print(
             "[MFSDP_FULL_PARALLEL] "
             "topology=tp2_ep2_etp1_pp2_cp2 "
@@ -1858,10 +1896,12 @@ def test_mfsdp_matches_fsdp2_full_parallel_precision_curve(monkeypatch):
             f"dp_cp_size={ps.dp_cp_size} "
             f"microbatches={_FULL_PARALLEL_MICROBATCHES} "
             f"steps={_FULL_PARALLEL_STEPS} "
+            f"reference={reference_backend} "
+            f"sft_loss_rel_tol={_E2E_SFT_LOSS_REL_TOL:.3e} "
             f"initial_max_abs_diff={float(initial_max_abs):.8e} "
             f"max_loss_rel_diff={float(max_loss_rel_diff):.8e} "
             f"max_grad_norm_rel_diff={float(max_grad_norm_rel_diff):.8e} "
-            f"fsdp2_losses={','.join(f'{value:.8f}' for value in losses['fsdp2'])} "
+            f"{reference_backend}_losses={','.join(f'{value:.8f}' for value in losses[reference_backend])} "
             f"mfsdp_losses={','.join(f'{value:.8f}' for value in losses['mfsdp'])} "
             f"cp_split={cp_splits[0][0]}->{cp_splits[0][1]} "
             f"cp_split_calls={len(cp_splits)}",
@@ -1877,13 +1917,13 @@ def test_mfsdp_matches_fsdp2_full_parallel_precision_curve(monkeypatch):
                 f"step={curve_index + 1} "
                 f"loss_rel_diff={float(loss_rel_curve[curve_index]):.8e} "
                 f"grad_norm_rel_diff={float(grad_norm_rel_curve[curve_index]):.8e} "
-                f"loss_fsdp2={losses['fsdp2'][curve_index]:.8f} "
+                f"loss_{reference_backend}={losses[reference_backend][curve_index]:.8f} "
                 f"loss_mfsdp={losses['mfsdp'][curve_index]:.8f} "
-                f"grad_norm_fsdp2={grad_norms['fsdp2'][curve_index]:.8f} "
+                f"grad_norm_{reference_backend}={grad_norms[reference_backend][curve_index]:.8f} "
                 f"grad_norm_mfsdp={grad_norms['mfsdp'][curve_index]:.8f}",
                 flush=True,
             )
-        for backend in ("fsdp2", "mfsdp"):
+        for backend in (reference_backend, "mfsdp"):
             trace = traces[backend]
             print(
                 "[MFSDP_COMM_TRACE] "
@@ -1894,7 +1934,9 @@ def test_mfsdp_matches_fsdp2_full_parallel_precision_curve(monkeypatch):
 
     assert torch.isfinite(loss_rel_curve).all()
     assert torch.isfinite(grad_norm_rel_curve).all()
-    assert float(max_loss_rel_diff) <= _LOSS_REL_TOL
+    assert float(max_loss_rel_diff) <= _E2E_SFT_LOSS_REL_TOL
     assert float(max_grad_norm_rel_diff) <= _LOSS_REL_TOL
-    assert losses["fsdp2"][-1] < losses["fsdp2"][0]
+    assert losses[reference_backend][-1] < losses[reference_backend][0]
     assert losses["mfsdp"][-1] < losses["mfsdp"][0]
+    if wandb_run is not None:
+        wandb_run.finish()

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -1592,13 +1592,13 @@ def _build_full_parallel_handle(backend: str, *, seed: int):
     initial_params = _named_model_tensors(bundle.chunks)
     assert bundle.extras.get("optimizer_backend") == backend
     post_load_hook = bundle.extras.get("post_model_load_hook")
-    assert callable(post_load_hook), (
-        f"{backend} did not expose its production post-load hook."
-    )
-    updates = post_load_hook()
-    assert isinstance(updates, dict)
-    optimizer = updates.get("optimizer", bundle.optimizer)
-    finalize_grads = updates.get("finalize_grads", bundle.finalize_grads)
+    optimizer = bundle.optimizer
+    finalize_grads = bundle.finalize_grads
+    if callable(post_load_hook):
+        updates = post_load_hook()
+        assert isinstance(updates, dict)
+        optimizer = updates.get("optimizer", optimizer)
+        finalize_grads = updates.get("finalize_grads", finalize_grads)
     assert optimizer is not None
 
     extras = dict(bundle.extras)

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -1795,9 +1795,25 @@ def test_mfsdp_matches_reference_full_parallel_precision_curve(
         reference_backend, seed=7345
     )
     mfsdp_handle, mfsdp_initial = _build_full_parallel_handle("mfsdp", seed=7345)
-    _assert_distinct_backend_identities(
-        reference_handle._optimizer, mfsdp_handle._optimizer
-    )
+    if reference_backend == "fsdp2":
+        _assert_distinct_backend_identities(
+            reference_handle._optimizer, mfsdp_handle._optimizer
+        )
+    else:
+        assert reference_handle._optimizer is not mfsdp_handle._optimizer
+        assert _qualified_type(reference_handle._optimizer).startswith(
+            "megatron.core.optimizer."
+        )
+        assert _qualified_type(mfsdp_handle._optimizer).startswith(
+            "megatron.lite.primitive.optimizers.mfsdp."
+        )
+        if dist.get_rank() == 0:
+            print(
+                "[MFSDP_BACKEND] "
+                f"configured={reference_backend} optimizer_type="
+                f"{_qualified_type(reference_handle._optimizer)}",
+                flush=True,
+            )
 
     for handle in (reference_handle, mfsdp_handle):
         ps = handle._parallel_state

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -1020,7 +1020,9 @@ def test_mfsdp_non_fused_wgrad_accumulates_in_fp32_per_microbatch():
     ps = _parallel_state(parallel)
     torch.manual_seed(10103)
     torch.cuda.manual_seed_all(10103)
-    chunks = [TinyNonFusedLinear().cuda()]
+    model = TinyNonFusedLinear().cuda()
+    assert not hasattr(model.linear, "fuse_wgrad_accumulation")
+    chunks = [model]
     optimizer_config = _optimizer_cfg(use_fused_optimizer=False)
     impl_cfg = SimpleNamespace(
         parallel=parallel,
@@ -1039,7 +1041,6 @@ def test_mfsdp_non_fused_wgrad_accumulates_in_fp32_per_microbatch():
         optimizer_factory=build_recording_optimizer,
     )
     chunk = chunks[0]
-    assert not hasattr(chunk.linear, "fuse_wgrad_accumulation")
     assert len(chunk.param_sync.buckets) == 1
     spec = chunk.param_sync.buckets[0].specs[0]
     assert spec.shard_param is not None

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -357,6 +357,58 @@ def _mfsdp_cpu_master_devices(optimizer: Any) -> list[str]:
     return sorted({param.device.type for param in cpu_params})
 
 
+def _tensor_role(tensors: list[torch.Tensor]) -> dict[str, Any]:
+    assert tensors
+    devices = sorted({tensor.device.type for tensor in tensors})
+    dtypes = sorted({str(tensor.dtype) for tensor in tensors})
+    numel = sum(tensor.numel() for tensor in tensors)
+    return {
+        "devices": devices,
+        "dtypes": dtypes,
+        "numel": numel,
+        "bytes": sum(tensor.numel() * tensor.element_size() for tensor in tensors),
+    }
+
+
+def _mfsdp_optimizer_byte_ledger(chunks, optimizer: Any) -> dict[str, Any]:
+    inner = optimizer._inner_optimizer
+    buckets = [bucket for chunk in chunks for bucket in chunk.param_sync.buckets]
+    cpu_group = inner.cpu_group
+    param_tensors = [bucket.local_compute_buffer for bucket in buckets]
+    main_grad_tensors = [bucket.main_grad_buffer for bucket in buckets]
+    if cpu_group is None:
+        master_tensors = [bucket.main_param_buffer for bucket in buckets]
+        exp_avg_tensors = [
+            state["exp_avg"]
+            for state in inner.optimizer.state.values()
+            if "exp_avg" in state
+        ]
+        exp_avg_sq_tensors = [
+            state["exp_avg_sq"]
+            for state in inner.optimizer.state.values()
+            if "exp_avg_sq" in state
+        ]
+    else:
+        master_tensors = list(cpu_group._cpu_params)
+        exp_avg_tensors = [
+            state["exp_avg"]
+            for state in cpu_group._cpu_optimizer.state.values()
+            if "exp_avg" in state
+        ]
+        exp_avg_sq_tensors = [
+            state["exp_avg_sq"]
+            for state in cpu_group._cpu_optimizer.state.values()
+            if "exp_avg_sq" in state
+        ]
+    return {
+        "param": _tensor_role(param_tensors),
+        "main_grad": _tensor_role(main_grad_tensors),
+        "master": _tensor_role(master_tensors),
+        "exp_avg": _tensor_role(exp_avg_tensors),
+        "exp_avg_sq": _tensor_role(exp_avg_sq_tensors),
+    }
+
+
 def _profiled_train_step(chunks, optimizer, finalize, x, target):
     optimizer.zero_grad()
     torch.cuda.synchronize()
@@ -450,6 +502,11 @@ def _run_offload_arm(
         ),
         "optimizer_tensor_devices": _optimizer_tensor_devices(optimizer),
         "cpu_master_devices": _mfsdp_cpu_master_devices(optimizer),
+        "optimizer_byte_ledger": (
+            _mfsdp_optimizer_byte_ledger(chunks, optimizer)
+            if backend == "mfsdp"
+            else None
+        ),
         "params": params,
     }
     del optimizer, chunks
@@ -968,6 +1025,28 @@ def test_mfsdp_offload_matrix_matches_fsdp2_precision_speed_and_memory():
             if backend == "mfsdp":
                 assert optimizer_off["cpu_master_devices"] == []
                 assert optimizer_on["cpu_master_devices"] == ["cpu"]
+                off_ledger = optimizer_off["optimizer_byte_ledger"]
+                on_ledger = optimizer_on["optimizer_byte_ledger"]
+                assert off_ledger["param"]["devices"] == ["cuda"]
+                assert off_ledger["param"]["dtypes"] == ["torch.bfloat16"]
+                assert off_ledger["main_grad"]["devices"] == ["cuda"]
+                assert off_ledger["main_grad"]["dtypes"] == ["torch.float32"]
+                for role in ("master", "exp_avg", "exp_avg_sq"):
+                    assert off_ledger[role]["devices"] == ["cuda"]
+                    assert off_ledger[role]["dtypes"] == ["torch.float32"]
+                    assert on_ledger[role]["devices"] == ["cpu"]
+                    assert on_ledger[role]["dtypes"] == ["torch.float32"]
+                assert on_ledger["param"]["devices"] == ["cuda"]
+                assert on_ledger["param"]["dtypes"] == ["torch.bfloat16"]
+                assert on_ledger["main_grad"]["devices"] == ["cuda"]
+                assert on_ledger["main_grad"]["dtypes"] == ["torch.float32"]
+                for ledger in (off_ledger, on_ledger):
+                    assert ledger["param"]["bytes"] == 2 * ledger["param"]["numel"]
+                    assert ledger["main_grad"]["bytes"] == (
+                        4 * ledger["main_grad"]["numel"]
+                    )
+                    for role in ("master", "exp_avg", "exp_avg_sq"):
+                        assert ledger[role]["bytes"] == 4 * ledger[role]["numel"]
         for optimizer_offload in (False, True):
             activation_off = matrix[(backend, optimizer_offload, False)]
             activation_on = matrix[(backend, optimizer_offload, True)]

--- a/experimental/lite/tests/unit/primitive/test_hf_weights_streaming.py
+++ b/experimental/lite/tests/unit/primitive/test_hf_weights_streaming.py
@@ -37,7 +37,8 @@ class _FakeSharded(nn.Module):
         super().__init__()
         for name in names:
             self.register_parameter(
-                name.replace(".", "_"), nn.Parameter(torch.zeros(2), requires_grad=False)
+                name.replace(".", "_"),
+                nn.Parameter(torch.zeros(2), requires_grad=False),
             )
         self._names = list(names)
 
@@ -88,7 +89,9 @@ def test_iter_export_stream_unexpected_name_fails_loud() -> None:
         list(_iter_export_named_parameters(chunk, base))
 
 
-def test_safe_tensor_reader_context_reuses_and_closes_shard(monkeypatch, tmp_path) -> None:
+def test_safe_tensor_reader_context_reuses_and_closes_shard(
+    monkeypatch, tmp_path
+) -> None:
     (tmp_path / "model.safetensors.index.json").write_text(
         json.dumps({"weight_map": {"a": "shard.safetensors", "b": "shard.safetensors"}})
     )
@@ -118,7 +121,9 @@ def test_safe_tensor_reader_context_reuses_and_closes_shard(monkeypatch, tmp_pat
     assert events == ["enter", ("get", "a"), ("get", "b"), "exit"]
 
 
-def test_stream_export_removes_stale_owned_files_when_reusing_directory(tmp_path) -> None:
+def test_stream_export_removes_stale_owned_files_when_reusing_directory(
+    tmp_path,
+) -> None:
     for name in (
         "model.safetensors",
         "model-00001-of-00002.safetensors",
@@ -256,7 +261,9 @@ def test_bucketed_all_gather_uses_bounded_flat_buffers(monkeypatch) -> None:
         output[: tensor.numel()].copy_(tensor)
         output[tensor.numel() :].copy_(tensor + 100)
 
-    monkeypatch.setattr(torch.distributed, "all_gather_into_tensor", fake_all_gather_into_tensor)
+    monkeypatch.setattr(
+        torch.distributed, "all_gather_into_tensor", fake_all_gather_into_tensor
+    )
 
     gathered = bucketed_all_gather_into_tensor(
         bucket,
@@ -328,9 +335,7 @@ def test_fsdp_dtensors_share_one_bounded_flat_collective(monkeypatch) -> None:
         output[: tensor.numel()].copy_(tensor)
         output[tensor.numel() :].copy_(tensor + 100)
 
-    monkeypatch.setattr(
-        "megatron.lite.primitive.ckpt.hf_weights.DTensor", FakeDTensor
-    )
+    monkeypatch.setattr("megatron.lite.primitive.ckpt.hf_weights.DTensor", FakeDTensor)
     monkeypatch.setattr(
         torch.distributed,
         "get_world_size",
@@ -403,9 +408,7 @@ def test_oversized_fsdp_shard_is_gathered_in_shard_dimension_chunks(
         output[: tensor.numel()].copy_(tensor)
         output[tensor.numel() :].copy_(tensor + 100)
 
-    monkeypatch.setattr(
-        "megatron.lite.primitive.ckpt.hf_weights.DTensor", FakeDTensor
-    )
+    monkeypatch.setattr("megatron.lite.primitive.ckpt.hf_weights.DTensor", FakeDTensor)
     monkeypatch.setattr(torch.distributed, "get_world_size", lambda group: 2)
     monkeypatch.setattr(
         torch.distributed, "get_process_group_ranks", lambda group: [0, 1]
@@ -449,9 +452,7 @@ def test_replicated_dtensor_uses_local_tensor_without_collective(monkeypatch) ->
             raise AssertionError("replicated parameters must not call full_tensor")
 
     local = torch.arange(5, dtype=torch.float32)
-    monkeypatch.setattr(
-        "megatron.lite.primitive.ckpt.hf_weights.DTensor", FakeDTensor
-    )
+    monkeypatch.setattr("megatron.lite.primitive.ckpt.hf_weights.DTensor", FakeDTensor)
     monkeypatch.setattr(
         torch.distributed,
         "all_gather_into_tensor",
@@ -474,8 +475,12 @@ def test_export_batches_adjacent_tp_weights_into_one_flat_collective(
     class Model(nn.Module):
         def __init__(self) -> None:
             super().__init__()
-            self.first = nn.Parameter(torch.arange(4, dtype=torch.float32).reshape(2, 2))
-            self.second = nn.Parameter(torch.arange(3, dtype=torch.float32).reshape(1, 3))
+            self.first = nn.Parameter(
+                torch.arange(4, dtype=torch.float32).reshape(2, 2)
+            )
+            self.second = nn.Parameter(
+                torch.arange(3, dtype=torch.float32).reshape(1, 3)
+            )
 
     class Spec:
         num_experts = 0
@@ -513,9 +518,13 @@ def test_export_batches_adjacent_tp_weights_into_one_flat_collective(
         output[: tensor.numel()].copy_(tensor)
         output[tensor.numel() :].copy_(tensor + 10)
 
-    monkeypatch.setattr(torch.distributed, "all_gather_into_tensor", fake_all_gather_into_tensor)
+    monkeypatch.setattr(
+        torch.distributed, "all_gather_into_tensor", fake_all_gather_into_tensor
+    )
 
-    exported = dict(export_hf_weights(Model(), Spec(), ps, cpu=False, buffer_max_size_bytes=1024))
+    exported = dict(
+        export_hf_weights(Model(), Spec(), ps, cpu=False, buffer_max_size_bytes=1024)
+    )
 
     assert len(calls) == 1
     assert torch.equal(
@@ -535,7 +544,9 @@ def test_expert_export_yields_when_bounded_ep_bucket_fills(monkeypatch) -> None:
             for idx in range(2):
                 self.register_parameter(
                     f"weight{idx}",
-                    nn.Parameter(torch.arange(4, dtype=torch.float32) + offset + idx * 10),
+                    nn.Parameter(
+                        torch.arange(4, dtype=torch.float32) + offset + idx * 10
+                    ),
                 )
 
     class Model(nn.Module):
@@ -595,9 +606,7 @@ def test_expert_export_yields_when_bounded_ep_bucket_fills(monkeypatch) -> None:
         torch.distributed, "all_gather_into_tensor", fake_all_gather_into_tensor
     )
 
-    stream = export_hf_weights(
-        Model(), Spec(), ps, cpu=False, buffer_max_size_bytes=64
-    )
+    stream = export_hf_weights(Model(), Spec(), ps, cpu=False, buffer_max_size_bytes=64)
     name, tensor = next(stream)
 
     assert name == "first.experts.packed"
@@ -630,17 +639,31 @@ def test_pp_export_streams_over_nccl_and_matches_materialized(monkeypatch) -> No
         tp_spec = staticmethod(lambda name: None)
         native_to_hf = staticmethod(lambda name, tensor: [(name, tensor)])
 
-    ps = type("ParallelState", (), {
-        "pp_size": 2, "pp_rank": 0, "pp_global_ranks": [0, 1],
-        "tp_size": 1, "tp_group": None, "ep_size": 1, "ep_group": None,
-        "etp_size": 1, "etp_group": None,
-        "pp_group": "nccl-pp", "pp_cpu_group": "gloo-pp",
-    })()
+    ps = type(
+        "ParallelState",
+        (),
+        {
+            "pp_size": 2,
+            "pp_rank": 0,
+            "pp_global_ranks": [0, 1],
+            "tp_size": 1,
+            "tp_group": None,
+            "ep_size": 1,
+            "ep_group": None,
+            "etp_size": 1,
+            "etp_group": None,
+            "pp_group": "nccl-pp",
+            "pp_cpu_group": "gloo-pp",
+        },
+    )()
 
     groups = []
     remote_bias = torch.tensor([3.0, 4.0])
     remote_headers = iter(
-        [[("weight2", (2, 3), torch.float32), ("router_bias2", (2,), torch.float32)], []]
+        [
+            [("weight2", (2, 3), torch.float32), ("router_bias2", (2,), torch.float32)],
+            [],
+        ]
     )
     remote_tensors = iter([remote_weight, remote_bias])
 
@@ -656,8 +679,9 @@ def test_pp_export_streams_over_nccl_and_matches_materialized(monkeypatch) -> No
 
     monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
     monkeypatch.setattr(torch.distributed, "get_rank", lambda group=None: 0)
-    monkeypatch.setattr(torch.distributed, "broadcast_object_list",
-                        fake_broadcast_object_list)
+    monkeypatch.setattr(
+        torch.distributed, "broadcast_object_list", fake_broadcast_object_list
+    )
     monkeypatch.setattr(torch.distributed, "broadcast", fake_broadcast)
 
     exported = dict(export_hf_weights(Model(), Spec(), ps))
@@ -668,7 +692,6 @@ def test_pp_export_streams_over_nccl_and_matches_materialized(monkeypatch) -> No
     assert torch.equal(exported["router_bias"], torch.tensor([1.0, 2.0]))
     assert torch.equal(exported["weight2"], remote_weight)
     assert torch.equal(exported["router_bias2"], remote_bias)
-
 
 
 def test_pp_export_never_materializes_the_whole_stage(monkeypatch) -> None:

--- a/experimental/lite/tests/unit/primitive/test_hf_weights_streaming.py
+++ b/experimental/lite/tests/unit/primitive/test_hf_weights_streaming.py
@@ -23,10 +23,69 @@ if importlib.util.find_spec("safetensors") is None:
 from megatron.lite.primitive.ckpt.hf_weights import (
     SafeTensorReader,
     _iter_bucketed_materialized_tensors,
+    _iter_export_named_parameters,
     bucketed_all_gather_into_tensor,
     export_hf_weights,
     stream_export_to_shards,
 )
+
+
+class _FakeSharded(nn.Module):
+    """Unwrapped chunk: reports the full (sharded) parameter name set cheaply."""
+
+    def __init__(self, names):
+        super().__init__()
+        for name in names:
+            self.register_parameter(
+                name.replace(".", "_"), nn.Parameter(torch.zeros(2), requires_grad=False)
+            )
+        self._names = list(names)
+
+    def named_parameters(self, *args, **kwargs):  # noqa: D401 - test shim
+        return iter([(name, torch.ones(2)) for name in self._names])
+
+
+class _FakeStreamer:
+    """Wrapped chunk exposing a bounded ``stream_full_parameters``."""
+
+    def __init__(self, yielded_names):
+        self._yielded = list(yielded_names)
+
+    def stream_full_parameters(self):
+        for name in self._yielded:
+            yield name, torch.ones(2)
+
+
+def test_iter_export_falls_back_to_named_parameters_without_streamer() -> None:
+    base = _FakeSharded(["decoder.layers.0.self_attn.q_proj.weight", "lm_head.weight"])
+    chunk = base  # no stream_full_parameters attribute
+    out = [name for name, _ in _iter_export_named_parameters(chunk, base)]
+    assert out == ["decoder.layers.0.self_attn.q_proj.weight", "lm_head.weight"]
+
+
+def test_iter_export_stream_covers_bias_passes_completeness_guard() -> None:
+    names = ["decoder.layers.0.mlp.up_proj.weight", "decoder.layers.0.mlp.up_proj.bias"]
+    base = _FakeSharded(names)
+    chunk = _FakeStreamer(names)
+    out = [name for name, _ in _iter_export_named_parameters(chunk, base)]
+    assert sorted(out) == sorted(names)
+
+
+def test_iter_export_stream_dropping_bias_fails_loud() -> None:
+    names = ["decoder.layers.0.mlp.up_proj.weight", "decoder.layers.0.mlp.up_proj.bias"]
+    base = _FakeSharded(names)
+    # A bucket-identity mismatch would drop the bias from the stream entirely.
+    chunk = _FakeStreamer(["decoder.layers.0.mlp.up_proj.weight"])
+    with pytest.raises(RuntimeError, match="truncated weight shard"):
+        list(_iter_export_named_parameters(chunk, base))
+
+
+def test_iter_export_stream_unexpected_name_fails_loud() -> None:
+    names = ["decoder.layers.0.mlp.up_proj.weight"]
+    base = _FakeSharded(names)
+    chunk = _FakeStreamer(names + ["decoder.layers.0.mlp.up_proj.ghost"])
+    with pytest.raises(RuntimeError, match="unexpected="):
+        list(_iter_export_named_parameters(chunk, base))
 
 
 def test_safe_tensor_reader_context_reuses_and_closes_shard(monkeypatch, tmp_path) -> None:

--- a/experimental/lite/tests/unit/primitive/test_hf_weights_streaming.py
+++ b/experimental/lite/tests/unit/primitive/test_hf_weights_streaming.py
@@ -20,14 +20,7 @@ if importlib.util.find_spec("safetensors") is None:
     sys.modules["safetensors"] = safetensors
     sys.modules["safetensors.torch"] = safetensors_torch
 
-from megatron.lite.primitive.ckpt.hf_weights import (
-    SafeTensorReader,
-    _iter_bucketed_materialized_tensors,
-    _iter_export_named_parameters,
-    bucketed_all_gather_into_tensor,
-    export_hf_weights,
-    stream_export_to_shards,
-)
+import megatron.lite.primitive.ckpt.hf_weights as hf_weights
 from megatron.lite.primitive.quantization.qat import QATSpec, apply_qat_to_chunks
 
 
@@ -61,7 +54,7 @@ class _FakeStreamer:
 def test_iter_export_falls_back_to_named_parameters_without_streamer() -> None:
     base = _FakeSharded(["decoder.layers.0.self_attn.q_proj.weight", "lm_head.weight"])
     chunk = base  # no stream_full_parameters attribute
-    out = [name for name, _ in _iter_export_named_parameters(chunk, base)]
+    out = [name for name, _ in hf_weights._iter_export_named_parameters(chunk, base)]
     assert out == ["decoder.layers.0.self_attn.q_proj.weight", "lm_head.weight"]
 
 
@@ -69,7 +62,7 @@ def test_iter_export_stream_covers_bias_passes_completeness_guard() -> None:
     names = ["decoder.layers.0.mlp.up_proj.weight", "decoder.layers.0.mlp.up_proj.bias"]
     base = _FakeSharded(names)
     chunk = _FakeStreamer(names)
-    out = [name for name, _ in _iter_export_named_parameters(chunk, base)]
+    out = [name for name, _ in hf_weights._iter_export_named_parameters(chunk, base)]
     assert sorted(out) == sorted(names)
 
 
@@ -79,7 +72,7 @@ def test_iter_export_stream_dropping_bias_fails_loud() -> None:
     # A bucket-identity mismatch would drop the bias from the stream entirely.
     chunk = _FakeStreamer(["decoder.layers.0.mlp.up_proj.weight"])
     with pytest.raises(RuntimeError, match="truncated weight shard"):
-        list(_iter_export_named_parameters(chunk, base))
+        list(hf_weights._iter_export_named_parameters(chunk, base))
 
 
 def test_iter_export_stream_unexpected_name_fails_loud() -> None:
@@ -87,7 +80,7 @@ def test_iter_export_stream_unexpected_name_fails_loud() -> None:
     base = _FakeSharded(names)
     chunk = _FakeStreamer(names + ["decoder.layers.0.mlp.up_proj.ghost"])
     with pytest.raises(RuntimeError, match="unexpected="):
-        list(_iter_export_named_parameters(chunk, base))
+        list(hf_weights._iter_export_named_parameters(chunk, base))
 
 
 def test_safe_tensor_reader_context_reuses_and_closes_shard(
@@ -115,7 +108,7 @@ def test_safe_tensor_reader_context_reuses_and_closes_shard(
         lambda *args, **kwargs: Handle(),
     )
 
-    with SafeTensorReader(str(tmp_path)) as reader:
+    with hf_weights.SafeTensorReader(str(tmp_path)) as reader:
         assert reader.get_tensor("a").item() == 1
         assert reader.get_tensor("b").item() == 2
 
@@ -135,7 +128,7 @@ def test_stream_export_removes_stale_owned_files_when_reusing_directory(
     unrelated = tmp_path / "README.txt"
     unrelated.write_text("keep")
 
-    stream_export_to_shards(
+    hf_weights.stream_export_to_shards(
         iter([("new", torch.ones(2))]), str(tmp_path), shard_size_bytes=1024
     )
 
@@ -163,7 +156,7 @@ def test_stream_export_flushes_bounded_shards_and_writes_hf_index(
     )
     tensors = [(f"weight_{i}", torch.ones(2, dtype=torch.float32)) for i in range(3)]
 
-    stream_export_to_shards(iter(tensors), str(tmp_path), shard_size_bytes=8)
+    hf_weights.stream_export_to_shards(iter(tensors), str(tmp_path), shard_size_bytes=8)
 
     assert flushed == [(["weight_0"], 8), (["weight_1"], 8), (["weight_2"], 8)]
     index = json.loads((tmp_path / "model.safetensors.index.json").read_text())
@@ -190,7 +183,7 @@ def test_stream_export_nonzero_rank_drains_iterator_for_collectives(
     monkeypatch.setattr(torch.distributed, "get_rank", lambda: 1)
     monkeypatch.setattr(torch.distributed, "barrier", lambda: barriers.append(True))
 
-    stream_export_to_shards(export_iter(), str(tmp_path), shard_size_bytes=4)
+    hf_weights.stream_export_to_shards(export_iter(), str(tmp_path), shard_size_bytes=4)
 
     assert consumed == [0, 1, 2]
     assert barriers == [True]
@@ -198,7 +191,10 @@ def test_stream_export_nonzero_rank_drains_iterator_for_collectives(
 
 
 def test_export_defaults_to_device_resident_tensors() -> None:
-    assert inspect.signature(export_hf_weights).parameters["cpu"].default is False
+    assert (
+        inspect.signature(hf_weights.export_hf_weights).parameters["cpu"].default
+        is False
+    )
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
@@ -240,8 +236,8 @@ def test_gpu_resident_export_is_bitwise_equal_to_legacy_cpu_export() -> None:
     )()
     model = Model()
 
-    legacy = dict(export_hf_weights(model, Spec(), ps, cpu=True))
-    resident = dict(export_hf_weights(model, Spec(), ps))
+    legacy = dict(hf_weights.export_hf_weights(model, Spec(), ps, cpu=True))
+    resident = dict(hf_weights.export_hf_weights(model, Spec(), ps))
 
     assert legacy.keys() == resident.keys()
     assert legacy["weight"].device.type == "cpu"
@@ -266,7 +262,7 @@ def test_bucketed_all_gather_uses_bounded_flat_buffers(monkeypatch) -> None:
         torch.distributed, "all_gather_into_tensor", fake_all_gather_into_tensor
     )
 
-    gathered = bucketed_all_gather_into_tensor(
+    gathered = hf_weights.bucketed_all_gather_into_tensor(
         bucket, group="tp", group_size=2, buffer_max_size_bytes=32
     )
 
@@ -343,7 +339,7 @@ def test_fsdp_dtensors_share_one_bounded_flat_collective(monkeypatch) -> None:
     )
 
     outputs = list(
-        _iter_bucketed_materialized_tensors(
+        hf_weights._iter_bucketed_materialized_tensors(
             [
                 ("first", first),
                 ("plain", torch.tensor([7.0])),
@@ -416,7 +412,7 @@ def test_oversized_fsdp_shard_is_gathered_in_shard_dimension_chunks(
     )
 
     outputs = dict(
-        _iter_bucketed_materialized_tensors(
+        hf_weights._iter_bucketed_materialized_tensors(
             [("oversized", FakeDTensor(local))], buffer_max_size_bytes=32
         )
     )
@@ -454,7 +450,9 @@ def test_replicated_dtensor_uses_local_tensor_without_collective(monkeypatch) ->
     )
 
     outputs = list(
-        _iter_bucketed_materialized_tensors([("replicated", FakeDTensor(local))])
+        hf_weights._iter_bucketed_materialized_tensors(
+            [("replicated", FakeDTensor(local))]
+        )
     )
 
     assert outputs[0][0] == "replicated"
@@ -515,7 +513,9 @@ def test_export_batches_adjacent_tp_weights_into_one_flat_collective(
     )
 
     exported = dict(
-        export_hf_weights(Model(), Spec(), ps, cpu=False, buffer_max_size_bytes=1024)
+        hf_weights.export_hf_weights(
+            Model(), Spec(), ps, cpu=False, buffer_max_size_bytes=1024
+        )
     )
 
     assert len(calls) == 1
@@ -598,7 +598,9 @@ def test_expert_export_yields_when_bounded_ep_bucket_fills(monkeypatch) -> None:
         torch.distributed, "all_gather_into_tensor", fake_all_gather_into_tensor
     )
 
-    stream = export_hf_weights(Model(), Spec(), ps, cpu=False, buffer_max_size_bytes=64)
+    stream = hf_weights.export_hf_weights(
+        Model(), Spec(), ps, cpu=False, buffer_max_size_bytes=64
+    )
     name, tensor = next(stream)
 
     assert name == "first.experts.packed"
@@ -656,7 +658,7 @@ def test_packed_expert_export_rejects_incomplete_group() -> None:
     )()
 
     with pytest.raises(RuntimeError, match=r"experts\.packed.*3/4"):
-        list(export_hf_weights(Model(), Spec(), ps, cpu=True))
+        list(hf_weights.export_hf_weights(Model(), Spec(), ps, cpu=True))
 
 
 def test_pp_export_streams_over_nccl_and_matches_materialized(monkeypatch) -> None:
@@ -725,7 +727,7 @@ def test_pp_export_streams_over_nccl_and_matches_materialized(monkeypatch) -> No
     )
     monkeypatch.setattr(torch.distributed, "broadcast", fake_broadcast)
 
-    exported = dict(export_hf_weights(Model(), Spec(), ps))
+    exported = dict(hf_weights.export_hf_weights(Model(), Spec(), ps))
 
     assert set(groups) == {"nccl-pp"}
     assert exported.keys() == {"weight", "router_bias", "weight2", "router_bias2"}
@@ -767,7 +769,7 @@ def test_persistent_buffer_load_export_mapping_must_match() -> None:
     with pytest.raises(
         RuntimeError, match=r"Spec.*router_bias.*hf\.expected_bias.*hf\.different_bias"
     ):
-        dict(export_hf_weights(Model(), Spec(), ps))
+        dict(hf_weights.export_hf_weights(Model(), Spec(), ps))
 
 
 def test_qat_parametrized_parameter_exports_with_logical_name() -> None:
@@ -807,7 +809,7 @@ def test_qat_parametrized_parameter_exports_with_logical_name() -> None:
     )
 
     assert stats["quantized_modules"] == 1
-    exported = dict(export_hf_weights(model, Spec(), ps))
+    exported = dict(hf_weights.export_hf_weights(model, Spec(), ps))
     assert exported.keys() == {"hf.proj.weight"}
     assert torch.equal(exported["hf.proj.weight"], expected)
 
@@ -884,7 +886,7 @@ def test_pp_export_never_materializes_the_whole_stage(monkeypatch) -> None:
     monkeypatch.setattr(torch.distributed, "broadcast", fake_broadcast)
 
     # buffer_max_size_bytes=1 caps every bucket at a single parameter.
-    stream = export_hf_weights(Model(), Spec(), ps, buffer_max_size_bytes=1)
+    stream = hf_weights.export_hf_weights(Model(), Spec(), ps, buffer_max_size_bytes=1)
     first_name, first_tensor = next(stream)
 
     assert first_name == "weight_a"

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -64,8 +64,11 @@ class _FusedMainGradLinearFunction(torch.autograd.Function):
     def backward(ctx, grad_output):
         value, weight = ctx.saved_tensors
         grad_input = grad_output.matmul(weight)
-        grad_weight = grad_output.float().reshape(-1, grad_output.shape[-1]).t().matmul(
-            value.float().reshape(-1, value.shape[-1])
+        grad_weight = (
+            grad_output.float()
+            .reshape(-1, grad_output.shape[-1])
+            .t()
+            .matmul(value.float().reshape(-1, value.shape[-1]))
         )
         if ctx.fuse_wgrad_accumulation:
             ctx.weight.main_grad.add_(grad_weight)
@@ -1490,6 +1493,7 @@ def test_mfsdp_routes_fused_wgrad_through_bucketed_fp32_main_grad():
     spec = bucket.specs[0]
     assert model.fuse_wgrad_accumulation is True
     assert spec.full_param.grad_added_to_main_grad is True
+    assert spec.full_param.grad is None
     assert spec.full_param.main_grad.dtype is torch.float32
     assert spec.full_param.main_grad.untyped_storage().data_ptr() == (
         bucket.full_main_grad_buffer.untyped_storage().data_ptr()
@@ -1503,6 +1507,7 @@ def test_mfsdp_routes_fused_wgrad_through_bucketed_fp32_main_grad():
 
     second_value = torch.randn(8, 4, dtype=torch.bfloat16)
     chunk(second_value).float().sum().backward()
+    assert spec.full_param.grad is None
     second_expected = second_value.float().sum(dim=0).repeat(4, 1)
     assert spec.full_param.main_grad.untyped_storage().data_ptr() == main_grad_storage
     assert torch.equal(spec.full_param.main_grad, first_main_grad + second_expected)

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -808,6 +808,73 @@ def test_mfsdp_offload_fraction_keeps_optimizer_state_on_cpu():
         assert gpu_param.device.type != "cuda" or gpu_param.data is not None
 
 
+def test_mfsdp_full_offload_has_six_gpu_and_twelve_cpu_bytes_per_param():
+    _Model, _Unit, ps, engine_cfg = _build_offload_stack(offload_fraction=1.0)
+
+    torch.manual_seed(43)
+    model = _Model().to(dtype=torch.bfloat16)
+    chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [model],
+        engine_cfg=engine_cfg,
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_Unit,),
+    )
+
+    value = torch.randn(3, 4, dtype=torch.bfloat16)
+    target = torch.randn(3, 2, dtype=torch.bfloat16)
+    optimizer.zero_grad()
+    torch.nn.functional.mse_loss(chunks[0](value), target).backward()
+    optimizer.finish_grad_sync()
+    success, _grad_norm, _ = optimizer.step()
+    assert success
+
+    inner = optimizer._inner_optimizer
+    cpu_group = inner.cpu_group
+    assert cpu_group is not None
+    total_numel = sum(param.numel() for param in inner.params)
+    buckets = [bucket for chunk in chunks for bucket in chunk.param_sync.buckets]
+    assert all(
+        bucket.local_compute_buffer is bucket.main_param_buffer for bucket in buckets
+    )
+
+    gpu_param_bytes = sum(
+        param.numel() * param.element_size() for param in inner.params
+    )
+    gpu_main_grad_bytes = sum(
+        param.grad.numel() * param.grad.element_size()
+        for param in inner.params
+        if param.grad is not None
+    )
+    cpu_master_bytes = sum(
+        param.numel() * param.element_size() for param in cpu_group._cpu_params
+    )
+    cpu_exp_avg_bytes = sum(
+        cpu_group._cpu_optimizer.state[param]["exp_avg"].numel()
+        * cpu_group._cpu_optimizer.state[param]["exp_avg"].element_size()
+        for param in cpu_group._cpu_params
+    )
+    cpu_exp_avg_sq_bytes = sum(
+        cpu_group._cpu_optimizer.state[param]["exp_avg_sq"].numel()
+        * cpu_group._cpu_optimizer.state[param]["exp_avg_sq"].element_size()
+        for param in cpu_group._cpu_params
+    )
+
+    assert all(param.dtype == torch.bfloat16 for param in inner.params)
+    assert all(
+        param.grad is not None and param.grad.dtype == torch.float32
+        for param in inner.params
+    )
+    assert all(
+        param.device.type == "cpu" and param.dtype == torch.float32
+        for param in cpu_group._cpu_params
+    )
+    assert gpu_param_bytes + gpu_main_grad_bytes == 6 * total_numel
+    assert cpu_master_bytes == 4 * total_numel
+    assert cpu_exp_avg_bytes == 4 * total_numel
+    assert cpu_exp_avg_sq_bytes == 4 * total_numel
+
+
 def test_mfsdp_offload_fraction_numerically_matches_no_offload():
     _Model, _Unit, ps, engine_cfg_offload = _build_offload_stack(offload_fraction=1.0)
     _, _, _, engine_cfg_gpu = _build_offload_stack(offload_fraction=0.0)
@@ -989,11 +1056,27 @@ def test_mfsdp_offload_fraction_checkpoint_round_trips():
     optimizer.finish_grad_sync()
     optimizer.step()
 
-    saved = optimizer.state_dict()
+    saved = copy.deepcopy(optimizer.state_dict())
     assert "gpu" in saved
     assert "cpu" in saved
+    assert "master_params" in saved["cpu"]
+
+    cpu_group = optimizer._inner_optimizer.cpu_group
+    assert cpu_group is not None
+    expected_masters = [
+        param.detach().clone() for param in saved["cpu"]["master_params"]
+    ]
+    with torch.no_grad():
+        for cpu_param, gpu_param in zip(cpu_group._cpu_params, cpu_group._gpu_params):
+            cpu_param.add_(17.0)
+            gpu_param.add_(23.0)
 
     optimizer.load_state_dict(saved)
+    for cpu_param, gpu_param, expected in zip(
+        cpu_group._cpu_params, cpu_group._gpu_params, expected_masters
+    ):
+        assert torch.equal(cpu_param, expected)
+        assert torch.equal(gpu_param, expected.to(dtype=gpu_param.dtype))
 
     optimizer.zero_grad()
     torch.nn.functional.mse_loss(chunks[0](value), target).backward()

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -52,6 +52,44 @@ class _DirectParamModel(torch.nn.Module):
         return torch.nn.functional.linear(hidden, self.projection.weight)
 
 
+class _FusedMainGradLinearFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, value, weight, fuse_wgrad_accumulation):
+        ctx.save_for_backward(value, weight)
+        ctx.weight = weight
+        ctx.fuse_wgrad_accumulation = fuse_wgrad_accumulation
+        return torch.nn.functional.linear(value, weight)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        value, weight = ctx.saved_tensors
+        grad_input = grad_output.matmul(weight)
+        grad_weight = grad_output.float().reshape(-1, grad_output.shape[-1]).t().matmul(
+            value.float().reshape(-1, value.shape[-1])
+        )
+        if ctx.fuse_wgrad_accumulation:
+            ctx.weight.main_grad.add_(grad_weight)
+            ctx.weight.grad_added_to_main_grad = True
+            grad_weight = torch.zeros_like(weight)
+        return grad_input, grad_weight, None
+
+
+class _FusedMainGradLinear(torch.nn.Module):
+    """CPU stand-in for TE's dynamic ``weight.main_grad`` backward contract."""
+
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.randn(4, 4, dtype=torch.bfloat16))
+        self.fuse_wgrad_accumulation = False
+
+    def forward(self, value):
+        return _FusedMainGradLinearFunction.apply(
+            value,
+            self.weight,
+            self.fuse_wgrad_accumulation,
+        )
+
+
 def _optimizer_params(optimizer) -> list[torch.nn.Parameter]:
     return optimizer._inner_optimizer.params
 
@@ -1410,6 +1448,93 @@ def test_mfsdp_keeps_fp32_shards_for_bfloat16_compute_parameters():
     assert all(param.dtype is torch.float32 for param in optimizer_params)
     assert any(not torch.equal(old, new) for old, new in zip(before, optimizer_params))
     assert torch.isfinite(chunks[0](value).float()).all()
+
+
+def test_mfsdp_routes_fused_wgrad_through_bucketed_fp32_main_grad():
+    model = _FusedMainGradLinear()
+    ps = SimpleNamespace(
+        dp_cp_group=None,
+        dp_group=None,
+        ep_dp_group=None,
+        ep_group=None,
+        etp_group=None,
+        tp_group=None,
+        pp_group=None,
+        dp_cp_size=1,
+        expert_dp_size=1,
+    )
+    opt = SimpleNamespace(
+        optimizer="sgd",
+        lr=0.0,
+        weight_decay=0.0,
+        clip_grad=0.0,
+        override_optimizer_config={"mfsdp_sharding_strategy": "optim_grads_params"},
+    )
+    chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [model],
+        engine_cfg=SimpleNamespace(
+            parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1),
+            optimizer=opt,
+        ),
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_FusedMainGradLinear,),
+    )
+
+    chunk = chunks[0]
+    bucket = chunk.param_sync.buckets[0]
+    optimizer.zero_grad()
+    value = torch.randn(8, 4, dtype=torch.bfloat16)
+    chunk(value).float().sum().backward()
+
+    spec = bucket.specs[0]
+    assert model.fuse_wgrad_accumulation is True
+    assert spec.full_param.grad_added_to_main_grad is True
+    assert spec.full_param.main_grad.dtype is torch.float32
+    assert spec.full_param.main_grad.untyped_storage().data_ptr() == (
+        bucket.full_main_grad_buffer.untyped_storage().data_ptr()
+    )
+    assert not torch.equal(
+        spec.full_param.main_grad,
+        spec.full_param.main_grad.to(torch.bfloat16).to(torch.float32),
+    )
+    first_main_grad = spec.full_param.main_grad.detach().clone()
+    main_grad_storage = spec.full_param.main_grad.untyped_storage().data_ptr()
+
+    second_value = torch.randn(8, 4, dtype=torch.bfloat16)
+    chunk(second_value).float().sum().backward()
+    second_expected = second_value.float().sum(dim=0).repeat(4, 1)
+    assert spec.full_param.main_grad.untyped_storage().data_ptr() == main_grad_storage
+    assert torch.equal(spec.full_param.main_grad, first_main_grad + second_expected)
+    expected_main_grad = spec.full_param.main_grad.detach().reshape(-1).clone()
+
+    optimizer.finish_grad_sync()
+    consumed_grad = _optimizer_params(optimizer)[0].grad
+    assert consumed_grad is not None
+    assert consumed_grad.dtype is torch.float32
+    assert torch.equal(consumed_grad, expected_main_grad)
+    assert not torch.equal(
+        consumed_grad,
+        consumed_grad.to(torch.bfloat16).to(torch.float32),
+    )
+
+
+def test_mfsdp_keeps_regular_autograd_grad_as_main_grad_fallback():
+    chunk, optimizer = _single_rank_mfsdp_stack()
+    optimizer.zero_grad()
+    value = torch.randn(3, 4)
+    chunk(value).square().mean().backward()
+    expected = {
+        spec.name: spec.full_param.grad.detach().float().clone()
+        for bucket in chunk.param_sync.buckets
+        for spec in bucket.specs
+    }
+
+    optimizer.finish_grad_sync()
+
+    for name, shard in _optimizer_named_shards(optimizer).items():
+        assert shard.grad is not None
+        assert torch.equal(shard.grad.reshape(-1), expected[name].reshape(-1))
 
 
 def _run_mfsdp_gloo_parity(rank: int, world_size: int, init_file: str) -> None:

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -1042,7 +1042,37 @@ def test_mfsdp_offload_fraction_zero_preserves_optimizer_state_dict_contract():
     optimizer.finish_grad_sync()
     optimizer.step()
 
-    assert optimizer.state_dict().keys() == {"state", "param_groups"}
+    assert optimizer.state_dict().keys() == {
+        "state",
+        "param_groups",
+        "_mfsdp_param_values",
+    }
+
+
+def test_mfsdp_optimizer_checkpoint_round_trips_fp32_shard_values():
+    _Model, _Unit, ps, engine_cfg = _build_offload_stack(offload_fraction=0.0)
+
+    torch.manual_seed(11)
+    _chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [_Model()],
+        engine_cfg=engine_cfg,
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_Unit,),
+    )
+    expected = [param.detach().clone() for param in _optimizer_params(optimizer)]
+    saved = copy.deepcopy(optimizer.state_dict())
+
+    with torch.no_grad():
+        for param in _optimizer_params(optimizer):
+            param.add_(17.0)
+
+    optimizer.load_state_dict(saved)
+
+    for param, expected_param in zip(
+        _optimizer_params(optimizer), expected, strict=True
+    ):
+        assert torch.equal(param, expected_param)
 
 
 @pytest.mark.parametrize("offload_fraction", [-0.01, 1.01])

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -93,6 +93,17 @@ class _FusedMainGradLinear(torch.nn.Module):
         )
 
 
+class _RegularMainGradLinear(torch.nn.Module):
+    """Non-TE linear used to exercise the autograd gradient fallback."""
+
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.ones(4, 4, dtype=torch.bfloat16))
+
+    def forward(self, value):
+        return torch.nn.functional.linear(value, self.weight)
+
+
 def _optimizer_params(optimizer) -> list[torch.nn.Parameter]:
     return optimizer._inner_optimizer.params
 
@@ -1524,22 +1535,82 @@ def test_mfsdp_routes_fused_wgrad_through_bucketed_fp32_main_grad():
     )
 
 
-def test_mfsdp_keeps_regular_autograd_grad_as_main_grad_fallback():
+def test_mfsdp_routes_regular_autograd_grad_through_fp32_main_grad():
     chunk, optimizer = _single_rank_mfsdp_stack()
     optimizer.zero_grad()
     value = torch.randn(3, 4)
     chunk(value).square().mean().backward()
     expected = {
-        spec.name: spec.full_param.grad.detach().float().clone()
+        spec.name: spec.full_param.main_grad.detach().clone()
         for bucket in chunk.param_sync.buckets
         for spec in bucket.specs
     }
+    for bucket in chunk.param_sync.buckets:
+        for spec in bucket.specs:
+            assert spec.full_param.grad is None
+            assert spec.full_param.main_grad.dtype is torch.float32
 
     optimizer.finish_grad_sync()
 
     for name, shard in _optimizer_named_shards(optimizer).items():
         assert shard.grad is not None
         assert torch.equal(shard.grad.reshape(-1), expected[name].reshape(-1))
+
+
+def test_mfsdp_accumulates_regular_wgrad_in_fp32_per_microbatch():
+    model = _RegularMainGradLinear()
+    ps = SimpleNamespace(
+        dp_cp_group=None,
+        dp_group=None,
+        ep_dp_group=None,
+        ep_group=None,
+        etp_group=None,
+        tp_group=None,
+        pp_group=None,
+        dp_cp_size=1,
+        expert_dp_size=1,
+    )
+    opt = SimpleNamespace(
+        optimizer="sgd",
+        lr=0.0,
+        weight_decay=0.0,
+        clip_grad=0.0,
+        override_optimizer_config={"mfsdp_sharding_strategy": "optim_grads_params"},
+    )
+    chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [model],
+        engine_cfg=SimpleNamespace(
+            parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1),
+            optimizer=opt,
+        ),
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_RegularMainGradLinear,),
+    )
+
+    chunk = chunks[0]
+    bucket = chunk.param_sync.buckets[0]
+    spec = bucket.specs[0]
+    optimizer.zero_grad()
+
+    chunk(torch.full((1, 4), 256.0, dtype=torch.bfloat16)).sum().backward()
+    assert spec.full_param.grad is None
+    assert torch.equal(spec.full_param.main_grad, torch.full((4, 4), 256.0))
+
+    chunk(torch.ones(1, 4, dtype=torch.bfloat16)).sum().backward()
+    assert spec.full_param.grad is None
+    expected = torch.full((4, 4), 257.0)
+    assert torch.equal(spec.full_param.main_grad, expected)
+    assert not torch.equal(
+        spec.full_param.main_grad,
+        spec.full_param.main_grad.to(torch.bfloat16).to(torch.float32),
+    )
+
+    optimizer.finish_grad_sync()
+    consumed_grad = _optimizer_params(optimizer)[0].grad
+    assert consumed_grad is not None
+    assert consumed_grad.dtype is torch.float32
+    assert torch.equal(consumed_grad, expected.reshape(-1))
 
 
 def _run_mfsdp_gloo_parity(rank: int, world_size: int, init_file: str) -> None:

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -1,0 +1,1504 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from __future__ import annotations
+
+import ast
+import copy
+import inspect
+import os
+from pathlib import Path
+import subprocess
+import sys
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from megatron.lite.primitive.optimizers.mfsdp import config as mfsdp_config
+from megatron.lite.primitive.optimizers.mfsdp import buffer as mfsdp_buffer
+from megatron.lite.primitive.optimizers.mfsdp import optimizer as mfsdp_optimizer
+from megatron.lite.runtime.contracts.config import ParallelConfig
+
+
+class _GlooUnit(torch.nn.Module):
+    def __init__(self, in_features: int, out_features: int):
+        super().__init__()
+        self.linear = torch.nn.Linear(in_features, out_features, bias=False)
+
+    def forward(self, value):
+        return torch.nn.functional.gelu(self.linear(value))
+
+
+class _GlooModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.unit0 = _GlooUnit(4, 5)
+        self.unit1 = _GlooUnit(5, 3)
+        self.out = torch.nn.Linear(3, 2, bias=False)
+
+    def forward(self, value):
+        return self.out(self.unit1(self.unit0(value)))
+
+
+class _DirectParamModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.unit = _GlooUnit(4, 4)
+        self.projection = torch.nn.Linear(4, 3, bias=False)
+
+    def forward(self, value):
+        hidden = self.unit(value)
+        return torch.nn.functional.linear(hidden, self.projection.weight)
+
+
+def _optimizer_params(optimizer) -> list[torch.nn.Parameter]:
+    return optimizer._inner_optimizer.params
+
+
+def _optimizer_named_shards(optimizer) -> dict[str, torch.nn.Parameter]:
+    result = {}
+    for chunk in optimizer._model_chunks:
+        for bucket in chunk.param_sync.buckets:
+            for spec in bucket.specs:
+                assert spec.shard_param is not None
+                result[spec.name] = spec.shard_param
+    return result
+
+
+def test_mfsdp_zero_grad_supports_fused_optimizer_contract():
+    class NoArgZeroGradOptimizer:
+        def __init__(self):
+            self.called = False
+
+        def zero_grad(self):
+            self.called = True
+
+    fused_optimizer = NoArgZeroGradOptimizer()
+    adapter = mfsdp_optimizer._StandaloneOptimizer(
+        fused_optimizer,
+        [],
+        ps=SimpleNamespace(),
+        clip_grad=0.0,
+        grad_norm_accum_dtype=torch.float32,
+        expert_params=[],
+        expert_grad_scale=1.0,
+    )
+
+    adapter.zero_grad()
+
+    assert fused_optimizer.called is True
+
+
+def test_mfsdp_has_no_megatron_core_imports():
+    package = Path(mfsdp_config.__file__).parent
+    violations = []
+    for source_path in package.rglob("*.py"):
+        tree = ast.parse(source_path.read_text(), filename=str(source_path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                modules = [alias.name for alias in node.names]
+            elif isinstance(node, ast.ImportFrom):
+                modules = [node.module or ""]
+            else:
+                continue
+            for module in modules:
+                if module == "megatron.core" or module.startswith("megatron.core."):
+                    relative_path = source_path.relative_to(package)
+                    violations.append(f"{relative_path}:{node.lineno}: {module}")
+
+    assert violations == []
+
+
+def test_mfsdp_standalone_smoke_has_no_megatron_core_imports():
+    smoke_path = (
+        Path(__file__).parents[2] / "smoke" / "primitive" / "test_mfsdp_parity_smoke.py"
+    )
+    tree = ast.parse(smoke_path.read_text(), filename=str(smoke_path))
+    violations = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules = [alias.name for alias in node.names]
+        elif isinstance(node, ast.ImportFrom):
+            modules = [node.module or ""]
+        else:
+            continue
+        for module in modules:
+            if module == "megatron.core" or module.startswith("megatron.core."):
+                violations.append(f"{smoke_path.name}:{node.lineno}: {module}")
+
+    assert violations == []
+
+
+def test_mfsdp_full_parallel_signoff_is_single_node_50_step_curve():
+    tests_root = Path(__file__).parents[2]
+    smoke_path = tests_root / "smoke" / "primitive" / "test_mfsdp_parity_smoke.py"
+    smoke_source = smoke_path.read_text()
+    smoke_tree = ast.parse(smoke_source, filename=str(smoke_path))
+    constants = {}
+    for node in smoke_tree.body:
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        if isinstance(target, ast.Name) and isinstance(node.value, ast.Constant):
+            constants[target.id] = node.value.value
+
+    assert constants["_FULL_PARALLEL_WORLD_SIZE"] == 8
+    assert constants["_FULL_PARALLEL_STEPS"] == 50
+    assert constants["_FULL_PARALLEL_CURVE_INTERVAL"] == 10
+    assert "[MFSDP_FULL_PARALLEL_CURVE]" in smoke_source
+    assert "batch_seed=8345 + step" in smoke_source
+
+    runner_source = (tests_root / "run_mfsdp_hopper_validation.sh").read_text()
+    assert "full-parallel mode requires NNODES=1 and NPROC_PER_NODE=8." in runner_source
+
+
+def test_mfsdp_is_standalone_without_vendored_mcore_or_fsdp2_dependencies():
+    package = Path(mfsdp_config.__file__).parent
+
+    assert not list((package / "impl").glob("*.py")), (
+        "Do not vendor the MCore FSDP implementation."
+    )
+    violations = []
+    for source_path in package.rglob("*.py"):
+        tree = ast.parse(source_path.read_text(), filename=str(source_path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                modules = [alias.name for alias in node.names]
+            elif isinstance(node, ast.ImportFrom):
+                modules = [node.module or ""]
+            else:
+                continue
+            for module in modules:
+                if module.startswith("megatron.") and not module.startswith(
+                    "megatron.lite.primitive.optimizers.mfsdp"
+                ):
+                    relative_path = source_path.relative_to(package)
+                    violations.append(f"{relative_path}:{node.lineno}: {module}")
+
+    assert violations == []
+
+
+def test_mfsdp_source_layout_is_bounded():
+    package = Path(mfsdp_config.__file__).parent
+    modules = {path.name for path in package.glob("*.py")}
+
+    assert modules == {
+        "__init__.py",
+        "backend.py",
+        "buffer.py",
+        "config.py",
+        "cpu_offload.py",
+        "fully_shard.py",
+        "fused_ops.py",
+        "grad_norm.py",
+        "optimizer.py",
+        "wrapper.py",
+    }
+    assert len(modules) <= 10
+    assert not (package / "impl").exists()
+
+
+def test_mfsdp_primitive_has_no_model_specific_knowledge():
+    package = Path(mfsdp_config.__file__).parent
+    violations = []
+    for source_path in package.rglob("*.py"):
+        source = source_path.read_text()
+        for forbidden in ("_SUPPORTED_MODELS", "model_name", "Qwen3", "qwen3"):
+            if forbidden in source:
+                relative_path = source_path.relative_to(package)
+                violations.append(f"{relative_path}: {forbidden}")
+
+    assert violations == []
+    assert (
+        "model_name"
+        not in inspect.signature(
+            mfsdp_optimizer.build_mfsdp_training_optimizer
+        ).parameters
+    )
+
+
+def test_mfsdp_config_validation_does_not_require_or_filter_model_name():
+    engine_cfg = _engine_cfg()
+    mfsdp_config.validate_mfsdp_config(engine_cfg)
+
+    engine_cfg.model_name = "arbitrary_2d_transformer"
+    mfsdp_config.validate_mfsdp_config(engine_cfg)
+
+
+def test_mfsdp_reference_rewrite_modules_are_live():
+    package = Path(mfsdp_config.__file__).parent
+    required_modules = {
+        "buffer.py",
+        "config.py",
+        "cpu_offload.py",
+        "fully_shard.py",
+        "fused_ops.py",
+        "grad_norm.py",
+        "optimizer.py",
+        "wrapper.py",
+    }
+    missing = sorted(
+        name for name in required_modules if not (package / name).is_file()
+    )
+    assert missing == []
+
+    # These are production edges, not files kept alive only by tests.  The
+    # optimizer constructs the wrapper, and the wrapper owns the M-FSDP buffer
+    # plus both communication pipelines.
+    optimizer_source = (package / "optimizer.py").read_text()
+    wrapper_source = (package / "wrapper.py").read_text()
+    assert "mfsdp.wrapper" in optimizer_source
+    assert "ParamAndGradBuffer" in wrapper_source
+    assert "AllGatherPipeline" in wrapper_source
+    assert "GradReducePipeline" in wrapper_source
+
+
+def test_mfsdp_has_no_legacy_test_only_production_surface():
+    package = Path(mfsdp_config.__file__).parent
+    forbidden_top_level = {
+        "config.py": {
+            "_collect_mfsdp_overrides",
+            "_distributed_optimizer_instance_override",
+            "_validate_ddp_knob_value",
+            "coerce_dtype",
+            "split_mfsdp_overrides",
+            "validate_mfsdp_topology_optimizer_combo",
+        },
+        "grad_norm.py": {
+            "CanonicalGradNormMegatronFSDPOptimizer",
+            "GradNormBreakdown",
+            "_clip_mfsdp_grads_by_total_norm",
+            "_leaf_optimizers",
+            "_sum_if_distributed",
+            "_unique_parameters",
+            "compute_mfsdp_grad_norm",
+        },
+        "optimizer.py": {
+            "_default_expert_classifier",
+            "finalize_mfsdp_grads",
+        },
+    }
+    forbidden_methods = {
+        "optimizer.py": {"sync_model_weights_to_main_weights"},
+    }
+
+    violations = []
+    for module_name, names in forbidden_top_level.items():
+        tree = ast.parse((package / module_name).read_text())
+        defined = {
+            node.name
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef | ast.ClassDef)
+        }
+        violations.extend(
+            f"test-only definition: {module_name}:{name}"
+            for name in sorted(defined & names)
+        )
+    for module_name, names in forbidden_methods.items():
+        tree = ast.parse((package / module_name).read_text())
+        defined = {
+            child.name
+            for node in tree.body
+            if isinstance(node, ast.ClassDef)
+            for child in node.body
+            if isinstance(child, ast.FunctionDef)
+        }
+        violations.extend(
+            f"test-only method: {module_name}:{name}"
+            for name in sorted(defined & names)
+        )
+
+    stack_params = inspect.signature(mfsdp_optimizer.build_mfsdp_stack).parameters
+    training_params = inspect.signature(
+        mfsdp_optimizer.build_mfsdp_training_optimizer
+    ).parameters
+    for name in ("model_cfg", "proto", "skip_fsdp_wrap"):
+        if name in stack_params:
+            violations.append(f"unused build_mfsdp_stack argument: {name}")
+    for name in ("model_cfg", "deterministic"):
+        if name in training_params:
+            violations.append(f"unused build_mfsdp_training_optimizer argument: {name}")
+
+    assert violations == []
+
+
+def test_mfsdp_imports_when_megatron_core_is_blocked():
+    script = """
+import builtins
+original_import = builtins.__import__
+def guarded_import(name, *args, **kwargs):
+    forbidden = (
+        name == 'megatron.core'
+        or name.startswith('megatron.core.')
+        or name == 'megatron.lite.primitive.optimizers.fsdp2'
+        or name.startswith('megatron.lite.primitive.optimizers.fsdp2.')
+    )
+    if forbidden:
+        raise RuntimeError(f'forbidden import: {name}')
+    return original_import(name, *args, **kwargs)
+builtins.__import__ = guarded_import
+import megatron.lite.primitive.optimizers.mfsdp
+"""
+    subprocess.run([sys.executable, "-c", script], check=True)
+
+
+def _engine_cfg(**overrides):
+    cfg = SimpleNamespace(
+        parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1),
+        optimizer=SimpleNamespace(optimizer="adam", override_optimizer_config={}),
+    )
+    for key, value in overrides.items():
+        setattr(cfg, key, value)
+    return cfg
+
+
+def test_mfsdp_config_rejects_unsupported_optimizer():
+    engine_cfg = _engine_cfg(
+        optimizer=SimpleNamespace(optimizer="adamw", override_optimizer_config={})
+    )
+    with pytest.raises(ValueError, match="adam/sgd"):
+        mfsdp_config.validate_mfsdp_config(engine_cfg)
+
+
+def test_mfsdp_accepts_an_optional_optimizer_factory():
+    model = _GlooModel()
+    ps = SimpleNamespace(
+        dp_cp_group=None,
+        dp_group=None,
+        ep_dp_group=None,
+        ep_group=None,
+        etp_group=None,
+        tp_group=None,
+        pp_group=None,
+        dp_cp_size=1,
+        expert_dp_size=1,
+    )
+    opt = SimpleNamespace(
+        optimizer="muon",
+        lr=1.0e-3,
+        weight_decay=0.0,
+        clip_grad=1.0,
+        override_optimizer_config={"mfsdp_sharding_strategy": "optim_grads_params"},
+    )
+    calls = []
+
+    def optimizer_factory(param_groups, optimizer_config):
+        calls.append((param_groups, optimizer_config))
+        return torch.optim.SGD(param_groups, lr=optimizer_config.lr)
+
+    chunks = [model]
+    optimizer, finalize_grads = mfsdp_optimizer.build_mfsdp_training_optimizer(
+        chunks,
+        impl_cfg=SimpleNamespace(
+            parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1),
+            optimizer_config=opt,
+        ),
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_GlooUnit,),
+        optimizer_factory=optimizer_factory,
+    )
+
+    assert len(calls) == 1
+    assert calls[0][1] is opt
+    assert isinstance(optimizer._inner_optimizer.optimizer, torch.optim.SGD)
+    finalize_grads()
+
+
+def test_mfsdp_config_enables_double_buffer_for_nccl_user_buffers():
+    config = mfsdp_config.build_mfsdp_config(
+        SimpleNamespace(
+            override_optimizer_config={
+                "mfsdp_sharding_strategy": "optim_grads_params",
+                "nccl_ub": True,
+            }
+        )
+    )
+
+    assert config.nccl_ub is True
+    assert config.fsdp_double_buffer is True
+
+
+def test_mfsdp_nccl_user_buffer_falls_back_when_apex_is_missing(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+
+    def missing_apex(_name):
+        raise ImportError("optional allocator missing")
+
+    monkeypatch.setattr(mfsdp_buffer.importlib, "import_module", missing_apex)
+    user_buffer = mfsdp_buffer.NCCLUserBuffer(
+        enabled=True,
+        groups=(),
+        symmetric=True,
+    )
+
+    assert user_buffer.active is False
+
+
+def test_mfsdp_parallel_metadata_uses_topology_and_explicit_classifier():
+    model = torch.nn.Module()
+    model.dense_matrix = torch.nn.Parameter(torch.ones(4, 4))
+    model.routed_matrix = torch.nn.Parameter(torch.ones(4, 4))
+    model.replicated_matrix = torch.nn.Parameter(torch.ones(4, 4))
+    model.replicated_matrix.average_gradients_across_tp_domain = True
+
+    mfsdp_optimizer._mark_mfsdp_parallel_attrs(
+        model,
+        lambda name: name == "routed_matrix",
+        tp_size=2,
+        etp_size=1,
+    )
+
+    assert model.dense_matrix.tensor_model_parallel is True
+    assert model.routed_matrix.tensor_model_parallel is False
+    assert model.routed_matrix.allreduce is False
+    assert model.replicated_matrix.tensor_model_parallel is False
+
+
+def test_mfsdp_marks_sequence_parallel_shards_for_tp_gradient_sync():
+    model = _GlooModel()
+    model.sp_params = [model.out.weight]
+    ps = SimpleNamespace(
+        dp_cp_group=None,
+        dp_group=None,
+        ep_dp_group=None,
+        ep_group=None,
+        etp_group=None,
+        tp_group=None,
+        pp_group=None,
+        dp_cp_size=1,
+        expert_dp_size=1,
+    )
+    opt = SimpleNamespace(
+        optimizer="adam",
+        lr=1.0e-3,
+        min_lr=0.0,
+        weight_decay=0.0,
+        clip_grad=1.0,
+        adam_beta1=0.9,
+        adam_beta2=0.999,
+        adam_eps=1.0e-8,
+        override_optimizer_config={"mfsdp_sharding_strategy": "optim_grads_params"},
+    )
+
+    _chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [model],
+        engine_cfg=SimpleNamespace(
+            parallel=ParallelConfig(tp=2, ep=1, etp=1, pp=1, vpp=1, cp=1),
+            optimizer=opt,
+        ),
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_GlooUnit,),
+    )
+
+    out_shard = _optimizer_named_shards(optimizer)["out.weight"]
+    assert out_shard.sequence_parallel is True
+    assert out_shard.tensor_model_parallel is False
+    assert optimizer._inner_optimizer.tp_replicated_params == [out_shard]
+
+
+def test_mfsdp_syncs_average_gradients_across_tp_domain_params(monkeypatch):
+    vision_param = torch.nn.Parameter(torch.ones(1))
+    vision_param.average_gradients_across_tp_domain = True
+    vision_param.grad = torch.ones(1)
+    tp_group = object()
+    reduced = []
+
+    def record_grad_reduction(grad, group, *, average=False):
+        reduced.append((grad, group, average))
+
+    monkeypatch.setattr(
+        mfsdp_optimizer, "_all_reduce_grad_if_distributed", record_grad_reduction
+    )
+    adapter = mfsdp_optimizer._StandaloneOptimizer(
+        torch.optim.SGD([vision_param], lr=0.0),
+        [vision_param],
+        ps=SimpleNamespace(
+            dp_cp_group=None,
+            dp_group=None,
+            ep_dp_group=None,
+            ep_group=None,
+            etp_group=None,
+            tp_group=tp_group,
+            pp_group=None,
+        ),
+        clip_grad=0.0,
+        grad_norm_accum_dtype=torch.float32,
+        expert_params=[],
+        expert_grad_scale=1.0,
+    )
+
+    adapter.step()
+
+    assert adapter.tp_replicated_params == [vision_param]
+    assert reduced == [(vision_param.grad, tp_group, True)]
+
+
+def test_mfsdp_tp_gradient_average_divides_the_collective_sum(monkeypatch):
+    grad = torch.ones(2)
+    group = object()
+
+    monkeypatch.setattr(dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(dist, "get_world_size", lambda _group: 2)
+    monkeypatch.setattr(
+        dist,
+        "all_reduce",
+        lambda value, *, op, group: value.mul_(2.0),
+    )
+
+    mfsdp_optimizer._all_reduce_grad_if_distributed(grad, group, average=True)
+
+    assert torch.equal(grad, torch.ones_like(grad))
+
+
+def test_mfsdp_standalone_step_covers_tp_and_expert_norm_domains(monkeypatch):
+    dense = torch.nn.Parameter(torch.ones(1))
+    dense.grad = torch.ones(1)
+    tp_replicated = torch.nn.Parameter(torch.ones(1))
+    tp_replicated.sequence_parallel = True
+    tp_replicated.grad = torch.ones(1)
+    expert = torch.nn.Parameter(torch.ones(1))
+    expert.grad = torch.ones(1)
+    ps = SimpleNamespace(
+        dp_cp_group="dense_dp",
+        dp_group=None,
+        ep_dp_group="expert_dp",
+        ep_group="expert",
+        etp_group="expert_tp",
+        tp_group="tensor",
+        pp_group="pipeline",
+    )
+    scalar_reductions = []
+    grad_reductions = []
+
+    def record_scalar_reduction(_value, group):
+        scalar_reductions.append(group)
+
+    def record_grad_reduction(grad, group, *, average=False):
+        grad_reductions.append(group)
+        grad.mul_(2.0)
+
+    monkeypatch.setattr(mfsdp_optimizer, "_sum_if_distributed", record_scalar_reduction)
+    monkeypatch.setattr(
+        mfsdp_optimizer, "_all_reduce_grad_if_distributed", record_grad_reduction
+    )
+    adapter = mfsdp_optimizer._StandaloneOptimizer(
+        torch.optim.SGD([dense, tp_replicated, expert], lr=0.0),
+        [dense, tp_replicated, expert],
+        ps=ps,
+        clip_grad=0.0,
+        grad_norm_accum_dtype=torch.float32,
+        expert_params=[expert],
+        expert_grad_scale=1.0,
+    )
+
+    success, grad_norm, _ = adapter.step()
+
+    assert success
+    assert grad_norm == pytest.approx((1.0 + 4.0 + 1.0) ** 0.5)
+    assert grad_reductions == ["tensor"]
+    assert scalar_reductions == [
+        "dense_dp",
+        "tensor",
+        "dense_dp",
+        "expert_dp",
+        "expert_tp",
+        "expert",
+        "pipeline",
+    ]
+
+
+def test_mfsdp_cpu_single_rank_matches_torch_adamw_optimizer_step():
+    class _Unit(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(4, 4, bias=False)
+
+        def forward(self, value):
+            return torch.nn.functional.gelu(self.linear(value))
+
+    class _Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.unit0 = _Unit()
+            self.unit1 = _Unit()
+            self.out = torch.nn.Linear(4, 2, bias=False)
+
+        def forward(self, value):
+            return self.out(self.unit1(self.unit0(value)))
+
+    torch.manual_seed(123)
+    reference = _Model()
+    candidate = copy.deepcopy(reference)
+    ps = SimpleNamespace(
+        dp_cp_group=None,
+        dp_group=None,
+        ep_dp_group=None,
+        ep_group=None,
+        tp_group=None,
+        pp_group=None,
+        dp_cp_size=1,
+        expert_dp_size=1,
+    )
+    opt = SimpleNamespace(
+        optimizer="adam",
+        lr=1.0e-3,
+        min_lr=0.0,
+        weight_decay=0.0,
+        clip_grad=1000.0,
+        adam_beta1=0.9,
+        adam_beta2=0.999,
+        adam_eps=1.0e-8,
+        override_optimizer_config={"mfsdp_sharding_strategy": "optim_grads_params"},
+    )
+    engine_cfg = SimpleNamespace(
+        parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1),
+        optimizer=opt,
+    )
+
+    reference_optimizer = torch.optim.AdamW(
+        reference.parameters(),
+        lr=opt.lr,
+        betas=(opt.adam_beta1, opt.adam_beta2),
+        eps=opt.adam_eps,
+        weight_decay=opt.weight_decay,
+        foreach=False,
+    )
+    chunks, candidate_optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [candidate],
+        engine_cfg=engine_cfg,
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_Unit,),
+    )
+
+    value = torch.randn(3, 4)
+    target = torch.randn(3, 2)
+    reference_optimizer.zero_grad()
+    torch.nn.functional.mse_loss(reference(value), target).backward()
+
+    candidate_optimizer.zero_grad()
+    torch.nn.functional.mse_loss(chunks[0](value), target).backward()
+    candidate_optimizer.finish_grad_sync()
+
+    reference_grads = {
+        name: param.grad.detach().reshape(-1)
+        for name, param in reference.named_parameters()
+    }
+    candidate_grads = {
+        name: param.grad.detach().reshape(-1)
+        for name, param in _optimizer_named_shards(candidate_optimizer).items()
+    }
+    assert reference_grads.keys() == candidate_grads.keys()
+    for name, reference_grad in reference_grads.items():
+        assert torch.equal(reference_grad, candidate_grads[name]), name
+
+    reference_optimizer.step()
+    success, _grad_norm, _num_zeros = candidate_optimizer.step()
+    assert success
+
+    reference_params = dict(reference.named_parameters())
+    candidate_params = {
+        name.removeprefix("module."): param
+        for name, param in chunks[0].named_parameters()
+    }
+    assert reference_params.keys() == candidate_params.keys()
+    for name, reference_param in reference_params.items():
+        assert torch.equal(reference_param, candidate_params[name]), name
+
+    saved_model = {
+        name: value.clone() for name, value in chunks[0].state_dict().items()
+    }
+    with torch.no_grad():
+        for param in chunks[0].parameters():
+            param.add_(7.0)
+    chunks[0].load_state_dict(saved_model)
+    restored_model = chunks[0].state_dict()
+    assert saved_model.keys() == restored_model.keys()
+    for name, value in saved_model.items():
+        assert torch.equal(value, restored_model[name]), name
+
+
+def _build_offload_stack(offload_fraction: float):
+    class _Unit(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(4, 4, bias=False)
+
+        def forward(self, value):
+            return torch.nn.functional.gelu(self.linear(value))
+
+    class _Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.unit0 = _Unit()
+            self.unit1 = _Unit()
+            self.out = torch.nn.Linear(4, 2, bias=False)
+
+        def forward(self, value):
+            return self.out(self.unit1(self.unit0(value)))
+
+    ps = SimpleNamespace(
+        dp_cp_group=None,
+        dp_group=None,
+        ep_dp_group=None,
+        ep_group=None,
+        tp_group=None,
+        pp_group=None,
+        dp_cp_size=1,
+        expert_dp_size=1,
+    )
+    opt = SimpleNamespace(
+        optimizer="adam",
+        lr=1.0e-3,
+        min_lr=0.0,
+        weight_decay=0.0,
+        clip_grad=1000.0,
+        adam_beta1=0.9,
+        adam_beta2=0.999,
+        adam_eps=1.0e-8,
+        offload_fraction=offload_fraction,
+        override_optimizer_config={"mfsdp_sharding_strategy": "optim_grads_params"},
+    )
+    engine_cfg = SimpleNamespace(
+        parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1),
+        optimizer=opt,
+    )
+    return _Model, _Unit, ps, engine_cfg
+
+
+def test_mfsdp_offload_fraction_keeps_optimizer_state_on_cpu():
+    _Model, _Unit, ps, engine_cfg = _build_offload_stack(offload_fraction=1.0)
+
+    torch.manual_seed(42)
+    chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [_Model()],
+        engine_cfg=engine_cfg,
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_Unit,),
+    )
+
+    value = torch.randn(3, 4)
+    target = torch.randn(3, 2)
+    optimizer.zero_grad()
+    torch.nn.functional.mse_loss(chunks[0](value), target).backward()
+    optimizer.finish_grad_sync()
+    success, _grad_norm, _ = optimizer.step()
+    assert success
+
+    inner = optimizer._inner_optimizer
+    cpu_group = inner.cpu_group
+    assert cpu_group is not None, (
+        "Expected cpu_group to be set for offload_fraction=1.0"
+    )
+
+    for cpu_p in cpu_group._cpu_params:
+        assert cpu_p.device.type == "cpu", "cpu_param should be on CPU"
+    cpu_opt_state = cpu_group._cpu_optimizer.state
+    for cpu_p in cpu_group._cpu_params:
+        if cpu_p in cpu_opt_state:
+            state = cpu_opt_state[cpu_p]
+            assert state["exp_avg"].device.type == "cpu"
+            assert state["exp_avg_sq"].device.type == "cpu"
+
+    for gpu_param in inner.params:
+        assert gpu_param.device.type != "cuda" or gpu_param.data is not None
+
+
+def test_mfsdp_offload_fraction_numerically_matches_no_offload():
+    _Model, _Unit, ps, engine_cfg_offload = _build_offload_stack(offload_fraction=1.0)
+    _, _, _, engine_cfg_gpu = _build_offload_stack(offload_fraction=0.0)
+
+    torch.manual_seed(77)
+    model_ref = _Model()
+    model_cpu = copy.deepcopy(model_ref)
+
+    chunks_ref, opt_ref = mfsdp_optimizer.build_mfsdp_stack(
+        [model_ref],
+        engine_cfg=engine_cfg_gpu,
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_Unit,),
+    )
+    chunks_cpu, opt_cpu = mfsdp_optimizer.build_mfsdp_stack(
+        [model_cpu],
+        engine_cfg=engine_cfg_offload,
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_Unit,),
+    )
+
+    value = torch.randn(3, 4)
+    target = torch.randn(3, 2)
+
+    opt_ref.zero_grad()
+    torch.nn.functional.mse_loss(chunks_ref[0](value), target).backward()
+    opt_ref.finish_grad_sync()
+    success_ref, _norm_ref, _ = opt_ref.step()
+    assert success_ref
+
+    opt_cpu.zero_grad()
+    torch.nn.functional.mse_loss(chunks_cpu[0](value), target).backward()
+    opt_cpu.finish_grad_sync()
+    success_cpu, _norm_cpu, _ = opt_cpu.step()
+    assert success_cpu
+
+    ref_params = {
+        name.removeprefix("module."): param
+        for name, param in chunks_ref[0].named_parameters()
+    }
+    cpu_params = {
+        name.removeprefix("module."): param
+        for name, param in chunks_cpu[0].named_parameters()
+    }
+    assert ref_params.keys() == cpu_params.keys()
+    for name in ref_params:
+        assert torch.allclose(
+            ref_params[name], cpu_params[name], atol=1e-5, rtol=1e-4
+        ), f"Parameter {name} diverges between GPU-only and CPU-offload runs"
+
+
+def test_mfsdp_offload_fraction_partial_splits_by_numel():
+    _Model, _Unit, ps, engine_cfg = _build_offload_stack(offload_fraction=0.5)
+
+    torch.manual_seed(7)
+    chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [_Model()],
+        engine_cfg=engine_cfg,
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_Unit,),
+    )
+
+    inner = optimizer._inner_optimizer
+    cpu_group = inner.cpu_group
+    assert cpu_group is not None
+
+    total_numel = sum(p.numel() for p in inner.params)
+    cpu_numel = sum(p.numel() for p in cpu_group._gpu_params)
+    gpu_numel = total_numel - cpu_numel
+    assert cpu_numel > 0, "Expected some params to be CPU-offloaded at fraction=0.5"
+    assert gpu_numel > 0, "Expected some params to remain on GPU at fraction=0.5"
+    ratio = cpu_numel / total_numel
+    # The greedy split assigns whole params; exact ratio depends on model shape.
+    # For fraction=0.5 with 3 params of unequal size the ratio will be ≥0.4.
+    assert ratio >= 0.4, (
+        f"Expected substantial CPU offload at fraction=0.5, got {ratio:.2%}"
+    )
+    assert ratio <= 0.95, f"Expected some GPU params at fraction=0.5, got {ratio:.2%}"
+
+
+def test_mfsdp_offload_fraction_zero_has_no_cpu_group():
+    _Model, _Unit, ps, engine_cfg = _build_offload_stack(offload_fraction=0.0)
+
+    torch.manual_seed(9)
+    _chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [_Model()],
+        engine_cfg=engine_cfg,
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_Unit,),
+    )
+    assert optimizer._inner_optimizer.cpu_group is None
+
+
+def test_mfsdp_offload_fraction_zero_preserves_optimizer_state_dict_contract():
+    _Model, _Unit, ps, engine_cfg = _build_offload_stack(offload_fraction=0.0)
+
+    torch.manual_seed(10)
+    chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [_Model()],
+        engine_cfg=engine_cfg,
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_Unit,),
+    )
+    value = torch.randn(3, 4)
+    target = torch.randn(3, 2)
+    optimizer.zero_grad()
+    torch.nn.functional.mse_loss(chunks[0](value), target).backward()
+    optimizer.finish_grad_sync()
+    optimizer.step()
+
+    assert optimizer.state_dict().keys() == {"state", "param_groups"}
+
+
+@pytest.mark.parametrize("offload_fraction", [-0.01, 1.01])
+def test_mfsdp_offload_fraction_rejects_out_of_range_values(offload_fraction):
+    _Model, _Unit, ps, engine_cfg = _build_offload_stack(
+        offload_fraction=offload_fraction
+    )
+
+    with pytest.raises(ValueError, match="offload_fraction"):
+        mfsdp_optimizer.build_mfsdp_stack(
+            [_Model()],
+            engine_cfg=engine_cfg,
+            ps=ps,
+            is_expert=lambda _name: False,
+            fsdp_unit_modules=(_Unit,),
+        )
+
+
+def test_mfsdp_cpu_offload_rejects_non_adam_optimizer():
+    _Model, _Unit, ps, engine_cfg = _build_offload_stack(offload_fraction=1.0)
+    engine_cfg.optimizer.optimizer = "sgd"
+
+    with pytest.raises(ValueError, match="only supports Adam"):
+        mfsdp_optimizer.build_mfsdp_stack(
+            [_Model()],
+            engine_cfg=engine_cfg,
+            ps=ps,
+            is_expert=lambda _name: False,
+            fsdp_unit_modules=(_Unit,),
+        )
+
+
+def test_mfsdp_cpu_offload_rejects_custom_optimizer_factory():
+    _Model, _Unit, ps, engine_cfg = _build_offload_stack(offload_fraction=1.0)
+
+    with pytest.raises(ValueError, match="optimizer_factory"):
+        mfsdp_optimizer.build_mfsdp_stack(
+            [_Model()],
+            engine_cfg=engine_cfg,
+            ps=ps,
+            is_expert=lambda _name: False,
+            fsdp_unit_modules=(_Unit,),
+            optimizer_factory=lambda groups, opt: torch.optim.SGD(groups, lr=opt.lr),
+        )
+
+
+def test_mfsdp_offload_fraction_checkpoint_round_trips():
+    _Model, _Unit, ps, engine_cfg = _build_offload_stack(offload_fraction=1.0)
+
+    torch.manual_seed(55)
+    chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [_Model()],
+        engine_cfg=engine_cfg,
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_Unit,),
+    )
+
+    value = torch.randn(3, 4)
+    target = torch.randn(3, 2)
+    optimizer.zero_grad()
+    torch.nn.functional.mse_loss(chunks[0](value), target).backward()
+    optimizer.finish_grad_sync()
+    optimizer.step()
+
+    saved = optimizer.state_dict()
+    assert "gpu" in saved
+    assert "cpu" in saved
+
+    optimizer.load_state_dict(saved)
+
+    optimizer.zero_grad()
+    torch.nn.functional.mse_loss(chunks[0](value), target).backward()
+    optimizer.finish_grad_sync()
+    success, _, _ = optimizer.step()
+    assert success
+
+
+def _single_rank_mfsdp_stack():
+    """Build a trained single-rank M-FSDP stack for scratch-release tests."""
+
+    class _Unit(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(4, 4, bias=False)
+
+        def forward(self, value):
+            return torch.nn.functional.gelu(self.linear(value))
+
+    class _Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.unit0 = _Unit()
+            self.unit1 = _Unit()
+            self.out = torch.nn.Linear(4, 2, bias=False)
+
+        def forward(self, value):
+            return self.out(self.unit1(self.unit0(value)))
+
+    torch.manual_seed(123)
+    ps = SimpleNamespace(
+        dp_cp_group=None,
+        dp_group=None,
+        ep_dp_group=None,
+        ep_group=None,
+        tp_group=None,
+        pp_group=None,
+        dp_cp_size=1,
+        expert_dp_size=1,
+    )
+    opt = SimpleNamespace(
+        optimizer="adam",
+        lr=1.0e-3,
+        min_lr=0.0,
+        weight_decay=0.0,
+        clip_grad=1000.0,
+        adam_beta1=0.9,
+        adam_beta2=0.999,
+        adam_eps=1.0e-8,
+        override_optimizer_config={"mfsdp_sharding_strategy": "optim_grads_params"},
+    )
+    chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [_Model()],
+        engine_cfg=SimpleNamespace(
+            parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1),
+            optimizer=opt,
+        ),
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_Unit,),
+    )
+    # One real train step so the double-buffer allocator has cached scratch and
+    # the optimizer holds shard-aliased params in their steady sharded state.
+    value = torch.randn(3, 4)
+    target = torch.randn(3, 2)
+    optimizer.zero_grad()
+    torch.nn.functional.mse_loss(chunks[0](value), target).backward()
+    optimizer.finish_grad_sync()
+    assert optimizer.step()[0]
+    return chunks[0], optimizer
+
+
+def test_mfsdp_release_export_scratch_keeps_weights_and_aliases():
+    chunk, _optimizer = _single_rank_mfsdp_stack()
+
+    # Byte-equivalent export reference: the full (materialized) parameters before
+    # the scratch release. Materializing installs full-parameter leases, so
+    # return to the sharded steady state (what the pre-wake production call sees,
+    # post optimizer.step) before releasing the scratch.
+    full_before = {
+        name: param.detach().clone() for name, param in chunk.named_parameters()
+    }
+    chunk.param_sync.release_all()
+    chunk.param_sync.discard_full_parameter_views()
+
+    # Record the sharded weight storage so we can prove it is not moved/rebuilt.
+    weight_storage = {
+        id(bucket): bucket.main_param_buffer.data_ptr()
+        for bucket in chunk.param_sync.buckets
+    }
+    weight_values = {
+        id(bucket): bucket.main_param_buffer.detach().clone()
+        for bucket in chunk.param_sync.buckets
+    }
+
+    chunk.release_export_scratch()
+
+    for bucket in chunk.param_sync.buckets:
+        # Sharded weights stay put (same storage, same values, still on CPU).
+        assert bucket.main_param_buffer.data_ptr() == weight_storage[id(bucket)]
+        assert bucket.main_param_buffer.device.type == "cpu"
+        assert torch.equal(bucket.main_param_buffer, weight_values[id(bucket)])
+        # The double-buffer scratch was handed back to the driver.
+        assert getattr(bucket.allocator, "_slots", {}) == {}
+        # Optimizer aliases still view the resident shard (no dangling storage).
+        for spec in bucket.specs:
+            assert spec.shard_param is not None
+            if spec.shard_numel:
+                expected = bucket.main_param_buffer.narrow(
+                    0, spec.local_offset, spec.shard_numel
+                )
+                assert spec.shard_param.data.data_ptr() == expected.data_ptr()
+            # Full-parameter views are dropped, not left aliasing freed scratch.
+            assert spec.full_param.data.numel() == 0
+
+    # Export after the release reproduces the pre-release parameters byte-for-byte.
+    full_after = {
+        name: param.detach().clone() for name, param in chunk.named_parameters()
+    }
+    assert full_before.keys() == full_after.keys()
+    for name in full_before:
+        assert torch.equal(full_before[name], full_after[name]), name
+
+
+def test_mfsdp_release_export_scratch_is_idempotent():
+    chunk, optimizer = _single_rank_mfsdp_stack()
+    chunk.release_export_scratch()
+    # A second release on already-sharded state must not raise (the busy-buffer
+    # guard passes: no collective is in flight) and must keep training usable.
+    chunk.release_export_scratch()
+    value = torch.randn(3, 4)
+    target = torch.randn(3, 2)
+    optimizer.zero_grad()
+    torch.nn.functional.mse_loss(chunk(value), target).backward()
+    optimizer.finish_grad_sync()
+    assert optimizer.step()[0]
+
+
+def test_mfsdp_bucket_policy_splits_one_unit_without_splitting_parameters():
+    model = torch.nn.Module()
+    model.weight0 = torch.nn.Parameter(torch.ones(4))
+    model.weight1 = torch.nn.Parameter(torch.ones(4))
+    model.weight2 = torch.nn.Parameter(torch.ones(4))
+    ps = SimpleNamespace(
+        dp_cp_group=None,
+        dp_group=None,
+        ep_dp_group=None,
+        ep_group=None,
+        etp_group=None,
+        tp_group=None,
+        pp_group=None,
+        dp_cp_size=1,
+        expert_dp_size=1,
+    )
+    opt = SimpleNamespace(
+        optimizer="sgd",
+        lr=0.0,
+        weight_decay=0.0,
+        clip_grad=0.0,
+        override_optimizer_config={
+            "mfsdp_sharding_strategy": "optim_grads_params",
+            "bucket_size": 4,
+        },
+    )
+
+    chunks, _optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [model],
+        engine_cfg=SimpleNamespace(
+            parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1),
+            optimizer=opt,
+        ),
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(),
+    )
+
+    buckets = chunks[0].param_sync.buckets
+    assert len(buckets) == 3
+    assert [[spec.name for spec in bucket.specs] for bucket in buckets] == [
+        ["weight0"],
+        ["weight1"],
+        ["weight2"],
+    ]
+
+
+def test_mfsdp_empty_uneven_shard_stays_inside_local_buffer(monkeypatch):
+    monkeypatch.setattr(mfsdp_buffer, "group_size", lambda _group: 4)
+    monkeypatch.setattr(mfsdp_buffer, "group_rank", lambda _group: 0)
+    model = torch.nn.Module()
+    model.weight0 = torch.nn.Parameter(torch.arange(4.0))
+    model.weight1 = torch.nn.Parameter(torch.arange(4.0))
+    groups = mfsdp_buffer.MFSDPProcessGroups(
+        dense_dp=None,
+        expert_dp=None,
+        dense_ag=None,
+        expert_ag=None,
+        tp=None,
+        etp=None,
+        ep=None,
+        pp=None,
+    )
+    config = mfsdp_config.MFSDPConfig(bucket_size=None)
+
+    buffers = mfsdp_buffer.ParamAndGradBuffer(
+        model,
+        groups=groups,
+        config=config,
+        is_expert=lambda _name: False,
+        unit_modules=(),
+    )
+
+    bucket = buffers.buckets[0]
+    assert bucket.local_numel == 2
+    assert bucket.specs[1].shard_numel == 0
+    assert bucket.specs[1].local_offset == bucket.local_numel
+    assert bucket.specs[1].shard_param is not None
+    assert bucket.specs[1].shard_param.numel() == 0
+
+
+def test_mfsdp_accumulates_all_microbatches_before_grad_reduce():
+    torch.manual_seed(321)
+    reference = _GlooModel()
+    candidate = copy.deepcopy(reference)
+    ps = SimpleNamespace(
+        dp_cp_group=None,
+        dp_group=None,
+        ep_dp_group=None,
+        ep_group=None,
+        etp_group=None,
+        tp_group=None,
+        pp_group=None,
+        dp_cp_size=1,
+        expert_dp_size=1,
+    )
+    opt = SimpleNamespace(
+        optimizer="adam",
+        lr=1.0e-3,
+        min_lr=0.0,
+        weight_decay=0.0,
+        clip_grad=1000.0,
+        adam_beta1=0.9,
+        adam_beta2=0.999,
+        adam_eps=1.0e-8,
+        override_optimizer_config={"mfsdp_sharding_strategy": "optim_grads_params"},
+    )
+    reference_optimizer = torch.optim.AdamW(
+        reference.parameters(),
+        lr=opt.lr,
+        betas=(opt.adam_beta1, opt.adam_beta2),
+        eps=opt.adam_eps,
+        weight_decay=opt.weight_decay,
+        foreach=False,
+    )
+    chunks, candidate_optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [candidate],
+        engine_cfg=SimpleNamespace(
+            parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1),
+            optimizer=opt,
+        ),
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_GlooUnit,),
+    )
+    microbatches = [
+        (torch.randn(3, 4), torch.randn(3, 2)),
+        (torch.randn(2, 4), torch.randn(2, 2)),
+    ]
+
+    reference_optimizer.zero_grad()
+    candidate_optimizer.zero_grad()
+    for microbatch_idx, (value, target) in enumerate(microbatches):
+        reference_loss = torch.nn.functional.mse_loss(reference(value), target)
+        (reference_loss / len(microbatches)).backward()
+
+        candidate_loss = torch.nn.functional.mse_loss(chunks[0](value), target)
+        if microbatch_idx == len(microbatches) - 1:
+            candidate_optimizer.grad_sync_enabled = True
+        (candidate_loss / len(microbatches)).backward()
+
+    candidate_optimizer.finish_grad_sync()
+
+    reference_grads = {
+        name: param.grad.detach().reshape(-1)
+        for name, param in reference.named_parameters()
+    }
+    candidate_grads = {
+        name: param.grad.detach().reshape(-1)
+        for name, param in _optimizer_named_shards(candidate_optimizer).items()
+    }
+    assert reference_grads.keys() == candidate_grads.keys()
+    for name, reference_grad in reference_grads.items():
+        assert torch.equal(reference_grad, candidate_grads[name]), name
+
+
+def test_mfsdp_materializes_root_params_used_without_calling_their_leaf_module():
+    torch.manual_seed(654)
+    reference = _DirectParamModel()
+    candidate = copy.deepcopy(reference)
+    ps = SimpleNamespace(
+        dp_cp_group=None,
+        dp_group=None,
+        ep_dp_group=None,
+        ep_group=None,
+        etp_group=None,
+        tp_group=None,
+        pp_group=None,
+        dp_cp_size=1,
+        expert_dp_size=1,
+    )
+    opt = SimpleNamespace(
+        optimizer="adam",
+        lr=1.0e-3,
+        min_lr=0.0,
+        weight_decay=0.0,
+        clip_grad=1000.0,
+        adam_beta1=0.9,
+        adam_beta2=0.999,
+        adam_eps=1.0e-8,
+        override_optimizer_config={"mfsdp_sharding_strategy": "optim_grads_params"},
+    )
+    chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [candidate],
+        engine_cfg=SimpleNamespace(
+            parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1),
+            optimizer=opt,
+        ),
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_GlooUnit,),
+    )
+
+    value = torch.randn(2, 4)
+    reference_output = reference(value)
+    candidate_output = chunks[0](value)
+    assert torch.equal(reference_output, candidate_output)
+
+    reference_output.square().mean().backward()
+    candidate_output.square().mean().backward()
+    optimizer.finish_grad_sync()
+    projection_shard = _optimizer_named_shards(optimizer)["projection.weight"]
+    assert torch.equal(
+        reference.projection.weight.grad.reshape(-1), projection_shard.grad.reshape(-1)
+    )
+
+
+def test_mfsdp_keeps_fp32_shards_for_bfloat16_compute_parameters():
+    model = _GlooModel().to(torch.bfloat16)
+    ps = SimpleNamespace(
+        dp_cp_group=None,
+        dp_group=None,
+        ep_dp_group=None,
+        ep_group=None,
+        tp_group=None,
+        pp_group=None,
+        dp_cp_size=1,
+        expert_dp_size=1,
+    )
+    opt = SimpleNamespace(
+        optimizer="adam",
+        lr=1.0e-3,
+        min_lr=0.0,
+        weight_decay=0.0,
+        clip_grad=1.0,
+        adam_beta1=0.9,
+        adam_beta2=0.999,
+        adam_eps=1.0e-8,
+        override_optimizer_config={"mfsdp_sharding_strategy": "optim_grads_params"},
+    )
+    chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [model],
+        engine_cfg=SimpleNamespace(
+            parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1),
+            optimizer=opt,
+        ),
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_GlooUnit,),
+    )
+
+    optimizer_params = _optimizer_params(optimizer)
+    assert all(param.dtype is torch.float32 for param in optimizer_params)
+    assert all(
+        param.dtype is torch.bfloat16 for _name, param in chunks[0].named_parameters()
+    )
+    assert all(
+        bucket.grad_shard_buffer.dtype is torch.float32
+        for bucket in chunks[0].param_sync.buckets
+    )
+    for bucket in chunks[0].param_sync.buckets:
+        main_storage = bucket.main_param_buffer.untyped_storage().data_ptr()
+        assert all(
+            spec.shard_param is not None
+            and spec.shard_param.untyped_storage().data_ptr() == main_storage
+            for spec in bucket.specs
+        )
+
+    before = [param.detach().clone() for param in optimizer_params]
+    value = torch.randn(3, 4, dtype=torch.bfloat16)
+    optimizer.zero_grad()
+    chunks[0](value).float().square().mean().backward()
+    optimizer.finish_grad_sync()
+    for bucket in chunks[0].param_sync.buckets:
+        grad_storage = bucket.main_grad_buffer.untyped_storage().data_ptr()
+        assert all(
+            spec.shard_param is not None
+            and spec.shard_param.grad is not None
+            and spec.shard_param.grad.untyped_storage().data_ptr() == grad_storage
+            for spec in bucket.specs
+        )
+    success, grad_norm, _ = optimizer.step()
+
+    assert success
+    assert grad_norm > 0.0
+    assert all(param.dtype is torch.float32 for param in optimizer_params)
+    assert any(not torch.equal(old, new) for old, new in zip(before, optimizer_params))
+    assert torch.isfinite(chunks[0](value).float()).all()
+
+
+def _run_mfsdp_gloo_parity(rank: int, world_size: int, init_file: str) -> None:
+    os.environ.setdefault("GLOO_SOCKET_IFNAME", "lo")
+    dist.init_process_group(
+        "gloo",
+        init_method=f"file://{init_file}",
+        rank=rank,
+        world_size=world_size,
+    )
+    try:
+        torch.manual_seed(456)
+        reference = _GlooModel()
+        candidate = copy.deepcopy(reference)
+        ps = SimpleNamespace(
+            dp_cp_group=dist.group.WORLD,
+            dp_group=dist.group.WORLD,
+            ep_dp_group=dist.group.WORLD,
+            ep_group=None,
+            tp_group=None,
+            pp_group=None,
+            dp_cp_size=world_size,
+            expert_dp_size=world_size,
+        )
+        opt = SimpleNamespace(
+            optimizer="adam",
+            lr=1.0e-3,
+            min_lr=0.0,
+            weight_decay=0.0,
+            clip_grad=1000.0,
+            adam_beta1=0.9,
+            adam_beta2=0.999,
+            adam_eps=1.0e-8,
+            override_optimizer_config={"mfsdp_sharding_strategy": "optim_grads_params"},
+        )
+        engine_cfg = SimpleNamespace(
+            parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1),
+            optimizer=opt,
+        )
+
+        reference_optimizer = torch.optim.AdamW(
+            reference.parameters(),
+            lr=opt.lr,
+            betas=(opt.adam_beta1, opt.adam_beta2),
+            eps=opt.adam_eps,
+            weight_decay=opt.weight_decay,
+            foreach=False,
+        )
+        chunks, candidate_optimizer = mfsdp_optimizer.build_mfsdp_stack(
+            [candidate],
+            engine_cfg=engine_cfg,
+            ps=ps,
+            is_expert=lambda _name: False,
+            fsdp_unit_modules=(_GlooUnit,),
+        )
+
+        torch.manual_seed(900 + rank)
+        value = torch.randn(3, 4)
+        target = torch.randn(3, 2)
+        reference_optimizer.zero_grad()
+        torch.nn.functional.mse_loss(reference(value), target).backward()
+        candidate_optimizer.zero_grad()
+        torch.nn.functional.mse_loss(chunks[0](value), target).backward()
+        for param in reference.parameters():
+            assert param.grad is not None
+            dist.all_reduce(param.grad, op=dist.ReduceOp.SUM)
+            param.grad.div_(world_size)
+        candidate_optimizer.finish_grad_sync()
+
+        reference_norm = torch.linalg.vector_norm(
+            torch.cat([param.grad.reshape(-1) for param in reference.parameters()])
+        ).item()
+        reference_optimizer.step()
+        candidate_success, candidate_norm, _ = candidate_optimizer.step()
+        assert candidate_success
+        assert reference_norm == candidate_norm
+
+        reference_params = dict(reference.named_parameters())
+        candidate_params = {
+            name.removeprefix("module."): param
+            for name, param in chunks[0].named_parameters()
+        }
+        assert reference_params.keys() == candidate_params.keys()
+        for name, reference_param in reference_params.items():
+            assert torch.equal(reference_param, candidate_params[name]), name
+    finally:
+        dist.destroy_process_group()
+
+
+def test_mfsdp_cpu_two_rank_gloo_matches_replicated_reference(tmp_path):
+    init_file = str(tmp_path / "mfsdp-gloo-init")
+    mp.spawn(_run_mfsdp_gloo_parity, args=(2, init_file), nprocs=2, join=True)

--- a/experimental/lite/tests/unit/primitive/test_ops_data_trainstep_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_ops_data_trainstep_unit.py
@@ -9,11 +9,21 @@ import torch.nn.functional as F
 from megatron.lite.primitive.data import _resolve_thd_padding, fixed_batches
 from megatron.lite.primitive.deterministic import deterministic_requested
 from megatron.lite.primitive.ops.cross_entropy import vocab_parallel_cross_entropy
-from megatron.lite.primitive.ops.gated_delta_rule import l2norm, torch_chunk_gated_delta_rule
+from megatron.lite.primitive.ops.gated_delta_rule import (
+    l2norm,
+    torch_chunk_gated_delta_rule,
+)
 from megatron.lite.primitive.ops.linear_cross_entropy import linear_cross_entropy
 from megatron.lite.primitive.ops.logprob import vocab_parallel_log_probs_from_logits
-from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec
-from megatron.lite.primitive.train_step import compute_and_clip_grad_norm, run_microbatch_loop
+from megatron.lite.primitive.recompute import (
+    apply_offload,
+    apply_recompute,
+    parse_recompute_spec,
+)
+from megatron.lite.primitive.train_step import (
+    compute_and_clip_grad_norm,
+    run_microbatch_loop,
+)
 from megatron.lite.primitive.utils import ensure_divisible
 
 pytestmark = pytest.mark.mlite
@@ -49,7 +59,9 @@ def test_logprob_selects_labels_in_batch_sequence_or_sequence_batch_layout():
 
     torch.testing.assert_close(selected, expected)
     with pytest.raises(ValueError, match="Could not align"):
-        vocab_parallel_log_probs_from_logits(logits, torch.zeros(4, 2, dtype=torch.long))
+        vocab_parallel_log_probs_from_logits(
+            logits, torch.zeros(4, 2, dtype=torch.long)
+        )
 
 
 def test_linear_cross_entropy_fallback_matches_explicit_matmul():
@@ -110,8 +122,12 @@ def test_data_padding_env_and_fixed_batches_are_deterministic(monkeypatch):
     with pytest.raises(ValueError, match="PAD_MULTIPLE"):
         _resolve_thd_padding(seq_len=7, cp_size=2)
 
-    batches_a = fixed_batches(11, seq_len=4, num_steps=2, batch_size=2, device="cpu", seed=123)
-    batches_b = fixed_batches(11, seq_len=4, num_steps=2, batch_size=2, device="cpu", seed=123)
+    batches_a = fixed_batches(
+        11, seq_len=4, num_steps=2, batch_size=2, device="cpu", seed=123
+    )
+    batches_b = fixed_batches(
+        11, seq_len=4, num_steps=2, batch_size=2, device="cpu", seed=123
+    )
     for (ids_a, labels_a), (ids_b, labels_b) in zip(batches_a, batches_b, strict=True):
         torch.testing.assert_close(ids_a, ids_b)
         torch.testing.assert_close(labels_a, labels_b)
@@ -160,6 +176,73 @@ def test_recompute_parser_and_wrapper_replays_forward_on_backward():
     torch.testing.assert_close(x.grad, torch.tensor([4.0, -6.0]))
 
 
+def test_activation_offload_uses_cpu_saved_tensors_without_recompute(monkeypatch):
+    entered = 0
+    real_save_on_cpu = torch.autograd.graph.save_on_cpu
+
+    class TrackingSaveOnCpu(real_save_on_cpu):
+        def __enter__(self):
+            nonlocal entered
+            entered += 1
+            return super().__enter__()
+
+    monkeypatch.setattr(torch.autograd.graph, "save_on_cpu", TrackingSaveOnCpu)
+
+    class CountingModule(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.calls = 0
+
+        def forward(self, x):
+            self.calls += 1
+            hidden = x * x
+            return hidden.sin()
+
+    class Layer(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.inner = CountingModule()
+
+    layer = Layer()
+    result = apply_offload(
+        nn.ModuleList([layer]),
+        ["inner"],
+        {"inner": lambda module: module.inner},
+    )
+
+    x = torch.tensor([2.0, -3.0], requires_grad=True)
+    layer.inner(x).sum().backward()
+
+    assert (result.units, result.matched, result.wrapped) == (1, 1, 1)
+    assert entered == 1
+    assert layer.inner.calls == 1
+    torch.testing.assert_close(
+        x.grad,
+        2 * x.detach() * (x.detach().square()).cos(),
+    )
+
+
+def test_activation_offload_fails_loud_and_does_not_double_wrap():
+    layer = nn.Module()
+    layer.inner = nn.Linear(2, 2)
+    layers = nn.ModuleList([layer])
+    module_map = {"inner": lambda module: module.inner}
+
+    first = apply_offload(layers, ["inner"], module_map)
+    second = apply_offload(layers, ["inner"], module_map)
+
+    assert (first.units, first.matched, first.wrapped) == (1, 1, 1)
+    assert (second.units, second.matched, second.wrapped) == (1, 1, 0)
+    with pytest.raises(
+        ValueError, match=r"activation offload requested.*0 transformer units"
+    ):
+        apply_offload(nn.ModuleList(), ["inner"], module_map)
+    with pytest.raises(
+        ValueError, match=r"activation offload requested.*matched 0 modules"
+    ):
+        apply_offload(layers, ["missing"], module_map)
+
+
 def test_train_step_microbatch_loop_and_grad_clip_cpu_contract():
     model = nn.Linear(2, 1, bias=False)
     with torch.no_grad():
@@ -181,7 +264,9 @@ def test_train_step_microbatch_loop_and_grad_clip_cpu_contract():
     assert model.weight.grad is not None
     assert torch.isfinite(model.weight.grad).all()
 
-    grad_norm = compute_and_clip_grad_norm(model, optimizer=None, max_norm=0.25, use_dist_opt=False)
+    grad_norm = compute_and_clip_grad_norm(
+        model, optimizer=None, max_norm=0.25, use_dist_opt=False
+    )
 
     assert torch.isfinite(grad_norm)
     assert model.weight.grad.norm() <= 0.25 + 1.0e-6

--- a/experimental/lite/tests/unit/primitive/test_training_checkpoint.py
+++ b/experimental/lite/tests/unit/primitive/test_training_checkpoint.py
@@ -81,6 +81,58 @@ def test_optimizer_checkpoint_roundtrips_rank_local_state(tmp_path) -> None:
     _assert_state_equal(optimizer.state_dict(), expected)
 
 
+def test_dcp_load_refreshes_mfsdp_shards_from_loaded_full_parameters(
+    monkeypatch, tmp_path
+) -> None:
+    class FakeParamSync:
+        def __init__(self, full_param: torch.nn.Parameter) -> None:
+            self.full_param = full_param
+            self.shard_param = torch.full_like(full_param, -7.0, dtype=torch.float32)
+            self.copy_calls = 0
+
+        def copy_full_parameters_to_shards(self) -> None:
+            self.copy_calls += 1
+            self.shard_param.copy_(self.full_param.float())
+
+    class FakeMFSdpModule(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.zeros(2, dtype=torch.bfloat16))
+            self.param_sync = FakeParamSync(self.weight)
+
+    model = FakeMFSdpModule()
+
+    monkeypatch.setattr(dcp, "_supports_dist_opt_distckpt", lambda *_args: False)
+    monkeypatch.setattr(dcp, "_build_meshes", lambda _config: (object(), object()))
+    monkeypatch.setattr(
+        dcp,
+        "_empty_dcp_tensor_like_param",
+        lambda param, _mesh, _placements: torch.empty_like(param),
+    )
+
+    def fake_load(state_dict, checkpoint_id) -> None:
+        assert checkpoint_id == str(tmp_path)
+        state_dict["model.weight"].fill_(3.0)
+
+    monkeypatch.setattr(dcp.dcp, "load", fake_load)
+
+    dcp.load_training_checkpoint(
+        model,
+        optimizer=None,
+        path=str(tmp_path),
+        config=object(),
+        ps=ParallelState(),
+        load_rng=False,
+        load_optimizer=False,
+    )
+
+    assert model.param_sync.copy_calls == 1
+    torch.testing.assert_close(
+        model.param_sync.shard_param,
+        torch.full_like(model.param_sync.shard_param, 3.0),
+    )
+
+
 class FakeDistOpt:
     def __init__(self):
         self.save_model_sd = None

--- a/experimental/lite/tests/unit/primitive/test_training_checkpoint.py
+++ b/experimental/lite/tests/unit/primitive/test_training_checkpoint.py
@@ -84,24 +84,20 @@ def test_optimizer_checkpoint_roundtrips_rank_local_state(tmp_path) -> None:
 def test_dcp_load_refreshes_mfsdp_shards_from_loaded_full_parameters(
     monkeypatch, tmp_path
 ) -> None:
-    class FakeParamSync:
-        def __init__(self, full_param: torch.nn.Parameter) -> None:
-            self.full_param = full_param
-            self.shard_param = torch.full_like(full_param, -7.0, dtype=torch.float32)
-            self.copy_calls = 0
-
-        def copy_full_parameters_to_shards(self) -> None:
-            self.copy_calls += 1
-            self.shard_param.copy_(self.full_param.float())
-
     class FakeMFSdpModule(torch.nn.Module):
         def __init__(self) -> None:
             super().__init__()
             self.weight = torch.nn.Parameter(torch.zeros(2, dtype=torch.bfloat16))
-            self.param_sync = FakeParamSync(self.weight)
+            self.shard_param = torch.full_like(self.weight, -7.0, dtype=torch.float32)
+            self.install_calls = 0
+
+        def install_optimized_model_weights(self) -> None:
+            self.install_calls += 1
+            self.shard_param.copy_(self.weight.float())
 
     model = FakeMFSdpModule()
 
+    monkeypatch.setattr(dcp, "MFSdpModule", FakeMFSdpModule)
     monkeypatch.setattr(dcp, "_supports_dist_opt_distckpt", lambda *_args: False)
     monkeypatch.setattr(dcp, "_build_meshes", lambda _config: (object(), object()))
     monkeypatch.setattr(
@@ -126,10 +122,10 @@ def test_dcp_load_refreshes_mfsdp_shards_from_loaded_full_parameters(
         load_optimizer=False,
     )
 
-    assert model.param_sync.copy_calls == 1
+    assert model.install_calls == 1
     torch.testing.assert_close(
-        model.param_sync.shard_param,
-        torch.full_like(model.param_sync.shard_param, 3.0),
+        model.shard_param,
+        torch.full_like(model.shard_param, 3.0),
     )
 
 

--- a/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
+++ b/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
@@ -22,10 +22,18 @@ from megatron.lite.runtime.backends.mlite.runtime import (
     _build_impl_cfg,
     _pipeline_callbacks,
 )
-from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig, RuntimeConfig
+from megatron.lite.runtime.contracts.config import (
+    OptimizerConfig,
+    ParallelConfig,
+    RuntimeConfig,
+)
 from megatron.lite.runtime.contracts.data import PackedBatch
 from megatron.lite.runtime.contracts.handle import ModelHandle
-from megatron.lite.runtime.contracts.loss import LossContext, get_loss_context, use_loss_context
+from megatron.lite.runtime.contracts.loss import (
+    LossContext,
+    get_loss_context,
+    use_loss_context,
+)
 
 pytestmark = pytest.mark.mlite
 
@@ -73,9 +81,13 @@ def test_pipeline_callbacks_accept_wrapped_and_presplit_context():
     context = LossContext(source_batch="source")
     seen = []
     forward, loss = _pipeline_callbacks(
-        lambda _model, batch: seen.append((batch, get_loss_context()))
-        or {"loss": torch.tensor(1.0)},
-        lambda out, batch, ctx: (out["loss"], {"batch": batch, "source": ctx.source_batch}),
+        lambda _model, batch: (
+            seen.append((batch, get_loss_context())) or {"loss": torch.tensor(1.0)}
+        ),
+        lambda out, batch, ctx: (
+            out["loss"],
+            {"batch": batch, "source": ctx.source_batch},
+        ),
     )
 
     output = forward(None, ("wrapped", context))
@@ -171,7 +183,8 @@ def test_runtime_config_accepts_mlite_backend_cfg():
 
 def test_mlite_config_defaults_and_parallel_fields():
     cfg = MegatronLiteConfig(
-        model_name="qwen3_moe", parallel=ParallelConfig(tp=4, etp=1, ep=8, pp=2, vpp=2, cp=2)
+        model_name="qwen3_moe",
+        parallel=ParallelConfig(tp=4, etp=1, ep=8, pp=2, vpp=2, cp=2),
     )
 
     assert cfg.model_name == "qwen3_moe"
@@ -300,7 +313,9 @@ class HookedOptimizer:
 
 def test_runtime_to_prefers_optimizer_specific_offload_hooks():
     optimizer = HookedOptimizer()
-    handle = ModelHandle(model=nn.Linear(2, 2), optimizer=optimizer, _extras={"model_chunks": []})
+    handle = ModelHandle(
+        model=nn.Linear(2, 2), optimizer=optimizer, _extras={"model_chunks": []}
+    )
     runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
 
     runtime.to(handle, "cpu", model=False, optimizer=True, grad=False)
@@ -499,7 +514,10 @@ def test_megatron_ddp_detection_accepts_ddp_and_subclasses(monkeypatch):
 
 @pytest.mark.parametrize("model_cls", [_FakeMegatronDDP, _FakeMegatronDDPSubclass])
 def test_megatron_ddp_model_move_helpers_use_buffer_path(monkeypatch, model_cls):
-    from megatron.lite.runtime.megatron_utils import load_model_to_gpu, offload_model_to_cpu
+    from megatron.lite.runtime.megatron_utils import (
+        load_model_to_gpu,
+        offload_model_to_cpu,
+    )
 
     _install_fake_megatron_ddp(monkeypatch)
     model = model_cls()
@@ -526,7 +544,10 @@ def test_megatron_ddp_model_move_helpers_use_buffer_path(monkeypatch, model_cls)
 
 
 def test_native_model_move_helpers_do_not_require_megatron_core(monkeypatch):
-    from megatron.lite.runtime.megatron_utils import load_model_to_gpu, offload_model_to_cpu
+    from megatron.lite.runtime.megatron_utils import (
+        load_model_to_gpu,
+        offload_model_to_cpu,
+    )
 
     monkeypatch.setitem(sys.modules, "megatron.core", None)
     monkeypatch.setitem(sys.modules, "megatron.core.distributed", None)
@@ -585,7 +606,9 @@ def test_model_handle_dp_from_parallel_state():
 def test_model_handle_cp_range_and_config_properties():
     cfg = {"tp": 8, "ep": 4}
     default_handle = ModelHandle(model=MagicMock())
-    configured_handle = ModelHandle(model=MagicMock(), config=cfg, _extras={"cp_range": (1, 8)})
+    configured_handle = ModelHandle(
+        model=MagicMock(), config=cfg, _extras={"cp_range": (1, 8)}
+    )
 
     assert default_handle.cp_range == (1, 1)
     assert configured_handle.cp_range == (1, 8)
@@ -599,7 +622,9 @@ def test_runtime_dispatch_creates_mlite_backend():
 
         runtime = create_runtime(
             RuntimeConfig(
-                backend="mlite", hf_path="/models/test", backend_cfg={"model_name": "qwen3"}
+                backend="mlite",
+                hf_path="/models/test",
+                backend_cfg={"model_name": "qwen3"},
             )
         )
 
@@ -628,7 +653,9 @@ def _run_verl_sft_dry_run(script: Path, tmp_path: Path, **env_overrides: str) ->
         "ETP_SIZE": "1",
         **env_overrides,
     }
-    completed = subprocess.run([str(script)], env=env, text=True, capture_output=True, check=True)
+    completed = subprocess.run(
+        [str(script)], env=env, text=True, capture_output=True, check=True
+    )
     return completed.stdout
 
 
@@ -652,7 +679,9 @@ def test_verl_sft_script_maps_offload_env_to_backend_args(tmp_path):
     assert "engine.param_offload=True" in command
     assert "engine.optimizer_offload=True" in command
     assert "+optim.override_optimizer_config.offload_fraction=0.75" in command
-    assert "+optim.override_optimizer_config.use_precision_aware_optimizer=True" in command
+    assert (
+        "+optim.override_optimizer_config.use_precision_aware_optimizer=True" in command
+    )
 
 
 def test_verl_sft_script_does_not_emit_optimizer_state_offload_when_disabled(tmp_path):

--- a/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
+++ b/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
@@ -14,6 +14,7 @@ import torch
 import torch.nn as nn
 
 from megatron.lite.runtime import create_runtime
+from megatron.lite.primitive.optimizers.mfsdp.optimizer import MFSdpOptimizer
 from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig
 from megatron.lite.runtime.backends.mlite.runtime import (
     MegatronLiteRuntime,
@@ -22,6 +23,7 @@ from megatron.lite.runtime.backends.mlite.runtime import (
     _pipeline_callbacks,
 )
 from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig, RuntimeConfig
+from megatron.lite.runtime.contracts.data import PackedBatch
 from megatron.lite.runtime.contracts.handle import ModelHandle
 from megatron.lite.runtime.contracts.loss import LossContext, get_loss_context, use_loss_context
 
@@ -47,6 +49,26 @@ def test_runtime_returns_loss_separately_from_microbatch_metrics():
     assert result.model_output.loss is not None
 
 
+def test_release_export_scratch_routes_to_mfsdp_chunks_and_skips_plain_ones():
+    """Pre-wake scratch release loops the chunks and no-ops non-M-FSDP ones."""
+    released = []
+
+    class _MFSDPChunk:
+        def release_export_scratch(self):
+            released.append(id(self))
+
+    mfsdp_a, mfsdp_b = _MFSDPChunk(), _MFSDPChunk()
+    handle = ModelHandle(
+        model=nn.Linear(1, 1, bias=False),
+        parallel_state=types.SimpleNamespace(pp_size=1),
+        _extras={"model_chunks": [mfsdp_a, nn.Linear(1, 1), mfsdp_b]},
+    )
+
+    MegatronLiteRuntime.__new__(MegatronLiteRuntime).release_export_scratch(handle)
+
+    assert released == [id(mfsdp_a), id(mfsdp_b)]
+
+
 def test_pipeline_callbacks_accept_wrapped_and_presplit_context():
     context = LossContext(source_batch="source")
     seen = []
@@ -63,6 +85,68 @@ def test_pipeline_callbacks_accept_wrapped_and_presplit_context():
 
     assert seen == [("wrapped", context), ("presplit", context)]
     assert metrics == {"batch": "presplit", "source": "source"}
+
+
+def test_pipeline_runtime_enables_mfsdp_grad_reduce_on_last_microbatch(monkeypatch):
+    from megatron.lite.primitive.parallel import pipeline as pipeline_module
+
+    grad_sync_transitions = []
+    param_sync = types.SimpleNamespace(
+        set_grad_sync_enabled=grad_sync_transitions.append,
+    )
+    optimizer = MFSdpOptimizer(
+        optimizer=types.SimpleNamespace(),
+        model_chunks=[types.SimpleNamespace(param_sync=param_sync)],
+    )
+    observed_callbacks = []
+
+    def fake_pipeline(*_args, grad_sync_fn=None, **_kwargs):
+        assert callable(grad_sync_fn)
+        assert optimizer.grad_sync_enabled is False
+        grad_sync_fn()
+        observed_callbacks.append(optimizer.grad_sync_enabled)
+        return [{"loss": torch.ones(())}]
+
+    monkeypatch.setattr(pipeline_module, "forward_backward_pipelining", fake_pipeline)
+
+    original_tensor = torch.tensor
+
+    def cpu_tensor(data, *args, **kwargs):
+        kwargs.pop("device", None)
+        return original_tensor(data, *args, **kwargs)
+
+    monkeypatch.setattr(torch, "tensor", cpu_tensor)
+    parallel_state = types.SimpleNamespace(
+        pp_size=2,
+        pp_group=None,
+        pp_global_ranks=None,
+        tp_size=1,
+        cp_size=1,
+    )
+    model = nn.Linear(1, 1, bias=False)
+    handle = ModelHandle(
+        model=model,
+        optimizer=optimizer,
+        parallel_state=parallel_state,
+        _extras={
+            "forward_step": lambda _model, _batch: {"loss": torch.ones(())},
+            "model_chunks": [model],
+            "model_cfg": types.SimpleNamespace(hidden_size=1),
+        },
+    )
+    batch = PackedBatch(
+        input_ids=torch.ones(4, dtype=torch.long),
+        labels=torch.ones(4, dtype=torch.long),
+        seq_lens=torch.tensor([4]),
+    )
+    MegatronLiteRuntime.__new__(MegatronLiteRuntime).forward_backward(
+        handle,
+        iter([batch, batch]),
+        None,
+        num_microbatches=2,
+    )
+    assert observed_callbacks == [True]
+    assert grad_sync_transitions == [True]
 
 
 def test_runtime_config_defaults_to_mlite_backend():


### PR DESCRIPTION
## Summary

- Add a standalone M-FSDP optimizer for MLite without a Megatron-Core or FSDP2 implementation dependency.
- Support two independent CPU-offload axes:
  1. optimizer state / FP32 master offload between steps;
  2. tensors saved for backward during forward/backward.
- Validate all four offload combinations against FSDP2 for numerical accuracy, throughput, and allocator memory.
- Keep ZeRO-1 out of scope.

## Offload A: optimizer state and FP32 master

**Previous state and failure mode.** `offload_fraction` did not select a CPU update path for the standalone optimizer, so a configuration requesting full offload still constructed the regular GPU optimizer and retained its state on GPU.

**Fix.** The selected parameter fraction now uses synchronous CPU AdamW:

1. copy the GPU shard gradient to a pinned CPU buffer;
2. update the authoritative FP32 CPU parameter and Adam moments on CPU;
3. copy the updated value back to the GPU shard used by forward/all-gather.

The GPU shard is intentionally retained as the compute mirror; the authoritative FP32 master, `exp_avg`, and `exp_avg_sq` live on CPU. The path is Adam-only and fails loud for unsupported optimizer factories or algorithms.

## Offload B: forward/backward saved tensors

**Previous state and failure mode.** The nominal offload wrapper only applied non-reentrant activation checkpointing. It recomputed tensors but performed no CPU D2H/H2D transfer, so enabling "offload" did not actually offload tensors.

**Fix.** Wrapped units now use `torch.autograd.graph.save_on_cpu` with pinned memory when CUDA is available. Tensors saved by autograd for backward are moved to CPU and restored on demand. Selection is observable and fails loud for empty unit lists or selectors that match nothing. Recompute and saved-tensor offload are mutually exclusive on the same unit.

## Validation

Validated commit: `2777c27d1bcc8d2782e066ced60cf788760d4010`

- CPU/Gloo regression: **100 passed, 1 skipped**.
- Ruff 0.15.17 format/check, shell syntax, and diff checks: passed.
- GPU matrix: 8 H100 GPUs, 2 warm-up + 5 measured steps per arm, all eight ranks passed.
- W&B: https://wandb.ai/megatron-core-moe-dev/mlite-mfsdp-offload/runs/vgihnxmw

### Accuracy

The four M-FSDP arms match the corresponding FSDP2 loss curves within the established 1% relative tolerance.

| Optimizer offload | Saved-tensor offload | Max loss relative diff | Max parameter abs diff | Min parameter cosine |
|---:|---:|---:|---:|---:|
| off | off | 0.0004874 | 0.0018311 | 0.999999316 |
| off | on  | 0.0004874 | 0.0018311 | 0.999999316 |
| on  | off | 0.0012796 | 0.0017700 | 0.999999281 |
| on  | on  | 0.0012796 | 0.0017700 | 0.999999281 |

Saved-tensor offload is numerically identical within each backend. Enabling optimizer offload changes the update rounding slightly; for M-FSDP its maximum loss relative difference from the no-offload arm is `0.0009144`, with minimum parameter cosine `0.999995167`.

### Speed and memory

Memory values below are per-arm increments in GiB, recorded at the same instant as `(allocated / reserved / scratch)`, where `scratch = reserved - allocated`. Training-side snapshots are taken after forward; optimizer-side snapshots are taken after `optimizer.step`. Per-arm baselines avoid contamination from process-lifetime composable-FSDP bookkeeping; the W&B run also contains the raw absolute snapshots.

| Backend | Optimizer offload | Saved-tensor offload | Step ms | tok/s/GPU | Training Δ alloc/reserved/scratch GiB | Optimizer Δ alloc/reserved/scratch GiB |
|---|---:|---:|---:|---:|---:|---:|
| FSDP2  | off | off | 28.303 | 4522 | 0.1724 / 0.3652 / 0.1929 | 0.1804 / 0.3652 / 0.1848 |
| FSDP2  | off | on  | 32.840 | 3898 | 0.0955 / 0.3535 / 0.2581 | 0.1179 / 0.3535 / 0.2356 |
| FSDP2  | on  | off | 49.430 | 2590 | 0.0396 / 0.2949 / 0.2554 | 0.0476 / 0.2949 / 0.2473 |
| FSDP2  | on  | on  | 60.098 | 2130 | 0.0251 / 0.2812 / 0.2561 | 0.0476 / 0.2812 / 0.2336 |
| M-FSDP | off | off | 20.467 | 6254 | 0.1685 / 0.3398 / 0.1714 | 0.1531 / 0.3398 / 0.1868 |
| M-FSDP | off | on  | 18.767 | 6821 | 0.1541 / 0.2871 / 0.1331 | 0.1531 / 0.2871 / 0.1340 |
| M-FSDP | on  | off | 37.337 | 3428 | 0.1216 / 0.2617 / 0.1401 | 0.1062 / 0.2617 / 0.1555 |
| M-FSDP | on  | on  | 37.867 | 3380 | 0.1072 / 0.2676 / 0.1604 | 0.1062 / 0.2676 / 0.1614 |

For M-FSDP, optimizer offload reduces optimizer-side allocated memory by **30.6%** (`0.1531 → 0.1062 GiB`). Saved-tensor offload reduces training-side allocated memory by **8.6%** with optimizer offload disabled (`0.1685 → 0.1541 GiB`) and **11.8%** with it enabled (`0.1216 → 0.1072 GiB`).

## Ownership and layering

- The implementation remains under `primitive/optimizers/mfsdp/`; model protocols only provide architecture-owned wrap granularity.
- Runtime integration is capability-based rather than keyed on model names or an M-FSDP-specific branch.
- The shared HF exporter consumes an optional streaming full-parameter capability and fails loud on incomplete exports.
- Pipeline grad-sync is enabled through an optimizer lifecycle callback at the final-microbatch boundary.

## Checkpoint resume synchronization

Validated commit: `15145be3a6bfd4a138e31757c1adfcce08d0522f`

- DCP load now calls the explicit `MFSdpModule.install_optimized_model_weights()` contract after loading full parameters; interface drift fails loudly instead of silently skipping shard refresh through `getattr` capability probing.
- Optimizer checkpoints preserve the authoritative FP32 GPU shard values; checkpoints without the sidecar remain loadable. CPU-offloaded parameters continue to use their existing `master_params` state.
- CPU checkpoint and M-FSDP regression coverage: **58 passed** total (**57 passed** in the combined run; the sandbox-blocked two-rank Gloo case passed separately with socket permission).
- `py_compile` and `git diff --check`: passed.
- Repository-pinned pre-commit was run but is not green: isort rewrites the three touched pre-existing files wholesale, and Black spawned excessive parallel workers without completing. The mechanical formatting churn was intentionally excluded from this focused fix.
