### PR TITLE
MLite Muon optimizer step 1: native config + parameter-routing contract (WIP)

### DIFF
--- a/experimental/lite/examples/bench/scripts/run_pinned_adam_distopt_correctness.sh
+++ b/experimental/lite/examples/bench/scripts/run_pinned_adam_distopt_correctness.sh
@@ -103,7 +103,6 @@ manifest = {
     "seq_len": 8,
     "truncate_layers": 1,
     "keep_experts": 2,
-    "mount_vision_model": False,
     "optimizer": "adam",
     "optimizer_backend": "dist_opt",
     "reference_backend": "mbridge",
@@ -113,45 +112,7 @@ output.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
 print(json.dumps(manifest, sort_keys=True))
 PY
 
-common_args=(
-  --hf-path "${HF_PATH}"
-  --model-name qwen3_5
-  --tp "${TP}"
-  --etp "${ETP}"
-  --ep "${EP}"
-  --pp "${PP}"
-  --cp "${CP}"
-  --steps "${STEPS}"
-  --num-microbatches "${NUM_MICROBATCHES}"
-  --seq-len "${SEQ_LEN}"
-  --seed "${SEED}"
-  --truncate-layers "${TRUNCATE_LAYERS}"
-  --keep-experts "${KEEP_EXPERTS}"
-  --disable-mtp
-  --same-data-across-dp
-)
-
-# The validated Adam×DistOpt gate predates deterministic bench's vision-mount default.
-# Keep the text-only baseline explicit so this rerun does not add a new parameter family.
-torchrun --nproc_per_node "${NPROC}" \
-  "${REPO_ROOT}/experimental/lite/examples/bench/correctness.py" run \
-  --backend mlite "${common_args[@]}" \
-  --impl-cfg-json '{"mount_vision_model": false}' \
-  --output-json "${OUTPUT_DIR}/qwen35_mlite_correctness.json" \
-  2>&1 | tee "${OUTPUT_DIR}/qwen35_mlite_correctness.log"
-
-torchrun --nproc_per_node "${NPROC}" \
-  "${REPO_ROOT}/experimental/lite/examples/bench/correctness.py" run \
-  --backend mbridge "${common_args[@]}" \
-  --output-json "${OUTPUT_DIR}/qwen35_mbridge_correctness.json" \
-  2>&1 | tee "${OUTPUT_DIR}/qwen35_mbridge_correctness.log"
-
-python "${REPO_ROOT}/experimental/lite/examples/bench/correctness.py" compare \
-  "${OUTPUT_DIR}/qwen35_mlite_correctness.json" \
-  "${OUTPUT_DIR}/qwen35_mbridge_correctness.json" \
-  --output-json "${OUTPUT_DIR}/qwen35_correctness_compare.json" \
-  --fail-on-mismatch \
-  2>&1 | tee "${OUTPUT_DIR}/qwen35_correctness_compare.log"
+bash "${REPO_ROOT}/experimental/lite/examples/bench/scripts/run_qwen35_correctness_pair.sh"
 
 sha256sum \
   "${OUTPUT_DIR}/runtime_manifest.json" \

--- a/experimental/lite/examples/bench/scripts/run_pinned_adam_distopt_correctness.sh
+++ b/experimental/lite/examples/bench/scripts/run_pinned_adam_distopt_correctness.sh
@@ -103,6 +103,7 @@ manifest = {
     "seq_len": 8,
     "truncate_layers": 1,
     "keep_experts": 2,
+    "mount_vision_model": False,
     "optimizer": "adam",
     "optimizer_backend": "dist_opt",
     "reference_backend": "mbridge",
@@ -112,7 +113,45 @@ output.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
 print(json.dumps(manifest, sort_keys=True))
 PY
 
-bash "${REPO_ROOT}/experimental/lite/examples/bench/scripts/run_qwen35_correctness_pair.sh"
+common_args=(
+  --hf-path "${HF_PATH}"
+  --model-name qwen3_5
+  --tp "${TP}"
+  --etp "${ETP}"
+  --ep "${EP}"
+  --pp "${PP}"
+  --cp "${CP}"
+  --steps "${STEPS}"
+  --num-microbatches "${NUM_MICROBATCHES}"
+  --seq-len "${SEQ_LEN}"
+  --seed "${SEED}"
+  --truncate-layers "${TRUNCATE_LAYERS}"
+  --keep-experts "${KEEP_EXPERTS}"
+  --disable-mtp
+  --same-data-across-dp
+)
+
+# The validated Adam×DistOpt gate predates deterministic bench's vision-mount default.
+# Keep the text-only baseline explicit so this rerun does not add a new parameter family.
+torchrun --nproc_per_node "${NPROC}" \
+  "${REPO_ROOT}/experimental/lite/examples/bench/correctness.py" run \
+  --backend mlite "${common_args[@]}" \
+  --impl-cfg-json '{"mount_vision_model": false}' \
+  --output-json "${OUTPUT_DIR}/qwen35_mlite_correctness.json" \
+  2>&1 | tee "${OUTPUT_DIR}/qwen35_mlite_correctness.log"
+
+torchrun --nproc_per_node "${NPROC}" \
+  "${REPO_ROOT}/experimental/lite/examples/bench/correctness.py" run \
+  --backend mbridge "${common_args[@]}" \
+  --output-json "${OUTPUT_DIR}/qwen35_mbridge_correctness.json" \
+  2>&1 | tee "${OUTPUT_DIR}/qwen35_mbridge_correctness.log"
+
+python "${REPO_ROOT}/experimental/lite/examples/bench/correctness.py" compare \
+  "${OUTPUT_DIR}/qwen35_mlite_correctness.json" \
+  "${OUTPUT_DIR}/qwen35_mbridge_correctness.json" \
+  --output-json "${OUTPUT_DIR}/qwen35_correctness_compare.json" \
+  --fail-on-mismatch \
+  2>&1 | tee "${OUTPUT_DIR}/qwen35_correctness_compare.log"
 
 sha256sum \
   "${OUTPUT_DIR}/runtime_manifest.json" \

--- a/experimental/lite/examples/bench/scripts/run_pinned_adam_distopt_correctness.sh
+++ b/experimental/lite/examples/bench/scripts/run_pinned_adam_distopt_correctness.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+set -euo pipefail
+
+readonly PINNED_MEGATRON_REVISION=d64ba4ccb1e3e878c15171c9cc58d5d3b46bf4d5
+readonly PINNED_EMERGING_REVISION=b309e2f01cda75dc96a6dc1a2355a7b3b64b5e16
+
+REPO_ROOT=${REPO_ROOT:-$(git rev-parse --show-toplevel)}
+MEGATRON_ROOT=${MEGATRON_ROOT:?set MEGATRON_ROOT to the pinned Megatron checkout}
+EMERGING_ROOT=${EMERGING_ROOT:?set EMERGING_ROOT to the pinned Emerging-Optimizers checkout}
+HF_PATH=${HF_PATH:?set HF_PATH to the fixed HuggingFace Qwen3.5 checkpoint}
+OUTPUT_DIR=${OUTPUT_DIR:?set OUTPUT_DIR to a persistent artifact directory}
+MLITE_CONTAINER_IMAGE=${MLITE_CONTAINER_IMAGE:?record the Slurm container image path}
+
+actual_megatron_revision=$(git -C "${MEGATRON_ROOT}" rev-parse HEAD)
+actual_emerging_revision=$(git -C "${EMERGING_ROOT}" rev-parse HEAD)
+if [[ "${actual_megatron_revision}" != "${PINNED_MEGATRON_REVISION}" ]]; then
+  echo "Megatron revision mismatch: ${actual_megatron_revision}" >&2
+  exit 2
+fi
+if [[ "${actual_emerging_revision}" != "${PINNED_EMERGING_REVISION}" ]]; then
+  echo "Emerging-Optimizers revision mismatch: ${actual_emerging_revision}" >&2
+  exit 2
+fi
+if [[ ! -f "${HF_PATH}/config.json" ]]; then
+  echo "Qwen3.5 checkpoint is missing config.json: ${HF_PATH}" >&2
+  exit 2
+fi
+
+mkdir -p "${OUTPUT_DIR}"
+export REPO_ROOT MEGATRON_ROOT EMERGING_ROOT HF_PATH OUTPUT_DIR MLITE_CONTAINER_IMAGE
+export PINNED_MEGATRON_REVISION PINNED_EMERGING_REVISION
+export PYTHONPATH="${REPO_ROOT}/experimental/lite:${MEGATRON_ROOT}:${EMERGING_ROOT}${PYTHONPATH:+:${PYTHONPATH}}"
+
+# This is the previously validated Adam×DistOpt bitwise topology. Keep these values fixed;
+# Muon topology/layout variants are validated by subsequent implementation slices.
+export REFERENCE_BACKEND=mbridge
+export NPROC=1 TP=1 ETP=1 EP=1 PP=1 CP=1
+export STEPS=2 NUM_MICROBATCHES=1 SEQ_LEN=8 SEED=42
+export TRUNCATE_LAYERS=1 KEEP_EXPERTS=2
+export MEGATRON_LITE_DETERMINISTIC=1
+export CUBLAS_WORKSPACE_CONFIG=:4096:8
+
+python - <<'PY'
+import hashlib
+import importlib.metadata
+import inspect
+import json
+import os
+from pathlib import Path
+
+import torch
+import transformer_engine
+import emerging_optimizers
+from megatron.core.optimizer.optimizer_config import OptimizerConfig as CoreOptimizerConfig
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+checkpoint = Path(os.environ["HF_PATH"]).resolve()
+fingerprints = {"config.json": sha256(checkpoint / "config.json")}
+index = checkpoint / "model.safetensors.index.json"
+if index.exists():
+    fingerprints[index.name] = sha256(index)
+try:
+    emerging_version = importlib.metadata.version("emerging-optimizers")
+except importlib.metadata.PackageNotFoundError:
+    emerging_version = "source-checkout"
+
+manifest = {
+    "container_image": os.environ["MLITE_CONTAINER_IMAGE"],
+    "megatron_revision": os.environ["PINNED_MEGATRON_REVISION"],
+    "emerging_optimizers_revision": os.environ["PINNED_EMERGING_REVISION"],
+    "megatron_optimizer_config_source": inspect.getsourcefile(CoreOptimizerConfig),
+    "torch_version": torch.__version__,
+    "transformer_engine_version": transformer_engine.__version__,
+    "emerging_optimizers_version": emerging_version,
+    "emerging_optimizers_source": emerging_optimizers.__file__,
+    "checkpoint": str(checkpoint),
+    "checkpoint_fingerprints": fingerprints,
+    "topology": {"world": 1, "tp": 1, "etp": 1, "ep": 1, "pp": 1, "cp": 1},
+    "seed": 42,
+    "steps": 2,
+    "num_microbatches": 1,
+    "seq_len": 8,
+    "truncate_layers": 1,
+    "keep_experts": 2,
+    "optimizer": "adam",
+    "optimizer_backend": "dist_opt",
+    "reference_backend": "mbridge",
+}
+output = Path(os.environ["OUTPUT_DIR"]) / "runtime_manifest.json"
+output.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+print(json.dumps(manifest, sort_keys=True))
+PY
+
+bash "${REPO_ROOT}/experimental/lite/examples/bench/scripts/run_qwen35_correctness_pair.sh"
+
+sha256sum \
+  "${OUTPUT_DIR}/runtime_manifest.json" \
+  "${OUTPUT_DIR}/qwen35_mlite_correctness.json" \
+  "${OUTPUT_DIR}/qwen35_mbridge_correctness.json" \
+  "${OUTPUT_DIR}/qwen35_correctness_compare.json" \
+  >"${OUTPUT_DIR}/artifact_sha256.txt"

--- a/experimental/lite/examples/bench/scripts/run_pinned_adam_distopt_correctness.sh
+++ b/experimental/lite/examples/bench/scripts/run_pinned_adam_distopt_correctness.sh
@@ -5,12 +5,14 @@ set -euo pipefail
 readonly PINNED_MEGATRON_REVISION=d64ba4ccb1e3e878c15171c9cc58d5d3b46bf4d5
 readonly PINNED_EMERGING_REVISION=b309e2f01cda75dc96a6dc1a2355a7b3b64b5e16
 
-REPO_ROOT=${REPO_ROOT:-$(git rev-parse --show-toplevel)}
+VALIDATE_PINNED_REVISIONS_ONLY=${VALIDATE_PINNED_REVISIONS_ONLY:-0}
+if [[ "${VALIDATE_PINNED_REVISIONS_ONLY}" != 0 && "${VALIDATE_PINNED_REVISIONS_ONLY}" != 1 ]]; then
+  echo "VALIDATE_PINNED_REVISIONS_ONLY must be 0 or 1" >&2
+  exit 2
+fi
+
 MEGATRON_ROOT=${MEGATRON_ROOT:?set MEGATRON_ROOT to the pinned Megatron checkout}
 EMERGING_ROOT=${EMERGING_ROOT:?set EMERGING_ROOT to the pinned Emerging-Optimizers checkout}
-HF_PATH=${HF_PATH:?set HF_PATH to the fixed HuggingFace Qwen3.5 checkpoint}
-OUTPUT_DIR=${OUTPUT_DIR:?set OUTPUT_DIR to a persistent artifact directory}
-MLITE_CONTAINER_IMAGE=${MLITE_CONTAINER_IMAGE:?record the Slurm container image path}
 
 actual_megatron_revision=$(git -C "${MEGATRON_ROOT}" rev-parse HEAD)
 actual_emerging_revision=$(git -C "${EMERGING_ROOT}" rev-parse HEAD)
@@ -22,6 +24,16 @@ if [[ "${actual_emerging_revision}" != "${PINNED_EMERGING_REVISION}" ]]; then
   echo "Emerging-Optimizers revision mismatch: ${actual_emerging_revision}" >&2
   exit 2
 fi
+if [[ "${VALIDATE_PINNED_REVISIONS_ONLY}" == 1 ]]; then
+  echo "Pinned Megatron revision verified: ${actual_megatron_revision}"
+  echo "Pinned Emerging-Optimizers revision verified: ${actual_emerging_revision}"
+  exit 0
+fi
+
+REPO_ROOT=${REPO_ROOT:-$(git rev-parse --show-toplevel)}
+HF_PATH=${HF_PATH:?set HF_PATH to the fixed HuggingFace Qwen3.5 checkpoint}
+OUTPUT_DIR=${OUTPUT_DIR:?set OUTPUT_DIR to a persistent artifact directory}
+MLITE_CONTAINER_IMAGE=${MLITE_CONTAINER_IMAGE:?record the Slurm container image path}
 if [[ ! -f "${HF_PATH}/config.json" ]]; then
   echo "Qwen3.5 checkpoint is missing config.json: ${HF_PATH}" >&2
   exit 2

--- a/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
@@ -578,9 +578,22 @@ class MegatronLiteEngine(BaseEngine):
         optimizer_name = self._normalize_optimizer_name(self.optimizer_config)
         betas = tuple(getattr(self.optimizer_config, "betas", (0.9, 0.999)))
         override = getattr(self.optimizer_config, "override_optimizer_config", {}) or {}
-        offload_fraction = override.get(
-            "offload_fraction", override.get("optimizer_offload_fraction")
-        )
+        alias_present = "offload_fraction" in override
+        canonical_present = "optimizer_offload_fraction" in override
+        if (
+            alias_present
+            and canonical_present
+            and override["offload_fraction"] is not None
+            and override["optimizer_offload_fraction"] is not None
+            and override["offload_fraction"] != override["optimizer_offload_fraction"]
+        ):
+            raise ValueError(
+                "offload_fraction compatibility alias conflicts with "
+                "optimizer_offload_fraction"
+            )
+        offload_fraction = override.get("optimizer_offload_fraction")
+        if offload_fraction is None:
+            offload_fraction = override.get("offload_fraction")
         if offload_fraction is None and override.get("optimizer_cpu_offload"):
             offload_fraction = 1.0
         if offload_fraction is None and self.is_optimizer_offload_enabled:
@@ -594,6 +607,39 @@ class MegatronLiteEngine(BaseEngine):
         lr_decay_style = getattr(self.optimizer_config, "lr_decay_style", None)
         if lr_decay_style is None:
             lr_decay_style = getattr(self.optimizer_config, "lr_scheduler_type", "constant")
+
+        native_override_fields = (
+            "muon_momentum",
+            "muon_split_qkv",
+            "muon_nesterov",
+            "muon_scale_mode",
+            "muon_fp32_matmul_prec",
+            "muon_coefficient_type",
+            "muon_num_ns_steps",
+            "muon_tp_mode",
+            "muon_extra_scale_factor",
+            "muon_scalar_optimizer",
+            "use_layer_wise_param_layout",
+            "overlap_grad_reduce",
+            "overlap_param_gather",
+            "overlap_param_gather_with_optimizer_step",
+            "use_torch_optimizer_for_cpu_offload",
+            "overlap_cpu_optimizer_d2h_h2d",
+            "pin_cpu_grads",
+            "pin_cpu_params",
+            "offload_optimizer_states",
+        )
+        native_overrides = {
+            name: override[name] for name in native_override_fields if name in override
+        }
+        if offload_fraction is not None:
+            # Keep the legacy field populated during the compatibility window for older
+            # backend consumers, but make the Megatron-native field authoritative.
+            native_overrides["optimizer_offload_fraction"] = float(offload_fraction)
+            native_overrides["offload_fraction"] = float(offload_fraction)
+            native_overrides.setdefault("optimizer_cpu_offload", float(offload_fraction) > 0.0)
+        elif "optimizer_cpu_offload" in override:
+            native_overrides["optimizer_cpu_offload"] = bool(override["optimizer_cpu_offload"])
 
         return MegatronLiteOptimizerConfig(
             optimizer=optimizer_name,
@@ -618,9 +664,9 @@ class MegatronLiteEngine(BaseEngine):
             adam_beta1=betas[0],
             adam_beta2=betas[1],
             adam_eps=override.get("adam_eps", override.get("eps")),
-            offload_fraction=offload_fraction,
             use_precision_aware_optimizer=override.get("use_precision_aware_optimizer"),
             decoupled_weight_decay=override.get("decoupled_weight_decay"),
+            **native_overrides,
         )
 
     @staticmethod
@@ -629,8 +675,10 @@ class MegatronLiteEngine(BaseEngine):
         lower = str(optimizer_name).lower()
         if "adam" in lower:
             return "adam"
+        if lower == "muon":
+            return "muon"
         raise ValueError(
-            f"MegatronLiteEngine only supports Adam-style optimizers today, got {optimizer_name!r}"
+            f"MegatronLiteEngine supports optimizer='adam' or 'muon', got {optimizer_name!r}"
         )
 
     def _extract_primary_module(self):

--- a/experimental/lite/megatron/lite/primitive/optimizers/megatron_wrap.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/megatron_wrap.py
@@ -74,7 +74,17 @@ def build_dist_opt_optimizer_config(
         OptimizerConfig as CoreOptimizerConfig,  # pyright: ignore[reportMissingImports]
     )
 
-    offload = getattr(opt, "offload_fraction", None) or 0.0
+    legacy_offload = getattr(opt, "offload_fraction", None)
+    native_offload = getattr(opt, "optimizer_offload_fraction", None)
+    if (
+        legacy_offload is not None
+        and native_offload not in (None, 0.0, legacy_offload)
+    ):
+        raise ValueError(
+            "offload_fraction compatibility alias conflicts with optimizer_offload_fraction"
+        )
+    offload = native_offload if native_offload is not None else legacy_offload
+    offload = float(offload or 0.0)
     args: dict[str, Any] = {
         "optimizer": opt.optimizer,
         "lr": opt.lr,
@@ -85,6 +95,32 @@ def build_dist_opt_optimizer_config(
         "bf16": True,
         "params_dtype": torch.bfloat16,
     }
+    core_fields = {field.name for field in fields(CoreOptimizerConfig)}
+    native_fields = (
+        "muon_momentum",
+        "muon_split_qkv",
+        "muon_nesterov",
+        "muon_scale_mode",
+        "muon_fp32_matmul_prec",
+        "muon_coefficient_type",
+        "muon_num_ns_steps",
+        "muon_tp_mode",
+        "muon_extra_scale_factor",
+        "muon_scalar_optimizer",
+        "use_layer_wise_param_layout",
+        "overlap_param_gather",
+        "overlap_param_gather_with_optimizer_step",
+        "optimizer_cpu_offload",
+        "optimizer_offload_fraction",
+        "use_torch_optimizer_for_cpu_offload",
+        "overlap_cpu_optimizer_d2h_h2d",
+        "pin_cpu_grads",
+        "pin_cpu_params",
+        "offload_optimizer_states",
+    )
+    for name in native_fields:
+        if name in core_fields and hasattr(opt, name):
+            args[name] = getattr(opt, name)
     if offload > 0:
         args["optimizer_offload_fraction"] = offload
         args["overlap_cpu_optimizer_d2h_h2d"] = True
@@ -99,6 +135,26 @@ def build_dist_opt_optimizer_config(
         args["use_precision_aware_optimizer"] = opt.use_precision_aware_optimizer
     if getattr(opt, "decoupled_weight_decay", None) is not None:
         args["decoupled_weight_decay"] = opt.decoupled_weight_decay
+    if opt.optimizer == "muon":
+        required_muon_fields = {
+            "muon_momentum",
+            "muon_split_qkv",
+            "muon_nesterov",
+            "muon_scale_mode",
+            "muon_fp32_matmul_prec",
+            "muon_coefficient_type",
+            "muon_num_ns_steps",
+            "muon_tp_mode",
+            "muon_extra_scale_factor",
+            "muon_scalar_optimizer",
+            "use_layer_wise_param_layout",
+        }
+        missing = sorted(required_muon_fields - core_fields)
+        if missing:
+            raise RuntimeError(
+                "Muon requires the pinned Megatron d64ba4ccb optimizer contract; "
+                f"runtime is missing fields: {missing}"
+            )
     if override_optimizer_config:
         args.update(override_optimizer_config)
     return CoreOptimizerConfig(**args)
@@ -123,24 +179,37 @@ def build_dist_opt_stack(
             influences optimizer master-grad sharding, so callers that prewrap
             chunks own the DDP config compatibility.
     """
-    from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig
-    from megatron.core.distributed.finalize_model_grads import finalize_model_grads
-    from megatron.core.optimizer import get_megatron_optimizer
-    from megatron.core.transformer.enums import ModelType
-
     validate_dist_opt_config(engine_cfg)
 
     p = engine_cfg.parallel
     opt = engine_cfg.optimizer
-
-    dist_opt_transformer_cfg = _build_transformer_config(model_cfg, engine_cfg)
-    dist_opt_transformer_cfg.finalize_model_grads_func = finalize_model_grads
     if is_expert is not None:
         is_expert_param = is_expert
     elif proto is not None and hasattr(proto, "EXPERT_CLASSIFIER"):
         is_expert_param = proto.EXPERT_CLASSIFIER
     else:
         is_expert_param = default_expert_classifier
+
+    if opt.optimizer == "muon":
+        from megatron.lite.primitive.optimizers.muon_routing import (
+            tag_muon_parameter_metadata,
+        )
+
+        tag_muon_parameter_metadata(model_chunks, is_expert_param=is_expert_param)
+        raise NotImplementedError(
+            "Muon×dist_opt step lowering is intentionally deferred: the next slice must "
+            "tag parameters before DDP, compute the LayerWise full-param layout, wrap DDP "
+            "with that layout, and pass explicit pg_collection owner groups. It must not "
+            "reuse the current WORLD/singleton process-group assumptions."
+        )
+
+    from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig
+    from megatron.core.distributed.finalize_model_grads import finalize_model_grads
+    from megatron.core.optimizer import get_megatron_optimizer
+    from megatron.core.transformer.enums import ModelType
+
+    dist_opt_transformer_cfg = _build_transformer_config(model_cfg, engine_cfg)
+    dist_opt_transformer_cfg.finalize_model_grads_func = finalize_model_grads
     use_mpu_groups = bool(getattr(engine_cfg, "deterministic", False))
     if use_mpu_groups:
         _ensure_dist_opt_mpu_parallel_state(engine_cfg)
@@ -153,7 +222,13 @@ def build_dist_opt_stack(
         wrapped_chunks = list(model_chunks)
     else:
         ddp_config = DistributedDataParallelConfig(
-            use_distributed_optimizer=True, overlap_grad_reduce=False, grad_reduce_in_fp32=True
+            use_distributed_optimizer=True,
+            overlap_grad_reduce=bool(getattr(opt, "overlap_grad_reduce", False)),
+            overlap_param_gather=bool(getattr(opt, "overlap_param_gather", False)),
+            use_layer_wise_param_layout=bool(
+                getattr(opt, "use_layer_wise_param_layout", False)
+            ),
+            grad_reduce_in_fp32=True,
         )
         wrapped_chunks = []
         for chunk_idx, chunk in enumerate(model_chunks):

--- a/experimental/lite/megatron/lite/primitive/optimizers/megatron_wrap.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/megatron_wrap.py
@@ -121,7 +121,9 @@ def build_dist_opt_optimizer_config(
     for name in native_fields:
         if name in core_fields and hasattr(opt, name):
             args[name] = getattr(opt, name)
-    if offload > 0:
+    if legacy_offload is not None and offload > 0:
+        # Preserve the legacy alias semantics. Canonical Megatron fields above are
+        # otherwise forwarded verbatim, including an explicitly disabled overlap.
         args["optimizer_offload_fraction"] = offload
         args["overlap_cpu_optimizer_d2h_h2d"] = True
         args["optimizer_cpu_offload"] = True

--- a/experimental/lite/megatron/lite/primitive/optimizers/muon_routing.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/muon_routing.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Megatron-native Muon parameter routing metadata for MLite models."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+
+import torch.nn as nn  # pyright: ignore[reportMissingImports]
+
+from megatron.lite.primitive.protocols import ExpertClassifierFn
+
+_EMBEDDING_OUTPUT_MODULES = frozenset({"VocabParallelEmbedding", "VocabParallelOutput"})
+
+
+def is_managed_by_muon(param: nn.Parameter) -> bool:
+    """Mirror Megatron's Muon route: matrix weights except embeddings/outputs."""
+
+    return param.dim() == 2 and not getattr(
+        param, "is_embedding_or_output_parameter", False
+    )
+
+
+def _tag_embedding_and_output_parameters(model: nn.Module) -> None:
+    # All five native model families assemble their token embedding and LM head from these
+    # shared primitive types. Central type-name routing avoids model-protocol edits while
+    # keeping this helper importable in CPU tests without importing Transformer Engine.
+    for module in model.modules():
+        if type(module).__name__ not in _EMBEDDING_OUTPUT_MODULES:
+            continue
+        for param in module.parameters(recurse=True):
+            param.is_embedding_or_output_parameter = True
+
+
+def _tag_fused_qkv_parameters(model: nn.Module) -> None:
+    """Attach the same per-query-group QKV split metadata used by Megatron."""
+
+    for module in model.modules():
+        if type(module).__name__ != "GQAttention":
+            continue
+        num_q_heads = int(module.num_heads_local)
+        num_kv_heads = int(module.num_kv_heads_local)
+        head_dim = int(module.head_dim)
+        if num_kv_heads <= 0 or num_q_heads % num_kv_heads:
+            continue
+        q_projection_size = (num_q_heads // num_kv_heads) * head_dim
+        if bool(getattr(module, "_output_gate", False)):
+            split_shapes = [q_projection_size, q_projection_size, head_dim, head_dim]
+        else:
+            split_shapes = [q_projection_size, head_dim, head_dim]
+        param = module.qkv.linear.weight
+        if param.dim() == 2 and param.shape[0] % sum(split_shapes) == 0:
+            param.is_qkv = True
+            param.qkv_split_shapes = split_shapes
+
+
+def tag_muon_parameter_metadata(
+    model_chunks: Iterable[nn.Module],
+    *,
+    is_expert_param: ExpertClassifierFn | Callable[[str], bool],
+) -> None:
+    """Tag Muon routing, QKV splitting, and expert metadata before DDP wrapping.
+
+    Existing TP/EP attributes are deliberately left untouched. The subsequent DistOpt
+    metadata pass may fill missing attributes, but must continue to respect model-provided
+    ``tensor_model_parallel``, ``sequence_parallel``, ``partition_*``, and ``allreduce``.
+    """
+
+    for model in model_chunks:
+        _tag_embedding_and_output_parameters(model)
+        _tag_fused_qkv_parameters(model)
+        for name, param in model.named_parameters():
+            if not param.requires_grad:
+                continue
+            if is_expert_param(name):
+                param.expert_tp = True
+            param.is_managed_by_layer_wise_optimizer = is_managed_by_muon(param)
+
+
+__all__ = ["is_managed_by_muon", "tag_muon_parameter_metadata"]

--- a/experimental/lite/megatron/lite/runtime/contracts/config.py
+++ b/experimental/lite/megatron/lite/runtime/contracts/config.py
@@ -60,6 +60,33 @@ class OptimizerConfig:
     lr_wsd_decay_steps: int | None = None
     use_checkpoint_opt_param_scheduler: bool = False
 
+    # --- Megatron native Muon fields (Megatron-LM d64ba4ccb) ---
+    muon_momentum: float = 0.95
+    muon_split_qkv: bool = True
+    muon_nesterov: bool = False
+    muon_scale_mode: str = "spectral"
+    muon_fp32_matmul_prec: str = "medium"
+    muon_coefficient_type: str = "quintic"
+    muon_num_ns_steps: int = 5
+    muon_tp_mode: str = "blockwise"
+    muon_extra_scale_factor: float = 1.0
+    muon_scalar_optimizer: str = "adam"
+
+    # --- Megatron native LayerWise/DDP fields ---
+    use_layer_wise_param_layout: bool = False
+    overlap_grad_reduce: bool = False
+    overlap_param_gather: bool = False
+    overlap_param_gather_with_optimizer_step: bool = False
+
+    # --- Megatron native optimizer-offload fields ---
+    optimizer_cpu_offload: bool = False
+    optimizer_offload_fraction: float = 0.0
+    use_torch_optimizer_for_cpu_offload: bool = False
+    overlap_cpu_optimizer_d2h_h2d: bool = False
+    pin_cpu_grads: bool = True
+    pin_cpu_params: bool = True
+    offload_optimizer_states: bool = False
+
     # --- compatibility aliases ---
     adam_beta1: float | None = None
     adam_beta2: float | None = None
@@ -67,6 +94,25 @@ class OptimizerConfig:
     offload_fraction: float | None = None
     use_precision_aware_optimizer: bool | None = None
     decoupled_weight_decay: bool | None = None
+
+    def __post_init__(self) -> None:
+        """Normalize legacy aliases and reject ambiguous native contracts."""
+
+        if self.offload_fraction is not None:
+            if self.optimizer_offload_fraction not in (0.0, self.offload_fraction):
+                raise ValueError(
+                    "offload_fraction compatibility alias conflicts with "
+                    "optimizer_offload_fraction"
+                )
+            self.optimizer_offload_fraction = float(self.offload_fraction)
+        if not 0.0 <= self.optimizer_offload_fraction <= 1.0:
+            raise ValueError("optimizer_offload_fraction must be in [0, 1]")
+        if self.muon_scalar_optimizer != "adam":
+            raise ValueError("muon_scalar_optimizer currently supports only 'adam'")
+        if self.optimizer.lower() == "muon" and self.overlap_param_gather_with_optimizer_step:
+            raise ValueError(
+                "overlap_param_gather_with_optimizer_step is not supported with Muon"
+            )
 
 
 @dataclass

--- a/experimental/lite/tests/unit/primitive/test_muon_routing.py
+++ b/experimental/lite/tests/unit/primitive/test_muon_routing.py
@@ -1,14 +1,22 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from __future__ import annotations
 
+import sys
+import types
+from dataclasses import field as dataclass_field
+from dataclasses import fields, make_dataclass
 from types import SimpleNamespace
 
 import pytest
 import torch
 import torch.nn as nn
 
-from megatron.lite.primitive.optimizers.megatron_wrap import build_dist_opt_stack
+from megatron.lite.primitive.optimizers.megatron_wrap import (
+    build_dist_opt_optimizer_config,
+    build_dist_opt_stack,
+)
 from megatron.lite.primitive.optimizers.muon_routing import tag_muon_parameter_metadata
+from megatron.lite.runtime.contracts.config import OptimizerConfig
 
 
 class VocabParallelEmbedding(nn.Module):
@@ -134,3 +142,84 @@ def test_dist_opt_entry_tags_metadata_then_fails_before_owner_group_or_step_lowe
     assert model.embed.embedding.weight.is_managed_by_layer_wise_optimizer is False
     assert model.attn.qkv.linear.weight.qkv_split_shapes == [4, 4, 2, 2]
     assert model.experts[0].weight.expert_tp is True
+
+
+def test_native_fields_route_without_rewriting_and_legacy_offload_keeps_compat(
+    monkeypatch,
+) -> None:
+    core_field_names = {
+        "optimizer",
+        "lr",
+        "min_lr",
+        "weight_decay",
+        "clip_grad",
+        "use_distributed_optimizer",
+        "bf16",
+        "params_dtype",
+        *(item.name for item in fields(OptimizerConfig)),
+    }
+    fake_core_config = make_dataclass(
+        "FakeCoreOptimizerConfig",
+        [
+            (name, object, dataclass_field(default=None))
+            for name in sorted(core_field_names)
+        ],
+    )
+    fake_module = types.ModuleType("megatron.core.optimizer.optimizer_config")
+    fake_module.OptimizerConfig = fake_core_config
+    monkeypatch.setitem(
+        sys.modules, "megatron.core.optimizer.optimizer_config", fake_module
+    )
+
+    config = OptimizerConfig(
+        optimizer="muon",
+        muon_momentum=0.9,
+        muon_split_qkv=False,
+        muon_nesterov=True,
+        muon_scale_mode="unit_rms_norm",
+        muon_fp32_matmul_prec="high",
+        muon_coefficient_type="simple",
+        muon_num_ns_steps=7,
+        muon_tp_mode="duplicated",
+        muon_extra_scale_factor=0.2,
+        use_layer_wise_param_layout=True,
+        overlap_param_gather=True,
+        optimizer_cpu_offload=True,
+        optimizer_offload_fraction=0.25,
+        use_torch_optimizer_for_cpu_offload=True,
+        overlap_cpu_optimizer_d2h_h2d=False,
+        pin_cpu_grads=False,
+        pin_cpu_params=False,
+        offload_optimizer_states=True,
+    )
+
+    core = build_dist_opt_optimizer_config(config)
+
+    assert core.muon_momentum == 0.9
+    assert core.muon_split_qkv is False
+    assert core.muon_nesterov is True
+    assert core.muon_scale_mode == "unit_rms_norm"
+    assert core.muon_fp32_matmul_prec == "high"
+    assert core.muon_coefficient_type == "simple"
+    assert core.muon_num_ns_steps == 7
+    assert core.muon_tp_mode == "duplicated"
+    assert core.muon_extra_scale_factor == 0.2
+    assert core.muon_scalar_optimizer == "adam"
+    assert core.use_layer_wise_param_layout is True
+    assert core.overlap_param_gather is True
+    assert core.overlap_param_gather_with_optimizer_step is False
+    assert core.optimizer_cpu_offload is True
+    assert core.optimizer_offload_fraction == 0.25
+    assert core.use_torch_optimizer_for_cpu_offload is True
+    assert core.overlap_cpu_optimizer_d2h_h2d is False
+    assert core.pin_cpu_grads is False
+    assert core.pin_cpu_params is False
+    assert core.offload_optimizer_states is True
+
+    legacy_core = build_dist_opt_optimizer_config(
+        OptimizerConfig(offload_fraction=0.5, overlap_cpu_optimizer_d2h_h2d=False)
+    )
+
+    assert legacy_core.optimizer_cpu_offload is True
+    assert legacy_core.optimizer_offload_fraction == 0.5
+    assert legacy_core.overlap_cpu_optimizer_d2h_h2d is True

--- a/experimental/lite/tests/unit/primitive/test_muon_routing.py
+++ b/experimental/lite/tests/unit/primitive/test_muon_routing.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+from megatron.lite.primitive.optimizers.megatron_wrap import build_dist_opt_stack
+from megatron.lite.primitive.optimizers.muon_routing import tag_muon_parameter_metadata
+
+
+class VocabParallelEmbedding(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.embedding = nn.Embedding(8, 4)
+
+
+class _OutputColumn(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.linear = nn.Linear(4, 8, bias=False)
+
+
+class VocabParallelOutput(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.col = _OutputColumn()
+
+
+class _QKVProjection(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.linear = nn.Linear(4, 12, bias=False)
+
+
+class GQAttention(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.num_heads_local = 2
+        self.num_kv_heads_local = 1
+        self.head_dim = 2
+        self._output_gate = True
+        self.qkv = _QKVProjection()
+
+
+class _SyntheticModel(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.embed = VocabParallelEmbedding()
+        self.attn = GQAttention()
+        self.experts = nn.ModuleList([nn.Linear(4, 4, bias=False)])
+        self.dense = nn.Linear(4, 4, bias=False)
+        self.head = VocabParallelOutput()
+
+
+def test_central_routing_excludes_embedding_and_output_and_tags_qkv() -> None:
+    model = _SyntheticModel()
+
+    tag_muon_parameter_metadata(
+        [model], is_expert_param=lambda name: name.startswith("experts.")
+    )
+
+    embedding = model.embed.embedding.weight
+    output = model.head.col.linear.weight
+    qkv = model.attn.qkv.linear.weight
+
+    assert embedding.is_embedding_or_output_parameter is True
+    assert embedding.is_managed_by_layer_wise_optimizer is False
+    assert output.is_embedding_or_output_parameter is True
+    assert output.is_managed_by_layer_wise_optimizer is False
+    assert qkv.is_qkv is True
+    assert qkv.qkv_split_shapes == [4, 4, 2, 2]
+    assert qkv.is_managed_by_layer_wise_optimizer is True
+
+
+def test_central_routing_preserves_expert_and_tensor_parallel_metadata() -> None:
+    model = _SyntheticModel()
+    expert = model.experts[0].weight
+    dense = model.dense.weight
+    expert.tensor_model_parallel = True
+    expert.partition_dim = 0
+    expert.partition_stride = 2
+    expert.allreduce = False
+    dense.tensor_model_parallel = False
+    dense.sequence_parallel = True
+
+    tag_muon_parameter_metadata(
+        [model], is_expert_param=lambda name: name.startswith("experts.")
+    )
+
+    assert expert.expert_tp is True
+    assert expert.tensor_model_parallel is True
+    assert expert.partition_dim == 0
+    assert expert.partition_stride == 2
+    assert expert.allreduce is False
+    assert dense.tensor_model_parallel is False
+    assert dense.sequence_parallel is True
+
+
+def test_qkv_metadata_is_not_set_when_shape_is_incompatible() -> None:
+    model = _SyntheticModel()
+    model.attn.qkv.linear.weight = nn.Parameter(torch.empty(15, 4))
+
+    tag_muon_parameter_metadata([model], is_expert_param=lambda _name: False)
+
+    assert not getattr(model.attn.qkv.linear.weight, "is_qkv", False)
+
+
+def test_dist_opt_entry_tags_metadata_then_fails_before_owner_group_or_step_lowering() -> (
+    None
+):
+    model = _SyntheticModel()
+    parallel = SimpleNamespace(vpp=1, pp=1, tp=1, ep=1, etp=1, cp=1)
+    engine_config = SimpleNamespace(
+        parallel=parallel,
+        optimizer=SimpleNamespace(optimizer="muon"),
+        deterministic=False,
+    )
+
+    with pytest.raises(
+        NotImplementedError,
+        match="full-param layout.*pg_collection owner groups.*WORLD/singleton",
+    ):
+        build_dist_opt_stack(
+            [model],
+            model_cfg=SimpleNamespace(),
+            engine_cfg=engine_config,
+            ps=None,
+            is_expert=lambda name: name.startswith("experts."),
+        )
+
+    assert model.embed.embedding.weight.is_managed_by_layer_wise_optimizer is False
+    assert model.attn.qkv.linear.weight.qkv_split_shapes == [4, 4, 2, 2]
+    assert model.experts[0].weight.expert_tp is True

--- a/experimental/lite/tests/unit/runtime/test_optimizer_config_contract.py
+++ b/experimental/lite/tests/unit/runtime/test_optimizer_config_contract.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from __future__ import annotations
+
+import pytest
+
+from megatron.lite.runtime.contracts.config import OptimizerConfig
+
+
+def test_muon_contract_matches_pinned_megatron_defaults() -> None:
+    config = OptimizerConfig(optimizer="muon")
+
+    assert config.muon_momentum == 0.95
+    assert config.muon_split_qkv is True
+    assert config.muon_nesterov is False
+    assert config.muon_scale_mode == "spectral"
+    assert config.muon_fp32_matmul_prec == "medium"
+    assert config.muon_coefficient_type == "quintic"
+    assert config.muon_num_ns_steps == 5
+    assert config.muon_tp_mode == "blockwise"
+    assert config.muon_extra_scale_factor == 1.0
+    assert config.muon_scalar_optimizer == "adam"
+
+
+def test_layerwise_overlap_and_offload_contract_matches_pinned_megatron_defaults() -> (
+    None
+):
+    config = OptimizerConfig()
+
+    assert config.use_layer_wise_param_layout is False
+    assert config.overlap_grad_reduce is False
+    assert config.overlap_param_gather is False
+    assert config.overlap_param_gather_with_optimizer_step is False
+    assert config.optimizer_cpu_offload is False
+    assert config.optimizer_offload_fraction == 0.0
+    assert config.use_torch_optimizer_for_cpu_offload is False
+    assert config.overlap_cpu_optimizer_d2h_h2d is False
+    assert config.pin_cpu_grads is True
+    assert config.pin_cpu_params is True
+    assert config.offload_optimizer_states is False
+
+
+def test_legacy_offload_fraction_alias_normalizes_to_canonical_field() -> None:
+    config = OptimizerConfig(offload_fraction=0.25)
+
+    assert config.optimizer_offload_fraction == 0.25
+
+
+def test_conflicting_offload_fraction_alias_fails_loudly() -> None:
+    with pytest.raises(
+        ValueError, match="offload_fraction.*optimizer_offload_fraction"
+    ):
+        OptimizerConfig(offload_fraction=0.25, optimizer_offload_fraction=0.5)
+
+
+def test_muon_scalar_optimizer_is_currently_adam_only() -> None:
+    with pytest.raises(ValueError, match="muon_scalar_optimizer.*adam"):
+        OptimizerConfig(optimizer="muon", muon_scalar_optimizer="lion")
+
+
+def test_muon_rejects_cross_step_param_gather_overlap() -> None:
+    with pytest.raises(ValueError, match="overlap_param_gather_with_optimizer_step"):
+        OptimizerConfig(optimizer="muon", overlap_param_gather_with_optimizer_step=True)

--- a/experimental/lite/tests/unit/verl/test_mlite_engine_config.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_engine_config.py
@@ -100,6 +100,52 @@ def test_explicit_optimizer_offload_fraction_overrides_engine_default() -> None:
     assert optimizer.offload_fraction == 0.25
 
 
+def test_canonical_optimizer_offload_fraction_is_preferred() -> None:
+    engine = _engine(
+        engine_config=_engine_config(optimizer_offload=True),
+        optimizer_config=_optimizer_config(optimizer_offload_fraction=0.25),
+    )
+
+    optimizer = engine._build_mlite_optimizer_config()
+
+    assert optimizer.optimizer_offload_fraction == 0.25
+
+
+def test_conflicting_optimizer_offload_alias_fails_loudly() -> None:
+    engine = _engine(
+        engine_config=_engine_config(),
+        optimizer_config=_optimizer_config(
+            offload_fraction=0.25, optimizer_offload_fraction=0.5
+        ),
+    )
+
+    with pytest.raises(ValueError, match="offload_fraction.*optimizer_offload_fraction"):
+        engine._build_mlite_optimizer_config()
+
+
+def test_verl_muon_overrides_route_to_native_contract() -> None:
+    engine = _engine(
+        engine_config=_engine_config(),
+        optimizer_config=_optimizer_config(
+            muon_momentum=0.9,
+            muon_num_ns_steps=7,
+            use_layer_wise_param_layout=True,
+            overlap_grad_reduce=True,
+            overlap_param_gather=True,
+        ),
+    )
+    engine.optimizer_config.optimizer = "muon"
+
+    optimizer = engine._build_mlite_optimizer_config()
+
+    assert optimizer.optimizer == "muon"
+    assert optimizer.muon_momentum == 0.9
+    assert optimizer.muon_num_ns_steps == 7
+    assert optimizer.use_layer_wise_param_layout is True
+    assert optimizer.overlap_grad_reduce is True
+    assert optimizer.overlap_param_gather is True
+
+
 def test_optimizer_cpu_offload_alias_maps_to_full_offload_fraction() -> None:
     engine = _engine(
         engine_config=_engine_config(optimizer_offload=False),


### PR DESCRIPTION
## MLite Muon optimizer, step 1: native config and parameter-routing contract (WIP)

Implements the first step of the Muon integration design (`experimental/lite/docs/muon_optimizer.md`): 

- Native Muon configuration surface plus the parameter-routing contract (non-embedding 2-D parameters → Muon; embeddings/output/bias/norm and non-2-D → Adam; chained coexistence).
- Fail-loud pinned-revision validation anchoring the implementation baseline (NVIDIA Megatron-LM dev + NeMo Emerging-Optimizers v0.3.0).

Next steps in the same track: DistOpt bitwise parity, padded/overlap handling, offload, FSDP2 lowering, and end-to-end quality/perf validation.

⚠️ Work in progress — shared early for owner review of the API shape. No GPU validation yet (CPU-first policy).
