### PR TITLE
Analyze incremental RL weight synchronization

### DIFF
--- a/experimental/lite/README.md
+++ b/experimental/lite/README.md
@@ -128,6 +128,7 @@ bash experimental/lite/examples/bench/scripts/run_qwen35_correctness_pair.sh
 
 - [Architecture](docs/architecture.md)
 - [Runtime](docs/runtime.md)
+- [RL Incremental Weight Synchronization](docs/rl-incremental-weight-sync.md)
 - [Models](docs/models.md)
 - [Porting Notes](docs/porting.md)
 - [Skills](skills/README.md)

--- a/experimental/lite/docs/rl-incremental-weight-sync.md
+++ b/experimental/lite/docs/rl-incremental-weight-sync.md
@@ -1,0 +1,479 @@
+# Incremental RL weight synchronization
+
+## Decision summary
+
+MLite should prototype **lossless, versioned incremental synchronization**, but
+should not replace the current full-weight path yet. The current path already
+matches the Megatron reference: the validated Qwen3.5 harness measured 11.837 s
+for MLite versus 11.903 s for mbridge. Incremental synchronization therefore has
+to beat a seconds-scale, GPU-resident baseline; the obsolete 100 s measurement
+is not a valid benefit baseline.
+
+The first implementation candidate is adaptive per export bucket:
+
+1. send only a version manifest when the target bytes are unchanged;
+2. send the current dense bucket when compression is not profitable;
+3. otherwise send either an exact bitmap plus replacement values for the local
+   GPU transport, or a bytewise XOR compressed with zstd for object storage;
+4. always retain full synchronization as recovery and compatibility fallback.
+
+Both incremental codecs reconstruct the exact target representation. Top-k,
+low-rank, and quantized deltas are intentionally deferred because they change
+the rollout policy and require a separate numerical approval. The empirical
+decision below is based on exported BF16 weights, which are the values consumed
+by the rollout engine, rather than FP32 optimizer master weights.
+
+<!-- RESULT_VERDICT_BEGIN -->
+The evidence supports an opt-in lossless prototype, not a production-path
+replacement. A real first actor update with nonzero gradient norm produced no
+change in the exported BF16 representation at its warm-up learning rate. The
+two Qwen3.5 ten-update windows were sparse but not stationary: exact changed
+density rose from 9.755% to 10.881%, and per-tensor XOR-plus-zstd grew from
+9.862% to 10.642% of dense bytes. This does not reproduce Cognition's reported
+over-99% reduction.
+
+For the local GPU candidate, treating an unchanged tensor as a manifest-only
+update and all other tensors as bitmap plus replacement values gives payload
+lower bounds of 15.925% and 17.052%. Applied to the validated 69.321 GB
+Qwen3.5 transfer, that is approximately 11.04--11.82 GB. The next decision
+should therefore authorize only the lossless encode/apply prototype and its
+bucket-level wall-time benchmark. Production integration and lossy top-k or
+quantized deltas remain gated.
+<!-- RESULT_VERDICT_END -->
+
+## Empirical protocol
+
+The CPU-only analyzer is
+[`analyze_checkpoint_delta.py`](../examples/verl/scripts/analyze_checkpoint_delta.py).
+It streams one safetensor at a time and reports, for every tensor:
+
+- delta L-infinity, L2, and relative L2 norms;
+- exact changed-element density plus densities above `1e-8` through `1e-3`;
+- an absolute-delta magnitude histogram;
+- exact bitmap-plus-replacement and 32-bit COO payload estimates;
+- nonzero bytes in the bitwise XOR; and
+- zstd level-3 bytes for independent per-tensor XOR frames.
+
+The zstd total is conservative relative to a production bucket stream because
+each tensor starts a separate frame. Bitmap and COO estimates exclude names,
+shapes, version manifests, checksums, and kernel launch cost, so they are payload
+lower bounds rather than wall-time predictions.
+
+Two evidence sets are kept separate:
+
+- **True one-step window.** Qwen3-8B-Base DAPO calibration run, BF16, learning
+  rate configured to peak at `1e-6`, base to `global_step_1`. The scheduler's
+  logged step-1 actor rate was `1e-7` during its ten-step warm-up. The run logged
+  a nonzero gradient norm and completed `update_actor` before saving. The
+  four-rank FP32 FSDP checkpoint was merged to HF BF16 on a CPU Slurm partition
+  before comparison.
+- **Training-stage windows.** Qwen3.5-35B-A3B, DAPO, BF16 exported HF weights,
+  learning rate `1e-6`, adjacent stored checkpoints `10 -> 20` and `20 -> 30`
+  from one Megatron/mbridge run. Each window contains ten optimizer updates; it
+  shows early-to-late behavior but must not be presented as a single-step
+  density.
+
+The Qwen3.5 run used a controlled DAPO pipeline with DAPO-Math-17k, AIME-2024,
+train batch 32, generation batch 96, eight responses per prompt, token-mean
+loss, and TP1/PP1/CP1/EP8. The run's Megatron leg was selected because the
+historical MLite leg only retained step 10 and therefore cannot form an adjacent
+checkpoint pair.
+
+### Aggregate results
+
+<!-- RESULT_TABLE_BEGIN -->
+| Window | Updates | Dense GiB | Exact changed | `>1e-5` | L-infinity | L2 | Relative L2 | XOR nonzero bytes | XOR+zstd / dense | Unchanged+bitmap / dense |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Qwen3-8B base -> 1 | 1 | 15.256 | 0% | 0% | 0 | 0 | 0 | 0% | n/a | manifest only |
+| Qwen3.5 10 -> 20 | 10 | 65.392 | 9.7550% | 2.3056% | 6.104e-5 | 0.55882 | 2.277e-4 | 4.9441% | 9.8623% | 15.9255% |
+| Qwen3.5 20 -> 30 | 10 | 65.392 | 10.8811% | 3.3970% | 6.104e-5 | 0.74595 | 3.039e-4 | 5.5088% | 10.6415% | 17.0516% |
+
+The one-step result is not an empty training event: the run logged actor
+gradient norm 1.286 and 25.98 s in `update_actor` before saving. It shows why
+delta detection must use the exported target dtype. The optimizer's FP32 state
+can move while the rollout-visible BF16 bits remain unchanged. Zstandard was
+not available in that analysis environment, but an unchanged manifest is
+strictly smaller than compressing an all-zero XOR payload.
+
+The final column sums a zero-byte payload for unchanged tensors and a bitmap
+plus BF16 target values for changed tensors. It excludes manifests and kernels.
+Choosing the byte-minimum of bitmap, COO, and dense per tensor would improve
+the two Qwen3.5 lower bounds only slightly, to 15.785% and 16.918%.
+<!-- RESULT_TABLE_END -->
+
+For BF16 with `N` elements and `k` exact changes, the payload-only ratios are:
+
+- bitmap plus target values: `ceil(N / 8) + 2k` bytes, approximately
+  `6.25% + k/N` of dense BF16;
+- 32-bit index plus target value: `6k` bytes, approximately `3k/N` of dense;
+- XOR plus zstd: measured directly, because its ratio cannot be inferred from
+  element density alone.
+
+Thus COO only beats dense BF16 below 33.3% density, a bitmap can still be
+smaller below 93.75%, and COO beats a bitmap below 3.125%. These are byte
+crossovers, not performance gates: GPU scatter cost can make a theoretically
+smaller payload slower.
+
+### Parameter-family results
+
+Family classification exists only in the analysis layer. It is not a runtime
+dispatch mechanism and must not leak model names into a primitive.
+
+<!-- FAMILY_TABLE_BEGIN -->
+| Window | Family | Dense GiB | Exact changed | `>1e-5` | L-infinity | Relative L2 |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| base -> 1 | embedding | 2.318 | 0% | 0% | 0 | 0 |
+| base -> 1 | attention | 2.813 | 0% | 0% | 0 | 0 |
+| base -> 1 | router | n/a | n/a | n/a | n/a | n/a |
+| base -> 1 | expert | n/a | n/a | n/a | n/a | n/a |
+| 10 -> 20 | embedding | 1.895 | 0.6993% | 0.1244% | 6.104e-5 | 4.454e-5 |
+| 10 -> 20 | attention | 2.659 | 9.3761% | 3.4519% | 6.104e-5 | 1.959e-4 |
+| 10 -> 20 | router | 0.039 | 14.3340% | 5.1497% | 6.104e-5 | 2.574e-4 |
+| 10 -> 20 | expert | 60.234 | 10.1450% | 2.3434% | 6.104e-5 | 2.778e-4 |
+| 20 -> 30 | embedding | 1.895 | 0.8279% | 0.2262% | 6.104e-5 | 6.364e-5 |
+| 20 -> 30 | attention | 2.659 | 10.2445% | 4.3323% | 6.104e-5 | 2.576e-4 |
+| 20 -> 30 | router | 0.039 | 15.2466% | 6.1305% | 6.104e-5 | 3.262e-4 |
+| 20 -> 30 | expert | 60.234 | 11.3246% | 3.4855% | 6.104e-5 | 3.712e-4 |
+
+Router tensors have the highest density, but they are only 0.039 GiB. Experts
+hold 92.1% of the analyzed bytes and therefore dominate payload. All four
+requested families become denser in the later window. The vision/dense-MLP
+family remained unchanged in both windows.
+<!-- FAMILY_TABLE_END -->
+
+<!-- HISTOGRAM_BEGIN -->
+All 399 tensors in the true one-step window are in the zero-density bin. The
+Qwen3.5 per-tensor exact-density distribution is:
+
+| Per-tensor exact density | 10 -> 20 tensors | 10 -> 20 dense-byte share | 20 -> 30 tensors | 20 -> 30 dense-byte share |
+| --- | ---: | ---: | ---: | ---: |
+| 0 | 449 | 1.2721% | 449 | 1.2721% |
+| (0, 1%] | 62 | 2.8975% | 57 | 2.8975% |
+| (1%, 5%] | 16 | 0.0003% | 20 | 0.0001% |
+| (5%, 10%] | 70 | 31.1468% | 39 | 14.4661% |
+| (10%, 25%] | 362 | 64.6776% | 393 | 81.3555% |
+| (25%, 50%] | 61 | 0.0057% | 66 | 0.0086% |
+| (50%, 100%] | 6 | <0.0001% | 2 | <0.0001% |
+
+Among elements that changed exactly, the absolute BF16 delta distribution is:
+
+| Absolute delta | 10 -> 20 changed-element share | 20 -> 30 changed-element share |
+| --- | ---: | ---: |
+| (0, `1e-7`] | 0.0218% | 0.0195% |
+| (`1e-7`, `1e-6`] | 3.7625% | 3.3822% |
+| (`1e-6`, `1e-5`] | 72.5806% | 65.3789% |
+| (`1e-5`, `1e-4`] | 23.6352% | 31.2194% |
+| `>1e-4` | 0% | 0% |
+
+The largest per-tensor relative L2 values belong to 4 KiB shared-expert gate
+tensors: 2.015e-3 at 10 -> 20 and 2.336e-3 at 20 -> 30. Reporting their sizes
+prevents an unweighted top-tensor list from obscuring the byte-dominant expert
+weights.
+<!-- HISTOGRAM_END -->
+
+### Limitations
+
+- The one-step result is dense Qwen3-8B; the stage result is Qwen3.5 MoE. One
+  run per model is enough to reject a universal sparsity assumption, but not to
+  establish a production p95 across seeds, recipes, and training phases.
+- The stage windows accumulate ten updates. Cancellation within a window can
+  make cumulative density smaller than the union of per-step changes, while
+  repeated small updates can make it larger after BF16 rounding.
+- Exported BF16 sparsity is the right transport metric for BF16 rollout, but it
+  says nothing by itself about block-FP8 output bytes.
+- Payload reduction does not remove all of the current 11.837 s. Export gather,
+  mapping, version checks, encode, decode, and apply remain.
+
+## Reference systems and what transfers
+
+[Cognition's SWE-1.7 report](https://cognition.com/blog/swe-1-7) describes a
+single trainer feeding rollout clusters on three continents through object
+storage. The public architecture sends a compressed delta every K gradient
+steps, shows an XOR-plus-zstd data path, reports over 99% transfer reduction,
+publishes version manifests, prefetches into CPU memory, and recovers a new
+worker from a checkpoint followed by a delta chain. It does **not** publish the
+bucket format, crossover policy, checksum protocol, or how that compression
+ratio varies by model and step. Its headline ratio is therefore a motivation,
+not an MLite estimate.
+
+The same report also describes Muon and replaying the inference-time sampling
+distribution from recorded token masks. Those address optimizer behavior and
+train/rollout policy consistency; they are orthogonal to the lossless transport
+codec proposed here and are not silently imported into this design.
+
+Relevant compression work has different correctness contracts:
+
+- [Deep Gradient Compression](https://research.google/pubs/deep-gradient-compression-reducing-the-communication-bandwidth-for-distributed-training/)
+  applies top-k-style sparsification to gradients and needs momentum correction,
+  local clipping, momentum masking, and warm-up to preserve convergence.
+- [QSGD](https://papers.nips.cc/paper/6768-qsgd-communication-efficient-sgd-via-gradient-quantization-and-encoding)
+  quantizes gradients and trades communication for variance and convergence
+  time.
+- [Error Feedback Fixes SignSGD](https://proceedings.mlr.press/v97/karimireddy19a.html)
+  demonstrates why biased lossy compression needs residual error feedback.
+- [PowerSGD](https://proceedings.neurips.cc/paper/2019/hash/d9fbed9da256e344c1fa46bb46c34c5f-Abstract.html)
+  is useful when matrix gradients are low-rank and compression plus all-reduce
+  is faster than the optimized dense collective.
+- [DeltaZip](https://www.research-collection.ethz.ch/handle/20.500.11850/731441)
+  co-designs compressed fine-tuning deltas with multi-model serving. Its
+  long-lived base-plus-variant setting is closer to model weights, but not to a
+  latency-sensitive update after every RL optimizer step.
+
+These methods justify candidates, not correctness. MLite rollout weights are
+state, not an optimization message. Dropping or quantizing a weight update
+immediately changes log probabilities and importance ratios. Lossy methods need
+same-cache logprob/KL and short-RL evidence in addition to optimizer convergence
+arguments.
+
+[NCCL collectives](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/collectives.html)
+require participating ranks to use matching counts and datatypes. Sparse data
+must therefore be packed into explicit dense index/mask/value buffers before a
+collective or point-to-point transfer; a Python sparse object is not a wire
+format.
+
+## Proposed MLite design
+
+### Layering and ownership
+
+The design follows the MLite primitive contract:
+
+- A new generic checkpoint primitive owns delta metadata, lossless codecs,
+  checksums, and apply semantics. It knows shapes, dtypes, byte layouts, and
+  versions, but no model-family names and no veRL or Miles classes.
+- `hf_weights.py` supplies final exported tensors and layout-aware gather hooks.
+  Model protocols continue to own Qwen, Kimi, GLM, or DeepSeek mapping.
+- Application adapters own transport: veRL CUDA IPC, Miles/SGLang distributed
+  broadcast, or object storage.
+- A codec registry is selected by measured bucket properties and receiver
+  capability. Unsupported combinations fail closed to the existing dense path.
+
+A possible primitive API is:
+
+```python
+manifest, payloads = encode_weight_update(
+    current=bucket,
+    previous=shadow,
+    base_version=17,
+    target_version=18,
+    codecs=("unchanged", "bitmap_values", "xor_zstd", "dense"),
+)
+
+apply_weight_update(
+    target=rollout_bucket,
+    manifest=manifest,
+    payloads=payloads,
+    current_version=17,
+)
+```
+
+The manifest includes tensor identity, canonical flat layout, shape, dtype,
+base and target versions, codec, payload length, and digests of both encoded
+payload and reconstructed target. A duplicate target version is idempotent; a
+missing base, gap, stale update, unsupported codec, or digest mismatch requests
+a full resync. The receiver publishes the new version only after all buckets
+have applied successfully. A receiver that fails after a partial in-place apply
+is quarantined until full resync; it must not serve a mixed model.
+
+### Where delta detection runs
+
+The comparison must use the **final target representation**:
+
+1. optimizer step finishes;
+2. model-specific mapping and export dtype are resolved;
+3. current export bytes are compared with the last acknowledged shadow;
+4. the selected payload is emitted and the shadow advances only after ACK.
+
+The initial rollout cadence remains one synchronization per optimizer step.
+Increasing Cognition's `K` above one would add policy staleness and is an RL
+algorithm change, not a transparent transport optimization.
+
+Comparing FP32 master parameters earlier is incorrect: BF16 rounding can turn a
+nonzero master update into an unchanged rollout value, while mapping can split,
+concatenate, reorder, or quantize a tensor.
+
+The initial prototype should compare after the existing full gather. This saves
+transport and apply bytes without changing gather semantics and gives a clean
+performance attribution. A second phase may compare local FSDP/TP/EP shards
+against local shadows before gather, exchange change masks, and gather only
+selected blocks. That optimization is more valuable but substantially harder
+because local coordinates must map to canonical exported coordinates.
+
+The shadow is the main memory cost. It must be bounded and explicit:
+
+- same-cluster prototype: keep the acknowledged canonical shadow on CPU or
+  local storage and stage one previous exported bucket at a time; do not retain
+  a second full model on every GPU;
+- object storage: previous canonical checkpoint or delta base on CPU/local disk;
+- offloaded training: evaluate reusing the existing CPU parameter state, but do
+  not assume it equals the last acknowledged exported representation.
+
+Reading a full CPU shadow and comparing every byte can erase the transport win;
+it is an evidence prototype, not yet a production fast path. The later
+pre-gather phase should record exact BF16 replacement masks while local shards
+are updated, then map those coordinates through the existing exporter. An
+alternative exact format is a changed-block bitmap plus complete replacement
+blocks, which needs only previous block digests on the sender, but block
+amplification must be measured before selection.
+
+Today the Miles
+[`MLiteWeightUpdater.update_weights`](../examples/miles/miles_mlite/weight_update.py)
+increments a weight version, pauses and flushes rollout engines, iterates
+bounded `_export_weight_chunks`, fans every dense chunk out to colocated and
+distributed receivers, waits for their acknowledgements, and resumes serving.
+The delta encoder belongs between final chunk export and those transport
+adapters. Shadow and base-version state must be receiver-scoped: a new or stale
+receiver needs a dense resync without forcing already-current receivers back to
+the same base.
+
+### Lossless wire formats
+
+**Unchanged** emits only the authenticated manifest when old and target bytes
+are identical. The receiver verifies the base and target digest, advances its
+version, and acknowledges without touching weight storage. Advancing the
+version is necessary even with an empty payload so that the next incremental
+update names the same base on both sides.
+
+**Bitmap plus replacement values** uses one bit per canonical element and packs
+the new target values in index order. Applying replacement values, rather than
+adding numeric deltas, prevents arithmetic drift and makes replay idempotent.
+It is the preferred GPU candidate when exact density is low enough.
+
+**XOR plus zstd** XORs the old and new serialized target bytes and compresses
+the result. Applying the decompressed XOR reconstructs the target bits exactly.
+It is attractive for object storage and CPU staging, but its CPU encode/decode
+cost must be included in wall time. It should not be inserted into the current
+11.837 s local path solely because the byte ratio is good.
+
+**Dense** is always available. Codec selection is per bounded export bucket,
+using actual encoded bytes and a configured safety margin rather than a global
+model-level guess. Metadata, encode time, and apply time are included in the
+decision benchmark.
+
+### Interaction with two-slot prefetch
+
+The validated veRL compatibility path in
+[`compat.py`](../examples/verl/verl_mlite/compat.py) already uses two bounded
+staging slots to overlap synchronous production with receiver ACKs.
+Incremental payloads should occupy those same slots; they must not add a third
+unbounded queue. A slot owns its payload until ACK, after which it can be reused
+and its shadow transition can be committed.
+
+Those two slots overlap buckets within one synchronization; they are recycled
+after ACK and are not a cross-step copy of the previous model. The acknowledged
+shadow or change-recording mechanism above remains separate state with its own
+memory accounting.
+
+The separate Miles/SGLang two-slot transport work is not implemented yet. This
+design does not claim that veRL's compatibility-layer prefetch automatically
+covers the distributed Miles/SGLang leg. That leg needs its own ordering,
+weight-version, termination, and failure tests before enabling incremental
+payloads.
+
+### BF16 to block-FP8 resync
+
+BF16 deltas must never be applied directly to an FP8 rollout tensor. Block-FP8
+quantization couples a weight block to its scale, so one BF16 change can alter
+the scale and many serialized FP8 bytes.
+
+The safe path is:
+
+1. produce the same canonical block-FP8 target artifact as a full resync;
+2. include weight bytes and scale bytes in one versioned block;
+3. compare that serialized target with the last acknowledged FP8 artifact;
+4. send exact changed blocks or lossless XOR; and
+5. verify the reconstructed FP8 bytes before publishing the version.
+
+This adds no error beyond the already validated BF16-to-FP8 quantization. If the
+canonical FP8 serializer is unavailable, nondeterministic, or changes version,
+the codec must fall back to a full FP8 resync. Exact BF16 density must not be
+used to predict FP8 density; it needs a separate measurement.
+
+### Full calibration and recovery
+
+Lossless replacement and XOR do not accumulate numerical error, but full
+snapshots remain necessary for recovery, shadow refresh, serializer upgrades,
+and bounded replay time. Rather than hard-coding an arbitrary interval, write a
+new full base when any of these is true:
+
+- the delta chain reaches a configured maximum length;
+- cumulative encoded bytes exceed a dense snapshot;
+- a version or checksum mismatch occurs;
+- codec, mapping, dtype, topology, or quantizer identity changes; or
+- an operator requests calibration.
+
+Lossy top-k or quantized deltas, if ever approved, additionally require residual
+error feedback and a fixed full-calibration cadence. They are a separate
+numerical feature, not an optimization flag on the lossless protocol.
+
+## Benefit model and acceptance gates
+
+For the current Qwen3.5 baseline, use 69.321 GB transferred and 11.837 s wall as
+the dense reference. If an observed encoded payload ratio is `r`, the payload
+estimate is `69.321 * r` GB. Wall time is **not** `11.837 * r`: full-gather,
+mapping, encode, synchronization, receiver apply, and fixed handshakes remain.
+
+| Evidence window | Unchanged+bitmap `r` | Estimated transfer | Byte reduction | Optimistic post-gather bound |
+| --- | ---: | ---: | ---: | ---: |
+| 10 -> 20 | 0.1593 | 11.04 GB | 84.1% | 4.90 s + new overhead |
+| 20 -> 30 | 0.1705 | 11.82 GB | 82.9% | 5.00 s + new overhead |
+
+The last column is deliberately optimistic:
+`3.591 + r * (11.837 - 3.591)`. It preserves the measured 3.591 s full-gather
+time, assumes every other second scales linearly with bytes, and charges no
+detect, encode, decode, or sparse-apply cost. It is a lower bound under those
+assumptions, not a latency forecast. Fixed handshakes and shadow reads make the
+real post-gather prototype slower. Conversely, a future pre-gather change-mask
+path can remove work that this bound preserves.
+
+For object storage, the measured XOR-plus-zstd ratios map to 6.84 GB and 7.38 GB
+on the same 69.321 GB reference. No object-store latency is projected because
+the current seconds-scale same-cluster path is not a valid cross-cluster
+bandwidth baseline.
+
+The implementation benchmark must report at least:
+
+- detect, gather, encode, transport, decode, apply, and total wall time;
+- encoded bytes and peak live bytes per rank;
+- dense fallback rate and codec choice per bucket;
+- bitwise target equality for lossless codecs;
+- receiver version/failure recovery; and
+- same-cache logprob equality plus a short RL loss/reward check before rollout
+  delivery.
+
+Recommended staged decision:
+
+1. **Land the analyzer and collect distribution evidence** across at least one
+   dense and one MoE run at early, middle, and late stages.
+2. **Prototype lossless encode/apply outside the production wire.** Proceed only
+   if p95 encoded bytes are at most 25% of dense and encode plus apply cost leaves
+   a credible end-to-end win against 11.837 s.
+3. **Integrate adaptive unchanged/dense/bitmap transport** into one veRL path
+   behind an opt-in flag; require bitwise fast-versus-full equality and bounded
+   two-slot memory.
+4. **Add object-storage XOR plus zstd** when cross-cluster synchronization is in
+   scope; cap checkpoint-plus-delta replay length.
+5. **Measure canonical block-FP8 deltas** before enabling DS4 incremental
+   resync. Keep full resync as the only FP8 path until that gate passes.
+6. **Do not start top-k or quantized-delta implementation** without a separately
+   approved numerical experiment.
+
+The 25% byte gate is a proposal for the prototype, not a claimed crossover. It
+leaves room for metadata and scatter/decompression overhead and should be
+revised only from measured end-to-end data. The aggregate 15.9--17.1% evidence
+clears an initial byte screen, but does not establish bucket-level p95; the
+prototype must still measure it.
+
+## Reproduction
+
+```bash
+python experimental/lite/examples/verl/scripts/analyze_checkpoint_delta.py \
+  --before /path/to/previous/exported-hf \
+  --after /path/to/current/exported-hf \
+  --output /tmp/weight-delta.json \
+  --metadata model=my-model \
+  --metadata window_steps=1
+```
+
+The command is CPU-only. Point it at immutable exported safetensor directories.
+Do not compare optimizer checkpoints, different model revisions, different
+export dtypes, or independently quantized artifacts under one result label.

--- a/experimental/lite/docs/rl-incremental-weight-sync.md
+++ b/experimental/lite/docs/rl-incremental-weight-sync.md
@@ -349,25 +349,28 @@ using actual encoded bytes and a configured safety margin rather than a global
 model-level guess. Metadata, encode time, and apply time are included in the
 decision benchmark.
 
-### Interaction with two-slot prefetch
+### Interaction with proposed two-slot transport
 
-The validated veRL compatibility path in
-[`compat.py`](../examples/verl/verl_mlite/compat.py) already uses two bounded
-staging slots to overlap synchronous production with receiver ACKs.
-Incremental payloads should occupy those same slots; they must not add a third
-unbounded queue. A slot owns its payload until ACK, after which it can be reused
-and its shadow transition can be committed.
+The separate Miles/SGLang two-slot producer/consumer transport is not
+implemented in the current tree. Today `RawHFWeightUpdater` iterates
+`_export_weight_chunks` synchronously, accumulates receiver references and
+colocated live tensors, and waits for acknowledgements only after every chunk
+has been submitted. The incremental prototype must not assume that export and
+transport already overlap.
 
-Those two slots overlap buckets within one synchronization; they are recycled
-after ACK and are not a cross-step copy of the previous model. The acknowledged
-shadow or change-recording mechanism above remains separate state with its own
-memory accounting.
+The two proposals should compose without creating another queue. At most two
+in-flight slots may exist. A slot owns its exported bucket, encoded payload,
+receiver references, and pending shadow transition until every receiver ACKs.
+Only then may the sender commit that receiver's new base version and reuse the
+slot. A timeout or failed receiver leaves its shadow unadvanced and forces a
+dense resync before that receiver serves the target version.
 
-The separate Miles/SGLang two-slot transport work is not implemented yet. This
-design does not claim that veRL's compatibility-layer prefetch automatically
-covers the distributed Miles/SGLang leg. That leg needs its own ordering,
-weight-version, termination, and failure tests before enabling incremental
-payloads.
+Until the bounded transport lands and is validated independently, the lossless
+prototype should encode and apply buckets serially and report its peak live
+memory without claiming overlap. The future colocated and distributed legs both
+need chunk-order, weight-version, termination, and failure tests. The
+acknowledged cross-step shadow remains separately accounted state; it is not one
+of the two transient transport slots.
 
 ### BF16 to block-FP8 resync
 

--- a/experimental/lite/examples/verl/scripts/analyze_checkpoint_delta.py
+++ b/experimental/lite/examples/verl/scripts/analyze_checkpoint_delta.py
@@ -1,0 +1,440 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Measure element-wise deltas between two exported safetensor checkpoints.
+
+The analyzer is deliberately CPU-only and reads tensors one at a time.  It
+measures the values that an inference backend would receive, rather than
+optimizer master weights, so exact nonzero counts describe the lossless
+replacement payload needed by weight synchronization.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import torch
+from safetensors import safe_open
+
+try:
+    import zstandard
+except ImportError:  # pragma: no cover - the other statistics remain useful.
+    zstandard = None
+
+
+DEFAULT_THRESHOLDS = (0.0, 1e-8, 1e-7, 1e-6, 1e-5, 1e-4, 1e-3)
+DEFAULT_MAGNITUDE_EDGES = (
+    0.0,
+    1e-8,
+    1e-7,
+    1e-6,
+    1e-5,
+    1e-4,
+    1e-3,
+    1e-2,
+    1e-1,
+    1.0,
+    math.inf,
+)
+
+
+def _number_key(value: float) -> str:
+    return format(value, ".12g")
+
+
+def classify_parameter_family(name: str) -> str:
+    """Classify an exported parameter name for reporting, not dispatch."""
+
+    lowered = name.lower()
+    if any(token in lowered for token in ("embed_tokens", "word_embeddings", "wte")):
+        return "embedding"
+    if lowered.endswith("lm_head.weight") or "output_layer" in lowered:
+        return "embedding"
+    if (
+        ".router." in lowered
+        or ".mlp.gate." in lowered
+        or "shared_expert_gate" in lowered
+        or lowered.endswith("router.weight")
+    ):
+        return "router"
+    if any(token in lowered for token in (".experts.", ".expert.", "shared_expert")):
+        return "expert"
+    if any(
+        token in lowered
+        for token in (
+            ".self_attn.",
+            ".linear_attn.",
+            ".attention.",
+            ".attn.",
+            ".q_proj.",
+            ".k_proj.",
+            ".v_proj.",
+            ".o_proj.",
+        )
+    ):
+        return "attention"
+    if "norm" in lowered:
+        return "norm"
+    if any(token in lowered for token in (".mlp.", "feed_forward", ".ffn.")):
+        return "dense_mlp"
+    return "other"
+
+
+def _validate_bins(values: Sequence[float], *, name: str) -> tuple[float, ...]:
+    result = tuple(float(value) for value in values)
+    if not result or any(value < 0 for value in result):
+        raise ValueError(f"{name} must contain non-negative values")
+    if tuple(sorted(set(result))) != result:
+        raise ValueError(f"{name} must be strictly increasing")
+    return result
+
+
+def tensor_delta_statistics(
+    name: str,
+    before: torch.Tensor,
+    after: torch.Tensor,
+    *,
+    thresholds: Sequence[float] = DEFAULT_THRESHOLDS,
+    magnitude_edges: Sequence[float] = DEFAULT_MAGNITUDE_EDGES,
+    chunk_elements: int = 8 * 1024 * 1024,
+) -> dict[str, object]:
+    """Return bounded-memory delta statistics for a same-shape tensor pair."""
+
+    thresholds = _validate_bins(thresholds, name="thresholds")
+    magnitude_edges = _validate_bins(magnitude_edges, name="magnitude_edges")
+    if thresholds[0] != 0.0:
+        raise ValueError("thresholds must start at zero for lossless density")
+    if magnitude_edges[0] != 0.0 or not math.isinf(magnitude_edges[-1]):
+        raise ValueError("magnitude_edges must span zero through infinity")
+    if chunk_elements <= 0:
+        raise ValueError("chunk_elements must be positive")
+    if before.shape != after.shape:
+        raise ValueError(f"shape mismatch for {name}: {before.shape} != {after.shape}")
+    if before.dtype != after.dtype:
+        raise ValueError(f"dtype mismatch for {name}: {before.dtype} != {after.dtype}")
+    if not before.dtype.is_floating_point:
+        raise TypeError(
+            f"non-floating checkpoint tensor is unsupported: {name} {before.dtype}"
+        )
+
+    threshold_keys = [_number_key(value) for value in thresholds]
+    changed_counts = {key: 0 for key in threshold_keys}
+    histogram = [0] * (len(magnitude_edges) - 1)
+    delta_square_sum = 0.0
+    before_square_sum = 0.0
+    l_inf = 0.0
+    xor_nonzero_bytes = 0
+    xor_compressor = (
+        zstandard.ZstdCompressor(level=3).compressobj() if zstandard else None
+    )
+    xor_zstd_bytes = 0 if xor_compressor else None
+    flat_before = before.reshape(-1)
+    flat_after = after.reshape(-1)
+
+    for start in range(0, flat_before.numel(), chunk_elements):
+        stop = min(start + chunk_elements, flat_before.numel())
+        before_raw = flat_before[start:stop].contiguous()
+        after_raw = flat_after[start:stop].contiguous()
+        xor_bytes = torch.bitwise_xor(
+            before_raw.view(torch.uint8), after_raw.view(torch.uint8)
+        )
+        xor_nonzero_bytes += int(torch.count_nonzero(xor_bytes).item())
+        if xor_compressor is not None:
+            xor_zstd_bytes += len(xor_compressor.compress(xor_bytes.numpy().tobytes()))
+
+        before_chunk = before_raw.to(torch.float32)
+        after_chunk = after_raw.to(torch.float32)
+        absolute = (after_chunk - before_chunk).abs()
+        l_inf = max(l_inf, float(absolute.max().item()) if absolute.numel() else 0.0)
+        delta_square_sum += float(
+            torch.sum(absolute * absolute, dtype=torch.float64).item()
+        )
+        before_square_sum += float(
+            torch.sum(before_chunk * before_chunk, dtype=torch.float64).item()
+        )
+        for threshold, key in zip(thresholds, threshold_keys, strict=True):
+            changed_counts[key] += int(torch.count_nonzero(absolute > threshold).item())
+
+        nonzero = absolute[absolute > 0]
+        if nonzero.numel():
+            boundaries = torch.tensor(
+                magnitude_edges[1:-1], dtype=nonzero.dtype, device=nonzero.device
+            )
+            bin_ids = torch.bucketize(nonzero, boundaries, right=False)
+            counts = torch.bincount(bin_ids, minlength=len(histogram)).tolist()
+            histogram = [
+                left + int(right) for left, right in zip(histogram, counts, strict=True)
+            ]
+
+    if xor_compressor is not None:
+        xor_zstd_bytes += len(xor_compressor.flush())
+
+    numel = flat_before.numel()
+    value_bytes = before.element_size()
+    fractions = {
+        key: count / numel if numel else 0.0 for key, count in changed_counts.items()
+    }
+    bitmap_value_bytes = {
+        key: math.ceil(numel / 8) + count * value_bytes
+        for key, count in changed_counts.items()
+    }
+    coo32_value_bytes = {
+        key: count * (4 + value_bytes) for key, count in changed_counts.items()
+    }
+    l2 = math.sqrt(delta_square_sum)
+    before_l2 = math.sqrt(before_square_sum)
+
+    return {
+        "name": name,
+        "family": classify_parameter_family(name),
+        "shape": list(before.shape),
+        "dtype": str(before.dtype).removeprefix("torch."),
+        "numel": numel,
+        "dense_bytes": numel * value_bytes,
+        "value_bytes": value_bytes,
+        "xor_nonzero_bytes": xor_nonzero_bytes,
+        "xor_nonzero_byte_fraction": xor_nonzero_bytes / (numel * value_bytes)
+        if numel
+        else 0.0,
+        "xor_zstd_bytes": xor_zstd_bytes,
+        "l_inf": l_inf,
+        "l2": l2,
+        "reference_l2": before_l2,
+        "relative_l2": l2 / before_l2 if before_l2 else (0.0 if l2 == 0.0 else None),
+        "changed_counts": changed_counts,
+        "changed_fractions": fractions,
+        "bitmap_value_bytes": bitmap_value_bytes,
+        "coo32_value_bytes": coo32_value_bytes,
+        "magnitude_histogram": histogram,
+    }
+
+
+def _checkpoint_index(root: Path) -> dict[str, Path]:
+    if not root.is_dir():
+        raise FileNotFoundError(f"checkpoint directory does not exist: {root}")
+    result: dict[str, Path] = {}
+    files = sorted(root.rglob("*.safetensors"))
+    if not files:
+        raise FileNotFoundError(f"no safetensor shards found below {root}")
+    for path in files:
+        with safe_open(path, framework="pt", device="cpu") as handle:
+            for key in handle.keys():
+                if key in result:
+                    raise ValueError(
+                        f"duplicate tensor {key!r} in {result[key]} and {path}"
+                    )
+                result[key] = path
+    return result
+
+
+def _empty_aggregate(
+    threshold_keys: Iterable[str], histogram_bins: int
+) -> dict[str, object]:
+    keys = tuple(threshold_keys)
+    return {
+        "tensor_count": 0,
+        "numel": 0,
+        "dense_bytes": 0,
+        "l_inf": 0.0,
+        "delta_square_sum": 0.0,
+        "before_square_sum": 0.0,
+        "xor_nonzero_bytes": 0,
+        "xor_zstd_bytes": 0,
+        "changed_counts": {key: 0 for key in keys},
+        "changed_value_bytes": {key: 0 for key in keys},
+        "magnitude_histogram": [0] * histogram_bins,
+    }
+
+
+def _add_tensor(aggregate: dict[str, object], stats: dict[str, object]) -> None:
+    aggregate["tensor_count"] += 1
+    aggregate["numel"] += stats["numel"]
+    aggregate["dense_bytes"] += stats["dense_bytes"]
+    aggregate["l_inf"] = max(aggregate["l_inf"], stats["l_inf"])
+    aggregate["delta_square_sum"] += stats["l2"] ** 2
+    aggregate["before_square_sum"] += stats["reference_l2"] ** 2
+    aggregate["xor_nonzero_bytes"] += stats["xor_nonzero_bytes"]
+    if aggregate["xor_zstd_bytes"] is not None:
+        if stats["xor_zstd_bytes"] is None:
+            aggregate["xor_zstd_bytes"] = None
+        else:
+            aggregate["xor_zstd_bytes"] += stats["xor_zstd_bytes"]
+    for key, count in stats["changed_counts"].items():
+        aggregate["changed_counts"][key] += count
+        aggregate["changed_value_bytes"][key] += count * stats["value_bytes"]
+    aggregate["magnitude_histogram"] = [
+        left + right
+        for left, right in zip(
+            aggregate["magnitude_histogram"], stats["magnitude_histogram"], strict=True
+        )
+    ]
+
+
+def _finish_aggregate(aggregate: dict[str, object]) -> dict[str, object]:
+    numel = aggregate.pop("numel")
+    delta_square_sum = aggregate.pop("delta_square_sum")
+    before_square_sum = aggregate.pop("before_square_sum")
+    changed_value_bytes = aggregate.pop("changed_value_bytes")
+    changed_counts = aggregate["changed_counts"]
+    l2 = math.sqrt(delta_square_sum)
+    before_l2 = math.sqrt(before_square_sum)
+    aggregate.update(
+        {
+            "numel": numel,
+            "l2": l2,
+            "relative_l2": l2 / before_l2
+            if before_l2
+            else (0.0 if l2 == 0.0 else None),
+            "xor_nonzero_byte_fraction": aggregate["xor_nonzero_bytes"]
+            / aggregate["dense_bytes"]
+            if aggregate["dense_bytes"]
+            else 0.0,
+            "changed_fractions": {
+                key: count / numel if numel else 0.0
+                for key, count in changed_counts.items()
+            },
+            "bitmap_value_bytes": {
+                key: math.ceil(numel / 8) + changed_value_bytes[key]
+                for key in changed_counts
+            },
+            "coo32_value_bytes": {
+                key: count * 4 + changed_value_bytes[key]
+                for key, count in changed_counts.items()
+            },
+        }
+    )
+    return aggregate
+
+
+def analyze_checkpoints(
+    before_root: str | Path,
+    after_root: str | Path,
+    *,
+    thresholds: Sequence[float] = DEFAULT_THRESHOLDS,
+    magnitude_edges: Sequence[float] = DEFAULT_MAGNITUDE_EDGES,
+    chunk_elements: int = 8 * 1024 * 1024,
+) -> dict[str, object]:
+    """Compare matching exported tensors below two checkpoint directories."""
+
+    before_root = Path(before_root).resolve()
+    after_root = Path(after_root).resolve()
+    if before_root == after_root:
+        raise ValueError("before and after checkpoints must be different directories")
+    thresholds = _validate_bins(thresholds, name="thresholds")
+    magnitude_edges = _validate_bins(magnitude_edges, name="magnitude_edges")
+    before_index = _checkpoint_index(before_root)
+    after_index = _checkpoint_index(after_root)
+    missing_after = sorted(before_index.keys() - after_index.keys())
+    missing_before = sorted(after_index.keys() - before_index.keys())
+    if missing_after or missing_before:
+        raise ValueError(
+            f"checkpoint tensor sets differ: missing_after={missing_after[:8]}, "
+            f"missing_before={missing_before[:8]}"
+        )
+
+    threshold_keys = [_number_key(value) for value in thresholds]
+    summary = _empty_aggregate(threshold_keys, len(magnitude_edges) - 1)
+    families: dict[str, dict[str, object]] = {}
+    tensors = []
+    for name in sorted(before_index):
+        with safe_open(
+            before_index[name], framework="pt", device="cpu"
+        ) as before_handle:
+            before = before_handle.get_tensor(name)
+        with safe_open(after_index[name], framework="pt", device="cpu") as after_handle:
+            after = after_handle.get_tensor(name)
+        stats = tensor_delta_statistics(
+            name,
+            before,
+            after,
+            thresholds=thresholds,
+            magnitude_edges=magnitude_edges,
+            chunk_elements=chunk_elements,
+        )
+        tensors.append(stats)
+        _add_tensor(summary, stats)
+        family = stats["family"]
+        if family not in families:
+            families[family] = _empty_aggregate(
+                threshold_keys, len(magnitude_edges) - 1
+            )
+        _add_tensor(families[family], stats)
+        del before, after
+
+    return {
+        "schema_version": "mlite.rl_checkpoint_delta.v1",
+        "before": str(before_root),
+        "after": str(after_root),
+        "thresholds": list(thresholds),
+        "magnitude_edges": [_number_key(value) for value in magnitude_edges],
+        "summary": _finish_aggregate(summary),
+        "families": {
+            family: _finish_aggregate(aggregate)
+            for family, aggregate in sorted(families.items())
+        },
+        "tensors": tensors,
+    }
+
+
+def _parse_csv_floats(
+    value: str, *, append_infinity: bool = False
+) -> tuple[float, ...]:
+    values = [float(item) for item in value.split(",") if item.strip()]
+    if append_infinity and (not values or not math.isinf(values[-1])):
+        values.append(math.inf)
+    return tuple(values)
+
+
+def _parse_metadata(items: Sequence[str]) -> dict[str, str]:
+    metadata = {}
+    for item in items:
+        if "=" not in item:
+            raise ValueError(f"metadata must use KEY=VALUE: {item!r}")
+        key, value = item.split("=", 1)
+        metadata[key] = value
+    return metadata
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument("--before", type=Path, required=True)
+    parser.add_argument("--after", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--thresholds", default=",".join(map(str, DEFAULT_THRESHOLDS)))
+    parser.add_argument(
+        "--magnitude-edges", default=",".join(map(str, DEFAULT_MAGNITUDE_EDGES[:-1]))
+    )
+    parser.add_argument("--chunk-elements", type=int, default=8 * 1024 * 1024)
+    parser.add_argument("--metadata", action="append", default=[], metavar="KEY=VALUE")
+    args = parser.parse_args()
+
+    report = analyze_checkpoints(
+        args.before,
+        args.after,
+        thresholds=_parse_csv_floats(args.thresholds),
+        magnitude_edges=_parse_csv_floats(args.magnitude_edges, append_infinity=True),
+        chunk_elements=args.chunk_elements,
+    )
+    report["metadata"] = _parse_metadata(args.metadata)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    print(
+        json.dumps(
+            {
+                "output": str(args.output),
+                "tensor_count": report["summary"]["tensor_count"],
+                "numel": report["summary"]["numel"],
+                "exact_changed_fraction": report["summary"]["changed_fractions"]["0"],
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/experimental/lite/tests/unit/verl/test_checkpoint_delta_analysis.py
+++ b/experimental/lite/tests/unit/verl/test_checkpoint_delta_analysis.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+import importlib.util
+import math
+from pathlib import Path
+
+import torch
+from safetensors.torch import save_file
+
+
+SCRIPT = (
+    Path(__file__).parents[3]
+    / "examples"
+    / "verl"
+    / "scripts"
+    / "analyze_checkpoint_delta.py"
+)
+SPEC = importlib.util.spec_from_file_location("analyze_checkpoint_delta", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+delta_analysis = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(delta_analysis)
+
+
+def test_classify_parameter_family_uses_exported_names() -> None:
+    classify = delta_analysis.classify_parameter_family
+
+    assert classify("model.embed_tokens.weight") == "embedding"
+    assert classify("model.layers.0.self_attn.q_proj.weight") == "attention"
+    assert classify("model.layers.0.linear_attn.in_proj_qkv.weight") == "attention"
+    assert classify("model.layers.0.mlp.experts.3.down_proj.weight") == "expert"
+    assert classify("model.layers.0.mlp.gate.weight") == "router"
+    assert classify("model.layers.0.mlp.shared_expert_gate.weight") == "router"
+    assert classify("model.layers.0.mlp.shared_expert.gate_proj.weight") == "expert"
+    assert classify("model.layers.0.input_layernorm.weight") == "norm"
+
+
+def test_tensor_delta_statistics_counts_exact_and_thresholded_changes() -> None:
+    before = torch.tensor([0.0, 1.0, 2.0, 3.0], dtype=torch.float32)
+    after = torch.tensor([0.0, 1.005, 2.02, 5.0], dtype=torch.float32)
+
+    stats = delta_analysis.tensor_delta_statistics(
+        "model.layers.0.self_attn.q_proj.weight",
+        before,
+        after,
+        thresholds=(0.0, 0.01, 1.0),
+        magnitude_edges=(0.0, 0.01, 0.1, 1.0, math.inf),
+        chunk_elements=2,
+    )
+
+    assert stats["family"] == "attention"
+    assert stats["numel"] == 4
+    assert stats["changed_counts"] == {"0": 3, "0.01": 2, "1": 1}
+    assert stats["changed_fractions"] == {"0": 0.75, "0.01": 0.5, "1": 0.25}
+    assert stats["l_inf"] == 2.0
+    assert stats["l2"] == pytest_approx(math.sqrt(2.0**2 + 0.02**2 + 0.005**2))
+    assert stats["magnitude_histogram"] == [1, 1, 0, 1]
+
+
+def test_tensor_delta_statistics_measures_lossless_xor_compression() -> None:
+    before = torch.zeros(4096, dtype=torch.bfloat16)
+    after = before.clone()
+    after[17] = 1.0
+
+    stats = delta_analysis.tensor_delta_statistics(
+        "model.layers.0.self_attn.q_proj.weight", before, after, chunk_elements=257
+    )
+
+    assert stats["xor_nonzero_bytes"] > 0
+    assert stats["xor_nonzero_bytes"] < stats["dense_bytes"]
+    if delta_analysis.zstandard is None:
+        assert stats["xor_zstd_bytes"] is None
+    else:
+        assert stats["xor_zstd_bytes"] < stats["dense_bytes"]
+
+
+def test_analyze_safetensor_checkpoints_aggregates_families_and_bytes(tmp_path) -> None:
+    before = tmp_path / "before"
+    after = tmp_path / "after"
+    before.mkdir()
+    after.mkdir()
+    save_file(
+        {
+            "model.embed_tokens.weight": torch.tensor([1.0, 2.0], dtype=torch.bfloat16),
+            "model.layers.0.self_attn.q_proj.weight": torch.tensor(
+                [1.0, 2.0], dtype=torch.bfloat16
+            ),
+        },
+        before / "model-00001-of-00001.safetensors",
+    )
+    save_file(
+        {
+            "model.embed_tokens.weight": torch.tensor([1.0, 2.0], dtype=torch.bfloat16),
+            "model.layers.0.self_attn.q_proj.weight": torch.tensor(
+                [1.0, 3.0], dtype=torch.bfloat16
+            ),
+        },
+        after / "model-00001-of-00001.safetensors",
+    )
+
+    report = delta_analysis.analyze_checkpoints(
+        before,
+        after,
+        thresholds=(0.0, 0.5),
+        magnitude_edges=(0.0, 0.5, math.inf),
+        chunk_elements=1,
+    )
+
+    assert report["summary"]["tensor_count"] == 2
+    assert report["summary"]["numel"] == 4
+    assert report["summary"]["changed_counts"] == {"0": 1, "0.5": 1}
+    assert report["summary"]["dense_bytes"] == 8
+    assert report["summary"]["bitmap_value_bytes"]["0"] == 3
+    assert report["summary"]["xor_nonzero_bytes"] == 1
+    assert report["summary"]["xor_nonzero_byte_fraction"] == 0.125
+    assert report["families"]["embedding"]["changed_counts"]["0"] == 0
+    assert report["families"]["attention"]["changed_counts"]["0"] == 1
+
+
+def test_analyze_rejects_the_same_checkpoint_directory(tmp_path) -> None:
+    import pytest
+
+    save_file(
+        {"model.embed_tokens.weight": torch.ones(1, dtype=torch.bfloat16)},
+        tmp_path / "model.safetensors",
+    )
+
+    with pytest.raises(ValueError, match="must be different"):
+        delta_analysis.analyze_checkpoints(tmp_path, tmp_path)
+
+
+def pytest_approx(value: float):
+    import pytest
+
+    return pytest.approx(value, rel=1e-6, abs=1e-8)

--- a/experimental/lite/tests/unit/verl/test_incremental_weight_sync_doc.py
+++ b/experimental/lite/tests/unit/verl/test_incremental_weight_sync_doc.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from pathlib import Path
+
+
+DOC = Path(__file__).parents[3] / "docs" / "rl-incremental-weight-sync.md"
+
+
+def test_two_slot_transport_is_documented_as_future_work() -> None:
+    text = DOC.read_text()
+    section = text.split("### Interaction with proposed two-slot transport", 1)[1]
+    section = section.split("### BF16 to block-FP8 resync", 1)[0]
+    normalized = " ".join(section.split()).lower()
+
+    assert "is not implemented in the current tree" in normalized
+    assert "compat.py" not in normalized
+    assert "at most two in-flight slots" in normalized


### PR DESCRIPTION
## Summary

- Add a CPU-only safetensor checkpoint analyzer for exact element changes, norms, parameter-family distributions, bitmap and COO payload estimates, and XOR plus zstd compression.
- Document one true DAPO actor update and two Qwen3.5 ten-update windows. Exported BF16 exact-change density was 0%, 9.7550%, and 10.8811%, respectively.
- Propose an opt-in, lossless, versioned manifest, bitmap-replacement, XOR, or dense protocol with receiver-scoped recovery and full-sync fallback.
- Clarify that bounded two-slot Miles and SGLang transport is future work; the current RawHFWeightUpdater path remains serial and must not be treated as an existing overlap mechanism.

## Validation

- CPU Slurm 4366225: Qwen3-8B base to step 1 analysis, COMPLETED 0:0, zero GPUs.
- CPU Slurm 13633273: Qwen3.5 step 10 to 20 independent recomputation, COMPLETED 0:0, zero GPUs.
- CPU Slurm 13632330: Qwen3.5 step 20 to 30 analysis, COMPLETED 0:0, zero GPUs.
- pytest -c /dev/null --rootdir=. --confcutdir=. experimental/lite/tests/unit/verl/test_checkpoint_delta_analysis.py experimental/lite/tests/unit/verl/test_incremental_weight_sync_doc.py -q: 6 passed.
- ruff check on the analyzer and both test files: passed.
- git diff --check: passed.

## Review notes

- Precision: the proposed codecs reconstruct exact target bytes; lossy top-k and quantized deltas remain gated on separate numerical evidence.
- Parallel and runtime integration: not implemented in this change. The analyzer is read-only, and the document keeps transport in application adapters and model-family classification in the analysis layer.
- Weight I/O: no production checkpoint or update path changes.