### PR TITLE
Add Hopper blockwise FP8 precision profiles

### DIFF
--- a/experimental/lite/README.md
+++ b/experimental/lite/README.md
@@ -130,6 +130,7 @@ bash experimental/lite/examples/bench/scripts/run_qwen35_correctness_pair.sh
 - [Runtime](docs/runtime.md)
 - [Models](docs/models.md)
 - [Porting Notes](docs/porting.md)
+- [Hopper Blockwise FP8 Contract](docs/hopper-blockwise-fp8-contract.md)
 - [Skills](skills/README.md)
 - [Bench Example](examples/bench/README.md)
 

--- a/experimental/lite/docs/hopper-blockwise-fp8-contract.md
+++ b/experimental/lite/docs/hopper-blockwise-fp8-contract.md
@@ -100,12 +100,20 @@ The image is qualified only if all of the following preflight checks pass:
    the single authoritative gate -- the same one the runtime uses -- and it
    determines device/toolchain support (SM, CUDA, cuBLAS, block scaling)
    directly rather than through hard-coded version thresholds.
-2. The device class, CUDA, cuBLAS, and TE versions are recorded in the
-   environment manifest for provenance and diagnosis, not enforced as
-   independent hard gates: whatever image runs BF16 must run FP8, so an exact SM
-   class, TE version, or CUDA/cuBLAS threshold is deliberately not pinned. The
+2. The device class, CUDA, and TE versions are recorded in the environment
+   manifest for provenance and diagnosis, not enforced as independent hard
+   gates: whatever image runs BF16 must run FP8, so an exact SM class, TE
+   version, or general CUDA/cuBLAS threshold is deliberately not pinned. The
    canonical qualification image reported SM90, CUDA 13.2, cuBLAS 13.4, and TE
-   2.15.0; TE 2.15's grouped-GEMM path itself requires cuBLAS 13.3+.
+   2.15.0. The one exception is scoped and TE-owned: a profile selecting MoE
+   experts additionally gates the grouped-GEMM cuBLAS requirement, because TE
+   2.15's blockwise `GroupedLinear` path requires cuBLAS 13.3+
+   (`CUBLAS_GROUPED_GEMM_VERSION`) and `check_fp8_block_scaling_support()` does
+   not cover it. The runtime fails loud on an under-versioned cuBLAS
+   (`CUBLAS_GROUPED_GEMM_MIN_VERSION`, encoded like `get_cublasLt_version()` as
+   `130300`) rather than crashing inside the grouped GEMM. This is not a
+   reintroduced device/CUDA pin: it is the grouped path's own hard requirement,
+   scoped to MoE profiles, and the canonical image (cuBLAS 130401) satisfies it.
 3. `NVTE_FP8_BLOCK_SCALING_FP32_SCALES` is absent or `0`,
    `NVTE_BACKWARD_OVERRIDE` is absent, and the constructed recipe equals the
    frozen recipe below.
@@ -338,6 +346,7 @@ model construction, or checkpoint load as indicated below.
 | unknown profile or any ad-hoc recipe/format/target value | config error listing the accepted profile names |
 | reserved `hopper_blockwise_fp8_weight` (FP8 parameter storage) is requested | not-implemented error at resolution; the pending second profile is never sold as usable |
 | TE's `check_fp8_block_scaling_support()` reports no blockwise FP8 support | environment error before model allocation, quoting TE's reason and the recorded toolchain (device, TE, CUDA, cuBLAS) |
+| MoE-expert profile on cuBLAS below the grouped-GEMM requirement (`< CUBLAS_GROUPED_GEMM_MIN_VERSION`) | environment error before model allocation; the grouped path is gated instead of crashing inside `GroupedLinear` |
 | recipe differs, FP8 DPA/MHA is enabled, or scale/backward env overrides are set | environment/recipe mismatch error |
 | selected shape violates blockwise rules | construction error with semantic site and shape |
 | missing, duplicate, or incompatible typed coverage | construction error before optimizer creation |

--- a/experimental/lite/docs/hopper-blockwise-fp8-contract.md
+++ b/experimental/lite/docs/hopper-blockwise-fp8-contract.md
@@ -1,0 +1,543 @@
+# Hopper Blockwise FP8 Contract and Parity Protocol
+
+This document is the normative contract for the first Megatron Lite FP8
+training implementation. It freezes behavior and validation before production
+code is added. It does not claim that the profiles described here are already
+implemented.
+
+The first release is deliberately closed. It has two named Hopper blockwise
+profiles, one fixed compute coverage set, and no user-composable recipe policy.
+Any extension requires a separate contract and evidence.
+
+## Scope
+
+The only new public configuration values are:
+
+- `hopper_blockwise_bf16_weight`
+- `hopper_blockwise_fp8_weight`
+
+`bf16` remains the default and preserves the current behavior. No public
+`recipe`, `format`, `target`, `weight_dtype`, rule list, ordered matcher, or
+model-specific FP8 configuration is part of this release.
+
+Both Hopper profiles apply blockwise FP8 compute to every covered instance of:
+
+- attention projection GEMMs, including QKV and output projections;
+- dense MLP GEMMs; and
+- routed and shared MoE expert GEMMs.
+
+The attention core, router, normalization, embedding, vocabulary/LM head,
+residual paths, losses, and public module boundaries stay BF16. In particular,
+attention projections and the attention core are separate semantic sites.
+Transformer Engine does not support FP8 DPA or MHA with
+`Float8BlockScaling`.
+
+MXFP8, delayed/tensorwise scaling, FP8 attention core, FP8 parameter
+all-gather, lower-precision optimizer state, FP8 communication, arbitrary
+target combinations, model allowlists, and model-local FP8 implementations are
+out of scope.
+
+## Frozen Independent Reference
+
+Parity uses direct upstream source, not Megatron Lite through a second runtime
+path:
+
+- Megatron-Core commit
+  [`cf2f07d7b1315c96c05554c670c43207c6783e5e`][mcore-commit];
+- Transformer Engine commit
+  [`8b9968255eb879e6e390f427836906b29aad64d2`][te-commit], which reports
+  version `2.18.0.dev0`; and
+- an NVIDIA Hopper GPU with compute capability exactly 9.0.
+
+The reference driver must import Megatron-Core from the frozen checkout and
+Transformer Engine from a build of the frozen TE commit. A package version
+string alone is insufficient. The driver must assert both source revisions
+before allocating model state.
+
+### Environment seal
+
+Before any target result is produced, the reference owner must write and seal
+an environment manifest containing:
+
+- immutable container path and content digest;
+- GPU name, UUIDs, compute capability, and driver version;
+- CUDA build and runtime versions, cuBLAS build and runtime versions, cuDNN,
+  NCCL, PyTorch, and Python versions;
+- the full Megatron-Core and Transformer Engine commit IDs;
+- installed TE distribution versions and the TE shared-object hashes;
+- all `NVTE_*`, determinism, and allocator environment variables; and
+- the Slurm cluster, partition, node list, and job ID used for qualification.
+
+Reference calibration and Megatron Lite comparison jobs must use the same
+sealed container digest and hardware class. A mutable tag, an unrecorded
+overlay, a different TE wheel, or a different CUDA/cuBLAS build invalidates the
+comparison.
+
+The image is qualified only if all of the following preflight checks pass:
+
+1. `torch.cuda.get_device_capability()` is `(9, 0)`. Blackwell emulation is not
+   accepted by these Hopper-named profiles.
+2. TE's `check_fp8_block_scaling_support()` succeeds. At the frozen TE commit,
+   this requires CUDA 12.9 or newer in addition to SM90.
+3. The TE build and runtime cuBLAS versions are both at least 13.4. The frozen
+   TE GroupedLinear implementation requires that version for blockwise FP8
+   grouped GEMM, and MoE is mandatory in this release.
+4. `NVTE_FP8_BLOCK_SCALING_FP32_SCALES` is absent or `0`,
+   `NVTE_BACKWARD_OVERRIDE` is absent, and the constructed recipe equals the
+   frozen recipe below.
+5. The reference linear and grouped-linear probes execute, rather than skip or
+   fall back to a non-blockwise kernel.
+
+There is no pre-qualified image assumed by this document. The first image that
+passes these checks is bound by its digest in the environment manifest before
+reference calibration. If no available image passes, implementation parity is
+blocked; dropping MoE, changing TE, or accepting a fallback is not a valid
+substitute.
+
+## Primitive Principle and Invariants
+
+The primitive changes internal GEMM quantization and, in one profile, compute
+weight storage. It must not change model math, topology, tensor shapes, public
+dtypes, process-group membership, parameter ownership, optimizer math, or
+checkpoint continuity.
+
+The following invariants apply to both profiles:
+
+1. Inputs and outputs at primitive, residual, pipeline, loss, and checkpoint
+   API boundaries keep their existing shapes and BF16 dtype.
+2. Forward output, input gradient, weight gradient, and the FP32-master
+   optimizer update match the frozen reference under the gates below.
+3. Every selected semantic site is covered exactly once by a compatible TE
+   primitive. Missing, duplicate, or incompatible coverage fails during model
+   construction.
+4. Every fixed BF16 site remains outside the FP8 context. It is an error to
+   make attention core, router, norm, embedding, or LM head FP8 as a side
+   effect of a broad context.
+5. Coverage and selection use typed semantic declarations. Module-name globs,
+   ordered matchers, model names, model allowlists, and class-name heuristics
+   are forbidden.
+6. The precision primitive owns no model configuration, model registry,
+   optimizer state, checkpoint mapping, or process-group construction.
+7. FP8 compute precision, compute-parameter storage, parameter communication,
+   optimizer master precision, gradients, and optimizer states remain
+   separate fields with one explicit owner each.
+8. Unsupported hardware, shapes, modules, parallel combinations, or state
+   transitions fail loudly before training. Silent BF16 fallback is forbidden.
+
+## Closed Profile Contract
+
+The recipe is constructed with these exact values:
+
+```text
+Float8BlockScaling(
+  fp8_format=Format.E4M3,
+  x_block_scaling_dim=1,
+  w_block_scaling_dim=2,
+  grad_block_scaling_dim=1,
+  fp8_gemm_fprop.use_split_accumulator=True,
+  fp8_gemm_dgrad.use_split_accumulator=True,
+  fp8_gemm_wgrad.use_split_accumulator=True,
+  fp8_dpa=False,
+  fp8_mha=False,
+  backward_override=None,
+)
+```
+
+Scales are FP32 containers constrained to powers of two. Activations and
+output gradients use 1x128 blocks; weights use 128x128 blocks. Rowwise and
+columnwise 1D representations must both be quantized from the high-precision
+source. No amax history or amax-reduction process group exists for this
+blockwise recipe.
+
+| Contract field | `hopper_blockwise_bf16_weight` | `hopper_blockwise_fp8_weight` |
+| --- | --- | --- |
+| GEMM compute | frozen blockwise E4M3 recipe | frozen blockwise E4M3 recipe |
+| selected compute weights | BF16 parameters, quantized for GEMM | TE blockwise FP8 compute parameters |
+| public inputs/outputs | BF16 | BF16 |
+| non-GEMM parameters and bias | BF16 | BF16 |
+| authoritative initialization/load source | BF16/FP32 source tensor | the same high-precision source, never reconstructed from FP8 |
+| optimizer master parameters | FP32 | FP32 |
+| accumulated/main gradients | FP32 | FP32 |
+| Adam moments and step | FP32 moments, integral step | FP32 moments, integral step |
+| parameter all-gather | BF16; no FP8 parameter gather | BF16; no FP8 parameter gather |
+| recipe checkpoint state | stateless | stateless |
+| parameter checkpoint state | BF16 compute weight | FP8 data and block scales |
+
+For the FP8-weight profile, model construction uses TE
+`quantized_model_init` (the frozen revision's `fp8_model_init` is only a
+deprecated forwarding alias) with the frozen recipe and
+`preserve_high_precision_init_val=True`. The same high-precision tensor must
+initialize the TE compute parameter and the single FP32 optimizer master.
+After master ownership is established, the temporary high-precision init value
+is cleared. An FP32 master reconstructed by dequantizing the FP8 parameter is a
+contract violation.
+
+DistOpt and FSDP2 consume the same explicit parameter contract. Neither backend
+may infer ownership from tensor class or profile-name string. Exactly one
+component owns and updates each FP32 master. TE must not retain a competing
+optimizer master when MLite owns it.
+
+## Public and Internal API Boundary
+
+The public runtime field is a string with exactly three accepted values:
+
+```python
+MegatronLiteConfig(precision="bf16")
+MegatronLiteConfig(precision="hopper_blockwise_bf16_weight")
+MegatronLiteConfig(precision="hopper_blockwise_fp8_weight")
+```
+
+Internally, the precision package may share only the following narrow typed
+data:
+
+- `PrecisionImplementation`: immutable profile identity, the one frozen recipe
+  factory, the fixed covered semantic sites, and its `ParameterContract`;
+- `ParameterContract`: compute-weight storage, authoritative load source,
+  master/gradient/state dtypes, all-gather dtype, and ownership; and
+- typed coverage requirements and claims for `ATTENTION_PROJECTION`,
+  `DENSE_MLP`, and `MOE_EXPERT`.
+
+These are closed records for the two profiles, not a base class for arbitrary
+recipes or a generic policy language. There is no public constructor that can
+mix recipe, format, targets, and weight mode.
+
+### Coverage protocol
+
+Coverage is per concrete semantic site, not merely “at least one module of this
+kind”. Model composition emits typed site requirements; reusable primitives
+emit typed capability claims for the exact sites they own. Runtime binding
+matches object identity plus the semantic enum, injects one
+`PrecisionImplementation`, and seals the manifest before optimizer creation.
+
+The manifest must prove:
+
+- each present attention projection, dense MLP GEMM, and expert GEMM has one
+  compatible claim;
+- every requirement is matched exactly once and there are no unconsumed claims;
+- attention core, router, norms, embeddings, and LM head are explicit BF16
+  exclusions;
+- selected modules are TE Linear, LayerNormLinear, or GroupedLinear paths that
+  support the frozen recipe; and
+- inline `nn.Linear`, torch matmul/SDPA, local attention, LoRA side paths, and
+  any other non-TE implementation cannot satisfy a selected requirement.
+
+Paths and module names may be recorded only as diagnostic evidence after typed
+binding. They must never decide selection or eligibility. A model becomes
+eligible by composing fully covered primitives, not by appearing in a support
+list.
+
+## Owned Files and Replacement Boundary
+
+The precision primitive owns only:
+
+```text
+experimental/lite/megatron/lite/primitive/precision/
+  __init__.py
+  contract.py
+  coverage.py
+  hopper_blockwise.py
+```
+
+`contract.py` owns the closed records and semantic enums. `coverage.py` owns
+typed requirement/claim matching and diagnostics. `hopper_blockwise.py` owns
+the two profile instances, frozen recipe creation, environment validation, and
+model-init/forward contexts. `__init__.py` exposes the three-name resolver and
+the narrow records.
+
+The following files remain consumers and retain their existing layer
+responsibilities:
+
+- `runtime/backends/mlite/config.py`: the public `precision` string;
+- `runtime/backends/mlite/runtime.py`: resolve, preflight, construction context,
+  typed injection, and coverage sealing;
+- `primitive/parallel/linear.py`, `primitive/modules/gqa.py`,
+  `primitive/modules/mlp.py`, and `primitive/modules/experts.py`: capability
+  declarations and correctly scoped forward contexts;
+- `primitive/optimizers/megatron_wrap.py` and `primitive/optimizers/fsdp2/`:
+  consume `ParameterContract` and own FP32 master/update state;
+- `primitive/ckpt/distckpt.py` and `primitive/ckpt/dcp.py`: save and restore
+  model/optimizer state without learning profile policy; and
+- model protocol compose sites: emit typed requirements and remove old
+  model-threaded FP8 switches only after their primitive coverage is complete.
+
+No `model/*/fp8.py`, FP8 model subclass, recipe-specific model registry entry,
+generic `policy.py`/`base.py`, or glob matcher may be added.
+
+Existing whole-model `fp8_autocast` branches and the delayed-scaling
+`build_fp8_recipe()` helper are not a second supported path. They are currently
+disabled by production protocols. When the first production composition moves
+to this contract, those unreachable branches and any exports used only by them
+must be removed rather than kept alive by tests. Other model families remain
+BF16 and fail typed coverage until separately migrated; they do not receive
+copied FP8 branches.
+
+## State, Device, and Process Groups
+
+The recipe object is immutable and reused. `Float8BlockScaling` is stateless at
+the frozen TE revision, so it has no delayed-scaling amax history to synchronize
+or checkpoint. TE-owned ephemeral rowwise/columnwise quantized activations are
+not MLite checkpoint state.
+
+Process-group ownership does not change:
+
+- column/row parallel linears continue to use their existing TP group;
+- expert dispatch continues to use EP, expert computation continues to use ETP
+  where configured, and expert-data-parallel ownership stays with the optimizer;
+- router padding follows the frozen Megatron rule and pads the routing map to
+  the blockwise FP8 alignment of 16;
+- blockwise scales are local and do not introduce an amax collective; and
+- DP/FSDP groups remain optimizer/runtime state, not precision-primitive state.
+
+Ordinary blockwise linear operands must satisfy TE's shape rules: rank at least
+two, last dimension divisible by 128, and the product of preceding dimensions
+divisible by 128. Grouped expert GEMMs keep their K/N dimensions block-aligned
+and follow Megatron's separate routing-map alignment of 16 for the routed M
+dimension. The frozen TE GroupedLinear capability check is authoritative for
+that path; MLite must not invent a different padding rule.
+
+## Legal Combinations and Failure Modes
+
+The initial validated topology has TP and EP/ETP, with `pp=1` and `cp=1`.
+Pipeline and context parallel compositions remain unavailable for these two
+profiles until separately validated. BF16 retains its existing topology
+support.
+
+The implementation must reject during config parsing, environment preflight,
+model construction, or checkpoint load as indicated below.
+
+| Condition | Required failure |
+| --- | --- |
+| unknown profile or any ad-hoc recipe/format/target value | config error listing the three accepted profile names |
+| device is not SM90, TE revision differs, CUDA is below 12.9 | environment error before model allocation |
+| compile-time or runtime cuBLAS is below 13.4 | environment error identifying mandatory MoE GroupedLinear support |
+| recipe differs, FP8 DPA/MHA is enabled, or scale/backward env overrides are set | environment/recipe mismatch error |
+| selected shape violates blockwise rules | construction error with semantic site and shape |
+| missing, duplicate, or incompatible typed coverage | construction error before optimizer creation |
+| selected site is `nn.Linear`, torch matmul/SDPA, or an unsupported TE path | construction error; never BF16 fallback |
+| attention core, router, norm, embed, or LM head is selected | construction error identifying the fixed BF16 boundary |
+| LoRA or another side path changes a selected GEMM without reviewed coverage | construction error |
+| `pp>1`, `cp>1`, CUDA graph, or another unvalidated composition is requested | unsupported-combination error |
+| `fp8_param_gather`, FP8 communication, MXFP8, or lower-precision optimizer state is requested | unsupported-combination error |
+| FP8-weight profile cannot establish one FP32 master from the high-precision source | construction error; no dequantize-and-continue |
+| checkpoint lacks FP8 data/scales, FP32 master, moments, step, RNG, or contract identity | checkpoint compatibility error |
+| checkpoint profile/contract differs from the requested profile | checkpoint compatibility error |
+
+If the frozen TE/optimizer revisions cannot legally implement a mandatory
+DistOpt or FSDP2 cell, that cell is blocked with source and runtime evidence.
+The implementation must not relax ownership, change precision, or drop a
+backend to make the matrix green.
+
+## Controlled Parity Variables
+
+Reference and target consume the same serialized input and initialization
+artifacts. The artifact hashes, not matching generator code, define equality.
+Reference and target drivers must not share MLite implementation helpers.
+
+Unless a cell below explicitly changes one variable, freeze:
+
+- seed `1234`, three exact repeats, dropout `0`, deterministic algorithms on,
+  and `CUBLAS_WORKSPACE_CONFIG=:4096:8`;
+- BF16 public activations, E4M3 blockwise recipe above, no TF32, no autocast
+  outside the selected contexts, no activation recompute, no CUDA graph, and no
+  offload;
+- hidden size `1024`, sequence length `256`, micro-batch size `2`, attention
+  heads `16`, KV heads `8`, head dimension `64`, and dense/intermediate size
+  `4096`;
+- MoE experts `4`, top-k `2`, no expert bias, routing-map padding to `16`, and
+  expert intermediate size `4096`;
+- AdamW with learning rate `1e-4`, betas `(0.9, 0.95)`, epsilon `1e-8`, weight
+  decay `0.1`, constant learning rate, no warmup, FP32 master/main gradients and
+  FP32 moments; and
+- identical loss reduction, gradient accumulation count, parameter order,
+  process-group rank order, initialization/load tensors, labels, and optimizer
+  step number.
+
+The BF16 baseline must align before either FP8 profile is evaluated. Each FP8
+profile is compared to its matching direct Megatron reference; the two profiles
+are not used as references for each other.
+
+## Precision Gate Seal
+
+Thresholds are derived only from Megatron reference repeats. Target output must
+not exist when the threshold artifact is created.
+
+The formula, repeat count, multiplier, exact-comparison cases, and review rule
+in this section are the pre-implementation threshold freeze. Numeric values are
+filled only by the later reference-only calibration; they are not guessed in
+advance and cannot depend on a target run.
+
+For every tensor or scalar metric `x`, run the identical reference cell three
+times and compute over all reference pairs:
+
+```text
+noise_abs(x) = max(max(abs(reference_i(x) - reference_j(x))))
+noise_l2(x)  = max(
+  norm(reference_i(x) - reference_j(x), 2)
+  / max(norm(reference_i(x), 2), norm(reference_j(x), 2), tiny_fp32)
+)
+```
+
+The sealed comparison gate is:
+
+```text
+atol(x) = 4 * noise_abs(x)
+rtol_l2(x) = 4 * noise_l2(x)
+```
+
+There is no target-derived floor and no default “1% FP8 tolerance”. If both
+reference noise terms are zero, comparison is bitwise. Otherwise the generated
+non-bitwise gate requires review, as required by `basic.review_threshold`, and
+the approved `thresholds.json` content hash must be recorded before target
+runs. Excessively noisy or non-finite reference results block the cell; they do
+not authorize a wider gate.
+
+A target tensor passes only when shape and dtype are exact, all values are
+finite, max-absolute error is at most `atol`, relative L2 error is at most
+`rtol_l2`, and the target's three-repeat noise is no greater than the reference
+noise gate. Loss and grad norm use the same rule. Coverage, profile identity,
+parameter dtype/ownership, checkpoint keys, and failure behavior are exact
+comparisons rather than tolerant metrics.
+
+Save/load continuity is stricter: within one implementation, uninterrupted and
+save-load-resume executions from the same state must be bitwise equal for the
+next-step public outputs, restored FP32 optimizer state, and updated
+high-precision weights. A source-backed exception must be reviewed before the
+run, never after seeing the result.
+
+Once sealed, a gate can only be replaced by rerunning reference-only
+calibration in a newly sealed environment manifest. The old and new artifacts
+must both remain in evidence. A failing target run cannot trigger recalibration.
+
+## Validation Matrix
+
+All GPU cells run through Slurm. A result is valid only with a real job ID,
+`sacct` state `COMPLETED`, exit code `0:0`, and explicit proof that no test or
+kernel path skipped.
+
+### Phase 0: CPU and static contract
+
+- Parse and round-trip all three public names.
+- Assert the exact recipe mapping and both `ParameterContract` records with
+  mocked TE capability results.
+- Reject every unsupported combination in the failure table.
+- Exercise missing, duplicate, incompatible, and unconsumed typed coverage.
+- Assert the precision package imports no model package and contains no model
+  names, glob matcher, ordered rule, or generic recipe policy.
+- Prove production reachability for every new function/export; test-only callers
+  do not count.
+
+### Phase 1: direct primitive reference
+
+1. A single TE linear on one H100, then TP=2, with input shape
+   `[256, 2, 1024]` and output size `4096`.
+2. A one-layer attention split with TP=2. Compare QKV and output projection
+   sites under the profile while proving DotProductAttention and Q/K norm sites
+   remain BF16.
+3. A reduced MoE with four experts, top-k two, TP=2 and EP=2. Prove routing-map
+   padding, GroupedLinear blockwise kernel use, BF16 router/dispatch, and expert
+   dX/dW.
+
+For both profiles, collect public forward output, dX, every selected dW, every
+fixed-BF16 boundary, and one optimizer update from identical FP32 masters.
+
+### Phase 2: optimizer and checkpoint ownership
+
+Run the same one-step case with DP/FSDP size two for:
+
+- Megatron-Core DistributedOptimizer versus MLite DistOpt; and
+- the direct Megatron math/update reference versus MLite FSDP2.
+
+Materialize global values before comparison. Record compute-parameter dtype and
+storage class, FP32 master owner and shard, main-gradient dtype, both Adam
+moments, optimizer step, and updated high-precision weight.
+
+For each backend and profile, compare a two-step uninterrupted run against
+step-one save/load plus step two. The FP8-weight checkpoint must contain TE FP8
+data and block scales as well as the FP32 master and optimizer state. The
+blockwise recipe itself has no amax history to save.
+
+### Phase 3: Qwen3 MoE composition
+
+Use a two-layer reduced Qwen3 MoE composition with the frozen dimensions and
+TP=2, EP=2, DP=2 on one eight-H100 node. Run:
+
+1. BF16 baseline;
+2. `hopper_blockwise_bf16_weight`; and
+3. `hopper_blockwise_fp8_weight`.
+
+For DistOpt and FSDP2, compare loss, logits, grad norm, selected parameter
+gradients, fixed-BF16 boundaries, updated high-precision weights, and a
+checkpoint-resumed next step. The production runtime and model protocol must be
+used; isolated constructors and otherwise unreachable FP8 branches do not
+count.
+
+### Phase 4: performance after correctness
+
+Performance is measured only after every required correctness cell passes.
+Within the same allocation, use ten warmup steps and thirty measured steps per
+profile, repeat the paired order at least three times, and report step time,
+tokens per second, and peak allocated/reserved memory together with loss.
+Report both Hopper profiles relative to BF16 and the matching Megatron
+reference. There is no performance pass threshold in this contract, and no
+precision or coverage rule may be changed to improve a number.
+
+## Evidence and Delivery Gate
+
+Each cell leaves:
+
+- sealed environment and case manifests with content hashes;
+- the three raw reference repeats and reference-only threshold artifact;
+- the three raw target repeats;
+- tensor-level comparison reports for forward, dX, dW, update, and resume;
+- typed coverage and parameter-ownership manifests;
+- checkpoint inventory and uninterrupted-versus-resume report;
+- Slurm job script, stdout/stderr, job ID, and `sacct` result; and
+- proof of actual blockwise Linear/GroupedLinear execution and zero skips.
+
+Delivery also requires the relevant MLite skill invariants: the smallest
+replaceable primitive (`basic.constitution`), explicit math/dtype/update gates
+(`primitive.principle`), owned API/state/groups/failures
+(`primitive.contract`), checkable reference and replacement boundary
+(`primitive.design`), and static/proxy/composition/runtime validation
+(`primitive.validate`). The final review must separately inspect production
+dead code and primitive-to-model layering; a green test suite alone is not
+sufficient.
+
+## Frozen Source Anchors
+
+- Megatron maps `blockwise` to TE `Float8BlockScaling`, restricts formats to
+  E4M3/HYBRID, and constructs init/forward contexts in
+  [`fp8_utils.py`][mcore-fp8].
+- Megatron keeps attention DPA/MHA as separate controls in
+  [`transformer_config.py`][mcore-config] and applies non-delayed FP8 contexts
+  per layer in [`transformer_block.py`][mcore-block].
+- Megatron's MoE path validates TE/grouped-GEMM support and quantized routing
+  padding in [`transformer_config.py`][mcore-moe-config] and derives the blockwise
+  padding alignment in [`moe_utils.py`][mcore-moe].
+- Megatron's optimizer contract defaults main parameters, main gradients, and
+  Adam states to FP32 in [`optimizer_config.py`][mcore-optimizer].
+- TE freezes block dimensions, format, split accumulation, scale behavior, and
+  the FP8-attention rejection in [`recipe/__init__.py`][te-recipe].
+- TE freezes the SM90/CUDA 12.9 capability check in
+  [`quantization.py`][te-quantization] and declares blockwise recipe state
+  stateless in [`Float8BlockScalingRecipeState`][te-state].
+- TE requires cuBLAS 13.4 for blockwise GroupedLinear in
+  [`cublaslt_grouped_gemm.cu`][te-grouped] and checks the runtime version in
+  the same implementation's [scale-pointer setup][te-grouped-runtime].
+- TE defines high-precision-source preservation for FP8 compute weights in
+  [`quantization.py`][te-model-init].
+
+[mcore-commit]: https://github.com/NVIDIA/Megatron-LM/commit/cf2f07d7b1315c96c05554c670c43207c6783e5e
+[mcore-fp8]: https://github.com/NVIDIA/Megatron-LM/blob/cf2f07d7b1315c96c05554c670c43207c6783e5e/megatron/core/fp8_utils.py#L554-L672
+[mcore-config]: https://github.com/NVIDIA/Megatron-LM/blob/cf2f07d7b1315c96c05554c670c43207c6783e5e/megatron/core/transformer/transformer_config.py#L556-L613
+[mcore-moe-config]: https://github.com/NVIDIA/Megatron-LM/blob/cf2f07d7b1315c96c05554c670c43207c6783e5e/megatron/core/transformer/transformer_config.py#L2258-L2289
+[mcore-block]: https://github.com/NVIDIA/Megatron-LM/blob/cf2f07d7b1315c96c05554c670c43207c6783e5e/megatron/core/transformer/transformer_block.py#L600-L664
+[mcore-moe]: https://github.com/NVIDIA/Megatron-LM/blob/cf2f07d7b1315c96c05554c670c43207c6783e5e/megatron/core/transformer/moe/moe_utils.py#L1340-L1374
+[mcore-optimizer]: https://github.com/NVIDIA/Megatron-LM/blob/cf2f07d7b1315c96c05554c670c43207c6783e5e/megatron/core/optimizer/optimizer_config.py#L184-L207
+[te-commit]: https://github.com/NVIDIA/TransformerEngine/commit/8b9968255eb879e6e390f427836906b29aad64d2
+[te-recipe]: https://github.com/NVIDIA/TransformerEngine/blob/8b9968255eb879e6e390f427836906b29aad64d2/transformer_engine/common/recipe/__init__.py#L388-L475
+[te-quantization]: https://github.com/NVIDIA/TransformerEngine/blob/8b9968255eb879e6e390f427836906b29aad64d2/transformer_engine/pytorch/quantization.py#L175-L245
+[te-grouped]: https://github.com/NVIDIA/TransformerEngine/blob/8b9968255eb879e6e390f427836906b29aad64d2/transformer_engine/common/gemm/cublaslt_grouped_gemm.cu#L35-L48
+[te-grouped-runtime]: https://github.com/NVIDIA/TransformerEngine/blob/8b9968255eb879e6e390f427836906b29aad64d2/transformer_engine/common/gemm/cublaslt_grouped_gemm.cu#L920-L957
+[te-model-init]: https://github.com/NVIDIA/TransformerEngine/blob/8b9968255eb879e6e390f427836906b29aad64d2/transformer_engine/pytorch/quantization.py#L837-L924
+[te-state]: https://github.com/NVIDIA/TransformerEngine/blob/8b9968255eb879e6e390f427836906b29aad64d2/transformer_engine/pytorch/quantization.py#L1526-L1575

--- a/experimental/lite/docs/hopper-blockwise-fp8-contract.md
+++ b/experimental/lite/docs/hopper-blockwise-fp8-contract.md
@@ -37,22 +37,33 @@ all-gather, lower-precision optimizer state, FP8 communication, arbitrary
 target combinations, model allowlists, and model-local FP8 implementations are
 out of scope.
 
-## Frozen Independent Reference
+## Independent Reference
 
 Parity uses direct upstream source, not Megatron Lite through a second runtime
 path:
 
 - Megatron-Core commit
   [`cf2f07d7b1315c96c05554c670c43207c6783e5e`][mcore-commit];
-- Transformer Engine commit
-  [`8b9968255eb879e6e390f427836906b29aad64d2`][te-commit], which reports
-  version `2.18.0.dev0`; and
+- the canonical training image's released Transformer Engine `2.15.0`, whose
+  blockwise kernels (Linear, LayerNormLinear, GroupedLinear) run forward and
+  backward under `Float8BlockScaling` -- verified by a read-only capability
+  inventory on that image (SM90, CUDA 13.2, cuBLAS 13.4, block scaling
+  supported, all mandatory ops ran); and
 - an NVIDIA Hopper GPU with compute capability exactly 9.0.
 
+Blockwise FP8 runs on the same image that runs BF16 -- there is no FP8-only
+build overlay. The runtime gate pins the released Transformer Engine version
+`2.15.0`; requiring an exact build SHA would recreate a special-environment
+requirement, so the build SHA is recorded for provenance only and the
+capability preflight below is the fail-loud safety net. The [te-commit] link
+and the `[te-*]` source citations point at readable upstream source for the
+blockwise recipe, quantization, and grouped-GEMM APIs; TE 2.15 implements the
+same blockwise contract, which the inventory confirms at runtime.
+
 The reference driver must import Megatron-Core from the frozen checkout and
-Transformer Engine from a build of the frozen TE commit. A package version
-string alone is insufficient. The driver must assert both source revisions
-before allocating model state.
+Transformer Engine from the canonical image. A package version string is
+matched against `2.15.0`; the driver must assert the Megatron-Core revision and
+the TE version before allocating model state.
 
 ### Environment seal
 
@@ -77,11 +88,11 @@ The image is qualified only if all of the following preflight checks pass:
 
 1. `torch.cuda.get_device_capability()` is `(9, 0)`. Blackwell emulation is not
    accepted by these Hopper-named profiles.
-2. TE's `check_fp8_block_scaling_support()` succeeds. At the frozen TE commit,
+2. TE's `check_fp8_block_scaling_support()` succeeds. On canonical TE 2.15,
    this requires CUDA 12.9 or newer in addition to SM90.
-3. The TE build and runtime cuBLAS versions are both at least 13.4. The frozen
-   TE GroupedLinear implementation requires that version for blockwise FP8
-   grouped GEMM, and MoE is mandatory in this release.
+3. The runtime cuBLAS version is at least 13.4. TE 2.15's GroupedLinear
+   implementation requires that version for blockwise FP8 grouped GEMM, and MoE
+   is mandatory in this release.
 4. `NVTE_FP8_BLOCK_SCALING_FP32_SCALES` is absent or `0`,
    `NVTE_BACKWARD_OVERRIDE` is absent, and the constructed recipe equals the
    frozen recipe below.

--- a/experimental/lite/docs/hopper-blockwise-fp8-contract.md
+++ b/experimental/lite/docs/hopper-blockwise-fp8-contract.md
@@ -211,16 +211,12 @@ optimizer master when MLite owns it.
 
 ## Public and Internal API Boundary
 
-The public runtime field is a string. Two values are currently usable; the
-third names the closed design's reserved second profile, which is not yet
-implemented and therefore fails loud (a `NotImplementedError`) rather than being
-sold as usable:
+The public runtime field is a string with exactly these three closed values:
 
 ```python
 MegatronLiteConfig(precision="bf16")
 MegatronLiteConfig(precision="hopper_blockwise_bf16_weight")
-# Reserved, not yet implemented -- raises NotImplementedError at resolution:
-# MegatronLiteConfig(precision="hopper_blockwise_fp8_weight")
+MegatronLiteConfig(precision="hopper_blockwise_fp8_weight")
 ```
 
 Internally, the precision package may share only the following narrow typed
@@ -344,7 +340,7 @@ model construction, or checkpoint load as indicated below.
 | Condition | Required failure |
 | --- | --- |
 | unknown profile or any ad-hoc recipe/format/target value | config error listing the accepted profile names |
-| reserved `hopper_blockwise_fp8_weight` (FP8 parameter storage) is requested | not-implemented error at resolution; the pending second profile is never sold as usable |
+| `hopper_blockwise_fp8_weight` (FP8 parameter storage) is requested | construct selected TE GEMMs under `quantized_model_init`; preserve the high-precision source for the single MLite FP32 master |
 | TE's `check_fp8_block_scaling_support()` reports no blockwise FP8 support | environment error before model allocation, quoting TE's reason and the recorded toolchain (device, TE, CUDA, cuBLAS) |
 | MoE-expert profile on cuBLAS below the grouped-GEMM requirement (`< CUBLAS_GROUPED_GEMM_MIN_VERSION`) | environment error before model allocation; the grouped path is gated instead of crashing inside `GroupedLinear` |
 | recipe differs, FP8 DPA/MHA is enabled, or scale/backward env overrides are set | environment/recipe mismatch error |
@@ -453,8 +449,8 @@ kernel path skipped.
 
 ### Phase 0: CPU and static contract
 
-- Parse and round-trip the two usable public names, and assert the reserved
-  `hopper_blockwise_fp8_weight` name fails loud (`NotImplementedError`).
+- Parse and round-trip all three public names, including the FP8-weight
+  profile's closed parameter contract.
 - Assert the exact recipe mapping and the `hopper_blockwise_bf16_weight`
   `ParameterContract` record with mocked TE capability results.
 - Reject every unsupported combination in the failure table.

--- a/experimental/lite/docs/hopper-blockwise-fp8-contract.md
+++ b/experimental/lite/docs/hopper-blockwise-fp8-contract.md
@@ -16,6 +16,13 @@ The only new public configuration values are:
 - `hopper_blockwise_bf16_weight`
 - `hopper_blockwise_fp8_weight`
 
+Implementation status: `hopper_blockwise_bf16_weight` is implemented. The
+`hopper_blockwise_fp8_weight` profile (FP8 parameter storage) is the closed
+design's declared-but-pending second profile: resolving it fails loud with a
+`NotImplementedError` rather than being advertised as usable, and FP8-weight
+initialization is tracked as a separate follow-up. The rest of this document
+describes both profiles as the frozen design contract.
+
 `bf16` remains the default and preserves the current behavior. No public
 `recipe`, `format`, `target`, `weight_dtype`, rule list, ordered matcher, or
 model-specific FP8 configuration is part of this release.
@@ -47,23 +54,26 @@ path:
 - the canonical training image's released Transformer Engine `2.15.0`, whose
   blockwise kernels (Linear, LayerNormLinear, GroupedLinear) run forward and
   backward under `Float8BlockScaling` -- verified by a read-only capability
-  inventory on that image (SM90, CUDA 13.2, cuBLAS 13.4, block scaling
+  inventory on that image (SM90, CUDA 13.2, cuBLAS 13.4 present, block scaling
   supported, all mandatory ops ran); and
-- an NVIDIA Hopper GPU with compute capability exactly 9.0.
+- an NVIDIA GPU on which TE's blockwise-FP8 capability probe passes.
 
 Blockwise FP8 runs on the same image that runs BF16 -- there is no FP8-only
-build overlay. The runtime gate pins the released Transformer Engine version
-`2.15.0`; requiring an exact build SHA would recreate a special-environment
-requirement, so the build SHA is recorded for provenance only and the
-capability preflight below is the fail-loud safety net. The [te-commit] link
-and the `[te-*]` source citations point at readable upstream source for the
-blockwise recipe, quantization, and grouped-GEMM APIs; TE 2.15 implements the
-same blockwise contract, which the inventory confirms at runtime.
+build overlay. The runtime gate is deliberately *not* a hard pin on an exact
+device class, TE version, or CUDA/cuBLAS threshold: the single authoritative
+gate is TE's own `check_fp8_block_scaling_support()` capability probe. Pinning
+exact versions would recreate a special-environment requirement (whatever runs
+BF16 must run FP8) and could reject a newer or different accelerator where BF16
+is fine. The released TE `2.15.0` is the version the parity evidence was
+recorded against; it is kept as provenance, and a probed toolchain that differs
+from it emits a fail-loud provenance warning but is not blocked. The `[te-*]`
+source citations point at readable upstream source (pinned to the `v2.15` tag)
+for the blockwise recipe, quantization, and grouped-GEMM APIs.
 
 The reference driver must import Megatron-Core from the frozen checkout and
-Transformer Engine from the canonical image. A package version string is
-matched against `2.15.0`; the driver must assert the Megatron-Core revision and
-the TE version before allocating model state.
+Transformer Engine from the canonical image. It records the Megatron-Core
+revision and the TE version for provenance and asserts TE's capability probe
+before allocating model state.
 
 ### Environment seal
 
@@ -86,17 +96,20 @@ comparison.
 
 The image is qualified only if all of the following preflight checks pass:
 
-1. `torch.cuda.get_device_capability()` is `(9, 0)`. Blackwell emulation is not
-   accepted by these Hopper-named profiles.
-2. TE's `check_fp8_block_scaling_support()` succeeds. On canonical TE 2.15,
-   this requires CUDA 12.9 or newer in addition to SM90.
-3. The runtime cuBLAS version is at least 13.4. TE 2.15's GroupedLinear
-   implementation requires that version for blockwise FP8 grouped GEMM, and MoE
-   is mandatory in this release.
-4. `NVTE_FP8_BLOCK_SCALING_FP32_SCALES` is absent or `0`,
+1. TE's `check_fp8_block_scaling_support()` succeeds. This capability probe is
+   the single authoritative gate -- the same one the runtime uses -- and it
+   determines device/toolchain support (SM, CUDA, cuBLAS, block scaling)
+   directly rather than through hard-coded version thresholds.
+2. The device class, CUDA, cuBLAS, and TE versions are recorded in the
+   environment manifest for provenance and diagnosis, not enforced as
+   independent hard gates: whatever image runs BF16 must run FP8, so an exact SM
+   class, TE version, or CUDA/cuBLAS threshold is deliberately not pinned. The
+   canonical qualification image reported SM90, CUDA 13.2, cuBLAS 13.4, and TE
+   2.15.0; TE 2.15's grouped-GEMM path itself requires cuBLAS 13.3+.
+3. `NVTE_FP8_BLOCK_SCALING_FP32_SCALES` is absent or `0`,
    `NVTE_BACKWARD_OVERRIDE` is absent, and the constructed recipe equals the
    frozen recipe below.
-5. The reference linear and grouped-linear probes execute, rather than skip or
+4. The reference linear and grouped-linear probes execute, rather than skip or
    fall back to a non-blockwise kernel.
 
 There is no pre-qualified image assumed by this document. The first image that
@@ -190,12 +203,16 @@ optimizer master when MLite owns it.
 
 ## Public and Internal API Boundary
 
-The public runtime field is a string with exactly three accepted values:
+The public runtime field is a string. Two values are currently usable; the
+third names the closed design's reserved second profile, which is not yet
+implemented and therefore fails loud (a `NotImplementedError`) rather than being
+sold as usable:
 
 ```python
 MegatronLiteConfig(precision="bf16")
 MegatronLiteConfig(precision="hopper_blockwise_bf16_weight")
-MegatronLiteConfig(precision="hopper_blockwise_fp8_weight")
+# Reserved, not yet implemented -- raises NotImplementedError at resolution:
+# MegatronLiteConfig(precision="hopper_blockwise_fp8_weight")
 ```
 
 Internally, the precision package may share only the following narrow typed
@@ -318,9 +335,9 @@ model construction, or checkpoint load as indicated below.
 
 | Condition | Required failure |
 | --- | --- |
-| unknown profile or any ad-hoc recipe/format/target value | config error listing the three accepted profile names |
-| device is not SM90, TE revision differs, CUDA is below 12.9 | environment error before model allocation |
-| compile-time or runtime cuBLAS is below 13.4 | environment error identifying mandatory MoE GroupedLinear support |
+| unknown profile or any ad-hoc recipe/format/target value | config error listing the accepted profile names |
+| reserved `hopper_blockwise_fp8_weight` (FP8 parameter storage) is requested | not-implemented error at resolution; the pending second profile is never sold as usable |
+| TE's `check_fp8_block_scaling_support()` reports no blockwise FP8 support | environment error before model allocation, quoting TE's reason and the recorded toolchain (device, TE, CUDA, cuBLAS) |
 | recipe differs, FP8 DPA/MHA is enabled, or scale/backward env overrides are set | environment/recipe mismatch error |
 | selected shape violates blockwise rules | construction error with semantic site and shape |
 | missing, duplicate, or incompatible typed coverage | construction error before optimizer creation |
@@ -427,9 +444,10 @@ kernel path skipped.
 
 ### Phase 0: CPU and static contract
 
-- Parse and round-trip all three public names.
-- Assert the exact recipe mapping and both `ParameterContract` records with
-  mocked TE capability results.
+- Parse and round-trip the two usable public names, and assert the reserved
+  `hopper_blockwise_fp8_weight` name fails loud (`NotImplementedError`).
+- Assert the exact recipe mapping and the `hopper_blockwise_bf16_weight`
+  `ParameterContract` record with mocked TE capability results.
 - Reject every unsupported combination in the failure table.
 - Exercise missing, duplicate, incompatible, and unconsumed typed coverage.
 - Assert the precision package imports no model package and contains no model
@@ -529,12 +547,14 @@ sufficient.
   Adam states to FP32 in [`optimizer_config.py`][mcore-optimizer].
 - TE freezes block dimensions, format, split accumulation, scale behavior, and
   the FP8-attention rejection in [`recipe/__init__.py`][te-recipe].
-- TE freezes the SM90/CUDA 12.9 capability check in
-  [`quantization.py`][te-quantization] and declares blockwise recipe state
-  stateless in [`Float8BlockScalingRecipeState`][te-state].
-- TE requires cuBLAS 13.4 for blockwise GroupedLinear in
-  [`cublaslt_grouped_gemm.cu`][te-grouped] and checks the runtime version in
-  the same implementation's [scale-pointer setup][te-grouped-runtime].
+- TE owns the blockwise FP8 capability check (device, CUDA, cuBLAS, and block
+  scaling support) in [`check_fp8_block_scaling_support`][te-quantization] and
+  declares blockwise recipe state stateless in
+  [`Float8BlockScalingRecipeState`][te-state].
+- TE requires cuBLAS 13.3+ for blockwise GroupedLinear (the
+  `CUBLAS_GROUPED_GEMM_VERSION` guard in [`cublaslt_grouped_gemm.cu`][te-grouped])
+  and enforces it at runtime in
+  [`check_grouped_gemm_requirements`][te-grouped-runtime].
 - TE defines high-precision-source preservation for FP8 compute weights in
   [`quantization.py`][te-model-init].
 
@@ -545,10 +565,10 @@ sufficient.
 [mcore-block]: https://github.com/NVIDIA/Megatron-LM/blob/cf2f07d7b1315c96c05554c670c43207c6783e5e/megatron/core/transformer/transformer_block.py#L600-L664
 [mcore-moe]: https://github.com/NVIDIA/Megatron-LM/blob/cf2f07d7b1315c96c05554c670c43207c6783e5e/megatron/core/transformer/moe/moe_utils.py#L1340-L1374
 [mcore-optimizer]: https://github.com/NVIDIA/Megatron-LM/blob/cf2f07d7b1315c96c05554c670c43207c6783e5e/megatron/core/optimizer/optimizer_config.py#L184-L207
-[te-commit]: https://github.com/NVIDIA/TransformerEngine/commit/8b9968255eb879e6e390f427836906b29aad64d2
-[te-recipe]: https://github.com/NVIDIA/TransformerEngine/blob/8b9968255eb879e6e390f427836906b29aad64d2/transformer_engine/common/recipe/__init__.py#L388-L475
-[te-quantization]: https://github.com/NVIDIA/TransformerEngine/blob/8b9968255eb879e6e390f427836906b29aad64d2/transformer_engine/pytorch/quantization.py#L175-L245
-[te-grouped]: https://github.com/NVIDIA/TransformerEngine/blob/8b9968255eb879e6e390f427836906b29aad64d2/transformer_engine/common/gemm/cublaslt_grouped_gemm.cu#L35-L48
-[te-grouped-runtime]: https://github.com/NVIDIA/TransformerEngine/blob/8b9968255eb879e6e390f427836906b29aad64d2/transformer_engine/common/gemm/cublaslt_grouped_gemm.cu#L920-L957
-[te-model-init]: https://github.com/NVIDIA/TransformerEngine/blob/8b9968255eb879e6e390f427836906b29aad64d2/transformer_engine/pytorch/quantization.py#L837-L924
-[te-state]: https://github.com/NVIDIA/TransformerEngine/blob/8b9968255eb879e6e390f427836906b29aad64d2/transformer_engine/pytorch/quantization.py#L1526-L1575
+[te-commit]: https://github.com/NVIDIA/TransformerEngine/tree/v2.15
+[te-recipe]: https://github.com/NVIDIA/TransformerEngine/blob/v2.15/transformer_engine/common/recipe/__init__.py#L346-L436
+[te-quantization]: https://github.com/NVIDIA/TransformerEngine/blob/v2.15/transformer_engine/pytorch/quantization.py#L120-L127
+[te-grouped]: https://github.com/NVIDIA/TransformerEngine/blob/v2.15/transformer_engine/common/gemm/cublaslt_grouped_gemm.cu#L35-L48
+[te-grouped-runtime]: https://github.com/NVIDIA/TransformerEngine/blob/v2.15/transformer_engine/common/gemm/cublaslt_grouped_gemm.cu#L302-L309
+[te-model-init]: https://github.com/NVIDIA/TransformerEngine/blob/v2.15/transformer_engine/pytorch/quantization.py#L745-L808
+[te-state]: https://github.com/NVIDIA/TransformerEngine/blob/v2.15/transformer_engine/pytorch/quantization.py#L1218-L1322

--- a/experimental/lite/docs/runs/hopper-blockwise-fp8-weight-fsdp2.md
+++ b/experimental/lite/docs/runs/hopper-blockwise-fp8-weight-fsdp2.md
@@ -49,6 +49,37 @@ JUnit: `tests=2 failures=0 errors=0 skipped=0`. Artifacts and immutable stdout:
 .../work/codex/fp8-primitives-c9c00dfac-cw/fp8-weight-fsdp2-14237043.out
 ```
 
+## Distributed-optimizer FP8-weight path (fail-loud, no run by design)
+
+The two optimizer paths for the FP8-weight profile are FSDP2 and the distributed
+optimizer. Only FSDP2 is a supported FP8-weight training path in this version:
+its per-parameter update keeps the FP8 compute weights live. The
+distributed-optimizer FP8 write-back instead depends on the upstream Megatron
+`fp8_param_gather` path, which is out of scope for the closed Hopper profiles.
+
+A distributed-optimizer run against `hopper_blockwise_fp8_weight` is
+*constructible* (the distributed optimizer is qwen3_moe's default), so leaving it
+unguarded would silently update only the BF16-gathered parameters while the FP8
+compute weights stayed stale — a run that looks FP8-trained but is not. The
+precision gate (`require_optimizer_supports_precision`, wired into `build_model`)
+therefore rejects the combination loudly. This is the fail-loud behaviour AC#4
+requires; there is deliberately **no** distributed-optimizer FP8 Slurm run.
+
+The guard is proven on CPU (no GPU needed — it fires before allocation):
+
+- `tests/unit/model/test_qwen3_moe_precision_static.py::test_qwen3_moe_rejects_fp8_weight_with_distributed_optimizer`
+  — `build_model` rejects the default (`dist_opt`) and explicit distributed-optimizer
+  cases for the FP8-weight profile.
+- `tests/unit/primitive/test_precision_profiles_unit.py::test_fp8_weight_profile_rejects_optimizers_without_fp8_param_gather`
+  and `::test_optimizer_precision_gate_allows_supported_combinations` — the
+  primitive gate rejects FP8-weight under any optimizer lacking `fp8_param_gather`
+  and accepts FP8-weight+FSDP2 and BF16-weight under every backend.
+
+Un-deferring the distributed-optimizer FP8-weight path (i.e. landing
+`fp8_param_gather`) is tracked separately in the backlog and is a human decision.
+
+## Terminal verification scope
+
 FP8-weight throughput A/B (fp8-vs-bf16 speedup, vs-Megatron-FP8 tokens/s) and the
 FP8-weight precision-parity profile are the terminal Qwen3-MoE verification and
 are run under the sibling terminal-verification task, not here.

--- a/experimental/lite/docs/runs/hopper-blockwise-fp8-weight-fsdp2.md
+++ b/experimental/lite/docs/runs/hopper-blockwise-fp8-weight-fsdp2.md
@@ -1,0 +1,54 @@
+# Hopper blockwise FP8-weight FSDP2 GPU regression
+
+Runs the FP8-weight FSDP2 optimizer regressions on a real Hopper GPU against the
+canonical training image's native Transformer Engine 2.15. These cases are
+skipped on CPU (they require CUDA + FSDP2 `fully_shard`), so this Slurm run is
+the only place they actually execute.
+
+## What it covers
+
+`tests/unit/primitive/test_fsdp2_offload_gpu.py -k fp8_weight`:
+
+- `test_fsdp2_fp8_weight_uses_te_source_for_fp32_master_and_updates` — the FP8
+  compute weights are built with TE `quantized_model_init`; the single FP32
+  master is taken bit-for-bit from TE's preserved high-precision source (never
+  by dequantizing the FP8 param), TE's source is consumed exactly once, and one
+  AdamW step runs with a finite loss and grad norm.
+- `test_fsdp2_fp8_weight_local_checkpoint_resume_matches_uninterrupted` — save
+  after one step, rebuild, resume, and confirm the restored FP32 masters match
+  the uninterrupted run bit-for-bit, then match again after the next step.
+
+The FP32 master mirrors the sharded FP8 param as a DTensor (same mesh, placements,
+shape, stride), so the master/`exp_avg`/`exp_avg_sq` and the FSDP2 gradient share
+one tensor type through the AdamW update.
+
+## Environment
+
+- image: `pytorch_26.04-py3.sqsh` (native TE `2.15.0+42b84005`, CUDA 13.2)
+- `PYTHONPATH`: extracted `experimental/lite` + a pure-python pytest target dir +
+  the Megatron-LM repo root (namespace package, for `megatron.core` used by the
+  checkpoint RNG-tracker path). No FP8-only overlay.
+- single H100, `WORLD_SIZE=1` (`fully_shard` still yields DTensor params).
+
+## Accepted result
+
+Slurm job `14237043` on `pool0-01735` `COMPLETED 0:0` (elapsed 0:56). The Hopper
+gate reported `block_scaling_supported=True` before allocation. Non-skipped
+markers:
+
+```text
+_HopperEnvironment(compute_capability=(9, 0), transformer_engine_version='2.15.0+42b84005', cuda_version=(13, 2), cublas_version=130401, block_scaling_supported=True)
+2 passed, 2 deselected
+MLITE_FP8_WEIGHT_FSDP2_JOB_OK
+```
+
+JUnit: `tests=2 failures=0 errors=0 skipped=0`. Artifacts and immutable stdout:
+
+```text
+.../work/codex/fp8-primitives-c9c00dfac-cw/results/fp8-weight-fsdp2-14237043
+.../work/codex/fp8-primitives-c9c00dfac-cw/fp8-weight-fsdp2-14237043.out
+```
+
+FP8-weight throughput A/B (fp8-vs-bf16 speedup, vs-Megatron-FP8 tokens/s) and the
+FP8-weight precision-parity profile are the terminal Qwen3-MoE verification and
+are run under the sibling terminal-verification task, not here.

--- a/experimental/lite/docs/runs/hopper-blockwise-fp8-weight-fsdp2.sbatch
+++ b/experimental/lite/docs/runs/hopper-blockwise-fp8-weight-fsdp2.sbatch
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=mlite-fp8w-fsdp2
+#SBATCH --account=coreai_devtech_all
+#SBATCH --partition=batch
+#SBATCH --qos=normal
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=16
+#SBATCH --gres=gpu:1
+#SBATCH --time=00:40:00
+#SBATCH --output=/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/work/codex/fp8-primitives-c9c00dfac-cw/fp8-weight-fsdp2-%j.out
+
+set -euo pipefail
+
+RUN_ROOT=/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/work/codex/fp8-primitives-c9c00dfac-cw
+BASE_IMAGE=/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/code/env/pytorch_26.04-py3.sqsh
+TARBALL=$RUN_ROOT/fp8-weight-fsdp2/mlite-fp8-fsdp2-727fd8ed5.tar
+TARBALL_SHA=832b979df00156d4a6fdd09ac1d539d4a050f1c64028b88a6024ac95e6622116
+
+srun --ntasks=1 \
+  --container-image="$BASE_IMAGE" \
+  --container-mounts=/lustre:/lustre \
+  --container-workdir="$RUN_ROOT" \
+  bash -lc "set -euo pipefail
+    RUN_ROOT=$RUN_ROOT
+    TARBALL=$TARBALL
+    RUN_DIR=\$RUN_ROOT/fp8-weight-fsdp2/run-\${SLURM_JOB_ID}
+    OUTPUT=\$RUN_ROOT/results/fp8-weight-fsdp2-\${SLURM_JOB_ID}
+
+    export PATH=/usr/local/cuda/bin:/usr/local/bin:/usr/bin:/bin
+    unset CONDA_PREFIX CONDA_DEFAULT_ENV CONDA_EXE CONDA_PYTHON_EXE || true
+    unset CONDA_SHLVL CPATH C_INCLUDE_PATH CPLUS_INCLUDE_PATH LIBRARY_PATH || true
+    export PYTHONNOUSERSITE=1
+    export CC=/usr/bin/gcc CXX=/usr/bin/g++
+    export XDG_CACHE_HOME=\$RUN_DIR/cache/xdg
+    export TRITON_CACHE_DIR=\$RUN_DIR/cache/triton
+    export TORCHINDUCTOR_CACHE_DIR=\$RUN_DIR/cache/torchinductor
+    export TMPDIR=\$RUN_DIR/cache/tmp
+    export HOME=\$RUN_DIR/home
+    export CUBLAS_WORKSPACE_CONFIG=:4096:8
+    export CUDA_DEVICE_MAX_CONNECTIONS=1
+    export OMP_NUM_THREADS=1
+
+    test -f \$TARBALL
+    test \"\$(sha256sum \$TARBALL | cut -d' ' -f1)\" = $TARBALL_SHA
+    mkdir -p \$RUN_DIR \$OUTPUT \$XDG_CACHE_HOME \$TRITON_CACHE_DIR \$TORCHINDUCTOR_CACHE_DIR \$TMPDIR \$HOME
+    tar -xf \$TARBALL -C \$RUN_DIR
+    export PYTHONPATH=\$RUN_DIR/experimental/lite:/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/work/codex/fp8-primitives-c9c00dfac-cw/pytools:/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/code/megatron_lite/Megatron-LM
+
+    cd \$RUN_DIR
+    python -c 'import torch, transformer_engine; print(\"torch\", torch.__version__, \"TE\", transformer_engine.__version__, \"cuda\", torch.cuda.is_available(), torch.cuda.get_device_name(0))'
+    python -c 'from megatron.lite.primitive.precision import validate_hopper_environment; print(validate_hopper_environment())'
+
+    python -m pytest -v -p no:cacheprovider \
+      experimental/lite/tests/unit/primitive/test_fsdp2_offload_gpu.py \
+      -k fp8_weight \
+      --junitxml=\$OUTPUT/fp8-weight-fsdp2.xml \
+      | tee \$OUTPUT/fp8-weight-fsdp2.log
+
+    echo MLITE_FP8_WEIGHT_FSDP2_JOB_OK output=\$OUTPUT"

--- a/experimental/lite/docs/runs/hopper-blockwise-primitive-parity.md
+++ b/experimental/lite/docs/runs/hopper-blockwise-primitive-parity.md
@@ -1,0 +1,71 @@
+# Hopper blockwise BF16-weight primitive parity
+
+This run compares the production Megatron Lite primitives with the frozen
+Megatron-Core Transformer Engine wrappers. Reference repeats are completed and
+their thresholds are sealed before the corresponding target modules are
+constructed.
+
+## Frozen inputs
+
+- Megatron-Core: `cf2f07d7b1315c96c05554c670c43207c6783e5e`
+- Megatron source archive SHA-256:
+  `c08272b18d171553f2dcd04937d27e77d3a6be223860726be7c56fcc90c558b1`
+- Transformer Engine: `2.18.0.dev0+8b99682`, source commit
+  `8b9968255eb879e6e390f427836906b29aad64d2`
+- Transformer Engine overlay:
+  `/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/code/te-8b9968255-cu132-py312-overlay-r7`
+- driver SHA-256:
+  `4d02d222a8455f70c988018e696f979d5618c24e618c882aace7981706c43c1f`
+- launcher: `hopper-blockwise-primitive-parity.sbatch`
+
+The cell uses four H100 GPUs with TP=2 and EP=2. Both `bf16` and
+`hopper_blockwise_bf16_weight` use seed 1234, three repeats, hidden size 1024,
+sequence length 256, micro-batch size 2, 16 query heads, eight KV heads, four
+experts, top-k two, and routing-map padding to 16. The one-step update is AdamW
+with an FP32 master, learning rate `1e-4`, betas `(0.9, 0.95)`, epsilon `1e-8`,
+and weight decay `0.1`.
+
+## Attempts
+
+Failed jobs remain in the immutable Slurm logs. No failed threshold or target
+artifact was reused by a later job.
+
+| Job | Result | Finding |
+| --- | --- | --- |
+| `13713809` | `FAILED 1:0` | An installed checkpoint-only NVRx package was older than the frozen Megatron import requirement; the primitive driver now makes that unused optional integration absent. |
+| `13713952` | `FAILED 1:0` | Corrected the frozen-source `AttnMaskType` import. |
+| `13714092` | `FAILED 1:0` | Adapted the MCore DPA wrapper's explicit mask arguments. |
+| `13714182` | `FAILED 1:0` | Normalized already-flattened MCore and raw TE core-attention outputs to `[S, B, H/tp]`. |
+| `13714272` | `FAILED 1:0` | Explicitly selected SwiGLU in the reference configuration. |
+| `13714386` | `FAILED 1:0` | Cleared an inherited Miniforge host compiler before Triton compilation. |
+| `13714455` | `FAILED 1:0` | Moved Triton, TorchInductor, XDG, and temporary caches off the container root filesystem. |
+| `13714533` | `FAILED 1:0` | Fixed a comparison-harness metric lookup after three BF16 reference and target repeats completed. |
+| `13714605` | `FAILED 1:0` | BF16 passed; the blockwise reference was missing MCore's production `get_fp8_context` wrapper. |
+| `13714801` | `COMPLETED 0:0` | Accepted BF16 and blockwise primitive parity. |
+
+## Accepted result
+
+Slurm job `13714801` completed every step with exit code `0:0` on node
+`pool0-01422`. It emitted the non-skipped markers:
+
+```text
+HOPPER_BLOCKWISE_BF16_BASELINE_PARITY_OK
+HOPPER_BLOCKWISE_PRIMITIVE_PARITY_OK
+HOPPER_BLOCKWISE_PRIMITIVE_PARITY_JOB_OK
+```
+
+The comparison covers TP column linear, GQA QKV/core/output split, and the
+reduced grouped-expert path. It checks public forward tensors, dX, every dW,
+the FP32 AdamW result, BF16 attention-core/norm/router boundaries, and an
+11-entry typed coverage manifest. Reference noise was zero, so both profiles
+passed bitwise gates; target repeat noise was also zero.
+
+The manifest SHA-256 is
+`fcfd21e29db21af104a5437c2a77a9702579a1a9efb962e7df1fd6ee85231761`.
+There are eight threshold files and eight comparison files, one for each
+profile and rank. Artifacts and immutable stdout are stored under:
+
+```text
+/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/work/codex/fp8-primitives-c9c00dfac-cw/results/primitive-parity-13714801
+/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/work/codex/fp8-primitives-c9c00dfac-cw/primitive-parity-13714801.out
+```

--- a/experimental/lite/docs/runs/hopper-blockwise-primitive-parity.md
+++ b/experimental/lite/docs/runs/hopper-blockwise-primitive-parity.md
@@ -1,19 +1,21 @@
 # Hopper blockwise BF16-weight primitive parity
 
-This run compares the production Megatron Lite primitives with the frozen
-Megatron-Core Transformer Engine wrappers. Reference repeats are completed and
-their thresholds are sealed before the corresponding target modules are
-constructed.
+This run compares the production Megatron Lite primitives with the Megatron-Core
+Transformer Engine wrappers on the canonical training image's native
+Transformer Engine. Reference repeats are completed and their thresholds are
+sealed before the corresponding target modules are constructed.
 
-## Frozen inputs
+## Inputs
 
 - Megatron-Core: `cf2f07d7b1315c96c05554c670c43207c6783e5e`
 - Megatron source archive SHA-256:
   `c08272b18d171553f2dcd04937d27e77d3a6be223860726be7c56fcc90c558b1`
-- Transformer Engine: `2.18.0.dev0+8b99682`, source commit
-  `8b9968255eb879e6e390f427836906b29aad64d2`
-- Transformer Engine overlay:
-  `/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/code/te-8b9968255-cu132-py312-overlay-r7`
+- Transformer Engine: the canonical image's released `2.15.0` (build tag
+  `+42b84005`), used natively -- no FP8-only overlay. The `[te-*]` source
+  citations in the contract point at readable upstream source for the same
+  blockwise APIs.
+- canonical image:
+  `/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/code/env/pytorch_26.04-py3.sqsh`
 - driver SHA-256:
   `4d02d222a8455f70c988018e696f979d5618c24e618c882aace7981706c43c1f`
 - launcher: `hopper-blockwise-primitive-parity.sbatch`
@@ -41,12 +43,18 @@ artifact was reused by a later job.
 | `13714455` | `FAILED 1:0` | Moved Triton, TorchInductor, XDG, and temporary caches off the container root filesystem. |
 | `13714533` | `FAILED 1:0` | Fixed a comparison-harness metric lookup after three BF16 reference and target repeats completed. |
 | `13714605` | `FAILED 1:0` | BF16 passed; the blockwise reference was missing MCore's production `get_fp8_context` wrapper. |
-| `13714801` | `COMPLETED 0:0` | Accepted BF16 and blockwise primitive parity. |
+| `13714801` | `COMPLETED 0:0` | Accepted BF16 and blockwise primitive parity on the earlier TE 2.18-dev overlay (later superseded). |
+| `13756286` | `COMPLETED 0:0` | Re-accepted the same parity on the canonical image's native TE 2.15, with the overlay removed. |
 
 ## Accepted result
 
-Slurm job `13714801` completed every step with exit code `0:0` on node
-`pool0-01422`. It emitted the non-skipped markers:
+Slurm job `13756286` completed every step with exit code `0:0` on node
+`pool0-01782` (elapsed 2:02) against the canonical image's native Transformer
+Engine `2.15.0+42b84005`. The environment gate reported
+`_HopperEnvironment(compute_capability=(9, 0),
+transformer_engine_version='2.15.0+42b84005', cuda_version=(13, 2),
+cublas_version=130401, block_scaling_supported=True)` and passed before model
+allocation. It emitted the non-skipped markers:
 
 ```text
 HOPPER_BLOCKWISE_BF16_BASELINE_PARITY_OK
@@ -61,11 +69,14 @@ the FP32 AdamW result, BF16 attention-core/norm/router boundaries, and an
 passed bitwise gates; target repeat noise was also zero.
 
 The manifest SHA-256 is
-`fcfd21e29db21af104a5437c2a77a9702579a1a9efb962e7df1fd6ee85231761`.
-There are eight threshold files and eight comparison files, one for each
-profile and rank. Artifacts and immutable stdout are stored under:
+`fcfd21e29db21af104a5437c2a77a9702579a1a9efb962e7df1fd6ee85231761`, byte-for-byte
+identical to the earlier overlay run `13714801`. Native TE 2.15 therefore
+reproduces the blockwise numerics of the superseded overlay exactly, confirming
+the re-anchor changed the environment, not the results. There are eight
+threshold files and eight comparison files, one for each profile and rank.
+Artifacts and immutable stdout are stored under:
 
 ```text
-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/work/codex/fp8-primitives-c9c00dfac-cw/results/primitive-parity-13714801
-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/work/codex/fp8-primitives-c9c00dfac-cw/primitive-parity-13714801.out
+/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/work/codex/fp8-primitives-c9c00dfac-cw/results/primitive-parity-13756286
+/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/work/codex/fp8-primitives-c9c00dfac-cw/primitive-parity-13756286.out
 ```

--- a/experimental/lite/docs/runs/hopper-blockwise-primitive-parity.sbatch
+++ b/experimental/lite/docs/runs/hopper-blockwise-primitive-parity.sbatch
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=mlite-blockwise-parity
+#SBATCH --account=coreai_devtech_all
+#SBATCH --partition=batch
+#SBATCH --qos=normal
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=32
+#SBATCH --gres=gpu:4
+#SBATCH --time=01:00:00
+#SBATCH --output=/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/work/codex/fp8-primitives-c9c00dfac-cw/primitive-parity-%j.out
+
+set -euo pipefail
+
+RUN_ROOT=${RUN_ROOT:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/work/codex/fp8-primitives-c9c00dfac-cw}
+BASE_IMAGE=${BASE_IMAGE:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/code/env/pytorch_26.04-py3.sqsh}
+OVERLAY=${OVERLAY:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/code/te-8b9968255-cu132-py312-overlay-r7}
+
+srun --ntasks=1 \
+  --container-image="$BASE_IMAGE" \
+  --container-mounts=/lustre:/lustre \
+  --container-workdir="$RUN_ROOT" \
+  bash -lc 'set -euo pipefail
+    RUN_ROOT=${RUN_ROOT:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/work/codex/fp8-primitives-c9c00dfac-cw}
+    OVERLAY=${OVERLAY:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/code/te-8b9968255-cu132-py312-overlay-r7}
+    OVERLAY_SITE="$OVERLAY/lib/python3.12/site-packages"
+    RUN_DIR="$RUN_ROOT/run-primitive-parity-${SLURM_JOB_ID}"
+    REFERENCE_ROOT="$RUN_DIR/mcore-reference"
+    OUTPUT="$RUN_ROOT/results/primitive-parity-${SLURM_JOB_ID}"
+
+    export PATH="$OVERLAY/bin:/usr/local/bin:/usr/bin:/bin"
+    export PYTHONPATH="$OVERLAY_SITE:$RUN_DIR/experimental/lite:$REFERENCE_ROOT"
+    unset CONDA_PREFIX CONDA_DEFAULT_ENV CONDA_EXE CONDA_PYTHON_EXE
+    unset CONDA_BUILD_CROSS_COMPILATION CONDA_BUILD_SYSROOT CONDA_SHLVL
+    unset CONDA_TOOLCHAIN_BUILD CONDA_TOOLCHAIN_HOST
+    unset CPATH C_INCLUDE_PATH CPLUS_INCLUDE_PATH LIBRARY_PATH
+    unset GCC GCC_AR GCC_NM GCC_RANLIB GCC_EXEC_PREFIX COMPILER_PATH
+    unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS CMAKE_ARGS CMAKE_PREFIX_PATH
+    unset NVCC_APPEND_FLAGS NVCC_PREPEND_FLAGS NVCC_PREPEND_FLAGS_BACKUP
+    export CC=/usr/bin/gcc
+    export CXX=/usr/bin/g++
+    export XDG_CACHE_HOME="$RUN_DIR/cache/xdg"
+    export TRITON_CACHE_DIR="$RUN_DIR/cache/triton"
+    export TORCHINDUCTOR_CACHE_DIR="$RUN_DIR/cache/torchinductor"
+    export TMPDIR="$RUN_DIR/cache/tmp"
+    export CUBLAS_WORKSPACE_CONFIG=:4096:8
+    export NVTE_ALLOW_NONDETERMINISTIC_ALGO=0
+    export NVTE_DEBUG=1
+    export NVTE_DEBUG_LEVEL=1
+    export OMP_NUM_THREADS=1
+    export CUDA_DEVICE_MAX_CONNECTIONS=1
+    unset NVTE_FP8_BLOCK_SCALING_FP32_SCALES NVTE_BACKWARD_OVERRIDE
+
+    test -f "$OVERLAY/BUILD_OK"
+    test -f "$RUN_ROOT/hopper_blockwise_primitive_parity.py"
+    test "$(sha256sum "$RUN_ROOT/mcore-cf2f07d7.tar.gz" | cut -d " " -f 1)" = "c08272b18d171553f2dcd04937d27e77d3a6be223860726be7c56fcc90c558b1"
+    mkdir -p "$RUN_DIR" "$REFERENCE_ROOT" "$OUTPUT" \
+      "$XDG_CACHE_HOME" "$TRITON_CACHE_DIR" "$TORCHINDUCTOR_CACHE_DIR" "$TMPDIR"
+    tar -xf "$RUN_ROOT/mlite-fp8-c9c00dfac.tar" -C "$RUN_DIR"
+    tar -xf "$RUN_ROOT/mcore-cf2f07d7.tar.gz" -C "$REFERENCE_ROOT"
+    test "$(cat "$REFERENCE_ROOT/REFERENCE_COMMIT")" = "cf2f07d7b1315c96c05554c670c43207c6783e5e"
+    cd "$RUN_DIR"
+    sha256sum "$RUN_ROOT/hopper_blockwise_primitive_parity.py"
+    python -c "from megatron.lite.primitive.precision import validate_hopper_environment; print(validate_hopper_environment())"
+    torchrun --standalone --nproc_per_node=4 \
+      "$RUN_ROOT/hopper_blockwise_primitive_parity.py" \
+      --output "$OUTPUT"
+    test -s "$OUTPUT/manifest.json"
+    sha256sum "$OUTPUT/manifest.json"
+    echo "HOPPER_BLOCKWISE_PRIMITIVE_PARITY_JOB_OK output=$OUTPUT"'

--- a/experimental/lite/docs/runs/hopper-blockwise-primitive-parity.sbatch
+++ b/experimental/lite/docs/runs/hopper-blockwise-primitive-parity.sbatch
@@ -14,22 +14,22 @@ set -euo pipefail
 
 RUN_ROOT=${RUN_ROOT:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/work/codex/fp8-primitives-c9c00dfac-cw}
 BASE_IMAGE=${BASE_IMAGE:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/code/env/pytorch_26.04-py3.sqsh}
-OVERLAY=${OVERLAY:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/code/te-8b9968255-cu132-py312-overlay-r7}
 
+# The canonical training image ships Transformer Engine 2.15 with the blockwise
+# kernels this parity needs (verified by te215-blockwise-inventory). No FP8-only
+# overlay: parity runs against the image's native TE, the same one BF16 uses.
 srun --ntasks=1 \
   --container-image="$BASE_IMAGE" \
   --container-mounts=/lustre:/lustre \
   --container-workdir="$RUN_ROOT" \
   bash -lc 'set -euo pipefail
     RUN_ROOT=${RUN_ROOT:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/work/codex/fp8-primitives-c9c00dfac-cw}
-    OVERLAY=${OVERLAY:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/code/te-8b9968255-cu132-py312-overlay-r7}
-    OVERLAY_SITE="$OVERLAY/lib/python3.12/site-packages"
     RUN_DIR="$RUN_ROOT/run-primitive-parity-${SLURM_JOB_ID}"
     REFERENCE_ROOT="$RUN_DIR/mcore-reference"
     OUTPUT="$RUN_ROOT/results/primitive-parity-${SLURM_JOB_ID}"
 
-    export PATH="$OVERLAY/bin:/usr/local/bin:/usr/bin:/bin"
-    export PYTHONPATH="$OVERLAY_SITE:$RUN_DIR/experimental/lite:$REFERENCE_ROOT"
+    export PATH="/usr/local/bin:/usr/bin:/bin"
+    export PYTHONPATH="$RUN_DIR/experimental/lite:$REFERENCE_ROOT"
     unset CONDA_PREFIX CONDA_DEFAULT_ENV CONDA_EXE CONDA_PYTHON_EXE
     unset CONDA_BUILD_CROSS_COMPILATION CONDA_BUILD_SYSROOT CONDA_SHLVL
     unset CONDA_TOOLCHAIN_BUILD CONDA_TOOLCHAIN_HOST
@@ -51,7 +51,6 @@ srun --ntasks=1 \
     export CUDA_DEVICE_MAX_CONNECTIONS=1
     unset NVTE_FP8_BLOCK_SCALING_FP32_SCALES NVTE_BACKWARD_OVERRIDE
 
-    test -f "$OVERLAY/BUILD_OK"
     test -f "$RUN_ROOT/hopper_blockwise_primitive_parity.py"
     test "$(sha256sum "$RUN_ROOT/mcore-cf2f07d7.tar.gz" | cut -d " " -f 1)" = "c08272b18d171553f2dcd04937d27e77d3a6be223860726be7c56fcc90c558b1"
     mkdir -p "$RUN_DIR" "$REFERENCE_ROOT" "$OUTPUT" \

--- a/experimental/lite/docs/runs/hopper-blockwise-te-overlay-build.sbatch
+++ b/experimental/lite/docs/runs/hopper-blockwise-te-overlay-build.sbatch
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=mlite-te-blockwise-build
+#SBATCH --account=coreai_devtech_all
+#SBATCH --partition=cpu
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=96
+#SBATCH --time=02:00:00
+#SBATCH --output=/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/work/codex/fp8-primitives-c9c00dfac-cw/te-overlay-build-%j.out
+
+set -euo pipefail
+
+RUN_ROOT=${RUN_ROOT:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/work/codex/fp8-primitives-c9c00dfac-cw}
+BASE_IMAGE=${BASE_IMAGE:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/code/env/pytorch_26.04-py3.sqsh}
+OVERLAY=${OVERLAY:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/code/te-8b9968255-cu132-py312-overlay-r7}
+
+srun --ntasks=1 \
+  --container-image="$BASE_IMAGE" \
+  --container-mounts=/lustre:/lustre \
+  --container-workdir="$RUN_ROOT" \
+  bash -lc 'set -euo pipefail
+    RUN_ROOT=${RUN_ROOT:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/work/codex/fp8-primitives-c9c00dfac-cw}
+    OVERLAY=${OVERLAY:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/code/te-8b9968255-cu132-py312-overlay-r7}
+    CACHE_ROOT=/lustre/fs1/portfolios/coreai/users/bayan
+    SOURCE_COMMIT=8b9968255eb879e6e390f427836906b29aad64d2
+    RUN_DIR="$RUN_ROOT/run-te-build-${SLURM_JOB_ID}"
+    SRC_ROOT="$RUN_DIR/TransformerEngine"
+    NCCL_INCLUDE_ROOT="$RUN_DIR/nccl-include"
+
+    export PATH=/usr/local/bin:/usr/bin:/bin
+    unset CONDA_PREFIX CONDA_DEFAULT_ENV CONDA_EXE CONDA_PYTHON_EXE
+    unset CONDA_BUILD_CROSS_COMPILATION CONDA_BUILD_SYSROOT CONDA_SHLVL
+    unset CONDA_TOOLCHAIN_BUILD CONDA_TOOLCHAIN_HOST
+    unset CPATH C_INCLUDE_PATH CPLUS_INCLUDE_PATH LIBRARY_PATH
+    unset GCC_EXEC_PREFIX COMPILER_PATH CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
+    unset GCC GCC_AR GCC_NM GCC_RANLIB
+    unset CMAKE_ARGS CMAKE_PREFIX_PATH CUDA_PATH
+    unset NVCC_APPEND_FLAGS NVCC_PREPEND_FLAGS NVCC_PREPEND_FLAGS_BACKUP
+    export CC=/usr/bin/gcc
+    export CXX=/usr/bin/g++
+    export NVCC_CXX_COMPILER=/usr/bin/g++
+    export TMPDIR="$CACHE_ROOT/tmp/te-8b9968255-${SLURM_JOB_ID}"
+    export XDG_CACHE_HOME="$CACHE_ROOT/.cache"
+    export CUDA_HOME=/usr/local/cuda-13.2
+    export CUDACXX=/usr/local/cuda-13.2/bin/nvcc
+    export CUDAToolkit_ROOT=/usr/local/cuda-13.2
+    export NVTE_CMAKE_EXTRA_ARGS="-DCUDAToolkit_ROOT=/usr/local/cuda-13.2 -DCMAKE_CUDA_COMPILER=/usr/local/cuda-13.2/bin/nvcc -DNCCL_INCLUDE_DIR=$NCCL_INCLUDE_ROOT -DCMAKE_CXX_FLAGS=-I$NCCL_INCLUDE_ROOT -DCMAKE_CUDA_FLAGS=-I$NCCL_INCLUDE_ROOT"
+    export CMAKE_BUILD_PARALLEL_LEVEL=${SLURM_CPUS_PER_TASK:-96}
+    export MAX_JOBS=${SLURM_CPUS_PER_TASK:-96}
+    export NVTE_BUILD_THREADS=${SLURM_CPUS_PER_TASK:-96}
+    export NVTE_CUDA_ARCHS=90
+    export NVTE_FRAMEWORK=pytorch
+    export NVTE_WITH_NCCL_EP=0
+
+    test ! -e "$OVERLAY"
+    mkdir -p "$RUN_DIR" "$TMPDIR" "$XDG_CACHE_HOME" "$NCCL_INCLUDE_ROOT"
+    ln -s /usr/include/nccl.h "$NCCL_INCLUDE_ROOT/nccl.h"
+    command -v "$CC"
+    command -v "$CXX"
+    "$CXX" -v
+
+    git init "$SRC_ROOT"
+    git -C "$SRC_ROOT" remote add origin https://github.com/NVIDIA/TransformerEngine.git
+    git -C "$SRC_ROOT" fetch --depth=1 origin "$SOURCE_COMMIT"
+    SOURCE_SHA=$(git -C "$SRC_ROOT" rev-parse "FETCH_HEAD^{commit}")
+    git -C "$SRC_ROOT" checkout --detach "$SOURCE_SHA"
+    git -C "$SRC_ROOT" submodule update --init --recursive --depth=1
+    test "$(git -C "$SRC_ROOT" rev-parse HEAD)" = "$SOURCE_SHA"
+    case "$SOURCE_SHA" in
+      "$SOURCE_COMMIT"*) ;;
+      *) echo "unexpected Transformer Engine commit: $SOURCE_SHA" >&2; exit 1 ;;
+    esac
+
+    python -m venv --system-site-packages "$OVERLAY"
+    . "$OVERLAY/bin/activate"
+    python -m pip install --upgrade pip "setuptools<82" wheel ninja cmake pybind11
+    python -m pip install --no-build-isolation --no-deps "$SRC_ROOT"
+
+    python - "$SOURCE_SHA" "$OVERLAY" <<"PY"
+import pathlib
+import sys
+
+import torch
+import transformer_engine as te
+
+source_sha, overlay = sys.argv[1:]
+assert source_sha == "8b9968255eb879e6e390f427836906b29aad64d2", source_sha
+assert te.__version__.startswith("2.18.0.dev0"), te.__version__
+assert pathlib.Path(te.__file__).is_relative_to(pathlib.Path(overlay)), te.__file__
+print(f"torch={torch.__version__} cuda={torch.version.cuda}")
+print(f"te={te.__version__} path={te.__file__}")
+print(f"source_sha={source_sha}")
+print("TE_BLOCKWISE_OVERLAY_IMPORT_OK")
+PY
+
+    printf "SOURCE_SHA=%s\nBASE_IMAGE=%s\nOVERLAY=%s\n" \
+      "$SOURCE_SHA" "/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/code/env/pytorch_26.04-py3.sqsh" "$OVERLAY" \
+      > "$OVERLAY/BUILD_OK"
+    printenv | LC_ALL=C sort > "$RUN_DIR/build-environment.txt"
+    python -m pip freeze > "$RUN_DIR/pip-freeze.txt"
+    echo "TE_BLOCKWISE_OVERLAY_BUILD_OK overlay=$OVERLAY source_sha=$SOURCE_SHA"'

--- a/experimental/lite/docs/runs/hopper-blockwise-te-overlay-probe.sbatch
+++ b/experimental/lite/docs/runs/hopper-blockwise-te-overlay-probe.sbatch
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=mlite-te-blockwise-probe
+#SBATCH --account=coreai_devtech_all
+#SBATCH --partition=batch
+#SBATCH --qos=normal
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --gres=gpu:1
+#SBATCH --time=00:15:00
+#SBATCH --output=/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/work/codex/fp8-primitives-c9c00dfac-cw/te-overlay-probe-%j.out
+
+set -euo pipefail
+
+RUN_ROOT=${RUN_ROOT:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/work/codex/fp8-primitives-c9c00dfac-cw}
+BASE_IMAGE=${BASE_IMAGE:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/code/env/pytorch_26.04-py3.sqsh}
+OVERLAY=${OVERLAY:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/code/te-8b9968255-cu132-py312-overlay-r7}
+
+srun --ntasks=1 \
+  --container-image="$BASE_IMAGE" \
+  --container-mounts=/lustre:/lustre \
+  --container-workdir="$RUN_ROOT" \
+  bash -lc 'set -euo pipefail
+    RUN_ROOT=${RUN_ROOT:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/work/codex/fp8-primitives-c9c00dfac-cw}
+    OVERLAY=${OVERLAY:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/code/te-8b9968255-cu132-py312-overlay-r7}
+    OVERLAY_SITE="$OVERLAY/lib/python3.12/site-packages"
+    RUN_DIR="$RUN_ROOT/run-te-probe-${SLURM_JOB_ID}"
+    REFERENCE_ROOT="$RUN_DIR/mcore-reference"
+
+    export PATH="$OVERLAY/bin:/usr/local/bin:/usr/bin:/bin"
+    export PYTHONPATH="$OVERLAY_SITE:$RUN_DIR/experimental/lite:$REFERENCE_ROOT"
+    export CUBLAS_WORKSPACE_CONFIG=:4096:8
+    export NVTE_ALLOW_NONDETERMINISTIC_ALGO=0
+    export OMP_NUM_THREADS=1
+    unset NVTE_FP8_BLOCK_SCALING_FP32_SCALES NVTE_BACKWARD_OVERRIDE
+
+    test -f "$OVERLAY/BUILD_OK"
+    test "$(sha256sum "$RUN_ROOT/mcore-cf2f07d7.tar.gz" | cut -d " " -f 1)" = "c08272b18d171553f2dcd04937d27e77d3a6be223860726be7c56fcc90c558b1"
+    mkdir -p "$RUN_DIR" "$REFERENCE_ROOT"
+    tar -xf "$RUN_ROOT/mlite-fp8-c9c00dfac.tar" -C "$RUN_DIR"
+    tar -xf "$RUN_ROOT/mcore-cf2f07d7.tar.gz" -C "$REFERENCE_ROOT"
+    test "$(cat "$REFERENCE_ROOT/REFERENCE_COMMIT")" = "cf2f07d7b1315c96c05554c670c43207c6783e5e"
+    cd "$RUN_DIR"
+    nvidia-smi -L
+    python - <<"PY"
+import pathlib
+
+import torch
+import transformer_engine as te
+import transformer_engine.pytorch as tex
+import transformer_engine_torch as tex_cpp
+from transformer_engine.pytorch.quantization import check_fp8_block_scaling_support
+
+from megatron.lite.primitive.precision import (
+    build_hopper_blockwise_recipe,
+    validate_hopper_environment,
+)
+
+torch.manual_seed(1234)
+torch.cuda.manual_seed_all(1234)
+torch.use_deterministic_algorithms(True)
+torch.backends.cuda.matmul.allow_tf32 = False
+
+overlay = pathlib.Path("/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/code/te-8b9968255-cu132-py312-overlay-r7")
+assert pathlib.Path(te.__file__).is_relative_to(overlay), te.__file__
+environment = validate_hopper_environment()
+supported, reason = check_fp8_block_scaling_support()
+assert supported, reason
+recipe = build_hopper_blockwise_recipe()
+
+linear = tex.Linear(1024, 4096, bias=False, params_dtype=torch.bfloat16).cuda()
+x = torch.randn(256, 2, 1024, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+with tex.fp8_autocast(enabled=True, fp8_recipe=recipe):
+    y = linear(x)
+y.float().square().mean().backward()
+assert torch.isfinite(y).all() and torch.isfinite(x.grad).all()
+assert torch.isfinite(linear.weight.grad).all()
+
+grouped = tex.GroupedLinear(
+    2, 1024, 8192, bias=False, params_dtype=torch.bfloat16
+).cuda()
+gx = torch.randn(32, 1024, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+with tex.fp8_autocast(enabled=True, fp8_recipe=recipe):
+    gy = grouped(gx, [16, 16])
+gy.float().square().mean().backward()
+assert torch.isfinite(gy).all() and torch.isfinite(gx.grad).all()
+assert all(parameter.grad is not None and torch.isfinite(parameter.grad).all() for parameter in grouped.parameters())
+
+print(f"python_te={te.__version__} path={te.__file__}")
+print(f"torch={torch.__version__} cuda={torch.version.cuda} capability={torch.cuda.get_device_capability()}")
+print(f"cublaslt={tex_cpp.get_cublasLt_version()} blockwise={(supported, reason)}")
+print(f"environment={environment}")
+print(f"linear_forward={tuple(y.shape)} dx={tuple(x.grad.shape)} dw={tuple(linear.weight.grad.shape)}")
+print(f"grouped_forward={tuple(gy.shape)} dx={tuple(gx.grad.shape)} params={len(list(grouped.parameters()))}")
+print("TE_BLOCKWISE_OVERLAY_GPU_PROBE_OK")
+PY'

--- a/experimental/lite/docs/runs/hopper-blockwise-te-overlay.md
+++ b/experimental/lite/docs/runs/hopper-blockwise-te-overlay.md
@@ -1,0 +1,85 @@
+# Hopper blockwise Transformer Engine overlay
+
+This run record builds the frozen Transformer Engine source used by the Hopper
+blockwise precision profiles. The build is intentionally separate from GPU
+validation: compilation runs on a CPU Slurm node, while import and kernel
+validation run on an H100 Slurm node.
+
+## Frozen inputs
+
+- Transformer Engine: `8b9968255eb879e6e390f427836906b29aad64d2`
+  (`2.18.0.dev0`)
+- base image:
+  `/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/code/env/pytorch_26.04-py3.sqsh`
+- CUDA toolkit selected inside the image: `/usr/local/cuda-13.2`
+- target architecture: `SM90`
+- Megatron reference: `cf2f07d7b1315c96c05554c670c43207c6783e5e`
+- reference source archive SHA-256:
+  `c08272b18d171553f2dcd04937d27e77d3a6be223860726be7c56fcc90c558b1`
+- output overlay:
+  `/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/code/te-8b9968255-cu132-py312-overlay-r7`
+- build launcher: `hopper-blockwise-te-overlay-build.sbatch`
+- GPU probe launcher: `hopper-blockwise-te-overlay-probe.sbatch`
+
+The optional TE NCCL-EP transport extension is disabled with
+`NVTE_WITH_NCCL_EP=0`. The frozen source documents this as the supported way to
+skip NCCL-EP while building the rest of TE. The Hopper blockwise profiles use
+TE Linear, LayerNormLinear, and GroupedLinear; they do not use NCCL-EP.
+
+## Build attempts
+
+All attempts ran in the CW `cpu` partition. Failed directories were preserved;
+no failed overlay was reused as validation input.
+
+| Job | Slurm result | Finding |
+| --- | --- | --- |
+| `13711582` | `FAILED` | A short commit ID is not accepted as a remote Git ref; compilation did not start. |
+| `13711645` | `FAILED` | Inherited Miniforge GCC 14 headers mixed with the image system headers during the optional NCCL-EP build. |
+| `13711870` | `FAILED` | System GCC 13 was selected correctly; optional NCCL-EP was incompatible with the image's NCCL device headers. |
+| `13711996` | `FAILED` | NCCL-EP was skipped correctly, but CMake selected a Lustre Miniforge CUDA 12.8 toolkit and therefore missed the image's CUDA 13.2 target headers. |
+| `13712580` | `FAILED` | CUDA 13.2 compiled 92 of 93 TE common objects; the NCCL-EP-off CMake branch did not add the existing `/usr/include/nccl.h` include root. |
+| `13712832` | `FAILED` | Adding raw `/usr/include` to CUDA flags made NVCC resolve host C library headers before its CUDA sysroot during compiler detection. |
+| `13712941` | `FAILED` | A private `nccl.h` include avoided raw `/usr/include`, but NVCC still inherited a hidden Lustre Miniforge sysroot not present in the emitted CMake compile command. |
+| `13713346` | `COMPLETED 0:0` | Built and imported `2.18.0.dev0+8b99682` from the r7 overlay at the full frozen source SHA. |
+
+A read-only header probe, job `13712183`, completed with exit code `0:0` and
+located the required NVTX and NVML headers under
+`/usr/local/cuda-13.2/targets/x86_64-linux/include`, plus `nccl.h` under
+`/usr/include`. The final launcher consequently clears inherited CMake/CUDA
+prefixes and pins both `CUDACXX` and `CUDAToolkit_ROOT` to CUDA 13.2.
+The accepted launcher exposes only `nccl.h` through a private include directory;
+it does not add raw `/usr/include` to host or CUDA compilation flags.
+The read-only `hopper-blockwise-te-toolchain-probe.sbatch` launcher records
+inherited compiler variables and NVCC dry-run commands before another build is
+submitted.
+
+Toolchain probe job `13713113` completed with exit code `0:0`. It showed that
+the container inherited `NVCC_PREPEND_FLAGS` with a Miniforge `-ccbin`, while
+the same CUDA source compiled successfully with `/usr/bin/g++`. The build
+launcher therefore clears inherited NVCC, Conda toolchain, GCC wrapper, and
+`CMAKE_ARGS` variables before selecting the system compilers.
+
+The immutable stdout logs are in:
+
+```text
+/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/work/codex/fp8-primitives-c9c00dfac-cw/te-overlay-build-<job>.out
+```
+
+## Accepted build and GPU probe
+
+Build job `13713346` satisfied the build gate: every Slurm step completed with
+exit code `0:0`, the source SHA was
+`8b9968255eb879e6e390f427836906b29aad64d2`, and the imported package was
+`2.18.0.dev0+8b99682` under the r7 overlay. The built wheel SHA-256 was
+`edd66a6e9912800e9ec4e0d65c458603fa6f79838804abdee3d91718fc69b80f`.
+
+The GPU probe is accepted only with SM90, CUDA at least 12.9, cuBLASLt at least
+13.4, block-scaling support, and non-skipped Linear and GroupedLinear
+forward/backward markers.
+
+GPU probe job `13713715` satisfied that gate with all Slurm steps
+`COMPLETED 0:0`. It reported compute capability `(9, 0)`, CUDA `13.2`,
+cuBLASLt `130401`, and block-scaling support. The non-skipped outputs were
+Linear `(256, 2, 4096)` with dX `(256, 2, 1024)` and dW `(4096, 1024)`, plus
+GroupedLinear `(32, 8192)` with dX `(32, 1024)` and two parameter gradients.
+The terminal marker was `TE_BLOCKWISE_OVERLAY_GPU_PROBE_OK`.

--- a/experimental/lite/docs/runs/hopper-blockwise-te-overlay.md
+++ b/experimental/lite/docs/runs/hopper-blockwise-te-overlay.md
@@ -1,9 +1,19 @@
-# Hopper blockwise Transformer Engine overlay
+# Hopper blockwise Transformer Engine overlay (SUPERSEDED)
 
-This run record builds the frozen Transformer Engine source used by the Hopper
-blockwise precision profiles. The build is intentionally separate from GPU
-validation: compilation runs on a CPU Slurm node, while import and kernel
-validation run on an H100 Slurm node.
+> **Superseded.** This overlay is no longer used. A read-only capability
+> inventory (`hopper-blockwise-te215-inventory`) showed the canonical training
+> image's native Transformer Engine 2.15 already runs every mandatory blockwise
+> primitive forward and backward under `Float8BlockScaling`. Blockwise FP8 now
+> runs on the same image as BF16 with no FP8-only overlay, and the primitive
+> parity re-anchored to native TE 2.15 (job `13756286`) reproduces the overlay's
+> manifest byte-for-byte. This record is retained only for build-recipe
+> provenance (CUDA 13.2 TE-from-source on `pytorch_26.04-py3.sqsh`); nothing in
+> the shipped profiles or the parity harness depends on it.
+
+This run record builds a pinned Transformer Engine source that an earlier
+iteration used for the Hopper blockwise precision profiles. The build is
+intentionally separate from GPU validation: compilation runs on a CPU Slurm
+node, while import and kernel validation run on an H100 Slurm node.
 
 ## Frozen inputs
 

--- a/experimental/lite/docs/runs/hopper-blockwise-te-toolchain-probe.sbatch
+++ b/experimental/lite/docs/runs/hopper-blockwise-te-toolchain-probe.sbatch
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=mlite-te-toolchain-probe
+#SBATCH --account=coreai_devtech_all
+#SBATCH --partition=cpu
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=2
+#SBATCH --time=00:10:00
+#SBATCH --output=/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/work/codex/fp8-primitives-c9c00dfac-cw/te-toolchain-probe-%j.out
+
+set -euo pipefail
+
+RUN_ROOT=${RUN_ROOT:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/work/codex/fp8-primitives-c9c00dfac-cw}
+BASE_IMAGE=${BASE_IMAGE:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/code/env/pytorch_26.04-py3.sqsh}
+
+srun --ntasks=1 \
+  --container-image="$BASE_IMAGE" \
+  --container-mounts=/lustre:/lustre \
+  --container-workdir="$RUN_ROOT" \
+  bash -lc 'set -euo pipefail
+    RUN_ROOT=${RUN_ROOT:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/work/codex/fp8-primitives-c9c00dfac-cw}
+    PROBE_DIR="$RUN_ROOT/run-te-toolchain-probe-${SLURM_JOB_ID}"
+    mkdir -p "$PROBE_DIR"
+    printf "#include <cuda_runtime.h>\n#include <stdio.h>\nint main() { return 0; }\n" > "$PROBE_DIR/probe.cu"
+
+    echo "== inherited compiler environment =="
+    printenv | LC_ALL=C sort | grep -E "^(CONDA|CPATH|C_INCLUDE_PATH|CPLUS_INCLUDE_PATH|CUDA|CMAKE|GCC|COMPILER|NVCC|PATH|PYTHON)" || true
+    echo "== compiler paths =="
+    command -v gcc g++ /usr/bin/g++ /usr/local/cuda-13.2/bin/nvcc
+    readlink -f /usr/bin/g++
+    /usr/bin/g++ -v
+    echo "== default NVCC dry run =="
+    /usr/local/cuda-13.2/bin/nvcc -v --dryrun -c "$PROBE_DIR/probe.cu" -o "$PROBE_DIR/default.o" 2>&1
+    echo "== explicit host compiler NVCC dry run =="
+    /usr/local/cuda-13.2/bin/nvcc -v --dryrun -ccbin /usr/bin/g++ \
+      -c "$PROBE_DIR/probe.cu" -o "$PROBE_DIR/explicit.o" 2>&1
+    echo "== explicit host compiler compile =="
+    /usr/local/cuda-13.2/bin/nvcc -v -ccbin /usr/bin/g++ \
+      -c "$PROBE_DIR/probe.cu" -o "$PROBE_DIR/explicit.o" 2>&1
+    echo "TE_TOOLCHAIN_PROBE_OK"'

--- a/experimental/lite/docs/runs/hopper-blockwise-te215-inventory.md
+++ b/experimental/lite/docs/runs/hopper-blockwise-te215-inventory.md
@@ -1,0 +1,64 @@
+# Canonical TE 2.15 blockwise capability inventory
+
+This read-only inventory answers one question before any overlay is considered:
+does the canonical training image's native Transformer Engine already run every
+mandatory Hopper blockwise primitive? Blockwise FP8 must run on the same image
+that runs BF16, so the parity baseline may only add a bespoke Transformer Engine
+build if the canonical image genuinely lacks a kernel.
+
+## Inputs
+
+- canonical image:
+  `/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/code/env/pytorch_26.04-py3.sqsh`
+- launcher: `hopper-blockwise-te215-inventory.sbatch`
+- probe: constructs the frozen `Float8BlockScaling` recipe (E4M3, x/w/grad block
+  dims `1/2/1`, split accumulator, `fp8_dpa=False`, `fp8_mha=False`) and runs a
+  forward + backward for each mandatory primitive under `fp8_autocast`.
+
+The probe is intentionally not a profile validation. It records whether each op
+can run and where it fails, nothing more.
+
+## Result
+
+Slurm job `13755858` completed every step with exit code `0:0` (elapsed 41s) and
+emitted `TE215_BLOCKWISE_INVENTORY_COMPLETE status=all-ran`. The JSON payload:
+
+```json
+{
+  "all_mandatory_ops_ran": true,
+  "block_scaling_support": [true, ""],
+  "capability": [9, 0],
+  "cublaslt": 130401,
+  "cuda": "13.2",
+  "operations": {
+    "grouped_linear": {"output": [32, 8192], "status": "ran"},
+    "layernorm_linear": {"output": [256, 2, 4096], "status": "ran"},
+    "linear": {"output": [256, 2, 4096], "status": "ran"}
+  },
+  "te_path": "/usr/local/lib/python3.12/dist-packages/transformer_engine/__init__.py",
+  "te_version": "2.15.0+42b84005",
+  "torch": "2.12.0a0+5aff3928d8.nv26.05"
+}
+```
+
+Immutable stdout:
+
+```text
+/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/work/codex/fp8-primitives-c9c00dfac-cw/te215-blockwise-inventory-13755858.out
+```
+
+## Conclusion
+
+The canonical image ships released Transformer Engine `2.15.0+42b84005` on SM90
+with CUDA 13.2 and cuBLAS 130401. `check_fp8_block_scaling_support()` succeeds,
+and all three mandatory blockwise primitives -- `Linear`, `LayerNormLinear`, and
+`GroupedLinear` -- run forward and backward under `Float8BlockScaling` with
+finite gradients. No mandatory kernel is missing.
+
+Therefore the Hopper blockwise parity baseline is anchored to the canonical
+image's native TE 2.15, and the earlier TE 2.18-dev build overlay is superseded
+(see `hopper-blockwise-te-overlay.md`). The runtime gate pins the released
+version `2.15.0` and keeps the capability preflight (SM90, block-scaling
+support, cuBLAS >= 13.4, CUDA >= 12.9) as the fail-loud safety net; the build tag
+is recorded for provenance only, because requiring an exact build SHA would
+recreate a special-environment requirement.

--- a/experimental/lite/docs/runs/hopper-blockwise-te215-inventory.sbatch
+++ b/experimental/lite/docs/runs/hopper-blockwise-te215-inventory.sbatch
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Read-only capability inventory for the canonical image's TE 2.15 package.
+# This is intentionally not a profile validation: it records whether each
+# mandatory blockwise primitive can run before an overlay is considered.
+#SBATCH --job-name=mlite-te215-blockwise-inventory
+#SBATCH --account=coreai_devtech_all
+#SBATCH --partition=batch
+#SBATCH --qos=normal
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --gres=gpu:1
+#SBATCH --time=00:15:00
+#SBATCH --output=/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/work/codex/fp8-primitives-c9c00dfac-cw/te215-blockwise-inventory-%j.out
+
+set -euo pipefail
+
+RUN_ROOT=${RUN_ROOT:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/work/codex/fp8-primitives-c9c00dfac-cw}
+BASE_IMAGE=${BASE_IMAGE:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/code/env/pytorch_26.04-py3.sqsh}
+
+srun --ntasks=1 \
+  --container-image="$BASE_IMAGE" \
+  --container-mounts=/lustre:/lustre \
+  --container-workdir="$RUN_ROOT" \
+  bash -lc 'set -euo pipefail
+    export PATH=/usr/local/bin:/usr/bin:/bin
+    export PYTHONPATH=""
+    export CUBLAS_WORKSPACE_CONFIG=:4096:8
+    export NVTE_ALLOW_NONDETERMINISTIC_ALGO=0
+    export OMP_NUM_THREADS=1
+    unset NVTE_FP8_BLOCK_SCALING_FP32_SCALES NVTE_BACKWARD_OVERRIDE
+
+    python - <<"PY"
+import json
+import traceback
+
+import torch
+
+result = {"operations": {}}
+
+try:
+    import transformer_engine as te
+    import transformer_engine.pytorch as tex
+    import transformer_engine_torch as tex_cpp
+    from transformer_engine.common.recipe import Format
+    from transformer_engine.common.recipe import Float8BlockScaling
+    from transformer_engine.common.recipe import MMParams
+except Exception as error:
+    result["import_error"] = repr(error)
+    print(json.dumps(result, sort_keys=True))
+    print("TE215_BLOCKWISE_INVENTORY_COMPLETE status=package-unavailable")
+    raise SystemExit(0)
+
+result.update(
+    te_version=getattr(te, "__version__", "unknown"),
+    te_path=te.__file__,
+    torch=torch.__version__,
+    cuda=torch.version.cuda,
+    capability=torch.cuda.get_device_capability(),
+    cublaslt=(getattr(tex_cpp, "get_cublasLt_version", lambda: "unavailable")()),
+)
+
+try:
+    from transformer_engine.pytorch.quantization import check_fp8_block_scaling_support
+    result["block_scaling_support"] = list(check_fp8_block_scaling_support())
+except Exception as error:
+    result["block_scaling_support"] = [False, repr(error)]
+
+try:
+    recipe = Float8BlockScaling(
+        fp8_format=Format.E4M3,
+        x_block_scaling_dim=1,
+        w_block_scaling_dim=2,
+        grad_block_scaling_dim=1,
+        fp8_gemm_fprop=MMParams(use_split_accumulator=True),
+        fp8_gemm_dgrad=MMParams(use_split_accumulator=True),
+        fp8_gemm_wgrad=MMParams(use_split_accumulator=True),
+        fp8_dpa=False,
+        fp8_mha=False,
+    )
+except Exception as error:
+    result["recipe_error"] = repr(error)
+    print(json.dumps(result, sort_keys=True))
+    print("TE215_BLOCKWISE_INVENTORY_COMPLETE status=recipe-unavailable")
+    raise SystemExit(0)
+
+torch.manual_seed(1234)
+torch.cuda.manual_seed_all(1234)
+torch.use_deterministic_algorithms(True)
+torch.backends.cuda.matmul.allow_tf32 = False
+
+def probe(name, factory, args):
+    try:
+        module = factory().cuda()
+        x = torch.randn(*args, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+        with tex.fp8_autocast(enabled=True, fp8_recipe=recipe):
+            y = module(x) if name != "grouped_linear" else module(x, [16, 16])
+        y.float().square().mean().backward()
+        assert torch.isfinite(y).all() and torch.isfinite(x.grad).all()
+        assert all(p.grad is not None and torch.isfinite(p.grad).all() for p in module.parameters())
+        result["operations"][name] = {"status": "ran", "output": list(y.shape)}
+    except Exception as error:
+        result["operations"][name] = {
+            "status": "unavailable",
+            "error": repr(error),
+            "traceback": traceback.format_exc(limit=2),
+        }
+
+probe("linear", lambda: tex.Linear(1024, 4096, bias=False, params_dtype=torch.bfloat16), (256, 2, 1024))
+probe("layernorm_linear", lambda: tex.LayerNormLinear(1024, 4096, bias=False, normalization="RMSNorm", params_dtype=torch.bfloat16), (256, 2, 1024))
+probe("grouped_linear", lambda: tex.GroupedLinear(2, 1024, 8192, bias=False, params_dtype=torch.bfloat16), (32, 1024))
+
+all_ran = all(value["status"] == "ran" for value in result["operations"].values())
+result["all_mandatory_ops_ran"] = all_ran
+print(json.dumps(result, sort_keys=True))
+status = "all-ran" if all_ran else "missing-op"
+print(f"TE215_BLOCKWISE_INVENTORY_COMPLETE status={status}")
+PY'

--- a/experimental/lite/megatron/lite/model/_legacy_fp8.py
+++ b/experimental/lite/megatron/lite/model/_legacy_fp8.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Legacy delayed-scaling FP8 recipe for pre-blockwise model implementations.
+
+This helper is intentionally **not** part of the shared precision primitive. The
+closed blockwise precision system (``megatron.lite.primitive.precision``) owns
+the frozen ``Float8BlockScaling`` recipe and routes precision exclusively through
+its three closed names. The delayed-scaling ``HYBRID`` recipe below belongs to
+the older model implementations (DeepSeek-V4, GLM5, Kimi-K2, Qwen3.5) that gate
+FP8 on a ``train_config.fp8`` boolean and have not yet migrated to the closed
+profiles. Keeping it here rather than in ``primitive/utils`` prevents a shared
+primitive from silently handing back a recipe that violates the blockwise
+contract.
+
+Follow-up: migrate the four legacy models onto the closed
+``hopper_blockwise_*`` profiles and delete this shim.
+"""
+
+from __future__ import annotations
+
+
+def build_fp8_recipe(train_config=None):
+    """Build the legacy TE FP8 recipe (DelayedScaling, HYBRID format, H100)."""
+    from transformer_engine.common.recipe import DelayedScaling, Format
+
+    return DelayedScaling(margin=0, fp8_format=Format.HYBRID)
+
+
+__all__ = ["build_fp8_recipe"]

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/model.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/model.py
@@ -62,7 +62,7 @@ from megatron.lite.primitive.parallel.mhc import (
     unfold_mhc_hidden_from_pipeline,
 )
 from megatron.lite.primitive.parallel.thd import _roll_packed_thd_left_local
-from megatron.lite.primitive.utils import build_fp8_recipe
+from megatron.lite.model._legacy_fp8 import build_fp8_recipe
 
 
 def _roll_mtp_left(

--- a/experimental/lite/megatron/lite/model/glm5/lite/model.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/model.py
@@ -62,7 +62,7 @@ from megatron.lite.primitive.parallel import (
     scatter_to_sequence_parallel,
 )
 from megatron.lite.primitive.parallel.cp import contiguous_position_ids_for_cp
-from megatron.lite.primitive.utils import build_fp8_recipe
+from megatron.lite.model._legacy_fp8 import build_fp8_recipe
 from megatron.lite.primitive.utils.moe import (
     compute_routing_scores_for_aux_loss,
     router_gating_linear,

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/model.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/model.py
@@ -36,7 +36,7 @@ from megatron.lite.primitive.parallel import (
     roll_packed_thd_left,
     scatter_to_sequence_parallel,
 )
-from megatron.lite.primitive.utils import build_fp8_recipe
+from megatron.lite.model._legacy_fp8 import build_fp8_recipe
 from megatron.lite.primitive.utils.moe import (
     compute_routing_scores_for_aux_loss,
     router_gating_linear,

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
@@ -41,7 +41,7 @@ from megatron.lite.primitive.parallel import (
     gather_from_sequence_parallel,
     scatter_to_sequence_parallel,
 )
-from megatron.lite.primitive.utils import build_fp8_recipe
+from megatron.lite.model._legacy_fp8 import build_fp8_recipe
 
 _SP_GRAD_SUFFIXES: tuple[str, ...] = (
     ".full_attn.qkv.linear.layer_norm_weight",

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
@@ -8,8 +8,6 @@ loss computation).
 
 from __future__ import annotations
 
-from contextlib import nullcontext
-
 import torch
 import torch.nn as nn
 import transformer_engine.pytorch as te
@@ -33,7 +31,100 @@ from megatron.lite.primitive.parallel import (
     roll_packed_thd_left,
     scatter_to_sequence_parallel,
 )
-from megatron.lite.primitive.utils import build_fp8_recipe
+from megatron.lite.primitive.precision import (
+    PrecisionCoverage,
+    PrimitiveCapability,
+    SemanticSite,
+)
+
+
+def _declare_layer_precision_requirements(
+    layer: nn.Module, coverage: PrecisionCoverage
+) -> None:
+    """Declare the concrete selected and fixed-BF16 sites in one Qwen layer."""
+
+    layer_idx = getattr(layer, "layer_idx", "unknown")
+    coverage.require(
+        layer.attn.qkv,
+        SemanticSite.ATTENTION_PROJECTION,
+        frozenset({PrimitiveCapability.TE_LAYERNORM_LINEAR}),
+        diagnostic=f"layer {layer_idx} attention qkv projection",
+    )
+    coverage.require(
+        layer.attn.proj,
+        SemanticSite.ATTENTION_PROJECTION,
+        frozenset({PrimitiveCapability.TE_LINEAR}),
+        diagnostic=f"layer {layer_idx} attention output projection",
+    )
+    coverage.require(
+        layer.moe.experts.fc1,
+        SemanticSite.MOE_EXPERT,
+        frozenset({PrimitiveCapability.TE_GROUPED_LINEAR}),
+        diagnostic=f"layer {layer_idx} expert fc1",
+    )
+    coverage.require(
+        layer.moe.experts.fc2,
+        SemanticSite.MOE_EXPERT,
+        frozenset({PrimitiveCapability.TE_GROUPED_LINEAR}),
+        diagnostic=f"layer {layer_idx} expert fc2",
+    )
+    coverage.require(
+        layer.attn.qkv,
+        SemanticSite.NORM,
+        diagnostic=f"layer {layer_idx} fused pre-attention RMSNorm",
+    )
+    coverage.require(
+        layer.attn.core_attn,
+        SemanticSite.ATTENTION_CORE,
+        diagnostic=f"layer {layer_idx} attention core",
+    )
+    coverage.require(
+        layer.attn.q_norm,
+        SemanticSite.NORM,
+        diagnostic=f"layer {layer_idx} q norm",
+    )
+    coverage.require(
+        layer.attn.k_norm,
+        SemanticSite.NORM,
+        diagnostic=f"layer {layer_idx} k norm",
+    )
+    coverage.require(
+        layer.mlp_norm,
+        SemanticSite.NORM,
+        diagnostic=f"layer {layer_idx} pre-MoE RMSNorm",
+    )
+    coverage.require(
+        layer.moe.router,
+        SemanticSite.ROUTER,
+        diagnostic=f"layer {layer_idx} router",
+    )
+
+
+def _declare_model_precision_requirements(
+    model: nn.Module, coverage: PrecisionCoverage
+) -> None:
+    """Declare typed coverage from the explicit Qwen3-MoE composition."""
+
+    for layer in model.layers:
+        _declare_layer_precision_requirements(layer, coverage)
+    if model.embed is not None:
+        coverage.require(
+            model.embed,
+            SemanticSite.EMBEDDING,
+            diagnostic="input embedding",
+        )
+    if model.norm is not None:
+        coverage.require(
+            model.norm,
+            SemanticSite.NORM,
+            diagnostic="final RMSNorm",
+        )
+    if model.head is not None:
+        coverage.require(
+            model.head,
+            SemanticSite.LM_HEAD,
+            diagnostic="vocabulary head",
+        )
 
 # ---------------------------------------------------------------------------
 # MoE Layer (thin assembly over megatron.lite.primitive.modules)
@@ -48,9 +139,9 @@ class MoELayer(nn.Module):
         *,
         use_deepep: bool = True,
         router_bias_rate: float = 0.0,
-        fp8: bool = False,
         moe_act_recompute: bool = False,
         lora_config: LoraConfig | dict | None = None,
+        precision_coverage: PrecisionCoverage | None = None,
     ):
         super().__init__()
         # Match Qwen3-MoE's `load_balancing_type="none"` setting: no aux loss.
@@ -58,7 +149,11 @@ class MoELayer(nn.Module):
             config, ps, router_bias_rate=router_bias_rate, compute_aux_loss=False
         )
         self.experts = Experts(
-            config, ps, fp8=fp8, moe_act_recompute=moe_act_recompute, lora_config=lora_config
+            config,
+            ps,
+            moe_act_recompute=moe_act_recompute,
+            lora_config=lora_config,
+            precision_coverage=precision_coverage,
         )
         self.dispatcher = TokenDispatcher(
             config.num_experts, config.hidden_size, ps, use_deepep=use_deepep
@@ -122,10 +217,10 @@ class TransformerLayer(nn.Module):
         *,
         use_deepep: bool = True,
         router_bias_rate: float = 0.0,
-        fp8: bool = False,
         moe_act_recompute: bool = False,
         use_thd: bool = False,
         lora_config: LoraConfig | dict | None = None,
+        precision_coverage: PrecisionCoverage | None = None,
     ):
         super().__init__()
         self.layer_idx = layer_idx
@@ -146,6 +241,7 @@ class TransformerLayer(nn.Module):
             use_thd=use_thd,
             qkv_layout="mcore",
             lora_config=lora_config,
+            precision_coverage=precision_coverage,
         )
         self.mlp_norm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.moe = MoELayer(
@@ -153,9 +249,9 @@ class TransformerLayer(nn.Module):
             ps,
             use_deepep=use_deepep,
             router_bias_rate=router_bias_rate,
-            fp8=fp8,
             moe_act_recompute=moe_act_recompute,
             lora_config=lora_config,
+            precision_coverage=precision_coverage,
         )
 
     def forward(
@@ -208,7 +304,6 @@ class MultiTokenPredictionLayer(nn.Module):
         embedding: VocabParallelEmbedding,
         use_deepep: bool,
         router_bias_rate: float,
-        fp8: bool,
         moe_act_recompute: bool,
         use_thd: bool,
         detach_encoder: bool,
@@ -229,7 +324,6 @@ class MultiTokenPredictionLayer(nn.Module):
             config.num_hidden_layers + layer_idx,
             use_deepep=use_deepep,
             router_bias_rate=router_bias_rate,
-            fp8=fp8,
             moe_act_recompute=moe_act_recompute,
             use_thd=use_thd,
             lora_config=lora_config,
@@ -281,7 +375,6 @@ class MultiTokenPredictionBlock(nn.Module):
         embedding: VocabParallelEmbedding,
         use_deepep: bool,
         router_bias_rate: float,
-        fp8: bool,
         moe_act_recompute: bool,
         use_thd: bool,
         detach_encoder: bool,
@@ -301,7 +394,6 @@ class MultiTokenPredictionBlock(nn.Module):
                     embedding=embedding,
                     use_deepep=use_deepep,
                     router_bias_rate=router_bias_rate,
-                    fp8=fp8,
                     moe_act_recompute=moe_act_recompute,
                     use_thd=use_thd,
                     detach_encoder=detach_encoder,
@@ -353,7 +445,6 @@ class Qwen3MoEModel(nn.Module):
         vpp_chunk_id: int | None = None,
         *,
         use_deepep: bool = False,
-        fp8: bool = False,
         recompute_modules: list[str] | None = None,
         router_bias_rate: float = 0.0,
         use_thd: bool = False,
@@ -361,11 +452,15 @@ class Qwen3MoEModel(nn.Module):
         mtp_enable_train: bool = False,
         mtp_detach_encoder: bool = False,
         lora_config: LoraConfig | dict | None = None,
+        precision_coverage: PrecisionCoverage | None = None,
     ):
         super().__init__()
+        if precision_coverage is not None and mtp_enable:
+            raise ValueError(
+                "MTP is not covered by the closed Hopper precision profiles."
+            )
         self.config = config
         self.ps = ps
-        self.fp8 = fp8
         self.mtp_enable_train = bool(mtp_enable and mtp_enable_train)
         self.mtp_loss_scaling_factor = config.mtp_loss_scaling_factor
         self._input_tensor: torch.Tensor | None = None
@@ -391,10 +486,10 @@ class Qwen3MoEModel(nn.Module):
                     idx,
                     use_deepep=use_deepep,
                     router_bias_rate=router_bias_rate,
-                    fp8=fp8,
                     moe_act_recompute=moe_act_recompute,
                     use_thd=use_thd,
                     lora_config=lora_config,
+                    precision_coverage=precision_coverage,
                 )
                 for idx in self.layer_indices
             ]
@@ -419,13 +514,15 @@ class Qwen3MoEModel(nn.Module):
                 embedding=mtp_embedding,
                 use_deepep=use_deepep,
                 router_bias_rate=router_bias_rate,
-                fp8=fp8,
                 moe_act_recompute=moe_act_recompute,
                 use_thd=use_thd,
                 detach_encoder=mtp_detach_encoder,
                 repeated_layer=config.mtp_use_repeated_layer,
                 lora_config=lora_config,
             )
+
+        if precision_coverage is not None:
+            _declare_model_precision_requirements(self, precision_coverage)
 
         self.sp_params: list[nn.Parameter] = []
         if ps.tp_size > 1:
@@ -460,20 +557,13 @@ class Qwen3MoEModel(nn.Module):
             assert hidden_states is not None
             h = hidden_states
 
-        fp8_ctx = (
-            te.fp8_autocast(enabled=True, fp8_recipe=build_fp8_recipe())
-            if self.fp8
-            else nullcontext()
-        )
-
-        with fp8_ctx:
-            if self.embed is not None:
-                h = scatter_to_sequence_parallel(h, self.ps)
-            for layer in self.layers:
-                h = layer(h, position_ids=position_ids, packed_seq_params=packed_seq_params)
-            # Head path is SP-aware: norm runs on SP-sharded [S/tp, B, H] and
-            # head's internal all-gather happens inside VocabParallelOutput.
-            # Mirrors MC GPTModel's final_layernorm → output_layer(sp=True).
+        if self.embed is not None:
+            h = scatter_to_sequence_parallel(h, self.ps)
+        for layer in self.layers:
+            h = layer(h, position_ids=position_ids, packed_seq_params=packed_seq_params)
+        # Head path is SP-aware: norm runs on SP-sharded [S/tp, B, H] and
+        # head's internal all-gather happens inside VocabParallelOutput.
+        # Mirrors MC GPTModel's final_layernorm → output_layer(sp=True).
 
         output = {"hidden_states": h}
 

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
@@ -46,6 +46,11 @@ from megatron.lite.primitive.modules.lora import (
     trainable_param_stats,
 )
 from megatron.lite.primitive.parallel import ParallelState, init_parallel
+from megatron.lite.primitive.precision import (
+    ParameterContract,
+    PrecisionCoverage,
+    PrecisionImplementation,
+)
 from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec
 from megatron.lite.runtime.contracts import OptimizerConfig, ParallelConfig
 from megatron.lite.runtime.contracts.data import PackedBatch
@@ -89,6 +94,9 @@ class ImplConfig:
     mtp_use_repeated_layer: bool | None = None
     deterministic: bool = True
     lora: LoraConfig | dict | None = None
+    precision_coverage: PrecisionCoverage | None = None
+    precision_implementation: PrecisionImplementation | None = None
+    precision_parameter_contract: ParameterContract | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -150,6 +158,44 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
     """
     p = impl_cfg.parallel
     lora_config = normalize_lora_config(impl_cfg.lora)
+    precision_fields = (
+        impl_cfg.precision_coverage,
+        impl_cfg.precision_implementation,
+        impl_cfg.precision_parameter_contract,
+    )
+    if any(field is not None for field in precision_fields) and not all(
+        field is not None for field in precision_fields
+    ):
+        raise ValueError("Runtime precision injection must provide all three typed fields.")
+    if impl_cfg.precision_implementation is not None:
+        precision_coverage = impl_cfg.precision_coverage
+        precision_parameter_contract = impl_cfg.precision_parameter_contract
+        if precision_coverage is None or precision_parameter_contract is None:
+            raise ValueError(
+                "Runtime precision injection must provide all three typed fields."
+            )
+        if (
+            precision_coverage.implementation is not impl_cfg.precision_implementation
+        ):
+            raise ValueError("Precision coverage and implementation do not match.")
+        if (
+            precision_parameter_contract
+            is not impl_cfg.precision_implementation.parameter_contract
+        ):
+            raise ValueError("Precision parameter contract does not match implementation.")
+        unsupported = []
+        if impl_cfg.recompute:
+            unsupported.append("recompute")
+        if impl_cfg.offload:
+            unsupported.append("offload")
+        if impl_cfg.mtp_enable:
+            unsupported.append("mtp")
+        if lora_config.enabled:
+            unsupported.append("lora")
+        if unsupported:
+            raise ValueError(
+                f"Closed Hopper precision profiles do not cover {unsupported}."
+            )
 
     # ── validation ──
     if impl_cfg.use_deepep and (p.etp is not None and p.etp > 1):
@@ -177,7 +223,6 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
     recompute_spec = parse_recompute_spec(impl_cfg.recompute)
     model_kwargs: dict[str, Any] = dict(
         use_deepep=impl_cfg.use_deepep,
-        fp8=False,
         recompute_modules=recompute_spec,
         router_bias_rate=impl_cfg.router_bias_rate,
         use_thd=impl_cfg.use_thd,
@@ -185,6 +230,7 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
         mtp_enable_train=mtp_enable_train,
         mtp_detach_encoder=impl_cfg.mtp_detach_encoder,
         lora_config=lora_config,
+        precision_coverage=impl_cfg.precision_coverage,
     )
 
     vpp = None if p.vpp == 1 else p.vpp
@@ -198,6 +244,9 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
                 .to(torch.bfloat16)
                 .cuda()
             )
+
+    if impl_cfg.precision_coverage is not None:
+        impl_cfg.precision_coverage.seal()
 
     set_cross_entropy_fusion(chunks, impl_cfg.cross_entropy_fusion)
 

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
@@ -50,6 +50,7 @@ from megatron.lite.primitive.precision import (
     ParameterContract,
     PrecisionCoverage,
     PrecisionImplementation,
+    require_optimizer_supports_precision,
 )
 from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec
 from megatron.lite.runtime.contracts import OptimizerConfig, ParallelConfig
@@ -195,6 +196,10 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
         if unsupported:
             raise ValueError(
                 f"Closed Hopper precision profiles do not cover {unsupported}."
+            )
+        if impl_cfg.optimizer is not None:
+            require_optimizer_supports_precision(
+                impl_cfg.precision_implementation, impl_cfg.optimizer
             )
 
     # ── validation ──

--- a/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
@@ -726,10 +726,28 @@ def load_hf_weights(
     for name, param in base_model.named_parameters():
         if name in loaded:
             param.data.copy_(loaded[name])
+            _replace_te_high_precision_init_val(param, loaded[name])
         elif "lora" in name.lower() or "adapter" in name.lower():
             continue
         else:
             log_rank0(f"WARNING: {name} not loaded from checkpoint")
+
+
+def _replace_te_high_precision_init_val(param: nn.Parameter, source: torch.Tensor) -> None:
+    """Replace TE's construction value with the authoritative HF load tensor.
+
+    ``quantized_model_init(..., preserve_high_precision_init_val=True)`` retains
+    a CPU high-precision construction value solely to seed MLite's FP32 master.
+    HF loading happens later in this runtime, so leaving TE's random construction
+    value in place would create a master unrelated to the quantized compute
+    weight.  TE deliberately exposes this storage as a parameter attribute;
+    replace it only for parameters that opted into that API, never for BF16
+    parameters.
+    """
+
+    if not callable(getattr(param, "get_high_precision_init_val", None)):
+        return
+    param._high_precision_init_val = source.detach().to(device="cpu").clone()
 
 
 def _load_expert_weight(native_name, hf_names, reader, spec, ps, loaded, expert_gid, expert_shard):

--- a/experimental/lite/megatron/lite/primitive/modules/experts.py
+++ b/experimental/lite/megatron/lite/primitive/modules/experts.py
@@ -25,7 +25,6 @@ from megatron.lite.primitive.precision import (
     PrecisionPhase,
     PrimitiveCapability,
     SemanticSite,
-    WeightStorage,
     active_precision,
     precision_site_forward_context,
 )
@@ -256,11 +255,6 @@ class Experts(nn.Module):
         implementation = active_precision(PrecisionPhase.MODEL_INIT)
         if coverage.implementation is not implementation:
             raise RuntimeError("precision coverage is bound to a different implementation")
-        if implementation.parameter_contract.compute_weight is not WeightStorage.BF16:
-            raise NotImplementedError(
-                "FP8-weight GroupedLinear initialization is not implemented by the "
-                "BF16-weight expert primitive path."
-            )
         dimensions = (
             ("hidden_size", int(config.hidden_size)),
             (

--- a/experimental/lite/megatron/lite/primitive/modules/experts.py
+++ b/experimental/lite/megatron/lite/primitive/modules/experts.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import os
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from typing import Any
 
 import torch  # pyright: ignore[reportMissingImports]
@@ -19,6 +19,16 @@ from megatron.lite.primitive.modules.lora import (
     normalize_lora_config,
 )
 from megatron.lite.primitive.parallel import ParallelState
+from megatron.lite.primitive.precision import (
+    PrecisionCoverage,
+    PrecisionImplementation,
+    PrecisionPhase,
+    PrimitiveCapability,
+    SemanticSite,
+    WeightStorage,
+    active_precision,
+    precision_site_forward_context,
+)
 from megatron.lite.primitive.recompute import CheckpointWithoutOutput
 from megatron.lite.primitive.utils import ensure_divisible
 
@@ -78,9 +88,22 @@ class Experts(nn.Module):
         fp8: bool = False,
         moe_act_recompute: bool = False,
         lora_config: LoraConfig | dict | None = None,
+        precision_coverage: PrecisionCoverage | None = None,
     ):
         super().__init__()
         self.num_local_experts = ensure_divisible(config.num_experts, ps.ep_size)
+        lora = normalize_lora_config(lora_config)
+        if precision_coverage is not None and lora.enabled:
+            raise ValueError(
+                "LoRA expert side paths are not covered by the closed Hopper profiles."
+            )
+        if precision_coverage is not None and fp8:
+            raise ValueError(
+                "model-threaded fp8 and typed precision coverage cannot be enabled together"
+            )
+        self._precision_implementation = self._bind_bf16_weight_precision(
+            precision_coverage, config=config, ps=ps
+        )
         self.fp8 = fp8
         self.moe_act_recompute = moe_act_recompute
         self.etp_group = ps.etp_group if ps.etp_size > 1 else None
@@ -100,7 +123,17 @@ class Experts(nn.Module):
             bias=False,
             params_dtype=torch.bfloat16,
         )
-        lora = normalize_lora_config(lora_config)
+        if precision_coverage is not None:
+            precision_coverage.claim(
+                self.fc1,
+                SemanticSite.MOE_EXPERT,
+                PrimitiveCapability.TE_GROUPED_LINEAR,
+            )
+            precision_coverage.claim(
+                self.fc2,
+                SemanticSite.MOE_EXPERT,
+                PrimitiveCapability.TE_GROUPED_LINEAR,
+            )
         self.fc1_lora: SharedGroupedLinearLoRA | None = None
         self.fc2_lora: SharedGroupedLinearLoRA | None = None
         if lora.enabled and lora.targets_module("linear_fc1"):
@@ -147,7 +180,7 @@ class Experts(nn.Module):
             else list(tokens_per_expert_list)
         )
         pad_mask = None
-        if self.fp8:
+        if self._precision_implementation is not None or self.fp8:
             x, permuted_probs, m_splits, pad_mask = self._fp8_pad(x, permuted_probs, m_splits)
 
         etp_real_len = x.shape[0]
@@ -182,20 +215,24 @@ class Experts(nn.Module):
         with _expert_nvtx_range("ep_experts.forward"):
             if self.moe_act_recompute and probs is not None:
                 act_ckpt = CheckpointWithoutOutput(preserve_rng_state=True)
-                fc1_out = self.fc1(x, m_splits)
+                with self._precision_context():
+                    fc1_out = self.fc1(x, m_splits)
                 if self.fc1_lora is not None:
                     fc1_out = fc1_out + self.fc1_lora(x, m_splits)
                 h = act_ckpt.checkpoint(swiglu_with_probs, fc1_out, probs, self.swiglu_limit)
-                out = self.fc2(h, m_splits)
+                with self._precision_context():
+                    out = self.fc2(h, m_splits)
                 if self.fc2_lora is not None:
                     out = out + self.fc2_lora(h, m_splits)
                 act_ckpt.discard_output_and_register_recompute(out)
             else:
-                fc1_out = self.fc1(x, m_splits)
+                with self._precision_context():
+                    fc1_out = self.fc1(x, m_splits)
                 if self.fc1_lora is not None:
                     fc1_out = fc1_out + self.fc1_lora(x, m_splits)
                 h = swiglu_with_probs(fc1_out, probs, self.swiglu_limit)
-                out = self.fc2(h, m_splits)
+                with self._precision_context():
+                    out = self.fc2(h, m_splits)
                 if self.fc2_lora is not None:
                     out = out + self.fc2_lora(h, m_splits)
 
@@ -206,6 +243,49 @@ class Experts(nn.Module):
         if pad_mask is not None:
             out = out[pad_mask]
         return out
+
+    def _bind_bf16_weight_precision(
+        self,
+        coverage: PrecisionCoverage | None,
+        *,
+        config: Any,
+        ps: ParallelState,
+    ) -> PrecisionImplementation | None:
+        if coverage is None:
+            return None
+        implementation = active_precision(PrecisionPhase.MODEL_INIT)
+        if coverage.implementation is not implementation:
+            raise RuntimeError("precision coverage is bound to a different implementation")
+        if implementation.parameter_contract.compute_weight is not WeightStorage.BF16:
+            raise NotImplementedError(
+                "FP8-weight GroupedLinear initialization is not implemented by the "
+                "BF16-weight expert primitive path."
+            )
+        dimensions = (
+            ("hidden_size", int(config.hidden_size)),
+            (
+                "fc1 output",
+                int(config.moe_intermediate_size * 2 // ps.etp_size),
+            ),
+            (
+                "fc2 input",
+                int(config.moe_intermediate_size // ps.etp_size),
+            ),
+        )
+        for label, value in dimensions:
+            if value % 128 != 0:
+                raise ValueError(
+                    f"MoE expert {label} must be divisible by 128 for Hopper "
+                    f"blockwise FP8; got {value}."
+                )
+        return implementation
+
+    def _precision_context(self):
+        if self._precision_implementation is None:
+            return nullcontext()
+        return precision_site_forward_context(
+            self._precision_implementation, SemanticSite.MOE_EXPERT
+        )
 
     @staticmethod
     def _fp8_pad(x, permuted_probs, m_splits):

--- a/experimental/lite/megatron/lite/primitive/modules/gqa.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gqa.py
@@ -23,6 +23,7 @@ from megatron.lite.primitive.parallel import (
     RowParallelLinear,
     all_gather_last_dim_with_grad_reduce,
 )
+from megatron.lite.primitive.precision import PrecisionCoverage, SemanticSite
 from megatron.lite.primitive.utils import ensure_divisible
 from megatron.lite.primitive.utils.rope import _apply_rotary_pos_emb_bshd, _apply_rotary_pos_emb_thd
 from megatron.lite.primitive.utils.rotary import RotaryEmbedding
@@ -67,6 +68,7 @@ class GQAttention(nn.Module):
         qkv_layout: str = "flat",
         lora_config: LoraConfig | dict | None = None,
         mrope_section: list[int] | None = None,
+        precision_coverage: PrecisionCoverage | None = None,
     ):
         super().__init__()
         self.num_heads_local = ensure_divisible(num_attention_heads, ps.tp_size)
@@ -88,6 +90,16 @@ class GQAttention(nn.Module):
             raise ValueError(f"Unsupported qkv_layout={qkv_layout!r}")
         self._qkv_layout = qkv_layout
         self._mrope_section = list(mrope_section) if mrope_section is not None else None
+        lora = normalize_lora_config(lora_config)
+        if precision_coverage is not None and lora.enabled:
+            raise ValueError(
+                "LoRA attention side paths are not covered by the closed Hopper profiles."
+            )
+        precision_site = (
+            SemanticSite.ATTENTION_PROJECTION
+            if precision_coverage is not None
+            else None
+        )
 
         # Declaration order follows MC's `SelfAttention` submodule order
         # (linear_proj → linear_qkv → q_layernorm → k_layernorm). `named_
@@ -96,7 +108,14 @@ class GQAttention(nn.Module):
         # Mismatched order would put bucket boundaries in different places,
         # producing different per-rank fp32 master shard layouts and
         # non-bitwise step-1 divergence.
-        self.proj = RowParallelLinear(num_attention_heads * head_dim, hidden_size, ps, bias=False)
+        self.proj = RowParallelLinear(
+            num_attention_heads * head_dim,
+            hidden_size,
+            ps,
+            bias=False,
+            precision_coverage=precision_coverage,
+            precision_site=precision_site,
+        )
         q_cols = num_attention_heads * (2 if output_gate else 1)
         qkv_size = (q_cols + 2 * num_key_value_heads) * head_dim
         self.qkv = ColumnParallelLinear(
@@ -107,6 +126,8 @@ class GQAttention(nn.Module):
             normalization="RMSNorm",
             eps=rms_norm_eps,
             zero_centered_gamma=zero_centered_gamma,
+            precision_coverage=precision_coverage,
+            precision_site=precision_site,
         )
         self.q_norm = te.RMSNorm(
             head_dim, eps=rms_norm_eps, zero_centered_gamma=zero_centered_gamma
@@ -115,7 +136,6 @@ class GQAttention(nn.Module):
             head_dim, eps=rms_norm_eps, zero_centered_gamma=zero_centered_gamma
         )
 
-        lora = normalize_lora_config(lora_config)
         self.qkv_lora: LinearLoRA | None = None
         self.proj_lora: LinearLoRA | None = None
         if lora.enabled and lora.targets_module("linear_qkv"):

--- a/experimental/lite/megatron/lite/primitive/modules/mlp.py
+++ b/experimental/lite/megatron/lite/primitive/modules/mlp.py
@@ -1,8 +1,21 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from contextlib import nullcontext
+
 import torch
 import torch.nn as nn
+import transformer_engine.pytorch as te
 
 from megatron.lite.primitive.modules.experts import swiglu_with_probs
+from megatron.lite.primitive.precision import (
+    PrecisionCoverage,
+    PrecisionImplementation,
+    PrecisionPhase,
+    PrimitiveCapability,
+    SemanticSite,
+    WeightStorage,
+    active_precision,
+    precision_site_forward_context,
+)
 
 
 class SwiGLUMLP(nn.Module):
@@ -12,12 +25,82 @@ class SwiGLUMLP(nn.Module):
         intermediate_size: int,
         *,
         swiglu_limit: float = 0.0,
+        precision_coverage: PrecisionCoverage | None = None,
     ):
         super().__init__()
-        self.gate_up = nn.Linear(hidden_size, 2 * intermediate_size, bias=False)
-        self.down = nn.Linear(intermediate_size, hidden_size, bias=False)
+        self._precision_implementation = self._bind_bf16_weight_precision(
+            precision_coverage,
+            dimensions=(hidden_size, 2 * intermediate_size, intermediate_size),
+        )
+        self.gate_up = te.Linear(
+            hidden_size,
+            2 * intermediate_size,
+            bias=False,
+            params_dtype=torch.bfloat16,
+        )
+        self.down = te.Linear(
+            intermediate_size,
+            hidden_size,
+            bias=False,
+            params_dtype=torch.bfloat16,
+        )
+        if precision_coverage is not None:
+            precision_coverage.claim(
+                self.gate_up,
+                SemanticSite.DENSE_MLP,
+                PrimitiveCapability.TE_LINEAR,
+            )
+            precision_coverage.claim(
+                self.down,
+                SemanticSite.DENSE_MLP,
+                PrimitiveCapability.TE_LINEAR,
+            )
         self.swiglu_limit = float(swiglu_limit or 0.0)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        y = swiglu_with_probs(self.gate_up(x), None, self.swiglu_limit)
-        return self.down(y.to(dtype=x.dtype))
+        with self._precision_context(x):
+            gate_up = self.gate_up(x)
+        y = swiglu_with_probs(gate_up, None, self.swiglu_limit)
+        with self._precision_context(y):
+            return self.down(y.to(dtype=x.dtype))
+
+    @staticmethod
+    def _bind_bf16_weight_precision(
+        coverage: PrecisionCoverage | None,
+        *,
+        dimensions: tuple[int, ...],
+    ) -> PrecisionImplementation | None:
+        if coverage is None:
+            return None
+        implementation = active_precision(PrecisionPhase.MODEL_INIT)
+        if coverage.implementation is not implementation:
+            raise RuntimeError("precision coverage is bound to a different implementation")
+        if implementation.parameter_contract.compute_weight is not WeightStorage.BF16:
+            raise NotImplementedError(
+                "FP8-weight Linear initialization is not implemented by the "
+                "BF16-weight dense MLP primitive path."
+            )
+        for value in dimensions:
+            if value % 128 != 0:
+                raise ValueError(
+                    "Dense MLP features must be divisible by 128 for Hopper "
+                    f"blockwise FP8; got {value}."
+                )
+        return implementation
+
+    def _precision_context(self, x: torch.Tensor):
+        if self._precision_implementation is None:
+            return nullcontext()
+        if x.dim() < 2 or x.shape[-1] % 128 != 0:
+            raise ValueError(
+                "dense_mlp input must have rank at least 2 and a last dimension "
+                "divisible by 128"
+            )
+        rows = x.numel() // x.shape[-1]
+        if rows % 128 != 0:
+            raise ValueError(
+                f"dense_mlp input row product must be divisible by 128; got {rows}."
+            )
+        return precision_site_forward_context(
+            self._precision_implementation, SemanticSite.DENSE_MLP
+        )

--- a/experimental/lite/megatron/lite/primitive/modules/mlp.py
+++ b/experimental/lite/megatron/lite/primitive/modules/mlp.py
@@ -12,7 +12,6 @@ from megatron.lite.primitive.precision import (
     PrecisionPhase,
     PrimitiveCapability,
     SemanticSite,
-    WeightStorage,
     active_precision,
     precision_site_forward_context,
 )
@@ -75,11 +74,6 @@ class SwiGLUMLP(nn.Module):
         implementation = active_precision(PrecisionPhase.MODEL_INIT)
         if coverage.implementation is not implementation:
             raise RuntimeError("precision coverage is bound to a different implementation")
-        if implementation.parameter_contract.compute_weight is not WeightStorage.BF16:
-            raise NotImplementedError(
-                "FP8-weight Linear initialization is not implemented by the "
-                "BF16-weight dense MLP primitive path."
-            )
         for value in dimensions:
             if value % 128 != 0:
                 raise ValueError(

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/adamw.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/adamw.py
@@ -192,9 +192,24 @@ class FP32AdamW:
                     "local shard; FP8 masters must be initialized from TE's local "
                     "preserved source, never by dequantizing the FP8 parameter."
                 )
-            return high_precision_init.to(
+            master_local = high_precision_init.to(
                 device="cpu" if self.cpu_update else local_param.device, dtype=torch.float32
             ).clone()
+            if self.cpu_update or not is_dtensor_like(param):
+                return master_local
+            # The FP8 param is a DTensor, but its preserved high-precision source is
+            # a plain local shard. Mirror the param's sharding so the master (and the
+            # exp_avg/exp_avg_sq derived from it) stay DTensors like the grad; a plain
+            # local master would collide with the DTensor grad in the AdamW update.
+            # Pass the param's exact global shape/stride so unevenly-sharded params
+            # round-trip correctly, and never dequantize the FP8 param to build it.
+            return dtensor_from_local(
+                master_local,
+                param.device_mesh,
+                param.placements,
+                shape=param.shape,
+                stride=param.stride(),
+            )
         if self.cpu_update:
             local_param = to_local_tensor(param.detach())
             return local_param.detach().to(device="cpu", dtype=torch.float32).clone()

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/adamw.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/adamw.py
@@ -81,6 +81,28 @@ def all_reduce_grad_(grad: torch.Tensor, *, group: dist.ProcessGroup) -> None:
     dist.all_reduce(local_grad, op=dist.ReduceOp.SUM, group=group)
 
 
+def _take_te_high_precision_init_val(param: nn.Parameter) -> torch.Tensor | None:
+    """Consume TE's preserved source exactly once when constructing an FP32 master."""
+
+    local = to_local_tensor(param)
+    targets = (local,) if local is param else (local, param)
+    for target in targets:
+        get_value = getattr(target, "get_high_precision_init_val", None)
+        if not callable(get_value):
+            continue
+        value = get_value()
+        if value is None:
+            continue
+        if not isinstance(value, torch.Tensor):
+            raise TypeError("TE high-precision initialization value must be a tensor.")
+        clear_value = getattr(target, "clear_high_precision_init_val", None)
+        if not callable(clear_value):
+            raise RuntimeError("TE FP8 parameter exposes no clear_high_precision_init_val method.")
+        clear_value()
+        return value
+    return None
+
+
 class ChainedOptimizer:
     def __init__(self, optimizers: Iterable[torch.optim.Optimizer]):
         self.optimizers = list(optimizers)
@@ -161,6 +183,18 @@ class FP32AdamW:
                 self._master_for_param[param] = master
 
     def _init_master_param(self, param: nn.Parameter) -> torch.Tensor:
+        high_precision_init = _take_te_high_precision_init_val(param)
+        if high_precision_init is not None:
+            local_param = to_local_tensor(param.detach())
+            if high_precision_init.shape != local_param.shape:
+                raise RuntimeError(
+                    "TE high-precision initialization value does not match this FSDP2 "
+                    "local shard; FP8 masters must be initialized from TE's local "
+                    "preserved source, never by dequantizing the FP8 parameter."
+                )
+            return high_precision_init.to(
+                device="cpu" if self.cpu_update else local_param.device, dtype=torch.float32
+            ).clone()
         if self.cpu_update:
             local_param = to_local_tensor(param.detach())
             return local_param.detach().to(device="cpu", dtype=torch.float32).clone()

--- a/experimental/lite/megatron/lite/primitive/parallel/linear.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/linear.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from contextlib import nullcontext
 from typing import TYPE_CHECKING
 
 import torch  # pyright: ignore[reportMissingImports]
@@ -10,10 +11,93 @@ import torch.distributed as dist  # pyright: ignore[reportMissingImports]
 import torch.nn as nn  # pyright: ignore[reportMissingImports]
 import transformer_engine.pytorch as te  # pyright: ignore[reportMissingImports]
 
+from megatron.lite.primitive.precision import (
+    PrecisionCoverage,
+    PrecisionImplementation,
+    PrecisionPhase,
+    PrimitiveCapability,
+    SemanticSite,
+    WeightStorage,
+    active_precision,
+    precision_site_forward_context,
+)
 from megatron.lite.primitive.utils import ensure_divisible
 
 if TYPE_CHECKING:
     from megatron.lite.primitive.parallel.state import ParallelState
+
+
+def _validate_blockwise_features(
+    in_features: int,
+    out_features: int,
+    site: SemanticSite,
+) -> None:
+    for label, value in (("input", in_features), ("output", out_features)):
+        if value % 128 != 0:
+            raise ValueError(
+                f"{site.value} {label} features must be divisible by 128 for "
+                f"Hopper blockwise FP8; got {value}."
+            )
+
+
+def _bind_bf16_weight_precision(
+    coverage: PrecisionCoverage | None,
+    owner: object,
+    site: SemanticSite | None,
+    capability: PrimitiveCapability,
+    *,
+    in_features: int,
+    out_features: int,
+) -> PrecisionImplementation | None:
+    if coverage is None:
+        if site is not None:
+            raise ValueError("precision_site requires a typed precision coverage collector")
+        return None
+    if site is None:
+        raise ValueError("precision_coverage requires an explicit semantic site")
+    implementation = active_precision(PrecisionPhase.MODEL_INIT)
+    if coverage.implementation is not implementation:
+        raise RuntimeError("precision coverage is bound to a different implementation")
+    if implementation.parameter_contract.compute_weight is not WeightStorage.BF16:
+        raise NotImplementedError(
+            "FP8-weight parameter initialization is not implemented by the "
+            "BF16-weight TE primitive path."
+        )
+    if site not in implementation.fp8_sites:
+        raise ValueError(f"site {site.value} is not an FP8 GEMM site")
+    _validate_blockwise_features(in_features, out_features, site)
+    coverage.claim(owner, site, capability)
+    return implementation
+
+
+def _validate_blockwise_input(x: torch.Tensor, site: SemanticSite) -> None:
+    if x.dim() < 2:
+        raise ValueError(
+            f"{site.value} input rank must be at least 2 for Hopper blockwise FP8"
+        )
+    if x.shape[-1] % 128 != 0:
+        raise ValueError(
+            f"{site.value} input last dimension must be divisible by 128; "
+            f"got {x.shape[-1]}."
+        )
+    rows = x.numel() // x.shape[-1]
+    if rows % 128 != 0:
+        raise ValueError(
+            f"{site.value} input row product must be divisible by 128; got {rows}."
+        )
+
+
+def _linear_precision_context(
+    implementation: PrecisionImplementation | None,
+    site: SemanticSite | None,
+    x: torch.Tensor,
+):
+    if implementation is None:
+        return nullcontext()
+    if site is None:
+        raise RuntimeError("bound precision linear is missing its semantic site")
+    _validate_blockwise_input(x, site)
+    return precision_site_forward_context(implementation, site)
 
 
 # ---------------------------------------------------------------------------
@@ -177,6 +261,8 @@ class ColumnParallelLinear(nn.Module):
         eps: float = 1e-6,
         zero_centered_gamma: bool = False,
         sequence_parallel: bool | None = None,
+        precision_coverage: PrecisionCoverage | None = None,
+        precision_site: SemanticSite | None = None,
     ):
         super().__init__()
         self.tp_size = ps.tp_size
@@ -185,6 +271,20 @@ class ColumnParallelLinear(nn.Module):
         self.local_out = ensure_divisible(out_features, ps.tp_size)
         self.use_sp = (
             ps.tp_size > 1 and not gather_output if sequence_parallel is None else sequence_parallel
+        )
+        self._precision_site = precision_site
+        capability = (
+            PrimitiveCapability.TE_LAYERNORM_LINEAR
+            if normalization is not None
+            else PrimitiveCapability.TE_LINEAR
+        )
+        self._precision_implementation = _bind_bf16_weight_precision(
+            precision_coverage,
+            self,
+            precision_site,
+            capability,
+            in_features=in_features,
+            out_features=self.local_out,
         )
         if normalization is not None:
             self.linear = te.LayerNormLinear(
@@ -214,7 +314,10 @@ class ColumnParallelLinear(nn.Module):
         self.gather_output = gather_output
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        out = self.linear(x)
+        with _linear_precision_context(
+            self._precision_implementation, self._precision_site, x
+        ):
+            out = self.linear(x)
         if self.gather_output and self.tp_size > 1:
             out = _AllGatherLastDim.apply(out, self.tp_size, self.tp_group)
         return out
@@ -230,6 +333,8 @@ class RowParallelLinear(nn.Module):
         ps: ParallelState,
         bias: bool = False,
         input_is_parallel: bool = True,
+        precision_coverage: PrecisionCoverage | None = None,
+        precision_site: SemanticSite | None = None,
     ):
         super().__init__()
         self.tp_size = ps.tp_size
@@ -237,6 +342,15 @@ class RowParallelLinear(nn.Module):
         self.tp_group = ps.tp_group
         self.use_sp = ps.tp_size > 1
         self.local_in = ensure_divisible(in_features, ps.tp_size)
+        self._precision_site = precision_site
+        self._precision_implementation = _bind_bf16_weight_precision(
+            precision_coverage,
+            self,
+            precision_site,
+            PrimitiveCapability.TE_LINEAR,
+            in_features=self.local_in,
+            out_features=out_features,
+        )
         self.linear = te.Linear(
             in_features,
             out_features,
@@ -249,7 +363,10 @@ class RowParallelLinear(nn.Module):
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self.linear(x)
+        with _linear_precision_context(
+            self._precision_implementation, self._precision_site, x
+        ):
+            return self.linear(x)
 
 
 def pad_vocab_for_tp(vocab_size: int, tp_size: int) -> int:
@@ -258,8 +375,8 @@ def pad_vocab_for_tp(vocab_size: int, tp_size: int) -> int:
     Matches MC's `_vocab_size_with_padding(..., make_vocab_size_divisible_by=128)`:
     pad to 128-multiple for GEMM alignment, and also require tp-divisibility.
     For typical `tp_size ∈ {1,2,4,...,128}`, `lcm = 128` so a vocab already
-    divisible by 128 (e.g. Qwen3-MoE's 151936) stays unchanged — which is
-    what MC's `output_layer` sees. Using `128 * tp_size` instead would
+    divisible by 128 stays unchanged, matching MC's `output_layer`. Using
+    `128 * tp_size` instead would
     over-pad (e.g. 151936 -> 152064
     at tp=2), introducing 128 extra logits into the vocab-parallel cross-
     entropy log-sum-exp and driving a ~3e-4 loss drift.

--- a/experimental/lite/megatron/lite/primitive/parallel/linear.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/linear.py
@@ -17,7 +17,6 @@ from megatron.lite.primitive.precision import (
     PrecisionPhase,
     PrimitiveCapability,
     SemanticSite,
-    WeightStorage,
     active_precision,
     precision_site_forward_context,
 )
@@ -50,6 +49,9 @@ def _validate_bf16_weight_precision(
     """Validate one TP linear site against the active model-init profile.
 
     Returns the bound implementation (or ``None`` when precision is unmanaged).
+    The only resolvable blockwise profile stores BF16 compute weights, so this
+    path always sees ``WeightStorage.BF16``; the reserved FP8-weight profile
+    fails loud earlier at ``resolve_precision`` and never reaches construction.
     The capability claim itself is registered by the caller after the TE module
     is constructed, so coverage can bind to the real TE primitive instance.
     """
@@ -63,11 +65,6 @@ def _validate_bf16_weight_precision(
     implementation = active_precision(PrecisionPhase.MODEL_INIT)
     if coverage.implementation is not implementation:
         raise RuntimeError("precision coverage is bound to a different implementation")
-    if implementation.parameter_contract.compute_weight is not WeightStorage.BF16:
-        raise NotImplementedError(
-            "FP8-weight parameter initialization is not implemented by the "
-            "BF16-weight TE primitive path."
-        )
     if site not in implementation.fp8_sites:
         raise ValueError(f"site {site.value} is not an FP8 GEMM site")
     _validate_blockwise_features(in_features, out_features, site)

--- a/experimental/lite/megatron/lite/primitive/parallel/linear.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/linear.py
@@ -40,15 +40,20 @@ def _validate_blockwise_features(
             )
 
 
-def _bind_bf16_weight_precision(
+def _validate_bf16_weight_precision(
     coverage: PrecisionCoverage | None,
-    owner: object,
     site: SemanticSite | None,
-    capability: PrimitiveCapability,
     *,
     in_features: int,
     out_features: int,
 ) -> PrecisionImplementation | None:
+    """Validate one TP linear site against the active model-init profile.
+
+    Returns the bound implementation (or ``None`` when precision is unmanaged).
+    The capability claim itself is registered by the caller after the TE module
+    is constructed, so coverage can bind to the real TE primitive instance.
+    """
+
     if coverage is None:
         if site is not None:
             raise ValueError("precision_site requires a typed precision coverage collector")
@@ -66,7 +71,6 @@ def _bind_bf16_weight_precision(
     if site not in implementation.fp8_sites:
         raise ValueError(f"site {site.value} is not an FP8 GEMM site")
     _validate_blockwise_features(in_features, out_features, site)
-    coverage.claim(owner, site, capability)
     return implementation
 
 
@@ -278,11 +282,9 @@ class ColumnParallelLinear(nn.Module):
             if normalization is not None
             else PrimitiveCapability.TE_LINEAR
         )
-        self._precision_implementation = _bind_bf16_weight_precision(
+        self._precision_implementation = _validate_bf16_weight_precision(
             precision_coverage,
-            self,
             precision_site,
-            capability,
             in_features=in_features,
             out_features=self.local_out,
         )
@@ -311,6 +313,8 @@ class ColumnParallelLinear(nn.Module):
                 tp_group=ps.tp_group,
                 tp_size=ps.tp_size,
             )
+        if self._precision_implementation is not None:
+            precision_coverage.claim(self, precision_site, capability, self.linear)
         self.gather_output = gather_output
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -343,11 +347,9 @@ class RowParallelLinear(nn.Module):
         self.use_sp = ps.tp_size > 1
         self.local_in = ensure_divisible(in_features, ps.tp_size)
         self._precision_site = precision_site
-        self._precision_implementation = _bind_bf16_weight_precision(
+        self._precision_implementation = _validate_bf16_weight_precision(
             precision_coverage,
-            self,
             precision_site,
-            PrimitiveCapability.TE_LINEAR,
             in_features=self.local_in,
             out_features=out_features,
         )
@@ -361,6 +363,10 @@ class RowParallelLinear(nn.Module):
             tp_group=ps.tp_group,
             tp_size=ps.tp_size,
         )
+        if self._precision_implementation is not None:
+            precision_coverage.claim(
+                self, precision_site, PrimitiveCapability.TE_LINEAR, self.linear
+            )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         with _linear_precision_context(

--- a/experimental/lite/megatron/lite/primitive/parallel/linear.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/linear.py
@@ -39,21 +39,20 @@ def _validate_blockwise_features(
             )
 
 
-def _validate_bf16_weight_precision(
+def _validate_blockwise_precision(
     coverage: PrecisionCoverage | None,
     site: SemanticSite | None,
     *,
     in_features: int,
     out_features: int,
 ) -> PrecisionImplementation | None:
-    """Validate one TP linear site against the active model-init profile.
+    """Validate one TP linear site against the active blockwise profile.
 
     Returns the bound implementation (or ``None`` when precision is unmanaged).
-    The only resolvable blockwise profile stores BF16 compute weights, so this
-    path always sees ``WeightStorage.BF16``; the reserved FP8-weight profile
-    fails loud earlier at ``resolve_precision`` and never reaches construction.
-    The capability claim itself is registered by the caller after the TE module
-    is constructed, so coverage can bind to the real TE primitive instance.
+    Both closed profiles use the same typed site coverage; their compute-weight
+    storage differs only at Transformer Engine parameter construction. The
+    capability claim itself is registered by the caller after the TE module is
+    constructed, so coverage can bind to the real TE primitive instance.
     """
 
     if coverage is None:
@@ -279,7 +278,7 @@ class ColumnParallelLinear(nn.Module):
             if normalization is not None
             else PrimitiveCapability.TE_LINEAR
         )
-        self._precision_implementation = _validate_bf16_weight_precision(
+        self._precision_implementation = _validate_blockwise_precision(
             precision_coverage,
             precision_site,
             in_features=in_features,
@@ -344,7 +343,7 @@ class RowParallelLinear(nn.Module):
         self.use_sp = ps.tp_size > 1
         self.local_in = ensure_divisible(in_features, ps.tp_size)
         self._precision_site = precision_site
-        self._precision_implementation = _validate_bf16_weight_precision(
+        self._precision_implementation = _validate_blockwise_precision(
             precision_coverage,
             precision_site,
             in_features=self.local_in,

--- a/experimental/lite/megatron/lite/primitive/precision/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/precision/__init__.py
@@ -17,6 +17,7 @@ from megatron.lite.primitive.precision.coverage import (
     PrecisionCoverage,
 )
 from megatron.lite.primitive.precision.hopper_blockwise import (
+    FP8_WEIGHT_SUPPORTED_OPTIMIZERS,
     PRECISION_NAMES,
     PrecisionPhase,
     active_precision,
@@ -24,6 +25,7 @@ from megatron.lite.primitive.precision.hopper_blockwise import (
     precision_forward_context,
     precision_model_init_context,
     precision_site_forward_context,
+    require_optimizer_supports_precision,
     resolve_precision,
     validate_hopper_environment,
 )
@@ -32,6 +34,7 @@ __all__ = [
     "AuthoritativeSource",
     "CoverageEntry",
     "CoverageManifest",
+    "FP8_WEIGHT_SUPPORTED_OPTIMIZERS",
     "MasterOwner",
     "PRECISION_NAMES",
     "ParameterContract",
@@ -47,6 +50,7 @@ __all__ = [
     "precision_forward_context",
     "precision_model_init_context",
     "precision_site_forward_context",
+    "require_optimizer_supports_precision",
     "resolve_precision",
     "validate_hopper_environment",
 ]

--- a/experimental/lite/megatron/lite/primitive/precision/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/precision/__init__.py
@@ -23,6 +23,7 @@ from megatron.lite.primitive.precision.hopper_blockwise import (
     build_hopper_blockwise_recipe,
     precision_forward_context,
     precision_model_init_context,
+    precision_site_forward_context,
     resolve_precision,
     validate_hopper_environment,
 )
@@ -45,6 +46,7 @@ __all__ = [
     "build_hopper_blockwise_recipe",
     "precision_forward_context",
     "precision_model_init_context",
+    "precision_site_forward_context",
     "resolve_precision",
     "validate_hopper_environment",
 ]

--- a/experimental/lite/megatron/lite/primitive/precision/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/precision/__init__.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Public entrypoints for the closed MLite precision primitive."""
+
+from megatron.lite.primitive.precision.contract import (
+    AuthoritativeSource,
+    MasterOwner,
+    ParameterContract,
+    PrecisionDType,
+    PrecisionImplementation,
+    PrimitiveCapability,
+    SemanticSite,
+    WeightStorage,
+)
+from megatron.lite.primitive.precision.coverage import (
+    CoverageEntry,
+    CoverageManifest,
+    PrecisionCoverage,
+)
+from megatron.lite.primitive.precision.hopper_blockwise import (
+    PRECISION_NAMES,
+    PrecisionPhase,
+    active_precision,
+    build_hopper_blockwise_recipe,
+    precision_forward_context,
+    precision_model_init_context,
+    resolve_precision,
+    validate_hopper_environment,
+)
+
+__all__ = [
+    "AuthoritativeSource",
+    "CoverageEntry",
+    "CoverageManifest",
+    "MasterOwner",
+    "PRECISION_NAMES",
+    "ParameterContract",
+    "PrecisionCoverage",
+    "PrecisionDType",
+    "PrecisionImplementation",
+    "PrecisionPhase",
+    "PrimitiveCapability",
+    "SemanticSite",
+    "WeightStorage",
+    "active_precision",
+    "build_hopper_blockwise_recipe",
+    "precision_forward_context",
+    "precision_model_init_context",
+    "resolve_precision",
+    "validate_hopper_environment",
+]

--- a/experimental/lite/megatron/lite/primitive/precision/contract.py
+++ b/experimental/lite/megatron/lite/primitive/precision/contract.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Closed precision records shared by MLite runtime and primitives."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+
+class SemanticSite(str, Enum):
+    """Typed model-composition sites relevant to the closed FP8 profiles."""
+
+    ATTENTION_PROJECTION = "attention_projection"
+    DENSE_MLP = "dense_mlp"
+    MOE_EXPERT = "moe_expert"
+    ATTENTION_CORE = "attention_core"
+    ROUTER = "router"
+    NORM = "norm"
+    EMBEDDING = "embedding"
+    LM_HEAD = "lm_head"
+
+
+class PrimitiveCapability(str, Enum):
+    """TE primitive capabilities that may satisfy an FP8 coverage requirement."""
+
+    TE_LINEAR = "te_linear"
+    TE_LAYERNORM_LINEAR = "te_layernorm_linear"
+    TE_GROUPED_LINEAR = "te_grouped_linear"
+
+
+class WeightStorage(str, Enum):
+    """Storage used by selected GEMM compute parameters."""
+
+    BF16 = "bf16"
+    FP8_BLOCKWISE_E4M3 = "fp8_blockwise_e4m3"
+
+
+class PrecisionDType(str, Enum):
+    """Dtypes at the parameter, gradient, optimizer, and communication boundaries."""
+
+    BF16 = "bf16"
+    FP32 = "fp32"
+
+
+class AuthoritativeSource(str, Enum):
+    """Source from which compute and master parameters must be initialized."""
+
+    HIGH_PRECISION = "high_precision_source"
+
+
+class MasterOwner(str, Enum):
+    """The single owner of the authoritative FP32 optimizer master."""
+
+    MLITE_OPTIMIZER = "mlite_optimizer"
+
+
+@dataclass(frozen=True, slots=True)
+class ParameterContract:
+    """Precision and ownership boundaries for one closed profile."""
+
+    compute_weight: WeightStorage
+    authoritative_load_source: AuthoritativeSource
+    master_parameter: PrecisionDType
+    main_gradient: PrecisionDType
+    optimizer_state: PrecisionDType
+    parameter_all_gather: PrecisionDType
+    master_owner: MasterOwner
+
+
+@dataclass(frozen=True, slots=True)
+class PrecisionImplementation:
+    """One immutable, closed precision profile implementation."""
+
+    name: str
+    recipe_factory: Callable[[], Any]
+    fp8_sites: frozenset[SemanticSite]
+    bf16_sites: frozenset[SemanticSite]
+    parameter_contract: ParameterContract

--- a/experimental/lite/megatron/lite/primitive/precision/coverage.py
+++ b/experimental/lite/megatron/lite/primitive/precision/coverage.py
@@ -15,6 +15,23 @@ from megatron.lite.primitive.precision.hopper_blockwise import (
     active_precision,
 )
 
+# Each FP8 capability may only be claimed by the exact Transformer Engine GEMM
+# primitive that implements it. Resolving the class lazily keeps this module
+# importable on hosts without Transformer Engine (CPU unit tests).
+_CAPABILITY_TE_ATTR: dict[PrimitiveCapability, str] = {
+    PrimitiveCapability.TE_LINEAR: "Linear",
+    PrimitiveCapability.TE_LAYERNORM_LINEAR: "LayerNormLinear",
+    PrimitiveCapability.TE_GROUPED_LINEAR: "GroupedLinear",
+}
+
+
+def _te_primitive_type(capability: PrimitiveCapability) -> type:
+    """Return the TE primitive class that a capability must be backed by."""
+
+    import transformer_engine.pytorch as te  # local import: keep CPU import-safety
+
+    return getattr(te, _CAPABILITY_TE_ATTR[capability])
+
 
 @dataclass(frozen=True, slots=True)
 class _Requirement:
@@ -111,15 +128,35 @@ class PrecisionCoverage:
         owner: object,
         site: SemanticSite,
         capability: PrimitiveCapability,
+        primitive: object = None,
         *,
         diagnostic: str = "",
     ) -> None:
-        """Claim one exact concrete site from a typed reusable primitive."""
+        """Claim one exact concrete site, backed by a real TE primitive.
+
+        ``owner`` is the identity matched against the declared requirement.
+        ``primitive`` is the object whose type must actually implement the
+        capability; it defaults to ``owner`` for primitives that expose the TE
+        module directly (dense MLP, MoE experts) and is passed explicitly by
+        wrappers whose owner is not itself the TE module (TP linears). The
+        type check makes a capability unforgeable: a non-TE module (e.g. a raw
+        ``torch.nn.Linear`` or an SDPA/matmul owner) cannot masquerade as an
+        FP8-capable GEMM site.
+        """
 
         self._ensure_collecting()
         self._validate_owner_site(owner, site)
         if not isinstance(capability, PrimitiveCapability):
             raise TypeError("coverage capability must be a PrimitiveCapability")
+        witness = owner if primitive is None else primitive
+        expected = _te_primitive_type(capability)
+        if not isinstance(witness, expected):
+            actual = type(witness)
+            raise TypeError(
+                f"capability {capability.value} at {site.value} must be backed by a "
+                f"real transformer_engine.pytorch.{_CAPABILITY_TE_ATTR[capability]} "
+                f"primitive; got {actual.__module__}.{actual.__qualname__}"
+            )
         self._claims.append(_Claim(owner, site, capability, diagnostic))
 
     @property

--- a/experimental/lite/megatron/lite/primitive/precision/coverage.py
+++ b/experimental/lite/megatron/lite/primitive/precision/coverage.py
@@ -33,6 +33,29 @@ def _te_primitive_type(capability: PrimitiveCapability) -> type:
     return getattr(te, _CAPABILITY_TE_ATTR[capability])
 
 
+def _witness_belongs_to_owner(owner: object, witness: object) -> bool:
+    """True only when ``witness`` is ``owner`` itself or a submodule registered on it.
+
+    Closes the borrowed-witness hole: the primitive type check alone proves only
+    that *some* real TE instance exists, not that *this* owner's GEMM is that
+    instance. A caller could otherwise hand an unrelated ``te.Linear`` as witness
+    to seal a foreign owner (e.g. a raw ``nn.Linear``) and forge coverage. Every
+    genuine claim keeps the witness bound to the owner: dense MLP and MoE experts
+    pass the TE module itself as owner (witness is owner), while a TP-linear
+    wrapper passes its own registered ``self.linear`` submodule as witness. TE
+    GEMM primitives are ``nn.Module`` instances, so an authentic witness is
+    always reachable from the owner via ``nn.Module.modules()``.
+    """
+
+    if witness is owner:
+        return True
+    import torch  # local import: keep this module import-safe without torch at import time
+
+    if not isinstance(owner, torch.nn.Module):
+        return False
+    return any(module is witness for module in owner.modules())
+
+
 @dataclass(frozen=True, slots=True)
 class _Requirement:
     owner: object
@@ -149,6 +172,14 @@ class PrecisionCoverage:
         if not isinstance(capability, PrimitiveCapability):
             raise TypeError("coverage capability must be a PrimitiveCapability")
         witness = owner if primitive is None else primitive
+        if not _witness_belongs_to_owner(owner, witness):
+            actual = type(witness)
+            raise TypeError(
+                f"capability {capability.value} at {site.value} witness "
+                f"{actual.__module__}.{actual.__qualname__} is neither the coverage "
+                "owner nor one of its registered submodules; a claim cannot borrow an "
+                "unrelated primitive instance to seal a foreign owner"
+            )
         expected = _te_primitive_type(capability)
         if not isinstance(witness, expected):
             actual = type(witness)

--- a/experimental/lite/megatron/lite/primitive/precision/coverage.py
+++ b/experimental/lite/megatron/lite/primitive/precision/coverage.py
@@ -123,6 +123,12 @@ class PrecisionCoverage:
         self._claims.append(_Claim(owner, site, capability, diagnostic))
 
     @property
+    def implementation(self) -> PrecisionImplementation:
+        """Return the closed implementation this collector is bound to."""
+
+        return self._implementation
+
+    @property
     def manifest(self) -> CoverageManifest:
         if self._manifest is None:
             raise RuntimeError(

--- a/experimental/lite/megatron/lite/primitive/precision/coverage.py
+++ b/experimental/lite/megatron/lite/primitive/precision/coverage.py
@@ -1,0 +1,213 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Exact typed coverage binding for the closed precision profiles."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from megatron.lite.primitive.precision.contract import (
+    PrecisionImplementation,
+    PrimitiveCapability,
+    SemanticSite,
+)
+from megatron.lite.primitive.precision.hopper_blockwise import (
+    PrecisionPhase,
+    active_precision,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _Requirement:
+    owner: object
+    site: SemanticSite
+    capabilities: frozenset[PrimitiveCapability]
+    diagnostic: str
+
+
+@dataclass(frozen=True, slots=True)
+class _Claim:
+    owner: object
+    site: SemanticSite
+    capability: PrimitiveCapability
+    diagnostic: str
+
+
+@dataclass(frozen=True, slots=True)
+class CoverageEntry:
+    """One sealed semantic site and the primitive capability bound to it."""
+
+    object_id: int
+    site: SemanticSite
+    capability: PrimitiveCapability | None
+    diagnostic: str
+
+
+@dataclass(frozen=True, slots=True)
+class CoverageManifest:
+    """Immutable proof that every declared concrete site was bound exactly once."""
+
+    implementation_name: str
+    entries: tuple[CoverageEntry, ...]
+
+
+class PrecisionCoverage:
+    """Collect typed requirements and claims during one model construction."""
+
+    __slots__ = ("_claims", "_implementation", "_manifest", "_requirements")
+
+    def __init__(self, implementation: PrecisionImplementation):
+        if not isinstance(implementation, PrecisionImplementation):
+            raise TypeError("coverage requires a PrecisionImplementation")
+        self._implementation = implementation
+        self._requirements: list[_Requirement] = []
+        self._claims: list[_Claim] = []
+        self._manifest: CoverageManifest | None = None
+
+    def _ensure_collecting(self) -> None:
+        if self._manifest is not None:
+            raise RuntimeError("precision coverage is already sealed")
+        if active_precision(PrecisionPhase.MODEL_INIT) is not self._implementation:
+            raise RuntimeError(
+                "precision coverage is bound to a different model-init context"
+            )
+
+    @staticmethod
+    def _validate_owner_site(owner: object, site: SemanticSite) -> None:
+        if owner is None:
+            raise TypeError("coverage owner cannot be None")
+        if not isinstance(site, SemanticSite):
+            raise TypeError("coverage site must be a SemanticSite")
+
+    def require(
+        self,
+        owner: object,
+        site: SemanticSite,
+        capabilities: frozenset[PrimitiveCapability] = frozenset(),
+        *,
+        diagnostic: str = "",
+    ) -> None:
+        """Declare one concrete FP8 site or fixed-BF16 exclusion."""
+
+        self._ensure_collecting()
+        self._validate_owner_site(owner, site)
+        if not isinstance(capabilities, frozenset) or not all(
+            isinstance(capability, PrimitiveCapability) for capability in capabilities
+        ):
+            raise TypeError(
+                "coverage capabilities must be a frozenset of PrimitiveCapability"
+            )
+        if site in self._implementation.fp8_sites and not capabilities:
+            raise ValueError(
+                f"FP8 site {site.value} must declare compatible primitive capabilities"
+            )
+        if site in self._implementation.bf16_sites and capabilities:
+            raise ValueError(
+                f"fixed BF16 site {site.value} cannot accept an FP8 capability"
+            )
+        self._requirements.append(_Requirement(owner, site, capabilities, diagnostic))
+
+    def claim(
+        self,
+        owner: object,
+        site: SemanticSite,
+        capability: PrimitiveCapability,
+        *,
+        diagnostic: str = "",
+    ) -> None:
+        """Claim one exact concrete site from a typed reusable primitive."""
+
+        self._ensure_collecting()
+        self._validate_owner_site(owner, site)
+        if not isinstance(capability, PrimitiveCapability):
+            raise TypeError("coverage capability must be a PrimitiveCapability")
+        self._claims.append(_Claim(owner, site, capability, diagnostic))
+
+    @property
+    def manifest(self) -> CoverageManifest:
+        if self._manifest is None:
+            raise RuntimeError(
+                "precision coverage was not sealed before optimizer construction"
+            )
+        return self._manifest
+
+    @staticmethod
+    def _key(item: _Requirement | _Claim) -> tuple[int, SemanticSite]:
+        return (id(item.owner), item.site)
+
+    def seal(self) -> CoverageManifest:
+        """Match requirements and claims exactly, then make the manifest immutable."""
+
+        self._ensure_collecting()
+        requirement_groups: dict[tuple[int, SemanticSite], list[_Requirement]] = {}
+        claim_groups: dict[tuple[int, SemanticSite], list[_Claim]] = {}
+        for requirement in self._requirements:
+            requirement_groups.setdefault(self._key(requirement), []).append(
+                requirement
+            )
+        for claim in self._claims:
+            claim_groups.setdefault(self._key(claim), []).append(claim)
+
+        errors: list[str] = []
+        for requirements in requirement_groups.values():
+            if len(requirements) > 1:
+                errors.append(
+                    f"duplicate requirement for {requirements[0].site.value} "
+                    f"({requirements[0].diagnostic})"
+                )
+        for claims in claim_groups.values():
+            if len(claims) > 1:
+                errors.append(
+                    f"duplicate claim for {claims[0].site.value} ({claims[0].diagnostic})"
+                )
+
+        entries: list[CoverageEntry] = []
+        for requirement in self._requirements:
+            key = self._key(requirement)
+            claims = claim_groups.get(key, [])
+            if requirement.site in self._implementation.bf16_sites:
+                if claims:
+                    errors.append(
+                        f"fixed BF16 site {requirement.site.value} received an FP8 claim "
+                        f"({requirement.diagnostic})"
+                    )
+                entries.append(
+                    CoverageEntry(
+                        id(requirement.owner),
+                        requirement.site,
+                        None,
+                        requirement.diagnostic,
+                    )
+                )
+                continue
+            if not claims:
+                errors.append(
+                    f"missing claim for {requirement.site.value} ({requirement.diagnostic})"
+                )
+                continue
+            claim = claims[0]
+            if claim.capability not in requirement.capabilities:
+                errors.append(
+                    f"incompatible capability {claim.capability.value} for {requirement.site.value} "
+                    f"({requirement.diagnostic})"
+                )
+                continue
+            entries.append(
+                CoverageEntry(
+                    id(requirement.owner),
+                    requirement.site,
+                    claim.capability,
+                    requirement.diagnostic or claim.diagnostic,
+                )
+            )
+
+        for key, claims in claim_groups.items():
+            if key not in requirement_groups:
+                claim = claims[0]
+                errors.append(
+                    f"unconsumed claim for {claim.site.value} ({claim.diagnostic})"
+                )
+
+        if errors:
+            raise ValueError("precision coverage failed: " + "; ".join(errors))
+        self._manifest = CoverageManifest(self._implementation.name, tuple(entries))
+        return self._manifest

--- a/experimental/lite/megatron/lite/primitive/precision/hopper_blockwise.py
+++ b/experimental/lite/megatron/lite/primitive/precision/hopper_blockwise.py
@@ -21,9 +21,14 @@ from megatron.lite.primitive.precision.contract import (
     WeightStorage,
 )
 
-FROZEN_TRANSFORMER_ENGINE_VERSION = "2.18.0.dev0"
-FROZEN_TRANSFORMER_ENGINE_COMMIT = "8b9968255eb879e6e390f427836906b29aad64d2"
-_FROZEN_TRANSFORMER_ENGINE_SHORT_COMMIT = FROZEN_TRANSFORMER_ENGINE_COMMIT[:7]
+# The canonical training image ships a released Transformer Engine. Blockwise
+# FP8 runs on the same image that runs BF16 -- no FP8-only overlay -- so the gate
+# pins the released version validated on that image, not a bespoke build commit.
+# Requiring an exact build SHA would recreate a special-environment requirement;
+# the real fail-loud safety net is the capability probe below (SM90, block
+# scaling support, cuBLAS, CUDA). The build tag is recorded for provenance only.
+CANONICAL_TRANSFORMER_ENGINE_VERSION = "2.15.0"
+CANONICAL_TRANSFORMER_ENGINE_BUILD_TAG = "42b84005"
 
 PRECISION_NAMES = (
     "bf16",
@@ -197,7 +202,7 @@ def _probe_hopper_environment() -> _HopperEnvironment:
 
 
 def validate_hopper_environment() -> _HopperEnvironment:
-    """Fail before model allocation unless the frozen Hopper environment is present."""
+    """Fail before model allocation unless the canonical Hopper environment is present."""
 
     _validate_recipe_environment()
     environment = _probe_hopper_environment()
@@ -207,19 +212,11 @@ def validate_hopper_environment() -> _HopperEnvironment:
             f"{environment.compute_capability}."
         )
 
-    version, separator, local = environment.transformer_engine_version.partition("+")
-    if version != FROZEN_TRANSFORMER_ENGINE_VERSION:
+    version, _separator, _local = environment.transformer_engine_version.partition("+")
+    if version != CANONICAL_TRANSFORMER_ENGINE_VERSION:
         raise RuntimeError(
             "Hopper blockwise FP8 requires Transformer Engine "
-            f"{FROZEN_TRANSFORMER_ENGINE_VERSION}; found {environment.transformer_engine_version}."
-        )
-    if separator and (
-        len(local) < len(_FROZEN_TRANSFORMER_ENGINE_SHORT_COMMIT)
-        or not FROZEN_TRANSFORMER_ENGINE_COMMIT.startswith(local)
-    ):
-        raise RuntimeError(
-            "Hopper blockwise FP8 requires Transformer Engine commit "
-            f"{_FROZEN_TRANSFORMER_ENGINE_SHORT_COMMIT}; found local version {local!r}."
+            f"{CANONICAL_TRANSFORMER_ENGINE_VERSION}; found {environment.transformer_engine_version}."
         )
     if environment.cuda_version < (12, 9):
         raise RuntimeError(

--- a/experimental/lite/megatron/lite/primitive/precision/hopper_blockwise.py
+++ b/experimental/lite/megatron/lite/primitive/precision/hopper_blockwise.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+import warnings
 from contextlib import AbstractContextManager, contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -21,19 +22,26 @@ from megatron.lite.primitive.precision.contract import (
     WeightStorage,
 )
 
-# The canonical training image ships a released Transformer Engine. Blockwise
-# FP8 runs on the same image that runs BF16 -- no FP8-only overlay -- so the gate
-# pins the released version validated on that image, not a bespoke build commit.
-# Requiring an exact build SHA would recreate a special-environment requirement;
-# the real fail-loud safety net is the capability probe below (SM90, block
-# scaling support, cuBLAS, CUDA). The build tag is recorded for provenance only.
+# The canonical training image ships a released Transformer Engine on which the
+# parity evidence was recorded. Blockwise FP8 runs on the *same* image that runs
+# BF16 -- no FP8-only overlay -- so this version is recorded for provenance, not
+# used as a hard runtime gate. The only authoritative runtime gate is Transformer
+# Engine's own capability probe (``check_fp8_block_scaling_support``); pinning an
+# exact TE/CUDA/SM version would recreate a special-environment requirement and
+# could reject FP8 on a newer or different accelerator where BF16 runs fine. A
+# probed toolchain that differs from this canonical version emits a fail-loud
+# provenance warning but is not blocked.
 CANONICAL_TRANSFORMER_ENGINE_VERSION = "2.15.0"
-CANONICAL_TRANSFORMER_ENGINE_BUILD_TAG = "42b84005"
+
+# Reserved name for the second closed profile (FP8 parameter storage). The closed
+# design declares it, but its FP8-weight initialization is not implemented in this
+# build, so it is not offered as a usable precision: resolving it fails loud
+# instead of advertising a profile no primitive can construct.
+_RESERVED_FP8_WEIGHT_NAME = "hopper_blockwise_fp8_weight"
 
 PRECISION_NAMES = (
     "bf16",
     "hopper_blockwise_bf16_weight",
-    "hopper_blockwise_fp8_weight",
 )
 
 _FP8_SITES = frozenset(
@@ -140,17 +148,17 @@ HOPPER_BLOCKWISE_BF16_WEIGHT = PrecisionImplementation(
     bf16_sites=_BF16_SITES,
     parameter_contract=_parameter_contract(WeightStorage.BF16),
 )
-HOPPER_BLOCKWISE_FP8_WEIGHT = PrecisionImplementation(
-    name="hopper_blockwise_fp8_weight",
-    recipe_factory=build_hopper_blockwise_recipe,
-    fp8_sites=_FP8_SITES,
-    bf16_sites=_BF16_SITES,
-    parameter_contract=_parameter_contract(WeightStorage.FP8_BLOCKWISE_E4M3),
-)
 
 
 def resolve_precision(name: str) -> PrecisionImplementation | None:
-    """Resolve one of the three accepted public precision names."""
+    """Resolve one of the accepted public precision names.
+
+    ``bf16`` disables managed precision. ``hopper_blockwise_bf16_weight`` is the
+    single implemented blockwise profile. ``hopper_blockwise_fp8_weight`` is a
+    reserved-but-unimplemented profile (FP8 parameter storage,
+    ``WeightStorage.FP8_BLOCKWISE_E4M3``); requesting it fails loud rather than
+    handing back a profile that no primitive can construct.
+    """
 
     if not isinstance(name, str):
         raise TypeError("precision must be a string")
@@ -158,8 +166,14 @@ def resolve_precision(name: str) -> PrecisionImplementation | None:
         return None
     if name == HOPPER_BLOCKWISE_BF16_WEIGHT.name:
         return HOPPER_BLOCKWISE_BF16_WEIGHT
-    if name == HOPPER_BLOCKWISE_FP8_WEIGHT.name:
-        return HOPPER_BLOCKWISE_FP8_WEIGHT
+    if name == _RESERVED_FP8_WEIGHT_NAME:
+        raise NotImplementedError(
+            f"{_RESERVED_FP8_WEIGHT_NAME} (FP8 parameter storage, "
+            f"{WeightStorage.FP8_BLOCKWISE_E4M3.value}) is not implemented in this "
+            "build; only hopper_blockwise_bf16_weight is available. FP8-weight "
+            "initialization is a declared-but-pending second profile tracked as a "
+            "separate follow-up."
+        )
     accepted = ", ".join(PRECISION_NAMES)
     raise ValueError(f"precision must be one of: {accepted}; got {name!r}")
 
@@ -201,39 +215,57 @@ def _probe_hopper_environment() -> _HopperEnvironment:
     )
 
 
-def validate_hopper_environment() -> _HopperEnvironment:
-    """Fail before model allocation unless the canonical Hopper environment is present."""
+def _warn_on_unvalidated_toolchain(environment: _HopperEnvironment) -> None:
+    """Emit a non-blocking provenance warning when the toolchain is not canonical.
 
-    _validate_recipe_environment()
-    environment = _probe_hopper_environment()
-    if environment.compute_capability != (9, 0):
-        raise RuntimeError(
-            "Hopper blockwise FP8 requires exactly SM90; found compute capability "
-            f"{environment.compute_capability}."
-        )
+    Honours the environment rule "whatever runs BF16 must run FP8": a differing
+    Transformer Engine version is *not* a hard gate (the capability probe already
+    proved blockwise FP8 works), but it is surfaced loudly so a run on an
+    unvalidated toolchain is never silent.
+    """
 
     version, _separator, _local = environment.transformer_engine_version.partition("+")
     if version != CANONICAL_TRANSFORMER_ENGINE_VERSION:
-        raise RuntimeError(
-            "Hopper blockwise FP8 requires Transformer Engine "
-            f"{CANONICAL_TRANSFORMER_ENGINE_VERSION}; found {environment.transformer_engine_version}."
+        warnings.warn(
+            "Blockwise FP8 is running on Transformer Engine "
+            f"{environment.transformer_engine_version}, which differs from the "
+            f"canonical validated version {CANONICAL_TRANSFORMER_ENGINE_VERSION}. "
+            "The capability probe succeeded so this is allowed, but parity evidence "
+            "was recorded against the canonical version.",
+            RuntimeWarning,
+            stacklevel=2,
         )
-    if environment.cuda_version < (12, 9):
-        raise RuntimeError(
-            "Hopper blockwise FP8 requires CUDA 12.9 or newer; found "
-            f"{environment.cuda_version[0]}.{environment.cuda_version[1]}."
-        )
-    if environment.cublas_version < 130400:
-        raise RuntimeError(
-            "Hopper blockwise FP8 MoE requires cuBLAS 13.4 or newer; found encoded version "
-            f"{environment.cublas_version}."
-        )
+
+
+def validate_hopper_environment() -> _HopperEnvironment:
+    """Fail loud before model allocation unless this environment supports blockwise FP8.
+
+    The single authoritative gate is Transformer Engine's own capability probe
+    (``check_fp8_block_scaling_support`` inside ``_probe_hopper_environment``).
+    There is deliberately no hard pin on an exact device class, TE version, or
+    CUDA/cuBLAS threshold: blockwise FP8 must run on the same canonical image
+    that runs BF16, and version pins would recreate a special-environment
+    requirement and could reject FP8 on a newer or different accelerator where
+    BF16 is fine. When the probe rejects the environment we fail loud with its
+    concrete reason plus the recorded toolchain for diagnosis.
+    """
+
+    _validate_recipe_environment()
+    environment = _probe_hopper_environment()
     if not environment.block_scaling_supported:
         reason = (
             environment.unsupported_reason
-            or "Transformer Engine rejected block scaling"
+            or "Transformer Engine reported no blockwise FP8 support"
         )
-        raise RuntimeError(f"Hopper blockwise FP8 is unavailable: {reason}")
+        raise RuntimeError(
+            "Blockwise FP8 is unavailable in this environment: "
+            f"{reason} (device compute capability "
+            f"{environment.compute_capability[0]}.{environment.compute_capability[1]}, "
+            f"Transformer Engine {environment.transformer_engine_version}, "
+            f"CUDA {environment.cuda_version[0]}.{environment.cuda_version[1]}, "
+            f"cuBLASLt {environment.cublas_version})."
+        )
+    _warn_on_unvalidated_toolchain(environment)
     return environment
 
 

--- a/experimental/lite/megatron/lite/primitive/precision/hopper_blockwise.py
+++ b/experimental/lite/megatron/lite/primitive/precision/hopper_blockwise.py
@@ -33,6 +33,20 @@ from megatron.lite.primitive.precision.contract import (
 # provenance warning but is not blocked.
 CANONICAL_TRANSFORMER_ENGINE_VERSION = "2.15.0"
 
+# Minimum cuBLASLt version for the blockwise *GroupedLinear* (MoE expert) path.
+# TE guards grouped GEMM with ``CUBLAS_GROUPED_GEMM_VERSION`` and requires cuBLAS
+# >= 13.3, a requirement the general block-scaling capability probe does not
+# cover: an environment can pass ``check_fp8_block_scaling_support`` (blockwise
+# Linear/LayerNormLinear work) while grouped GEMM crashes for lack of the grouped
+# kernel. A MoE FP8 profile therefore gates this requirement independently and
+# fails loud before allocation instead of dying inside the grouped GEMM. Encoded
+# like ``tex.get_cublasLt_version()`` (major*10000 + minor*100 + patch): 13.3 ->
+# 130300; the canonical qualification image reports 130401 (cuBLAS 13.4.1). This
+# is *not* a device/CUDA/TE version pin (that hard gate was removed): it is TE's
+# own grouped-GEMM hard requirement, scoped to profiles that select MoE experts.
+# Source: TransformerEngine v2.15 common/gemm/cublaslt_grouped_gemm.cu.
+CUBLAS_GROUPED_GEMM_MIN_VERSION = 130300
+
 # Reserved name for the second closed profile (FP8 parameter storage). The closed
 # design declares it, but its FP8-weight initialization is not implemented in this
 # build, so it is not offered as a usable precision: resolving it fails loud
@@ -237,17 +251,26 @@ def _warn_on_unvalidated_toolchain(environment: _HopperEnvironment) -> None:
         )
 
 
-def validate_hopper_environment() -> _HopperEnvironment:
+def validate_hopper_environment(
+    implementation: PrecisionImplementation | None = None,
+) -> _HopperEnvironment:
     """Fail loud before model allocation unless this environment supports blockwise FP8.
 
-    The single authoritative gate is Transformer Engine's own capability probe
+    The primary authoritative gate is Transformer Engine's own capability probe
     (``check_fp8_block_scaling_support`` inside ``_probe_hopper_environment``).
     There is deliberately no hard pin on an exact device class, TE version, or
-    CUDA/cuBLAS threshold: blockwise FP8 must run on the same canonical image
-    that runs BF16, and version pins would recreate a special-environment
-    requirement and could reject FP8 on a newer or different accelerator where
-    BF16 is fine. When the probe rejects the environment we fail loud with its
-    concrete reason plus the recorded toolchain for diagnosis.
+    CUDA/cuBLAS threshold for the general blockwise path: blockwise FP8 must run
+    on the same canonical image that runs BF16, and version pins would recreate a
+    special-environment requirement and could reject FP8 on a newer or different
+    accelerator where BF16 is fine. When the probe rejects the environment we
+    fail loud with its concrete reason plus the recorded toolchain for diagnosis.
+
+    When ``implementation`` selects MoE experts (blockwise ``GroupedLinear``),
+    one additional TE-owned requirement is gated: the grouped GEMM needs cuBLAS
+    >= ``CUBLAS_GROUPED_GEMM_MIN_VERSION``, which the block-scaling probe does not
+    cover. This is not a reintroduced device/CUDA pin; it is TE's own grouped
+    hard requirement, so a MoE FP8 run on an under-versioned cuBLAS fails loud
+    here rather than crashing inside the grouped GEMM.
     """
 
     _validate_recipe_environment()
@@ -264,6 +287,20 @@ def validate_hopper_environment() -> _HopperEnvironment:
             f"Transformer Engine {environment.transformer_engine_version}, "
             f"CUDA {environment.cuda_version[0]}.{environment.cuda_version[1]}, "
             f"cuBLASLt {environment.cublas_version})."
+        )
+    if (
+        implementation is not None
+        and SemanticSite.MOE_EXPERT in implementation.fp8_sites
+        and environment.cublas_version < CUBLAS_GROUPED_GEMM_MIN_VERSION
+    ):
+        raise RuntimeError(
+            "Blockwise FP8 MoE experts require Transformer Engine's grouped GEMM, "
+            f"which needs cuBLAS >= {CUBLAS_GROUPED_GEMM_MIN_VERSION} "
+            "(CUBLAS_GROUPED_GEMM_VERSION guard); this environment reports cuBLASLt "
+            f"{environment.cublas_version}. The block-scaling probe can pass for "
+            "blockwise Linear/LayerNormLinear while GroupedLinear crashes, so the "
+            f"MoE FP8 profile {implementation.name!r} is gated here rather than left "
+            "to fail inside the grouped GEMM."
         )
     _warn_on_unvalidated_toolchain(environment)
     return environment

--- a/experimental/lite/megatron/lite/primitive/precision/hopper_blockwise.py
+++ b/experimental/lite/megatron/lite/primitive/precision/hopper_blockwise.py
@@ -281,6 +281,35 @@ def precision_forward_context(
     return _precision_context(PrecisionPhase.FORWARD, implementation)
 
 
+def precision_site_forward_context(
+    implementation: PrecisionImplementation,
+    site: SemanticSite,
+) -> AbstractContextManager[None]:
+    """Open TE FP8 autocast for one selected semantic GEMM site only."""
+
+    if not isinstance(site, SemanticSite):
+        raise TypeError("precision site must be a SemanticSite")
+    active = active_precision(PrecisionPhase.FORWARD)
+    if active is not implementation:
+        raise RuntimeError(
+            "precision primitive is bound to a different runtime forward context"
+        )
+    if site in implementation.bf16_sites:
+        raise ValueError(f"fixed BF16 site {site.value} cannot enter FP8 autocast")
+    if site not in implementation.fp8_sites:
+        raise ValueError(
+            f"site {site.value} is not selected by {implementation.name}"
+        )
+
+    import transformer_engine.pytorch as te
+
+    return te.fp8_autocast(
+        enabled=True,
+        fp8_recipe=implementation.recipe_factory(),
+        fp8_group=None,
+    )
+
+
 def active_precision(phase: PrecisionPhase) -> PrecisionImplementation:
     """Return the runtime-bound implementation for an exact lifecycle phase."""
 

--- a/experimental/lite/megatron/lite/primitive/precision/hopper_blockwise.py
+++ b/experimental/lite/megatron/lite/primitive/precision/hopper_blockwise.py
@@ -47,15 +47,10 @@ CANONICAL_TRANSFORMER_ENGINE_VERSION = "2.15.0"
 # Source: TransformerEngine v2.15 common/gemm/cublaslt_grouped_gemm.cu.
 CUBLAS_GROUPED_GEMM_MIN_VERSION = 130300
 
-# Reserved name for the second closed profile (FP8 parameter storage). The closed
-# design declares it, but its FP8-weight initialization is not implemented in this
-# build, so it is not offered as a usable precision: resolving it fails loud
-# instead of advertising a profile no primitive can construct.
-_RESERVED_FP8_WEIGHT_NAME = "hopper_blockwise_fp8_weight"
-
 PRECISION_NAMES = (
     "bf16",
     "hopper_blockwise_bf16_weight",
+    "hopper_blockwise_fp8_weight",
 )
 
 _FP8_SITES = frozenset(
@@ -163,15 +158,21 @@ HOPPER_BLOCKWISE_BF16_WEIGHT = PrecisionImplementation(
     parameter_contract=_parameter_contract(WeightStorage.BF16),
 )
 
+HOPPER_BLOCKWISE_FP8_WEIGHT = PrecisionImplementation(
+    name="hopper_blockwise_fp8_weight",
+    recipe_factory=build_hopper_blockwise_recipe,
+    fp8_sites=_FP8_SITES,
+    bf16_sites=_BF16_SITES,
+    parameter_contract=_parameter_contract(WeightStorage.FP8_BLOCKWISE_E4M3),
+)
+
 
 def resolve_precision(name: str) -> PrecisionImplementation | None:
     """Resolve one of the accepted public precision names.
 
-    ``bf16`` disables managed precision. ``hopper_blockwise_bf16_weight`` is the
-    single implemented blockwise profile. ``hopper_blockwise_fp8_weight`` is a
-    reserved-but-unimplemented profile (FP8 parameter storage,
-    ``WeightStorage.FP8_BLOCKWISE_E4M3``); requesting it fails loud rather than
-    handing back a profile that no primitive can construct.
+    ``bf16`` disables managed precision. The two Hopper profiles share the
+    frozen recipe and typed coverage but differ only in selected GEMM weight
+    storage.
     """
 
     if not isinstance(name, str):
@@ -180,14 +181,8 @@ def resolve_precision(name: str) -> PrecisionImplementation | None:
         return None
     if name == HOPPER_BLOCKWISE_BF16_WEIGHT.name:
         return HOPPER_BLOCKWISE_BF16_WEIGHT
-    if name == _RESERVED_FP8_WEIGHT_NAME:
-        raise NotImplementedError(
-            f"{_RESERVED_FP8_WEIGHT_NAME} (FP8 parameter storage, "
-            f"{WeightStorage.FP8_BLOCKWISE_E4M3.value}) is not implemented in this "
-            "build; only hopper_blockwise_bf16_weight is available. FP8-weight "
-            "initialization is a declared-but-pending second profile tracked as a "
-            "separate follow-up."
-        )
+    if name == HOPPER_BLOCKWISE_FP8_WEIGHT.name:
+        return HOPPER_BLOCKWISE_FP8_WEIGHT
     accepted = ", ".join(PRECISION_NAMES)
     raise ValueError(f"precision must be one of: {accepted}; got {name!r}")
 
@@ -336,7 +331,31 @@ def precision_model_init_context(
 ) -> AbstractContextManager[PrecisionImplementation]:
     """Bind one implementation while model composition declares typed coverage."""
 
-    return _precision_context(PrecisionPhase.MODEL_INIT, implementation)
+    if implementation.parameter_contract.compute_weight is WeightStorage.BF16:
+        return _precision_context(PrecisionPhase.MODEL_INIT, implementation)
+    return _quantized_precision_model_init_context(implementation)
+
+
+@contextmanager
+def _quantized_precision_model_init_context(
+    implementation: PrecisionImplementation,
+) -> Iterator[PrecisionImplementation]:
+    """Construct TE FP8 parameters while retaining their FP32 source values.
+
+    TE owns quantization and FSDP hooks for its Float8Tensor.  MLite only owns
+    the subsequently-created FP32 optimizer master, so this deliberately does
+    not request TE optimizer masters.
+    """
+
+    from transformer_engine.pytorch.quantization import quantized_model_init
+
+    with quantized_model_init(
+        enabled=True,
+        recipe=implementation.recipe_factory(),
+        preserve_high_precision_init_val=True,
+    ):
+        with _precision_context(PrecisionPhase.MODEL_INIT, implementation) as active:
+            yield active
 
 
 def precision_forward_context(

--- a/experimental/lite/megatron/lite/primitive/precision/hopper_blockwise.py
+++ b/experimental/lite/megatron/lite/primitive/precision/hopper_blockwise.py
@@ -1,0 +1,292 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""The two closed Hopper blockwise FP8 profiles and their runtime gates."""
+
+from __future__ import annotations
+
+import os
+from contextlib import AbstractContextManager, contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from enum import Enum
+from functools import lru_cache
+from typing import Any, Iterator
+
+from megatron.lite.primitive.precision.contract import (
+    AuthoritativeSource,
+    MasterOwner,
+    ParameterContract,
+    PrecisionDType,
+    PrecisionImplementation,
+    SemanticSite,
+    WeightStorage,
+)
+
+FROZEN_TRANSFORMER_ENGINE_VERSION = "2.18.0.dev0"
+FROZEN_TRANSFORMER_ENGINE_COMMIT = "8b9968255eb879e6e390f427836906b29aad64d2"
+_FROZEN_TRANSFORMER_ENGINE_SHORT_COMMIT = FROZEN_TRANSFORMER_ENGINE_COMMIT[:7]
+
+PRECISION_NAMES = (
+    "bf16",
+    "hopper_blockwise_bf16_weight",
+    "hopper_blockwise_fp8_weight",
+)
+
+_FP8_SITES = frozenset(
+    {
+        SemanticSite.ATTENTION_PROJECTION,
+        SemanticSite.DENSE_MLP,
+        SemanticSite.MOE_EXPERT,
+    }
+)
+_BF16_SITES = frozenset(
+    {
+        SemanticSite.ATTENTION_CORE,
+        SemanticSite.ROUTER,
+        SemanticSite.NORM,
+        SemanticSite.EMBEDDING,
+        SemanticSite.LM_HEAD,
+    }
+)
+
+
+def _parameter_contract(compute_weight: WeightStorage) -> ParameterContract:
+    return ParameterContract(
+        compute_weight=compute_weight,
+        authoritative_load_source=AuthoritativeSource.HIGH_PRECISION,
+        master_parameter=PrecisionDType.FP32,
+        main_gradient=PrecisionDType.FP32,
+        optimizer_state=PrecisionDType.FP32,
+        parameter_all_gather=PrecisionDType.BF16,
+        master_owner=MasterOwner.MLITE_OPTIMIZER,
+    )
+
+
+def _validate_recipe_environment() -> None:
+    scale_override = os.getenv("NVTE_FP8_BLOCK_SCALING_FP32_SCALES")
+    if scale_override not in (None, "0"):
+        raise RuntimeError(
+            "NVTE_FP8_BLOCK_SCALING_FP32_SCALES must be unset or 0 for Hopper blockwise FP8."
+        )
+    if os.getenv("NVTE_BACKWARD_OVERRIDE") is not None:
+        raise RuntimeError(
+            "NVTE_BACKWARD_OVERRIDE must be unset for Hopper blockwise FP8."
+        )
+
+
+@lru_cache(maxsize=1)
+def _build_hopper_blockwise_recipe() -> Any:
+    _validate_recipe_environment()
+    from transformer_engine.common.recipe import Float8BlockScaling, Format, MMParams
+
+    recipe = Float8BlockScaling(
+        use_f32_scales=False,
+        fp8_format=Format.E4M3,
+        x_block_scaling_dim=1,
+        w_block_scaling_dim=2,
+        grad_block_scaling_dim=1,
+        fp8_gemm_fprop=MMParams(use_split_accumulator=True),
+        fp8_gemm_dgrad=MMParams(use_split_accumulator=True),
+        fp8_gemm_wgrad=MMParams(use_split_accumulator=True),
+        fp8_dpa=False,
+        fp8_mha=False,
+        backward_override=None,
+    )
+    return recipe
+
+
+def _validate_hopper_blockwise_recipe(recipe: Any) -> None:
+    from transformer_engine.common.recipe import Format
+
+    quantizers = (
+        recipe.fp8_quant_fwd_inp,
+        recipe.fp8_quant_fwd_weight,
+        recipe.fp8_quant_bwd_grad,
+    )
+    matches_frozen_recipe = (
+        recipe.use_f32_scales is False
+        and recipe.fp8_format is Format.E4M3
+        and recipe.x_block_scaling_dim == 1
+        and recipe.w_block_scaling_dim == 2
+        and recipe.grad_block_scaling_dim == 1
+        and recipe.fp8_gemm_fprop.use_split_accumulator is True
+        and recipe.fp8_gemm_dgrad.use_split_accumulator is True
+        and recipe.fp8_gemm_wgrad.use_split_accumulator is True
+        and recipe.fp8_dpa is False
+        and recipe.fp8_mha is False
+        and recipe.backward_override is None
+        and all(quantizer.power_2_scale for quantizer in quantizers)
+    )
+    if not matches_frozen_recipe:
+        raise RuntimeError("Hopper blockwise FP8 recipe no longer matches the frozen contract.")
+
+
+def build_hopper_blockwise_recipe() -> Any:
+    """Return the single frozen Transformer Engine blockwise recipe."""
+
+    recipe = _build_hopper_blockwise_recipe()
+    _validate_hopper_blockwise_recipe(recipe)
+    return recipe
+
+
+HOPPER_BLOCKWISE_BF16_WEIGHT = PrecisionImplementation(
+    name="hopper_blockwise_bf16_weight",
+    recipe_factory=build_hopper_blockwise_recipe,
+    fp8_sites=_FP8_SITES,
+    bf16_sites=_BF16_SITES,
+    parameter_contract=_parameter_contract(WeightStorage.BF16),
+)
+HOPPER_BLOCKWISE_FP8_WEIGHT = PrecisionImplementation(
+    name="hopper_blockwise_fp8_weight",
+    recipe_factory=build_hopper_blockwise_recipe,
+    fp8_sites=_FP8_SITES,
+    bf16_sites=_BF16_SITES,
+    parameter_contract=_parameter_contract(WeightStorage.FP8_BLOCKWISE_E4M3),
+)
+
+
+def resolve_precision(name: str) -> PrecisionImplementation | None:
+    """Resolve one of the three accepted public precision names."""
+
+    if not isinstance(name, str):
+        raise TypeError("precision must be a string")
+    if name == "bf16":
+        return None
+    if name == HOPPER_BLOCKWISE_BF16_WEIGHT.name:
+        return HOPPER_BLOCKWISE_BF16_WEIGHT
+    if name == HOPPER_BLOCKWISE_FP8_WEIGHT.name:
+        return HOPPER_BLOCKWISE_FP8_WEIGHT
+    accepted = ", ".join(PRECISION_NAMES)
+    raise ValueError(f"precision must be one of: {accepted}; got {name!r}")
+
+
+@dataclass(frozen=True, slots=True)
+class _HopperEnvironment:
+    compute_capability: tuple[int, int]
+    transformer_engine_version: str
+    cuda_version: tuple[int, int]
+    cublas_version: int
+    block_scaling_supported: bool
+    unsupported_reason: str
+
+
+def _parse_cuda_version(value: str | None) -> tuple[int, int]:
+    if not value:
+        return (0, 0)
+    parts = value.split(".")
+    try:
+        return (int(parts[0]), int(parts[1]))
+    except (IndexError, ValueError) as exc:
+        raise RuntimeError(f"Cannot parse CUDA version {value!r}.") from exc
+
+
+def _probe_hopper_environment() -> _HopperEnvironment:
+    import torch
+    import transformer_engine
+    import transformer_engine_torch as tex
+    from transformer_engine.pytorch.quantization import check_fp8_block_scaling_support
+
+    supported, reason = check_fp8_block_scaling_support()
+    return _HopperEnvironment(
+        compute_capability=tuple(torch.cuda.get_device_capability()),
+        transformer_engine_version=str(transformer_engine.__version__),
+        cuda_version=_parse_cuda_version(torch.version.cuda),
+        cublas_version=int(tex.get_cublasLt_version()),
+        block_scaling_supported=bool(supported),
+        unsupported_reason=str(reason),
+    )
+
+
+def validate_hopper_environment() -> _HopperEnvironment:
+    """Fail before model allocation unless the frozen Hopper environment is present."""
+
+    _validate_recipe_environment()
+    environment = _probe_hopper_environment()
+    if environment.compute_capability != (9, 0):
+        raise RuntimeError(
+            "Hopper blockwise FP8 requires exactly SM90; found compute capability "
+            f"{environment.compute_capability}."
+        )
+
+    version, separator, local = environment.transformer_engine_version.partition("+")
+    if version != FROZEN_TRANSFORMER_ENGINE_VERSION:
+        raise RuntimeError(
+            "Hopper blockwise FP8 requires Transformer Engine "
+            f"{FROZEN_TRANSFORMER_ENGINE_VERSION}; found {environment.transformer_engine_version}."
+        )
+    if separator and (
+        len(local) < len(_FROZEN_TRANSFORMER_ENGINE_SHORT_COMMIT)
+        or not FROZEN_TRANSFORMER_ENGINE_COMMIT.startswith(local)
+    ):
+        raise RuntimeError(
+            "Hopper blockwise FP8 requires Transformer Engine commit "
+            f"{_FROZEN_TRANSFORMER_ENGINE_SHORT_COMMIT}; found local version {local!r}."
+        )
+    if environment.cuda_version < (12, 9):
+        raise RuntimeError(
+            "Hopper blockwise FP8 requires CUDA 12.9 or newer; found "
+            f"{environment.cuda_version[0]}.{environment.cuda_version[1]}."
+        )
+    if environment.cublas_version < 130400:
+        raise RuntimeError(
+            "Hopper blockwise FP8 MoE requires cuBLAS 13.4 or newer; found encoded version "
+            f"{environment.cublas_version}."
+        )
+    if not environment.block_scaling_supported:
+        reason = (
+            environment.unsupported_reason
+            or "Transformer Engine rejected block scaling"
+        )
+        raise RuntimeError(f"Hopper blockwise FP8 is unavailable: {reason}")
+    return environment
+
+
+class PrecisionPhase(str, Enum):
+    """Runtime phase in which precision-aware primitives may operate."""
+
+    MODEL_INIT = "model-init"
+    FORWARD = "forward"
+
+
+_ACTIVE_PRECISION: ContextVar[tuple[PrecisionPhase, PrecisionImplementation] | None] = (
+    ContextVar("mlite_active_precision", default=None)
+)
+
+
+@contextmanager
+def _precision_context(
+    phase: PrecisionPhase, implementation: PrecisionImplementation
+) -> Iterator[PrecisionImplementation]:
+    if not isinstance(implementation, PrecisionImplementation):
+        raise TypeError("precision context requires a PrecisionImplementation")
+    token = _ACTIVE_PRECISION.set((phase, implementation))
+    try:
+        yield implementation
+    finally:
+        _ACTIVE_PRECISION.reset(token)
+
+
+def precision_model_init_context(
+    implementation: PrecisionImplementation,
+) -> AbstractContextManager[PrecisionImplementation]:
+    """Bind one implementation while model composition declares typed coverage."""
+
+    return _precision_context(PrecisionPhase.MODEL_INIT, implementation)
+
+
+def precision_forward_context(
+    implementation: PrecisionImplementation,
+) -> AbstractContextManager[PrecisionImplementation]:
+    """Bind one implementation for correctly scoped primitive forward contexts."""
+
+    return _precision_context(PrecisionPhase.FORWARD, implementation)
+
+
+def active_precision(phase: PrecisionPhase) -> PrecisionImplementation:
+    """Return the runtime-bound implementation for an exact lifecycle phase."""
+
+    active = _ACTIVE_PRECISION.get()
+    if active is None or active[0] is not phase:
+        raise RuntimeError(
+            f"precision primitive requires the runtime {phase.value} context"
+        )
+    return active[1]

--- a/experimental/lite/megatron/lite/primitive/precision/hopper_blockwise.py
+++ b/experimental/lite/megatron/lite/primitive/precision/hopper_blockwise.py
@@ -167,6 +167,46 @@ HOPPER_BLOCKWISE_FP8_WEIGHT = PrecisionImplementation(
 )
 
 
+# Optimizer backends whose parameter write-back can currently own FP8 *compute*
+# weights. The distributed optimizer needs the upstream Megatron
+# ``fp8_param_gather`` path to gather and re-quantize FP8 compute parameters
+# during its sharded update; that path is deliberately out of scope for the
+# closed Hopper profiles. A DistOpt run against an FP8-weight profile would
+# silently update only the BF16-gathered parameters while the FP8 compute
+# weights stay stale -- a run that looks FP8-trained but is not. Only FSDP2 keeps
+# the FP8 compute weights live through its per-parameter update today.
+FP8_WEIGHT_SUPPORTED_OPTIMIZERS = frozenset({"fsdp2"})
+
+
+def require_optimizer_supports_precision(
+    implementation: PrecisionImplementation, optimizer_backend: str
+) -> None:
+    """Fail loud on optimizer/precision combinations that cannot train correctly.
+
+    BF16-weight profiles work under every optimizer backend. FP8 *compute*
+    weights currently require the FSDP2 optimizer: the distributed-optimizer
+    write-back for FP8 weights depends on the upstream Megatron
+    ``fp8_param_gather`` path, which is out of scope for the closed Hopper
+    profiles. Constructing a distributed-optimizer run against an FP8-weight
+    profile is therefore rejected here instead of silently producing a run that
+    looks FP8-trained but leaves the FP8 compute weights stale.
+    """
+
+    if implementation.parameter_contract.compute_weight is WeightStorage.BF16:
+        return
+    if optimizer_backend in FP8_WEIGHT_SUPPORTED_OPTIMIZERS:
+        return
+    supported = ", ".join(sorted(FP8_WEIGHT_SUPPORTED_OPTIMIZERS))
+    raise ValueError(
+        f"{implementation.name} stores FP8 compute weights, which the "
+        f"{optimizer_backend!r} optimizer cannot train correctly: the "
+        "distributed-optimizer FP8 write-back requires the upstream Megatron "
+        "fp8_param_gather path, which is out of scope for the closed Hopper "
+        f"profiles. Use a supported optimizer ({supported}) for FP8-weight "
+        "training, or select the hopper_blockwise_bf16_weight profile."
+    )
+
+
 def resolve_precision(name: str) -> PrecisionImplementation | None:
     """Resolve one of the accepted public precision names.
 

--- a/experimental/lite/megatron/lite/primitive/utils/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/utils/__init__.py
@@ -4,13 +4,6 @@ from __future__ import annotations
 import torch  # pyright: ignore[reportMissingImports]
 
 
-def build_fp8_recipe(train_config=None):
-    """Build the standard TE FP8 recipe (DelayedScaling, HYBRID format, H100)."""
-    from transformer_engine.common.recipe import DelayedScaling, Format
-
-    return DelayedScaling(margin=0, fp8_format=Format.HYBRID)
-
-
 def ensure_divisible(numerator: int, denominator: int, msg: str = "") -> int:
     if numerator % denominator != 0:
         detail = f" ({msg})" if msg else ""
@@ -23,4 +16,4 @@ def log_rank0(msg: str) -> None:
         print(f"[megatron.lite] {msg}", flush=True)
 
 
-__all__ = ["build_fp8_recipe", "ensure_divisible", "log_rank0"]
+__all__ = ["ensure_divisible", "log_rank0"]

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/config.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/config.py
@@ -8,6 +8,32 @@ from typing import Any
 
 from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig, pick_fields
 
+_AD_HOC_PRECISION_KEYS = frozenset(
+    {
+        "format",
+        "fp8",
+        "fp8_format",
+        "fp8_recipe",
+        "recipe",
+        "target",
+        "targets",
+        "weight_dtype",
+    }
+)
+_HOPPER_UNSUPPORTED_FEATURES = frozenset(
+    {
+        "cuda_graph",
+        "fp8_communication",
+        "fp8_param_gather",
+        "lora",
+        "mxfp8",
+        "use_cuda_graph",
+    }
+)
+_PRECISION_INJECTION_KEYS = frozenset(
+    {"precision_coverage", "precision_implementation", "precision_parameter_contract"}
+)
+
 
 @dataclass(slots=True)
 class DebugConfig:
@@ -42,6 +68,7 @@ class MegatronLiteConfig:
     attention_backend_override: str | None = "flash"
     router_aux_loss_coef: float | None = None
     load_hf_weights: bool = True
+    precision: str = "bf16"
 
     # ── impl-specific (each impl reads its own keys) ──
     impl_cfg: dict[str, Any] = field(default_factory=dict)
@@ -52,6 +79,47 @@ class MegatronLiteConfig:
     # ── bench-only hook: mutate model_cfg after build (e.g. expert truncation) ──
     model_config_hook: Any = None
 
+    def __post_init__(self) -> None:
+        from megatron.lite.primitive.precision import resolve_precision
+
+        implementation = resolve_precision(self.precision)
+        forbidden = sorted(_AD_HOC_PRECISION_KEYS.intersection(self.impl_cfg))
+        if forbidden:
+            raise ValueError(
+                "Precision is configured only through the three closed precision names; "
+                f"remove impl_cfg keys {forbidden}."
+            )
+        injected = sorted(_PRECISION_INJECTION_KEYS.intersection(self.impl_cfg))
+        if injected:
+            raise ValueError(
+                f"Runtime-owned precision injection keys cannot be configured: {injected}."
+            )
+        if implementation is None:
+            return
+        if self.parallel.pp != 1 or self.parallel.cp != 1:
+            raise ValueError(
+                f"{implementation.name} currently requires pp=1 and cp=1; got "
+                f"pp={self.parallel.pp}, cp={self.parallel.cp}."
+            )
+        unsupported = sorted(
+            key
+            for key in _HOPPER_UNSUPPORTED_FEATURES
+            if bool(self.impl_cfg.get(key, False))
+        )
+        if unsupported:
+            raise ValueError(
+                f"{implementation.name} does not support impl_cfg features {unsupported}."
+            )
+        if self.optimizer.use_precision_aware_optimizer:
+            raise ValueError(
+                f"{implementation.name} does not support lower-precision optimizer state."
+            )
+        optimizer_overrides = getattr(self.optimizer, "override_optimizer_config", {})
+        if isinstance(optimizer_overrides, dict) and optimizer_overrides.get(
+            "fp8_param_gather", False
+        ):
+            raise ValueError(f"{implementation.name} does not support fp8_param_gather.")
+
     @classmethod
     def from_dict(cls, hf_path: str, cfg: dict[str, Any]) -> MegatronLiteConfig:
         """Construct MegatronLiteConfig from a flat dict (legacy / OmegaConf path)."""
@@ -60,6 +128,21 @@ class MegatronLiteConfig:
                 "MegatronLiteConfig no longer accepts `num_microbatches`; "
                 "pass it to Runtime.forward_backward(..., num_microbatches=...) instead"
             )
+        ad_hoc = sorted(_AD_HOC_PRECISION_KEYS.intersection(cfg))
+        if ad_hoc:
+            raise ValueError(
+                "Precision is configured only through the three closed precision names; "
+                f"remove keys {ad_hoc}."
+            )
+        requested_precision = cfg.get("precision", "bf16")
+        if requested_precision != "bf16":
+            unsupported = sorted(
+                key for key in _HOPPER_UNSUPPORTED_FEATURES if bool(cfg.get(key, False))
+            )
+            if unsupported:
+                raise ValueError(
+                    f"{requested_precision} does not support configuration features {unsupported}."
+                )
         parallel = ParallelConfig(**pick_fields(ParallelConfig, cfg))
 
         opt_d = cfg.get("optimizer", {})

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -13,6 +13,14 @@ from typing import Any
 
 import torch
 import torch.distributed as dist
+from megatron.lite.primitive.precision import (
+    PrecisionCoverage,
+    PrecisionImplementation,
+    precision_forward_context,
+    precision_model_init_context,
+    resolve_precision,
+    validate_hopper_environment,
+)
 from megatron.lite.runtime.backends import Runtime as RuntimeBase
 from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig
 from megatron.lite.runtime.contracts.data import ForwardResult, ModelOutputs, PackedBatch
@@ -20,7 +28,13 @@ from megatron.lite.runtime.contracts.handle import ModelHandle
 from megatron.lite.runtime.contracts.loss import get_loss_context, split_loss_context, use_loss_context
 
 
-def _build_impl_cfg(proto, rt_cfg: MegatronLiteConfig):
+def _build_impl_cfg(
+    proto,
+    rt_cfg: MegatronLiteConfig,
+    *,
+    precision_implementation: PrecisionImplementation | None = None,
+    precision_coverage: PrecisionCoverage | None = None,
+):
     """Construct typed impl config, backfilling hf_path + optimizer_config."""
     init_fields = {f.name for f in dc_fields(proto.ImplConfig) if f.init}
     # Only forward impl_cfg keys this model's ImplConfig declares: the connector
@@ -48,6 +62,25 @@ def _build_impl_cfg(proto, rt_cfg: MegatronLiteConfig):
         and getattr(rt_cfg, "optimizer", None) is not None
     ):
         impl_cfg_kwargs["optimizer_config"] = rt_cfg.optimizer
+    if precision_implementation is not None:
+        injection_fields = {
+            "precision_coverage",
+            "precision_implementation",
+            "precision_parameter_contract",
+        }
+        missing = sorted(injection_fields.difference(init_fields))
+        if missing:
+            raise ValueError(
+                f"Protocol ImplConfig must declare precision injection fields {missing} "
+                f"for {precision_implementation.name}."
+            )
+        if precision_coverage is None:
+            raise ValueError("A typed precision coverage collector is required.")
+        impl_cfg_kwargs["precision_implementation"] = precision_implementation
+        impl_cfg_kwargs["precision_parameter_contract"] = (
+            precision_implementation.parameter_contract
+        )
+        impl_cfg_kwargs["precision_coverage"] = precision_coverage
     return proto.ImplConfig(**impl_cfg_kwargs)
 
 
@@ -187,6 +220,13 @@ class MegatronLiteRuntime(RuntimeBase):
         else:
             rt_cfg = self._cfg
 
+        precision_implementation = resolve_precision(rt_cfg.precision)
+        precision_coverage = None
+        if precision_implementation is not None:
+            validate_hopper_environment()
+            precision_implementation.recipe_factory()
+            precision_coverage = PrecisionCoverage(precision_implementation)
+
         # ── init distributed ──
         if not dist.is_initialized():
             dist.init_process_group("nccl", timeout=timedelta(minutes=10))
@@ -202,10 +242,19 @@ class MegatronLiteRuntime(RuntimeBase):
 
         # ── escape hatch: model takes over ──
         if hasattr(proto, "create_runtime"):
+            if precision_implementation is not None:
+                raise ValueError(
+                    "Closed Hopper precision profiles require the standard MLite typed runtime path."
+                )
             return proto.create_runtime(rt_cfg.hf_path, rt_cfg).build_model()
 
         # ── construct impl_cfg (parallel injected) ──
-        impl_cfg = _build_impl_cfg(proto, rt_cfg)
+        impl_cfg = _build_impl_cfg(
+            proto,
+            rt_cfg,
+            precision_implementation=precision_implementation,
+            precision_coverage=precision_coverage,
+        )
 
         # ── build model config ──
         model_cfg = proto.build_model_config(rt_cfg.hf_path)
@@ -213,7 +262,31 @@ class MegatronLiteRuntime(RuntimeBase):
             model_cfg = rt_cfg.model_config_hook(model_cfg)
 
         # ── build model (model owns ps + optimizer + everything) ──
-        bundle = proto.build_model(model_cfg, impl_cfg=impl_cfg)
+        if precision_implementation is None:
+            bundle = proto.build_model(model_cfg, impl_cfg=impl_cfg)
+        else:
+            with precision_model_init_context(precision_implementation):
+                bundle = proto.build_model(model_cfg, impl_cfg=impl_cfg)
+                assert precision_coverage is not None
+                precision_manifest = precision_coverage.manifest
+
+            reserved = {
+                "precision_coverage",
+                "precision_implementation",
+                "precision_parameter_contract",
+            }
+            collisions = sorted(reserved.intersection(bundle.extras))
+            if collisions:
+                raise ValueError(
+                    f"Model bundle cannot override runtime precision keys {collisions}."
+                )
+            bundle.extras.update(
+                {
+                    "precision_coverage": precision_manifest,
+                    "precision_implementation": precision_implementation,
+                    "precision_parameter_contract": precision_implementation.parameter_contract,
+                }
+            )
 
         # ── load HF weights (optional) ──
         loaded_hf_weights = False
@@ -450,6 +523,14 @@ class MegatronLiteRuntime(RuntimeBase):
         from megatron.lite.runtime.backends.mlite.router_replay import RouterReplayDriver
 
         forward_step = handle._extras["forward_step"]
+        precision_implementation = handle._extras.get("precision_implementation")
+        if precision_implementation is not None:
+            unwrapped_forward_step = forward_step
+
+            def forward_step(model, batch):
+                with precision_forward_context(precision_implementation):
+                    return unwrapped_forward_step(model, batch)
+
         if num_microbatches < 1:
             raise ValueError("num_microbatches must be >= 1")
 

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -223,7 +223,7 @@ class MegatronLiteRuntime(RuntimeBase):
         precision_implementation = resolve_precision(rt_cfg.precision)
         precision_coverage = None
         if precision_implementation is not None:
-            validate_hopper_environment()
+            validate_hopper_environment(precision_implementation)
             precision_implementation.recipe_factory()
             precision_coverage = PrecisionCoverage(precision_implementation)
 

--- a/experimental/lite/tests/conftest.py
+++ b/experimental/lite/tests/conftest.py
@@ -42,6 +42,62 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(skip_smoke)
 
 
+def _build_transformer_engine_stub_modules() -> dict[str, types.ModuleType]:
+    class _UnavailableTE:
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError("Transformer Engine is not installed in this test environment.")
+
+    root = types.ModuleType("transformer_engine")
+    root.__version__ = "0.0.0"
+    pytorch = types.ModuleType("transformer_engine.pytorch")
+    pytorch.DotProductAttention = _UnavailableTE
+    pytorch.LayerNormLinear = _UnavailableTE
+    pytorch.Linear = _UnavailableTE
+    pytorch.GroupedLinear = _UnavailableTE
+    pytorch.RMSNorm = _UnavailableTE
+    permutation = types.ModuleType("transformer_engine.pytorch.permutation")
+    router = types.ModuleType("transformer_engine.pytorch.router")
+    cpp_extensions = types.ModuleType("transformer_engine.pytorch.cpp_extensions")
+    module = types.ModuleType("transformer_engine.pytorch.module")
+    module_base = types.ModuleType("transformer_engine.pytorch.module.base")
+
+    def unavailable_kernel(*args, **kwargs):
+        raise RuntimeError("Transformer Engine fused kernel is not installed.")
+
+    permutation.moe_permute = unavailable_kernel
+    permutation.moe_permute_and_pad_with_probs = unavailable_kernel
+    permutation.moe_permute_with_probs = unavailable_kernel
+    permutation.moe_unpermute = unavailable_kernel
+    router.fused_compute_score_for_moe_aux_loss = unavailable_kernel
+    router.fused_moe_aux_loss = unavailable_kernel
+    router.fused_topk_with_score_function = unavailable_kernel
+    cpp_extensions.general_gemm = lambda *args, **kwargs: None
+    module_base.get_workspace = lambda: None
+    module.base = module_base
+    pytorch.permutation = permutation
+    pytorch.router = router
+    pytorch.cpp_extensions = cpp_extensions
+    pytorch.module = module
+    root.pytorch = pytorch
+    return {
+        "transformer_engine": root,
+        "transformer_engine.pytorch": pytorch,
+        "transformer_engine.pytorch.permutation": permutation,
+        "transformer_engine.pytorch.router": router,
+        "transformer_engine.pytorch.cpp_extensions": cpp_extensions,
+        "transformer_engine.pytorch.module": module,
+        "transformer_engine.pytorch.module.base": module_base,
+    }
+
+
+# Built once and reused across tests so that the module *identity* stays stable.
+# Primitive modules cache ``import transformer_engine.pytorch as te`` at import
+# time, while callers such as PrecisionCoverage resolve it lazily; sharing one
+# stub object keeps those references in agreement even though ``monkeypatch``
+# reverts the sys.modules entries between tests.
+_TE_STUB_MODULES: dict[str, types.ModuleType] | None = None
+
+
 @pytest.fixture
 def transformer_engine_import_stub(monkeypatch):
     def install() -> None:
@@ -56,49 +112,10 @@ def transformer_engine_import_stub(monkeypatch):
             }:
                 raise
 
-        class _UnavailableTE:
-            def __init__(self, *args, **kwargs):
-                raise RuntimeError("Transformer Engine is not installed in this test environment.")
-
-        root = types.ModuleType("transformer_engine")
-        root.__version__ = "0.0.0"
-        pytorch = types.ModuleType("transformer_engine.pytorch")
-        pytorch.DotProductAttention = _UnavailableTE
-        pytorch.LayerNormLinear = _UnavailableTE
-        pytorch.Linear = _UnavailableTE
-        pytorch.RMSNorm = _UnavailableTE
-        permutation = types.ModuleType("transformer_engine.pytorch.permutation")
-        router = types.ModuleType("transformer_engine.pytorch.router")
-        cpp_extensions = types.ModuleType("transformer_engine.pytorch.cpp_extensions")
-        module = types.ModuleType("transformer_engine.pytorch.module")
-        module_base = types.ModuleType("transformer_engine.pytorch.module.base")
-
-        def unavailable_kernel(*args, **kwargs):
-            raise RuntimeError("Transformer Engine fused kernel is not installed.")
-
-        permutation.moe_permute = unavailable_kernel
-        permutation.moe_permute_and_pad_with_probs = unavailable_kernel
-        permutation.moe_permute_with_probs = unavailable_kernel
-        permutation.moe_unpermute = unavailable_kernel
-        router.fused_compute_score_for_moe_aux_loss = unavailable_kernel
-        router.fused_moe_aux_loss = unavailable_kernel
-        router.fused_topk_with_score_function = unavailable_kernel
-        cpp_extensions.general_gemm = lambda *args, **kwargs: None
-        module_base.get_workspace = lambda: None
-        module.base = module_base
-        pytorch.permutation = permutation
-        pytorch.router = router
-        pytorch.cpp_extensions = cpp_extensions
-        pytorch.module = module
-        root.pytorch = pytorch
-        monkeypatch.setitem(sys.modules, "transformer_engine", root)
-        monkeypatch.setitem(sys.modules, "transformer_engine.pytorch", pytorch)
-        monkeypatch.setitem(sys.modules, "transformer_engine.pytorch.permutation", permutation)
-        monkeypatch.setitem(sys.modules, "transformer_engine.pytorch.router", router)
-        monkeypatch.setitem(
-            sys.modules, "transformer_engine.pytorch.cpp_extensions", cpp_extensions
-        )
-        monkeypatch.setitem(sys.modules, "transformer_engine.pytorch.module", module)
-        monkeypatch.setitem(sys.modules, "transformer_engine.pytorch.module.base", module_base)
+        global _TE_STUB_MODULES
+        if _TE_STUB_MODULES is None:
+            _TE_STUB_MODULES = _build_transformer_engine_stub_modules()
+        for name, mod in _TE_STUB_MODULES.items():
+            monkeypatch.setitem(sys.modules, name, mod)
 
     return install

--- a/experimental/lite/tests/smoke/primitive/hopper_blockwise_primitive_parity.py
+++ b/experimental/lite/tests/smoke/primitive/hopper_blockwise_primitive_parity.py
@@ -1,0 +1,728 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Hopper blockwise BF16-weight primitive parity under torchrun.
+
+The reference path uses the frozen Megatron-Core Transformer Engine wrappers.
+It does not import MLite modules or precision helpers. Three complete reference
+repeats are sealed before the target path is constructed. The target path then
+exercises the production MLite primitives.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.abc
+import json
+import os
+import sys
+from contextlib import nullcontext
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+
+
+SEED = 1234
+PROFILES = ("bf16", "hopper_blockwise_bf16_weight")
+REPEATS = 3
+
+
+class _OptionalNvrxBlocker(importlib.abc.MetaPathFinder):
+    """Make the unused checkpoint-only NVRx integration deterministically absent."""
+
+    def find_spec(self, fullname, path, target=None):
+        del path, target
+        if fullname == "nvidia_resiliency_ext" or fullname.startswith(
+            "nvidia_resiliency_ext."
+        ):
+            raise ModuleNotFoundError(
+                "NVRx is disabled for primitive parity", name=fullname
+            )
+        return None
+
+
+def _block_optional_nvrx() -> None:
+    if any(isinstance(finder, _OptionalNvrxBlocker) for finder in sys.meta_path):
+        return
+    if any(name.startswith("nvidia_resiliency_ext") for name in sys.modules):
+        raise RuntimeError("NVRx was imported before the primitive parity isolation")
+    sys.meta_path.insert(0, _OptionalNvrxBlocker())
+
+
+@dataclass
+class _Bundle:
+    linear: torch.nn.Module
+    attention: Any
+    experts: Any
+    parameters: dict[str, torch.nn.Parameter]
+    coverage_manifest: Any = None
+    reference_config: Any = None
+
+
+def _stable_seed(label: str, rank: int) -> int:
+    digest = hashlib.sha256(f"{SEED}:{rank}:{label}".encode()).digest()
+    return int.from_bytes(digest[:8], "little") % (2**31)
+
+
+def _tensor(shape: tuple[int, ...], label: str, rank: int) -> torch.Tensor:
+    generator = torch.Generator(device="cpu")
+    generator.manual_seed(_stable_seed(label, rank))
+    return torch.randn(shape, generator=generator, dtype=torch.bfloat16) * 0.02
+
+
+class _ReferenceAttention(torch.nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        from megatron.core.extensions.transformer_engine import (
+            TEDotProductAttention,
+            TELayerNormColumnParallelLinear,
+            TENorm,
+            TERowParallelLinear,
+        )
+        from megatron.core.transformer.enums import AttnMaskType
+
+        self.qkv = TELayerNormColumnParallelLinear(
+            input_size=1024,
+            output_size=2048,
+            config=config,
+            init_method=config.init_method,
+            gather_output=False,
+            bias=False,
+            skip_bias_add=False,
+            is_expert=False,
+            tp_comm_buffer_name="qkv",
+            name="reference.attention.qkv",
+        )
+        self.proj = TERowParallelLinear(
+            input_size=1024,
+            output_size=1024,
+            config=config,
+            init_method=config.output_layer_init_method,
+            bias=False,
+            input_is_parallel=True,
+            skip_bias_add=False,
+            is_expert=False,
+            tp_comm_buffer_name="proj",
+            name="reference.attention.proj",
+        )
+        self.q_norm = TENorm(config, 64, eps=1e-6)
+        self.k_norm = TENorm(config, 64, eps=1e-6)
+        self._attn_mask_type = AttnMaskType.causal
+        self.core = TEDotProductAttention(
+            config=config,
+            layer_number=1,
+            attn_mask_type=self._attn_mask_type,
+            attention_type="self",
+            attention_dropout=0.0,
+        )
+
+    def forward(self, x: torch.Tensor):
+        qkv, _ = self.qkv(x)
+        qkv = qkv.view(*qkv.shape[:-1], 16, 64)
+        q = self.q_norm(qkv[..., :8, :])
+        k = self.k_norm(qkv[..., 8:12, :])
+        v = qkv[..., 12:, :]
+        core = self.core(q, k, v, None, self._attn_mask_type)
+        if core.dim() > x.dim():
+            core = core.reshape(*core.shape[:-2], 512)
+        output, _ = self.proj(core)
+        return output, core
+
+
+def _named_te_parameters(prefix: str, module: torch.nn.Module):
+    return {
+        f"{prefix}.{name}": parameter for name, parameter in module.named_parameters()
+    }
+
+
+def _reference_config(profile: str):
+    from megatron.core.transformer.transformer_config import TransformerConfig
+
+    fp8 = "e4m3" if profile != "bf16" else None
+    return TransformerConfig(
+        num_layers=1,
+        hidden_size=1024,
+        num_attention_heads=16,
+        num_query_groups=8,
+        ffn_hidden_size=4096,
+        moe_ffn_hidden_size=4096,
+        num_moe_experts=4,
+        moe_router_topk=2,
+        tensor_model_parallel_size=2,
+        expert_model_parallel_size=2,
+        expert_tensor_parallel_size=1,
+        sequence_parallel=True,
+        params_dtype=torch.bfloat16,
+        normalization="RMSNorm",
+        layernorm_epsilon=1e-6,
+        hidden_dropout=0.0,
+        attention_dropout=0.0,
+        add_bias_linear=False,
+        gated_linear_unit=True,
+        activation_func=F.silu,
+        bias_activation_fusion=True,
+        deterministic_mode=True,
+        fp8=fp8,
+        fp8_recipe=("blockwise" if fp8 else None),
+        fp8_param=False,
+    )
+
+
+def _build_reference(profile: str) -> _Bundle:
+    from megatron.core.extensions.transformer_engine import TEColumnParallelLinear
+    from megatron.core.models.gpt.gpt_layer_specs import (
+        get_gpt_layer_with_transformer_engine_submodules,
+    )
+    from megatron.core.transformer.moe.experts import GroupedMLPSubmodules, TEGroupedMLP
+    from megatron.core.transformer.moe.moe_layer import MoESubmodules
+    from megatron.core.transformer.moe.moe_utils import get_default_pg_collection
+    from megatron.core.transformer.spec_utils import get_submodules
+
+    config = _reference_config(profile)
+    linear = TEColumnParallelLinear(
+        input_size=1024,
+        output_size=4096,
+        config=config,
+        init_method=config.init_method,
+        gather_output=False,
+        bias=False,
+        skip_bias_add=False,
+        is_expert=False,
+        name="reference.linear",
+    )
+    attention = _ReferenceAttention(config)
+    layer_submodules = get_gpt_layer_with_transformer_engine_submodules(
+        num_experts=4, moe_grouped_gemm=True
+    )
+    mlp_submodules = get_submodules(layer_submodules.mlp)
+    if not isinstance(mlp_submodules, MoESubmodules):
+        raise TypeError("Megatron reference did not construct MoE submodules")
+    expert_submodules = get_submodules(mlp_submodules.experts)
+    if not isinstance(expert_submodules, GroupedMLPSubmodules):
+        raise TypeError(
+            "Megatron reference did not construct grouped expert submodules"
+        )
+    experts = TEGroupedMLP(
+        2,
+        config,
+        expert_submodules,
+        get_default_pg_collection(),
+        name="reference.experts",
+    )
+    modules = {
+        "linear": linear,
+        "attention": attention,
+        "experts.fc1": experts.linear_fc1,
+        "experts.fc2": experts.linear_fc2,
+    }
+    parameters: dict[str, torch.nn.Parameter] = {}
+    for prefix, module in modules.items():
+        module.cuda().to(torch.bfloat16)
+        parameters.update(_named_te_parameters(prefix, module))
+    return _Bundle(linear, attention, experts, parameters, reference_config=config)
+
+
+def _build_target(ps, profile: str) -> _Bundle:
+    from megatron.lite.primitive.modules.experts import Experts
+    from megatron.lite.primitive.modules.gqa import GQAttention
+    from megatron.lite.primitive.parallel.linear import ColumnParallelLinear
+    from megatron.lite.primitive.precision import (
+        PrecisionCoverage,
+        PrimitiveCapability,
+        SemanticSite,
+        precision_model_init_context,
+        resolve_precision,
+    )
+
+    implementation = resolve_precision(profile)
+    coverage = PrecisionCoverage(implementation) if implementation is not None else None
+    init_context = (
+        precision_model_init_context(implementation)
+        if implementation is not None
+        else nullcontext()
+    )
+    with init_context:
+        linear = ColumnParallelLinear(
+            1024,
+            4096,
+            ps,
+            bias=False,
+            sequence_parallel=True,
+            precision_coverage=coverage,
+            precision_site=(SemanticSite.ATTENTION_PROJECTION if coverage else None),
+        )
+        attention = GQAttention(
+            hidden_size=1024,
+            num_attention_heads=16,
+            num_key_value_heads=8,
+            head_dim=64,
+            ps=ps,
+            rotary_percent=0.0,
+            qkv_layout="flat",
+            precision_coverage=coverage,
+        )
+        experts = Experts(
+            SimpleNamespace(
+                num_experts=4,
+                hidden_size=1024,
+                moe_intermediate_size=4096,
+                swiglu_limit=0.0,
+            ),
+            ps,
+            precision_coverage=coverage,
+        )
+        manifest = None
+        if coverage is not None:
+            coverage.require(
+                linear,
+                SemanticSite.ATTENTION_PROJECTION,
+                frozenset({PrimitiveCapability.TE_LINEAR}),
+                diagnostic="tp column linear",
+            )
+            coverage.require(
+                attention.qkv,
+                SemanticSite.ATTENTION_PROJECTION,
+                frozenset({PrimitiveCapability.TE_LAYERNORM_LINEAR}),
+                diagnostic="gqa qkv projection",
+            )
+            coverage.require(
+                attention.proj,
+                SemanticSite.ATTENTION_PROJECTION,
+                frozenset({PrimitiveCapability.TE_LINEAR}),
+                diagnostic="gqa output projection",
+            )
+            coverage.require(
+                experts.fc1,
+                SemanticSite.MOE_EXPERT,
+                frozenset({PrimitiveCapability.TE_GROUPED_LINEAR}),
+                diagnostic="expert fc1",
+            )
+            coverage.require(
+                experts.fc2,
+                SemanticSite.MOE_EXPERT,
+                frozenset({PrimitiveCapability.TE_GROUPED_LINEAR}),
+                diagnostic="expert fc2",
+            )
+            for owner, site, diagnostic in (
+                (attention.core_attn, SemanticSite.ATTENTION_CORE, "TE DPA"),
+                (attention.q_norm, SemanticSite.NORM, "query norm"),
+                (attention.k_norm, SemanticSite.NORM, "key norm"),
+                (object(), SemanticSite.ROUTER, "router boundary"),
+                (object(), SemanticSite.EMBEDDING, "embedding boundary"),
+                (object(), SemanticSite.LM_HEAD, "LM head boundary"),
+            ):
+                coverage.require(owner, site, diagnostic=diagnostic)
+            manifest = coverage.seal()
+
+    modules = {
+        "linear": linear.linear,
+        "attention.qkv": attention.qkv.linear,
+        "attention.proj": attention.proj.linear,
+        "attention.q_norm": attention.q_norm,
+        "attention.k_norm": attention.k_norm,
+        "experts.fc1": experts.fc1,
+        "experts.fc2": experts.fc2,
+    }
+    parameters: dict[str, torch.nn.Parameter] = {}
+    for module in (linear, attention, experts):
+        module.cuda().to(torch.bfloat16)
+    for prefix, module in modules.items():
+        parameters.update(_named_te_parameters(prefix, module))
+    return _Bundle(linear, attention, experts, parameters, manifest)
+
+
+def _canonical_key(key: str) -> str:
+    return key.replace("attention.qkv.linear.", "attention.qkv.").replace(
+        "attention.proj.linear.", "attention.proj."
+    )
+
+
+def _canonical_parameters(bundle: _Bundle) -> dict[str, torch.nn.Parameter]:
+    canonical = {_canonical_key(key): value for key, value in bundle.parameters.items()}
+    if len(canonical) != len(bundle.parameters):
+        raise RuntimeError("duplicate canonical parameter name")
+    return canonical
+
+
+def _make_artifact(reference: _Bundle, rank: int) -> dict[str, Any]:
+    parameters = _canonical_parameters(reference)
+    state = {
+        name: _tensor(tuple(parameter.shape), f"parameter:{name}", rank)
+        for name, parameter in parameters.items()
+    }
+    return {
+        "parameters": state,
+        "linear_input": _tensor((128, 2, 1024), "linear_input", rank),
+        "attention_input": _tensor((128, 2, 1024), "attention_input", rank),
+        "expert_input": _tensor((16, 1024), "expert_input", rank),
+        "expert_probs": torch.sigmoid(_tensor((16,), "expert_probs", rank).float()).to(
+            torch.bfloat16
+        ),
+        "tokens_per_expert": torch.tensor([7, 9], dtype=torch.int64),
+    }
+
+
+def _load_artifact(bundle: _Bundle, artifact: dict[str, Any]) -> None:
+    parameters = _canonical_parameters(bundle)
+    if parameters.keys() != artifact["parameters"].keys():
+        raise RuntimeError(
+            f"parameter mapping mismatch: target={sorted(parameters)} "
+            f"artifact={sorted(artifact['parameters'])}"
+        )
+    with torch.no_grad():
+        for name, parameter in parameters.items():
+            value = artifact["parameters"][name]
+            if tuple(value.shape) != tuple(parameter.shape):
+                raise RuntimeError(
+                    f"shape mismatch for {name}: {value.shape} != {parameter.shape}"
+                )
+            parameter.copy_(value.to(device="cuda", dtype=parameter.dtype))
+
+
+def _adamw_step(parameter: torch.Tensor, gradient: torch.Tensor) -> torch.Tensor:
+    master = parameter.detach().float().clone()
+    grad = gradient.detach().float()
+    beta1, beta2 = 0.9, 0.95
+    first = (1.0 - beta1) * grad
+    second = (1.0 - beta2) * grad.square()
+    master.mul_(1.0 - 1.0e-4 * 0.1)
+    master.addcdiv_(
+        first / (1.0 - beta1),
+        (second / (1.0 - beta2)).sqrt().add_(1.0e-8),
+        value=-1.0e-4,
+    )
+    return master.cpu()
+
+
+def _run(bundle: _Bundle, artifact: dict[str, Any], profile: str, reference: bool):
+    _load_artifact(bundle, artifact)
+    for parameter in bundle.parameters.values():
+        parameter.grad = None
+    fp8 = profile != "bf16"
+    implementation = None
+    forward_context = nullcontext()
+    if not reference and fp8:
+        from megatron.lite.primitive.precision import (
+            precision_forward_context,
+            resolve_precision,
+        )
+
+        implementation = resolve_precision(profile)
+        forward_context = precision_forward_context(implementation)
+
+    linear_input = artifact["linear_input"].cuda().requires_grad_(True)
+    attention_input = artifact["attention_input"].cuda().requires_grad_(True)
+    expert_input = artifact["expert_input"].cuda().requires_grad_(True)
+    expert_probs = artifact["expert_probs"].cuda()
+    tokens_per_expert = artifact["tokens_per_expert"].cuda()
+    captured: dict[str, Any] = {}
+
+    with forward_context:
+        if reference:
+            if fp8:
+                from megatron.core.fp8_utils import get_fp8_context
+
+                reference_context = get_fp8_context(bundle.reference_config)
+            else:
+                reference_context = nullcontext()
+            with reference_context:
+                linear_output, _ = bundle.linear(linear_input)
+                attention_output, core_output = bundle.attention(attention_input)
+                expert_output, _ = bundle.experts(
+                    expert_input, tokens_per_expert, expert_probs
+                )
+        else:
+            linear_output = bundle.linear(linear_input)
+
+            def _capture_input(_module, args):
+                captured["core_input_dtypes"] = tuple(value.dtype for value in args[:3])
+
+            def _capture_output(_module, _args, output):
+                captured["core_output"] = output.detach()
+
+            pre_handle = bundle.attention.core_attn.register_forward_pre_hook(
+                _capture_input
+            )
+            post_handle = bundle.attention.core_attn.register_forward_hook(
+                _capture_output
+            )
+            try:
+                attention_output = bundle.attention(attention_input)
+            finally:
+                pre_handle.remove()
+                post_handle.remove()
+            core_output = captured["core_output"]
+            if core_output.dim() > attention_input.dim():
+                core_output = core_output.reshape(*core_output.shape[:-2], 512)
+            expert_output = bundle.experts(
+                expert_input, tokens_per_expert, permuted_probs=expert_probs
+            )
+
+    loss = sum(
+        output.float().square().mean()
+        for output in (linear_output, attention_output, expert_output)
+    )
+    loss.backward()
+    parameters = _canonical_parameters(bundle)
+    metrics: dict[str, torch.Tensor] = {
+        "linear.forward": linear_output.detach().cpu(),
+        "linear.dx": linear_input.grad.detach().cpu(),
+        "attention.forward": attention_output.detach().cpu(),
+        "attention.core": core_output.detach().cpu(),
+        "attention.dx": attention_input.grad.detach().cpu(),
+        "experts.forward": expert_output.detach().cpu(),
+        "experts.dx": expert_input.grad.detach().cpu(),
+        "loss": loss.detach().cpu(),
+    }
+    for name, parameter in parameters.items():
+        if parameter.grad is None:
+            raise RuntimeError(f"missing gradient for {name}")
+        metrics[f"gradient.{name}"] = parameter.grad.detach().cpu()
+        metrics[f"update.{name}"] = _adamw_step(parameter, parameter.grad)
+    if reference:
+        metrics["boundary.dtypes"] = torch.tensor(
+            [int(core_output.dtype is torch.bfloat16), 1, 1, 1], dtype=torch.int8
+        )
+    else:
+        core_dtypes = captured["core_input_dtypes"]
+        metrics["boundary.dtypes"] = torch.tensor(
+            [
+                int(all(dtype is torch.bfloat16 for dtype in core_dtypes)),
+                int(core_output.dtype is torch.bfloat16),
+                int(expert_probs.dtype is torch.bfloat16),
+                int(
+                    all(
+                        parameter.dtype is torch.bfloat16
+                        for name, parameter in parameters.items()
+                        if "q_norm" in name or "k_norm" in name
+                    )
+                ),
+            ],
+            dtype=torch.int8,
+        )
+    if not all(
+        torch.isfinite(value).all()
+        for value in metrics.values()
+        if value.is_floating_point()
+    ):
+        raise RuntimeError("non-finite primitive metric")
+    return metrics
+
+
+def _noise(repeats: list[dict[str, torch.Tensor]]) -> dict[str, dict[str, float]]:
+    thresholds: dict[str, dict[str, float]] = {}
+    for name in repeats[0]:
+        values = [repeat[name] for repeat in repeats]
+        max_abs = 0.0
+        max_l2 = 0.0
+        for left_index in range(len(values)):
+            for right_index in range(left_index + 1, len(values)):
+                left = values[left_index].float()
+                right = values[right_index].float()
+                diff = left - right
+                max_abs = max(max_abs, float(diff.abs().max()))
+                denominator = max(
+                    float(torch.linalg.vector_norm(left)),
+                    float(torch.linalg.vector_norm(right)),
+                    torch.finfo(torch.float32).tiny,
+                )
+                max_l2 = max(
+                    max_l2, float(torch.linalg.vector_norm(diff)) / denominator
+                )
+        thresholds[name] = {
+            "atol": 4.0 * max_abs,
+            "rtol_l2": 4.0 * max_l2,
+            "shape": list(values[0].shape),
+            "dtype": str(values[0].dtype),
+        }
+    return thresholds
+
+
+def _compare(
+    reference: dict[str, torch.Tensor],
+    targets: list[dict[str, torch.Tensor]],
+    thresholds: dict[str, dict[str, float]],
+) -> dict[str, Any]:
+    report: dict[str, Any] = {}
+    target_noise = _noise(targets)
+    for name, expected in reference.items():
+        gate = thresholds[name]
+        for repeat_index, target in enumerate(targets):
+            actual = target[name]
+            if actual.shape != expected.shape or actual.dtype != expected.dtype:
+                raise AssertionError(
+                    f"{name} repeat {repeat_index} shape/dtype mismatch"
+                )
+            if gate["atol"] == 0.0 and gate["rtol_l2"] == 0.0:
+                if not torch.equal(actual, expected):
+                    raise AssertionError(
+                        f"{name} repeat {repeat_index} is not bitwise equal"
+                    )
+                max_abs = 0.0
+                rel_l2 = 0.0
+            else:
+                diff = actual.float() - expected.float()
+                max_abs = float(diff.abs().max())
+                denominator = max(
+                    float(torch.linalg.vector_norm(expected.float())),
+                    torch.finfo(torch.float32).tiny,
+                )
+                rel_l2 = float(torch.linalg.vector_norm(diff)) / denominator
+                if max_abs > gate["atol"] or rel_l2 > gate["rtol_l2"]:
+                    raise AssertionError(
+                        f"{name} repeat {repeat_index} exceeds frozen gate"
+                    )
+        if (
+            target_noise[name]["atol"] > gate["atol"]
+            or target_noise[name]["rtol_l2"] > gate["rtol_l2"]
+        ):
+            raise AssertionError(f"{name} target repeat noise exceeds reference gate")
+        report[name] = {
+            "atol": gate["atol"],
+            "rtol_l2": gate["rtol_l2"],
+            "target_noise_atol": target_noise[name]["atol"],
+            "target_noise_rtol_l2": target_noise[name]["rtol_l2"],
+        }
+    return report
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    args.output.mkdir(parents=True, exist_ok=True)
+
+    dist.init_process_group("nccl")
+    rank = dist.get_rank()
+    if dist.get_world_size() != 4:
+        raise RuntimeError("primitive parity requires exactly four ranks")
+    torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
+    torch.manual_seed(SEED)
+    torch.cuda.manual_seed_all(SEED)
+    torch.use_deterministic_algorithms(True)
+    torch.backends.cuda.matmul.allow_tf32 = False
+
+    _block_optional_nvrx()
+    from megatron.core import parallel_state as mcore_parallel_state
+    from megatron.lite.primitive.parallel import init_parallel
+
+    mcore_parallel_state.initialize_model_parallel(
+        tensor_model_parallel_size=2,
+        expert_model_parallel_size=2,
+        expert_tensor_parallel_size=1,
+        order="tp-ep-dp-pp",
+        create_gloo_process_groups=False,
+    )
+    ps = init_parallel(SimpleNamespace(tp=2, ep=2, etp=1, cp=1, pp=1, pp_layout=None))
+    reference_bundle = _build_reference("bf16")
+    artifact = _make_artifact(reference_bundle, rank)
+    artifact_path = args.output / f"artifact-rank{rank}.pt"
+    torch.save(artifact, artifact_path)
+    artifact_hash = _sha256(artifact_path)
+    del reference_bundle
+    torch.cuda.empty_cache()
+
+    all_reports: dict[str, Any] = {}
+    for profile in PROFILES:
+        reference_repeats = []
+        for repeat_index in range(REPEATS):
+            bundle = _build_reference(profile)
+            repeat = _run(bundle, artifact, profile, reference=True)
+            torch.save(
+                repeat,
+                args.output / f"reference-{profile}-repeat{repeat_index}-rank{rank}.pt",
+            )
+            reference_repeats.append(repeat)
+            del bundle
+            torch.cuda.empty_cache()
+
+        thresholds = _noise(reference_repeats)
+        threshold_path = args.output / f"thresholds-{profile}-rank{rank}.json"
+        threshold_path.write_text(
+            json.dumps(thresholds, indent=2, sort_keys=True) + "\n"
+        )
+        if any(
+            gate["atol"] != 0.0 or gate["rtol_l2"] != 0.0
+            for gate in thresholds.values()
+        ):
+            raise RuntimeError(
+                f"{profile} reference noise is non-zero; review the sealed threshold before target"
+            )
+
+        target_repeats = []
+        for repeat_index in range(REPEATS):
+            bundle = _build_target(ps, profile)
+            repeat = _run(bundle, artifact, profile, reference=False)
+            torch.save(
+                repeat,
+                args.output / f"target-{profile}-repeat{repeat_index}-rank{rank}.pt",
+            )
+            target_repeats.append(repeat)
+            if profile != "bf16":
+                assert bundle.coverage_manifest is not None
+                assert len(bundle.coverage_manifest.entries) == 11
+            del bundle
+            torch.cuda.empty_cache()
+
+        report = _compare(reference_repeats[0], target_repeats, thresholds)
+        report_path = args.output / f"comparison-{profile}-rank{rank}.json"
+        report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+        all_reports[profile] = {
+            "threshold_sha256": _sha256(threshold_path),
+            "comparison_sha256": _sha256(report_path),
+        }
+
+    hashes = [None for _ in range(dist.get_world_size())]
+    dist.all_gather_object(
+        hashes, {"rank": rank, "artifact_sha256": artifact_hash, **all_reports}
+    )
+    if rank == 0:
+        print("OPTIONAL_NVRX_DISABLED_FOR_PRIMITIVE_PARITY")
+        manifest = {
+            "seed": SEED,
+            "repeats": REPEATS,
+            "world_size": 4,
+            "tp": 2,
+            "ep": 2,
+            "global_sequence_length": 256,
+            "micro_batch_size": 2,
+            "hidden_size": 1024,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 8,
+            "num_experts": 4,
+            "top_k": 2,
+            "expert_padding": 16,
+            "optimizer": {
+                "name": "AdamW",
+                "lr": 1.0e-4,
+                "betas": [0.9, 0.95],
+                "eps": 1.0e-8,
+                "weight_decay": 0.1,
+                "master": "fp32",
+            },
+            "ranks": hashes,
+        }
+        manifest_path = args.output / "manifest.json"
+        manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+        print(f"manifest_sha256={_sha256(manifest_path)}")
+        print("HOPPER_BLOCKWISE_BF16_BASELINE_PARITY_OK")
+        print("HOPPER_BLOCKWISE_PRIMITIVE_PARITY_OK")
+    dist.barrier()
+    mcore_parallel_state.destroy_model_parallel()
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/experimental/lite/tests/unit/model/test_qwen3_moe_precision_static.py
+++ b/experimental/lite/tests/unit/model/test_qwen3_moe_precision_static.py
@@ -64,6 +64,39 @@ def test_qwen3_moe_rejects_partial_or_unvalidated_precision_composition(
         )
 
 
+def test_qwen3_moe_rejects_fp8_weight_with_distributed_optimizer(
+    transformer_engine_import_stub,
+):
+    transformer_engine_import_stub()
+    from megatron.lite.model.qwen3_moe.lite import protocol
+    from megatron.lite.primitive.precision import PrecisionCoverage, resolve_precision
+
+    fp8_weight = resolve_precision("hopper_blockwise_fp8_weight")
+    assert fp8_weight is not None
+
+    def _fp8_impl_cfg(**overrides):
+        return protocol.ImplConfig(
+            precision_coverage=PrecisionCoverage(fp8_weight),
+            precision_implementation=fp8_weight,
+            precision_parameter_contract=fp8_weight.parameter_contract,
+            **overrides,
+        )
+
+    # BLOCKER regression (distopt-fp8-silent): FP8 compute weights need the
+    # upstream Megatron fp8_param_gather write-back, which the closed profiles do
+    # not ship. The distributed-optimizer path is qwen3_moe's default optimizer,
+    # so an FP8-weight run under it is *constructible*; build_model must reject it
+    # loudly instead of silently training BF16-gathered params while the FP8
+    # compute weights stay stale (a run that looks FP8-trained but is not).
+    assert protocol.ImplConfig().optimizer == "dist_opt"
+    with pytest.raises(ValueError, match="fp8_param_gather"):
+        protocol.build_model(SimpleNamespace(), impl_cfg=_fp8_impl_cfg())
+    with pytest.raises(ValueError, match="fp8_param_gather"):
+        protocol.build_model(
+            SimpleNamespace(), impl_cfg=_fp8_impl_cfg(optimizer="dist_opt")
+        )
+
+
 def test_qwen3_moe_composition_declares_every_selected_and_fixed_bf16_site(
     transformer_engine_import_stub,
 ):

--- a/experimental/lite/tests/unit/model/test_qwen3_moe_precision_static.py
+++ b/experimental/lite/tests/unit/model/test_qwen3_moe_precision_static.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from __future__ import annotations
+
+from dataclasses import fields
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytestmark = pytest.mark.mlite
+
+
+def test_qwen3_moe_removes_the_legacy_model_threaded_fp8_path():
+    lite_root = Path(__file__).resolve().parents[3]
+    model_source = (
+        lite_root / "megatron" / "lite" / "model" / "qwen3_moe" / "lite" / "model.py"
+    ).read_text(encoding="utf-8")
+    protocol_source = (
+        lite_root / "megatron" / "lite" / "model" / "qwen3_moe" / "lite" / "protocol.py"
+    ).read_text(encoding="utf-8")
+
+    assert "build_fp8_recipe" not in model_source
+    assert "fp8_autocast" not in model_source
+    assert "fp8: bool" not in model_source
+    assert "fp8=False" not in protocol_source
+
+
+def test_qwen3_moe_impl_config_accepts_only_runtime_owned_precision_injection(
+    transformer_engine_import_stub,
+):
+    transformer_engine_import_stub()
+    from megatron.lite.model.qwen3_moe.lite.protocol import ImplConfig
+
+    declared = {field.name: field.default for field in fields(ImplConfig)}
+    assert declared["precision_coverage"] is None
+    assert declared["precision_implementation"] is None
+    assert declared["precision_parameter_contract"] is None
+
+
+def test_qwen3_moe_rejects_partial_or_unvalidated_precision_composition(
+    transformer_engine_import_stub,
+):
+    transformer_engine_import_stub()
+    from megatron.lite.model.qwen3_moe.lite import protocol
+    from megatron.lite.primitive.precision import PrecisionCoverage, resolve_precision
+
+    with pytest.raises(ValueError, match="all three typed fields"):
+        protocol.build_model(
+            SimpleNamespace(),
+            impl_cfg=protocol.ImplConfig(precision_coverage=object()),
+        )
+
+    implementation = resolve_precision("hopper_blockwise_bf16_weight")
+    assert implementation is not None
+    with pytest.raises(ValueError, match="do not cover.*mtp"):
+        protocol.build_model(
+            SimpleNamespace(),
+            impl_cfg=protocol.ImplConfig(
+                mtp_enable=True,
+                precision_coverage=PrecisionCoverage(implementation),
+                precision_implementation=implementation,
+                precision_parameter_contract=implementation.parameter_contract,
+            ),
+        )
+
+
+def test_qwen3_moe_composition_declares_every_selected_and_fixed_bf16_site(
+    transformer_engine_import_stub,
+):
+    transformer_engine_import_stub()
+    from megatron.lite.model.qwen3_moe.lite.model import (
+        _declare_model_precision_requirements,
+    )
+    from megatron.lite.primitive.precision import (
+        PrimitiveCapability,
+        SemanticSite,
+    )
+
+    layer = SimpleNamespace(
+        attn=SimpleNamespace(
+            qkv=object(),
+            proj=object(),
+            core_attn=object(),
+            q_norm=object(),
+            k_norm=object(),
+        ),
+        mlp_norm=object(),
+        moe=SimpleNamespace(
+            router=object(),
+            experts=SimpleNamespace(fc1=object(), fc2=object()),
+        ),
+    )
+    model = SimpleNamespace(
+        layers=[layer],
+        embed=object(),
+        norm=object(),
+        head=object(),
+    )
+    requirements = []
+
+    class RecordingCoverage:
+        def require(self, owner, site, capabilities=frozenset(), *, diagnostic=""):
+            requirements.append((owner, site, capabilities, diagnostic))
+
+    _declare_model_precision_requirements(model, RecordingCoverage())
+
+    selected = [item for item in requirements if item[2]]
+    fixed_bf16 = [item for item in requirements if not item[2]]
+    assert [(item[0], item[1], item[2]) for item in selected] == [
+        (
+            layer.attn.qkv,
+            SemanticSite.ATTENTION_PROJECTION,
+            frozenset({PrimitiveCapability.TE_LAYERNORM_LINEAR}),
+        ),
+        (
+            layer.attn.proj,
+            SemanticSite.ATTENTION_PROJECTION,
+            frozenset({PrimitiveCapability.TE_LINEAR}),
+        ),
+        (
+            layer.moe.experts.fc1,
+            SemanticSite.MOE_EXPERT,
+            frozenset({PrimitiveCapability.TE_GROUPED_LINEAR}),
+        ),
+        (
+            layer.moe.experts.fc2,
+            SemanticSite.MOE_EXPERT,
+            frozenset({PrimitiveCapability.TE_GROUPED_LINEAR}),
+        ),
+    ]
+    assert [(item[0], item[1]) for item in fixed_bf16] == [
+        (layer.attn.qkv, SemanticSite.NORM),
+        (layer.attn.core_attn, SemanticSite.ATTENTION_CORE),
+        (layer.attn.q_norm, SemanticSite.NORM),
+        (layer.attn.k_norm, SemanticSite.NORM),
+        (layer.mlp_norm, SemanticSite.NORM),
+        (layer.moe.router, SemanticSite.ROUTER),
+        (model.embed, SemanticSite.EMBEDDING),
+        (model.norm, SemanticSite.NORM),
+        (model.head, SemanticSite.LM_HEAD),
+    ]
+
+
+def test_qwen3_moe_seals_precision_coverage_before_optimizer_construction():
+    lite_root = Path(__file__).resolve().parents[3]
+    source = (
+        lite_root / "megatron" / "lite" / "model" / "qwen3_moe" / "lite" / "protocol.py"
+    ).read_text(encoding="utf-8")
+
+    assert source.index("precision_coverage.seal()") < source.index(
+        'if impl_cfg.optimizer == "dist_opt"'
+    )

--- a/experimental/lite/tests/unit/primitive/test_fsdp2_offload_gpu.py
+++ b/experimental/lite/tests/unit/primitive/test_fsdp2_offload_gpu.py
@@ -24,6 +24,37 @@ from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
 from megatron.lite.runtime.contracts.handle import ModelHandle
 
 
+class TinyFP8Model(nn.Module):
+    """A blockwise TE MLP whose parameters are constructed as FP8 weights."""
+
+    def __init__(self):
+        super().__init__()
+        from megatron.lite.primitive.modules.mlp import SwiGLUMLP
+        from megatron.lite.primitive.precision import (
+            PrecisionCoverage,
+            precision_model_init_context,
+            resolve_precision,
+        )
+
+        implementation = resolve_precision("hopper_blockwise_fp8_weight")
+        assert implementation is not None
+        coverage = PrecisionCoverage(implementation)
+        with precision_model_init_context(implementation):
+            self.mlp = SwiGLUMLP(
+                128,
+                128,
+                precision_coverage=coverage,
+            )
+            self.coverage_manifest = coverage.seal()
+        self.precision_implementation = implementation
+
+    def forward(self, x):
+        from megatron.lite.primitive.precision import precision_forward_context
+
+        with precision_forward_context(self.precision_implementation):
+            return self.mlp(x)
+
+
 class TinyUnit(nn.Module):
     def __init__(self):
         super().__init__()
@@ -173,6 +204,23 @@ def _build_optimizer(model: nn.Module, ps: ParallelState, *, offload_fraction: f
         ps,
         use_fp32_master=True,
     )
+
+
+def _build_fp8_fsdp2_model() -> tuple[nn.Module, ParallelState, dict[str, torch.Tensor]]:
+    torch.manual_seed(1234)
+    model = TinyFP8Model().cuda().to(dtype=torch.bfloat16)
+    sources = {}
+    for name, param in model.named_parameters():
+        get_source = getattr(param, "get_high_precision_init_val", None)
+        assert callable(get_source), f"{name} is missing TE's preserved FP32 source"
+        source = get_source()
+        assert isinstance(source, torch.Tensor)
+        sources[name] = source.detach().float().cpu().clone()
+
+    ps = _parallel_state()
+    config = FSDP2Config(unit_modules=(type(model.mlp),), reshard_after_forward=True)
+    mesh = build_fsdp2_device_mesh(ps, config)
+    return wrap_fsdp2(model, ps, config, mesh=mesh), ps, sources
 
 
 def _local_param_devices(model: nn.Module) -> set[str]:
@@ -447,3 +495,28 @@ def test_fsdp2_pp_edp_reshard_and_offload_roundtrip_eight_gpus():
 
     runtime.to(materialized_handle, "cuda", model=True, optimizer=False, grad=False)
     assert _local_param_devices(materialized_model) == {"cuda"}
+
+
+def test_fsdp2_fp8_weight_uses_te_source_for_fp32_master_and_updates_single_gpu():
+    model, ps, sources = _build_fp8_fsdp2_model()
+    optimizer = _build_optimizer(model, ps, offload_fraction=0.0)
+
+    masters = {
+        name: optimizer.optimizer.state[param]["master_param"].detach().float().cpu()
+        for name, param in model.named_parameters()
+    }
+    assert masters.keys() == sources.keys()
+    for name in sources:
+        torch.testing.assert_close(masters[name], sources[name], atol=0.0, rtol=0.0)
+        assert getattr(model.get_parameter(name), "get_high_precision_init_val")() is None
+
+    x = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16)
+    target = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16)
+    optimizer.zero_grad()
+    loss = torch.nn.functional.mse_loss(model(x).float(), target.float())
+    loss.backward()
+    success, grad_norm, _ = optimizer.step()
+
+    assert success
+    assert torch.isfinite(loss)
+    assert torch.isfinite(torch.tensor(grad_norm))

--- a/experimental/lite/tests/unit/primitive/test_fsdp2_offload_gpu.py
+++ b/experimental/lite/tests/unit/primitive/test_fsdp2_offload_gpu.py
@@ -239,6 +239,25 @@ def _optimizer_state_devices(optimizer) -> set[str]:
     return devices
 
 
+def _fp8_step(model: nn.Module, optimizer, x: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    optimizer.zero_grad()
+    loss = torch.nn.functional.mse_loss(model(x).float(), target.float())
+    loss.backward()
+    success, grad_norm, _ = optimizer.step()
+
+    assert success
+    assert torch.isfinite(loss)
+    assert torch.isfinite(torch.tensor(grad_norm))
+    return loss.detach()
+
+
+def _fp32_masters(model: nn.Module, optimizer) -> dict[str, torch.Tensor]:
+    return {
+        name: optimizer.optimizer.state[param]["master_param"].detach().float().cpu().clone()
+        for name, param in model.named_parameters()
+    }
+
+
 def test_fsdp2_runtime_model_and_optimizer_offload_roundtrip_single_gpu():
     model, ps = _build_fsdp2_model()
     optimizer = _build_optimizer(model, ps, offload_fraction=0.0)
@@ -512,11 +531,62 @@ def test_fsdp2_fp8_weight_uses_te_source_for_fp32_master_and_updates_single_gpu(
 
     x = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16)
     target = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16)
-    optimizer.zero_grad()
-    loss = torch.nn.functional.mse_loss(model(x).float(), target.float())
-    loss.backward()
-    success, grad_norm, _ = optimizer.step()
+    _fp8_step(model, optimizer, x, target)
 
-    assert success
-    assert torch.isfinite(loss)
-    assert torch.isfinite(torch.tensor(grad_norm))
+
+def test_fsdp2_fp8_weight_local_checkpoint_resume_matches_uninterrupted_single_gpu(tmp_path):
+    direct_model, direct_ps, _ = _build_fp8_fsdp2_model()
+    direct_optimizer = _build_optimizer(direct_model, direct_ps, offload_fraction=0.0)
+    saved_model, saved_ps, _ = _build_fp8_fsdp2_model()
+    saved_optimizer = _build_optimizer(saved_model, saved_ps, offload_fraction=0.0)
+
+    torch.manual_seed(4321)
+    x0 = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16)
+    target0 = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16)
+    x1 = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16)
+    target1 = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16)
+
+    torch.testing.assert_close(
+        _fp8_step(direct_model, direct_optimizer, x0, target0),
+        _fp8_step(saved_model, saved_optimizer, x0, target0),
+        atol=0.0,
+        rtol=0.0,
+    )
+
+    runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
+    runtime.save_checkpoint(
+        ModelHandle(
+            model=saved_model,
+            optimizer=saved_optimizer,
+            parallel_state=saved_ps,
+            _extras={"model_chunks": [saved_model]},
+        ),
+        str(tmp_path),
+        step=1,
+        use_dcp=False,
+    )
+
+    resumed_model, resumed_ps, _ = _build_fp8_fsdp2_model()
+    resumed_optimizer = _build_optimizer(resumed_model, resumed_ps, offload_fraction=0.0)
+    assert runtime.load_checkpoint(
+        ModelHandle(
+            model=resumed_model,
+            optimizer=resumed_optimizer,
+            parallel_state=resumed_ps,
+            _extras={"model_chunks": [resumed_model]},
+        ),
+        str(tmp_path),
+        use_dcp=False,
+    ) == 1
+
+    for name, master in _fp32_masters(saved_model, saved_optimizer).items():
+        torch.testing.assert_close(
+            _fp32_masters(resumed_model, resumed_optimizer)[name], master, atol=0.0, rtol=0.0
+        )
+
+    _fp8_step(direct_model, direct_optimizer, x1, target1)
+    _fp8_step(resumed_model, resumed_optimizer, x1, target1)
+    for name, master in _fp32_masters(direct_model, direct_optimizer).items():
+        torch.testing.assert_close(
+            _fp32_masters(resumed_model, resumed_optimizer)[name], master, atol=0.0, rtol=0.0
+        )

--- a/experimental/lite/tests/unit/primitive/test_fsdp2_offload_gpu.py
+++ b/experimental/lite/tests/unit/primitive/test_fsdp2_offload_gpu.py
@@ -270,8 +270,13 @@ def _fp8_step(model: nn.Module, optimizer, x: torch.Tensor, target: torch.Tensor
 
 
 def _fp32_masters(model: nn.Module, optimizer) -> dict[str, torch.Tensor]:
+    # FP8-weight masters are DTensors mirroring the sharded param, so localize
+    # the shard before comparing against plain-tensor references.
     return {
-        name: optimizer.optimizer.state[param]["master_param"].detach().float().cpu().clone()
+        name: to_local_tensor(optimizer.optimizer.state[param]["master_param"].detach())
+        .float()
+        .cpu()
+        .clone()
         for name, param in model.named_parameters()
     }
 
@@ -539,7 +544,9 @@ def test_fsdp2_fp8_weight_uses_te_source_for_fp32_master_and_updates_single_gpu(
     optimizer = _build_optimizer(model, ps, offload_fraction=0.0)
 
     masters = {
-        name: optimizer.optimizer.state[param]["master_param"].detach().float().cpu()
+        name: to_local_tensor(optimizer.optimizer.state[param]["master_param"].detach())
+        .float()
+        .cpu()
         for name, param in model.named_parameters()
     }
     assert masters.keys() == sources.keys()

--- a/experimental/lite/tests/unit/primitive/test_fsdp2_offload_gpu.py
+++ b/experimental/lite/tests/unit/primitive/test_fsdp2_offload_gpu.py
@@ -32,6 +32,8 @@ class TinyFP8Model(nn.Module):
         from megatron.lite.primitive.modules.mlp import SwiGLUMLP
         from megatron.lite.primitive.precision import (
             PrecisionCoverage,
+            PrimitiveCapability,
+            SemanticSite,
             precision_model_init_context,
             resolve_precision,
         )
@@ -44,6 +46,22 @@ class TinyFP8Model(nn.Module):
                 128,
                 128,
                 precision_coverage=coverage,
+            )
+            # SwiGLUMLP claims its two dense_mlp GEMMs; the composing layer owns
+            # the matching requirements (mirrors _declare_layer_precision_requirements
+            # and the primitive-parity harness). Declare them against the same
+            # owner objects the primitive claimed, then seal.
+            coverage.require(
+                self.mlp.gate_up,
+                SemanticSite.DENSE_MLP,
+                frozenset({PrimitiveCapability.TE_LINEAR}),
+                diagnostic="dense mlp gate_up projection",
+            )
+            coverage.require(
+                self.mlp.down,
+                SemanticSite.DENSE_MLP,
+                frozenset({PrimitiveCapability.TE_LINEAR}),
+                diagnostic="dense mlp down projection",
             )
             self.coverage_manifest = coverage.seal()
         self.precision_implementation = implementation

--- a/experimental/lite/tests/unit/primitive/test_fsdp2_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_fsdp2_unit.py
@@ -17,7 +17,7 @@ from megatron.lite.primitive.optimizers.fsdp2 import (
     clip_grads_with_sharded_norm_,
     fsdp2_available,
 )
-from megatron.lite.primitive.optimizers.fsdp2.adamw import build_adamw_optimizer
+from megatron.lite.primitive.optimizers.fsdp2.adamw import FP32AdamW, build_adamw_optimizer
 from megatron.lite.primitive.optimizers.fsdp2.wrap import build_fsdp2_shard_placement_fn
 from megatron.lite.primitive.parallel.state import ParallelState
 
@@ -199,6 +199,29 @@ def test_fsdp2_optimizer_offloads_dtensor_state_without_extra_knob(monkeypatch):
 
     assert calls == [True]
     assert not hasattr(optimizer, "optimizer_offload_dtensor_state")
+
+
+def test_fp32_adamw_uses_and_clears_te_high_precision_init_value():
+    """The optimizer master must never be reconstructed from an FP8 compute value."""
+
+    param = nn.Parameter(torch.tensor([9.0, -7.0], dtype=torch.bfloat16))
+    source = torch.tensor([1.125, -2.25], dtype=torch.bfloat16)
+    cleared = []
+
+    def get_high_precision_init_val():
+        return source
+
+    def clear_high_precision_init_val():
+        cleared.append(True)
+
+    param.get_high_precision_init_val = get_high_precision_init_val
+    param.clear_high_precision_init_val = clear_high_precision_init_val
+    optimizer = FP32AdamW(
+        [param], lr=1.0e-3, weight_decay=0.0, betas=(0.9, 0.999), eps=1.0e-8
+    )
+
+    torch.testing.assert_close(optimizer.state[param]["master_param"], source.float())
+    assert cleared == [True]
 
 
 def test_fsdp2_shard_placement_prefers_first_divisible_dimension():

--- a/experimental/lite/tests/unit/primitive/test_precision_primitives_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_precision_primitives_unit.py
@@ -155,7 +155,7 @@ def test_tp_te_linear_primitives_claim_capability_and_enter_scoped_context(
     ]
 
 
-def test_bf16_weight_linear_binding_fails_loud_for_shape_or_fp8_weight_profile(
+def test_bf16_weight_linear_binding_fails_loud_for_bad_shape(
     transformer_engine_import_stub, monkeypatch
 ):
     transformer_engine_import_stub()
@@ -169,8 +169,7 @@ def test_bf16_weight_linear_binding_fails_loud_for_shape_or_fp8_weight_profile(
 
     monkeypatch.setattr(linear.te, "Linear", _FakeLinear)
     bf16_weight = resolve_precision("hopper_blockwise_bf16_weight")
-    fp8_weight = resolve_precision("hopper_blockwise_fp8_weight")
-    assert bf16_weight is not None and fp8_weight is not None
+    assert bf16_weight is not None
 
     with precision_model_init_context(bf16_weight):
         with pytest.raises(ValueError, match="divisible by 128"):
@@ -181,15 +180,17 @@ def test_bf16_weight_linear_binding_fails_loud_for_shape_or_fp8_weight_profile(
                 precision_coverage=PrecisionCoverage(bf16_weight),
                 precision_site=SemanticSite.ATTENTION_PROJECTION,
             )
-    with precision_model_init_context(fp8_weight):
-        with pytest.raises(NotImplementedError, match="FP8-weight"):
-            linear.ColumnParallelLinear(
-                128,
-                128,
-                _parallel_state(),
-                precision_coverage=PrecisionCoverage(fp8_weight),
-                precision_site=SemanticSite.ATTENTION_PROJECTION,
-            )
+
+
+def test_reserved_fp8_weight_profile_is_not_sold_as_a_working_profile():
+    # The FP8-weight profile is declared by the closed design but its FP8
+    # parameter initialization is not implemented in this build. It must fail
+    # loud at resolution instead of being handed back and then dying deep inside
+    # linear construction.
+    from megatron.lite.primitive.precision import resolve_precision
+
+    with pytest.raises(NotImplementedError, match="not implemented"):
+        resolve_precision("hopper_blockwise_fp8_weight")
 
 
 def test_unbound_te_linear_preserves_bf16_path_without_precision_context(

--- a/experimental/lite/tests/unit/primitive/test_precision_primitives_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_precision_primitives_unit.py
@@ -237,21 +237,27 @@ def test_non_te_dense_requirement_fails_coverage_instead_of_falling_back():
 def test_precision_coverage_rejects_forged_capability_from_non_te_owner(
     transformer_engine_import_stub, monkeypatch
 ):
-    """A non-TE module cannot masquerade as an FP8-capable GEMM primitive.
+    """A non-TE owner cannot forge FP8 coverage, and no owner can borrow a witness.
 
-    Regression for the claim-forgery gap: a bare ``nn.Linear`` could previously
-    ``require`` an FP8 site and ``claim`` a TE capability, and ``seal`` returned
-    a manifest instead of failing loud. The claim now binds the capability to a
-    genuine TE primitive instance and rejects any other owner/witness.
+    Regression for two claim-forgery gaps: (1) a bare ``nn.Linear`` could
+    ``require`` an FP8 site and ``claim`` a TE capability and ``seal`` returned a
+    manifest instead of failing loud; (2) an *unrelated* genuine TE instance
+    could be borrowed as a witness to seal a foreign owner, passing the type
+    check without proving that owner's GEMM is really a TE primitive. The claim
+    now requires the witness to be the owner itself or one of its registered
+    submodules, and to be a genuine TE primitive type.
     """
 
     transformer_engine_import_stub()
     import transformer_engine.pytorch as te
 
-    # A distinct, constructible TE Linear so the *legitimate* path still seals,
-    # proving the guard rejects only the non-TE owner, not every claim.
-    te_linear_type = type("FakeTELinear", (object,), {"__init__": lambda self: None})
-    monkeypatch.setattr(te, "Linear", te_linear_type, raising=False)
+    # te.Linear is an ``nn.Module`` in production; model the stub the same way so
+    # a legitimately-registered submodule witness is reachable via ``modules()``.
+    class FakeTELinear(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+    monkeypatch.setattr(te, "Linear", FakeTELinear, raising=False)
 
     from megatron.lite.primitive.precision import (
         PrecisionCoverage,
@@ -263,9 +269,10 @@ def test_precision_coverage_rejects_forged_capability_from_non_te_owner(
 
     implementation = resolve_precision("hopper_blockwise_bf16_weight")
     assert implementation is not None
-    coverage = PrecisionCoverage(implementation)
     forged_owner = nn.Linear(128, 128, bias=False)
 
+    # ── every forgery attempt is rejected ──
+    coverage = PrecisionCoverage(implementation)
     with precision_model_init_context(implementation):
         coverage.require(
             forged_owner,
@@ -286,12 +293,37 @@ def test_precision_coverage_rejects_forged_capability_from_non_te_owner(
                 PrimitiveCapability.TE_LINEAR,
                 forged_owner,
             )
-        # The genuine TE primitive witness is accepted for the same site.
+        # A borrowed *genuine* TE instance for a foreign owner is rejected: it is
+        # neither the owner nor a submodule registered on it, so it cannot be
+        # borrowed to seal an unrelated owner.
+        with pytest.raises(TypeError, match="neither the coverage owner"):
+            coverage.claim(
+                forged_owner,
+                SemanticSite.DENSE_MLP,
+                PrimitiveCapability.TE_LINEAR,
+                FakeTELinear(),
+            )
+
+    # ── the legitimate path still seals: the owner owns the TE witness ──
+    class OwnerWithTE(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = FakeTELinear()
+
+    legit_owner = OwnerWithTE()
+    coverage = PrecisionCoverage(implementation)
+    with precision_model_init_context(implementation):
+        coverage.require(
+            legit_owner,
+            SemanticSite.DENSE_MLP,
+            frozenset({PrimitiveCapability.TE_LINEAR}),
+            diagnostic="registered te linear",
+        )
         coverage.claim(
-            forged_owner,
+            legit_owner,
             SemanticSite.DENSE_MLP,
             PrimitiveCapability.TE_LINEAR,
-            te_linear_type(),
+            legit_owner.linear,
         )
         manifest = coverage.seal()
 

--- a/experimental/lite/tests/unit/primitive/test_precision_primitives_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_precision_primitives_unit.py
@@ -182,15 +182,13 @@ def test_bf16_weight_linear_binding_fails_loud_for_bad_shape(
             )
 
 
-def test_reserved_fp8_weight_profile_is_not_sold_as_a_working_profile():
-    # The FP8-weight profile is declared by the closed design but its FP8
-    # parameter initialization is not implemented in this build. It must fail
-    # loud at resolution instead of being handed back and then dying deep inside
-    # linear construction.
-    from megatron.lite.primitive.precision import resolve_precision
+def test_fp8_weight_profile_is_resolved_for_te_quantized_initialization():
+    from megatron.lite.primitive.precision import WeightStorage, resolve_precision
 
-    with pytest.raises(NotImplementedError, match="not implemented"):
-        resolve_precision("hopper_blockwise_fp8_weight")
+    implementation = resolve_precision("hopper_blockwise_fp8_weight")
+
+    assert implementation is not None
+    assert implementation.parameter_contract.compute_weight is WeightStorage.FP8_BLOCKWISE_E4M3
 
 
 def test_unbound_te_linear_preserves_bf16_path_without_precision_context(

--- a/experimental/lite/tests/unit/primitive/test_precision_primitives_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_precision_primitives_unit.py
@@ -233,6 +233,72 @@ def test_non_te_dense_requirement_fails_coverage_instead_of_falling_back():
             coverage.seal()
 
 
+def test_precision_coverage_rejects_forged_capability_from_non_te_owner(
+    transformer_engine_import_stub, monkeypatch
+):
+    """A non-TE module cannot masquerade as an FP8-capable GEMM primitive.
+
+    Regression for the claim-forgery gap: a bare ``nn.Linear`` could previously
+    ``require`` an FP8 site and ``claim`` a TE capability, and ``seal`` returned
+    a manifest instead of failing loud. The claim now binds the capability to a
+    genuine TE primitive instance and rejects any other owner/witness.
+    """
+
+    transformer_engine_import_stub()
+    import transformer_engine.pytorch as te
+
+    # A distinct, constructible TE Linear so the *legitimate* path still seals,
+    # proving the guard rejects only the non-TE owner, not every claim.
+    te_linear_type = type("FakeTELinear", (object,), {"__init__": lambda self: None})
+    monkeypatch.setattr(te, "Linear", te_linear_type, raising=False)
+
+    from megatron.lite.primitive.precision import (
+        PrecisionCoverage,
+        PrimitiveCapability,
+        SemanticSite,
+        precision_model_init_context,
+        resolve_precision,
+    )
+
+    implementation = resolve_precision("hopper_blockwise_bf16_weight")
+    assert implementation is not None
+    coverage = PrecisionCoverage(implementation)
+    forged_owner = nn.Linear(128, 128, bias=False)
+
+    with precision_model_init_context(implementation):
+        coverage.require(
+            forged_owner,
+            SemanticSite.DENSE_MLP,
+            frozenset({PrimitiveCapability.TE_LINEAR}),
+            diagnostic="forged non-te linear",
+        )
+        # Owner-as-witness (default) is rejected: the owner is a raw nn.Linear.
+        with pytest.raises(TypeError, match="must be backed by a real"):
+            coverage.claim(
+                forged_owner, SemanticSite.DENSE_MLP, PrimitiveCapability.TE_LINEAR
+            )
+        # An explicit non-TE witness is rejected as well.
+        with pytest.raises(TypeError, match="must be backed by a real"):
+            coverage.claim(
+                forged_owner,
+                SemanticSite.DENSE_MLP,
+                PrimitiveCapability.TE_LINEAR,
+                forged_owner,
+            )
+        # The genuine TE primitive witness is accepted for the same site.
+        coverage.claim(
+            forged_owner,
+            SemanticSite.DENSE_MLP,
+            PrimitiveCapability.TE_LINEAR,
+            te_linear_type(),
+        )
+        manifest = coverage.seal()
+
+    assert [entry.capability for entry in manifest.entries] == [
+        PrimitiveCapability.TE_LINEAR
+    ]
+
+
 def test_gqa_binds_both_projection_linears_to_attention_projection(
     transformer_engine_import_stub, monkeypatch
 ):

--- a/experimental/lite/tests/unit/primitive/test_precision_primitives_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_precision_primitives_unit.py
@@ -1,0 +1,402 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+pytestmark = pytest.mark.mlite
+
+
+class _FakeLinear(nn.Module):
+    def __init__(self, in_features: int, out_features: int, **kwargs):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.kwargs = kwargs
+        self.weight = nn.Parameter(torch.empty(out_features, in_features))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.zeros(*x.shape[:-1], self.out_features, dtype=x.dtype)
+
+
+def _parallel_state(**overrides):
+    values = {
+        "tp_size": 1,
+        "tp_rank": 0,
+        "tp_group": None,
+        "ep_size": 1,
+        "etp_size": 1,
+        "etp_group": None,
+        "cp_size": 1,
+        "cp_group": None,
+        "cp_global_ranks": None,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_precision_site_context_opens_only_the_selected_te_scope(
+    transformer_engine_import_stub, monkeypatch
+):
+    transformer_engine_import_stub()
+    import transformer_engine.pytorch as te
+    from megatron.lite.primitive.precision import (
+        SemanticSite,
+        precision_forward_context,
+        precision_site_forward_context,
+        resolve_precision,
+    )
+
+    recipe = object()
+    base = resolve_precision("hopper_blockwise_bf16_weight")
+    assert base is not None
+    implementation = replace(base, recipe_factory=lambda: recipe)
+    calls = []
+
+    @contextmanager
+    def fake_fp8_autocast(**kwargs):
+        calls.append(("enter", kwargs))
+        yield
+        calls.append(("exit", kwargs))
+
+    monkeypatch.setattr(te, "fp8_autocast", fake_fp8_autocast, raising=False)
+
+    with precision_forward_context(implementation):
+        with precision_site_forward_context(
+            implementation, SemanticSite.ATTENTION_PROJECTION
+        ):
+            calls.append(("body", None))
+
+    assert calls == [
+        ("enter", {"enabled": True, "fp8_recipe": recipe, "fp8_group": None}),
+        ("body", None),
+        ("exit", {"enabled": True, "fp8_recipe": recipe, "fp8_group": None}),
+    ]
+    with pytest.raises(ValueError, match="fixed BF16"):
+        with precision_forward_context(implementation):
+            precision_site_forward_context(implementation, SemanticSite.ATTENTION_CORE)
+    with pytest.raises(RuntimeError, match="forward context"):
+        precision_site_forward_context(implementation, SemanticSite.DENSE_MLP)
+
+
+def test_tp_te_linear_primitives_claim_capability_and_enter_scoped_context(
+    transformer_engine_import_stub, monkeypatch
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.parallel import linear
+    from megatron.lite.primitive.precision import (
+        PrecisionCoverage,
+        PrimitiveCapability,
+        SemanticSite,
+        precision_forward_context,
+        precision_model_init_context,
+        resolve_precision,
+    )
+
+    monkeypatch.setattr(linear.te, "Linear", _FakeLinear)
+    monkeypatch.setattr(linear.te, "LayerNormLinear", _FakeLinear)
+    implementation = resolve_precision("hopper_blockwise_bf16_weight")
+    assert implementation is not None
+    coverage = PrecisionCoverage(implementation)
+
+    with precision_model_init_context(implementation):
+        qkv = linear.ColumnParallelLinear(
+            128,
+            128,
+            _parallel_state(),
+            normalization="RMSNorm",
+            precision_coverage=coverage,
+            precision_site=SemanticSite.ATTENTION_PROJECTION,
+        )
+        proj = linear.RowParallelLinear(
+            128,
+            128,
+            _parallel_state(),
+            precision_coverage=coverage,
+            precision_site=SemanticSite.ATTENTION_PROJECTION,
+        )
+        coverage.require(
+            qkv,
+            SemanticSite.ATTENTION_PROJECTION,
+            frozenset({PrimitiveCapability.TE_LAYERNORM_LINEAR}),
+        )
+        coverage.require(
+            proj,
+            SemanticSite.ATTENTION_PROJECTION,
+            frozenset({PrimitiveCapability.TE_LINEAR}),
+        )
+        manifest = coverage.seal()
+
+    assert [entry.capability for entry in manifest.entries] == [
+        PrimitiveCapability.TE_LAYERNORM_LINEAR,
+        PrimitiveCapability.TE_LINEAR,
+    ]
+    scopes = []
+
+    @contextmanager
+    def record_scope(bound_implementation, site):
+        scopes.append((bound_implementation, site))
+        yield
+
+    monkeypatch.setattr(linear, "precision_site_forward_context", record_scope)
+    x = torch.zeros(128, 128)
+    with precision_forward_context(implementation):
+        qkv(x)
+        proj(x)
+
+    assert scopes == [
+        (implementation, SemanticSite.ATTENTION_PROJECTION),
+        (implementation, SemanticSite.ATTENTION_PROJECTION),
+    ]
+
+
+def test_bf16_weight_linear_binding_fails_loud_for_shape_or_fp8_weight_profile(
+    transformer_engine_import_stub, monkeypatch
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.parallel import linear
+    from megatron.lite.primitive.precision import (
+        PrecisionCoverage,
+        SemanticSite,
+        precision_model_init_context,
+        resolve_precision,
+    )
+
+    monkeypatch.setattr(linear.te, "Linear", _FakeLinear)
+    bf16_weight = resolve_precision("hopper_blockwise_bf16_weight")
+    fp8_weight = resolve_precision("hopper_blockwise_fp8_weight")
+    assert bf16_weight is not None and fp8_weight is not None
+
+    with precision_model_init_context(bf16_weight):
+        with pytest.raises(ValueError, match="divisible by 128"):
+            linear.ColumnParallelLinear(
+                64,
+                128,
+                _parallel_state(),
+                precision_coverage=PrecisionCoverage(bf16_weight),
+                precision_site=SemanticSite.ATTENTION_PROJECTION,
+            )
+    with precision_model_init_context(fp8_weight):
+        with pytest.raises(NotImplementedError, match="FP8-weight"):
+            linear.ColumnParallelLinear(
+                128,
+                128,
+                _parallel_state(),
+                precision_coverage=PrecisionCoverage(fp8_weight),
+                precision_site=SemanticSite.ATTENTION_PROJECTION,
+            )
+
+
+def test_unbound_te_linear_preserves_bf16_path_without_precision_context(
+    transformer_engine_import_stub, monkeypatch
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.parallel import linear
+
+    monkeypatch.setattr(linear.te, "Linear", _FakeLinear)
+
+    def unexpected_context(*args, **kwargs):
+        raise AssertionError("the default BF16 path must not enter FP8 autocast")
+
+    monkeypatch.setattr(linear, "precision_site_forward_context", unexpected_context)
+    module = linear.ColumnParallelLinear(128, 128, _parallel_state())
+
+    assert module(torch.zeros(4, 128)).shape == (4, 128)
+
+
+def test_non_te_dense_requirement_fails_coverage_instead_of_falling_back():
+    from megatron.lite.primitive.precision import (
+        PrecisionCoverage,
+        PrimitiveCapability,
+        SemanticSite,
+        precision_model_init_context,
+        resolve_precision,
+    )
+
+    implementation = resolve_precision("hopper_blockwise_bf16_weight")
+    assert implementation is not None
+    coverage = PrecisionCoverage(implementation)
+    inline_torch_linear = nn.Linear(128, 128, bias=False)
+    with precision_model_init_context(implementation):
+        coverage.require(
+            inline_torch_linear,
+            SemanticSite.DENSE_MLP,
+            frozenset({PrimitiveCapability.TE_LINEAR}),
+            diagnostic="inline torch linear",
+        )
+        with pytest.raises(ValueError, match="missing claim.*inline torch linear"):
+            coverage.seal()
+
+
+def test_gqa_binds_both_projection_linears_to_attention_projection(
+    transformer_engine_import_stub, monkeypatch
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules import gqa
+    from megatron.lite.primitive.precision import SemanticSite
+
+    calls = []
+
+    class FakeProjection(nn.Module):
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+            calls.append(kwargs)
+            self.local_in = args[0]
+            self.local_out = args[1]
+            self.use_sp = False
+
+    class FakeModule(nn.Module):
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+
+    monkeypatch.setattr(gqa, "ColumnParallelLinear", FakeProjection)
+    monkeypatch.setattr(gqa, "RowParallelLinear", FakeProjection)
+    monkeypatch.setattr(gqa.te, "RMSNorm", FakeModule)
+    monkeypatch.setattr(gqa.te, "DotProductAttention", FakeModule)
+    monkeypatch.setattr(gqa, "RotaryEmbedding", FakeModule)
+    coverage = object()
+
+    gqa.GQAttention(
+        hidden_size=128,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=64,
+        ps=_parallel_state(),
+        precision_coverage=coverage,
+    )
+
+    assert len(calls) == 2
+    for kwargs in calls:
+        assert kwargs["precision_coverage"] is coverage
+        assert kwargs["precision_site"] is SemanticSite.ATTENTION_PROJECTION
+
+
+def test_dense_mlp_uses_two_precision_aware_te_linears(
+    transformer_engine_import_stub, monkeypatch
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules import mlp
+    from megatron.lite.primitive.precision import (
+        PrecisionCoverage,
+        PrimitiveCapability,
+        SemanticSite,
+        precision_forward_context,
+        precision_model_init_context,
+        resolve_precision,
+    )
+
+    monkeypatch.setattr(mlp.te, "Linear", _FakeLinear)
+    monkeypatch.setattr(
+        mlp,
+        "swiglu_with_probs",
+        lambda y, probs, swiglu_limit=0.0: y[..., : y.shape[-1] // 2],
+    )
+    implementation = resolve_precision("hopper_blockwise_bf16_weight")
+    assert implementation is not None
+    coverage = PrecisionCoverage(implementation)
+    with precision_model_init_context(implementation):
+        module = mlp.SwiGLUMLP(128, 128, precision_coverage=coverage)
+        for owner in (module.gate_up, module.down):
+            coverage.require(
+                owner,
+                SemanticSite.DENSE_MLP,
+                frozenset({PrimitiveCapability.TE_LINEAR}),
+            )
+        manifest = coverage.seal()
+
+    assert isinstance(module.gate_up, _FakeLinear)
+    assert isinstance(module.down, _FakeLinear)
+    assert not hasattr(module.gate_up, "linear")
+    assert set(module.state_dict()) == {"gate_up.weight", "down.weight"}
+    assert len(manifest.entries) == 2
+    scopes = []
+
+    @contextmanager
+    def record_scope(bound_implementation, site):
+        scopes.append((bound_implementation, site))
+        yield
+
+    monkeypatch.setattr(mlp, "precision_site_forward_context", record_scope)
+    with precision_forward_context(implementation):
+        output = module(torch.zeros(128, 128))
+    assert output.shape == (128, 128)
+    assert scopes == [
+        (implementation, SemanticSite.DENSE_MLP),
+        (implementation, SemanticSite.DENSE_MLP),
+    ]
+
+
+def test_moe_experts_claim_grouped_linears_and_use_blockwise_padding(
+    transformer_engine_import_stub, monkeypatch
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules import experts
+    from megatron.lite.primitive.precision import (
+        PrecisionCoverage,
+        PrimitiveCapability,
+        SemanticSite,
+        precision_forward_context,
+        precision_model_init_context,
+        resolve_precision,
+    )
+
+    class FakeGroupedLinear(nn.Module):
+        def __init__(self, groups, in_features, out_features, **kwargs):
+            super().__init__()
+            self.out_features = out_features
+
+        def forward(self, x, m_splits):
+            return torch.zeros(x.shape[0], self.out_features, dtype=x.dtype)
+
+    monkeypatch.setattr(experts.te, "GroupedLinear", FakeGroupedLinear, raising=False)
+    monkeypatch.setattr(
+        experts,
+        "swiglu_with_probs",
+        lambda y, probs, swiglu_limit=0.0: y[..., : y.shape[-1] // 2],
+    )
+    implementation = resolve_precision("hopper_blockwise_bf16_weight")
+    assert implementation is not None
+    coverage = PrecisionCoverage(implementation)
+    config = SimpleNamespace(
+        num_experts=2,
+        hidden_size=128,
+        moe_intermediate_size=128,
+        swiglu_limit=0.0,
+    )
+
+    with precision_model_init_context(implementation):
+        module = experts.Experts(
+            config,
+            _parallel_state(),
+            precision_coverage=coverage,
+        )
+        for owner in (module.fc1, module.fc2):
+            coverage.require(
+                owner,
+                SemanticSite.MOE_EXPERT,
+                frozenset({PrimitiveCapability.TE_GROUPED_LINEAR}),
+            )
+        coverage.seal()
+
+    scopes = []
+
+    @contextmanager
+    def record_scope(bound_implementation, site):
+        scopes.append((bound_implementation, site))
+        yield
+
+    monkeypatch.setattr(experts, "precision_site_forward_context", record_scope)
+    x = torch.ones(2, 128)
+    with precision_forward_context(implementation):
+        output = module(x, torch.tensor([1, 1]))
+
+    assert output.shape == (2, 128)
+    assert scopes == [
+        (implementation, SemanticSite.MOE_EXPERT),
+        (implementation, SemanticSite.MOE_EXPERT),
+    ]

--- a/experimental/lite/tests/unit/primitive/test_precision_profiles_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_precision_profiles_unit.py
@@ -1,0 +1,352 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from __future__ import annotations
+
+import sys
+import types
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytestmark = pytest.mark.mlite
+
+
+def test_precision_resolver_exposes_only_the_closed_profiles():
+    from megatron.lite.primitive.precision import (
+        AuthoritativeSource,
+        MasterOwner,
+        PRECISION_NAMES,
+        PrecisionDType,
+        SemanticSite,
+        WeightStorage,
+        resolve_precision,
+    )
+
+    assert PRECISION_NAMES == (
+        "bf16",
+        "hopper_blockwise_bf16_weight",
+        "hopper_blockwise_fp8_weight",
+    )
+    assert resolve_precision("bf16") is None
+
+    bf16_weight = resolve_precision("hopper_blockwise_bf16_weight")
+    fp8_weight = resolve_precision("hopper_blockwise_fp8_weight")
+    assert bf16_weight is not None
+    assert fp8_weight is not None
+    assert bf16_weight.recipe_factory is fp8_weight.recipe_factory
+    assert bf16_weight.fp8_sites == frozenset(
+        {
+            SemanticSite.ATTENTION_PROJECTION,
+            SemanticSite.DENSE_MLP,
+            SemanticSite.MOE_EXPERT,
+        }
+    )
+    assert bf16_weight.bf16_sites == frozenset(
+        {
+            SemanticSite.ATTENTION_CORE,
+            SemanticSite.ROUTER,
+            SemanticSite.NORM,
+            SemanticSite.EMBEDDING,
+            SemanticSite.LM_HEAD,
+        }
+    )
+    assert bf16_weight.parameter_contract.compute_weight is WeightStorage.BF16
+    assert (
+        fp8_weight.parameter_contract.compute_weight is WeightStorage.FP8_BLOCKWISE_E4M3
+    )
+    for implementation in (bf16_weight, fp8_weight):
+        contract = implementation.parameter_contract
+        assert contract.authoritative_load_source is AuthoritativeSource.HIGH_PRECISION
+        assert contract.master_parameter is PrecisionDType.FP32
+        assert contract.main_gradient is PrecisionDType.FP32
+        assert contract.optimizer_state is PrecisionDType.FP32
+        assert contract.parameter_all_gather is PrecisionDType.BF16
+        assert contract.master_owner is MasterOwner.MLITE_OPTIMIZER
+        with pytest.raises(FrozenInstanceError):
+            contract.master_parameter = PrecisionDType.BF16
+
+    with pytest.raises(ValueError, match="bf16.*hopper_blockwise_bf16_weight"):
+        resolve_precision("blockwise")
+    with pytest.raises(TypeError, match="string"):
+        resolve_precision(None)
+
+
+def test_hopper_recipe_matches_the_frozen_transformer_engine_mapping(monkeypatch):
+    from megatron.lite.primitive.precision import build_hopper_blockwise_recipe
+    from megatron.lite.primitive.precision import hopper_blockwise
+
+    class FakeFormat:
+        E4M3 = "E4M3"
+
+    class FakeMMParams:
+        def __init__(self, *, use_split_accumulator):
+            self.use_split_accumulator = use_split_accumulator
+
+    class FakeFloat8BlockScaling:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+            self.fp8_quant_fwd_inp = SimpleNamespace(power_2_scale=True)
+            self.fp8_quant_fwd_weight = SimpleNamespace(power_2_scale=True)
+            self.fp8_quant_bwd_grad = SimpleNamespace(power_2_scale=True)
+
+    te = types.ModuleType("transformer_engine")
+    common = types.ModuleType("transformer_engine.common")
+    recipe = types.ModuleType("transformer_engine.common.recipe")
+    recipe.Float8BlockScaling = FakeFloat8BlockScaling
+    recipe.Format = FakeFormat
+    recipe.MMParams = FakeMMParams
+    te.common = common
+    common.recipe = recipe
+    monkeypatch.setitem(sys.modules, "transformer_engine", te)
+    monkeypatch.setitem(sys.modules, "transformer_engine.common", common)
+    monkeypatch.setitem(sys.modules, "transformer_engine.common.recipe", recipe)
+    monkeypatch.delenv("NVTE_FP8_BLOCK_SCALING_FP32_SCALES", raising=False)
+    monkeypatch.delenv("NVTE_BACKWARD_OVERRIDE", raising=False)
+
+    hopper_blockwise._build_hopper_blockwise_recipe.cache_clear()
+    built = build_hopper_blockwise_recipe()
+    try:
+        assert built.fp8_format == "E4M3"
+        assert built.use_f32_scales is False
+        assert built.x_block_scaling_dim == 1
+        assert built.w_block_scaling_dim == 2
+        assert built.grad_block_scaling_dim == 1
+        assert built.fp8_gemm_fprop.use_split_accumulator is True
+        assert built.fp8_gemm_dgrad.use_split_accumulator is True
+        assert built.fp8_gemm_wgrad.use_split_accumulator is True
+        assert built.fp8_dpa is False
+        assert built.fp8_mha is False
+        assert built.backward_override is None
+        assert build_hopper_blockwise_recipe() is built
+        built.fp8_mha = True
+        with pytest.raises(RuntimeError, match="frozen contract"):
+            build_hopper_blockwise_recipe()
+    finally:
+        hopper_blockwise._build_hopper_blockwise_recipe.cache_clear()
+
+
+def _valid_hopper_environment(**overrides):
+    values = {
+        "compute_capability": (9, 0),
+        "transformer_engine_version": "2.18.0.dev0",
+        "cuda_version": (12, 9),
+        "cublas_version": 130400,
+        "block_scaling_supported": True,
+        "unsupported_reason": "",
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"compute_capability": (8, 9)}, "SM90"),
+        ({"compute_capability": (10, 0)}, "SM90"),
+        ({"transformer_engine_version": "2.17.0"}, "2.18.0.dev0"),
+        ({"transformer_engine_version": "2.18.0.dev0+deadbee"}, "8b99682"),
+        ({"cuda_version": (12, 8)}, "CUDA 12.9"),
+        ({"cublas_version": 130300}, "cuBLAS 13.4"),
+        (
+            {
+                "block_scaling_supported": False,
+                "unsupported_reason": "kernel unavailable",
+            },
+            "kernel unavailable",
+        ),
+    ],
+)
+def test_hopper_environment_fails_loud_on_reference_mismatch(
+    monkeypatch, overrides, message
+):
+    from megatron.lite.primitive.precision import hopper_blockwise
+
+    monkeypatch.setattr(
+        hopper_blockwise,
+        "_probe_hopper_environment",
+        lambda: _valid_hopper_environment(**overrides),
+    )
+    monkeypatch.delenv("NVTE_FP8_BLOCK_SCALING_FP32_SCALES", raising=False)
+    monkeypatch.delenv("NVTE_BACKWARD_OVERRIDE", raising=False)
+
+    with pytest.raises(RuntimeError, match=message):
+        hopper_blockwise.validate_hopper_environment()
+
+
+@pytest.mark.parametrize(
+    "version",
+    [
+        "2.18.0.dev0+8b99682",
+        "2.18.0.dev0+8b9968255eb879e6e390f427836906b29aad64d2",
+    ],
+)
+def test_hopper_environment_accepts_the_frozen_reference(monkeypatch, version):
+    from megatron.lite.primitive.precision import hopper_blockwise
+
+    environment = _valid_hopper_environment(transformer_engine_version=version)
+    monkeypatch.setattr(
+        hopper_blockwise, "_probe_hopper_environment", lambda: environment
+    )
+    monkeypatch.delenv("NVTE_FP8_BLOCK_SCALING_FP32_SCALES", raising=False)
+    monkeypatch.delenv("NVTE_BACKWARD_OVERRIDE", raising=False)
+
+    assert hopper_blockwise.validate_hopper_environment() is environment
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("NVTE_FP8_BLOCK_SCALING_FP32_SCALES", "1"),
+        ("NVTE_BACKWARD_OVERRIDE", "high_precision"),
+    ],
+)
+def test_hopper_environment_rejects_recipe_overrides(monkeypatch, name, value):
+    from megatron.lite.primitive.precision import hopper_blockwise
+
+    monkeypatch.setattr(
+        hopper_blockwise, "_probe_hopper_environment", _valid_hopper_environment
+    )
+    monkeypatch.setenv(name, value)
+
+    with pytest.raises(RuntimeError, match=name):
+        hopper_blockwise.validate_hopper_environment()
+
+
+def _coverage_types():
+    from megatron.lite.primitive.precision import (
+        PrecisionCoverage,
+        PrimitiveCapability,
+        SemanticSite,
+        resolve_precision,
+    )
+
+    implementation = resolve_precision("hopper_blockwise_bf16_weight")
+    assert implementation is not None
+    return implementation, PrecisionCoverage, PrimitiveCapability, SemanticSite
+
+
+def test_typed_coverage_seals_exact_selected_sites_and_bf16_exclusions():
+    from megatron.lite.primitive.precision import precision_model_init_context
+
+    implementation, PrecisionCoverage, Capability, Site = _coverage_types()
+    attention_projection = object()
+    attention_core = object()
+    router = object()
+    coverage = PrecisionCoverage(implementation)
+
+    with precision_model_init_context(implementation):
+        coverage.require(
+            attention_projection,
+            Site.ATTENTION_PROJECTION,
+            frozenset({Capability.TE_LINEAR, Capability.TE_LAYERNORM_LINEAR}),
+            diagnostic="attention projection 0",
+        )
+        coverage.claim(
+            attention_projection,
+            Site.ATTENTION_PROJECTION,
+            Capability.TE_LINEAR,
+            diagnostic="TE column parallel linear",
+        )
+        coverage.require(
+            attention_core, Site.ATTENTION_CORE, diagnostic="attention core 0"
+        )
+        coverage.require(router, Site.ROUTER, diagnostic="router 0")
+        manifest = coverage.seal()
+
+    assert manifest.implementation_name == implementation.name
+    assert [entry.site for entry in manifest.entries] == [
+        Site.ATTENTION_PROJECTION,
+        Site.ATTENTION_CORE,
+        Site.ROUTER,
+    ]
+    assert manifest.entries[0].capability is Capability.TE_LINEAR
+    assert manifest.entries[1].capability is None
+    assert coverage.manifest is manifest
+
+    with pytest.raises(RuntimeError, match="sealed"):
+        coverage.require(object(), Site.NORM, diagnostic="late norm")
+
+
+def test_typed_coverage_requires_the_runtime_model_init_context():
+    implementation, PrecisionCoverage, _, Site = _coverage_types()
+    coverage = PrecisionCoverage(implementation)
+
+    with pytest.raises(RuntimeError, match="model-init"):
+        coverage.require(object(), Site.ATTENTION_CORE)
+
+
+@pytest.mark.parametrize(
+    ("case", "message"),
+    [
+        ("missing", "missing"),
+        ("duplicate_requirement", "duplicate requirement"),
+        ("duplicate_claim", "duplicate claim"),
+        ("incompatible", "incompatible"),
+        ("unconsumed", "unconsumed"),
+        ("bf16_claim", "fixed BF16"),
+    ],
+)
+def test_typed_coverage_fails_loud_for_incomplete_or_ambiguous_binding(case, message):
+    from megatron.lite.primitive.precision import precision_model_init_context
+
+    implementation, PrecisionCoverage, Capability, Site = _coverage_types()
+    covered = object()
+    coverage = PrecisionCoverage(implementation)
+
+    with precision_model_init_context(implementation):
+        coverage.require(
+            covered,
+            Site.DENSE_MLP,
+            frozenset({Capability.TE_LINEAR}),
+            diagnostic="dense mlp 0",
+        )
+        if case == "duplicate_requirement":
+            coverage.require(
+                covered,
+                Site.DENSE_MLP,
+                frozenset({Capability.TE_LINEAR}),
+                diagnostic="dense mlp duplicate",
+            )
+        elif case == "duplicate_claim":
+            coverage.claim(covered, Site.DENSE_MLP, Capability.TE_LINEAR)
+            coverage.claim(covered, Site.DENSE_MLP, Capability.TE_LINEAR)
+        elif case == "incompatible":
+            coverage.claim(covered, Site.DENSE_MLP, Capability.TE_GROUPED_LINEAR)
+        elif case == "unconsumed":
+            coverage.claim(covered, Site.DENSE_MLP, Capability.TE_LINEAR)
+            coverage.claim(object(), Site.MOE_EXPERT, Capability.TE_GROUPED_LINEAR)
+        elif case == "bf16_claim":
+            coverage.claim(covered, Site.DENSE_MLP, Capability.TE_LINEAR)
+            core = object()
+            coverage.require(core, Site.ATTENTION_CORE)
+            coverage.claim(core, Site.ATTENTION_CORE, Capability.TE_LINEAR)
+
+        with pytest.raises(ValueError, match=message):
+            coverage.seal()
+
+
+def test_precision_package_stays_narrow_and_model_agnostic():
+    root = Path(__file__).resolve().parents[3]
+    precision_root = root / "megatron" / "lite" / "primitive" / "precision"
+    assert {path.name for path in precision_root.glob("*.py")} == {
+        "__init__.py",
+        "contract.py",
+        "coverage.py",
+        "hopper_blockwise.py",
+    }
+    source = "\n".join(
+        path.read_text(encoding="utf-8") for path in sorted(precision_root.glob("*.py"))
+    ).lower()
+    for forbidden in (
+        "megatron.lite.model",
+        "qwen",
+        "deepseek",
+        "glm",
+        "kimi",
+        "fnmatch",
+        "glob(",
+        "re.compile",
+    ):
+        assert forbidden not in source
+    assert list((root / "megatron" / "lite" / "model").glob("*/fp8.py")) == []

--- a/experimental/lite/tests/unit/primitive/test_precision_profiles_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_precision_profiles_unit.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+import torch.nn as nn
 
 pytestmark = pytest.mark.mlite
 
@@ -240,6 +241,42 @@ def test_hopper_environment_rejects_recipe_overrides(monkeypatch, name, value):
         hopper_blockwise.validate_hopper_environment()
 
 
+def test_hopper_environment_gates_grouped_cublas_only_for_moe_profiles(monkeypatch):
+    # BLOCKER regression (FP8-CUBLAS-GATE): the general block-scaling probe does
+    # not cover TE's grouped-GEMM cuBLAS requirement, so a MoE FP8 profile must
+    # gate it independently or risk crashing inside GroupedLinear. The gate is
+    # scoped to profiles that select MoE experts; it is not a general device/
+    # CUDA/TE version pin, so the no-profile probe still ignores cuBLAS.
+    from megatron.lite.primitive.precision import hopper_blockwise
+    from megatron.lite.primitive.precision.hopper_blockwise import (
+        CUBLAS_GROUPED_GEMM_MIN_VERSION,
+        HOPPER_BLOCKWISE_BF16_WEIGHT,
+    )
+
+    monkeypatch.delenv("NVTE_FP8_BLOCK_SCALING_FP32_SCALES", raising=False)
+    monkeypatch.delenv("NVTE_BACKWARD_OVERRIDE", raising=False)
+
+    under = _valid_hopper_environment(
+        cublas_version=CUBLAS_GROUPED_GEMM_MIN_VERSION - 1
+    )
+    monkeypatch.setattr(hopper_blockwise, "_probe_hopper_environment", lambda: under)
+    # A MoE-expert profile fails loud on the under-versioned cuBLAS ...
+    with pytest.raises(RuntimeError, match="grouped GEMM"):
+        hopper_blockwise.validate_hopper_environment(HOPPER_BLOCKWISE_BF16_WEIGHT)
+    # ... while the no-profile probe does not apply the grouped requirement.
+    assert hopper_blockwise.validate_hopper_environment() is under
+
+    # At exactly the minimum grouped cuBLAS version, the MoE profile passes.
+    at_min = _valid_hopper_environment(
+        cublas_version=CUBLAS_GROUPED_GEMM_MIN_VERSION
+    )
+    monkeypatch.setattr(hopper_blockwise, "_probe_hopper_environment", lambda: at_min)
+    assert (
+        hopper_blockwise.validate_hopper_environment(HOPPER_BLOCKWISE_BF16_WEIGHT)
+        is at_min
+    )
+
+
 def _coverage_types():
     from megatron.lite.primitive.precision import (
         PrecisionCoverage,
@@ -257,16 +294,19 @@ def _install_te_witnesses(transformer_engine_import_stub, monkeypatch):
     """Install stub TE classes and return real instances usable as claim witnesses.
 
     ``PrecisionCoverage.claim`` binds each capability to a genuine TE primitive
-    instance, so coverage-algebra tests must present real TE-typed witnesses
-    rather than bare ``object()`` claims.
+    instance that must also be the owner itself or one of its registered
+    submodules, so coverage-algebra tests must present real TE-typed witnesses
+    bound to their owner rather than bare ``object()`` claims. TE GEMM primitives
+    are ``nn.Module`` instances in production, so the stubs subclass ``nn.Module``
+    and register as submodules of an owner.
     """
 
     transformer_engine_import_stub()
     import transformer_engine.pytorch as te
 
-    class _FakeTEModule:
+    class _FakeTEModule(nn.Module):
         def __init__(self, *args, **kwargs):
-            pass
+            super().__init__()
 
     linear_type = type("FakeTELinear", (_FakeTEModule,), {})
     layernorm_type = type("FakeTELayerNormLinear", (_FakeTEModule,), {})
@@ -281,6 +321,21 @@ def _install_te_witnesses(transformer_engine_import_stub, monkeypatch):
     )
 
 
+class _TEOwner(nn.Module):
+    """A model-composition owner that registers its TE GEMM primitives as submodules.
+
+    Mirrors the real binding: dense MLP / MoE experts pass the TE module as owner,
+    while a TP-linear wrapper owns a registered ``self.linear`` submodule. A claim's
+    witness must be reachable from the owner, so tests build owners this way rather
+    than borrowing an unrelated primitive.
+    """
+
+    def __init__(self, **primitives):
+        super().__init__()
+        for name, primitive in primitives.items():
+            setattr(self, name, primitive)
+
+
 def test_typed_coverage_seals_exact_selected_sites_and_bf16_exclusions(
     transformer_engine_import_stub, monkeypatch
 ):
@@ -288,7 +343,9 @@ def test_typed_coverage_seals_exact_selected_sites_and_bf16_exclusions(
 
     witnesses = _install_te_witnesses(transformer_engine_import_stub, monkeypatch)
     implementation, PrecisionCoverage, Capability, Site = _coverage_types()
-    attention_projection = object()
+    # Owner-as-witness: the projection GEMM owner *is* the TE linear (dense/expert
+    # pattern). BF16 sites carry no claim, so their owner identity is opaque.
+    attention_projection = witnesses.linear
     attention_core = object()
     router = object()
     coverage = PrecisionCoverage(implementation)
@@ -353,7 +410,10 @@ def test_typed_coverage_fails_loud_for_incomplete_or_ambiguous_binding(
 
     witnesses = _install_te_witnesses(transformer_engine_import_stub, monkeypatch)
     implementation, PrecisionCoverage, Capability, Site = _coverage_types()
-    covered = object()
+    # Owner carries both its TE linear and grouped GEMM as registered submodules,
+    # so every claim presents a witness genuinely bound to its owner and the only
+    # defect under test is the coverage-algebra one named by ``case``.
+    covered = _TEOwner(linear=witnesses.linear, grouped=witnesses.grouped)
     coverage = PrecisionCoverage(implementation)
 
     with precision_model_init_context(implementation):
@@ -371,22 +431,23 @@ def test_typed_coverage_fails_loud_for_incomplete_or_ambiguous_binding(
                 diagnostic="dense mlp duplicate",
             )
         elif case == "duplicate_claim":
-            coverage.claim(covered, Site.DENSE_MLP, Capability.TE_LINEAR, witnesses.linear)
-            coverage.claim(covered, Site.DENSE_MLP, Capability.TE_LINEAR, witnesses.linear)
+            coverage.claim(covered, Site.DENSE_MLP, Capability.TE_LINEAR, covered.linear)
+            coverage.claim(covered, Site.DENSE_MLP, Capability.TE_LINEAR, covered.linear)
         elif case == "incompatible":
             coverage.claim(
-                covered, Site.DENSE_MLP, Capability.TE_GROUPED_LINEAR, witnesses.grouped
+                covered, Site.DENSE_MLP, Capability.TE_GROUPED_LINEAR, covered.grouped
             )
         elif case == "unconsumed":
-            coverage.claim(covered, Site.DENSE_MLP, Capability.TE_LINEAR, witnesses.linear)
+            coverage.claim(covered, Site.DENSE_MLP, Capability.TE_LINEAR, covered.linear)
+            extra = _TEOwner(grouped=type(witnesses.grouped)())
             coverage.claim(
-                object(), Site.MOE_EXPERT, Capability.TE_GROUPED_LINEAR, witnesses.grouped
+                extra, Site.MOE_EXPERT, Capability.TE_GROUPED_LINEAR, extra.grouped
             )
         elif case == "bf16_claim":
-            coverage.claim(covered, Site.DENSE_MLP, Capability.TE_LINEAR, witnesses.linear)
-            core = object()
+            coverage.claim(covered, Site.DENSE_MLP, Capability.TE_LINEAR, covered.linear)
+            core = _TEOwner(linear=type(witnesses.linear)())
             coverage.require(core, Site.ATTENTION_CORE)
-            coverage.claim(core, Site.ATTENTION_CORE, Capability.TE_LINEAR, witnesses.linear)
+            coverage.claim(core, Site.ATTENTION_CORE, Capability.TE_LINEAR, core.linear)
 
         with pytest.raises(ValueError, match=message):
             coverage.seal()

--- a/experimental/lite/tests/unit/primitive/test_precision_profiles_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_precision_profiles_unit.py
@@ -12,7 +12,7 @@ import pytest
 pytestmark = pytest.mark.mlite
 
 
-def test_precision_resolver_exposes_only_the_closed_profiles():
+def test_precision_resolver_exposes_only_the_implemented_profile():
     from megatron.lite.primitive.precision import (
         AuthoritativeSource,
         MasterOwner,
@@ -23,18 +23,17 @@ def test_precision_resolver_exposes_only_the_closed_profiles():
         resolve_precision,
     )
 
+    # The reserved FP8-weight name is not advertised as usable: only the two
+    # implemented names are offered, and requesting the reserved profile fails
+    # loud instead of returning an unbuildable implementation.
     assert PRECISION_NAMES == (
         "bf16",
         "hopper_blockwise_bf16_weight",
-        "hopper_blockwise_fp8_weight",
     )
     assert resolve_precision("bf16") is None
 
     bf16_weight = resolve_precision("hopper_blockwise_bf16_weight")
-    fp8_weight = resolve_precision("hopper_blockwise_fp8_weight")
     assert bf16_weight is not None
-    assert fp8_weight is not None
-    assert bf16_weight.recipe_factory is fp8_weight.recipe_factory
     assert bf16_weight.fp8_sites == frozenset(
         {
             SemanticSite.ATTENTION_PROJECTION,
@@ -52,19 +51,20 @@ def test_precision_resolver_exposes_only_the_closed_profiles():
         }
     )
     assert bf16_weight.parameter_contract.compute_weight is WeightStorage.BF16
-    assert (
-        fp8_weight.parameter_contract.compute_weight is WeightStorage.FP8_BLOCKWISE_E4M3
-    )
-    for implementation in (bf16_weight, fp8_weight):
-        contract = implementation.parameter_contract
-        assert contract.authoritative_load_source is AuthoritativeSource.HIGH_PRECISION
-        assert contract.master_parameter is PrecisionDType.FP32
-        assert contract.main_gradient is PrecisionDType.FP32
-        assert contract.optimizer_state is PrecisionDType.FP32
-        assert contract.parameter_all_gather is PrecisionDType.BF16
-        assert contract.master_owner is MasterOwner.MLITE_OPTIMIZER
-        with pytest.raises(FrozenInstanceError):
-            contract.master_parameter = PrecisionDType.BF16
+    contract = bf16_weight.parameter_contract
+    assert contract.authoritative_load_source is AuthoritativeSource.HIGH_PRECISION
+    assert contract.master_parameter is PrecisionDType.FP32
+    assert contract.main_gradient is PrecisionDType.FP32
+    assert contract.optimizer_state is PrecisionDType.FP32
+    assert contract.parameter_all_gather is PrecisionDType.BF16
+    assert contract.master_owner is MasterOwner.MLITE_OPTIMIZER
+    with pytest.raises(FrozenInstanceError):
+        contract.master_parameter = PrecisionDType.BF16
+
+    # The reserved second profile is a declared-but-pending follow-up: it fails
+    # loud rather than being sold as a working profile.
+    with pytest.raises(NotImplementedError, match="not implemented"):
+        resolve_precision("hopper_blockwise_fp8_weight")
 
     with pytest.raises(ValueError, match="bf16.*hopper_blockwise_bf16_weight"):
         resolve_precision("blockwise")
@@ -139,52 +139,74 @@ def _valid_hopper_environment(**overrides):
     return SimpleNamespace(**values)
 
 
-@pytest.mark.parametrize(
-    ("overrides", "message"),
-    [
-        ({"compute_capability": (8, 9)}, "SM90"),
-        ({"compute_capability": (10, 0)}, "SM90"),
-        ({"transformer_engine_version": "2.17.0"}, "2.15.0"),
-        ({"transformer_engine_version": "2.18.0.dev0+8b99682"}, "2.15.0"),
-        ({"cuda_version": (12, 8)}, "CUDA 12.9"),
-        ({"cublas_version": 130300}, "cuBLAS 13.4"),
-        (
-            {
-                "block_scaling_supported": False,
-                "unsupported_reason": "kernel unavailable",
-            },
-            "kernel unavailable",
-        ),
-    ],
-)
-def test_hopper_environment_fails_loud_on_reference_mismatch(
-    monkeypatch, overrides, message
-):
+def test_hopper_environment_fails_loud_when_te_capability_probe_rejects(monkeypatch):
+    # The single authoritative gate is Transformer Engine's own capability probe.
+    # When it rejects the environment we fail loud with its concrete reason and
+    # the recorded toolchain for diagnosis.
     from megatron.lite.primitive.precision import hopper_blockwise
 
     monkeypatch.setattr(
         hopper_blockwise,
         "_probe_hopper_environment",
-        lambda: _valid_hopper_environment(**overrides),
+        lambda: _valid_hopper_environment(
+            block_scaling_supported=False, unsupported_reason="kernel unavailable"
+        ),
     )
     monkeypatch.delenv("NVTE_FP8_BLOCK_SCALING_FP32_SCALES", raising=False)
     monkeypatch.delenv("NVTE_BACKWARD_OVERRIDE", raising=False)
 
-    with pytest.raises(RuntimeError, match=message):
+    with pytest.raises(RuntimeError, match="kernel unavailable"):
         hopper_blockwise.validate_hopper_environment()
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        # Iron-law environment rule: whatever runs BF16 must run FP8. A newer or
+        # different device class, TE version, CUDA, or cuBLAS is *not* a hard
+        # gate -- if TE's capability probe says blockwise FP8 works, it runs.
+        {"compute_capability": (8, 9)},
+        {"compute_capability": (10, 0)},
+        {"transformer_engine_version": "2.17.0"},
+        {"transformer_engine_version": "2.18.0.dev0+8b99682"},
+        {"cuda_version": (12, 8)},
+        {"cublas_version": 130300},
+    ],
+)
+def test_hopper_environment_gates_on_capability_not_version(monkeypatch, overrides):
+    from megatron.lite.primitive.precision import hopper_blockwise
+
+    environment = _valid_hopper_environment(**overrides)
+    monkeypatch.setattr(
+        hopper_blockwise, "_probe_hopper_environment", lambda: environment
+    )
+    monkeypatch.delenv("NVTE_FP8_BLOCK_SCALING_FP32_SCALES", raising=False)
+    monkeypatch.delenv("NVTE_BACKWARD_OVERRIDE", raising=False)
+
+    # A non-canonical toolchain is allowed but surfaced loudly (never silent).
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        if overrides.get("transformer_engine_version"):
+            with pytest.raises(RuntimeWarning, match="canonical validated version"):
+                hopper_blockwise.validate_hopper_environment()
+            warnings.simplefilter("ignore", RuntimeWarning)
+        assert hopper_blockwise.validate_hopper_environment() is environment
 
 
 @pytest.mark.parametrize(
     "version",
     [
-        # The released version is the contract; any build tag on it is accepted
-        # so FP8 needs no bespoke build -- it runs on the canonical BF16 image.
+        # The canonical released version passes without any provenance warning.
         "2.15.0",
         "2.15.0+42b84005",
         "2.15.0+deadbeef",
     ],
 )
 def test_hopper_environment_accepts_the_canonical_reference(monkeypatch, version):
+    import warnings
+
     from megatron.lite.primitive.precision import hopper_blockwise
 
     environment = _valid_hopper_environment(transformer_engine_version=version)
@@ -194,7 +216,9 @@ def test_hopper_environment_accepts_the_canonical_reference(monkeypatch, version
     monkeypatch.delenv("NVTE_FP8_BLOCK_SCALING_FP32_SCALES", raising=False)
     monkeypatch.delenv("NVTE_BACKWARD_OVERRIDE", raising=False)
 
-    assert hopper_blockwise.validate_hopper_environment() is environment
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        assert hopper_blockwise.validate_hopper_environment() is environment
 
 
 @pytest.mark.parametrize(

--- a/experimental/lite/tests/unit/primitive/test_precision_profiles_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_precision_profiles_unit.py
@@ -507,6 +507,38 @@ def test_typed_coverage_fails_loud_for_incomplete_or_ambiguous_binding(
             coverage.seal()
 
 
+@pytest.mark.parametrize("optimizer_backend", ["dist_opt", "adam", "megatron"])
+def test_fp8_weight_profile_rejects_optimizers_without_fp8_param_gather(optimizer_backend):
+    from megatron.lite.primitive.precision import (
+        FP8_WEIGHT_SUPPORTED_OPTIMIZERS,
+        require_optimizer_supports_precision,
+        resolve_precision,
+    )
+
+    assert FP8_WEIGHT_SUPPORTED_OPTIMIZERS == frozenset({"fsdp2"})
+    fp8_weight = resolve_precision("hopper_blockwise_fp8_weight")
+    # FP8 compute weights need the upstream Megatron fp8_param_gather write-back,
+    # absent from the closed profiles, so any optimizer that lacks it must fail
+    # loud instead of silently training BF16-gathered params.
+    with pytest.raises(ValueError, match="fp8_param_gather"):
+        require_optimizer_supports_precision(fp8_weight, optimizer_backend)
+
+
+def test_optimizer_precision_gate_allows_supported_combinations():
+    from megatron.lite.primitive.precision import (
+        require_optimizer_supports_precision,
+        resolve_precision,
+    )
+
+    fp8_weight = resolve_precision("hopper_blockwise_fp8_weight")
+    bf16_weight = resolve_precision("hopper_blockwise_bf16_weight")
+    # FSDP2 keeps FP8 compute weights live through its per-parameter update.
+    require_optimizer_supports_precision(fp8_weight, "fsdp2")
+    # A BF16-weight profile trains under every optimizer backend unchanged.
+    for backend in ("dist_opt", "fsdp2", "adam", "megatron"):
+        require_optimizer_supports_precision(bf16_weight, backend)
+
+
 def test_precision_package_stays_narrow_and_model_agnostic():
     root = Path(__file__).resolve().parents[3]
     precision_root = root / "megatron" / "lite" / "primitive" / "precision"

--- a/experimental/lite/tests/unit/primitive/test_precision_profiles_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_precision_profiles_unit.py
@@ -129,7 +129,7 @@ def test_hopper_recipe_matches_the_frozen_transformer_engine_mapping(monkeypatch
 def _valid_hopper_environment(**overrides):
     values = {
         "compute_capability": (9, 0),
-        "transformer_engine_version": "2.18.0.dev0",
+        "transformer_engine_version": "2.15.0+42b84005",
         "cuda_version": (12, 9),
         "cublas_version": 130400,
         "block_scaling_supported": True,
@@ -144,8 +144,8 @@ def _valid_hopper_environment(**overrides):
     [
         ({"compute_capability": (8, 9)}, "SM90"),
         ({"compute_capability": (10, 0)}, "SM90"),
-        ({"transformer_engine_version": "2.17.0"}, "2.18.0.dev0"),
-        ({"transformer_engine_version": "2.18.0.dev0+deadbee"}, "8b99682"),
+        ({"transformer_engine_version": "2.17.0"}, "2.15.0"),
+        ({"transformer_engine_version": "2.18.0.dev0+8b99682"}, "2.15.0"),
         ({"cuda_version": (12, 8)}, "CUDA 12.9"),
         ({"cublas_version": 130300}, "cuBLAS 13.4"),
         (
@@ -177,11 +177,14 @@ def test_hopper_environment_fails_loud_on_reference_mismatch(
 @pytest.mark.parametrize(
     "version",
     [
-        "2.18.0.dev0+8b99682",
-        "2.18.0.dev0+8b9968255eb879e6e390f427836906b29aad64d2",
+        # The released version is the contract; any build tag on it is accepted
+        # so FP8 needs no bespoke build -- it runs on the canonical BF16 image.
+        "2.15.0",
+        "2.15.0+42b84005",
+        "2.15.0+deadbeef",
     ],
 )
-def test_hopper_environment_accepts_the_frozen_reference(monkeypatch, version):
+def test_hopper_environment_accepts_the_canonical_reference(monkeypatch, version):
     from megatron.lite.primitive.precision import hopper_blockwise
 
     environment = _valid_hopper_environment(transformer_engine_version=version)

--- a/experimental/lite/tests/unit/primitive/test_precision_profiles_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_precision_profiles_unit.py
@@ -229,9 +229,40 @@ def _coverage_types():
     return implementation, PrecisionCoverage, PrimitiveCapability, SemanticSite
 
 
-def test_typed_coverage_seals_exact_selected_sites_and_bf16_exclusions():
+def _install_te_witnesses(transformer_engine_import_stub, monkeypatch):
+    """Install stub TE classes and return real instances usable as claim witnesses.
+
+    ``PrecisionCoverage.claim`` binds each capability to a genuine TE primitive
+    instance, so coverage-algebra tests must present real TE-typed witnesses
+    rather than bare ``object()`` claims.
+    """
+
+    transformer_engine_import_stub()
+    import transformer_engine.pytorch as te
+
+    class _FakeTEModule:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    linear_type = type("FakeTELinear", (_FakeTEModule,), {})
+    layernorm_type = type("FakeTELayerNormLinear", (_FakeTEModule,), {})
+    grouped_type = type("FakeTEGroupedLinear", (_FakeTEModule,), {})
+    monkeypatch.setattr(te, "Linear", linear_type, raising=False)
+    monkeypatch.setattr(te, "LayerNormLinear", layernorm_type, raising=False)
+    monkeypatch.setattr(te, "GroupedLinear", grouped_type, raising=False)
+    return SimpleNamespace(
+        linear=linear_type(),
+        layernorm_linear=layernorm_type(),
+        grouped=grouped_type(),
+    )
+
+
+def test_typed_coverage_seals_exact_selected_sites_and_bf16_exclusions(
+    transformer_engine_import_stub, monkeypatch
+):
     from megatron.lite.primitive.precision import precision_model_init_context
 
+    witnesses = _install_te_witnesses(transformer_engine_import_stub, monkeypatch)
     implementation, PrecisionCoverage, Capability, Site = _coverage_types()
     attention_projection = object()
     attention_core = object()
@@ -249,6 +280,7 @@ def test_typed_coverage_seals_exact_selected_sites_and_bf16_exclusions():
             attention_projection,
             Site.ATTENTION_PROJECTION,
             Capability.TE_LINEAR,
+            witnesses.linear,
             diagnostic="TE column parallel linear",
         )
         coverage.require(
@@ -290,9 +322,12 @@ def test_typed_coverage_requires_the_runtime_model_init_context():
         ("bf16_claim", "fixed BF16"),
     ],
 )
-def test_typed_coverage_fails_loud_for_incomplete_or_ambiguous_binding(case, message):
+def test_typed_coverage_fails_loud_for_incomplete_or_ambiguous_binding(
+    case, message, transformer_engine_import_stub, monkeypatch
+):
     from megatron.lite.primitive.precision import precision_model_init_context
 
+    witnesses = _install_te_witnesses(transformer_engine_import_stub, monkeypatch)
     implementation, PrecisionCoverage, Capability, Site = _coverage_types()
     covered = object()
     coverage = PrecisionCoverage(implementation)
@@ -312,18 +347,22 @@ def test_typed_coverage_fails_loud_for_incomplete_or_ambiguous_binding(case, mes
                 diagnostic="dense mlp duplicate",
             )
         elif case == "duplicate_claim":
-            coverage.claim(covered, Site.DENSE_MLP, Capability.TE_LINEAR)
-            coverage.claim(covered, Site.DENSE_MLP, Capability.TE_LINEAR)
+            coverage.claim(covered, Site.DENSE_MLP, Capability.TE_LINEAR, witnesses.linear)
+            coverage.claim(covered, Site.DENSE_MLP, Capability.TE_LINEAR, witnesses.linear)
         elif case == "incompatible":
-            coverage.claim(covered, Site.DENSE_MLP, Capability.TE_GROUPED_LINEAR)
+            coverage.claim(
+                covered, Site.DENSE_MLP, Capability.TE_GROUPED_LINEAR, witnesses.grouped
+            )
         elif case == "unconsumed":
-            coverage.claim(covered, Site.DENSE_MLP, Capability.TE_LINEAR)
-            coverage.claim(object(), Site.MOE_EXPERT, Capability.TE_GROUPED_LINEAR)
+            coverage.claim(covered, Site.DENSE_MLP, Capability.TE_LINEAR, witnesses.linear)
+            coverage.claim(
+                object(), Site.MOE_EXPERT, Capability.TE_GROUPED_LINEAR, witnesses.grouped
+            )
         elif case == "bf16_claim":
-            coverage.claim(covered, Site.DENSE_MLP, Capability.TE_LINEAR)
+            coverage.claim(covered, Site.DENSE_MLP, Capability.TE_LINEAR, witnesses.linear)
             core = object()
             coverage.require(core, Site.ATTENTION_CORE)
-            coverage.claim(core, Site.ATTENTION_CORE, Capability.TE_LINEAR)
+            coverage.claim(core, Site.ATTENTION_CORE, Capability.TE_LINEAR, witnesses.linear)
 
         with pytest.raises(ValueError, match=message):
             coverage.seal()

--- a/experimental/lite/tests/unit/primitive/test_precision_profiles_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_precision_profiles_unit.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import sys
 import types
+import dataclasses
 from dataclasses import FrozenInstanceError
 from pathlib import Path
 from types import SimpleNamespace
@@ -13,7 +14,7 @@ import torch.nn as nn
 pytestmark = pytest.mark.mlite
 
 
-def test_precision_resolver_exposes_only_the_implemented_profile():
+def test_precision_resolver_exposes_both_closed_hopper_profiles():
     from megatron.lite.primitive.precision import (
         AuthoritativeSource,
         MasterOwner,
@@ -24,12 +25,10 @@ def test_precision_resolver_exposes_only_the_implemented_profile():
         resolve_precision,
     )
 
-    # The reserved FP8-weight name is not advertised as usable: only the two
-    # implemented names are offered, and requesting the reserved profile fails
-    # loud instead of returning an unbuildable implementation.
     assert PRECISION_NAMES == (
         "bf16",
         "hopper_blockwise_bf16_weight",
+        "hopper_blockwise_fp8_weight",
     )
     assert resolve_precision("bf16") is None
 
@@ -62,15 +61,70 @@ def test_precision_resolver_exposes_only_the_implemented_profile():
     with pytest.raises(FrozenInstanceError):
         contract.master_parameter = PrecisionDType.BF16
 
-    # The reserved second profile is a declared-but-pending follow-up: it fails
-    # loud rather than being sold as a working profile.
-    with pytest.raises(NotImplementedError, match="not implemented"):
-        resolve_precision("hopper_blockwise_fp8_weight")
+    fp8_weight = resolve_precision("hopper_blockwise_fp8_weight")
+    assert fp8_weight is not None
+    assert fp8_weight.parameter_contract.compute_weight is WeightStorage.FP8_BLOCKWISE_E4M3
+    assert fp8_weight.parameter_contract.master_owner is MasterOwner.MLITE_OPTIMIZER
 
-    with pytest.raises(ValueError, match="bf16.*hopper_blockwise_bf16_weight"):
+    with pytest.raises(ValueError, match="bf16.*hopper_blockwise_bf16_weight.*fp8_weight"):
         resolve_precision("blockwise")
     with pytest.raises(TypeError, match="string"):
         resolve_precision(None)
+
+
+def test_fp8_weight_model_init_uses_te_quantized_init_and_preserves_source(monkeypatch):
+    from contextlib import contextmanager
+
+    from megatron.lite.primitive.precision import (
+        PrecisionPhase,
+        active_precision,
+        precision_model_init_context,
+        resolve_precision,
+    )
+
+    calls = []
+
+    @contextmanager
+    def quantized_model_init(**kwargs):
+        calls.append(("enter", kwargs))
+        yield
+        calls.append(("exit", kwargs))
+
+    te = types.ModuleType("transformer_engine")
+    pytorch = types.ModuleType("transformer_engine.pytorch")
+    quantization = types.ModuleType("transformer_engine.pytorch.quantization")
+    quantization.quantized_model_init = quantized_model_init
+    te.pytorch = pytorch
+    pytorch.quantization = quantization
+    monkeypatch.setitem(sys.modules, "transformer_engine", te)
+    monkeypatch.setitem(sys.modules, "transformer_engine.pytorch", pytorch)
+    monkeypatch.setitem(sys.modules, "transformer_engine.pytorch.quantization", quantization)
+
+    implementation = resolve_precision("hopper_blockwise_fp8_weight")
+    assert implementation is not None
+    recipe = object()
+    implementation = dataclasses.replace(implementation, recipe_factory=lambda: recipe)
+    with precision_model_init_context(implementation):
+        assert active_precision(PrecisionPhase.MODEL_INIT) is implementation
+
+    assert calls == [
+        (
+            "enter",
+            {
+                "enabled": True,
+                "recipe": recipe,
+                "preserve_high_precision_init_val": True,
+            },
+        ),
+        (
+            "exit",
+            {
+                "enabled": True,
+                "recipe": recipe,
+                "preserve_high_precision_init_val": True,
+            },
+        ),
+    ]
 
 
 def test_hopper_recipe_matches_the_frozen_transformer_engine_mapping(monkeypatch):

--- a/experimental/lite/tests/unit/primitive/test_runtime_config_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_runtime_config_unit.py
@@ -26,7 +26,7 @@ def test_mlite_config_defaults_are_stable():
 
 @pytest.mark.parametrize(
     "precision",
-    ["bf16", "hopper_blockwise_bf16_weight"],
+    ["bf16", "hopper_blockwise_bf16_weight", "hopper_blockwise_fp8_weight"],
 )
 def test_mlite_config_round_trips_closed_precision_names(precision):
     direct = MegatronLiteConfig(model_name="qwen3_moe", precision=precision)
@@ -43,17 +43,6 @@ def test_mlite_config_rejects_unknown_precision_name_at_construction():
         MegatronLiteConfig(precision="blockwise")
     with pytest.raises(ValueError, match="hopper_blockwise_bf16_weight"):
         MegatronLiteConfig.from_dict("/models/qwen", {"precision": "fp8"})
-
-
-def test_mlite_config_rejects_reserved_unimplemented_fp8_weight_profile():
-    # The reserved FP8-weight profile is not sold as usable: selecting it fails
-    # loud at config construction rather than advertising a working profile.
-    with pytest.raises(NotImplementedError, match="not implemented"):
-        MegatronLiteConfig(precision="hopper_blockwise_fp8_weight")
-    with pytest.raises(NotImplementedError, match="not implemented"):
-        MegatronLiteConfig.from_dict(
-            "/models/qwen", {"precision": "hopper_blockwise_fp8_weight"}
-        )
 
 
 @pytest.mark.parametrize(

--- a/experimental/lite/tests/unit/primitive/test_runtime_config_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_runtime_config_unit.py
@@ -26,7 +26,7 @@ def test_mlite_config_defaults_are_stable():
 
 @pytest.mark.parametrize(
     "precision",
-    ["bf16", "hopper_blockwise_bf16_weight", "hopper_blockwise_fp8_weight"],
+    ["bf16", "hopper_blockwise_bf16_weight"],
 )
 def test_mlite_config_round_trips_closed_precision_names(precision):
     direct = MegatronLiteConfig(model_name="qwen3_moe", precision=precision)
@@ -41,8 +41,19 @@ def test_mlite_config_round_trips_closed_precision_names(precision):
 def test_mlite_config_rejects_unknown_precision_name_at_construction():
     with pytest.raises(ValueError, match="hopper_blockwise_bf16_weight"):
         MegatronLiteConfig(precision="blockwise")
-    with pytest.raises(ValueError, match="hopper_blockwise_fp8_weight"):
+    with pytest.raises(ValueError, match="hopper_blockwise_bf16_weight"):
         MegatronLiteConfig.from_dict("/models/qwen", {"precision": "fp8"})
+
+
+def test_mlite_config_rejects_reserved_unimplemented_fp8_weight_profile():
+    # The reserved FP8-weight profile is not sold as usable: selecting it fails
+    # loud at config construction rather than advertising a working profile.
+    with pytest.raises(NotImplementedError, match="not implemented"):
+        MegatronLiteConfig(precision="hopper_blockwise_fp8_weight")
+    with pytest.raises(NotImplementedError, match="not implemented"):
+        MegatronLiteConfig.from_dict(
+            "/models/qwen", {"precision": "hopper_blockwise_fp8_weight"}
+        )
 
 
 @pytest.mark.parametrize(
@@ -80,7 +91,7 @@ def test_hopper_profiles_reject_unvalidated_parallel_combinations(parallel):
 def test_hopper_profiles_reject_unvalidated_runtime_features(impl_cfg):
     with pytest.raises(ValueError, match="does not support"):
         MegatronLiteConfig(
-            precision="hopper_blockwise_fp8_weight",
+            precision="hopper_blockwise_bf16_weight",
             impl_cfg=impl_cfg,
         )
 
@@ -90,7 +101,7 @@ def test_hopper_profiles_reject_fp8_parameter_gather_in_optimizer_overrides():
         MegatronLiteConfig.from_dict(
             "/models/qwen",
             {
-                "precision": "hopper_blockwise_fp8_weight",
+                "precision": "hopper_blockwise_bf16_weight",
                 "optimizer": {
                     "override_optimizer_config": {"fp8_param_gather": True}
                 },

--- a/experimental/lite/tests/unit/primitive/test_runtime_config_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_runtime_config_unit.py
@@ -21,6 +21,81 @@ def test_mlite_config_defaults_are_stable():
     assert cfg.parallel.cp == 1
     assert isinstance(cfg.optimizer, OptimizerConfig)
     assert isinstance(cfg.debug, DebugConfig)
+    assert cfg.precision == "bf16"
+
+
+@pytest.mark.parametrize(
+    "precision",
+    ["bf16", "hopper_blockwise_bf16_weight", "hopper_blockwise_fp8_weight"],
+)
+def test_mlite_config_round_trips_closed_precision_names(precision):
+    direct = MegatronLiteConfig(model_name="qwen3_moe", precision=precision)
+    parsed = MegatronLiteConfig.from_dict(
+        "/models/qwen", {"model_name": "qwen3_moe", "precision": precision}
+    )
+
+    assert direct.precision == precision
+    assert parsed.precision == precision
+
+
+def test_mlite_config_rejects_unknown_precision_name_at_construction():
+    with pytest.raises(ValueError, match="hopper_blockwise_bf16_weight"):
+        MegatronLiteConfig(precision="blockwise")
+    with pytest.raises(ValueError, match="hopper_blockwise_fp8_weight"):
+        MegatronLiteConfig.from_dict("/models/qwen", {"precision": "fp8"})
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"fp8_recipe": "blockwise"},
+        {"recipe": "blockwise"},
+        {"targets": ["attention"]},
+        {"weight_dtype": "fp8"},
+    ],
+)
+def test_mlite_config_rejects_ad_hoc_precision_overrides(override):
+    with pytest.raises(ValueError, match="closed precision names"):
+        MegatronLiteConfig.from_dict(
+            "/models/qwen",
+            {"precision": "hopper_blockwise_bf16_weight", **override},
+        )
+
+
+@pytest.mark.parametrize("parallel", [ParallelConfig(pp=2), ParallelConfig(cp=2)])
+def test_hopper_profiles_reject_unvalidated_parallel_combinations(parallel):
+    with pytest.raises(ValueError, match="pp=1 and cp=1"):
+        MegatronLiteConfig(precision="hopper_blockwise_bf16_weight", parallel=parallel)
+
+
+@pytest.mark.parametrize(
+    "impl_cfg",
+    [
+        {"cuda_graph": True},
+        {"fp8_param_gather": True},
+        {"fp8_communication": True},
+        {"mxfp8": True},
+    ],
+)
+def test_hopper_profiles_reject_unvalidated_runtime_features(impl_cfg):
+    with pytest.raises(ValueError, match="does not support"):
+        MegatronLiteConfig(
+            precision="hopper_blockwise_fp8_weight",
+            impl_cfg=impl_cfg,
+        )
+
+
+def test_hopper_profiles_reject_fp8_parameter_gather_in_optimizer_overrides():
+    with pytest.raises(ValueError, match="does not support fp8_param_gather"):
+        MegatronLiteConfig.from_dict(
+            "/models/qwen",
+            {
+                "precision": "hopper_blockwise_fp8_weight",
+                "optimizer": {
+                    "override_optimizer_config": {"fp8_param_gather": True}
+                },
+            },
+        )
 
 
 def test_mlite_config_from_dict_preserves_parallel_optimizer_and_impl_cfg():

--- a/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
+++ b/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
@@ -244,7 +244,23 @@ def _patch_cpu_precision_build(monkeypatch, runtime, proto):
     monkeypatch.setattr(torch.cuda, "manual_seed", lambda _seed: None)
 
 
-def _precision_protocol(*, seal: bool, events: list[str]):
+def _te_linear_witness(transformer_engine_import_stub, monkeypatch):
+    """Install a stub TE Linear class and return a real instance of it.
+
+    ``PrecisionCoverage.claim`` requires a genuine TE primitive instance, so the
+    fabricated production-path protocol must present one instead of a bare
+    ``object()``.
+    """
+
+    transformer_engine_import_stub()
+    import transformer_engine.pytorch as te
+
+    linear_type = type("FakeTELinear", (object,), {"__init__": lambda self: None})
+    monkeypatch.setattr(te, "Linear", linear_type, raising=False)
+    return linear_type()
+
+
+def _precision_protocol(*, seal: bool, events: list[str], projection_witness: object):
     from megatron.lite.primitive.bundle import ModelBundle
     from megatron.lite.primitive.precision import (
         PrecisionPhase,
@@ -280,6 +296,7 @@ def _precision_protocol(*, seal: bool, events: list[str]):
                 projection,
                 SemanticSite.ATTENTION_PROJECTION,
                 PrimitiveCapability.TE_LINEAR,
+                projection_witness,
             )
             impl_cfg.precision_coverage.require(
                 core, SemanticSite.ATTENTION_CORE, diagnostic="unit attention core"
@@ -305,10 +322,11 @@ def _precision_protocol(*, seal: bool, events: list[str]):
 
 
 def test_runtime_injects_and_seals_precision_on_the_production_build_and_forward_path(
-    monkeypatch,
+    monkeypatch, transformer_engine_import_stub
 ):
     events: list[str] = []
-    proto = _precision_protocol(seal=True, events=events)
+    witness = _te_linear_witness(transformer_engine_import_stub, monkeypatch)
+    proto = _precision_protocol(seal=True, events=events, projection_witness=witness)
     cfg = MegatronLiteConfig(
         model_name="unit",
         precision="hopper_blockwise_bf16_weight",
@@ -340,8 +358,11 @@ def test_runtime_injects_and_seals_precision_on_the_production_build_and_forward
     assert events == [implementation.name]
 
 
-def test_runtime_rejects_unsealed_precision_coverage(monkeypatch):
-    proto = _precision_protocol(seal=False, events=[])
+def test_runtime_rejects_unsealed_precision_coverage(
+    monkeypatch, transformer_engine_import_stub
+):
+    witness = _te_linear_witness(transformer_engine_import_stub, monkeypatch)
+    proto = _precision_protocol(seal=False, events=[], projection_witness=witness)
     cfg = MegatronLiteConfig(
         model_name="unit",
         precision="hopper_blockwise_bf16_weight",

--- a/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
+++ b/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
@@ -228,7 +228,7 @@ def _patch_cpu_precision_build(monkeypatch, runtime, proto):
     monkeypatch.setattr(runtime, "_load_protocol", lambda _cfg: proto)
     monkeypatch.setattr(
         "megatron.lite.runtime.backends.mlite.runtime.validate_hopper_environment",
-        lambda: SimpleNamespace(compute_capability=(9, 0)),
+        lambda *_args, **_kwargs: SimpleNamespace(compute_capability=(9, 0)),
     )
     monkeypatch.setattr(
         hopper_blockwise, "_build_hopper_blockwise_recipe", lambda: SimpleNamespace()
@@ -284,7 +284,9 @@ def _precision_protocol(*, seal: bool, events: list[str], projection_witness: ob
                 impl_cfg.precision_parameter_contract
                 is implementation.parameter_contract
             )
-            projection = object()
+            # Owner-as-witness: the projection GEMM owner *is* the TE linear, as in
+            # the dense/expert production path, so the claim's witness is bound.
+            projection = projection_witness
             core = object()
             impl_cfg.precision_coverage.require(
                 projection,

--- a/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
+++ b/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
@@ -7,6 +7,7 @@ import sys
 import types
 from dataclasses import dataclass
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -173,6 +174,202 @@ def test_build_impl_cfg_preserves_explicit_impl_hf_path():
     impl_cfg = _build_impl_cfg(proto, cfg)
 
     assert impl_cfg.hf_path == "/models/impl"
+
+
+@dataclass
+class _PrecisionImplConfig:
+    parallel: object
+    precision_implementation: object = None
+    precision_parameter_contract: object = None
+    precision_coverage: object = None
+
+
+def test_build_impl_cfg_injects_typed_precision_contract_and_coverage():
+    from megatron.lite.primitive.precision import PrecisionCoverage, resolve_precision
+
+    proto = type("Proto", (), {"ImplConfig": _PrecisionImplConfig})
+    cfg = MegatronLiteConfig(precision="hopper_blockwise_bf16_weight")
+    implementation = resolve_precision(cfg.precision)
+    assert implementation is not None
+    coverage = PrecisionCoverage(implementation)
+
+    impl_cfg = _build_impl_cfg(
+        proto,
+        cfg,
+        precision_implementation=implementation,
+        precision_coverage=coverage,
+    )
+
+    assert impl_cfg.precision_implementation is implementation
+    assert impl_cfg.precision_parameter_contract is implementation.parameter_contract
+    assert impl_cfg.precision_coverage is coverage
+
+
+def test_build_impl_cfg_rejects_protocol_without_precision_injection_fields():
+    from megatron.lite.primitive.precision import PrecisionCoverage, resolve_precision
+
+    proto = type("Proto", (), {"ImplConfig": _FakeImplConfig})
+    cfg = MegatronLiteConfig(precision="hopper_blockwise_bf16_weight")
+    implementation = resolve_precision(cfg.precision)
+    assert implementation is not None
+
+    with pytest.raises(ValueError, match="precision_implementation"):
+        _build_impl_cfg(
+            proto,
+            cfg,
+            precision_implementation=implementation,
+            precision_coverage=PrecisionCoverage(implementation),
+        )
+
+
+def _patch_cpu_precision_build(monkeypatch, runtime, proto):
+    from megatron.lite.primitive.precision import hopper_blockwise
+
+    monkeypatch.setattr(runtime, "_load_protocol", lambda _cfg: proto)
+    monkeypatch.setattr(
+        "megatron.lite.runtime.backends.mlite.runtime.validate_hopper_environment",
+        lambda: SimpleNamespace(compute_capability=(9, 0)),
+    )
+    monkeypatch.setattr(
+        hopper_blockwise, "_build_hopper_blockwise_recipe", lambda: SimpleNamespace()
+    )
+    monkeypatch.setattr(
+        hopper_blockwise, "_validate_hopper_blockwise_recipe", lambda _recipe: None
+    )
+    monkeypatch.setattr(dist := torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(dist, "get_rank", lambda: 0)
+    monkeypatch.setattr(dist, "get_world_size", lambda: 1)
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 1)
+    monkeypatch.setattr(torch.cuda, "set_device", lambda _device: None)
+    monkeypatch.setattr(torch.cuda, "manual_seed", lambda _seed: None)
+
+
+def _precision_protocol(*, seal: bool, events: list[str]):
+    from megatron.lite.primitive.bundle import ModelBundle
+    from megatron.lite.primitive.precision import (
+        PrecisionPhase,
+        PrimitiveCapability,
+        SemanticSite,
+        active_precision,
+    )
+
+    class Proto:
+        ImplConfig = _PrecisionImplConfig
+
+        @staticmethod
+        def build_model_config(_source):
+            return SimpleNamespace(hidden_size=1)
+
+        @staticmethod
+        def build_model(_model_cfg, *, impl_cfg):
+            implementation = active_precision(PrecisionPhase.MODEL_INIT)
+            assert implementation is impl_cfg.precision_implementation
+            assert (
+                impl_cfg.precision_parameter_contract
+                is implementation.parameter_contract
+            )
+            projection = object()
+            core = object()
+            impl_cfg.precision_coverage.require(
+                projection,
+                SemanticSite.ATTENTION_PROJECTION,
+                frozenset({PrimitiveCapability.TE_LINEAR}),
+                diagnostic="unit projection",
+            )
+            impl_cfg.precision_coverage.claim(
+                projection,
+                SemanticSite.ATTENTION_PROJECTION,
+                PrimitiveCapability.TE_LINEAR,
+            )
+            impl_cfg.precision_coverage.require(
+                core, SemanticSite.ATTENTION_CORE, diagnostic="unit attention core"
+            )
+            if seal:
+                impl_cfg.precision_coverage.seal()
+
+            model = nn.Linear(1, 1, bias=False)
+
+            def forward_step(module, batch):
+                events.append(active_precision(PrecisionPhase.FORWARD).name)
+                return {"logits": module(batch)}
+
+            ps = SimpleNamespace(pp_size=1, tp_size=1, cp_size=1)
+            return ModelBundle(
+                chunks=[model],
+                parallel_state=ps,
+                optimizer=None,
+                forward_step=forward_step,
+            )
+
+    return Proto
+
+
+def test_runtime_injects_and_seals_precision_on_the_production_build_and_forward_path(
+    monkeypatch,
+):
+    events: list[str] = []
+    proto = _precision_protocol(seal=True, events=events)
+    cfg = MegatronLiteConfig(
+        model_name="unit",
+        precision="hopper_blockwise_bf16_weight",
+        load_hf_weights=False,
+        attention_backend_override=None,
+    )
+    runtime = MegatronLiteRuntime("", cfg)
+    _patch_cpu_precision_build(monkeypatch, runtime, proto)
+
+    handle = runtime.build_model()
+    implementation = handle._extras["precision_implementation"]
+    assert implementation.name == "hopper_blockwise_bf16_weight"
+    assert (
+        handle._extras["precision_parameter_contract"]
+        is implementation.parameter_contract
+    )
+    assert (
+        handle._extras["precision_coverage"].implementation_name == implementation.name
+    )
+
+    result = runtime.forward_backward(
+        handle,
+        iter([torch.ones(1, 1)]),
+        None,
+        forward_only=True,
+    )
+
+    assert result.model_output.vocab_parallel_logits is not None
+    assert events == [implementation.name]
+
+
+def test_runtime_rejects_unsealed_precision_coverage(monkeypatch):
+    proto = _precision_protocol(seal=False, events=[])
+    cfg = MegatronLiteConfig(
+        model_name="unit",
+        precision="hopper_blockwise_bf16_weight",
+        load_hf_weights=False,
+        attention_backend_override=None,
+    )
+    runtime = MegatronLiteRuntime("", cfg)
+    _patch_cpu_precision_build(monkeypatch, runtime, proto)
+
+    with pytest.raises(RuntimeError, match="not sealed before optimizer"):
+        runtime.build_model()
+
+
+def test_runtime_runs_hopper_preflight_before_distributed_initialization(monkeypatch):
+    cfg = MegatronLiteConfig(precision="hopper_blockwise_bf16_weight")
+    runtime = MegatronLiteRuntime("", cfg)
+    init_process_group = MagicMock()
+    monkeypatch.setattr(torch.distributed, "init_process_group", init_process_group)
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: False)
+    monkeypatch.setattr(
+        "megatron.lite.runtime.backends.mlite.runtime.validate_hopper_environment",
+        MagicMock(side_effect=RuntimeError("preflight rejected environment")),
+    )
+
+    with pytest.raises(RuntimeError, match="preflight rejected environment"):
+        runtime.build_model()
+
+    init_process_group.assert_not_called()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- add the two closed `hopper_blockwise_bf16_weight` and `hopper_blockwise_fp8_weight` runtime profiles
- bind attention projections, dense MLPs, and MoE experts to exact Transformer Engine primitives through typed coverage while keeping attention core, router, norms, embeddings, and the LM head in BF16
- initialize FP8 compute weights and the FSDP2 FP32 master from one preserved high-precision source, including checkpoint-resume coverage
- reject unsupported distributed-optimizer FP8-weight training before allocation instead of silently leaving FP8 compute weights stale

## Validation

- targeted CPU suite on the rebased branch: 126 passed, 1 skipped (the skip is the existing CUDA/NCCL-only scalar test)
- current-main GQA compatibility suite: 13 passed
- post-cleanup precision/attention regression: 58 passed
- `python -m compileall` and `git diff --check`: passed
- Slurm job `13756286`: `COMPLETED 0:0`, non-skipped BF16-weight primitive parity on 4x H100 with TP=2 and EP=2 against Megatron-Core and native Transformer Engine 2.15
- Slurm job `14237043`: `COMPLETED 0:0`, 2 passed with no skips for FP8-weight FSDP2 initialization, update, and checkpoint resume on H100

End-to-end Qwen3-MoE throughput and terminal FP8-weight precision comparisons are intentionally left to the separately scoped terminal verification; this PR does not claim those results.