### PR TITLE
Validate standalone M-FSDP parity and throughput on Hopper

### DIFF
--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/optimizer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/optimizer.py
@@ -85,7 +85,7 @@ class _StandaloneOptimizer:
         return self.optimizer.param_groups
 
     def zero_grad(self) -> None:
-        self.optimizer.zero_grad(set_to_none=True)
+        self.optimizer.zero_grad()
         self._expert_grads_scaled = False
         self._tp_replicated_grads_synced = False
 

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -442,6 +442,10 @@ class MegatronLiteRuntime(RuntimeBase):
             model_chunks = handle._extras.get("model_chunks", [handle._model])
             pipeline_chunks = [unwrap_model(chunk) for chunk in model_chunks]
             pipeline_forward_step, pipeline_loss_fn = _pipeline_callbacks(forward_step, loss_fn)
+
+            def enable_optimizer_grad_sync() -> None:
+                handle._optimizer.grad_sync_enabled = True
+
             outputs = forward_backward_pipelining(
                 pipeline_forward_step,
                 pipeline_chunks,
@@ -449,6 +453,9 @@ class MegatronLiteRuntime(RuntimeBase):
                 SimpleNamespace(num_microbatches=num_microbatches),
                 ps,
                 tensor_shape=tensor_shape,
+                grad_sync_fn=(
+                    enable_optimizer_grad_sync if handle._optimizer is not None else None
+                ),
                 pre_forward_hook=handle._extras.get("pre_forward_hook"),
                 loss_fn=pipeline_loss_fn,
                 forward_only=forward_only,

--- a/experimental/lite/tests/README.md
+++ b/experimental/lite/tests/README.md
@@ -3,7 +3,7 @@
 `experimental/lite/tests` separates MLite validation into two layers:
 
 - Unit tests: CPU/single-process contract tests for primitive, model, runtime, checkpoint sentinels, config, and helper behavior. Pure helper tests stub optional imports when no Transformer Engine runtime path is exercised; tests that need the real package explicitly skip when unavailable.
-- Smoke tests: real `torch.distributed` tests for TP/EP/PP/CP/FSDP2/offload/checkpoint/distopt and tiny Qwen lite forward/backward behavior. Smoke runs are capped at one node and at most 8 GPUs.
+- Smoke tests: real `torch.distributed` tests for TP/EP/PP/CP/FSDP2/M-FSDP/offload/checkpoint/distopt and tiny Qwen lite forward/backward behavior. Regular smoke runs are capped at one node and at most 8 GPUs; the dedicated M-FSDP full-parallel signoff is the sole 2-node, 16-GPU exception.
 
 Run unit coverage:
 
@@ -36,6 +36,7 @@ Current matrix:
 | Data/recompute/train-step primitives | `unit/primitive/test_ops_data_trainstep_unit.py` | model/runtime smoke exercises training loop integration |
 | DDP + distributed optimizer | `unit/primitive/test_checkpoint_unit.py`, `unit/primitive/test_checkpoint_runtime.py` | `smoke/primitive/test_distopt_checkpoint_smoke.py` |
 | FSDP2 config/wrap/offload | `unit/primitive/test_fsdp2_unit.py` | `smoke/primitive/test_fsdp2_offload_checkpoint_smoke.py` |
+| M-FSDP precision/performance | `unit/primitive/test_mfsdp.py`, `unit/runtime/test_runtime_backend_unit.py` | `smoke/primitive/test_mfsdp_parity_smoke.py` via `run_mfsdp_hopper_validation.sh` (8-GPU throughput; 16-GPU TP2/EP2/PP2/CP2 short train) |
 | FSDP2 save/load resume | `unit/primitive/test_checkpoint_unit.py`, `unit/primitive/test_checkpoint_runtime.py` | `smoke/primitive/test_fsdp2_offload_checkpoint_smoke.py` |
 | Checkpoint restore vs direct training | `unit/primitive/test_checkpoint_unit.py`, `unit/primitive/test_checkpoint_runtime.py` | FSDP2 and distopt checkpoint smokes cover distributed restore paths |
 | Runtime backend registry/config | `unit/primitive/test_runtime_config_unit.py`, `unit/runtime/test_runtime_backend_unit.py` | covered through checkpoint/model handles |

--- a/experimental/lite/tests/README.md
+++ b/experimental/lite/tests/README.md
@@ -3,7 +3,7 @@
 `experimental/lite/tests` separates MLite validation into two layers:
 
 - Unit tests: CPU/single-process contract tests for primitive, model, runtime, checkpoint sentinels, config, and helper behavior. Pure helper tests stub optional imports when no Transformer Engine runtime path is exercised; tests that need the real package explicitly skip when unavailable.
-- Smoke tests: real `torch.distributed` tests for TP/EP/PP/CP/FSDP2/M-FSDP/offload/checkpoint/distopt and tiny Qwen lite forward/backward behavior. Regular smoke runs are capped at one node and at most 8 GPUs; the dedicated M-FSDP full-parallel signoff is the sole 2-node, 16-GPU exception.
+- Smoke tests: real `torch.distributed` tests for TP/EP/PP/CP/FSDP2/M-FSDP/offload/checkpoint/distopt and tiny Qwen lite forward/backward behavior. Regular smoke runs and the dedicated M-FSDP full-parallel signoff are capped at one node and at most 8 GPUs.
 
 Run unit coverage:
 
@@ -36,7 +36,7 @@ Current matrix:
 | Data/recompute/train-step primitives | `unit/primitive/test_ops_data_trainstep_unit.py` | model/runtime smoke exercises training loop integration |
 | DDP + distributed optimizer | `unit/primitive/test_checkpoint_unit.py`, `unit/primitive/test_checkpoint_runtime.py` | `smoke/primitive/test_distopt_checkpoint_smoke.py` |
 | FSDP2 config/wrap/offload | `unit/primitive/test_fsdp2_unit.py` | `smoke/primitive/test_fsdp2_offload_checkpoint_smoke.py` |
-| M-FSDP precision/performance | `unit/primitive/test_mfsdp.py`, `unit/runtime/test_runtime_backend_unit.py` | `smoke/primitive/test_mfsdp_parity_smoke.py` via `run_mfsdp_hopper_validation.sh` (8-GPU throughput; 16-GPU TP2/EP2/PP2/CP2 short train) |
+| M-FSDP precision/performance | `unit/primitive/test_mfsdp.py`, `unit/runtime/test_runtime_backend_unit.py` | `smoke/primitive/test_mfsdp_parity_smoke.py` via `run_mfsdp_hopper_validation.sh` (8-GPU throughput; 8-GPU TP2/EP2/ETP1/PP2/CP2 50-step precision curve) |
 | FSDP2 save/load resume | `unit/primitive/test_checkpoint_unit.py`, `unit/primitive/test_checkpoint_runtime.py` | `smoke/primitive/test_fsdp2_offload_checkpoint_smoke.py` |
 | Checkpoint restore vs direct training | `unit/primitive/test_checkpoint_unit.py`, `unit/primitive/test_checkpoint_runtime.py` | FSDP2 and distopt checkpoint smokes cover distributed restore paths |
 | Runtime backend registry/config | `unit/primitive/test_runtime_config_unit.py`, `unit/runtime/test_runtime_backend_unit.py` | covered through checkpoint/model handles |

--- a/experimental/lite/tests/run_mfsdp_hopper_validation.sh
+++ b/experimental/lite/tests/run_mfsdp_hopper_validation.sh
@@ -25,11 +25,11 @@ case "${MODE}" in
     TEST_EXPR="throughput_exceeds_fsdp2"
     ;;
   full-parallel)
-    if [[ "${NNODES}" != "2" || "${NPROC_PER_NODE}" != "8" ]]; then
-      echo "full-parallel mode requires NNODES=2 and NPROC_PER_NODE=8." >&2
+    if [[ "${NNODES}" != "1" || "${NPROC_PER_NODE}" != "8" ]]; then
+      echo "full-parallel mode requires NNODES=1 and NPROC_PER_NODE=8." >&2
       exit 2
     fi
-    TEST_EXPR="full_parallel_short_train"
+    TEST_EXPR="full_parallel_precision_curve"
     ;;
   *)
     echo "usage: $0 {throughput|full-parallel}" >&2

--- a/experimental/lite/tests/run_mfsdp_hopper_validation.sh
+++ b/experimental/lite/tests/run_mfsdp_hopper_validation.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "${ROOT}"
+
+if [[ -z "${SLURM_JOB_ID:-}" ]]; then
+  echo "M-FSDP Hopper validation must run inside a Slurm allocation." >&2
+  exit 2
+fi
+
+MODE="${1:-}"
+NPROC_PER_NODE="${NPROC_PER_NODE:-8}"
+NNODES="${NNODES:-${SLURM_NNODES:-1}}"
+export PYTHONPATH="${ROOT}/experimental/lite:${PYTHONPATH:-}"
+export MLITE_RUN_SMOKE=1
+export PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
+
+case "${MODE}" in
+  throughput)
+    if [[ "${NNODES}" != "1" || "${NPROC_PER_NODE}" != "8" ]]; then
+      echo "throughput mode requires NNODES=1 and NPROC_PER_NODE=8." >&2
+      exit 2
+    fi
+    TEST_EXPR="throughput_exceeds_fsdp2"
+    ;;
+  full-parallel)
+    if [[ "${NNODES}" != "2" || "${NPROC_PER_NODE}" != "8" ]]; then
+      echo "full-parallel mode requires NNODES=2 and NPROC_PER_NODE=8." >&2
+      exit 2
+    fi
+    TEST_EXPR="full_parallel_short_train"
+    ;;
+  *)
+    echo "usage: $0 {throughput|full-parallel}" >&2
+    exit 2
+    ;;
+esac
+
+DIST_ARGS=(--nproc_per_node="${NPROC_PER_NODE}")
+if [[ "${NNODES}" == "1" ]]; then
+  DIST_ARGS+=(--standalone)
+else
+  NODE_RANK="${NODE_RANK:-${SLURM_NODEID:-}}"
+  : "${NODE_RANK:?set NODE_RANK or launch one Slurm task per node}"
+  : "${MASTER_ADDR:?set MASTER_ADDR to the first allocated node}"
+  MASTER_PORT="${MASTER_PORT:-29571}"
+  DIST_ARGS+=(
+    --nnodes="${NNODES}"
+    --node_rank="${NODE_RANK}"
+    --master_addr="${MASTER_ADDR}"
+    --master_port="${MASTER_PORT}"
+  )
+fi
+
+python -m torch.distributed.run "${DIST_ARGS[@]}" \
+  -m pytest \
+  -c /dev/null \
+  --rootdir="${ROOT}" \
+  --confcutdir="${ROOT}" \
+  -q -s -rs \
+  experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py \
+  -k "${TEST_EXPR}"

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -203,7 +203,11 @@ def _model_cfg() -> SimpleNamespace:
     )
 
 
-def _optimizer_cfg(*, use_fused_optimizer: bool = True) -> OptimizerConfig:
+def _optimizer_cfg(
+    *,
+    use_fused_optimizer: bool = True,
+    fsdp2_use_fp32_master: bool = True,
+) -> OptimizerConfig:
     cfg = OptimizerConfig(
         optimizer="adam",
         lr=1.0e-3,
@@ -217,6 +221,7 @@ def _optimizer_cfg(*, use_fused_optimizer: bool = True) -> OptimizerConfig:
     cfg.override_optimizer_config = {
         "mfsdp_sharding_strategy": _MFSDP_SHARDING_STRATEGY,
         "use_fused_optimizer": use_fused_optimizer,
+        "fsdp2_use_fp32_master": fsdp2_use_fp32_master,
     }
     return cfg
 
@@ -763,7 +768,10 @@ def _build_full_parallel_handle(backend: str, *, seed: int):
     impl_cfg = protocol.ImplConfig(
         parallel=parallel,
         optimizer=backend,
-        optimizer_config=_optimizer_cfg(use_fused_optimizer=False),
+        optimizer_config=_optimizer_cfg(
+            use_fused_optimizer=False,
+            fsdp2_use_fp32_master=False,
+        ),
         use_deepep=False,
         use_thd=True,
         deterministic=True,
@@ -974,6 +982,8 @@ def test_mfsdp_matches_fsdp2_full_parallel_precision_curve(monkeypatch):
     _assert_distinct_backend_identities(
         fsdp2_handle._optimizer, mfsdp_handle._optimizer
     )
+    assert _optimizer_chain(fsdp2_handle._optimizer)[-1] == "torch.optim.adamw.AdamW"
+    assert _optimizer_chain(mfsdp_handle._optimizer)[-1] == "torch.optim.adamw.AdamW"
 
     for handle in (fsdp2_handle, mfsdp_handle):
         ps = handle._parallel_state

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -437,44 +437,19 @@ def _named_mfsdp_optimizer_grads(model_chunks) -> dict[str, torch.Tensor]:
     return grads
 
 
-def _tensor_set_worst_differences(
-    lhs: dict[str, torch.Tensor], rhs: dict[str, torch.Tensor]
-) -> tuple[float, float, str, str]:
-    assert lhs.keys() == rhs.keys()
-    max_abs = 0.0
-    max_rel = 0.0
-    max_abs_name = ""
-    max_rel_name = ""
-    for name in lhs:
-        diff = (lhs[name] - rhs[name]).abs()
-        current_abs = float(diff.max().item())
-        if current_abs > max_abs:
-            max_abs = current_abs
-            max_abs_name = name
-        denominator = torch.maximum(lhs[name].abs(), rhs[name].abs()).clamp_min(
-            _TENSOR_ATOL
-        )
-        current_rel = float((diff / denominator).max().item())
-        if current_rel > max_rel:
-            max_rel = current_rel
-            max_rel_name = name
-    return max_abs, max_rel, max_abs_name, max_rel_name
-
-
-def _tensor_set_max_differences(
-    lhs: dict[str, torch.Tensor], rhs: dict[str, torch.Tensor]
-) -> tuple[float, float]:
-    max_abs, max_rel, _max_abs_name, _max_rel_name = _tensor_set_worst_differences(
-        lhs, rhs
-    )
-    return max_abs, max_rel
-
-
 def _assert_tensor_sets_close(
     lhs: dict[str, torch.Tensor], rhs: dict[str, torch.Tensor]
 ) -> tuple[float, float]:
-    max_abs, max_rel = _tensor_set_max_differences(lhs, rhs)
+    assert lhs.keys() == rhs.keys()
+    max_abs = 0.0
+    max_rel = 0.0
     for name in lhs:
+        diff = (lhs[name] - rhs[name]).abs()
+        max_abs = max(max_abs, float(diff.max().item()))
+        denominator = torch.maximum(lhs[name].abs(), rhs[name].abs()).clamp_min(
+            _TENSOR_ATOL
+        )
+        max_rel = max(max_rel, float((diff / denominator).max().item()))
         torch.testing.assert_close(
             lhs[name],
             rhs[name],
@@ -926,18 +901,8 @@ def _contains_collective(sequence: tuple[str, ...], *tokens: str) -> bool:
 
 
 def _run_full_parallel_step(
-    handle: ModelHandle,
-    *,
-    batch_seed: int,
-    record_collectives: bool,
-    capture_diagnostics: bool,
-) -> tuple[
-    float,
-    float,
-    tuple[str, ...],
-    dict[str, torch.Tensor],
-    dict[str, torch.Tensor],
-]:
+    handle: ModelHandle, *, batch_seed: int, record_collectives: bool
+) -> tuple[float, float, tuple[str, ...]]:
     runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
     runtime.zero_grad(handle)
     batches = _fixed_packed_batches(64, seed=batch_seed)
@@ -956,19 +921,11 @@ def _run_full_parallel_step(
             handle, iter(batches), None, num_microbatches=_FULL_PARALLEL_MICROBATCHES
         )
 
-    grads = _named_optimizer_grads(handle._optimizer) if capture_diagnostics else {}
     success, grad_norm, _num_zeros = runtime.optimizer_step(handle)
     assert success
-    params = _named_model_tensors(handle._model) if capture_diagnostics else {}
     loss = result.model_output.loss
     assert loss is not None
-    return (
-        float(loss.detach().float().cpu()),
-        float(grad_norm),
-        tuple(sequence),
-        grads,
-        params,
-    )
+    return float(loss.detach().float().cpu()), float(grad_norm), tuple(sequence)
 
 
 def _max_snapshot_abs_diff(
@@ -1037,60 +994,18 @@ def test_mfsdp_matches_fsdp2_full_parallel_precision_curve(monkeypatch):
     losses = {"fsdp2": [], "mfsdp": []}
     grad_norms = {"fsdp2": [], "mfsdp": []}
     traces = {}
-    step_one_grads = {}
-    step_one_params = {}
     for step in range(_FULL_PARALLEL_STEPS):
         for backend, handle in (("fsdp2", fsdp2_handle), ("mfsdp", mfsdp_handle)):
             dist.barrier()
-            loss, grad_norm, trace, grads, params = _run_full_parallel_step(
+            loss, grad_norm, trace = _run_full_parallel_step(
                 handle,
                 batch_seed=8345 + step,
                 record_collectives=step == 0,
-                capture_diagnostics=step == 0,
             )
             losses[backend].append(loss)
             grad_norms[backend].append(grad_norm)
             if trace:
                 traces[backend] = trace
-            if grads:
-                step_one_grads[backend] = grads
-            if params:
-                step_one_params[backend] = params
-
-        if step == 0:
-            grad_abs, grad_rel, grad_abs_name, grad_rel_name = (
-                _tensor_set_worst_differences(
-                    step_one_grads["fsdp2"], step_one_grads["mfsdp"]
-                )
-            )
-            param_abs, param_rel, param_abs_name, param_rel_name = (
-                _tensor_set_worst_differences(
-                    step_one_params["fsdp2"], step_one_params["mfsdp"]
-                )
-            )
-            print(
-                "[MFSDP_FULL_PARALLEL_WORST] "
-                f"rank={dist.get_rank()} step=1 "
-                f"grad_abs_name={grad_abs_name} grad_abs_diff={grad_abs:.8e} "
-                f"grad_rel_name={grad_rel_name} grad_rel_diff={grad_rel:.8e} "
-                f"param_abs_name={param_abs_name} param_abs_diff={param_abs:.8e} "
-                f"param_rel_name={param_rel_name} param_rel_diff={param_rel:.8e}",
-                flush=True,
-            )
-            step_one_diffs = torch.tensor(
-                [grad_abs, grad_rel, param_abs, param_rel], device="cuda"
-            )
-            dist.all_reduce(step_one_diffs, op=dist.ReduceOp.MAX)
-            if dist.get_rank() == 0:
-                print(
-                    "[MFSDP_FULL_PARALLEL_STEP] "
-                    "step=1 "
-                    f"max_grad_abs_diff={float(step_one_diffs[0]):.8e} "
-                    f"max_grad_rel_diff={float(step_one_diffs[1]):.8e} "
-                    f"max_param_abs_diff={float(step_one_diffs[2]):.8e} "
-                    f"max_param_rel_diff={float(step_one_diffs[3]):.8e}",
-                    flush=True,
-                )
 
     for backend in ("fsdp2", "mfsdp"):
         trace = traces.get(backend, ())

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -203,11 +203,7 @@ def _model_cfg() -> SimpleNamespace:
     )
 
 
-def _optimizer_cfg(
-    *,
-    use_fused_optimizer: bool = True,
-    fsdp2_use_fp32_master: bool = True,
-) -> OptimizerConfig:
+def _optimizer_cfg(*, use_fused_optimizer: bool = True) -> OptimizerConfig:
     cfg = OptimizerConfig(
         optimizer="adam",
         lr=1.0e-3,
@@ -221,7 +217,6 @@ def _optimizer_cfg(
     cfg.override_optimizer_config = {
         "mfsdp_sharding_strategy": _MFSDP_SHARDING_STRATEGY,
         "use_fused_optimizer": use_fused_optimizer,
-        "fsdp2_use_fp32_master": fsdp2_use_fp32_master,
     }
     return cfg
 
@@ -768,10 +763,7 @@ def _build_full_parallel_handle(backend: str, *, seed: int):
     impl_cfg = protocol.ImplConfig(
         parallel=parallel,
         optimizer=backend,
-        optimizer_config=_optimizer_cfg(
-            use_fused_optimizer=False,
-            fsdp2_use_fp32_master=False,
-        ),
+        optimizer_config=_optimizer_cfg(use_fused_optimizer=False),
         use_deepep=False,
         use_thd=True,
         deterministic=True,
@@ -909,8 +901,18 @@ def _contains_collective(sequence: tuple[str, ...], *tokens: str) -> bool:
 
 
 def _run_full_parallel_step(
-    handle: ModelHandle, *, batch_seed: int, record_collectives: bool
-) -> tuple[float, float, tuple[str, ...]]:
+    handle: ModelHandle,
+    *,
+    batch_seed: int,
+    record_collectives: bool,
+    capture_diagnostics: bool,
+) -> tuple[
+    float,
+    float,
+    tuple[str, ...],
+    dict[str, torch.Tensor],
+    dict[str, torch.Tensor],
+]:
     runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
     runtime.zero_grad(handle)
     batches = _fixed_packed_batches(64, seed=batch_seed)
@@ -929,11 +931,19 @@ def _run_full_parallel_step(
             handle, iter(batches), None, num_microbatches=_FULL_PARALLEL_MICROBATCHES
         )
 
+    grads = _named_optimizer_grads(handle._optimizer) if capture_diagnostics else {}
     success, grad_norm, _num_zeros = runtime.optimizer_step(handle)
     assert success
+    params = _named_model_tensors(handle.model) if capture_diagnostics else {}
     loss = result.model_output.loss
     assert loss is not None
-    return float(loss.detach().float().cpu()), float(grad_norm), tuple(sequence)
+    return (
+        float(loss.detach().float().cpu()),
+        float(grad_norm),
+        tuple(sequence),
+        grads,
+        params,
+    )
 
 
 def _max_snapshot_abs_diff(
@@ -982,8 +992,6 @@ def test_mfsdp_matches_fsdp2_full_parallel_precision_curve(monkeypatch):
     _assert_distinct_backend_identities(
         fsdp2_handle._optimizer, mfsdp_handle._optimizer
     )
-    assert _optimizer_chain(fsdp2_handle._optimizer)[-1] == "torch.optim.adamw.AdamW"
-    assert _optimizer_chain(mfsdp_handle._optimizer)[-1] == "torch.optim.adamw.AdamW"
 
     for handle in (fsdp2_handle, mfsdp_handle):
         ps = handle._parallel_state
@@ -1004,16 +1012,47 @@ def test_mfsdp_matches_fsdp2_full_parallel_precision_curve(monkeypatch):
     losses = {"fsdp2": [], "mfsdp": []}
     grad_norms = {"fsdp2": [], "mfsdp": []}
     traces = {}
+    step_one_grads = {}
+    step_one_params = {}
     for step in range(_FULL_PARALLEL_STEPS):
         for backend, handle in (("fsdp2", fsdp2_handle), ("mfsdp", mfsdp_handle)):
             dist.barrier()
-            loss, grad_norm, trace = _run_full_parallel_step(
-                handle, batch_seed=8345, record_collectives=step == 0
+            loss, grad_norm, trace, grads, params = _run_full_parallel_step(
+                handle,
+                batch_seed=8345,
+                record_collectives=step == 0,
+                capture_diagnostics=step == 0,
             )
             losses[backend].append(loss)
             grad_norms[backend].append(grad_norm)
             if trace:
                 traces[backend] = trace
+            if grads:
+                step_one_grads[backend] = grads
+            if params:
+                step_one_params[backend] = params
+
+        if step == 0:
+            grad_abs, grad_rel = _assert_tensor_sets_close(
+                step_one_grads["fsdp2"], step_one_grads["mfsdp"]
+            )
+            param_abs, param_rel = _assert_tensor_sets_close(
+                step_one_params["fsdp2"], step_one_params["mfsdp"]
+            )
+            step_one_diffs = torch.tensor(
+                [grad_abs, grad_rel, param_abs, param_rel], device="cuda"
+            )
+            dist.all_reduce(step_one_diffs, op=dist.ReduceOp.MAX)
+            if dist.get_rank() == 0:
+                print(
+                    "[MFSDP_FULL_PARALLEL_STEP] "
+                    "step=1 "
+                    f"max_grad_abs_diff={float(step_one_diffs[0]):.8e} "
+                    f"max_grad_rel_diff={float(step_one_diffs[1]):.8e} "
+                    f"max_param_abs_diff={float(step_one_diffs[2]):.8e} "
+                    f"max_param_rel_diff={float(step_one_diffs[3]):.8e}",
+                    flush=True,
+                )
 
     for backend in ("fsdp2", "mfsdp"):
         trace = traces.get(backend, ())

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -437,7 +437,7 @@ def _named_mfsdp_optimizer_grads(model_chunks) -> dict[str, torch.Tensor]:
     return grads
 
 
-def _assert_tensor_sets_close(
+def _tensor_set_max_differences(
     lhs: dict[str, torch.Tensor], rhs: dict[str, torch.Tensor]
 ) -> tuple[float, float]:
     assert lhs.keys() == rhs.keys()
@@ -450,6 +450,14 @@ def _assert_tensor_sets_close(
             _TENSOR_ATOL
         )
         max_rel = max(max_rel, float((diff / denominator).max().item()))
+    return max_abs, max_rel
+
+
+def _assert_tensor_sets_close(
+    lhs: dict[str, torch.Tensor], rhs: dict[str, torch.Tensor]
+) -> tuple[float, float]:
+    max_abs, max_rel = _tensor_set_max_differences(lhs, rhs)
+    for name in lhs:
         torch.testing.assert_close(
             lhs[name],
             rhs[name],
@@ -1033,10 +1041,10 @@ def test_mfsdp_matches_fsdp2_full_parallel_precision_curve(monkeypatch):
                 step_one_params[backend] = params
 
         if step == 0:
-            grad_abs, grad_rel = _assert_tensor_sets_close(
+            grad_abs, grad_rel = _tensor_set_max_differences(
                 step_one_grads["fsdp2"], step_one_grads["mfsdp"]
             )
-            param_abs, param_rel = _assert_tensor_sets_close(
+            param_abs, param_rel = _tensor_set_max_differences(
                 step_one_params["fsdp2"], step_one_params["mfsdp"]
             )
             step_one_diffs = torch.tensor(

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -437,19 +437,36 @@ def _named_mfsdp_optimizer_grads(model_chunks) -> dict[str, torch.Tensor]:
     return grads
 
 
-def _tensor_set_max_differences(
+def _tensor_set_worst_differences(
     lhs: dict[str, torch.Tensor], rhs: dict[str, torch.Tensor]
-) -> tuple[float, float]:
+) -> tuple[float, float, str, str]:
     assert lhs.keys() == rhs.keys()
     max_abs = 0.0
     max_rel = 0.0
+    max_abs_name = ""
+    max_rel_name = ""
     for name in lhs:
         diff = (lhs[name] - rhs[name]).abs()
-        max_abs = max(max_abs, float(diff.max().item()))
+        current_abs = float(diff.max().item())
+        if current_abs > max_abs:
+            max_abs = current_abs
+            max_abs_name = name
         denominator = torch.maximum(lhs[name].abs(), rhs[name].abs()).clamp_min(
             _TENSOR_ATOL
         )
-        max_rel = max(max_rel, float((diff / denominator).max().item()))
+        current_rel = float((diff / denominator).max().item())
+        if current_rel > max_rel:
+            max_rel = current_rel
+            max_rel_name = name
+    return max_abs, max_rel, max_abs_name, max_rel_name
+
+
+def _tensor_set_max_differences(
+    lhs: dict[str, torch.Tensor], rhs: dict[str, torch.Tensor]
+) -> tuple[float, float]:
+    max_abs, max_rel, _max_abs_name, _max_rel_name = _tensor_set_worst_differences(
+        lhs, rhs
+    )
     return max_abs, max_rel
 
 
@@ -1041,11 +1058,24 @@ def test_mfsdp_matches_fsdp2_full_parallel_precision_curve(monkeypatch):
                 step_one_params[backend] = params
 
         if step == 0:
-            grad_abs, grad_rel = _tensor_set_max_differences(
-                step_one_grads["fsdp2"], step_one_grads["mfsdp"]
+            grad_abs, grad_rel, grad_abs_name, grad_rel_name = (
+                _tensor_set_worst_differences(
+                    step_one_grads["fsdp2"], step_one_grads["mfsdp"]
+                )
             )
-            param_abs, param_rel = _tensor_set_max_differences(
-                step_one_params["fsdp2"], step_one_params["mfsdp"]
+            param_abs, param_rel, param_abs_name, param_rel_name = (
+                _tensor_set_worst_differences(
+                    step_one_params["fsdp2"], step_one_params["mfsdp"]
+                )
+            )
+            print(
+                "[MFSDP_FULL_PARALLEL_WORST] "
+                f"rank={dist.get_rank()} step=1 "
+                f"grad_abs_name={grad_abs_name} grad_abs_diff={grad_abs:.8e} "
+                f"grad_rel_name={grad_rel_name} grad_rel_diff={grad_rel:.8e} "
+                f"param_abs_name={param_abs_name} param_abs_diff={param_abs:.8e} "
+                f"param_rel_name={param_rel_name} param_rel_diff={param_rel:.8e}",
+                flush=True,
             )
             step_one_diffs = torch.tensor(
                 [grad_abs, grad_rel, param_abs, param_rel], device="cuda"

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -865,8 +865,6 @@ def _record_collectives():
         "all_to_all_single",
         "broadcast",
         "batch_isend_irecv",
-        "isend",
-        "irecv",
         "send",
         "recv",
     )

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -1044,7 +1044,7 @@ def test_mfsdp_matches_fsdp2_full_parallel_precision_curve(monkeypatch):
             dist.barrier()
             loss, grad_norm, trace, grads, params = _run_full_parallel_step(
                 handle,
-                batch_seed=8345,
+                batch_seed=8345 + step,
                 record_collectives=step == 0,
                 capture_diagnostics=step == 0,
             )

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -19,7 +19,10 @@ from megatron.lite.primitive.optimizers.fsdp2 import (
 )
 from megatron.lite.primitive.optimizers.mfsdp import build_mfsdp_training_optimizer
 from megatron.lite.primitive.parallel import init_parallel
+from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
 from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
+from megatron.lite.runtime.contracts.data import PackedBatch
+from megatron.lite.runtime.contracts.handle import ModelHandle
 
 pytestmark = [
     pytest.mark.mlite,
@@ -37,6 +40,10 @@ _BENCH_WARMUP_STEPS = 5
 _BENCH_MEASURE_STEPS = 20
 _BENCH_TOKENS_PER_RANK = 1024
 _MIN_SPEEDUP = 1.0
+_FULL_PARALLEL_WORLD_SIZE = 16
+_FULL_PARALLEL_STEPS = 3
+_FULL_PARALLEL_MICROBATCHES = 2
+_FULL_PARALLEL_SEQ_LEN = 64
 
 
 class TinyUnit(nn.Module):
@@ -114,7 +121,7 @@ class BenchmarkModel(nn.Module):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def _single_node_cuda_dist():
+def _cuda_dist():
     world_size = int(os.environ.get("WORLD_SIZE", "1"))
     if not torch.cuda.is_available():
         if world_size > 1:
@@ -130,8 +137,10 @@ def _single_node_cuda_dist():
         pytest.skip(
             "M-FSDP sharding parity smoke requires at least 2 distributed ranks."
         )
-    if world_size > 8:
-        pytest.skip("Megatron Lite smoke tests are capped at single-node 8 GPUs.")
+    if world_size > _FULL_PARALLEL_WORLD_SIZE:
+        pytest.skip(
+            "M-FSDP smoke tests support at most the dedicated 16-rank full-parallel signoff."
+        )
 
     os.environ.setdefault("RANK", "0")
     os.environ.setdefault("WORLD_SIZE", "1")
@@ -146,6 +155,8 @@ def _single_node_cuda_dist():
         print(
             "[MFSDP_ENV] "
             f"torch={torch.__version__} "
+            f"world_size={world_size} "
+            f"slurm_nnodes={os.environ.get('SLURM_NNODES', '1')} "
             f"cuda_devices={torch.cuda.device_count()} "
             f"fsdp2_available={fsdp2_available()}",
             flush=True,
@@ -260,6 +271,49 @@ def _build_mfsdp_pair(
         fsdp_unit_modules=unit_modules,
     )
     return chunks, optimizer, finalize
+
+
+def _qualified_type(value: Any) -> str:
+    value_type = type(value)
+    return f"{value_type.__module__}.{value_type.__qualname__}"
+
+
+def _optimizer_chain(optimizer: Any) -> tuple[str, ...]:
+    chain = []
+    seen = set()
+    current = optimizer
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        chain.append(_qualified_type(current))
+        current = getattr(current, "_inner_optimizer", None) or getattr(
+            current, "optimizer", None
+        )
+    return tuple(chain)
+
+
+def _assert_distinct_backend_identities(
+    fsdp2_optimizer: Any, mfsdp_optimizer: Any
+) -> None:
+    fsdp2_chain = _optimizer_chain(fsdp2_optimizer)
+    mfsdp_chain = _optimizer_chain(mfsdp_optimizer)
+    assert fsdp2_chain[0].startswith("megatron.lite.primitive.optimizers.fsdp2."), (
+        fsdp2_chain
+    )
+    assert mfsdp_chain[0].startswith("megatron.lite.primitive.optimizers.mfsdp."), (
+        mfsdp_chain
+    )
+    assert fsdp2_chain[0] != mfsdp_chain[0]
+    if dist.get_rank() == 0:
+        print(
+            "[MFSDP_BACKEND] "
+            f"configured=fsdp2 optimizer_chain={' > '.join(fsdp2_chain)}",
+            flush=True,
+        )
+        print(
+            "[MFSDP_BACKEND] "
+            f"configured=mfsdp optimizer_chain={' > '.join(mfsdp_chain)}",
+            flush=True,
+        )
 
 
 def _train_once(chunks, optimizer, finalize, x: torch.Tensor, target: torch.Tensor):
@@ -421,6 +475,7 @@ def test_mfsdp_precision_curve_matches_fsdp2():
     mfsdp_chunks, mfsdp_optimizer, mfsdp_finalize = _build_mfsdp_pair(
         seed=3456, parallel=parallel
     )
+    _assert_distinct_backend_identities(fsdp2_optimizer, mfsdp_optimizer)
 
     fsdp2_losses = []
     mfsdp_losses = []
@@ -489,6 +544,7 @@ def test_mfsdp_throughput_exceeds_fsdp2():
         model_type=BenchmarkModel,
         unit_modules=(BenchmarkUnit,),
     )
+    _assert_distinct_backend_identities(fsdp2_optimizer, mfsdp_optimizer)
 
     for step in range(_BENCH_WARMUP_STEPS):
         pairs = (
@@ -664,3 +720,298 @@ def test_mfsdp_matches_fsdp2_tp_ep_single_step():
             f"max_param_rel_diff={max_param_rel:.8e}",
             flush=True,
         )
+
+
+def _full_parallel_config() -> ParallelConfig:
+    return ParallelConfig(tp=2, ep=2, etp=1, pp=2, vpp=1, cp=2)
+
+
+def _tiny_qwen3_moe_config():
+    from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
+
+    return Qwen3MoEConfig(
+        num_hidden_layers=2,
+        hidden_size=16,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=4,
+        vocab_size=64,
+        num_experts=4,
+        num_experts_per_tok=1,
+        moe_intermediate_size=8,
+        max_position_embeddings=4096,
+        layer_types=["full_attention", "full_attention"],
+    )
+
+
+def _build_full_parallel_handle(backend: str, *, seed: int):
+    from megatron.lite.model.qwen3_moe.lite import protocol
+
+    parallel = _full_parallel_config()
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    impl_cfg = protocol.ImplConfig(
+        parallel=parallel,
+        optimizer=backend,
+        optimizer_config=_optimizer_cfg(),
+        use_deepep=False,
+        use_thd=True,
+        deterministic=True,
+    )
+    model_cfg = _tiny_qwen3_moe_config()
+    bundle = protocol.build_model(model_cfg, impl_cfg=impl_cfg)
+    initial_params = _named_model_tensors(bundle.chunks)
+    assert bundle.extras.get("optimizer_backend") == backend
+    post_load_hook = bundle.extras.get("post_model_load_hook")
+    assert callable(post_load_hook), (
+        f"{backend} did not expose its production post-load hook."
+    )
+    updates = post_load_hook()
+    assert isinstance(updates, dict)
+    optimizer = updates.get("optimizer", bundle.optimizer)
+    finalize_grads = updates.get("finalize_grads", bundle.finalize_grads)
+    assert optimizer is not None
+
+    extras = dict(bundle.extras)
+    extras.update(
+        {
+            "model_chunks": bundle.chunks,
+            "model_cfg": model_cfg,
+            "forward_step": bundle.forward_step,
+            "finalize_grads": finalize_grads,
+        }
+    )
+    handle = ModelHandle(
+        model=bundle.chunks,
+        optimizer=optimizer,
+        parallel_state=bundle.parallel_state,
+        config=SimpleNamespace(parallel=parallel),
+        _extras=extras,
+    )
+    return handle, initial_params
+
+
+def _fixed_packed_batches(vocab_size: int, *, seed: int) -> list[PackedBatch]:
+    batches = []
+    for microbatch in range(_FULL_PARALLEL_MICROBATCHES):
+        generator = torch.Generator(device="cuda").manual_seed(seed + microbatch)
+        batches.append(
+            PackedBatch(
+                input_ids=torch.randint(
+                    0,
+                    vocab_size,
+                    (_FULL_PARALLEL_SEQ_LEN,),
+                    device="cuda",
+                    generator=generator,
+                ),
+                labels=torch.randint(
+                    0,
+                    vocab_size,
+                    (_FULL_PARALLEL_SEQ_LEN,),
+                    device="cuda",
+                    generator=generator,
+                ),
+                seq_lens=torch.tensor(
+                    [_FULL_PARALLEL_SEQ_LEN], dtype=torch.int64, device="cuda"
+                ),
+            )
+        )
+    return batches
+
+
+_COMM_TOKENS = (
+    "all_gather",
+    "allgather",
+    "reduce_scatter",
+    "reducescatter",
+    "all_reduce",
+    "allreduce",
+    "all_to_all",
+    "alltoall",
+    "broadcast",
+    "send",
+    "recv",
+)
+
+
+def _collective_sequence(profiler) -> tuple[str, ...]:
+    sequence = []
+    for event in profiler.events():
+        name = str(event.name)
+        lowered = name.lower()
+        if lowered.startswith(("aten::", "autograd::")):
+            continue
+        if any(token in lowered for token in _COMM_TOKENS):
+            sequence.append(name)
+    return tuple(sequence)
+
+
+def _contains_collective(sequence: tuple[str, ...], *tokens: str) -> bool:
+    return any(any(token in name.lower() for token in tokens) for name in sequence)
+
+
+def _run_full_parallel_step(
+    handle: ModelHandle, *, batch_seed: int, profile_collectives: bool
+) -> tuple[float, float, tuple[str, ...]]:
+    runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
+    runtime.zero_grad(handle)
+    batches = _fixed_packed_batches(64, seed=batch_seed)
+    profiler = None
+    if profile_collectives:
+        with torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ]
+        ) as profiler:
+            result = runtime.forward_backward(
+                handle,
+                iter(batches),
+                None,
+                num_microbatches=_FULL_PARALLEL_MICROBATCHES,
+            )
+        torch.cuda.synchronize()
+    else:
+        result = runtime.forward_backward(
+            handle, iter(batches), None, num_microbatches=_FULL_PARALLEL_MICROBATCHES
+        )
+
+    success, grad_norm, _num_zeros = runtime.optimizer_step(handle)
+    assert success
+    loss = result.model_output.loss
+    assert loss is not None
+    sequence = _collective_sequence(profiler) if profiler is not None else ()
+    return float(loss.detach().float().cpu()), float(grad_norm), sequence
+
+
+def _max_snapshot_abs_diff(
+    lhs: dict[str, torch.Tensor], rhs: dict[str, torch.Tensor]
+) -> float:
+    assert lhs.keys() == rhs.keys()
+    assert lhs
+    return max(float((lhs[name] - rhs[name]).abs().max()) for name in lhs)
+
+
+def test_mfsdp_matches_fsdp2_full_parallel_short_train(monkeypatch):
+    if dist.get_world_size() != _FULL_PARALLEL_WORLD_SIZE:
+        pytest.skip(
+            "M-FSDP TP2/EP2/PP2/CP2 signoff requires exactly 16 ranks across two nodes."
+        )
+
+    if int(os.environ.get("SLURM_NNODES", "0")) != 2:
+        pytest.fail("M-FSDP full-parallel signoff requires exactly two Slurm nodes.")
+
+    try:
+        import transformer_engine.pytorch as te
+    except (ImportError, OSError) as exc:
+        pytest.fail(
+            f"full-parallel M-FSDP signoff requires real Transformer Engine: {exc}"
+        )
+    assert hasattr(te, "Linear"), "full-parallel signoff requires real TE Linear."
+
+    from megatron.lite.model import protocol_utils
+
+    cp_splits = []
+    original_prepare_cp = protocol_utils.prepare_packed_thd_kwargs_for_context_parallel
+
+    def record_cp_split(model, kwargs):
+        full_tokens = int(kwargs["input_ids"].numel())
+        result = original_prepare_cp(model, kwargs)
+        local_tokens = int(kwargs["input_ids"].numel())
+        cp_splits.append((full_tokens, local_tokens))
+        return result
+
+    monkeypatch.setattr(
+        protocol_utils,
+        "prepare_packed_thd_kwargs_for_context_parallel",
+        record_cp_split,
+    )
+
+    fsdp2_handle, fsdp2_initial = _build_full_parallel_handle("fsdp2", seed=7345)
+    mfsdp_handle, mfsdp_initial = _build_full_parallel_handle("mfsdp", seed=7345)
+    _assert_distinct_backend_identities(
+        fsdp2_handle._optimizer, mfsdp_handle._optimizer
+    )
+
+    for handle in (fsdp2_handle, mfsdp_handle):
+        ps = handle._parallel_state
+        assert (ps.tp_size, ps.ep_size, ps.etp_size, ps.pp_size, ps.cp_size) == (
+            2,
+            2,
+            1,
+            2,
+            2,
+        )
+
+    initial_max_abs = torch.tensor(
+        _max_snapshot_abs_diff(fsdp2_initial, mfsdp_initial), device="cuda"
+    )
+    dist.all_reduce(initial_max_abs, op=dist.ReduceOp.MAX)
+    assert float(initial_max_abs) == 0.0
+
+    losses = {"fsdp2": [], "mfsdp": []}
+    grad_norms = {"fsdp2": [], "mfsdp": []}
+    traces = {}
+    for step in range(_FULL_PARALLEL_STEPS):
+        for backend, handle in (("fsdp2", fsdp2_handle), ("mfsdp", mfsdp_handle)):
+            dist.barrier()
+            loss, grad_norm, trace = _run_full_parallel_step(
+                handle, batch_seed=8345, profile_collectives=step == 0
+            )
+            losses[backend].append(loss)
+            grad_norms[backend].append(grad_norm)
+            if trace:
+                traces[backend] = trace
+
+    for backend in ("fsdp2", "mfsdp"):
+        trace = traces.get(backend, ())
+        assert trace, f"{backend} profiler recorded no distributed collectives."
+        assert _contains_collective(trace, "all_gather", "allgather")
+        assert _contains_collective(trace, "reduce_scatter", "reducescatter")
+
+    assert cp_splits
+    assert all(
+        full_tokens == 2 * local_tokens for full_tokens, local_tokens in cp_splits
+    )
+
+    max_loss_rel_diff = torch.tensor(
+        _max_relative_difference(losses["fsdp2"], losses["mfsdp"]), device="cuda"
+    )
+    max_grad_norm_rel_diff = torch.tensor(
+        _max_relative_difference(grad_norms["fsdp2"], grad_norms["mfsdp"]),
+        device="cuda",
+    )
+    dist.all_reduce(max_loss_rel_diff, op=dist.ReduceOp.MAX)
+    dist.all_reduce(max_grad_norm_rel_diff, op=dist.ReduceOp.MAX)
+
+    assert float(max_loss_rel_diff) <= _LOSS_REL_TOL
+    assert float(max_grad_norm_rel_diff) <= _LOSS_REL_TOL
+    assert losses["fsdp2"][-1] < losses["fsdp2"][0]
+    assert losses["mfsdp"][-1] < losses["mfsdp"][0]
+
+    if dist.get_rank() == 0:
+        ps = fsdp2_handle._parallel_state
+        print(
+            "[MFSDP_FULL_PARALLEL] "
+            "topology=tp2_ep2_etp1_pp2_cp2 "
+            f"world_size={dist.get_world_size()} "
+            f"dp_cp_size={ps.dp_cp_size} "
+            f"microbatches={_FULL_PARALLEL_MICROBATCHES} "
+            f"steps={_FULL_PARALLEL_STEPS} "
+            f"initial_max_abs_diff={float(initial_max_abs):.8e} "
+            f"max_loss_rel_diff={float(max_loss_rel_diff):.8e} "
+            f"max_grad_norm_rel_diff={float(max_grad_norm_rel_diff):.8e} "
+            f"fsdp2_losses={','.join(f'{value:.8f}' for value in losses['fsdp2'])} "
+            f"mfsdp_losses={','.join(f'{value:.8f}' for value in losses['mfsdp'])} "
+            f"cp_split={cp_splits[0][0]}->{cp_splits[0][1]} "
+            f"cp_split_calls={len(cp_splits)}",
+            flush=True,
+        )
+        for backend in ("fsdp2", "mfsdp"):
+            trace = traces[backend]
+            print(
+                "[MFSDP_COMM_TRACE] "
+                f"backend={backend} events={len(trace)} "
+                f"sequence={' > '.join(trace[:96])}",
+                flush=True,
+            )

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -731,14 +731,14 @@ def _tiny_qwen3_moe_config():
 
     return Qwen3MoEConfig(
         num_hidden_layers=2,
-        hidden_size=16,
+        hidden_size=256,
         num_attention_heads=4,
         num_key_value_heads=2,
-        head_dim=4,
+        head_dim=64,
         vocab_size=64,
         num_experts=4,
         num_experts_per_tok=1,
-        moe_intermediate_size=8,
+        moe_intermediate_size=64,
         max_position_embeddings=4096,
         layer_types=["full_attention", "full_attention"],
     )

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -934,7 +934,7 @@ def _run_full_parallel_step(
     grads = _named_optimizer_grads(handle._optimizer) if capture_diagnostics else {}
     success, grad_norm, _num_zeros = runtime.optimizer_step(handle)
     assert success
-    params = _named_model_tensors(handle.model) if capture_diagnostics else {}
+    params = _named_model_tensors(handle._model) if capture_diagnostics else {}
     loss = result.model_output.loss
     assert loss is not None
     return (

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -42,8 +42,9 @@ _BENCH_WARMUP_STEPS = 5
 _BENCH_MEASURE_STEPS = 20
 _BENCH_TOKENS_PER_RANK = 1024
 _MIN_SPEEDUP = 1.0
-_FULL_PARALLEL_WORLD_SIZE = 16
-_FULL_PARALLEL_STEPS = 3
+_FULL_PARALLEL_WORLD_SIZE = 8
+_FULL_PARALLEL_STEPS = 50
+_FULL_PARALLEL_CURVE_INTERVAL = 10
 _FULL_PARALLEL_MICROBATCHES = 2
 _FULL_PARALLEL_SEQ_LEN = 64
 
@@ -141,7 +142,7 @@ def _cuda_dist():
         )
     if world_size > _FULL_PARALLEL_WORLD_SIZE:
         pytest.skip(
-            "M-FSDP smoke tests support at most the dedicated 16-rank full-parallel signoff."
+            "M-FSDP smoke tests support at most the dedicated 8-rank full-parallel signoff."
         )
 
     os.environ.setdefault("RANK", "0")
@@ -354,11 +355,17 @@ def _timed_train_step(chunks, optimizer, finalize, x, target) -> float:
     return float(elapsed)
 
 
-def _max_relative_difference(lhs: list[float], rhs: list[float]) -> float:
-    return max(
+def _relative_difference_curve(lhs: list[float], rhs: list[float]) -> list[float]:
+    assert len(lhs) == len(rhs)
+    assert lhs
+    return [
         abs(left - right) / max(abs(left), abs(right), 1.0e-12)
         for left, right in zip(lhs, rhs)
-    )
+    ]
+
+
+def _max_relative_difference(lhs: list[float], rhs: list[float]) -> float:
+    return max(_relative_difference_curve(lhs, rhs))
 
 
 def _full_tensor(tensor: torch.Tensor) -> torch.Tensor:
@@ -929,14 +936,12 @@ def _max_snapshot_abs_diff(
     return max(float((lhs[name] - rhs[name]).abs().max()) for name in lhs)
 
 
-def test_mfsdp_matches_fsdp2_full_parallel_short_train(monkeypatch):
+def test_mfsdp_matches_fsdp2_full_parallel_precision_curve(monkeypatch):
     if dist.get_world_size() != _FULL_PARALLEL_WORLD_SIZE:
-        pytest.skip(
-            "M-FSDP TP2/EP2/PP2/CP2 signoff requires exactly 16 ranks across two nodes."
-        )
+        pytest.skip("M-FSDP TP2/EP2/ETP1/PP2/CP2 signoff requires exactly 8 ranks.")
 
-    if int(os.environ.get("SLURM_NNODES", "0")) != 2:
-        pytest.fail("M-FSDP full-parallel signoff requires exactly two Slurm nodes.")
+    if int(os.environ.get("SLURM_NNODES", "0")) != 1:
+        pytest.fail("M-FSDP full-parallel signoff requires exactly one Slurm node.")
 
     try:
         import transformer_engine.pytorch as te
@@ -1011,15 +1016,18 @@ def test_mfsdp_matches_fsdp2_full_parallel_short_train(monkeypatch):
         full_tokens == 2 * local_tokens for full_tokens, local_tokens in cp_splits
     )
 
-    max_loss_rel_diff = torch.tensor(
-        _max_relative_difference(losses["fsdp2"], losses["mfsdp"]), device="cuda"
-    )
-    max_grad_norm_rel_diff = torch.tensor(
-        _max_relative_difference(grad_norms["fsdp2"], grad_norms["mfsdp"]),
+    loss_rel_curve = torch.tensor(
+        _relative_difference_curve(losses["fsdp2"], losses["mfsdp"]),
         device="cuda",
     )
-    dist.all_reduce(max_loss_rel_diff, op=dist.ReduceOp.MAX)
-    dist.all_reduce(max_grad_norm_rel_diff, op=dist.ReduceOp.MAX)
+    grad_norm_rel_curve = torch.tensor(
+        _relative_difference_curve(grad_norms["fsdp2"], grad_norms["mfsdp"]),
+        device="cuda",
+    )
+    dist.all_reduce(loss_rel_curve, op=dist.ReduceOp.MAX)
+    dist.all_reduce(grad_norm_rel_curve, op=dist.ReduceOp.MAX)
+    max_loss_rel_diff = loss_rel_curve.max()
+    max_grad_norm_rel_diff = grad_norm_rel_curve.max()
 
     if dist.get_rank() == 0:
         ps = fsdp2_handle._parallel_state
@@ -1039,6 +1047,22 @@ def test_mfsdp_matches_fsdp2_full_parallel_short_train(monkeypatch):
             f"cp_split_calls={len(cp_splits)}",
             flush=True,
         )
+        for curve_index in range(
+            _FULL_PARALLEL_CURVE_INTERVAL - 1,
+            _FULL_PARALLEL_STEPS,
+            _FULL_PARALLEL_CURVE_INTERVAL,
+        ):
+            print(
+                "[MFSDP_FULL_PARALLEL_CURVE] "
+                f"step={curve_index + 1} "
+                f"loss_rel_diff={float(loss_rel_curve[curve_index]):.8e} "
+                f"grad_norm_rel_diff={float(grad_norm_rel_curve[curve_index]):.8e} "
+                f"loss_fsdp2={losses['fsdp2'][curve_index]:.8f} "
+                f"loss_mfsdp={losses['mfsdp'][curve_index]:.8f} "
+                f"grad_norm_fsdp2={grad_norms['fsdp2'][curve_index]:.8f} "
+                f"grad_norm_mfsdp={grad_norms['mfsdp'][curve_index]:.8f}",
+                flush=True,
+            )
         for backend in ("fsdp2", "mfsdp"):
             trace = traces[backend]
             print(
@@ -1048,6 +1072,8 @@ def test_mfsdp_matches_fsdp2_full_parallel_short_train(monkeypatch):
                 flush=True,
             )
 
+    assert torch.isfinite(loss_rel_curve).all()
+    assert torch.isfinite(grad_norm_rel_curve).all()
     assert float(max_loss_rel_diff) <= _LOSS_REL_TOL
     assert float(max_grad_norm_rel_diff) <= _LOSS_REL_TOL
     assert losses["fsdp2"][-1] < losses["fsdp2"][0]

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -202,7 +202,7 @@ def _model_cfg() -> SimpleNamespace:
     )
 
 
-def _optimizer_cfg() -> OptimizerConfig:
+def _optimizer_cfg(*, use_fused_optimizer: bool = True) -> OptimizerConfig:
     cfg = OptimizerConfig(
         optimizer="adam",
         lr=1.0e-3,
@@ -214,7 +214,8 @@ def _optimizer_cfg() -> OptimizerConfig:
         adam_eps=1.0e-8,
     )
     cfg.override_optimizer_config = {
-        "mfsdp_sharding_strategy": _MFSDP_SHARDING_STRATEGY
+        "mfsdp_sharding_strategy": _MFSDP_SHARDING_STRATEGY,
+        "use_fused_optimizer": use_fused_optimizer,
     }
     return cfg
 
@@ -755,7 +756,7 @@ def _build_full_parallel_handle(backend: str, *, seed: int):
     impl_cfg = protocol.ImplConfig(
         parallel=parallel,
         optimizer=backend,
-        optimizer_config=_optimizer_cfg(),
+        optimizer_config=_optimizer_cfg(use_fused_optimizer=False),
         use_deepep=False,
         use_thd=True,
         deterministic=True,
@@ -1020,11 +1021,6 @@ def test_mfsdp_matches_fsdp2_full_parallel_short_train(monkeypatch):
     dist.all_reduce(max_loss_rel_diff, op=dist.ReduceOp.MAX)
     dist.all_reduce(max_grad_norm_rel_diff, op=dist.ReduceOp.MAX)
 
-    assert float(max_loss_rel_diff) <= _LOSS_REL_TOL
-    assert float(max_grad_norm_rel_diff) <= _LOSS_REL_TOL
-    assert losses["fsdp2"][-1] < losses["fsdp2"][0]
-    assert losses["mfsdp"][-1] < losses["mfsdp"][0]
-
     if dist.get_rank() == 0:
         ps = fsdp2_handle._parallel_state
         print(
@@ -1051,3 +1047,8 @@ def test_mfsdp_matches_fsdp2_full_parallel_short_train(monkeypatch):
                 f"sequence={' > '.join(trace[:96])}",
                 flush=True,
             )
+
+    assert float(max_loss_rel_diff) <= _LOSS_REL_TOL
+    assert float(max_grad_norm_rel_diff) <= _LOSS_REL_TOL
+    assert losses["fsdp2"][-1] < losses["fsdp2"][0]
+    assert losses["mfsdp"][-1] < losses["mfsdp"][0]

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -5,6 +5,7 @@ import os
 import statistics
 import sys
 import time
+from contextlib import contextmanager
 from types import SimpleNamespace
 from typing import Any
 
@@ -12,6 +13,7 @@ import pytest
 import torch
 import torch.distributed as dist
 import torch.nn as nn
+from torch.utils._python_dispatch import TorchDispatchMode
 
 from megatron.lite.primitive.optimizers.fsdp2 import (
     build_fsdp2_training_optimizer,
@@ -834,16 +836,58 @@ _COMM_TOKENS = (
 )
 
 
-def _collective_sequence(profiler) -> tuple[str, ...]:
+class _CollectiveDispatchTap(TorchDispatchMode):
+    def __init__(self, sequence: list[str]):
+        super().__init__()
+        self.sequence = sequence
+
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+        del types
+        name = str(func)
+        if any(token in name.lower() for token in _COMM_TOKENS):
+            self.sequence.append(f"dispatch::{name}")
+        return func(*args, **(kwargs or {}))
+
+
+@contextmanager
+def _record_collectives():
     sequence = []
-    for event in profiler.events():
-        name = str(event.name)
-        lowered = name.lower()
-        if lowered.startswith(("aten::", "autograd::")):
+    originals = {}
+    api_names = (
+        "all_gather",
+        "all_gather_into_tensor",
+        "_all_gather_base",
+        "reduce_scatter",
+        "reduce_scatter_tensor",
+        "_reduce_scatter_base",
+        "all_reduce",
+        "all_to_all",
+        "all_to_all_single",
+        "broadcast",
+        "batch_isend_irecv",
+        "isend",
+        "irecv",
+        "send",
+        "recv",
+    )
+    for name in api_names:
+        original = getattr(dist, name, None)
+        if original is None:
             continue
-        if any(token in lowered for token in _COMM_TOKENS):
-            sequence.append(name)
-    return tuple(sequence)
+        originals[name] = original
+
+        def wrapped(*args, _name=name, _original=original, **kwargs):
+            sequence.append(f"python::torch.distributed.{_name}")
+            return _original(*args, **kwargs)
+
+        setattr(dist, name, wrapped)
+
+    try:
+        with _CollectiveDispatchTap(sequence):
+            yield sequence
+    finally:
+        for name, original in originals.items():
+            setattr(dist, name, original)
 
 
 def _contains_collective(sequence: tuple[str, ...], *tokens: str) -> bool:
@@ -851,19 +895,14 @@ def _contains_collective(sequence: tuple[str, ...], *tokens: str) -> bool:
 
 
 def _run_full_parallel_step(
-    handle: ModelHandle, *, batch_seed: int, profile_collectives: bool
+    handle: ModelHandle, *, batch_seed: int, record_collectives: bool
 ) -> tuple[float, float, tuple[str, ...]]:
     runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
     runtime.zero_grad(handle)
     batches = _fixed_packed_batches(64, seed=batch_seed)
-    profiler = None
-    if profile_collectives:
-        with torch.profiler.profile(
-            activities=[
-                torch.profiler.ProfilerActivity.CPU,
-                torch.profiler.ProfilerActivity.CUDA,
-            ]
-        ) as profiler:
+    sequence = []
+    if record_collectives:
+        with _record_collectives() as sequence:
             result = runtime.forward_backward(
                 handle,
                 iter(batches),
@@ -880,8 +919,7 @@ def _run_full_parallel_step(
     assert success
     loss = result.model_output.loss
     assert loss is not None
-    sequence = _collective_sequence(profiler) if profiler is not None else ()
-    return float(loss.detach().float().cpu()), float(grad_norm), sequence
+    return float(loss.detach().float().cpu()), float(grad_norm), tuple(sequence)
 
 
 def _max_snapshot_abs_diff(
@@ -956,7 +994,7 @@ def test_mfsdp_matches_fsdp2_full_parallel_short_train(monkeypatch):
         for backend, handle in (("fsdp2", fsdp2_handle), ("mfsdp", mfsdp_handle)):
             dist.barrier()
             loss, grad_norm, trace = _run_full_parallel_step(
-                handle, batch_seed=8345, profile_collectives=step == 0
+                handle, batch_seed=8345, record_collectives=step == 0
             )
             losses[backend].append(loss)
             grad_norms[backend].append(grad_norm)
@@ -965,7 +1003,7 @@ def test_mfsdp_matches_fsdp2_full_parallel_short_train(monkeypatch):
 
     for backend in ("fsdp2", "mfsdp"):
         trace = traces.get(backend, ())
-        assert trace, f"{backend} profiler recorded no distributed collectives."
+        assert trace, f"{backend} tap recorded no distributed collectives."
         assert _contains_collective(trace, "all_gather", "allgather")
         assert _contains_collective(trace, "reduce_scatter", "reducescatter")
 
@@ -1011,7 +1049,7 @@ def test_mfsdp_matches_fsdp2_full_parallel_short_train(monkeypatch):
             trace = traces[backend]
             print(
                 "[MFSDP_COMM_TRACE] "
-                f"backend={backend} events={len(trace)} "
+                f"backend={backend} phase=forward_backward events={len(trace)} "
                 f"sequence={' > '.join(trace[:96])}",
                 flush=True,
             )

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -149,6 +149,7 @@ def test_mfsdp_full_parallel_signoff_is_single_node_50_step_curve():
     assert constants["_FULL_PARALLEL_CURVE_INTERVAL"] == 10
     assert "[MFSDP_FULL_PARALLEL_CURVE]" in smoke_source
     assert "[MFSDP_FULL_PARALLEL_STEP]" in smoke_source
+    assert "[MFSDP_FULL_PARALLEL_WORST]" in smoke_source
     assert "_tensor_set_max_differences" in smoke_source
     assert "_named_model_tensors(handle._model)" in smoke_source
     assert "_named_model_tensors(handle.model)" not in smoke_source

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -149,6 +149,7 @@ def test_mfsdp_full_parallel_signoff_is_single_node_50_step_curve():
     assert constants["_FULL_PARALLEL_CURVE_INTERVAL"] == 10
     assert "[MFSDP_FULL_PARALLEL_CURVE]" in smoke_source
     assert "[MFSDP_FULL_PARALLEL_STEP]" in smoke_source
+    assert "_tensor_set_max_differences" in smoke_source
     assert "_named_model_tensors(handle._model)" in smoke_source
     assert "_named_model_tensors(handle.model)" not in smoke_source
 

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -148,6 +148,8 @@ def test_mfsdp_full_parallel_signoff_is_single_node_50_step_curve():
     assert constants["_FULL_PARALLEL_STEPS"] == 50
     assert constants["_FULL_PARALLEL_CURVE_INTERVAL"] == 10
     assert "[MFSDP_FULL_PARALLEL_CURVE]" in smoke_source
+    assert '"fsdp2_use_fp32_master": fsdp2_use_fp32_master' in smoke_source
+    assert "fsdp2_use_fp32_master=False" in smoke_source
 
     runner_source = (tests_root / "run_mfsdp_hopper_validation.sh").read_text()
     assert "full-parallel mode requires NNODES=1 and NPROC_PER_NODE=8." in runner_source

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -149,6 +149,8 @@ def test_mfsdp_full_parallel_signoff_is_single_node_50_step_curve():
     assert constants["_FULL_PARALLEL_CURVE_INTERVAL"] == 10
     assert "[MFSDP_FULL_PARALLEL_CURVE]" in smoke_source
     assert "[MFSDP_FULL_PARALLEL_STEP]" in smoke_source
+    assert "_named_model_tensors(handle._model)" in smoke_source
+    assert "_named_model_tensors(handle.model)" not in smoke_source
 
     runner_source = (tests_root / "run_mfsdp_hopper_validation.sh").read_text()
     assert "full-parallel mode requires NNODES=1 and NPROC_PER_NODE=8." in runner_source

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -148,11 +148,6 @@ def test_mfsdp_full_parallel_signoff_is_single_node_50_step_curve():
     assert constants["_FULL_PARALLEL_STEPS"] == 50
     assert constants["_FULL_PARALLEL_CURVE_INTERVAL"] == 10
     assert "[MFSDP_FULL_PARALLEL_CURVE]" in smoke_source
-    assert "[MFSDP_FULL_PARALLEL_STEP]" in smoke_source
-    assert "[MFSDP_FULL_PARALLEL_WORST]" in smoke_source
-    assert "_tensor_set_max_differences" in smoke_source
-    assert "_named_model_tensors(handle._model)" in smoke_source
-    assert "_named_model_tensors(handle.model)" not in smoke_source
     assert "batch_seed=8345 + step" in smoke_source
 
     runner_source = (tests_root / "run_mfsdp_hopper_validation.sh").read_text()

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -67,6 +67,30 @@ def _optimizer_named_shards(optimizer) -> dict[str, torch.nn.Parameter]:
     return result
 
 
+def test_mfsdp_zero_grad_supports_fused_optimizer_contract():
+    class NoArgZeroGradOptimizer:
+        def __init__(self):
+            self.called = False
+
+        def zero_grad(self):
+            self.called = True
+
+    fused_optimizer = NoArgZeroGradOptimizer()
+    adapter = mfsdp_optimizer._StandaloneOptimizer(
+        fused_optimizer,
+        [],
+        ps=SimpleNamespace(),
+        clip_grad=0.0,
+        grad_norm_accum_dtype=torch.float32,
+        expert_params=[],
+        expert_grad_scale=1.0,
+    )
+
+    adapter.zero_grad()
+
+    assert fused_optimizer.called is True
+
+
 def test_mfsdp_has_no_megatron_core_imports():
     package = Path(mfsdp_config.__file__).parent
     violations = []

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -148,8 +148,7 @@ def test_mfsdp_full_parallel_signoff_is_single_node_50_step_curve():
     assert constants["_FULL_PARALLEL_STEPS"] == 50
     assert constants["_FULL_PARALLEL_CURVE_INTERVAL"] == 10
     assert "[MFSDP_FULL_PARALLEL_CURVE]" in smoke_source
-    assert '"fsdp2_use_fp32_master": fsdp2_use_fp32_master' in smoke_source
-    assert "fsdp2_use_fp32_master=False" in smoke_source
+    assert "[MFSDP_FULL_PARALLEL_STEP]" in smoke_source
 
     runner_source = (tests_root / "run_mfsdp_hopper_validation.sh").read_text()
     assert "full-parallel mode requires NNODES=1 and NPROC_PER_NODE=8." in runner_source

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -153,6 +153,7 @@ def test_mfsdp_full_parallel_signoff_is_single_node_50_step_curve():
     assert "_tensor_set_max_differences" in smoke_source
     assert "_named_model_tensors(handle._model)" in smoke_source
     assert "_named_model_tensors(handle.model)" not in smoke_source
+    assert "batch_seed=8345 + step" in smoke_source
 
     runner_source = (tests_root / "run_mfsdp_hopper_validation.sh").read_text()
     assert "full-parallel mode requires NNODES=1 and NPROC_PER_NODE=8." in runner_source

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -131,6 +131,28 @@ def test_mfsdp_standalone_smoke_has_no_megatron_core_imports():
     assert violations == []
 
 
+def test_mfsdp_full_parallel_signoff_is_single_node_50_step_curve():
+    tests_root = Path(__file__).parents[2]
+    smoke_path = tests_root / "smoke" / "primitive" / "test_mfsdp_parity_smoke.py"
+    smoke_source = smoke_path.read_text()
+    smoke_tree = ast.parse(smoke_source, filename=str(smoke_path))
+    constants = {}
+    for node in smoke_tree.body:
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        if isinstance(target, ast.Name) and isinstance(node.value, ast.Constant):
+            constants[target.id] = node.value.value
+
+    assert constants["_FULL_PARALLEL_WORLD_SIZE"] == 8
+    assert constants["_FULL_PARALLEL_STEPS"] == 50
+    assert constants["_FULL_PARALLEL_CURVE_INTERVAL"] == 10
+    assert "[MFSDP_FULL_PARALLEL_CURVE]" in smoke_source
+
+    runner_source = (tests_root / "run_mfsdp_hopper_validation.sh").read_text()
+    assert "full-parallel mode requires NNODES=1 and NPROC_PER_NODE=8." in runner_source
+
+
 def test_mfsdp_is_standalone_without_vendored_mcore_or_fsdp2_dependencies():
     package = Path(mfsdp_config.__file__).parent
 

--- a/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
+++ b/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
@@ -22,6 +22,7 @@ from megatron.lite.runtime.backends.mlite.runtime import (
     _pipeline_callbacks,
 )
 from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig, RuntimeConfig
+from megatron.lite.runtime.contracts.data import PackedBatch
 from megatron.lite.runtime.contracts.handle import ModelHandle
 from megatron.lite.runtime.contracts.loss import LossContext, get_loss_context, use_loss_context
 
@@ -63,6 +64,60 @@ def test_pipeline_callbacks_accept_wrapped_and_presplit_context():
 
     assert seen == [("wrapped", context), ("presplit", context)]
     assert metrics == {"batch": "presplit", "source": "source"}
+
+
+def test_pipeline_runtime_enables_optimizer_grad_sync_on_last_microbatch(monkeypatch):
+    from megatron.lite.primitive.parallel import pipeline as pipeline_module
+
+    optimizer = types.SimpleNamespace(grad_sync_enabled=False)
+    observed_callbacks = []
+
+    def fake_pipeline(*_args, grad_sync_fn=None, **_kwargs):
+        assert callable(grad_sync_fn)
+        assert optimizer.grad_sync_enabled is False
+        grad_sync_fn()
+        observed_callbacks.append(optimizer.grad_sync_enabled)
+        return [{"loss": torch.ones(())}]
+
+    monkeypatch.setattr(pipeline_module, "forward_backward_pipelining", fake_pipeline)
+
+    original_tensor = torch.tensor
+
+    def cpu_tensor(data, *args, **kwargs):
+        kwargs.pop("device", None)
+        return original_tensor(data, *args, **kwargs)
+
+    monkeypatch.setattr(torch, "tensor", cpu_tensor)
+    parallel_state = types.SimpleNamespace(
+        pp_size=2,
+        pp_group=None,
+        pp_global_ranks=None,
+        tp_size=1,
+        cp_size=1,
+    )
+    model = nn.Linear(1, 1, bias=False)
+    handle = ModelHandle(
+        model=model,
+        optimizer=optimizer,
+        parallel_state=parallel_state,
+        _extras={
+            "forward_step": lambda _model, _batch: {"loss": torch.ones(())},
+            "model_chunks": [model],
+            "model_cfg": types.SimpleNamespace(hidden_size=1),
+        },
+    )
+    batch = PackedBatch(
+        input_ids=torch.ones(4, dtype=torch.long),
+        labels=torch.ones(4, dtype=torch.long),
+        seq_lens=torch.tensor([4]),
+    )
+    MegatronLiteRuntime.__new__(MegatronLiteRuntime).forward_backward(
+        handle,
+        iter([batch, batch]),
+        None,
+        num_microbatches=2,
+    )
+    assert observed_callbacks == [True]
 
 
 def test_runtime_config_defaults_to_mlite_backend():


### PR DESCRIPTION
## Summary

- Add a standalone Hopper validation harness that compares M-FSDP with FSDP2 while asserting distinct optimizer implementation paths.
- Exercise fused optimizer zeroing and pipeline gradient synchronization through full-parallel training coverage.
- Use deterministic matched batches for a 50-step precision curve and report global worst-case loss and gradient-norm differences.
- Add a steady-state throughput gate that requires M-FSDP to outperform FSDP2.

This PR is stacked on #89 and should be reviewed after it.

## Validation

- Unit contracts: 27 passed, 1 deselected.
- Distributed Gloo contract: 1 passed.
- Runtime and layering contracts: 35 passed.
- Static checks: Ruff check and format check, Python compilation, shell syntax, and git diff check passed.
- Hopper precision, 8 × H100, TP2 / EP2 / ETP1 / PP2 / CP2, 50 steps: maximum relative loss difference 3.26907053e-3; maximum relative gradient-norm difference 1.69806718e-3; both below the 1e-2 gate.
- Hopper throughput, 8 × H100: FSDP2 196,970.06 tokens/s versus M-FSDP 470,715.91 tokens/s, a 2.3898× speedup.