### PR TITLE
Add DeepSeek-V4 CSA THD context-parallel path to Megatron-Lite

### DIFF
--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/model.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/model.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import os
 from contextlib import nullcontext
+from typing import Any
 
 import torch
 import torch.nn as nn
@@ -100,10 +101,19 @@ class DeepseekV4CSAAttention(nn.Module):
         self.ps = ps
         self.self_attn = CompressedSparseAttention(config, layer_idx=layer_idx, ps=ps)
 
-    def forward(self, x: torch.Tensor, *, position_ids: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self, x: torch.Tensor, *, position_ids: torch.Tensor, packed_seq_params: Any = None
+    ) -> torch.Tensor:
         # Skeleton feeds SBHD [S, B, H]; CSA needs batch-first [B, S, H].
+        # packed_seq_params (cu_seqlens etc.) passes through unchanged: the THD
+        # token axis lives in S, so the [S, B] <-> [B, S] transpose leaves it alone.
         x_bsh = x.transpose(0, 1).contiguous()
-        out_bsh = self.self_attn(x_bsh, position_ids=position_ids, attention_mask=None)
+        out_bsh = self.self_attn(
+            x_bsh,
+            position_ids=position_ids,
+            attention_mask=None,
+            packed_seq_params=packed_seq_params,
+        )
         # Back to SBHD [S, B, H] for the skeleton.
         return out_bsh.transpose(0, 1).contiguous()
 
@@ -151,13 +161,18 @@ class DeepseekV4Layer(nn.Module):
         *,
         position_ids: torch.Tensor,
         input_ids: torch.Tensor | None = None,
+        packed_seq_params: Any = None,
     ) -> torch.Tensor:
         # x is SBHD mHC [S, B, hc_mult, H].  HyperConnection collapses the
         # streams to a 3-D [S, B, H] pre-mix, the sub-block runs SBHD, and
         # HyperConnection.post recombines into the 4-D residual streams.
         residual = x
         attn_in, post, comb = self.attn_hc(x)
-        attn_out = self.self_attn(self.input_layernorm(attn_in), position_ids=position_ids)
+        attn_out = self.self_attn(
+            self.input_layernorm(attn_in),
+            position_ids=position_ids,
+            packed_seq_params=packed_seq_params,
+        )
         x = HyperConnection.post(attn_out, residual, post, comb)
 
         residual = x
@@ -403,6 +418,7 @@ class DeepseekV4Model(nn.Module):
         use_fused_kernels: bool = False,
         calculate_entropy: bool = False,
         enable_mtp: bool = True,
+        packed_seq_params: Any = None,
     ) -> dict:
         # THD-packed inputs may arrive 1-D ([total_tokens]); VocabParallelEmbedding
         # and the dense skeleton expect [B, S], so add the batch row (matches the
@@ -433,7 +449,12 @@ class DeepseekV4Model(nn.Module):
         )
         with fp8_ctx:
             for layer in self.layers.values():
-                h = layer(h, position_ids=position_ids, input_ids=input_ids)
+                h = layer(
+                    h,
+                    position_ids=position_ids,
+                    input_ids=input_ids,
+                    packed_seq_params=packed_seq_params,
+                )
 
         output: dict = {"hidden_states": fold_mhc_hidden_for_pipeline(h)}
         if self.lm_head is None or self.norm is None or self.hc_head is None:

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
@@ -79,6 +79,7 @@ _MODEL_FORWARD_KEYS = (
     "temperature",
     "calculate_entropy",
     "enable_mtp",
+    "packed_seq_params",
 )
 
 
@@ -167,7 +168,6 @@ def _prepare_packed_batch_kwargs(model, batch: PackedBatch) -> dict[str, Any]:
     }
     add_loss_context_kwargs(kwargs)
     _prepare_packed_contiguous_cp_kwargs(model, kwargs)
-    kwargs.pop("packed_seq_params", None)
     return {key: value for key, value in kwargs.items() if key in _MODEL_FORWARD_KEYS}
 
 

--- a/experimental/lite/megatron/lite/primitive/modules/attention/csa.py
+++ b/experimental/lite/megatron/lite/primitive/modules/attention/csa.py
@@ -769,7 +769,7 @@ class CompressedSparseAttention(nn.Module):
 
         # TE-THD convention: query (total, np, hn); key (total, 1, 1, hn); x/qr (total, 1, *).
         query_thd = q.squeeze(0).transpose(0, 1).contiguous()  # (total, np, hn)
-        key_thd = kv.permute(2, 0, 1, 3).unsqueeze(-2).contiguous()  # (total, 1, 1, hn)
+        key_thd = kv.permute(2, 0, 1, 3).contiguous()  # (total, 1, 1, hn)
         x_thd = x.transpose(0, 1).contiguous()  # (total, 1, hidden)
         qr_thd = q_low.transpose(0, 1).contiguous()  # (total, 1, q_lora_rank)
 

--- a/experimental/lite/megatron/lite/primitive/modules/attention/csa.py
+++ b/experimental/lite/megatron/lite/primitive/modules/attention/csa.py
@@ -5,11 +5,28 @@ from typing import Any
 import torch
 import torch.nn as nn
 import transformer_engine.pytorch as te
-from megatron.lite.primitive.modules.attention.dsa import rotate_activation
-from megatron.lite.primitive.modules.attention.cp import (
-    compress_contiguous_chunks_for_cp,
-    iter_cp_sources,
+# Zero-copy imports of the DSv4 THD-CP helpers that live in Megatron Core. The
+# lite CSA module reuses Core's differentiable kernels, CP row-mapping utilities,
+# and CuTeDSL layout kernels rather than vendoring them; see the module docstring
+# of ``csa_cp_utils`` / ``csa_cp_layout_kernels`` for the exact contracts.
+from megatron.core.tensor_parallel.mappings import gather_from_sequence_parallel_region
+from megatron.core.transformer.experimental_attention_variant import (
+    csa_cp_layout_kernels,
+    csa_cp_utils as cp_utils,
 )
+from megatron.core.transformer.experimental_attention_variant.csa import (
+    _unfused_indexer_sparse_attn_from_topk,
+    unfused_compressed_sparse_attn,
+)
+from megatron.core.transformer.experimental_attention_variant.dsa import (
+    DSAIndexerLossAutoScaler,
+    DSAIndexerLossLoggingHelper,
+)
+from megatron.core.transformer.experimental_attention_variant.dsa_kernels import (
+    FusedIndexerSparseAttnFromTopkFunc,
+    dsa_sparse_attn,
+)
+from megatron.lite.primitive.modules.attention.dsa import rotate_activation
 from megatron.lite.primitive.parallel.state import ParallelState
 from megatron.lite.primitive.utils.rotary import (
     _yarn_find_correction_range,
@@ -182,21 +199,87 @@ class CompressedSequenceCompressor(nn.Module):
         compressed = apply_partial_rope(compressed, cos, sin, self.rope_head_dim)
         return rotate_activation(compressed) if self.rotate else compressed
 
+    def _overlap_transform_thd(
+        self, tensor: torch.Tensor, is_first_in_seg: torch.Tensor, fill_value: float
+    ) -> torch.Tensor:
+        """Batched overlapping-window transform for the THD (pre-grouped) layout.
 
-def _source_scores_mask(
-    q_positions: torch.Tensor, k_positions: torch.Tensor, *, sliding_window: int
-) -> torch.Tensor:
-    q_pos = q_positions.unsqueeze(-1)
-    k_pos = k_positions.unsqueeze(1)
-    return (k_pos <= q_pos) & (k_pos >= q_pos - sliding_window + 1)
+        Mirrors Core ``Compressor._overlap_transform_thd``: operates on the flat
+        ``(total_comp, ratio, 1, coff * head_dim)`` tensor from all segments at
+        once. ``is_first_in_seg`` is a ``(total_comp,)`` bool mask, ``True`` for
+        each compressed entry that starts a new segment (no predecessor group).
+        Output shape ``(total_comp, 2 * ratio, 1, head_dim)``.
+        """
+        n, ratio, b_dim, _ = tensor.size()
+        d = self.head_dim
+        out = tensor.new_full((n, 2 * ratio, b_dim, d), fill_value)
+        out[:, ratio:] = tensor[:, :, :, d:]
+        prev_data = torch.roll(tensor[:, :, :, :d], shifts=1, dims=0)
+        prev_data[is_first_in_seg] = fill_value
+        out[:, :ratio] = prev_data
+        return out
 
+    def _forward_thd(
+        self,
+        hidden_compact: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        *,
+        max_seqlen_q: int,
+        compressed_group_ids: torch.Tensor,
+    ) -> tuple[torch.Tensor | None, None]:
+        """Pre-grouped THD compression for the DSv4 CP path.
 
-def _compressed_scores_mask(
-    q_positions: torch.Tensor, comp_positions: torch.Tensor, *, ratio: int
-) -> torch.Tensor:
-    visible = (q_positions + 1) // ratio
-    comp_ids = comp_positions // ratio
-    return comp_ids.unsqueeze(1) < visible.unsqueeze(-1)
+        ``hidden_compact`` is ``(compact_group_capacity * ratio, 1, hidden)``,
+        already packed into ratio-sized groups by
+        ``cp_utils.prepare_cp_compressor_input``; ``compressed_group_ids`` is
+        ``(compact_group_capacity,)`` int32 giving each compressed group's
+        per-sequence compressed id (its RoPE position is ``id * ratio``).
+
+        Reproduces Core ``Compressor._forward_thd`` pre-grouped semantics using
+        lite's compressor params (``wkv``/``wgate``/``ape``/``norm``) and lite's
+        RoPE convention (``build_compressed_rope_cos_sin`` + ``apply_partial_rope``)
+        so the CP path stays numerically identical to lite's BSHD path. ``cu_seqlens``
+        and ``max_seqlen_q`` are accepted to match Core's signature; they are only
+        needed by Core's fused-RoPE cache, which lite does not use.
+
+        Returns ``(compressed_thd (total_comp, 1, head_dim), None)``.
+        """
+        del cu_seqlens, max_seqlen_q  # Only used by Core's fused-RoPE cache path.
+        ratio = self.compress_ratio
+        total_comp = int(compressed_group_ids.shape[0])
+        if total_comp == 0:
+            return None, None
+        kv = self.wkv(hidden_compact)  # (total_comp * ratio, 1, coff * head_dim)
+        gate = self.wgate(hidden_compact)
+        kv_grouped = kv.reshape(total_comp, ratio, 1, -1)
+        gate_grouped = gate.reshape(total_comp, ratio, 1, -1)
+        gate_grouped = gate_grouped + self.ape.view(1, ratio, 1, -1).to(gate_grouped.device)
+        if self.overlap:
+            is_first = compressed_group_ids[:total_comp] == 0
+            kv_grouped = self._overlap_transform_thd(kv_grouped, is_first, 0.0)
+            gate_grouped = self._overlap_transform_thd(gate_grouped, is_first, float("-inf"))
+        # Non-overlap (coff == 1): kv_grouped/gate_grouped are already
+        # (total_comp, ratio, 1, head_dim); no windowing needed.
+        weights = torch.softmax(gate_grouped.float(), dim=1).to(kv_grouped.dtype)
+        compressed = (kv_grouped * weights).sum(dim=1)  # (total_comp, 1, head_dim)
+        compressed = self.norm(compressed)
+        positions = compressed_group_ids[:total_comp].clamp_min(0).to(torch.long) * ratio
+        cos, sin = build_compressed_rope_cos_sin(
+            positions.view(1, total_comp),
+            self.rope_head_dim,
+            self.config.compress_rope_theta,
+            config=self.config,
+            use_yarn=ratio > 1,
+            device=compressed.device,
+            dtype=compressed.dtype,
+        )
+        # apply_partial_rope wants the sequence axis at dim -2; view as (1, total_comp, d).
+        compressed = compressed.transpose(0, 1)  # (1, total_comp, head_dim)
+        compressed = apply_partial_rope(compressed, cos, sin, self.rope_head_dim)
+        compressed = compressed.transpose(0, 1)  # (total_comp, 1, head_dim)
+        if self.rotate:
+            compressed = rotate_activation(compressed)
+        return compressed, None
 
 
 def _window_topk_indices(
@@ -245,11 +328,19 @@ class CompressedSparseAttention(nn.Module):
         super().__init__()
         self.config = config
         self.ps = ps
+        self.layer_idx = layer_idx
         self.attention_backend = "torch"
         self.num_heads = config.num_attention_heads
         self.head_dim = config.head_dim
         self.rope_head_dim = config.qk_rope_head_dim
+        self.softmax_scale = self.head_dim**-0.5
         self.num_heads_per_group = config.num_attention_heads // config.o_groups
+        # DSv4 THD-CP faithfulness: these knobs are absent from the lite DS4 config;
+        # thread them with Core-matching defaults. ``apply_dsa_kernel_fusion=False``
+        # selects the differentiable unfused sparse-attention / indexer-loss path
+        # (Core's ``_unfused_indexer_sparse_attn_from_topk``), which is the lite
+        # default backend (``self.attention_backend == "torch"``).
+        self.apply_dsa_kernel_fusion = getattr(config, "apply_dsa_kernel_fusion", False)
         # MTP layers use layer_idx == num_hidden_layers (+i), which is past the
         # per-decoder-layer compress_ratios list (length num_hidden_layers); fall
         # back to the last real layer's ratio so the MTP CSA still builds.
@@ -287,7 +378,17 @@ class CompressedSparseAttention(nn.Module):
         *,
         position_ids: torch.Tensor,
         attention_mask: torch.Tensor | None = None,
+        packed_seq_params: Any = None,
     ) -> torch.Tensor:
+        # THD packed sequences take the primary DSv4 CP path. THD is the only
+        # sequence-parallel route now: the BSHD dense fallback has been removed.
+        if packed_seq_params is not None:
+            if attention_mask is not None:
+                raise ValueError(
+                    "THD packed CSA expects attention_mask=None; masks are derived "
+                    "from cu_seqlens / position_ids."
+                )
+            return self._forward_thd_packed(x, position_ids, packed_seq_params)
         if self.ps.cp_size > 1 and attention_mask is not None:
             raise ValueError("CP expects attention_mask=None; masks are derived from position_ids.")
         batch, seq_len, _ = x.shape
@@ -339,139 +440,15 @@ class CompressedSparseAttention(nn.Module):
                 sin=sin,
             )
 
-        dense_score_parts = []
-        dense_value_parts = []
-        for _source_rank, source_kv, source_pos in iter_cp_sources(
-            kv,
-            position_ids,
-            cp_rank=self.ps.cp_rank,
-            cp_size=self.ps.cp_size,
-            cp_group=self.ps.cp_group,
-        ):
-            source_heads = source_kv.expand(-1, self.num_heads, -1, -1)
-            scores = torch.matmul(q.float(), source_heads.float().transpose(-1, -2)) / (
-                self.head_dim**0.5
-            )
-            source_mask = _source_scores_mask(
-                position_ids,
-                source_pos,
-                sliding_window=self.config.sliding_window,
-            ).unsqueeze(1)
-            scores = scores.masked_fill(~source_mask, -float("inf"))
-            dense_score_parts.append(scores)
-            dense_value_parts.append(source_heads)
-        dense_scores = torch.cat(dense_score_parts, dim=-1)
-        if attention_mask is not None:
-            dense_scores = dense_scores + attention_mask.to(dtype=dense_scores.dtype)
-        score_parts = [dense_scores]
-        value_parts = [torch.cat(dense_value_parts, dim=2)]
-
-        if self.compressor is not None:
-            compressed_pack = compress_contiguous_chunks_for_cp(
-                self.compressor,
-                x,
-                position_ids=position_ids,
-                cp_rank=self.ps.cp_rank,
-                cp_size=self.ps.cp_size,
-                cp_group=self.ps.cp_group,
-                compress_kwargs={"rope_theta": self.config.compress_rope_theta},
-            )
-        else:
-            compressed_pack = None
-        if compressed_pack is not None:
-            compressed, compressed_pos = compressed_pack
-            compressed, compressed_pos = self._gather_cp_sources(
-                compressed, compressed_pos, seq_dim=2
-            )
-            compressed_values = compressed.expand(-1, self.num_heads, -1, -1)
-            compressed_scores = torch.matmul(
-                q.float(), compressed_values.float().transpose(-1, -2)
-            ) / (self.head_dim**0.5)
-            compressed_valid = _compressed_scores_mask(
-                position_ids,
-                compressed_pos,
-                ratio=self.compress_ratio,
-            ).unsqueeze(1)
-            compressed_scores = compressed_scores.masked_fill(~compressed_valid, -float("inf"))
-
-            if self.indexer is not None:
-                index_comp_pack = compress_contiguous_chunks_for_cp(
-                    self.indexer.compressor,
-                    x,
-                    position_ids=position_ids,
-                    cp_rank=self.ps.cp_rank,
-                    cp_size=self.ps.cp_size,
-                    cp_group=self.ps.cp_group,
-                    compress_kwargs={"rope_theta": self.config.compress_rope_theta},
-                )
-                if index_comp_pack is not None:
-                    index_comp, index_pos = index_comp_pack
-                    index_comp, index_pos = self._gather_cp_sources(
-                        index_comp, index_pos, seq_dim=2
-                    )
-                    idx_cos, idx_sin = build_compressed_rope_cos_sin(
-                        position_ids,
-                        self.indexer.rope_head_dim,
-                        self.config.compress_rope_theta,
-                        config=self.config,
-                        use_yarn=self.compress_ratio > 1,
-                        device=x.device,
-                        dtype=x.dtype,
-                    )
-                    q_idx = (
-                        self.indexer.wq_b(q_low)
-                        .view(
-                            batch, seq_len, self.indexer.index_n_heads, self.indexer.index_head_dim
-                        )
-                        .transpose(1, 2)
-                    )
-                    q_idx = apply_partial_rope(q_idx, idx_cos, idx_sin, self.indexer.rope_head_dim)
-                    index_weights = (
-                        self.indexer.weights_proj(x).float()
-                        * (self.indexer.index_n_heads**-0.5)
-                        * self.indexer.softmax_scale
-                    )
-                    k_idx = index_comp.squeeze(1)
-                    index_scores = torch.einsum(
-                        "bhsd,btd->bsht", q_idx.float(), k_idx.float()
-                    ).relu()
-                    index_scores = (index_scores * index_weights.unsqueeze(-1)).sum(dim=2)
-                    index_valid = _compressed_scores_mask(
-                        position_ids,
-                        index_pos,
-                        ratio=self.compress_ratio,
-                    )
-                    index_scores = index_scores.masked_fill(~index_valid, -float("inf"))
-                    topk = min(self.indexer.index_topk, index_scores.size(-1))
-                    topk_indices = index_scores.topk(topk, dim=-1).indices
-                    topk_mask = torch.zeros_like(index_scores, dtype=torch.bool)
-                    topk_mask.scatter_(-1, topk_indices, True)
-                    compressed_scores = compressed_scores + index_scores.unsqueeze(1)
-                    compressed_scores = compressed_scores.masked_fill(
-                        ~topk_mask.unsqueeze(1), -float("inf")
-                    )
-            score_parts.append(compressed_scores)
-            value_parts.append(compressed_values)
-
-        scores = torch.cat(score_parts, dim=-1)
-        sink = (
-            self.sinks.view(1, self.num_heads, 1, 1)
-            .expand(batch, -1, seq_len, -1)
-            .to(dtype=scores.dtype)
+        # The BSHD dense-softmax fallback (and its CP all-gather loop) has been
+        # removed: DSv4 sequence parallelism now goes exclusively through the THD
+        # packed CP path (``packed_seq_params is not None`` above), and the only
+        # supported BSHD routes are the CP=1 fused sparse kernels dispatched above.
+        raise NotImplementedError(
+            "DSv4 CSA BSHD path supports only the CP=1 fused sparse backends; pass "
+            "packed_seq_params for the THD context-parallel path. The dense BSHD "
+            "fallback was removed."
         )
-        combined_scores = torch.cat([scores, sink], dim=-1)
-        combined_scores = combined_scores - combined_scores.max(dim=-1, keepdim=True).values
-        probs = torch.softmax(combined_scores, dim=-1, dtype=torch.float32).to(dtype=q.dtype)
-
-        context = q.new_zeros(batch, self.num_heads, seq_len, self.head_dim)
-        offset = 0
-        for values in value_parts:
-            next_offset = offset + values.size(2)
-            partial = torch.matmul(probs[..., offset:next_offset], values)
-            context = context + partial
-            offset = next_offset
-
-        return self._project_context(context, cos, sin)
 
     def _project_context(
         self, context: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor
@@ -482,22 +459,6 @@ class CompressedSparseAttention(nn.Module):
             batch, seq_len, self.config.o_groups, self.num_heads_per_group * self.head_dim
         )
         return self.wo_b(self.wo_a(grouped).flatten(2))
-
-    def _gather_cp_sources(
-        self, tensor: torch.Tensor, position_ids: torch.Tensor, *, seq_dim: int
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        parts, pos_parts = [], []
-        for _rank, source, source_pos in iter_cp_sources(
-            tensor,
-            position_ids,
-            cp_rank=self.ps.cp_rank,
-            cp_size=self.ps.cp_size,
-            cp_group=self.ps.cp_group,
-        ):
-            parts.append(source)
-            pos_parts.append(source_pos)
-        pos = torch.cat(pos_parts, dim=1)
-        return torch.cat(parts, dim=seq_dim), pos
 
     def _forward_fused_sparse_no_indexer_cp1(
         self,
@@ -712,3 +673,380 @@ class CompressedSparseAttention(nn.Module):
         if pad:
             context = context[:, :, :orig_seq_len, :].contiguous()
         return self._project_context(context, cos, sin)
+
+    # ------------------------------------------------------------------
+    # THD packed context-parallel path
+    # ------------------------------------------------------------------
+
+    def _thd_cu_seqlens(self, packed_seq_params: Any) -> torch.Tensor:
+        """Padded cu_seqlens (falling back to unpadded) for the THD packed layout."""
+        return (
+            packed_seq_params.cu_seqlens_q_padded
+            if packed_seq_params.cu_seqlens_q_padded is not None
+            else packed_seq_params.cu_seqlens_q
+        )
+
+    def _project_boundary_kv(
+        self,
+        boundary_hidden: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        global_start: int,
+        rope_theta: float,
+    ) -> torch.Tensor:
+        """Project the exchanged left-boundary hidden rows into MQA KV rows.
+
+        Faithful to the DSv4 hybrid-attention boundary-KV path: the boundary rows
+        sit immediately left of this rank's block, so they are KV-projected
+        (``wkv`` -> ``kv_norm``) and RoPE'd at their own within-sequence positions
+        (``global_start - d_window .. global_start - 1``) using lite's RoPE
+        convention. Returns ``(d_window, 1, 1, head_dim)`` matching Core's
+        ``boundary_kv.squeeze(-2).squeeze(1)`` contract in ``_forward_thd_cp``.
+        """
+        d_window = boundary_hidden.shape[0]
+        bkv = self.kv_norm(self.wkv(boundary_hidden.reshape(d_window, -1)))  # (d_window, head_dim)
+        b_pos = cp_utils._thd_cp_position_ids(cu_seqlens, int(global_start) - d_window, d_window)
+        cos, sin = build_compressed_rope_cos_sin(
+            b_pos.view(1, d_window).long(),
+            self.rope_head_dim,
+            rope_theta,
+            config=self.config,
+            use_yarn=self.compress_ratio > 1,
+            device=bkv.device,
+            dtype=bkv.dtype,
+        )
+        bkv = bkv.view(1, 1, d_window, self.head_dim)  # (batch=1, head=1, seq=d_window, hd)
+        bkv = apply_partial_rope(bkv, cos, sin, self.rope_head_dim)
+        return bkv.permute(2, 0, 1, 3).contiguous()  # (d_window, 1, 1, head_dim)
+
+    def _forward_thd_packed(
+        self,
+        x: torch.Tensor,
+        position_ids: torch.Tensor,
+        packed_seq_params: Any,
+    ) -> torch.Tensor:
+        """Build THD-packed q/key/x/qr, exchange boundaries, and run CP attention.
+
+        ``x`` is ``[1, total, hidden]`` (batch-first, packed). Produces the
+        TE-THD-convention tensors consumed by :meth:`_forward_thd_cp`, then applies
+        the output projection (inverse RoPE + ``wo``) via :meth:`_project_context`.
+        Returns ``[1, total, hidden]`` for the SBHD shim.
+        """
+        batch, seq_len, _ = x.shape
+        if batch != 1:
+            raise RuntimeError(
+                f"DSv4 THD packed CSA expects batch-collapsed input [1, total, h]; got batch={batch}."
+            )
+        cp_group = self.ps.cp_group
+        cp_rank = self.ps.cp_rank
+        cu_seqlens = self._thd_cu_seqlens(packed_seq_params)
+        global_start = cp_rank * seq_len
+
+        attention_rope_theta = (
+            self.config.compress_rope_theta if self.compress_ratio > 1 else self.config.rope_theta
+        )
+        # Positions come from cu_seqlens + this rank's global offset (CP-correct
+        # within-sequence positions), not the raw position_ids tensor, so the
+        # mapping is identical to the unsharded reference at cp_size == 1.
+        del position_ids
+        local_pos = cp_utils._thd_cp_position_ids(cu_seqlens, global_start, seq_len).view(1, seq_len)
+        cos, sin = build_compressed_rope_cos_sin(
+            local_pos.long(),
+            self.rope_head_dim,
+            attention_rope_theta,
+            config=self.config,
+            use_yarn=self.compress_ratio > 1,
+            device=x.device,
+            dtype=x.dtype,
+        )
+        q_low = self.q_norm(self.wq_a(x))
+        q = self.wq_b(q_low).view(batch, seq_len, self.num_heads, self.head_dim).transpose(1, 2)
+        q = q * torch.rsqrt(
+            q.float().pow(2).mean(dim=-1, keepdim=True) + self.config.rms_norm_eps
+        ).to(dtype=q.dtype)
+        kv = self.kv_norm(self.wkv(x)).view(batch, seq_len, 1, self.head_dim).transpose(1, 2)
+        q = apply_partial_rope(q, cos, sin, self.rope_head_dim)
+        kv = apply_partial_rope(kv, cos, sin, self.rope_head_dim)
+
+        # TE-THD convention: query (total, np, hn); key (total, 1, 1, hn); x/qr (total, 1, *).
+        query_thd = q.squeeze(0).transpose(0, 1).contiguous()  # (total, np, hn)
+        key_thd = kv.permute(2, 0, 1, 3).unsqueeze(-2).contiguous()  # (total, 1, 1, hn)
+        x_thd = x.transpose(0, 1).contiguous()  # (total, 1, hidden)
+        qr_thd = q_low.transpose(0, 1).contiguous()  # (total, 1, q_lora_rank)
+
+        if self.ps.cp_size > 1:
+            boundary_hidden = cp_utils.exchange_cp_boundary_hidden(
+                x_thd, self.compress_ratio, self.config.sliding_window, cp_group
+            )
+        else:
+            # cp_size == 1 has no left neighbour, so the boundary window is exactly
+            # zeros. Core reaches ``_forward_thd_cp`` only at cp>1 and never calls
+            # the P2P exchange with an empty op list; the lite path routes cp=1 THD
+            # through the same method, so materialize the zero boundary directly
+            # (matching ``cp_utils.exchange_cp_boundary_hidden``'s D_window sizing).
+            d_comp = (
+                8 if self.compress_ratio == 4 else self.compress_ratio if self.compress_ratio > 1 else 0
+            )
+            d_window = max(int(self.config.sliding_window), d_comp)
+            boundary_hidden = x_thd.new_zeros((d_window,) + tuple(x_thd.shape[1:]))
+        boundary_kv = self._project_boundary_kv(
+            boundary_hidden, cu_seqlens, global_start, attention_rope_theta
+        )
+
+        context = self._forward_thd_cp(
+            query_thd, key_thd, x_thd, qr_thd, boundary_hidden, boundary_kv, packed_seq_params
+        )
+        # context: (total, 1, np * hn). Reshape to (1, np, total, hn) for the shared
+        # output projection (inverse RoPE + wo), then return (1, total, hidden).
+        context = (
+            context.squeeze(1)
+            .view(seq_len, self.num_heads, self.head_dim)
+            .permute(1, 0, 2)
+            .unsqueeze(0)
+            .contiguous()
+        )
+        return self._project_context(context, cos, sin)
+
+    def _forward_thd_cp(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        x: torch.Tensor,
+        qr: torch.Tensor,
+        boundary_hidden: torch.Tensor | None,
+        boundary_kv: torch.Tensor | None,
+        packed_seq_params: Any,
+    ) -> torch.Tensor:
+        """THD-packed context-parallel branch (faithful port of Core
+        ``CompressedSparseAttention._forward_thd_cp``).
+
+        Builds this rank's local KV context from boundary rows and fixed-capacity
+        compressed KV, then runs sparse attention with an optional indexer loss.
+        RoPE is applied to the indexer query with lite's convention (deviating from
+        Core's ``cp_utils.apply_thd_cp_local_rope_*``) so the CP path stays
+        identical to lite's BSHD path; ``apply_dsa_kernel_fusion`` gates the
+        fused vs. differentiable-unfused kernels exactly as Core does.
+        """
+        cp_group = self.ps.cp_group
+        cp_size = self.ps.cp_size
+        cp_rank = self.ps.cp_rank
+
+        l_local = query.shape[0]
+        if l_local != key.shape[0]:
+            raise RuntimeError("DSv4 THD CP path currently supports self-attention only.")
+        cu_seqlens = self._thd_cu_seqlens(packed_seq_params)
+        max_seqlen_q = int(packed_seq_params.max_seqlen_q)
+
+        global_start = cp_rank * l_local
+        kv_local = key.squeeze(-2).squeeze(1)  # (l_local, head_dim)
+        if boundary_hidden is None or boundary_kv is None:
+            raise RuntimeError(
+                "DSv4 THD CP path requires boundary_hidden and boundary_kv from the "
+                "hidden-only boundary exchange and boundary KV projection path."
+            )
+        boundary_kv = boundary_kv.squeeze(-2).squeeze(1)  # (d_window, head_dim)
+        d_window = boundary_hidden.shape[0]
+        compressed_kv_rank_major = kv_local.new_empty((0, kv_local.shape[-1]))
+        cu_seqlens_compressed = None
+
+        compressed_topk = seq_to_rank_row = None
+        indexer_layout = q_indexer_cp = weights_indexer_cp = None
+        k_indexer_rank_major = k_indexer_seq_major = None
+        ratio = self.compress_ratio
+        indexer = self.indexer
+        indexer_loss_coeff = getattr(self.config, "dsa_indexer_loss_coeff", 0.0) or 0.0
+        training_with_grad = self.training and torch.is_grad_enabled()
+        sparse_indexer_loss = getattr(self.config, "dsa_indexer_use_sparse_loss", True)
+        calculate_per_token_loss = getattr(self.config, "calculate_per_token_loss", False)
+
+        if self.compressor is not None and ratio > 1:
+            compressed_lens = torch.div(
+                cu_seqlens[1:] - cu_seqlens[:-1], ratio, rounding_mode="floor"
+            )
+            cu_seqlens_compressed = torch.cat(
+                (
+                    torch.zeros_like(cu_seqlens[:1]),
+                    torch.cumsum(compressed_lens, dim=0, dtype=torch.int32),
+                )
+            )
+            hidden_compact, compressed_group_ids, seq_to_rank_row = (
+                cp_utils.prepare_cp_compressor_input(
+                    x,
+                    boundary_hidden,
+                    cu_seqlens,
+                    cu_seqlens_compressed,
+                    global_start,
+                    cp_size,
+                    ratio,
+                )
+            )
+
+            if indexer is not None:
+                indexer_x, indexer_qr = x.detach(), qr.detach()
+                if indexer_x.shape[1] != 1:
+                    raise RuntimeError(
+                        f"DSv4 THD CP indexer expects bsz=1, got {indexer_x.shape[1]}."
+                    )
+                q_indexer_cp = indexer.wq_b(indexer_qr.squeeze(1)).view(
+                    l_local, indexer.index_n_heads, indexer.index_head_dim
+                )
+                idx_pos = cp_utils._thd_cp_position_ids(cu_seqlens, global_start, l_local)
+                idx_cos, idx_sin = build_compressed_rope_cos_sin(
+                    idx_pos.view(1, l_local).long(),
+                    indexer.rope_head_dim,
+                    self.config.compress_rope_theta,
+                    config=self.config,
+                    use_yarn=ratio > 1,
+                    device=q_indexer_cp.device,
+                    dtype=q_indexer_cp.dtype,
+                )
+                # lite RoPE wants the sequence axis at dim -2: (1, n_heads, l_local, hd).
+                q_rope = q_indexer_cp.permute(1, 0, 2).unsqueeze(0)
+                q_rope = apply_partial_rope(q_rope, idx_cos, idx_sin, indexer.rope_head_dim)
+                q_indexer_cp = q_rope.squeeze(0).permute(1, 0, 2).contiguous()
+                q_indexer_cp = rotate_activation(q_indexer_cp)
+                weights_indexer_cp = indexer.weights_proj(indexer_x.squeeze(1)) * (
+                    indexer.index_n_heads**-0.5
+                )
+
+                indexer_compressed_local, _ = indexer.compressor._forward_thd(
+                    hidden_compact.detach(),
+                    cu_seqlens,
+                    max_seqlen_q=max_seqlen_q,
+                    compressed_group_ids=compressed_group_ids,
+                )
+                k_indexer_rank_major = gather_from_sequence_parallel_region(
+                    indexer_compressed_local.squeeze(1), group=cp_group
+                )
+                k_indexer_seq_major = torch.index_select(
+                    k_indexer_rank_major, 0, seq_to_rank_row.clamp_min(0)
+                )
+                compressed_topk, indexer_layout = cp_utils.compute_cp_indexer_topk(
+                    q_indexer_cp,
+                    weights_indexer_cp,
+                    k_indexer_seq_major,
+                    cu_seqlens,
+                    cu_seqlens_compressed,
+                    global_start,
+                    ratio,
+                    indexer.index_topk,
+                    indexer.softmax_scale,
+                    max_seqlen_q=max_seqlen_q,
+                    use_fused=self.apply_dsa_kernel_fusion,
+                )
+
+            compressed_kv_local, _ = self.compressor._forward_thd(
+                hidden_compact,
+                cu_seqlens,
+                max_seqlen_q=max_seqlen_q,
+                compressed_group_ids=compressed_group_ids,
+            )
+            compressed_kv_rank_major = gather_from_sequence_parallel_region(
+                compressed_kv_local.squeeze(1), group=cp_group
+            )
+
+        kv_full_thd = torch.cat((boundary_kv, kv_local, compressed_kv_rank_major), dim=0)
+        use_indexer_loss = (
+            training_with_grad and indexer_loss_coeff > 0 and compressed_topk is not None
+        )
+        compressed_width = (
+            compressed_topk.shape[-1]
+            if compressed_topk is not None
+            else (max_seqlen_q // ratio if ratio > 1 else 0)
+        )
+        topk_idxs, topk_length, indexer_topk_rank_major = (
+            csa_cp_layout_kernels.build_attention_indices(
+                cu_seqlens,
+                global_start,
+                l_local,
+                d_window,
+                self.config.sliding_window,
+                ratio,
+                compressed_width,
+                compressed_topk,
+                cu_seqlens_compressed=cu_seqlens_compressed,
+                seq_to_rank_row=seq_to_rank_row,
+                for_indexer_loss=use_indexer_loss,
+            )
+        )
+
+        if use_indexer_loss:
+            k_indexer_for_loss = k_indexer_rank_major
+            compressed_kv_for_loss = compressed_kv_rank_major
+            if not sparse_indexer_loss:
+                k_indexer_for_loss = k_indexer_seq_major
+                compressed_kv_for_loss = torch.index_select(
+                    compressed_kv_rank_major, 0, seq_to_rank_row.clamp_min(0)
+                )
+            cu_seqlens_q_unpadded = None
+            if (
+                packed_seq_params.cu_seqlens_q is not None
+                and packed_seq_params.cu_seqlens_q_padded is not None
+                and packed_seq_params.cu_seqlens_q.data_ptr()
+                != packed_seq_params.cu_seqlens_q_padded.data_ptr()
+            ):
+                cu_seqlens_q_unpadded = packed_seq_params.cu_seqlens_q
+            q_padding_mask = None
+            if cu_seqlens_q_unpadded is not None:
+                global_rows = torch.arange(
+                    global_start,
+                    global_start + l_local,
+                    device=query.device,
+                    dtype=cu_seqlens.dtype,
+                )
+                batch_ids = torch.bucketize(
+                    global_rows, cu_seqlens[1:], out_int32=True, right=True
+                ).clamp_max(cu_seqlens.shape[0] - 2)
+                real_seqlens = cu_seqlens_q_unpadded[1:] - cu_seqlens_q_unpadded[:-1]
+                positions = global_rows - cu_seqlens[batch_ids]
+                q_padding_mask = positions >= real_seqlens[batch_ids]
+            apply_from_topk = (
+                FusedIndexerSparseAttnFromTopkFunc.apply
+                if self.apply_dsa_kernel_fusion
+                else _unfused_indexer_sparse_attn_from_topk
+            )
+            output, indexer_loss = apply_from_topk(
+                query,
+                kv_full_thd,
+                self.sinks.float(),
+                topk_idxs,
+                q_indexer_cp,
+                k_indexer_for_loss,
+                weights_indexer_cp,
+                indexer_topk_rank_major,
+                compressed_kv_for_loss,
+                self.softmax_scale,
+                indexer.softmax_scale,
+                indexer_loss_coeff,
+                1 if calculate_per_token_loss else l_local * cp_size,
+                sparse_indexer_loss,
+                ratio,
+                max_seqlen_q,
+                indexer_layout,
+                q_padding_mask,
+            )
+            if indexer_loss_coeff > 0:
+                DSAIndexerLossLoggingHelper.save_loss_to_tracker(
+                    loss=indexer_loss,
+                    layer_number=self.layer_idx,
+                    num_layers=self.config.num_hidden_layers
+                    + (getattr(self.config, "num_nextn_predict_layers", 0) or 0),
+                    reduce_group=cp_group,
+                )
+            output = DSAIndexerLossAutoScaler.apply(output, indexer_loss)
+            return output.unsqueeze(1)
+
+        if self.apply_dsa_kernel_fusion:
+            output = dsa_sparse_attn(
+                query,
+                kv_full_thd,
+                self.sinks.float(),
+                topk_idxs,
+                self.softmax_scale,
+                topk_length=topk_length,
+                is_thd=True,
+            )
+        else:
+            output = unfused_compressed_sparse_attn(
+                query, kv_full_thd, self.sinks.float(), topk_idxs, self.softmax_scale
+            )
+        return output.unsqueeze(1)

--- a/experimental/lite/megatron/lite/primitive/modules/attention/csa.py
+++ b/experimental/lite/megatron/lite/primitive/modules/attention/csa.py
@@ -324,6 +324,10 @@ class CompressedSparseAttention(nn.Module):
         *,
         layer_idx: int,
         ps: ParallelState,
+        apply_dsa_kernel_fusion: bool = True,
+        dsa_indexer_loss_coeff: float = 0.0,
+        dsa_indexer_use_sparse_loss: bool = False,
+        calculate_per_token_loss: bool = False,
     ):
         super().__init__()
         self.config = config
@@ -335,12 +339,15 @@ class CompressedSparseAttention(nn.Module):
         self.rope_head_dim = config.qk_rope_head_dim
         self.softmax_scale = self.head_dim**-0.5
         self.num_heads_per_group = config.num_attention_heads // config.o_groups
-        # DSv4 THD-CP faithfulness: these knobs are absent from the lite DS4 config;
-        # thread them with Core-matching defaults. ``apply_dsa_kernel_fusion=False``
-        # selects the differentiable unfused sparse-attention / indexer-loss path
-        # (Core's ``_unfused_indexer_sparse_attn_from_topk``), which is the lite
-        # default backend (``self.attention_backend == "torch"``).
-        self.apply_dsa_kernel_fusion = getattr(config, "apply_dsa_kernel_fusion", False)
+        # Kernel / indexer-loss knobs are implementation config (not part of the
+        # HF model config), threaded as constructor arguments like GLM-5's DSA.
+        # Fused DSA kernels are the production default; the unfused sparse-attn /
+        # indexer-loss path (Core's ``_unfused_indexer_sparse_attn_from_topk``) is
+        # a debug fallback selected via ``apply_dsa_kernel_fusion=False``.
+        self.apply_dsa_kernel_fusion = apply_dsa_kernel_fusion
+        self.dsa_indexer_loss_coeff = dsa_indexer_loss_coeff
+        self.dsa_indexer_use_sparse_loss = dsa_indexer_use_sparse_loss
+        self.calculate_per_token_loss = calculate_per_token_loss
         # MTP layers use layer_idx == num_hidden_layers (+i), which is past the
         # per-decoder-layer compress_ratios list (length num_hidden_layers); fall
         # back to the last real layer's ratio so the MTP CSA still builds.
@@ -853,10 +860,10 @@ class CompressedSparseAttention(nn.Module):
         k_indexer_rank_major = k_indexer_seq_major = None
         ratio = self.compress_ratio
         indexer = self.indexer
-        indexer_loss_coeff = getattr(self.config, "dsa_indexer_loss_coeff", 0.0) or 0.0
+        indexer_loss_coeff = self.dsa_indexer_loss_coeff or 0.0
         training_with_grad = self.training and torch.is_grad_enabled()
-        sparse_indexer_loss = getattr(self.config, "dsa_indexer_use_sparse_loss", True)
-        calculate_per_token_loss = getattr(self.config, "calculate_per_token_loss", False)
+        sparse_indexer_loss = self.dsa_indexer_use_sparse_loss
+        calculate_per_token_loss = self.calculate_per_token_loss
 
         if self.compressor is not None and ratio > 1:
             compressed_lens = torch.div(
@@ -1029,7 +1036,7 @@ class CompressedSparseAttention(nn.Module):
                     loss=indexer_loss,
                     layer_number=self.layer_idx,
                     num_layers=self.config.num_hidden_layers
-                    + (getattr(self.config, "num_nextn_predict_layers", 0) or 0),
+                    + self.config.num_nextn_predict_layers,
                     reduce_group=cp_group,
                 )
             output = DSAIndexerLossAutoScaler.apply(output, indexer_loss)

--- a/experimental/lite/tests/unit/primitive/test_csa_thd_cp.py
+++ b/experimental/lite/tests/unit/primitive/test_csa_thd_cp.py
@@ -1,0 +1,220 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Unit tests for the DeepSeek-V4 CSA THD context-parallel path.
+
+Coverage strategy (see the module docstring of
+``megatron.core.transformer.experimental_attention_variant.csa_cp_layout_kernels``):
+the full ``_forward_thd_cp`` is gated behind CuTeDSL/CUDA kernels
+(``prepare_cp_compressor_input`` and ``build_attention_indices``), so its numeric
+``CP=1 == unsharded`` invariant is only reachable on a GPU with those kernels and
+is marked ``gpu``. The CPU-reachable pieces -- the THD tensor layout built by the
+dispatch, the zero left-boundary at ``cp_size == 1``, the boundary-KV projection,
+the differentiability of that pre-CP path, and the pre-grouped compressor overlap
+transform -- are exercised directly here by stubbing ``_forward_thd_cp``.
+
+These tests require a real Transformer Engine install (Megatron Core's CSA module
+imports ``transformer_engine.pytorch.float8_tensor``); they skip cleanly when it
+is absent rather than failing collection.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.mlite
+
+
+def _csa():
+    """Import the lite CSA module or skip (needs real TE + Megatron Core)."""
+    return pytest.importorskip("megatron.lite.primitive.modules.attention.csa")
+
+
+def _tiny_config():
+    from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
+
+    return DeepseekV4Config(
+        hidden_size=32,
+        num_attention_heads=4,
+        head_dim=8,
+        qk_rope_head_dim=4,
+        q_lora_rank=16,
+        o_lora_rank=16,
+        o_groups=2,
+        compress_ratios=[4],
+        sliding_window=4,
+        index_head_dim=8,
+        index_n_heads=4,
+        index_topk=4,
+        rms_norm_eps=1e-6,
+        initializer_range=0.02,
+        num_hidden_layers=1,
+        num_nextn_predict_layers=1,
+    )
+
+
+def _ps(cp_size: int = 1, cp_rank: int = 0):
+    group = SimpleNamespace(size=lambda: cp_size, rank=lambda: cp_rank)
+    return SimpleNamespace(cp_size=cp_size, cp_rank=cp_rank, cp_group=group)
+
+
+def _packed_seq_params(seq_len: int, device: torch.device):
+    cu = torch.tensor([0, seq_len], dtype=torch.int32, device=device)
+    return SimpleNamespace(
+        qkv_format="thd",
+        cu_seqlens_q=cu,
+        cu_seqlens_q_padded=None,
+        cu_seqlens_kv=cu,
+        cu_seqlens_kv_padded=None,
+        max_seqlen_q=seq_len,
+        max_seqlen_kv=seq_len,
+    )
+
+
+def _d_window(config) -> int:
+    d_comp = 8 if config.compress_ratios[0] == 4 else config.compress_ratios[0]
+    return max(int(config.sliding_window), d_comp)
+
+
+# ---------------------------------------------------------------------------
+# Pure-tensor logic (no CUDA / no CuTeDSL).
+# ---------------------------------------------------------------------------
+
+
+def test_overlap_transform_thd_layout():
+    """Pre-grouped THD overlap transform matches the DSv4 windowing contract."""
+    csa = _csa()
+    d = 3
+    fake_self = SimpleNamespace(head_dim=d)
+    ratio, n = 4, 2
+    # (total_comp, ratio, 1, coff * d) with coff == 2.
+    tensor = torch.arange(n * ratio * 1 * (2 * d), dtype=torch.float32).reshape(n, ratio, 1, 2 * d)
+    is_first = torch.tensor([True, False])
+    out = csa.CompressedSequenceCompressor._overlap_transform_thd(
+        fake_self, tensor, is_first, fill_value=0.0
+    )
+    assert out.shape == (n, 2 * ratio, 1, d)
+    # Second half is the [d:] channel of the same group.
+    assert torch.equal(out[:, ratio:], tensor[:, :, :, d:])
+    # First group starts a segment -> its first half is fill (0).
+    assert torch.equal(out[0, :ratio], torch.zeros(ratio, 1, d))
+    # Second group pulls the [:d] channel of the previous group.
+    assert torch.equal(out[1, :ratio], tensor[0, :, :, :d])
+
+
+# ---------------------------------------------------------------------------
+# THD dispatch + boundary-KV projection (CPU-reachable with real TE; the
+# CuTeDSL-gated core is stubbed out).
+# ---------------------------------------------------------------------------
+
+
+def test_forward_thd_packed_builds_layout_and_is_differentiable(monkeypatch):
+    csa = _csa()
+    torch.manual_seed(0)
+    config = _tiny_config()
+    try:
+        module = csa.CompressedSparseAttention(config, layer_idx=0, ps=_ps())
+    except RuntimeError as exc:  # te.RMSNorm/te.Linear unavailable (stubbed TE)
+        pytest.skip(f"real Transformer Engine required to build CSA: {exc}")
+
+    seq_len = 8  # divisible by ratio; >= D_window so the boundary window fits.
+    device = torch.device("cpu")
+    x = torch.randn(1, seq_len, config.hidden_size, device=device, requires_grad=True)
+    position_ids = torch.arange(seq_len, device=device).unsqueeze(0)
+    psp = _packed_seq_params(seq_len, device)
+
+    captured = {}
+
+    def _fake_forward_thd_cp(query, key, x_thd, qr, boundary_hidden, boundary_kv, packed):
+        captured.update(
+            query=query,
+            key=key,
+            x_thd=x_thd,
+            qr=qr,
+            boundary_hidden=boundary_hidden,
+            boundary_kv=boundary_kv,
+        )
+        # (total_q, 1, np * hn) attention-context contract; keep it in the graph.
+        return query.reshape(seq_len, 1, config.num_attention_heads * config.head_dim)
+
+    monkeypatch.setattr(module, "_forward_thd_cp", _fake_forward_thd_cp)
+
+    out = module(x, position_ids=position_ids, packed_seq_params=psp)
+
+    nh, hd, hidden = config.num_attention_heads, config.head_dim, config.hidden_size
+    assert captured["query"].shape == (seq_len, nh, hd)
+    assert captured["key"].shape == (seq_len, 1, 1, hd)
+    assert captured["x_thd"].shape == (seq_len, 1, hidden)
+    assert captured["qr"].shape == (seq_len, 1, config.q_lora_rank)
+    dwin = _d_window(config)
+    assert captured["boundary_hidden"].shape == (dwin, 1, hidden)
+    # cp_size == 1 -> zero left boundary.
+    assert torch.count_nonzero(captured["boundary_hidden"]) == 0
+    assert captured["boundary_kv"].shape == (dwin, 1, 1, hd)
+    # Output is projected back to [B, S, hidden] for the SBHD shim.
+    assert out.shape == (1, seq_len, hidden)
+
+    # The pre-CP path (projection + boundary + differentiable layout) must carry
+    # gradients back to the hidden input (no non-differentiable collective).
+    out.sum().backward()
+    assert x.grad is not None
+    assert torch.isfinite(x.grad).all()
+
+
+def test_project_boundary_kv_shape(monkeypatch):
+    csa = _csa()
+    torch.manual_seed(0)
+    config = _tiny_config()
+    try:
+        module = csa.CompressedSparseAttention(config, layer_idx=0, ps=_ps())
+    except RuntimeError as exc:
+        pytest.skip(f"real Transformer Engine required to build CSA: {exc}")
+
+    dwin = _d_window(config)
+    boundary_hidden = torch.randn(dwin, 1, config.hidden_size)
+    cu = torch.tensor([0, 8], dtype=torch.int32)
+    bkv = module._project_boundary_kv(
+        boundary_hidden, cu, global_start=0, rope_theta=config.compress_rope_theta
+    )
+    assert bkv.shape == (dwin, 1, 1, config.head_dim)
+    assert torch.isfinite(bkv).all()
+
+
+# ---------------------------------------------------------------------------
+# CP=1 == unsharded numeric invariant (GPU + CuTeDSL only).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA + CuTeDSL kernels")
+def test_cp1_thd_equals_bshd_fused():
+    """CP=1 THD packed attention equals the (unsharded) CP=1 BSHD fused path.
+
+    Both routes share the DSv4 sparse-attention formula (sliding window +
+    compressed KV + learned indexer top-k + attention sink); for a single
+    ratio-aligned sequence with no CP sharding they must produce the same
+    output. This is the concrete ``CP=1 == unsharded`` CP invariant, runnable
+    only where the CuTeDSL layout kernels and DSA kernels are available.
+    """
+    csa = _csa()
+    torch.manual_seed(0)
+    config = _tiny_config()
+    device = torch.device("cuda")
+    module = csa.CompressedSparseAttention(config, layer_idx=0, ps=_ps()).to(device)
+    # Select a fused sparse backend for both the BSHD and THD routes.
+    module.attention_backend = "flash"
+    module.apply_dsa_kernel_fusion = True
+    module.eval()
+
+    seq_len = 8
+    x = torch.randn(1, seq_len, config.hidden_size, device=device)
+    position_ids = torch.arange(seq_len, device=device).unsqueeze(0)
+
+    with torch.no_grad():
+        out_bshd = module(x, position_ids=position_ids)
+        out_thd = module(
+            x, position_ids=position_ids, packed_seq_params=_packed_seq_params(seq_len, device)
+        )
+
+    assert out_thd.shape == out_bshd.shape == (1, seq_len, config.hidden_size)
+    torch.testing.assert_close(out_thd, out_bshd, rtol=2e-2, atol=2e-2)


### PR DESCRIPTION
## What
Implements the **THD-packed context-parallel path** for DeepSeek-V4 Compressed Sparse Attention (CSA) in Megatron-Lite, faithfully porting Megatron Core's `CompressedSparseAttention._forward_thd_cp` (NVIDIA/dev, #5087) and importing Core's CP helpers **zero-copy**.

## Design
- **mcore = NVIDIA/dev** (container-provided). This PR does **not** vendor or modify `megatron/core`; lite CSA imports the DSv4 THD-CP helpers directly: `csa_cp_utils` (`prepare_cp_compressor_input`, `exchange_cp_boundary_hidden`, `compute_cp_indexer_topk`, `_thd_cp_position_ids`), `csa_cp_layout_kernels.build_attention_indices`, and THD sparse-attn kernels (`dsa_sparse_attn(is_thd=True)`, `FusedIndexerSparseAttnFromTopkFunc`, `unfused_compressed_sparse_attn`, `_unfused_indexer_sparse_attn_from_topk`).
- **THD is the primary CP route.** Seam disease fixed: `protocol.py` no longer pops `packed_seq_params`, `model.py` no longer discards the THD signal — `cu_seqlens` threaded end-to-end (`DeepseekV4Model` → `Layer` → `CSAAttention` → `CompressedSparseAttention`).
- **BSHD dense-softmax fallback deleted** (+ dead helpers); only BSHD routes are the existing CP=1 fused sparse kernels.

## Faithfulness deviations (justified)
1. **RoPE**: lite's `apply_partial_rope` with CP-correct positions from `_thd_cp_position_ids` instead of Core's `apply_thd_cp_local_rope_*`. RoPE is relative → sharing lite's convention across q/k/compressed/boundary is self-consistent and preserves the hard `CP=1 == lite-BSHD` invariant.
2. **cp_size==1** materializes a zero left-boundary window directly.
3. Missing lite-config knobs threaded via `getattr` with Core-matching defaults.

## Verification status
- ✅ Static: 4 files compile, dead helpers removed, style-consistent imports, CPU pytest collects clean.
- ⚠️ **Numeric `CP=1 == unsharded` invariant NOT yet run**: Core layout kernels (`build_attention_indices`, `prepare_cp_compressor_input`) require CuTeDSL/CUDA + TransformerEngine → whole THD path is GPU-only. GPU parity + multi-rank CP tests in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
