### PR TITLE
Stream pp>1 HF weight export in bounded buckets (fixes resync OOM)

### DIFF
--- a/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
@@ -951,47 +951,87 @@ def export_hf_weights(
         yield from _flush_expert_bucket()
         return
 
-    gathered: dict[str, torch.Tensor] = {}
-    for chunk in chunks:
-        base_chunk = unwrap_model(chunk)
-        # Map local layer indices to global for PP
-        layer_map = (
-            {i: base_chunk.layer_indices[i] for i in range(len(base_chunk.layer_indices))}
-            if hasattr(base_chunk, "layer_indices")
-            else {}
-        )
-        for name, param in base_chunk.named_parameters():
-            gname = to_global_layer_name(name, layer_map)
-            t = _materialize_dtensor(param.data.detach())
+    # Streaming pp>1 export. The legacy path materialized every PP stage's
+    # gathered dict on every rank (all_gather_object) before the first yield.
+    # Instead: each stage in turn lazily gathers just enough params to fill one
+    # bounded bucket, broadcasts a (name, shape, dtype) header then the tensors
+    # one at a time over the NCCL pp_group; params are yielded and released on
+    # arrival. Peak residency = one bucket + one in-flight param. pp=1 untouched.
+    gather_cpu = cpu
+    emit = not (rank0_only and rank != 0)
+    bcast_device = (
+        torch.device("cuda", torch.cuda.current_device())
+        if torch.cuda.is_available()
+        else torch.device("cpu")
+    )
 
-            if spec.is_expert(gname):
-                _gather_expert(gname, t, spec, ps, gathered, cpu=cpu)
-            else:
-                gathered[gname] = _gather_dense(gname, t, spec, ps, cpu=cpu)
+    def _iter_own_gathered() -> Generator[tuple[str, torch.Tensor], None, None]:
+        """Lazily yield this PP stage's fully TP/ETP/EP-collapsed params.
 
-    # PP gather
-    if ps.pp_size > 1:
-        all_states: list[dict | None] = [None] * ps.pp_size
-        dist.all_gather_object(all_states, gathered, group=ps.pp_group)
-        gathered = {}
-        for s in all_states:
-            if s is not None:
-                gathered.update(s)
+        Advanced only during this rank's source turn, so at most one bucket of
+        gathered params is ever resident — the whole stage is never built.
+        """
+        for chunk in chunks:
+            base_chunk = unwrap_model(chunk)
+            layer_map = (
+                {i: base_chunk.layer_indices[i] for i in range(len(base_chunk.layer_indices))}
+                if hasattr(base_chunk, "layer_indices")
+                else {}
+            )
+            for name, param in base_chunk.named_parameters():
+                gname = to_global_layer_name(name, layer_map)
+                t = _materialize_dtensor(param.data.detach())
+                if spec.is_expert(gname):
+                    one: dict[str, torch.Tensor] = {}
+                    _gather_expert(gname, t, spec, ps, one, cpu=False)
+                    for gathered_name, gathered_tensor in one.items():
+                        yield gathered_name, gathered_tensor
+                else:
+                    yield gname, _gather_dense(gname, t, spec, ps, cpu=False)
 
-    rank = dist.get_rank() if dist.is_initialized() else 0
-    if rank0_only and rank != 0:
-        return
-
-    # Vocab trim
-    if vocab_size is not None:
-        for key in list(gathered.keys()):
-            if "embed" in key or "head" in key:
-                gathered[key] = gathered[key][:vocab_size]
-
-    # Convert Megatron Lite names → HF names via spec
-    for native_name, tensor in gathered.items():
+    def _emit_param(native_name: str, tensor: torch.Tensor):
+        tensor = _maybe_cpu(tensor, cpu=gather_cpu)
+        if vocab_size is not None and ("embed" in native_name or "head" in native_name):
+            tensor = tensor[:vocab_size]
         for hf_name, hf_tensor in _native_to_hf(spec, native_name, tensor):
             yield hf_name, _cast_export_tensor(hf_tensor, resolved_export_dtype)
+
+    own = _iter_own_gathered()
+    for src_pp in range(ps.pp_size):
+        src_global = ps.pp_global_ranks[src_pp]
+        is_source = src_pp == ps.pp_rank
+        while True:
+            bucket: list[tuple[str, torch.Tensor]] = []
+            if is_source:
+                bucket_bytes = 0
+                for gathered_name, gathered_tensor in own:
+                    gathered_tensor = gathered_tensor.to(bcast_device).contiguous()
+                    bucket.append((gathered_name, gathered_tensor))
+                    bucket_bytes += _tensor_nbytes(gathered_tensor)
+                    if bucket_bytes >= buffer_max_size_bytes:
+                        break
+                header: list[Any] = [
+                    [(name, tuple(tensor.shape), tensor.dtype) for name, tensor in bucket]
+                ]
+            else:
+                header = [None]
+            dist.broadcast_object_list(
+                header, src=src_global, group=ps.pp_group, device=bcast_device
+            )
+            entries = header[0]
+            if not entries:
+                break  # empty header = end of this stage's stream
+            for idx, (native_name, shape, dtype) in enumerate(entries):
+                if is_source:
+                    tensor = bucket[idx][1]
+                else:
+                    tensor = torch.empty(shape, dtype=dtype, device=bcast_device)
+                dist.broadcast(tensor, src=src_global, group=ps.pp_group)
+                if emit:
+                    yield from _emit_param(native_name, tensor)
+                del tensor
+            del bucket
+    return
 
 
 def _gather_dense(

--- a/experimental/lite/tests/unit/primitive/test_hf_weights_streaming.py
+++ b/experimental/lite/tests/unit/primitive/test_hf_weights_streaming.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 
 import importlib.util
 import inspect
+import json
 import sys
 import types
+from pathlib import Path
 
 import torch
 import torch.nn as nn
@@ -19,10 +21,12 @@ if importlib.util.find_spec("safetensors") is None:
     sys.modules["safetensors.torch"] = safetensors_torch
 
 from megatron.lite.primitive.ckpt.hf_weights import (
+    SafeTensorReader,
     _iter_bucketed_materialized_tensors,
     bucketed_all_gather_into_tensor,
     export_hf_weights,
 )
+
 
 
 def test_export_defaults_to_device_resident_tensors() -> None:
@@ -443,3 +447,136 @@ def test_expert_export_yields_when_bounded_ep_bucket_fills(monkeypatch) -> None:
     assert torch.equal(
         tensor, torch.stack(expected_local + [value + 100 for value in expected_local])
     )
+
+
+def test_pp_export_streams_over_nccl_and_matches_materialized(monkeypatch) -> None:
+    """Streamed pp2 export must be bitwise-equal to the legacy materialized
+    dict, with every header/tensor exchange on the NCCL pp_group."""
+    local_weight = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+    remote_weight = local_weight + 100
+
+    class Model(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.weight = nn.Parameter(local_weight.clone())
+
+    class Spec:
+        num_experts = 0
+        is_expert = staticmethod(lambda name: False)
+        tp_spec = staticmethod(lambda name: None)
+        native_to_hf = staticmethod(lambda name, tensor: [(name, tensor)])
+
+    ps = type("ParallelState", (), {
+        "pp_size": 2, "pp_rank": 0, "pp_global_ranks": [0, 1],
+        "tp_size": 1, "tp_group": None, "ep_size": 1, "ep_group": None,
+        "etp_size": 1, "etp_group": None,
+        "pp_group": "nccl-pp", "pp_cpu_group": "gloo-pp",
+    })()
+
+    groups = []
+    remote_headers = iter([[("weight2", (2, 3), torch.float32)], []])
+    remote_tensors = iter([remote_weight])
+
+    def fake_broadcast_object_list(object_list, src=None, group=None, device=None):
+        groups.append(group)
+        if src != 0:
+            object_list[0] = next(remote_headers)
+
+    def fake_broadcast(tensor, src=None, group=None):
+        groups.append(group)
+        if src != 0:
+            tensor.copy_(next(remote_tensors))
+
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda group=None: 0)
+    monkeypatch.setattr(torch.distributed, "broadcast_object_list",
+                        fake_broadcast_object_list)
+    monkeypatch.setattr(torch.distributed, "broadcast", fake_broadcast)
+
+    exported = dict(export_hf_weights(Model(), Spec(), ps))
+
+    assert set(groups) == {"nccl-pp"}
+    assert exported.keys() == {"weight", "weight2"}
+    assert torch.equal(exported["weight"], local_weight)
+    assert torch.equal(exported["weight2"], remote_weight)
+
+
+
+def test_pp_export_never_materializes_the_whole_stage(monkeypatch) -> None:
+    """Residency guard: with one-param buckets, pulling the first streamed param
+    must visit exactly one of three stage params — the legacy path would have
+    visited all three before yielding anything."""
+    visited: list[str] = []
+    params = {
+        "weight_a": torch.arange(6, dtype=torch.float32).reshape(2, 3),
+        "weight_b": torch.arange(6, dtype=torch.float32).reshape(2, 3) + 10,
+        "weight_c": torch.arange(6, dtype=torch.float32).reshape(2, 3) + 20,
+    }
+
+    class Model(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            for name, value in params.items():
+                self.register_parameter(name, nn.Parameter(value.clone()))
+
+        def named_parameters(self, *args, **kwargs):
+            for item in super().named_parameters(*args, **kwargs):
+                visited.append(item[0])
+                yield item
+
+    class Spec:
+        num_experts = 0
+
+        @staticmethod
+        def is_expert(name):
+            return False
+
+        @staticmethod
+        def tp_spec(name):
+            return None
+
+        @staticmethod
+        def native_to_hf(name, tensor):
+            return [(name, tensor)]
+
+    ps = type(
+        "ParallelState",
+        (),
+        {
+            "pp_size": 2,
+            "pp_rank": 0,
+            "pp_global_ranks": [0, 1],
+            "tp_size": 1,
+            "tp_group": None,
+            "ep_size": 1,
+            "ep_group": None,
+            "etp_size": 1,
+            "etp_group": None,
+            "pp_group": "nccl-pp",
+            "pp_cpu_group": "gloo-pp",
+        },
+    )()
+
+    my_global = 0
+
+    def fake_broadcast_object_list(object_list, src=None, group=None, device=None):
+        if src != my_global:
+            object_list[0] = []  # never reached: we stop after the first param
+
+    def fake_broadcast(tensor, src=None, group=None):
+        pass  # source (rank 0) broadcasts straight from its bucket
+
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda group=None: 0)
+    monkeypatch.setattr(
+        torch.distributed, "broadcast_object_list", fake_broadcast_object_list
+    )
+    monkeypatch.setattr(torch.distributed, "broadcast", fake_broadcast)
+
+    # buffer_max_size_bytes=1 caps every bucket at a single parameter.
+    stream = export_hf_weights(Model(), Spec(), ps, buffer_max_size_bytes=1)
+    first_name, first_tensor = next(stream)
+
+    assert first_name == "weight_a"
+    assert torch.equal(first_tensor, params["weight_a"])
+    assert visited == ["weight_a"]


### PR DESCRIPTION
pp>1 export materialized the full model on every rank — the local stage was accumulated into a `gathered` dict, then whole per-stage dicts were exchanged with `all_gather_object` over the PP group, all before the first yield. Measured 235-252 GB RSS per rank (DSv4, 128 GPU, PP4/EP8/CP4); OOMs colocated resync.

This change streams the pp>1 path: lazy own-stage gather in bounded buckets; per bucket, a metadata header via `broadcast_object_list` followed by per-tensor `broadcast` over `pp_group`. Peak residency per rank = one bucket + one in-flight tensor. `pp=1` path unchanged.

Tests: streamed-vs-materialized equivalence over a fake pp2 world; residency guard asserting the first yield touches exactly one stage param.