### PR TITLE
verl example: move training hyperparameters out of launchers into config

### DIFF
--- a/experimental/lite/examples/verl/scripts/run_qwen3moe_gsm8k_grpo.sh
+++ b/experimental/lite/examples/verl/scripts/run_qwen3moe_gsm8k_grpo.sh
@@ -89,15 +89,13 @@ ATTENTION_BACKEND="${ATTENTION_BACKEND:-flash}"
 # - fsdp2: Megatron Lite FSDP2 wrapper + optimizer.
 MLITE_OPTIMIZER_BACKEND="${MLITE_OPTIMIZER_BACKEND:-dist_opt}"
 
-ACTOR_LR="${ACTOR_LR:-1e-6}"
-POLICY_LOSS_MODE="${POLICY_LOSS_MODE:-vanilla}"
-LOSS_AGG_MODE="${LOSS_AGG_MODE:-seq-mean-token-sum-norm}"
-WEIGHT_DECAY="${WEIGHT_DECAY:-0.1}"
-BETAS="${BETAS:-[0.9,0.95]}"
-CLIP_GRAD="${CLIP_GRAD:-1.0}"
-LR_WARMUP_STEPS="${LR_WARMUP_STEPS:-0}"
-LR_DECAY_STYLE="${LR_DECAY_STYLE:-constant}"
-ENTROPY_COEFF="${ENTROPY_COEFF:-0}"
+# Training hyperparameters (lr / betas / weight_decay / clip_grad / warmup /
+# decay style / loss aggregation / entropy / policy-loss mode) are NOT set here.
+# They live in the verl_mlite config (actor/mlite_actor.yaml -> optim@megatron)
+# so the resolved config has a single source of truth; override explicitly on
+# the command line via the trailing EXTRA_ARGS passthrough when needed. Notably
+# betas now inherits the verl upstream default [0.9, 0.999] instead of a
+# launcher-baked [0.9, 0.95].
 USE_DYNAMIC_BSZ="${USE_DYNAMIC_BSZ:-True}"
 PARAM_OFFLOAD="${PARAM_OFFLOAD:-False}"
 OPTIMIZER_OFFLOAD="${OPTIMIZER_OFFLOAD:-True}"
@@ -152,8 +150,9 @@ CKPT_DIR="${CKPT_DIR:-${OUTPUT_ROOT}/checkpoints/${RUN_NAME}}"
 LOG_FILE="${LOG_FILE:-${OUTPUT_ROOT}/${RUN_NAME}.log}"
 JSONL_FILE="${JSONL_FILE:-${OUTPUT_ROOT}/${RUN_NAME}.jsonl}"
 CMD_FILE="${CMD_FILE:-${OUTPUT_ROOT}/${RUN_NAME}.cmd.sh}"
+RESOLVED_CONFIG_FILE="${RESOLVED_CONFIG_FILE:-${OUTPUT_ROOT}/${RUN_NAME}.resolved.yaml}"
 
-mkdir -p "${OUTPUT_ROOT}" "${CKPT_DIR}" "$(dirname "${LOG_FILE}")" "$(dirname "${JSONL_FILE}")" "$(dirname "${CMD_FILE}")"
+mkdir -p "${OUTPUT_ROOT}" "${CKPT_DIR}" "$(dirname "${LOG_FILE}")" "$(dirname "${JSONL_FILE}")" "$(dirname "${CMD_FILE}")" "$(dirname "${RESOLVED_CONFIG_FILE}")"
 export VERL_FILE_LOGGER_PATH="${JSONL_FILE}"
 
 CACHE_ROOT="${VERL_MLITE_CACHE_ROOT:-${TMPDIR:-/tmp}/verl_mlite}"
@@ -166,7 +165,6 @@ ALGORITHM=(
   "algorithm.adv_estimator=grpo"
   "algorithm.use_kl_in_reward=${USE_KL_IN_REWARD:-False}"
   "algorithm.kl_ctrl.kl_coef=${KL_COEF:-0.0}"
-  "algorithm.rollout_correction.bypass_mode=True"
   "algorithm.norm_adv_by_std_in_grpo=False"
 )
 
@@ -190,22 +188,12 @@ MODEL=(
 
 ACTOR=(
   "actor@actor_rollout_ref.actor=mlite_actor"
-  "actor_rollout_ref.actor.optim.lr=${ACTOR_LR}"
-  "actor_rollout_ref.actor.optim.weight_decay=${WEIGHT_DECAY}"
-  "actor_rollout_ref.actor.optim.betas=${BETAS}"
-  "actor_rollout_ref.actor.optim.clip_grad=${CLIP_GRAD}"
-  "actor_rollout_ref.actor.optim.lr_warmup_steps=${LR_WARMUP_STEPS}"
-  "actor_rollout_ref.actor.optim.lr_warmup_init=0"
-  "actor_rollout_ref.actor.optim.lr_decay_style=${LR_DECAY_STYLE}"
   "actor_rollout_ref.actor.ppo_mini_batch_size=${PPO_MINI_BATCH_SIZE}"
   "actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=${ACTOR_PPO_MICRO_BATCH_SIZE_PER_GPU}"
   "actor_rollout_ref.actor.use_dynamic_bsz=${USE_DYNAMIC_BSZ}"
   "actor_rollout_ref.actor.ppo_max_token_len_per_gpu=${PPO_MAX_TOKEN_LEN_PER_GPU}"
   "actor_rollout_ref.actor.use_kl_loss=${USE_KL_LOSS:-False}"
   "actor_rollout_ref.actor.kl_loss_coef=${KL_LOSS_COEF:-0.0}"
-  "actor_rollout_ref.actor.entropy_coeff=${ENTROPY_COEFF}"
-  "actor_rollout_ref.actor.policy_loss.loss_mode=${POLICY_LOSS_MODE}"
-  "actor_rollout_ref.actor.loss_agg_mode=${LOSS_AGG_MODE}"
   "actor_rollout_ref.actor.engine.dtype=${DTYPE}"
   "actor_rollout_ref.actor.engine.model_name=${MLITE_MODEL_NAME}"
   "actor_rollout_ref.actor.engine.impl=${MLITE_IMPL}"
@@ -312,6 +300,15 @@ if [[ "${DRY_RUN}" == "1" ]]; then
   printf '%q ' "${COMMAND[@]}"
   printf '\n'
   exit 0
+fi
+
+# Dump the Hydra-resolved config to the output dir as run-alignment evidence.
+# `--cfg job --resolve` composes and resolves without launching training, so it
+# is CPU-cheap. Kept non-fatal so a resolver hiccup never blocks the real run.
+if [[ "${DUMP_RESOLVED_CONFIG:-1}" == "1" ]]; then
+  "${COMMAND[@]}" --cfg job --resolve > "${RESOLVED_CONFIG_FILE}" 2>/dev/null \
+    && echo "[mlite] resolved_config=${RESOLVED_CONFIG_FILE}" \
+    || echo "[mlite] resolved_config dump skipped (hydra --cfg failed)" >&2
 fi
 
 echo "[mlite] output_root=${OUTPUT_ROOT}"

--- a/experimental/lite/examples/verl/scripts/run_qwen3moe_sft.sh
+++ b/experimental/lite/examples/verl/scripts/run_qwen3moe_sft.sh
@@ -79,14 +79,12 @@ ATTENTION_BACKEND="${ATTENTION_BACKEND:-flash}"
 # - fsdp2: Megatron Lite FSDP2 wrapper + optimizer.
 MLITE_OPTIMIZER_BACKEND="${MLITE_OPTIMIZER_BACKEND:-dist_opt}"
 
-LR="${LR:-1e-5}"
-MIN_LR="${MIN_LR:-${LR}}"
-WEIGHT_DECAY="${WEIGHT_DECAY:-0.1}"
-BETAS="${BETAS:-[0.9,0.95]}"
-CLIP_GRAD="${CLIP_GRAD:-1.0}"
-LR_WARMUP_STEPS="${LR_WARMUP_STEPS:-0}"
-LR_DECAY_STYLE="${LR_DECAY_STYLE:-constant}"
-
+# Optimizer hyperparameters (lr / min_lr / betas / weight_decay / clip_grad /
+# warmup / decay style) are NOT set here. They live in the verl_mlite config
+# (optim/mlite_sft.yaml, which extends optim@megatron) so the resolved config has
+# a single source of truth; override explicitly via the trailing EXTRA_ARGS
+# passthrough when needed. betas now inherits the verl upstream default
+# [0.9, 0.999] instead of a launcher-baked [0.9, 0.95].
 PARAM_OFFLOAD="${PARAM_OFFLOAD:-False}"
 OPTIMIZER_OFFLOAD="${OPTIMIZER_OFFLOAD:-True}"
 GRAD_OFFLOAD="${GRAD_OFFLOAD:-False}"
@@ -129,8 +127,9 @@ CKPT_DIR="${CKPT_DIR:-${OUTPUT_ROOT}/checkpoints/${RUN_NAME}}"
 LOG_FILE="${LOG_FILE:-${OUTPUT_ROOT}/${RUN_NAME}.log}"
 JSONL_FILE="${JSONL_FILE:-${OUTPUT_ROOT}/${RUN_NAME}.jsonl}"
 CMD_FILE="${CMD_FILE:-${OUTPUT_ROOT}/${RUN_NAME}.cmd.sh}"
+RESOLVED_CONFIG_FILE="${RESOLVED_CONFIG_FILE:-${OUTPUT_ROOT}/${RUN_NAME}.resolved.yaml}"
 
-mkdir -p "${OUTPUT_ROOT}" "${CKPT_DIR}" "$(dirname "${LOG_FILE}")" "$(dirname "${JSONL_FILE}")" "$(dirname "${CMD_FILE}")"
+mkdir -p "${OUTPUT_ROOT}" "${CKPT_DIR}" "$(dirname "${LOG_FILE}")" "$(dirname "${JSONL_FILE}")" "$(dirname "${CMD_FILE}")" "$(dirname "${RESOLVED_CONFIG_FILE}")"
 export VERL_FILE_LOGGER_PATH="${JSONL_FILE}"
 
 CACHE_ROOT="${VERL_MLITE_CACHE_ROOT:-${TMPDIR:-/tmp}/verl_mlite}"
@@ -154,15 +153,7 @@ COMMON_ARGS=(
   "model=hf_model"
   "model.path=${MODEL_PATH}"
   "model.trust_remote_code=${TRUST_REMOTE_CODE}"
-  "optim=megatron"
-  "optim.lr=${LR}"
-  "optim.min_lr=${MIN_LR}"
-  "optim.weight_decay=${WEIGHT_DECAY}"
-  "optim.betas=${BETAS}"
-  "optim.clip_grad=${CLIP_GRAD}"
-  "optim.lr_warmup_steps=${LR_WARMUP_STEPS}"
-  "optim.lr_warmup_init=0"
-  "optim.lr_decay_style=${LR_DECAY_STYLE}"
+  "optim=mlite_sft"
   "trainer.logger=[console,file]"
   "trainer.project_name=${PROJECT_NAME}"
   "trainer.experiment_name=${RUN_NAME}"
@@ -234,6 +225,23 @@ if [[ "${DRY_RUN}" == "1" ]]; then
   printf '%q ' "${COMMAND[@]}"
   printf '\n'
   exit 0
+fi
+
+# Dump the Hydra-resolved config to the output dir as run-alignment evidence.
+# Uses a single-process (no torchrun) `--cfg job --resolve` compose, which is
+# CPU-cheap and never launches training. Kept non-fatal so a resolver hiccup
+# never blocks the real run.
+if [[ "${DUMP_RESOLVED_CONFIG:-1}" == "1" ]]; then
+  RESOLVE_COMMAND=(
+    python3 -m verl_mlite.launch verl.trainer.sft_trainer
+    "${COMMON_ARGS[@]}"
+    "${BACKEND_ARGS[@]}"
+    "${EXTRA_ARGS[@]}"
+    --cfg job --resolve
+  )
+  "${RESOLVE_COMMAND[@]}" > "${RESOLVED_CONFIG_FILE}" 2>/dev/null \
+    && echo "[${BACKEND}] resolved_config=${RESOLVED_CONFIG_FILE}" \
+    || echo "[${BACKEND}] resolved_config dump skipped (hydra --cfg failed)" >&2
 fi
 
 echo "[${BACKEND}] output_root=${OUTPUT_ROOT}"

--- a/experimental/lite/examples/verl/verl_mlite/config/actor/mlite_actor.yaml
+++ b/experimental/lite/examples/verl/verl_mlite/config/actor/mlite_actor.yaml
@@ -8,3 +8,18 @@ defaults:
 _target_: verl.workers.config.ActorConfig
 
 strategy: mlite
+
+# Training hyperparameters for the Qwen3-MoE GRPO example. These used to be baked
+# into the launcher shell (run_qwen3moe_gsm8k_grpo.sh) as CLI overrides; they now
+# live here so the resolved config has a single source of truth and the launcher
+# only handles environment/orchestration. Values below reproduce the example's
+# prior behaviour EXCEPT betas: it is intentionally left unset so it inherits the
+# verl upstream default [0.9, 0.999] (the launcher previously smuggled
+# [0.9, 0.95]). Anything not listed here inherits optim@megatron / the actor base
+# defaults, which already match verl upstream (clip_grad=1.0, lr_decay_style=
+# constant, lr_warmup_init=0.0, entropy_coeff=0, policy_loss.loss_mode=vanilla).
+loss_agg_mode: seq-mean-token-sum-norm
+optim:
+  lr: 1e-6
+  weight_decay: 0.1
+  lr_warmup_steps: 0

--- a/experimental/lite/examples/verl/verl_mlite/config/optim/__init__.py
+++ b/experimental/lite/examples/verl/verl_mlite/config/optim/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Hydra optim config group for Verl MLite."""

--- a/experimental/lite/examples/verl/verl_mlite/config/optim/mlite_sft.yaml
+++ b/experimental/lite/examples/verl/verl_mlite/config/optim/mlite_sft.yaml
@@ -1,0 +1,17 @@
+# Megatron optimizer config for the Qwen3-MoE SFT example (run_qwen3moe_sft.sh).
+# Extends verl's upstream `optim/megatron` and carries the SFT example's training
+# hyperparameters, which used to be baked into the launcher shell as CLI
+# overrides. Moving them here gives the resolved config a single source of truth;
+# the launcher only handles environment/orchestration. Values reproduce the
+# example's prior behaviour EXCEPT betas: it is intentionally left unset so it
+# inherits the upstream default [0.9, 0.999] (the launcher previously smuggled
+# [0.9, 0.95]). clip_grad / lr_decay_style / lr_warmup_init already match
+# upstream and are inherited unchanged.
+defaults:
+  - megatron
+  - _self_
+
+lr: 1e-5
+min_lr: 1e-5
+weight_decay: 0.1
+lr_warmup_steps: 0


### PR DESCRIPTION
## Summary

The Qwen3-MoE GRPO and SFT example launchers (`experimental/lite/examples/verl/scripts/run_qwen3moe_gsm8k_grpo.sh`, `run_qwen3moe_sft.sh`) baked optimizer/loss training hyperparameters into the shell as Hydra CLI overrides (lr, betas, weight_decay, clip_grad, warmup, decay style, loss aggregation, entropy, policy-loss mode). This let a launcher-local `betas=[0.9,0.95]` silently override the config and diverge from the verl upstream default `[0.9,0.999]`.

This change strips those overrides from both launchers and recovers the values into the `verl_mlite` config, so the resolved config has a single source of truth and the launcher only handles environment/orchestration plus the trailing explicit-CLI passthrough.

## Changes

- **GRPO** (`run_qwen3moe_gsm8k_grpo.sh`): drop the optimizer/loss CLI overrides and the hardcoded `algorithm.rollout_correction.bypass_mode=True`. Recover `lr=1e-6`, `weight_decay=0.1`, `lr_warmup_steps=0`, `loss_agg_mode=seq-mean-token-sum-norm` into `verl_mlite/config/actor/mlite_actor.yaml`.
- **SFT** (`run_qwen3moe_sft.sh`): drop the optimizer CLI overrides. Add `verl_mlite/config/optim/mlite_sft.yaml` (extends `optim@megatron`) carrying `lr=1e-5`, `min_lr=1e-5`, `weight_decay=0.1`, `lr_warmup_steps=0`; switch the launcher to `optim=mlite_sft`.
- `betas` is intentionally left unset in both configs so it inherits the verl upstream default `[0.9,0.999]`.
- `bypass_mode` now falls back to the upstream default (`False`).
- Both launchers dump the Hydra-resolved config to `${OUTPUT_ROOT}/${RUN_NAME}.resolved.yaml` (`--cfg job --resolve`, no training) as run-alignment evidence.

## Verification

A CPU-only before/after resolved-config diff (Hydra compose + full resolve, no GPU) over both launchers confirms the only resolved fields that change are:

- GRPO: `optim.betas` `[0.9,0.95]`->`[0.9,0.999]`, `rollout_correction.bypass_mode` `True`->`False`
- SFT: `optim.betas` `[0.9,0.95]`->`[0.9,0.999]`

Every other resolved field is bitwise identical, i.e. the recovery preserves the prior values exactly.