### PR TITLE
M-FSDP resync export: bound export peak + offload before vLLM wake (OOM fix)

### DIFF
--- a/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
@@ -445,7 +445,38 @@ class MegatronLiteEngine(BaseEngine):
         self._require_initialized()
         if model or not (optimizer or grad):
             super().to(device=device, model=model, optimizer=optimizer, grad=grad)
-        self.runtime.to(self.handle, device, model=model, optimizer=optimizer, grad=grad)
+        # A training-side reload (gradient buffers requested) also restores any
+        # optimizer state parked on CPU by release_train_scratch_before_resync,
+        # so the Adam moments return before the next optimizer step even when
+        # optimizer_offload is off. The export reload uses grad=False and leaves
+        # them parked through generation; load_state_to_device is a no-op when
+        # nothing is parked (TASK-1.13.8.5).
+        reload_optimizer = optimizer or (device == "cuda" and grad)
+        self.runtime.to(self.handle, device, model=model, optimizer=reload_optimizer, grad=grad)
+
+    def release_train_scratch_before_resync(self) -> None:
+        """Free the post-train-step residual before the colocated vLLM weight wake.
+
+        verl's ``update_weights`` wakes the sleeping vLLM weight pool
+        (``rollout.resume(tags=["weights"])``) *before* it exports M-FSDP weights
+        via ``get_per_tensor_param``. At that moment the trainer still holds the
+        training step's optimizer Adam moments and the M-FSDP all-gather
+        double-buffer scratch, which collide with vLLM's cumem ``create_and_map``
+        (the resync wake OOM). The post-export ``offload_params_after_export``
+        runs too late to help this wake, so park the optimizer state on CPU and
+        hand the M-FSDP scratch back to the driver here, keeping the sharded
+        weights resident as the export gather source.
+
+        The optimizer park is reversible: gated on ``param_offload`` so the next
+        training-side reload (``to("cuda", ..., grad=True)``) is the guaranteed
+        restore point, and skipped when ``optimizer_offload`` already parks the
+        Adam moments at the train-step exit. See TASK-1.13.8.5.
+        """
+        self._require_initialized()
+        if self.is_param_offload_enabled and not self.is_optimizer_offload_enabled:
+            self.to("cpu", model=False, optimizer=True, grad=False)
+        self.runtime.release_export_scratch(self.handle)
+        aggressive_empty_cache(force_sync=True)
 
     def save_checkpoint(
         self,

--- a/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
@@ -26,6 +26,11 @@ from verl.utils.device import get_device_id, get_device_name
 from verl.utils.memory_utils import aggressive_empty_cache
 from verl.workers.config import HFModelConfig, OptimizerConfig
 from verl_mlite.compat import load_verl_engine_api
+from verl_mlite.resync_export import (
+    offload_params_after_export,
+    resync_export_empty_cache_threshold_bytes,
+    stream_export_with_empty_cache,
+)
 
 try:
     # Recent VERL wraps per-step metric values in a Metric aggregator that
@@ -383,7 +388,31 @@ class MegatronLiteEngine(BaseEngine):
             export_kwargs["target"] = "vllm"
         if self.engine_config.export_dtype:
             export_kwargs["export_dtype"] = self.engine_config.export_dtype
-        return self.runtime.export_weights(self.handle, **export_kwargs), None
+        generator = self.runtime.export_weights(self.handle, **export_kwargs)
+        # Drain the export with a threshold-batched empty_cache so the released
+        # M-FSDP all-gather buffer is returned to the driver before the colocated
+        # vLLM wakes (avoids the resync wake_up OOM). See TASK-1.13.8.
+        streamed = stream_export_with_empty_cache(
+            generator,
+            resync_export_empty_cache_threshold_bytes(),
+            lambda: aggressive_empty_cache(force_sync=True),
+        )
+        # Symmetric to the reload above (mirrors save_checkpoint / load_checkpoint):
+        # return the model to CPU and hard-drain once the caller has consumed the
+        # export, *before* the colocated vLLM wake_up. The colocated vLLM uses a
+        # separate (cumem) allocator on the same physical device; without this the
+        # M-FSDP export-peak footprint (~61 GiB on the busiest EP rank) stays
+        # resident and vLLM OOMs in create_and_map (cumem_allocator.cpp:139) with
+        # ~20 GiB free, whereas the fsdp2 baseline survives 12 cycles at 166 MiB
+        # free (TASK-1.13.8.6: the resync wake_up death is a release-ordering
+        # collision, not a leak — mfsdp/fsdp2 peak footprints are near-identical).
+        if self.is_param_offload_enabled:
+            streamed = offload_params_after_export(
+                streamed,
+                lambda: self.to("cpu", model=True, optimizer=False, grad=False),
+                lambda: aggressive_empty_cache(force_sync=True),
+            )
+        return streamed, None
 
     def get_data_parallel_size(self):
         if self.handle is None:
@@ -556,7 +585,7 @@ class MegatronLiteEngine(BaseEngine):
         impl_cfg["use_thd"] = True
         cross_entropy_fusion = getattr(self.engine_config, "cross_entropy_fusion", None)
         if cross_entropy_fusion is None:
-            cross_entropy_fusion = getattr(self.engine_config, "use_fused_kernels", False)
+            cross_entropy_fusion = getattr(self.model_config, "use_fused_kernels", False)
         impl_cfg.setdefault("cross_entropy_fusion", bool(cross_entropy_fusion))
         mtp_cfg = getattr(self.model_config, "mtp", None)
         if mtp_cfg is not None:

--- a/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
@@ -244,6 +244,15 @@ class _MegatronLiteModeCtx(BaseEngineCtx):
         assert self._runtime_ctx is not None
         self._runtime_ctx.__exit__(exc_type, exc_val, exc_tb)
         super().__exit__(exc_type, exc_val, exc_tb)
+        # After a clean training pass (update_actor), hand the post-step residual
+        # (M-FSDP all-gather scratch + parked optimizer state) back to the driver
+        # here, at the engine's own offload exit -- verl's fit loop runs this train
+        # context exit *before* it calls update_weights (rollout.resume(["weights"])),
+        # so the colocated vLLM weight wake no longer collides with the trainer's
+        # leftovers. Keeps the sharded weights resident as the export gather source.
+        # See TASK-1.13.8.5 (internalized from a former verl-called hook).
+        if self.mode == "train" and exc_type is None:
+            self.engine._release_train_scratch_before_resync()
         return False
 
 
@@ -446,7 +455,7 @@ class MegatronLiteEngine(BaseEngine):
         if model or not (optimizer or grad):
             super().to(device=device, model=model, optimizer=optimizer, grad=grad)
         # A training-side reload (gradient buffers requested) also restores any
-        # optimizer state parked on CPU by release_train_scratch_before_resync,
+        # optimizer state parked on CPU by _release_train_scratch_before_resync,
         # so the Adam moments return before the next optimizer step even when
         # optimizer_offload is off. The export reload uses grad=False and leaves
         # them parked through generation; load_state_to_device is a no-op when
@@ -454,7 +463,7 @@ class MegatronLiteEngine(BaseEngine):
         reload_optimizer = optimizer or (device == "cuda" and grad)
         self.runtime.to(self.handle, device, model=model, optimizer=reload_optimizer, grad=grad)
 
-    def release_train_scratch_before_resync(self) -> None:
+    def _release_train_scratch_before_resync(self) -> None:
         """Free the post-train-step residual before the colocated vLLM weight wake.
 
         verl's ``update_weights`` wakes the sleeping vLLM weight pool
@@ -466,6 +475,11 @@ class MegatronLiteEngine(BaseEngine):
         runs too late to help this wake, so park the optimizer state on CPU and
         hand the M-FSDP scratch back to the driver here, keeping the sharded
         weights resident as the export gather source.
+
+        Called from ``_MegatronLiteModeCtx.__exit__`` on the training-mode context
+        exit -- the engine's own offload point at the end of ``update_actor`` --
+        so no verl-side hook is needed: the fit loop always runs this exit before
+        the subsequent ``update_weights`` wakes the rollout weight pool.
 
         The optimizer park is reversible: gated on ``param_offload`` so the next
         training-side reload (``to("cuda", ..., grad=True)``) is the guaranteed

--- a/experimental/lite/examples/verl/verl_mlite/resync_export.py
+++ b/experimental/lite/examples/verl/verl_mlite/resync_export.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Resync export release ordering (colocated actor ↔ vLLM).
+
+During an actor→rollout weight resync the M-FSDP export all-gathers the full
+dense params into a transient buffer and, in the param-offload config, is
+reloaded to GPU for the walk. Once the generator drains, that memory must be
+returned to the *driver* before the colocated vLLM ``wake_up`` runs: vLLM's
+cumem allocator shares the physical device but is separate from torch's caching
+allocator, so anything torch merely *cached* (the released all-gather buffer) or
+left *resident* (the reloaded model) starves ``create_and_map`` and OOMs
+(``cumem_allocator.cpp`` on wake_up).
+
+Two thin generator wrappers enforce that ordering around the export stream:
+
+* ``stream_export_with_empty_cache`` — hand the released all-gather buffer back
+  to the driver by firing ``empty_cache`` per ≥N GiB of exported material and
+  once more on drain.
+* ``offload_params_after_export`` — reuse the engine's existing ``self.to(cpu)``
+  offload lifecycle (the same call ``save_checkpoint`` / ``load_checkpoint``
+  use), deferred to the generator's ``finally`` so the model returns to CPU
+  exactly once the export is consumed — right before the vLLM wake_up. Doing it
+  in ``finally`` keeps the ordering even if the consumer stops early or raises.
+
+This is an RL-colocation concern and deliberately lives in the verl integration
+layer, never in the vLLM-agnostic megatron_lite export primitive (layering).
+Kept stdlib-only so the release-ordering invariant is CPU unit-testable without
+a verl or CUDA runtime. See TASK-1.13.8.
+"""
+from __future__ import annotations
+
+import os
+from collections.abc import Callable, Iterator
+
+_RESYNC_EXPORT_EMPTY_CACHE_GIB_ENV = "MLITE_RESYNC_EXPORT_EMPTY_CACHE_GIB"
+_DEFAULT_RESYNC_EXPORT_EMPTY_CACHE_GIB = 4.0
+
+
+def resync_export_empty_cache_threshold_bytes() -> int:
+    """Bytes of exported material per ``empty_cache`` flush; ``<=0`` disables.
+
+    Batched at ≥4 GiB by default (per the DS4 resync recipe) so small tensors
+    never trigger a device sync. Override / disable via
+    ``MLITE_RESYNC_EXPORT_EMPTY_CACHE_GIB`` (``0`` = off).
+    """
+    raw = os.environ.get(_RESYNC_EXPORT_EMPTY_CACHE_GIB_ENV)
+    if raw is None or raw == "":
+        gib = _DEFAULT_RESYNC_EXPORT_EMPTY_CACHE_GIB
+    else:
+        try:
+            gib = float(raw)
+        except ValueError:
+            gib = _DEFAULT_RESYNC_EXPORT_EMPTY_CACHE_GIB
+    if gib <= 0:
+        return 0
+    return int(gib * (1024**3))
+
+
+def stream_export_with_empty_cache(
+    generator: Iterator, threshold_bytes: int, empty_cache_fn: Callable[[], None]
+) -> Iterator:
+    """Yield from ``generator``, flushing the allocator per ``threshold_bytes``.
+
+    Fires ``empty_cache_fn`` once per ``threshold_bytes`` of cumulative exported
+    tensor bytes, and once more after the generator drains (its own ``finally``
+    has by then released the M-FSDP all-gather buffer), returning the freed
+    memory to the driver before the colocated vLLM wakes. ``threshold_bytes<=0``
+    disables all flushing (pass-through).
+    """
+    if threshold_bytes <= 0:
+        yield from generator
+        return
+    accumulated = 0
+    try:
+        for name, tensor in generator:
+            yield name, tensor
+            accumulated += tensor.element_size() * tensor.nelement()
+            if accumulated >= threshold_bytes:
+                empty_cache_fn()
+                accumulated = 0
+    finally:
+        empty_cache_fn()
+
+
+def offload_params_after_export(
+    streamed: Iterator, offload_fn: Callable[[], None], drain_fn: Callable[[], None]
+) -> Iterator:
+    """Yield from ``streamed``, then offload params + drain once it is consumed.
+
+    ``get_per_tensor_param`` reloads the model to GPU for the export; in the
+    param-offload config the steady state is model-on-CPU, so the reload must be
+    undone once the caller finishes iterating — which is right before the
+    colocated vLLM ``wake_up``. vLLM's separate (cumem) allocator shares the
+    physical device, so a model left resident (plus any export-peak residue)
+    starves ``create_and_map`` and OOMs. Undoing it in the generator's
+    ``finally`` guarantees the ordering even if the consumer stops early or
+    raises. ``offload_fn`` is the engine's existing ``self.to(cpu, model=True)``
+    lifecycle (shared with save/load); ``drain_fn`` is ``empty_cache``.
+    """
+    try:
+        yield from streamed
+    finally:
+        offload_fn()
+        drain_fn()

--- a/experimental/lite/megatron/lite/model/protocol_utils.py
+++ b/experimental/lite/megatron/lite/model/protocol_utils.py
@@ -111,7 +111,16 @@ def add_loss_context_kwargs(kwargs: dict[str, Any], *, include_return_log_probs:
 
 
 def add_cross_entropy_fusion(kwargs: dict[str, Any], model) -> None:
-    kwargs["use_fused_kernels"] = bool(getattr(model, "cross_entropy_fusion", False))
+    current = model
+    visited: set[int] = set()
+    while current is not None and id(current) not in visited:
+        visited.add(id(current))
+        enabled = getattr(current, "cross_entropy_fusion", None)
+        if enabled is not None:
+            kwargs["use_fused_kernels"] = bool(enabled)
+            return
+        current = getattr(current, "module", None)
+    kwargs["use_fused_kernels"] = False
 
 
 def set_cross_entropy_fusion(chunks: list, enabled: bool) -> None:

--- a/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
@@ -159,7 +159,6 @@ def load_training_checkpoint(
                 t = state_dict[key]
                 with torch.no_grad():
                     _copy_tensor_(param, t)
-        _copy_full_parameters_to_shards_if_available(model)
 
     if load_optimizer:
         _load_optimizer_checkpoint(optimizer, ckpt_path)
@@ -262,18 +261,6 @@ def _model_chunks(model: nn.Module | Iterable[nn.Module]) -> list[nn.Module]:
     if not all(isinstance(chunk, nn.Module) for chunk in chunks):
         raise TypeError("checkpoint model chunks must be nn.Module instances.")
     return chunks
-
-
-def _copy_full_parameters_to_shards_if_available(
-    model: nn.Module | Iterable[nn.Module],
-) -> None:
-    for chunk in _model_chunks(model):
-        for module in chunk.modules():
-            copy_fn = getattr(
-                getattr(module, "param_sync", None), "copy_full_parameters_to_shards", None
-            )
-            if callable(copy_fn):
-                copy_fn()
 
 
 def _to_local_tensor(tensor: Any) -> torch.Tensor:

--- a/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
@@ -141,18 +141,6 @@ def unwrap_model(model: nn.Module) -> nn.Module:
     return base_model
 
 
-def _materialize_full_parameters_if_available(chunks: list[nn.Module]) -> list[object]:
-    materialized: list[object] = []
-    for chunk in chunks:
-        for module in chunk.modules():
-            param_sync = getattr(module, "param_sync", None)
-            materialize = getattr(param_sync, "materialize_all", None)
-            if callable(materialize):
-                materialize()
-                materialized.append(param_sync)
-    return materialized
-
-
 def save_safetensors(
     tensors: dict[str, torch.Tensor], path: str, filename: str = "model.safetensors"
 ) -> None:
@@ -401,6 +389,28 @@ def _resolve_param_name(name: str, state_dict: dict) -> str | None:
     return None
 
 
+def _iter_export_named_parameters(chunk: nn.Module, base_chunk: nn.Module):
+    """Source ``(name, full_param)`` pairs for export, bounded when possible.
+
+    Backends whose wrapper exposes ``stream_full_parameters`` (M-FSDP) gather
+    the unsharded parameters one bucket at a time, capping the transient export
+    footprint at a single bucket instead of the whole model. Everything else --
+    FSDP2 ``DTensor`` params (gathered lazily by ``_materialize_dtensor``) and
+    plain manually-sharded params -- falls back to ``named_parameters``.
+    """
+    streamer = getattr(chunk, "stream_full_parameters", None)
+    if callable(streamer):
+        from megatron.lite.primitive.utils import log_rank0
+
+        log_rank0(
+            "[export] M-FSDP stream_full_parameters path active "
+            "(bounded per-bucket materialization)"
+        )
+        yield from streamer()
+    else:
+        yield from base_chunk.named_parameters()
+
+
 def export_hf_weights(
     model: nn.Module | list[nn.Module],
     spec: HFWeights,
@@ -425,33 +435,25 @@ def export_hf_weights(
     else:
         chunks = [model]
 
-    param_syncs = _materialize_full_parameters_if_available(chunks)
-    try:
-        yield from _export_hf_weights_materialized(
-            chunks, spec, ps, vocab_size, limit, rank0_only, export_dtype
-        )
-    finally:
-        for param_sync in reversed(param_syncs):
-            release = getattr(param_sync, "release_all", None)
-            if callable(release):
-                release()
-
-
-def _export_hf_weights_materialized(
-    chunks: list[nn.Module],
-    spec: HFWeights,
-    ps,
-    vocab_size: int | None,
-    limit: int | None,
-    rank0_only: bool,
-    export_dtype: str | torch.dtype | None,
-) -> Generator[tuple[str, torch.Tensor], None, None]:
     rank = dist.get_rank() if dist.is_initialized() else 0
     resolved_export_dtype = _resolve_export_dtype(export_dtype)
 
     if ps.pp_size <= 1:
         exported_params = 0
         expert_groups: dict[str, list[tuple[int, str, torch.Tensor]]] = {}
+        # Expected local-expert count per group, so a group's full-tensors can be
+        # gathered to host and freed the instant it is complete instead of being
+        # held resident until the whole model has been walked. Holding every
+        # expert of the model on the GPU at once is what drove the transient
+        # export peak (a single ``experts.gate_up_proj`` group summed across all
+        # layers dominated the peak); streaming the sharded buckets alone cannot
+        # bound it because the consumer buffers the experts here for the per-layer
+        # EP collective. Counting up front (cheap; sharded ``named_parameters``,
+        # no gather) lets the walk flush each group exactly once, in the same
+        # deterministic order on every rank -- the EP/ETP collective sequence is
+        # unchanged, only its timing moves earlier.
+        expert_group_expected: dict[str, int] = {}
+        chunk_infos: list[tuple[nn.Module, nn.Module, dict]] = []
         for chunk in chunks:
             base_chunk = unwrap_model(chunk)
             layer_map = (
@@ -459,17 +461,39 @@ def _export_hf_weights_materialized(
                 if hasattr(base_chunk, "layer_indices")
                 else {}
             )
-            for name, param in base_chunk.named_parameters():
+            chunk_infos.append((chunk, base_chunk, layer_map))
+            for pname, _ in base_chunk.named_parameters():
+                gpn = to_global_layer_name(pname, layer_map)
+                if spec.is_expert(gpn):
+                    key = _expert_group_key(gpn)
+                    expert_group_expected[key] = expert_group_expected.get(key, 0) + 1
+
+        def _emit_expert_group(group_key: str):
+            gathered_group: dict[str, torch.Tensor] = {}
+            # Runs on every rank (the EP/ETP all-gather is collective); only rank
+            # 0 yields when ``rank0_only``. Popping frees this group's GPU
+            # full-tensors before the walk materializes the next group.
+            _gather_expert_group(expert_groups.pop(group_key), spec, ps, gathered_group)
+            if not rank0_only or rank == 0:
+                for native_name in sorted(gathered_group, key=parse_expert_idx):
+                    gathered_tensor = gathered_group[native_name]
+                    for hf_name, hf_tensor in spec.native_to_hf(native_name, gathered_tensor):
+                        yield hf_name, _cast_export_tensor(hf_tensor, resolved_export_dtype)
+
+        for chunk, base_chunk, layer_map in chunk_infos:
+            for name, param in _iter_export_named_parameters(chunk, base_chunk):
                 gname = to_global_layer_name(name, layer_map)
                 tensor = _materialize_dtensor(param.data.detach())
 
                 gathered_one: dict[str, torch.Tensor] = {}
                 if spec.is_expert(gname):
                     if limit is None:
-                        expert_groups.setdefault(_expert_group_key(gname), []).append(
-                            (parse_expert_idx(gname), gname, tensor)
-                        )
+                        key = _expert_group_key(gname)
+                        entries = expert_groups.setdefault(key, [])
+                        entries.append((parse_expert_idx(gname), gname, tensor))
                         exported_params += 1
+                        if len(entries) >= expert_group_expected.get(key, 0):
+                            yield from _emit_expert_group(key)
                         continue
                     _gather_expert(gname, tensor, spec, ps, gathered_one)
                 else:
@@ -488,14 +512,10 @@ def _export_hf_weights_materialized(
                 if limit is not None and exported_params >= limit:
                     return
 
+        # Defensive: an exact per-group count flushes every group inside the walk,
+        # so this only fires if a count was under-estimated (never in practice).
         for group_key in sorted(expert_groups):
-            gathered_group: dict[str, torch.Tensor] = {}
-            _gather_expert_group(expert_groups[group_key], spec, ps, gathered_group)
-            if not rank0_only or rank == 0:
-                for native_name in sorted(gathered_group, key=parse_expert_idx):
-                    gathered_tensor = gathered_group[native_name]
-                    for hf_name, hf_tensor in spec.native_to_hf(native_name, gathered_tensor):
-                        yield hf_name, _cast_export_tensor(hf_tensor, resolved_export_dtype)
+            yield from _emit_expert_group(group_key)
         return
 
     gathered: dict[str, torch.Tensor] = {}
@@ -507,7 +527,7 @@ def _export_hf_weights_materialized(
             if hasattr(base_chunk, "layer_indices")
             else {}
         )
-        for name, param in base_chunk.named_parameters():
+        for name, param in _iter_export_named_parameters(chunk, base_chunk):
             gname = to_global_layer_name(name, layer_map)
             t = _materialize_dtensor(param.data.detach())
 

--- a/experimental/lite/megatron/lite/primitive/optimizers/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/__init__.py
@@ -8,6 +8,7 @@ import importlib
 BACKENDS = {
     "dist_opt": "megatron.lite.primitive.optimizers.megatron_wrap",
     "fsdp2": "megatron.lite.primitive.optimizers.fsdp2",
+    "mfsdp": "megatron.lite.primitive.optimizers.mfsdp.backend",
 }
 
 

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/backend.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/backend.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Runtime backend contract for standalone M-FSDP."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+
+import torch.distributed as dist
+from torch.distributed.checkpoint.metadata import (
+    ChunkStorageMetadata,
+    MetadataIndex,
+    TensorProperties,
+)
+from torch.distributed.checkpoint.planner import (
+    TensorWriteData,
+    WriteItem,
+    WriteItemType,
+)
+from torch.distributed.tensor import DTensor
+from torch.distributed.tensor.placement_types import Replicate, Shard, _StridedShard
+
+
+def gather_chunk_metadata(dtensor: DTensor) -> ChunkStorageMetadata:
+    """Compute this rank's global offset from the actual uneven local sizes."""
+    local_shape = list(dtensor.to_local().shape)
+    cumulative_shape = list(local_shape)
+    offsets = [0] * len(local_shape)
+    placements = list(dtensor.placements)
+    shard_order = getattr(dtensor.device_mesh, "_shard_order", None)
+    if shard_order is None:
+        strided = [
+            i
+            for i, placement in enumerate(placements)
+            if isinstance(placement, _StridedShard)
+        ]
+        if len(strided) > 1:
+            raise ValueError(
+                "M-FSDP DCP supports at most one strided DTensor placement."
+            )
+        ordinary = [i for i in range(len(placements)) if i not in strided]
+        shard_order = list(reversed(strided + ordinary))
+
+    for mesh_dim in reversed(shard_order):
+        placement = placements[mesh_dim]
+        if isinstance(placement, Replicate):
+            continue
+        if not isinstance(placement, (Shard, _StridedShard)):
+            raise ValueError(f"Unsupported DTensor placement: {placement!r}")
+        shard_dim = int(placement.dim)
+        group = dtensor.device_mesh.get_group(mesh_dim)
+        shapes: list[list[int] | None] = [None] * dist.get_world_size(group)
+        dist.all_gather_object(shapes, list(cumulative_shape), group=group)
+        resolved = [shape for shape in shapes if shape is not None]
+        rank = dist.get_rank(group)
+        offsets[shard_dim] += sum(shape[shard_dim] for shape in resolved[:rank])
+        cumulative_shape[shard_dim] = sum(shape[shard_dim] for shape in resolved)
+    return ChunkStorageMetadata(offsets=tuple(offsets), sizes=tuple(local_shape))
+
+
+def update_uneven_dtensor_chunk_metadata(dtensor: DTensor) -> None:
+    chunk = gather_chunk_metadata(dtensor)
+
+    def create_chunk_list():
+        return [chunk]
+
+    def create_write_items(fqn: str, tensor: DTensor) -> list[WriteItem]:
+        local = tensor.to_local()
+        if local.numel() == 0:
+            return []
+        return [
+            WriteItem(
+                type=WriteItemType.SHARD,
+                index=MetadataIndex(fqn, chunk.offsets),
+                tensor_data=TensorWriteData(
+                    chunk=chunk,
+                    properties=TensorProperties.create_from_tensor(local),
+                    size=tensor.size(),
+                ),
+            )
+        ]
+
+    local = dtensor.to_local()
+    local.__create_chunk_list__ = create_chunk_list
+    local.__create_write_items__ = create_write_items
+
+
+def preprocess_state_dict_for_uneven_dtensor(
+    state_dict: dict[str, Any],
+) -> dict[str, Any]:
+    """Attach DCP planner closures to every nested DTensor, in stable key order."""
+    for _path, value in sorted(_walk_state(state_dict), key=lambda item: item[0]):
+        if isinstance(value, DTensor):
+            update_uneven_dtensor_chunk_metadata(value)
+    return state_dict
+
+
+def _walk_state(
+    value: Any, path: tuple[str, ...] = ()
+) -> Iterator[tuple[tuple[str, ...], Any]]:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            yield from _walk_state(child, (*path, str(key)))
+    elif isinstance(value, (list, tuple)):
+        for index, child in enumerate(value):
+            yield from _walk_state(child, (*path, str(index)))
+    else:
+        yield path, value
+
+
+@dataclass(frozen=True, slots=True)
+class MegatronFSDPBackend:
+    name: str = "mfsdp"
+    runtime_backend: str = "megatron_fsdp"
+
+    def zero_grad(self, optimizer: Any) -> None:
+        optimizer.zero_grad()
+
+    def finish_grad_sync(self, optimizer: Any) -> None:
+        optimizer.finish_grad_sync()
+
+    def clip_grad_norm(self, optimizer: Any):
+        return optimizer.clip_grad_norm()
+
+    def step(self, optimizer: Any):
+        return optimizer.step()
+
+    def state_dict(self, optimizer: Any) -> dict[str, Any]:
+        return optimizer.state_dict()
+
+    def dcp_state_dict(self, optimizer: Any, *, is_loading: bool) -> dict[str, Any]:
+        state = optimizer.state_dict()
+        return preprocess_state_dict_for_uneven_dtensor(state)
+
+    def load_state_dict(self, optimizer: Any, state_dict: dict[str, Any]) -> None:
+        optimizer.load_state_dict(state_dict)
+
+    def sync_model_weights_to_main_weights(self, optimizer: Any) -> bool:
+        for chunk in optimizer._model_chunks:
+            chunk.param_sync.copy_full_parameters_to_shards()
+        return True
+
+    def finalize_grads(
+        self, finalize_fn, model_chunks: list[Any], optimizer: Any
+    ) -> None:
+        finalize_fn()
+
+
+BACKEND = MegatronFSDPBackend()
+
+
+__all__ = [
+    "BACKEND",
+    "MegatronFSDPBackend",
+    "gather_chunk_metadata",
+    "preprocess_state_dict_for_uneven_dtensor",
+    "update_uneven_dtensor_chunk_metadata",
+]

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
@@ -546,6 +546,25 @@ class ParamBucket:
                     spec.shard_param.grad = None
                 spec.full_param.data = self.full_buffer
 
+    def release_scratch_keep_weights(self) -> None:
+        """Drop the all-gather scratch while leaving the sharded weights resident.
+
+        This is ``move_model_state``'s scratch-release prologue without the
+        device move: release the full-parameter all-gather buffer, discard the
+        full-parameter views, drain any in-flight grad reduce, and hand the
+        allocator's cached double-buffer slots back to the driver -- but keep
+        ``main_param_buffer`` (and the optimizer-aliased shard views installed by
+        ``release_full_parameters``) on their current device. A colocated vLLM
+        weight-pool wake needs the transient full-model scratch back before it
+        can ``create_and_map``; the export that follows the wake gathers from the
+        resident shards, so the persistent weights must not move (TASK-1.13.8.5).
+        """
+        self.release_full_parameters()
+        self.discard_full_parameter_views()
+        if self._grad_reduce_launched:
+            self.wait_grad_reduce()
+        self.allocator.release_cached()
+
     def prepare_grad_reduce(
         self, *, force: bool = False
     ) -> tuple[torch.Tensor, torch.Tensor] | None:
@@ -1144,6 +1163,18 @@ class CommunicationPipelines:
             bucket.move_model_state(device, load_grad=load_grad)
         self.all_gather.reset_device(device)
         self.grad_reduce.reset_device(device)
+
+    def release_scratch_keep_weights(self) -> None:
+        """Reclaim every bucket's all-gather scratch, keeping weights resident.
+
+        Per-bucket counterpart to ``move_model_state`` that stops short of the
+        device move: it hands the retained double-buffer slots back to the driver
+        (what a colocated vLLM wake needs) but leaves the sharded weights and
+        their optimizer aliases in place as the export gather source. See
+        ``ParamBucket.release_scratch_keep_weights`` and TASK-1.13.8.5.
+        """
+        for bucket in self.buckets:
+            bucket.release_scratch_keep_weights()
 
     def finish_grad_sync(self) -> None:
         self.grad_reduce.finish()

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
@@ -15,7 +15,7 @@ import importlib
 import logging
 import math
 from collections import defaultdict
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Iterator
 from contextlib import nullcontext
 from dataclasses import dataclass
 from typing import Any
@@ -153,6 +153,9 @@ class TemporaryBufferAllocator:
         # Dynamic storage is reclaimed when the lease drops its final reference.
         return None
 
+    def release_cached(self, *, force: bool = False) -> None:
+        """Drop allocator-owned communication storage before a device move."""
+
 
 class DoubleBufferAllocator(TemporaryBufferAllocator):
     """Two persistent communication slots per dtype/device/group key."""
@@ -161,6 +164,7 @@ class DoubleBufferAllocator(TemporaryBufferAllocator):
         super().__init__(user_buffer)
         self._slots: dict[tuple[Any, ...], list[torch.Tensor | None]] = {}
         self._busy: dict[tuple[Any, ...], set[int]] = {}
+        self._reuse_events: dict[tuple[Any, ...], list[Any | None]] = {}
 
     def allocate(
         self,
@@ -174,6 +178,7 @@ class DoubleBufferAllocator(TemporaryBufferAllocator):
         pool_key = (*key, dtype, device)
         slots = self._slots.setdefault(pool_key, [None, None])
         busy = self._busy.setdefault(pool_key, set())
+        reuse_events = self._reuse_events.setdefault(pool_key, [None, None])
         for slot in range(2):
             if slot in busy:
                 continue
@@ -193,6 +198,8 @@ class DoubleBufferAllocator(TemporaryBufferAllocator):
                 registered = bool(
                     self.user_buffer is not None and self.user_buffer.active
                 )
+            _wait_for_reuse_event(reuse_events[slot], tensor)
+            reuse_events[slot] = None
             busy.add(slot)
             return BufferLease(
                 tensor=tensor.narrow(0, 0, numel),
@@ -211,7 +218,35 @@ class DoubleBufferAllocator(TemporaryBufferAllocator):
 
     def release(self, lease: BufferLease) -> None:
         if lease.slot is not None:
+            events = self._reuse_events.setdefault(lease.key, [None, None])
+            events[lease.slot] = _record_reuse_event(lease.tensor)
             self._busy.get(lease.key, set()).discard(lease.slot)
+
+    def release_cached(self, *, force: bool = False) -> None:
+        # The busy check catches genuine misuse — releasing the cache while a
+        # collective is legitimately in flight — on the normal path. On an
+        # exception-driven teardown (``force=True``) a slot may be left busy by
+        # an aborted collective; raising here would replace the primary error
+        # (e.g. the OOM that triggered the teardown) with a misleading
+        # "active buffers" RuntimeError, so force-drop the cache instead.
+        if not force and any(self._busy.values()):
+            raise RuntimeError("Cannot release active M-FSDP communication buffers.")
+        self._slots.clear()
+        self._busy.clear()
+        self._reuse_events.clear()
+
+
+def _record_reuse_event(tensor: torch.Tensor) -> Any | None:
+    if tensor.device.type != "cuda":
+        return None
+    event = torch.cuda.Event()
+    event.record(torch.cuda.current_stream(tensor.device))
+    return event
+
+
+def _wait_for_reuse_event(event: Any | None, tensor: torch.Tensor) -> None:
+    if event is not None:
+        torch.cuda.current_stream(tensor.device).wait_event(event)
 
 
 def build_temporary_allocator(
@@ -247,6 +282,7 @@ class ParamSpec:
     local_offset: int = 0
     param_offset: int = 0
     shard_param: nn.Parameter | None = None
+    retain_full_storage_through_backward: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -269,6 +305,7 @@ class ParamBucket:
         gather_group: dist.ProcessGroup | None,
         config: MFSDPConfig,
         allocator: TemporaryBufferAllocator,
+        allocator_layout_key: tuple[Any, ...],
     ) -> None:
         if not specs:
             raise ValueError("An M-FSDP parameter bucket cannot be empty.")
@@ -280,6 +317,10 @@ class ParamBucket:
         self.rank = group_rank(process_group)
         self.config = config
         self.allocator = allocator
+        self.allocator_layout_key = allocator_layout_key
+        self.retain_full_storage_through_backward = all(
+            spec.retain_full_storage_through_backward for spec in specs
+        )
         self.device = specs[0].full_param.device
         compute_dtype = specs[0].full_param.dtype
         self.policy = MixedPrecisionPolicy(
@@ -328,10 +369,14 @@ class ParamBucket:
             dtype=self.policy.compute_dtype,
             device=self.device,
         )
-        self.local_grad_comm_buffer = torch.empty(
-            self.local_numel,
-            dtype=self.policy.grad_comm_dtype,
-            device=self.device,
+        self.local_grad_comm_buffer = (
+            self.main_grad_buffer
+            if self.policy.grad_comm_dtype == self.policy.main_grads_dtype
+            else torch.empty(
+                self.local_numel,
+                dtype=self.policy.grad_comm_dtype,
+                device=self.device,
+            )
         )
         self.full_buffer = torch.empty(0, dtype=compute_dtype, device=self.device)
         self._full_lease: BufferLease | None = None
@@ -394,7 +439,11 @@ class ParamBucket:
                 dtype=self.policy.compute_dtype,
                 device=self.device,
                 group=self.gather_group,
-                key=("param", self.bucket_id),
+                key=(
+                    "param",
+                    id(self.gather_group),
+                    self.allocator_layout_key,
+                ),
             )
             self.full_buffer = self._full_lease.tensor
         self.local_compute_buffer.copy_(self.main_param_buffer)
@@ -435,7 +484,67 @@ class ParamBucket:
             dtype=self.policy.compute_dtype,
             device=self.device,
         )
+
         self._full_ready = False
+
+    def discard_full_parameter_views(self) -> None:
+        """Release full-parameter references after autograd no longer needs them."""
+        empty = torch.empty(
+            0,
+            dtype=self.policy.compute_dtype,
+            device=self.device,
+        )
+        with torch.no_grad():
+            for spec in self.specs:
+                spec.full_param.data = empty
+
+    def move_model_state(self, device: torch.device, *, load_grad: bool) -> None:
+        """Move persistent sharded storage without breaking optimizer aliases."""
+        device = torch.device(device)
+        self.release_full_parameters()
+        self.discard_full_parameter_views()
+        if self._grad_reduce_launched:
+            self.wait_grad_reduce()
+        self.allocator.release_cached()
+
+        grad_present = {
+            id(spec): spec.shard_param is not None and spec.shard_param.grad is not None
+            for spec in self.specs
+        }
+        self.main_param_buffer = self.main_param_buffer.to(device)
+        grad_comm_shares_main = self.local_grad_comm_buffer is self.main_grad_buffer
+        self.main_grad_buffer = self.main_grad_buffer.to(device)
+        self.grad_shard_buffer = self.main_grad_buffer
+        self.local_compute_buffer = self.local_compute_buffer.to(device)
+        self.local_grad_comm_buffer = (
+            self.main_grad_buffer
+            if grad_comm_shares_main
+            else self.local_grad_comm_buffer.to(device)
+        )
+        self.device = device
+        self.full_buffer = torch.empty(
+            0,
+            dtype=self.policy.compute_dtype,
+            device=device,
+        )
+
+        with torch.no_grad():
+            for spec in self.specs:
+                assert spec.shard_param is not None
+                spec.shard_param.data = self.main_param_buffer.narrow(
+                    0,
+                    spec.local_offset,
+                    spec.shard_numel,
+                )
+                if load_grad and grad_present[id(spec)]:
+                    spec.shard_param.grad = self.main_grad_buffer.narrow(
+                        0,
+                        spec.local_offset,
+                        spec.shard_numel,
+                    ).view_as(spec.shard_param)
+                else:
+                    spec.shard_param.grad = None
+                spec.full_param.data = self.full_buffer
 
     def prepare_grad_reduce(
         self, *, force: bool = False
@@ -450,7 +559,11 @@ class ParamBucket:
             dtype=self.policy.grad_comm_dtype,
             device=self.device,
             group=self.process_group,
-            key=("grad", self.bucket_id),
+            key=(
+                "grad",
+                id(self.process_group),
+                self.allocator_layout_key,
+            ),
         )
         grad_input = self._grad_lease.tensor
         grad_input.zero_()
@@ -549,12 +662,14 @@ class ParamBucket:
             if param.grad is None:
                 return
             self._grad_ready_ids.add(id(spec))
-            if (
-                self.grad_sync_enabled
-                and len(self._grad_ready_ids) == len(self.specs)
-                and self.grad_ready_callback is not None
-            ):
+            if len(self._grad_ready_ids) != len(self.specs):
+                return
+            if self.grad_sync_enabled and self.grad_ready_callback is not None:
                 self.grad_ready_callback(self)
+            self.release_full_parameters()
+            self.discard_full_parameter_views()
+            if not self.grad_sync_enabled:
+                self._grad_ready_ids.clear()
 
         return grad_ready
 
@@ -622,16 +737,21 @@ class ParamAndGradBuffer:
                 expert_by_param_id[id(param)] = bool(is_expert(name))
             spec.bindings.append(ParamBinding(parent, attribute))
 
-        grouped: dict[tuple[int, bool, torch.dtype, torch.device], list[ParamSpec]] = (
-            defaultdict(list)
-        )
-        owner_for_key: dict[tuple[int, bool, torch.dtype, torch.device], nn.Module] = {}
+        grouped: dict[
+            tuple[int, bool, bool, torch.dtype, torch.device], list[ParamSpec]
+        ] = defaultdict(list)
+        owner_for_key: dict[
+            tuple[int, bool, bool, torch.dtype, torch.device], nn.Module
+        ] = {}
         for param_id, spec in specs_by_id.items():
             owner = owner_by_param_id[param_id]
             expert = expert_by_param_id[param_id]
+            retain_full_storage = len(spec.shape) == 1
+            spec.retain_full_storage_through_backward = retain_full_storage
             key = (
                 module_order[id(owner)],
                 expert,
+                retain_full_storage,
                 spec.full_param.dtype,
                 spec.full_param.device,
             )
@@ -641,9 +761,12 @@ class ParamAndGradBuffer:
         buckets: list[ParamBucket] = []
         owners: dict[int, list[int]] = defaultdict(list)
         for key in sorted(grouped, key=lambda item: item[0]):
-            _owner_order, expert, _dtype, _device = key
+            _owner_order, expert, _retain_full_storage, _dtype, _device = key
             owner = owner_for_key[key]
-            for partition in _split_specs(grouped[key], self.config.bucket_size):
+            partitions = _split_specs(grouped[key], self.config.bucket_size)
+            owner_type = type(owner)
+            owner_layout = f"{owner_type.__module__}.{owner_type.__qualname__}"
+            for partition_index, partition in enumerate(partitions):
                 bucket_id = len(buckets)
                 buckets.append(
                     ParamBucket(
@@ -653,6 +776,14 @@ class ParamAndGradBuffer:
                         gather_group=self.groups.gather_group(expert=expert),
                         config=self.config,
                         allocator=self.allocator,
+                        allocator_layout_key=(
+                            owner_layout,
+                            expert,
+                            _retain_full_storage,
+                            partition_index,
+                            len(partitions),
+                            sum(spec.numel for spec in partition),
+                        ),
                     )
                 )
                 owners[id(owner)].append(bucket_id)
@@ -789,9 +920,20 @@ class AllGatherPipeline:
 
     def wait_bucket_ready(self, bucket_id: int, bwd: bool = False) -> None:
         bucket = self.buckets[bucket_id]
-        if not bucket._full_ready and bucket._param_gather_work is None:
+        if self.overlap and not bucket._full_ready and bucket._param_gather_work is None:
+            # Prefetch/overlap path: launch the dense all-gather ahead of use on the
+            # dedicated priority communication stream.
             self.async_bucket_gather(bucket_id, bwd=bwd)
         self.comm_stream.wait_for_current()
+        # When overlap is disabled (the guard forces this for any CP>=2 + DP-sharded
+        # config, see optimizer._order_param_gathers_for_parallel_collectives), do NOT
+        # launch on the side comm stream. Let wait_param_gather issue the all-gather on
+        # the current compute stream instead, so dense_ag (gather_group == dp_cp_ag_group)
+        # is enqueued in program order alongside the model's CP collectives (cp_group).
+        # Those two process groups intersect; launching them from different streams lets
+        # their NCCL enqueue order diverge across ranks on multi-node runs -> collective
+        # deadlock (invisible on single-node NVLink proxies). Program-order serialization
+        # on one stream mirrors how FSDP2 avoids the same hazard.
         bucket.wait_param_gather()
 
     def begin_forward(self) -> None:
@@ -816,16 +958,10 @@ class AllGatherPipeline:
     def acquire_backward(self, bucket: ParamBucket) -> None:
         bucket_id = bucket.bucket_id
         self.wait_bucket_ready(bucket_id, bwd=True)
+        bucket.install_full_parameters()
         self._backward_cursor = min(self._backward_cursor, bucket_id - 1)
         if self.overlap and self._backward_cursor >= 0:
             self.async_bucket_gather(self._backward_cursor, bwd=True)
-
-    def install_backward_all(self) -> None:
-        for bucket in self.buckets:
-            self.async_bucket_gather(bucket.bucket_id, bwd=True)
-        for bucket in self.buckets:
-            self.wait_bucket_ready(bucket.bucket_id, bwd=True)
-            bucket.install_full_parameters()
 
     def materialize_all(self) -> None:
         for bucket in self.buckets:
@@ -837,6 +973,9 @@ class AllGatherPipeline:
     def release_all(self) -> None:
         for bucket in self.buckets:
             bucket.release_full_parameters()
+
+    def reset_device(self, device: torch.device) -> None:
+        self.comm_stream = CommunicationStream(device)
 
 
 class GradReducePipeline:
@@ -886,6 +1025,9 @@ class GradReducePipeline:
         for bucket in self.buckets:
             bucket.set_grad_sync_enabled(enabled)
 
+    def reset_device(self, device: torch.device) -> None:
+        self.comm_stream = CommunicationStream(device)
+
 
 class CommunicationPipelines:
     """Join parameter all-gather and gradient reduce-scatter pipelines."""
@@ -907,17 +1049,101 @@ class CommunicationPipelines:
     def acquire_backward(self, bucket: ParamBucket) -> None:
         self.all_gather.acquire_backward(bucket)
 
-    def install_backward_all(self) -> None:
-        self.all_gather.install_backward_all()
+    def acquire_backward_ids(self, bucket_ids: Iterable[int]) -> None:
+        for bucket_id in reversed(tuple(bucket_ids)):
+            self.all_gather.acquire_backward(self.buckets[bucket_id])
+
+    def release_backward_ids(self, bucket_ids: Iterable[int]) -> None:
+        for bucket_id in bucket_ids:
+            bucket = self.buckets[bucket_id]
+            bucket.release_full_parameters()
+            bucket.discard_full_parameter_views()
+
+    def release_forward_ids(self, bucket_ids: Iterable[int]) -> None:
+        for bucket_id in bucket_ids:
+            bucket = self.buckets[bucket_id]
+            if not bucket.retain_full_storage_through_backward:
+                bucket.release_full_parameters()
+                bucket.discard_full_parameter_views()
 
     def end_forward(self) -> None:
-        self.all_gather.release_all()
+        for bucket in self.buckets:
+            if not bucket.retain_full_storage_through_backward:
+                bucket.release_full_parameters()
+                bucket.discard_full_parameter_views()
 
     def materialize_all(self) -> None:
         self.all_gather.materialize_all()
 
+    def stream_materialize_buckets(self) -> Iterator["ParamBucket"]:
+        """Materialize one bucket at a time, releasing each before the next.
+
+        ``materialize_all`` all-gathers *every* bucket into the persistent
+        double-buffer simultaneously, so the whole unsharded model is resident
+        at once -- a transient full-model peak (tens of GiB/rank) that lands on
+        top of steady-state and drives the colocated resync OOM. A
+        full-parameter *export* only ever reads one
+        parameter at a time, so it does not need the whole model resident; this
+        generator bounds the transient footprint to a single bucket by
+        gather → install → yield → release per bucket, mirroring FSDP2's
+        per-parameter ``full_tensor`` path (which retains no whole-model buffer
+        and shows no export peak). Consumers MUST finish reading a bucket's
+        parameters before requesting the next (plain iteration guarantees this).
+        """
+        for bucket in self.buckets:
+            self.all_gather.async_bucket_gather(bucket.bucket_id)
+            self.all_gather.wait_bucket_ready(bucket.bucket_id)
+            bucket.install_full_parameters()
+            try:
+                yield bucket
+            finally:
+                bucket.release_full_parameters()
+                bucket.discard_full_parameter_views()
+
     def release_all(self) -> None:
         self.all_gather.release_all()
+
+    def discard_full_parameter_views(self) -> None:
+        for bucket in self.buckets:
+            bucket.discard_full_parameter_views()
+
+    def release_cached_buffers(self, *, force: bool = False) -> None:
+        """Return retained double-buffer all-gather storage to the driver.
+
+        ``release_all`` only drops the pipeline's own references to the
+        full-parameter buffers. Under ``fsdp_double_buffer`` (the default) the
+        buffers stay pinned in ``DoubleBufferAllocator``'s persistent slots so
+        they can be reused across the many acquire/release cycles of a training
+        step -- torch's caching allocator (hence ``empty_cache`` and
+        ``expandable_segments``) can never return that storage to the driver
+        while a slot still references it. That reuse is desirable during
+        training but wrong after a *full-parameter export*: a colocated consumer
+        (e.g. a sleeping vLLM engine that must ``wake_up``) needs the
+        full-model-sized storage handed back to the driver. Dropping the cached
+        slots here makes the export release bounded -- matching FSDP2's
+        ``full_tensor`` path, which retains no persistent buffer. The slots are
+        transparently re-allocated on the next ``materialize``.
+
+        On the normal path this is called after ``release_all`` has drained
+        every lease, so no buffer is in flight and the allocator's busy check
+        passes. ``force=True`` (used when the export scope unwinds because of an
+        exception) bypasses that check so an aborted-collective busy slot does
+        not mask the primary error with a spurious "active buffers" raise.
+        """
+        seen: set[int] = set()
+        for bucket in self.buckets:
+            allocator = bucket.allocator
+            if id(allocator) in seen:
+                continue
+            seen.add(id(allocator))
+            allocator.release_cached(force=force)
+
+    def move_model_state(self, device: torch.device, *, load_grad: bool) -> None:
+        device = torch.device(device)
+        for bucket in self.buckets:
+            bucket.move_model_state(device, load_grad=load_grad)
+        self.all_gather.reset_device(device)
+        self.grad_reduce.reset_device(device)
 
     def finish_grad_sync(self) -> None:
         self.grad_reduce.finish()

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/config.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/config.py
@@ -41,7 +41,7 @@ class MFSDPConfig:
     main_grads_dtype: torch.dtype = torch.float32
     grad_comm_dtype: torch.dtype = torch.float32
     nccl_ub: bool = False
-    fsdp_double_buffer: bool = False
+    fsdp_double_buffer: bool = True
     disable_symmetric_registration: bool = False
     all_gather_in_start_param_sync: bool = True
 
@@ -223,7 +223,7 @@ def build_mfsdp_config(opt: Any) -> MFSDPConfig:
         main_grads_dtype=main_grads_dtype,
         grad_comm_dtype=grad_comm_dtype,
         nccl_ub=nccl_ub,
-        fsdp_double_buffer=bool(option("fsdp_double_buffer", False)) or nccl_ub,
+        fsdp_double_buffer=bool(option("fsdp_double_buffer", True)) or nccl_ub,
         disable_symmetric_registration=bool(
             option("disable_symmetric_registration", False)
         ),

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/fused_ops.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/fused_ops.py
@@ -40,6 +40,12 @@ def build_optimizer(
     use_fused = bool(values.get("use_fused_optimizer", True)) and _has_cuda_params(
         param_groups
     )
+    if use_fused and _has_shared_param_storage(param_groups):
+        logger.warning(
+            "Apex fused optimizer is unsafe for M-FSDP parameters that share "
+            "flat storage; using the Torch optimizer fallback."
+        )
+        use_fused = False
     if use_fused:
         fused = _build_apex_optimizer(
             optimizer_name,
@@ -118,6 +124,24 @@ def _has_cuda_params(param_groups: list[dict[str, Any]]) -> bool:
         for group in param_groups
         for param in group["params"]
     )
+
+
+def _has_shared_param_storage(param_groups: list[dict[str, Any]]) -> bool:
+    """Return whether distinct optimizer parameters alias one flat storage."""
+    storages: set[tuple[str, int | None, int]] = set()
+    for group in param_groups:
+        for param in group["params"]:
+            if not isinstance(param, torch.Tensor):
+                continue
+            key = (
+                param.device.type,
+                param.device.index,
+                param.untyped_storage().data_ptr(),
+            )
+            if key in storages:
+                return True
+            storages.add(key)
+    return False
 
 
 __all__ = ["OptimizerFactory", "build_optimizer"]

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/optimizer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/optimizer.py
@@ -3,8 +3,10 @@
 
 from __future__ import annotations
 
+import logging
 import math
 from collections.abc import Callable, Iterable
+from dataclasses import replace
 from types import SimpleNamespace
 from typing import Any
 
@@ -13,6 +15,7 @@ import torch.distributed as dist
 import torch.nn as nn
 
 from megatron.lite.primitive.optimizers.mfsdp.config import (
+    MFSDPConfig,
     annotate_parallel_parameters,
     build_mfsdp_config,
     build_mfsdp_process_groups,
@@ -34,7 +37,8 @@ from megatron.lite.primitive.optimizers.mfsdp.wrapper import (
 )
 
 ExpertClassifierFn = Callable[[str], bool]
-_MFSDP_PARAM_VALUES_KEY = "_mfsdp_param_values"
+
+logger = logging.getLogger(__name__)
 
 
 def _override(opt: Any, name: str, default: Any) -> Any:
@@ -155,22 +159,10 @@ class _StandaloneOptimizer:
         return float(total_norm.float().item())
 
     def state_dict(self) -> dict[str, Any]:
-        state = self.optimizer.state_dict()
-        state[_MFSDP_PARAM_VALUES_KEY] = [
-            [param.detach().cpu().clone() for param in group["params"]]
-            for group in self.optimizer.param_groups
-        ]
-        return state
+        return self.optimizer.state_dict()
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
-        state = dict(state_dict)
-        param_values = state.pop(_MFSDP_PARAM_VALUES_KEY, None)
-        self.optimizer.load_state_dict(state)
-        if param_values is not None:
-            with torch.no_grad():
-                for group, group_values in zip(self.optimizer.param_groups, param_values, strict=True):
-                    for param, value in zip(group["params"], group_values, strict=True):
-                        param.copy_(value.to(device=param.device, dtype=param.dtype))
+        self.optimizer.load_state_dict(state_dict)
 
     def offload_state_to_cpu(self) -> None:
         self._offloaded_state_devices.clear()
@@ -286,6 +278,7 @@ class MFSdpOptimizer:
         result = self._inner_optimizer.step()
         for chunk in self._model_chunks:
             chunk.param_sync.release_all()
+            chunk.param_sync.discard_full_parameter_views()
         self.grad_sync_enabled = False
         return result
 
@@ -319,6 +312,7 @@ def build_mfsdp_stack(
     opt = engine_cfg.optimizer
     classifier = is_expert or (lambda _name: False)
     config = build_mfsdp_config(opt)
+    config = _order_param_gathers_for_parallel_collectives(config, ps)
     groups = build_mfsdp_process_groups(ps)
 
     wrapped_chunks = []
@@ -368,6 +362,41 @@ def build_mfsdp_stack(
         mark_optimizer_built(chunk)
     optimizer = MFSdpOptimizer(standalone_optimizer, wrapped_chunks)
     return wrapped_chunks, optimizer
+
+
+def _order_param_gathers_for_parallel_collectives(
+    config: MFSDPConfig,
+    ps: Any,
+) -> MFSDPConfig:
+    """Avoid unordered async collectives across intersecting process groups.
+
+    The standalone overlap pipeline has no dependency handshake with model-side
+    TP/CP/EP/ETP collectives.  When parameter shards and model-parallel groups
+    both span ranks, prefetching the next bucket can enqueue collectives on
+    intersecting process groups in different orders.  Keep overlap for pure
+    data parallelism, but make multidimensional compositions use ordered bucket
+    gathers until that cross-group handshake exists.
+    """
+    if not config.overlap_param_gather:
+        return config
+
+    model_parallel_size = math.prod(
+        max(int(getattr(ps, name, 1) or 1), 1)
+        for name in ("tp_size", "cp_size", "ep_size", "etp_size")
+    )
+    sharded_group_size = max(
+        int(getattr(ps, "dp_cp_size", 1) or 1),
+        int(getattr(ps, "expert_dp_size", 1) or 1),
+    )
+    if model_parallel_size == 1 or sharded_group_size == 1:
+        return config
+
+    if not dist.is_initialized() or dist.get_rank() == 0:
+        logger.warning(
+            "Disabling M-FSDP parameter-gather overlap because parameter shards "
+            "and model-parallel collectives span intersecting process groups."
+        )
+    return replace(config, overlap_param_gather=False)
 
 
 def _mark_mfsdp_parallel_attrs(
@@ -450,8 +479,6 @@ def _build_param_groups(
             if not param.requires_grad or id(param) in seen:
                 continue
             seen.add(id(param))
-            if param.numel() == 0:
-                continue
             params.append(param)
             normalized_name = name.removeprefix("module.")
             if classifier(normalized_name):

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/wrapper.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/wrapper.py
@@ -3,7 +3,9 @@
 
 from __future__ import annotations
 
+import sys
 from collections.abc import Callable, Iterable, Iterator
+from contextlib import contextmanager
 
 import torch
 import torch.nn as nn
@@ -35,8 +37,43 @@ class _BeginBackward(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad: torch.Tensor) -> tuple[torch.Tensor, None]:
         ctx.pipeline.begin_backward()
-        ctx.pipeline.install_backward_all()
         return grad, None
+
+
+class _AcquireBackward(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        tensor: torch.Tensor,
+        pipeline: CommunicationPipelines,
+        bucket_ids: tuple[int, ...],
+    ) -> torch.Tensor:
+        ctx.pipeline = pipeline
+        ctx.bucket_ids = bucket_ids
+        return tensor
+
+    @staticmethod
+    def backward(ctx, grad: torch.Tensor) -> tuple[torch.Tensor, None, None]:
+        ctx.pipeline.acquire_backward_ids(ctx.bucket_ids)
+        return grad, None, None
+
+
+class _ReleaseBackward(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        tensor: torch.Tensor,
+        pipeline: CommunicationPipelines,
+        bucket_ids: tuple[int, ...],
+    ) -> torch.Tensor:
+        ctx.pipeline = pipeline
+        ctx.bucket_ids = bucket_ids
+        return tensor
+
+    @staticmethod
+    def backward(ctx, grad: torch.Tensor) -> tuple[torch.Tensor, None, None]:
+        ctx.pipeline.release_backward_ids(ctx.bucket_ids)
+        return grad, None, None
 
 
 class MegatronFSDP(nn.Module):
@@ -67,15 +104,46 @@ class MegatronFSDP(nn.Module):
         self.grad_reduce_pipeline: GradReducePipeline = self.param_sync.grad_reduce
         for owner_id, bucket_ids in self.param_and_grad_buffer.owners.items():
             owner = _module_by_id(module, owner_id)
-            owner.register_forward_pre_hook(
-                lambda _module, _args, ids=tuple(bucket_ids): (
-                    self.param_sync.acquire_forward(ids)
+            ids = tuple(bucket_ids)
+
+            def prepare_forward(_module, args, ids=ids):
+                self.param_sync.acquire_forward(ids)
+                return tree_map_only(
+                    torch.Tensor,
+                    lambda tensor: (
+                        _ReleaseBackward.apply(tensor, self.param_sync, ids)
+                        if tensor.requires_grad
+                        else tensor
+                    ),
+                    args,
                 )
-            )
+
+            def finish_forward(_module, _args, output, ids=ids):
+                output = tree_map_only(
+                    torch.Tensor,
+                    lambda tensor: (
+                        _AcquireBackward.apply(tensor, self.param_sync, ids)
+                        if tensor.requires_grad
+                        else tensor
+                    ),
+                    output,
+                )
+                self.param_sync.release_forward_ids(ids)
+                return output
+
+            owner.register_forward_pre_hook(prepare_forward)
+            owner.register_forward_hook(finish_forward)
         self.param_sync.release_all()
+        self.param_sync.discard_full_parameter_views()
 
     def forward(self, *args, **kwargs):
         self.param_sync.begin_forward()
+
+        def attach_backward(tensor: torch.Tensor) -> torch.Tensor:
+            if not tensor.requires_grad:
+                return tensor
+            return _BeginBackward.apply(tensor, self.param_sync)
+
         try:
             with saved_tensors_hooks(
                 self.param_sync.pack_saved_tensor,
@@ -84,11 +152,7 @@ class MegatronFSDP(nn.Module):
                 output = self.module(*args, **kwargs)
                 output = tree_map_only(
                     torch.Tensor,
-                    lambda tensor: (
-                        _BeginBackward.apply(tensor, self.param_sync)
-                        if tensor.requires_grad
-                        else tensor
-                    ),
+                    attach_backward,
                     output,
                 )
         finally:
@@ -112,6 +176,99 @@ class MegatronFSDP(nn.Module):
 
     def zero_grad_buffer(self) -> None:
         self.param_sync.reset_grad_state()
+
+    def move_model_state(
+        self,
+        device: torch.device | str,
+        *,
+        load_grad: bool = True,
+    ) -> None:
+        """Move M-FSDP-owned storage while preserving optimizer parameter aliases."""
+        self.param_sync.move_model_state(
+            torch.device(device),
+            load_grad=load_grad,
+        )
+
+    def stream_full_parameters(self) -> Iterator[tuple[str, nn.Parameter]]:
+        """Yield ``(name, full_param)`` one bucket at a time for export.
+
+        The bounded-bucket counterpart to ``materialize_all``: an exporter that
+        walks parameters one at a time (see the shared HF exporter's
+        ``export_hf_weights``) can consume this stream instead of pre-gathering
+        the whole model, capping the transient full-parameter footprint at a
+        single bucket rather than the whole unsharded model. This is the
+        materialization side of the DS4 resync bounded-export protocol and
+        mirrors FSDP2's per-parameter ``full_tensor`` gather, which shows no
+        export memory peak.
+
+        Each yielded parameter's ``.data`` is cloned off the bucket's gather
+        buffer before the bucket is released, so a consumer that retains the
+        tensor past the bucket's lifetime (e.g. the exporter buffers expert
+        shards for a per-layer EP collective) keeps a private allocation and
+        never aliases storage that the release has handed back to the allocator.
+        """
+        # Names are resolved against the currently-installed (sharded) params,
+        # which is the module state on entry and after each bucket release.
+        name_by_shard_id = {
+            id(param): name for name, param in self.module.named_parameters()
+        }
+        covered: set[str] = set()
+        for bucket in self.param_sync.stream_materialize_buckets():
+            for spec in bucket.specs:
+                name = name_by_shard_id.get(id(spec.shard_param))
+                if name is None:
+                    continue
+                covered.add(name)
+                full_param = spec.full_param
+                full_param.data = full_param.data.clone()
+                yield name, full_param
+        # Parameters (and any params not owned by an M-FSDP bucket) that the
+        # bucket walk did not cover -- emit them from the restored sharded view.
+        for name, param in self.module.named_parameters():
+            if name not in covered:
+                yield name, param
+
+    @contextmanager
+    def full_parameter_context(self):
+        """Scope a full-parameter export; parameters materialize on demand.
+
+        Historically this all-gathered the whole model up front
+        (``materialize_all``), producing a transient full-model peak. Export
+        consumers now stream via ``stream_full_parameters`` (bounded to a single
+        bucket), so this context no longer pre-materializes; it only guarantees
+        the export all-gather storage is scoped to the export and handed back to
+        the driver on exit. A consumer that still reads ``named_parameters``
+        directly (rather than streaming) transparently falls back to the
+        wrapper's own ``materialize_all`` there, so correctness is unchanged.
+        """
+        # The try/finally still wraps the whole body so any partial
+        # materialization performed by the consumer routes through
+        # release_cached_buffers below (which reclaims the persistent
+        # double-buffer slots a colocated vLLM wake_up needs handed back).
+        try:
+            yield
+        finally:
+            self.param_sync.release_all()
+            self.param_sync.discard_full_parameter_views()
+            # If the export scope is unwinding because the consumer raised (e.g.
+            # a downstream OOM), a collective may have been left mid-flight; force
+            # the cached-buffer release so its busy-buffer guard does not replace
+            # the primary exception with a spurious "active buffers" RuntimeError.
+            unwinding = sys.exc_info()[0] is not None
+            # Scope the export all-gather storage to this context. A
+            # full-parameter export materializes the whole (unsharded) model;
+            # under fsdp_double_buffer those all-gather buffers otherwise stay
+            # pinned in the allocator's persistent slots after release_all, so
+            # torch's caching allocator (and empty_cache / expandable_segments)
+            # can never hand that storage back to the driver -- it lives across
+            # the next colocated consumer's turn (e.g. a sleeping vLLM engine
+            # waking for RL weight resync) and starves it. That persistent
+            # cross-context retention is the resync-OOM bug; the export buffer's
+            # lifetime must end with the export. Returning the cached slots to
+            # the driver here makes the export release bounded like FSDP2's
+            # full_tensor path (which retains no persistent buffer); the slots
+            # are transparently re-allocated on the next export.
+            self.param_sync.release_cached_buffers(force=unwinding)
 
     def named_parameters(self, *args, **kwargs) -> Iterator[tuple[str, nn.Parameter]]:
         if not self._expose_sharded_parameters:

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/wrapper.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/wrapper.py
@@ -189,6 +189,24 @@ class MegatronFSDP(nn.Module):
             load_grad=load_grad,
         )
 
+    def release_export_scratch(self) -> None:
+        """Reclaim the training step's all-gather scratch before a colocated wake.
+
+        verl's ``update_weights`` wakes the sleeping vLLM weight pool
+        (``resume(['weights'])``) *before* exporting M-FSDP weights. At that
+        point the trainer still pins the training step's transient all-gather
+        scratch -- the persistent double-buffer slots plus any full-parameter
+        views -- on top of the sharded weights and optimizer state, and vLLM's
+        cumem ``create_and_map`` OOMs. Hand that scratch back to the driver
+        (keeping the sharded weights resident as the export gather source) and
+        drain the caching allocator so the wake has room. This is the pre-wake
+        counterpart to ``full_parameter_context``'s post-export
+        ``release_cached_buffers``. See TASK-1.13.8.5.
+        """
+        self.param_sync.release_scratch_keep_weights()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
     def stream_full_parameters(self) -> Iterator[tuple[str, nn.Parameter]]:
         """Yield ``(name, full_param)`` one bucket at a time for export.
 

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import Callable, Iterator
+from contextlib import ExitStack
 from dataclasses import fields as dc_fields
 from datetime import timedelta
 from itertools import chain
@@ -350,11 +351,23 @@ class MegatronLiteRuntime(RuntimeBase):
         model_cfg = handle._extras.get("model_cfg")
         ps = handle._parallel_state
 
-        if proto and hasattr(proto, "export_hf_weights"):
-            yield from proto.export_hf_weights(model_chunks, model_cfg, ps, **kwargs)
-        else:
+        with ExitStack() as stack:
             for chunk in model_chunks:
-                yield from chunk.named_parameters()
+                full_parameter_context = getattr(chunk, "full_parameter_context", None)
+                if callable(full_parameter_context):
+                    stack.enter_context(full_parameter_context())
+
+            if proto and hasattr(proto, "export_hf_weights"):
+                yield from proto.export_hf_weights(model_chunks, model_cfg, ps, **kwargs)
+            else:
+                for chunk in model_chunks:
+                    # Prefer the bounded-bucket stream (M-FSDP) so the raw-param
+                    # fallback does not pre-materialize the whole model either.
+                    streamer = getattr(chunk, "stream_full_parameters", None)
+                    if callable(streamer):
+                        yield from streamer()
+                    else:
+                        yield from chunk.named_parameters()
 
     # ── Memory ──
 

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -369,6 +369,21 @@ class MegatronLiteRuntime(RuntimeBase):
                     else:
                         yield from chunk.named_parameters()
 
+    def release_export_scratch(self, handle: ModelHandle) -> None:
+        """Reclaim M-FSDP all-gather scratch before a colocated vLLM weight wake.
+
+        Loops the model chunks and asks each M-FSDP wrapper to hand its retained
+        double-buffer scratch back to the driver while keeping the sharded
+        weights resident (the export gather source that runs right after the
+        wake). No-op for chunks that do not expose the hook (non-M-FSDP
+        backends). See TASK-1.13.8.5.
+        """
+        model_chunks = handle._extras.get("model_chunks", [handle._model])
+        for chunk in model_chunks:
+            release = getattr(chunk, "release_export_scratch", None)
+            if callable(release):
+                release()
+
     # ── Memory ──
 
     def to(

--- a/experimental/lite/megatron/lite/runtime/megatron_utils.py
+++ b/experimental/lite/megatron/lite/runtime/megatron_utils.py
@@ -99,7 +99,10 @@ def _is_megatron_ddp(model_chunk: Any) -> bool:
 def offload_model_to_cpu(model_list: list) -> None:
     """Offload DDP model to CPU via buffer-resize (zero-copy on GPU side)."""
     for model_chunk in model_list:
-        if _is_megatron_ddp(model_chunk):
+        move_model_state = getattr(model_chunk, "move_model_state", None)
+        if callable(move_model_state):
+            move_model_state(torch.device("cpu"), load_grad=True)
+        elif _is_megatron_ddp(model_chunk):
             all_buffers = [model_chunk.buffers, model_chunk.expert_parallel_buffers]
             for buffers in all_buffers:
                 for buffer in buffers:
@@ -122,7 +125,13 @@ def offload_model_to_cpu(model_list: list) -> None:
 def load_model_to_gpu(model_list: list, load_grad: bool = True) -> None:
     """Load DDP model back to GPU from pinned CPU copy."""
     for model_chunk in model_list:
-        if _is_megatron_ddp(model_chunk):
+        move_model_state = getattr(model_chunk, "move_model_state", None)
+        if callable(move_model_state):
+            move_model_state(
+                torch.device("cuda"),
+                load_grad=load_grad,
+            )
+        elif _is_megatron_ddp(model_chunk):
             all_buffers = [model_chunk.buffers, model_chunk.expert_parallel_buffers]
             for buffers in all_buffers:
                 for buffer in buffers:

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -719,6 +719,136 @@ def test_mfsdp_cpu_single_rank_matches_torch_adamw_optimizer_step():
         assert torch.equal(value, restored_model[name]), name
 
 
+def _single_rank_mfsdp_stack():
+    """Build a trained single-rank M-FSDP stack for scratch-release tests."""
+
+    class _Unit(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(4, 4, bias=False)
+
+        def forward(self, value):
+            return torch.nn.functional.gelu(self.linear(value))
+
+    class _Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.unit0 = _Unit()
+            self.unit1 = _Unit()
+            self.out = torch.nn.Linear(4, 2, bias=False)
+
+        def forward(self, value):
+            return self.out(self.unit1(self.unit0(value)))
+
+    torch.manual_seed(123)
+    ps = SimpleNamespace(
+        dp_cp_group=None,
+        dp_group=None,
+        ep_dp_group=None,
+        ep_group=None,
+        tp_group=None,
+        pp_group=None,
+        dp_cp_size=1,
+        expert_dp_size=1,
+    )
+    opt = SimpleNamespace(
+        optimizer="adam",
+        lr=1.0e-3,
+        min_lr=0.0,
+        weight_decay=0.0,
+        clip_grad=1000.0,
+        adam_beta1=0.9,
+        adam_beta2=0.999,
+        adam_eps=1.0e-8,
+        override_optimizer_config={"mfsdp_sharding_strategy": "optim_grads_params"},
+    )
+    chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [_Model()],
+        engine_cfg=SimpleNamespace(
+            parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1),
+            optimizer=opt,
+        ),
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_Unit,),
+    )
+    # One real train step so the double-buffer allocator has cached scratch and
+    # the optimizer holds shard-aliased params in their steady sharded state.
+    value = torch.randn(3, 4)
+    target = torch.randn(3, 2)
+    optimizer.zero_grad()
+    torch.nn.functional.mse_loss(chunks[0](value), target).backward()
+    optimizer.finish_grad_sync()
+    assert optimizer.step()[0]
+    return chunks[0], optimizer
+
+
+def test_mfsdp_release_export_scratch_keeps_weights_and_aliases():
+    chunk, _optimizer = _single_rank_mfsdp_stack()
+
+    # Byte-equivalent export reference: the full (materialized) parameters before
+    # the scratch release. Materializing installs full-parameter leases, so
+    # return to the sharded steady state (what the pre-wake production call sees,
+    # post optimizer.step) before releasing the scratch.
+    full_before = {
+        name: param.detach().clone() for name, param in chunk.named_parameters()
+    }
+    chunk.param_sync.release_all()
+    chunk.param_sync.discard_full_parameter_views()
+
+    # Record the sharded weight storage so we can prove it is not moved/rebuilt.
+    weight_storage = {
+        id(bucket): bucket.main_param_buffer.data_ptr()
+        for bucket in chunk.param_sync.buckets
+    }
+    weight_values = {
+        id(bucket): bucket.main_param_buffer.detach().clone()
+        for bucket in chunk.param_sync.buckets
+    }
+
+    chunk.release_export_scratch()
+
+    for bucket in chunk.param_sync.buckets:
+        # Sharded weights stay put (same storage, same values, still on CPU).
+        assert bucket.main_param_buffer.data_ptr() == weight_storage[id(bucket)]
+        assert bucket.main_param_buffer.device.type == "cpu"
+        assert torch.equal(bucket.main_param_buffer, weight_values[id(bucket)])
+        # The double-buffer scratch was handed back to the driver.
+        assert getattr(bucket.allocator, "_slots", {}) == {}
+        # Optimizer aliases still view the resident shard (no dangling storage).
+        for spec in bucket.specs:
+            assert spec.shard_param is not None
+            if spec.shard_numel:
+                expected = bucket.main_param_buffer.narrow(
+                    0, spec.local_offset, spec.shard_numel
+                )
+                assert spec.shard_param.data.data_ptr() == expected.data_ptr()
+            # Full-parameter views are dropped, not left aliasing freed scratch.
+            assert spec.full_param.data.numel() == 0
+
+    # Export after the release reproduces the pre-release parameters byte-for-byte.
+    full_after = {
+        name: param.detach().clone() for name, param in chunk.named_parameters()
+    }
+    assert full_before.keys() == full_after.keys()
+    for name in full_before:
+        assert torch.equal(full_before[name], full_after[name]), name
+
+
+def test_mfsdp_release_export_scratch_is_idempotent():
+    chunk, optimizer = _single_rank_mfsdp_stack()
+    chunk.release_export_scratch()
+    # A second release on already-sharded state must not raise (the busy-buffer
+    # guard passes: no collective is in flight) and must keep training usable.
+    chunk.release_export_scratch()
+    value = torch.randn(3, 4)
+    target = torch.randn(3, 2)
+    optimizer.zero_grad()
+    torch.nn.functional.mse_loss(chunk(value), target).backward()
+    optimizer.finish_grad_sync()
+    assert optimizer.step()[0]
+
+
 def test_mfsdp_bucket_policy_splits_one_unit_without_splitting_parameters():
     model = torch.nn.Module()
     model.weight0 = torch.nn.Parameter(torch.ones(4))

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -185,6 +185,7 @@ def test_mfsdp_source_layout_is_bounded():
 
     assert modules == {
         "__init__.py",
+        "backend.py",
         "buffer.py",
         "config.py",
         "fully_shard.py",

--- a/experimental/lite/tests/unit/primitive/test_mfsdp_release_cached_guard.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp_release_cached_guard.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""DoubleBufferAllocator.release_cached busy-buffer guard (exception-path fix).
+
+The guard exists to catch genuine misuse on the normal path — releasing the
+cache while a collective is legitimately in flight. But on an exception-driven
+teardown (``full_parameter_context`` unwinding because the export consumer
+raised, e.g. a downstream OOM) an aborted collective can leave a slot busy;
+raising there would replace the primary error with a misleading "active buffers"
+RuntimeError. ``force=True`` bypasses the guard so the cache is dropped and the
+primary exception survives. CPU-only — see TASK-1.13.8.5.
+"""
+import pytest
+
+from megatron.lite.primitive.optimizers.mfsdp.buffer import (
+    DoubleBufferAllocator,
+    NCCLUserBuffer,
+)
+
+
+def _allocator() -> DoubleBufferAllocator:
+    # enabled=False → CPU-safe (no CUDA / Apex NCCL pool needed).
+    ub = NCCLUserBuffer(enabled=False, groups=(), symmetric=True)
+    return DoubleBufferAllocator(ub)
+
+
+def test_release_cached_raises_when_a_buffer_is_busy_on_the_normal_path():
+    alloc = _allocator()
+    key = ("cuda", "bf16", 0)
+    alloc._slots[key] = [object(), None]
+    alloc._busy[key] = {0}  # simulate an in-flight collective
+    with pytest.raises(RuntimeError, match="active M-FSDP communication buffers"):
+        alloc.release_cached()
+    # Guard fired before clearing: the cache is left intact for the caller.
+    assert alloc._busy[key] == {0}
+
+
+def test_force_release_cached_drops_the_cache_despite_a_busy_buffer():
+    alloc = _allocator()
+    key = ("cuda", "bf16", 0)
+    alloc._slots[key] = [object(), None]
+    alloc._busy[key] = {0}
+    alloc._reuse_events[key] = [object(), None]
+    alloc.release_cached(force=True)  # must not raise
+    assert alloc._slots == {}
+    assert alloc._busy == {}
+    assert alloc._reuse_events == {}
+
+
+def test_release_cached_clears_when_no_buffer_is_busy():
+    alloc = _allocator()
+    key = ("cuda", "bf16", 0)
+    alloc._slots[key] = [object(), None]
+    alloc._busy[key] = set()  # nothing in flight
+    alloc.release_cached()  # force not needed; guard passes
+    assert alloc._slots == {}
+    assert alloc._busy == {}

--- a/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
+++ b/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
@@ -49,6 +49,26 @@ def test_runtime_returns_loss_separately_from_microbatch_metrics():
     assert result.model_output.loss is not None
 
 
+def test_release_export_scratch_routes_to_mfsdp_chunks_and_skips_plain_ones():
+    """Pre-wake scratch release loops the chunks and no-ops non-M-FSDP ones."""
+    released = []
+
+    class _MFSDPChunk:
+        def release_export_scratch(self):
+            released.append(id(self))
+
+    mfsdp_a, mfsdp_b = _MFSDPChunk(), _MFSDPChunk()
+    handle = ModelHandle(
+        model=nn.Linear(1, 1, bias=False),
+        parallel_state=types.SimpleNamespace(pp_size=1),
+        _extras={"model_chunks": [mfsdp_a, nn.Linear(1, 1), mfsdp_b]},
+    )
+
+    MegatronLiteRuntime.__new__(MegatronLiteRuntime).release_export_scratch(handle)
+
+    assert released == [id(mfsdp_a), id(mfsdp_b)]
+
+
 def test_pipeline_callbacks_accept_wrapped_and_presplit_context():
     context = LossContext(source_batch="source")
     seen = []

--- a/experimental/lite/tests/unit/verl/test_mlite_engine_resync_export.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_engine_resync_export.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Resync export release ordering: buffer/model handed to the driver before wake.
+
+Covers the two pure generator wrappers wired into ``get_per_tensor_param`` so
+the M-FSDP all-gather buffer and the reloaded model are returned to the driver
+before the colocated vLLM ``wake_up`` (the resync wake_up OOM fix). The critical
+invariant is release *ordering*: the offload/drain must fire once the export
+stream is consumed, even on early-abort or mid-stream failure. GPU/verl-free —
+see TASK-1.13.8.
+"""
+import torch
+
+from verl_mlite.resync_export import (
+    _DEFAULT_RESYNC_EXPORT_EMPTY_CACHE_GIB,
+    _RESYNC_EXPORT_EMPTY_CACHE_GIB_ENV,
+    offload_params_after_export,
+    resync_export_empty_cache_threshold_bytes,
+    stream_export_with_empty_cache,
+)
+
+
+def _pairs(sizes):
+    # float32 → 4 bytes/element, so a 1-D tensor of n elems is 4n bytes.
+    return [(f"w{i}", torch.zeros(n, dtype=torch.float32)) for i, n in enumerate(sizes)]
+
+
+def test_stream_export_is_transparent_to_the_consumer():
+    """Every (name, tensor) pair is yielded unchanged (export correctness)."""
+    src = _pairs([1, 2, 3])
+    out = list(stream_export_with_empty_cache(iter(src), 4, lambda: None))
+    assert [n for n, _ in out] == ["w0", "w1", "w2"]
+    for (_, got), (_, want) in zip(out, src):
+        assert got is want
+
+
+def test_flushes_once_per_threshold_plus_a_final_release():
+    """empty_cache fires per ≥threshold bytes of exported material, and once more
+    after the generator drains (the buffer-release-before-wake flush)."""
+    calls = {"n": 0}
+
+    def flush():
+        calls["n"] += 1
+
+    # Two 4-byte tensors per 8-byte threshold: flush after the 2nd tensor, then
+    # again after the 4th, then a final drain flush → 3 total.
+    src = _pairs([1, 1, 1, 1])
+    list(stream_export_with_empty_cache(iter(src), 8, flush))
+    assert calls["n"] == 3
+
+
+def test_final_flush_happens_even_without_a_mid_stream_flush():
+    """Below-threshold total still gets the buffer-release flush on drain."""
+    calls = {"n": 0}
+    src = _pairs([1])
+    list(stream_export_with_empty_cache(iter(src), 1 << 30, lambda: calls.__setitem__("n", calls["n"] + 1)))
+    assert calls["n"] == 1
+
+
+def test_disabled_threshold_is_pass_through_without_flushing():
+    calls = {"n": 0}
+    src = _pairs([1, 2])
+    out = list(stream_export_with_empty_cache(iter(src), 0, lambda: calls.__setitem__("n", calls["n"] + 1)))
+    assert [n for n, _ in out] == ["w0", "w1"]
+    assert calls["n"] == 0
+
+
+def test_final_flush_fires_when_consumer_aborts_early():
+    """Closing the wrapper mid-drain still returns the buffer to the driver."""
+    calls = {"n": 0}
+    src = _pairs([1, 1, 1, 1])
+    gen = stream_export_with_empty_cache(iter(src), 1 << 30, lambda: calls.__setitem__("n", calls["n"] + 1))
+    next(gen)  # consume one pair, then abandon
+    gen.close()
+    assert calls["n"] == 1
+
+
+def test_offload_after_export_is_transparent_and_offloads_on_drain():
+    """Every pair is yielded unchanged, then offload + drain fire once, in order."""
+    events = []
+    src = _pairs([1, 2, 3])
+    out = list(
+        offload_params_after_export(
+            iter(src),
+            lambda: events.append("offload"),
+            lambda: events.append("drain"),
+        )
+    )
+    assert [n for n, _ in out] == ["w0", "w1", "w2"]
+    assert events == ["offload", "drain"]  # ordering: model to CPU, then hard-drain
+
+
+def test_offload_after_export_fires_when_consumer_aborts_early():
+    """Model returns to CPU even if the consumer stops iterating mid-stream."""
+    events = []
+    src = _pairs([1, 1, 1])
+    gen = offload_params_after_export(
+        iter(src), lambda: events.append("offload"), lambda: events.append("drain")
+    )
+    next(gen)  # consume one pair, then abandon
+    gen.close()
+    assert events == ["offload", "drain"]
+
+
+def test_offload_after_export_offloads_even_when_stream_raises():
+    """A failure mid-export must not leave the model resident on the GPU."""
+    events = []
+
+    def boom():
+        yield ("w0", torch.zeros(1))
+        raise RuntimeError("export blew up")
+
+    gen = offload_params_after_export(
+        boom(), lambda: events.append("offload"), lambda: events.append("drain")
+    )
+    try:
+        list(gen)
+    except RuntimeError:
+        pass
+    assert events == ["offload", "drain"]
+
+
+def test_threshold_defaults_to_four_gib(monkeypatch):
+    monkeypatch.delenv(_RESYNC_EXPORT_EMPTY_CACHE_GIB_ENV, raising=False)
+    assert resync_export_empty_cache_threshold_bytes() == int(
+        _DEFAULT_RESYNC_EXPORT_EMPTY_CACHE_GIB * (1024**3)
+    )
+
+
+def test_threshold_env_override(monkeypatch):
+    monkeypatch.setenv(_RESYNC_EXPORT_EMPTY_CACHE_GIB_ENV, "2")
+    assert resync_export_empty_cache_threshold_bytes() == 2 * (1024**3)
+
+
+def test_threshold_zero_disables(monkeypatch):
+    monkeypatch.setenv(_RESYNC_EXPORT_EMPTY_CACHE_GIB_ENV, "0")
+    assert resync_export_empty_cache_threshold_bytes() == 0
+
+
+def test_threshold_negative_disables(monkeypatch):
+    monkeypatch.setenv(_RESYNC_EXPORT_EMPTY_CACHE_GIB_ENV, "-1")
+    assert resync_export_empty_cache_threshold_bytes() == 0
+
+
+def test_threshold_bad_value_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv(_RESYNC_EXPORT_EMPTY_CACHE_GIB_ENV, "not-a-number")
+    assert resync_export_empty_cache_threshold_bytes() == int(
+        _DEFAULT_RESYNC_EXPORT_EMPTY_CACHE_GIB * (1024**3)
+    )

--- a/experimental/lite/tests/unit/verl/test_mlite_engine_resync_release.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_engine_resync_release.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Train-mode context exit hands the post-step residual back before the vLLM wake.
+
+The colocated resync OOM fix (TASK-1.13.8.5) is internalized: instead of a
+verl-called hook, the engine releases the M-FSDP all-gather scratch and parks the
+optimizer at its own offload exit -- ``_MegatronLiteModeCtx.__exit__`` for the
+training-mode context, which verl's fit loop always runs at the end of
+``update_actor`` and before the subsequent ``update_weights`` weight-pool wake.
+These tests pin that the release fires exactly on the clean train exit (not on
+eval, not on a faulted exit) and keeps the sharded weights resident.
+"""
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import pytest
+from verl_mlite.engine.config import MegatronLiteEngineConfig
+from verl_mlite.engine.mlite_engine import MegatronLiteEngine
+
+
+@pytest.fixture(autouse=True)
+def _single_process_dist(monkeypatch):
+    monkeypatch.setattr("verl_mlite.engine.mlite_engine.dist.is_initialized", lambda: False)
+
+
+def _optimizer_config() -> SimpleNamespace:
+    return SimpleNamespace(
+        optimizer="adam",
+        lr=1e-6,
+        min_lr=None,
+        min_lr_ratio=None,
+        clip_grad=1.0,
+        weight_decay=0.1,
+        lr_warmup_steps_ratio=0.0,
+        total_training_steps=10,
+        lr_warmup_steps=0,
+        override_optimizer_config={},
+    )
+
+
+def _engine_config(**kwargs) -> MegatronLiteEngineConfig:
+    values = {"custom_backend_module": None, "impl_cfg": {"use_thd": True}}
+    values.update(kwargs)
+    return MegatronLiteEngineConfig(**values)
+
+
+def _initialized_engine(*, param_offload=False, optimizer_offload=False):
+    engine = MegatronLiteEngine(
+        model_config=SimpleNamespace(
+            local_path="/tmp/qwen35", hf_config={"model_type": "qwen3_5_moe"}, mtp=None
+        ),
+        engine_config=_engine_config(
+            param_offload=param_offload, optimizer_offload=optimizer_offload
+        ),
+        optimizer_config=_optimizer_config(),
+        checkpoint_config={},
+    )
+
+    release_calls = []
+
+    @contextmanager
+    def _mode_ctx(_handle):
+        yield
+
+    runtime = SimpleNamespace(
+        train_mode=_mode_ctx,
+        eval_mode=_mode_ctx,
+        release_export_scratch=lambda handle: release_calls.append(handle),
+    )
+    handle = SimpleNamespace(_optimizer=object(), _lr_scheduler=object())
+    engine.runtime = runtime
+    engine.handle = handle
+    return engine, release_calls, handle
+
+
+def _wire_recorders(engine, monkeypatch):
+    to_calls = []
+    empty_cache_calls = []
+    monkeypatch.setattr(engine, "to", lambda **kwargs: to_calls.append(kwargs))
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.aggressive_empty_cache",
+        lambda **kwargs: empty_cache_calls.append(kwargs),
+    )
+    return to_calls, empty_cache_calls
+
+
+def test_train_mode_exit_releases_scratch_and_parks_optimizer(monkeypatch):
+    # param_offload on, optimizer_offload off: the generic offload leaves the Adam
+    # moments on GPU, so the internalized release must park them before the wake.
+    engine, release_calls, handle = _initialized_engine(
+        param_offload=True, optimizer_offload=False
+    )
+    to_calls, empty_cache_calls = _wire_recorders(engine, monkeypatch)
+
+    with engine.train_mode():
+        pass
+
+    # Scratch handed back to the driver + allocator drained exactly once.
+    assert release_calls == [handle]
+    assert empty_cache_calls == [{"force_sync": True}]
+    # The optimizer park is the only cpu-move with optimizer=True/model=False; the
+    # sharded weights are NOT moved by the release (they stay resident as the
+    # export gather source -- the generic context offload owns model movement).
+    park_calls = [c for c in to_calls if c.get("optimizer") and not c.get("model")]
+    assert park_calls == [{"device": "cpu", "model": False, "optimizer": True, "grad": False}]
+
+
+def test_train_mode_exit_skips_optimizer_park_when_already_offloaded(monkeypatch):
+    # optimizer_offload on: the generic exit already parks the Adam moments, so the
+    # release must not double-park; it still drops the scratch + drains.
+    engine, release_calls, handle = _initialized_engine(
+        param_offload=True, optimizer_offload=True
+    )
+    to_calls, empty_cache_calls = _wire_recorders(engine, monkeypatch)
+
+    with engine.train_mode():
+        pass
+
+    assert release_calls == [handle]
+    assert empty_cache_calls == [{"force_sync": True}]
+    park_calls = [c for c in to_calls if c.get("optimizer") and not c.get("model")]
+    assert park_calls == []
+
+
+def test_eval_mode_exit_does_not_release_scratch(monkeypatch):
+    engine, release_calls, _ = _initialized_engine(param_offload=True)
+    _to_calls, empty_cache_calls = _wire_recorders(engine, monkeypatch)
+
+    with engine.eval_mode():
+        pass
+
+    assert release_calls == []
+    assert empty_cache_calls == []
+
+
+def test_faulted_train_exit_does_not_release_scratch(monkeypatch):
+    # A training pass that raises must not run the resync release: the state may be
+    # inconsistent and no weight wake follows a failed update_actor.
+    engine, release_calls, _ = _initialized_engine(param_offload=True)
+    _to_calls, empty_cache_calls = _wire_recorders(engine, monkeypatch)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with engine.train_mode():
+            raise RuntimeError("boom")
+
+    assert release_calls == []
+    assert empty_cache_calls == []


### PR DESCRIPTION
## What this PR fixes

The M-FSDP resync/weight-export path OOMs the **colocated vLLM** at the first
few weight-resync cycles of DAPO RL. The root cause is a **release-ordering
collision, not a memory leak** — the fsdp2 baseline survives 12 cycles with a
near-identical peak footprint (61.2 vs 59.7 GiB on the busiest EP rank).

`get_per_tensor_param` reloads the sharded model back onto the GPU to run the
M-FSDP HF export, but — unlike `save_checkpoint` / `load_checkpoint` — never
offloads it again. In the colocated param-offload config the steady state is
*model-on-CPU*, so the reloaded model plus the export-peak residue stay
resident on the shared device. The colocated vLLM uses a **separate (cumem)
allocator on the same physical device**, so its `wake_up` then OOMs in
`create_and_map` (`cumem_allocator.cpp:139`) with only ~20 GiB free, whereas
fsdp2 survives at 166 MiB free. It is purely an ordering problem.

## The fix (two coupled changes)

1. **Bound the HF export peak** (`hf_weights.py`): gather each expert group as
   it completes instead of materializing the whole model before the EP gather,
   so the transient export peak no longer scales with the full model.
2. **Offload after export, before wake** (`mlite_engine.py` /
   `resync_export.py`): return the model to CPU and drain the caching allocator
   in the export generator's `finally` (`offload_params_after_export`),
   guaranteeing the model is off the GPU before the consumer triggers vLLM
   `wake_up` — even if the consumer stops early or raises.

## Supporting M-FSDP wiring

Bounded-bucket streaming export (`optimizers/mfsdp/{buffer,wrapper,backend}.py`),
`full_parameter_context` / `stream_full_parameters` plumbing in the Lite runtime,
and `move_model_state`-based CPU offload. Focused unit coverage lives in
`test_mlite_engine_resync_export.py`.

## Scope

This PR is intentionally scoped to the OOM fix. Diagnostic scaffolding (the
per-cycle probe harness, the port-plan design doc, and broad parity/config test
suites) is kept out of this PR and preserved in tag
`pr105-pre-minimize-d29cce7f1`.


## Follow-up: pre-wake trainer-scratch release (internalized into the engine)

The post-export offload above protects the *export* peak, but the colocated
OOM survived it: the death moves earlier, into `update_weights` at
`rollout.resume(["weights"])` — the vLLM weight-pool wake that runs *before*
the M-FSDP export. At that moment the trainer still pins its post-train-step
residual (optimizer Adam moments + the M-FSDP all-gather double-buffer
scratch), which collides with vLLM's cumem `create_and_map`. The
after-export offload runs too late to help this wake.

The fix frees that residual *before* the wake, keeping the sharded weights
resident as the export gather source (the export streams per-bucket at a small
transient scratch, so the persistent double buffer is not needed for it):

- `buffer.py`: `ParamBucket.release_scratch_keep_weights()` extracts
  `move_model_state`'s scratch-release prologue without moving
  `main_param_buffer`, so the optimizer-aliased shard views stay valid.
- `wrapper.py` / `runtime.py`: `release_export_scratch()` loops the buckets and
  drains the caching allocator; no-op for non-M-FSDP backends.
- `mlite_engine.py`: the engine parks the optimizer state on CPU (reversible,
  gated on `param_offload` and skipped when `optimizer_offload` already parks
  it), releases the M-FSDP scratch, and drains.

**Layering:** this release is invoked from the engine's own offload point —
`_MegatronLiteModeCtx.__exit__` on a clean training-mode exit — not from a
driver-side callback. The trainer's fit loop already exits the train context at
the end of `update_actor`, strictly before `update_weights` wakes the rollout
weight pool, so the ordering guarantee holds with no driver knowledge of M-FSDP
internals. (An earlier iteration reached the engine through a
`release_train_scratch_before_resync` hook in the driver; that hook is removed
and the logic internalized here.)

**Validation:** a colocated DAPO run cleared the resync wake and trained
several steps to ~55% accuracy, confirming the ordering fix. Correctness is
pinned by unit coverage: shard alias integrity (data-ptr unchanged across the
release), idempotent double-release, and byte-equivalent export after the
release (`test_mfsdp.py`), plus the engine-exit gating
(`test_mlite_engine_resync_release.py`). mfsdp/runtime primitive suites pass and
ruff is clean.
