### PR TITLE
[review] GDN CP: port upstream headwise (head-parallel a2a)

### DIFF
--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
@@ -237,7 +237,7 @@ class Qwen35Layer(nn.Module):
         moe_act_recompute: bool = False,
         use_thd: bool = False,
         deterministic: bool = False,
-        gdn_cp_mode: str = "replicated",
+        gdn_cp_mode: str = "headwise",
     ):
         super().__init__()
         self.layer_idx = layer_idx
@@ -341,7 +341,7 @@ class Qwen35Model(nn.Module):
         mtp_enable_train: bool = False,
         mtp_detach_encoder: bool = False,
         mount_vision_model: bool = False,
-        gdn_cp_mode: str = "replicated",
+        gdn_cp_mode: str = "headwise",
     ):
         super().__init__()
         del attention_backend_override

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
@@ -66,7 +66,10 @@ class ImplConfig:
     mtp_loss_scaling_factor: float = 0.1
     mtp_use_repeated_layer: bool | None = None
     mount_vision_model: bool = False
-    gdn_cp_mode: str = "replicated"
+    # GatedDeltaNet context-parallel mode: "headwise" (default, head-parallel a2a;
+    # bitwise-exact vs CP-off and memory-sharded) or "replicated" (all-gather, exact
+    # but full sequence replicated on every rank).
+    gdn_cp_mode: str = "headwise"
 
 
 def _full_attn_module(layer, name: str):

--- a/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
@@ -1,5 +1,24 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-"""Qwen-style Gated DeltaNet primitive."""
+"""Qwen-style Gated DeltaNet primitive.
+
+Context-parallel (CP) modes
+---------------------------
+- ``headwise`` (default under CP): head-parallel all-to-all. Each rank all-to-alls
+  its zigzag sequence shard so it ends up holding the *full* sequence for ``1/cp`` of
+  the heads (with the matching slices of conv1d / A_log / dt_bias), runs the ordinary
+  full-sequence gated-delta recurrence, then all-to-alls back. Heads are independent,
+  so this is numerically **bitwise-identical to CP-off** while sharding the per-head
+  state/activation memory across ranks. This mirrors upstream Megatron
+  ``linear_cp_mode='headwise'`` (``megatron/core/ssm/gated_delta_net.py``).
+- ``replicated``: all-gather the sequence, run the full recurrence on every rank
+  (every head replicated), zigzag-slice the output. Also bitwise-identical to CP-off,
+  but every rank materialises the full sequence for *all* heads (worst memory).
+
+The FLA chunkwise ``cp_context`` ring path (formerly ``sharded``) has been removed:
+its cross-rank chunk-state accumulation order differs from the reference, which under
+RL amplifies bf16 rounding into a large train/inference log-prob mismatch. Use
+``headwise`` for a memory-efficient *and* numerically exact CP linear-attention.
+"""
 
 from __future__ import annotations
 
@@ -19,10 +38,11 @@ from megatron.lite.primitive.parallel import (
     RowParallelLinear,
 )
 from megatron.lite.primitive.parallel.cp import (
-    contiguous_to_zigzag_chunks,
+    all_to_all_hidden_shards,
+    build_headwise_section_perm,
+    get_parameter_local_cp_headwise,
     zigzag_reconstruct_from_cp_parts,
     zigzag_slice_for_cp,
-    zigzag_to_contiguous_chunks,
 )
 from megatron.lite.primitive.parallel.thd import (
     reconstruct_packed_from_cp_parts,
@@ -43,16 +63,13 @@ try:
 except ImportError:
     _HAS_FLA = False
 
-try:
-    from fla.ops.cp import build_cp_context as _fla_build_cp_context  # pyright: ignore[reportMissingImports]
-except ImportError:
-    _fla_build_cp_context = None
-
 _CONV_PAD_ALIGNMENT = 4096
+
+_CP_MODES = {"headwise", "replicated"}
 
 
 class GatedDeltaNet(nn.Module):
-    """Native Gated DeltaNet with dense/packed all-gather CP support."""
+    """Native Gated DeltaNet with head-parallel / replicated CP support."""
 
     def __init__(
         self,
@@ -66,11 +83,13 @@ class GatedDeltaNet(nn.Module):
         rms_norm_eps: float,
         ps: ParallelState,
         deterministic: bool = False,
-        cp_mode: str = "replicated",
+        cp_mode: str = "headwise",
     ):
         super().__init__()
-        if cp_mode not in {"sharded", "replicated"}:
-            raise ValueError(f"Unsupported GatedDeltaNet CP mode: {cp_mode!r}.")
+        if cp_mode not in _CP_MODES:
+            raise ValueError(
+                f"Unsupported GatedDeltaNet CP mode: {cp_mode!r}; expected one of {sorted(_CP_MODES)}."
+            )
         self.ps = ps
         self.deterministic = bool(deterministic)
         self.cp_mode = cp_mode
@@ -97,6 +116,7 @@ class GatedDeltaNet(nn.Module):
             zero_centered_gamma=True,
         )
         conv_dim_local = self.qk_dim_local * 2 + self.v_dim_local
+        self.conv_dim_local = conv_dim_local
         self.conv1d = nn.Conv1d(
             in_channels=conv_dim_local,
             out_channels=conv_dim_local,
@@ -113,9 +133,20 @@ class GatedDeltaNet(nn.Module):
         )
         self.norm = te.RMSNorm(self.dv, eps=rms_norm_eps, zero_centered_gamma=True)
         self.o_proj = RowParallelLinear(self.v_dim, hidden_size, ps, bias=False)
-        self._cp_context_cache: dict[
-            tuple[int, int, torch.device], tuple[torch.Tensor, object]
-        ] = {}
+
+    # The six ``qkvzba`` sections and the three conv channel sections, in hidden order.
+    def _qkvzba_sections(self) -> list[int]:
+        return [
+            self.qk_dim_local,
+            self.qk_dim_local,
+            self.v_dim_local,
+            self.v_dim_local,
+            self.num_v_heads_local,
+            self.num_v_heads_local,
+        ]
+
+    def _conv_sections(self) -> list[int]:
+        return [self.qk_dim_local, self.qk_dim_local, self.v_dim_local]
 
     def forward(
         self, x: torch.Tensor, position_ids: torch.Tensor | None = None, packed_seq_params=None
@@ -124,32 +155,47 @@ class GatedDeltaNet(nn.Module):
         is_packed = packed_seq_params is not None
         qkvzba = self.in_proj(x).transpose(0, 1).contiguous()
         cu_seqlens = self._packed_cu_seqlens(packed_seq_params) if is_packed else None
-        cp_context = None
+
+        headwise = False
         replicated = False
+        cp_div = 1
         if self.ps.cp_size > 1:
             if self.ps.cp_group is None:
                 raise RuntimeError("CP>1 requires ParallelState.cp_group.")
             if self.cp_mode == "replicated":
                 qkvzba, cu_seqlens = self._replicate_cp_qkvzba(qkvzba, cu_seqlens)
                 replicated = True
-            else:
-                if not _HAS_FLA or _fla_build_cp_context is None:
-                    raise NotImplementedError(
-                        "GatedDeltaNet all-gather CP requires FLA kernels."
-                    )
+            else:  # headwise
                 if not is_packed and qkvzba.shape[0] > 1:
                     raise ValueError(
-                        "GatedDeltaNet all-gather CP with SBHD inputs currently requires "
+                        "GatedDeltaNet headwise CP with SBHD inputs currently requires "
                         "micro_batch_size == 1. Use packed THD input or micro_batch_size=1."
                     )
-                qkvzba = self._cp_swap_qkvzba(
-                    qkvzba,
-                    cu_seqlens if is_packed else None,
-                    to_contiguous=True,
-                )
-                cu_seqlens, cp_context = self._build_cp_context(qkvzba, cu_seqlens)
+                qkvzba, cu_seqlens = self._headwise_cp2hp(qkvzba, cu_seqlens)
+                headwise = True
+                cp_div = self.ps.cp_size
+
         batch, seq_len = qkvzba.shape[:2]
-        query, key, value, gate, beta, alpha = self._split_proj(qkvzba)
+
+        # Per-rank parameter slices (identity unless headwise).
+        if headwise:
+            conv_weight = get_parameter_local_cp_headwise(
+                self.conv1d.weight,
+                dim=0,
+                cp_size=self.ps.cp_size,
+                cp_rank=self.ps.cp_rank,
+                split_sections=self._conv_sections(),
+            )
+            A_log = get_parameter_local_cp_headwise(
+                self.A_log, dim=0, cp_size=self.ps.cp_size, cp_rank=self.ps.cp_rank
+            )
+            dt_bias = get_parameter_local_cp_headwise(
+                self.dt_bias, dim=0, cp_size=self.ps.cp_size, cp_rank=self.ps.cp_rank
+            )
+        else:
+            conv_weight, A_log, dt_bias = None, self.A_log, self.dt_bias
+
+        query, key, value, gate, beta, alpha = self._split_proj(qkvzba, cp_div)
         qkv = torch.cat(
             [
                 query.reshape(batch, seq_len, -1),
@@ -160,12 +206,12 @@ class GatedDeltaNet(nn.Module):
         )
 
         qkv = self._causal_conv1d(
-            qkv, seq_len, cu_seqlens=cu_seqlens, cp_context=cp_context
+            qkv, seq_len, cu_seqlens=cu_seqlens, conv_weight=conv_weight, cp_div=cp_div
         )
         query, key, value, gate, beta, alpha = self._prepare_qkv(
-            qkv, gate, beta, alpha, batch, seq_len
+            qkv, gate, beta, alpha, batch, seq_len, cp_div
         )
-        g, beta = self._compute_g_and_beta(self.A_log, self.dt_bias, alpha, beta)
+        g, beta = self._compute_g_and_beta(A_log, dt_bias, alpha, beta)
         out, _ = self._gated_delta_rule(
             query,
             key,
@@ -175,24 +221,20 @@ class GatedDeltaNet(nn.Module):
             initial_state=None,
             output_final_state=False,
             cu_seqlens=cu_seqlens,
-            cp_context=cp_context,
         )
 
         out = self._apply_gated_norm(out, gate)
-        out = out.reshape(batch, seq_len, self.v_dim_local)
+        out = out.reshape(batch, seq_len, self.v_dim_local // cp_div)
         if self.ps.cp_size > 1:
             if replicated:
                 out = self._slice_replicated_output(out, cu_seqlens)
-            else:
-                out = self._cp_swap_qkvzba(
-                    out,
-                    cu_seqlens if is_packed else None,
-                    to_contiguous=False,
-                )
+            else:  # headwise
+                out = self._headwise_hp2cp(out, cu_seqlens)
             batch, seq_len = out.shape[:2]
         out = out.transpose(0, 1).contiguous()
         return self.o_proj(out)
 
+    # ------------------------------------------------------------------ CP: replicated
     def _all_gather_cp_tensor(self, tensor: torch.Tensor) -> list[torch.Tensor]:
         if self.ps.cp_size <= 1:
             return [tensor]
@@ -242,91 +284,94 @@ class GatedDeltaNet(nn.Module):
         )
         return local.unsqueeze(0).contiguous()
 
-    def _cp_swap_qkvzba(
-        self,
-        tensor: torch.Tensor,
-        cu_seqlens: torch.Tensor | None,
-        *,
-        to_contiguous: bool,
-    ) -> torch.Tensor:
-        if cu_seqlens is None:
-            swap = (
-                zigzag_to_contiguous_chunks
-                if to_contiguous
-                else contiguous_to_zigzag_chunks
-            )
-            return swap(tensor, self.ps.cp_group, seq_dim=1)
-        if tensor.shape[0] != 1:
-            raise ValueError(
-                "Packed THD GatedDeltaNet expects a single packed batch row."
-            )
-        local_cu_seqlens = cu_seqlens // self.ps.cp_size
-        pieces = []
-        swap = (
-            zigzag_to_contiguous_chunks
-            if to_contiguous
-            else contiguous_to_zigzag_chunks
-        )
-        for idx in range(int(local_cu_seqlens.numel()) - 1):
-            start = int(local_cu_seqlens[idx].item())
-            end = int(local_cu_seqlens[idx + 1].item())
-            if end <= start:
-                continue
-            pieces.append(swap(tensor[:, start:end, :], self.ps.cp_group, seq_dim=1))
-        if not pieces:
-            return tensor
-        return torch.cat(pieces, dim=1).contiguous()
-
-    def _build_cp_context(
+    # ------------------------------------------------------------------ CP: headwise
+    def _headwise_cp2hp(
         self,
         qkvzba: torch.Tensor,
         cu_seqlens: torch.Tensor | None,
-    ) -> tuple[torch.Tensor, object]:
-        if _fla_build_cp_context is None:
-            raise NotImplementedError(
-                "GatedDeltaNet all-gather CP requires FLA cp context."
-            )
-        if cu_seqlens is not None:
-            return (
-                cu_seqlens,
-                _fla_build_cp_context(
-                    cu_seqlens=cu_seqlens,
-                    group=self.ps.cp_group,
-                    conv1d_kernel_size=self.conv1d.kernel_size[0],
-                ),
-            )
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Zigzag-sharded ``[b, s_local, h]`` -> contiguous full-seq ``[b, s_global, h/cp]``.
 
-        batch, local_seq_len = qkvzba.shape[:2]
-        global_seq_len = local_seq_len * self.ps.cp_size
-        cache_key = (global_seq_len, batch, qkvzba.device)
-        cached = self._cp_context_cache.get(cache_key)
-        if cached is None:
-            dense_cu_seqlens = (
-                torch.arange(batch + 1, device=qkvzba.device, dtype=torch.long)
-                * global_seq_len
-            )
-            cached = (
-                dense_cu_seqlens,
-                _fla_build_cp_context(
-                    cu_seqlens=dense_cu_seqlens,
-                    group=self.ps.cp_group,
-                    conv1d_kernel_size=self.conv1d.kernel_size[0],
-                ),
-            )
-            self._cp_context_cache[cache_key] = cached
-        return cached
+        Permutes the hidden dim section-wise so a plain hidden-scatter all-to-all leaves
+        each rank with ``1/cp`` heads of every section, then reassembles the full
+        sequence from the per-rank shards with the same (verified) reconstruction used by
+        ``replicated``.
+        """
+        cp_size = self.ps.cp_size
+        perm = build_headwise_section_perm(
+            self._qkvzba_sections(), cp_size, qkvzba.device
+        )
+        qkvzba = qkvzba.index_select(-1, perm)
+        h = qkvzba.shape[-1]
+        hpc = h // cp_size
+        send_parts = [qkvzba[..., k * hpc : (k + 1) * hpc].contiguous() for k in range(cp_size)]
+        recv = all_to_all_hidden_shards(send_parts, self.ps.cp_group)
+        if cu_seqlens is None:
+            full = zigzag_reconstruct_from_cp_parts(recv, seq_dim=1)
+            return full.contiguous(), None
+        if qkvzba.shape[0] != 1:
+            raise ValueError("Packed THD GatedDeltaNet expects a single packed batch row.")
+        parts = [p[0].contiguous() for p in recv]
+        full = reconstruct_packed_from_cp_parts(
+            parts,
+            cu_seqlens_padded=cu_seqlens,
+            cp_size=cp_size,
+            dim=0,
+        )
+        return full.unsqueeze(0).contiguous(), cu_seqlens
 
+    def _headwise_hp2cp(
+        self,
+        out: torch.Tensor,
+        cu_seqlens: torch.Tensor | None,
+    ) -> torch.Tensor:
+        """Inverse of :meth:`_headwise_cp2hp` for the value output.
+
+        Full-seq ``[b, s_global, v/cp]`` (this rank owns value-head shard ``cp_rank``) ->
+        zigzag-sharded ``[b, s_local, v]`` with all heads. The value section's per-rank
+        blocks are contiguous, so concatenating the received hidden shards in rank order
+        restores the natural head order (no inverse permutation required).
+        """
+        cp_size = self.ps.cp_size
+        if cu_seqlens is None:
+            send_parts = [
+                zigzag_slice_for_cp(out, j, cp_size, seq_dim=1).contiguous()
+                for j in range(cp_size)
+            ]
+            recv = all_to_all_hidden_shards(send_parts, self.ps.cp_group)
+            return torch.cat(recv, dim=-1).contiguous()
+        if out.shape[0] != 1:
+            raise ValueError("Packed THD GatedDeltaNet expects a single packed batch row.")
+        base = out[0].contiguous()
+        send_parts = [
+            split_packed_to_cp_local(
+                base,
+                cu_seqlens_padded=cu_seqlens,
+                cp_size=cp_size,
+                cp_rank=j,
+                dim=0,
+            ).contiguous()
+            for j in range(cp_size)
+        ]
+        recv = all_to_all_hidden_shards(send_parts, self.ps.cp_group)
+        return torch.cat(recv, dim=-1).unsqueeze(0).contiguous()
+
+    # ------------------------------------------------------------------ compute
     def _causal_conv1d(
         self,
         qkv: torch.Tensor,
         seq_len: int,
         *,
         cu_seqlens: torch.Tensor | None,
-        cp_context,
+        conv_weight: torch.Tensor | None,
+        cp_div: int,
     ) -> torch.Tensor:
-        if _HAS_FLA and (cp_context is not None or cu_seqlens is not None or not self.deterministic):
+        # ``conv_weight`` is the (headwise) per-rank slice; None means use the full module.
+        weight = self.conv1d.weight if conv_weight is None else conv_weight
+        groups = self.conv_dim_local // cp_div
+        if _HAS_FLA and (cu_seqlens is not None or not self.deterministic):
             orig_seq_len = qkv.shape[1]
-            pad_n = 0 if cp_context is not None else (-orig_seq_len % _CONV_PAD_ALIGNMENT)
+            pad_n = -orig_seq_len % _CONV_PAD_ALIGNMENT
             conv_input = qkv
             conv_cu_seqlens = cu_seqlens
             if pad_n > 0:
@@ -334,24 +379,25 @@ class GatedDeltaNet(nn.Module):
                 if conv_cu_seqlens is not None:
                     conv_cu_seqlens = conv_cu_seqlens.clone()
                     conv_cu_seqlens[-1] += pad_n
-            kwargs = {}
-            if cp_context is not None:
-                kwargs["cp_context"] = cp_context
             qkv, _ = _fla_causal_conv1d(
                 x=conv_input,
-                weight=self.conv1d.weight.squeeze(1),
+                weight=weight.squeeze(1),
                 bias=None,
                 activation="silu",
                 cu_seqlens=conv_cu_seqlens,
-                **kwargs,
             )
             if pad_n > 0:
                 qkv = qkv[:, :orig_seq_len, :]
             return qkv
-        if cu_seqlens is None and cp_context is None:
-            return F.silu(
-                self.conv1d(qkv.transpose(1, 2))[:, :, :seq_len].transpose(1, 2)
+        if cu_seqlens is None:
+            conv_out = F.conv1d(
+                qkv.transpose(1, 2),
+                weight=weight,
+                bias=None,
+                padding=self.conv1d.padding[0],
+                groups=groups,
             )
+            return F.silu(conv_out[:, :, :seq_len].transpose(1, 2))
         raise NotImplementedError("GatedDeltaNet packed THD requires FLA causal conv.")
 
     def _gated_delta_rule(
@@ -365,12 +411,8 @@ class GatedDeltaNet(nn.Module):
         initial_state: torch.Tensor | None,
         output_final_state: bool,
         cu_seqlens: torch.Tensor | None,
-        cp_context,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        if _HAS_FLA and (cp_context is not None or not self.deterministic):
-            kwargs = {}
-            if cp_context is not None:
-                kwargs["cp_context"] = cp_context
+        if _HAS_FLA and (cu_seqlens is not None or not self.deterministic):
             return _fla_chunk_gated_delta_rule(
                 query,
                 key,
@@ -381,11 +423,6 @@ class GatedDeltaNet(nn.Module):
                 output_final_state=output_final_state,
                 use_qk_l2norm_in_kernel=False,
                 cu_seqlens=cu_seqlens,
-                **kwargs,
-            )
-        if cp_context is not None:
-            raise NotImplementedError(
-                "GatedDeltaNet all-gather CP requires FLA gated delta rule."
             )
         return torch_chunk_gated_delta_rule(
             query,
@@ -410,39 +447,33 @@ class GatedDeltaNet(nn.Module):
             )
         return cu_seqlens
 
-    def _split_proj(self, qkvzba: torch.Tensor):
-        q, k, v, z, b, a = qkvzba.split(
-            [
-                self.qk_dim_local,
-                self.qk_dim_local,
-                self.v_dim_local,
-                self.v_dim_local,
-                self.num_v_heads_local,
-                self.num_v_heads_local,
-            ],
-            dim=-1,
-        )
+    def _split_proj(self, qkvzba: torch.Tensor, cp_div: int):
+        qk = self.qk_dim_local // cp_div
+        vd = self.v_dim_local // cp_div
+        nvh = self.num_v_heads_local // cp_div
+        nkh = self.num_k_heads_local // cp_div
+        q, k, v, z, b, a = qkvzba.split([qk, qk, vd, vd, nvh, nvh], dim=-1)
         batch, seq_len = qkvzba.shape[:2]
         return (
-            q.reshape(batch, seq_len, self.num_k_heads_local, self.dk),
-            k.reshape(batch, seq_len, self.num_k_heads_local, self.dk),
-            v.reshape(batch, seq_len, self.num_v_heads_local, self.dv),
-            z.reshape(batch, seq_len, self.num_v_heads_local, self.dv),
-            b.reshape(batch, seq_len, self.num_v_heads_local),
-            a.reshape(batch, seq_len, self.num_v_heads_local),
+            q.reshape(batch, seq_len, nkh, self.dk),
+            k.reshape(batch, seq_len, nkh, self.dk),
+            v.reshape(batch, seq_len, nvh, self.dv),
+            z.reshape(batch, seq_len, nvh, self.dv),
+            b.reshape(batch, seq_len, nvh),
+            a.reshape(batch, seq_len, nvh),
         )
 
     @jit_fuser
     def _prepare_qkv(
-        self, qkv: torch.Tensor, gate, beta, alpha, batch: int, seq_len: int
+        self, qkv: torch.Tensor, gate, beta, alpha, batch: int, seq_len: int, cp_div: int
     ):
-        query_key, value = qkv.split([2 * self.qk_dim_local, self.v_dim_local], dim=-1)
-        query_key = query_key.reshape(
-            batch, seq_len, 2 * self.num_k_heads_local, self.dk
-        )
-        value = value.reshape(batch, seq_len, self.num_v_heads_local, self.dv)
+        qk = self.qk_dim_local // cp_div
+        nkh = self.num_k_heads_local // cp_div
+        query_key, value = qkv.split([2 * qk, self.v_dim_local // cp_div], dim=-1)
+        query_key = query_key.reshape(batch, seq_len, 2 * nkh, self.dk)
+        value = value.reshape(batch, seq_len, self.num_v_heads_local // cp_div, self.dv)
         query_key = self._l2norm(query_key.contiguous())
-        query, key = query_key.split(self.num_k_heads_local, dim=2)
+        query, key = query_key.split(nkh, dim=2)
         if self.v_heads_per_k_head > 1:
             query = query.repeat_interleave(self.v_heads_per_k_head, dim=2)
             key = key.repeat_interleave(self.v_heads_per_k_head, dim=2)

--- a/experimental/lite/megatron/lite/primitive/parallel/cp.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/cp.py
@@ -350,10 +350,100 @@ def split_packed_for_cp(
     return new_ids, new_pos, new_cu, max(new_lengths)
 
 
+def build_headwise_section_perm(
+    split_sections: tuple[int, ...] | list[int],
+    cp_size: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """Permutation over the hidden dim so a single contiguous ``1/cp`` slice equals
+    the concatenation of each section's ``k``-th contiguous block.
+
+    ``qkvzba`` is a concatenation of independently-headed sections (q, k, v, z,
+    beta, alpha). Head-parallel CP wants each rank to own ``1/cp`` heads of *every*
+    section. Applying this permutation before a plain hidden-scatter all-to-all makes
+    rank ``k``'s contiguous hidden shard hold section-block ``k`` of each section, so
+    the per-section split downstream (and the matching parameter slicing) is exact.
+
+    Mirrors upstream Megatron ``_build_head_perm_for_split_sections``.
+    """
+    assert all(
+        s % cp_size == 0 for s in split_sections
+    ), f"split_sections {tuple(split_sections)} must each be divisible by cp_size={cp_size}."
+    offset = 0
+    parts = []
+    for s in split_sections:
+        parts.append(
+            torch.arange(offset, offset + s, device=device, dtype=torch.long).view(cp_size, -1)
+        )
+        offset += s
+    return torch.cat(parts, dim=-1).view(-1)
+
+
+def get_parameter_local_cp_headwise(
+    param: torch.Tensor,
+    dim: int,
+    cp_size: int,
+    cp_rank: int,
+    split_sections: Optional[list[int]] = None,
+) -> torch.Tensor:
+    """Return this CP rank's head-wise slice of a parameter.
+
+    With ``split_sections`` the parameter is first split into sections along ``dim``,
+    each section is sliced to its rank-``cp_rank`` contiguous block, and the blocks are
+    re-concatenated — matching :func:`build_headwise_section_perm`. Slicing happens in
+    the forward path so gradients flow back to the full (cp_size=1) parameter.
+
+    Mirrors upstream Megatron ``get_parameter_local_cp_headwise``.
+    """
+    if cp_size <= 1:
+        return param
+    if split_sections is not None:
+        pieces = torch.split(param, split_sections, dim=dim)
+        return torch.cat(
+            [get_parameter_local_cp_headwise(p, dim, cp_size, cp_rank) for p in pieces],
+            dim=dim,
+        )
+    dim_size = param.size(dim)
+    assert (
+        dim_size % cp_size == 0
+    ), f"parameter dim {dim} size {dim_size} not divisible by cp_size={cp_size}."
+    slices: list[slice] = [slice(None)] * param.dim()
+    block = dim_size // cp_size
+    slices[dim] = slice(cp_rank * block, (cp_rank + 1) * block)
+    return param[tuple(slices)]
+
+
+def all_to_all_hidden_shards(
+    send_parts: list[torch.Tensor],
+    cp_group: dist.ProcessGroup | None,
+) -> list[torch.Tensor]:
+    """Even all-to-all over a CP group: ``send_parts[j]`` is delivered to rank ``j``;
+    the returned ``recv[i]`` is the tensor rank ``i`` sent to this rank.
+
+    All parts must share the same shape and dtype. Autograd-aware via
+    ``torch.distributed.nn.functional.all_to_all_single``.
+    """
+    cp_size = dist.get_world_size(cp_group) if cp_group is not None else 1
+    if cp_size <= 1:
+        return [send_parts[0]]
+    assert len(send_parts) == cp_size, (len(send_parts), cp_size)
+    ref = send_parts[0]
+    send = torch.stack([p.contiguous() for p in send_parts], dim=0)  # [cp, *shape]
+    flat = send.reshape(cp_size, -1).contiguous()
+    from torch.distributed.nn.functional import all_to_all_single
+
+    recv_flat = all_to_all_single(torch.empty_like(flat), flat, group=cp_group)
+    recv = recv_flat.reshape(cp_size, *ref.shape)
+    return [recv[i] for i in range(cp_size)]
+
+
 __all__ = [
+    "all_to_all_hidden_shards",
+    "build_headwise_section_perm",
     "contiguous_position_ids_for_cp",
     "contiguous_slice_for_cp",
     "contiguous_to_zigzag_chunks",
+    "get_parameter_local_cp_headwise",
     "split_packed_for_cp",
     "zigzag_to_contiguous_chunks",
     "zigzag_reconstruct_from_cp_parts",

--- a/experimental/lite/tests/unit/model/test_qwen35_export.py
+++ b/experimental/lite/tests/unit/model/test_qwen35_export.py
@@ -54,8 +54,8 @@ def test_qwen35_protocol_registers_vllm_export_entrypoint() -> None:
 
 
 def test_qwen35_gdn_cp_mode_is_configurable() -> None:
-    assert ImplConfig().gdn_cp_mode == "replicated"
-    assert ImplConfig(gdn_cp_mode="sharded").gdn_cp_mode == "sharded"
+    assert ImplConfig().gdn_cp_mode == "headwise"
+    assert ImplConfig(gdn_cp_mode="replicated").gdn_cp_mode == "replicated"
 
 
 def test_qwen35_export_uses_hf_checkpoint_names_without_module_prefix() -> None:


### PR DESCRIPTION
## GDN CP: port upstream headwise (head-parallel a2a), replace divergent chunkwise

**Upstream source (ported from):** [NVIDIA/Megatron-LM#5389 — Restore fused GDN THD all-to-all](https://github.com/NVIDIA/Megatron-LM/pull/5389), base commit `d1384c2d9`.

### Motivation
Users reported GDN RL reward failing to rise under the alternate CP (chunkwise mirror). Root cause: chunkwise (FLA `build_cp_context` seq-shard) diverges numerically in bf16 and amplifies to ppo_kl ~220x in RL. Switched to upstream headwise (all-to-all over the head dimension, mathematically exact).

### Changes (core code only)
- `primitive/modules/gated_delta_net.py` — headwise a2a (replaces chunkwise/sharded).
- `primitive/parallel/cp.py` — head-parallel a2a helpers.
- `model/qwen3_5/lite/{model,protocol}.py` — wiring.
- `tests/unit/model/test_qwen35_export.py` — unit test.

Parity validation harness (proxy sbatch/smoke) is not part of this PR.

### Verification
- ✅ Offline CPU gloo a2a: packed-THD round-trip is **bitwise-lossless**.
- ✅ GPU precision A/B (headwise vs CP-off, job 13989285): CP2 `max_abs=0`, CP4 within replicated-bf16 noise — headwise is numerically equivalent to CP-off.
- ✅ GPU RL mismatch check (32-card DAPO, 2 steps, job 14005065): `actor/ppo_kl = 0.00057` (both steps), i.e. training↔inference log-prob mismatch is essentially zero — vs the chunkwise ~220×. `grad_norm` healthy (0.11–0.13).

Counterpart PR against `verl-project/Megatron-LM:lite` filed separately so both land together.
