### PR TITLE
Fix DS4 THD packing crash: expand response-only loss_mask to full length (+ dedup primitive)

### DIFF
--- a/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
@@ -758,8 +758,35 @@ class MegatronLiteEngine(BaseEngine):
             return None
 
         loss_mask = micro_batch["loss_mask"]
+        input_lengths = input_ids.offsets().diff().tolist()
         if getattr(loss_mask, "is_nested", False):
-            return loss_mask
+            # VERL delivers ``response_mask`` / ``loss_mask`` as a *response-only*
+            # nested tensor (shape ``[bsz, response_len]``), while ``input_ids`` is
+            # the full ``[prompt; response]`` packed sequence. Returning it as-is
+            # left the packed loss_mask (sum of response lengths) shorter than the
+            # ``input_ids`` seq_lens, so ``_nested_from_packed_tensor`` narrowed a
+            # full-length slice out of a response-only buffer and crashed the
+            # actor-update step. Expand it here to the full sequence the same way
+            # the native Megatron path does (``_build_mtp_loss_mask_nested``):
+            # left-pad each row with prompt zeros and keep the whole valid response
+            # span (response_mask may carry internal zeros for tool outputs).
+            resp_offsets = loss_mask.offsets().tolist()
+            resp_values = loss_mask.values()
+            rows = []
+            for i, total in enumerate(input_lengths):
+                start, end = resp_offsets[i], resp_offsets[i + 1]
+                response_piece = resp_values[start:end]
+                prompt_len = total - (end - start)
+                if prompt_len < 0:
+                    raise ValueError(
+                        f"response loss mask has {end - start} tokens but packed input "
+                        f"sequence has {total} tokens"
+                    )
+                prompt_pad = torch.zeros(
+                    prompt_len, dtype=response_piece.dtype, device=response_piece.device
+                )
+                rows.append(torch.cat([prompt_pad, response_piece], dim=0))
+            return torch.nested.as_nested_tensor(rows, layout=torch.jagged)
 
         rows = []
         for seq_ids, row_mask in zip(input_ids.unbind(0), loss_mask, strict=True):

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
@@ -15,7 +15,7 @@ from megatron.lite.model.deepseek_v4.lite.checkpoint import (
     load_hf_weights as _load_hf_weights_impl,
     save_hf_weights as _save_hf_weights_impl,
 )
-from megatron.lite.model.protocol_utils import add_loss_context_kwargs
+from megatron.lite.model.protocol_utils import add_loss_context_kwargs, nested_from_packed
 from megatron.lite.primitive.bundle import ModelBundle
 from megatron.lite.primitive.parallel import ParallelState, init_parallel
 from megatron.lite.primitive.parallel.cp import (
@@ -127,23 +127,12 @@ def _infer_cp_local_seq_len(
     return seq_len // cp_size if seq_len % cp_size == 0 else seq_len
 
 
-def _nested_from_packed_tensor(tensor, seq_lens):
-    if tensor is None:
-        return None
-    if tensor.dim() == 2 and tensor.size(0) == 1:
-        tensor = tensor.squeeze(0)
-    if tensor.dim() != 1:
-        raise ValueError(f"PackedBatch tensor must be 1-D, got {tuple(tensor.shape)}.")
-
-    pieces = []
-    offset = 0
-    for length_t in seq_lens:
-        length = int(length_t.item())
-        pieces.append(tensor.narrow(0, offset, length))
-        offset += length
-    if offset != tensor.numel():
-        raise ValueError(f"PackedBatch sizes sum to {offset}, tensor has {tensor.numel()} tokens.")
-    return torch.nested.as_nested_tensor(pieces, layout=torch.jagged)
+# The 1-D-packed -> jagged-nested split is model-agnostic and lives in the shared
+# protocol_utils layer. DS4 only forks the *CP layout* pair (contiguous DSA, see
+# ``_prepare_packed_batch_kwargs`` below); this pre-CP primitive must not diverge,
+# so alias the shared implementation instead of re-copying it. Keeping the local
+# name preserves existing call sites and unit tests.
+_nested_from_packed_tensor = nested_from_packed
 
 
 def _prepare_packed_batch_kwargs(model, batch: PackedBatch) -> dict[str, Any]:

--- a/experimental/lite/tests/unit/model/test_thd_packing_consistency.py
+++ b/experimental/lite/tests/unit/model/test_thd_packing_consistency.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Reproduce the DS4 THD packing inconsistency crash (seq_len 206 > packed tensor 128).
+
+``_nested_from_packed_tensor(tensor, seq_lens)`` narrows a 1-D packed tensor one
+sequence at a time. When a declared ``seq_len`` exceeds the remaining length of
+the packed tensor (i.e. ``seq_lens`` is inconsistent with ``input_ids.numel()``),
+``tensor.narrow(0, offset, length)`` raises ``RuntimeError`` "...exceeds dimension
+size..." -- exactly the 206 > 128 crash seen at the actor-update step.
+
+These tests only reproduce the inconsistency (proving it must crash); they do not
+exercise the fix (which restores full-length loss_mask upstream in the engine).
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from megatron.lite.model.deepseek_v4.lite.protocol import _nested_from_packed_tensor
+
+
+def test_reproduce_seqlen_exceeds_packed_tensor_206_over_128():
+    """Packed tensor holds 128 tokens but seq_lens declares 206 -> narrow overruns."""
+    packed = torch.arange(128, dtype=torch.long)           # 128 tokens
+    seq_lens = torch.tensor([206], dtype=torch.long)        # declares 206 (> 128)
+    with pytest.raises(RuntimeError) as ei:
+        _nested_from_packed_tensor(packed, seq_lens)
+    msg = str(ei.value).lower()
+    assert "exceeds" in msg or "size" in msg or "range" in msg, str(ei.value)
+
+
+def test_reproduce_multi_seq_second_overruns():
+    """Multiple sequences: the second one pushes the cumulative offset past the end."""
+    packed = torch.arange(128, dtype=torch.long)
+    seq_lens = torch.tensor([100, 128], dtype=torch.long)   # 100+128=228 > 128
+    with pytest.raises(RuntimeError):
+        _nested_from_packed_tensor(packed, seq_lens)
+
+
+def test_sum_mismatch_underrun_raises_valueerror():
+    """seq_lens sum < numel (each fits, but the buffer is not filled) -> ValueError.
+
+    This distinguishes the two inconsistency kinds: overrun -> RuntimeError (narrow),
+    underrun -> ValueError (the offset != numel sum check).
+    """
+    packed = torch.arange(128, dtype=torch.long)
+    seq_lens = torch.tensor([100], dtype=torch.long)        # 100 < 128
+    with pytest.raises(ValueError, match="sizes sum to 100"):
+        _nested_from_packed_tensor(packed, seq_lens)
+
+
+def test_consistent_packing_succeeds():
+    """Consistent case (sum(seq_lens) == numel) returns a nested tensor.
+
+    Control case: proves the crash comes from the inconsistency, not the function.
+    """
+    packed = torch.arange(128, dtype=torch.long)
+    seq_lens = torch.tensor([50, 78], dtype=torch.long)     # 50+78=128
+    out = _nested_from_packed_tensor(packed, seq_lens)
+    assert out is not None
+    assert out.size(0) == 2                                  # 2 segments

--- a/experimental/lite/tests/unit/verl/test_mlite_engine_loss_mask_packing.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_engine_loss_mask_packing.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Regression coverage for THD loss-mask packing in the MLite VERL engine.
+
+VERL hands the actor-update batch a *response-only* ``loss_mask`` /
+``response_mask`` nested tensor (shape ``[bsz, response_len]``), while
+``input_ids`` is the full ``[prompt; response]`` packed sequence. The engine
+must expand that mask to the full sequence length before the model protocol
+packs it against the ``input_ids`` seq_lens. Returning the response-only mask
+unchanged left ``loss_mask`` shorter than the declared seq_lens and crashed the
+update step inside ``_nested_from_packed_tensor``::
+
+    torch.narrow(0, offset, 206): start + length exceeds dimension size (128)
+
+These tests exercise the pure ``_loss_mask_for_packing`` static logic end-to-end
+with ``_nested_from_packed_tensor``; no GPU, model init, or torch.distributed.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from tensordict import TensorDict
+
+from verl_mlite.engine.mlite_engine import MegatronLiteEngine
+from megatron.lite.model.deepseek_v4.lite.protocol import _nested_from_packed_tensor
+
+pytestmark = pytest.mark.mlite
+
+
+def _full_input_ids(full_lengths: list[int]) -> torch.Tensor:
+    return torch.nested.as_nested_tensor(
+        [torch.arange(length) for length in full_lengths], layout=torch.jagged
+    )
+
+
+def _response_mask_row(response_len: int) -> torch.Tensor:
+    # Include an internal zero to model a masked span (e.g. tool output); the
+    # whole valid response span must be preserved, not collapsed to its sum.
+    row = torch.ones(response_len, dtype=torch.float32)
+    if response_len > 4:
+        row[3] = 0.0
+    return row
+
+
+def _assert_packs_to_full(packed_mask, input_ids, full_lengths, response_lengths):
+    seq_lens = input_ids.offsets().diff().to(torch.int64)
+    # Must be full-length: sum of response lengths alone would be too short.
+    assert int(packed_mask.values().numel()) == sum(full_lengths)
+    # Packing against the full seq_lens must not overflow (the original crash).
+    nested = _nested_from_packed_tensor(packed_mask.values().contiguous(), seq_lens)
+    rows = nested.unbind(0)
+    for i, (total, resp) in enumerate(zip(full_lengths, response_lengths, strict=True)):
+        prompt_len = total - resp
+        # Prompt positions are masked out (zeros); response span is kept intact.
+        assert torch.count_nonzero(rows[i][:prompt_len]) == 0
+        assert rows[i][prompt_len:].numel() == resp
+
+
+def test_nested_response_only_loss_mask_expands_to_full_length():
+    """The production crash case: response-only nested mask + full input_ids."""
+    full_lengths = [206, 130, 40]
+    response_lengths = [78, 30, 20]  # sum 128 < a single full length (206)
+    input_ids = _full_input_ids(full_lengths)
+    loss_mask = torch.nested.as_nested_tensor(
+        [_response_mask_row(r) for r in response_lengths], layout=torch.jagged
+    )
+    micro_batch = TensorDict(
+        {"input_ids": input_ids, "loss_mask": loss_mask}, batch_size=[len(full_lengths)]
+    )
+
+    packed = MegatronLiteEngine._loss_mask_for_packing(micro_batch, input_ids)
+    _assert_packs_to_full(packed, input_ids, full_lengths, response_lengths)
+
+
+def test_full_length_nested_loss_mask_is_unchanged():
+    """A response covering the whole sequence (prompt_len == 0) still round-trips."""
+    full_lengths = [100, 100]
+    response_lengths = [100, 100]
+    input_ids = _full_input_ids(full_lengths)
+    loss_mask = torch.nested.as_nested_tensor(
+        [torch.ones(r, dtype=torch.float32) for r in response_lengths], layout=torch.jagged
+    )
+    micro_batch = TensorDict(
+        {"input_ids": input_ids, "loss_mask": loss_mask}, batch_size=[len(full_lengths)]
+    )
+
+    packed = MegatronLiteEngine._loss_mask_for_packing(micro_batch, input_ids)
+    _assert_packs_to_full(packed, input_ids, full_lengths, response_lengths)
+
+
+def test_dense_response_loss_mask_expands_to_full_length():
+    """The dense (V0 left_right_2_no_padding) path stays full-length too."""
+    full_lengths = [206, 130, 40]
+    response_lengths = [78, 30, 20]
+    input_ids = _full_input_ids(full_lengths)
+    max_response = max(response_lengths)
+    dense = torch.zeros(len(response_lengths), max_response, dtype=torch.float32)
+    for i, r in enumerate(response_lengths):
+        dense[i, :r] = torch.ones(r, dtype=torch.float32)
+    micro_batch = TensorDict(
+        {"input_ids": input_ids, "loss_mask": dense}, batch_size=[len(full_lengths)]
+    )
+
+    packed = MegatronLiteEngine._loss_mask_for_packing(micro_batch, input_ids)
+    seq_lens = input_ids.offsets().diff().to(torch.int64)
+    assert int(packed.values().numel()) == sum(full_lengths)
+    # Must not overflow when packed against the full seq_lens.
+    _nested_from_packed_tensor(packed.values().contiguous(), seq_lens)
+
+
+def test_response_longer_than_input_is_rejected():
+    """A response mask longer than its input sequence is a hard error, not silent."""
+    full_lengths = [40]
+    input_ids = _full_input_ids(full_lengths)
+    loss_mask = torch.nested.as_nested_tensor(
+        [torch.ones(64, dtype=torch.float32)], layout=torch.jagged
+    )
+    micro_batch = TensorDict(
+        {"input_ids": input_ids, "loss_mask": loss_mask}, batch_size=[1]
+    )
+    with pytest.raises(ValueError, match="tokens but packed input"):
+        MegatronLiteEngine._loss_mask_for_packing(micro_batch, input_ids)


### PR DESCRIPTION
## What

Fixes the DS4 THD **packing crash** that blocked 12+ RL runs at `update_actor`:

```
RuntimeError: start (0) + length (206) exceeds dimension size (128).
```

## Root cause

VERL delivers `loss_mask` (= `response_mask`) as a **response-only** nested tensor
(`[bsz, response_len]`), while `input_ids` is the full `[prompt; response]` packed
sequence. `verl_mlite`'s `MegatronLiteEngine._loss_mask_for_packing` returned that
nested mask **unchanged**, so the packed loss_mask (sum of response lengths) was
shorter than the `input_ids` seq_lens. The DeepSeek-V4 protocol then narrowed a
full-length slice (206) out of the response-only buffer (128) and crashed.

This is DS4-specific: only `deepseek_v4/lite/protocol.py` unpacks `loss_mask` by
the full `seq_lens` (Qwen3.5 / GLM5 don't), and DS4's MTP path assumes a
full-length mask — so Qwen3.5 DAPO never hit it (not a regression).

## Fix

1. **`_loss_mask_for_packing`** (mlite_engine.py): expand the response-only nested
   loss_mask to the full `[prompt; response]` length — left-pad each row with
   prompt zeros, keep the whole valid response span — mirroring the native
   Megatron `_build_mtp_loss_mask_nested`. Dense (non-nested) branch unchanged.
2. **Dedup** (deepseek_v4/lite/protocol.py): DS4 carried a byte-identical private
   copy of the model-agnostic `nested_from_packed` primitive (the exact function
   this bug lived in). Recover it to the shared `protocol_utils` layer via an
   alias so this class of divergence can't recur. The legitimate CP-layout fork
   (`_prepare_packed_batch_kwargs`, contiguous DSA) is kept.

## Tests

- `test_thd_packing_consistency.py` (4 passed) — reproduces the 206>128 overrun at
  the protocol primitive; distinguishes overrun (RuntimeError) vs underrun
  (ValueError) vs consistent (ok); green after the dedup alias.
- `test_mlite_engine_loss_mask_packing.py` — engine-level: response-only mask ->
  expand -> no crash (needs the verl/TE runtime env).

Both pass in the full DS4 worktree env; the CPU protocol test is env-light.
