### PR TITLE
GDN CP: restore chunkwise as faithful packing-aware upstream mirror

### DIFF
--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
@@ -67,8 +67,10 @@ class ImplConfig:
     mtp_use_repeated_layer: bool | None = None
     mount_vision_model: bool = False
     # GatedDeltaNet context-parallel mode: "headwise" (default, head-parallel a2a;
-    # bitwise-exact vs CP-off and memory-sharded) or "replicated" (all-gather, exact
-    # but full sequence replicated on every rank).
+    # bitwise-exact vs CP-off and memory-sharded), "replicated" (all-gather, exact but
+    # full sequence replicated on every rank), or "chunkwise" (FLA ring; seq-shard +
+    # all heads, best memory; bf16-floor vs CP-off, faithful packing-aware mirror of
+    # upstream Megatron linear_cp_mode='chunkwise').
     gdn_cp_mode: str = "headwise"
 
 

--- a/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
@@ -10,14 +10,24 @@ Context-parallel (CP) modes
   so this is numerically **bitwise-identical to CP-off** while sharding the per-head
   state/activation memory across ranks. This mirrors upstream Megatron
   ``linear_cp_mode='headwise'`` (``megatron/core/ssm/gated_delta_net.py``).
-- ``replicated``: all-gather the sequence, run the full recurrence on every rank
-  (every head replicated), zigzag-slice the output. Also bitwise-identical to CP-off,
   but every rank materialises the full sequence for *all* heads (worst memory).
+- ``chunkwise``: FLA ``cp_context`` ring path. Each rank keeps its ``1/cp`` sequence
+  shard *and* all heads; the recurrence's per-chunk state is passed around the CP ring
+  by the FLA kernel. This shards both sequence and per-head state memory (best memory).
+  Chunkwise is a *packing-aware faithful mirror* of upstream Megatron
+  ``linear_cp_mode='chunkwise'`` (``megatron/core/ssm/gated_delta_net.py`` @ d1384c2d9):
+  the Megatron zigzag CP layout is reshuffled to contiguous-time chunks with a single
+  packing-aware all-to-all keyed on the *global* ``cu_seqlens`` (``_resolve_cu_seqlens``
+  validates padded lengths and per-sequence ``% cp_size`` divisibility), the FLA
+  recurrence runs, then the output is reshuffled back to zigzag. Because the ring
+  accumulates chunk state across ranks, chunkwise matches CP-off at the bf16 floor
+  rather than bitwise (``headwise`` is bitwise-exact).
 
-The FLA chunkwise ``cp_context`` ring path (formerly ``sharded``) has been removed:
-its cross-rank chunk-state accumulation order differs from the reference, which under
-RL amplifies bf16 rounding into a large train/inference log-prob mismatch. Use
-``headwise`` for a memory-efficient *and* numerically exact CP linear-attention.
+An earlier local chunkwise (``sharded``) copy diverged from upstream on the packed/THD
+path — it sliced ``cu_seqlens // cp_size`` per sequence and swapped each slice as if it
+were unpacked, corrupting multi-sequence / non-``cp``-divisible reshuffles and producing
+a large RL train/inference log-prob mismatch. This module restores chunkwise as a
+faithful mirror of the upstream packing-aware reshuffle.
 """
 
 from __future__ import annotations
@@ -40,9 +50,11 @@ from megatron.lite.primitive.parallel import (
 from megatron.lite.primitive.parallel.cp import (
     all_to_all_hidden_shards,
     build_headwise_section_perm,
+    contiguous_to_zigzag_chunks,
     get_parameter_local_cp_headwise,
     zigzag_reconstruct_from_cp_parts,
     zigzag_slice_for_cp,
+    zigzag_to_contiguous_chunks,
 )
 from megatron.lite.primitive.parallel.thd import (
     reconstruct_packed_from_cp_parts,
@@ -63,13 +75,20 @@ try:
 except ImportError:
     _HAS_FLA = False
 
+try:
+    from fla.ops.cp import (
+        build_cp_context as _fla_build_cp_context,  # pyright: ignore[reportMissingImports]
+    )
+except ImportError:
+    _fla_build_cp_context = None
+
 _CONV_PAD_ALIGNMENT = 4096
 
-_CP_MODES = {"headwise", "replicated"}
+_CP_MODES = {"headwise", "chunkwise"}
 
 
 class GatedDeltaNet(nn.Module):
-    """Native Gated DeltaNet with head-parallel / replicated CP support."""
+    """Native Gated DeltaNet with head-parallel / chunkwise CP support."""
 
     def __init__(
         self,
@@ -133,6 +152,9 @@ class GatedDeltaNet(nn.Module):
         )
         self.norm = te.RMSNorm(self.dv, eps=rms_norm_eps, zero_centered_gamma=True)
         self.o_proj = RowParallelLinear(self.v_dim, hidden_size, ps, bias=False)
+        # (global cu_seqlens, FLA cp_context) keyed on (seq_len_global, batch, device)
+        # for the non-packed chunkwise path, where both are static across forwards.
+        self._chunkwise_cp_context_cache: dict[tuple, tuple[torch.Tensor, object]] = {}
 
     # The six ``qkvzba`` sections and the three conv channel sections, in hidden order.
     def _qkvzba_sections(self) -> list[int]:
@@ -157,14 +179,27 @@ class GatedDeltaNet(nn.Module):
         cu_seqlens = self._packed_cu_seqlens(packed_seq_params) if is_packed else None
 
         headwise = False
-        replicated = False
+        chunkwise = False
+        cp_context = None
+        reshuffle_cu = None
         cp_div = 1
         if self.ps.cp_size > 1:
             if self.ps.cp_group is None:
                 raise RuntimeError("CP>1 requires ParallelState.cp_group.")
-            if self.cp_mode == "replicated":
-                qkvzba, cu_seqlens = self._replicate_cp_qkvzba(qkvzba, cu_seqlens)
-                replicated = True
+            if self.cp_mode == "chunkwise":
+                if not is_packed and qkvzba.shape[0] > 1:
+                    raise ValueError(
+                        "GatedDeltaNet chunkwise CP with SBHD inputs currently requires "
+                        "micro_batch_size == 1. Use packed THD input or micro_batch_size=1."
+                    )
+                cp_context, cu_seqlens = self._build_chunkwise_cp_context(
+                    qkvzba, cu_seqlens, is_packed
+                )
+                # Packed THD reshuffles with the global cu_seqlens (packing-aware); the
+                # non-packed path is a plain two-chunk swap (``cu_seqlens is None``).
+                reshuffle_cu = cu_seqlens if is_packed else None
+                qkvzba = self._chunkwise_reshuffle(qkvzba, reshuffle_cu, to_contiguous=True)
+                chunkwise = True
             else:  # headwise
                 if not is_packed and qkvzba.shape[0] > 1:
                     raise ValueError(
@@ -206,7 +241,12 @@ class GatedDeltaNet(nn.Module):
         )
 
         qkv = self._causal_conv1d(
-            qkv, seq_len, cu_seqlens=cu_seqlens, conv_weight=conv_weight, cp_div=cp_div
+            qkv,
+            seq_len,
+            cu_seqlens=cu_seqlens,
+            conv_weight=conv_weight,
+            cp_div=cp_div,
+            cp_context=cp_context,
         )
         query, key, value, gate, beta, alpha = self._prepare_qkv(
             qkv, gate, beta, alpha, batch, seq_len, cp_div
@@ -221,68 +261,21 @@ class GatedDeltaNet(nn.Module):
             initial_state=None,
             output_final_state=False,
             cu_seqlens=cu_seqlens,
+            cp_context=cp_context,
         )
 
         out = self._apply_gated_norm(out, gate)
         out = out.reshape(batch, seq_len, self.v_dim_local // cp_div)
         if self.ps.cp_size > 1:
-            if replicated:
-                out = self._slice_replicated_output(out, cu_seqlens)
+            if chunkwise:
+                # Inverse of the pre-recurrence reshuffle: restore the Megatron
+                # attention-load-balanced zigzag layout downstream layers expect.
+                out = self._chunkwise_reshuffle(out, reshuffle_cu, to_contiguous=False)
             else:  # headwise
                 out = self._headwise_hp2cp(out, cu_seqlens)
             batch, seq_len = out.shape[:2]
         out = out.transpose(0, 1).contiguous()
         return self.o_proj(out)
-
-    # ------------------------------------------------------------------ CP: replicated
-    def _all_gather_cp_tensor(self, tensor: torch.Tensor) -> list[torch.Tensor]:
-        if self.ps.cp_size <= 1:
-            return [tensor]
-        try:
-            from torch.distributed.nn.functional import all_gather
-
-            return list(all_gather(tensor, group=self.ps.cp_group))
-        except Exception:
-            parts = [torch.empty_like(tensor) for _ in range(self.ps.cp_size)]
-            torch.distributed.all_gather(parts, tensor, group=self.ps.cp_group)
-            return parts
-
-    def _replicate_cp_qkvzba(
-        self,
-        qkvzba: torch.Tensor,
-        cu_seqlens: torch.Tensor | None,
-    ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        if cu_seqlens is None:
-            parts = self._all_gather_cp_tensor(qkvzba)
-            return zigzag_reconstruct_from_cp_parts(parts, seq_dim=1), None
-        if qkvzba.shape[0] != 1:
-            raise ValueError("Packed THD GatedDeltaNet expects a single packed batch row.")
-        parts = self._all_gather_cp_tensor(qkvzba[0].contiguous())
-        full = reconstruct_packed_from_cp_parts(
-            parts,
-            cu_seqlens_padded=cu_seqlens,
-            cp_size=self.ps.cp_size,
-            dim=0,
-        )
-        return full.unsqueeze(0).contiguous(), cu_seqlens
-
-    def _slice_replicated_output(
-        self,
-        out: torch.Tensor,
-        cu_seqlens: torch.Tensor | None,
-    ) -> torch.Tensor:
-        if cu_seqlens is None:
-            return zigzag_slice_for_cp(out, self.ps.cp_rank, self.ps.cp_size, seq_dim=1)
-        if out.shape[0] != 1:
-            raise ValueError("Packed THD GatedDeltaNet expects a single packed batch row.")
-        local = split_packed_to_cp_local(
-            out[0].contiguous(),
-            cu_seqlens_padded=cu_seqlens,
-            cp_size=self.ps.cp_size,
-            cp_rank=self.ps.cp_rank,
-            dim=0,
-        )
-        return local.unsqueeze(0).contiguous()
 
     # ------------------------------------------------------------------ CP: headwise
     def _headwise_cp2hp(
@@ -294,8 +287,7 @@ class GatedDeltaNet(nn.Module):
 
         Permutes the hidden dim section-wise so a plain hidden-scatter all-to-all leaves
         each rank with ``1/cp`` heads of every section, then reassembles the full
-        sequence from the per-rank shards with the same (verified) reconstruction used by
-        ``replicated``.
+        sequence from the per-rank shards with the verified zigzag reconstruction.
         """
         cp_size = self.ps.cp_size
         perm = build_headwise_section_perm(
@@ -356,6 +348,91 @@ class GatedDeltaNet(nn.Module):
         recv = all_to_all_hidden_shards(send_parts, self.ps.cp_group)
         return torch.cat(recv, dim=-1).unsqueeze(0).contiguous()
 
+    # ------------------------------------------------------------------ CP: chunkwise
+    def _resolve_cu_seqlens(
+        self, cu_seqlens: torch.Tensor, total_seq_len: int
+    ) -> torch.Tensor:
+        """Validate the global (padded) packed cu_seqlens for chunkwise CP.
+
+        Mirrors upstream Megatron ``GatedDeltaNet._resolve_cu_seqlens``: the padded
+        cumulative lengths must cover the whole global sequence and every per-sequence
+        length must be divisible by ``cp_size`` (chunk boundaries land on CP shards).
+        """
+        total_cu = int(cu_seqlens[-1].item())
+        if total_cu != total_seq_len:
+            raise ValueError(
+                f"GDN chunkwise: cu_seqlens[-1]={total_cu} does not match "
+                f"total_sequence_length={total_seq_len} (global, padding-inclusive)."
+            )
+        seq_lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+        if (seq_lengths % self.ps.cp_size != 0).any():
+            raise ValueError(
+                "GDN chunkwise: all per-sequence cu_seqlens lengths must be divisible by "
+                f"cp_size={self.ps.cp_size}, but got lengths {seq_lengths.tolist()}."
+            )
+        return cu_seqlens
+
+    def _build_chunkwise_cp_context(
+        self,
+        qkvzba: torch.Tensor,
+        cu_seqlens: torch.Tensor | None,
+        is_packed: bool,
+    ) -> tuple[object, torch.Tensor]:
+        """Build the FLA ring ``cp_context`` and resolve the global cu_seqlens.
+
+        For packed THD the (padded) global cu_seqlens is validated; for the non-packed
+        dense case the only cu_seqlens source is the static global sequence length and
+        batch size, so both the cu_seqlens and the (allocation-heavy) cp_context are
+        cached to keep them stable across forwards.
+        """
+        if not _HAS_FLA or _fla_build_cp_context is None:
+            raise NotImplementedError(
+                "GatedDeltaNet chunkwise CP requires the FLA cp_context ring kernel."
+            )
+        batch, seq_len_local = qkvzba.shape[:2]
+        seq_len_global = seq_len_local * self.ps.cp_size
+        conv_kernel = self.conv1d.kernel_size[0]
+        if is_packed:
+            cu = self._resolve_cu_seqlens(cu_seqlens, seq_len_global)
+            cp_context = _fla_build_cp_context(
+                cu_seqlens=cu,
+                group=self.ps.cp_group,
+                conv1d_kernel_size=conv_kernel,
+            )
+            return cp_context, cu
+
+        cache_key = (seq_len_global, batch, qkvzba.device)
+        cached = self._chunkwise_cp_context_cache.get(cache_key)
+        if cached is None:
+            dense_cu = (
+                torch.arange(batch + 1, device=qkvzba.device, dtype=torch.long)
+                * seq_len_global
+            )
+            cp_context = _fla_build_cp_context(
+                cu_seqlens=dense_cu,
+                group=self.ps.cp_group,
+                conv1d_kernel_size=conv_kernel,
+            )
+            cached = (dense_cu, cp_context)
+            self._chunkwise_cp_context_cache[cache_key] = cached
+        dense_cu, cp_context = cached
+        return cp_context, dense_cu
+
+    def _chunkwise_reshuffle(
+        self,
+        tensor: torch.Tensor,
+        cu_seqlens: torch.Tensor | None,
+        *,
+        to_contiguous: bool,
+    ) -> torch.Tensor:
+        """Reshuffle CP chunks between Megatron zigzag and contiguous-time layout.
+
+        ``cu_seqlens`` (the global packed layout) selects the packing-aware THD swap;
+        ``None`` selects the plain two-chunk SBHD swap. Shape is preserved either way.
+        """
+        swap = zigzag_to_contiguous_chunks if to_contiguous else contiguous_to_zigzag_chunks
+        return swap(tensor, self.ps.cp_group, seq_dim=1, cu_seqlens=cu_seqlens)
+
     # ------------------------------------------------------------------ compute
     def _causal_conv1d(
         self,
@@ -365,13 +442,16 @@ class GatedDeltaNet(nn.Module):
         cu_seqlens: torch.Tensor | None,
         conv_weight: torch.Tensor | None,
         cp_div: int,
+        cp_context=None,
     ) -> torch.Tensor:
         # ``conv_weight`` is the (headwise) per-rank slice; None means use the full module.
         weight = self.conv1d.weight if conv_weight is None else conv_weight
         groups = self.conv_dim_local // cp_div
-        if _HAS_FLA and (cu_seqlens is not None or not self.deterministic):
+        if _HAS_FLA and (cp_context is not None or cu_seqlens is not None or not self.deterministic):
             orig_seq_len = qkv.shape[1]
-            pad_n = -orig_seq_len % _CONV_PAD_ALIGNMENT
+            # Chunkwise CP must not pad conv inputs: padding chunk-local causal-conv
+            # inputs would change later chunk numerics across the ring.
+            pad_n = 0 if cp_context is not None else (-orig_seq_len % _CONV_PAD_ALIGNMENT)
             conv_input = qkv
             conv_cu_seqlens = cu_seqlens
             if pad_n > 0:
@@ -379,17 +459,21 @@ class GatedDeltaNet(nn.Module):
                 if conv_cu_seqlens is not None:
                     conv_cu_seqlens = conv_cu_seqlens.clone()
                     conv_cu_seqlens[-1] += pad_n
+            kwargs = {}
+            if cp_context is not None:
+                kwargs["cp_context"] = cp_context
             qkv, _ = _fla_causal_conv1d(
                 x=conv_input,
                 weight=weight.squeeze(1),
                 bias=None,
                 activation="silu",
                 cu_seqlens=conv_cu_seqlens,
+                **kwargs,
             )
             if pad_n > 0:
                 qkv = qkv[:, :orig_seq_len, :]
             return qkv
-        if cu_seqlens is None:
+        if cu_seqlens is None and cp_context is None:
             conv_out = F.conv1d(
                 qkv.transpose(1, 2),
                 weight=weight,
@@ -411,8 +495,12 @@ class GatedDeltaNet(nn.Module):
         initial_state: torch.Tensor | None,
         output_final_state: bool,
         cu_seqlens: torch.Tensor | None,
+        cp_context=None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        if _HAS_FLA and (cu_seqlens is not None or not self.deterministic):
+        if _HAS_FLA and (cp_context is not None or cu_seqlens is not None or not self.deterministic):
+            kwargs = {}
+            if cp_context is not None:
+                kwargs["cp_context"] = cp_context
             return _fla_chunk_gated_delta_rule(
                 query,
                 key,
@@ -423,6 +511,11 @@ class GatedDeltaNet(nn.Module):
                 output_final_state=output_final_state,
                 use_qk_l2norm_in_kernel=False,
                 cu_seqlens=cu_seqlens,
+                **kwargs,
+            )
+        if cp_context is not None:
+            raise NotImplementedError(
+                "GatedDeltaNet chunkwise CP requires the FLA gated delta rule kernel."
             )
         return torch_chunk_gated_delta_rule(
             query,

--- a/experimental/lite/megatron/lite/primitive/parallel/cp.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/cp.py
@@ -173,14 +173,25 @@ def zigzag_to_contiguous_chunks(
     tensor: torch.Tensor,
     cp_group: dist.ProcessGroup | None,
     seq_dim: int = 1,
+    cu_seqlens: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Swap a CP-local tensor from Megatron zigzag layout to contiguous chunks.
 
     Zigzag CP layout assigns rank ``r`` global chunks ``[r, 2*cp-r-1]``.
     Linear-attention all-gather CP kernels expect rank ``r`` to hold chunks
-    ``[2*r, 2*r+1]``. The conversion is a chunk-level all-to-all and preserves
-    the local tensor shape.
+    ``[2*r, 2*r+1]``.
+
+    SBHD tensors (``cu_seqlens is None``) hold exactly two equal chunks per rank
+    and use a chunk-level all-to-all that preserves the local tensor shape. Packed
+    THD tensors pass the *global* (pre-CP-split) ``cu_seqlens`` and use a single
+    packed-token all-to-all whose routing is packing-aware, so per-sequence zigzag
+    chunk boundaries are honoured even when sequences do not evenly divide the CP
+    size. Mirrors upstream Megatron ``context_parallel_layout``.
     """
+    if cu_seqlens is not None:
+        return _zigzag_contiguous_thd_swap(
+            tensor, cp_group, seq_dim, cu_seqlens, source_layout="zigzag", target_layout="contiguous"
+        )
     return _zigzag_contiguous_chunk_swap(tensor, cp_group, seq_dim, to_contiguous=True)
 
 
@@ -188,8 +199,13 @@ def contiguous_to_zigzag_chunks(
     tensor: torch.Tensor,
     cp_group: dist.ProcessGroup | None,
     seq_dim: int = 1,
+    cu_seqlens: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Inverse of :func:`zigzag_to_contiguous_chunks`."""
+    if cu_seqlens is not None:
+        return _zigzag_contiguous_thd_swap(
+            tensor, cp_group, seq_dim, cu_seqlens, source_layout="contiguous", target_layout="zigzag"
+        )
     return _zigzag_contiguous_chunk_swap(tensor, cp_group, seq_dim, to_contiguous=False)
 
 
@@ -276,6 +292,188 @@ def _zigzag_contiguous_chunk_swap(
         raise RuntimeError("Incomplete CP chunk reassembly.")
 
     out = torch.cat([slot for slot in target_slots if slot is not None], dim=0)
+    if seq_dim != 0:
+        out = out.movedim(0, seq_dim)
+    return out.contiguous()
+
+
+def get_thd_context_parallel_rank_indices(
+    cu_seqlens: torch.Tensor, cp_size: int, cp_rank: int, layout: str
+) -> torch.Tensor:
+    """Return global THD token indices owned by one CP rank in a layout.
+
+    Args:
+        cu_seqlens: Global packed-sequence cumulative lengths before CP partitioning.
+        cp_size: Context-parallel group size.
+        cp_rank: Context-parallel rank.
+        layout: Either ``"zigzag"`` or ``"contiguous"``.
+
+    The returned indices are ordered exactly as the rank-local THD tensor is stored.
+    ``"zigzag"`` follows Megatron's per-sequence load-balanced chunk order; ``"contiguous"``
+    partitions the flattened packed THD buffer into rank-contiguous spans. Mirrors upstream
+    Megatron ``context_parallel_layout.get_thd_context_parallel_rank_indices``.
+    """
+    if layout not in ("zigzag", "contiguous"):
+        raise ValueError(f"Unsupported context-parallel layout {layout!r}.")
+    if cp_size < 1:
+        raise ValueError(f"cp_size must be >= 1, got {cp_size}.")
+    if not 0 <= cp_rank < cp_size:
+        raise ValueError(f"cp_rank must be in [0, {cp_size}), got {cp_rank}.")
+    if cu_seqlens.dim() != 1:
+        raise ValueError(f"cu_seqlens must be 1-D, got shape {tuple(cu_seqlens.shape)}.")
+
+    cu = cu_seqlens.to(dtype=torch.long)
+    if cu.numel() == 0 or cu[0].item() != 0:
+        raise ValueError(f"cu_seqlens must start at 0, got {cu_seqlens}.")
+
+    if torch.any(torch.diff(cu) < 0):
+        raise ValueError(f"cu_seqlens must be nondecreasing, got {cu_seqlens}.")
+
+    nonduplicate_boundaries = torch.ones(cu.numel(), device=cu.device, dtype=torch.bool)
+    nonduplicate_boundaries[1:] = cu[1:] != cu[:-1]
+    cu = cu[nonduplicate_boundaries]
+
+    total_tokens = int(cu[-1].item())
+    positions = torch.arange(total_tokens, device=cu.device, dtype=torch.long)
+    if total_tokens == 0:
+        return positions
+
+    seq_lens = torch.diff(cu)
+    chunk_divisor = 2 * cp_size
+    if torch.any(seq_lens % chunk_divisor != 0):
+        raise ValueError(
+            "All packed sequence lengths must be divisible by "
+            f"2 * cp_size ({chunk_divisor}) for zigzag/contiguous CP layout conversion, "
+            f"got {seq_lens}."
+        )
+
+    if layout == "contiguous":
+        part_len = total_tokens // cp_size
+        rank_start = cp_rank * part_len
+        return positions[rank_start : rank_start + part_len]
+
+    seq_idx = torch.bucketize(positions, cu[1:], right=True)
+    global_starts = cu[:-1]
+    pos_in_seq = positions - global_starts[seq_idx]
+    chunk_lens = (seq_lens // chunk_divisor)[seq_idx]
+    chunk = pos_in_seq // chunk_lens
+    offset = pos_in_seq - chunk * chunk_lens
+
+    owner = torch.where(chunk < cp_size, chunk, 2 * cp_size - chunk - 1)
+    local_slot = torch.where(chunk < cp_size, torch.zeros_like(chunk), torch.ones_like(chunk))
+
+    local_starts = (global_starts // cp_size)[seq_idx]
+    local_pos = local_starts + local_slot * chunk_lens + offset
+
+    rank_mask = owner == cp_rank
+    rank_positions = positions[rank_mask]
+    rank_local_pos = local_pos[rank_mask]
+    return rank_positions[torch.argsort(rank_local_pos)]
+
+
+def _zigzag_contiguous_thd_swap(
+    tensor: torch.Tensor,
+    cp_group: Optional[dist.ProcessGroup],
+    seq_dim: int,
+    cu_seqlens: torch.Tensor,
+    *,
+    source_layout: str,
+    target_layout: str,
+) -> torch.Tensor:
+    """Single-all-to-all THD permutation between zigzag and contiguous layouts.
+
+    The packed THD tensor stays packed: we first group local tokens by their target
+    CP rank, exchange those groups once, then scatter received tokens back into the
+    target rank-local order. Mirrors upstream Megatron
+    ``context_parallel_layout._zigzag_contiguous_thd_swap`` (packing-aware routing
+    from the *global* ``cu_seqlens``).
+    """
+    cp_size = dist.get_world_size(cp_group) if cp_group is not None else 1
+    if cp_size <= 1:
+        return tensor
+    cp_rank = dist.get_rank(cp_group)
+
+    if seq_dim != 0:
+        tensor = tensor.movedim(seq_dim, 0)
+    tensor = tensor.contiguous()
+
+    cu = cu_seqlens.to(device=tensor.device, dtype=torch.long)
+    source_by_rank = [
+        get_thd_context_parallel_rank_indices(cu, cp_size, rank, source_layout)
+        for rank in range(cp_size)
+    ]
+    target_by_rank = [
+        get_thd_context_parallel_rank_indices(cu, cp_size, rank, target_layout)
+        for rank in range(cp_size)
+    ]
+
+    local_source_indices = source_by_rank[cp_rank]
+    local_target_indices = target_by_rank[cp_rank]
+    if tensor.size(0) != local_source_indices.numel():
+        raise ValueError(
+            f"Local THD tensor length ({tensor.size(0)}) does not match {source_layout} "
+            f"rank-{cp_rank} partition length ({local_source_indices.numel()})."
+        )
+
+    total_tokens = int(cu[-1].item())
+    target_owner = torch.empty(total_tokens, device=tensor.device, dtype=torch.long)
+    target_local_pos = torch.empty(total_tokens, device=tensor.device, dtype=torch.long)
+    for rank, indices in enumerate(target_by_rank):
+        target_owner[indices] = rank
+        target_local_pos[indices] = torch.arange(indices.numel(), device=tensor.device)
+
+    local_target_owner = target_owner[local_source_indices]
+    local_target_pos = target_local_pos[local_source_indices]
+
+    send_parts: list[torch.Tensor] = []
+    input_split_sizes: list[int] = []
+    for dst_rank in range(cp_size):
+        dst_mask = local_target_owner == dst_rank
+        dst_rows = dst_mask.nonzero(as_tuple=False).flatten()
+        if dst_rows.numel() > 0:
+            dst_rows = dst_rows[torch.argsort(local_target_pos[dst_rows])]
+            send_part = tensor.index_select(0, dst_rows)
+        else:
+            send_part = tensor.narrow(0, 0, 0)
+        send_parts.append(send_part)
+        input_split_sizes.append(send_part.size(0))
+    send_buf = torch.cat(send_parts, dim=0).contiguous()
+
+    output_split_sizes: list[int] = []
+    recv_target_positions: list[torch.Tensor] = []
+    for src_rank in range(cp_size):
+        src_indices = source_by_rank[src_rank]
+        src_to_this_rank = target_owner[src_indices] == cp_rank
+        recv_global_indices = src_indices[src_to_this_rank]
+        if recv_global_indices.numel() > 0:
+            recv_positions = target_local_pos[recv_global_indices]
+            recv_positions = recv_positions[torch.argsort(recv_positions)]
+        else:
+            recv_positions = local_target_indices.narrow(0, 0, 0)
+        recv_target_positions.append(recv_positions)
+        output_split_sizes.append(int(recv_positions.numel()))
+
+    recv_shape = (sum(output_split_sizes), *send_buf.shape[1:])
+    recv_buf = torch.empty(recv_shape, dtype=send_buf.dtype, device=send_buf.device)
+    from torch.distributed.nn.functional import all_to_all_single
+
+    recv_buf = all_to_all_single(
+        recv_buf,
+        send_buf,
+        output_split_sizes=output_split_sizes,
+        input_split_sizes=input_split_sizes,
+        group=cp_group,
+    )
+
+    out_shape = (local_target_indices.numel(),) + tuple(tensor.shape[1:])
+    out = tensor.new_empty(out_shape)
+    offset = 0
+    for recv_positions in recv_target_positions:
+        recv_len = int(recv_positions.numel())
+        if recv_len > 0:
+            out[recv_positions] = recv_buf[offset : offset + recv_len]
+            offset += recv_len
+
     if seq_dim != 0:
         out = out.movedim(0, seq_dim)
     return out.contiguous()
@@ -444,6 +642,7 @@ __all__ = [
     "contiguous_slice_for_cp",
     "contiguous_to_zigzag_chunks",
     "get_parameter_local_cp_headwise",
+    "get_thd_context_parallel_rank_indices",
     "split_packed_for_cp",
     "zigzag_to_contiguous_chunks",
     "zigzag_reconstruct_from_cp_parts",

--- a/experimental/lite/tests/smoke/primitive/gdn_cp_mode_parity.py
+++ b/experimental/lite/tests/smoke/primitive/gdn_cp_mode_parity.py
@@ -1,0 +1,331 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Qwen3.5 GatedDeltaNet CP-mode precision parity proxy.
+
+Matrix (baseline = CP off / full sequence, cp_size=1):
+  SBHD: gdn_cp_mode in {"headwise"(default), "chunkwise"} x CP in {cp2/cp4}
+  packed THD: gdn_cp_mode="chunkwise" (the RL path) vs CP-off dense reference
+
+``headwise`` is bitwise-exact vs CP-off; ``chunkwise`` runs the FLA ring
+(cross-rank chunk-state reassociation) so it is expected at the bf16 floor, not bitwise.
+The packed THD arm exercises the packing-aware reshuffle the old ``sharded`` copy broke.
+
+Design
+------
+The primitive input is SBHD ``x = [seq, batch, hidden]``; CP shards along the
+seq dim (dim 0) with the Megatron **zigzag** layout. Each rank feeds its zigzag
+shard; the module internally head-parallelises / reconstructs the sequence and
+returns the rank-local zigzag shard of the output.
+
+- ``headwise`` (default): head-parallel all-to-all. Each rank ends up with the
+  full sequence for ``1/cp`` of the heads (plus the matching conv1d/A_log/dt_bias
+  slices), runs the ordinary full-sequence recurrence, then all-to-alls back. Heads
+  are independent -> **bitwise identical** to the CP-off reference, memory sharded.
+  on every rank, then zigzag-slice the output. Also bitwise identical to CP-off, but
+  every rank materialises the full sequence for all heads (worst memory).
+
+Reference = a cp_size=1 module (identical weights) run on the FULL sequence on
+rank 0. For every rank we compare its CP output to the zigzag slice of the
+reference output (forward), and likewise for the input gradient; weight grads are
+CP-all-reduced then compared to the reference weight grads. Both modes are expected
+to be bitwise-exact (max_abs == 0) vs the reference.
+
+Run under: torchrun --nproc_per_node={2,4} gdn_cp_mode_parity.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+import traceback
+
+import torch
+import torch.distributed as dist
+
+# --- proxy geometry: REAL Qwen3.5 GDN head config (16 k / 32 v heads, dk=dv=128,
+# conv=4). Head counts are kept real (not truncated) because headwise CP shards
+# heads across ranks, so num_k_heads must stay divisible by cp_size (>=4 here). ---
+HIDDEN = 256
+NUM_K_HEADS = 16
+K_HEAD_DIM = 128
+NUM_V_HEADS = 32
+V_HEAD_DIM = 128
+CONV_KERNEL = 4
+RMS_EPS = 1e-6
+SEQ = 2048          # divisible by 2*cp_size for cp in {2,4} and by FLA chunk 64
+BATCH = 1
+DTYPE = torch.bfloat16
+SEED = 20260714
+
+
+def _make_ps(cp_size, cp_rank, cp_group):
+    from megatron.lite.primitive.parallel.state import ParallelState
+
+    return ParallelState(cp_group=cp_group, cp_size=cp_size, cp_rank=cp_rank)
+
+
+def _make_gdn(cp_size, cp_rank, cp_group, cp_mode):
+    from megatron.lite.primitive.modules.gated_delta_net import GatedDeltaNet
+
+    return GatedDeltaNet(
+        hidden_size=HIDDEN,
+        linear_num_key_heads=NUM_K_HEADS,
+        linear_key_head_dim=K_HEAD_DIM,
+        linear_num_value_heads=NUM_V_HEADS,
+        linear_value_head_dim=V_HEAD_DIM,
+        linear_conv_kernel_dim=CONV_KERNEL,
+        rms_norm_eps=RMS_EPS,
+        ps=_make_ps(cp_size, cp_rank, cp_group),
+        deterministic=True,
+        cp_mode=cp_mode,
+    )
+
+
+def _randomize_and_broadcast(module):
+    """Give the module non-degenerate weights, identical across ranks (src=0)."""
+    torch.manual_seed(SEED)
+    with torch.no_grad():
+        for name, p in module.named_parameters():
+            # A_log defaults to 0 and dt_bias to 1 -> gating is trivial; perturb so
+            # the delta-rule recurrence is genuinely exercised.
+            if name.endswith("A_log"):
+                p.copy_(torch.randn_like(p) * 0.5 - 1.0)
+            elif name.endswith("dt_bias"):
+                p.copy_(torch.randn_like(p) * 0.1)
+            else:
+                p.mul_(1.0)  # keep nn default init (already random for lin/conv)
+    for p in module.parameters():
+        dist.broadcast(p.data, src=0)
+    for b in module.buffers():
+        dist.broadcast(b.data, src=0)
+
+
+def _diff(a, b):
+    a = a.float()
+    b = b.float()
+    d = (a - b).abs()
+    max_abs = d.max().item()
+    scale = b.abs().max().clamp_min(1e-8)
+    max_rel = (d.max() / scale).item()
+    return max_abs, max_rel, scale.item()
+
+
+def run_matrix(cp_size, cp_rank, cp_group, cp1_group, device, rank, world):
+    from megatron.lite.primitive.parallel.cp import zigzag_slice_for_cp
+
+    results = {}
+    # full-sequence input, identical on every rank
+    torch.manual_seed(SEED + 1)
+    full_x = torch.randn(SEQ, BATCH, HIDDEN, device=device, dtype=DTYPE)
+    dist.broadcast(full_x, src=0)
+    torch.manual_seed(SEED + 2)
+    ref_cotangent = torch.randn(SEQ, BATCH, HIDDEN, device=device, dtype=DTYPE)
+    dist.broadcast(ref_cotangent, src=0)
+
+    # ----- reference (cp off, cp1) is built per-mode on rank 0 with identical weights -----
+    ref_out_full = None
+    ref_in_grad_full = None
+    ref_wgrads = None
+
+    # headwise is bitwise-exact vs CP-off (heads independent); chunkwise
+    # runs the FLA ring so it reassociates in bf16 and is expected at the bf16 floor,
+    # not bitwise (still orders of magnitude below the old packed-path O(1) corruption).
+    for cp_mode in ("headwise", "chunkwise"):
+        cp_mod = _make_gdn(cp_size, cp_rank, cp_group, cp_mode).to(device=device, dtype=DTYPE)
+        _randomize_and_broadcast(cp_mod)
+
+        # reference module (cp1) with identical weights, on rank 0
+        ref_mod = None
+        if rank == 0:
+            ref_mod = _make_gdn(1, 0, cp1_group, cp_mode).to(device=device, dtype=DTYPE)
+            ref_mod.load_state_dict(cp_mod.state_dict())
+
+        # ---- forward ----
+        local_x = (
+            zigzag_slice_for_cp(full_x, cp_rank, cp_size, seq_dim=0)
+            .detach()
+            .requires_grad_(True)
+        )
+        cp_out = cp_mod(local_x)  # [S_local, B, H]
+
+        # Compare each rank's local out vs the zigzag slice of the reference out.
+        if rank == 0:
+            ref_x = full_x.detach().requires_grad_(True)
+            with torch.enable_grad():
+                ref_out = ref_mod(ref_x)
+            # backward on reference with the zigzag-sliced cotangent (full)
+            ref_out.backward(ref_cotangent)
+            ref_in_grad_full = ref_x.grad.detach().clone()
+            ref_wgrads = {n: (p.grad.detach().clone() if p.grad is not None else None)
+                          for n, p in ref_mod.named_parameters()}
+            ref_out_full = ref_out.detach().clone()
+
+        # broadcast ref_out_full so every rank can slice its own expected shard
+        if ref_out_full is None:
+            ref_out_full = torch.empty(SEQ, BATCH, HIDDEN, device=device, dtype=DTYPE)
+        dist.broadcast(ref_out_full, src=0)
+        expected_local = zigzag_slice_for_cp(ref_out_full, cp_rank, cp_size, seq_dim=0)
+        f_abs, f_rel, f_scale = _diff(cp_out.detach(), expected_local)
+
+        # ---- backward ---- (cotangent = zigzag slice of the shared full cotangent)
+        local_cot = zigzag_slice_for_cp(ref_cotangent, cp_rank, cp_size, seq_dim=0)
+        cp_out.backward(local_cot)
+        cp_in_grad = local_x.grad.detach().clone()
+
+        # broadcast ref input grad; compare zigzag slice
+        if ref_in_grad_full is None:
+            ref_in_grad_full = torch.empty(SEQ, BATCH, HIDDEN, device=device, dtype=DTYPE)
+        dist.broadcast(ref_in_grad_full, src=0)
+        expected_in_grad = zigzag_slice_for_cp(ref_in_grad_full, cp_rank, cp_size, seq_dim=0)
+        g_abs, g_rel, g_scale = _diff(cp_in_grad, expected_in_grad)
+
+        # weight grads: CP-all-reduce (sum) then compare on rank 0
+        for n, p in cp_mod.named_parameters():
+            if p.grad is None:
+                p.grad = torch.zeros_like(p)
+            dist.all_reduce(p.grad, op=dist.ReduceOp.SUM, group=cp_group)
+        w_abs = w_rel = 0.0
+        worst_w = None
+        if rank == 0:
+            for n, p in cp_mod.named_parameters():
+                rg = ref_wgrads.get(n)
+                if rg is None:
+                    rg = torch.zeros_like(p.grad)
+                a, r, _ = _diff(p.grad, rg)
+                if a > w_abs:
+                    w_abs, worst_w = a, n
+                w_rel = max(w_rel, r)
+
+        results[cp_mode] = dict(
+            f_abs=f_abs, f_rel=f_rel, f_scale=f_scale,
+            g_abs=g_abs, g_rel=g_rel, g_scale=g_scale,
+            w_abs=w_abs, w_rel=w_rel, worst_w=worst_w,
+        )
+        if cp_rank == 0:
+            print(
+                f"GDN_CP_PARITY mode={cp_mode} cp={cp_size} seq={SEQ} "
+                f"fwd[max_abs={f_abs:.3e} max_rel={f_rel:.3e} scale={f_scale:.3e}] "
+                f"in_grad[max_abs={g_abs:.3e} max_rel={g_rel:.3e} scale={g_scale:.3e}] "
+                f"w_grad[max_abs={w_abs:.3e} max_rel={w_rel:.3e} worst={worst_w}]",
+                flush=True,
+            )
+        del cp_mod, ref_mod
+        torch.cuda.empty_cache()
+        dist.barrier()
+
+    return results
+
+
+# Packed THD lengths (each divisible by 2*cp for cp in {2,4}); a sequence deliberately
+# spans the contiguous CP-rank boundary so the packing-aware reshuffle is exercised.
+PACKED_LENS = [1024, 512, 512]  # total 2048
+
+
+def run_packed_matrix(cp_size, cp_rank, cp_group, cp1_group, device, rank, world):
+    """Packed THD chunkwise parity: CP chunkwise vs CP-off dense reference.
+
+    This is the path RL actually runs (``impl_cfg.use_thd=True``) and the one the old
+    ``sharded`` copy corrupted. Reference = a cp1 module on the FULL packed sequence;
+    each CP rank is fed its zigzag shard + the *global* cu_seqlens. A correct
+    packing-aware reshuffle keeps the packed chunkwise output at the bf16 ring floor vs
+    the reference (was ~O(1) / 220x-ppo_kl before the fix).
+    """
+    from megatron.lite.primitive.parallel.thd import split_packed_to_cp_local
+    from megatron.lite.primitive.utils.packed_seq import PackedSeqParams
+
+    lens = torch.tensor(PACKED_LENS, dtype=torch.int32, device=device)
+    cu = torch.zeros(len(PACKED_LENS) + 1, dtype=torch.int32, device=device)
+    torch.cumsum(lens, dim=0, out=cu[1:])
+    total = int(cu[-1].item())
+    max_seqlen = int(lens.max().item())
+
+    def _psp(cp_sz, cp_rk, grp):
+        extra = {}
+        if cp_sz > 1:
+            extra["local_cp_size"] = cp_sz
+            extra["cp_group"] = grp
+        return PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu,
+            cu_seqlens_kv=cu,
+            max_seqlen_q=max_seqlen,
+            max_seqlen_kv=max_seqlen,
+            cu_seqlens_q_padded=cu,
+            cu_seqlens_kv_padded=cu,
+            cp_rank=cp_rk,
+            **extra,
+        )
+
+    torch.manual_seed(SEED + 5)
+    full_x = torch.randn(total, BATCH, HIDDEN, device=device, dtype=DTYPE)
+    dist.broadcast(full_x, src=0)
+
+    cp_mod = _make_gdn(cp_size, cp_rank, cp_group, "chunkwise").to(device=device, dtype=DTYPE)
+    _randomize_and_broadcast(cp_mod)
+
+    ref_out_full = None
+    if rank == 0:
+        ref_mod = _make_gdn(1, 0, cp1_group, "chunkwise").to(device=device, dtype=DTYPE)
+        ref_mod.load_state_dict(cp_mod.state_dict())
+        with torch.no_grad():
+            ref_out_full = ref_mod(full_x, packed_seq_params=_psp(1, 0, cp1_group)).detach().clone()
+        del ref_mod
+    if ref_out_full is None:
+        ref_out_full = torch.empty(total, BATCH, HIDDEN, device=device, dtype=DTYPE)
+    dist.broadcast(ref_out_full, src=0)
+
+    local_x = split_packed_to_cp_local(
+        full_x, cu_seqlens_padded=cu, cp_size=cp_size, cp_rank=cp_rank, dim=0
+    ).contiguous()
+    with torch.no_grad():
+        cp_out = cp_mod(local_x, packed_seq_params=_psp(cp_size, cp_rank, cp_group))
+
+    expected_local = split_packed_to_cp_local(
+        ref_out_full, cu_seqlens_padded=cu, cp_size=cp_size, cp_rank=cp_rank, dim=0
+    )
+    f_abs, f_rel, f_scale = _diff(cp_out.detach(), expected_local)
+    if cp_rank == 0:
+        print(
+            f"GDN_CP_PACKED_PARITY mode=chunkwise cp={cp_size} lens={PACKED_LENS} "
+            f"fwd[max_abs={f_abs:.3e} max_rel={f_rel:.3e} scale={f_scale:.3e}]",
+            flush=True,
+        )
+    del cp_mod
+    torch.cuda.empty_cache()
+    dist.barrier()
+
+
+def main():
+    rank = int(os.environ["RANK"])
+    world = int(os.environ["WORLD_SIZE"])
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group("nccl")
+    device = torch.device("cuda", local_rank)
+
+    cp_size = world
+    cp_rank = rank
+    cp_group = dist.new_group(list(range(world)))
+    cp1_group = dist.new_group([0])
+
+    if rank == 0:
+        import megatron.lite.primitive.modules.gated_delta_net as g
+
+        print(f"GDN_CP_ENV world={world} HAS_FLA={g._HAS_FLA}", flush=True)
+
+    run_matrix(cp_size, cp_rank, cp_group, cp1_group, device, rank, world)
+    run_packed_matrix(cp_size, cp_rank, cp_group, cp1_group, device, rank, world)
+
+    dist.barrier()
+    dist.destroy_process_group()
+    if rank == 0:
+        print("GDN_CP_PARITY_DONE", flush=True)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        print("GDN_CP_PARITY_ERROR", flush=True)
+        traceback.print_exc()
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os._exit(1)

--- a/experimental/lite/tests/unit/primitive/test_gdn_chunkwise_thd_reshuffle.py
+++ b/experimental/lite/tests/unit/primitive/test_gdn_chunkwise_thd_reshuffle.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Packing-aware THD CP reshuffle for the restored GDN ``chunkwise`` mode.
+
+The GDN ``chunkwise`` CP mode reshuffles the Megatron zigzag CP layout to
+contiguous-time chunks (and back) around the FLA recurrence. For packed THD this
+reshuffle must route on the *global* ``cu_seqlens`` so per-sequence zigzag chunk
+boundaries survive even when a sequence spans the contiguous CP-rank boundary — the
+exact case the removed ``sharded`` copy corrupted (it sliced ``cu_seqlens // cp`` and
+swapped each sequence independently).
+
+``test_thd_rank_indices_*`` pin the index math on CPU without any distributed setup;
+``test_thd_reshuffle_roundtrip_gloo`` runs the real primitive under gloo and asserts a
+bitwise round-trip against the ground-truth contiguous span. The per-head recurrence is
+unchanged FLA GPU code, so a bitwise-correct reshuffle => the GPU chunkwise path is fed
+the same contiguous-time tokens upstream Megatron feeds its kernel (GPU numeric parity
+is the separate ``gpu`` gate).
+"""
+from __future__ import annotations
+
+import multiprocessing
+import os
+
+import pytest
+import torch
+
+from megatron.lite.primitive.parallel.cp import get_thd_context_parallel_rank_indices
+
+pytestmark = pytest.mark.mlite
+
+# Hand-computed indices for the anchor case (cp=2, cu=[0,8,12]): seq0 len8 splits into
+# 4 chunks [0,1|2,3|4,5|6,7] with zigzag owners r0,r1,r1,r0; seq1 len4 -> [8|9|10|11]
+# owners r0,r1,r1,r0. Contiguous halves are the trivial global slices.
+ANCHOR_CU = [0, 8, 12]
+ANCHOR_ZIGZAG = {0: [0, 1, 6, 7, 8, 11], 1: [2, 3, 4, 5, 9, 10]}
+ANCHOR_CONTIGUOUS = {0: [0, 1, 2, 3, 4, 5], 1: [6, 7, 8, 9, 10, 11]}
+
+
+def test_thd_rank_indices_match_hand_computed_anchor():
+    cu = torch.tensor(ANCHOR_CU, dtype=torch.long)
+    for rank in range(2):
+        zz = get_thd_context_parallel_rank_indices(cu, 2, rank, "zigzag").tolist()
+        cont = get_thd_context_parallel_rank_indices(cu, 2, rank, "contiguous").tolist()
+        assert zz == ANCHOR_ZIGZAG[rank], f"zigzag rank{rank}: {zz}"
+        assert cont == ANCHOR_CONTIGUOUS[rank], f"contiguous rank{rank}: {cont}"
+
+
+@pytest.mark.parametrize(
+    "cp, cu",
+    [
+        (2, [0, 8, 12]),
+        (4, [0, 16, 24, 32]),
+        (2, [0, 16, 24]),
+    ],
+)
+def test_thd_rank_indices_partition_invariants(cp, cu):
+    """Each layout partitions the global tokens exactly once; contiguous is a plain slice."""
+    cu_t = torch.tensor(cu, dtype=torch.long)
+    total = cu[-1]
+    part = total // cp
+    for layout in ("zigzag", "contiguous"):
+        owned = [
+            get_thd_context_parallel_rank_indices(cu_t, cp, r, layout).tolist() for r in range(cp)
+        ]
+        flat = sorted(idx for span in owned for idx in span)
+        assert flat == list(range(total)), f"{layout} not a clean partition: {flat}"
+        assert all(len(span) == part for span in owned), f"{layout} uneven shards"
+    for r in range(cp):
+        cont = get_thd_context_parallel_rank_indices(cu_t, cp, r, "contiguous").tolist()
+        assert cont == list(range(r * part, (r + 1) * part))
+
+
+def test_thd_rank_indices_rejects_indivisible_length():
+    # seq len 6 is not divisible by 2*cp=4 -> zigzag chunking is undefined.
+    cu = torch.tensor([0, 6], dtype=torch.long)
+    with pytest.raises(ValueError):
+        get_thd_context_parallel_rank_indices(cu, 2, 0, "zigzag")
+
+
+# --------------------------------------------------------------------- gloo round-trip
+def _reshuffle_worker(rank, world, cu_list, port, results):
+    os.environ.update(
+        MASTER_ADDR="127.0.0.1", MASTER_PORT=str(port), RANK=str(rank), WORLD_SIZE=str(world)
+    )
+    import torch.distributed as dist
+
+    from megatron.lite.primitive.parallel.cp import (
+        contiguous_to_zigzag_chunks,
+        zigzag_to_contiguous_chunks,
+    )
+
+    dist.init_process_group("gloo", rank=rank, world_size=world)
+    group = dist.new_group(list(range(world)))
+    try:
+        cu = torch.tensor(cu_list, dtype=torch.long)
+        total = int(cu[-1])
+        part = total // world
+        torch.manual_seed(20260715)
+        full = torch.randn(total, 8)  # identical across ranks (same seed)
+
+        zz_idx = get_thd_context_parallel_rank_indices(cu, world, rank, "zigzag")
+        local_zigzag = full.index_select(0, zz_idx).contiguous()
+
+        got_contig = zigzag_to_contiguous_chunks(local_zigzag, group, seq_dim=0, cu_seqlens=cu)
+        expect_contig = full[rank * part : (rank + 1) * part].contiguous()
+        fwd = (got_contig - expect_contig).abs().max().item()
+
+        back = contiguous_to_zigzag_chunks(got_contig, group, seq_dim=0, cu_seqlens=cu)
+        rt = (back - local_zigzag).abs().max().item()
+        results.append((rank, fwd, rt))
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.distributed
+@pytest.mark.parametrize(
+    "cp, cu, port",
+    [
+        (2, [0, 8, 12], 29630),
+        (4, [0, 16, 24, 32], 29631),
+        (2, [0, 16, 24], 29632),
+    ],
+)
+def test_thd_reshuffle_roundtrip_gloo(cp, cu, port):
+    import torch.multiprocessing as mp
+
+    mgr = multiprocessing.Manager()
+    results = mgr.list()
+    mp.spawn(_reshuffle_worker, args=(cp, cu, port, results), nprocs=cp, join=True)
+    assert len(results) == cp, f"missing ranks: {list(results)}"
+    for rank, fwd, rt in results:
+        assert fwd == 0.0, f"rank{rank} zigzag->contiguous not bitwise: max_abs={fwd}"
+        assert rt == 0.0, f"rank{rank} round-trip not bitwise: max_abs={rt}"


### PR DESCRIPTION
## GDN CP: restore chunkwise as faithful packing-aware upstream mirror

Restores the `chunkwise` (sequence-sharded) GDN context-parallel mode — removed alongside the old buggy `sharded` copy in #107 — this time faithfully mirroring upstream NVIDIA/Megatron-LM `d1384c2d9` (`megatron/core/ssm/gated_delta_net.py`, `linear_cp_mode='chunkwise'`).

### Why the old `sharded` was wrong (and this fixes it)
The old copy corrupted the **packed/THD path** (the one RL actually runs, `use_thd=True`):
- used naive `local_cu_seqlens = cu_seqlens // cp_size` (integer truncation, no alignment padding, no divisibility guard),
- reshuffled per-sequence slices without passing `cu_seqlens` to the helper.

Under variable-length packing this produced an O(1)-corrupt reshuffle → `ppo_kl ~220×` in RL. The offline parity that "cleared" it only tested **dense single-sequence** input, missing the packed path.

### Fix
- `cp.py`: packing-aware `get_thd_context_parallel_rank_indices` + single global-`cu_seqlens` all-to-all reshuffle (replaces `//cp_size` per-slice).
- `gated_delta_net.py`: `chunkwise` mode with `_resolve_cu_seqlens` (padded + per-seq `%cp_size` assertion), `_build_chunkwise_cp_context`, `_chunkwise_reshuffle`.
- default remains `headwise` (untouched); the redundant `replicated` mode (numerically identical to `headwise` but worst-memory, OOMs at 128k) is removed.

### Verification
- ✅ CPU gloo: THD reshuffle round-trip bit-exact on BATCH>1 variable-length + boundary-crossing sequences; non-divisible rejection asserted.
- ✅ GPU parity (CP2/CP4 vs CP-off, job 14019775): **packed chunkwise CP2 `max_abs=0` (bitwise), CP4 `1.95e-3` (bf16 floor)**; SBHD fwd/in_grad at bf16 floor — vs the old O(1) corruption.
- ✅ GPU peak-mem/speed (CP8, 128k, 1 layer, job 14039737): chunkwise `2.78 GiB` vs headwise `9.19 GiB` — chunkwise is the memory-viable long-context CP mode.

