### PR TITLE
fix(ds4): pass chat template to native RLHF dataset

### DIFF
--- a/experimental/lite/examples/verl/scripts/run_deepseek_v4_dapo.sh
+++ b/experimental/lite/examples/verl/scripts/run_deepseek_v4_dapo.sh
@@ -179,6 +179,7 @@ DATA=(
   "data.max_prompt_length=${MAX_PROMPT_LENGTH}"
   "data.max_response_length=${MAX_RESPONSE_LENGTH}"
   "data.filter_overlong_prompts=True"
+  "+data.apply_chat_template_kwargs.chat_template='${DS4_CHAT_TEMPLATE}'"
   "data.truncation=error"
   "data.dataloader_num_workers=8"
 )

--- a/experimental/lite/tests/unit/examples/test_ds4_dapo_script.py
+++ b/experimental/lite/tests/unit/examples/test_ds4_dapo_script.py
@@ -83,6 +83,7 @@ def test_ds4_dapo_weight_and_r3_knobs(
     assert "algorithm.rollout_correction.bypass_mode=False" in command
     assert "data.max_response_length=6144" in command
     assert "actor_rollout_ref.model.custom_chat_template=" in command
+    assert "+data.apply_chat_template_kwargs.chat_template=" in command
     assert "data.custom_cls" not in command
     assert "data.label_key" not in command
     assert "data.default_data_source" not in command


### PR DESCRIPTION
## Summary

- pass the canonical DeepSeek V4 chat template to veRL's native `RLHFDataset`
- keep dataset prompt filtering, rollout agent-loop tokenization, and actor/ref tokenization on the same template
- add launcher coverage for the dataset-side template override

## Root cause

The DS4 launcher set `actor_rollout_ref.model.custom_chat_template`, but native `RLHFDataset` constructs and filters data with a separate tokenizer before the actor model config applies that override. DeepSeek-V4-Flash's tokenizer does not embed a default chat template, so overlong-prompt filtering called `tokenizer.apply_chat_template()` without a template, rejected every sample, and produced an empty dataset.

The launcher now also sets:

```text
+data.apply_chat_template_kwargs.chat_template=<canonical DS4 template>
```

This uses veRL's native dataset/agent-loop contract and avoids restoring a custom dataset class.

## Validation

- `bash -n experimental/lite/examples/verl/scripts/run_deepseek_v4_dapo.sh`
- `python -m pytest -q experimental/lite/tests/unit/examples/test_ds4_dapo_script.py` (4 passed)
- `git diff --check`
- 128-GPU W4 + R3, five-step validation: CW job `14107391` (pending scheduler allocation at PR creation; keep this PR draft until it passes)

The previous job `14106927` failed during native dataset filtering with `tokenizer.chat_template is not set`; it never reached model initialization or GPU training.
