### PR TITLE
Streaming HF export (bounded rank-0 memory) + honor save_contents=hf_model (#118)

### DIFF
--- a/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
@@ -436,9 +436,10 @@ class MegatronLiteEngine(BaseEngine):
         self._require_initialized()
 
         save_contents = self.checkpoint_config.get("save_contents", None)
+        save_hf_model = save_contents is not None and "hf_model" in save_contents
         save_model = save_contents is None or "model" in save_contents
         save_optimizer = save_contents is None or "optimizer" in save_contents
-        if not save_model and not save_optimizer:
+        if not save_model and not save_optimizer and not save_hf_model:
             if self._rank == 0:
                 print(
                     f"Skipping Megatron Lite checkpoint save at step {global_step}: save_contents={save_contents}"
@@ -449,33 +450,56 @@ class MegatronLiteEngine(BaseEngine):
 
         os.makedirs(local_path, exist_ok=True)
         placement_fn, expert_classifier = self._checkpoint_hooks()
-        reload_params_for_save = self.is_param_offload_enabled
+        reload_params_for_save = self.is_param_offload_enabled and (
+            save_model or save_optimizer or save_hf_model
+        )
         if reload_params_for_save:
             self.to(device="cuda", model=True, optimizer=False, grad=False)
             torch.cuda.synchronize()
         try:
-            save_training_checkpoint(
-                self.module,
-                self.handle._optimizer,
-                global_step,
-                local_path,
-                self.handle._config.parallel,
-                self.handle._parallel_state,
-                get_placements=placement_fn,
-                is_expert=expert_classifier,
-                save_model=save_model,
-                save_optimizer=save_optimizer,
-            )
-            if self.handle._lr_scheduler is not None and self._rank == 0:
-                torch.save(
-                    self.handle._lr_scheduler.state_dict(),
-                    os.path.join(local_path, _LR_SCHEDULER_STATE),
+            if save_model or save_optimizer:
+                save_training_checkpoint(
+                    self.module,
+                    self.handle._optimizer,
+                    global_step,
+                    local_path,
+                    self.handle._config.parallel,
+                    self.handle._parallel_state,
+                    get_placements=placement_fn,
+                    is_expert=expert_classifier,
+                    save_model=save_model,
+                    save_optimizer=save_optimizer,
                 )
-            if dist.is_initialized():
-                dist.barrier()
+                if self.handle._lr_scheduler is not None and self._rank == 0:
+                    torch.save(
+                        self.handle._lr_scheduler.state_dict(),
+                        os.path.join(local_path, _LR_SCHEDULER_STATE),
+                    )
+                if dist.is_initialized():
+                    dist.barrier()
+            if save_hf_model:
+                self._save_hf_checkpoint(local_path)
         finally:
             if reload_params_for_save:
                 self.to(device="cpu", model=True, optimizer=False, grad=False)
+
+    def _save_hf_checkpoint(self, local_path: str) -> None:
+        extras = self.handle._extras
+        protocol = extras.get("protocol")
+        save_hf_weights = getattr(protocol, "save_hf_weights", None)
+        if not callable(save_hf_weights):
+            raise RuntimeError(
+                f"MLite model protocol {protocol!r} does not expose save_hf_weights."
+            )
+        model_chunks = extras.get("model_chunks")
+        if model_chunks is None:
+            model_chunks = [self.handle._model]
+        save_hf_weights(
+            model_chunks,
+            local_path,
+            extras.get("model_cfg"),
+            self.handle._parallel_state,
+        )
 
     def load_checkpoint(
         self,

--- a/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
@@ -436,9 +436,9 @@ class MegatronLiteEngine(BaseEngine):
         self._require_initialized()
 
         save_contents = self.checkpoint_config.get("save_contents", None)
-        save_hf_model = save_contents is not None and "hf_model" in save_contents
         save_model = save_contents is None or "model" in save_contents
         save_optimizer = save_contents is None or "optimizer" in save_contents
+        save_hf_model = save_contents is not None and "hf_model" in save_contents
         if not save_model and not save_optimizer and not save_hf_model:
             if self._rank == 0:
                 print(
@@ -450,9 +450,7 @@ class MegatronLiteEngine(BaseEngine):
 
         os.makedirs(local_path, exist_ok=True)
         placement_fn, expert_classifier = self._checkpoint_hooks()
-        reload_params_for_save = self.is_param_offload_enabled and (
-            save_model or save_optimizer or save_hf_model
-        )
+        reload_params_for_save = self.is_param_offload_enabled
         if reload_params_for_save:
             self.to(device="cuda", model=True, optimizer=False, grad=False)
             torch.cuda.synchronize()
@@ -470,36 +468,55 @@ class MegatronLiteEngine(BaseEngine):
                     save_model=save_model,
                     save_optimizer=save_optimizer,
                 )
-                if self.handle._lr_scheduler is not None and self._rank == 0:
-                    torch.save(
-                        self.handle._lr_scheduler.state_dict(),
-                        os.path.join(local_path, _LR_SCHEDULER_STATE),
-                    )
-                if dist.is_initialized():
-                    dist.barrier()
+            if self.handle._lr_scheduler is not None and self._rank == 0:
+                torch.save(
+                    self.handle._lr_scheduler.state_dict(),
+                    os.path.join(local_path, _LR_SCHEDULER_STATE),
+                )
             if save_hf_model:
                 self._save_hf_checkpoint(local_path)
+            if dist.is_initialized():
+                dist.barrier()
         finally:
             if reload_params_for_save:
                 self.to(device="cpu", model=True, optimizer=False, grad=False)
 
     def _save_hf_checkpoint(self, local_path: str) -> None:
-        extras = self.handle._extras
-        protocol = extras.get("protocol")
-        save_hf_weights = getattr(protocol, "save_hf_weights", None)
-        if not callable(save_hf_weights):
-            raise RuntimeError(
-                f"MLite model protocol {protocol!r} does not expose save_hf_weights."
-            )
-        model_chunks = extras.get("model_chunks")
-        if model_chunks is None:
-            model_chunks = [self.handle._model]
-        save_hf_weights(
-            model_chunks,
-            local_path,
-            extras.get("model_cfg"),
-            self.handle._parallel_state,
-        )
+        proto = self.handle._extras.get("protocol")
+        if proto is None or not hasattr(proto, "save_hf_weights"):
+            if self._rank == 0:
+                print(
+                    "Skipping hf_model save: model protocol does not expose save_hf_weights."
+                )
+            return
+
+        model_chunks = self.handle._extras.get("model_chunks", [self.handle._model])
+        model_cfg = self.handle._extras.get("model_cfg")
+        ps = self.handle._parallel_state
+        hf_local_path = os.path.join(local_path, "huggingface")
+
+        if self._rank == 0:
+            os.makedirs(hf_local_path, exist_ok=True)
+        if dist.is_initialized():
+            dist.barrier()
+
+        proto.save_hf_weights(model_chunks, hf_local_path, model_cfg, ps)
+
+        if self._rank == 0:
+            hf_config = getattr(self.model_config, "hf_config", None)
+            if hf_config is not None:
+                auto_map = getattr(hf_config, "auto_map", None)
+                if isinstance(auto_map, dict) and None in auto_map:
+                    hf_config.auto_map = {k: v for k, v in auto_map.items() if k is not None}
+                hf_config.save_pretrained(hf_local_path)
+            tokenizer = getattr(self.model_config, "tokenizer", None)
+            if tokenizer is not None:
+                tokenizer.save_pretrained(hf_local_path)
+            processor = getattr(self.model_config, "processor", None)
+            if processor is not None:
+                processor.save_pretrained(hf_local_path)
+        if dist.is_initialized():
+            dist.barrier()
 
     def load_checkpoint(
         self,

--- a/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
@@ -484,14 +484,18 @@ class MegatronLiteEngine(BaseEngine):
     def _save_hf_checkpoint(self, local_path: str) -> None:
         proto = self.handle._extras.get("protocol")
         if proto is None or not hasattr(proto, "save_hf_weights"):
-            if self._rank == 0:
-                print(
-                    "Skipping hf_model save: model protocol does not expose save_hf_weights."
-                )
-            return
+            raise RuntimeError(
+                "hf_model save requested, but the model protocol does not expose "
+                "save_hf_weights; refusing to report a successful checkpoint save."
+            )
 
         model_chunks = self.handle._extras.get("model_chunks", [self.handle._model])
         model_cfg = self.handle._extras.get("model_cfg")
+        if model_cfg is None:
+            raise RuntimeError(
+                "hf_model save requested, but the runtime handle has no model_cfg; "
+                "the model-specific exporter cannot be called safely."
+            )
         ps = self.handle._parallel_state
         hf_local_path = os.path.join(local_path, "huggingface")
 

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
@@ -548,7 +548,10 @@ def _export_unquantized_weights(model, config: DeepseekV4Config, ps: ParallelSta
     router buffers (``tid2eid`` for hash layers, ``expert_bias`` for non-hash
     layers) which the parameter-only ``_export`` does not visit.
     """
-    from megatron.lite.primitive.ckpt.hf_weights import export_hf_weights as _export
+    from megatron.lite.primitive.ckpt.hf_weights import (
+        export_hf_weights as _export,
+        stream_pp_tensors,
+    )
 
     spec = DeepseekV4WeightSpec(config)
     rank0_only = bool(kwargs.get("rank0_only", False))
@@ -556,7 +559,6 @@ def _export_unquantized_weights(model, config: DeepseekV4Config, ps: ParallelSta
     export_dtype = _resolve_export_dtype(kwargs.get("export_dtype"))
     yield from _export(model, spec, ps, vocab_size=config.vocab_size, **kwargs)
 
-    rank = dist.get_rank() if dist.is_initialized() else 0
     chunks = list(model) if isinstance(model, list | nn.ModuleList) else [model]
     local_buffers: list[tuple[str, torch.Tensor]] = []
     for chunk in chunks:
@@ -575,51 +577,15 @@ def _export_unquantized_weights(model, config: DeepseekV4Config, ps: ParallelSta
             for hf_name, hf_tensor in spec.native_to_hf(global_name, buffer.detach()):
                 local_buffers.append((hf_name, hf_tensor.contiguous()))
 
-    emit = not (rank0_only and rank != 0)
-    if ps.pp_size <= 1:
-        if emit:
-            for hf_name, tensor in local_buffers:
-                tensor = tensor.cpu() if cpu else tensor
-                yield hf_name, _cast_export_tensor(tensor, export_dtype)
-        return
-
     # Router state is stored as buffers, so the parameter-only shared exporter
     # above cannot carry it across PP stages.  Every actor rank feeds one rollout
     # worker; yielding only this rank's local buffers leaves each online vLLM
-    # replica with router state for just one pipeline stage.  Stream every PP
-    # stage's buffers over the same PP group used for parameters so each rank
-    # emits a complete model without materializing the full checkpoint.
-    bcast_device = (
-        torch.device("cuda", torch.cuda.current_device())
-        if torch.cuda.is_available()
-        else torch.device("cpu")
-    )
-    for src_pp in range(ps.pp_size):
-        src_global = ps.pp_global_ranks[src_pp]
-        is_source = src_pp == ps.pp_rank
-        if is_source:
-            stage_buffers = [
-                (name, tensor.to(bcast_device).contiguous()) for name, tensor in local_buffers
-            ]
-            header = [
-                [(name, tuple(tensor.shape), tensor.dtype) for name, tensor in stage_buffers]
-            ]
-        else:
-            stage_buffers = []
-            header = [None]
-        dist.broadcast_object_list(
-            header, src=src_global, group=ps.pp_group, device=bcast_device
-        )
-        for idx, (hf_name, shape, dtype) in enumerate(header[0]):
-            tensor = (
-                stage_buffers[idx][1]
-                if is_source
-                else torch.empty(shape, dtype=dtype, device=bcast_device)
-            )
-            dist.broadcast(tensor, src=src_global, group=ps.pp_group)
-            if emit:
-                output = tensor.cpu() if cpu else tensor
-                yield hf_name, _cast_export_tensor(output, export_dtype)
+    # replica with router state for just one pipeline stage.  The shared helper
+    # streams every PP stage's buffers so every rank emits a complete model.
+    for hf_name, hf_tensor in stream_pp_tensors(
+        local_buffers, ps, rank0_only=rank0_only, cpu=cpu
+    ):
+        yield hf_name, _cast_export_tensor(hf_tensor, export_dtype)
 
 
 def export_hf_weights(model, config: DeepseekV4Config, ps: ParallelState, **kwargs):

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
@@ -657,15 +657,10 @@ def export_hf_weights(model, config: DeepseekV4Config, ps: ParallelState, **kwar
 
 
 def save_hf_weights(model, path: str, config: DeepseekV4Config, ps: ParallelState, **kwargs) -> None:
-    from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
+    from megatron.lite.primitive.ckpt.hf_weights import save_hf_weights as _save
 
-    rank = dist.get_rank() if dist.is_initialized() else 0
     kwargs.pop("cpu", None)
-    out = dict(export_hf_weights(model, config, ps, rank0_only=True, cpu=True, **kwargs))
-    if rank == 0 and out:
-        save_safetensors(out, path)
-    if dist.is_initialized():
-        dist.barrier()
+    _save(model, path, config, ps, export_fn=export_hf_weights, **kwargs)
 
 
 __all__ = [

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
@@ -548,10 +548,7 @@ def _export_unquantized_weights(model, config: DeepseekV4Config, ps: ParallelSta
     router buffers (``tid2eid`` for hash layers, ``expert_bias`` for non-hash
     layers) which the parameter-only ``_export`` does not visit.
     """
-    from megatron.lite.primitive.ckpt.hf_weights import (
-        export_hf_weights as _export,
-        stream_pp_tensors,
-    )
+    from megatron.lite.primitive.ckpt.hf_weights import export_hf_weights as _export
 
     spec = DeepseekV4WeightSpec(config)
     rank0_only = bool(kwargs.get("rank0_only", False))
@@ -559,6 +556,7 @@ def _export_unquantized_weights(model, config: DeepseekV4Config, ps: ParallelSta
     export_dtype = _resolve_export_dtype(kwargs.get("export_dtype"))
     yield from _export(model, spec, ps, vocab_size=config.vocab_size, **kwargs)
 
+    rank = dist.get_rank() if dist.is_initialized() else 0
     chunks = list(model) if isinstance(model, list | nn.ModuleList) else [model]
     local_buffers: list[tuple[str, torch.Tensor]] = []
     for chunk in chunks:
@@ -577,15 +575,51 @@ def _export_unquantized_weights(model, config: DeepseekV4Config, ps: ParallelSta
             for hf_name, hf_tensor in spec.native_to_hf(global_name, buffer.detach()):
                 local_buffers.append((hf_name, hf_tensor.contiguous()))
 
+    emit = not (rank0_only and rank != 0)
+    if ps.pp_size <= 1:
+        if emit:
+            for hf_name, tensor in local_buffers:
+                tensor = tensor.cpu() if cpu else tensor
+                yield hf_name, _cast_export_tensor(tensor, export_dtype)
+        return
+
     # Router state is stored as buffers, so the parameter-only shared exporter
     # above cannot carry it across PP stages.  Every actor rank feeds one rollout
     # worker; yielding only this rank's local buffers leaves each online vLLM
-    # replica with router state for just one pipeline stage.  The shared helper
-    # streams every PP stage's buffers so every rank emits a complete model.
-    for hf_name, hf_tensor in stream_pp_tensors(
-        local_buffers, ps, rank0_only=rank0_only, cpu=cpu
-    ):
-        yield hf_name, _cast_export_tensor(hf_tensor, export_dtype)
+    # replica with router state for just one pipeline stage.  Stream every PP
+    # stage's buffers over the same PP group used for parameters so each rank
+    # emits a complete model without materializing the full checkpoint.
+    bcast_device = (
+        torch.device("cuda", torch.cuda.current_device())
+        if torch.cuda.is_available()
+        else torch.device("cpu")
+    )
+    for src_pp in range(ps.pp_size):
+        src_global = ps.pp_global_ranks[src_pp]
+        is_source = src_pp == ps.pp_rank
+        if is_source:
+            stage_buffers = [
+                (name, tensor.to(bcast_device).contiguous()) for name, tensor in local_buffers
+            ]
+            header = [
+                [(name, tuple(tensor.shape), tensor.dtype) for name, tensor in stage_buffers]
+            ]
+        else:
+            stage_buffers = []
+            header = [None]
+        dist.broadcast_object_list(
+            header, src=src_global, group=ps.pp_group, device=bcast_device
+        )
+        for idx, (hf_name, shape, dtype) in enumerate(header[0]):
+            tensor = (
+                stage_buffers[idx][1]
+                if is_source
+                else torch.empty(shape, dtype=dtype, device=bcast_device)
+            )
+            dist.broadcast(tensor, src=src_global, group=ps.pp_group)
+            if emit:
+                output = tensor.cpu() if cpu else tensor
+                yield hf_name, _cast_export_tensor(output, export_dtype)
 
 
 def export_hf_weights(model, config: DeepseekV4Config, ps: ParallelState, **kwargs):

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
@@ -657,10 +657,16 @@ def export_hf_weights(model, config: DeepseekV4Config, ps: ParallelState, **kwar
 
 
 def save_hf_weights(model, path: str, config: DeepseekV4Config, ps: ParallelState, **kwargs) -> None:
-    from megatron.lite.primitive.ckpt.hf_weights import save_hf_weights as _save
+    """Export + write sharded safetensors via ``stream_export_to_shards``."""
+    from megatron.lite.primitive.ckpt.hf_weights import stream_export_to_shards
 
     kwargs.pop("cpu", None)
-    _save(model, path, config, ps, export_fn=export_hf_weights, **kwargs)
+    shard_size_bytes = int(kwargs.pop("shard_size_bytes", 5 * 1024**3))
+    stream_export_to_shards(
+        export_hf_weights(model, config, ps, rank0_only=True, cpu=True, **kwargs),
+        path,
+        shard_size_bytes=shard_size_bytes,
+    )
 
 
 __all__ = [

--- a/experimental/lite/megatron/lite/model/glm5/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/checkpoint.py
@@ -652,15 +652,10 @@ def export_hf_weights(model, config: Glm5Config, ps: ParallelState, **kwargs):
 
 
 def save_hf_weights(model, path: str, config: Glm5Config, ps: ParallelState, **kwargs) -> None:
-    from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
+    from megatron.lite.primitive.ckpt.hf_weights import save_hf_weights as _save
 
-    rank = dist.get_rank() if dist.is_initialized() else 0
     kwargs.pop("cpu", None)
-    out = dict(export_hf_weights(model, config, ps, rank0_only=True, cpu=True, **kwargs))
-    if rank == 0 and out:
-        save_safetensors(out, path)
-    if dist.is_initialized():
-        dist.barrier()
+    _save(model, path, config, ps, export_fn=export_hf_weights, **kwargs)
 
 
 __all__ = [

--- a/experimental/lite/megatron/lite/model/glm5/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/checkpoint.py
@@ -626,6 +626,8 @@ def load_hf_weights(model: nn.Module, path: str, config: Glm5Config, ps: Paralle
 def export_hf_weights(model, config: Glm5Config, ps: ParallelState, **kwargs):
     from megatron.lite.primitive.ckpt.hf_weights import export_hf_weights as _export
 
+    if config is None:
+        raise ValueError("GLM5 HF export requires a non-null model config")
     spec = Glm5WeightSpec(config)
     rank0_only = bool(kwargs.get("rank0_only", False))
     cpu = bool(kwargs.get("cpu", False))

--- a/experimental/lite/megatron/lite/model/glm5/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/checkpoint.py
@@ -30,10 +30,7 @@ from torch.distributed.tensor import Replicate, Shard
 from megatron.lite.model.glm5.config import Glm5Config
 from megatron.lite.primitive.ckpt.hf_weights import (
     SafeTensorReader,
-    _cast_export_tensor,
-    _resolve_export_dtype,
     parse_expert_idx,
-    to_global_layer_name,
     unwrap_model,
 )
 from megatron.lite.primitive.parallel import ParallelState
@@ -348,6 +345,10 @@ class Glm5WeightSpec:
         del native_name
         return hf_tensors[0]
 
+    @staticmethod
+    def is_export_buffer(native_name: str) -> bool:
+        return native_name.endswith(".moe.router.expert_bias")
+
     # GLM-5 ONLY: DSA attention native suffix -> HF suffix.  The wrapper places
     # the DSA module under `self_attention.self_attention.*`; the HF model uses
     # `self_attn.*` with identical submodule names.
@@ -623,36 +624,12 @@ def load_hf_weights(model: nn.Module, path: str, config: Glm5Config, ps: Paralle
 
 
 def export_hf_weights(model, config: Glm5Config, ps: ParallelState, **kwargs):
-    from megatron.lite.primitive.ckpt.hf_weights import (
-        export_hf_weights as _export,
-        stream_pp_tensors,
-    )
+    from megatron.lite.primitive.ckpt.hf_weights import export_hf_weights as _export
 
     if config is None:
         raise ValueError("GLM5 HF export requires a non-null model config")
     spec = Glm5WeightSpec(config)
-    rank0_only = bool(kwargs.get("rank0_only", False))
-    cpu = bool(kwargs.get("cpu", False))
-    export_dtype = _resolve_export_dtype(kwargs.get("export_dtype"))
     yield from _export(model, spec, ps, vocab_size=config.vocab_size, **kwargs)
-    chunks = list(model) if isinstance(model, list | nn.ModuleList) else [model]
-    local_buffers: list[tuple[str, torch.Tensor]] = []
-    for chunk in chunks:
-        base_chunk = unwrap_model(chunk)
-        layer_map = (
-            {i: base_chunk.layer_indices[i] for i in range(len(base_chunk.layer_indices))}
-            if hasattr(base_chunk, "layer_indices")
-            else {}
-        )
-        for name, buffer in base_chunk.named_buffers():
-            if not name.endswith(".moe.router.expert_bias"):
-                continue
-            global_name = to_global_layer_name(name, layer_map)
-            local_buffers.extend(spec.native_to_hf(global_name, buffer.detach()))
-    for hf_name, hf_tensor in stream_pp_tensors(
-        local_buffers, ps, rank0_only=rank0_only, cpu=cpu
-    ):
-        yield hf_name, _cast_export_tensor(hf_tensor, export_dtype)
 
 
 def save_hf_weights(model, path: str, config: Glm5Config, ps: ParallelState, **kwargs) -> None:

--- a/experimental/lite/megatron/lite/model/glm5/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/checkpoint.py
@@ -652,10 +652,16 @@ def export_hf_weights(model, config: Glm5Config, ps: ParallelState, **kwargs):
 
 
 def save_hf_weights(model, path: str, config: Glm5Config, ps: ParallelState, **kwargs) -> None:
-    from megatron.lite.primitive.ckpt.hf_weights import save_hf_weights as _save
+    """Export + write sharded safetensors via ``stream_export_to_shards``."""
+    from megatron.lite.primitive.ckpt.hf_weights import stream_export_to_shards
 
     kwargs.pop("cpu", None)
-    _save(model, path, config, ps, export_fn=export_hf_weights, **kwargs)
+    shard_size_bytes = int(kwargs.pop("shard_size_bytes", 5 * 1024**3))
+    stream_export_to_shards(
+        export_hf_weights(model, config, ps, rank0_only=True, cpu=True, **kwargs),
+        path,
+        shard_size_bytes=shard_size_bytes,
+    )
 
 
 __all__ = [

--- a/experimental/lite/megatron/lite/model/glm5/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/checkpoint.py
@@ -24,7 +24,6 @@ no-ops here; they are kept for structural parity with Kimi.
 from __future__ import annotations
 
 import torch
-import torch.distributed as dist
 import torch.nn as nn
 from torch.distributed.tensor import Replicate, Shard
 
@@ -624,7 +623,10 @@ def load_hf_weights(model: nn.Module, path: str, config: Glm5Config, ps: Paralle
 
 
 def export_hf_weights(model, config: Glm5Config, ps: ParallelState, **kwargs):
-    from megatron.lite.primitive.ckpt.hf_weights import export_hf_weights as _export
+    from megatron.lite.primitive.ckpt.hf_weights import (
+        export_hf_weights as _export,
+        stream_pp_tensors,
+    )
 
     if config is None:
         raise ValueError("GLM5 HF export requires a non-null model config")
@@ -633,10 +635,8 @@ def export_hf_weights(model, config: Glm5Config, ps: ParallelState, **kwargs):
     cpu = bool(kwargs.get("cpu", False))
     export_dtype = _resolve_export_dtype(kwargs.get("export_dtype"))
     yield from _export(model, spec, ps, vocab_size=config.vocab_size, **kwargs)
-    rank = dist.get_rank() if dist.is_initialized() else 0
-    if rank0_only and rank != 0:
-        return
     chunks = list(model) if isinstance(model, list | nn.ModuleList) else [model]
+    local_buffers: list[tuple[str, torch.Tensor]] = []
     for chunk in chunks:
         base_chunk = unwrap_model(chunk)
         layer_map = (
@@ -648,9 +648,11 @@ def export_hf_weights(model, config: Glm5Config, ps: ParallelState, **kwargs):
             if not name.endswith(".moe.router.expert_bias"):
                 continue
             global_name = to_global_layer_name(name, layer_map)
-            export_buffer = buffer.detach().cpu() if cpu else buffer.detach()
-            for hf_name, hf_tensor in spec.native_to_hf(global_name, export_buffer):
-                yield hf_name, _cast_export_tensor(hf_tensor, export_dtype)
+            local_buffers.extend(spec.native_to_hf(global_name, buffer.detach()))
+    for hf_name, hf_tensor in stream_pp_tensors(
+        local_buffers, ps, rank0_only=rank0_only, cpu=cpu
+    ):
+        yield hf_name, _cast_export_tensor(hf_tensor, export_dtype)
 
 
 def save_hf_weights(model, path: str, config: Glm5Config, ps: ParallelState, **kwargs) -> None:

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/checkpoint.py
@@ -641,15 +641,11 @@ def export_hf_weights(model, config: KimiK2Config, ps: ParallelState, **kwargs):
                 yield hf_name, _cast_export_tensor(hf_tensor, export_dtype)
 
 
-def save_hf_weights(model, path: str, config: KimiK2Config, ps: ParallelState) -> None:
-    from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
+def save_hf_weights(model, path: str, config: KimiK2Config, ps: ParallelState, **kwargs) -> None:
+    from megatron.lite.primitive.ckpt.hf_weights import save_hf_weights as _save
 
-    rank = dist.get_rank() if dist.is_initialized() else 0
-    out = dict(export_hf_weights(model, config, ps, rank0_only=True, cpu=True))
-    if rank == 0 and out:
-        save_safetensors(out, path)
-    if dist.is_initialized():
-        dist.barrier()
+    kwargs.pop("cpu", None)
+    _save(model, path, config, ps, export_fn=export_hf_weights, **kwargs)
 
 
 __all__ = [

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/checkpoint.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import torch
-import torch.distributed as dist
 import torch.nn as nn
 from torch.distributed.tensor import Replicate, Shard
 
@@ -614,17 +613,18 @@ def load_hf_weights(model: nn.Module, path: str, config: KimiK2Config, ps: Paral
 
 
 def export_hf_weights(model, config: KimiK2Config, ps: ParallelState, **kwargs):
-    from megatron.lite.primitive.ckpt.hf_weights import export_hf_weights as _export
+    from megatron.lite.primitive.ckpt.hf_weights import (
+        export_hf_weights as _export,
+        stream_pp_tensors,
+    )
 
     spec = KimiK2WeightSpec(config)
     rank0_only = bool(kwargs.get("rank0_only", False))
     cpu = bool(kwargs.get("cpu", False))
     export_dtype = _resolve_export_dtype(kwargs.get("export_dtype"))
     yield from _export(model, spec, ps, vocab_size=config.vocab_size, **kwargs)
-    rank = dist.get_rank() if dist.is_initialized() else 0
-    if rank0_only and rank != 0:
-        return
     chunks = list(model) if isinstance(model, list | nn.ModuleList) else [model]
+    local_buffers: list[tuple[str, torch.Tensor]] = []
     for chunk in chunks:
         base_chunk = unwrap_model(chunk)
         layer_map = (
@@ -636,9 +636,11 @@ def export_hf_weights(model, config: KimiK2Config, ps: ParallelState, **kwargs):
             if not name.endswith(".moe.router.expert_bias"):
                 continue
             global_name = to_global_layer_name(name, layer_map)
-            export_buffer = buffer.detach().cpu() if cpu else buffer.detach()
-            for hf_name, hf_tensor in spec.native_to_hf(global_name, export_buffer):
-                yield hf_name, _cast_export_tensor(hf_tensor, export_dtype)
+            local_buffers.extend(spec.native_to_hf(global_name, buffer.detach()))
+    for hf_name, hf_tensor in stream_pp_tensors(
+        local_buffers, ps, rank0_only=rank0_only, cpu=cpu
+    ):
+        yield hf_name, _cast_export_tensor(hf_tensor, export_dtype)
 
 
 def save_hf_weights(model, path: str, config: KimiK2Config, ps: ParallelState, **kwargs) -> None:

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/checkpoint.py
@@ -642,10 +642,16 @@ def export_hf_weights(model, config: KimiK2Config, ps: ParallelState, **kwargs):
 
 
 def save_hf_weights(model, path: str, config: KimiK2Config, ps: ParallelState, **kwargs) -> None:
-    from megatron.lite.primitive.ckpt.hf_weights import save_hf_weights as _save
+    """Export + write sharded safetensors via ``stream_export_to_shards``."""
+    from megatron.lite.primitive.ckpt.hf_weights import stream_export_to_shards
 
     kwargs.pop("cpu", None)
-    _save(model, path, config, ps, export_fn=export_hf_weights, **kwargs)
+    shard_size_bytes = int(kwargs.pop("shard_size_bytes", 5 * 1024**3))
+    stream_export_to_shards(
+        export_hf_weights(model, config, ps, rank0_only=True, cpu=True, **kwargs),
+        path,
+        shard_size_bytes=shard_size_bytes,
+    )
 
 
 __all__ = [

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/checkpoint.py
@@ -10,10 +10,7 @@ from torch.distributed.tensor import Replicate, Shard
 from megatron.lite.model.kimi_k2.config import KimiK2Config
 from megatron.lite.primitive.ckpt.hf_weights import (
     SafeTensorReader,
-    _cast_export_tensor,
-    _resolve_export_dtype,
     parse_expert_idx,
-    to_global_layer_name,
     unwrap_model,
 )
 from megatron.lite.primitive.parallel import ParallelState
@@ -342,6 +339,10 @@ class KimiK2WeightSpec:
         del native_name
         return hf_tensors[0]
 
+    @staticmethod
+    def is_export_buffer(native_name: str) -> bool:
+        return native_name.endswith(".moe.router.expert_bias")
+
     def native_to_hf(
         self, native_name: str, tensor: torch.Tensor
     ) -> list[tuple[str, torch.Tensor]]:
@@ -613,34 +614,10 @@ def load_hf_weights(model: nn.Module, path: str, config: KimiK2Config, ps: Paral
 
 
 def export_hf_weights(model, config: KimiK2Config, ps: ParallelState, **kwargs):
-    from megatron.lite.primitive.ckpt.hf_weights import (
-        export_hf_weights as _export,
-        stream_pp_tensors,
-    )
+    from megatron.lite.primitive.ckpt.hf_weights import export_hf_weights as _export
 
     spec = KimiK2WeightSpec(config)
-    rank0_only = bool(kwargs.get("rank0_only", False))
-    cpu = bool(kwargs.get("cpu", False))
-    export_dtype = _resolve_export_dtype(kwargs.get("export_dtype"))
     yield from _export(model, spec, ps, vocab_size=config.vocab_size, **kwargs)
-    chunks = list(model) if isinstance(model, list | nn.ModuleList) else [model]
-    local_buffers: list[tuple[str, torch.Tensor]] = []
-    for chunk in chunks:
-        base_chunk = unwrap_model(chunk)
-        layer_map = (
-            {i: base_chunk.layer_indices[i] for i in range(len(base_chunk.layer_indices))}
-            if hasattr(base_chunk, "layer_indices")
-            else {}
-        )
-        for name, buffer in base_chunk.named_buffers():
-            if not name.endswith(".moe.router.expert_bias"):
-                continue
-            global_name = to_global_layer_name(name, layer_map)
-            local_buffers.extend(spec.native_to_hf(global_name, buffer.detach()))
-    for hf_name, hf_tensor in stream_pp_tensors(
-        local_buffers, ps, rank0_only=rank0_only, cpu=cpu
-    ):
-        yield hf_name, _cast_export_tensor(hf_tensor, export_dtype)
 
 
 def save_hf_weights(model, path: str, config: KimiK2Config, ps: ParallelState, **kwargs) -> None:

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/protocol.py
@@ -278,6 +278,12 @@ def export_hf_weights(chunks, model_cfg: KimiK2Config, ps: ParallelState, **kwar
     yield from export_impl(chunks, model_cfg, ps, **kwargs)
 
 
+def save_hf_weights(chunks, path: str, model_cfg: KimiK2Config, ps: ParallelState) -> None:
+    from megatron.lite.model.kimi_k2.lite.checkpoint import save_hf_weights as save_impl
+
+    save_impl(chunks, path, model_cfg, ps)
+
+
 def vocab_size(model_cfg) -> int | None:
     cfg = getattr(model_cfg, "text_config", model_cfg)
     return getattr(cfg, "vocab_size", None)
@@ -292,5 +298,6 @@ __all__ = [
     "export_hf_weights",
     "is_expert_param",
     "load_hf_weights",
+    "save_hf_weights",
     "vocab_size",
 ]

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
@@ -12,6 +12,7 @@ Protocol convention (what runtime calls):
   Optional (in ModelBundle.extras or module-level):
     load_hf_weights(chunk, hf_path, model_cfg, ps)  — HF weight loading
     export_hf_weights(chunks, model_cfg, ps)         — HF weight export
+    save_hf_weights(chunks, path, model_cfg, ps)     — HF checkpoint writing
     vocab_size(model_cfg) -> int                     — benchmark metadata
   Escape hatch:
     create_runtime(hf_path, cfg) -> Runtime          — fully override runtime
@@ -57,6 +58,7 @@ __all__ = [
     "build_model_config",
     "export_hf_weights",
     "load_hf_weights",
+    "save_hf_weights",
     "vocab_size",
 ]
 
@@ -319,6 +321,17 @@ def export_hf_weights(
 
     for chunk in chunks:
         yield from _export(chunk, model_cfg, ps, **kwargs)
+
+
+def save_hf_weights(
+    chunks: list[nn.Module],
+    path: str,
+    model_cfg: Qwen3MoEConfig,
+    ps: ParallelState,
+) -> None:
+    from megatron.lite.model.qwen3_moe.lite.checkpoint import save_hf_weights as _save
+
+    _save(chunks, path, model_cfg, ps)
 
 
 # ---------------------------------------------------------------------------

--- a/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
@@ -1066,6 +1066,63 @@ def export_hf_weights(
     return
 
 
+def stream_pp_tensors(
+    local_tensors: Iterable[tuple[str, torch.Tensor]],
+    ps,
+    *,
+    rank0_only: bool = False,
+    cpu: bool = False,
+) -> Generator[tuple[str, torch.Tensor], None, None]:
+    """Stream model-specific tensors from every PP stage in stage order.
+
+    The shared HF exporter handles parameters, but persistent model state such
+    as router expert bias is stored in buffers.  All ranks must participate in
+    the broadcasts even when only rank 0 emits tensors for checkpoint writing.
+    """
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    emit = not (rank0_only and rank != 0)
+    tensors = [(name, tensor.detach().contiguous()) for name, tensor in local_tensors]
+
+    if ps.pp_size <= 1:
+        if emit:
+            for name, tensor in tensors:
+                yield name, _maybe_cpu(tensor, cpu=cpu)
+        return
+    if not dist.is_initialized():
+        raise RuntimeError("PP tensor export requires initialized torch.distributed")
+
+    bcast_device = (
+        torch.device("cuda", torch.cuda.current_device())
+        if torch.cuda.is_available()
+        else torch.device("cpu")
+    )
+    for src_pp in range(ps.pp_size):
+        src_global = ps.pp_global_ranks[src_pp]
+        is_source = src_pp == ps.pp_rank
+        if is_source:
+            stage_tensors = [
+                (name, tensor.to(bcast_device).contiguous()) for name, tensor in tensors
+            ]
+            header: list[Any] = [
+                [(name, tuple(tensor.shape), tensor.dtype) for name, tensor in stage_tensors]
+            ]
+        else:
+            stage_tensors = []
+            header = [None]
+        dist.broadcast_object_list(
+            header, src=src_global, group=ps.pp_group, device=bcast_device
+        )
+        for idx, (name, shape, dtype) in enumerate(header[0] or []):
+            tensor = (
+                stage_tensors[idx][1]
+                if is_source
+                else torch.empty(shape, dtype=dtype, device=bcast_device)
+            )
+            dist.broadcast(tensor, src=src_global, group=ps.pp_group)
+            if emit:
+                yield name, _maybe_cpu(tensor, cpu=cpu)
+
+
 def _gather_dense(
     name: str, tensor: torch.Tensor, spec: HFWeights, ps, *, cpu: bool = True
 ) -> torch.Tensor:

--- a/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
@@ -13,8 +13,6 @@ from __future__ import annotations
 import json
 import os
 import re
-import shutil
-import tempfile
 from collections.abc import Generator, Iterable
 from contextlib import ExitStack
 from pathlib import Path
@@ -1123,6 +1121,79 @@ def _gather_expert_etp(name: str, tensor: torch.Tensor, spec: HFWeights, ps) -> 
     return tensor
 
 
+def stream_export_to_shards(
+    export_iter: Iterable[tuple[str, torch.Tensor]],
+    path: str,
+    *,
+    shard_size_bytes: int = 5 * 1024**3,
+) -> None:
+    """Consume ``export_iter`` and write sharded safetensors on rank 0.
+
+    Flushes to disk once a shard reaches ``shard_size_bytes`` (default 5 GiB)
+    so rank 0's peak CPU RAM stays at ~one shard instead of the whole model.
+    Non-rank-0 still drains the iterator to drive collective communication
+    inside model-specific ``export_hf_weights`` implementations.
+
+    Emits ``model.safetensors`` when the export fits in a single shard, or
+    ``model-{i:05d}-of-{total:05d}.safetensors`` + ``model.safetensors.index.json``
+    when multiple shards are produced (HF-compatible layout).
+    """
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    if rank == 0:
+        os.makedirs(path, exist_ok=True)
+
+    shard: dict[str, torch.Tensor] = {}
+    shard_bytes = 0
+    tmp_names: list[str] = []
+    shard_keys: list[list[str]] = []
+    total_size = 0
+
+    def _flush() -> None:
+        nonlocal shard, shard_bytes
+        if not shard:
+            return
+        tmp = f".model-shard-{len(tmp_names) + 1:05d}.safetensors"
+        save_safetensors(shard, path, filename=tmp)
+        tmp_names.append(tmp)
+        shard_keys.append(list(shard.keys()))
+        shard = {}
+        shard_bytes = 0
+
+    for name, tensor in export_iter:
+        if rank != 0:
+            continue
+        nbytes = _tensor_nbytes(tensor)
+        if shard and shard_bytes + nbytes > shard_size_bytes:
+            _flush()
+        shard[name] = tensor
+        shard_bytes += nbytes
+        total_size += nbytes
+
+    if rank == 0:
+        _flush()
+        total = len(tmp_names)
+        if total == 1:
+            os.rename(
+                os.path.join(path, tmp_names[0]),
+                os.path.join(path, "model.safetensors"),
+            )
+        elif total > 1:
+            weight_map: dict[str, str] = {}
+            for idx, (tmp, keys) in enumerate(zip(tmp_names, shard_keys), start=1):
+                final = f"model-{idx:05d}-of-{total:05d}.safetensors"
+                os.rename(os.path.join(path, tmp), os.path.join(path, final))
+                for k in keys:
+                    weight_map[k] = final
+            with open(os.path.join(path, "model.safetensors.index.json"), "w") as f:
+                json.dump(
+                    {"metadata": {"total_size": total_size}, "weight_map": weight_map},
+                    f,
+                )
+
+    if dist.is_initialized():
+        dist.barrier()
+
+
 def save_hf_weights(
     model: nn.Module | list[nn.Module],
     hf_path: str,
@@ -1131,147 +1202,12 @@ def save_hf_weights(
     *,
     vocab_size: int | None = None,
     shard_size_bytes: int = 5 * 1024**3,
-    **export_kwargs: Any,
 ) -> None:
-    """Stream an HF export into bounded safetensor shards.
-
-    ``export_hf_weights`` is deliberately a generator, but collecting it into a
-    dict here would still materialize the entire checkpoint on rank 0.  Keep
-    only one shard in memory, write into a temporary directory, and promote the
-    complete set of HF weight artifacts after the export succeeds.  Unrelated
-    files in ``hf_path`` (for example a training checkpoint or config.json) are
-    preserved.
-    """
-    if shard_size_bytes <= 0:
-        raise ValueError(f"shard_size_bytes must be positive, got {shard_size_bytes}")
-
-    rank = dist.get_rank() if dist.is_initialized() else 0
-
-    export_fn = export_kwargs.pop("export_fn", export_hf_weights)
-    export_kwargs.pop("rank0_only", None)
-    export_kwargs.pop("cpu", None)
-    export_call_kwargs = dict(export_kwargs)
-    export_call_kwargs.update(rank0_only=True, cpu=True)
-    if export_fn is export_hf_weights:
-        export_call_kwargs["vocab_size"] = vocab_size
-    exported = export_fn(model, spec, ps, **export_call_kwargs)
-
-    staging_path: Path | None = None
-    shard_paths: list[Path] = []
-    shard_names: list[list[str]] = []
-    weight_map: dict[str, str] = {}
-    total_size = 0
-    shard: dict[str, torch.Tensor] = {}
-    shard_size = 0
-
-    def flush_shard() -> None:
-        nonlocal shard, shard_size
-        if not shard:
-            return
-        assert staging_path is not None
-        shard_path = staging_path / f".shard-{len(shard_paths) + 1:05d}.safetensors"
-        save_safetensors(shard, str(staging_path), shard_path.name)
-        shard_paths.append(shard_path)
-        shard_names.append(list(shard))
-        shard = {}
-        shard_size = 0
-
-    try:
-        if rank == 0:
-            output_path = Path(hf_path)
-            staging_path = Path(
-                tempfile.mkdtemp(
-                    prefix=f".{output_path.name}.hf-staging-",
-                    dir=str(output_path.parent),
-                )
-            )
-
-        for name, tensor in exported:
-            if rank != 0:
-                continue
-            if name in weight_map:
-                raise ValueError(f"duplicate HF tensor key: {name}")
-            tensor_size = _tensor_nbytes(tensor)
-            if shard and shard_size + tensor_size > shard_size_bytes:
-                flush_shard()
-            weight_map[name] = ""
-            shard[name] = tensor
-            shard_size += tensor_size
-            total_size += tensor_size
-
-        if rank == 0:
-            flush_shard()
-            if shard_paths:
-                output_path = Path(hf_path)
-                shard_count = len(shard_paths)
-                for index, shard_path in enumerate(shard_paths, start=1):
-                    filename = (
-                        "model.safetensors"
-                        if shard_count == 1
-                        else f"model-{index:05d}-of-{shard_count:05d}.safetensors"
-                    )
-                    final_path = staging_path / filename
-                    os.replace(shard_path, final_path)
-                    for name in shard_names[index - 1]:
-                        weight_map[name] = filename
-
-                if shard_count > 1:
-                    (staging_path / "model.safetensors.index.json").write_text(
-                        json.dumps(
-                            {"metadata": {"total_size": total_size}, "weight_map": weight_map},
-                            indent=2,
-                            sort_keys=True,
-                        )
-                        + "\n"
-                    )
-
-                output_path.parent.mkdir(parents=True, exist_ok=True)
-                existing = list(output_path.iterdir()) if output_path.exists() else []
-                unrelated = any(
-                    not path.is_file()
-                    or (path.suffix != ".safetensors" and path.name != "model.safetensors.index.json")
-                    for path in existing
-                )
-                if not unrelated:
-                    backup_path = None
-                    if output_path.exists():
-                        backup_path = Path(
-                            tempfile.mkdtemp(
-                                prefix=f".{output_path.name}.hf-backup-",
-                                dir=str(output_path.parent),
-                            )
-                        )
-                        backup_path.rmdir()
-                        os.replace(output_path, backup_path)
-                    try:
-                        os.replace(staging_path, output_path)
-                        staging_path = None
-                    except Exception:
-                        if backup_path is not None and not output_path.exists():
-                            os.replace(backup_path, output_path)
-                        raise
-                    finally:
-                        if backup_path is not None and backup_path.exists():
-                            shutil.rmtree(backup_path)
-                else:
-                    managed_names = {
-                        path.name
-                        for path in existing
-                        if path.is_file()
-                        and (
-                            path.suffix == ".safetensors"
-                            or path.name == "model.safetensors.index.json"
-                        )
-                    }
-                    managed_names.update(path.name for path in staging_path.iterdir())
-                    for name in managed_names:
-                        old_path = output_path / name
-                        if old_path.exists():
-                            old_path.unlink()
-                    for path in staging_path.iterdir():
-                        os.replace(path, output_path / path.name)
-    finally:
-        if staging_path is not None and staging_path.exists():
-            shutil.rmtree(staging_path)
-    if dist.is_initialized():
-        dist.barrier()
+    """Export + write sharded safetensors via ``stream_export_to_shards``."""
+    stream_export_to_shards(
+        export_hf_weights(
+            model, spec, ps, vocab_size=vocab_size, rank0_only=True, cpu=True
+        ),
+        hf_path,
+        shard_size_bytes=shard_size_bytes,
+    )

--- a/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
@@ -815,6 +815,27 @@ def export_hf_weights(
     rank = dist.get_rank() if dist.is_initialized() else 0
     resolved_export_dtype = _resolve_export_dtype(export_dtype)
 
+    def _iter_native_tensors():
+        """Yield parameters plus model-declared persistent export buffers."""
+        is_export_buffer = getattr(spec, "is_export_buffer", None)
+        for chunk in chunks:
+            base_chunk = unwrap_model(chunk)
+            layer_map = (
+                {
+                    i: base_chunk.layer_indices[i]
+                    for i in range(len(base_chunk.layer_indices))
+                }
+                if hasattr(base_chunk, "layer_indices")
+                else {}
+            )
+            for name, param in base_chunk.named_parameters():
+                yield to_global_layer_name(name, layer_map), param.data.detach()
+            if callable(is_export_buffer):
+                for name, buffer in base_chunk.named_buffers():
+                    global_name = to_global_layer_name(name, layer_map)
+                    if is_export_buffer(global_name):
+                        yield global_name, buffer.detach()
+
     if ps.pp_size <= 1:
         exported_params = 0
         expert_bucket: list[tuple[str, torch.Tensor]] = []
@@ -898,24 +919,10 @@ def export_hf_weights(
                         del packed_expert_buffers[packed_name]
                         yield from _iter_mapped({packed_name: packed_tensor})
 
-        def _iter_native_params():
-            for chunk in chunks:
-                base_chunk = unwrap_model(chunk)
-                layer_map = (
-                    {
-                        i: base_chunk.layer_indices[i]
-                        for i in range(len(base_chunk.layer_indices))
-                    }
-                    if hasattr(base_chunk, "layer_indices")
-                    else {}
-                )
-                for name, param in base_chunk.named_parameters():
-                    tensor = _cast_export_tensor(
-                        param.data.detach(), resolved_export_dtype
-                    )
-                    yield to_global_layer_name(name, layer_map), tensor
-
-        native_params = _iter_native_params()
+        native_params = (
+            (name, _cast_export_tensor(tensor, resolved_export_dtype))
+            for name, tensor in _iter_native_tensors()
+        )
         materialized_params = (
             _iter_bucketed_materialized_tensors(
                 native_params, buffer_max_size_bytes=buffer_max_size_bytes
@@ -1003,23 +1010,15 @@ def export_hf_weights(
         Advanced only during this rank's source turn, so at most one bucket of
         gathered params is ever resident — the whole stage is never built.
         """
-        for chunk in chunks:
-            base_chunk = unwrap_model(chunk)
-            layer_map = (
-                {i: base_chunk.layer_indices[i] for i in range(len(base_chunk.layer_indices))}
-                if hasattr(base_chunk, "layer_indices")
-                else {}
-            )
-            for name, param in base_chunk.named_parameters():
-                gname = to_global_layer_name(name, layer_map)
-                t = _materialize_dtensor(param.data.detach())
-                if spec.is_expert(gname):
-                    one: dict[str, torch.Tensor] = {}
-                    _gather_expert(gname, t, spec, ps, one, cpu=False)
-                    for gathered_name, gathered_tensor in one.items():
-                        yield gathered_name, gathered_tensor
-                else:
-                    yield gname, _gather_dense(gname, t, spec, ps, cpu=False)
+        for gname, tensor in _iter_native_tensors():
+            tensor = _materialize_dtensor(tensor)
+            if spec.is_expert(gname):
+                one: dict[str, torch.Tensor] = {}
+                _gather_expert(gname, tensor, spec, ps, one, cpu=False)
+                for gathered_name, gathered_tensor in one.items():
+                    yield gathered_name, gathered_tensor
+            else:
+                yield gname, _gather_dense(gname, tensor, spec, ps, cpu=False)
 
     def _emit_param(native_name: str, tensor: torch.Tensor):
         tensor = _maybe_cpu(tensor, cpu=gather_cpu)
@@ -1064,63 +1063,6 @@ def export_hf_weights(
                 del tensor
             del bucket
     return
-
-
-def stream_pp_tensors(
-    local_tensors: Iterable[tuple[str, torch.Tensor]],
-    ps,
-    *,
-    rank0_only: bool = False,
-    cpu: bool = False,
-) -> Generator[tuple[str, torch.Tensor], None, None]:
-    """Stream model-specific tensors from every PP stage in stage order.
-
-    The shared HF exporter handles parameters, but persistent model state such
-    as router expert bias is stored in buffers.  All ranks must participate in
-    the broadcasts even when only rank 0 emits tensors for checkpoint writing.
-    """
-    rank = dist.get_rank() if dist.is_initialized() else 0
-    emit = not (rank0_only and rank != 0)
-    tensors = [(name, tensor.detach().contiguous()) for name, tensor in local_tensors]
-
-    if ps.pp_size <= 1:
-        if emit:
-            for name, tensor in tensors:
-                yield name, _maybe_cpu(tensor, cpu=cpu)
-        return
-    if not dist.is_initialized():
-        raise RuntimeError("PP tensor export requires initialized torch.distributed")
-
-    bcast_device = (
-        torch.device("cuda", torch.cuda.current_device())
-        if torch.cuda.is_available()
-        else torch.device("cpu")
-    )
-    for src_pp in range(ps.pp_size):
-        src_global = ps.pp_global_ranks[src_pp]
-        is_source = src_pp == ps.pp_rank
-        if is_source:
-            stage_tensors = [
-                (name, tensor.to(bcast_device).contiguous()) for name, tensor in tensors
-            ]
-            header: list[Any] = [
-                [(name, tuple(tensor.shape), tensor.dtype) for name, tensor in stage_tensors]
-            ]
-        else:
-            stage_tensors = []
-            header = [None]
-        dist.broadcast_object_list(
-            header, src=src_global, group=ps.pp_group, device=bcast_device
-        )
-        for idx, (name, shape, dtype) in enumerate(header[0] or []):
-            tensor = (
-                stage_tensors[idx][1]
-                if is_source
-                else torch.empty(shape, dtype=dtype, device=bcast_device)
-            )
-            dist.broadcast(tensor, src=src_global, group=ps.pp_group)
-            if emit:
-                yield name, _maybe_cpu(tensor, cpu=cpu)
 
 
 def _gather_dense(

--- a/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
@@ -1141,6 +1141,17 @@ def stream_export_to_shards(
     rank = dist.get_rank() if dist.is_initialized() else 0
     if rank == 0:
         os.makedirs(path, exist_ok=True)
+        # Reusing an export directory must not leave stale shards or an index
+        # that describes a previous export.  Restrict cleanup to files owned by
+        # this writer; unrelated user files in the directory are preserved.
+        stale_patterns = (
+            re.compile(r"^model(?:-\d{5}-of-\d{5})?\.safetensors$"),
+            re.compile(r"^model\.safetensors\.index\.json$"),
+            re.compile(r"^\.model-shard-\d{5}\.safetensors$"),
+        )
+        for entry in os.listdir(path):
+            if any(pattern.fullmatch(entry) for pattern in stale_patterns):
+                os.remove(os.path.join(path, entry))
 
     shard: dict[str, torch.Tensor] = {}
     shard_bytes = 0

--- a/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import json
 import os
 import re
+import shutil
+import tempfile
 from collections.abc import Generator, Iterable
 from contextlib import ExitStack
 from pathlib import Path
@@ -1128,15 +1130,148 @@ def save_hf_weights(
     ps,
     *,
     vocab_size: int | None = None,
+    shard_size_bytes: int = 5 * 1024**3,
+    **export_kwargs: Any,
 ) -> None:
-    """Export + write to safetensors."""
+    """Stream an HF export into bounded safetensor shards.
+
+    ``export_hf_weights`` is deliberately a generator, but collecting it into a
+    dict here would still materialize the entire checkpoint on rank 0.  Keep
+    only one shard in memory, write into a temporary directory, and promote the
+    complete set of HF weight artifacts after the export succeeds.  Unrelated
+    files in ``hf_path`` (for example a training checkpoint or config.json) are
+    preserved.
+    """
+    if shard_size_bytes <= 0:
+        raise ValueError(f"shard_size_bytes must be positive, got {shard_size_bytes}")
+
     rank = dist.get_rank() if dist.is_initialized() else 0
-    out = dict(
-        export_hf_weights(
-            model, spec, ps, vocab_size=vocab_size, rank0_only=True, cpu=True
-        )
-    )
-    if rank == 0 and out:
-        save_safetensors(out, hf_path)
+
+    export_fn = export_kwargs.pop("export_fn", export_hf_weights)
+    export_kwargs.pop("rank0_only", None)
+    export_kwargs.pop("cpu", None)
+    export_call_kwargs = dict(export_kwargs)
+    export_call_kwargs.update(rank0_only=True, cpu=True)
+    if export_fn is export_hf_weights:
+        export_call_kwargs["vocab_size"] = vocab_size
+    exported = export_fn(model, spec, ps, **export_call_kwargs)
+
+    staging_path: Path | None = None
+    shard_paths: list[Path] = []
+    shard_names: list[list[str]] = []
+    weight_map: dict[str, str] = {}
+    total_size = 0
+    shard: dict[str, torch.Tensor] = {}
+    shard_size = 0
+
+    def flush_shard() -> None:
+        nonlocal shard, shard_size
+        if not shard:
+            return
+        assert staging_path is not None
+        shard_path = staging_path / f".shard-{len(shard_paths) + 1:05d}.safetensors"
+        save_safetensors(shard, str(staging_path), shard_path.name)
+        shard_paths.append(shard_path)
+        shard_names.append(list(shard))
+        shard = {}
+        shard_size = 0
+
+    try:
+        if rank == 0:
+            output_path = Path(hf_path)
+            staging_path = Path(
+                tempfile.mkdtemp(
+                    prefix=f".{output_path.name}.hf-staging-",
+                    dir=str(output_path.parent),
+                )
+            )
+
+        for name, tensor in exported:
+            if rank != 0:
+                continue
+            if name in weight_map:
+                raise ValueError(f"duplicate HF tensor key: {name}")
+            tensor_size = _tensor_nbytes(tensor)
+            if shard and shard_size + tensor_size > shard_size_bytes:
+                flush_shard()
+            weight_map[name] = ""
+            shard[name] = tensor
+            shard_size += tensor_size
+            total_size += tensor_size
+
+        if rank == 0:
+            flush_shard()
+            if shard_paths:
+                output_path = Path(hf_path)
+                shard_count = len(shard_paths)
+                for index, shard_path in enumerate(shard_paths, start=1):
+                    filename = (
+                        "model.safetensors"
+                        if shard_count == 1
+                        else f"model-{index:05d}-of-{shard_count:05d}.safetensors"
+                    )
+                    final_path = staging_path / filename
+                    os.replace(shard_path, final_path)
+                    for name in shard_names[index - 1]:
+                        weight_map[name] = filename
+
+                if shard_count > 1:
+                    (staging_path / "model.safetensors.index.json").write_text(
+                        json.dumps(
+                            {"metadata": {"total_size": total_size}, "weight_map": weight_map},
+                            indent=2,
+                            sort_keys=True,
+                        )
+                        + "\n"
+                    )
+
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                existing = list(output_path.iterdir()) if output_path.exists() else []
+                unrelated = any(
+                    not path.is_file()
+                    or (path.suffix != ".safetensors" and path.name != "model.safetensors.index.json")
+                    for path in existing
+                )
+                if not unrelated:
+                    backup_path = None
+                    if output_path.exists():
+                        backup_path = Path(
+                            tempfile.mkdtemp(
+                                prefix=f".{output_path.name}.hf-backup-",
+                                dir=str(output_path.parent),
+                            )
+                        )
+                        backup_path.rmdir()
+                        os.replace(output_path, backup_path)
+                    try:
+                        os.replace(staging_path, output_path)
+                        staging_path = None
+                    except Exception:
+                        if backup_path is not None and not output_path.exists():
+                            os.replace(backup_path, output_path)
+                        raise
+                    finally:
+                        if backup_path is not None and backup_path.exists():
+                            shutil.rmtree(backup_path)
+                else:
+                    managed_names = {
+                        path.name
+                        for path in existing
+                        if path.is_file()
+                        and (
+                            path.suffix == ".safetensors"
+                            or path.name == "model.safetensors.index.json"
+                        )
+                    }
+                    managed_names.update(path.name for path in staging_path.iterdir())
+                    for name in managed_names:
+                        old_path = output_path / name
+                        if old_path.exists():
+                            old_path.unlink()
+                    for path in staging_path.iterdir():
+                        os.replace(path, output_path / path.name)
+    finally:
+        if staging_path is not None and staging_path.exists():
+            shutil.rmtree(staging_path)
     if dist.is_initialized():
         dist.barrier()

--- a/experimental/lite/tests/smoke/primitive/test_save_load_export_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_save_load_export_smoke.py
@@ -185,13 +185,15 @@ def _deepseek_v4():
         hidden_size=128,
         moe_intermediate_size=16,
         num_hidden_layers=2,
-        num_attention_heads=8,
+        num_attention_heads=64,
         num_key_value_heads=1,
-        head_dim=64,
-        qk_rope_head_dim=16,
+        # Keep the production fused-kernel geometry; only model width/depth and
+        # expert counts are reduced for the proxy.
+        head_dim=512,
+        qk_rope_head_dim=64,
         q_lora_rank=32,
         o_lora_rank=32,
-        o_groups=2,
+        o_groups=8,
         n_routed_experts=4,
         n_shared_experts=1,
         num_experts_per_tok=2,
@@ -201,8 +203,9 @@ def _deepseek_v4():
         sliding_window=128,
         num_hash_layers=2,
         hc_mult=2,
-        index_head_dim=64,
-        index_n_heads=8,
+        # The authoritative SM90 DSA indexer kernel requires 128 exactly.
+        index_head_dim=128,
+        index_n_heads=64,
         index_topk=512,
         # DeepSeek-V4 really has MTP; its ImplConfig defaults mtp_enable=True and
         # requires >=1 nextn layer, so give it one (exercises MTP weight IO too).
@@ -483,19 +486,22 @@ def _export_and_reload(handle: ModelHandle, cfg, protocol, out_dir: str, model_n
     shards = [f for f in os.listdir(out_dir) if f.endswith(".safetensors")]
     assert shards, f"no safetensors exported to {out_dir}"
     keys: set[str] = set()
-    # The shared exporter casts EVERY floating tensor to bf16 (``_cast_export_tensor``
-    # with export_dtype=bf16) and leaves integers untouched.  So every float weight
-    # — including the router correction bias — must be bf16, while integer auxiliary
-    # buffers (e.g. DS4 hash-routing ``tid2eid`` index tables; casting them would
-    # corrupt the indices) keep their native integral dtype.  Excluding such buffers
-    # from the export would be a de-scope; we keep them and check their dtype.
+    # Trainable model weights are bf16. Kimi/GLM router correction biases are
+    # deliberately persistent fp32 state in both the native model and official HF
+    # checkpoints, while integer auxiliary buffers (for example DS4 ``tid2eid``)
+    # retain their integral dtype.
     for shard in shards:
         with safe_open(os.path.join(out_dir, shard), framework="pt") as fh:
             for key in fh.keys():
                 tensor = fh.get_tensor(key)
                 if tensor.dtype.is_floating_point:
-                    assert tensor.dtype == torch.bfloat16, (
-                        f"{key} exported as {tensor.dtype}, want bf16"
+                    expected_dtype = (
+                        torch.float32
+                        if key.endswith(".e_score_correction_bias")
+                        else torch.bfloat16
+                    )
+                    assert tensor.dtype == expected_dtype, (
+                        f"{key} exported as {tensor.dtype}, want {expected_dtype}"
                     )
                 else:
                     assert tensor.dtype in (torch.int64, torch.int32, torch.bool), (

--- a/experimental/lite/tests/unit/model/test_glm5_lite_static.py
+++ b/experimental/lite/tests/unit/model/test_glm5_lite_static.py
@@ -390,11 +390,11 @@ def test_glm5_checkpoint_exports_and_saves_hf_style_weights(tmp_path):
     state = model.state_dict()
 
     assert torch.equal(
-        exported["model.layers.1.mlp.experts.2.gate_proj.weight"],
+        exported["model.layers.1.mlp.experts.2.gate_proj.weight"].detach().cpu(),
         state["layers.1.moe.experts.fc1.weight2"][: cfg.moe_intermediate_size].detach().cpu(),
     )
     assert torch.equal(
-        exported["model.layers.1.mlp.gate.e_score_correction_bias"],
+        exported["model.layers.1.mlp.gate.e_score_correction_bias"].detach().cpu(),
         state["layers.1.moe.router.expert_bias"].detach().cpu(),
     )
     assert "model.layers.1.mlp.experts.gate_up_proj" not in exported

--- a/experimental/lite/tests/unit/model/test_glm5_lite_static.py
+++ b/experimental/lite/tests/unit/model/test_glm5_lite_static.py
@@ -446,6 +446,14 @@ def test_glm5_checkpoint_exports_and_saves_hf_style_weights(tmp_path):
     )
 
 
+def test_glm5_hf_export_rejects_missing_model_config():
+    from megatron.lite.model.glm5.lite.checkpoint import export_hf_weights
+    from megatron.lite.primitive.parallel import ParallelState
+
+    with pytest.raises(ValueError, match="non-null model config"):
+        next(export_hf_weights(None, None, ParallelState()))
+
+
 def test_glm5_checkpoint_exports_and_loads_mtp_layers(tmp_path):
     import torch
 

--- a/experimental/lite/tests/unit/model/test_glm5_lite_static.py
+++ b/experimental/lite/tests/unit/model/test_glm5_lite_static.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 
 def _make_train_config(ps):
     from types import SimpleNamespace

--- a/experimental/lite/tests/unit/model/test_hf_save_protocol_contract.py
+++ b/experimental/lite/tests/unit/model/test_hf_save_protocol_contract.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""HF-save entry-point contract for every registered Lite model protocol."""
+
+from __future__ import annotations
+
+import ast
+import importlib
+from pathlib import Path
+
+import pytest
+
+from megatron.lite.model.registry import TRAIN_RUNTIME_MODULES
+
+pytestmark = pytest.mark.mlite
+
+LITE_ROOT = Path(__file__).resolve().parents[3]
+_REGISTERED_PROTOCOLS = sorted(TRAIN_RUNTIME_MODULES.items())
+
+
+@pytest.mark.parametrize(
+    ("runtime_name", "module_name"),
+    _REGISTERED_PROTOCOLS,
+    ids=[runtime_name for runtime_name, _ in _REGISTERED_PROTOCOLS],
+)
+def test_registered_protocol_exposes_hf_save(
+    runtime_name: str, module_name: str
+) -> None:
+    protocol_path = LITE_ROOT / Path(*module_name.split(".")).with_suffix(".py")
+    tree = ast.parse(protocol_path.read_text())
+    functions = {
+        node.name for node in tree.body if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+    assert "save_hf_weights" in functions, (
+        f"{runtime_name} ({module_name}) cannot honor save_contents=['hf_model']"
+    )
+
+
+@pytest.mark.parametrize("model_name", ["kimi_k2", "qwen3_moe"])
+def test_new_hf_save_protocols_delegate_all_arguments(
+    model_name: str, monkeypatch: pytest.MonkeyPatch, transformer_engine_import_stub
+) -> None:
+    transformer_engine_import_stub()
+    protocol = importlib.import_module(f"megatron.lite.model.{model_name}.lite.protocol")
+    checkpoint = importlib.import_module(f"megatron.lite.model.{model_name}.lite.checkpoint")
+    calls = []
+    monkeypatch.setattr(
+        checkpoint,
+        "save_hf_weights",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+    chunks, model_cfg, parallel_state = object(), object(), object()
+
+    protocol.save_hf_weights(
+        chunks,
+        "/tmp/hf-save-contract",
+        model_cfg,
+        parallel_state,
+    )
+
+    assert calls == [
+        (
+            (chunks, "/tmp/hf-save-contract", model_cfg, parallel_state),
+            {},
+        )
+    ]

--- a/experimental/lite/tests/unit/primitive/test_hf_weights_streaming.py
+++ b/experimental/lite/tests/unit/primitive/test_hf_weights_streaming.py
@@ -6,7 +6,6 @@ import inspect
 import json
 import sys
 import types
-from pathlib import Path
 
 import torch
 import torch.nn as nn
@@ -25,6 +24,7 @@ from megatron.lite.primitive.ckpt.hf_weights import (
     _iter_bucketed_materialized_tensors,
     bucketed_all_gather_into_tensor,
     export_hf_weights,
+    save_hf_weights,
 )
 
 
@@ -61,6 +61,93 @@ def test_safe_tensor_reader_context_reuses_and_closes_shard(monkeypatch, tmp_pat
 
 def test_export_defaults_to_device_resident_tensors() -> None:
     assert inspect.signature(export_hf_weights).parameters["cpu"].default is False
+
+
+def test_save_hf_weights_streams_shards_and_replaces_stale_artifacts(tmp_path, monkeypatch):
+    import megatron.lite.primitive.ckpt.hf_weights as hf_weights
+
+    output = tmp_path / "huggingface"
+    output.mkdir()
+    (output / "config.json").write_text('{"model_type": "test"}')
+    (output / "model.safetensors").write_bytes(b"stale")
+    (output / "model-00002-of-00002.safetensors").write_bytes(b"stale")
+    (output / "model.safetensors.index.json").write_text(
+        '{"metadata": {}, "weight_map": {"stale": "model.safetensors"}}'
+    )
+    stage = tmp_path / "stage"
+
+    def fake_export(*args, **kwargs):
+        assert kwargs["rank0_only"] is True
+        assert kwargs["cpu"] is True
+        yield "first", torch.arange(2, dtype=torch.float32)
+        yield "second", torch.arange(2, dtype=torch.float32) + 10
+
+    monkeypatch.setattr(hf_weights, "export_hf_weights", fake_export)
+
+    save_hf_weights(
+        object(),
+        str(output),
+        object(),
+        object(),
+        shard_size_bytes=8,
+    )
+
+    assert sorted(path.name for path in output.iterdir()) == [
+        "config.json",
+        "model-00001-of-00002.safetensors",
+        "model-00002-of-00002.safetensors",
+        "model.safetensors.index.json",
+    ]
+    assert (output / "config.json").read_text() == '{"model_type": "test"}'
+    index = __import__("json").loads(
+        (output / "model.safetensors.index.json").read_text()
+    )
+    assert index["weight_map"] == {
+        "first": "model-00001-of-00002.safetensors",
+        "second": "model-00002-of-00002.safetensors",
+    }
+    reader = SafeTensorReader(str(output))
+    assert torch.equal(reader.get_tensor("first"), torch.arange(2, dtype=torch.float32))
+    assert not stage.exists()
+
+
+def test_save_hf_weights_rejects_duplicate_keys(tmp_path, monkeypatch):
+    import megatron.lite.primitive.ckpt.hf_weights as hf_weights
+
+    def fake_export(*args, **kwargs):
+        yield "same", torch.ones(1)
+        yield "same", torch.zeros(1)
+
+    monkeypatch.setattr(hf_weights, "export_hf_weights", fake_export)
+
+    with pytest.raises(ValueError, match="duplicate HF tensor key"):
+        save_hf_weights(object(), str(tmp_path / "huggingface"), object(), object())
+
+
+def test_save_hf_weights_accepts_model_owned_exporter(tmp_path):
+    marker = object()
+    calls = []
+
+    def model_owned_export(model, spec, ps, **kwargs):
+        calls.append((model, spec, ps, kwargs))
+        yield "mapped", torch.ones(1)
+
+    save_hf_weights(
+        "model",
+        str(tmp_path / "huggingface"),
+        marker,
+        "parallel",
+        export_fn=model_owned_export,
+    )
+
+    assert calls == [
+        (
+            "model",
+            marker,
+            "parallel",
+            {"rank0_only": True, "cpu": True},
+        )
+    ]
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")

--- a/experimental/lite/tests/unit/primitive/test_hf_weights_streaming.py
+++ b/experimental/lite/tests/unit/primitive/test_hf_weights_streaming.py
@@ -6,6 +6,7 @@ import inspect
 import json
 import sys
 import types
+from pathlib import Path
 
 import torch
 import torch.nn as nn
@@ -24,7 +25,6 @@ from megatron.lite.primitive.ckpt.hf_weights import (
     _iter_bucketed_materialized_tensors,
     bucketed_all_gather_into_tensor,
     export_hf_weights,
-    save_hf_weights,
 )
 
 
@@ -61,93 +61,6 @@ def test_safe_tensor_reader_context_reuses_and_closes_shard(monkeypatch, tmp_pat
 
 def test_export_defaults_to_device_resident_tensors() -> None:
     assert inspect.signature(export_hf_weights).parameters["cpu"].default is False
-
-
-def test_save_hf_weights_streams_shards_and_replaces_stale_artifacts(tmp_path, monkeypatch):
-    import megatron.lite.primitive.ckpt.hf_weights as hf_weights
-
-    output = tmp_path / "huggingface"
-    output.mkdir()
-    (output / "config.json").write_text('{"model_type": "test"}')
-    (output / "model.safetensors").write_bytes(b"stale")
-    (output / "model-00002-of-00002.safetensors").write_bytes(b"stale")
-    (output / "model.safetensors.index.json").write_text(
-        '{"metadata": {}, "weight_map": {"stale": "model.safetensors"}}'
-    )
-    stage = tmp_path / "stage"
-
-    def fake_export(*args, **kwargs):
-        assert kwargs["rank0_only"] is True
-        assert kwargs["cpu"] is True
-        yield "first", torch.arange(2, dtype=torch.float32)
-        yield "second", torch.arange(2, dtype=torch.float32) + 10
-
-    monkeypatch.setattr(hf_weights, "export_hf_weights", fake_export)
-
-    save_hf_weights(
-        object(),
-        str(output),
-        object(),
-        object(),
-        shard_size_bytes=8,
-    )
-
-    assert sorted(path.name for path in output.iterdir()) == [
-        "config.json",
-        "model-00001-of-00002.safetensors",
-        "model-00002-of-00002.safetensors",
-        "model.safetensors.index.json",
-    ]
-    assert (output / "config.json").read_text() == '{"model_type": "test"}'
-    index = __import__("json").loads(
-        (output / "model.safetensors.index.json").read_text()
-    )
-    assert index["weight_map"] == {
-        "first": "model-00001-of-00002.safetensors",
-        "second": "model-00002-of-00002.safetensors",
-    }
-    reader = SafeTensorReader(str(output))
-    assert torch.equal(reader.get_tensor("first"), torch.arange(2, dtype=torch.float32))
-    assert not stage.exists()
-
-
-def test_save_hf_weights_rejects_duplicate_keys(tmp_path, monkeypatch):
-    import megatron.lite.primitive.ckpt.hf_weights as hf_weights
-
-    def fake_export(*args, **kwargs):
-        yield "same", torch.ones(1)
-        yield "same", torch.zeros(1)
-
-    monkeypatch.setattr(hf_weights, "export_hf_weights", fake_export)
-
-    with pytest.raises(ValueError, match="duplicate HF tensor key"):
-        save_hf_weights(object(), str(tmp_path / "huggingface"), object(), object())
-
-
-def test_save_hf_weights_accepts_model_owned_exporter(tmp_path):
-    marker = object()
-    calls = []
-
-    def model_owned_export(model, spec, ps, **kwargs):
-        calls.append((model, spec, ps, kwargs))
-        yield "mapped", torch.ones(1)
-
-    save_hf_weights(
-        "model",
-        str(tmp_path / "huggingface"),
-        marker,
-        "parallel",
-        export_fn=model_owned_export,
-    )
-
-    assert calls == [
-        (
-            "model",
-            marker,
-            "parallel",
-            {"rank0_only": True, "cpu": True},
-        )
-    ]
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")

--- a/experimental/lite/tests/unit/primitive/test_hf_weights_streaming.py
+++ b/experimental/lite/tests/unit/primitive/test_hf_weights_streaming.py
@@ -6,6 +6,7 @@ import inspect
 import json
 import sys
 import types
+from pathlib import Path
 
 import torch
 import torch.nn as nn
@@ -79,6 +80,56 @@ def test_stream_export_removes_stale_owned_files_when_reusing_directory(tmp_path
     assert not (tmp_path / "model.safetensors.index.json").exists()
     assert not (tmp_path / ".model-shard-00001.safetensors").exists()
 
+
+def test_stream_export_flushes_bounded_shards_and_writes_hf_index(
+    tmp_path, monkeypatch
+) -> None:
+    flushed = []
+
+    def fake_save_safetensors(tensors, path, *, filename):
+        flushed.append(
+            (list(tensors), sum(t.numel() * t.element_size() for t in tensors.values()))
+        )
+        (Path(path) / filename).touch()
+
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.hf_weights.save_safetensors",
+        fake_save_safetensors,
+    )
+    tensors = [(f"weight_{i}", torch.ones(2, dtype=torch.float32)) for i in range(3)]
+
+    stream_export_to_shards(iter(tensors), str(tmp_path), shard_size_bytes=8)
+
+    assert flushed == [(["weight_0"], 8), (["weight_1"], 8), (["weight_2"], 8)]
+    index = json.loads((tmp_path / "model.safetensors.index.json").read_text())
+    assert index["metadata"] == {"total_size": 24}
+    assert index["weight_map"] == {
+        "weight_0": "model-00001-of-00003.safetensors",
+        "weight_1": "model-00002-of-00003.safetensors",
+        "weight_2": "model-00003-of-00003.safetensors",
+    }
+
+
+def test_stream_export_nonzero_rank_drains_iterator_for_collectives(
+    tmp_path, monkeypatch
+) -> None:
+    consumed = []
+    barriers = []
+
+    def export_iter():
+        for i in range(3):
+            consumed.append(i)
+            yield f"weight_{i}", torch.ones(1)
+
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: 1)
+    monkeypatch.setattr(torch.distributed, "barrier", lambda: barriers.append(True))
+
+    stream_export_to_shards(export_iter(), str(tmp_path), shard_size_bytes=4)
+
+    assert consumed == [0, 1, 2]
+    assert barriers == [True]
+    assert list(tmp_path.iterdir()) == []
 
 
 def test_export_defaults_to_device_resident_tensors() -> None:

--- a/experimental/lite/tests/unit/primitive/test_hf_weights_streaming.py
+++ b/experimental/lite/tests/unit/primitive/test_hf_weights_streaming.py
@@ -6,7 +6,6 @@ import inspect
 import json
 import sys
 import types
-from pathlib import Path
 
 import torch
 import torch.nn as nn
@@ -26,6 +25,7 @@ from megatron.lite.primitive.ckpt.hf_weights import (
     bucketed_all_gather_into_tensor,
     export_hf_weights,
     stream_export_to_shards,
+    stream_pp_tensors,
 )
 
 
@@ -552,6 +552,50 @@ def test_pp_export_streams_over_nccl_and_matches_materialized(monkeypatch) -> No
     assert exported.keys() == {"weight", "weight2"}
     assert torch.equal(exported["weight"], local_weight)
     assert torch.equal(exported["weight2"], remote_weight)
+
+
+def test_pp_model_specific_tensors_stream_from_every_stage(monkeypatch) -> None:
+    local_bias = torch.tensor([1.0, 2.0])
+    remote_bias = torch.tensor([3.0, 4.0])
+    ps = type(
+        "ParallelState",
+        (),
+        {
+            "pp_size": 2,
+            "pp_rank": 0,
+            "pp_global_ranks": [0, 1],
+            "pp_group": "nccl-pp",
+        },
+    )()
+    groups = []
+
+    def fake_broadcast_object_list(object_list, src=None, group=None, device=None):
+        groups.append(group)
+        if src == 1:
+            object_list[0] = [("stage1.router_bias", (2,), torch.float32)]
+
+    def fake_broadcast(tensor, src=None, group=None):
+        groups.append(group)
+        if src == 1:
+            tensor.copy_(remote_bias)
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda group=None: 0)
+    monkeypatch.setattr(
+        torch.distributed, "broadcast_object_list", fake_broadcast_object_list
+    )
+    monkeypatch.setattr(torch.distributed, "broadcast", fake_broadcast)
+
+    exported = dict(
+        stream_pp_tensors(
+            [("stage0.router_bias", local_bias)], ps, rank0_only=True, cpu=True
+        )
+    )
+
+    assert set(groups) == {"nccl-pp"}
+    assert torch.equal(exported["stage0.router_bias"], local_bias)
+    assert torch.equal(exported["stage1.router_bias"], remote_bias)
 
 
 

--- a/experimental/lite/tests/unit/primitive/test_hf_weights_streaming.py
+++ b/experimental/lite/tests/unit/primitive/test_hf_weights_streaming.py
@@ -25,7 +25,6 @@ from megatron.lite.primitive.ckpt.hf_weights import (
     bucketed_all_gather_into_tensor,
     export_hf_weights,
     stream_export_to_shards,
-    stream_pp_tensors,
 )
 
 
@@ -512,10 +511,12 @@ def test_pp_export_streams_over_nccl_and_matches_materialized(monkeypatch) -> No
         def __init__(self) -> None:
             super().__init__()
             self.weight = nn.Parameter(local_weight.clone())
+            self.register_buffer("router_bias", torch.tensor([1.0, 2.0]))
 
     class Spec:
         num_experts = 0
         is_expert = staticmethod(lambda name: False)
+        is_export_buffer = staticmethod(lambda name: name == "router_bias")
         tp_spec = staticmethod(lambda name: None)
         native_to_hf = staticmethod(lambda name, tensor: [(name, tensor)])
 
@@ -527,8 +528,11 @@ def test_pp_export_streams_over_nccl_and_matches_materialized(monkeypatch) -> No
     })()
 
     groups = []
-    remote_headers = iter([[("weight2", (2, 3), torch.float32)], []])
-    remote_tensors = iter([remote_weight])
+    remote_bias = torch.tensor([3.0, 4.0])
+    remote_headers = iter(
+        [[("weight2", (2, 3), torch.float32), ("router_bias2", (2,), torch.float32)], []]
+    )
+    remote_tensors = iter([remote_weight, remote_bias])
 
     def fake_broadcast_object_list(object_list, src=None, group=None, device=None):
         groups.append(group)
@@ -549,53 +553,11 @@ def test_pp_export_streams_over_nccl_and_matches_materialized(monkeypatch) -> No
     exported = dict(export_hf_weights(Model(), Spec(), ps))
 
     assert set(groups) == {"nccl-pp"}
-    assert exported.keys() == {"weight", "weight2"}
+    assert exported.keys() == {"weight", "router_bias", "weight2", "router_bias2"}
     assert torch.equal(exported["weight"], local_weight)
+    assert torch.equal(exported["router_bias"], torch.tensor([1.0, 2.0]))
     assert torch.equal(exported["weight2"], remote_weight)
-
-
-def test_pp_model_specific_tensors_stream_from_every_stage(monkeypatch) -> None:
-    local_bias = torch.tensor([1.0, 2.0])
-    remote_bias = torch.tensor([3.0, 4.0])
-    ps = type(
-        "ParallelState",
-        (),
-        {
-            "pp_size": 2,
-            "pp_rank": 0,
-            "pp_global_ranks": [0, 1],
-            "pp_group": "nccl-pp",
-        },
-    )()
-    groups = []
-
-    def fake_broadcast_object_list(object_list, src=None, group=None, device=None):
-        groups.append(group)
-        if src == 1:
-            object_list[0] = [("stage1.router_bias", (2,), torch.float32)]
-
-    def fake_broadcast(tensor, src=None, group=None):
-        groups.append(group)
-        if src == 1:
-            tensor.copy_(remote_bias)
-
-    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
-    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
-    monkeypatch.setattr(torch.distributed, "get_rank", lambda group=None: 0)
-    monkeypatch.setattr(
-        torch.distributed, "broadcast_object_list", fake_broadcast_object_list
-    )
-    monkeypatch.setattr(torch.distributed, "broadcast", fake_broadcast)
-
-    exported = dict(
-        stream_pp_tensors(
-            [("stage0.router_bias", local_bias)], ps, rank0_only=True, cpu=True
-        )
-    )
-
-    assert set(groups) == {"nccl-pp"}
-    assert torch.equal(exported["stage0.router_bias"], local_bias)
-    assert torch.equal(exported["stage1.router_bias"], remote_bias)
+    assert torch.equal(exported["router_bias2"], remote_bias)
 
 
 

--- a/experimental/lite/tests/unit/primitive/test_hf_weights_streaming.py
+++ b/experimental/lite/tests/unit/primitive/test_hf_weights_streaming.py
@@ -25,6 +25,7 @@ from megatron.lite.primitive.ckpt.hf_weights import (
     _iter_bucketed_materialized_tensors,
     bucketed_all_gather_into_tensor,
     export_hf_weights,
+    stream_export_to_shards,
 )
 
 
@@ -56,6 +57,28 @@ def test_safe_tensor_reader_context_reuses_and_closes_shard(monkeypatch, tmp_pat
         assert reader.get_tensor("b").item() == 2
 
     assert events == ["enter", ("get", "a"), ("get", "b"), "exit"]
+
+
+def test_stream_export_removes_stale_owned_files_when_reusing_directory(tmp_path) -> None:
+    for name in (
+        "model.safetensors",
+        "model-00001-of-00002.safetensors",
+        "model.safetensors.index.json",
+        ".model-shard-00001.safetensors",
+    ):
+        (tmp_path / name).write_text("stale")
+    unrelated = tmp_path / "README.txt"
+    unrelated.write_text("keep")
+
+    stream_export_to_shards(
+        iter([("new", torch.ones(2))]), str(tmp_path), shard_size_bytes=1024
+    )
+
+    assert (tmp_path / "model.safetensors").exists()
+    assert unrelated.read_text() == "keep"
+    assert not (tmp_path / "model-00001-of-00002.safetensors").exists()
+    assert not (tmp_path / "model.safetensors.index.json").exists()
+    assert not (tmp_path / ".model-shard-00001.safetensors").exists()
 
 
 

--- a/experimental/lite/tests/unit/verl/test_mlite_engine_checkpoint.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_engine_checkpoint.py
@@ -148,49 +148,6 @@ def test_save_checkpoint_skips_when_contents_exclude_model_and_optimizer(tmp_pat
     assert not checkpoint_path.exists()
 
 
-def test_save_checkpoint_hf_model_is_explicit_and_does_not_write_training_state(
-    tmp_path, monkeypatch
-):
-    engine, *_ = _initialized_engine(checkpoint_config={"save_contents": ["hf_model"]})
-    save_calls = []
-    hf_calls = []
-    monkeypatch.setattr(
-        "verl_mlite.engine.mlite_engine.save_training_checkpoint",
-        lambda *args, **kwargs: save_calls.append((args, kwargs)),
-    )
-    monkeypatch.setattr(
-        engine,
-        "_save_hf_checkpoint",
-        lambda path: hf_calls.append(path),
-    )
-
-    engine.save_checkpoint(str(tmp_path), global_step=13)
-
-    assert save_calls == []
-    assert hf_calls == [str(tmp_path)]
-    assert not (tmp_path / "lr_scheduler.pt").exists()
-
-
-def test_save_checkpoint_default_contents_do_not_export_hf_model(tmp_path, monkeypatch):
-    engine, *_ = _initialized_engine()
-    save_calls = []
-    hf_calls = []
-    monkeypatch.setattr(
-        "verl_mlite.engine.mlite_engine.save_training_checkpoint",
-        lambda *args, **kwargs: save_calls.append((args, kwargs)),
-    )
-    monkeypatch.setattr(
-        engine,
-        "_save_hf_checkpoint",
-        lambda path: hf_calls.append(path),
-    )
-
-    engine.save_checkpoint(str(tmp_path), global_step=13)
-
-    assert len(save_calls) == 1
-    assert hf_calls == []
-
-
 def test_load_checkpoint_restores_scheduler_and_param_offload_reload(tmp_path, monkeypatch):
     (
         engine,

--- a/experimental/lite/tests/unit/verl/test_mlite_engine_checkpoint.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_engine_checkpoint.py
@@ -207,3 +207,53 @@ def test_hf_model_save_fails_loudly_when_model_config_is_missing(tmp_path):
     with pytest.raises(RuntimeError, match="no model_cfg"):
         engine.save_checkpoint(str(tmp_path), global_step=1)
     assert calls == []
+
+
+def test_hf_model_only_save_uses_protocol_and_writes_hf_metadata(tmp_path, monkeypatch):
+    engine, module, *_ = _initialized_engine(
+        checkpoint_config={"save_contents": ["hf_model"]}
+    )
+    model_cfg = object()
+    chunks = [module, object()]
+    export_calls = []
+    metadata_calls = []
+
+    class Artifact:
+        def __init__(self, name):
+            self.name = name
+
+        def save_pretrained(self, path):
+            metadata_calls.append((self.name, path))
+
+    hf_config = Artifact("config")
+    hf_config.auto_map = {None: "invalid", "AutoModel": "modeling.Model"}
+    engine.model_config.hf_config = hf_config
+    engine.model_config.tokenizer = Artifact("tokenizer")
+    engine.model_config.processor = Artifact("processor")
+    engine.handle._model = module
+    engine.handle._extras.update(
+        {
+            "model_cfg": model_cfg,
+            "model_chunks": chunks,
+            "protocol": SimpleNamespace(
+                save_hf_weights=lambda *args: export_calls.append(args)
+            ),
+        }
+    )
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.save_training_checkpoint",
+        lambda *args, **kwargs: pytest.fail(
+            "hf_model-only save wrote a native checkpoint"
+        ),
+    )
+
+    engine.save_checkpoint(str(tmp_path), global_step=1)
+
+    hf_path = str(tmp_path / "huggingface")
+    assert export_calls == [(chunks, hf_path, model_cfg, engine.handle._parallel_state)]
+    assert metadata_calls == [
+        ("config", hf_path),
+        ("tokenizer", hf_path),
+        ("processor", hf_path),
+    ]
+    assert hf_config.auto_map == {"AutoModel": "modeling.Model"}

--- a/experimental/lite/tests/unit/verl/test_mlite_engine_checkpoint.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_engine_checkpoint.py
@@ -148,6 +148,49 @@ def test_save_checkpoint_skips_when_contents_exclude_model_and_optimizer(tmp_pat
     assert not checkpoint_path.exists()
 
 
+def test_save_checkpoint_hf_model_is_explicit_and_does_not_write_training_state(
+    tmp_path, monkeypatch
+):
+    engine, *_ = _initialized_engine(checkpoint_config={"save_contents": ["hf_model"]})
+    save_calls = []
+    hf_calls = []
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.save_training_checkpoint",
+        lambda *args, **kwargs: save_calls.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        engine,
+        "_save_hf_checkpoint",
+        lambda path: hf_calls.append(path),
+    )
+
+    engine.save_checkpoint(str(tmp_path), global_step=13)
+
+    assert save_calls == []
+    assert hf_calls == [str(tmp_path)]
+    assert not (tmp_path / "lr_scheduler.pt").exists()
+
+
+def test_save_checkpoint_default_contents_do_not_export_hf_model(tmp_path, monkeypatch):
+    engine, *_ = _initialized_engine()
+    save_calls = []
+    hf_calls = []
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.save_training_checkpoint",
+        lambda *args, **kwargs: save_calls.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        engine,
+        "_save_hf_checkpoint",
+        lambda path: hf_calls.append(path),
+    )
+
+    engine.save_checkpoint(str(tmp_path), global_step=13)
+
+    assert len(save_calls) == 1
+    assert hf_calls == []
+
+
 def test_load_checkpoint_restores_scheduler_and_param_offload_reload(tmp_path, monkeypatch):
     (
         engine,

--- a/experimental/lite/tests/unit/verl/test_mlite_engine_checkpoint.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_engine_checkpoint.py
@@ -185,3 +185,25 @@ def test_load_checkpoint_restores_scheduler_and_param_offload_reload(tmp_path, m
     assert load_kwargs["is_expert"] is expert_classifier
     assert load_kwargs["load_model"] is True
     assert load_kwargs["load_optimizer"] is True
+
+
+def test_hf_model_save_fails_loudly_when_protocol_has_no_export(tmp_path):
+    engine, *_ = _initialized_engine(checkpoint_config={"save_contents": ["hf_model"]})
+    engine.handle._model = engine.module
+    engine.handle._extras["protocol"] = SimpleNamespace()
+
+    with pytest.raises(RuntimeError, match="does not expose save_hf_weights"):
+        engine.save_checkpoint(str(tmp_path), global_step=1)
+
+
+def test_hf_model_save_fails_loudly_when_model_config_is_missing(tmp_path):
+    engine, *_ = _initialized_engine(checkpoint_config={"save_contents": ["hf_model"]})
+    engine.handle._model = engine.module
+    calls = []
+    engine.handle._extras["protocol"] = SimpleNamespace(
+        save_hf_weights=lambda *args: calls.append(args)
+    )
+
+    with pytest.raises(RuntimeError, match="no model_cfg"):
+        engine.save_checkpoint(str(tmp_path), global_step=1)
+    assert calls == []


### PR DESCRIPTION
## Streaming HF export (bounded rank-0 memory) + honor save_contents=hf_model (#118)

Fix the two concrete HF-export failures surfaced by #118:
- **rank-0 OOM**: large-model HF save now streams instead of materializing the whole model via `dict(export_hf_weights)` → bounded rank-0 memory
- the verl engine now actually honors `save_contents=hf_model`
- keeps the #118 boundary: a shared streaming exporter (comm side) + per-model HFWeights spec (pure tensor math)

**Verification**: CPU primitive 13 passed + verl 5 passed; real-environment GPU verification (model static suite + HF-save bounded rank-0 memory) in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)