### PR TITLE
chore(lite): add missing copyright headers

### DIFF
--- a/experimental/lite/examples/verl/scripts/validate_deepseek_v4_dapo.py
+++ b/experimental/lite/examples/verl/scripts/validate_deepseek_v4_dapo.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 """Validate the fixed DeepSeek-V4 DAPO launch contract."""
 
 from __future__ import annotations

--- a/experimental/lite/examples/verl/verl_mlite/rollout/__init__.py
+++ b/experimental/lite/examples/verl/verl_mlite/rollout/__init__.py
@@ -1,1 +1,3 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 """Rollout-engine extensions for MLite weight synchronization."""

--- a/experimental/lite/megatron/lite/model/deepseek_v4/__init__.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/__init__.py
@@ -1,1 +1,3 @@
-from .config import DeepseekV4Config
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from .config import DeepseekV4Config as DeepseekV4Config

--- a/experimental/lite/megatron/lite/model/glm5/__init__.py
+++ b/experimental/lite/megatron/lite/model/glm5/__init__.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 """GLM-5 model family."""
 
 from megatron.lite.model.glm5.config import Glm5Config

--- a/experimental/lite/megatron/lite/model/glm5/config.py
+++ b/experimental/lite/megatron/lite/model/glm5/config.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 """GLM-5 architecture config."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/model/glm5/lite/__init__.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/__init__.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 """Native GLM-5 lite implementation."""
 
 from megatron.lite.model.glm5.lite.model import Glm5Model

--- a/experimental/lite/tests/unit/examples/test_ds4_dapo_script.py
+++ b/experimental/lite/tests/unit/examples/test_ds4_dapo_script.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 from __future__ import annotations
 
 import json

--- a/experimental/lite/tests/unit/model/test_deepseek_v4_resync.py
+++ b/experimental/lite/tests/unit/model/test_deepseek_v4_resync.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 import importlib.util
 from pathlib import Path
 from types import SimpleNamespace

--- a/experimental/lite/tests/unit/model/test_glm5_lite_cp_smoke.py
+++ b/experimental/lite/tests/unit/model/test_glm5_lite_cp_smoke.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 from __future__ import annotations
 
 import pytest

--- a/experimental/lite/tests/unit/model/test_glm5_lite_static.py
+++ b/experimental/lite/tests/unit/model/test_glm5_lite_static.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 """Static and CPU smoke tests for native GLM-5 lite."""
 
 from __future__ import annotations

--- a/experimental/lite/tests/unit/runtime/test_weight_contracts.py
+++ b/experimental/lite/tests/unit/runtime/test_weight_contracts.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 import pytest
 
 from megatron.lite.runtime.contracts.weights import ResyncFormat


### PR DESCRIPTION
Adds the NVIDIA copyright headers required by the upstream check to all 11 affected MLite Python files. Also makes the DeepSeek-V4 config import an explicit same-name re-export for the fork Ruff configuration. Follow-up to #121 and NVIDIA/Megatron-LM#5862.