### PR TITLE
verl/ds4: env-overridable MoE backend & offload fraction — Blackwell (SM100) validation of the resync-format KL matrix

### DIFF
--- a/experimental/lite/examples/verl/scripts/run_deepseek_v4_dapo.sh
+++ b/experimental/lite/examples/verl/scripts/run_deepseek_v4_dapo.sh
@@ -96,13 +96,13 @@ case "${ROLLOUT_WEIGHT_BITS}" in
   4)
     ROLLOUT_RESYNC_FORMAT=mxfp4
     ROLLOUT_EXPERT_DTYPE=fp4
-    ROLLOUT_MOE_BACKEND=marlin
+    ROLLOUT_MOE_BACKEND="${ROLLOUT_MOE_BACKEND:-marlin}"
     ROLLOUT_SCALE_FMT=ue8m0
     ;;
   8)
     ROLLOUT_RESYNC_FORMAT=block_fp8
     ROLLOUT_EXPERT_DTYPE=fp8
-    ROLLOUT_MOE_BACKEND=flashinfer_cutlass
+    ROLLOUT_MOE_BACKEND="${ROLLOUT_MOE_BACKEND:-flashinfer_cutlass}"
     ROLLOUT_SCALE_FMT=float32
     ;;
   *)
@@ -239,7 +239,7 @@ ACTOR=(
 
 if [[ "${OPTIMIZER_OFFLOAD}" =~ ^(True|true|1)$ ]]; then
   ACTOR+=(
-    "+actor_rollout_ref.actor.optim.override_optimizer_config.offload_fraction=1.0"
+    "+actor_rollout_ref.actor.optim.override_optimizer_config.offload_fraction=${OFFLOAD_FRACTION:-1.0}"
     "+actor_rollout_ref.actor.optim.override_optimizer_config.use_precision_aware_optimizer=True"
     "+actor_rollout_ref.actor.optim.override_optimizer_config.decoupled_weight_decay=True"
   )


### PR DESCRIPTION
### What

Two minimal, behavior-preserving knobs in `run_deepseek_v4_dapo.sh` (stock behavior is byte-identical when the envs are unset):

- **`ROLLOUT_MOE_BACKEND`** — the per-weight-bits backend default (`flashinfer_cutlass` for W8, `marlin` for W4) becomes overridable. On SM100, vLLM's fp8-MoE support matrix gates the block-fp8 scheme (`kFp8Static128BlockSym × kFp8Dynamic128Sym`) to `is_device_capability(90)` — Hopper only — so the W8 arm cannot start as shipped on Blackwell; `deep_gemm` is the working backend there (verified below).
- **`OFFLOAD_FRACTION`** — the hardcoded `offload_fraction=1.0` becomes overridable (memory-topology tuning; note the fsdp2 optimizer path ignores this value, so on fsdp2 the effective lever is `PARAM_OFFLOAD`).

### Why / validation — full `rollout_corr/kl` matrix on Blackwell

Ran this script end-to-end on **64×GB200 (aarch64, SM100)** at 2048+13312 seq / global batch 128 / 3 steps per arm, DAPO-math-17k, official DeepSeek-V4-Flash weights (bf16 pre-export), completing the 2×2 resync-format × R3 matrix:

| mean `rollout_corr/kl` (3 steps) | no R3 | R3 |
|---|---|---|
| **W8** (block_fp8, deep_gemm) | 0.134 | 0.097 |
| **W4** (mxfp4, marlin) | 0.131 | **0.093** |

Per-step values:

| arm | step 1 | step 2 | step 3 |
|---|---|---|---|
| w8_nor3 | 0.1327 | 0.1300 | 0.1384 |
| w8_r3 | 0.0962 | 0.0968 | 0.0987 |
| w4_nor3 | 0.1260 | 0.1338 | 0.1327 |
| w4_r3 | 0.0939 | 0.0918 | 0.0944 |

Observations:

1. **R3 reduces train-vs-infer KL by ~28–29% under both resync formats** (0.134→0.097, 0.131→0.093), matching the H100 reference (~0.13 → ~0.095) despite the backend difference (deep_gemm vs flashinfer on Hopper).
2. **W4 (mxfp4) < W8 (block_fp8) holds both with and without R3** — reproducing the counterintuitive observation that mxfp4 resync yields *lower* policy divergence than block-fp8, now confirmed on SM100/marlin.
3. Resync (`update_weights`) itself is cheap at this scale: ~26 s per step.

![rollout_corr/kl per step and 2x2 matrix](https://raw.githubusercontent.com/Meirtz/Megatron-LM/f9d0c22ae96135a7812cdd4fdcf1620515a494aa/kl_matrix.png)

*Left: per-step train-vs-infer KL for all four arms with upstream H100 reference lines. Right: 3-step means, resync format × R3.*

### Blackwell/aarch64 notes for other users (documentation only, no code changes)

- **Memory sizing**: 32 GPUs pass a short-seq probe but are memory-starved at real scale — training-side residency collides with the vLLM wake/reload path (`cumem` OOM for W8; marlin repack OOM for W4). A working configuration: 64 GPUs, `ROLLOUT_GPU_MEMORY_UTILIZATION=0.50` (W8) / `0.40` (W4, repack transient), `PARAM_OFFLOAD=False`.
- **Cross-rack NCCL**: 16-node GB200 allocations span two NVL72 domains; without IMEX channels, MNNVL collectives fail with CUDA error 800 — `NCCL_MNNVL_ENABLE=0` required.
- **aarch64 wheels**: `tilelang` needs ≥0.1.10 (no aarch64 wheel at the pinned 0.1.9; pair with same-version `apache-tvm-ffi` to avoid a TVM-FFI double-registration abort) plus `z3-solver==4.15.4.0`; FlashMLA (nv_dev) has no released wheel — source build works (~18 min on GB200, `TORCH_CUDA_ARCH_LIST=10.0a`, CCCL include injection).
- **Known issue** (separate report to follow): after the final step, the vLLM layerwise reload occasionally hangs in the shutdown path (metrics unaffected; a log-staleness watchdog reaps it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
