### PR TITLE
[experimental] Add Agent Compose package and skills skeleton

### DIFF
--- a/experimental/agent_compose/README.md
+++ b/experimental/agent_compose/README.md
@@ -41,6 +41,9 @@ backends. Primitive code must remain model-agnostic.
 ```text
 experimental/agent_compose/
   README.md
+  docs/
+    architecture.md
+    model.md
   megatron/
     lite/
       primitive/
@@ -61,8 +64,23 @@ For local source-tree use:
 export PYTHONPATH=/path/to/Megatron-LM/experimental/agent_compose:$PYTHONPATH
 ```
 
-The skeleton is intentionally import-only. Public runtime, model, and primitive
-APIs will be added in separate reviewable PRs.
+The skeleton exposes the stable runtime interface and shared runtime contracts,
+but contains no built-in runtime backend, model, or primitive implementation.
+Those implementations will be added in separate reviewable PRs.
+
+```python
+from megatron.lite.runtime import Runtime, RuntimeConfig, create_runtime, register_runtime
+```
+
+Backends subclass `Runtime` and register a module-level factory before
+`create_runtime` is called. The skeleton intentionally registers no built-in
+backend.
+
+## Documentation
+
+- [Three-layer architecture](docs/architecture.md)
+- [Runtime interface](docs/runtime.md)
+- [Model layer and protocol](docs/model.md)
 
 ## Skills
 

--- a/experimental/agent_compose/README.md
+++ b/experimental/agent_compose/README.md
@@ -1,45 +1,89 @@
 # Agent Compose (experimental)
 
-Agent Compose is an experimental effort to make Megatron-LM development
-agentic-native: composing Megatron Core primitives with coding agents, rather
-than introducing a new standalone product or training stack.
+Agent Compose is the upstream home for incrementally reviewed Megatron Lite
+components. It makes Megatron-LM development agentic-native by composing
+Megatron Core primitives with coding agents, rather than introducing a new
+standalone product or training stack.
 
-This directory is a placeholder that establishes the location and naming for
-the upstreamed work. Content will land here incrementally as a series of small,
-reviewable PRs.
+`experimental/agent_compose` is the project and review location. The Python
+package keeps the public namespace `megatron.lite`; `experimental.agent_compose`
+is not an import path.
 
-## Preview
+## Main And Dev
 
-The full work-in-progress implementation lives on the `dev` branch under
-`experimental/lite/`:
+The complete work-in-progress implementation remains on the `dev` branch under
+[`experimental/lite`](https://github.com/NVIDIA/Megatron-LM/tree/dev/experimental/lite).
+Code is promoted from that preview one independently validated primitive at a
+time.
 
-- https://github.com/NVIDIA/Megatron-LM/tree/dev/experimental/lite
+| Surface | `main` | `dev` |
+| --- | --- | --- |
+| Project tree | `experimental/agent_compose` | `experimental/lite` |
+| Role | Reviewed upstream subset | Work-in-progress superset |
+| Python namespace | `megatron.lite` | `megatron.lite` |
 
-The preview currently includes:
+The upstream package has no runtime dependency on the preview tree. Do not add
+both source roots to the same `PYTHONPATH`; select the tree from the branch being
+tested.
 
-- A lightweight runtime API built from small composable primitives.
-- Native model implementations with explicit model/runtime protocols.
-- Hugging Face safetensors load/export helpers.
-- Validation recipes and benchmark examples against Megatron-Core reference
-  paths (bitwise loss/grad-norm parity on the distributed-optimizer path).
-- Skills playbooks that let coding agents extend models and primitives in a
-  reviewable way.
+## Architecture
+
+The initial package establishes three layers:
+
+- `primitive`: replaceable lower-level components built from Megatron Core.
+- `model`: model declarations and composition from validated primitives.
+- `runtime`: lifecycle and training orchestration through model protocols.
+
+Dependencies flow from runtime to model to primitive. Model and primitive code
+may use an explicitly stable runtime contract, but they must not import runtime
+backends. Primitive code must remain model-agnostic.
+
+```text
+experimental/agent_compose/
+  README.md
+  megatron/
+    lite/
+      primitive/
+      model/
+      runtime/
+  skills/
+    basic/
+    primitive/
+    model/
+    runtime/
+  tests/
+    unit/
+```
+
+For local source-tree use:
+
+```bash
+export PYTHONPATH=/path/to/Megatron-LM/experimental/agent_compose:$PYTHONPATH
+```
+
+The skeleton is intentionally import-only. Public runtime, model, and primitive
+APIs will be added in separate reviewable PRs.
+
+## Skills
+
+`skills/` contains agent-agnostic operational contracts. The initial skills set
+the global constraints and the minimum contract for each architecture layer.
+Each primitive PR should add or update the corresponding leaf skill together
+with its reference and validation path.
 
 ## Principles
 
-- **Compose, don't fork.** Primitives reuse and build from existing Megatron
-  Core modules wherever appropriate. When a primitive cannot reuse an existing
-  module and needs a separate implementation, the reason is documented in the
-  docstring, making gaps explicit and providing input for future Megatron Core
-  improvements.
-- **Reviewable by construction.** Runtime, model, and primitive code are split
-  into small contracts so agents and humans can make targeted changes without
-  touching unrelated Megatron subsystems.
-- **Core performance.** Changes are validated against Megatron-Core reference
-  paths for both correctness and speed.
+- **Compose, don't fork.** Reuse Megatron Core wherever appropriate. Document
+  why a separate implementation is necessary when reuse is not possible.
+- **Reviewable by construction.** Keep runtime, model, and primitive contracts
+  small enough to review independently.
+- **Reference before implementation.** Every implementation needs a checkable
+  Megatron, Hugging Face, Torch, or first-principles reference.
+- **Core performance.** Validate accepted code against Megatron Core for both
+  correctness and speed where applicable.
 
 ## Status
 
-Upstreaming is being scoped: the current work is being evaluated for splitting
-into small PRs, after which a timeline will be shared. Until then, please use
-the preview branch above.
+The package and skill boundaries are established here. Implementations will
+land incrementally; use the `dev` preview for surfaces not yet present on
+`main`.

--- a/experimental/agent_compose/docs/architecture.md
+++ b/experimental/agent_compose/docs/architecture.md
@@ -1,0 +1,61 @@
+# Three-Layer Architecture
+
+Agent Compose upstreams Megatron Lite as three reviewable layers under the
+public `megatron.lite` namespace.
+
+## Layers
+
+### Primitive
+
+`megatron.lite.primitive` owns reusable lower-level components: parallel
+operations and state, modules, checkpoint conversion, optimizer integration,
+and focused math or kernel shims. A primitive must be independently selectable
+and validated. It may build on Megatron Core, but it must not know model family
+names or runtime backend implementations.
+
+### Model
+
+`megatron.lite.model` owns model-family configuration and the protocol that
+composes validated primitives into model chunks. It also owns model-specific
+checkpoint mappings and forward adaptation. It does not own the training loop
+or distributed runtime lifecycle.
+
+### Runtime
+
+`megatron.lite.runtime` owns the backend-neutral lifecycle: model construction,
+mode changes, forward/backward microbatch orchestration, checkpoint dispatch,
+optimizer and scheduler steps, weight export, and optional device offload.
+Concrete backends implement the public `Runtime` interface.
+
+## Dependency Direction
+
+```text
+runtime orchestration -> model protocol -> primitive -> Megatron Core
+          |                    |
+          +---- runtime contracts <----+
+```
+
+`runtime.contracts` is the shared boundary surface, not a runtime backend.
+Model and primitive code may import these stable data types. They must not
+import `runtime.backends` or backend implementation modules.
+
+The static layering test enforces import direction:
+
+- primitive does not import model;
+- primitive and model do not import runtime implementation code;
+- reviewed code never imports the `dev/experimental/lite` preview at runtime.
+
+The runtime skill and human review additionally require runtime code to remain
+model-family agnostic; that semantic rule cannot be fully expressed as an
+import-prefix check before model families exist in this tree.
+
+## Composition Flow
+
+1. A runtime resolves a model protocol without importing model-family details
+   into the runtime layer.
+2. The model protocol selects validated primitives and constructs model chunks.
+3. The protocol returns backend-consumable model state through shared contracts.
+4. The runtime drives training without reaching into model internals.
+
+The current skeleton exposes the runtime interface and shared contracts. Model,
+primitive, and backend implementations will land in separate PRs.

--- a/experimental/agent_compose/docs/model.md
+++ b/experimental/agent_compose/docs/model.md
@@ -1,0 +1,44 @@
+# Model Layer
+
+Model code lives under `megatron.lite.model`. The layer turns a model-family
+declaration into backend-consumable model state by composing validated
+primitives; it is not a second runtime.
+
+## Responsibilities
+
+The model layer owns:
+
+- typed architecture configuration;
+- construction of model chunks from primitives;
+- model-specific forward input/output adaptation;
+- recompute and offload placement choices;
+- Hugging Face load and export mappings;
+- model-specific optimizer wiring when it cannot be expressed generically.
+
+It does not own distributed initialization, the training-step lifecycle,
+checkpoint scheduling, or runtime backend selection.
+
+## Protocol Direction
+
+The Lite preview currently uses module-level model protocols. A model protocol
+provides these required operations:
+
+```text
+ImplConfig
+build_model_config(source, **overrides)
+build_model(model_cfg, *, impl_cfg)
+```
+
+Optional operations include Hugging Face load/export helpers and vocabulary
+metadata. This document records the intended boundary; no concrete model or
+registry is included in the skeleton PR. The first model PR should upstream the
+smallest protocol surface justified by its selected primitives rather than
+freezing every preview-only hook here.
+
+## Rules For Adding A Model
+
+1. Declare required features before choosing primitives.
+2. Use only primitives with a checkable reference and validation path.
+3. Keep model-family imports out of runtime code.
+4. Keep heavyweight optional imports inside protocol operations where possible.
+5. Add a composition test and an end-to-end runtime validation before delivery.

--- a/experimental/agent_compose/docs/runtime.md
+++ b/experimental/agent_compose/docs/runtime.md
@@ -1,0 +1,50 @@
+# Runtime Interface
+
+The public runtime entrypoint is `megatron.lite.runtime`. It defines a
+backend-neutral interface so training applications do not depend on a concrete
+Megatron Lite, Megatron Bridge, or integration-specific backend.
+
+## API Tiers
+
+Every backend implements the pretraining tier:
+
+- `build_model`
+- `save_checkpoint` and `load_checkpoint`
+- `train_mode` and `eval_mode`
+- `forward_backward`
+- `zero_grad`
+- `optimizer_step`
+- `lr_scheduler_step`
+
+Implementing `export_weights` adds the `rl_ready` tier. Implementing both
+`export_weights` and `to` adds the `rl_best` tier, including model and optimizer
+offload between training and rollout phases. `Runtime.tier` reports the highest
+implemented tier.
+
+## Shared Contracts
+
+The runtime package exposes:
+
+- `RuntimeConfig`, `ParallelConfig`, and `OptimizerConfig`;
+- `Batch`, `PackedBatch`, and legacy `TrainBatch` inputs;
+- `ModelOutputs` and `ForwardResult` outputs;
+- the opaque `ModelHandle` returned by `build_model`;
+- `LossContext` for per-microbatch output and loss policy.
+
+Imports are lazy where Torch-backed data contracts are involved. Importing
+`megatron.lite.runtime` alone does not load Torch.
+
+## Backend Registration
+
+A backend module provides `create(hf_path, backend_cfg)` and registers its
+dotted module path:
+
+```python
+from megatron.lite.runtime import RuntimeConfig, create_runtime, register_runtime
+
+register_runtime("my_backend", "my_package.runtime")
+runtime = create_runtime(RuntimeConfig(backend="my_backend"))
+```
+
+No built-in backend is registered in the skeleton. Each backend will be added
+with its own reference, implementation skill, and lifecycle validation.

--- a/experimental/agent_compose/megatron/lite/__init__.py
+++ b/experimental/agent_compose/megatron/lite/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Megatron Lite components reviewed through Agent Compose."""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/experimental/agent_compose/megatron/lite/model/__init__.py
+++ b/experimental/agent_compose/megatron/lite/model/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Megatron Lite model composition layer."""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/experimental/agent_compose/megatron/lite/primitive/__init__.py
+++ b/experimental/agent_compose/megatron/lite/primitive/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Composable Megatron Lite primitives."""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/experimental/agent_compose/megatron/lite/runtime/__init__.py
+++ b/experimental/agent_compose/megatron/lite/runtime/__init__.py
@@ -1,6 +1,80 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-"""Megatron Lite runtime orchestration layer."""
+"""Public runtime interface for Megatron Lite."""
 
 from __future__ import annotations
 
-__all__: list[str] = []
+import importlib
+from typing import TYPE_CHECKING
+
+from megatron.lite.runtime.contracts.config import RuntimeConfig
+
+if TYPE_CHECKING:
+    from megatron.lite.runtime.backends import Runtime
+    from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
+    from megatron.lite.runtime.contracts.data import (
+        Batch,
+        ForwardResult,
+        ModelOutputs,
+        PackedBatch,
+        TrainBatch,
+    )
+    from megatron.lite.runtime.contracts.handle import ModelHandle
+    from megatron.lite.runtime.contracts.loss import LossContext
+
+_RUNTIME_REGISTRY: dict[str, str] = {}
+
+
+def register_runtime(name: str, module_path: str) -> None:
+    """Register a module that provides ``create(hf_path, backend_cfg)``."""
+    if not name or not module_path:
+        raise ValueError("runtime name and module path must be non-empty")
+    _RUNTIME_REGISTRY[name] = module_path
+
+
+def create_runtime(cfg: RuntimeConfig) -> Runtime:
+    """Create a registered runtime backend for ``cfg``."""
+    if cfg.backend not in _RUNTIME_REGISTRY:
+        raise ValueError(
+            f"No runtime backend registered for {cfg.backend!r}. "
+            f"Available: {sorted(_RUNTIME_REGISTRY)}"
+        )
+    module = importlib.import_module(_RUNTIME_REGISTRY[cfg.backend])
+    return module.create(cfg.hf_path, cfg.backend_cfg)
+
+
+def __getattr__(name: str):
+    lazy = {
+        "Batch": "megatron.lite.runtime.contracts.data",
+        "ForwardResult": "megatron.lite.runtime.contracts.data",
+        "LossContext": "megatron.lite.runtime.contracts.loss",
+        "ModelHandle": "megatron.lite.runtime.contracts.handle",
+        "ModelOutputs": "megatron.lite.runtime.contracts.data",
+        "OptimizerConfig": "megatron.lite.runtime.contracts.config",
+        "PackedBatch": "megatron.lite.runtime.contracts.data",
+        "ParallelConfig": "megatron.lite.runtime.contracts.config",
+        "Runtime": "megatron.lite.runtime.backends",
+        "TrainBatch": "megatron.lite.runtime.contracts.data",
+    }
+    if name in lazy:
+        module = importlib.import_module(lazy[name])
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = [
+    "Batch",
+    "ForwardResult",
+    "LossContext",
+    "ModelHandle",
+    "ModelOutputs",
+    "OptimizerConfig",
+    "PackedBatch",
+    "ParallelConfig",
+    "Runtime",
+    "RuntimeConfig",
+    "TrainBatch",
+    "create_runtime",
+    "register_runtime",
+]

--- a/experimental/agent_compose/megatron/lite/runtime/__init__.py
+++ b/experimental/agent_compose/megatron/lite/runtime/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Megatron Lite runtime orchestration layer."""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/experimental/agent_compose/megatron/lite/runtime/backends/__init__.py
+++ b/experimental/agent_compose/megatron/lite/runtime/backends/__init__.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Runtime interface implemented by Megatron Lite backends."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Callable, Iterator
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    import torch
+
+    from megatron.lite.runtime.contracts.data import ForwardResult
+    from megatron.lite.runtime.contracts.handle import ModelHandle
+
+
+class Runtime(ABC):
+    """Backend-neutral lifecycle and training interface.
+
+    The required methods form the pretraining tier. Implementing
+    :meth:`export_weights` adds the RL-ready tier; implementing both
+    :meth:`export_weights` and :meth:`to` adds the RL-best tier.
+    """
+
+    @abstractmethod
+    def build_model(
+        self, hf_path: str | None = None, cfg: Any = None, **kwargs
+    ) -> ModelHandle:
+        """Build model state and return an opaque handle."""
+        ...
+
+    @abstractmethod
+    def save_checkpoint(self, handle: ModelHandle, path: str, **kwargs) -> None: ...
+
+    @abstractmethod
+    def load_checkpoint(self, handle: ModelHandle, path: str, **kwargs) -> int: ...
+
+    @abstractmethod
+    def train_mode(self, handle: ModelHandle) -> Any: ...
+
+    @abstractmethod
+    def eval_mode(self, handle: ModelHandle) -> Any: ...
+
+    @abstractmethod
+    def forward_backward(
+        self,
+        handle: ModelHandle,
+        data: Any,
+        loss_fn: Callable | None,
+        *,
+        num_microbatches: int = 1,
+        forward_only: bool = False,
+        router_replay: Any = None,
+    ) -> ForwardResult:
+        """Run a logical forward/backward step over one or more microbatches."""
+        ...
+
+    @abstractmethod
+    def zero_grad(self, handle: ModelHandle) -> None: ...
+
+    @abstractmethod
+    def optimizer_step(self, handle: ModelHandle) -> tuple[bool, float, int | None]:
+        """Return ``(update_successful, grad_norm, num_zeros_in_grad)``."""
+        ...
+
+    @abstractmethod
+    def lr_scheduler_step(self, handle: ModelHandle) -> float | list[float]: ...
+
+    def is_mp_src_rank_with_outputs(self, handle: ModelHandle) -> bool:
+        """Return whether this rank owns complete model outputs."""
+        return True
+
+    def export_weights(
+        self, handle: ModelHandle, **kwargs
+    ) -> Iterator[tuple[str, torch.Tensor]]:
+        """Iterate over inference-compatible ``(name, tensor)`` pairs."""
+        raise NotImplementedError(
+            f"{type(self).__name__} does not implement export_weights. "
+            "Implement it to unlock the RL Ready tier."
+        )
+
+    def to(
+        self,
+        handle: ModelHandle,
+        device: str,
+        *,
+        model: bool = True,
+        optimizer: bool = True,
+        grad: bool = True,
+    ) -> None:
+        """Move selected model state between devices."""
+        raise NotImplementedError(
+            f"{type(self).__name__} does not implement to(). "
+            "Implement it to unlock the RL Best tier."
+        )
+
+    @property
+    def tier(self) -> Literal["pretrain", "rl_ready", "rl_best"]:
+        """Report the highest runtime API tier implemented by this backend."""
+        cls = type(self)
+        has_export = cls.export_weights is not Runtime.export_weights
+        has_to = cls.to is not Runtime.to
+        if has_export and has_to:
+            return "rl_best"
+        if has_export:
+            return "rl_ready"
+        return "pretrain"
+
+
+__all__ = ["Runtime"]

--- a/experimental/agent_compose/megatron/lite/runtime/contracts/__init__.py
+++ b/experimental/agent_compose/megatron/lite/runtime/contracts/__init__.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Lazy public exports for shared runtime contracts."""
+
+from __future__ import annotations
+
+import importlib
+
+_EXPORTS = {
+    "Batch": "megatron.lite.runtime.contracts.data",
+    "ForwardResult": "megatron.lite.runtime.contracts.data",
+    "LossContext": "megatron.lite.runtime.contracts.loss",
+    "ModelHandle": "megatron.lite.runtime.contracts.handle",
+    "ModelOutputs": "megatron.lite.runtime.contracts.data",
+    "OptimizerConfig": "megatron.lite.runtime.contracts.config",
+    "PackedBatch": "megatron.lite.runtime.contracts.data",
+    "ParallelConfig": "megatron.lite.runtime.contracts.config",
+    "RuntimeConfig": "megatron.lite.runtime.contracts.config",
+    "TrainBatch": "megatron.lite.runtime.contracts.data",
+}
+
+
+def __getattr__(name: str):
+    if name not in _EXPORTS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = importlib.import_module(_EXPORTS[name])
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+__all__ = list(_EXPORTS)

--- a/experimental/agent_compose/megatron/lite/runtime/contracts/config.py
+++ b/experimental/agent_compose/megatron/lite/runtime/contracts/config.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Backend-neutral runtime configuration contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class ParallelConfig:
+    """Parallel dimensions shared by runtime backends."""
+
+    tp: int = 1
+    etp: int | None = None
+    ep: int = 1
+    pp: int = 1
+    vpp: int = 1
+    cp: int = 1
+    pp_layout: str | list | None = None
+
+
+@dataclass
+class OptimizerConfig:
+    """Optimizer and learning-rate scheduler settings."""
+
+    optimizer: str = "adam"
+    lr: float = 1e-3
+    min_lr: float = 0.0
+    clip_grad: float = 1.0
+    weight_decay: float = 0.01
+    lr_warmup_steps_ratio: float = 0.0
+    total_training_steps: int = -1
+    lr_warmup_steps: int = -1
+    lr_warmup_init: float = 0.0
+    lr_decay_steps: int | None = None
+    lr_decay_style: str = "linear"
+    weight_decay_incr_style: str = "constant"
+    lr_wsd_decay_style: str = "exponential"
+    lr_wsd_decay_steps: int | None = None
+    use_checkpoint_opt_param_scheduler: bool = False
+
+    adam_beta1: float | None = None
+    adam_beta2: float | None = None
+    adam_eps: float | None = None
+    offload_fraction: float | None = None
+    use_precision_aware_optimizer: bool | None = None
+    decoupled_weight_decay: bool | None = None
+
+
+@dataclass
+class RuntimeConfig:
+    """Select a runtime backend and provide its configuration."""
+
+    backend: str = "mlite"
+    hf_path: str = ""
+    backend_cfg: Any = field(default_factory=dict)
+
+
+__all__ = ["OptimizerConfig", "ParallelConfig", "RuntimeConfig"]

--- a/experimental/agent_compose/megatron/lite/runtime/contracts/data.py
+++ b/experimental/agent_compose/megatron/lite/runtime/contracts/data.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Input and output contracts for ``Runtime.forward_backward``."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+
+
+class Batch:
+    """Base contract for a model-agnostic runtime batch."""
+
+    def __len__(self) -> int:
+        """Return the number of sequences in the batch."""
+        raise NotImplementedError
+
+    def sizes(self) -> torch.Tensor:
+        """Return per-sequence token counts."""
+        raise NotImplementedError
+
+
+@dataclass(slots=True)
+class PackedBatch(Batch):
+    """Variable-length sequences packed without padding."""
+
+    input_ids: torch.Tensor
+    labels: torch.Tensor
+    seq_lens: torch.Tensor
+    loss_mask: torch.Tensor | None = None
+    position_ids: torch.Tensor | None = None
+    routed_experts: torch.Tensor | None = None
+    extras: dict[str, Any] = field(default_factory=dict)
+
+    def __len__(self) -> int:
+        return len(self.seq_lens)
+
+    def sizes(self) -> torch.Tensor:
+        return self.seq_lens
+
+    @property
+    def cu_seqlens(self) -> torch.Tensor:
+        """Return cumulative sequence lengths in int32."""
+        return torch.cat(
+            [
+                torch.zeros(1, dtype=torch.int32, device=self.seq_lens.device),
+                self.seq_lens.cumsum(0).to(torch.int32),
+            ]
+        )
+
+    @property
+    def total_tokens(self) -> int:
+        return int(self.seq_lens.sum())
+
+    def make_position_ids(self) -> torch.Tensor:
+        """Return explicit or generated per-token position IDs."""
+        if self.position_ids is not None:
+            return self.position_ids
+        return torch.cat(
+            [
+                torch.arange(length, device=self.seq_lens.device)
+                for length in self.seq_lens.tolist()
+            ]
+        )
+
+
+@dataclass(slots=True)
+class TrainBatch:
+    """Legacy fixed-shape batch contract."""
+
+    input_ids: torch.Tensor
+    labels: torch.Tensor
+    loss_mask: torch.Tensor | None = None
+    position_ids: torch.Tensor | None = None
+    routed_experts: torch.Tensor | None = None
+    cp_size: int | None = None
+    extras: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class ModelOutputs:
+    """Model outputs understood by runtime integrations."""
+
+    loss: torch.Tensor | None = None
+    vocab_parallel_logits: torch.Tensor | None = None
+    log_probs: torch.Tensor | None = None
+    hidden_states: torch.Tensor | None = None
+    values: torch.Tensor | None = None
+    mtp_logits: torch.Tensor | None = None
+    mtp_loss: torch.Tensor | None = None
+    routed_experts: torch.Tensor | None = None
+
+
+@dataclass(slots=True)
+class ForwardResult:
+    """Result of one logical runtime forward/backward call."""
+
+    model_output: ModelOutputs = field(default_factory=ModelOutputs)
+    metrics: dict[str, Any] = field(default_factory=dict)
+
+
+__all__ = ["Batch", "ForwardResult", "ModelOutputs", "PackedBatch", "TrainBatch"]

--- a/experimental/agent_compose/megatron/lite/runtime/contracts/handle.py
+++ b/experimental/agent_compose/megatron/lite/runtime/contracts/handle.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Opaque model handle exchanged through the runtime interface."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class ModelHandle:
+    """Hold backend state while exposing only stable distributed metadata."""
+
+    def __init__(
+        self,
+        *,
+        model: Any,
+        optimizer: Any = None,
+        lr_scheduler: Any = None,
+        parallel_state: Any = None,
+        config: Any = None,
+        _extras: dict[str, Any] | None = None,
+    ):
+        self._model = model
+        self._optimizer = optimizer
+        self._lr_scheduler = lr_scheduler
+        self._parallel_state = parallel_state
+        self._config = config
+        self._extras = _extras or {}
+
+    @property
+    def dp_rank(self) -> int:
+        return getattr(self._parallel_state, "dp_rank", 0)
+
+    @property
+    def dp_size(self) -> int:
+        return getattr(self._parallel_state, "dp_size", 1)
+
+    @property
+    def dp_group(self):
+        return getattr(self._parallel_state, "dp_group", None)
+
+    @property
+    def cp_range(self) -> tuple[int, int]:
+        return self._extras.get("cp_range", (1, 1))
+
+    @property
+    def config(self) -> Any:
+        return self._config
+
+
+__all__ = ["ModelHandle"]

--- a/experimental/agent_compose/megatron/lite/runtime/contracts/loss.py
+++ b/experimental/agent_compose/megatron/lite/runtime/contracts/loss.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Per-microbatch loss and output policy."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class LossContext:
+    temperature: float = 1.0
+    calculate_entropy: bool = False
+    return_log_probs: bool = True
+    loss_scale: float = 1.0
+    source_batch: Any | None = None
+
+
+_CURRENT_LOSS_CONTEXT: ContextVar[LossContext | None] = ContextVar(
+    "megatron_lite_loss_context", default=None
+)
+
+
+def get_loss_context() -> LossContext | None:
+    return _CURRENT_LOSS_CONTEXT.get()
+
+
+@contextmanager
+def use_loss_context(loss_context: LossContext | None) -> Iterator[None]:
+    token = _CURRENT_LOSS_CONTEXT.set(loss_context)
+    try:
+        yield
+    finally:
+        _CURRENT_LOSS_CONTEXT.reset(token)
+
+
+def split_loss_context(item):
+    if (
+        isinstance(item, tuple)
+        and len(item) == 2
+        and (item[1] is None or isinstance(item[1], LossContext))
+    ):
+        return item
+    return item, None
+
+
+__all__ = ["LossContext", "get_loss_context", "split_loss_context", "use_loss_context"]

--- a/experimental/agent_compose/skills/README.md
+++ b/experimental/agent_compose/skills/README.md
@@ -1,0 +1,29 @@
+# Agent Compose Skills
+
+This directory defines agent-agnostic operational contracts for upstreaming
+Megatron Lite through Agent Compose. Skills describe how to make and validate a
+change; they do not replace executable tests.
+
+## Format
+
+Each skill is one Markdown file with three parts:
+
+1. A short human-facing title.
+2. A schema between `MLITE_SKILL_SCHEMA_BEGIN` and
+   `MLITE_SKILL_SCHEMA_END`.
+3. A finite Python-like pseudocode body with a declared exit.
+
+Schema names map to paths by replacing underscores with hyphens and dots with
+directories. For example, `runtime.validate` maps to
+`runtime/validate.md`.
+
+## Initial Registry
+
+- `basic.constitution`: global design and validation constraints.
+- `basic.lint_skill`: structural validation for skills.
+- `primitive.contract`: required contract for a primitive.
+- `model.compose`: compose a model only from contracted primitives.
+- `runtime.validate`: validate the runtime lifecycle end to end.
+
+Load this file, then exactly one leaf skill for the current work type and every
+skill named by that leaf's `imports`.

--- a/experimental/agent_compose/skills/basic/constitution.md
+++ b/experimental/agent_compose/skills/basic/constitution.md
@@ -1,0 +1,37 @@
+# Agent Compose Constitution
+
+Global constraints for Megatron Lite work upstreamed through Agent Compose.
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "basic.constitution", kind="constitution", purpose="set global Agent Compose constraints",
+    imports=[], calls=[],
+    inputs=["task", "layer", "reference"],
+    outputs=["constraints", "validation", "stop"], exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def constitution(task, layer, reference):
+    if layer not in ["primitive", "model", "runtime"]:
+        return out_of_scope("unknown Agent Compose layer")
+    if reference is None:
+        return blocked("no checkable validation reference")
+
+    constraints = [
+        occam_razor("choose the smallest correct and reviewable design"),
+        modularity("keep primitives replaceable unless explicitly fused"),
+        layering("runtime -> model -> primitive -> Megatron Core"),
+        isolation("do not import the dev preview at runtime"),
+    ]
+    validation = [
+        reference_order(["Megatron", "HuggingFace", "Torch", "first principles"]),
+        require_bitwise_when_possible(reference),
+        require_layer_test(layer),
+        require_end_to_end_before_delivery(task),
+    ]
+    stop = ["missing reference", "missing validation path", "layer boundary violation"]
+    return done(constraints=constraints, validation=validation, stop=stop)
+```

--- a/experimental/agent_compose/skills/basic/lint-skill.md
+++ b/experimental/agent_compose/skills/basic/lint-skill.md
@@ -1,0 +1,42 @@
+# Skill Lint
+
+Validate an Agent Compose skill before review.
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "basic.lint_skill", kind="state_machine", purpose="validate skill structure",
+    imports=[], calls=[],
+    inputs=["skill_file", "registry", "budget"],
+    outputs=["lint", "risks"], exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def lint_skill(skill_file, registry, budget):
+    root = "experimental/agent_compose/skills/"
+    if not skill_file.path.startswith(root):
+        return out_of_scope("not an Agent Compose skill")
+
+    schema = extract_schema_block(skill_file)
+    if schema is None:
+        return blocked("missing schema markers")
+    spec = parse_skill_schema(schema)
+    expected_path = root + module_name_to_path(spec.name)
+    if skill_file.path != expected_path:
+        return blocked("schema name does not match file path")
+
+    checks = [
+        require_python_like_body(skill_file),
+        require_top_level_function(skill_file, spec.name.split(".")[-1], spec.inputs),
+        require_declared_exits(skill_file, spec.exits),
+        require_bounded_loops(skill_file, max_steps=budget.max_steps),
+        require_resolved_imports(spec.imports, registry),
+        require_resolved_calls(spec.calls, registry),
+        require_body_calls_declared(skill_file.body, spec.calls),
+    ]
+    if any(check.fail for check in checks):
+        return blocked("skill lint failed", lint=checks)
+    return done(lint=checks, risks=["structural lint does not replace executable tests"])
+```

--- a/experimental/agent_compose/skills/model/compose.md
+++ b/experimental/agent_compose/skills/model/compose.md
@@ -1,0 +1,35 @@
+# Model Compose
+
+Compose a model only from primitives with explicit review contracts.
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "model.compose", kind="state_machine", purpose="compose a model from validated primitives",
+    imports=["basic.constitution", "primitive.contract"],
+    calls=["basic.constitution", "primitive.contract"],
+    inputs=["task", "model_spec", "primitives", "reference", "budget"],
+    outputs=["model", "evidence", "risks"], exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def compose(task, model_spec, primitives, reference, budget):
+    base = basic.constitution(task, layer="model", reference=reference)
+    if not base.done:
+        return blocked("model constitution failed", evidence=base)
+
+    evidence = []
+    selected = primitives[:budget.max_primitives]
+    for candidate in selected:
+        checked = primitive.contract(task, primitive=candidate, reference=candidate.reference)
+        evidence.append(checked)
+        if not checked.done:
+            return blocked("primitive contract failed before composition", evidence=evidence)
+
+    if not covers_required_features(selected, model_spec.required_features):
+        return blocked("selected primitives do not cover the model spec", evidence=evidence)
+    model = compose_layers(model_spec, selected, boundary=["model", "primitive"])
+    return done(model=model, evidence=evidence, risks=["composition can hide boundary bugs"])
+```

--- a/experimental/agent_compose/skills/primitive/contract.md
+++ b/experimental/agent_compose/skills/primitive/contract.md
@@ -1,0 +1,41 @@
+# Primitive Contract
+
+Define the minimum review contract for an upstreamed primitive.
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "primitive.contract", kind="constitution", purpose="define primitive review outputs",
+    imports=["basic.constitution"], calls=["basic.constitution"],
+    inputs=["task", "primitive", "reference"],
+    outputs=["principle", "implementation", "usage", "validation", "risks"],
+    exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def contract(task, primitive, reference):
+    base = basic.constitution(task, layer="primitive", reference=reference)
+    if not base.done:
+        return blocked("primitive constitution failed", evidence=base)
+
+    principle = require(["semantics", "invariants", "shape_dtype_rank_rules"])
+    implementation = require([
+        "owned_modules", "public_api", "state_and_config", "failure_modes",
+    ])
+    usage = require([
+        "minimal_example", "selection_rules", "valid_combinations", "unsupported_combinations",
+    ])
+    validation = require([
+        "single_gpu_or_single_node_proxy", "reference_comparison", "composition_test",
+    ])
+    risks = ["silent mismatch", "dtype drift", "hidden coupling", "wrong selection rule"]
+    return done(
+        principle=principle,
+        implementation=implementation,
+        usage=usage,
+        validation=validation,
+        risks=risks,
+    )
+```

--- a/experimental/agent_compose/skills/runtime/validate.md
+++ b/experimental/agent_compose/skills/runtime/validate.md
@@ -1,0 +1,46 @@
+# Runtime Validate
+
+Validate the runtime lifecycle through a composed model.
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "runtime.validate", kind="state_machine", purpose="validate the runtime lifecycle end to end",
+    imports=["basic.constitution", "model.compose"],
+    calls=["basic.constitution", "model.compose"],
+    inputs=["task", "runtime_config", "model_spec", "primitives", "reference", "budget"],
+    outputs=["runtime", "evidence", "risks"], exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def validate(task, runtime_config, model_spec, primitives, reference, budget):
+    base = basic.constitution(task, layer="runtime", reference=reference)
+    if not base.done:
+        return blocked("runtime constitution failed", evidence=base)
+
+    composed = model.compose(
+        task,
+        model_spec=model_spec,
+        primitives=primitives,
+        reference=reference,
+        budget=budget.model,
+    )
+    if not composed.done:
+        return blocked("model composition failed before runtime validation", evidence=composed)
+
+    run = execute_runtime_steps(
+        ["init", "build_model", "train_step", "save", "load"],
+        runtime_config,
+        composed.model,
+        max_steps=budget.max_steps,
+    )
+    if run.return_code != 0:
+        return blocked("runtime lifecycle failed", evidence=[composed, run])
+    return done(
+        runtime=run,
+        evidence=[composed, run],
+        risks=["runtime success can hide model-local mismatch"],
+    )
+```

--- a/experimental/agent_compose/skills/runtime/validate.md
+++ b/experimental/agent_compose/skills/runtime/validate.md
@@ -19,6 +19,8 @@ def validate(task, runtime_config, model_spec, primitives, reference, budget):
     base = basic.constitution(task, layer="runtime", reference=reference)
     if not base.done:
         return blocked("runtime constitution failed", evidence=base)
+    if not conforms_to_runtime_interface(runtime_config.backend):
+        return blocked("backend does not implement the public Runtime interface")
 
     composed = model.compose(
         task,

--- a/experimental/agent_compose/tests/unit/test_import.py
+++ b/experimental/agent_compose/tests/unit/test_import.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Import checks for the Agent Compose package skeleton."""
+
+from __future__ import annotations
+
+import importlib
+
+
+def test_three_layer_skeleton_imports() -> None:
+    modules = [
+        "megatron.lite",
+        "megatron.lite.primitive",
+        "megatron.lite.model",
+        "megatron.lite.runtime",
+    ]
+
+    for module in modules:
+        imported = importlib.import_module(module)
+        assert imported.__name__ == module

--- a/experimental/agent_compose/tests/unit/test_import.py
+++ b/experimental/agent_compose/tests/unit/test_import.py
@@ -17,3 +17,40 @@ def test_three_layer_skeleton_imports() -> None:
     for module in modules:
         imported = importlib.import_module(module)
         assert imported.__name__ == module
+
+
+def test_runtime_public_surface_imports() -> None:
+    from megatron.lite.runtime import (
+        Batch,
+        ForwardResult,
+        LossContext,
+        ModelHandle,
+        ModelOutputs,
+        OptimizerConfig,
+        PackedBatch,
+        ParallelConfig,
+        Runtime,
+        RuntimeConfig,
+        TrainBatch,
+        create_runtime,
+        register_runtime,
+    )
+
+    assert all(
+        value is not None
+        for value in (
+            Batch,
+            ForwardResult,
+            LossContext,
+            ModelHandle,
+            ModelOutputs,
+            OptimizerConfig,
+            PackedBatch,
+            ParallelConfig,
+            Runtime,
+            RuntimeConfig,
+            TrainBatch,
+            create_runtime,
+            register_runtime,
+        )
+    )

--- a/experimental/agent_compose/tests/unit/test_layering_contracts.py
+++ b/experimental/agent_compose/tests/unit/test_layering_contracts.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Static import guards for the runtime, model, and primitive layers."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+AGENT_COMPOSE_ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_ROOT = AGENT_COMPOSE_ROOT / "megatron" / "lite"
+LAYER_ROOTS = {
+    "primitive": PACKAGE_ROOT / "primitive",
+    "model": PACKAGE_ROOT / "model",
+    "runtime": PACKAGE_ROOT / "runtime",
+}
+DENIED_IMPORTS = {
+    "primitive": ("megatron.lite.model", "megatron.lite.runtime"),
+    "model": ("megatron.lite.runtime",),
+    "runtime": (),
+}
+SHARED_CONTRACTS = ("megatron.lite.runtime.contracts",)
+
+
+def _matches(module: str, prefix: str) -> bool:
+    return module == prefix or module.startswith(prefix + ".")
+
+
+def _imports(path: Path) -> list[tuple[int, str]]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    found: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            found.extend((node.lineno, alias.name) for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            found.append((node.lineno, node.module))
+    return found
+
+
+def test_layer_import_boundaries() -> None:
+    violations: list[str] = []
+    for layer, root in LAYER_ROOTS.items():
+        for path in sorted(root.rglob("*.py")):
+            for lineno, module in _imports(path):
+                if any(_matches(module, allowed) for allowed in SHARED_CONTRACTS):
+                    continue
+                for denied in DENIED_IMPORTS[layer]:
+                    if _matches(module, denied):
+                        rel = path.relative_to(AGENT_COMPOSE_ROOT)
+                        violations.append(f"{rel}:{lineno}: {module} imports {denied}")
+    assert violations == []

--- a/experimental/agent_compose/tests/unit/test_layering_contracts.py
+++ b/experimental/agent_compose/tests/unit/test_layering_contracts.py
@@ -14,9 +14,9 @@ LAYER_ROOTS = {
     "runtime": PACKAGE_ROOT / "runtime",
 }
 DENIED_IMPORTS = {
-    "primitive": ("megatron.lite.model", "megatron.lite.runtime"),
-    "model": ("megatron.lite.runtime",),
-    "runtime": (),
+    "primitive": ("experimental.lite", "megatron.lite.model", "megatron.lite.runtime"),
+    "model": ("experimental.lite", "megatron.lite.runtime"),
+    "runtime": ("experimental.lite",),
 }
 SHARED_CONTRACTS = ("megatron.lite.runtime.contracts",)
 

--- a/experimental/agent_compose/tests/unit/test_runtime_interface.py
+++ b/experimental/agent_compose/tests/unit/test_runtime_interface.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Contract tests for the public runtime interface."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import types
+
+import pytest
+
+
+def test_runtime_import_stays_lightweight() -> None:
+    script = (
+        "import sys; "
+        "import megatron.lite.runtime as runtime; "
+        "assert runtime.RuntimeConfig().backend == 'mlite'; "
+        "assert 'torch' not in sys.modules"
+    )
+    subprocess.run([sys.executable, "-c", script], check=True)
+
+
+def test_public_runtime_contracts() -> None:
+    import torch
+
+    from megatron.lite.runtime import PackedBatch, ParallelConfig
+
+    batch = PackedBatch(
+        input_ids=torch.tensor([1, 2, 3]),
+        labels=torch.tensor([2, 3, 4]),
+        seq_lens=torch.tensor([2, 1]),
+    )
+
+    assert ParallelConfig(tp=2).tp == 2
+    assert len(batch) == 2
+    assert batch.total_tokens == 3
+    assert batch.cu_seqlens.tolist() == [0, 2, 3]
+    assert batch.make_position_ids().tolist() == [0, 1, 0]
+
+
+def test_unregistered_backend_fails_explicitly() -> None:
+    from megatron.lite.runtime import RuntimeConfig, create_runtime
+
+    with pytest.raises(ValueError, match="No runtime backend registered"):
+        create_runtime(RuntimeConfig(backend="missing"))
+
+
+def test_runtime_required_method_set() -> None:
+    from megatron.lite.runtime import Runtime
+
+    assert Runtime.__abstractmethods__ == {
+        "build_model",
+        "eval_mode",
+        "forward_backward",
+        "load_checkpoint",
+        "lr_scheduler_step",
+        "optimizer_step",
+        "save_checkpoint",
+        "train_mode",
+        "zero_grad",
+    }
+
+
+def test_registered_runtime_factory(monkeypatch) -> None:
+    from megatron.lite.runtime import RuntimeConfig, create_runtime, register_runtime
+
+    module = types.ModuleType("agent_compose_test_runtime")
+    module.create = lambda hf_path, cfg: (hf_path, cfg)
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+    register_runtime("test", module.__name__)
+
+    cfg = RuntimeConfig(backend="test", hf_path="model", backend_cfg={"tp": 2})
+    assert create_runtime(cfg) == ("model", {"tp": 2})

--- a/experimental/agent_compose/tests/unit/test_skills.py
+++ b/experimental/agent_compose/tests/unit/test_skills.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Structural checks for the initial Agent Compose skill registry."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+AGENT_COMPOSE_ROOT = Path(__file__).resolve().parents[2]
+SKILL_ROOT = AGENT_COMPOSE_ROOT / "skills"
+EXPECTED = {
+    "basic.constitution": "basic/constitution.md",
+    "basic.lint_skill": "basic/lint-skill.md",
+    "primitive.contract": "primitive/contract.md",
+    "model.compose": "model/compose.md",
+    "runtime.validate": "runtime/validate.md",
+}
+SCHEMA_NAME = re.compile(r'schema\s*=\s*Skill\(\s*"([^"]+)"', re.DOTALL)
+LIST_FIELD = re.compile(r"\b(imports|calls)\s*=\s*\[([^]]*)\]", re.DOTALL)
+QUOTED = re.compile(r'"([^"]+)"')
+
+
+def test_skill_registry_is_complete_and_resolved() -> None:
+    for expected_name, relative_path in EXPECTED.items():
+        path = SKILL_ROOT / relative_path
+        text = path.read_text(encoding="utf-8")
+        assert text.count("MLITE_SKILL_SCHEMA_BEGIN") == 1
+        assert text.count("MLITE_SKILL_SCHEMA_END") == 1
+        match = SCHEMA_NAME.search(text)
+        assert match is not None
+        assert match.group(1) == expected_name
+        assert f"def {expected_name.rsplit('.', 1)[-1]}(" in text
+
+        fields = {
+            name: QUOTED.findall(values) for name, values in LIST_FIELD.findall(text)
+        }
+        for dependency in fields.get("imports", []) + fields.get("calls", []):
+            assert dependency in EXPECTED


### PR DESCRIPTION
## What changed

- establish the `megatron.lite` package under `experimental/agent_compose`
- define the `runtime`, `model`, and `primitive` package boundaries
- expose the mature backend-neutral Runtime ABC, L1/L2/L3 tiers, registry, and factory
- expose shared runtime config, batch/result, model-handle, and loss contracts
- add the initial Agent Compose skills constitution and one contract per layer
- document the three-layer architecture, Runtime interface, model protocol, and the relationship to the `dev/experimental/lite` preview
- add import, Runtime API, layering, and skill-registry contract tests

## Why

This establishes the reviewed framework before individual Megatron Lite implementations are proposed. Agent Compose remains the project/review location while the public Python namespace stays `megatron.lite`. The stable Runtime interface is available immediately, while built-in backends, models, and primitives remain separate follow-up PRs.

This is an internal review PR against `agent-compose-bootstrap`. Any later NVIDIA upstream PR will be rebased onto `main`.

## Validation

```text
PYTHONPATH="$PWD:$PWD/experimental/agent_compose" python -m pytest -q experimental/agent_compose/tests/unit
# 9 passed

ruff check experimental/agent_compose/megatron experimental/agent_compose/tests
# All checks passed

ruff format --check experimental/agent_compose/megatron experimental/agent_compose/tests
# 14 files already formatted
```