### PR TITLE
Fix M-FSDP "active buffers" error on device migration / scratch release

### DIFF
--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
@@ -505,7 +505,7 @@ class ParamBucket:
         self.discard_full_parameter_views()
         if self._grad_reduce_launched:
             self.wait_grad_reduce()
-        self.allocator.release_cached()
+        self.allocator.release_cached(force=True)
 
         grad_present = {
             id(spec): spec.shard_param is not None and spec.shard_param.grad is not None
@@ -563,7 +563,7 @@ class ParamBucket:
         self.discard_full_parameter_views()
         if self._grad_reduce_launched:
             self.wait_grad_reduce()
-        self.allocator.release_cached()
+        self.allocator.release_cached(force=True)
 
     def prepare_grad_reduce(
         self, *, force: bool = False


### PR DESCRIPTION
## Problem

`ParamBucket.move_model_state` (device offload/onload) and
`release_scratch_keep_weights` (the colocated-rollout scratch reclaim) both run a
quiesce prologue — `release_full_parameters()` + `discard_full_parameter_views()`
+ `wait_grad_reduce()` — and then call `self.allocator.release_cached()`.

`release_cached()` without `force` raises
`RuntimeError("Cannot release active M-FSDP communication buffers.")` whenever an
allocator slot is still marked busy. After a training step the persistent
all-gather double buffer can leave a slot leased — a *stale* lease, not a live
collective — so `runtime.to("cpu", ...)` right after a step (the RL
train↔rollout GPU-reclaim boundary) hits:

```
File ".../mfsdp/buffer.py", in move_model_state
    self.allocator.release_cached()
RuntimeError: Cannot release active M-FSDP communication buffers.
```

## Fix

Both call sites are teardown paths whose prologue already drained the live
collectives, so any remaining busy slot is stale. Pass `force=True` — the escape
hatch `release_cached` already documents for teardown — to force-drop the cache
instead of raising.

## How it was found

Surfaced by an M-FSDP runtime-contract validation test exercising the
`runtime.to("cpu") -> to("cuda")` roundtrip after a training step on an 8×GPU
qwen3_moe fixture (tp1·ep2·pp2). Without the fix `to("cpu")` raises the error
above; with it, offload/onload completes and training resumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
