### PR TITLE
Add M-FSDP CPU optimizer offload (offload_fraction support)

### DIFF
--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/cpu_offload.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/cpu_offload.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""CPU Adam momentum offload for M-FSDP shard parameters."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+
+class CpuAdamGroup:
+    """Adam momentum state on CPU for a subset of M-FSDP shard parameters.
+
+    Memory savings: exp_avg + exp_avg_sq moved off GPU (2 × 4B × numel).
+    Hard constraint: shard_param.data (fp32 master) stays on GPU for all-gather.
+
+    Per-step flow (synchronous):
+      1. D2H — copy GPU gradient → pinned CPU grad buffer  (blocking)
+      2. CPU AdamW step updates cpu_param
+      3. H2D — copy updated cpu_param → GPU shard_param.data  (blocking)
+    """
+
+    def __init__(
+        self,
+        gpu_param_groups: list[dict[str, Any]],
+        *,
+        lr: float,
+        betas: tuple[float, float],
+        eps: float,
+    ) -> None:
+        use_pinned = torch.cuda.is_available()
+        self._use_pinned = use_pinned
+        self._gpu_params: list[nn.Parameter] = []
+        self._cpu_params: list[torch.Tensor] = []
+        self._cpu_grad_bufs: list[torch.Tensor | None] = []
+        cpu_groups: list[dict[str, Any]] = []
+
+        for group in gpu_param_groups:
+            cpu_group_params: list[torch.Tensor] = []
+            for gpu_param in group["params"]:
+                flat = gpu_param.detach().cpu().float().contiguous()
+                if use_pinned:
+                    flat = flat.pin_memory()
+                # Wrap as leaf tensor with grad support so AdamW can update it.
+                cpu_p = flat.clone().detach().requires_grad_(True)
+                self._gpu_params.append(gpu_param)
+                self._cpu_params.append(cpu_p)
+                self._cpu_grad_bufs.append(None)
+                cpu_group_params.append(cpu_p)
+
+            cpu_group = {k: v for k, v in group.items() if k != "params"}
+            cpu_group["params"] = cpu_group_params
+            cpu_groups.append(cpu_group)
+
+        self._cpu_optimizer = torch.optim.AdamW(
+            cpu_groups,
+            lr=lr,
+            betas=betas,
+            eps=eps,
+            foreach=False,
+        )
+
+    @property
+    def param_groups(self) -> list[dict[str, Any]]:
+        return self._cpu_optimizer.param_groups
+
+    @property
+    def gpu_param_id_set(self) -> set[int]:
+        return {id(p) for p in self._gpu_params}
+
+    def step(self) -> None:
+        for i, (gpu_param, cpu_param) in enumerate(
+            zip(self._gpu_params, self._cpu_params)
+        ):
+            if gpu_param.grad is None:
+                cpu_param.grad = None
+                continue
+
+            flat_gpu_grad = gpu_param.grad.detach().view(-1)
+
+            buf = self._cpu_grad_bufs[i]
+            if buf is None or buf.shape != flat_gpu_grad.shape:
+                buf = torch.zeros(
+                    flat_gpu_grad.shape, dtype=torch.float32, device="cpu"
+                )
+                if self._use_pinned:
+                    buf = buf.pin_memory()
+                self._cpu_grad_bufs[i] = buf
+
+            buf.copy_(flat_gpu_grad)
+            cpu_param.grad = buf
+
+        self._cpu_optimizer.step()
+
+        for gpu_param, cpu_param in zip(self._gpu_params, self._cpu_params):
+            gpu_param.data.view(-1).copy_(cpu_param.data)
+            cpu_param.grad = None
+
+    def state_dict(self) -> dict[str, Any]:
+        return self._cpu_optimizer.state_dict()
+
+    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        self._cpu_optimizer.load_state_dict(state_dict)
+        for gpu_param, cpu_param in zip(self._gpu_params, self._cpu_params):
+            cpu_param.data.copy_(gpu_param.data.view(-1).cpu())

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/optimizer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/optimizer.py
@@ -31,6 +31,7 @@ from megatron.lite.primitive.optimizers.mfsdp.grad_norm import (
     local_grad_sq_sum,
     resolve_torch_dtype,
 )
+from megatron.lite.primitive.optimizers.mfsdp.cpu_offload import CpuAdamGroup
 from megatron.lite.primitive.optimizers.mfsdp.wrapper import (
     MFSdpModule,
     mark_optimizer_built,
@@ -46,6 +47,26 @@ def _override(opt: Any, name: str, default: Any) -> Any:
     return values.get(name, getattr(opt, name, default))
 
 
+class _NullOptimizer:
+    """No-op GPU optimizer used when all parameters are CPU-offloaded."""
+
+    def __init__(self) -> None:
+        self.param_groups: list = []
+        self.state: dict = {}
+
+    def step(self) -> None:
+        pass
+
+    def zero_grad(self, *, set_to_none: bool = True) -> None:
+        pass
+
+    def state_dict(self) -> dict[str, Any]:
+        return {"state": {}, "param_groups": []}
+
+    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        pass
+
+
 class _StandaloneOptimizer:
     """Torch optimizer adapter with M-FSDP-aware norm and state movement."""
 
@@ -59,6 +80,7 @@ class _StandaloneOptimizer:
         grad_norm_accum_dtype: str | torch.dtype,
         expert_params: Iterable[nn.Parameter],
         expert_grad_scale: float,
+        cpu_group: CpuAdamGroup | None = None,
     ) -> None:
         self.optimizer = optimizer
         self.params = params
@@ -84,10 +106,14 @@ class _StandaloneOptimizer:
         self._expert_grads_scaled = False
         self._tp_replicated_grads_synced = False
         self._offloaded_state_devices: dict[tuple[int, str], torch.device] = {}
+        self.cpu_group = cpu_group
 
     @property
     def param_groups(self) -> list[dict[str, Any]]:
-        return self.optimizer.param_groups
+        groups = list(self.optimizer.param_groups)
+        if self.cpu_group is not None:
+            groups += list(self.cpu_group.param_groups)
+        return groups
 
     def zero_grad(self) -> None:
         self.optimizer.zero_grad()
@@ -101,6 +127,8 @@ class _StandaloneOptimizer:
         if not math.isfinite(grad_norm):
             return False, grad_norm, 0
         self.optimizer.step()
+        if self.cpu_group is not None:
+            self.cpu_group.step()
         return True, grad_norm, 0
 
     def clip_grad_norm(self) -> float:
@@ -159,10 +187,18 @@ class _StandaloneOptimizer:
         return float(total_norm.float().item())
 
     def state_dict(self) -> dict[str, Any]:
-        return self.optimizer.state_dict()
+        result: dict[str, Any] = {"gpu": self.optimizer.state_dict()}
+        if self.cpu_group is not None:
+            result["cpu"] = self.cpu_group.state_dict()
+        return result
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
-        self.optimizer.load_state_dict(state_dict)
+        if "gpu" in state_dict:
+            self.optimizer.load_state_dict(state_dict["gpu"])
+            if self.cpu_group is not None and "cpu" in state_dict:
+                self.cpu_group.load_state_dict(state_dict["cpu"])
+        else:
+            self.optimizer.load_state_dict(state_dict)
 
     def offload_state_to_cpu(self) -> None:
         self._offloaded_state_devices.clear()
@@ -172,6 +208,7 @@ class _StandaloneOptimizer:
                     continue
                 self._offloaded_state_devices[(id(param), str(key))] = value.device
                 state[key] = value.cpu()
+        # cpu_group state is already on CPU; nothing to move.
 
     def load_state_to_device(self) -> None:
         for param, state in self.optimizer.state.items():
@@ -180,6 +217,7 @@ class _StandaloneOptimizer:
                 if device is not None and isinstance(value, torch.Tensor):
                     state[key] = value.to(device)
         self._offloaded_state_devices.clear()
+        # cpu_group state remains on CPU.
 
     def _scale_expert_grads_once(self) -> None:
         if self._expert_grads_scaled:
@@ -339,11 +377,43 @@ def build_mfsdp_stack(
         weight_decay=float(getattr(opt, "weight_decay", 0.01)),
         apply_wd_to_qk_layernorm=bool(getattr(opt, "apply_wd_to_qk_layernorm", False)),
     )
-    torch_optimizer = _build_optimizer_algorithm(
-        param_groups,
-        opt,
-        optimizer_factory=optimizer_factory,
-    )
+    offload_fraction = float(getattr(opt, "offload_fraction", 0.0) or 0.0)
+    offload_fraction = max(0.0, min(1.0, offload_fraction))
+
+    if offload_fraction > 0.0:
+        gpu_param_groups, cpu_param_groups = _split_param_groups_by_fraction(
+            param_groups, offload_fraction
+        )
+        torch_optimizer = (
+            _build_optimizer_algorithm(
+                gpu_param_groups,
+                opt,
+                optimizer_factory=optimizer_factory,
+            )
+            if gpu_param_groups
+            else _NullOptimizer()
+        )
+        cpu_group = _build_cpu_adam_group(cpu_param_groups, opt)
+        if not dist.is_initialized() or dist.get_rank() == 0:
+            cpu_numel = sum(
+                p.numel() for g in cpu_param_groups for p in g["params"]
+            )
+            total_numel = sum(p.numel() for p in params)
+            logger.info(
+                "M-FSDP CPU optimizer offload: %.1f%% of parameter elements "
+                "(%d / %d) use CPU Adam; exp_avg + exp_avg_sq moved off GPU.",
+                100.0 * cpu_numel / max(total_numel, 1),
+                cpu_numel,
+                total_numel,
+            )
+    else:
+        torch_optimizer = _build_optimizer_algorithm(
+            param_groups,
+            opt,
+            optimizer_factory=optimizer_factory,
+        )
+        cpu_group = None
+
     standalone_optimizer = _StandaloneOptimizer(
         torch_optimizer,
         params,
@@ -357,6 +427,7 @@ def build_mfsdp_stack(
             if expert_params
             else 1.0
         ),
+        cpu_group=cpu_group,
     )
     for chunk in wrapped_chunks:
         mark_optimizer_built(chunk)
@@ -456,6 +527,55 @@ def build_mfsdp_training_optimizer(
         optimizer.finish_grad_sync()
 
     return optimizer, finalize_grads
+
+
+def _split_param_groups_by_fraction(
+    param_groups: list[dict[str, Any]],
+    offload_fraction: float,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Split param groups so the first *offload_fraction* of numel goes to CPU."""
+    total_numel = sum(p.numel() for g in param_groups for p in g["params"])
+    cpu_numel_target = int(total_numel * offload_fraction)
+
+    gpu_groups: list[dict[str, Any]] = []
+    cpu_groups: list[dict[str, Any]] = []
+    cpu_numel_so_far = 0
+
+    for group in param_groups:
+        gpu_params: list[nn.Parameter] = []
+        cpu_params: list[nn.Parameter] = []
+        for param in group["params"]:
+            if cpu_numel_so_far < cpu_numel_target:
+                cpu_params.append(param)
+                cpu_numel_so_far += param.numel()
+            else:
+                gpu_params.append(param)
+        if gpu_params:
+            g = dict(group)
+            g["params"] = gpu_params
+            gpu_groups.append(g)
+        if cpu_params:
+            g = dict(group)
+            g["params"] = cpu_params
+            cpu_groups.append(g)
+
+    return gpu_groups, cpu_groups
+
+
+def _build_cpu_adam_group(
+    cpu_param_groups: list[dict[str, Any]],
+    opt: Any,
+) -> CpuAdamGroup:
+    lr = float(getattr(opt, "lr", 1.0e-4))
+    beta1 = getattr(opt, "adam_beta1", None)
+    beta2 = getattr(opt, "adam_beta2", None)
+    eps = getattr(opt, "adam_eps", None)
+    return CpuAdamGroup(
+        cpu_param_groups,
+        lr=lr,
+        betas=(0.9 if beta1 is None else beta1, 0.999 if beta2 is None else beta2),
+        eps=1.0e-8 if eps is None else eps,
+    )
 
 
 def _build_param_groups(

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -188,13 +188,14 @@ def test_mfsdp_source_layout_is_bounded():
         "backend.py",
         "buffer.py",
         "config.py",
+        "cpu_offload.py",
         "fully_shard.py",
         "fused_ops.py",
         "grad_norm.py",
         "optimizer.py",
         "wrapper.py",
     }
-    assert len(modules) <= 9
+    assert len(modules) <= 10
     assert not (package / "impl").exists()
 
 
@@ -230,6 +231,7 @@ def test_mfsdp_reference_rewrite_modules_are_live():
     required_modules = {
         "buffer.py",
         "config.py",
+        "cpu_offload.py",
         "fully_shard.py",
         "fused_ops.py",
         "grad_norm.py",
@@ -717,6 +719,218 @@ def test_mfsdp_cpu_single_rank_matches_torch_adamw_optimizer_step():
     assert saved_model.keys() == restored_model.keys()
     for name, value in saved_model.items():
         assert torch.equal(value, restored_model[name]), name
+
+
+def _build_offload_stack(offload_fraction: float):
+    class _Unit(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(4, 4, bias=False)
+
+        def forward(self, value):
+            return torch.nn.functional.gelu(self.linear(value))
+
+    class _Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.unit0 = _Unit()
+            self.unit1 = _Unit()
+            self.out = torch.nn.Linear(4, 2, bias=False)
+
+        def forward(self, value):
+            return self.out(self.unit1(self.unit0(value)))
+
+    ps = SimpleNamespace(
+        dp_cp_group=None,
+        dp_group=None,
+        ep_dp_group=None,
+        ep_group=None,
+        tp_group=None,
+        pp_group=None,
+        dp_cp_size=1,
+        expert_dp_size=1,
+    )
+    opt = SimpleNamespace(
+        optimizer="adam",
+        lr=1.0e-3,
+        min_lr=0.0,
+        weight_decay=0.0,
+        clip_grad=1000.0,
+        adam_beta1=0.9,
+        adam_beta2=0.999,
+        adam_eps=1.0e-8,
+        offload_fraction=offload_fraction,
+        override_optimizer_config={"mfsdp_sharding_strategy": "optim_grads_params"},
+    )
+    engine_cfg = SimpleNamespace(
+        parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1),
+        optimizer=opt,
+    )
+    return _Model, _Unit, ps, engine_cfg
+
+
+def test_mfsdp_offload_fraction_keeps_optimizer_state_on_cpu():
+    _Model, _Unit, ps, engine_cfg = _build_offload_stack(offload_fraction=1.0)
+
+    torch.manual_seed(42)
+    chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [_Model()],
+        engine_cfg=engine_cfg,
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_Unit,),
+    )
+
+    value = torch.randn(3, 4)
+    target = torch.randn(3, 2)
+    optimizer.zero_grad()
+    torch.nn.functional.mse_loss(chunks[0](value), target).backward()
+    optimizer.finish_grad_sync()
+    success, _grad_norm, _ = optimizer.step()
+    assert success
+
+    inner = optimizer._inner_optimizer
+    cpu_group = inner.cpu_group
+    assert cpu_group is not None, "Expected cpu_group to be set for offload_fraction=1.0"
+
+    for cpu_p in cpu_group._cpu_params:
+        assert cpu_p.device.type == "cpu", "cpu_param should be on CPU"
+    cpu_opt_state = cpu_group._cpu_optimizer.state
+    for cpu_p in cpu_group._cpu_params:
+        if cpu_p in cpu_opt_state:
+            state = cpu_opt_state[cpu_p]
+            assert state["exp_avg"].device.type == "cpu"
+            assert state["exp_avg_sq"].device.type == "cpu"
+
+    for gpu_param in inner.params:
+        assert gpu_param.device.type != "cuda" or gpu_param.data is not None
+
+
+def test_mfsdp_offload_fraction_numerically_matches_no_offload():
+    _Model, _Unit, ps, engine_cfg_offload = _build_offload_stack(offload_fraction=1.0)
+    _, _, _, engine_cfg_gpu = _build_offload_stack(offload_fraction=0.0)
+
+    torch.manual_seed(77)
+    model_ref = _Model()
+    model_cpu = copy.deepcopy(model_ref)
+
+    chunks_ref, opt_ref = mfsdp_optimizer.build_mfsdp_stack(
+        [model_ref],
+        engine_cfg=engine_cfg_gpu,
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_Unit,),
+    )
+    chunks_cpu, opt_cpu = mfsdp_optimizer.build_mfsdp_stack(
+        [model_cpu],
+        engine_cfg=engine_cfg_offload,
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_Unit,),
+    )
+
+    value = torch.randn(3, 4)
+    target = torch.randn(3, 2)
+
+    opt_ref.zero_grad()
+    torch.nn.functional.mse_loss(chunks_ref[0](value), target).backward()
+    opt_ref.finish_grad_sync()
+    success_ref, _norm_ref, _ = opt_ref.step()
+    assert success_ref
+
+    opt_cpu.zero_grad()
+    torch.nn.functional.mse_loss(chunks_cpu[0](value), target).backward()
+    opt_cpu.finish_grad_sync()
+    success_cpu, _norm_cpu, _ = opt_cpu.step()
+    assert success_cpu
+
+    ref_params = {
+        name.removeprefix("module."): param
+        for name, param in chunks_ref[0].named_parameters()
+    }
+    cpu_params = {
+        name.removeprefix("module."): param
+        for name, param in chunks_cpu[0].named_parameters()
+    }
+    assert ref_params.keys() == cpu_params.keys()
+    for name in ref_params:
+        assert torch.allclose(ref_params[name], cpu_params[name], atol=1e-5, rtol=1e-4), (
+            f"Parameter {name} diverges between GPU-only and CPU-offload runs"
+        )
+
+
+def test_mfsdp_offload_fraction_partial_splits_by_numel():
+    _Model, _Unit, ps, engine_cfg = _build_offload_stack(offload_fraction=0.5)
+
+    torch.manual_seed(7)
+    chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [_Model()],
+        engine_cfg=engine_cfg,
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_Unit,),
+    )
+
+    inner = optimizer._inner_optimizer
+    cpu_group = inner.cpu_group
+    assert cpu_group is not None
+
+    total_numel = sum(p.numel() for p in inner.params)
+    cpu_numel = sum(p.numel() for p in cpu_group._gpu_params)
+    gpu_numel = total_numel - cpu_numel
+    assert cpu_numel > 0, "Expected some params to be CPU-offloaded at fraction=0.5"
+    assert gpu_numel > 0, "Expected some params to remain on GPU at fraction=0.5"
+    ratio = cpu_numel / total_numel
+    # The greedy split assigns whole params; exact ratio depends on model shape.
+    # For fraction=0.5 with 3 params of unequal size the ratio will be ≥0.4.
+    assert ratio >= 0.4, f"Expected substantial CPU offload at fraction=0.5, got {ratio:.2%}"
+    assert ratio <= 0.95, f"Expected some GPU params at fraction=0.5, got {ratio:.2%}"
+
+
+def test_mfsdp_offload_fraction_zero_has_no_cpu_group():
+    _Model, _Unit, ps, engine_cfg = _build_offload_stack(offload_fraction=0.0)
+
+    torch.manual_seed(9)
+    _chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [_Model()],
+        engine_cfg=engine_cfg,
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_Unit,),
+    )
+    assert optimizer._inner_optimizer.cpu_group is None
+
+
+def test_mfsdp_offload_fraction_checkpoint_round_trips():
+    _Model, _Unit, ps, engine_cfg = _build_offload_stack(offload_fraction=1.0)
+
+    torch.manual_seed(55)
+    chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [_Model()],
+        engine_cfg=engine_cfg,
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_Unit,),
+    )
+
+    value = torch.randn(3, 4)
+    target = torch.randn(3, 2)
+    optimizer.zero_grad()
+    torch.nn.functional.mse_loss(chunks[0](value), target).backward()
+    optimizer.finish_grad_sync()
+    optimizer.step()
+
+    saved = optimizer.state_dict()
+    assert "gpu" in saved
+    assert "cpu" in saved
+
+    optimizer.load_state_dict(saved)
+
+    optimizer.zero_grad()
+    torch.nn.functional.mse_loss(chunks[0](value), target).backward()
+    optimizer.finish_grad_sync()
+    success, _, _ = optimizer.step()
+    assert success
 
 
 def _single_rank_mfsdp_stack():


### PR DESCRIPTION
## Summary

- **新增 `mfsdp/cpu_offload.py` — `CpuAdamGroup`**: 把部分参数的 Adam 动量(`exp_avg` + `exp_avg_sq`)挪到 CPU 上。每步流程：D2H 梯度拷贝（阻塞）→ CPU `AdamW(foreach=False)` step → H2D 权重写回（阻塞）。fp32 master 仍留在 GPU（all-gather 从此处读取）。CUDA 可用时对传输缓冲区使用 pinned memory。
- **修改 `mfsdp/optimizer.py`**: 新增 `_NullOptimizer`（`offload_fraction=1.0` 时无 GPU 参数的占位符）；`_StandaloneOptimizer` 增加 `cpu_group` 字段；`param_groups` 合并 GPU+CPU 组供 LR scheduler 访问；`state_dict` 格式为 `{"gpu": ..., "cpu": ...}`，`load_state_dict` 向后兼容旧格式；新增 `_split_param_groups_by_fraction`（贪心 numel 切分）和 `_build_cpu_adam_group` 工厂函数；`build_mfsdp_stack` 读取 `offload_fraction` 并记录日志。
- **修改 `tests/unit/primitive/test_mfsdp.py`**: 更新 layout/rewrite 白名单测试以包含 `cpu_offload.py`；新增 5 个测试。

## 架构约束

`shard_param.data`（fp32 master）必须留在 GPU，因为 `prepare_param_gather` 在 all-gather 时直接从中读取。因此本方案节省的是 `exp_avg + exp_avg_sq`（约 2×4B×numel/GPU），master 暂不可节省（需改底层 buffer 引擎，列为后续增强）。

## 测试

- [x] `test_mfsdp_offload_fraction_keeps_optimizer_state_on_cpu` — step 后 exp_avg/exp_avg_sq 确认在 CPU
- [x] `test_mfsdp_offload_fraction_numerically_matches_no_offload` — CPU offload 结果与纯 GPU 运行在 `atol=1e-5` 内一致
- [x] `test_mfsdp_offload_fraction_partial_splits_by_numel` — fraction=0.5 时正确切分一部分参数
- [x] `test_mfsdp_offload_fraction_zero_has_no_cpu_group` — 关闭时无额外开销
- [x] `test_mfsdp_offload_fraction_checkpoint_round_trips` — save/load/step 可往返
- [x] 全部 33 个原有单元测试通过（1 个多进程 Gloo 测试因 login node `RLIMIT_NPROC` 限制失败，与本 PR 无关，原本已失败）

🤖 Generated with [Claude Code](https://claude.com/claude-code)