### PR TITLE
Bound vocab-parallel cross entropy memory by token chunks

### DIFF
--- a/experimental/lite/megatron/lite/primitive/ops/cross_entropy.py
+++ b/experimental/lite/megatron/lite/primitive/ops/cross_entropy.py
@@ -61,12 +61,9 @@ class _VocabParallelCrossEntropy(torch.autograd.Function):
     def forward(ctx, vocab_parallel_logits, target, tp_group, chunk_size):
         if chunk_size <= 0:
             raise ValueError(f"chunk_size must be positive, got {chunk_size}")
-        if (
-            vocab_parallel_logits.numel() // vocab_parallel_logits.size(-1)
-            != target.numel()
-        ):
+        if vocab_parallel_logits.shape[:-1] != target.shape:
             raise ValueError(
-                "logits and target must contain the same number of tokens, "
+                "logits leading shape must match target shape, "
                 f"got {vocab_parallel_logits.shape[:-1]} and {target.shape}"
             )
 
@@ -142,8 +139,10 @@ def vocab_parallel_cross_entropy(
     Example:
         ``loss = vocab_parallel_cross_entropy(logits, labels, tp_group, chunk_size=512)``
     """
+    if isinstance(chunk_size, bool) or not isinstance(chunk_size, int):
+        raise TypeError(f"chunk_size must be an integer, got {chunk_size!r}")
     return _VocabParallelCrossEntropy.apply(
-        vocab_parallel_logits, target, tp_group, int(chunk_size)
+        vocab_parallel_logits, target, tp_group, chunk_size
     )
 
 

--- a/experimental/lite/megatron/lite/primitive/ops/cross_entropy.py
+++ b/experimental/lite/megatron/lite/primitive/ops/cross_entropy.py
@@ -11,103 +11,140 @@ from __future__ import annotations
 import torch  # pyright: ignore[reportMissingImports]
 import torch.distributed as dist  # pyright: ignore[reportMissingImports]
 
+_DEFAULT_CHUNK_SIZE = 1024
+
 
 def _vocab_range(partition_vocab_size: int, rank: int, world_size: int):
     start = rank * partition_vocab_size
     return start, start + partition_vocab_size
 
 
+def _tp_info(tp_group):
+    if tp_group is not None and dist.get_world_size(tp_group) > 1:
+        return dist.get_rank(tp_group), dist.get_world_size(tp_group)
+    return 0, 1
+
+
+def _chunk_loss_and_softmax(
+    logits, target, tp_group, vocab_start_index, vocab_end_index, *, return_softmax
+):
+    logits = logits.float()
+    logits_max = logits.max(dim=-1).values
+    if tp_group is not None and dist.get_world_size(tp_group) > 1:
+        dist.all_reduce(logits_max, op=dist.ReduceOp.MAX, group=tp_group)
+    logits -= logits_max.unsqueeze(-1)
+
+    target_mask = (target < vocab_start_index) | (target >= vocab_end_index)
+    masked_target = target - vocab_start_index
+    masked_target = masked_target.masked_fill(target_mask, 0)
+    row_indices = torch.arange(logits.size(0), device=logits.device)
+    predicted_logits = logits[row_indices, masked_target].clone()
+    predicted_logits.masked_fill_(target_mask, 0.0)
+
+    torch.exp(logits, out=logits)
+    sum_exp_logits = logits.sum(dim=-1)
+    if tp_group is not None and dist.get_world_size(tp_group) > 1:
+        dist.all_reduce(predicted_logits, op=dist.ReduceOp.SUM, group=tp_group)
+        dist.all_reduce(sum_exp_logits, op=dist.ReduceOp.SUM, group=tp_group)
+
+    loss = torch.log(sum_exp_logits) - predicted_logits
+    if not return_softmax:
+        return loss, None, None, None
+
+    logits.div_(sum_exp_logits.unsqueeze(-1))
+    return loss, logits, target_mask, masked_target
+
+
 class _VocabParallelCrossEntropy(torch.autograd.Function):
 
     @staticmethod
-    def forward(ctx, vocab_parallel_logits, target, tp_group):
-        # Cast to float32 and compute max for numerical stability.
-        vocab_parallel_logits = vocab_parallel_logits.float()
-        logits_max = torch.max(vocab_parallel_logits, dim=-1)[0]
+    def forward(ctx, vocab_parallel_logits, target, tp_group, chunk_size):
+        if chunk_size <= 0:
+            raise ValueError(f"chunk_size must be positive, got {chunk_size}")
+        if (
+            vocab_parallel_logits.numel() // vocab_parallel_logits.size(-1)
+            != target.numel()
+        ):
+            raise ValueError(
+                "logits and target must contain the same number of tokens, "
+                f"got {vocab_parallel_logits.shape[:-1]} and {target.shape}"
+            )
 
-        if tp_group is not None and dist.get_world_size(tp_group) > 1:
-            dist.all_reduce(logits_max, op=dist.ReduceOp.MAX, group=tp_group)
-
-        # In-place subtract max.
-        vocab_parallel_logits -= logits_max.unsqueeze(dim=-1)
-
-        # Partition info.
         partition_vocab_size = vocab_parallel_logits.size(-1)
-        if tp_group is not None and dist.get_world_size(tp_group) > 1:
-            rank = dist.get_rank(tp_group)
-            world_size = dist.get_world_size(tp_group)
-        else:
-            rank = 0
-            world_size = 1
-        vocab_start_index, vocab_end_index = _vocab_range(partition_vocab_size, rank, world_size)
+        rank, world_size = _tp_info(tp_group)
+        vocab_start_index, vocab_end_index = _vocab_range(
+            partition_vocab_size, rank, world_size
+        )
 
-        # Mask targets outside this partition's vocab range.
-        target_mask = (target < vocab_start_index) | (target >= vocab_end_index)
-        masked_target = target.clone() - vocab_start_index
-        masked_target[target_mask] = 0
+        logits_2d = vocab_parallel_logits.reshape(-1, partition_vocab_size)
+        target_1d = target.reshape(-1)
+        loss = torch.empty(target_1d.shape, dtype=torch.float32, device=target.device)
+        for start in range(0, target_1d.numel(), chunk_size):
+            end = min(start + chunk_size, target_1d.numel())
+            loss[start:end], _, _, _ = _chunk_loss_and_softmax(
+                logits_2d[start:end],
+                target_1d[start:end],
+                tp_group,
+                vocab_start_index,
+                vocab_end_index,
+                return_softmax=False,
+            )
 
-        # Get predicted logits = logits[target].
-        logits_2d = vocab_parallel_logits.view(-1, partition_vocab_size)
-        masked_target_1d = masked_target.view(-1)
-        arange_1d = torch.arange(logits_2d.size(0), device=logits_2d.device)
-        predicted_logits_1d = logits_2d[arange_1d, masked_target_1d]
-        predicted_logits_1d = predicted_logits_1d.clone().contiguous()
-        predicted_logits = predicted_logits_1d.view_as(target)
-        predicted_logits[target_mask] = 0.0
-
-        # Sum of exp(logits).
-        exp_logits = vocab_parallel_logits
-        torch.exp(vocab_parallel_logits, out=exp_logits)
-        sum_exp_logits = exp_logits.sum(dim=-1)
-
-        # All-reduce predicted_logits and sum_exp_logits across TP.
-        if tp_group is not None and dist.get_world_size(tp_group) > 1:
-            dist.all_reduce(predicted_logits, op=dist.ReduceOp.SUM, group=tp_group)
-            dist.all_reduce(sum_exp_logits, op=dist.ReduceOp.SUM, group=tp_group)
-
-        # Loss = log(sum(exp(logits))) - predicted_logit.
-        loss = torch.log(sum_exp_logits) - predicted_logits
-
-        # Normalize exp_logits to get softmax (reused in backward).
-        exp_logits.div_(sum_exp_logits.unsqueeze(dim=-1))
-
-        # Save for backward.
-        ctx.save_for_backward(exp_logits, target_mask, masked_target_1d)
-
-        return loss
+        ctx.save_for_backward(vocab_parallel_logits, target)
+        ctx.tp_group = tp_group
+        ctx.chunk_size = chunk_size
+        ctx.vocab_start_index = vocab_start_index
+        ctx.vocab_end_index = vocab_end_index
+        return loss.reshape_as(target)
 
     @staticmethod
     def backward(ctx, grad_output):
-        softmax, target_mask, masked_target_1d = ctx.saved_tensors
+        vocab_parallel_logits, target = ctx.saved_tensors
+        partition_vocab_size = vocab_parallel_logits.size(-1)
+        logits_2d = vocab_parallel_logits.reshape(-1, partition_vocab_size)
+        target_1d = target.reshape(-1)
+        grad_output_1d = grad_output.reshape(-1)
+        grad_input = torch.empty_like(vocab_parallel_logits)
+        grad_input_2d = grad_input.reshape(-1, partition_vocab_size)
 
-        # grad_input = softmax (copy is implicit since softmax is saved).
-        grad_input = softmax
-        partition_vocab_size = softmax.size(-1)
-        grad_2d = grad_input.view(-1, partition_vocab_size)
+        for start in range(0, target_1d.numel(), ctx.chunk_size):
+            end = min(start + ctx.chunk_size, target_1d.numel())
+            _, softmax, target_mask, masked_target = _chunk_loss_and_softmax(
+                logits_2d[start:end],
+                target_1d[start:end],
+                ctx.tp_group,
+                ctx.vocab_start_index,
+                ctx.vocab_end_index,
+                return_softmax=True,
+            )
+            row_indices = torch.arange(end - start, device=softmax.device)
+            softmax[row_indices, masked_target] -= 1.0 - target_mask.float()
+            softmax.mul_(grad_output_1d[start:end].unsqueeze(-1))
+            grad_input_2d[start:end].copy_(softmax)
 
-        arange_1d = torch.arange(grad_2d.size(0), device=grad_2d.device)
-        softmax_update = 1.0 - target_mask.view(-1).float()
-
-        grad_2d[arange_1d, masked_target_1d] -= softmax_update
-
-        # Scale by upstream gradient.
-        grad_input.mul_(grad_output.unsqueeze(dim=-1))
-
-        return grad_input, None, None
+        return grad_input, None, None, None
 
 
-def vocab_parallel_cross_entropy(vocab_parallel_logits, target, tp_group=None):
+def vocab_parallel_cross_entropy(
+    vocab_parallel_logits, target, tp_group=None, chunk_size=_DEFAULT_CHUNK_SIZE
+):
     """Cross entropy loss for vocab-parallel logits.
 
     Args:
         vocab_parallel_logits: [S, B, V/tp] logits split across TP ranks.
         target: [S, B] integer target token ids.
         tp_group: TP process group (None or single-rank group → no communication).
+        chunk_size: Maximum number of tokens materialized in float32 at once.
 
     Returns:
         Per-token loss tensor of shape [S, B].
+
+    Example:
+        ``loss = vocab_parallel_cross_entropy(logits, labels, tp_group, chunk_size=512)``
     """
-    return _VocabParallelCrossEntropy.apply(vocab_parallel_logits, target, tp_group)
+    return _VocabParallelCrossEntropy.apply(
+        vocab_parallel_logits, target, tp_group, int(chunk_size)
+    )
 
 
 __all__ = ["vocab_parallel_cross_entropy"]

--- a/experimental/lite/tests/unit/primitive/test_chunked_cross_entropy.py
+++ b/experimental/lite/tests/unit/primitive/test_chunked_cross_entropy.py
@@ -73,6 +73,52 @@ def test_chunked_cross_entropy_bounds_saved_fp32_state_and_matches_gradients():
     torch.testing.assert_close(logits.grad, logits_ref.grad)
 
 
+def test_chunked_cross_entropy_default_chunk_spans_multiple_chunks():
+    logits = torch.randn(1025, 1, 7, dtype=torch.float16, requires_grad=True)
+    labels = torch.randint(0, 7, (1025, 1))
+    logits_ref = logits.detach().clone().requires_grad_()
+
+    loss = cross_entropy.vocab_parallel_cross_entropy(logits, labels)
+    loss.sum().backward()
+    expected = F.cross_entropy(
+        logits_ref.float().reshape(-1, 7), labels.reshape(-1), reduction="none"
+    ).view_as(labels)
+    expected.sum().backward()
+
+    torch.testing.assert_close(loss, expected)
+    torch.testing.assert_close(logits.grad, logits_ref.grad)
+
+
+def test_chunked_cross_entropy_rejects_same_numel_different_layout():
+    logits = torch.randn(2, 3, 5)
+    labels = torch.randint(0, 5, (3, 2))
+
+    with pytest.raises(ValueError, match="leading shape"):
+        cross_entropy.vocab_parallel_cross_entropy(logits, labels)
+
+
+@pytest.mark.parametrize("chunk_size", [0, -1])
+def test_chunked_cross_entropy_rejects_nonpositive_chunk_size(chunk_size):
+    logits = torch.randn(2, 3, 5)
+    labels = torch.randint(0, 5, (2, 3))
+
+    with pytest.raises(ValueError, match="positive"):
+        cross_entropy.vocab_parallel_cross_entropy(
+            logits, labels, chunk_size=chunk_size
+        )
+
+
+@pytest.mark.parametrize("chunk_size", [3.9, True])
+def test_chunked_cross_entropy_rejects_noninteger_chunk_size(chunk_size):
+    logits = torch.randn(2, 3, 5)
+    labels = torch.randint(0, 5, (2, 3))
+
+    with pytest.raises(TypeError, match="integer"):
+        cross_entropy.vocab_parallel_cross_entropy(
+            logits, labels, chunk_size=chunk_size
+        )
+
+
 def test_chunked_cross_entropy_matches_two_rank_tp():
     with socket.socket() as sock:
         sock.bind(("127.0.0.1", 0))

--- a/experimental/lite/tests/unit/primitive/test_chunked_cross_entropy.py
+++ b/experimental/lite/tests/unit/primitive/test_chunked_cross_entropy.py
@@ -8,7 +8,7 @@ import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
 import torch.nn.functional as F
-from megatron.lite.primitive.ops.cross_entropy import vocab_parallel_cross_entropy
+from megatron.lite.primitive.ops import cross_entropy
 
 pytestmark = pytest.mark.mlite
 
@@ -25,7 +25,7 @@ def _tp_worker(rank, world_size, port):
             full_logits.chunk(world_size, dim=-1)[rank].clone().requires_grad_()
         )
 
-        loss = vocab_parallel_cross_entropy(
+        loss = cross_entropy.vocab_parallel_cross_entropy(
             local_logits, labels, dist.group.WORLD, chunk_size=3
         )
         loss.sum().backward()
@@ -57,7 +57,7 @@ def test_chunked_cross_entropy_bounds_saved_fp32_state_and_matches_gradients():
         return tensor
 
     with torch.autograd.graph.saved_tensors_hooks(record_saved, lambda tensor: tensor):
-        loss = vocab_parallel_cross_entropy(logits, labels, chunk_size=3)
+        loss = cross_entropy.vocab_parallel_cross_entropy(logits, labels, chunk_size=3)
     loss.sum().backward()
 
     expected = F.cross_entropy(

--- a/experimental/lite/tests/unit/primitive/test_chunked_cross_entropy.py
+++ b/experimental/lite/tests/unit/primitive/test_chunked_cross_entropy.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from __future__ import annotations
+
+import socket
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import torch.nn.functional as F
+from megatron.lite.primitive.ops.cross_entropy import vocab_parallel_cross_entropy
+
+pytestmark = pytest.mark.mlite
+
+
+def _tp_worker(rank, world_size, port):
+    dist.init_process_group(
+        "gloo", init_method=f"tcp://127.0.0.1:{port}", rank=rank, world_size=world_size
+    )
+    try:
+        torch.manual_seed(123)
+        full_logits = torch.randn(7, 2, 12, dtype=torch.float16)
+        labels = torch.randint(0, 12, (7, 2))
+        local_logits = (
+            full_logits.chunk(world_size, dim=-1)[rank].clone().requires_grad_()
+        )
+
+        loss = vocab_parallel_cross_entropy(
+            local_logits, labels, dist.group.WORLD, chunk_size=3
+        )
+        loss.sum().backward()
+
+        full_logits_ref = full_logits.clone().requires_grad_()
+        expected = F.cross_entropy(
+            full_logits_ref.float().reshape(-1, 12),
+            labels.reshape(-1),
+            reduction="none",
+        ).view_as(labels)
+        expected.sum().backward()
+
+        torch.testing.assert_close(loss, expected)
+        torch.testing.assert_close(
+            local_logits.grad, full_logits_ref.grad.chunk(world_size, dim=-1)[rank]
+        )
+    finally:
+        dist.destroy_process_group()
+
+
+def test_chunked_cross_entropy_bounds_saved_fp32_state_and_matches_gradients():
+    logits = torch.randn(7, 2, 11, dtype=torch.float16, requires_grad=True)
+    labels = torch.randint(0, 11, (7, 2))
+    logits_ref = logits.detach().clone().requires_grad_()
+    saved_tensors = []
+
+    def record_saved(tensor):
+        saved_tensors.append(tensor)
+        return tensor
+
+    with torch.autograd.graph.saved_tensors_hooks(record_saved, lambda tensor: tensor):
+        loss = vocab_parallel_cross_entropy(logits, labels, chunk_size=3)
+    loss.sum().backward()
+
+    expected = F.cross_entropy(
+        logits_ref.float().reshape(-1, 11), labels.reshape(-1), reduction="none"
+    ).view_as(labels)
+    expected.sum().backward()
+
+    assert not any(
+        tensor.dtype == torch.float32 and tensor.shape == logits.shape
+        for tensor in saved_tensors
+    )
+    torch.testing.assert_close(loss, expected)
+    torch.testing.assert_close(logits.grad, logits_ref.grad)
+
+
+def test_chunked_cross_entropy_matches_two_rank_tp():
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+    mp.spawn(_tp_worker, args=(2, port), nprocs=2, join=True)


### PR DESCRIPTION
## Summary

- compute vocab-parallel cross entropy in bounded token chunks instead of materializing the complete FP32 softmax working set
- recompute each softmax chunk during backward while retaining the existing per-token loss and TP semantics
- keep the production call sites unchanged; the default 1,024-token chunk applies automatically
- fail loudly when the target leading shape does not match the logits or when the chunk size is not a positive integer

For 8,192 tokens and a 151,936-token vocabulary, the FP32 working set is bounded to 0.580 GiB per chunk instead of 4.638 GiB for the complete tensor (8x reduction). The existing BF16 logits and the required logits gradient are unchanged.

## Validation

- single-rank forward and backward parity against `torch.nn.functional.cross_entropy`
- two-rank Gloo TP forward and backward parity against the unsharded Torch reference
- the default 1,024-token setting exercised across multiple chunks
- fail-loud coverage for mismatched layouts and invalid chunk sizes
- 17 related CPU tests passed
- the complete repository-pinned isort 5.13.2 and black 24.4.2 hook sequence passed twice consecutively on both changed files

A one-GPU 8,192-token memory measurement is staged and will be appended after the pre-GPU review gate. The 0.580 GiB figure above is the analytical per-chunk FP32 working-set bound, not a measured peak-memory claim.