### PR TITLE
mlite: fix cross_entropy_fusion never taking effect (all four models)

### DIFF
--- a/experimental/lite/megatron/lite/model/protocol_utils.py
+++ b/experimental/lite/megatron/lite/model/protocol_utils.py
@@ -48,7 +48,9 @@ def nested_from_packed(tensor: torch.Tensor | None, seq_lens: torch.Tensor):
         pieces.append(tensor.narrow(0, offset, length))
         offset += length
     if offset != tensor.numel():
-        raise ValueError(f"PackedBatch sizes sum to {offset}, tensor has {tensor.numel()} tokens.")
+        raise ValueError(
+            f"PackedBatch sizes sum to {offset}, tensor has {tensor.numel()} tokens."
+        )
     return torch.nested.as_nested_tensor(pieces, layout=torch.jagged)
 
 
@@ -74,7 +76,9 @@ def pack_thd_forward_kwargs(model, batch: PackedBatch) -> dict[str, Any]:
         loss_mask=nested_from_packed(batch.loss_mask, seq_lens),
         roll_loss_mask=batch.loss_mask is not None,
     )
-    max_seqlen = int(packed.padded_lengths.max().item()) if packed.padded_lengths.numel() else 0
+    max_seqlen = (
+        int(packed.padded_lengths.max().item()) if packed.padded_lengths.numel() else 0
+    )
     # pack_nested_thd already returns [1, T] token rows; do not unsqueeze again.
     kwargs: dict[str, Any] = {
         "input_ids": packed.input_ids,
@@ -89,7 +93,9 @@ def pack_thd_forward_kwargs(model, batch: PackedBatch) -> dict[str, Any]:
     return kwargs
 
 
-def unpack_thd_forward_output(model, batch: PackedBatch, output: torch.Tensor) -> torch.Tensor:
+def unpack_thd_forward_output(
+    model, batch: PackedBatch, output: torch.Tensor
+) -> torch.Tensor:
     """Reverse a zigzag-CP THD model output back to jagged true-length form."""
     ps = _parallel_state(model)
     meta = thd_pack_meta(
@@ -194,7 +200,9 @@ def pack_r3_replay_mask(
     ].bool()
 
 
-def add_loss_context_kwargs(kwargs: dict[str, Any], *, include_return_log_probs: bool = False) -> None:
+def add_loss_context_kwargs(
+    kwargs: dict[str, Any], *, include_return_log_probs: bool = False
+) -> None:
     loss_context = get_loss_context()
     if loss_context is None:
         return
@@ -204,8 +212,37 @@ def add_loss_context_kwargs(kwargs: dict[str, Any], *, include_return_log_probs:
         kwargs["return_log_probs"] = loss_context.return_log_probs
 
 
+def _resolve_cross_entropy_fusion(model) -> bool:
+    """Read the ``cross_entropy_fusion`` flag through any module wrappers.
+
+    ``set_cross_entropy_fusion`` runs at build time on the bare model chunks;
+    by the time ``_forward_step`` runs, the runtime has wrapped each chunk in a
+    data-parallel container. Megatron's ``_BaseDataParallel`` keeps the wrapped
+    module in ``self.module`` and does not proxy unknown attributes to it, so a
+    plain ``getattr(wrapper, "cross_entropy_fusion")`` misses the attribute
+    entirely and silently falls back to the default.
+
+    The consequence was invisible: the flag was set correctly, appeared as
+    ``True`` in every config dump, and the model still took the unfused branch —
+    materialising the full ``[tokens, vocab/tp]`` logits and upcasting them to
+    fp32. Walk the ``.module`` chain instead, checking each level's own
+    ``__dict__`` so an attribute on an inner chunk is found no matter how many
+    wrappers were added.
+    """
+
+    seen: set[int] = set()
+    current = model
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        own = getattr(current, "__dict__", None)
+        if isinstance(own, dict) and "cross_entropy_fusion" in own:
+            return bool(own["cross_entropy_fusion"])
+        current = getattr(current, "module", None)
+    return False
+
+
 def add_cross_entropy_fusion(kwargs: dict[str, Any], model) -> None:
-    kwargs["use_fused_kernels"] = bool(getattr(model, "cross_entropy_fusion", False))
+    kwargs["use_fused_kernels"] = _resolve_cross_entropy_fusion(model)
 
 
 def set_cross_entropy_fusion(chunks: list, enabled: bool) -> None:
@@ -214,6 +251,7 @@ def set_cross_entropy_fusion(chunks: list, enabled: bool) -> None:
 
 
 __all__ = [
+    "_resolve_cross_entropy_fusion",
     "add_cross_entropy_fusion",
     "add_loss_context_kwargs",
     "nested_from_packed",

--- a/experimental/lite/tests/unit/model/test_cross_entropy_fusion_unit.py
+++ b/experimental/lite/tests/unit/model/test_cross_entropy_fusion_unit.py
@@ -1,0 +1,174 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""cross_entropy_fusion must survive the data-parallel wrapper.
+
+``set_cross_entropy_fusion`` runs at build time on the bare model chunks. By the
+time ``_forward_step`` runs, the runtime has wrapped each chunk in a
+data-parallel container whose only reference to the wrapped model is
+``self.module`` and which does not proxy unknown attributes to it. A plain
+``getattr(wrapper, "cross_entropy_fusion")`` therefore misses, and the model
+silently takes the unfused branch.
+
+That failure is invisible from configuration: the key resolves to ``True``, it
+appears as ``True`` in the config dump, and the only symptom is memory: the
+unfused path materialises the full ``[tokens, vocab/tp]`` logits in fp32.
+
+**These tests assert which code path runs, not what the config says.** Asserting
+``use_fused_kernels is True`` would have passed even before the fix, because the
+configuration was never the broken part.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+from megatron.lite.model.protocol_utils import (
+    add_cross_entropy_fusion,
+    set_cross_entropy_fusion,
+)
+
+pytestmark = pytest.mark.mlite
+
+
+class _CountingCE:
+    """Stand-in for vocab_parallel_cross_entropy that records whether it ran."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self, logits, labels):
+        self.calls += 1
+        return logits.float().mean()
+
+
+class _Model(nn.Module):
+    """Minimal mirror of qwen3_moe's loss branch.
+
+    The unfused branch materialises logits and calls the (counted) cross-entropy;
+    the fused branch does neither. Which one runs is the observable under test.
+    """
+
+    def __init__(self, ce: _CountingCE):
+        super().__init__()
+        self.ce = ce
+        self.head = nn.Linear(4, 8, bias=False)
+        self.fused_calls = 0
+
+    def forward(self, x, use_fused_kernels: bool = False):
+        if use_fused_kernels:
+            self.fused_calls += 1
+            return {"loss": x.sum()}
+        logits = self.head(x)
+        return {"loss": self.ce(logits, None)}
+
+
+class _BaseDataParallelLike(nn.Module):
+    """Mirrors megatron.core.distributed.data_parallel_base._BaseDataParallel.
+
+    Holds the wrapped model in ``self.module`` but does not proxy unknown
+    attributes to it.
+    """
+
+    def __init__(self, module: nn.Module):
+        super().__init__()
+        self.module = module
+
+    def forward(self, *args, **kwargs):
+        return self.module(*args, **kwargs)
+
+
+def _forward_step(model, x):
+    """Mirrors qwen3_moe/lite/protocol.py::_forward_step."""
+    kwargs: dict = {}
+    add_cross_entropy_fusion(kwargs, model)
+    return model(x, **kwargs)
+
+
+def test_wrapper_does_not_forward_attributes():
+    """The premise of the bug, pinned so it cannot silently change."""
+    inner = _Model(_CountingCE())
+    inner.cross_entropy_fusion = True
+    wrapped = _BaseDataParallelLike(inner)
+    assert "cross_entropy_fusion" not in vars(wrapped)
+    assert not hasattr(wrapped, "cross_entropy_fusion")
+
+
+def test_fusion_enabled_through_wrapper_skips_cross_entropy():
+    """THE regression test: behaviour, not configuration."""
+    ce = _CountingCE()
+    inner = _Model(ce)
+    set_cross_entropy_fusion([inner], True)
+    wrapped = _BaseDataParallelLike(inner)
+
+    _forward_step(wrapped, torch.randn(3, 4))
+
+    assert ce.calls == 0, (
+        "cross-entropy ran despite cross_entropy_fusion=True -- the flag did not "
+        "survive the data-parallel wrapper"
+    )
+    assert inner.fused_calls == 1, "the fused branch did not run"
+
+
+def test_fusion_disabled_through_wrapper_still_uses_cross_entropy():
+    """Negative control: with the flag off, the unfused branch must run."""
+    ce = _CountingCE()
+    inner = _Model(ce)
+    set_cross_entropy_fusion([inner], False)
+    wrapped = _BaseDataParallelLike(inner)
+
+    _forward_step(wrapped, torch.randn(3, 4))
+
+    assert ce.calls == 1
+    assert inner.fused_calls == 0
+
+
+def test_fusion_works_unwrapped_too():
+    """The pre-existing (unwrapped) path must keep working."""
+    ce = _CountingCE()
+    inner = _Model(ce)
+    set_cross_entropy_fusion([inner], True)
+    _forward_step(inner, torch.randn(3, 4))
+    assert ce.calls == 0 and inner.fused_calls == 1
+
+
+def test_fusion_survives_nested_wrappers():
+    """More than one wrapper is legal; the walk must not stop at the first."""
+    ce = _CountingCE()
+    inner = _Model(ce)
+    set_cross_entropy_fusion([inner], True)
+    doubly = _BaseDataParallelLike(_BaseDataParallelLike(inner))
+    _forward_step(doubly, torch.randn(3, 4))
+    assert ce.calls == 0 and inner.fused_calls == 1
+
+
+def test_unset_defaults_to_unfused():
+    """No attribute anywhere -> False, not a crash."""
+    ce = _CountingCE()
+    wrapped = _BaseDataParallelLike(_Model(ce))
+    _forward_step(wrapped, torch.randn(3, 4))
+    assert ce.calls == 1
+
+
+def test_resolution_terminates_on_self_referential_wrapper():
+    """A cycle must not hang the forward path."""
+    from megatron.lite.model.protocol_utils import _resolve_cross_entropy_fusion
+
+    class _Cyclic:
+        pass
+
+    a = _Cyclic()
+    a.module = a
+    assert _resolve_cross_entropy_fusion(a) is False
+
+
+def test_old_implementation_would_fail_this_suite():
+    """Proof the suite discriminates: the pre-fix lookup returns False here.
+
+    If this ever starts returning True, the tests above have stopped testing the
+    thing that was broken.
+    """
+    inner = _Model(_CountingCE())
+    set_cross_entropy_fusion([inner], True)
+    wrapped = _BaseDataParallelLike(inner)
+    old_result = bool(getattr(wrapped, "cross_entropy_fusion", False))
+    assert old_result is False, "the old lookup no longer reproduces the bug"


### PR DESCRIPTION
## Summary

Fix `cross_entropy_fusion` being silently disabled after model chunks are placed
behind Megatron data-parallel wrappers.

## Root cause

`set_cross_entropy_fusion` stores the flag on each bare model chunk during
construction. The forward path later receives a data-parallel wrapper whose
wrapped model lives in `.module`; unknown attributes are not proxied to that
model. Reading only
`getattr(wrapper, "cross_entropy_fusion", False)` therefore returned the default
even though configuration resolution was correct.

The fallback selected the unfused loss path, which materialises full
`[tokens, vocab/tp]` logits and upcasts them to fp32.

## Fix

Walk the `.module` chain and inspect attributes owned by each wrapper or model
level. A cycle guard prevents malformed self-referential wrappers from hanging
the forward path.

The shared helper covers every current caller of
`add_cross_entropy_fusion`: Qwen3-MoE, Qwen3.5, GLM-5, and Kimi-K2.

## Validation

- 8 focused behavioural tests pass.
- Replacing the new resolver with the previous outer-object lookup produces
  exactly 2 failures and 6 passes, demonstrating that the regression tests
  distinguish the broken implementation.
- Black 24.4.2 and Ruff checks pass for the changed files.

The tests observe which loss branch executes rather than merely checking the
configuration value.
