### PR TITLE
Add token-wise ChunkedEP overlap for MLite MoE models

### DIFF
--- a/experimental/lite/examples/bench/README.md
+++ b/experimental/lite/examples/bench/README.md
@@ -23,6 +23,47 @@ This benchmark separates two validation lines:
 
 Use the `mbridge` line for Core/distopt precision and speed claims.
 
+## Qwen3 MoE ChunkedEP
+
+Qwen3 MoE can compose the two-physical-slot DeepEP overlap implementation
+through its lite implementation config:
+
+```python
+from megatron.lite.model.qwen3_moe.lite.protocol import ImplConfig
+from megatron.lite.runtime.contracts import ParallelConfig
+
+impl = ImplConfig(
+    parallel=ParallelConfig(ep=8),
+    use_deepep=True,
+    enable_ep_chunk_overlap=True,
+    ep_chunk_max_token_rows_per_rank=4096,
+)
+```
+
+The public bench consumes the same fields through ``--impl-cfg-json``; use this
+surface for controlled MLite runs rather than a private validation entrypoint:
+
+```bash
+python experimental/lite/examples/bench/bench.py \
+  --backend mlite \
+  --hf-path /models/Qwen3-MoE \
+  --ep 8 \
+  --impl-cfg-json '{"use_deepep":true,"enable_ep_chunk_overlap":true,"ep_chunk_max_token_rows_per_rank":4096,"ep_chunk_full_recompute":false}'
+```
+
+The primitive keeps two physical workspace slots while its profile owns the
+logical chunk count; the current Qwen3 configuration selects two logical
+chunks. It requires DeepEP with `EP > 1`; there is no per-model scheduling
+policy. The caller must set
+`ep_chunk_max_token_rows_per_rank` to the true maximum flattened MoE input rows
+for one rank and one forward (including BSHD micro-batches or all packed THD
+tokens). Inputs above that fixed capacity fail loudly; scratch tensors are
+not allocated during Qwen3 model construction. The selected phase lazily
+materializes two dispatcher/dispatch-recv allocation-pool slots, while
+backward scratch is allocated at the actual received shape and may grow only
+within the fixed profile during preflight. Repeating the same preflight shape
+must not allocate or grow again.
+
 ## Dry-Run
 
 ```bash

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/head_loss.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/head_loss.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Qwen3-only choice of its bounded non-fused head-loss composition."""
+
+from __future__ import annotations
+
+
+def use_chunked_head_loss(
+    *,
+    has_labels: bool,
+    use_fused_kernels: bool,
+    calculate_entropy: bool,
+    has_chunked_ep: bool,
+) -> bool:
+    """Keep unsupported output and non-ChunkedEP compositions on their fallback."""
+    return (
+        has_labels
+        and has_chunked_ep
+        and not use_fused_kernels
+        and not calculate_entropy
+    )
+
+
+def balanced_head_loss_chunk_size(token_count: int, chunk_count: int) -> int:
+    """Use all configured EP chunks with token windows differing by at most one."""
+    if (
+        isinstance(token_count, bool)
+        or not isinstance(token_count, int)
+        or token_count <= 0
+    ):
+        raise ValueError(f"token_count must be a positive integer, got {token_count!r}")
+    if (
+        isinstance(chunk_count, bool)
+        or not isinstance(chunk_count, int)
+        or chunk_count <= 0
+    ):
+        raise ValueError(f"chunk_count must be a positive integer, got {chunk_count!r}")
+    return (token_count + chunk_count - 1) // chunk_count
+
+
+__all__ = ["balanced_head_loss_chunk_size", "use_chunked_head_loss"]

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/head_loss.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/head_loss.py
@@ -37,4 +37,17 @@ def balanced_head_loss_chunk_size(token_count: int, chunk_count: int) -> int:
     return (token_count + chunk_count - 1) // chunk_count
 
 
-__all__ = ["balanced_head_loss_chunk_size", "use_chunked_head_loss"]
+def validate_chunked_ep_mtp(*, enable_ep_chunk_overlap: bool, mtp_enable: bool) -> None:
+    """Reject MTP before allocation until its auxiliary head loss is bounded."""
+    if enable_ep_chunk_overlap and mtp_enable:
+        raise ValueError(
+            "ChunkedEP with MTP is unsupported: MTP auxiliary head loss can "
+            "materialize full-vocabulary logits; disable MTP or ChunkedEP."
+        )
+
+
+__all__ = [
+    "balanced_head_loss_chunk_size",
+    "use_chunked_head_loss",
+    "validate_chunked_ep_mtp",
+]

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
@@ -19,10 +19,29 @@ from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
 from megatron.lite.primitive.modules.experts import Experts
 from megatron.lite.primitive.modules.gqa import GQAttention
 from megatron.lite.primitive.modules.lora import LoraConfig
+from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+    EPChunkBackwardOp,
+    EPChunkForwardOp,
+    EPChunkFusedForwardBackwardOp,
+    EPChunkShapeProfile,
+    EPChunkWorkspaceKey,
+    get_ep_chunk_workspace,
+    release_ep_chunk_workspace,
+)
+from megatron.lite.primitive.modules.moe_ep_chunk_overlap_policy import (
+    validate_ep_chunk_overlap_config,
+)
 from megatron.lite.primitive.modules.router import TopKRouter
 from megatron.lite.primitive.ops.cross_entropy import vocab_parallel_cross_entropy
+from megatron.lite.primitive.ops.chunked_linear_cross_entropy import (
+    chunked_vocab_parallel_linear_cross_entropy,
+)
 from megatron.lite.primitive.ops.linear_cross_entropy import linear_cross_entropy
 from megatron.lite.primitive.ops.logprob import vocab_parallel_entropy
+from megatron.lite.model.qwen3_moe.lite.head_loss import (
+    balanced_head_loss_chunk_size,
+    use_chunked_head_loss,
+)
 from megatron.lite.primitive.parallel import (
     ParallelState,
     VanillaColumnParallelLinear,
@@ -40,6 +59,134 @@ from megatron.lite.primitive.utils import build_fp8_recipe
 # ---------------------------------------------------------------------------
 
 
+class _Qwen3TransformerLayerFullRecomputeFunction(torch.autograd.Function):
+    """Full layer checkpoint with ChunkedEP owning only MoE recomputation."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        x: torch.Tensor,
+        position_ids: torch.Tensor | None,
+        packed_seq_params,
+        layer: "TransformerLayer",
+        park_chunked_ep_after_backward: bool,
+        *params: torch.Tensor,
+    ):
+        # ``Function.apply`` must make the initial whole-layer pass graph-free:
+        # saving a post-attention residual or the MLP norm output would restore
+        # the 48-layer activation growth that full recompute is meant to remove.
+        if torch.is_grad_enabled():
+            raise RuntimeError(
+                "Qwen3 full-recompute layer forward must run with grad disabled"
+            )
+        if torch.is_tensor(position_ids) and position_ids.requires_grad:
+            raise RuntimeError(
+                "Qwen3 full-recompute position_ids must not require gradients"
+            )
+        ctx.param_ids = tuple(id(param) for param in params)
+        ctx.cpu_rng_state = torch.get_rng_state()
+        ctx.cuda_device = (
+            x.device if x.is_cuda and torch.cuda.is_initialized() else None
+        )
+        ctx.cuda_rng_state = (
+            torch.cuda.get_rng_state(ctx.cuda_device)
+            if ctx.cuda_device is not None
+            else None
+        )
+        del params
+        ctx.layer = layer
+        ctx.park_chunked_ep_after_backward = park_chunked_ep_after_backward
+        ctx.position_ids = position_ids
+        ctx.packed_seq_params = packed_seq_params
+        ctx.save_for_backward(x.detach())
+        return layer._ep_chunk_full_recompute_forward(
+            x, position_ids=position_ids, packed_seq_params=packed_seq_params
+        ).detach()
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        (x_saved,) = ctx.saved_tensors
+        layer = ctx.layer
+        x = x_saved.detach().requires_grad_(True)
+        attention_params = tuple(layer.attn.parameters())
+        norm_params = tuple(layer.mlp_norm.parameters())
+        router_params = tuple(layer.moe.router.parameters())
+        expert_params = tuple(layer.moe.experts.parameters())
+        if ctx.param_ids != tuple(
+            id(param)
+            for param in (
+                *attention_params,
+                *norm_params,
+                *router_params,
+                *expert_params,
+            )
+        ):
+            raise RuntimeError("Qwen3 full-recompute parameter order changed")
+        current_cpu_rng_state = torch.get_rng_state()
+        current_cuda_rng_state = (
+            torch.cuda.get_rng_state(ctx.cuda_device)
+            if ctx.cuda_device is not None
+            else None
+        )
+        try:
+            torch.set_rng_state(ctx.cpu_rng_state)
+            if ctx.cuda_rng_state is not None:
+                torch.cuda.set_rng_state(ctx.cuda_rng_state, ctx.cuda_device)
+            with torch.enable_grad():
+                attention_out = layer.attn(
+                    x,
+                    position_ids=ctx.position_ids,
+                    packed_seq_params=ctx.packed_seq_params,
+                )
+                residual = x + attention_out
+                norm_out = layer.mlp_norm(residual)
+                assert layer.moe.ep_chunk_fused is not None
+                grad_norm, router_grads, expert_grads = (
+                    layer.moe.ep_chunk_fused.forward_backward(norm_out, grad_output)
+                )
+                differentiable = (x, *attention_params, *norm_params)
+                required = tuple(
+                    value for value in differentiable if value.requires_grad
+                )
+                required_grads = torch.autograd.grad(
+                    (norm_out, residual),
+                    required,
+                    (grad_norm, grad_output),
+                    allow_unused=True,
+                )
+                if ctx.park_chunked_ep_after_backward:
+                    stream = torch.cuda.current_stream(x.device) if x.is_cuda else None
+                    layer.moe.ep_chunk_fused.workspace.park_expert_activations(
+                        stream=stream
+                    )
+        finally:
+            torch.set_rng_state(current_cpu_rng_state)
+            if current_cuda_rng_state is not None:
+                torch.cuda.set_rng_state(current_cuda_rng_state, ctx.cuda_device)
+
+        grads_by_id = {
+            id(value): grad
+            for value, grad in zip(required, required_grads, strict=True)
+        }
+        grad_x = grads_by_id.get(id(x))
+        param_grads = (
+            *[grads_by_id.get(id(param)) for param in attention_params],
+            *[grads_by_id.get(id(param)) for param in norm_params],
+            *router_grads,
+            *expert_grads,
+        )
+        if len(param_grads) != len(ctx.param_ids):
+            raise RuntimeError("Qwen3 full-recompute parameter gradient order changed")
+        return (
+            grad_x,
+            None,
+            None,
+            None,
+            None,
+            *param_grads,
+        )
+
+
 class MoELayer(nn.Module):
     def __init__(
         self,
@@ -50,21 +197,110 @@ class MoELayer(nn.Module):
         router_bias_rate: float = 0.0,
         fp8: bool = False,
         moe_act_recompute: bool = False,
+        enable_ep_chunk_overlap: bool = False,
+        ep_chunk_max_token_rows_per_rank: int | None = None,
+        ep_chunk_count: int = 2,
+        ep_chunk_full_recompute: bool = False,
         lora_config: LoraConfig | dict | None = None,
     ):
         super().__init__()
+        validate_qwen3_ep_chunk_recompute_composition(
+            enable_ep_chunk_overlap=enable_ep_chunk_overlap,
+            ep_chunk_full_recompute=ep_chunk_full_recompute,
+            recompute_modules=[],
+        )
+        validate_ep_chunk_overlap_config(
+            enable_ep_chunk_overlap,
+            use_deepep=use_deepep,
+            ep_size=ps.ep_size,
+            topk=config.num_experts_per_tok,
+            max_token_rows_per_rank=ep_chunk_max_token_rows_per_rank,
+        )
         # Match Qwen3-MoE's `load_balancing_type="none"` setting: no aux loss.
         self.router = TopKRouter(
             config, ps, router_bias_rate=router_bias_rate, compute_aux_loss=False
         )
         self.experts = Experts(
-            config, ps, fp8=fp8, moe_act_recompute=moe_act_recompute, lora_config=lora_config
+            config,
+            ps,
+            fp8=fp8,
+            moe_act_recompute=moe_act_recompute,
+            delay_wgrad_compute=enable_ep_chunk_overlap,
+            lora_config=lora_config,
         )
-        self.dispatcher = TokenDispatcher(
-            config.num_experts, config.hidden_size, ps, use_deepep=use_deepep
-        )
+        self.dispatcher: TokenDispatcher | None = None
+        self.ep_chunk_forward: EPChunkForwardOp | None = None
+        self.ep_chunk_backward: EPChunkBackwardOp | None = None
+        self.ep_chunk_fused: EPChunkFusedForwardBackwardOp | None = None
+        self.ep_chunk_full_recompute = ep_chunk_full_recompute
+        if enable_ep_chunk_overlap:
+            assert ep_chunk_max_token_rows_per_rank is not None
+            shape_profile = EPChunkShapeProfile.for_two_slot_chunked_ep(
+                max_input_rows=ep_chunk_max_token_rows_per_rank,
+                hidden_size=config.hidden_size,
+                expert_intermediate_size=getattr(
+                    config, "moe_intermediate_size", None
+                ),
+                topk=config.num_experts_per_tok,
+                ep_size=ps.ep_size,
+                chunk_count=ep_chunk_count,
+            )
+            common_key = dict(
+                device_type="cuda",
+                # Bind to the actual runtime tensor/explicit materialize device,
+                # after the CPU-constructed module has been moved to its rank device.
+                device_index=None,
+                ep_group_id=id(ps.tp_ep_group),
+                dtype=torch.bfloat16,
+                shape_profile=shape_profile,
+            )
+
+            def workspace(op):
+                key = EPChunkWorkspaceKey(op=op, **common_key)
+                workspace = get_ep_chunk_workspace(
+                    key,
+                    lambda _slot: TokenDispatcher(
+                        config.num_experts,
+                        config.hidden_size,
+                        ps,
+                        use_deepep=True,
+                    ),
+                )
+                return workspace
+
+            op_kwargs = dict(
+                router=self.router,
+                experts=self.experts,
+            )
+            if ep_chunk_full_recompute:
+                self.ep_chunk_forward = EPChunkForwardOp(
+                    workspace=workspace("forward"), **op_kwargs
+                )
+                self.ep_chunk_fused = EPChunkFusedForwardBackwardOp(
+                    workspace=workspace("fused_forward_backward"), **op_kwargs
+                )
+            else:
+                self.ep_chunk_backward = EPChunkBackwardOp(
+                    workspace=workspace("backward"), **op_kwargs
+                )
+                self.ep_chunk_forward = EPChunkForwardOp(
+                    workspace=workspace("forward"),
+                    backward_op=self.ep_chunk_backward,
+                    **op_kwargs,
+                )
+        else:
+            self.dispatcher = TokenDispatcher(
+                config.num_experts, config.hidden_size, ps, use_deepep=use_deepep
+            )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.ep_chunk_forward is not None:
+            if self.ep_chunk_full_recompute:
+                return self.ep_chunk_forward(x)
+            assert self.ep_chunk_forward is not None
+            return self.ep_chunk_forward(x)
+
+        assert self.dispatcher is not None
         input_shape = x.shape
         if x.dim() == 3:
             x_2d = x.view(-1, x.size(-1))
@@ -72,7 +308,9 @@ class MoELayer(nn.Module):
             x_2d = x
 
         scores, indices = self.router(x_2d)
-        dispatched, tpe, permuted_probs = self.dispatcher.dispatch(x_2d, scores, indices)
+        dispatched, tpe, permuted_probs = self.dispatcher.dispatch(
+            x_2d, scores, indices
+        )
         del scores, indices
         self.dispatcher.wait_dispatch_event()
         expert_out = self.experts(
@@ -87,6 +325,92 @@ class MoELayer(nn.Module):
 
         return combined.view(input_shape).to(x.dtype)
 
+    def _ep_chunk_workspaces(self):
+        """Return the unique lightweight workspaces selected by Qwen composition."""
+        workspaces = []
+        for op in (
+            self.ep_chunk_forward,
+            self.ep_chunk_backward,
+            self.ep_chunk_fused,
+        ):
+            if op is not None and all(
+                op.workspace is not workspace for workspace in workspaces
+            ):
+                workspaces.append(op.workspace)
+        return tuple(workspaces)
+
+    def _ep_chunk_workspaces_for_phase(self, phase: str):
+        """Select only workspaces first used by one execution phase."""
+        return tuple(
+            workspace
+            for workspace, _require_dispatcher in self._ep_chunk_requirements_for_phase(
+                phase
+            )
+        )
+
+    def _ep_chunk_requirements_for_phase(self, phase: str):
+        """Pair phase workspaces with their dispatcher materialization requirement."""
+        if phase == "forward":
+            requirements = ((self.ep_chunk_forward, True),)
+        elif phase == "backward":
+            requirements = (
+                (self.ep_chunk_fused, True)
+                if self.ep_chunk_full_recompute
+                else (self.ep_chunk_backward, False),
+            )
+        else:
+            raise ValueError(
+                f"Unsupported EP chunk workspace phase {phase!r}; expected 'forward' or 'backward'"
+            )
+        return tuple(
+            (op.workspace, require_dispatcher)
+            for op, require_dispatcher in requirements
+            if op is not None
+        )
+
+    def materialize_ep_chunk_workspaces(
+        self,
+        *,
+        phase: str = "forward",
+        device: torch.device | str | None = None,
+        expert_activation_max_rows: int | None = None,
+    ) -> None:
+        """Materialize one phase, optionally freezing caller-declared activations."""
+        for workspace, require_dispatcher in self._ep_chunk_requirements_for_phase(
+            phase
+        ):
+            if require_dispatcher:
+                workspace.materialize(device=device)
+            else:
+                workspace.prepare_scratch(device=device)
+            if expert_activation_max_rows is not None:
+                workspace.reserve_expert_activations(
+                    max_expert_rows=expert_activation_max_rows,
+                    device=device,
+                )
+
+    def ep_chunk_workspace_evidence(self) -> dict[str, dict]:
+        return {
+            workspace.key.op: workspace.evidence()
+            for workspace in self._ep_chunk_workspaces()
+        }
+
+    def release_ep_chunk_workspaces(
+        self, *, phase: str | None = None, stream=None
+    ) -> None:
+        """Release one phase or all selected workspaces for mode switch/teardown."""
+        workspaces = (
+            self._ep_chunk_workspaces()
+            if phase is None
+            else self._ep_chunk_workspaces_for_phase(phase)
+        )
+        for workspace in workspaces:
+            release_ep_chunk_workspace(workspace.key, stream=stream)
+
+    def reset_ep_chunk_workspace_tensors(self, *, phase: str, stream=None) -> None:
+        """Drop phase scratch at an explicit safe boundary, retaining DeepEP state."""
+        for workspace in self._ep_chunk_workspaces_for_phase(phase):
+            workspace.reset_tensors(stream=stream)
 
 # ---------------------------------------------------------------------------
 # Transformer Layer + Model
@@ -102,6 +426,39 @@ _SP_GRAD_SUFFIXES: tuple[str, ...] = (
     ".hnorm.weight",
     ".final_layernorm.weight",
 )
+
+
+def validate_qwen3_ep_chunk_recompute_composition(
+    *,
+    enable_ep_chunk_overlap: bool,
+    ep_chunk_full_recompute: bool,
+    recompute_modules: list[str] | tuple[str, ...],
+) -> None:
+    """Validate Qwen3 recompute composition without leaking policy to primitives."""
+    if ep_chunk_full_recompute and not enable_ep_chunk_overlap:
+        raise ValueError(
+            "ep_chunk_full_recompute=True requires enable_ep_chunk_overlap=True"
+        )
+    if (
+        enable_ep_chunk_overlap
+        and not ep_chunk_full_recompute
+        and any(module in {"moe", "full"} for module in recompute_modules)
+    ):
+        raise ValueError(
+            "normal ChunkedEP conflicts with outer MoE recompute; enable "
+            "ep_chunk_full_recompute or remove moe/full recompute"
+        )
+
+
+def _qwen3_moe_act_recompute_requested(
+    recompute_modules: list[str], *, ep_chunk_full_recompute: bool
+) -> bool:
+    """Keep recompute-policy interpretation in the Qwen composition layer."""
+    return (
+        "moe_act" in recompute_modules
+        and "moe" not in recompute_modules
+        and not ep_chunk_full_recompute
+    )
 
 
 def _collect_sp_grad_params(model: nn.Module) -> list[nn.Parameter]:
@@ -125,6 +482,10 @@ class TransformerLayer(nn.Module):
         fp8: bool = False,
         moe_act_recompute: bool = False,
         use_thd: bool = False,
+        enable_ep_chunk_overlap: bool = False,
+        ep_chunk_max_token_rows_per_rank: int | None = None,
+        ep_chunk_count: int = 2,
+        ep_chunk_full_recompute: bool = False,
         lora_config: LoraConfig | dict | None = None,
     ):
         super().__init__()
@@ -155,12 +516,47 @@ class TransformerLayer(nn.Module):
             router_bias_rate=router_bias_rate,
             fp8=fp8,
             moe_act_recompute=moe_act_recompute,
+            enable_ep_chunk_overlap=enable_ep_chunk_overlap,
+            ep_chunk_max_token_rows_per_rank=ep_chunk_max_token_rows_per_rank,
+            ep_chunk_count=ep_chunk_count,
+            ep_chunk_full_recompute=ep_chunk_full_recompute,
             lora_config=lora_config,
         )
 
-    def forward(
-        self, x: torch.Tensor, position_ids: torch.Tensor | None = None, packed_seq_params=None
+    def _ep_chunk_full_recompute_forward(
+        self,
+        x: torch.Tensor,
+        *,
+        position_ids: torch.Tensor | None,
+        packed_seq_params,
     ) -> torch.Tensor:
+        """Run the graph-free initial pass for the composition-owned checkpoint."""
+        residual = x
+        h = self.attn(x, position_ids=position_ids, packed_seq_params=packed_seq_params)
+        x = residual + h
+        residual = x
+        h = self.mlp_norm(x)
+        assert self.moe.ep_chunk_forward is not None
+        moe_out = self.moe.ep_chunk_forward(h)
+        return residual + moe_out
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        position_ids: torch.Tensor | None = None,
+        packed_seq_params=None,
+        park_chunked_ep_after_backward: bool = False,
+    ) -> torch.Tensor:
+        if self.moe.ep_chunk_full_recompute and torch.is_grad_enabled():
+            params = (
+                *tuple(self.attn.parameters()),
+                *tuple(self.mlp_norm.parameters()),
+                *tuple(self.moe.router.parameters()),
+                *tuple(self.moe.experts.parameters()),
+            )
+            return _Qwen3TransformerLayerFullRecomputeFunction.apply(
+                x, position_ids, packed_seq_params, self, park_chunked_ep_after_backward, *params
+            )
         residual = x
         h = self.attn(x, position_ids=position_ids, packed_seq_params=packed_seq_params)
         x = residual + h
@@ -186,7 +582,9 @@ class MTPLossAutoScaler(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad_output: torch.Tensor):
         (mtp_loss,) = ctx.saved_tensors
-        scaled_mtp_grad = torch.ones_like(mtp_loss) * MTPLossAutoScaler.main_loss_backward_scale
+        scaled_mtp_grad = (
+            torch.ones_like(mtp_loss) * MTPLossAutoScaler.main_loss_backward_scale
+        )
         return grad_output, scaled_mtp_grad
 
     @staticmethod
@@ -211,6 +609,10 @@ class MultiTokenPredictionLayer(nn.Module):
         fp8: bool,
         moe_act_recompute: bool,
         use_thd: bool,
+        enable_ep_chunk_overlap: bool,
+        ep_chunk_max_token_rows_per_rank: int | None,
+        ep_chunk_count: int,
+        ep_chunk_full_recompute: bool,
         detach_encoder: bool,
         lora_config: LoraConfig | dict | None,
     ):
@@ -221,7 +623,11 @@ class MultiTokenPredictionLayer(nn.Module):
         self.enorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.hnorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.eh_proj = VanillaColumnParallelLinear(
-            config.hidden_size * 2, config.hidden_size, ps, sp=ps.tp_size > 1, gather_output=True
+            config.hidden_size * 2,
+            config.hidden_size,
+            ps,
+            sp=ps.tp_size > 1,
+            gather_output=True,
         )
         self.transformer_layer = TransformerLayer(
             config,
@@ -232,6 +638,10 @@ class MultiTokenPredictionLayer(nn.Module):
             fp8=fp8,
             moe_act_recompute=moe_act_recompute,
             use_thd=use_thd,
+            enable_ep_chunk_overlap=enable_ep_chunk_overlap,
+            ep_chunk_max_token_rows_per_rank=ep_chunk_max_token_rows_per_rank,
+            ep_chunk_count=ep_chunk_count,
+            ep_chunk_full_recompute=ep_chunk_full_recompute,
             lora_config=lora_config,
         )
         self.final_layernorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
@@ -248,7 +658,9 @@ class MultiTokenPredictionLayer(nn.Module):
         attention_position_ids = (
             rotary_position_ids if rotary_position_ids is not None else position_ids
         )
-        input_ids, _ = roll_packed_thd_left(input_ids, packed_seq_params=packed_seq_params, dims=-1)
+        input_ids, _ = roll_packed_thd_left(
+            input_ids, packed_seq_params=packed_seq_params, dims=-1
+        )
         if position_ids is not None:
             position_ids, _ = roll_packed_thd_left(
                 position_ids, packed_seq_params=packed_seq_params, dims=-1
@@ -266,7 +678,9 @@ class MultiTokenPredictionLayer(nn.Module):
         hidden_states = self.eh_proj(hidden_states)
         hidden_states = scatter_to_sequence_parallel(hidden_states, self.ps)
         hidden_states = self.transformer_layer(
-            hidden_states, position_ids=attention_position_ids, packed_seq_params=packed_seq_params
+            hidden_states,
+            position_ids=attention_position_ids,
+            packed_seq_params=packed_seq_params,
         )
         hidden_states = self.final_layernorm(hidden_states)
         return hidden_states, input_ids, position_ids
@@ -284,6 +698,10 @@ class MultiTokenPredictionBlock(nn.Module):
         fp8: bool,
         moe_act_recompute: bool,
         use_thd: bool,
+        enable_ep_chunk_overlap: bool,
+        ep_chunk_max_token_rows_per_rank: int | None,
+        ep_chunk_count: int,
+        ep_chunk_full_recompute: bool,
         detach_encoder: bool,
         repeated_layer: bool,
         lora_config: LoraConfig | dict | None,
@@ -304,6 +722,10 @@ class MultiTokenPredictionBlock(nn.Module):
                     fp8=fp8,
                     moe_act_recompute=moe_act_recompute,
                     use_thd=use_thd,
+                    enable_ep_chunk_overlap=enable_ep_chunk_overlap,
+                    ep_chunk_max_token_rows_per_rank=ep_chunk_max_token_rows_per_rank,
+                    ep_chunk_count=ep_chunk_count,
+                    ep_chunk_full_recompute=ep_chunk_full_recompute,
                     detach_encoder=detach_encoder,
                     lora_config=lora_config,
                 )
@@ -360,16 +782,28 @@ class Qwen3MoEModel(nn.Module):
         mtp_enable: bool = False,
         mtp_enable_train: bool = False,
         mtp_detach_encoder: bool = False,
+        enable_ep_chunk_overlap: bool = False,
+        ep_chunk_max_token_rows_per_rank: int | None = None,
+        ep_chunk_count: int = 2,
+        ep_chunk_full_recompute: bool = False,
         lora_config: LoraConfig | dict | None = None,
     ):
         super().__init__()
+        validate_qwen3_ep_chunk_recompute_composition(
+            enable_ep_chunk_overlap=enable_ep_chunk_overlap,
+            ep_chunk_full_recompute=ep_chunk_full_recompute,
+            recompute_modules=recompute_modules or [],
+        )
         self.config = config
         self.ps = ps
         self.fp8 = fp8
+        self._head_loss_chunk_count = ep_chunk_count
         self.mtp_enable_train = bool(mtp_enable and mtp_enable_train)
         self.mtp_loss_scaling_factor = config.mtp_loss_scaling_factor
         self._input_tensor: torch.Tensor | None = None
-        layout = build_pipeline_chunk_layout(config.num_hidden_layers, ps, vpp, vpp_chunk_id)
+        layout = build_pipeline_chunk_layout(
+            config.num_hidden_layers, ps, vpp, vpp_chunk_id
+        )
         self.layer_indices = layout.layer_indices
         has_embed = layout.has_embed
         has_head = layout.has_head
@@ -379,10 +813,15 @@ class Qwen3MoEModel(nn.Module):
 
         self.embed: VocabParallelEmbedding | None = None
         if has_embed:
-            self.embed = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
+            self.embed = VocabParallelEmbedding(
+                config.vocab_size, config.hidden_size, ps
+            )
 
         _recompute = recompute_modules or []
-        moe_act_recompute = "moe_act" in _recompute and "moe" not in _recompute
+        moe_act_recompute = _qwen3_moe_act_recompute_requested(
+            _recompute,
+            ep_chunk_full_recompute=ep_chunk_full_recompute,
+        )
         self.layers = nn.ModuleList(
             [
                 TransformerLayer(
@@ -394,6 +833,10 @@ class Qwen3MoEModel(nn.Module):
                     fp8=fp8,
                     moe_act_recompute=moe_act_recompute,
                     use_thd=use_thd,
+                    enable_ep_chunk_overlap=enable_ep_chunk_overlap,
+                    ep_chunk_max_token_rows_per_rank=ep_chunk_max_token_rows_per_rank,
+                    ep_chunk_count=ep_chunk_count,
+                    ep_chunk_full_recompute=ep_chunk_full_recompute,
                     lora_config=lora_config,
                 )
                 for idx in self.layer_indices
@@ -411,7 +854,9 @@ class Qwen3MoEModel(nn.Module):
         if mtp_enable and config.num_nextn_predict_layers > 0 and self.head is not None:
             mtp_embedding = self.embed
             if mtp_embedding is None:
-                mtp_embedding = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
+                mtp_embedding = VocabParallelEmbedding(
+                    config.vocab_size, config.hidden_size, ps
+                )
                 self.mtp_embed = mtp_embedding
             self.mtp = MultiTokenPredictionBlock(
                 config,
@@ -422,6 +867,10 @@ class Qwen3MoEModel(nn.Module):
                 fp8=fp8,
                 moe_act_recompute=moe_act_recompute,
                 use_thd=use_thd,
+                enable_ep_chunk_overlap=enable_ep_chunk_overlap,
+                ep_chunk_max_token_rows_per_rank=ep_chunk_max_token_rows_per_rank,
+                ep_chunk_count=ep_chunk_count,
+                ep_chunk_full_recompute=ep_chunk_full_recompute,
                 detach_encoder=mtp_detach_encoder,
                 repeated_layer=config.mtp_use_repeated_layer,
                 lora_config=lora_config,
@@ -434,7 +883,9 @@ class Qwen3MoEModel(nn.Module):
     def set_input_tensor(self, input_tensor):
         if isinstance(input_tensor, list):
             if len(input_tensor) > 1:
-                raise ValueError("Qwen3MoEModel expects a single pipeline input tensor.")
+                raise ValueError(
+                    "Qwen3MoEModel expects a single pipeline input tensor."
+                )
             input_tensor = input_tensor[0] if input_tensor else None
         self._input_tensor = input_tensor
 
@@ -469,13 +920,30 @@ class Qwen3MoEModel(nn.Module):
         with fp8_ctx:
             if self.embed is not None:
                 h = scatter_to_sequence_parallel(h, self.ps)
+            final_local_backward_chunked_ep = next(
+                (layer for layer in self.layers if layer.moe.ep_chunk_fused is not None),
+                None,
+            )
             for layer in self.layers:
-                h = layer(h, position_ids=position_ids, packed_seq_params=packed_seq_params)
+                h = layer(
+                    h, position_ids=position_ids, packed_seq_params=packed_seq_params,
+                    park_chunked_ep_after_backward=layer is final_local_backward_chunked_ep,
+                )
             # Head path is SP-aware: norm runs on SP-sharded [S/tp, B, H] and
             # head's internal all-gather happens inside VocabParallelOutput.
             # Mirrors MC GPTModel's final_layernorm → output_layer(sp=True).
 
         output = {"hidden_states": h}
+
+        def reset_forward_chunked_ep() -> None:
+            """Park the shared forward arena after all Qwen3 MoE consumers."""
+            stream = torch.cuda.current_stream(h.device) if h.is_cuda else None
+            for layer in self.layers:
+                if layer.moe.ep_chunk_forward is not None:
+                    layer.moe.reset_ep_chunk_workspace_tensors(
+                        phase="forward", stream=stream
+                    )
+                    break
 
         if self.head is not None:
             hidden_for_head = self.norm(h)
@@ -495,9 +963,12 @@ class Qwen3MoEModel(nn.Module):
                 if mtp_result is not None:
                     hidden_for_head, mtp_loss = mtp_result
                     output["mtp_loss"] = mtp_loss
+                reset_forward_chunked_ep()
                 labels_sb = labels.transpose(0, 1).contiguous()
                 if use_fused_kernels:
-                    hidden_full = gather_from_sequence_parallel(hidden_for_head, self.ps)
+                    hidden_full = gather_from_sequence_parallel(
+                        hidden_for_head, self.ps
+                    )
                     log_probs, entropy = linear_cross_entropy(
                         hidden_full,
                         self._head_weight_for_fused_ce(hidden_full),
@@ -511,11 +982,39 @@ class Qwen3MoEModel(nn.Module):
                         output["log_probs"] = log_probs.transpose(0, 1).contiguous()
                     if calculate_entropy:
                         output["entropy"] = entropy.transpose(0, 1).contiguous()
+                elif use_chunked_head_loss(
+                    has_labels=True,
+                    use_fused_kernels=False,
+                    calculate_entropy=calculate_entropy,
+                    has_chunked_ep=any(
+                        layer.moe.ep_chunk_forward is not None
+                        or layer.moe.ep_chunk_backward is not None
+                        or layer.moe.ep_chunk_fused is not None
+                        for layer in self.layers
+                    )
+                    and self.mtp is None,
+                ):
+                    token_loss = chunked_vocab_parallel_linear_cross_entropy(
+                        hidden_for_head,
+                        self.head.col.linear.weight,
+                        labels_sb,
+                        tp_group=self.ps.tp_group,
+                        sequence_parallel=self.ps.tp_size > 1,
+                        temperature=temperature_value,
+                        chunk_size=balanced_head_loss_chunk_size(
+                            labels_sb.numel(), self._head_loss_chunk_count
+                        ),
+                    )
+                    output["loss"] = token_loss.mean()
+                    if return_log_probs:
+                        output["log_probs"] = (-token_loss).transpose(0, 1).contiguous()
                 else:
                     logits = self.head(hidden_for_head)
                     if temperature_value != 1.0:
                         logits = logits / temperature_value
-                    token_loss = vocab_parallel_cross_entropy(logits, labels_sb, self.ps.tp_group)
+                    token_loss = vocab_parallel_cross_entropy(
+                        logits, labels_sb, self.ps.tp_group
+                    )
                     output["loss"] = token_loss.mean()
                     if return_log_probs:
                         output["log_probs"] = (-token_loss).transpose(0, 1).contiguous()
@@ -524,8 +1023,11 @@ class Qwen3MoEModel(nn.Module):
                         output["entropy"] = entropy.transpose(0, 1).contiguous()
 
             if labels is None:
+                reset_forward_chunked_ep()
                 logits = self.head(hidden_for_head)
                 output["logits"] = self.head.gather(logits)
+        else:
+            reset_forward_chunked_ep()
 
         return output
 
@@ -586,12 +1088,16 @@ class Qwen3MoEModel(nn.Module):
                 logits = self.head(mtp_hidden)
                 if temperature != 1.0:
                     logits = logits / temperature
-                token_loss = vocab_parallel_cross_entropy(logits, labels_sb, self.ps.tp_group)
+                token_loss = vocab_parallel_cross_entropy(
+                    logits, labels_sb, self.ps.tp_group
+                )
             token_loss = token_loss * mask_sb.to(dtype=token_loss.dtype)
             num_tokens = num_tokens.to(dtype=token_loss.dtype).clamp_min(1.0)
             mtp_loss_values.append(token_loss.sum() / num_tokens)
 
-            mtp_loss_scale = self.mtp_loss_scaling_factor / max(len(mtp_hidden_states), 1)
+            mtp_loss_scale = self.mtp_loss_scaling_factor / max(
+                len(mtp_hidden_states), 1
+            )
             hidden_states = MTPLossAutoScaler.apply(
                 hidden_states, mtp_loss_scale * token_loss / num_tokens
             )

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
@@ -40,6 +40,7 @@ from megatron.lite.primitive.ops.linear_cross_entropy import linear_cross_entrop
 from megatron.lite.primitive.ops.logprob import vocab_parallel_entropy
 from megatron.lite.model.qwen3_moe.lite.head_loss import (
     balanced_head_loss_chunk_size,
+    validate_chunked_ep_mtp,
     use_chunked_head_loss,
 )
 from megatron.lite.primitive.parallel import (
@@ -215,6 +216,7 @@ class MoELayer(nn.Module):
             ep_size=ps.ep_size,
             topk=config.num_experts_per_tok,
             max_token_rows_per_rank=ep_chunk_max_token_rows_per_rank,
+            chunk_count=ep_chunk_count,
         )
         # Match Qwen3-MoE's `load_balancing_type="none"` setting: no aux loss.
         self.router = TopKRouter(
@@ -789,6 +791,9 @@ class Qwen3MoEModel(nn.Module):
         lora_config: LoraConfig | dict | None = None,
     ):
         super().__init__()
+        validate_chunked_ep_mtp(
+            enable_ep_chunk_overlap=enable_ep_chunk_overlap, mtp_enable=mtp_enable
+        )
         validate_qwen3_ep_chunk_recompute_composition(
             enable_ep_chunk_overlap=enable_ep_chunk_overlap,
             ep_chunk_full_recompute=ep_chunk_full_recompute,

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
@@ -25,6 +25,9 @@ Qwen3 ChunkedEP fields in ``ImplConfig``:
   composition. ChunkedEP requires DeepEP, EP>1, top-k<=EP, and an explicit
   capacity. Full recompute requires ChunkedEP; normal ChunkedEP rejects outer
   ``moe``/``full`` recompute. ChunkedEP with MTP is rejected before allocation.
+  ``cross_entropy_fusion`` can coexist with ChunkedEP and takes precedence over
+  its non-fused chunked head loss. Without fusion, ``calculate_entropy=True``
+  uses the full-vocabulary head fallback (not the bounded chunked CE path).
 """
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
@@ -229,11 +229,17 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
     # ── validation ──
     if impl_cfg.use_deepep and (p.etp is not None and p.etp > 1):
         raise ValueError("use_deepep and etp>1 are mutually exclusive")
+    try:
+        topk = model_cfg.num_experts_per_tok
+    except AttributeError as exc:
+        raise ValueError(
+            "Qwen3MoE model config requires num_experts_per_tok (router top-k)"
+        ) from exc
     validate_ep_chunk_overlap_config(
         impl_cfg.enable_ep_chunk_overlap,
         use_deepep=impl_cfg.use_deepep,
         ep_size=p.ep,
-        topk=model_cfg.num_experts_per_tok,
+        topk=topk,
         max_token_rows_per_rank=impl_cfg.ep_chunk_max_token_rows_per_rank,
         chunk_count=impl_cfg.ep_chunk_count,
     )

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
@@ -16,6 +16,15 @@ Protocol convention (what runtime calls):
     vocab_size(model_cfg) -> int                     — benchmark metadata
   Escape hatch:
     create_runtime(hf_path, cfg) -> Runtime          — fully override runtime
+
+Qwen3 ChunkedEP fields in ``ImplConfig``:
+  ``enable_ep_chunk_overlap`` enables the two-physical-slot DeepEP composition
+  (the current Qwen3 profile selects two logical chunks);
+  ``ep_chunk_max_token_rows_per_rank`` is the required flattened per-rank
+  forward capacity; ``ep_chunk_full_recompute`` selects fwd+fused-fwd-bwd
+  composition. ChunkedEP requires DeepEP, EP>1, top-k<=EP, and an explicit
+  capacity. Full recompute requires ChunkedEP; normal ChunkedEP rejects outer
+  ``moe``/``full`` recompute.
 """
 
 from __future__ import annotations
@@ -37,15 +46,27 @@ from megatron.lite.model.protocol_utils import (
 )
 from megatron.lite.model.qwen3_moe.common import is_expert_param
 from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
-from megatron.lite.model.qwen3_moe.lite.checkpoint import EXPERT_CLASSIFIER, PLACEMENT_FN
-from megatron.lite.model.qwen3_moe.lite.checkpoint import load_hf_weights as _load_hf_weights_impl
-from megatron.lite.model.qwen3_moe.lite.model import MTPLossAutoScaler, Qwen3MoEModel
+from megatron.lite.model.qwen3_moe.lite.checkpoint import (
+    EXPERT_CLASSIFIER,
+    PLACEMENT_FN,
+)
+from megatron.lite.model.qwen3_moe.lite.checkpoint import (
+    load_hf_weights as _load_hf_weights_impl,
+)
+from megatron.lite.model.qwen3_moe.lite.model import (
+    MTPLossAutoScaler,
+    Qwen3MoEModel,
+    validate_qwen3_ep_chunk_recompute_composition,
+)
 from megatron.lite.primitive.bundle import ModelBundle
 from megatron.lite.primitive.modules.lora import (
     LoraConfig,
     freeze_non_lora_params,
     normalize_lora_config,
     trainable_param_stats,
+)
+from megatron.lite.primitive.modules.moe_ep_chunk_overlap_policy import (
+    validate_ep_chunk_overlap_config,
 )
 from megatron.lite.primitive.parallel import ParallelState, init_parallel
 from megatron.lite.primitive.quantization import (
@@ -83,6 +104,10 @@ class ImplConfig:
     recompute: list[str] = field(default_factory=list)
     offload: list[str] = field(default_factory=list)
     use_deepep: bool = False
+    enable_ep_chunk_overlap: bool = False
+    ep_chunk_max_token_rows_per_rank: int | None = None
+    ep_chunk_count: int = 2
+    ep_chunk_full_recompute: bool = False
     use_thd: bool = False
     cross_entropy_fusion: bool = False
     router_aux_loss_coef: float | None = None
@@ -121,6 +146,7 @@ def _validate_meta_parameters(model: torch.nn.Module) -> None:
 # ---------------------------------------------------------------------------
 
 MODULE_MAP = {
+    "attn": lambda layer: layer.attn,
     "core_attn": lambda layer: layer.attn.core_attn,
     "experts": lambda layer: layer.moe.experts,
     "moe": lambda layer: layer.moe,
@@ -161,7 +187,18 @@ def _forward_step(model: nn.Module, batch: PackedBatch) -> dict:
 
 def _forward_step_bshd(model: nn.Module, batch: PackedBatch) -> dict:
     labels = batch.labels.reshape(1, -1) if batch.labels is not None else None
-    return model(input_ids=batch.input_ids.reshape(1, -1), labels=labels, packed_seq_params=None)
+    return model(
+        input_ids=batch.input_ids.reshape(1, -1), labels=labels, packed_seq_params=None
+    )
+
+
+def _qwen3_recompute_modules_for_ep_chunk_overlap(
+    modules: list[str], *, enabled: bool
+) -> list[str]:
+    """Let the Qwen composition own full ChunkedEP layer recomputation."""
+    if not enabled:
+        return modules
+    return []
 
 
 def unpack_forward_output(model: nn.Module, batch: PackedBatch, output) -> Any:
@@ -175,10 +212,22 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
     """
     p = impl_cfg.parallel
     lora_config = normalize_lora_config(impl_cfg.lora)
+    validate_qwen3_ep_chunk_recompute_composition(
+        enable_ep_chunk_overlap=impl_cfg.enable_ep_chunk_overlap,
+        ep_chunk_full_recompute=impl_cfg.ep_chunk_full_recompute,
+        recompute_modules=impl_cfg.recompute,
+    )
 
     # ── validation ──
     if impl_cfg.use_deepep and (p.etp is not None and p.etp > 1):
         raise ValueError("use_deepep and etp>1 are mutually exclusive")
+    validate_ep_chunk_overlap_config(
+        impl_cfg.enable_ep_chunk_overlap,
+        use_deepep=impl_cfg.use_deepep,
+        ep_size=p.ep,
+        topk=model_cfg.num_experts_per_tok,
+        max_token_rows_per_rank=impl_cfg.ep_chunk_max_token_rows_per_rank,
+    )
 
     # ── override model config from impl_cfg ──
     if impl_cfg.router_aux_loss_coef is not None:
@@ -187,7 +236,9 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
     mtp_enable_train = mtp_enable and bool(impl_cfg.mtp_enable_train)
     if mtp_enable:
         if model_cfg.num_nextn_predict_layers <= 0:
-            raise ValueError("mtp_enable=True but HF config has no num_nextn_predict_layers.")
+            raise ValueError(
+                "mtp_enable=True but HF config has no num_nextn_predict_layers."
+            )
         model_cfg.mtp_loss_scaling_factor = impl_cfg.mtp_loss_scaling_factor
         if impl_cfg.mtp_use_repeated_layer is not None:
             model_cfg.mtp_use_repeated_layer = impl_cfg.mtp_use_repeated_layer
@@ -199,7 +250,14 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
     deterministic = impl_cfg.deterministic
 
     # ── build chunks ──
-    recompute_spec = parse_recompute_spec(impl_cfg.recompute)
+    recompute_spec = parse_recompute_spec(
+        _qwen3_recompute_modules_for_ep_chunk_overlap(
+            impl_cfg.recompute,
+            enabled=(
+                impl_cfg.enable_ep_chunk_overlap and impl_cfg.ep_chunk_full_recompute
+            ),
+        )
+    )
     model_kwargs: dict[str, Any] = dict(
         use_deepep=impl_cfg.use_deepep,
         fp8=False,
@@ -209,6 +267,10 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
         mtp_enable=mtp_enable,
         mtp_enable_train=mtp_enable_train,
         mtp_detach_encoder=impl_cfg.mtp_detach_encoder,
+        enable_ep_chunk_overlap=impl_cfg.enable_ep_chunk_overlap,
+        ep_chunk_full_recompute=impl_cfg.ep_chunk_full_recompute,
+        ep_chunk_max_token_rows_per_rank=impl_cfg.ep_chunk_max_token_rows_per_rank,
+        ep_chunk_count=impl_cfg.ep_chunk_count,
         lora_config=lora_config,
     )
 
@@ -283,7 +345,9 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
 
         def _post_model_load_hook():
             from megatron.lite.model.qwen3_moe.lite.model import TransformerLayer
-            from megatron.lite.primitive.optimizers.fsdp2 import build_fsdp2_training_optimizer
+            from megatron.lite.primitive.optimizers.fsdp2 import (
+                build_fsdp2_training_optimizer,
+            )
 
             return {
                 "optimizer": build_fsdp2_training_optimizer(
@@ -350,7 +414,9 @@ def export_hf_weights(
     chunks: list[nn.Module], model_cfg: Qwen3MoEConfig, ps: ParallelState, **kwargs
 ):
     """Export HF weights from model chunks."""
-    from megatron.lite.model.qwen3_moe.lite.checkpoint import export_hf_weights as _export
+    from megatron.lite.model.qwen3_moe.lite.checkpoint import (
+        export_hf_weights as _export,
+    )
 
     for chunk in chunks:
         yield from _export(chunk, model_cfg, ps, **kwargs)

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
@@ -19,12 +19,12 @@ Protocol convention (what runtime calls):
 
 Qwen3 ChunkedEP fields in ``ImplConfig``:
   ``enable_ep_chunk_overlap`` enables the two-physical-slot DeepEP composition
-  (the current Qwen3 profile selects two logical chunks);
+  (``ep_chunk_count`` selects the logical chunk count, default 2);
   ``ep_chunk_max_token_rows_per_rank`` is the required flattened per-rank
   forward capacity; ``ep_chunk_full_recompute`` selects fwd+fused-fwd-bwd
   composition. ChunkedEP requires DeepEP, EP>1, top-k<=EP, and an explicit
   capacity. Full recompute requires ChunkedEP; normal ChunkedEP rejects outer
-  ``moe``/``full`` recompute.
+  ``moe``/``full`` recompute. ChunkedEP with MTP is rejected before allocation.
 """
 
 from __future__ import annotations
@@ -53,6 +53,7 @@ from megatron.lite.model.qwen3_moe.lite.checkpoint import (
 from megatron.lite.model.qwen3_moe.lite.checkpoint import (
     load_hf_weights as _load_hf_weights_impl,
 )
+from megatron.lite.model.qwen3_moe.lite.head_loss import validate_chunked_ep_mtp
 from megatron.lite.model.qwen3_moe.lite.model import (
     MTPLossAutoScaler,
     Qwen3MoEModel,
@@ -210,6 +211,10 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
 
     Model owns all construction. Runtime just consumes the ModelBundle.
     """
+    validate_chunked_ep_mtp(
+        enable_ep_chunk_overlap=impl_cfg.enable_ep_chunk_overlap,
+        mtp_enable=impl_cfg.mtp_enable,
+    )
     p = impl_cfg.parallel
     lora_config = normalize_lora_config(impl_cfg.lora)
     validate_qwen3_ep_chunk_recompute_composition(
@@ -227,6 +232,7 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
         ep_size=p.ep,
         topk=model_cfg.num_experts_per_tok,
         max_token_rows_per_rank=impl_cfg.ep_chunk_max_token_rows_per_rank,
+        chunk_count=impl_cfg.ep_chunk_count,
     )
 
     # ── override model config from impl_cfg ──

--- a/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
+++ b/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
@@ -4,6 +4,9 @@
 from __future__ import annotations
 
 import os
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any
 
 import torch  # pyright: ignore[reportMissingImports]
 import torch.distributed as dist  # pyright: ignore[reportMissingImports]
@@ -22,11 +25,39 @@ except ImportError:
     EventOverlap = None  # type: ignore
 
 
+@contextmanager
+def _deepep_nvtx(phase: str):
+    if (
+        os.environ.get("MEGATRON_LITE_EP_CHUNK_NVTX") != "1"
+        or not torch.cuda.is_available()
+    ):
+        yield
+        return
+    torch.cuda.nvtx.range_push(f"deepep.{phase}")
+    try:
+        yield
+    finally:
+        torch.cuda.nvtx.range_pop()
+
+
 def _hidden_bytes(hidden_size: int) -> int:
     return hidden_size * 2
 
 
-def _build_deepep_buffer(group: dist.ProcessGroup, hidden_size: int):
+@dataclass(frozen=True)
+class _DeepEPBufferAllocation:
+    buffer: Any
+    num_nvl_bytes: int
+    num_rdma_bytes: int
+
+    @property
+    def resident_bytes(self) -> int:
+        return self.num_nvl_bytes + self.num_rdma_bytes
+
+
+def _build_deepep_buffer(
+    group: dist.ProcessGroup, hidden_size: int
+) -> _DeepEPBufferAllocation:
     if deep_ep is None:
         raise RuntimeError("DeepEP buffer requested but deep_ep is not installed.")
 
@@ -46,7 +77,39 @@ def _build_deepep_buffer(group: dist.ProcessGroup, hidden_size: int):
             config.get_rdma_buffer_size_hint(hidden_bytes, group_size), num_rdma_bytes
         )
 
-    return deep_ep.Buffer(group=group, num_nvl_bytes=num_nvl_bytes, num_rdma_bytes=num_rdma_bytes)
+    return _DeepEPBufferAllocation(
+        buffer=deep_ep.Buffer(
+            group=group, num_nvl_bytes=num_nvl_bytes, num_rdma_bytes=num_rdma_bytes
+        ),
+        num_nvl_bytes=num_nvl_bytes,
+        num_rdma_bytes=num_rdma_bytes,
+    )
+
+
+def _event_is_waitable(event) -> bool:
+    if event is None:
+        return False
+    if hasattr(event, "current_stream_wait") and getattr(event, "event", None) is None:
+        return False
+    return True
+
+
+def _event_current_stream_wait(event) -> None:
+    if event is None:
+        return
+    if hasattr(event, "current_stream_wait"):
+        if getattr(event, "event", None) is None:
+            return
+        event.current_stream_wait()
+    else:
+        torch.cuda.current_stream().wait_event(event)
+
+
+def _record_current_stream_event_if_unwaitable(event, tensor: torch.Tensor):
+    if not _event_is_waitable(event) and torch.cuda.is_available() and tensor.is_cuda:
+        event = torch.cuda.Event()
+        event.record(torch.cuda.current_stream(tensor.device))
+    return event
 
 
 def _use_moe_permute_fusion() -> bool:
@@ -69,6 +132,8 @@ class _DeepEPDispatch(torch.autograd.Function):
         async_finish: bool,
         allocate_on_comm_stream: bool,
     ):
+        topk_indices = topk_indices.contiguous()
+        topk_scores = topk_scores.float().contiguous()
         previous_event = (
             EventOverlap(EventHandle())
             if async_finish and EventHandle is not None and EventOverlap is not None
@@ -87,19 +152,24 @@ class _DeepEPDispatch(torch.autograd.Function):
             async_finish=async_finish,
             allocate_on_comm_stream=allocate_on_comm_stream,
         )
-        (recv_hidden, recv_indices, recv_probs, recv_per_expert, handle, after_event) = (
-            buffer.dispatch(
-                hidden_states.contiguous(),
-                topk_idx=topk_indices,
-                topk_weights=topk_scores.float(),
-                num_tokens_per_rank=num_tokens_per_rank,
-                num_tokens_per_rdma_rank=num_tokens_per_rdma_rank,
-                is_token_in_rank=is_token_in_rank,
-                num_tokens_per_expert=num_tokens_per_expert,
-                previous_event=event,
-                async_finish=async_finish,
-                allocate_on_comm_stream=allocate_on_comm_stream,
-            )
+        (
+            recv_hidden,
+            recv_indices,
+            recv_probs,
+            recv_per_expert,
+            handle,
+            after_event,
+        ) = buffer.dispatch(
+            hidden_states.contiguous(),
+            topk_idx=topk_indices,
+            topk_weights=topk_scores,
+            num_tokens_per_rank=num_tokens_per_rank,
+            num_tokens_per_rdma_rank=num_tokens_per_rdma_rank,
+            is_token_in_rank=is_token_in_rank,
+            num_tokens_per_expert=num_tokens_per_expert,
+            previous_event=event,
+            async_finish=async_finish,
+            allocate_on_comm_stream=allocate_on_comm_stream,
         )
         if async_finish:
             after_event.current_stream_wait()
@@ -115,7 +185,12 @@ class _DeepEPDispatch(torch.autograd.Function):
 
     @staticmethod
     def backward(
-        ctx, grad_recv_hidden, grad_recv_indices, grad_recv_probs, grad_recv_per_expert, grad_handle
+        ctx,
+        grad_recv_hidden,
+        grad_recv_indices,
+        grad_recv_probs,
+        grad_recv_per_expert,
+        grad_handle,
     ):
         del grad_recv_indices, grad_recv_per_expert, grad_handle
         previous_event = (
@@ -124,14 +199,15 @@ class _DeepEPDispatch(torch.autograd.Function):
             else None
         )
         grad_scores = None if grad_recv_probs is None else grad_recv_probs.float()
-        grad_hidden, grad_topk_scores, after_event = ctx.buffer.combine(
-            grad_recv_hidden.contiguous(),
-            ctx.handle,
-            topk_weights=grad_scores,
-            previous_event=previous_event,
-            async_finish=ctx.async_finish,
-            allocate_on_comm_stream=ctx.allocate_on_comm_stream,
-        )
+        with _deepep_nvtx("dispatch.backward_combine"):
+            grad_hidden, grad_topk_scores, after_event = ctx.buffer.combine(
+                grad_recv_hidden.contiguous(),
+                ctx.handle,
+                topk_weights=grad_scores,
+                previous_event=previous_event,
+                async_finish=ctx.async_finish,
+                allocate_on_comm_stream=ctx.allocate_on_comm_stream,
+            )
         if ctx.async_finish:
             after_event.current_stream_wait()
         return None, grad_hidden, None, grad_topk_scores, None, None, None
@@ -174,20 +250,20 @@ class _DeepEPCombine(torch.autograd.Function):
             if ctx.async_finish and EventHandle is not None and EventOverlap is not None
             else None
         )
-        grad_rank_grouped, _, _, _, _, after_event = ctx.buffer.dispatch(
-            grad_output.contiguous(),
-            handle=ctx.handle,
-            previous_event=previous_event,
-            async_finish=ctx.async_finish,
-            allocate_on_comm_stream=ctx.allocate_on_comm_stream,
-        )
+        with _deepep_nvtx("combine.backward_dispatch"):
+            grad_rank_grouped, _, _, _, _, after_event = ctx.buffer.dispatch(
+                grad_output.contiguous(),
+                handle=ctx.handle,
+                previous_event=previous_event,
+                async_finish=ctx.async_finish,
+                allocate_on_comm_stream=ctx.allocate_on_comm_stream,
+            )
         if ctx.async_finish:
             after_event.current_stream_wait()
         return None, grad_rank_grouped, None, None, None
 
 
 class TokenDispatcher:
-
     def __init__(
         self,
         num_experts: int,
@@ -202,13 +278,17 @@ class TokenDispatcher:
         self.ep_size = ps.ep_size
         self.num_local_experts = ensure_divisible(num_experts, ps.ep_size)
         self.moe_permute_fusion = (
-            _use_moe_permute_fusion() if moe_permute_fusion is None else bool(moe_permute_fusion)
+            _use_moe_permute_fusion()
+            if moe_permute_fusion is None
+            else bool(moe_permute_fusion)
         )
 
         self.use_deepep = use_deepep and deep_ep is not None and ps.ep_size > 1
         if self.use_deepep:
             assert ps.tp_ep_group is not None
-            self.buffer = _build_deepep_buffer(ps.tp_ep_group, hidden_size)
+            allocation = _build_deepep_buffer(ps.tp_ep_group, hidden_size)
+            self.buffer = allocation.buffer
+            self.deepep_buffer_resident_bytes = allocation.resident_bytes
 
         self._row_id_map: torch.Tensor | None = None
         self._restore_shape: tuple | None = None
@@ -220,14 +300,21 @@ class TokenDispatcher:
         if self.ep_size > 1 and self.num_local_experts > 1:
             chunk_idxs = torch.arange(self.ep_size * self.num_local_experts, device="cpu")
             self._sort_by_experts = (
-                chunk_idxs.reshape(self.ep_size, self.num_local_experts).T.ravel().tolist()
+                chunk_idxs.reshape(self.ep_size, self.num_local_experts)
+                .T.ravel()
+                .tolist()
             )
             self._restore_by_ranks = (
-                chunk_idxs.reshape(self.num_local_experts, self.ep_size).T.ravel().tolist()
+                chunk_idxs.reshape(self.num_local_experts, self.ep_size)
+                .T.ravel()
+                .tolist()
             )
 
     def dispatch(
-        self, hidden_states: torch.Tensor, topk_scores: torch.Tensor, topk_indices: torch.Tensor
+        self,
+        hidden_states: torch.Tensor,
+        topk_scores: torch.Tensor,
+        topk_indices: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
         if self.ep_size <= 1:
             return self._dispatch_local(hidden_states, topk_scores, topk_indices)
@@ -246,7 +333,11 @@ class TokenDispatcher:
         return self._combine_alltoall(expert_output)
 
     def submit_deepep_combine(
-        self, expert_output: torch.Tensor, *, allocate_on_comm_stream: bool = False
+        self,
+        expert_output: torch.Tensor,
+        *,
+        allocate_on_comm_stream: bool = False,
+        async_finish: bool = True,
     ):
         if not self.use_deepep:
             raise RuntimeError("submit_deepep_combine requires DeepEP combine.")
@@ -258,14 +349,14 @@ class TokenDispatcher:
         )
         previous_event = (
             EventOverlap(EventHandle())
-            if EventHandle is not None and EventOverlap is not None
+            if async_finish and EventHandle is not None and EventOverlap is not None
             else None
         )
         combined = self.buffer.combine(
             rank_grouped,
             self._handle,
             previous_event=previous_event,
-            async_finish=True,
+            async_finish=async_finish,
             allocate_on_comm_stream=allocate_on_comm_stream,
         )
         event = None
@@ -273,19 +364,141 @@ class TokenDispatcher:
             if len(combined) >= 3:
                 event = combined[2]
             combined = combined[0]
-        return {"combined": combined, "event": event}
+        event = _record_current_stream_event_if_unwaitable(event, rank_grouped)
+        return {
+            "combined": combined,
+            "event": event,
+            "rank_grouped": rank_grouped,
+            "handle": self._handle,
+        }
 
-    def finish_deepep_combine(self, state):
+    def prepare_deepep_combine(self, expert_output: torch.Tensor):
         if not self.use_deepep:
-            raise RuntimeError("finish_deepep_combine requires DeepEP combine.")
-        event = state.get("event")
-        if event is not None:
-            event.current_stream_wait()
+            raise RuntimeError("prepare_deepep_combine requires DeepEP combine.")
+        rank_grouped = unpermute(
+            expert_output,
+            self._row_id_map,
+            restore_shape=self._restore_shape,
+            fused=self.moe_permute_fusion,
+        )
+        return rank_grouped, self._handle
+
+    def submit_deepep_combine_prepared(
+        self,
+        rank_grouped: torch.Tensor,
+        handle,
+        *,
+        allocate_on_comm_stream: bool = False,
+        async_finish: bool = True,
+    ):
+        if not self.use_deepep:
+            raise RuntimeError(
+                "submit_deepep_combine_prepared requires DeepEP combine."
+            )
+        previous_event = (
+            EventOverlap(EventHandle())
+            if async_finish and EventHandle is not None and EventOverlap is not None
+            else None
+        )
+        combined = self.buffer.combine(
+            rank_grouped,
+            handle,
+            previous_event=previous_event,
+            async_finish=async_finish,
+            allocate_on_comm_stream=allocate_on_comm_stream,
+        )
+        event = None
+        if isinstance(combined, tuple):
+            if len(combined) >= 3:
+                event = combined[2]
+            combined = combined[0]
+        event = _record_current_stream_event_if_unwaitable(event, rank_grouped)
+        return {
+            "combined": combined,
+            "event": event,
+            "rank_grouped": rank_grouped,
+            "handle": handle,
+        }
+
+    def clear_deepep_combine_state(self):
         self._row_id_map = None
         self._restore_shape = None
         self._handle = None
         self._local_tpe_list = None
-        return state["combined"]
+
+    def submit_deepep_combine_backward(
+        self,
+        grad_output: torch.Tensor,
+        handle,
+        *,
+        allocate_on_comm_stream: bool = False,
+    ):
+        if not self.use_deepep:
+            raise RuntimeError("submit_deepep_combine_backward requires DeepEP.")
+        previous_event = (
+            EventOverlap(EventHandle())
+            if EventHandle is not None and EventOverlap is not None
+            else None
+        )
+        grad_rank_grouped, _, _, _, _, event = self.buffer.dispatch(
+            grad_output.contiguous(),
+            handle=handle,
+            previous_event=previous_event,
+            async_finish=True,
+            allocate_on_comm_stream=allocate_on_comm_stream,
+        )
+        return {"grad_rank_grouped": grad_rank_grouped, "event": event}
+
+    def finish_deepep_combine_backward(self, state):
+        if not self.use_deepep:
+            raise RuntimeError("finish_deepep_combine_backward requires DeepEP.")
+        _event_current_stream_wait(state.get("event"))
+        return state["grad_rank_grouped"]
+
+    def submit_deepep_dispatch_backward(
+        self,
+        grad_recv_hidden: torch.Tensor,
+        grad_recv_probs: torch.Tensor | None,
+        handle,
+        *,
+        allocate_on_comm_stream: bool = False,
+    ):
+        if not self.use_deepep:
+            raise RuntimeError("submit_deepep_dispatch_backward requires DeepEP.")
+        previous_event = (
+            EventOverlap(EventHandle())
+            if EventHandle is not None and EventOverlap is not None
+            else None
+        )
+        grad_scores = None if grad_recv_probs is None else grad_recv_probs.float()
+        grad_hidden, grad_topk_scores, event = self.buffer.combine(
+            grad_recv_hidden.contiguous(),
+            handle,
+            topk_weights=grad_scores,
+            previous_event=previous_event,
+            async_finish=True,
+            allocate_on_comm_stream=allocate_on_comm_stream,
+        )
+        return {
+            "grad_hidden": grad_hidden,
+            "grad_topk_scores": grad_topk_scores,
+            "event": event,
+        }
+
+    def finish_deepep_dispatch_backward(self, state):
+        if not self.use_deepep:
+            raise RuntimeError("finish_deepep_dispatch_backward requires DeepEP.")
+        _event_current_stream_wait(state.get("event"))
+        return state["grad_hidden"], state["grad_topk_scores"]
+
+    def finish_deepep_combine(self, state):
+        if not self.use_deepep:
+            raise RuntimeError("finish_deepep_combine requires DeepEP combine.")
+        _event_current_stream_wait(state.get("event"))
+        combined = state["combined"]
+        state.clear()
+        self.clear_deepep_combine_state()
+        return combined
 
     def _dispatch_local(self, hidden_states, topk_scores, topk_indices):
         t, h = hidden_states.shape
@@ -351,22 +564,31 @@ class TokenDispatcher:
         self._restore_shape = hidden_states.shape
 
         tokens_per_expert = routing_map.sum(dim=0).to(torch.int64)
-        tpe_by_rank = tokens_per_expert.view(self.ep_size, self.num_local_experts).sum(dim=1)
+        tpe_by_rank = tokens_per_expert.view(self.ep_size, self.num_local_experts).sum(
+            dim=1
+        )
         self._input_splits = tpe_by_rank.tolist()
 
         global_tpe_flat = tokens_per_expert.new_empty(self.ep_size * e)
-        dist.all_gather_into_tensor(global_tpe_flat, tokens_per_expert, group=self.ps.ep_group)
+        dist.all_gather_into_tensor(
+            global_tpe_flat, tokens_per_expert, group=self.ps.ep_group
+        )
         global_tpe_2d = global_tpe_flat.view(self.ep_size, e)
         ep_rank = dist.get_rank(group=self.ps.ep_group)
         my_start = ep_rank * self.num_local_experts
-        recv_tpe_2d = global_tpe_2d[:, my_start : my_start + self.num_local_experts].contiguous()
+        recv_tpe_2d = global_tpe_2d[
+            :, my_start : my_start + self.num_local_experts
+        ].contiguous()
         self._output_splits = recv_tpe_2d.sum(dim=1).tolist()
 
         recv_flat = _AllToAll.apply(
             permuted, self._input_splits, self._output_splits, self.ps.ep_group
         )
         recv_scores = _AllToAll.apply(
-            permuted_probs.unsqueeze(-1), self._input_splits, self._output_splits, self.ps.ep_group
+            permuted_probs.unsqueeze(-1),
+            self._input_splits,
+            self._output_splits,
+            self.ps.ep_group,
         )
 
         if self.num_local_experts > 1:
@@ -419,13 +641,21 @@ class TokenDispatcher:
         return result
 
     def submit_deepep_dispatch(
-        self, hidden_states, topk_scores, topk_indices, *, allocate_on_comm_stream: bool = False
+        self,
+        hidden_states,
+        topk_scores,
+        topk_indices,
+        *,
+        allocate_on_comm_stream: bool = False,
+        async_finish: bool = True,
     ):
         if not self.use_deepep:
             raise RuntimeError("submit_deepep_dispatch requires DeepEP dispatch.")
+        topk_indices = topk_indices.contiguous()
+        topk_scores = topk_scores.float().contiguous()
         previous_event = (
             EventOverlap(EventHandle())
-            if EventHandle is not None and EventOverlap is not None
+            if async_finish and EventHandle is not None and EventOverlap is not None
             else None
         )
         (
@@ -438,14 +668,13 @@ class TokenDispatcher:
             topk_indices,
             num_experts=self.num_experts,
             previous_event=previous_event,
-            async_finish=True,
+            async_finish=async_finish,
             allocate_on_comm_stream=allocate_on_comm_stream,
         )
-
-        topk_scores = topk_scores.float()
+        hidden_states_contig = hidden_states.contiguous()
         recv_hidden, recv_indices, recv_probs, recv_per_expert, handle, event = (
             self.buffer.dispatch(
-                hidden_states,
+                hidden_states_contig,
                 topk_idx=topk_indices,
                 topk_weights=topk_scores,
                 num_tokens_per_rank=num_tokens_per_rank,
@@ -453,11 +682,21 @@ class TokenDispatcher:
                 is_token_in_rank=is_token_in_rank,
                 num_tokens_per_expert=num_tokens_per_expert,
                 previous_event=event,
-                async_finish=True,
+                async_finish=async_finish,
                 allocate_on_comm_stream=allocate_on_comm_stream,
             )
         )
+        event = _record_current_stream_event_if_unwaitable(event, hidden_states_contig)
         return {
+            "_dispatch_inputs": (
+                hidden_states_contig,
+                topk_indices,
+                topk_scores,
+                num_tokens_per_rank,
+                num_tokens_per_rdma_rank,
+                num_tokens_per_expert,
+                is_token_in_rank,
+            ),
             "recv_hidden": recv_hidden,
             "recv_indices": recv_indices,
             "recv_probs": recv_probs,
@@ -466,17 +705,22 @@ class TokenDispatcher:
             "event": event,
         }
 
-    def finish_deepep_dispatch(self, state):
+    def _resolve_deepep_recv_per_expert(self, state):
+        return state["recv_per_expert"]
+
+    def finish_deepep_dispatch(self, state, *, materialize_local_tpe: bool = True):
         if not self.use_deepep:
             raise RuntimeError("finish_deepep_dispatch requires DeepEP dispatch.")
         self._handle = state["handle"]
         self._deepep_event = state["event"]
         self.wait_dispatch_event()
+        recv_per_expert = self._resolve_deepep_recv_per_expert(state)
         return self._finish_deepep_dispatch(
             state["recv_hidden"],
             state["recv_indices"],
             state["recv_probs"],
-            state["recv_per_expert"],
+            recv_per_expert,
+            materialize_local_tpe=materialize_local_tpe,
         )
 
     def _finish_deepep_dispatch(
@@ -485,37 +729,111 @@ class TokenDispatcher:
         recv_indices: torch.Tensor,
         recv_probs: torch.Tensor,
         recv_per_expert,
+        *,
+        materialize_local_tpe: bool = True,
+    ):
+        dispatched, local_tpe, permuted_probs, metadata = (
+            self._finish_deepep_dispatch_external(
+                recv_hidden,
+                recv_indices,
+                recv_probs,
+                recv_per_expert,
+                materialize_local_tpe=materialize_local_tpe,
+            )
+        )
+        self._local_tpe_list = metadata["local_tpe_list"]
+        self._row_id_map = metadata["row_id_map"]
+        self._restore_shape = metadata["restore_shape"]
+        return dispatched, local_tpe, permuted_probs
+
+    def _finish_deepep_dispatch_external(
+        self,
+        recv_hidden: torch.Tensor,
+        recv_indices: torch.Tensor,
+        recv_probs: torch.Tensor,
+        recv_per_expert,
+        *,
+        force_manual_map: bool = False,
+        force_direct_permute: bool = False,
+        materialize_local_tpe: bool = True,
     ):
         if isinstance(recv_per_expert, torch.Tensor):
             recv_per_expert = [int(x) for x in recv_per_expert.detach().cpu().tolist()]
-        local_tpe = torch.tensor(
-            recv_per_expert[: self.num_local_experts], dtype=torch.int64, device=recv_hidden.device
+        local_tpe_list = [int(x) for x in recv_per_expert[: self.num_local_experts]]
+        local_tpe = (
+            torch.tensor(
+                local_tpe_list,
+                dtype=torch.int64,
+                device=recv_hidden.device,
+            )
+            if materialize_local_tpe
+            else None
         )
-        self._local_tpe_list = [int(x) for x in recv_per_expert[: self.num_local_experts]]
         rows = recv_hidden.size(0)
         recv_indices = recv_indices.to(torch.long)
-        routing_map = torch.zeros(
-            rows, self.num_local_experts, dtype=torch.bool, device=recv_hidden.device
-        )
-        probs_2d = torch.zeros(
-            rows, self.num_local_experts, dtype=recv_probs.dtype, device=recv_hidden.device
-        )
+        if recv_indices.dim() != 2:
+            raise RuntimeError(
+                "DeepEP dispatch indices must have shape [recv_rows, topk]"
+            )
         valid = recv_indices >= 0
-        row_ids = torch.arange(rows, device=recv_hidden.device).unsqueeze(1)
-        row_ids = row_ids.expand_as(recv_indices)[valid]
-        expert_ids = recv_indices[valid]
-        routing_map[row_ids, expert_ids] = True
-        probs_2d.index_put_((row_ids, expert_ids), recv_probs[valid], accumulate=True)
         num_out = sum(int(x) for x in recv_per_expert)
-        dispatched, permuted_probs, sorted_indices = permute(
-            recv_hidden,
-            routing_map,
-            probs=probs_2d,
-            num_out_tokens=num_out,
-            fused=self.moe_permute_fusion,
-        )[:3]
-        self._row_id_map = sorted_indices
-        self._restore_shape = recv_hidden.shape
+        use_direct_permute = force_direct_permute
+        need_manual_map = force_manual_map or use_direct_permute
+        valid_coords = valid.nonzero(as_tuple=False)
+        valid_row_ids = valid_coords[:, 0]
+        valid_topk_slots = valid_coords[:, 1]
+        valid_expert_ids = recv_indices[valid_row_ids, valid_topk_slots]
+        valid_prob_flat_indices = (
+            valid_row_ids * recv_indices.size(1) + valid_topk_slots
+        )
+        manual_order = None
+        manual_prob_flat_indices = None
+        if need_manual_map:
+            manual_order = torch.argsort(
+                valid_expert_ids * rows + valid_row_ids,
+                stable=True,
+            )
+            manual_row_id_map = valid_row_ids.index_select(0, manual_order)
+            manual_prob_flat_indices = valid_prob_flat_indices.index_select(
+                0, manual_order
+            )
+        else:
+            manual_row_id_map = None
+        if use_direct_permute:
+            assert manual_order is not None
+            sorted_indices = manual_row_id_map
+            assert sorted_indices is not None
+            dispatched = recv_hidden.index_select(0, sorted_indices)
+            permuted_probs = recv_probs.reshape(-1).index_select(
+                0, manual_prob_flat_indices
+            )
+        else:
+            routing_map = torch.zeros(
+                rows,
+                self.num_local_experts,
+                dtype=torch.bool,
+                device=recv_hidden.device,
+            )
+            probs_2d = torch.zeros(
+                rows,
+                self.num_local_experts,
+                dtype=recv_probs.dtype,
+                device=recv_hidden.device,
+            )
+            routing_map[valid_row_ids, valid_expert_ids] = True
+            probs_2d.index_put_(
+                (valid_row_ids, valid_expert_ids),
+                recv_probs.reshape(-1).index_select(0, valid_prob_flat_indices),
+                accumulate=True,
+            )
+            dispatched, permuted_probs, sorted_indices = permute(
+                recv_hidden,
+                routing_map,
+                probs=probs_2d,
+                num_out_tokens=num_out,
+                fused=self.moe_permute_fusion,
+            )[:3]
+        restore_shape = recv_hidden.shape
         if os.environ.get("MEGATRON_LITE_DEEPEP_DEBUG_METADATA") == "1":
             ep_rank = dist.get_rank(group=self.ps.ep_group)
             print(
@@ -526,44 +844,81 @@ class TokenDispatcher:
                 f"recv_per_expert_len={len(recv_per_expert)} "
                 f"recv_per_expert_sum={sum(int(x) for x in recv_per_expert)} "
                 f"recv_per_expert_head={recv_per_expert[: self.num_local_experts]} "
-                f"local_tpe_sum={int(local_tpe.sum().item())}",
+                f"local_tpe_sum={sum(local_tpe_list)}",
                 flush=True,
             )
-        if os.environ.get("MEGATRON_LITE_DEEPEP_SKIP_DISPATCH_METADATA_CHECK") != "1" and int(
-            local_tpe.sum().item()
-        ) != int(dispatched.shape[0]):
+        if sum(local_tpe_list) != int(dispatched.shape[0]):
             ep_rank = dist.get_rank(group=self.ps.ep_group)
             raise RuntimeError(
                 "DeepEP dispatch metadata mismatch: "
                 f"ep_rank={ep_rank} dispatched_tokens={int(dispatched.shape[0])} "
-                f"local_tpe={local_tpe.tolist()} recv_per_expert_len={len(recv_per_expert)}"
+                f"local_tpe={local_tpe_list} recv_per_expert_len={len(recv_per_expert)}"
             )
-        return dispatched, local_tpe, permuted_probs
+        metadata = {
+            "row_id_map": sorted_indices,
+            "restore_shape": restore_shape,
+            "manual_row_id_map": manual_row_id_map,
+            "manual_prob_flat_indices": manual_prob_flat_indices,
+            "local_tpe_list": local_tpe_list,
+        }
+        return dispatched, local_tpe, permuted_probs, metadata
+
+    def finish_deepep_dispatch_external_with_options(
+        self,
+        state,
+        *,
+        force_manual_map: bool = False,
+        force_direct_permute: bool = False,
+        materialize_local_tpe: bool = True,
+    ):
+        if not self.use_deepep:
+            raise RuntimeError(
+                "finish_deepep_dispatch_external requires DeepEP dispatch."
+            )
+        _event_current_stream_wait(state.get("event"))
+        recv_per_expert = self._resolve_deepep_recv_per_expert(state)
+        dispatched, local_tpe, permuted_probs, metadata = (
+            self._finish_deepep_dispatch_external(
+                state["recv_hidden"],
+                state["recv_indices"],
+                state["recv_probs"],
+                recv_per_expert,
+                force_manual_map=force_manual_map,
+                force_direct_permute=force_direct_permute,
+                materialize_local_tpe=materialize_local_tpe,
+            )
+        )
+        metadata["handle"] = state["handle"]
+        return dispatched, local_tpe, permuted_probs, metadata
 
     def _dispatch_deepep(self, hidden_states, topk_scores, topk_indices):
         if torch.is_grad_enabled():
-            recv_hidden, recv_indices, recv_probs, recv_per_expert, handle = _DeepEPDispatch.apply(
-                self.buffer,
-                hidden_states,
-                topk_indices,
-                topk_scores.float(),
-                self.num_experts,
-                False,
-                False,
-            )
+            with _deepep_nvtx("dispatch.forward"):
+                recv_hidden, recv_indices, recv_probs, recv_per_expert, handle = (
+                    _DeepEPDispatch.apply(
+                        self.buffer,
+                        hidden_states,
+                        topk_indices,
+                        topk_scores.float(),
+                        self.num_experts,
+                        False,
+                        False,
+                    )
+                )
             self._handle = handle
             self._deepep_event = None
             return self._finish_deepep_dispatch(
                 recv_hidden, recv_indices, recv_probs, recv_per_expert
             )
-        state = self.submit_deepep_dispatch(
-            hidden_states, topk_scores, topk_indices, allocate_on_comm_stream=False
-        )
+        with _deepep_nvtx("dispatch.forward"):
+            state = self.submit_deepep_dispatch(
+                hidden_states, topk_scores, topk_indices, allocate_on_comm_stream=False
+            )
         return self.finish_deepep_dispatch(state)
 
     def wait_dispatch_event(self):
         if self._deepep_event is not None:
-            self._deepep_event.current_stream_wait()
+            _event_current_stream_wait(self._deepep_event)
             self._deepep_event = None
 
     def _combine_deepep(self, expert_output):
@@ -574,15 +929,16 @@ class TokenDispatcher:
             fused=self.moe_permute_fusion,
         )
         if torch.is_grad_enabled():
-            combined = _DeepEPCombine.apply(self.buffer, rank_grouped, self._handle, False, False)
+            with _deepep_nvtx("combine.forward"):
+                combined = _DeepEPCombine.apply(
+                    self.buffer, rank_grouped, self._handle, False, False
+                )
         else:
-            combined = self.buffer.combine(rank_grouped, self._handle)
+            with _deepep_nvtx("combine.forward"):
+                combined = self.buffer.combine(rank_grouped, self._handle)
         if isinstance(combined, tuple):
             combined = combined[0]
-        self._row_id_map = None
-        self._restore_shape = None
-        self._handle = None
-        self._local_tpe_list = None
+        self.clear_deepep_combine_state()
         return combined
 
 

--- a/experimental/lite/megatron/lite/primitive/modules/experts.py
+++ b/experimental/lite/megatron/lite/primitive/modules/experts.py
@@ -4,8 +4,9 @@
 from __future__ import annotations
 
 import os
-from contextlib import contextmanager
-from typing import Any
+import weakref
+from contextlib import AbstractContextManager, contextmanager, nullcontext
+from typing import Any, Callable
 
 import torch  # pyright: ignore[reportMissingImports]
 import torch.distributed as dist  # pyright: ignore[reportMissingImports]
@@ -25,9 +26,315 @@ from megatron.lite.primitive.utils import ensure_divisible
 __all__ = ["Experts", "_AllReduceETP"]
 
 
+def _validate_caller_owned_buffer(
+    name: str,
+    buffer: torch.Tensor,
+    expected_shape: tuple[int, ...],
+    dtype: torch.dtype,
+    device: torch.device,
+) -> None:
+    """Match TE's explicit-output contract before exposing an arena view to autograd."""
+    if (
+        tuple(buffer.shape) != expected_shape
+        or buffer.dtype != dtype
+        or buffer.device != device
+        or not buffer.is_contiguous()
+        or buffer.requires_grad
+    ):
+        raise RuntimeError(
+            f"Caller-owned grouped GEMM {name} must be contiguous, non-grad, and match shape/dtype/device"
+        )
+
+
+def _tensor_byte_ranges_overlap(left: torch.Tensor, right: torch.Tensor) -> bool:
+    """Return whether two contiguous tensor views overlap in addressable bytes."""
+    if left.numel() == 0 or right.numel() == 0:
+        return False
+    left_start = left.data_ptr()
+    left_end = left_start + left.numel() * left.element_size()
+    right_start = right.data_ptr()
+    right_end = right_start + right.numel() * right.element_size()
+    return left_start < right_end and right_start < left_end
+
+
+def _record_immediate_wgrad_context(store: Any) -> None:
+    count = getattr(store, "_mlite_immediate_wgrad_contexts", 0)
+    if not isinstance(count, int) or count < 0:
+        raise RuntimeError("Invalid immediate delayed-wgrad context count")
+    store._mlite_immediate_wgrad_contexts = count + 1
+
+
+def _caller_owned_dummy_is_capturing(main_grad: torch.Tensor) -> bool:
+    """Whether a dummy wgrad must retain CUDA-graph replay pointer stability."""
+    return main_grad.is_cuda and bool(torch.cuda.is_current_stream_capturing())
+
+
+def _caller_owned_dummy_wgrad(
+    main_grad: torch.Tensor, weight: torch.Tensor, *, zero: bool
+) -> torch.Tensor:
+    """Return the custom-DDP hook sentinel without retaining eager allocations.
+
+    MCore requires a non-None gradient to keep the parameter hook on the main
+    backward thread when ``grad_added_to_main_grad`` is set.  TE's provider is
+    process-global, which is correct for its native module but unnecessarily
+    retains caller-owned ChunkedEP sentinels across eager steps.  CUDA graph
+    capture is the narrow exception: TE's keyed cache supplies a replay-stable
+    address until a graph lifecycle owner is available here.
+    """
+    if _caller_owned_dummy_is_capturing(main_grad):
+        from transformer_engine.pytorch.module.base import get_dummy_wgrad
+
+        return get_dummy_wgrad(list(main_grad.shape), weight.dtype, zero=zero)
+    dummy = torch.empty(
+        tuple(main_grad.shape), dtype=weight.dtype, device=main_grad.device
+    )
+    if zero:
+        dummy.zero_()
+    return dummy.detach()
+
+
+class _CallerOwnedGroupedLinear(torch.autograd.Function):
+    """TE 2.15 BF16 grouped-GEMM internals with explicit arena-owned outputs.
+
+    The enclosing helper deliberately retains TE's public module lifecycle.
+    This class changes only TE 2.15's two ``torch.empty`` allocation sites.
+    """
+
+    @staticmethod
+    def forward(ctx, inp, out, dgrad_out, non_tensor_args, *weights):
+        from transformer_engine.pytorch.cpp_extensions import general_grouped_gemm
+        from transformer_engine.pytorch.module.base import _2X_ACC_FPROP
+
+        (
+            m_splits,
+            is_first_microbatch,
+            wgrad_store,
+            fuse_wgrad_accumulation,
+            activation_dtype,
+        ) = non_tensor_args
+        if inp.dtype != torch.bfloat16 or activation_dtype != torch.bfloat16:
+            raise RuntimeError("Caller-owned grouped GEMM requires BF16 activation")
+        if not fuse_wgrad_accumulation or not wgrad_store.delay_wgrad_compute():
+            raise RuntimeError(
+                "Caller-owned grouped GEMM requires TE delayed fused wgrad"
+            )
+        _validate_caller_owned_buffer(
+            "output",
+            out,
+            (sum(m_splits), weights[0].shape[0]),
+            activation_dtype,
+            inp.device,
+        )
+        if inp.requires_grad:
+            if dgrad_out is None:
+                raise RuntimeError(
+                    "Caller-owned grouped GEMM requires dgrad output for grad input"
+                )
+            _validate_caller_owned_buffer(
+                "dgrad output",
+                dgrad_out,
+                tuple(inp.shape),
+                activation_dtype,
+                inp.device,
+            )
+        elif dgrad_out is not None:
+            raise RuntimeError(
+                "Caller-owned grouped GEMM received dgrad output for non-grad input"
+            )
+        inputmats = list(torch.split(inp.reshape(-1, inp.shape[-1]), m_splits))
+        general_grouped_gemm(
+            list(weights),
+            inputmats,
+            [out],
+            [None] * len(weights),
+            activation_dtype,
+            single_output=True,
+            m_splits=m_splits,
+            use_split_accumulator=_2X_ACC_FPROP,
+        )
+        if ctx is not None:
+            ctx.m_splits = list(m_splits)
+            ctx.inp_shape = inp.shape
+            ctx.dgrad_out = dgrad_out
+            ctx.wgrad_store = wgrad_store
+            ctx.is_first_microbatch = is_first_microbatch
+            ctx.fuse_wgrad_accumulation = fuse_wgrad_accumulation
+            ctx.requires_dgrad = inp.requires_grad
+            ctx.weights_requires_grad = weights[0].requires_grad
+            ctx.origin_weights_overwrite_main_grad = False
+            if ctx.fuse_wgrad_accumulation and ctx.weights_requires_grad:
+                # Match TE2.15: only a weak reference preserves MCore's Python
+                # attributes, and FSDP is allowed to materialize main_grad after
+                # forward but before backward.
+                ctx.origin_weight_refs = [weakref.ref(weight) for weight in weights]
+                ctx.origin_weights_overwrite_main_grad = getattr(
+                    weights[0], "overwrite_main_grad", False
+                )
+                if hasattr(weights[0], "__fsdp_param__"):
+                    ctx.main_grad_funcs = [weight.get_main_grad for weight in weights]
+                else:
+                    ctx.main_grad_funcs = [
+                        lambda index=index: weights[index].main_grad
+                        for index in range(len(weights))
+                    ]
+            ctx.save_for_backward(inp, *weights)
+        return out.view(-1, *inp.shape[1:-1], out.shape[-1])
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        from functools import partial
+
+        from transformer_engine.pytorch.cpp_extensions import general_grouped_gemm
+        from transformer_engine.pytorch.module.base import (
+            _2X_ACC_DGRAD,
+            _2X_ACC_WGRAD,
+        )
+
+        inp, *weights = ctx.saved_tensors
+        activation_dtype = inp.dtype
+        grad_view = grad_output.contiguous().view(-1, grad_output.shape[-1])
+        grad_mats = list(torch.split(grad_view, ctx.m_splits))
+        dgrad = None
+        dgrad_out = None
+        if ctx.requires_dgrad:
+            dgrad_out = ctx.dgrad_out
+            if dgrad_out is None:
+                raise RuntimeError("Caller-owned grouped GEMM lost its dgrad output")
+            dgrad = dgrad_out.view(-1, inp.shape[-1])
+        origin_weights = [None] * len(weights)
+        main_grads = [None] * len(weights)
+        if ctx.fuse_wgrad_accumulation and ctx.weights_requires_grad:
+            origin_weights = [ref() for ref in ctx.origin_weight_refs]
+            ctx.origin_weight_refs = None
+            if any(weight is None for weight in origin_weights):
+                raise RuntimeError(
+                    "Caller-owned grouped GEMM lost an original TE weight"
+                )
+            main_grads = [func() for func in ctx.main_grad_funcs]
+            if any(main_grad is None for main_grad in main_grads):
+                raise RuntimeError(
+                    "Caller-owned grouped GEMM requires prepared main_grad sinks"
+                )
+            for weight, main_grad in zip(origin_weights, main_grads, strict=True):
+                weight.main_grad = main_grad
+        if ctx.is_first_microbatch is not None:
+            accumulate = ctx.fuse_wgrad_accumulation and not ctx.is_first_microbatch
+        else:
+            accumulate = ctx.fuse_wgrad_accumulation
+        wgrad = partial(
+            general_grouped_gemm,
+            quantization_params=[None] * len(weights),
+            out_dtype=activation_dtype,
+            layout="NT",
+            grad=True,
+            m_splits=ctx.m_splits,
+            use_bias=False,
+            use_split_accumulator=_2X_ACC_WGRAD,
+            accumulate=accumulate and not ctx.origin_weights_overwrite_main_grad,
+        )
+        inputmats = list(torch.split(inp.reshape(-1, inp.shape[-1]), ctx.m_splits))
+        immediate_wgrad = (
+            ctx.weights_requires_grad
+            and dgrad is not None
+            and _tensor_byte_ranges_overlap(grad_view, dgrad)
+        )
+        if immediate_wgrad:
+            # A caller-owned dgrad view overlaps the live grad-output bytes.
+            # Wgrad must consume them before Dgrad writes the same storage.
+            wgrad(inputmats, grad_mats, main_grads)
+            _record_immediate_wgrad_context(ctx.wgrad_store)
+        if dgrad is not None:
+            general_grouped_gemm(
+                list(weights),
+                grad_mats,
+                [dgrad],
+                [None] * len(weights),
+                activation_dtype,
+                layout="NN",
+                single_output=True,
+                m_splits=ctx.m_splits,
+                grad=True,
+                use_split_accumulator=_2X_ACC_DGRAD,
+            )
+        if ctx.weights_requires_grad:
+            if not immediate_wgrad:
+                ctx.wgrad_store.put([inputmats, grad_mats, main_grads], wgrad)
+        wgrad_returns = []
+        for weight, main_grad in zip(origin_weights, main_grads, strict=True):
+            if weight is not None and hasattr(weight, "grad_added_to_main_grad"):
+                weight.grad_added_to_main_grad = True
+                wgrad_returns.append(
+                    _caller_owned_dummy_wgrad(
+                        main_grad,
+                        weight,
+                        zero=getattr(weight, "zero_out_wgrad", False),
+                    )
+                )
+            else:
+                wgrad_returns.append(None)
+        return (
+            dgrad.view(ctx.inp_shape) if dgrad is not None else None,
+            None,
+            None,
+            None,
+            *wgrad_returns,
+        )
+
+
+def _caller_owned_grouped_linear(
+    linear: Any,
+    x: torch.Tensor,
+    m_splits: list[int],
+    out: torch.Tensor,
+    dgrad_out: torch.Tensor | None,
+) -> torch.Tensor:
+    """Reuse TE2.15 ``GroupedLinear.forward`` lifecycle around its two buffers."""
+    if (
+        getattr(linear, "fp8", False)
+        or getattr(linear, "use_bias", False)
+        or getattr(linear, "return_bias", False)
+        or getattr(linear, "save_original_input", False)
+    ):
+        raise RuntimeError(
+            "Caller-owned grouped GEMM supports only BF16 bias-free Qwen3"
+        )
+    if len(m_splits) != linear.num_gemms:
+        raise RuntimeError(
+            "Caller-owned grouped GEMM split count does not match TE module"
+        )
+    prepared_x = linear.prepare_forward(x, num_gemms=linear.num_gemms)
+    try:
+        weights = linear._get_weight_tensors()
+        linear._get_bias_tensors()
+        quantizers = linear._get_quantizers()
+        if any(item is not None for group in quantizers for item in group):
+            raise RuntimeError(
+                "Caller-owned grouped GEMM does not support TE quantizers"
+            )
+        non_tensor_args = (
+            list(m_splits),
+            None,
+            linear.wgrad_store,
+            linear.fuse_wgrad_accumulation,
+            linear.activation_dtype,
+        )
+        if torch.is_grad_enabled():
+            return _CallerOwnedGroupedLinear.apply(
+                prepared_x, out, dgrad_out, non_tensor_args, *weights
+            )
+        return _CallerOwnedGroupedLinear.forward(
+            None, prepared_x, out, dgrad_out, non_tensor_args, *weights
+        )
+    finally:
+        linear.end_forward()
+
+
 @contextmanager
 def _expert_nvtx_range(name: str):
-    if os.environ.get("MEGATRON_LITE_EP_EXPERT_NVTX") != "1" or not torch.cuda.is_available():
+    if (
+        os.environ.get("MEGATRON_LITE_EP_EXPERT_NVTX") != "1"
+        or not torch.cuda.is_available()
+    ):
         yield
         return
     torch.cuda.nvtx.range_push(name)
@@ -54,6 +361,35 @@ def swiglu_with_probs(
     return bias_swiglu_impl(y, bias=None)
 
 
+def _record_cuda_tensor_tree_stream(value: Any, stream: Any) -> None:
+    """Record every nested CUDA tensor and its view bases on one stream."""
+    seen: set[int] = set()
+
+    def record(item: Any) -> None:
+        item_id = id(item)
+        if item_id in seen:
+            return
+        if torch.is_tensor(item):
+            seen.add(item_id)
+            if item.is_cuda:
+                item.record_stream(stream)
+            base = getattr(item, "_base", None)
+            if base is not None:
+                record(base)
+            return
+        if isinstance(item, dict):
+            seen.add(item_id)
+            for nested in item.values():
+                record(nested)
+            return
+        if isinstance(item, (list, tuple, set)):
+            seen.add(item_id)
+            for nested in item:
+                record(nested)
+
+    record(value)
+
+
 class _AllReduceETP(torch.autograd.Function):
     """AllReduce with proper autograd: grad(AllReduce) = AllReduce."""
 
@@ -69,7 +405,6 @@ class _AllReduceETP(torch.autograd.Function):
 
 
 class Experts(nn.Module):
-
     def __init__(
         self,
         config: Any,
@@ -77,12 +412,17 @@ class Experts(nn.Module):
         *,
         fp8: bool = False,
         moe_act_recompute: bool = False,
+        delay_wgrad_compute: bool = False,
         lora_config: LoraConfig | dict | None = None,
     ):
         super().__init__()
         self.num_local_experts = ensure_divisible(config.num_experts, ps.ep_size)
         self.fp8 = fp8
         self.moe_act_recompute = moe_act_recompute
+        self._delay_wgrad_compute = delay_wgrad_compute
+        self._owned_main_grad_aliases: dict[
+            int, weakref.ReferenceType[torch.Tensor]
+        ] = {}
         self.etp_group = ps.etp_group if ps.etp_size > 1 else None
         self.swiglu_limit = float(getattr(config, "swiglu_limit", 0.0) or 0.0)
         self.fc1 = te.GroupedLinear(
@@ -91,6 +431,8 @@ class Experts(nn.Module):
             config.moe_intermediate_size * 2 // ps.etp_size,
             bias=False,
             params_dtype=torch.bfloat16,
+            delay_wgrad_compute=delay_wgrad_compute,
+            fuse_wgrad_accumulation=delay_wgrad_compute,
         )
         self.fc2 = te.GroupedLinear(
             self.num_local_experts,
@@ -98,6 +440,8 @@ class Experts(nn.Module):
             config.hidden_size,
             bias=False,
             params_dtype=torch.bfloat16,
+            delay_wgrad_compute=delay_wgrad_compute,
+            fuse_wgrad_accumulation=delay_wgrad_compute,
         )
         lora = normalize_lora_config(lora_config)
         self.fc1_lora: SharedGroupedLinearLoRA | None = None
@@ -133,21 +477,145 @@ class Experts(nn.Module):
 
                     param.register_hook(_ar)
 
+    def _delayed_weight_parameters(self):
+        for linear in (self.fc1, self.fc2):
+            for idx in range(linear.num_gemms):
+                yield getattr(linear, f"weight{idx}")
+
+    @staticmethod
+    def _validate_weight_grad_sink(param: nn.Parameter, sink: torch.Tensor) -> None:
+        if (
+            not torch.is_tensor(sink)
+            or sink.shape != param.shape
+            or sink.device != param.device
+            or not sink.is_contiguous()
+        ):
+            raise RuntimeError(
+                "Expert delayed weight-gradient sink must be a contiguous tensor "
+                "with matching shape and device"
+            )
+
+    def _prepare_delayed_weight_grad_sinks(self) -> None:
+        """Prepare the sink selected by TE for each delayed expert wgrad."""
+        if not self._delay_wgrad_compute:
+            return
+        for param in self._delayed_weight_parameters():
+            # Frozen TE saves this accessor only for its FSDP parameter wrapper,
+            # then resolves it during delayed backward and writes main_grad back.
+            if hasattr(param, "__fsdp_param__"):
+                if not callable(getattr(param, "get_main_grad", None)):
+                    raise RuntimeError(
+                        "Expert FSDP parameter requires a callable get_main_grad"
+                    )
+                continue
+
+            param_id = id(param)
+            owned_ref = self._owned_main_grad_aliases.get(param_id)
+            owned = None if owned_ref is None else owned_ref()
+            main_grad = getattr(param, "main_grad", None)
+            if owned_ref is not None:
+                if main_grad is not owned:
+                    self._owned_main_grad_aliases.pop(param_id, None)
+                elif param.grad is owned:
+                    self._validate_weight_grad_sink(param, owned)
+                    continue
+                else:
+                    delattr(param, "main_grad")
+                    self._owned_main_grad_aliases.pop(param_id, None)
+                    main_grad = None
+
+            if main_grad is not None:
+                self._validate_weight_grad_sink(param, main_grad)
+                continue
+            if param.grad is None:
+                param.grad = torch.zeros_like(
+                    param,
+                    memory_format=torch.preserve_format,
+                )
+            self._validate_weight_grad_sink(param, param.grad)
+            param.main_grad = param.grad
+            self._owned_main_grad_aliases[param_id] = weakref.ref(param.grad)
+
+    def release_delayed_weight_grad_aliases(self) -> None:
+        """Drop owned TE aliases without changing standard parameter gradients."""
+        for param in self._delayed_weight_parameters():
+            owned_ref = self._owned_main_grad_aliases.pop(id(param), None)
+            owned = None if owned_ref is None else owned_ref()
+            if owned is not None and getattr(param, "main_grad", None) is owned:
+                delattr(param, "main_grad")
+
+    def flush_delayed_weight_grads(
+        self, *, num_contexts: int, stream: Any | None = None
+    ) -> None:
+        """Execute queued TE wgrads directly into their selected gradient sinks."""
+        for linear in (self.fc1, self.fc2):
+            store = linear.wgrad_store
+            if not store.delay_wgrad_compute():
+                raise RuntimeError("Expert delayed weight gradients are not enabled.")
+            if linear.use_bias:
+                raise RuntimeError(
+                    "Chunked EP expert grouped linears must not use bias."
+                )
+            immediate_contexts = getattr(store, "_mlite_immediate_wgrad_contexts", 0)
+            if (
+                not isinstance(immediate_contexts, int)
+                or immediate_contexts < 0
+                or immediate_contexts > num_contexts
+            ):
+                raise RuntimeError(
+                    "Expert delayed wgrad immediate/deferred context accounting "
+                    "does not match the requested flush"
+                )
+            for _ in range(num_contexts - immediate_contexts):
+                if store.context is None or store.context.empty():
+                    raise RuntimeError("Expert delayed weight-gradient queue is empty.")
+                result, tensors = store.pop()
+                if stream is not None:
+                    _record_cuda_tensor_tree_stream((result, tensors), stream)
+                _, _grad_biases, _ = result
+                weight_grads = tensors[2]
+                for idx, grad in enumerate(weight_grads):
+                    param = getattr(linear, f"weight{idx}")
+                    sink = getattr(param, "main_grad", None)
+                    if sink is None:
+                        raise RuntimeError(
+                            "Expert delayed wgrad produced no selected gradient sink"
+                        )
+                    self._validate_weight_grad_sink(param, sink)
+                    self._validate_weight_grad_sink(param, grad)
+                    if grad.data_ptr() != sink.data_ptr():
+                        raise RuntimeError(
+                            "Expert delayed wgrad did not reuse its selected gradient sink"
+                        )
+            store._mlite_immediate_wgrad_contexts = 0
+            if store.context is not None and not store.context.empty():
+                raise RuntimeError(
+                    "Expert delayed weight-gradient queue was not drained."
+                )
+        self.release_delayed_weight_grad_aliases()
+
     def forward(
         self,
         x: torch.Tensor,
-        tokens_per_expert: torch.Tensor,
+        tokens_per_expert: torch.Tensor | None,
         permuted_probs: torch.Tensor | None = None,
         tokens_per_expert_list: list[int] | None = None,
+        activation_allocation: Callable[[], AbstractContextManager[None]] | None = None,
+        output_allocation: Callable[[str, tuple[int, int]], torch.Tensor] | None = None,
     ) -> torch.Tensor:
-        m_splits = (
-            tokens_per_expert.tolist()
-            if tokens_per_expert_list is None
-            else list(tokens_per_expert_list)
-        )
+        if tokens_per_expert_list is None:
+            if tokens_per_expert is None:
+                raise RuntimeError(
+                    "Experts requires token counts in tensor or host-list form"
+                )
+            m_splits = tokens_per_expert.tolist()
+        else:
+            m_splits = list(tokens_per_expert_list)
         pad_mask = None
         if self.fp8:
-            x, permuted_probs, m_splits, pad_mask = self._fp8_pad(x, permuted_probs, m_splits)
+            x, permuted_probs, m_splits, pad_mask = self._fp8_pad(
+                x, permuted_probs, m_splits
+            )
 
         etp_real_len = x.shape[0]
         if self.etp_group is not None:
@@ -159,7 +627,10 @@ class Experts(nn.Module):
                     [
                         x,
                         torch.zeros(
-                            max_len - etp_real_len, x.shape[1], dtype=x.dtype, device=x.device
+                            max_len - etp_real_len,
+                            x.shape[1],
+                            dtype=x.dtype,
+                            device=x.device,
                         ),
                     ],
                     dim=0,
@@ -169,7 +640,9 @@ class Experts(nn.Module):
                         [
                             permuted_probs,
                             torch.zeros(
-                                max_len - etp_real_len, dtype=permuted_probs.dtype, device=x.device
+                                max_len - etp_real_len,
+                                dtype=permuted_probs.dtype,
+                                device=x.device,
                             ),
                         ],
                         dim=0,
@@ -178,25 +651,69 @@ class Experts(nn.Module):
                 m_splits[-1] += max_len - etp_real_len
 
         probs = permuted_probs.unsqueeze(-1) if permuted_probs is not None else None
+        caller_owned_outputs = output_allocation is not None
+        if caller_owned_outputs and (
+            self.fp8
+            or self.fc1_lora is not None
+            or self.fc2_lora is not None
+            or self.etp_group is not None
+            or self.moe_act_recompute
+        ):
+            raise RuntimeError(
+                "Caller-owned ChunkedEP outputs support only BF16 Qwen3 without "
+                "FP8, LoRA, ETP, or activation recompute"
+            )
         with _expert_nvtx_range("ep_experts.forward"):
-            if self.moe_act_recompute and probs is not None:
-                act_ckpt = CheckpointWithoutOutput(preserve_rng_state=True)
-                fc1_out = self.fc1(x, m_splits)
+            allocation_scope = (
+                nullcontext if activation_allocation is None else activation_allocation
+            )
+            with allocation_scope():
+                if caller_owned_outputs:
+                    fc1_out = _caller_owned_grouped_linear(
+                        self.fc1,
+                        x,
+                        m_splits,
+                        output_allocation(
+                            "fc1_output", (x.shape[0], self.fc1.out_features)
+                        ),
+                        (
+                            output_allocation("fc1_dgrad", tuple(x.shape))
+                            if x.requires_grad
+                            else None
+                        ),
+                    )
+                else:
+                    fc1_out = self.fc1(x, m_splits)
                 if self.fc1_lora is not None:
                     fc1_out = fc1_out + self.fc1_lora(x, m_splits)
-                h = act_ckpt.checkpoint(swiglu_with_probs, fc1_out, probs, self.swiglu_limit)
-                out = self.fc2(h, m_splits)
-                if self.fc2_lora is not None:
-                    out = out + self.fc2_lora(h, m_splits)
-                act_ckpt.discard_output_and_register_recompute(out)
+                if self.moe_act_recompute and probs is not None:
+                    act_ckpt = CheckpointWithoutOutput(preserve_rng_state=True)
+                    h = act_ckpt.checkpoint(
+                        swiglu_with_probs, fc1_out, probs, self.swiglu_limit
+                    )
+                else:
+                    act_ckpt = None
+                    h = swiglu_with_probs(fc1_out, probs, self.swiglu_limit)
+            if caller_owned_outputs:
+                out = _caller_owned_grouped_linear(
+                    self.fc2,
+                    h,
+                    m_splits,
+                    output_allocation(
+                        "fc2_output", (h.shape[0], self.fc2.out_features)
+                    ),
+                    (
+                        output_allocation("fc2_dgrad", tuple(h.shape))
+                        if h.requires_grad
+                        else None
+                    ),
+                )
             else:
-                fc1_out = self.fc1(x, m_splits)
-                if self.fc1_lora is not None:
-                    fc1_out = fc1_out + self.fc1_lora(x, m_splits)
-                h = swiglu_with_probs(fc1_out, probs, self.swiglu_limit)
                 out = self.fc2(h, m_splits)
-                if self.fc2_lora is not None:
-                    out = out + self.fc2_lora(h, m_splits)
+            if self.fc2_lora is not None:
+                out = out + self.fc2_lora(h, m_splits)
+            if act_ckpt is not None:
+                act_ckpt.discard_output_and_register_recompute(out)
 
         if self.etp_group is not None:
             out = _AllReduceETP.apply(out, self.etp_group)
@@ -217,13 +734,17 @@ class Experts(nn.Module):
         mask = torch.zeros(total_padded, dtype=torch.bool, device=device)
         probs_pad = None
         if permuted_probs is not None:
-            probs_pad = torch.zeros(total_padded, device=device, dtype=permuted_probs.dtype)
+            probs_pad = torch.zeros(
+                total_padded, device=device, dtype=permuted_probs.dtype
+            )
         src_off, dst_off = 0, 0
         for real, pad in zip(m_splits, padded, strict=True):
             x_pad[dst_off : dst_off + real] = x[src_off : src_off + real]
             mask[dst_off : dst_off + real] = True
             if probs_pad is not None:
-                probs_pad[dst_off : dst_off + real] = permuted_probs[src_off : src_off + real]
+                probs_pad[dst_off : dst_off + real] = permuted_probs[
+                    src_off : src_off + real
+                ]
             src_off += real
             dst_off += pad
         return x_pad, probs_pad, padded, mask

--- a/experimental/lite/megatron/lite/primitive/modules/moe_ep_chunk_overlap.py
+++ b/experimental/lite/megatron/lite/primitive/modules/moe_ep_chunk_overlap.py
@@ -1,0 +1,3013 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""DeepEP MoE EP chunk-overlap primitive."""
+
+from __future__ import annotations
+
+import math
+import os
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any, Callable, Literal
+
+import torch
+import torch.nn as nn
+from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
+from megatron.lite.primitive.modules.experts import Experts
+from megatron.lite.primitive.modules.moe_ep_chunk_overlap_policy import (
+    ep_chunk_ranges,
+)
+from megatron.lite.primitive.utils.moe import unpermute
+
+
+# Physical workspace capacity, deliberately independent of logical chunk count.
+EP_CHUNK_COUNT = 2
+EPChunkOpName = Literal["forward", "backward", "fused_forward_backward"]
+
+
+@dataclass(frozen=True)
+class EPChunkShapeProfile:
+    """Fixed token and DeepEP receive capacities for one EP rank."""
+
+    max_input_rows: int
+    hidden_size: int
+    topk: int
+    ep_size: int
+    chunk_count: int = 2
+    expert_intermediate_size: int | None = None
+    max_recv_rows: int = field(init=False)
+    max_expert_rows: int = field(init=False)
+
+    @classmethod
+    def for_two_slot_chunked_ep(
+        cls,
+        *,
+        max_input_rows: int,
+        hidden_size: int,
+        topk: int,
+        ep_size: int,
+        chunk_count: int = 2,
+        expert_intermediate_size: int | None = None,
+    ) -> "EPChunkShapeProfile":
+        if ep_size <= 1:
+            raise ValueError("Two-slot EP chunk profile requires EP > 1")
+        if max_input_rows < 2:
+            raise ValueError("Two-slot EP chunk profile requires at least two rows")
+        return cls(
+            max_input_rows=max_input_rows,
+            hidden_size=hidden_size,
+            topk=topk,
+            ep_size=ep_size,
+            chunk_count=chunk_count,
+            expert_intermediate_size=expert_intermediate_size,
+        )
+
+    def __post_init__(self) -> None:
+        if any(
+            int(value) <= 0
+            for value in (
+                self.max_input_rows,
+                self.hidden_size,
+                self.topk,
+                self.ep_size,
+                self.chunk_count,
+            )
+        ):
+            raise ValueError("EP chunk shape-profile capacities must be positive")
+        if self.ep_size <= 1:
+            raise ValueError("Two-slot EP chunk profile requires EP > 1")
+        if self.chunk_count < 2:
+            raise ValueError("EP chunk profile requires at least two chunks")
+        if self.max_input_rows < self.chunk_count:
+            raise ValueError("EP chunk profile requires at least one row per chunk")
+        max_chunk_rows = (
+            self.max_input_rows + self.chunk_count - 1
+        ) // self.chunk_count
+        # DeepEP recv storage may contain every source rank's chunk on one
+        # destination rank. It stores one hidden row per transported token and
+        # represents its local top-k destinations in recv_probs.
+        max_recv_rows = max_chunk_rows * self.ep_size
+        object.__setattr__(self, "max_recv_rows", max_recv_rows)
+        # Manual expert permutation can expand one received token into as many
+        # as top-k local expert rows. This is a validation ceiling only: the
+        # workspace still reserves the observed runtime shape lazily.
+        object.__setattr__(self, "max_expert_rows", max_recv_rows * self.topk)
+
+    def validate_input_rows(self, rows: int) -> None:
+        if rows > self.max_input_rows:
+            raise RuntimeError(
+                f"EP chunk input rows {rows} exceeds two-slot profile "
+                f"capacity {self.max_input_rows}"
+            )
+
+    def validate_recv_rows(self, rows: int) -> None:
+        """Validate DeepEP rows received by one destination rank for one chunk."""
+        if rows > self.max_recv_rows:
+            raise RuntimeError(
+                f"EP chunk recv rows {rows} exceeds two-slot profile "
+                f"capacity {self.max_recv_rows}"
+            )
+
+    def validate_expert_rows(self, rows: int) -> None:
+        """Validate rows after one received token expands to local experts."""
+        if rows > self.max_expert_rows:
+            raise RuntimeError(
+                f"EP chunk expert rows {rows} exceeds two-slot profile "
+                f"capacity {self.max_expert_rows}"
+            )
+
+    def validate_input(self, value: torch.Tensor) -> None:
+        if value.size(-1) != self.hidden_size:
+            raise RuntimeError(
+                f"EP chunk hidden size {value.size(-1)} does not match two-slot "
+                f"profile {self.hidden_size}"
+            )
+        self.validate_input_rows(value.numel() // self.hidden_size)
+
+
+def _validate_finished_deepep_dispatch(
+    profile: EPChunkShapeProfile,
+    state: dict[str, Any],
+    dispatched: torch.Tensor,
+) -> None:
+    """Validate runtime DeepEP outputs before expert use or arena allocation."""
+    recv_hidden = state.get("recv_hidden")
+    recv_probs = state.get("recv_probs")
+    if not torch.is_tensor(recv_hidden) or recv_hidden.dim() != 2:
+        raise RuntimeError("EP chunk DeepEP recv_hidden must be a rank-2 tensor")
+    if recv_hidden.size(1) != profile.hidden_size:
+        raise RuntimeError(
+            f"EP chunk recv hidden size {recv_hidden.size(1)} does not match "
+            f"fixed profile {profile.hidden_size}"
+        )
+    profile.validate_recv_rows(recv_hidden.size(0))
+    if not torch.is_tensor(recv_probs) or recv_probs.dim() != 2:
+        raise RuntimeError("EP chunk DeepEP recv_probs must be a rank-2 tensor")
+    if recv_probs.size(0) != recv_hidden.size(0):
+        raise RuntimeError("EP chunk recv_hidden and recv_probs rows must match")
+    if recv_probs.size(1) != profile.topk:
+        raise RuntimeError(
+            f"EP chunk recv_probs top-k {recv_probs.size(1)} does not match "
+            f"fixed profile {profile.topk}"
+        )
+    profile.validate_recv_rows(recv_probs.size(0))
+    if dispatched.dim() != 2 or dispatched.size(1) != profile.hidden_size:
+        raise RuntimeError(
+            "EP chunk dispatched expert input must be rank-2 with the fixed hidden size"
+        )
+    profile.validate_expert_rows(dispatched.size(0))
+
+
+def _expert_activation_output_allocation(
+    lease: _EPChunkExpertActivationLease,
+    input_tensor: torch.Tensor,
+) -> Callable[[str, tuple[int, int]], torch.Tensor]:
+    """Build the caller-owned expert-output allocation callback for one input."""
+
+    def allocate(name: str, shape: tuple[int, int]) -> torch.Tensor:
+        return lease.tensor(
+            name,
+            shape,
+            dtype=input_tensor.dtype,
+            device=input_tensor.device,
+        )
+
+    return allocate
+
+
+@dataclass(frozen=True)
+class EPChunkWorkspaceKey:
+    """Cross-layer workspace identity; layer and chunk are deliberately absent."""
+
+    op: EPChunkOpName
+    device_type: str
+    device_index: int | None
+    ep_group_id: int
+    dtype: torch.dtype
+    shape_profile: EPChunkShapeProfile
+
+    def __post_init__(self) -> None:
+        if self.op not in {"forward", "backward", "fused_forward_backward"}:
+            raise ValueError(f"Unsupported EP chunk op: {self.op!r}")
+        if not isinstance(self.shape_profile, EPChunkShapeProfile):
+            raise TypeError("EP chunk shape_profile must be EPChunkShapeProfile")
+
+
+@dataclass
+class _WorkspaceSlot:
+    dispatcher: TokenDispatcher | None = None
+    tensors: dict[str, torch.Tensor] = field(default_factory=dict)
+    in_use: bool = False
+    consumer_event: Any | None = None
+
+
+@dataclass
+class _EPChunkActivationTensorArena:
+    """Logical activation views; eager storage uses PyTorch's default allocator."""
+
+    tensors: dict[str, torch.Tensor] = field(default_factory=dict)
+
+
+_EXPERT_ACTIVATION_SIZE_CLASS_BYTES = 8 * 1024 * 1024
+_EXPERT_ACTIVATION_LOGICAL_NAMES = frozenset(
+    {"fc1_input", "fc1_output", "fc2_output", "fc1_dgrad", "fc2_dgrad"}
+)
+
+# Normal saved-context backward keeps FC2 output separate because its delayed
+# FC2 Wgrad remains deferred. FC2 dgrad is consumed by SwiGLU before FC1 dgrad
+# is written, making that pair the only safe normal-mode raw-byte alias.
+_NORMAL_EXPERT_ACTIVATION_STORAGE_SLOTS = {
+    "fc1_dgrad": "fc2_dgrad",
+}
+
+# Forward runs under no-grad. Experts finishes the FC1/SwiGLU allocation scope
+# before FC2 starts, and FC2 reads only h, so its output may overwrite the
+# now-dead FC1 input. Requires-grad paths deliberately do not use this mapping.
+_FORWARD_EXPERT_ACTIVATION_STORAGE_SLOTS = {
+    **_NORMAL_EXPERT_ACTIVATION_STORAGE_SLOTS,
+    "fc2_output": "fc1_input",
+}
+
+# Fused backward enqueues overlapping FC2 Wgrad on the current stream before
+# writing FC2 dgrad, then writes FC1 dgrad after SwiGLU consumes it. Same-stream
+# ordering makes the overwrite safe without a CUDA synchronize and permits all
+# three logical tensors to use FC2-output raw storage in this OP only.
+_FUSED_EXPERT_ACTIVATION_STORAGE_SLOTS = {
+    "fc1_dgrad": "fc2_output",
+    "fc2_dgrad": "fc2_output",
+}
+
+
+def _expert_activation_capacity_bytes(requested_bytes: int) -> int:
+    """Round an observed activation request to its 8 MiB reuse class."""
+    if requested_bytes <= 0:
+        raise ValueError("EP chunk expert activation must have positive byte size")
+    return (
+        (requested_bytes + _EXPERT_ACTIVATION_SIZE_CLASS_BYTES - 1)
+        // _EXPERT_ACTIVATION_SIZE_CLASS_BYTES
+    ) * _EXPERT_ACTIVATION_SIZE_CLASS_BYTES
+
+
+@dataclass(frozen=True)
+class _EPChunkExpertActivationKey:
+    """Physical activation ownership is shared across layers of one EP op."""
+
+    op: EPChunkOpName
+    device_type: str
+    device_index: int | None
+    ep_group_id: int
+    dtype: torch.dtype
+    shape_profile: EPChunkShapeProfile
+
+
+@dataclass(frozen=True)
+class _EPChunkExpertActivationArenaKey:
+    """Physical storage compatibility deliberately excludes the logical op."""
+
+    device_type: str
+    device_index: int | None
+    ep_group_id: int
+    dtype: torch.dtype
+    shape_profile: EPChunkShapeProfile
+
+
+@dataclass
+class _EPChunkExpertActivationArenaCoordinator:
+    key: _EPChunkExpertActivationArenaKey
+    arena: _EPChunkActivationTensorArena = field(
+        default_factory=_EPChunkActivationTensorArena
+    )
+    claimed_op: EPChunkOpName | None = None
+    consumer_event: Any | None = None
+    waits: int = 0
+    allocations: int = 0
+    grows: int = 0
+    parks: int = 0
+    rehydrates: int = 0
+    issued_storage_slots: set[str] = field(default_factory=set)
+    max_requested_bytes: dict[str, int] = field(default_factory=dict)
+    capacity_bytes: dict[str, int] = field(default_factory=dict)
+    logical_trailing_shapes: dict[str, tuple[int, ...]] = field(default_factory=dict)
+    pointer_signatures_by_op: dict[EPChunkOpName, dict[str, int]] = field(
+        default_factory=dict
+    )
+    backing_tensors: dict[str, torch.Tensor] = field(default_factory=dict)
+    # A graph owns captured allocations through replay. Keep Python backing
+    # references only for that lifetime; eager park returns them to the pool.
+    graph_backing_owned: bool = False
+    frozen: bool = False
+
+    def reserve(
+        self,
+        *,
+        max_expert_rows: int,
+        expert_intermediate_size: int,
+    ) -> None:
+        """Freeze caller-declared capacities; physical backing remains lazy."""
+        profile = self.key.shape_profile
+        if not 0 < max_expert_rows <= profile.max_expert_rows:
+            raise ValueError(
+                "EP chunk max_expert_rows must be positive and within the profile ceiling"
+            )
+        if expert_intermediate_size <= 0:
+            raise ValueError("EP chunk expert_intermediate_size must be positive")
+        capacities = {
+            "fc1_input": max_expert_rows * profile.hidden_size,
+            "fc1_output": max_expert_rows * 2 * expert_intermediate_size,
+            "fc2_output": max_expert_rows * profile.hidden_size,
+            # Normal backward aliases FC1 dgrad into FC2 dgrad storage.  The
+            # shared raw slot therefore must cover the wider of SwiGLU's
+            # intermediate gradient and FC1's hidden-size gradient.
+            "fc2_dgrad": max_expert_rows
+            * max(profile.hidden_size, expert_intermediate_size),
+        }
+        itemsize = torch.empty((), dtype=self.key.dtype).element_size()
+        capacities = {
+            name: _expert_activation_capacity_bytes(elements * itemsize)
+            for name, elements in capacities.items()
+        }
+        if self.frozen:
+            if capacities != self.capacity_bytes:
+                raise RuntimeError("EP chunk expert activation reservation is already frozen")
+            return
+        self.capacity_bytes = capacities
+        self.frozen = True
+
+    def acquire(self, *, op: EPChunkOpName, stream: Any | None) -> None:
+        if self.claimed_op is not None:
+            raise RuntimeError(
+                "EP chunk expert activation coordinator is already claimed by "
+                f"{self.claimed_op}"
+            )
+        event = self.consumer_event
+        if event is not None and not (
+            bool(event.query()) if hasattr(event, "query") else False
+        ):
+            if stream is not None and hasattr(stream, "wait_event"):
+                stream.wait_event(event)
+            elif hasattr(event, "current_stream_wait"):
+                event.current_stream_wait()
+            else:
+                raise RuntimeError(
+                    "Pending EP chunk expert activation event is not stream-waitable"
+                )
+            self.waits += 1
+        self.consumer_event = None
+        self.claimed_op = op
+        self.issued_storage_slots.clear()
+
+    def release(self, *, op: EPChunkOpName, event: Any) -> None:
+        if self.claimed_op != op:
+            raise RuntimeError("EP chunk expert activation coordinator release lost owner")
+        if self.frozen and self.graph_backing_owned:
+            self._record_pointer_signature(
+                op,
+                {
+                    name: tensor.data_ptr()
+                    for name, tensor in self.arena.tensors.items()
+                },
+            )
+        self.consumer_event = event
+        self.claimed_op = None
+
+    def _record_pointer_signature(
+        self, op: EPChunkOpName, current: dict[str, int]
+    ) -> None:
+        """Reject moved frozen backing, while allowing later lazy slot creation."""
+        previous = self.pointer_signatures_by_op.setdefault(op, {})
+        changed = {
+            name: (previous[name], pointer)
+            for name, pointer in current.items()
+            if name in previous and previous[name] != pointer
+        }
+        if changed:
+            details = ", ".join(
+                f"{name}: previous={old} current={new}"
+                for name, (old, new) in sorted(changed.items())
+            )
+            raise RuntimeError(
+                "EP chunk expert activation backing pointers changed after frozen rehydrate: "
+                f"{details}"
+            )
+        previous.update(current)
+
+    def park(self, *, stream: Any | None) -> None:
+        """Park views after the consumer event without a device-wide sync.
+
+        Eager execution releases physical backing to PyTorch's default caching
+        allocator while retaining frozen capacity. CUDA graph capture/replay
+        owns backing until explicit close, matching graph-private lifetime.
+        """
+        if self.claimed_op is not None:
+            raise RuntimeError("Cannot park a leased EP chunk expert activation arena")
+        event = self.consumer_event
+        if event is not None and not (
+            bool(event.query()) if hasattr(event, "query") else False
+        ):
+            if stream is not None and hasattr(stream, "wait_event"):
+                stream.wait_event(event)
+            elif hasattr(event, "current_stream_wait"):
+                event.current_stream_wait()
+            else:
+                raise RuntimeError(
+                    "Pending EP chunk expert activation event is not stream-waitable"
+                )
+            self.waits += 1
+        self.consumer_event = None
+        if stream is not None and not self.graph_backing_owned:
+            # The reset stream waits for the final expert consumer. Recording it
+            # before dropping the last eager reference keeps default-allocator
+            # reuse ordered.
+            for tensor in self.arena.tensors.values():
+                if tensor.is_cuda:
+                    tensor.record_stream(stream)
+        if self.arena.tensors:
+            self.parks += 1
+            self.arena.tensors.clear()
+        if not self.graph_backing_owned:
+            self.backing_tensors.clear()
+            # Eager re-acquisition may receive a new allocator address; stability is
+            # a CUDA graph capture/replay contract only.
+            self.pointer_signatures_by_op.clear()
+
+    def _is_current_stream_capturing(self) -> bool:
+        """Read capture state without taking ownership of a graph pool."""
+        return self.key.device_type == "cuda" and bool(
+            torch.cuda.is_current_stream_capturing()
+        )
+
+    def tensor(
+        self,
+        name: str,
+        shape: tuple[int, ...] | torch.Size,
+        *,
+        dtype: torch.dtype,
+        device: torch.device | str,
+        storage_name: str | None = None,
+    ) -> torch.Tensor:
+        requested = tuple(int(dim) for dim in shape)
+        if name not in _EXPERT_ACTIVATION_LOGICAL_NAMES:
+            raise RuntimeError(f"Unknown EP chunk expert activation {name!r}")
+        profile = self.key.shape_profile
+        ceiling = (
+            (profile.max_expert_rows, profile.hidden_size)
+            if name == "fc1_input"
+            else (profile.max_expert_rows, *requested[1:])
+        )
+        if (
+            not requested
+            or any(dim < 0 for dim in requested)
+            or len(requested) != 2
+            or requested[0] > profile.max_expert_rows
+            or dtype != self.key.dtype
+            or (name == "fc1_input" and requested[1:] != ceiling[1:])
+        ):
+            raise RuntimeError(
+                f"EP chunk expert activation {name!r} shape {requested} dtype {dtype} "
+                f"exceeds profile ceiling {ceiling} dtype {self.key.dtype}"
+            )
+        storage_name = name if storage_name is None else storage_name
+        trailing_shape = requested[1:]
+        previous_trailing_shape = self.logical_trailing_shapes.get(name)
+        if (
+            previous_trailing_shape is not None
+            and previous_trailing_shape != trailing_shape
+        ):
+            raise RuntimeError(
+                f"EP chunk expert activation {name!r} trailing shape {trailing_shape} "
+                f"does not match logical activation trailing shape "
+                f"{previous_trailing_shape}"
+            )
+        existing = self.arena.tensors.get(storage_name)
+        requested_numel = 1
+        for dim in requested:
+            requested_numel *= dim
+        element_size = int(torch.empty((), dtype=dtype).element_size())
+        requested_bytes = requested_numel * element_size
+        incompatible = existing is not None and (
+            existing.dtype != dtype or existing.device != torch.device(device)
+        )
+        if incompatible:
+            raise RuntimeError(
+                f"EP chunk expert activation {name!r} does not match colored storage "
+                f"{storage_name!r}"
+            )
+        if requested_numel == 0:
+            # A zero-token expert is a logical view, not a request for the
+            # allocator's positive-size reuse class.  In particular, a parked
+            # frozen reservation must not rehydrate merely to represent it.
+            if previous_trailing_shape is None:
+                self.logical_trailing_shapes[name] = trailing_shape
+            self.max_requested_bytes[storage_name] = max(
+                self.max_requested_bytes.get(storage_name, 0), 0
+            )
+            if existing is not None:
+                return existing.narrow(0, 0, 0).view(requested).detach()
+            return torch.empty(requested, dtype=dtype, device=device).detach()
+        reserved_capacity_bytes = self.capacity_bytes.get(storage_name, 0)
+        rehydrating = existing is None and reserved_capacity_bytes > 0
+        capture_now = self.frozen and self._is_current_stream_capturing()
+        if capture_now:
+            # The outer graph manager owns graph_pool_handle and replay lifetime.
+            self.graph_backing_owned = True
+        if existing is None and self.frozen and self.graph_backing_owned:
+            existing = self.backing_tensors.get(storage_name)
+            if existing is not None:
+                self.arena.tensors[storage_name] = existing
+        growing = requested_bytes > reserved_capacity_bytes > 0
+        if existing is not None:
+            growing = growing or requested_bytes > existing.numel() * existing.element_size()
+        if self.frozen and requested_bytes > reserved_capacity_bytes:
+            raise RuntimeError(
+                f"Frozen EP chunk expert activation {storage_name!r} requested "
+                f"{requested_bytes} bytes over reserved {reserved_capacity_bytes}"
+            )
+        if growing and storage_name in self.issued_storage_slots:
+            raise RuntimeError(
+                "EP chunk expert activation cannot grow colored storage "
+                f"{storage_name!r} during an active lease"
+            )
+        if existing is None or growing:
+            requested_capacity_bytes = _expert_activation_capacity_bytes(requested_bytes)
+            capacity_bytes = max(reserved_capacity_bytes, requested_capacity_bytes)
+            ceiling_numel = 1
+            for dim in ceiling:
+                ceiling_numel *= dim
+            ceiling_capacity_bytes = _expert_activation_capacity_bytes(
+                ceiling_numel * element_size
+            )
+            capacity_bytes = min(capacity_bytes, ceiling_capacity_bytes)
+            capacity_numel = (capacity_bytes + element_size - 1) // element_size
+            # MCore supplies graph_pool_handle to the outer torch.cuda.graph;
+            # eager allocation likewise uses the default caching allocator.
+            existing = torch.empty((capacity_numel,), dtype=dtype, device=device)
+            self.arena.tensors[storage_name] = existing
+            if self.frozen and self.graph_backing_owned:
+                self.backing_tensors[storage_name] = existing
+            self.allocations += int(reserved_capacity_bytes == 0)
+            self.grows += int(growing)
+            self.rehydrates += int(rehydrating)
+            self.capacity_bytes[storage_name] = capacity_bytes
+        if previous_trailing_shape is None:
+            self.logical_trailing_shapes[name] = trailing_shape
+        self.max_requested_bytes[storage_name] = max(
+            self.max_requested_bytes.get(storage_name, 0), requested_bytes
+        )
+        self.issued_storage_slots.add(storage_name)
+        return existing.narrow(0, 0, requested_numel).view(requested).detach()
+
+
+@dataclass
+class _EPChunkLogicalExpertActivationOwner:
+    """Per-OP lease identity layered over one profile-compatible arena."""
+
+    key: _EPChunkExpertActivationKey
+    coordinator: _EPChunkExpertActivationArenaCoordinator
+    in_use: bool = False
+    waits: int = 0
+    allocations: int = 0
+    grows: int = 0
+
+    @property
+    def arena(self) -> _EPChunkActivationTensorArena:
+        return self.coordinator.arena
+
+    @property
+    def consumer_event(self) -> Any | None:
+        return self.coordinator.consumer_event
+
+    def acquire(self, *, stream: Any | None) -> None:
+        if self.in_use:
+            raise RuntimeError("EP chunk expert activation arena is already leased")
+        waits_before = self.coordinator.waits
+        self.coordinator.acquire(op=self.key.op, stream=stream)
+        self.waits += self.coordinator.waits - waits_before
+        self.in_use = True
+
+    def release(self, event: Any) -> None:
+        if not self.in_use:
+            raise RuntimeError("EP chunk expert activation arena is not leased")
+        self.coordinator.release(op=self.key.op, event=event)
+        self.in_use = False
+
+    def tensor(
+        self,
+        name: str,
+        shape: tuple[int, ...] | torch.Size,
+        *,
+        dtype: torch.dtype,
+        device: torch.device | str,
+        storage_name: str | None = None,
+    ) -> torch.Tensor:
+        allocations_before = self.coordinator.allocations
+        grows_before = self.coordinator.grows
+        tensor = self.coordinator.tensor(
+            name,
+            shape,
+            dtype=dtype,
+            device=device,
+            storage_name=storage_name,
+        )
+        self.allocations += self.coordinator.allocations - allocations_before
+        self.grows += self.coordinator.grows - grows_before
+        return tensor
+
+
+class _EPChunkExpertActivationLease:
+    def __init__(self, workspace: "EPChunkWorkspace"):
+        self.workspace = workspace
+        self._active = True
+
+    @contextmanager
+    def allocate(self):
+        if not self._active:
+            raise RuntimeError(
+                "EP chunk expert activation lease has already been released"
+            )
+        yield
+
+    def tensor(
+        self,
+        name: str,
+        shape: tuple[int, ...] | torch.Size,
+        *,
+        dtype: torch.dtype,
+        device: torch.device | str,
+    ) -> torch.Tensor:
+        """Return this lease's stable activation storage.
+
+        The lease must remain live through every delayed TE consumer.  In
+        particular, FC1's saved input is reused only after the caller records
+        the wgrad completion event in ``release``.
+        """
+        if not self._active:
+            raise RuntimeError(
+                "EP chunk expert activation lease has already been released"
+            )
+        return self.workspace._expert_activation_tensor(
+            name, shape, dtype=dtype, device=device
+        )
+
+    def release(self, consumer_event: Any) -> None:
+        if not self._active:
+            raise RuntimeError(
+                "EP chunk expert activation lease has already been released"
+            )
+        if consumer_event is None:
+            raise RuntimeError(
+                "EP chunk expert activation release requires a consumer event"
+            )
+        self.workspace._expert_activation_owner.release(consumer_event)
+        self._active = False
+
+
+class EPChunkWorkspaceLease:
+    def __init__(
+        self,
+        workspace: "EPChunkWorkspace",
+        slot: int,
+        *,
+        require_dispatcher: bool,
+    ):
+        self.workspace = workspace
+        self.slot = slot
+        self._require_dispatcher = require_dispatcher
+        self._active = True
+
+    @property
+    def dispatcher(self) -> TokenDispatcher:
+        if not self._require_dispatcher:
+            raise RuntimeError("EP chunk scratch-only lease has no dispatcher")
+        return self.workspace.dispatcher(self.slot)
+
+    def tensor(
+        self,
+        name: str,
+        shape: tuple[int, ...] | torch.Size,
+        *,
+        dtype: torch.dtype,
+        device: torch.device | str,
+    ) -> torch.Tensor:
+        if not self._active:
+            raise RuntimeError("EP chunk workspace lease has already been released")
+        return self.workspace._lease_tensor(
+            self.slot,
+            name,
+            shape,
+            dtype=dtype,
+            device=device,
+        )
+
+    @contextmanager
+    def deepep_recv_allocation(self):
+        """Validate the active lease around a default-allocator DeepEP receive."""
+        if not self._active:
+            raise RuntimeError("EP chunk workspace lease has already been released")
+        yield
+
+    def release(self, consumer_event: Any) -> None:
+        if not self._active:
+            raise RuntimeError("EP chunk workspace lease has already been released")
+        if consumer_event is None:
+            raise RuntimeError("EP chunk workspace release requires a consumer event")
+        slot = self.workspace._slots[self.slot]
+        slot.consumer_event = consumer_event
+        slot.in_use = False
+        self._active = False
+
+
+class EPChunkWorkspace:
+    """Exactly two stable dispatcher/tensor slots owned by one explicit EP op."""
+
+    def __init__(
+        self,
+        key: EPChunkWorkspaceKey,
+        dispatcher_factory: Callable[[int], TokenDispatcher],
+    ):
+        self.key = key
+        self._dispatcher_factory = dispatcher_factory
+        self._registry: EPChunkWorkspaceRegistry | None = None
+        self._slots = [_WorkspaceSlot() for _ in range(EP_CHUNK_COUNT)]
+        activation_key = _EPChunkExpertActivationKey(
+            key.op,
+            key.device_type,
+            key.device_index,
+            key.ep_group_id,
+            key.dtype,
+            key.shape_profile,
+        )
+        self._expert_activation_owner = _EPChunkLogicalExpertActivationOwner(
+            activation_key,
+            _EPChunkExpertActivationArenaCoordinator(
+                _EPChunkExpertActivationArenaKey(
+                    key.device_type,
+                    key.device_index,
+                    key.ep_group_id,
+                    key.dtype,
+                    key.shape_profile,
+                )
+            ),
+        )
+        self._allocations = 0
+        self._runtime_allocations = 0
+        self._grows = 0
+        self._waits = 0
+        self._materialized = False
+        self._bound_device: torch.device | None = None
+
+    def dispatcher(self, slot: int) -> TokenDispatcher:
+        self._validate_slot(slot)
+        dispatcher = self._slots[slot].dispatcher
+        if dispatcher is None:
+            raise RuntimeError("EP chunk workspace is not materialized")
+        return dispatcher
+
+    def materialize(self, *, device: torch.device | str | None = None) -> None:
+        """Create this op's dispatchers on its bound runtime device."""
+        if self._materialized:
+            self._validate_bound_device(device)
+            if all(slot.dispatcher is not None for slot in self._slots):
+                return
+            profile_device = self._bound_device
+            if profile_device is None:
+                raise RuntimeError(
+                    "Materialized EP chunk workspace has no bound device"
+                )
+        else:
+            profile_device = self._bind(device)
+        if self.key.device_type == "cuda":
+            with torch.cuda.device(profile_device):
+                dispatchers = [
+                    self._dispatcher_factory(slot) for slot in range(EP_CHUNK_COUNT)
+                ]
+        else:
+            dispatchers = [
+                self._dispatcher_factory(slot) for slot in range(EP_CHUNK_COUNT)
+            ]
+        if len({id(dispatcher) for dispatcher in dispatchers}) != EP_CHUNK_COUNT:
+            raise RuntimeError("EP chunk workspace requires two distinct dispatchers")
+        for chunk_idx, dispatcher in enumerate(dispatchers):
+            if hasattr(dispatcher, "use_deepep") and not dispatcher.use_deepep:
+                raise RuntimeError(
+                    f"EP chunk dispatcher {chunk_idx} has DeepEP disabled"
+                )
+        for chunk_idx, dispatcher in enumerate(dispatchers):
+            self._slots[chunk_idx].dispatcher = dispatcher
+        self._materialized = True
+
+    def prepare_scratch(self, *, device: torch.device | str | None = None) -> None:
+        """Bind scratch ownership without constructing a dispatcher."""
+        if self._materialized:
+            self._validate_bound_device(device)
+            return
+        self._bind(device)
+
+    def reserve_expert_activations(
+        self,
+        *,
+        max_expert_rows: int,
+        expert_intermediate_size: int | None = None,
+        device: torch.device | str | None = None,
+    ) -> None:
+        """Declare a bounded activation arena for capture or frozen measurement.
+
+        This is opt-in: absent a caller capacity the arena preserves lazy-growth
+        behavior. Frozen capacity survives eager ``reset_tensors``, but physical
+        backing survives only CUDA graph capture/replay; close drops both.
+        """
+        if not self._materialized:
+            self._bind(device)
+        else:
+            self._validate_bound_device(device)
+        intermediate = expert_intermediate_size
+        if intermediate is None:
+            intermediate = self.key.shape_profile.expert_intermediate_size
+        if intermediate is None:
+            raise ValueError("EP chunk reservation requires expert_intermediate_size")
+        self._expert_activation_owner.coordinator.reserve(
+            max_expert_rows=max_expert_rows,
+            expert_intermediate_size=intermediate,
+        )
+
+    def acquire(
+        self,
+        slot: int,
+        *,
+        stream: Any | None = None,
+        require_dispatcher: bool = True,
+    ) -> EPChunkWorkspaceLease:
+        self._validate_slot(slot)
+        runtime_device = getattr(stream, "device", None)
+        if require_dispatcher:
+            self.materialize(device=runtime_device)
+        elif not self._materialized:
+            self._bind(runtime_device)
+        else:
+            self._validate_bound_device(runtime_device)
+        state = self._slots[slot]
+        if state.in_use:
+            raise RuntimeError(f"EP chunk workspace slot {slot} is already leased")
+        event = state.consumer_event
+        if event is not None:
+            ready = bool(event.query()) if hasattr(event, "query") else False
+            if not ready:
+                if stream is not None and hasattr(stream, "wait_event"):
+                    stream.wait_event(event)
+                elif hasattr(event, "current_stream_wait"):
+                    event.current_stream_wait()
+                else:
+                    raise RuntimeError(
+                        "Pending EP chunk consumer event is not stream-waitable"
+                    )
+                self._waits += 1
+        state.consumer_event = None
+        state.in_use = True
+        return EPChunkWorkspaceLease(
+            self,
+            slot,
+            require_dispatcher=require_dispatcher,
+        )
+
+    def acquire_expert_activation(
+        self, *, stream: Any | None = None
+    ) -> _EPChunkExpertActivationLease:
+        runtime_device = getattr(stream, "device", None)
+        if not self._materialized:
+            self._bind(runtime_device)
+        else:
+            self._validate_bound_device(runtime_device)
+        self._expert_activation_owner.acquire(stream=stream)
+        return _EPChunkExpertActivationLease(self)
+
+    def _bind(self, device: torch.device | str | None) -> torch.device:
+        """Claim registry identity and bind a runtime device without allocating."""
+        if self._registry is not None:
+            self._registry._claim(self)
+        profile_device = self._resolve_materialize_device(device)
+        self._bound_device = profile_device
+        self._materialized = True
+        return profile_device
+
+    def close(self, *, stream: Any | None = None) -> None:
+        """Release resident state without a device-wide synchronization."""
+        if not self._materialized:
+            return
+        self._prepare_slots_for_reset(stream=stream, operation="close")
+        for slot in self._slots:
+            slot.dispatcher = None
+        self._allocations = 0
+        self._runtime_allocations = 0
+        self._grows = 0
+        self._waits = 0
+        self._bound_device = None
+        self._materialized = False
+
+    def reset_tensors(self, *, stream: Any | None = None) -> None:
+        """Park activations and drop slot scratch without releasing DeepEP state."""
+        if not self._materialized:
+            return
+        self._prepare_slots_for_reset(stream=stream, operation="reset tensors")
+
+    def park_expert_activations(self, *, stream: Any | None = None) -> None:
+        """Park only the shared expert-activation coordinator.
+
+        This lifecycle boundary deliberately preserves workspace slots, their
+        DeepEP dispatchers, and slot scratch.  It is safe after a fused
+        backward has materialized its caller-visible outputs.
+        """
+        if not self._materialized:
+            return
+        self._expert_activation_owner.coordinator.park(stream=stream)
+
+    def _prepare_slots_for_reset(
+        self,
+        *,
+        stream: Any | None,
+        operation: str,
+    ) -> None:
+        coordinator = self._expert_activation_owner.coordinator
+        if coordinator.claimed_op is not None:
+            raise RuntimeError(
+                f"Cannot {operation} in EP chunk workspace: expert activation arena "
+                "is leased"
+            )
+        for slot_idx, slot in enumerate(self._slots):
+            if slot.in_use:
+                raise RuntimeError(
+                    f"Cannot {operation} in EP chunk workspace: slot {slot_idx} is leased"
+                )
+        activation_event = coordinator.consumer_event
+        if activation_event is not None and not (
+            bool(activation_event.query()) if hasattr(activation_event, "query") else False
+        ) and not (
+            (stream is not None and hasattr(stream, "wait_event"))
+            or hasattr(activation_event, "current_stream_wait")
+        ):
+            raise RuntimeError(
+                f"Cannot {operation} in EP chunk workspace with a pending "
+                "expert activation event"
+            )
+        for slot in self._slots:
+            event = slot.consumer_event
+            if event is not None and not (
+                bool(event.query()) if hasattr(event, "query") else False
+            ) and (stream is None or not hasattr(stream, "wait_event")):
+                raise RuntimeError(
+                    f"Cannot {operation} in EP chunk workspace with a pending "
+                    "consumer event"
+                )
+
+        coordinator.park(stream=stream)
+        for slot in self._slots:
+            event = slot.consumer_event
+            if event is not None:
+                ready = bool(event.query()) if hasattr(event, "query") else False
+                if not ready:
+                    if stream is None or not hasattr(stream, "wait_event"):
+                        raise RuntimeError(
+                            f"Cannot {operation} in EP chunk workspace with a pending "
+                            "consumer event"
+                        )
+                    stream.wait_event(event)
+                    for tensor in slot.tensors.values():
+                        if tensor.is_cuda:
+                            tensor.record_stream(stream)
+        for slot in self._slots:
+            slot.consumer_event = None
+            slot.tensors.clear()
+
+    def release(self, *, stream: Any | None = None) -> None:
+        """Idempotent alias for explicit lifecycle callers."""
+        self.close(stream=stream)
+
+    def _lease_tensor(
+        self,
+        slot: int,
+        name: str,
+        shape: tuple[int, ...] | torch.Size,
+        *,
+        dtype: torch.dtype,
+        device: torch.device | str,
+    ) -> torch.Tensor:
+        requested = tuple(int(dim) for dim in shape)
+        self._validate_runtime_tensor(name, requested, dtype)
+        tensor = self._reserve_tensor(
+            slot,
+            name,
+            requested,
+            dtype=dtype,
+            device=device,
+        )
+        slices = tuple(slice(0, dim) for dim in requested)
+        return tensor[slices].view(requested).detach()
+
+    def _expert_activation_tensor(
+        self,
+        name: str,
+        shape: tuple[int, ...] | torch.Size,
+        *,
+        dtype: torch.dtype,
+        device: torch.device | str,
+    ) -> torch.Tensor:
+        """Reserve caller-owned storage at the observed high-watermark.
+
+        ``max_expert_rows`` is an input-validity ceiling, not an allocation
+        target: allocating it would turn a sparse routing bound into a large,
+        permanently resident activation.  A replacement is safe here because
+        ``acquire_expert_activation`` has waited for the preceding consumer
+        event before this method can be called.
+        """
+        requested = tuple(int(dim) for dim in shape)
+        if self.key.op == "forward":
+            storage_slots = _FORWARD_EXPERT_ACTIVATION_STORAGE_SLOTS
+        elif self.key.op == "fused_forward_backward":
+            storage_slots = _FUSED_EXPERT_ACTIVATION_STORAGE_SLOTS
+        else:
+            storage_slots = _NORMAL_EXPERT_ACTIVATION_STORAGE_SLOTS
+        return self._expert_activation_owner.tensor(
+            name,
+            requested,
+            dtype=dtype,
+            device=device,
+            storage_name=storage_slots.get(name, name),
+        )
+
+    def _validate_runtime_tensor(
+        self, name: str, shape: tuple[int, ...], dtype: torch.dtype
+    ) -> None:
+        profile = self.key.shape_profile
+        contracts = {
+            "grad_expert_out": (
+                (profile.max_expert_rows, profile.hidden_size),
+                self.key.dtype,
+            ),
+        }
+        contract = contracts.get(name)
+        if contract is None:
+            return
+        capacity, expected_dtype = contract
+        if (
+            len(shape) != len(capacity)
+            or any(want > have for want, have in zip(shape, capacity, strict=True))
+            or shape[1:] != capacity[1:]
+            or dtype != expected_dtype
+        ):
+            raise RuntimeError(
+                f"EP chunk tensor {name!r} shape {shape} dtype {dtype} exceeds fixed "
+                f"profile capacity {capacity} dtype {expected_dtype}"
+            )
+
+    def _reserve_tensor(
+        self,
+        slot: int,
+        name: str,
+        shape: tuple[int, ...] | torch.Size,
+        *,
+        dtype: torch.dtype,
+        device: torch.device | str,
+    ) -> torch.Tensor:
+        self._validate_slot(slot)
+        requested = tuple(int(dim) for dim in shape)
+        if not requested or any(dim < 0 for dim in requested):
+            raise ValueError("EP chunk workspace tensor shape must be non-negative")
+        existing = self._slots[slot].tensors.get(name)
+        if existing is None:
+            existing = torch.empty(requested, dtype=dtype, device=device)
+            self._slots[slot].tensors[name] = existing
+            self._allocations += 1
+            self._runtime_allocations += 1
+            return existing
+        capacity = tuple(existing.shape)
+        incompatible = (
+            existing.dtype != dtype
+            or existing.device != torch.device(device)
+            or len(capacity) != len(requested)
+        )
+        too_small = not incompatible and any(
+            want > have for want, have in zip(requested, capacity, strict=True)
+        )
+        if too_small:
+            existing = torch.empty(requested, dtype=dtype, device=device)
+            self._slots[slot].tensors[name] = existing
+            self._allocations += 1
+            self._runtime_allocations += 1
+            self._grows += 1
+            return existing
+        if incompatible or too_small:
+            raise RuntimeError(
+                f"EP chunk tensor {name!r} shape {requested} exceeds the fixed "
+                f"workspace shape {capacity}"
+            )
+        return existing
+
+    def metrics(self) -> dict[str, int]:
+        return {
+            "allocations": self._allocations,
+            "runtime_allocations": self._runtime_allocations,
+            "waits": self._waits,
+            "grows": self._grows,
+            "fallbacks": 0,
+        }
+
+    def evidence(self) -> dict[str, Any]:
+        """Return allocation and DeepEP residency evidence for GPU validation."""
+        buffers: dict[int, int] = {}
+        data_ptrs: dict[str, int] = {}
+        tensor_details: dict[str, dict[str, Any]] = {}
+        for slot_idx, slot in enumerate(self._slots):
+            buffer = getattr(slot.dispatcher, "buffer", None)
+            if buffer is not None:
+                buffers[id(buffer)] = int(
+                    getattr(slot.dispatcher, "deepep_buffer_resident_bytes", 0)
+                )
+            for name, tensor in slot.tensors.items():
+                tensor_key = f"{slot_idx}:{name}"
+                data_ptrs[tensor_key] = tensor.data_ptr()
+                tensor_details[tensor_key] = {
+                    "shape": tuple(tensor.shape),
+                    "dtype": str(tensor.dtype),
+                    "nbytes": tensor.numel() * tensor.element_size(),
+                }
+        owner = self._expert_activation_owner
+        coordinator = owner.coordinator
+        expert_activation_tensors = {
+            name: {
+                "data_ptr": tensor.data_ptr(),
+                "shape": tuple(tensor.shape),
+                "dtype": str(tensor.dtype),
+                "nbytes": tensor.numel() * tensor.element_size(),
+            }
+            for name, tensor in owner.arena.tensors.items()
+        }
+        return {
+            **self.metrics(),
+            "data_ptrs": data_ptrs,
+            "tensor_details": tensor_details,
+            "dispatcher_count": sum(
+                slot.dispatcher is not None for slot in self._slots
+            ),
+            "deepep_buffer_count": len(buffers),
+            "deepep_buffer_resident_bytes": sum(buffers.values()),
+            "allocation_pool_count": 0,
+            "allocation_pool_ids": {},
+            "expert_activation_pool_count": 0,
+            "expert_activation_pool_id": None,
+            "expert_activation_waits": owner.waits,
+            "expert_activation_allocations": owner.allocations,
+            "expert_activation_grows": owner.grows,
+            "expert_activation_parks": coordinator.parks,
+            "expert_activation_rehydrates": coordinator.rehydrates,
+            "expert_activation_in_use": owner.in_use,
+            "expert_activation_event_guarded": (owner.consumer_event is not None),
+            "expert_activation_arena_id": id(coordinator),
+            "expert_activation_arena_claimed_op": coordinator.claimed_op,
+            "expert_activation_max_requested_bytes": dict(
+                coordinator.max_requested_bytes
+            ),
+            "expert_activation_capacity_bytes": dict(coordinator.capacity_bytes),
+            "expert_activation_tensors": expert_activation_tensors,
+            "active_lease_count": sum(slot.in_use for slot in self._slots),
+            "consumer_event_guard_count": sum(
+                slot.consumer_event is not None for slot in self._slots
+            ),
+            "recv_observer_enabled": os.environ.get(
+                "MEGATRON_LITE_EP_CHUNK_SCRATCH_TRACE", "0"
+            )
+            not in {"0", "false", "False"},
+            "materialized_device": (
+                None if self._bound_device is None else str(self._bound_device)
+            ),
+            "materialized": self._materialized,
+        }
+
+    def _resolve_materialize_device(
+        self, device: torch.device | str | None
+    ) -> torch.device:
+        key_device = (
+            torch.device(self.key.device_type)
+            if self.key.device_index is None
+            else torch.device(self.key.device_type, self.key.device_index)
+        )
+        requested = key_device if device is None else torch.device(device)
+        if requested.type != self.key.device_type:
+            raise RuntimeError(
+                f"EP chunk materialize device {requested} does not match workspace "
+                f"device type {self.key.device_type}"
+            )
+        if (
+            self.key.device_index is not None
+            and requested.index != self.key.device_index
+        ):
+            raise RuntimeError(
+                f"EP chunk materialize device {requested} does not match workspace "
+                f"key device {key_device}"
+            )
+        if requested.type == "cuda" and requested.index is None:
+            requested = torch.device("cuda", torch.cuda.current_device())
+        return requested
+
+    def _validate_bound_device(self, device: torch.device | str | None) -> None:
+        if device is None:
+            return
+        requested = torch.device(device)
+        if requested.type == "cuda" and requested.index is None:
+            requested = torch.device("cuda", torch.cuda.current_device())
+        if requested != self._bound_device:
+            raise RuntimeError(
+                f"EP chunk workspace already materialized on {self._bound_device}, "
+                f"cannot use stream/device {requested}"
+            )
+
+    @staticmethod
+    def _validate_slot(slot: int) -> None:
+        if not isinstance(slot, int) or not 0 <= slot < EP_CHUNK_COUNT:
+            raise IndexError(f"EP chunk slot must be 0 or 1, got {slot!r}")
+
+
+class EPChunkWorkspaceRegistry:
+    def __init__(self):
+        self._workspaces: dict[EPChunkWorkspaceKey, EPChunkWorkspace] = {}
+        self._expert_activation_owners: dict[
+            _EPChunkExpertActivationKey, _EPChunkLogicalExpertActivationOwner
+        ] = {}
+        self._expert_activation_arenas: dict[
+            _EPChunkExpertActivationArenaKey, _EPChunkExpertActivationArenaCoordinator
+        ] = {}
+
+    def get_or_create(
+        self,
+        key: EPChunkWorkspaceKey,
+        dispatcher_factory: Callable[[int], TokenDispatcher],
+    ) -> EPChunkWorkspace:
+        workspace = self._workspaces.get(key)
+        if workspace is None:
+            workspace = EPChunkWorkspace(key, dispatcher_factory)
+            workspace._registry = self
+            activation_key = _EPChunkExpertActivationKey(
+                key.op,
+                key.device_type,
+                key.device_index,
+                key.ep_group_id,
+                key.dtype,
+                key.shape_profile,
+            )
+            arena_key = _EPChunkExpertActivationArenaKey(
+                key.device_type,
+                key.device_index,
+                key.ep_group_id,
+                key.dtype,
+                key.shape_profile,
+            )
+            coordinator = self._expert_activation_arenas.setdefault(
+                arena_key, _EPChunkExpertActivationArenaCoordinator(arena_key)
+            )
+            workspace._expert_activation_owner = (
+                self._expert_activation_owners.setdefault(
+                    activation_key,
+                    _EPChunkLogicalExpertActivationOwner(activation_key, coordinator),
+                )
+            )
+            self._workspaces[key] = workspace
+        return workspace
+
+    def _claim(self, workspace: EPChunkWorkspace) -> None:
+        current = self._workspaces.get(workspace.key)
+        if current is not None and current is not workspace:
+            raise RuntimeError(
+                "Cannot rematerialize an EP chunk workspace after its key was reused"
+            )
+        activation_key = workspace._expert_activation_owner.key
+        current_owner = self._expert_activation_owners.get(activation_key)
+        if current_owner is None:
+            self._expert_activation_owners[activation_key] = workspace._expert_activation_owner
+        elif current_owner is not workspace._expert_activation_owner:
+            raise RuntimeError("Cannot rematerialize an EP chunk workspace with a replaced activation owner")
+        arena_key = workspace._expert_activation_owner.coordinator.key
+        current_arena = self._expert_activation_arenas.get(arena_key)
+        if current_arena is None:
+            self._expert_activation_arenas[arena_key] = workspace._expert_activation_owner.coordinator
+        elif current_arena is not workspace._expert_activation_owner.coordinator:
+            raise RuntimeError("Cannot rematerialize an EP chunk workspace with a replaced activation arena")
+        self._workspaces[workspace.key] = workspace
+
+    def release(
+        self,
+        key: EPChunkWorkspaceKey,
+        *,
+        stream: Any | None = None,
+    ) -> None:
+        """Close and unregister one workspace; missing keys are idempotent."""
+        workspace = self._workspaces.get(key)
+        if workspace is None:
+            return
+        workspace.close(stream=stream)
+        if self._workspaces.get(key) is workspace:
+            del self._workspaces[key]
+        activation_key = workspace._expert_activation_owner.key
+        if not any(
+            candidate._expert_activation_owner is workspace._expert_activation_owner
+            for candidate in self._workspaces.values()
+        ):
+            owner = self._expert_activation_owners.pop(activation_key, None)
+            if owner is not None and owner.in_use:
+                raise RuntimeError("Cannot release leased EP chunk expert activation owner")
+        coordinator = workspace._expert_activation_owner.coordinator
+        if not any(
+            candidate._expert_activation_owner.coordinator is coordinator
+            for candidate in self._workspaces.values()
+        ):
+            event = coordinator.consumer_event
+            if event is not None and not (
+                bool(event.query()) if hasattr(event, "query") else False
+            ):
+                if stream is None or not hasattr(stream, "wait_event"):
+                    raise RuntimeError(
+                        "Cannot release EP chunk expert activation arena with pending event"
+                    )
+                stream.wait_event(event)
+            if coordinator.claimed_op is not None:
+                raise RuntimeError("Cannot release leased EP chunk expert activation arena")
+            self._expert_activation_arenas.pop(coordinator.key, None)
+            coordinator.consumer_event = None
+            coordinator.arena.tensors.clear()
+            coordinator.backing_tensors.clear()
+            coordinator.max_requested_bytes.clear()
+            coordinator.capacity_bytes.clear()
+            coordinator.logical_trailing_shapes.clear()
+            coordinator.pointer_signatures_by_op.clear()
+            coordinator.graph_backing_owned = False
+            coordinator.frozen = False
+            coordinator.parks = 0
+            coordinator.rehydrates = 0
+
+_EP_CHUNK_WORKSPACES = EPChunkWorkspaceRegistry()
+
+
+def get_ep_chunk_workspace(
+    key: EPChunkWorkspaceKey,
+    dispatcher_factory: Callable[[int], TokenDispatcher],
+) -> EPChunkWorkspace:
+    """Return the process-local workspace shared by every matching model layer."""
+    return _EP_CHUNK_WORKSPACES.get_or_create(key, dispatcher_factory)
+
+
+def release_ep_chunk_workspace(
+    key: EPChunkWorkspaceKey,
+    *,
+    stream: Any | None = None,
+) -> None:
+    """Close and unregister a process-local EP chunk workspace."""
+    _EP_CHUNK_WORKSPACES.release(key, stream=stream)
+
+
+def _make_stream(device: torch.device | int | str) -> torch.cuda.Stream:
+    if not torch.cuda.is_available():
+        raise RuntimeError("EP chunk overlap requires CUDA streams.")
+    try:
+        return torch.cuda.Stream(device=device)
+    except TypeError:
+        with torch.cuda.device(device):
+            return torch.cuda.Stream()
+
+
+_EP_CHUNK_SHARED_COMM_STREAMS: dict[int, torch.cuda.Stream] = {}
+_EP_CHUNK_WGRAD_STREAMS: dict[int, torch.cuda.Stream] = {}
+_EP_CHUNK_RECV_ACTIVE: dict[tuple[str, EPChunkOpName, int], dict[str, int]] = {}
+_EP_CHUNK_RECV_STATS: dict[str, int] = {}
+
+
+def _tensor_numel_and_bytes(tensor: torch.Tensor | None) -> tuple[int, int]:
+    if tensor is None:
+        return 0, 0
+    numel = int(tensor.numel())
+    return numel, numel * tensor.element_size()
+
+
+def _record_ep_chunk_recv_tensors(
+    *,
+    action: str,
+    phase: str,
+    workspace: EPChunkOpName,
+    chunk_idx: int,
+    recv_hidden: torch.Tensor | None = None,
+    recv_probs: torch.Tensor | None = None,
+) -> None:
+    if os.environ.get("MEGATRON_LITE_EP_CHUNK_SCRATCH_TRACE", "0") in {
+        "0",
+        "false",
+        "False",
+    }:
+        return
+    key = (phase, workspace, int(chunk_idx))
+    if action == "acquire":
+        if key in _EP_CHUNK_RECV_ACTIVE:
+            raise RuntimeError(f"EP chunk recv block is already active: {key!r}")
+        hidden_numel, hidden_bytes = _tensor_numel_and_bytes(recv_hidden)
+        probs_numel, probs_bytes = _tensor_numel_and_bytes(recv_probs)
+        values = {
+            "hidden_numel": hidden_numel,
+            "hidden_bytes": hidden_bytes,
+            "probs_numel": probs_numel,
+            "probs_bytes": probs_bytes,
+        }
+        _EP_CHUNK_RECV_ACTIVE[key] = values
+        prefix = f"recv_{phase}_chunk_{chunk_idx}"
+        for name, value in values.items():
+            _EP_CHUNK_RECV_STATS[f"{prefix}_{name}"] = value
+        _EP_CHUNK_RECV_STATS["active_blocks"] = len(_EP_CHUNK_RECV_ACTIVE)
+        _EP_CHUNK_RECV_STATS["active_blocks_peak"] = max(
+            _EP_CHUNK_RECV_STATS.get("active_blocks_peak", 0),
+            len(_EP_CHUNK_RECV_ACTIVE),
+        )
+        active_bytes = sum(
+            value["hidden_bytes"] + value["probs_bytes"]
+            for value in _EP_CHUNK_RECV_ACTIVE.values()
+        )
+        _EP_CHUNK_RECV_STATS["active_bytes"] = active_bytes
+        _EP_CHUNK_RECV_STATS["active_bytes_peak"] = max(
+            _EP_CHUNK_RECV_STATS.get("active_bytes_peak", 0), active_bytes
+        )
+    elif action == "release":
+        values = _EP_CHUNK_RECV_ACTIVE.pop(key, None)
+        if values is None:
+            raise RuntimeError(f"EP chunk recv block is not active: {key!r}")
+        _EP_CHUNK_RECV_STATS["active_blocks"] = len(_EP_CHUNK_RECV_ACTIVE)
+        _EP_CHUNK_RECV_STATS["active_bytes"] = sum(
+            value["hidden_bytes"] + value["probs_bytes"]
+            for value in _EP_CHUNK_RECV_ACTIVE.values()
+        )
+    else:
+        raise ValueError(
+            f"EP chunk recv action must be acquire or release, got {action!r}"
+        )
+
+    values = (
+        _EP_CHUNK_RECV_ACTIVE.get(key, values)
+        if action == "release"
+        else _EP_CHUNK_RECV_ACTIVE[key]
+    )
+    print(
+        "[EPCHUNK_RECV_TRACE] "
+        f"action={action} phase={phase} workspace={workspace} chunk={chunk_idx} "
+        f"hidden_numel={values['hidden_numel']} hidden_bytes={values['hidden_bytes']} "
+        f"probs_numel={values['probs_numel']} probs_bytes={values['probs_bytes']} "
+        f"active_blocks={_EP_CHUNK_RECV_STATS.get('active_blocks', 0)} "
+        f"active_bytes={_EP_CHUNK_RECV_STATS.get('active_bytes', 0)}",
+        flush=True,
+    )
+
+
+@contextmanager
+def _ep_chunk_nvtx(phase: str, chunk_idx: int | None = None):
+    if (
+        os.environ.get("MEGATRON_LITE_EP_CHUNK_NVTX") != "1"
+        or not torch.cuda.is_available()
+    ):
+        yield
+        return
+    suffix = "" if chunk_idx is None else f".chunk{chunk_idx}"
+    torch.cuda.nvtx.range_push(f"chunked_ep.{phase}{suffix}")
+    try:
+        yield
+    finally:
+        torch.cuda.nvtx.range_pop()
+
+
+def _cuda_device_index(device: torch.device | int | str) -> int:
+    if isinstance(device, int):
+        return device
+    cuda_device = torch.device(device)
+    if cuda_device.type != "cuda":
+        raise RuntimeError("EP chunk overlap requires CUDA tensors.")
+    return (
+        torch.cuda.current_device() if cuda_device.index is None else cuda_device.index
+    )
+
+
+def _shared_comm_stream(device: torch.device | int | str) -> torch.cuda.Stream:
+    device_index = _cuda_device_index(device)
+    stream = _EP_CHUNK_SHARED_COMM_STREAMS.get(device_index)
+    if stream is None:
+        stream = _make_stream(device_index)
+        _EP_CHUNK_SHARED_COMM_STREAMS[device_index] = stream
+    return stream
+
+
+def _shared_wgrad_stream(device: torch.device | int | str) -> torch.cuda.Stream:
+    device_index = _cuda_device_index(device)
+    stream = _EP_CHUNK_WGRAD_STREAMS.get(device_index)
+    if stream is None:
+        stream = _make_stream(device_index)
+        _EP_CHUNK_WGRAD_STREAMS[device_index] = stream
+    return stream
+
+
+def _queue_backward_stream_wait(event: torch.cuda.Event, device: torch.device) -> None:
+    """Make work queued after backward wait for deferred expert wgrad."""
+
+    def wait_for_wgrad() -> None:
+        with torch.cuda.device(device):
+            torch.cuda.current_stream(device).wait_event(event)
+
+    torch.autograd.Variable._execution_engine.queue_callback(wait_for_wgrad)
+
+
+def _event_current_stream_wait(event: Any) -> None:
+    if event is None:
+        return
+    if hasattr(event, "current_stream_wait"):
+        event.current_stream_wait()
+    else:
+        torch.cuda.current_stream().wait_event(event)
+
+
+def _record_state_tensors_current_stream(state: dict[str, Any]) -> None:
+    for value in state.values():
+        if torch.is_tensor(value) and value.is_cuda:
+            value.record_stream(torch.cuda.current_stream(value.device))
+        elif isinstance(value, dict):
+            _record_state_tensors_current_stream(value)
+
+
+@dataclass
+class _BackwardChunk:
+    idx: int
+    start: int
+    end: int
+    x: torch.Tensor
+    scores: torch.Tensor | None
+    handle: Any
+    row_id_map: torch.Tensor
+    prob_flat_indices: torch.Tensor
+    recv_hidden_shape: torch.Size
+    recv_hidden_dtype: torch.dtype
+    recv_probs_shape: torch.Size
+    recv_probs_dtype: torch.dtype
+    recv_probs_base: torch.Tensor | None
+    dispatched: torch.Tensor | None
+    probs: torch.Tensor | None
+    expert_out: torch.Tensor | None
+    dispatcher: TokenDispatcher
+    workspace_lease: EPChunkWorkspaceLease
+    scores_edge: Any | None = None
+    scores_shape: torch.Size | None = None
+    scores_dtype: torch.dtype | None = None
+    expert_out_edge: Any | None = None
+    expert_out_shape: torch.Size | None = None
+    expert_out_dtype: torch.dtype | None = None
+
+
+@dataclass
+class _ForwardChunkContext:
+    idx: int
+    start: int
+    end: int
+    x: torch.Tensor
+    scores: torch.Tensor | None
+    handle: Any
+    row_id_map: torch.Tensor
+    prob_flat_indices: torch.Tensor
+    recv_hidden_shape: torch.Size
+    recv_hidden_dtype: torch.dtype
+    recv_probs_shape: torch.Size
+    recv_probs_dtype: torch.dtype
+    recv_probs_base: torch.Tensor | None
+    dispatched: torch.Tensor | None
+    probs: torch.Tensor | None
+    expert_out: torch.Tensor | None
+    dispatcher: TokenDispatcher
+    recv_consumed_event: Any
+    scores_edge: Any | None = None
+    scores_shape: torch.Size | None = None
+    scores_dtype: torch.dtype | None = None
+    expert_out_edge: Any | None = None
+    expert_out_shape: torch.Size | None = None
+    expert_out_dtype: torch.dtype | None = None
+
+
+@dataclass
+class _SavedForwardContext:
+    chunks: list[_ForwardChunkContext]
+    input_shape: torch.Size
+
+
+class _EPChunkOperationBase:
+    """Shared schedule mechanics; each public operation owns its own workspace."""
+
+    def __init__(
+        self,
+        *,
+        router: nn.Module,
+        experts: Experts,
+        workspace: EPChunkWorkspace,
+        router_forward: (
+            Callable[
+                [nn.Module, torch.Tensor, torch.Tensor | None],
+                tuple[torch.Tensor, torch.Tensor],
+            ]
+            | None
+        ) = None,
+    ):
+        self._router_forward = router_forward
+        self._active_routing_input: torch.Tensor | None = None
+        self.router = router
+        self.experts = experts
+        self.workspace = workspace
+
+    def _streams(
+        self, device: torch.device
+    ) -> tuple[torch.cuda.Stream, torch.cuda.Stream]:
+        return torch.cuda.current_stream(device), _shared_comm_stream(device)
+
+    @property
+    def _logical_chunk_count(self) -> int:
+        return self.workspace.key.shape_profile.chunk_count
+
+    @contextmanager
+    def _routing_context(self, routing_input: torch.Tensor | None):
+        previous = getattr(self, "_active_routing_input", None)
+        self._active_routing_input = routing_input
+        try:
+            yield
+        finally:
+            self._active_routing_input = previous
+
+    def _route(
+        self, x: torch.Tensor, start: int = 0, end: int | None = None
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        router_forward = getattr(self, "_router_forward", None)
+        if router_forward is None:
+            return self.router(x)
+        routing_input = self._active_routing_input
+        if routing_input is not None:
+            routing_input = routing_input.reshape(-1)[start:end]
+        return router_forward(self.router, x, routing_input)
+
+    def _forward_output_async(
+        self,
+        x_2d: torch.Tensor,
+        ranges: list[tuple[int, int]],
+        input_shape: torch.Size,
+        input_dtype: torch.dtype,
+    ) -> torch.Tensor:
+        self.workspace.key.shape_profile.validate_input(x_2d)
+        if not ranges:
+            return x_2d.new_empty(input_shape).to(input_dtype)
+        if len(ranges) != self._logical_chunk_count:
+            raise RuntimeError("EP chunk overlap ranges do not match the shape profile")
+
+        compute_stream, comm_stream = self._streams(x_2d.device)
+        caller_stream = torch.cuda.current_stream(x_2d.device)
+        input_ready = torch.cuda.Event()
+        input_ready.record(caller_stream)
+
+        def submit_dispatch(chunk_idx: int):
+            start, end = ranges[chunk_idx]
+            x_chunk = x_2d[start:end]
+            lease = self.workspace.acquire(
+                chunk_idx % EP_CHUNK_COUNT, stream=comm_stream
+            )
+            dispatcher = lease.dispatcher
+            with torch.cuda.stream(compute_stream):
+                compute_stream.wait_event(input_ready)
+                scores, indices = self._route(x_chunk, start, end)
+                route_ready = torch.cuda.Event()
+                route_ready.record(compute_stream)
+            with torch.cuda.stream(comm_stream):
+                comm_stream.wait_event(route_ready)
+                if x_chunk.is_cuda:
+                    x_chunk.record_stream(comm_stream)
+                if scores.is_cuda:
+                    scores.record_stream(comm_stream)
+                if indices.is_cuda:
+                    indices.record_stream(comm_stream)
+                with _ep_chunk_nvtx("forward.dispatch", chunk_idx):
+                    with lease.deepep_recv_allocation():
+                        state = dispatcher.submit_deepep_dispatch(
+                            x_chunk,
+                            scores,
+                            indices,
+                            allocate_on_comm_stream=True,
+                            async_finish=True,
+                        )
+            return chunk_idx, dispatcher, state, lease
+
+        def finish_dispatch(pending):
+            chunk_idx, dispatcher, state, lease = pending
+            with torch.cuda.stream(compute_stream):
+                with _ep_chunk_nvtx("forward.dispatch.finish", chunk_idx):
+                    dispatched, tpe, probs = dispatcher.finish_deepep_dispatch(
+                        state, materialize_local_tpe=False
+                    )
+                    _validate_finished_deepep_dispatch(
+                        self.workspace.key.shape_profile, state, dispatched
+                    )
+            return chunk_idx, dispatcher, state, lease, dispatched, tpe, probs
+
+        def run_expert(finished):
+            chunk_idx, dispatcher, state, lease, dispatched, tpe, probs = finished
+            with torch.cuda.stream(compute_stream):
+                expert_activation_lease = self.workspace.acquire_expert_activation(
+                    stream=compute_stream
+                )
+                recv_hidden = state.get("recv_hidden")
+                _record_ep_chunk_recv_tensors(
+                    action="acquire",
+                    phase="forward",
+                    workspace=self.workspace.key.op,
+                    chunk_idx=chunk_idx,
+                    recv_hidden=recv_hidden,
+                    recv_probs=state.get("recv_probs"),
+                )
+                with _ep_chunk_nvtx("forward.expert", chunk_idx):
+                    fc1_input = expert_activation_lease.tensor(
+                        "fc1_input",
+                        dispatched.shape,
+                        dtype=dispatched.dtype,
+                        device=dispatched.device,
+                    )
+                    fc1_input.copy_(dispatched)
+                    expert_out = self.experts(
+                        fc1_input,
+                        tpe,
+                        probs,
+                        tokens_per_expert_list=getattr(
+                            dispatcher, "_local_tpe_list", None
+                        ),
+                        activation_allocation=expert_activation_lease.allocate,
+                        output_allocation=_expert_activation_output_allocation(
+                            expert_activation_lease, fc1_input
+                        ),
+                    )
+                expert_ready = torch.cuda.Event()
+                expert_ready.record(compute_stream)
+                expert_activation_lease.release(expert_ready)
+                _record_state_tensors_current_stream(state)
+                state.pop("recv_hidden", None)
+                state.pop("recv_indices", None)
+                state.pop("recv_probs", None)
+                state.pop("recv_per_expert", None)
+                rank_grouped, handle = dispatcher.prepare_deepep_combine(expert_out)
+                ready = torch.cuda.Event()
+                ready.record(compute_stream)
+                _record_ep_chunk_recv_tensors(
+                    action="release",
+                    phase="forward",
+                    workspace=self.workspace.key.op,
+                    chunk_idx=chunk_idx,
+                )
+            del dispatched, probs, expert_out
+            return chunk_idx, dispatcher, rank_grouped, handle, ready, lease
+
+        def submit_combine(prepared):
+            chunk_idx, dispatcher, rank_grouped, handle, ready, lease = prepared
+            with torch.cuda.stream(comm_stream):
+                comm_stream.wait_event(ready)
+                with _ep_chunk_nvtx("forward.combine", chunk_idx):
+                    combine_state = dispatcher.submit_deepep_combine_prepared(
+                        rank_grouped,
+                        handle,
+                        allocate_on_comm_stream=True,
+                        async_finish=True,
+                    )
+            return chunk_idx, dispatcher, combine_state, lease
+
+        output_2d = x_2d.new_empty(x_2d.shape)
+
+        def finish_combine(pending) -> None:
+            chunk_idx, dispatcher, state, lease = pending
+            with _ep_chunk_nvtx("forward.combine.finish", chunk_idx):
+                chunk_out = dispatcher.finish_deepep_combine(state)
+            start, end = ranges[chunk_idx]
+            output_2d[start:end].copy_(chunk_out)
+            consumed = torch.cuda.Event()
+            consumed.record(torch.cuda.current_stream(output_2d.device))
+            lease.release(consumed)
+
+        pending_combine = None
+        with torch.no_grad():
+            current_state = submit_dispatch(0)
+            for loop_idx in range(len(ranges)):
+                finished = finish_dispatch(current_state)
+                if loop_idx + 1 < len(ranges):
+                    if pending_combine is not None:
+                        next_slot = (loop_idx + 1) % EP_CHUNK_COUNT
+                        pending_slot = pending_combine[0] % EP_CHUNK_COUNT
+                        if next_slot == pending_slot:
+                            finish_combine(pending_combine)
+                            pending_combine = None
+                    current_state = submit_dispatch(loop_idx + 1)
+                prepared = run_expert(finished)
+                # ``run_expert`` copies the permute result into fc1_input.
+                # Do not retain that result through the next iteration's
+                # finish_dispatch RHS, which otherwise creates a second large
+                # permute allocation before the first can be retired.
+                del finished
+                if pending_combine is not None:
+                    finish_combine(pending_combine)
+                pending_combine = submit_combine(prepared)
+
+        done = torch.cuda.Event()
+        done.record(compute_stream)
+        caller_stream.wait_event(done)
+        if pending_combine is None:
+            raise RuntimeError("EP chunk combine pipeline produced no pending output")
+        finish_combine(pending_combine)
+        return output_2d.view(input_shape).to(input_dtype).detach()
+
+    def _forward_saved_context_async(
+        self,
+        x_2d: torch.Tensor,
+        ranges: list[tuple[int, int]],
+        input_shape: torch.Size,
+        input_dtype: torch.dtype,
+    ) -> tuple[torch.Tensor, _SavedForwardContext]:
+        """Run the overlapped forward once and retain its graph for backward."""
+        self.workspace.key.shape_profile.validate_input(x_2d)
+        if len(ranges) != self._logical_chunk_count:
+            raise RuntimeError("EP chunk overlap ranges do not match the shape profile")
+
+        compute_stream, comm_stream = self._streams(x_2d.device)
+        caller_stream = torch.cuda.current_stream(x_2d.device)
+        input_ready = torch.cuda.Event()
+        input_ready.record(caller_stream)
+        saved_chunks: list[_ForwardChunkContext | None] = [None for _ in ranges]
+
+        def submit_dispatch(chunk_idx: int):
+            start, end = ranges[chunk_idx]
+            x_chunk = x_2d[start:end]
+            lease = self.workspace.acquire(
+                chunk_idx % EP_CHUNK_COUNT, stream=comm_stream
+            )
+            dispatcher = lease.dispatcher
+            with torch.cuda.stream(compute_stream):
+                compute_stream.wait_event(input_ready)
+                scores, indices = self._route(x_chunk, start, end)
+                route_ready = torch.cuda.Event()
+                route_ready.record(compute_stream)
+            with torch.cuda.stream(comm_stream):
+                comm_stream.wait_event(route_ready)
+                if x_chunk.is_cuda:
+                    x_chunk.record_stream(comm_stream)
+                if scores.is_cuda:
+                    scores.record_stream(comm_stream)
+                if indices.is_cuda:
+                    indices.record_stream(comm_stream)
+                with _ep_chunk_nvtx("forward.dispatch", chunk_idx):
+                    with lease.deepep_recv_allocation():
+                        state = dispatcher.submit_deepep_dispatch(
+                            x_chunk,
+                            scores,
+                            indices,
+                            allocate_on_comm_stream=True,
+                            async_finish=True,
+                        )
+            return chunk_idx, start, end, x_chunk, scores, dispatcher, state, lease
+
+        def finish_dispatch(pending):
+            chunk_idx, start, end, x_chunk, scores, dispatcher, state, lease = pending
+            with torch.cuda.stream(compute_stream):
+                state["recv_hidden"] = (
+                    state["recv_hidden"].detach().requires_grad_(True)
+                )
+                state["recv_probs"] = state["recv_probs"].detach().requires_grad_(True)
+                with _ep_chunk_nvtx("forward.dispatch.finish", chunk_idx):
+                    dispatched, local_tpe, probs, metadata = (
+                        dispatcher.finish_deepep_dispatch_external_with_options(
+                            state,
+                            force_manual_map=True,
+                            force_direct_permute=True,
+                            materialize_local_tpe=False,
+                        )
+                    )
+                _validate_finished_deepep_dispatch(
+                    self.workspace.key.shape_profile, state, dispatched
+                )
+                expert_input = dispatched.detach().requires_grad_(True)
+                expert_probs = (
+                    None if probs is None else probs.detach().requires_grad_(True)
+                )
+            return (
+                chunk_idx,
+                start,
+                end,
+                x_chunk,
+                scores,
+                dispatcher,
+                state,
+                lease,
+                expert_input,
+                expert_probs,
+                local_tpe,
+                metadata,
+            )
+
+        def run_expert(finished):
+            (
+                chunk_idx,
+                start,
+                end,
+                x_chunk,
+                scores,
+                dispatcher,
+                state,
+                lease,
+                expert_input,
+                expert_probs,
+                local_tpe,
+                metadata,
+            ) = finished
+            with torch.cuda.stream(compute_stream):
+                with _ep_chunk_nvtx("forward.expert", chunk_idx):
+                    expert_out = self.experts(
+                        expert_input,
+                        local_tpe,
+                        expert_probs,
+                        tokens_per_expert_list=metadata["local_tpe_list"],
+                    )
+                _record_state_tensors_current_stream(state)
+                row_id_map = metadata["manual_row_id_map"]
+                prob_flat_indices = metadata["manual_prob_flat_indices"]
+                if row_id_map is None or prob_flat_indices is None:
+                    raise RuntimeError(
+                        "EP chunk saved forward requires manual backward metadata"
+                    )
+                rank_grouped = unpermute(
+                    expert_out,
+                    row_id_map,
+                    restore_shape=state["recv_hidden"].shape,
+                    fused=dispatcher.moe_permute_fusion,
+                )
+                ready = torch.cuda.Event()
+                ready.record(compute_stream)
+                recv_consumed_event = torch.cuda.Event()
+                recv_consumed_event.record(compute_stream)
+
+                scores_edge = None
+                scores_ref: torch.Tensor | None = scores
+                expert_out_edge = None
+                expert_out_ref: torch.Tensor | None = expert_out
+                if hasattr(torch.autograd.graph, "get_gradient_edge"):
+                    scores_edge = torch.autograd.graph.get_gradient_edge(scores)
+                    scores_ref = None
+                    expert_out_edge = torch.autograd.graph.get_gradient_edge(expert_out)
+                    expert_out_ref = None
+                saved_chunks[chunk_idx] = _ForwardChunkContext(
+                    idx=chunk_idx,
+                    start=start,
+                    end=end,
+                    x=x_chunk,
+                    scores=scores_ref,
+                    handle=state["handle"],
+                    row_id_map=row_id_map.detach(),
+                    prob_flat_indices=prob_flat_indices.detach(),
+                    recv_hidden_shape=state["recv_hidden"].shape,
+                    recv_hidden_dtype=state["recv_hidden"].dtype,
+                    recv_probs_shape=state["recv_probs"].shape,
+                    recv_probs_dtype=state["recv_probs"].dtype,
+                    recv_probs_base=state["recv_probs"],
+                    dispatched=expert_input,
+                    probs=expert_probs,
+                    expert_out=expert_out_ref,
+                    scores_edge=scores_edge,
+                    scores_shape=scores.shape,
+                    scores_dtype=scores.dtype,
+                    expert_out_edge=expert_out_edge,
+                    expert_out_shape=expert_out.shape,
+                    expert_out_dtype=expert_out.dtype,
+                    dispatcher=dispatcher,
+                    recv_consumed_event=recv_consumed_event,
+                )
+                state.clear()
+            return (
+                chunk_idx,
+                dispatcher,
+                rank_grouped,
+                saved_chunks[chunk_idx].handle,
+                ready,
+                lease,
+            )
+
+        def submit_combine(prepared):
+            chunk_idx, dispatcher, rank_grouped, handle, ready, lease = prepared
+            with torch.cuda.stream(comm_stream):
+                comm_stream.wait_event(ready)
+                with _ep_chunk_nvtx("forward.combine", chunk_idx):
+                    combine_state = dispatcher.submit_deepep_combine_prepared(
+                        rank_grouped,
+                        handle,
+                        allocate_on_comm_stream=True,
+                        async_finish=True,
+                    )
+            return chunk_idx, dispatcher, combine_state, lease
+
+        output_2d = x_2d.new_empty(x_2d.shape)
+
+        def finish_combine(pending) -> None:
+            chunk_idx, dispatcher, state, lease = pending
+            with _ep_chunk_nvtx("forward.combine.finish", chunk_idx):
+                chunk_out = dispatcher.finish_deepep_combine(state)
+            start, end = ranges[chunk_idx]
+            output_2d[start:end].copy_(chunk_out)
+            consumed = torch.cuda.Event()
+            consumed.record(torch.cuda.current_stream(output_2d.device))
+            lease.release(consumed)
+
+        current_state = submit_dispatch(0)
+        pending_combine = None
+        for loop_idx in range(len(ranges)):
+            finished = finish_dispatch(current_state)
+            if loop_idx + 1 < len(ranges):
+                if pending_combine is not None:
+                    next_slot = (loop_idx + 1) % EP_CHUNK_COUNT
+                    pending_slot = pending_combine[0] % EP_CHUNK_COUNT
+                    if next_slot == pending_slot:
+                        finish_combine(pending_combine)
+                        pending_combine = None
+                current_state = submit_dispatch(loop_idx + 1)
+            prepared = run_expert(finished)
+            if pending_combine is not None:
+                finish_combine(pending_combine)
+            pending_combine = submit_combine(prepared)
+
+        done = torch.cuda.Event()
+        done.record(compute_stream)
+        caller_stream.wait_event(done)
+        if pending_combine is None:
+            raise RuntimeError("EP chunk combine pipeline produced no pending output")
+        finish_combine(pending_combine)
+        if any(chunk is None for chunk in saved_chunks):
+            raise RuntimeError("EP chunk saved forward context is incomplete")
+        context = _SavedForwardContext(
+            chunks=[chunk for chunk in saved_chunks if chunk is not None],
+            input_shape=input_shape,
+        )
+        return output_2d.view(input_shape).to(input_dtype).detach(), context
+
+    def _full_recompute_fused_backward(
+        self,
+        x_saved: torch.Tensor,
+        grad_2d: torch.Tensor,
+    ):
+        ranges = ep_chunk_ranges(x_saved.size(0), chunk_count=self._logical_chunk_count)
+        router_params = tuple(self.router.parameters())
+        expert_params = tuple(self.experts.parameters())
+        return self._full_recompute_fused_backward_v6(
+            x_saved,
+            grad_2d,
+            ranges,
+            router_params,
+            expert_params,
+        )
+
+    def _full_recompute_fused_backward_v6(
+        self,
+        x_2d: torch.Tensor,
+        grad_2d: torch.Tensor,
+        ranges: list[tuple[int, int]],
+        router_params: tuple[torch.Tensor, ...],
+        expert_params: tuple[torch.Tensor, ...],
+    ):
+        if not ranges:
+            return (
+                grad_2d.new_zeros(grad_2d.shape),
+                [torch.zeros_like(param) for param in router_params],
+                [torch.zeros_like(param) for param in expert_params],
+            )
+
+        compute_stream, comm_stream = self._streams(grad_2d.device)
+        wgrad_stream = _shared_wgrad_stream(grad_2d.device)
+        input_ready = torch.cuda.Event()
+        input_ready.record(torch.cuda.current_stream(grad_2d.device))
+        grad_x_chunks: list[torch.Tensor | None] = [None for _ in ranges]
+        router_accum: list[torch.Tensor | None] = [None for _ in router_params]
+        pending_dispatch_bwd: list[tuple[_BackwardChunk, dict[str, Any]]] = []
+        last_deepep_event: Any | None = None
+        last_wgrad_done: torch.cuda.Event | None = None
+
+        def chain_deepep_event() -> None:
+            if last_deepep_event is not None:
+                _event_current_stream_wait(last_deepep_event)
+
+        def remember_deepep_event(state: dict[str, Any]):
+            nonlocal last_deepep_event
+            last_deepep_event = state.get("event")
+            return state
+
+        def submit_recompute_dispatch(chunk_idx: int):
+            start, end = ranges[chunk_idx]
+            x_chunk = x_2d[start:end].detach().requires_grad_(True)
+            lease = self.workspace.acquire(
+                chunk_idx % EP_CHUNK_COUNT, stream=comm_stream
+            )
+            dispatcher = lease.dispatcher
+            with torch.cuda.stream(compute_stream):
+                compute_stream.wait_event(input_ready)
+                scores, indices = self._route(x_chunk, start, end)
+                router_ready = torch.cuda.Event()
+                router_ready.record(compute_stream)
+            with torch.cuda.stream(comm_stream):
+                comm_stream.wait_event(router_ready)
+                chain_deepep_event()
+                with _ep_chunk_nvtx("backward.dispatch", chunk_idx):
+                    with lease.deepep_recv_allocation():
+                        state = remember_deepep_event(
+                            dispatcher.submit_deepep_dispatch(
+                                x_chunk,
+                                scores,
+                                indices,
+                                allocate_on_comm_stream=True,
+                                async_finish=True,
+                            )
+                        )
+            return chunk_idx, start, end, x_chunk, scores, dispatcher, state, lease
+
+        def submit_combine_bwd(
+            chunk_idx: int,
+            start: int,
+            end: int,
+            dispatcher: TokenDispatcher,
+            handle: Any,
+        ):
+            with torch.cuda.stream(comm_stream):
+                grad_chunk = grad_2d[start:end].contiguous()
+                chain_deepep_event()
+                with _ep_chunk_nvtx("backward.combine", chunk_idx):
+                    return remember_deepep_event(
+                        dispatcher.submit_deepep_combine_backward(
+                            grad_chunk,
+                            handle,
+                            allocate_on_comm_stream=True,
+                        )
+                    )
+
+        def finish_recompute_expert(
+            chunk_idx: int,
+            dispatcher: TokenDispatcher,
+            state: dict[str, Any],
+            workspace_lease: EPChunkWorkspaceLease,
+        ):
+            with torch.cuda.stream(compute_stream):
+                state["recv_hidden"] = (
+                    state["recv_hidden"].detach().requires_grad_(True)
+                )
+                state["recv_probs"] = state["recv_probs"].detach().requires_grad_(True)
+                _record_ep_chunk_recv_tensors(
+                    action="acquire",
+                    phase="backward",
+                    workspace=self.workspace.key.op,
+                    chunk_idx=chunk_idx,
+                    recv_hidden=state["recv_hidden"],
+                    recv_probs=state["recv_probs"],
+                )
+                dispatched, local_tpe, probs, metadata = (
+                    dispatcher.finish_deepep_dispatch_external_with_options(
+                        state,
+                        force_manual_map=True,
+                        force_direct_permute=True,
+                        materialize_local_tpe=False,
+                    )
+                )
+                _validate_finished_deepep_dispatch(
+                    self.workspace.key.shape_profile, state, dispatched
+                )
+                expert_probs = (
+                    None if probs is None else probs.detach().requires_grad_(True)
+                )
+                expert_activation_lease = self.workspace.acquire_expert_activation(
+                    stream=compute_stream
+                )
+                fc1_input = expert_activation_lease.tensor(
+                    "fc1_input",
+                    dispatched.shape,
+                    dtype=dispatched.dtype,
+                    device=dispatched.device,
+                )
+                with torch.no_grad():
+                    fc1_input.copy_(dispatched)
+                expert_input = fc1_input.requires_grad_(True)
+                with _ep_chunk_nvtx("backward.expert", chunk_idx):
+                    expert_out = self.experts(
+                        expert_input,
+                        local_tpe,
+                        expert_probs,
+                        tokens_per_expert_list=metadata["local_tpe_list"],
+                        activation_allocation=expert_activation_lease.allocate,
+                        output_allocation=_expert_activation_output_allocation(
+                            expert_activation_lease, expert_input
+                        ),
+                    )
+                _record_state_tensors_current_stream(state)
+            return (
+                dispatched,
+                local_tpe,
+                probs,
+                metadata,
+                expert_input,
+                expert_probs,
+                expert_out,
+                expert_activation_lease,
+            )
+
+        def retire_pending_dispatch_bwd() -> None:
+            """Retire the previous chunk before the next large expert activation.
+
+            The next DeepEP receive may already be in flight, but a two-slot
+            workspace cannot keep a prior dispatch-backward lease and delayed
+            wgrad aliases alive through another FC1/SwiGLU activation.
+            """
+            _retire_one_fused_dispatch_bwd(
+                pending_dispatch_bwd,
+                compute_stream=compute_stream,
+                grad_2d=grad_2d,
+                router_params=router_params,
+                grad_x_chunks=grad_x_chunks,
+                router_accum=router_accum,
+            )
+
+        with torch.enable_grad():
+            next_state = submit_recompute_dispatch(len(ranges) - 1)
+            for rev_idx in range(len(ranges) - 1, -1, -1):
+                (
+                    chunk_idx,
+                    start,
+                    end,
+                    x_chunk,
+                    scores,
+                    dispatcher,
+                    state,
+                    workspace_lease,
+                ) = next_state
+                # `next_state` was prefetched by the preceding iteration. Retire
+                # the prior large context before this chunk can enter FC1/SwiGLU.
+                retire_pending_dispatch_bwd()
+                combine_state = submit_combine_bwd(
+                    chunk_idx,
+                    start,
+                    end,
+                    dispatcher,
+                    state["handle"],
+                )
+                (
+                    dispatched,
+                    local_tpe,
+                    probs,
+                    metadata,
+                    expert_input,
+                    expert_probs,
+                    expert_out,
+                    expert_activation_lease,
+                ) = finish_recompute_expert(
+                    chunk_idx, dispatcher, state, workspace_lease
+                )
+
+                row_id_map = metadata["manual_row_id_map"]
+                prob_flat_indices = metadata["manual_prob_flat_indices"]
+                if row_id_map is None or prob_flat_indices is None:
+                    raise RuntimeError(
+                        "EP chunk overlap fused backward requires manual dgrad metadata."
+                    )
+
+                scores_edge = None
+                scores_ref: torch.Tensor | None = scores
+                expert_out_edge = None
+                expert_out_ref: torch.Tensor | None = expert_out
+                if hasattr(torch.autograd.graph, "get_gradient_edge"):
+                    scores_edge = torch.autograd.graph.get_gradient_edge(scores)
+                    scores_ref = None
+                    expert_out_edge = torch.autograd.graph.get_gradient_edge(expert_out)
+
+                chunk = _BackwardChunk(
+                    idx=chunk_idx,
+                    start=start,
+                    end=end,
+                    x=x_chunk,
+                    scores=scores_ref,
+                    handle=state["handle"],
+                    row_id_map=row_id_map.detach(),
+                    prob_flat_indices=prob_flat_indices.detach(),
+                    recv_hidden_shape=state["recv_hidden"].shape,
+                    recv_hidden_dtype=state["recv_hidden"].dtype,
+                    recv_probs_shape=state["recv_probs"].shape,
+                    recv_probs_dtype=state["recv_probs"].dtype,
+                    recv_probs_base=state["recv_probs"],
+                    dispatched=expert_input,
+                    probs=expert_probs,
+                    expert_out=expert_out_ref,
+                    scores_edge=scores_edge,
+                    scores_shape=scores.shape,
+                    scores_dtype=scores.dtype,
+                    expert_out_edge=expert_out_edge,
+                    expert_out_shape=expert_out.shape,
+                    expert_out_dtype=expert_out.dtype,
+                    dispatcher=dispatcher,
+                    workspace_lease=workspace_lease,
+                )
+                state.clear()
+                del dispatched, probs, expert_out, scores, local_tpe
+                del expert_input, expert_probs, metadata
+
+                local_state: dict[str, Any] = {}
+                with torch.cuda.stream(compute_stream):
+                    grad_rank_grouped = dispatcher.finish_deepep_combine_backward(
+                        combine_state
+                    )
+                    combine_state.pop("grad_rank_grouped", None)
+                    combine_state.pop("event", None)
+                    if chunk.expert_out is None:
+                        raise RuntimeError(
+                            "EP chunk fused backward lost expert output storage."
+                        )
+                    local_state["grad_expert_out"] = _manual_unpermute_backward(
+                        chunk,
+                        grad_rank_grouped,
+                        out=chunk.expert_out.detach(),
+                    )
+                    del grad_rank_grouped
+
+                if rev_idx > 0:
+                    next_state = submit_recompute_dispatch(rev_idx - 1)
+
+                with torch.cuda.stream(compute_stream):
+                    expert_output = (
+                        chunk.expert_out_edge
+                        if chunk.expert_out_edge is not None
+                        else chunk.expert_out
+                    )
+                    expert_dispatched = chunk.dispatched
+                    expert_probs_input = chunk.probs
+                    if expert_dispatched is None or expert_output is None:
+                        raise RuntimeError(
+                            "EP chunk overlap expert graph was released."
+                        )
+                    expert_inputs = _expert_grad_inputs(
+                        expert_dispatched, expert_probs_input
+                    )
+                    # Fused mode flushes and releases owned aliases per chunk,
+                    # so each delayed TE context must rebind its selected sink.
+                    self.experts._prepare_delayed_weight_grad_sinks()
+                    with expert_activation_lease.allocate():
+                        expert_grads = torch.autograd.grad(
+                            expert_output,
+                            expert_inputs,
+                            local_state["grad_expert_out"],
+                            allow_unused=True,
+                        )
+                    grad_dispatched = expert_grads[0]
+                    if grad_dispatched is None:
+                        grad_dispatched = torch.zeros_like(expert_dispatched)
+                    if expert_probs_input is None:
+                        grad_probs = None
+                    else:
+                        grad_probs = expert_grads[1]
+                        if grad_probs is None:
+                            grad_probs = torch.zeros_like(expert_probs_input)
+                    # In fused mode FC1 dgrad aliases FC2 output, so autograd
+                    # can have overwritten grad_expert_out. FC1 input is the
+                    # delayed-Wgrad-flush local-scatter destination below.
+                    hidden_reuse_base = expert_dispatched.detach()
+                    local_state.pop("grad_expert_out")
+                    chunk.dispatched = None
+                    chunk.probs = None
+                    chunk.expert_out = None
+                    chunk.expert_out_edge = None
+                    _record_ep_chunk_recv_tensors(
+                        action="release",
+                        phase="backward",
+                        workspace=self.workspace.key.op,
+                        chunk_idx=chunk.idx,
+                    )
+                    del expert_dispatched, expert_probs_input
+                    del expert_inputs, expert_grads, expert_output
+                    dgrad_ready = torch.cuda.Event()
+                    dgrad_ready.record(compute_stream)
+
+                with torch.cuda.stream(wgrad_stream):
+                    wgrad_stream.wait_event(dgrad_ready)
+                    with _ep_chunk_nvtx("backward.wgrad"):
+                        self.experts.flush_delayed_weight_grads(
+                            num_contexts=1,
+                            stream=wgrad_stream,
+                        )
+                    wgrad_done = torch.cuda.Event()
+                    wgrad_done.record(wgrad_stream)
+                    for tensor in (
+                        grad_dispatched,
+                        grad_probs,
+                        hidden_reuse_base,
+                        chunk.recv_probs_base,
+                        chunk.row_id_map,
+                        chunk.prob_flat_indices,
+                    ):
+                        if tensor is not None and tensor.is_cuda:
+                            tensor.record_stream(wgrad_stream)
+                    grad_recv_hidden, grad_recv_probs = _dispatch_local_backward(
+                        chunk,
+                        grad_dispatched,
+                        grad_probs,
+                        hidden_reuse_base=hidden_reuse_base,
+                    )
+                    local_bwd_ready = torch.cuda.Event()
+                    local_bwd_ready.record(wgrad_stream)
+                    expert_activation_lease.release(local_bwd_ready)
+                    del grad_dispatched, grad_probs
+                last_wgrad_done = wgrad_done
+
+                with torch.cuda.stream(comm_stream):
+                    comm_stream.wait_event(local_bwd_ready)
+                    chain_deepep_event()
+                    with _ep_chunk_nvtx("backward.dispatch", chunk.idx):
+                        local_state["dispatch_bwd_state"] = remember_deepep_event(
+                            chunk.dispatcher.submit_deepep_dispatch_backward(
+                                grad_recv_hidden,
+                                grad_recv_probs,
+                                chunk.handle,
+                                allocate_on_comm_stream=True,
+                            )
+                        )
+                        if grad_recv_hidden.is_cuda:
+                            grad_recv_hidden.record_stream(comm_stream)
+                        if grad_recv_probs.is_cuda:
+                            grad_recv_probs.record_stream(comm_stream)
+                        chunk.recv_probs_base = None
+                        del grad_recv_hidden, grad_recv_probs, hidden_reuse_base
+
+                pending_dispatch_bwd.append((chunk, local_state))
+                if len(pending_dispatch_bwd) > 1:
+                    raise RuntimeError(
+                        "EP chunk fused backward pending queue exceeded one chunk"
+                    )
+
+        if last_wgrad_done is None:
+            raise RuntimeError("EP chunk fused backward did not flush expert wgrads")
+        _queue_backward_stream_wait(last_wgrad_done, grad_2d.device)
+
+        retire_pending_dispatch_bwd()
+
+        done = torch.cuda.Event()
+        done.record(compute_stream)
+        torch.cuda.current_stream(grad_2d.device).wait_event(done)
+
+        grad_x = torch.cat(
+            [
+                torch.zeros_like(x_2d[start:end]) if grad is None else grad
+                for (start, end), grad in zip(ranges, grad_x_chunks, strict=True)
+            ],
+            dim=0,
+        ).view_as(grad_2d)
+        router_grads_out = _materialize(router_params, router_accum)
+        return grad_x, router_grads_out, [None for _ in expert_params]
+
+    def _saved_context_backward(
+        self,
+        context: _SavedForwardContext,
+        grad_2d: torch.Tensor,
+    ) -> tuple[torch.Tensor, list[torch.Tensor], list[torch.Tensor | None]]:
+        """Consume saved forward graphs without rerunning router or experts."""
+        router_params = tuple(self.router.parameters())
+        expert_params = tuple(self.experts.parameters())
+        compute_stream, comm_stream = self._streams(grad_2d.device)
+        caller_stream = torch.cuda.current_stream(grad_2d.device)
+        grad_ready = torch.cuda.Event()
+        grad_ready.record(caller_stream)
+        wgrad_stream = _shared_wgrad_stream(grad_2d.device)
+        grad_x_chunks: list[torch.Tensor | None] = [None for _ in context.chunks]
+        router_accum: list[torch.Tensor | None] = [None for _ in router_params]
+        pending_dispatch_bwd: list[tuple[_BackwardChunk, dict[str, Any]]] = []
+        last_deepep_event: Any | None = grad_ready
+        if context.chunks:
+            self.experts._prepare_delayed_weight_grad_sinks()
+        expert_activation_lease = self.workspace.acquire_expert_activation(
+            stream=compute_stream
+        )
+
+        def remember_deepep_event(state: dict[str, Any]):
+            nonlocal last_deepep_event
+            last_deepep_event = state.get("event")
+            return state
+
+        for saved in reversed(context.chunks):
+            lease = self.workspace.acquire(
+                saved.idx % EP_CHUNK_COUNT,
+                stream=comm_stream,
+                require_dispatcher=False,
+            )
+            chunk = _BackwardChunk(
+                idx=saved.idx,
+                start=saved.start,
+                end=saved.end,
+                x=saved.x,
+                scores=saved.scores,
+                handle=saved.handle,
+                row_id_map=saved.row_id_map,
+                prob_flat_indices=saved.prob_flat_indices,
+                recv_hidden_shape=saved.recv_hidden_shape,
+                recv_hidden_dtype=saved.recv_hidden_dtype,
+                recv_probs_shape=saved.recv_probs_shape,
+                recv_probs_dtype=saved.recv_probs_dtype,
+                recv_probs_base=saved.recv_probs_base,
+                dispatched=saved.dispatched,
+                probs=saved.probs,
+                expert_out=saved.expert_out,
+                scores_edge=saved.scores_edge,
+                scores_shape=saved.scores_shape,
+                scores_dtype=saved.scores_dtype,
+                expert_out_edge=saved.expert_out_edge,
+                expert_out_shape=saved.expert_out_shape,
+                expert_out_dtype=saved.expert_out_dtype,
+                dispatcher=saved.dispatcher,
+                workspace_lease=lease,
+            )
+            with torch.cuda.stream(comm_stream):
+                if last_deepep_event is not None:
+                    _event_current_stream_wait(last_deepep_event)
+                with _ep_chunk_nvtx("backward.combine", chunk.idx):
+                    combine_state = remember_deepep_event(
+                        chunk.dispatcher.submit_deepep_combine_backward(
+                            grad_2d[chunk.start : chunk.end].contiguous(),
+                            chunk.handle,
+                            allocate_on_comm_stream=True,
+                        )
+                    )
+
+            local_state: dict[str, Any] = {}
+            with torch.cuda.stream(compute_stream):
+                compute_stream.wait_event(saved.recv_consumed_event)
+                grad_rank_grouped = chunk.dispatcher.finish_deepep_combine_backward(
+                    combine_state
+                )
+                local_state["grad_expert_out"] = _manual_unpermute_backward(
+                    chunk, grad_rank_grouped
+                )
+                expert_output = (
+                    chunk.expert_out_edge
+                    if chunk.expert_out_edge is not None
+                    else chunk.expert_out
+                )
+                if expert_output is None:
+                    raise RuntimeError("EP chunk saved expert graph was released")
+                dispatched = chunk.dispatched
+                probs = chunk.probs
+                if dispatched is None:
+                    raise RuntimeError("EP chunk saved expert input was released")
+                expert_inputs = _expert_grad_inputs(dispatched, probs)
+                with expert_activation_lease.allocate():
+                    expert_grads = torch.autograd.grad(
+                        expert_output,
+                        expert_inputs,
+                        local_state["grad_expert_out"],
+                        allow_unused=True,
+                    )
+                grad_dispatched = expert_grads[0]
+                if grad_dispatched is None:
+                    grad_dispatched = torch.zeros_like(dispatched)
+                grad_probs = None
+                if probs is not None:
+                    grad_probs = expert_grads[1]
+                    if grad_probs is None:
+                        grad_probs = torch.zeros_like(probs)
+                # FC1 dgrad aliases FC2 dgrad. Keep FC1 input as the delayed-
+                # Wgrad-flush local-scatter destination instead.
+                local_state["hidden_reuse_base"] = dispatched.detach()
+                local_state.pop("grad_expert_out")
+                local_state["grad_dispatched"] = grad_dispatched
+                local_state["grad_probs"] = grad_probs
+                saved.probs = None
+                saved.expert_out = None
+                saved.expert_out_edge = None
+                saved.dispatched = None
+                chunk.dispatched = None
+                chunk.probs = None
+                chunk.expert_out = None
+                chunk.expert_out_edge = None
+                del dispatched, probs, expert_inputs, expert_grads, expert_output
+            pending_dispatch_bwd.append((chunk, local_state))
+
+        wgrad_ready = torch.cuda.Event()
+        wgrad_ready.record(compute_stream)
+        with torch.cuda.stream(wgrad_stream):
+            wgrad_stream.wait_event(wgrad_ready)
+            with _ep_chunk_nvtx("backward.wgrad"):
+                self.experts.flush_delayed_weight_grads(
+                    num_contexts=len(pending_dispatch_bwd)
+                )
+            wgrad_done = torch.cuda.Event()
+            wgrad_done.record(wgrad_stream)
+        _queue_backward_stream_wait(wgrad_done, grad_2d.device)
+
+        # Delayed grouped-linear Wgrad retains FC1 input. Do not repurpose its
+        # distinct local-scatter destination until that queue drains.
+        for chunk, local_state in pending_dispatch_bwd:
+            with torch.cuda.stream(compute_stream):
+                compute_stream.wait_event(wgrad_done)
+                hidden_reuse_base = local_state.pop("hidden_reuse_base")
+                grad_recv_hidden, grad_recv_probs = _dispatch_local_backward(
+                    chunk,
+                    local_state.pop("grad_dispatched"),
+                    local_state.pop("grad_probs"),
+                    hidden_reuse_base=hidden_reuse_base,
+                )
+                local_ready = torch.cuda.Event()
+                local_ready.record(compute_stream)
+
+            with torch.cuda.stream(comm_stream):
+                comm_stream.wait_event(local_ready)
+                if last_deepep_event is not None:
+                    _event_current_stream_wait(last_deepep_event)
+                with _ep_chunk_nvtx("backward.dispatch", chunk.idx):
+                    local_state["dispatch_bwd_state"] = remember_deepep_event(
+                        chunk.dispatcher.submit_deepep_dispatch_backward(
+                            grad_recv_hidden,
+                            grad_recv_probs,
+                            chunk.handle,
+                            allocate_on_comm_stream=True,
+                        )
+                    )
+                    if grad_recv_hidden.is_cuda:
+                        grad_recv_hidden.record_stream(comm_stream)
+                    if grad_recv_probs.is_cuda:
+                        grad_recv_probs.record_stream(comm_stream)
+                    chunk.recv_probs_base = None
+                    del grad_recv_hidden, grad_recv_probs, hidden_reuse_base
+
+        with torch.cuda.stream(compute_stream):
+            backward_activation_done = torch.cuda.Event()
+            backward_activation_done.record(compute_stream)
+        expert_activation_lease.release(backward_activation_done)
+
+        for chunk, local_state in pending_dispatch_bwd:
+            with torch.cuda.stream(compute_stream):
+                grad_hidden, grad_scores = (
+                    chunk.dispatcher.finish_deepep_dispatch_backward(
+                        local_state["dispatch_bwd_state"]
+                    )
+                )
+                if grad_scores is None:
+                    if chunk.scores_shape is None or chunk.scores_dtype is None:
+                        raise RuntimeError("Missing saved router score metadata")
+                    grad_scores = torch.zeros(
+                        chunk.scores_shape,
+                        device=grad_2d.device,
+                        dtype=chunk.scores_dtype,
+                    )
+                router_output = (
+                    chunk.scores_edge if chunk.scores_edge is not None else chunk.scores
+                )
+                if router_output is None:
+                    raise RuntimeError("EP chunk saved router graph was released")
+                router_grads = torch.autograd.grad(
+                    router_output,
+                    (chunk.x, *router_params),
+                    grad_scores.to(chunk.scores_dtype),
+                    allow_unused=True,
+                )
+                grad_score_x = router_grads[0]
+                if grad_score_x is None:
+                    grad_score_x = torch.zeros_like(chunk.x)
+                grad_x_chunks[chunk.idx] = grad_hidden.to(chunk.x.dtype) + grad_score_x
+                _accumulate(router_accum, router_params, router_grads[1:])
+                consumed = torch.cuda.Event()
+                consumed.record(compute_stream)
+                chunk.workspace_lease.release(consumed)
+
+        done = torch.cuda.Event()
+        done.record(compute_stream)
+        torch.cuda.current_stream(grad_2d.device).wait_event(done)
+        grad_x = torch.cat(
+            [
+                torch.zeros_like(chunk.x) if grad is None else grad
+                for chunk, grad in zip(context.chunks, grad_x_chunks, strict=True)
+            ],
+            dim=0,
+        ).view(context.input_shape)
+        return (
+            grad_x,
+            _materialize(router_params, router_accum),
+            [None for _ in expert_params],
+        )
+
+
+class _SavedContextEPChunkFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        x_2d: torch.Tensor,
+        routing_input: torch.Tensor | None,
+        forward_op: "EPChunkForwardOp",
+        input_shape: torch.Size,
+        input_dtype: torch.dtype,
+        *params: torch.Tensor,
+    ) -> torch.Tensor:
+        del params, input_dtype
+        ctx.backward_op = forward_op.backward_op
+        ctx.num_router_params = len(tuple(forward_op.router.parameters()))
+        with torch.enable_grad(), forward_op._routing_context(routing_input):
+            x_graph = x_2d.detach().requires_grad_(True)
+            output, saved_context = forward_op._forward_saved_context_async(
+                x_graph,
+                ep_chunk_ranges(
+                    x_graph.size(0),
+                    chunk_count=forward_op._logical_chunk_count,
+                ),
+                input_shape,
+                x_graph.dtype,
+            )
+        ctx.saved_forward_context = saved_context
+        return output.detach()
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        with torch.enable_grad():
+            grad_x, router_grads, expert_grads = ctx.backward_op.backward(
+                ctx.saved_forward_context, grad_output
+            )
+        return grad_x, None, None, None, None, *router_grads, *expert_grads
+
+
+class EPChunkForwardOp(_EPChunkOperationBase):
+    """Two-chunk forward with saved-context autograd when gradients are enabled."""
+
+    def __init__(self, *, backward_op: "EPChunkBackwardOp | None" = None, **kwargs):
+        super().__init__(**kwargs)
+        if backward_op is not None and (
+            backward_op.router is not self.router
+            or backward_op.experts is not self.experts
+        ):
+            raise RuntimeError(
+                "Saved-context EP forward/backward must share router and experts"
+            )
+        self.backward_op = backward_op
+
+    def forward(
+        self, x: torch.Tensor, routing_input: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        input_shape = x.shape
+        x_2d = x.view(-1, x.size(-1)) if x.dim() == 3 else x
+        if torch.is_grad_enabled():
+            if self.backward_op is None:
+                raise RuntimeError(
+                    "Grad-enabled EPChunkForwardOp requires a paired backward op"
+                )
+            params = tuple(self.router.parameters()) + tuple(self.experts.parameters())
+            return _SavedContextEPChunkFunction.apply(
+                x_2d,
+                routing_input,
+                self,
+                input_shape,
+                x.dtype,
+                *params,
+            )
+        ranges = ep_chunk_ranges(x_2d.size(0), chunk_count=self._logical_chunk_count)
+        with self._routing_context(routing_input):
+            return self._forward_output_async(
+                x_2d,
+                ranges,
+                input_shape,
+                x.dtype,
+            )
+
+    __call__ = forward
+
+
+class EPChunkBackwardOp(_EPChunkOperationBase):
+    """Consume a saved forward context without rerunning forward compute."""
+
+    def backward(
+        self,
+        context: _SavedForwardContext,
+        grad_output: torch.Tensor,
+    ) -> tuple[torch.Tensor, list[torch.Tensor], list[torch.Tensor | None]]:
+        grad_2d = grad_output.contiguous().view(-1, grad_output.size(-1))
+        return self._saved_context_backward(context, grad_2d)
+
+
+class EPChunkFusedForwardBackwardOp(_EPChunkOperationBase):
+    """Explicit recompute-forward plus backward owned by the fused workspace."""
+
+    def forward_backward(
+        self,
+        x_saved: torch.Tensor,
+        grad_output: torch.Tensor,
+        routing_input: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, list[torch.Tensor], list[torch.Tensor | None]]:
+        x_2d = x_saved.view(-1, x_saved.size(-1))
+        grad_2d = grad_output.contiguous().view(-1, grad_output.size(-1))
+        with self._routing_context(routing_input), torch.enable_grad():
+            grad_x, router_grads, expert_grads = self._full_recompute_fused_backward(
+                x_2d, grad_2d
+            )
+        grad_x = grad_x.view_as(x_saved)
+        return grad_x, router_grads, expert_grads
+
+
+def _manual_unpermute_backward(
+    chunk: _BackwardChunk,
+    grad_rank_grouped: torch.Tensor,
+    *,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    if chunk.expert_out_shape is None or chunk.expert_out_dtype is None:
+        raise RuntimeError("Missing expert output metadata.")
+    row_id_map = chunk.row_id_map.reshape(-1).to(torch.long)
+    expected_shape = (row_id_map.numel(), grad_rank_grouped.size(1))
+    if (
+        tuple(chunk.expert_out_shape) != expected_shape
+        or grad_rank_grouped.dtype != chunk.expert_out_dtype
+    ):
+        raise RuntimeError(
+            "EP chunk manual unpermute output metadata does not match the "
+            "rank-grouped gradient"
+        )
+    if out is None:
+        grad_expert_out = chunk.workspace_lease.tensor(
+            "grad_expert_out",
+            chunk.expert_out_shape,
+            dtype=chunk.expert_out_dtype,
+            device=grad_rank_grouped.device,
+        )
+    else:
+        if (
+            out.shape != chunk.expert_out_shape
+            or out.dtype != chunk.expert_out_dtype
+            or out.device != grad_rank_grouped.device
+            or not out.is_contiguous()
+        ):
+            raise RuntimeError(
+                "EP chunk manual unpermute output storage must be contiguous "
+                "with matching shape, dtype, and device"
+            )
+        grad_expert_out = out
+    with torch.no_grad():
+        torch.index_select(
+            grad_rank_grouped.detach(),
+            0,
+            row_id_map,
+            out=grad_expert_out,
+        )
+    return grad_expert_out
+
+
+def _dispatch_local_backward(
+    chunk: _BackwardChunk,
+    grad_dispatched: torch.Tensor,
+    grad_probs: torch.Tensor | None,
+    *,
+    hidden_reuse_base: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if not grad_dispatched.is_contiguous():
+        raise RuntimeError("EP chunk local backward gradient source must be contiguous")
+    row_id_map = chunk.row_id_map.reshape(-1).to(torch.long)
+    if chunk.recv_probs_base is None:
+        raise RuntimeError(
+            "EP chunk backward requires retained recv probability storage"
+        )
+    required_hidden_numel = math.prod(chunk.recv_hidden_shape)
+    if (
+        hidden_reuse_base.dtype != chunk.recv_hidden_dtype
+        or hidden_reuse_base.device != grad_dispatched.device
+        or not hidden_reuse_base.is_contiguous()
+        or hidden_reuse_base.numel() < required_hidden_numel
+    ):
+        raise RuntimeError(
+            "EP chunk hidden reuse storage must be contiguous with matching "
+            "dtype/device and sufficient capacity"
+        )
+    grad_recv_hidden = (
+        hidden_reuse_base.detach()
+        .view(-1)[:required_hidden_numel]
+        .view(chunk.recv_hidden_shape)
+    )
+    if _tensor_byte_ranges_overlap(grad_dispatched, grad_recv_hidden):
+        raise RuntimeError(
+            "EP chunk local backward source and destination storage overlap"
+        )
+    grad_recv_probs = chunk.recv_probs_base.detach()
+    if (
+        grad_recv_probs.shape != chunk.recv_probs_shape
+        or grad_recv_probs.dtype != chunk.recv_probs_dtype
+        or grad_recv_probs.device != grad_dispatched.device
+    ):
+        raise RuntimeError(
+            "EP chunk retained recv probability storage does not match saved metadata"
+        )
+    grad_recv_hidden.zero_()
+    grad_recv_hidden.scatter_add_(
+        0,
+        row_id_map.unsqueeze(1).expand(-1, grad_dispatched.size(1)),
+        grad_dispatched.to(grad_recv_hidden.dtype),
+    )
+    grad_recv_probs.zero_()
+    if grad_probs is not None:
+        flat = chunk.prob_flat_indices.reshape(-1).to(grad_probs.device, torch.long)
+        grad_recv_probs.reshape(-1).index_copy_(
+            0, flat, grad_probs.reshape(-1).to(grad_recv_probs.dtype)
+        )
+    return grad_recv_hidden, grad_recv_probs
+
+
+def _tensor_byte_ranges_overlap(left: torch.Tensor, right: torch.Tensor) -> bool:
+    """Whether two contiguous tensor views overlap in addressable bytes."""
+    if left.numel() == 0 or right.numel() == 0:
+        return False
+    left_start = left.data_ptr()
+    left_end = left_start + left.numel() * left.element_size()
+    right_start = right.data_ptr()
+    right_end = right_start + right.numel() * right.element_size()
+    return left_start < right_end and right_start < left_end
+
+
+def _expert_grad_inputs(
+    dispatched: torch.Tensor, probs: torch.Tensor | None
+) -> tuple[torch.Tensor, ...]:
+    return (dispatched,) if probs is None else (dispatched, probs)
+
+
+def _accumulate(
+    accum: list[torch.Tensor | None],
+    params: tuple[torch.Tensor, ...],
+    grads: tuple[torch.Tensor | None, ...],
+) -> None:
+    for idx, (param, grad) in enumerate(zip(params, grads, strict=True)):
+        if grad is None:
+            continue
+        grad = grad.to(param.dtype)
+        if accum[idx] is None:
+            accum[idx] = grad
+        else:
+            accum[idx].add_(grad)
+
+
+def _retire_one_fused_dispatch_bwd(
+    pending: list[tuple[_BackwardChunk, dict[str, Any]]],
+    *,
+    compute_stream: torch.cuda.Stream,
+    grad_2d: torch.Tensor,
+    router_params: tuple[torch.Tensor, ...],
+    grad_x_chunks: list[torch.Tensor | None],
+    router_accum: list[torch.Tensor | None],
+) -> None:
+    """Finish one dispatched backward chunk and release its slot lease."""
+    if len(pending) > 1:
+        raise RuntimeError(
+            "EP chunk fused backward retained more than one pending chunk"
+        )
+    if not pending:
+        return
+    chunk, local_state = pending.pop()
+    with torch.cuda.stream(compute_stream):
+        grad_hidden, grad_scores = chunk.dispatcher.finish_deepep_dispatch_backward(
+            local_state["dispatch_bwd_state"]
+        )
+        if grad_scores is None:
+            if chunk.scores_shape is None or chunk.scores_dtype is None:
+                raise RuntimeError("Missing router score metadata.")
+            grad_scores = torch.zeros(
+                chunk.scores_shape,
+                device=grad_2d.device,
+                dtype=chunk.scores_dtype,
+            )
+        router_output = (
+            chunk.scores_edge if chunk.scores_edge is not None else chunk.scores
+        )
+        if router_output is None:
+            raise RuntimeError("EP chunk overlap router graph was released.")
+        router_grads = torch.autograd.grad(
+            router_output,
+            (chunk.x, *router_params),
+            grad_scores.to(chunk.scores_dtype),
+            allow_unused=True,
+        )
+        grad_score_x = router_grads[0]
+        if grad_score_x is None:
+            grad_score_x = torch.zeros_like(chunk.x)
+        grad_x_chunks[chunk.idx] = grad_hidden.to(chunk.x.dtype) + grad_score_x
+        _accumulate(router_accum, router_params, router_grads[1:])
+        chunk.scores = None
+        chunk.scores_edge = None
+        consumed = torch.cuda.Event()
+        consumed.record(compute_stream)
+        chunk.workspace_lease.release(consumed)
+        local_state.clear()
+
+
+def _materialize(
+    params: tuple[torch.Tensor, ...], accum: list[torch.Tensor | None]
+) -> list[torch.Tensor]:
+    return [
+        torch.zeros_like(param) if grad is None else grad
+        for param, grad in zip(params, accum, strict=True)
+    ]
+
+
+__all__ = [
+    "EP_CHUNK_COUNT",
+    "EPChunkBackwardOp",
+    "EPChunkForwardOp",
+    "EPChunkFusedForwardBackwardOp",
+    "EPChunkShapeProfile",
+    "EPChunkWorkspace",
+    "EPChunkWorkspaceKey",
+    "EPChunkWorkspaceRegistry",
+    "get_ep_chunk_workspace",
+    "release_ep_chunk_workspace",
+]

--- a/experimental/lite/megatron/lite/primitive/modules/moe_ep_chunk_overlap.py
+++ b/experimental/lite/megatron/lite/primitive/modules/moe_ep_chunk_overlap.py
@@ -15,7 +15,7 @@ import torch.nn as nn
 from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
 from megatron.lite.primitive.modules.experts import Experts
 from megatron.lite.primitive.modules.moe_ep_chunk_overlap_policy import (
-    ep_chunk_ranges,
+    runtime_ep_chunk_ranges,
 )
 from megatron.lite.primitive.utils.moe import unpermute
 
@@ -2053,7 +2053,9 @@ class _EPChunkOperationBase:
         x_saved: torch.Tensor,
         grad_2d: torch.Tensor,
     ):
-        ranges = ep_chunk_ranges(x_saved.size(0), chunk_count=self._logical_chunk_count)
+        ranges = runtime_ep_chunk_ranges(
+            x_saved.size(0), chunk_count=self._logical_chunk_count
+        )
         router_params = tuple(self.router.parameters())
         expert_params = tuple(self.experts.parameters())
         return self._full_recompute_fused_backward_v6(
@@ -2709,7 +2711,7 @@ class _SavedContextEPChunkFunction(torch.autograd.Function):
             x_graph = x_2d.detach().requires_grad_(True)
             output, saved_context = forward_op._forward_saved_context_async(
                 x_graph,
-                ep_chunk_ranges(
+                runtime_ep_chunk_ranges(
                     x_graph.size(0),
                     chunk_count=forward_op._logical_chunk_count,
                 ),
@@ -2761,7 +2763,9 @@ class EPChunkForwardOp(_EPChunkOperationBase):
                 x.dtype,
                 *params,
             )
-        ranges = ep_chunk_ranges(x_2d.size(0), chunk_count=self._logical_chunk_count)
+        ranges = runtime_ep_chunk_ranges(
+            x_2d.size(0), chunk_count=self._logical_chunk_count
+        )
         with self._routing_context(routing_input):
             return self._forward_output_async(
                 x_2d,

--- a/experimental/lite/megatron/lite/primitive/modules/moe_ep_chunk_overlap.py
+++ b/experimental/lite/megatron/lite/primitive/modules/moe_ep_chunk_overlap.py
@@ -1148,6 +1148,10 @@ class EPChunkWorkspace:
             ),
             "deepep_buffer_count": len(buffers),
             "deepep_buffer_resident_bytes": sum(buffers.values()),
+            # TODO: expose outer CUDA graph pool identity through its owner.
+            # These legacy fields describe only private pools owned here (none).
+            # They do not measure the default allocator or externally owned
+            # graph pools, and must not be used as total allocator evidence.
             "allocation_pool_count": 0,
             "allocation_pool_ids": {},
             "expert_activation_pool_count": 0,

--- a/experimental/lite/megatron/lite/primitive/modules/moe_ep_chunk_overlap_policy.py
+++ b/experimental/lite/megatron/lite/primitive/modules/moe_ep_chunk_overlap_policy.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Policy helpers for token-wise expert-parallel chunk overlap."""
+
+from __future__ import annotations
+
+
+def validate_ep_chunk_overlap_config(
+    enabled: bool,
+    *,
+    use_deepep: bool,
+    ep_size: int,
+    topk: int,
+    max_token_rows_per_rank: int | None = None,
+) -> bool:
+    if not isinstance(enabled, bool):
+        raise TypeError("enable_ep_chunk_overlap must be a bool")
+    if enabled and (not use_deepep or ep_size <= 1):
+        raise ValueError("ChunkedEP requires DeepEP and EP > 1")
+    if enabled and topk > ep_size:
+        raise ValueError("ChunkedEP router top-k must not exceed EP size")
+    if enabled and (
+        not isinstance(max_token_rows_per_rank, int)
+        or isinstance(max_token_rows_per_rank, bool)
+        or max_token_rows_per_rank < 2
+    ):
+        raise ValueError("ChunkedEP requires ep_chunk_max_token_rows_per_rank >= 2")
+    return enabled
+
+
+def ep_chunk_ranges(
+    num_tokens: int,
+    *,
+    chunk_count: int = 2,
+) -> list[tuple[int, int]]:
+    """Split tokens into a fixed number of contiguous non-empty chunks."""
+    if isinstance(num_tokens, bool) or not isinstance(num_tokens, int):
+        raise TypeError("EP chunk token count must be an int")
+    if isinstance(chunk_count, bool) or not isinstance(chunk_count, int):
+        raise TypeError("EP chunk count must be an int")
+    if chunk_count < 2:
+        raise ValueError("EP chunk overlap requires at least two chunks")
+    if num_tokens < chunk_count:
+        if chunk_count == 2:
+            raise ValueError("EP chunk overlap requires at least two tokens")
+        raise ValueError(
+            f"EP chunk overlap requires at least {chunk_count} tokens"
+        )
+    base, remainder = divmod(num_tokens, chunk_count)
+    ranges = []
+    start = 0
+    for index in range(chunk_count):
+        end = start + base + int(index < remainder)
+        ranges.append((start, end))
+        start = end
+    return ranges
+
+
+__all__ = [
+    "ep_chunk_ranges",
+    "validate_ep_chunk_overlap_config",
+]

--- a/experimental/lite/megatron/lite/primitive/modules/moe_ep_chunk_overlap_policy.py
+++ b/experimental/lite/megatron/lite/primitive/modules/moe_ep_chunk_overlap_policy.py
@@ -46,9 +46,7 @@ def ep_chunk_ranges(
     if num_tokens < chunk_count:
         if chunk_count == 2:
             raise ValueError("EP chunk overlap requires at least two tokens")
-        raise ValueError(
-            f"EP chunk overlap requires at least {chunk_count} tokens"
-        )
+        raise ValueError(f"EP chunk overlap requires at least {chunk_count} tokens")
     base, remainder = divmod(num_tokens, chunk_count)
     ranges = []
     start = 0
@@ -59,7 +57,24 @@ def ep_chunk_ranges(
     return ranges
 
 
+def runtime_ep_chunk_ranges(
+    num_tokens: int, *, chunk_count: int
+) -> list[tuple[int, int]]:
+    """Reduce active chunks without changing EP collective participation.
+
+    Empty ranges are communication slots, not dummy tokens. A rank with no
+    local rows can still receive remote expert work and must dispatch/combine
+    in the same order as ranks with a full microbatch.
+    """
+    if 0 <= num_tokens < chunk_count:
+        return [
+            (min(i, num_tokens), min(i + 1, num_tokens)) for i in range(chunk_count)
+        ]
+    return ep_chunk_ranges(num_tokens, chunk_count=chunk_count)
+
+
 __all__ = [
     "ep_chunk_ranges",
+    "runtime_ep_chunk_ranges",
     "validate_ep_chunk_overlap_config",
 ]

--- a/experimental/lite/megatron/lite/primitive/modules/moe_ep_chunk_overlap_policy.py
+++ b/experimental/lite/megatron/lite/primitive/modules/moe_ep_chunk_overlap_policy.py
@@ -12,6 +12,7 @@ def validate_ep_chunk_overlap_config(
     ep_size: int,
     topk: int,
     max_token_rows_per_rank: int | None = None,
+    chunk_count: int = 2,
 ) -> bool:
     if not isinstance(enabled, bool):
         raise TypeError("enable_ep_chunk_overlap must be a bool")
@@ -25,6 +26,8 @@ def validate_ep_chunk_overlap_config(
         or max_token_rows_per_rank < 2
     ):
         raise ValueError("ChunkedEP requires ep_chunk_max_token_rows_per_rank >= 2")
+    if enabled:
+        ep_chunk_ranges(max_token_rows_per_rank, chunk_count=chunk_count)
     return enabled
 
 

--- a/experimental/lite/megatron/lite/primitive/ops/_chunked_linear_cross_entropy_cuda.py
+++ b/experimental/lite/megatron/lite/primitive/ops/_chunked_linear_cross_entropy_cuda.py
@@ -1,0 +1,197 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""CUDA TP1 row-reduction kernels for chunked LM-head cross entropy.
+
+The kernels deliberately keep probability math local to a vocab tile.  Their
+only FP32 workspace is ``[tokens, ceil(vocab / block)]`` partial reductions,
+never a vocab-shaped FP32 tensor.  This is private to the chunked-head
+primitive: TP and CPU callers retain the established PyTorch implementation.
+"""
+
+from __future__ import annotations
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+except ImportError:  # pragma: no cover - exercised by the PyTorch fallback.
+    triton = None
+    tl = None
+
+
+ROW_BLOCK = 4096
+
+
+def is_available() -> bool:
+    return triton is not None
+
+
+def workspace_shape(
+    rows: int, vocab: int, block: int = ROW_BLOCK
+) -> tuple[tuple[int, int], tuple[int]]:
+    """Return the bounded FP32 partial and row workspaces for a CE window."""
+    if rows < 0 or vocab <= 0 or block <= 0:
+        raise ValueError("rows must be non-negative and vocab/block must be positive")
+    return (rows, (vocab + block - 1) // block), (rows,)
+
+
+if triton is not None:
+
+    @triton.jit
+    def _partial_max_kernel(
+        logits, partial, vocab: tl.constexpr, tiles: tl.constexpr, BLOCK: tl.constexpr
+    ):
+        program = tl.program_id(0)
+        row = (program // tiles).to(tl.int64)
+        tile = program % tiles
+        columns = tile * BLOCK + tl.arange(0, BLOCK)
+        values = tl.load(
+            logits + row * vocab + columns, mask=columns < vocab, other=-float("inf")
+        )
+        tl.store(partial + row * tiles + tile, tl.max(values.to(tl.float32), axis=0))
+
+    @triton.jit
+    def _final_max_kernel(
+        partial, row_max, tiles: tl.constexpr, REDUCE_BLOCK: tl.constexpr
+    ):
+        row = tl.program_id(0).to(tl.int64)
+        offsets = tl.arange(0, REDUCE_BLOCK)
+        values = tl.load(
+            partial + row * tiles + offsets, mask=offsets < tiles, other=-float("inf")
+        )
+        tl.store(row_max + row, tl.max(values, axis=0))
+
+    @triton.jit
+    def _partial_sum_kernel(
+        logits,
+        row_max,
+        partial,
+        vocab: tl.constexpr,
+        tiles: tl.constexpr,
+        BLOCK: tl.constexpr,
+    ):
+        program = tl.program_id(0)
+        row = (program // tiles).to(tl.int64)
+        tile = program % tiles
+        columns = tile * BLOCK + tl.arange(0, BLOCK)
+        values = tl.load(
+            logits + row * vocab + columns, mask=columns < vocab, other=-float("inf")
+        ).to(tl.float32)
+        values -= tl.load(row_max + row)
+        exp_values = tl.exp(values)
+        tl.store(partial + row * tiles + tile, tl.sum(exp_values, axis=0))
+
+    @triton.jit
+    def _final_sum_kernel(
+        partial, row_sum, tiles: tl.constexpr, REDUCE_BLOCK: tl.constexpr
+    ):
+        row = tl.program_id(0).to(tl.int64)
+        offsets = tl.arange(0, REDUCE_BLOCK)
+        values = tl.load(
+            partial + row * tiles + offsets, mask=offsets < tiles, other=0.0
+        )
+        tl.store(row_sum + row, tl.sum(values, axis=0))
+
+    @triton.jit
+    def _final_loss_kernel(logits, target, row_max, row_sum, loss, vocab: tl.constexpr):
+        row = tl.program_id(0).to(tl.int64)
+        target_column = tl.load(target + row)
+        target_logit = tl.load(logits + row * vocab + target_column).to(tl.float32)
+        tl.store(
+            loss + row,
+            tl.log(tl.load(row_sum + row)) + tl.load(row_max + row) - target_logit,
+        )
+
+    @triton.jit
+    def _inplace_gradient_kernel(
+        logits,
+        target,
+        grad_output,
+        row_max,
+        row_sum,
+        temperature,
+        vocab: tl.constexpr,
+        tiles: tl.constexpr,
+        BLOCK: tl.constexpr,
+    ):
+        program = tl.program_id(0)
+        row = (program // tiles).to(tl.int64)
+        tile = program % tiles
+        columns = tile * BLOCK + tl.arange(0, BLOCK)
+        values = tl.load(
+            logits + row * vocab + columns, mask=columns < vocab, other=-float("inf")
+        ).to(tl.float32)
+        probabilities = tl.exp(values - tl.load(row_max + row)) / tl.load(row_sum + row)
+        target_column = tl.load(target + row)
+        gradient = probabilities - (columns == target_column).to(tl.float32)
+        gradient *= tl.load(grad_output + row).to(tl.float32) / temperature
+        tl.store(logits + row * vocab + columns, gradient, mask=columns < vocab)
+
+
+def _workspaces(logits: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, int, int]:
+    rows, vocab = logits.shape
+    partial_shape, row_shape = workspace_shape(rows, vocab)
+    partial = torch.empty(partial_shape, dtype=torch.float32, device=logits.device)
+    row_values = torch.empty(row_shape, dtype=torch.float32, device=logits.device)
+    return partial, row_values, vocab, partial_shape[1]
+
+
+def _row_statistics(
+    logits: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]:
+    """Return bounded workspaces containing row max and exp sums."""
+    if triton is None:
+        raise RuntimeError("Triton is unavailable")
+    partial, row_max, vocab, tiles = _workspaces(logits)
+    rows = logits.shape[0]
+    reduce_block = triton.next_power_of_2(tiles)
+    _partial_max_kernel[(rows * tiles,)](
+        logits, partial, vocab=vocab, tiles=tiles, BLOCK=ROW_BLOCK
+    )
+    _final_max_kernel[(rows,)](partial, row_max, tiles=tiles, REDUCE_BLOCK=reduce_block)
+    _partial_sum_kernel[(rows * tiles,)](
+        logits, row_max, partial, vocab=vocab, tiles=tiles, BLOCK=ROW_BLOCK
+    )
+    row_sum = torch.empty_like(row_max)
+    _final_sum_kernel[(rows,)](partial, row_sum, tiles=tiles, REDUCE_BLOCK=reduce_block)
+    return partial, row_max, row_sum, tiles
+
+
+def token_loss(logits: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    """Compute TP1 token loss without a vocab-shaped FP32 materialization."""
+    _partial_sum, row_max, row_sum, _tiles = _row_statistics(logits)
+    loss = torch.empty(target.numel(), dtype=torch.float32, device=logits.device)
+    _final_loss_kernel[(target.numel(),)](
+        logits,
+        target.reshape(-1),
+        row_max,
+        row_sum,
+        loss,
+        vocab=logits.shape[1],
+    )
+    return loss
+
+
+def inplace_gradient(
+    logits: torch.Tensor,
+    target: torch.Tensor,
+    grad_output: torch.Tensor,
+    temperature: float,
+) -> torch.Tensor:
+    """Overwrite BF16 logits with BF16 dlogits, keeping FP32 math tile-local."""
+    _partial_sum, row_max, row_sum, tiles = _row_statistics(logits)
+    _inplace_gradient_kernel[(logits.shape[0] * tiles,)](
+        logits,
+        target.reshape(-1),
+        grad_output.reshape(-1),
+        row_max,
+        row_sum,
+        temperature,
+        vocab=logits.shape[1],
+        tiles=tiles,
+        BLOCK=ROW_BLOCK,
+    )
+    return logits
+
+
+__all__ = ["is_available", "inplace_gradient", "token_loss", "workspace_shape"]

--- a/experimental/lite/megatron/lite/primitive/ops/chunked_linear_cross_entropy.py
+++ b/experimental/lite/megatron/lite/primitive/ops/chunked_linear_cross_entropy.py
@@ -1,0 +1,242 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Chunked vocab-parallel LM-head projection plus cross entropy.
+
+This is deliberately a non-fused primitive: it preserves the default Qwen3
+BF16 LM-head/CE numerics while bounding vocab-shaped temporaries to one token
+window.  The caller decides whether its model composition may use it.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.distributed as dist
+
+from megatron.lite.primitive.ops import _chunked_linear_cross_entropy_cuda as _cuda_lce
+from megatron.lite.primitive.ops.cross_entropy import (
+    _DEFAULT_CHUNK_SIZE,
+    _chunk_loss_and_softmax,
+    _tp_info,
+    _vocab_range,
+)
+
+
+def _cuda_tp1_fast_path_eligible(
+    *, is_cuda: bool, dtype: torch.dtype, tp_world_size: int, triton_available: bool
+) -> bool:
+    """Keep the row-reduction implementation strictly to CUDA BF16 TP1."""
+    return is_cuda and dtype is torch.bfloat16 and tp_world_size == 1 and triton_available
+
+
+def _row_reduce_workspace_shape(
+    rows: int, vocab: int, block: int = _cuda_lce.ROW_BLOCK
+) -> tuple[tuple[int, int], tuple[int]]:
+    """Expose the private fast-path workspace contract to focused tests."""
+    return _cuda_lce.workspace_shape(rows, vocab, block)
+
+
+def _reuse_logits_storage_for_grad_logits(
+    logits: torch.Tensor, softmax: torch.Tensor
+) -> torch.Tensor:
+    """Overwrite BF16 logits with BF16 dlogits without a second vocab window."""
+    logits.copy_(softmax)
+    return logits
+
+
+def _forward_chunk_loss(
+    hidden_2d: torch.Tensor,
+    weight: torch.Tensor,
+    target_1d: torch.Tensor,
+    start: int,
+    end: int,
+    tp_group,
+    vocab_start: int,
+    vocab_end: int,
+    temperature: float,
+    use_cuda_fast_path: bool = False,
+) -> torch.Tensor:
+    """Compute one forward CE window and release its vocab logits on return."""
+    logits = hidden_2d[start:end].matmul(weight.t())
+    if temperature != 1.0:
+        logits.div_(temperature)
+    if use_cuda_fast_path:
+        loss = _cuda_lce.token_loss(logits, target_1d[start:end])
+    else:
+        loss, _, _, _ = _chunk_loss_and_softmax(
+            logits,
+            target_1d[start:end],
+            tp_group,
+            vocab_start,
+            vocab_end,
+            return_softmax=False,
+        )
+    del logits
+    return loss
+
+
+class _ChunkedVocabParallelLinearCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        hidden: torch.Tensor,
+        weight: torch.Tensor,
+        target: torch.Tensor,
+        tp_group,
+        sequence_parallel: bool,
+        temperature: float,
+        chunk_size: int,
+    ) -> torch.Tensor:
+        rank, world_size = _tp_info(tp_group)
+        if sequence_parallel and world_size > 1:
+            total_hidden = torch.empty(
+                (hidden.shape[0] * world_size, *hidden.shape[1:]),
+                dtype=hidden.dtype,
+                device=hidden.device,
+            )
+            dist.all_gather_into_tensor(
+                total_hidden, hidden.contiguous(), group=tp_group
+            )
+        else:
+            total_hidden = hidden
+
+        if total_hidden.shape[:-1] != target.shape:
+            raise ValueError(
+                "hidden leading shape must match target shape after sequence gathering, "
+                f"got {total_hidden.shape[:-1]} and {target.shape}"
+            )
+        local_vocab = weight.shape[0]
+        vocab_start, vocab_end = _vocab_range(local_vocab, rank, world_size)
+        hidden_2d = total_hidden.reshape(-1, total_hidden.shape[-1])
+        target_1d = target.reshape(-1)
+        loss = torch.empty(target_1d.shape, dtype=torch.float32, device=hidden.device)
+        use_cuda_fast_path = _cuda_tp1_fast_path_eligible(
+            is_cuda=hidden.is_cuda,
+            dtype=hidden.dtype,
+            tp_world_size=world_size,
+            triton_available=_cuda_lce.is_available(),
+        )
+        for start in range(0, target_1d.numel(), chunk_size):
+            end = min(start + chunk_size, target_1d.numel())
+            loss[start:end] = _forward_chunk_loss(
+                hidden_2d,
+                weight,
+                target_1d,
+                start,
+                end,
+                tp_group,
+                vocab_start,
+                vocab_end,
+                temperature,
+                use_cuda_fast_path,
+            )
+
+        ctx.save_for_backward(total_hidden, weight, target)
+        ctx.tp_group = tp_group
+        ctx.sequence_parallel = sequence_parallel
+        ctx.temperature = temperature
+        ctx.chunk_size = chunk_size
+        ctx.vocab_start = vocab_start
+        ctx.vocab_end = vocab_end
+        ctx.world_size = world_size
+        ctx.cuda_fast_path = use_cuda_fast_path
+        ctx.local_sequence = hidden.shape[0]
+        return loss.reshape_as(target)
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        total_hidden, weight, target = ctx.saved_tensors
+        hidden_2d = total_hidden.reshape(-1, total_hidden.shape[-1])
+        target_1d = target.reshape(-1)
+        # ``loss.sum().backward()`` supplies a stride-0 expanded dLoss view.
+        # Triton indexes this row-wise, so materialize only the O(tokens)
+        # scale vector before handing it to the CUDA TP1 path.
+        grad_output_1d = grad_output.reshape(-1).contiguous()
+        grad_hidden_full = torch.empty_like(total_hidden).reshape_as(hidden_2d)
+        grad_weight = torch.zeros_like(weight)
+
+        for start in range(0, target_1d.numel(), ctx.chunk_size):
+            end = min(start + ctx.chunk_size, target_1d.numel())
+            logits = hidden_2d[start:end].matmul(weight.t())
+            if ctx.temperature != 1.0:
+                logits.div_(ctx.temperature)
+            if ctx.cuda_fast_path:
+                # The CUDA TP1 kernel keeps row-reduction math tile-local in
+                # FP32 and writes BF16 dlogits directly into this allocation.
+                grad_logits = _cuda_lce.inplace_gradient(
+                    logits,
+                    target_1d[start:end],
+                    grad_output_1d[start:end],
+                    ctx.temperature,
+                )
+            else:
+                _, softmax, target_mask, masked_target = _chunk_loss_and_softmax(
+                    logits,
+                    target_1d[start:end],
+                    ctx.tp_group,
+                    ctx.vocab_start,
+                    ctx.vocab_end,
+                    return_softmax=True,
+                )
+                row_indices = torch.arange(end - start, device=softmax.device)
+                softmax[row_indices, masked_target] -= 1.0 - target_mask.float()
+                softmax.mul_(grad_output_1d[start:end].unsqueeze(-1))
+                if ctx.temperature != 1.0:
+                    softmax.div_(ctx.temperature)
+                # CE owns FP32 probability math; the vanilla BF16 head backward
+                # consumes a BF16 dlogits. Reuse logits storage so a second BF16
+                # vocab window is not live beside logits and FP32 softmax.
+                grad_logits = _reuse_logits_storage_for_grad_logits(logits, softmax)
+            grad_hidden_full[start:end].copy_(grad_logits.matmul(weight))
+            grad_weight.add_(grad_logits.t().matmul(hidden_2d[start:end]))
+            # Keep every vocab-shaped temporary scoped to one token window.
+            if not ctx.cuda_fast_path:
+                del row_indices, masked_target, target_mask, softmax
+            del grad_logits, logits
+
+        if ctx.sequence_parallel and ctx.world_size > 1:
+            grad_hidden = torch.empty(
+                (ctx.local_sequence, *total_hidden.shape[1:]),
+                dtype=total_hidden.dtype,
+                device=total_hidden.device,
+            )
+            # This one collective is both the TP sum and SP sequence split.
+            dist.reduce_scatter_tensor(
+                grad_hidden,
+                grad_hidden_full.reshape_as(total_hidden).contiguous(),
+                group=ctx.tp_group,
+            )
+        elif ctx.world_size > 1:
+            grad_hidden = grad_hidden_full.reshape_as(total_hidden)
+            dist.all_reduce(grad_hidden, group=ctx.tp_group)
+        else:
+            grad_hidden = grad_hidden_full.reshape_as(total_hidden)
+        return grad_hidden, grad_weight, None, None, None, None, None
+
+
+def chunked_vocab_parallel_linear_cross_entropy(
+    hidden: torch.Tensor,
+    weight: torch.Tensor,
+    target: torch.Tensor,
+    *,
+    tp_group=None,
+    sequence_parallel: bool = False,
+    temperature: float = 1.0,
+    chunk_size: int = _DEFAULT_CHUNK_SIZE,
+) -> torch.Tensor:
+    """Return per-token CE without materializing a full vocab-shaped tensor."""
+    if isinstance(chunk_size, bool) or not isinstance(chunk_size, int):
+        raise TypeError(f"chunk_size must be an integer, got {chunk_size!r}")
+    if chunk_size <= 0:
+        raise ValueError(f"chunk_size must be positive, got {chunk_size}")
+    temperature = float(temperature)
+    if temperature <= 0.0:
+        raise ValueError(f"temperature must be positive, got {temperature}")
+    if hidden.shape[-1] != weight.shape[-1]:
+        raise ValueError(
+            f"hidden and weight feature dimensions differ: {hidden.shape[-1]} and {weight.shape[-1]}"
+        )
+    return _ChunkedVocabParallelLinearCrossEntropy.apply(
+        hidden, weight, target, tp_group, sequence_parallel, temperature, chunk_size
+    )
+
+
+__all__ = ["chunked_vocab_parallel_linear_cross_entropy"]

--- a/experimental/lite/megatron/lite/primitive/ops/cross_entropy.py
+++ b/experimental/lite/megatron/lite/primitive/ops/cross_entropy.py
@@ -11,103 +11,136 @@ from __future__ import annotations
 import torch  # pyright: ignore[reportMissingImports]
 import torch.distributed as dist  # pyright: ignore[reportMissingImports]
 
+_DEFAULT_CHUNK_SIZE = 1024
+
 
 def _vocab_range(partition_vocab_size: int, rank: int, world_size: int):
     start = rank * partition_vocab_size
     return start, start + partition_vocab_size
 
 
+def _tp_info(tp_group):
+    if tp_group is not None and dist.get_world_size(tp_group) > 1:
+        return dist.get_rank(tp_group), dist.get_world_size(tp_group)
+    return 0, 1
+
+
+def _chunk_loss_and_softmax(
+    logits, target, tp_group, vocab_start_index, vocab_end_index, *, return_softmax
+):
+    logits = logits.float()
+    logits_max = logits.max(dim=-1).values
+    if tp_group is not None and dist.get_world_size(tp_group) > 1:
+        dist.all_reduce(logits_max, op=dist.ReduceOp.MAX, group=tp_group)
+    logits -= logits_max.unsqueeze(-1)
+
+    target_mask = (target < vocab_start_index) | (target >= vocab_end_index)
+    masked_target = target - vocab_start_index
+    masked_target = masked_target.masked_fill(target_mask, 0)
+    row_indices = torch.arange(logits.size(0), device=logits.device)
+    predicted_logits = logits[row_indices, masked_target].clone()
+    predicted_logits.masked_fill_(target_mask, 0.0)
+
+    torch.exp(logits, out=logits)
+    sum_exp_logits = logits.sum(dim=-1)
+    if tp_group is not None and dist.get_world_size(tp_group) > 1:
+        dist.all_reduce(predicted_logits, op=dist.ReduceOp.SUM, group=tp_group)
+        dist.all_reduce(sum_exp_logits, op=dist.ReduceOp.SUM, group=tp_group)
+
+    loss = torch.log(sum_exp_logits) - predicted_logits
+    if not return_softmax:
+        return loss, None, None, None
+
+    logits.div_(sum_exp_logits.unsqueeze(-1))
+    return loss, logits, target_mask, masked_target
+
+
 class _VocabParallelCrossEntropy(torch.autograd.Function):
 
     @staticmethod
-    def forward(ctx, vocab_parallel_logits, target, tp_group):
-        # Cast to float32 and compute max for numerical stability.
-        vocab_parallel_logits = vocab_parallel_logits.float()
-        logits_max = torch.max(vocab_parallel_logits, dim=-1)[0]
+    def forward(ctx, vocab_parallel_logits, target, tp_group, chunk_size):
+        if chunk_size <= 0:
+            raise ValueError(f"chunk_size must be positive, got {chunk_size}")
+        if vocab_parallel_logits.shape[:-1] != target.shape:
+            raise ValueError(
+                "logits leading shape must match target shape, "
+                f"got {vocab_parallel_logits.shape[:-1]} and {target.shape}"
+            )
 
-        if tp_group is not None and dist.get_world_size(tp_group) > 1:
-            dist.all_reduce(logits_max, op=dist.ReduceOp.MAX, group=tp_group)
-
-        # In-place subtract max.
-        vocab_parallel_logits -= logits_max.unsqueeze(dim=-1)
-
-        # Partition info.
         partition_vocab_size = vocab_parallel_logits.size(-1)
-        if tp_group is not None and dist.get_world_size(tp_group) > 1:
-            rank = dist.get_rank(tp_group)
-            world_size = dist.get_world_size(tp_group)
-        else:
-            rank = 0
-            world_size = 1
-        vocab_start_index, vocab_end_index = _vocab_range(partition_vocab_size, rank, world_size)
+        rank, world_size = _tp_info(tp_group)
+        vocab_start_index, vocab_end_index = _vocab_range(
+            partition_vocab_size, rank, world_size
+        )
 
-        # Mask targets outside this partition's vocab range.
-        target_mask = (target < vocab_start_index) | (target >= vocab_end_index)
-        masked_target = target.clone() - vocab_start_index
-        masked_target[target_mask] = 0
+        logits_2d = vocab_parallel_logits.reshape(-1, partition_vocab_size)
+        target_1d = target.reshape(-1)
+        loss = torch.empty(target_1d.shape, dtype=torch.float32, device=target.device)
+        for start in range(0, target_1d.numel(), chunk_size):
+            end = min(start + chunk_size, target_1d.numel())
+            loss[start:end], _, _, _ = _chunk_loss_and_softmax(
+                logits_2d[start:end],
+                target_1d[start:end],
+                tp_group,
+                vocab_start_index,
+                vocab_end_index,
+                return_softmax=False,
+            )
 
-        # Get predicted logits = logits[target].
-        logits_2d = vocab_parallel_logits.view(-1, partition_vocab_size)
-        masked_target_1d = masked_target.view(-1)
-        arange_1d = torch.arange(logits_2d.size(0), device=logits_2d.device)
-        predicted_logits_1d = logits_2d[arange_1d, masked_target_1d]
-        predicted_logits_1d = predicted_logits_1d.clone().contiguous()
-        predicted_logits = predicted_logits_1d.view_as(target)
-        predicted_logits[target_mask] = 0.0
-
-        # Sum of exp(logits).
-        exp_logits = vocab_parallel_logits
-        torch.exp(vocab_parallel_logits, out=exp_logits)
-        sum_exp_logits = exp_logits.sum(dim=-1)
-
-        # All-reduce predicted_logits and sum_exp_logits across TP.
-        if tp_group is not None and dist.get_world_size(tp_group) > 1:
-            dist.all_reduce(predicted_logits, op=dist.ReduceOp.SUM, group=tp_group)
-            dist.all_reduce(sum_exp_logits, op=dist.ReduceOp.SUM, group=tp_group)
-
-        # Loss = log(sum(exp(logits))) - predicted_logit.
-        loss = torch.log(sum_exp_logits) - predicted_logits
-
-        # Normalize exp_logits to get softmax (reused in backward).
-        exp_logits.div_(sum_exp_logits.unsqueeze(dim=-1))
-
-        # Save for backward.
-        ctx.save_for_backward(exp_logits, target_mask, masked_target_1d)
-
-        return loss
+        ctx.save_for_backward(vocab_parallel_logits, target)
+        ctx.tp_group = tp_group
+        ctx.chunk_size = chunk_size
+        ctx.vocab_start_index = vocab_start_index
+        ctx.vocab_end_index = vocab_end_index
+        return loss.reshape_as(target)
 
     @staticmethod
     def backward(ctx, grad_output):
-        softmax, target_mask, masked_target_1d = ctx.saved_tensors
+        vocab_parallel_logits, target = ctx.saved_tensors
+        partition_vocab_size = vocab_parallel_logits.size(-1)
+        logits_2d = vocab_parallel_logits.reshape(-1, partition_vocab_size)
+        target_1d = target.reshape(-1)
+        grad_output_1d = grad_output.reshape(-1)
+        grad_input = torch.empty_like(vocab_parallel_logits)
+        grad_input_2d = grad_input.reshape(-1, partition_vocab_size)
 
-        # grad_input = softmax (copy is implicit since softmax is saved).
-        grad_input = softmax
-        partition_vocab_size = softmax.size(-1)
-        grad_2d = grad_input.view(-1, partition_vocab_size)
+        for start in range(0, target_1d.numel(), ctx.chunk_size):
+            end = min(start + ctx.chunk_size, target_1d.numel())
+            _, softmax, target_mask, masked_target = _chunk_loss_and_softmax(
+                logits_2d[start:end],
+                target_1d[start:end],
+                ctx.tp_group,
+                ctx.vocab_start_index,
+                ctx.vocab_end_index,
+                return_softmax=True,
+            )
+            row_indices = torch.arange(end - start, device=softmax.device)
+            softmax[row_indices, masked_target] -= 1.0 - target_mask.float()
+            softmax.mul_(grad_output_1d[start:end].unsqueeze(-1))
+            grad_input_2d[start:end].copy_(softmax)
 
-        arange_1d = torch.arange(grad_2d.size(0), device=grad_2d.device)
-        softmax_update = 1.0 - target_mask.view(-1).float()
-
-        grad_2d[arange_1d, masked_target_1d] -= softmax_update
-
-        # Scale by upstream gradient.
-        grad_input.mul_(grad_output.unsqueeze(dim=-1))
-
-        return grad_input, None, None
+        return grad_input, None, None, None
 
 
-def vocab_parallel_cross_entropy(vocab_parallel_logits, target, tp_group=None):
+def vocab_parallel_cross_entropy(
+    vocab_parallel_logits, target, tp_group=None, chunk_size=_DEFAULT_CHUNK_SIZE
+):
     """Cross entropy loss for vocab-parallel logits.
 
     Args:
         vocab_parallel_logits: [S, B, V/tp] logits split across TP ranks.
         target: [S, B] integer target token ids.
         tp_group: TP process group (None or single-rank group → no communication).
+        chunk_size: Maximum number of tokens materialized in float32 at once.
 
     Returns:
         Per-token loss tensor of shape [S, B].
     """
-    return _VocabParallelCrossEntropy.apply(vocab_parallel_logits, target, tp_group)
+    if isinstance(chunk_size, bool) or not isinstance(chunk_size, int):
+        raise TypeError(f"chunk_size must be an integer, got {chunk_size!r}")
+    return _VocabParallelCrossEntropy.apply(
+        vocab_parallel_logits, target, tp_group, chunk_size
+    )
 
 
 __all__ = ["vocab_parallel_cross_entropy"]

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -421,6 +421,23 @@ class MegatronLiteRuntime(RuntimeBase):
             if callable(release):
                 release()
 
+    def release_ep_chunk_workspaces(self, handle: ModelHandle) -> None:
+        """Release unique ChunkedEP module workspaces at a training boundary."""
+        stream = None
+        released = set()
+        for chunk in handle._extras.get("model_chunks", [handle._model]):
+            modules = getattr(chunk, "modules", None)
+            candidates = (chunk,) if not callable(modules) else (chunk, *modules())
+            for module in candidates:
+                if id(module) in released:
+                    continue
+                released.add(id(module))
+                release = getattr(module, "release_ep_chunk_workspaces", None)
+                if callable(release):
+                    if stream is None and torch.cuda.is_available():
+                        stream = torch.cuda.current_stream()
+                    release(phase=None, stream=stream)
+
     # ── Memory ──
 
     def to(
@@ -447,6 +464,8 @@ class MegatronLiteRuntime(RuntimeBase):
         # scratch buffers or optimizer residency.
         training_transfer = model and grad
         if device == "cpu":
+            if training_transfer:
+                self.release_ep_chunk_workspaces(handle)
             if model:
                 offload_model_to_cpu(model_chunks)
             if (optimizer or training_transfer) and handle._optimizer is not None:

--- a/experimental/lite/skills/application/bench.md
+++ b/experimental/lite/skills/application/bench.md
@@ -21,11 +21,28 @@ def bench(task, bench_config, target, budget):
     if controlled.has_unknown_unfrozen_axes():
         return blocked("bench has uncontrolled variables", risks=controlled.unknown_axes)
 
+    if bench_config.axis == "chunked_ep":
+        target = require_public_bench_target(
+            target,
+            path="experimental/lite/examples/bench/bench.py",
+            config_transport="--impl-cfg-json",
+            required_fields=[
+                "use_deepep", "enable_ep_chunk_overlap",
+                "ep_chunk_max_token_rows_per_rank", "ep_chunk_full_recompute",
+            ],
+        )
+        if not target.done:
+            return blocked("public bench does not consume ChunkedEP config", evidence=target)
+
     measurement = perf.measure(task, target=target, workload=bench_config.workload, budget=budget.measure)
     if not measurement.done:
         return blocked("bench measurement failed", evidence=measurement)
 
     evidence = record_evidence(task, run=measurement.run, comparison=measurement.metrics, environment=budget.env)
-    risks = ["benchmarks are not correctness proof", "uncontrolled variables can dominate"]
+    risks = [
+        "benchmarks are not correctness proof",
+        "uncontrolled variables can dominate",
+        "ChunkedEP DeepEP claims require Slurm GPU evidence from the public bench",
+    ]
     return done(bench=measurement.metrics, evidence=evidence, risks=risks)
 ```

--- a/experimental/lite/skills/primitive/module/moe.md
+++ b/experimental/lite/skills/primitive/module/moe.md
@@ -33,10 +33,21 @@ def moe(task, implementation, config, reference, budget):
         "boundaries": ["module owns routing math; EP owns distributed expert placement; DeepEP owns dispatch/combine transport"],
     }
     usage_contract = {
-        "config": require_config_keys(config, ["num_experts", "top_k", "expert_parallel_size", "use_deepep"]),
+        "config": require_config_keys(config, [
+            "num_experts", "top_k", "expert_parallel_size", "use_deepep",
+            "enable_ep_chunk_overlap", "ep_chunk_max_token_rows_per_rank",
+            "ep_chunk_full_recompute",
+        ]),
         "choose_when": ["model architecture has sparse experts", "expert count justifies EP or grouped GEMM"],
         "avoid_when": ["router tie behavior cannot be stabilized", "DeepEP metadata cannot be validated against all-to-all"],
         "compose_with": ["primitive.parallel.ep", "DeepEP dispatcher when EP>1", "primitive.parallel.tp for expert MLP if explicit"],
+        "unsupported_combinations": [
+            "ChunkedEP without DeepEP or with EP<=1",
+            "ChunkedEP with top_k>expert_parallel_size",
+            "ChunkedEP without explicit per-rank flattened-token capacity",
+            "ep_chunk_full_recompute without enable_ep_chunk_overlap",
+            "normal ChunkedEP with outer moe/full recompute",
+        ],
     }
     ep_validation = None
     if config.expert_parallel_size > 1:

--- a/experimental/lite/skills/primitive/module/moe.md
+++ b/experimental/lite/skills/primitive/module/moe.md
@@ -41,7 +41,13 @@ def moe(task, implementation, config, reference, budget):
         "choose_when": ["model architecture has sparse experts", "expert count justifies EP or grouped GEMM"],
         "avoid_when": ["router tie behavior cannot be stabilized", "DeepEP metadata cannot be validated against all-to-all"],
         "compose_with": ["primitive.parallel.ep", "DeepEP dispatcher when EP>1", "primitive.parallel.tp for expert MLP if explicit"],
+        "head_loss_composition": [
+            "Qwen3 cross_entropy_fusion can coexist with ChunkedEP and takes precedence over non-fused chunked head CE",
+            "Qwen3 calculate_entropy=True without fusion uses full-vocabulary head fallback; bounded chunked head CE does not supply entropy",
+            "These head selections do not reject the MoE composition, unlike MTP and conflicting recompute settings",
+        ],
         "unsupported_combinations": [
+            "Qwen3 bounded non-fused chunked head CE with entropy output or fused CE selection (uses the documented alternative head path)",
             "Qwen3 ChunkedEP with MTP (auxiliary head loss is not bounded)",
             "ChunkedEP without DeepEP or with EP<=1",
             "ChunkedEP with top_k>expert_parallel_size",

--- a/experimental/lite/skills/primitive/module/moe.md
+++ b/experimental/lite/skills/primitive/module/moe.md
@@ -36,12 +36,13 @@ def moe(task, implementation, config, reference, budget):
         "config": require_config_keys(config, [
             "num_experts", "top_k", "expert_parallel_size", "use_deepep",
             "enable_ep_chunk_overlap", "ep_chunk_max_token_rows_per_rank",
-            "ep_chunk_full_recompute",
+            "ep_chunk_full_recompute", "ep_chunk_count",
         ]),
         "choose_when": ["model architecture has sparse experts", "expert count justifies EP or grouped GEMM"],
         "avoid_when": ["router tie behavior cannot be stabilized", "DeepEP metadata cannot be validated against all-to-all"],
         "compose_with": ["primitive.parallel.ep", "DeepEP dispatcher when EP>1", "primitive.parallel.tp for expert MLP if explicit"],
         "unsupported_combinations": [
+            "Qwen3 ChunkedEP with MTP (auxiliary head loss is not bounded)",
             "ChunkedEP without DeepEP or with EP<=1",
             "ChunkedEP with top_k>expert_parallel_size",
             "ChunkedEP without explicit per-rank flattened-token capacity",

--- a/experimental/lite/tests/unit/model/test_chunked_ep_model_coverage.py
+++ b/experimental/lite/tests/unit/model/test_chunked_ep_model_coverage.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+# Static scope guards only: public bench + Slurm GPU validation own end-to-end
+# DeepEP evidence.
+
+
+LITE_ROOT = Path(__file__).resolve().parents[3]
+MODEL_ROOT = LITE_ROOT / "megatron/lite/model"
+SKILL_ROOT = LITE_ROOT / "skills"
+
+
+def test_only_qwen3_moe_composes_the_chunked_ep_primitive():
+    qwen_protocol = (MODEL_ROOT / "qwen3_moe/lite/protocol.py").read_text()
+    qwen_model = (MODEL_ROOT / "qwen3_moe/lite/model.py").read_text()
+
+    assert "enable_ep_chunk_overlap: bool = False" in qwen_protocol
+    assert "validate_ep_chunk_overlap_config(" in qwen_protocol
+    assert "EPChunkForwardOp(" in qwen_model
+    assert "EPChunkBackwardOp(" in qwen_model
+    assert "EPChunkFusedForwardBackwardOp(" in qwen_model
+    assert "get_ep_chunk_workspace(" in qwen_model
+    assert "max_input_rows=ep_chunk_max_token_rows_per_rank" in qwen_model
+    assert "materialize_ep_chunk_workspaces" in qwen_model
+    assert "park_ep_chunk_workspace" not in qwen_model
+    assert "workspace.materialize(device=device)" in qwen_model
+    assert "workspace.warmup(device=" not in qwen_model
+    assert "ep_chunk_full_recompute" in qwen_model
+    assert (
+        "if torch.is_grad_enabled():\n                return self.ep_chunk_fused"
+        not in qwen_model
+    )
+
+    for model_name, implementation in (
+        ("qwen3_5", "model.py"),
+        ("kimi_k2", "model.py"),
+        ("glm5", "model.py"),
+        ("deepseek_v4", "moe.py"),
+    ):
+        protocol = (MODEL_ROOT / model_name / "lite/protocol.py").read_text()
+        model = (MODEL_ROOT / model_name / "lite" / implementation).read_text()
+        assert "enable_ep_chunk_overlap" not in protocol
+        assert "EPChunkForwardOp" not in model
+        assert "EPChunkBackwardOp" not in model
+        assert "EPChunkFusedForwardBackwardOp" not in model
+
+
+def test_qwen3_layer_is_only_a_lightweight_three_op_composition():
+    model = (MODEL_ROOT / "qwen3_moe/lite/model.py").read_text()
+
+    assert "_full_recompute_fused_backward" not in model
+    assert "submit_deepep_dispatch" not in model
+    assert "MEGATRON_LITE_EP_CHUNK" not in model
+    assert "layer_idx %" not in model
+    assert "buffer_slot=" not in model
+
+
+def test_dynamic_chunk_configuration_is_absent_from_product_code():
+    product = LITE_ROOT / "megatron/lite"
+    forbidden = (
+        "ep_chunk_num_chunks",
+        "ep_chunk_bwd_num_chunks",
+        "MEGATRON_LITE_EP_CHUNK_WEIGHTS",
+    )
+
+    matches = {
+        token: [path for path in product.rglob("*.py") if token in path.read_text()]
+        for token in forbidden
+    }
+
+    assert matches == {token: [] for token in forbidden}
+
+
+def test_chunk_policy_lives_with_the_moe_module_primitive():
+    policy = (
+        LITE_ROOT / "megatron/lite/primitive/modules/moe_ep_chunk_overlap_policy.py"
+    )
+    old_policy = LITE_ROOT / "megatron/lite/primitive/moe_ep_chunk_overlap_policy.py"
+
+    assert policy.is_file()
+    assert not old_policy.exists()
+
+
+def test_moe_and_bench_skills_publish_chunked_ep_usage_contract():
+    moe_skill = (SKILL_ROOT / "primitive/module/moe.md").read_text()
+    bench_skill = (SKILL_ROOT / "application/bench.md").read_text()
+    protocol = (MODEL_ROOT / "qwen3_moe/lite/protocol.py").read_text()
+
+    for key in (
+        "enable_ep_chunk_overlap",
+        "ep_chunk_max_token_rows_per_rank",
+        "ep_chunk_full_recompute",
+    ):
+        assert key in moe_skill
+        assert key in protocol
+    assert "unsupported_combinations" in moe_skill
+    assert "top_k>expert_parallel_size" in moe_skill
+    assert "experimental/lite/examples/bench/bench.py" in bench_skill
+    assert "--impl-cfg-json" in bench_skill

--- a/experimental/lite/tests/unit/model/test_qwen_config_unit.py
+++ b/experimental/lite/tests/unit/model/test_qwen_config_unit.py
@@ -2,15 +2,22 @@
 from __future__ import annotations
 
 import ast
+import inspect
 import os
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import torch.nn as nn
+import torch
 
 from megatron.lite.model.qwen3_5.config import Qwen35Config
 from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
-from megatron.lite.model.registry import resolve_model_type_from_hf, resolve_runtime_model_name
+from megatron.lite.model.registry import (
+    resolve_model_type_from_hf,
+    resolve_runtime_model_name,
+)
+from megatron.lite.runtime.contracts.config import ParallelConfig
 
 LITE_ROOT = Path(__file__).resolve().parents[3]
 
@@ -207,7 +214,9 @@ def test_qwen35_dense_and_moe_layers_select_distinct_ffn_branches(
     assert MODULE_MAP["experts"](dense_layer) is None
 
 
-def test_qwen_lite_protocols_build_configs_from_hf_dicts(transformer_engine_import_stub):
+def test_qwen_lite_protocols_build_configs_from_hf_dicts(
+    transformer_engine_import_stub,
+):
     transformer_engine_import_stub()
 
     from megatron.lite.model.qwen3_5.lite import protocol as qwen35_protocol
@@ -215,7 +224,8 @@ def test_qwen_lite_protocols_build_configs_from_hf_dicts(transformer_engine_impo
 
     qwen3_cfg = qwen3_protocol.build_model_config(_tiny_qwen3_hf_dict(), vocab_size=128)
     qwen35_cfg = qwen35_protocol.build_model_config(
-        {"model_type": "qwen3_5_moe", "text_config": _tiny_qwen35_text_config()}, vocab_size=128
+        {"model_type": "qwen3_5_moe", "text_config": _tiny_qwen35_text_config()},
+        vocab_size=128,
     )
 
     assert qwen3_cfg.vocab_size == 128
@@ -224,6 +234,972 @@ def test_qwen_lite_protocols_build_configs_from_hf_dicts(transformer_engine_impo
     assert qwen35_cfg.layer_type_at(1) == "full_attention"
 
 
+def test_qwen3_chunked_ep_is_one_boolean_fixed_profile(transformer_engine_import_stub):
+    transformer_engine_import_stub()
+    from megatron.lite.model.qwen3_moe.lite import protocol
+
+    cfg = protocol.ImplConfig(
+        parallel=ParallelConfig(ep=8),
+        use_deepep=True,
+        enable_ep_chunk_overlap=True,
+        ep_chunk_max_token_rows_per_rank=4096,
+    )
+
+    assert cfg.enable_ep_chunk_overlap is True
+    assert cfg.ep_chunk_max_token_rows_per_rank == 4096
+    assert not any("num_chunks" in name or "schedule" in name for name in vars(cfg))
+
+
+def test_qwen3_layer_builds_lazy_selected_ops_from_real_token_capacity(
+    monkeypatch, transformer_engine_import_stub
+):
+    transformer_engine_import_stub()
+    from megatron.lite.model.qwen3_moe.lite import model
+
+    workspaces = []
+    released = []
+
+    class FakeWorkspace:
+        def __init__(self, key):
+            self.key = key
+            self.materialize_devices = []
+            self.prepare_scratch_devices = []
+            self.activation_reservations = []
+
+        def reset_tensors(self, *, stream=None):
+            del stream
+
+        def materialize(self, *, device=None):
+            self.materialize_devices.append(device)
+
+        def prepare_scratch(self, *, device=None):
+            self.prepare_scratch_devices.append(device)
+
+        def reserve_expert_activations(self, *, max_expert_rows, device=None):
+            self.activation_reservations.append((max_expert_rows, device))
+
+    class FakeOp:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.workspace = kwargs["workspace"]
+
+    def get_workspace(key, _factory):
+        workspace = FakeWorkspace(key)
+        workspaces.append(workspace)
+        return workspace
+
+    monkeypatch.setattr(
+        model, "TopKRouter", lambda *_args, **_kwargs: torch.nn.Identity()
+    )
+    monkeypatch.setattr(model, "Experts", lambda *_args, **_kwargs: torch.nn.Identity())
+    monkeypatch.setattr(model, "get_ep_chunk_workspace", get_workspace)
+    monkeypatch.setattr(
+        model,
+        "release_ep_chunk_workspace",
+        lambda key, stream=None: released.append((key.op, stream)),
+    )
+    monkeypatch.setattr(model, "EPChunkForwardOp", FakeOp)
+    monkeypatch.setattr(model, "EPChunkBackwardOp", FakeOp)
+    monkeypatch.setattr(model, "EPChunkFusedForwardBackwardOp", FakeOp)
+    monkeypatch.setattr(
+        model.torch.cuda,
+        "current_device",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("Qwen construction must not bind a CUDA device")
+        ),
+    )
+
+    config = SimpleNamespace(
+        num_experts=128,
+        hidden_size=64,
+        num_experts_per_tok=8,
+        moe_intermediate_size=32,
+        max_position_embeddings=17,
+    )
+    ps = SimpleNamespace(ep_size=8, tp_ep_group=object())
+    layer = model.MoELayer(
+        config,
+        ps,
+        use_deepep=True,
+        enable_ep_chunk_overlap=True,
+        ep_chunk_max_token_rows_per_rank=33,
+    )
+
+    assert {workspace.key.op for workspace in workspaces} == {"forward", "backward"}
+    assert all(
+        workspace.key.shape_profile.max_input_rows == 33
+        and workspace.key.shape_profile.max_recv_rows == 17 * 8
+        and workspace.key.shape_profile.expert_intermediate_size == 32
+        and workspace.key.device_index is None
+        for workspace in workspaces
+    )
+    assert all(workspace.materialize_devices == [] for workspace in workspaces)
+    assert all(workspace.activation_reservations == [] for workspace in workspaces)
+    by_op = {workspace.key.op: workspace for workspace in workspaces}
+    layer.materialize_ep_chunk_workspaces(device=model.torch.device("cuda", 3))
+    assert by_op["forward"].materialize_devices == [model.torch.device("cuda", 3)]
+    assert by_op["forward"].activation_reservations == []
+    assert by_op["backward"].materialize_devices == []
+
+    layer.materialize_ep_chunk_workspaces(
+        phase="backward", device=model.torch.device("cuda", 3)
+    )
+    assert by_op["backward"].materialize_devices == []
+    assert by_op["backward"].prepare_scratch_devices == [model.torch.device("cuda", 3)]
+    assert by_op["backward"].activation_reservations == []
+
+    layer.materialize_ep_chunk_workspaces(
+        device=model.torch.device("cuda", 3), expert_activation_max_rows=19
+    )
+    assert by_op["forward"].activation_reservations == [
+        (19, model.torch.device("cuda", 3))
+    ]
+    assert by_op["backward"].activation_reservations == []
+
+    stream = object()
+    layer.release_ep_chunk_workspaces(phase="forward", stream=stream)
+    layer.release_ep_chunk_workspaces(phase="backward", stream=stream)
+    assert released == [("forward", stream), ("backward", stream)]
+    with pytest.raises(ValueError, match="expected 'forward' or 'backward'"):
+        layer.materialize_ep_chunk_workspaces(phase="unused")
+
+
+@pytest.mark.parametrize(
+    ("mtp_enable", "requested_chunk_count", "expected_chunk_count", "expected_moe_layers"),
+    [(False, None, 2, 1), (True, 3, 3, 3)],
+)
+def test_qwen3_model_build_propagates_logical_chunk_count_to_decoder_and_mtp(
+    mtp_enable,
+    requested_chunk_count,
+    expected_chunk_count,
+    expected_moe_layers,
+    monkeypatch,
+    transformer_engine_import_stub,
+):
+    """Exercise the real Qwen composition, including MTP's nested TransformerLayer."""
+    transformer_engine_import_stub()
+    from megatron.lite.model.qwen3_moe.lite import model
+    from megatron.lite.primitive.parallel import ParallelState
+
+    class NoOpModule(torch.nn.Identity):
+        def __init__(self, *_args, **_kwargs):
+            super().__init__()
+
+    class FakeWorkspace:
+        def __init__(self, key):
+            self.key = key
+
+    class FakeOp:
+        def __init__(self, **kwargs):
+            self.workspace = kwargs["workspace"]
+
+    for name in (
+        "GQAttention",
+        "TopKRouter",
+        "Experts",
+        "VocabParallelEmbedding",
+        "VocabParallelOutput",
+        "VanillaColumnParallelLinear",
+    ):
+        monkeypatch.setattr(model, name, NoOpModule)
+    monkeypatch.setattr(model.te, "RMSNorm", NoOpModule)
+    monkeypatch.setattr(
+        model, "get_ep_chunk_workspace", lambda key, _factory: FakeWorkspace(key)
+    )
+    monkeypatch.setattr(model, "EPChunkForwardOp", FakeOp)
+    monkeypatch.setattr(model, "EPChunkBackwardOp", FakeOp)
+    monkeypatch.setattr(model, "EPChunkFusedForwardBackwardOp", FakeOp)
+
+    hf = _tiny_qwen3_hf_dict()
+    if mtp_enable:
+        hf["num_nextn_predict_layers"] = 2
+    config = Qwen3MoEConfig._from_hf_dict(hf)
+    model_kwargs = dict(
+        use_deepep=True,
+        mtp_enable=mtp_enable,
+        enable_ep_chunk_overlap=True,
+        ep_chunk_max_token_rows_per_rank=8,
+    )
+    if requested_chunk_count is not None:
+        model_kwargs["ep_chunk_count"] = requested_chunk_count
+    built = model.Qwen3MoEModel(
+        config,
+        ParallelState(ep_size=2, tp_ep_group=object()),
+        **model_kwargs,
+    )
+
+    moe_layers = [layer.moe for layer in built.layers]
+    if mtp_enable:
+        assert built.mtp is not None
+        moe_layers.extend(layer.transformer_layer.moe for layer in built.mtp.layers)
+    assert len(moe_layers) == expected_moe_layers
+    assert {
+        moe.ep_chunk_forward.workspace.key.shape_profile.chunk_count for moe in moe_layers
+    } == {expected_chunk_count}
+    assert {
+        moe.ep_chunk_backward.workspace.key.shape_profile.chunk_count for moe in moe_layers
+    } == {expected_chunk_count}
+
+
+def test_qwen3_moe_resets_only_its_forward_workspace_phase():
+    """The composition layer uses its existing public forward reset boundary."""
+    from megatron.lite.model.qwen3_moe.lite import model
+
+    resets = []
+
+    class Workspace:
+        def __init__(self, key):
+            self.key = key
+
+        def reset_tensors(self, *, stream=None):
+            resets.append((self.key, stream))
+
+    layer = object.__new__(model.MoELayer)
+    forward_key = object()
+    backward_key = object()
+    layer.ep_chunk_forward = SimpleNamespace(workspace=Workspace(forward_key))
+    layer.ep_chunk_backward = SimpleNamespace(workspace=Workspace(backward_key))
+    layer.ep_chunk_fused = None
+
+    stream = object()
+    layer.reset_ep_chunk_workspace_tensors(phase="forward", stream=stream)
+
+    assert resets == [(forward_key, stream)]
+
+
+@pytest.mark.parametrize("mode", ["train", "inference", "headless"])
+def test_qwen3_resets_chunked_ep_views_after_last_moe_before_head_work(
+    monkeypatch, mode, transformer_engine_import_stub
+):
+    """The model composition boundary parks forward views before head work."""
+    transformer_engine_import_stub()
+    from megatron.lite.model.qwen3_moe.lite import model
+
+    events = []
+
+    class MainMoE:
+        ep_chunk_forward = object()
+        ep_chunk_fused = None
+
+        def reset_ep_chunk_workspace_tensors(self, *, phase, stream):
+            assert phase == "forward"
+            assert stream is None
+            events.append("reset")
+
+    class MainLayer:
+        moe = MainMoE()
+
+        def __call__(self, hidden_states, **_kwargs):
+            events.append("main_moe")
+            return hidden_states
+
+    class MTP(torch.nn.Module):
+        def forward(self, *, hidden_states, **_kwargs):
+            events.append("mtp_moe")
+            return (hidden_states,)
+
+    class Norm(torch.nn.Module):
+        def forward(self, hidden_states):
+            events.append("norm")
+            return hidden_states
+
+    class Head(torch.nn.Module):
+        def forward(self, hidden_states):
+            events.append("head")
+            return hidden_states
+
+        def gather(self, logits):
+            events.append("gather")
+            return logits
+
+    monkeypatch.setattr(
+        model,
+        "vocab_parallel_cross_entropy",
+        lambda logits, labels, _group: events.append("ce")
+        or torch.ones_like(labels, dtype=logits.dtype),
+    )
+    monkeypatch.setattr(
+        model,
+        "roll_packed_thd_left",
+        lambda value, **_kwargs: (value, torch.tensor(value.numel())),
+    )
+
+    qwen = model.Qwen3MoEModel.__new__(model.Qwen3MoEModel)
+    torch.nn.Module.__init__(qwen)
+    qwen.embed = None
+    qwen._input_tensor = None
+    qwen.fp8 = False
+    qwen.layers = [MainLayer()]
+    qwen.ps = SimpleNamespace(tp_group=None)
+    qwen.norm = Norm()
+    qwen.head = None if mode == "headless" else Head()
+    qwen.mtp = MTP() if mode == "train" else None
+    qwen.mtp_enable_train = mode == "train"
+    qwen.mtp_loss_scaling_factor = 1.0
+
+    hidden_states = torch.ones(1, 1, 1)
+    labels = torch.ones(1, 1, dtype=torch.long) if mode == "train" else None
+    input_ids = torch.ones(1, 1, dtype=torch.long) if mode == "train" else None
+    qwen(hidden_states=hidden_states, input_ids=input_ids, labels=labels)
+
+    assert events.count("reset") == 1
+    reset = events.index("reset")
+    if mode == "train":
+        assert events.index("main_moe") < events.index("mtp_moe") < reset
+        assert reset < events.index("head", reset) < events.index("ce", reset)
+    elif mode == "inference":
+        assert events.index("main_moe") < reset < events.index("head")
+    else:
+        assert events.index("main_moe") < reset
+        assert "head" not in events
+
+
+def test_qwen3_marks_only_final_local_backward_moe_for_one_park(
+    transformer_engine_import_stub,
+):
+    """Forward L0/L1 maps to reverse backward L1/L0 with one final park."""
+    transformer_engine_import_stub()
+    from megatron.lite.model.qwen3_moe.lite import model
+
+    events = []
+
+    class Workspace:
+        def park_expert_activations(self, **_kwargs):
+            events.append("park")
+
+    workspace = Workspace()
+
+    class Layer:
+        def __init__(self, name):
+            self.name = name
+            self.moe = SimpleNamespace(
+                ep_chunk_forward=None,
+                ep_chunk_fused=SimpleNamespace(workspace=workspace),
+            )
+
+        def __call__(self, hidden_states, *, park_chunked_ep_after_backward, **_kwargs):
+            events.append((self.name, park_chunked_ep_after_backward))
+            return hidden_states
+
+    qwen = model.Qwen3MoEModel.__new__(model.Qwen3MoEModel)
+    torch.nn.Module.__init__(qwen)
+    qwen.embed = None
+    qwen._input_tensor = None
+    qwen.fp8 = False
+    qwen.layers = [Layer("L0"), Layer("L1")]
+    qwen.ps = SimpleNamespace(tp_group=None)
+    qwen.norm = None
+    qwen.head = None
+    qwen.mtp = None
+    qwen.mtp_enable_train = False
+    qwen(hidden_states=torch.ones(1, 1, 1))
+
+    assert events[:2] == [("L0", True), ("L1", False)]
+    # Simulate autograd's reverse callback order: L1 first must not park;
+    # L0 is the final local MoE consumer and parks after its output/grad.
+    for name, should_park in reversed(events[:2]):
+        events.append(f"{name}:output_grad")
+        if should_park:
+            workspace.park_expert_activations()
+    assert events[-3:] == ["L1:output_grad", "L0:output_grad", "park"]
+    assert events.count("park") == 1
+
+
+@pytest.mark.parametrize(
+    "full_recompute,expected_ops",
+    [
+        (False, {"forward", "backward"}),
+        (True, {"forward", "fused_forward_backward"}),
+    ],
+)
+def test_qwen3_builds_only_two_cross_layer_workspaces_for_48_layers(
+    full_recompute,
+    expected_ops,
+    monkeypatch,
+    transformer_engine_import_stub,
+):
+    transformer_engine_import_stub()
+    from megatron.lite.model.qwen3_moe.lite import model
+
+    registry = {}
+    dispatcher_count = 0
+
+    class FakeWorkspace:
+        def __init__(self, key, factory):
+            self.key = key
+            self.factory = factory
+            self.dispatchers = []
+
+        def materialize(self, *, device=None):
+            if not self.dispatchers:
+                self.dispatchers = [self.factory(0), self.factory(1)]
+
+        def prepare_scratch(self, *, device=None):
+            del device
+
+    class FakeOp:
+        def __init__(self, **kwargs):
+            self.workspace = kwargs["workspace"]
+
+    def fake_dispatcher(*_args, **_kwargs):
+        nonlocal dispatcher_count
+        dispatcher_count += 1
+        return object()
+
+    def get_workspace(key, factory):
+        if key not in registry:
+            registry[key] = FakeWorkspace(key, factory)
+        return registry[key]
+
+    monkeypatch.setattr(model, "TopKRouter", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(model, "Experts", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(model, "TokenDispatcher", fake_dispatcher)
+    monkeypatch.setattr(model, "get_ep_chunk_workspace", get_workspace)
+    monkeypatch.setattr(model, "EPChunkForwardOp", FakeOp)
+    monkeypatch.setattr(model, "EPChunkBackwardOp", FakeOp)
+    monkeypatch.setattr(model, "EPChunkFusedForwardBackwardOp", FakeOp)
+    monkeypatch.setattr(model.torch.cuda, "current_device", lambda: 0)
+    config = SimpleNamespace(
+        num_experts=128,
+        hidden_size=64,
+        num_experts_per_tok=8,
+    )
+    ps = SimpleNamespace(ep_size=8, tp_ep_group=object())
+
+    layers = [
+        model.MoELayer(
+            config,
+            ps,
+            use_deepep=True,
+            enable_ep_chunk_overlap=True,
+            ep_chunk_max_token_rows_per_rank=16384,
+            ep_chunk_full_recompute=full_recompute,
+        )
+        for _ in range(48)
+    ]
+
+    assert {key.op for key in registry} == expected_ops
+    assert len(registry) == 2
+    assert dispatcher_count == 0
+    layers[0].materialize_ep_chunk_workspaces(device="cpu")
+    assert dispatcher_count == 2
+    assert (
+        registry[next(key for key in registry if key.op != "forward")].dispatchers == []
+    )
+    layers[0].materialize_ep_chunk_workspaces(phase="backward", device="cpu")
+    assert dispatcher_count == (4 if full_recompute else 2)
+    assert len({id(layer.ep_chunk_forward.workspace) for layer in layers}) == 1
+    companion = "ep_chunk_fused" if full_recompute else "ep_chunk_backward"
+    assert len({id(getattr(layer, companion).workspace) for layer in layers}) == 1
+
+
+def test_qwen3_chunked_ep_requires_explicit_per_rank_token_capacity(
+    transformer_engine_import_stub,
+):
+    transformer_engine_import_stub()
+    from megatron.lite.model.qwen3_moe.lite import protocol
+
+    model_cfg = Qwen3MoEConfig._from_hf_dict(_tiny_qwen3_hf_dict())
+    with pytest.raises(ValueError, match="ep_chunk_max_token_rows_per_rank"):
+        protocol.build_model(
+            model_cfg,
+            impl_cfg=protocol.ImplConfig(
+                parallel=ParallelConfig(ep=8),
+                use_deepep=True,
+                enable_ep_chunk_overlap=True,
+            ),
+        )
+
+
+@pytest.mark.parametrize(
+    "topk,max_rows,match",
+    [
+        (3, 8, "top-k must not exceed EP size"),
+        (2, 1, "ep_chunk_max_token_rows_per_rank >= 2"),
+    ],
+)
+def test_qwen3_moe_layer_direct_construction_reuses_chunk_policy_validation(
+    topk, max_rows, match, monkeypatch, transformer_engine_import_stub
+):
+    transformer_engine_import_stub()
+    from megatron.lite.model.qwen3_moe.lite import model
+
+    monkeypatch.setattr(
+        model,
+        "TopKRouter",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("policy validation must run before module construction")
+        ),
+    )
+    config = SimpleNamespace(
+        num_experts=8,
+        hidden_size=4,
+        num_experts_per_tok=topk,
+    )
+    ps = SimpleNamespace(ep_size=2, tp_ep_group=object())
+
+    with pytest.raises(ValueError, match=match):
+        model.MoELayer(
+            config,
+            ps,
+            use_deepep=True,
+            enable_ep_chunk_overlap=True,
+            ep_chunk_max_token_rows_per_rank=max_rows,
+        )
+
+
+@pytest.mark.parametrize(
+    "requested",
+    [False, True],
+)
+def test_qwen3_protocol_exposes_explicit_chunk_full_recompute_policy(
+    requested, transformer_engine_import_stub
+):
+    transformer_engine_import_stub()
+    from megatron.lite.model.qwen3_moe.lite import protocol
+
+    impl = protocol.ImplConfig(ep_chunk_full_recompute=requested)
+
+    assert impl.ep_chunk_full_recompute is requested
+    assert "_ep_chunk_full_recompute_requested" not in inspect.getsource(
+        protocol.build_model
+    )
+
+
+@pytest.mark.parametrize(
+    "overlap,full_recompute,recompute,error",
+    [
+        (False, True, [], "requires enable_ep_chunk_overlap=True"),
+        (True, False, ["moe"], "conflicts with outer MoE recompute"),
+        (True, False, ["full"], "conflicts with outer MoE recompute"),
+    ],
+)
+def test_qwen3_protocol_rejects_conflicting_chunk_recompute_composition(
+    overlap, full_recompute, recompute, error, transformer_engine_import_stub
+):
+    transformer_engine_import_stub()
+    from megatron.lite.model.qwen3_moe.lite import protocol
+
+    impl = protocol.ImplConfig(
+        enable_ep_chunk_overlap=overlap,
+        ep_chunk_full_recompute=full_recompute,
+        recompute=recompute,
+    )
+
+    with pytest.raises(ValueError, match=error):
+        protocol.validate_qwen3_ep_chunk_recompute_composition(
+            enable_ep_chunk_overlap=impl.enable_ep_chunk_overlap,
+            ep_chunk_full_recompute=impl.ep_chunk_full_recompute,
+            recompute_modules=impl.recompute,
+        )
+
+
+@pytest.mark.parametrize(
+    "overlap,full_recompute,recompute",
+    [
+        (False, False, ["moe"]),
+        (True, False, ["attn"]),
+        (True, True, ["moe"]),
+        (True, True, ["full"]),
+    ],
+)
+def test_qwen3_protocol_accepts_unambiguous_chunk_recompute_composition(
+    overlap, full_recompute, recompute, transformer_engine_import_stub
+):
+    transformer_engine_import_stub()
+    from megatron.lite.model.qwen3_moe.lite import protocol
+
+    protocol.validate_qwen3_ep_chunk_recompute_composition(
+        enable_ep_chunk_overlap=overlap,
+        ep_chunk_full_recompute=full_recompute,
+        recompute_modules=recompute,
+    )
+
+
+@pytest.mark.parametrize(
+    "overlap,full_recompute,recompute,error",
+    [
+        (False, True, [], "requires enable_ep_chunk_overlap=True"),
+        (True, False, ["moe"], "conflicts with outer MoE recompute"),
+        (True, False, ["full"], "conflicts with outer MoE recompute"),
+    ],
+)
+def test_qwen3_direct_model_construction_rejects_ambiguous_recompute(
+    overlap,
+    full_recompute,
+    recompute,
+    error,
+    transformer_engine_import_stub,
+):
+    transformer_engine_import_stub()
+    from megatron.lite.model.qwen3_moe.lite.model import Qwen3MoEModel
+
+    with pytest.raises(ValueError, match=error):
+        Qwen3MoEModel(
+            SimpleNamespace(),
+            SimpleNamespace(),
+            enable_ep_chunk_overlap=overlap,
+            ep_chunk_full_recompute=full_recompute,
+            recompute_modules=recompute,
+        )
+
+
+@pytest.mark.parametrize(
+    "modules,full_recompute,expected",
+    [
+        (["moe_act"], False, True),
+        (["moe_act"], True, False),
+        (["moe"], False, False),
+    ],
+)
+def test_qwen3_compose_layer_owns_moe_activation_recompute_selection(
+    modules, full_recompute, expected, transformer_engine_import_stub
+):
+    transformer_engine_import_stub()
+    from megatron.lite.model.qwen3_moe.lite import model
+
+    assert (
+        model._qwen3_moe_act_recompute_requested(
+            modules, ep_chunk_full_recompute=full_recompute
+        )
+        is expected
+    )
+
+
+def test_qwen3_full_chunked_recompute_owns_the_entire_layer_checkpoint(
+    transformer_engine_import_stub,
+):
+    transformer_engine_import_stub()
+    from megatron.lite.model.qwen3_moe.lite import protocol
+
+    requested = ["core_attn", "moe", "mlp"]
+    assert (
+        protocol._qwen3_recompute_modules_for_ep_chunk_overlap(requested, enabled=False)
+        == requested
+    )
+    assert (
+        protocol._qwen3_recompute_modules_for_ep_chunk_overlap(requested, enabled=True)
+        == []
+    )
+    assert (
+        protocol._qwen3_recompute_modules_for_ep_chunk_overlap(["full"], enabled=True)
+        == []
+    )
+
+
+@pytest.mark.parametrize(
+    "full_recompute,expected_counts",
+    [
+        (False, {"forward": 1, "backward": 1, "fused": 0}),
+    ],
+)
+def test_qwen3_training_mode_matches_no_recompute_and_full_recompute_parity(
+    full_recompute,
+    expected_counts,
+    monkeypatch,
+    transformer_engine_import_stub,
+):
+    transformer_engine_import_stub()
+    from megatron.lite.model.qwen3_moe.lite import model
+
+    calls = {"forward": 0, "backward": 0, "fused": 0}
+
+    class FakeWorkspace:
+        def __init__(self, key):
+            self.key = key
+
+        def reset_tensors(self, *, stream=None):
+            del stream
+
+    class FakeForward:
+        def __init__(self, *, backward_op=None, **_kwargs):
+            self.backward_op = backward_op
+
+        def __call__(self, x):
+            calls["forward"] += 1
+
+            class SavedForward(torch.autograd.Function):
+                @staticmethod
+                def forward(ctx, value, backward_op):
+                    ctx.backward_op = backward_op
+                    return value * 2
+
+                @staticmethod
+                def backward(ctx, grad_output):
+                    grad_x, _router, _experts = ctx.backward_op.backward(
+                        object(), grad_output
+                    )
+                    return grad_x, None
+
+            return SavedForward.apply(x, self.backward_op)
+
+    class FakeBackward:
+        def __init__(self, **_kwargs):
+            pass
+
+        def backward(self, _context, grad_output):
+            calls["backward"] += 1
+            return grad_output * 2, [], []
+
+    class FakeFused:
+        def __init__(self, **kwargs):
+            self.workspace = kwargs["workspace"]
+
+        def forward_backward(self, _x_saved, grad_output, _routing_input=None):
+            calls["fused"] += 1
+            return grad_output * 2, [], []
+
+    monkeypatch.setattr(
+        model, "TopKRouter", lambda *_args, **_kwargs: torch.nn.Identity()
+    )
+    monkeypatch.setattr(model, "Experts", lambda *_args, **_kwargs: torch.nn.Identity())
+    monkeypatch.setattr(
+        model,
+        "get_ep_chunk_workspace",
+        lambda key, _factory: FakeWorkspace(key),
+    )
+    monkeypatch.setattr(model, "EPChunkForwardOp", FakeForward)
+    monkeypatch.setattr(model, "EPChunkBackwardOp", FakeBackward)
+    monkeypatch.setattr(model, "EPChunkFusedForwardBackwardOp", FakeFused)
+    monkeypatch.setattr(model.torch.cuda, "current_device", lambda: 0)
+    config = SimpleNamespace(
+        num_experts=8,
+        hidden_size=4,
+        num_experts_per_tok=2,
+    )
+    ps = SimpleNamespace(ep_size=2, tp_ep_group=object())
+    layer = model.MoELayer(
+        config,
+        ps,
+        use_deepep=True,
+        enable_ep_chunk_overlap=True,
+        ep_chunk_max_token_rows_per_rank=8,
+        ep_chunk_full_recompute=full_recompute,
+    )
+    value = torch.randn(2, 4, requires_grad=True)
+    expected = value * 2
+
+    actual = layer(value)
+    torch.testing.assert_close(actual, expected)
+    actual.sum().backward()
+    torch.testing.assert_close(value.grad, torch.full_like(value, 2))
+    assert calls == expected_counts
+
+
+def test_qwen3_full_layer_recompute_runs_no_grad_once_and_recomputes_moe_once(
+    transformer_engine_import_stub,
+):
+    transformer_engine_import_stub()
+    from megatron.lite.model.qwen3_moe.lite.model import (
+        _Qwen3TransformerLayerFullRecomputeFunction,
+    )
+
+    calls = {"forward": 0, "fused": 0}
+
+    class Scale(torch.nn.Module):
+        def __init__(self, scale):
+            super().__init__()
+            self.scale = torch.nn.Parameter(torch.tensor(float(scale)))
+
+        def forward(self, value, **_kwargs):
+            return value * self.scale
+
+    class FakeForward:
+        def __call__(self, x):
+            assert torch.is_grad_enabled() is False
+            calls["forward"] += 1
+            return x * 2
+
+    class FakeFused:
+        def forward_backward(self, _x_saved, grad_output):
+            calls["fused"] += 1
+            return grad_output * 5, [torch.tensor(7.0)], [torch.tensor(8.0)]
+
+    class FakeLayer:
+        def __init__(self):
+            self.attn = Scale(2)
+            self.mlp_norm = Scale(3)
+            self.moe = SimpleNamespace(
+                router=Scale(1),
+                experts=Scale(1),
+                ep_chunk_forward=FakeForward(),
+                ep_chunk_fused=FakeFused(),
+            )
+
+        def _ep_chunk_full_recompute_forward(
+            self, x, *, position_ids, packed_seq_params
+        ):
+            del position_ids, packed_seq_params
+            residual = x
+            x = residual + self.attn(x)
+            residual = x
+            h = self.mlp_norm(x)
+            return residual + self.moe.ep_chunk_forward(h)
+
+    layer = FakeLayer()
+    value = torch.tensor([[1.0, 2.0], [3.0, 4.0]], requires_grad=True)
+    params = (
+        *layer.attn.parameters(),
+        *layer.mlp_norm.parameters(),
+        *layer.moe.router.parameters(),
+        *layer.moe.experts.parameters(),
+    )
+    actual = _Qwen3TransformerLayerFullRecomputeFunction.apply(
+        value, None, None, layer, False, *params
+    )
+    torch.testing.assert_close(actual, value.detach() * 21)
+    actual.sum().backward()
+
+    torch.testing.assert_close(value.grad, torch.full_like(value, 48))
+    assert calls == {"forward": 1, "fused": 1}
+    torch.testing.assert_close(layer.attn.scale.grad, torch.tensor(160.0))
+    torch.testing.assert_close(layer.mlp_norm.scale.grad, torch.tensor(150.0))
+    torch.testing.assert_close(layer.moe.router.scale.grad, torch.tensor(7.0))
+    torch.testing.assert_close(layer.moe.experts.scale.grad, torch.tensor(8.0))
+
+
+def test_qwen3_full_recompute_custom_function_forward_is_framework_no_grad(
+    transformer_engine_import_stub,
+):
+    transformer_engine_import_stub()
+    from megatron.lite.model.qwen3_moe.lite.model import (
+        _Qwen3TransformerLayerFullRecomputeFunction,
+    )
+
+    class Forward:
+        def __call__(self, value):
+            if torch.is_grad_enabled():
+                raise RuntimeError(
+                    "custom autograd Function.forward unexpectedly enabled grad"
+                )
+            return value * 2
+
+    layer = SimpleNamespace(
+        _ep_chunk_full_recompute_forward=lambda value, **_kwargs: Forward()(value)
+    )
+    value = torch.randn(2, 4, requires_grad=True)
+
+    output = _Qwen3TransformerLayerFullRecomputeFunction.apply(
+        value, None, None, layer, False
+    )
+
+    assert output.requires_grad
+    assert output.grad_fn is not None
+
+
+def test_qwen3_full_layer_recompute_rejects_differentiable_position_ids(
+    transformer_engine_import_stub,
+):
+    transformer_engine_import_stub()
+    from megatron.lite.model.qwen3_moe.lite.model import (
+        _Qwen3TransformerLayerFullRecomputeFunction,
+    )
+
+    value = torch.ones(1, 1, requires_grad=True)
+    position_ids = torch.ones(1, 1, requires_grad=True)
+    with pytest.raises(RuntimeError, match="position_ids must not require gradients"):
+        _Qwen3TransformerLayerFullRecomputeFunction.apply(
+            value, position_ids, None, SimpleNamespace(), False
+        )
+
+
+def test_qwen3_full_layer_recompute_restores_rng_for_dropout_replay(
+    monkeypatch, transformer_engine_import_stub
+):
+    transformer_engine_import_stub()
+    from megatron.lite.model.qwen3_moe.lite.model import (
+        _Qwen3TransformerLayerFullRecomputeFunction,
+    )
+
+    samples = []
+
+    class RandomAttention(torch.nn.Module):
+        def forward(self, value, **_kwargs):
+            sample = torch.rand_like(value)
+            samples.append(sample)
+            return value + sample
+
+    class IdentityScale(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.scale = torch.nn.Parameter(torch.tensor(1.0))
+
+        def forward(self, value):
+            return value * self.scale
+
+    class Forward:
+        def __call__(self, value):
+            return value
+
+    class Fused:
+        def forward_backward(self, _value, grad_output):
+            return grad_output, [], []
+
+    class Layer:
+        def __init__(self):
+            self.attn = RandomAttention()
+            self.mlp_norm = IdentityScale()
+            self.moe = SimpleNamespace(
+                router=torch.nn.Identity(),
+                experts=torch.nn.Identity(),
+                ep_chunk_forward=Forward(),
+                ep_chunk_fused=Fused(),
+            )
+
+        def _ep_chunk_full_recompute_forward(self, value, **_kwargs):
+            residual = value + self.attn(value)
+            return residual + self.moe.ep_chunk_forward(self.mlp_norm(residual))
+
+    layer = Layer()
+    value = torch.ones(2, 2, requires_grad=True)
+    monkeypatch.setattr(
+        torch.cuda,
+        "get_rng_state",
+        lambda *_args, **_kwargs: pytest.fail(
+            "CPU recompute must not initialize CUDA RNG"
+        ),
+    )
+    torch.manual_seed(20260810)
+    expected_sample = torch.rand_like(value)
+    expected_after = torch.get_rng_state()
+    torch.manual_seed(20260810)
+
+    output = _Qwen3TransformerLayerFullRecomputeFunction.apply(
+        value, None, None, layer, False, *layer.mlp_norm.parameters()
+    )
+    output.sum().backward()
+
+    assert len(samples) == 2
+    torch.testing.assert_close(samples[0], expected_sample)
+    torch.testing.assert_close(samples[1], expected_sample)
+    assert torch.equal(torch.get_rng_state(), expected_after)
+
+
+def test_qwen3_chunked_ep_fails_loud_without_deepep_or_ep(
+    transformer_engine_import_stub,
+):
+    transformer_engine_import_stub()
+    from megatron.lite.model.qwen3_moe.lite import protocol
+
+    model_cfg = Qwen3MoEConfig._from_hf_dict(_tiny_qwen3_hf_dict())
+    with pytest.raises(ValueError, match="DeepEP"):
+        protocol.build_model(
+            model_cfg,
+            impl_cfg=protocol.ImplConfig(
+                parallel=ParallelConfig(ep=8),
+                use_deepep=False,
+                enable_ep_chunk_overlap=True,
+            ),
+        )
+    with pytest.raises(ValueError, match="EP > 1"):
+        protocol.build_model(
+            model_cfg,
+            impl_cfg=protocol.ImplConfig(
+                parallel=ParallelConfig(ep=1),
+                use_deepep=True,
+                enable_ep_chunk_overlap=True,
+            ),
+        )
 @pytest.mark.parametrize(
     ("backend", "expected"),
     [
@@ -283,11 +1259,16 @@ def _string_list_assignment(tree: ast.Module, name: str) -> set[str]:
     for node in tree.body:
         if not isinstance(node, ast.Assign):
             continue
-        if not any(isinstance(target, ast.Name) and target.id == name for target in node.targets):
+        if not any(
+            isinstance(target, ast.Name) and target.id == name
+            for target in node.targets
+        ):
             continue
         if not isinstance(node.value, (ast.List, ast.Tuple)):
             return set()
-        return {item.value for item in node.value.elts if isinstance(item, ast.Constant)}
+        return {
+            item.value for item in node.value.elts if isinstance(item, ast.Constant)
+        }
     return set()
 
 

--- a/experimental/lite/tests/unit/model/test_qwen_config_unit.py
+++ b/experimental/lite/tests/unit/model/test_qwen_config_unit.py
@@ -365,18 +365,16 @@ def test_qwen3_layer_builds_lazy_selected_ops_from_real_token_capacity(
 
 
 @pytest.mark.parametrize(
-    ("mtp_enable", "requested_chunk_count", "expected_chunk_count", "expected_moe_layers"),
-    [(False, None, 2, 1), (True, 3, 3, 3)],
+    ("requested_chunk_count", "expected_chunk_count"),
+    [(None, 2), (3, 3)],
 )
-def test_qwen3_model_build_propagates_logical_chunk_count_to_decoder_and_mtp(
-    mtp_enable,
+def test_qwen3_model_build_propagates_logical_chunk_count_to_decoder(
     requested_chunk_count,
     expected_chunk_count,
-    expected_moe_layers,
     monkeypatch,
     transformer_engine_import_stub,
 ):
-    """Exercise the real Qwen composition, including MTP's nested TransformerLayer."""
+    """Exercise configurable logical chunks through the real Qwen composition."""
     transformer_engine_import_stub()
     from megatron.lite.model.qwen3_moe.lite import model
     from megatron.lite.primitive.parallel import ParallelState
@@ -411,12 +409,9 @@ def test_qwen3_model_build_propagates_logical_chunk_count_to_decoder_and_mtp(
     monkeypatch.setattr(model, "EPChunkFusedForwardBackwardOp", FakeOp)
 
     hf = _tiny_qwen3_hf_dict()
-    if mtp_enable:
-        hf["num_nextn_predict_layers"] = 2
     config = Qwen3MoEConfig._from_hf_dict(hf)
     model_kwargs = dict(
         use_deepep=True,
-        mtp_enable=mtp_enable,
         enable_ep_chunk_overlap=True,
         ep_chunk_max_token_rows_per_rank=8,
     )
@@ -429,10 +424,8 @@ def test_qwen3_model_build_propagates_logical_chunk_count_to_decoder_and_mtp(
     )
 
     moe_layers = [layer.moe for layer in built.layers]
-    if mtp_enable:
-        assert built.mtp is not None
-        moe_layers.extend(layer.transformer_layer.moe for layer in built.mtp.layers)
-    assert len(moe_layers) == expected_moe_layers
+    assert built.mtp is None
+    assert len(moe_layers) == 1
     assert {
         moe.ep_chunk_forward.workspace.key.shape_profile.chunk_count for moe in moe_layers
     } == {expected_chunk_count}
@@ -1281,3 +1274,31 @@ def _checkpoint_import_names(tree: ast.Module) -> set[str]:
             continue
         names.update(alias.name for alias in node.names)
     return names
+
+
+@pytest.mark.parametrize("entry", ["model", "protocol"])
+@pytest.mark.parametrize("mtp_enable_train", [False, True])
+def test_chunked_ep_mtp_rejected_before_model_allocation(
+    entry, mtp_enable_train, monkeypatch, transformer_engine_import_stub
+):
+    transformer_engine_import_stub()
+    from megatron.lite.model.qwen3_moe.lite import model, protocol
+
+    def unexpected_allocation(*args, **kwargs):
+        pytest.fail("unsupported composition must fail before allocation")
+
+    monkeypatch.setattr(model, "build_pipeline_chunk_layout", unexpected_allocation)
+    monkeypatch.setattr(protocol, "init_parallel", unexpected_allocation)
+    config = Qwen3MoEConfig._from_hf_dict(_tiny_qwen3_hf_dict())
+    config.num_nextn_predict_layers = 1
+    with pytest.raises(ValueError, match="ChunkedEP.*MTP.*full-vocabulary logits"):
+        if entry == "model":
+            model.Qwen3MoEModel(
+                config, SimpleNamespace(), enable_ep_chunk_overlap=True,
+                mtp_enable=True, mtp_enable_train=mtp_enable_train,
+            )
+        else:
+            protocol.build_model(config, impl_cfg=protocol.ImplConfig(
+                enable_ep_chunk_overlap=True, mtp_enable=True,
+                mtp_enable_train=mtp_enable_train,
+            ))

--- a/experimental/lite/tests/unit/primitive/test_chunked_cross_entropy.py
+++ b/experimental/lite/tests/unit/primitive/test_chunked_cross_entropy.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from __future__ import annotations
+
+import socket
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import torch.nn.functional as F
+
+from megatron.lite.primitive.ops import cross_entropy
+
+pytestmark = pytest.mark.mlite
+
+
+def _tp_worker(rank, world_size, port):
+    dist.init_process_group(
+        "gloo", init_method=f"tcp://127.0.0.1:{port}", rank=rank, world_size=world_size
+    )
+    try:
+        torch.manual_seed(123)
+        full_logits = torch.randn(7, 2, 12, dtype=torch.float16)
+        labels = torch.randint(0, 12, (7, 2))
+        local_logits = (
+            full_logits.chunk(world_size, dim=-1)[rank].clone().requires_grad_()
+        )
+
+        loss = cross_entropy.vocab_parallel_cross_entropy(
+            local_logits, labels, dist.group.WORLD, chunk_size=3
+        )
+        loss.sum().backward()
+
+        full_logits_ref = full_logits.clone().requires_grad_()
+        expected = F.cross_entropy(
+            full_logits_ref.float().reshape(-1, 12),
+            labels.reshape(-1),
+            reduction="none",
+        ).view_as(labels)
+        expected.sum().backward()
+
+        torch.testing.assert_close(loss, expected)
+        torch.testing.assert_close(
+            local_logits.grad, full_logits_ref.grad.chunk(world_size, dim=-1)[rank]
+        )
+    finally:
+        dist.destroy_process_group()
+
+
+def test_chunked_cross_entropy_bounds_saved_fp32_state_and_matches_gradients():
+    logits = torch.randn(7, 2, 11, dtype=torch.float16, requires_grad=True)
+    labels = torch.randint(0, 11, (7, 2))
+    logits_ref = logits.detach().clone().requires_grad_()
+    saved_tensors = []
+
+    def record_saved(tensor):
+        saved_tensors.append(tensor)
+        return tensor
+
+    with torch.autograd.graph.saved_tensors_hooks(record_saved, lambda tensor: tensor):
+        loss = cross_entropy.vocab_parallel_cross_entropy(logits, labels, chunk_size=3)
+    loss.sum().backward()
+
+    expected = F.cross_entropy(
+        logits_ref.float().reshape(-1, 11), labels.reshape(-1), reduction="none"
+    ).view_as(labels)
+    expected.sum().backward()
+
+    assert not any(
+        tensor.dtype == torch.float32 and tensor.shape == logits.shape
+        for tensor in saved_tensors
+    )
+    torch.testing.assert_close(loss, expected)
+    torch.testing.assert_close(logits.grad, logits_ref.grad)
+
+
+def test_chunked_cross_entropy_default_chunk_spans_multiple_chunks():
+    logits = torch.randn(1025, 1, 7, dtype=torch.float16, requires_grad=True)
+    labels = torch.randint(0, 7, (1025, 1))
+    logits_ref = logits.detach().clone().requires_grad_()
+
+    loss = cross_entropy.vocab_parallel_cross_entropy(logits, labels)
+    loss.sum().backward()
+    expected = F.cross_entropy(
+        logits_ref.float().reshape(-1, 7), labels.reshape(-1), reduction="none"
+    ).view_as(labels)
+    expected.sum().backward()
+
+    torch.testing.assert_close(loss, expected)
+    torch.testing.assert_close(logits.grad, logits_ref.grad)
+
+
+def test_chunked_cross_entropy_rejects_same_numel_different_layout():
+    logits = torch.randn(2, 3, 5)
+    labels = torch.randint(0, 5, (3, 2))
+
+    with pytest.raises(ValueError, match="leading shape"):
+        cross_entropy.vocab_parallel_cross_entropy(logits, labels)
+
+
+@pytest.mark.parametrize("chunk_size", [0, -1])
+def test_chunked_cross_entropy_rejects_nonpositive_chunk_size(chunk_size):
+    logits = torch.randn(2, 3, 5)
+    labels = torch.randint(0, 5, (2, 3))
+
+    with pytest.raises(ValueError, match="positive"):
+        cross_entropy.vocab_parallel_cross_entropy(
+            logits, labels, chunk_size=chunk_size
+        )
+
+
+@pytest.mark.parametrize("chunk_size", [3.9, True])
+def test_chunked_cross_entropy_rejects_noninteger_chunk_size(chunk_size):
+    logits = torch.randn(2, 3, 5)
+    labels = torch.randint(0, 5, (2, 3))
+
+    with pytest.raises(TypeError, match="integer"):
+        cross_entropy.vocab_parallel_cross_entropy(
+            logits, labels, chunk_size=chunk_size
+        )
+
+
+def test_chunked_cross_entropy_matches_two_rank_tp():
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+    mp.spawn(_tp_worker, args=(2, port), nprocs=2, join=True)

--- a/experimental/lite/tests/unit/primitive/test_chunked_ep_dispatcher_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_chunked_ep_dispatcher_unit.py
@@ -1,0 +1,373 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import importlib
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+
+@pytest.fixture(autouse=True)
+def _isolated_te_import(transformer_engine_import_stub):
+    transformer_engine_import_stub()
+
+
+def _dispatcher_module():
+    return importlib.import_module("megatron.lite.primitive.modules.dispatcher")
+
+
+class _Event:
+    def __init__(self):
+        self.waited = False
+        self.event = object()
+
+    def current_stream_wait(self):
+        self.waited = True
+
+
+class _Buffer:
+    def __init__(self):
+        self.combine_calls = []
+        self.dispatch_calls = []
+
+    def combine(self, tensor, handle, **kwargs):
+        self.combine_calls.append((tensor, handle, kwargs))
+        event = _Event()
+        return tensor + 1, tensor.new_zeros((tensor.size(0), 1)), event
+
+    def dispatch(self, tensor, **kwargs):
+        self.dispatch_calls.append((tensor, kwargs))
+        event = _Event()
+        return tensor + 2, None, None, None, None, event
+
+
+def _dispatcher(buffer=None):
+    value = object.__new__(_dispatcher_module().TokenDispatcher)
+    value.use_deepep = True
+    value.buffer = buffer or _Buffer()
+    value.num_experts = 4
+    value.num_local_experts = 2
+    value.ep_size = 2
+    value.moe_permute_fusion = False
+    value.ps = SimpleNamespace(ep_group=None)
+    value._row_id_map = torch.tensor([0, 1])
+    value._restore_shape = (2, 3)
+    value._handle = "dispatch-handle"
+    value._local_tpe_list = [1, 1]
+    return value
+
+
+def test_deepep_dispatch_materializes_contiguous_router_outputs():
+    class Buffer(_Buffer):
+        def __init__(self):
+            super().__init__()
+            self.layout_indices = None
+
+        def get_dispatch_layout(self, topk_indices, **_kwargs):
+            self.layout_indices = topk_indices
+            assert topk_indices.is_contiguous()
+            return None, None, None, None, _Event()
+
+    buffer = Buffer()
+    value = _dispatcher(buffer)
+    hidden = torch.zeros(3, 2)
+    scores = torch.ones(2, 3).transpose(0, 1)
+    indices = torch.zeros(2, 3, dtype=torch.long).transpose(0, 1)
+    assert not scores.is_contiguous()
+    assert not indices.is_contiguous()
+
+    state = value.submit_deepep_dispatch(
+        hidden, scores, indices, allocate_on_comm_stream=True
+    )
+
+    assert buffer.layout_indices is buffer.dispatch_calls[0][1]["topk_idx"]
+    assert buffer.dispatch_calls[0][1]["topk_weights"].is_contiguous()
+    assert state["_dispatch_inputs"][0] is hidden
+    assert state["_dispatch_inputs"][1] is buffer.layout_indices
+
+
+def test_chunked_dispatch_uses_native_deepep_layout_and_preserves_evidence():
+    class Buffer(_Buffer):
+        def get_dispatch_layout(self, topk_indices, **_kwargs):
+            self.layout_indices = topk_indices
+            return (
+                torch.tensor([3, 2], dtype=torch.int32),
+                None,
+                torch.tensor([2, 2, 1, 1], dtype=torch.int32),
+                torch.tensor([[True, True], [True, True], [True, False]]),
+                _Event(),
+            )
+
+    buffer = Buffer()
+    value = _dispatcher(buffer)
+    hidden = torch.zeros(3, 2)
+    scores = torch.ones(3, 2)
+    indices = torch.tensor([[0, 2], [1, 3], [0, 1]])
+
+    state = value.submit_deepep_dispatch(
+        hidden, scores, indices, allocate_on_comm_stream=True
+    )
+
+    kwargs = buffer.dispatch_calls[0][1]
+    torch.testing.assert_close(
+        kwargs["num_tokens_per_rank"], torch.tensor([3, 2], dtype=torch.int32)
+    )
+    torch.testing.assert_close(
+        kwargs["num_tokens_per_expert"], torch.tensor([2, 2, 1, 1], dtype=torch.int32)
+    )
+    torch.testing.assert_close(
+        kwargs["is_token_in_rank"],
+        torch.tensor([[True, True], [True, True], [True, False]]),
+    )
+    assert kwargs["num_tokens_per_rdma_rank"] is None
+    assert kwargs["previous_event"] is not None
+    assert kwargs["allocate_on_comm_stream"] is True
+    assert "num_worst_tokens" not in kwargs
+    dispatch_inputs = state["_dispatch_inputs"]
+    assert dispatch_inputs[0] is hidden
+    assert dispatch_inputs[1] is buffer.layout_indices
+    assert dispatch_inputs[2] is scores
+    assert dispatch_inputs[3] is kwargs["num_tokens_per_rank"]
+    assert dispatch_inputs[4] is kwargs["num_tokens_per_rdma_rank"]
+    assert dispatch_inputs[5] is kwargs["num_tokens_per_expert"]
+    assert dispatch_inputs[6] is kwargs["is_token_in_rank"]
+
+
+def test_dynamic_dispatch_uses_deepep_receive_counts():
+    class Buffer(_Buffer):
+        def get_dispatch_layout(self, _topk_indices, **_kwargs):
+            return (
+                torch.zeros(2, dtype=torch.int32),
+                None,
+                torch.tensor([1, 2, 3, 4], dtype=torch.int32),
+                torch.zeros(3, 2, dtype=torch.bool),
+                _Event(),
+            )
+
+        def dispatch(self, tensor, **kwargs):
+            self.dispatch_calls.append((tensor, kwargs))
+            return tensor + 2, None, None, [2], None, _Event()
+
+    value = _dispatcher(Buffer())
+    hidden = torch.zeros(3, 2)
+    scores = torch.ones(3, 1)
+    indices = torch.zeros(3, 1, dtype=torch.long)
+
+    state = value.submit_deepep_dispatch(hidden, scores, indices)
+    recv_per_expert = value._resolve_deepep_recv_per_expert(state)
+
+    assert "num_worst_tokens" not in value.buffer.dispatch_calls[0][1]
+    assert "capacity_rows" not in state
+    assert recv_per_expert == [2]
+
+
+def test_prepared_combine_preserves_manual_metadata_and_finishes(monkeypatch):
+    value = _dispatcher()
+    monkeypatch.setattr(
+        _dispatcher_module(),
+        "unpermute",
+        lambda tensor, row_id_map, restore_shape, fused: tensor + 10,
+    )
+    expert_output = torch.zeros(2, 3)
+
+    rank_grouped, handle = value.prepare_deepep_combine(expert_output)
+    state = value.submit_deepep_combine_prepared(
+        rank_grouped,
+        handle,
+        async_finish=True,
+        allocate_on_comm_stream=True,
+    )
+
+    assert handle == "dispatch-handle"
+    assert value.buffer.combine_calls[0][2]["allocate_on_comm_stream"] is True
+    event = state["event"]
+    result = value.finish_deepep_combine(state)
+    assert event.waited
+    assert torch.equal(result, torch.full((2, 3), 11.0))
+    assert state == {}
+    assert value._handle is None
+
+
+def test_manual_backward_submit_finish_pairs_wait_for_events():
+    value = _dispatcher()
+    grad = torch.zeros(2, 3)
+
+    combine_state = value.submit_deepep_combine_backward(
+        grad, "combine-handle", allocate_on_comm_stream=True
+    )
+    combine_event = combine_state["event"]
+    assert torch.equal(
+        value.finish_deepep_combine_backward(combine_state), torch.full((2, 3), 2.0)
+    )
+    assert combine_event.waited
+
+    dispatch_state = value.submit_deepep_dispatch_backward(
+        grad,
+        torch.ones(2, 1),
+        "dispatch-handle",
+        allocate_on_comm_stream=True,
+    )
+    dispatch_event = dispatch_state["event"]
+    grad_hidden, grad_scores = value.finish_deepep_dispatch_backward(dispatch_state)
+    assert torch.equal(grad_hidden, torch.ones(2, 3))
+    assert grad_scores.shape == (2, 1)
+    assert dispatch_event.waited
+    assert value.buffer.dispatch_calls[0][1]["allocate_on_comm_stream"] is True
+    assert value.buffer.combine_calls[0][2]["allocate_on_comm_stream"] is True
+
+
+def test_manual_backward_consumes_explicit_handle_on_its_origin_buffer():
+    class Buffer(_Buffer):
+        def __init__(self):
+            super().__init__()
+            self.backward_handles = []
+
+        def dispatch(self, tensor, **kwargs):
+            self.backward_handles.append(kwargs["handle"])
+            return tensor, None, None, None, None, _Event()
+
+        def combine(self, tensor, handle, **kwargs):
+            self.backward_handles.append(handle)
+            return tensor, tensor.new_zeros((tensor.size(0), 1)), _Event()
+
+    origin = Buffer()
+    value = _dispatcher(origin)
+    old_handle = object()
+    newer_handle = object()
+    value._handle = newer_handle
+    grad = torch.zeros(2, 3)
+
+    value.submit_deepep_combine_backward(grad, old_handle)
+    value.submit_deepep_dispatch_backward(grad, torch.ones(2, 1), old_handle)
+
+    assert origin.backward_handles == [old_handle, old_handle]
+    assert value._handle is newer_handle
+
+
+def test_external_finish_returns_manual_map_without_mutating_dispatcher():
+    value = _dispatcher()
+    value._row_id_map = None
+    value._restore_shape = None
+    recv_hidden = torch.tensor([[1.0], [2.0], [3.0]])
+    recv_indices = torch.tensor([[1, -1], [0, 1], [0, -1]])
+    recv_probs = torch.tensor([[0.2, 0.0], [0.3, 0.4], [0.5, 0.0]])
+
+    dispatched, local_tpe, probs, metadata = value._finish_deepep_dispatch_external(
+        recv_hidden,
+        recv_indices,
+        recv_probs,
+        [2, 2],
+        force_manual_map=True,
+        force_direct_permute=True,
+    )
+
+    assert dispatched.squeeze(-1).tolist() == [2.0, 3.0, 1.0, 2.0]
+    assert local_tpe.tolist() == [2, 2]
+    assert probs.tolist() == pytest.approx([0.3, 0.5, 0.2, 0.4])
+    assert metadata["manual_row_id_map"].tolist() == [1, 2, 0, 1]
+    assert value._row_id_map is None
+
+
+def test_external_finish_does_not_read_cuda_metadata_with_tensor_item(monkeypatch):
+    value = _dispatcher()
+    recv_hidden = torch.tensor([[1.0], [2.0], [3.0]])
+    recv_indices = torch.tensor([[1, -1], [0, 1], [0, -1]])
+    recv_probs = torch.tensor([[0.2, 0.0], [0.3, 0.4], [0.5, 0.0]])
+
+    def fail_item(_tensor):
+        raise AssertionError(
+            "dispatch finish must validate host metadata without a device sync"
+        )
+
+    monkeypatch.setattr(torch.Tensor, "item", fail_item)
+    dispatched, local_tpe, _probs, metadata = value._finish_deepep_dispatch_external(
+        recv_hidden,
+        recv_indices,
+        recv_probs,
+        [2, 2],
+        force_manual_map=True,
+        force_direct_permute=True,
+    )
+
+    assert dispatched.shape == (4, 1)
+    assert local_tpe.shape == (2,)
+    assert metadata["local_tpe_list"] == [2, 2]
+
+
+def test_external_finish_can_reuse_host_expert_splits_without_device_tpe(monkeypatch):
+    value = _dispatcher()
+    recv_hidden = torch.tensor([[1.0], [2.0], [3.0]])
+    recv_indices = torch.tensor([[1, -1], [0, 1], [0, -1]])
+    recv_probs = torch.tensor([[0.2, 0.0], [0.3, 0.4], [0.5, 0.0]])
+    original_tensor = torch.tensor
+
+    def reject_local_tpe(data, *args, **kwargs):
+        if data == [2, 2] and kwargs.get("dtype") == torch.int64:
+            raise AssertionError("chunked dispatch must not rematerialize host splits")
+        return original_tensor(data, *args, **kwargs)
+
+    monkeypatch.setattr(torch, "tensor", reject_local_tpe)
+    dispatched, local_tpe, probs, metadata = value._finish_deepep_dispatch_external(
+        recv_hidden,
+        recv_indices,
+        recv_probs,
+        [2, 2],
+        force_manual_map=True,
+        force_direct_permute=True,
+        materialize_local_tpe=False,
+    )
+
+    assert local_tpe is None
+    assert dispatched.squeeze(-1).tolist() == [2.0, 3.0, 1.0, 2.0]
+    assert probs.tolist() == pytest.approx([0.3, 0.5, 0.2, 0.4])
+    assert metadata["local_tpe_list"] == [2, 2]
+
+
+def test_external_manual_finish_derives_rows_from_one_valid_coordinate_map(monkeypatch):
+    value = _dispatcher()
+    recv_hidden = torch.tensor([[1.0], [2.0], [3.0]])
+    recv_indices = torch.tensor([[1, -1], [0, 1], [0, -1]])
+    recv_probs = torch.tensor([[0.2, 0.0], [0.3, 0.4], [0.5, 0.0]])
+
+    def reject_arange(*_args, **_kwargs):
+        raise AssertionError("manual finish must not build a dense row-id grid")
+
+    monkeypatch.setattr(torch, "arange", reject_arange)
+    dispatched, _local_tpe, probs, metadata = value._finish_deepep_dispatch_external(
+        recv_hidden,
+        recv_indices,
+        recv_probs,
+        [2, 2],
+        force_manual_map=True,
+        force_direct_permute=True,
+    )
+
+    assert dispatched.squeeze(-1).tolist() == [2.0, 3.0, 1.0, 2.0]
+    assert probs.tolist() == pytest.approx([0.3, 0.5, 0.2, 0.4])
+    assert metadata["manual_row_id_map"].tolist() == [1, 2, 0, 1]
+    assert metadata["manual_prob_flat_indices"].tolist() == [2, 4, 0, 3]
+
+
+def test_deepep_dispatch_sums_duplicate_expert_probabilities(monkeypatch):
+    """Preserve native hash-routing weights after external dispatch refactoring."""
+    module = _dispatcher_module()
+    value = _dispatcher()
+    hidden = torch.tensor([[2.0, 3.0], [5.0, 7.0]])
+    indices = torch.tensor([[0, 0], [1, -1]])
+    scores = torch.tensor([[0.25, 0.5], [0.75, 0.0]], requires_grad=True)
+
+    def permute(hidden_states, routing_map, *, probs, num_out_tokens, fused):
+        assert num_out_tokens == 2
+        assert not fused
+        torch.testing.assert_close(routing_map, torch.eye(2, dtype=torch.bool))
+        return hidden_states, probs.diag(), torch.arange(2)
+
+    monkeypatch.setattr(module, "permute", permute)
+    dispatched, counts, probabilities, _ = value._finish_deepep_dispatch_external(
+        hidden, indices, scores, [1, 1]
+    )
+    torch.testing.assert_close(dispatched, hidden)
+    torch.testing.assert_close(counts, torch.tensor([1, 1]))
+    torch.testing.assert_close(probabilities, torch.tensor([0.75, 0.75]))
+    probabilities.sum().backward()
+    torch.testing.assert_close(scores.grad, torch.tensor([[1.0, 1.0], [1.0, 0.0]]))

--- a/experimental/lite/tests/unit/primitive/test_chunked_ep_small_batch.py
+++ b/experimental/lite/tests/unit/primitive/test_chunked_ep_small_batch.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Real forward schedules with CPU transport/stream doubles, not GPU parity."""
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+
+@pytest.mark.parametrize("chunk_count", [2, 4])
+@pytest.mark.parametrize("rows", [0, 1, 3])
+@pytest.mark.parametrize("saved_context", [False, True])
+@pytest.mark.parametrize("peer_rows", [0, 2])
+def test_small_rank_forward_matches_ordinary_ep(
+    chunk_count,
+    rows,
+    saved_context,
+    peer_rows,
+    monkeypatch,
+    transformer_engine_import_stub,
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules import moe_ep_chunk_overlap as overlap
+
+    calls = []
+
+    class Stream:
+        def wait_event(self, event):
+            pass
+
+    class Event:
+        def record(self, stream):
+            pass
+
+    class Router(torch.nn.Module):
+        def forward(self, x):
+            return x[:, :1].sigmoid(), torch.zeros((len(x), 1), dtype=torch.long)
+
+    class Experts(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.tensor([[2.0, 1.0], [-1.0, 3.0]]))
+
+        def forward(self, x, counts, probs, **kwargs):
+            return (x @ self.weight) * probs
+
+    class Dispatcher:
+        moe_permute_fusion = False
+
+        def submit_deepep_dispatch(self, x, scores, indices, **kwargs):
+            calls.append(len(x))
+            self.local_rows = len(x)
+            return {
+                "recv_hidden": torch.cat((x, torch.ones(peer_rows, 2))),
+                "recv_probs": torch.cat((scores, torch.ones(peer_rows, 1))),
+                "handle": len(x),
+            }
+
+        def finish_deepep_dispatch(self, state, **kwargs):
+            return (
+                state["recv_hidden"],
+                [len(state["recv_hidden"])],
+                state["recv_probs"],
+            )
+
+        def finish_deepep_dispatch_external_with_options(self, state, **kwargs):
+            x, counts, scores = self.finish_deepep_dispatch(state)
+            ids = torch.arange(len(x))
+            return (
+                x,
+                counts,
+                scores,
+                {
+                    "local_tpe_list": counts,
+                    "manual_row_id_map": ids,
+                    "manual_prob_flat_indices": ids,
+                },
+            )
+
+        def prepare_deepep_combine(self, output):
+            return output, self.local_rows
+
+        def submit_deepep_combine_prepared(self, output, handle, **kwargs):
+            return output[:handle]
+
+        def finish_deepep_combine(self, state):
+            return state
+
+    class Lease:
+        def __init__(self):
+            self.dispatcher = Dispatcher()
+
+        def deepep_recv_allocation(self):
+            return nullcontext()
+
+        def release(self, event):
+            pass
+
+    class Activation:
+        def tensor(self, name, shape, **kwargs):
+            return torch.empty(shape, **kwargs)
+
+        def allocate(self):
+            return nullcontext()
+
+        def release(self, event):
+            pass
+
+    profile = overlap.EPChunkShapeProfile.for_two_slot_chunked_ep(
+        max_input_rows=8,
+        hidden_size=2,
+        topk=1,
+        ep_size=2,
+        chunk_count=chunk_count,
+    )
+    workspace = SimpleNamespace(
+        key=SimpleNamespace(op="forward", shape_profile=profile),
+        acquire=lambda *args, **kwargs: Lease(),
+        acquire_expert_activation=lambda **kwargs: Activation(),
+    )
+    stream = Stream()
+    monkeypatch.setattr(overlap.torch.cuda, "Event", Event)
+    monkeypatch.setattr(overlap.torch.cuda, "current_stream", lambda *args: stream)
+    monkeypatch.setattr(overlap.torch.cuda, "stream", lambda *args: nullcontext())
+    monkeypatch.setattr(
+        overlap._EPChunkOperationBase, "_streams", lambda *args: (stream, stream)
+    )
+    monkeypatch.setattr(overlap, "unpermute", lambda output, *args, **kwargs: output)
+    router, experts = Router(), Experts()
+    backward = overlap.EPChunkBackwardOp(
+        router=router, experts=experts, workspace=workspace
+    )
+    op = overlap.EPChunkForwardOp(
+        router=router,
+        experts=experts,
+        workspace=workspace,
+        backward_op=backward,
+    )
+    x = (
+        torch.arange(rows * 2, dtype=torch.float32)
+        .reshape(rows, 2)
+        .requires_grad_(True)
+    )
+    # Ordinary EP: one router -> dispatch -> expert -> combine, without chunks.
+    native = Dispatcher()
+    scores, indices = router(x)
+    state = native.submit_deepep_dispatch(x, scores, indices)
+    received, counts, probs = native.finish_deepep_dispatch(state)
+    output, handle = native.prepare_deepep_combine(experts(received, counts, probs))
+    expected = native.finish_deepep_combine(
+        native.submit_deepep_combine_prepared(output, handle)
+    )
+    calls.clear()
+    with torch.set_grad_enabled(saved_context):
+        actual = op.forward(x)
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    assert actual.shape == x.shape
+    # Empty ranks still participate in every collective, even receiving peer work.
+    assert len(calls) == profile.chunk_count
+    assert sum(calls) == rows

--- a/experimental/lite/tests/unit/primitive/test_chunked_linear_cross_entropy.py
+++ b/experimental/lite/tests/unit/primitive/test_chunked_linear_cross_entropy.py
@@ -1,0 +1,333 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from __future__ import annotations
+
+import gc
+import math
+import socket
+import weakref
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from megatron.lite.primitive.ops.cross_entropy import vocab_parallel_cross_entropy
+from megatron.lite.primitive.ops import chunked_linear_cross_entropy as chunked_lce
+from megatron.lite.primitive.ops.chunked_linear_cross_entropy import (
+    _cuda_tp1_fast_path_eligible,
+    _forward_chunk_loss,
+    _row_reduce_workspace_shape,
+    _reuse_logits_storage_for_grad_logits,
+    chunked_vocab_parallel_linear_cross_entropy,
+)
+
+
+pytestmark = pytest.mark.mlite
+
+
+@pytest.mark.parametrize(
+    ("is_cuda", "dtype", "tp_world_size", "triton_available", "expected"),
+    [
+        (True, torch.bfloat16, 1, True, True),
+        (False, torch.bfloat16, 1, True, False),
+        (True, torch.float32, 1, True, False),
+        (True, torch.float64, 1, True, False),
+        (True, torch.bfloat16, 2, True, False),
+        (True, torch.bfloat16, 1, False, False),
+    ],
+)
+def test_chunked_linear_cross_entropy_cuda_fast_path_is_tp1_only(
+    is_cuda, dtype, tp_world_size, triton_available, expected
+):
+    assert (
+        _cuda_tp1_fast_path_eligible(
+            is_cuda=is_cuda,
+            dtype=dtype,
+            tp_world_size=tp_world_size,
+            triton_available=triton_available,
+        )
+        is expected
+    )
+
+
+def test_chunked_linear_cross_entropy_cuda_row_reduce_workspace_is_not_vocab_shaped():
+    rows, vocab, block = 1024, 151936, 4096
+
+    partial_shape, row_shape = _row_reduce_workspace_shape(rows, vocab, block)
+
+    assert partial_shape == (rows, 38)
+    assert row_shape == (rows,)
+    assert partial_shape != (rows, vocab)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA Triton")
+def test_chunked_linear_cross_entropy_cuda_fast_path_materializes_stride_zero_dloss():
+    torch.manual_seed(19)
+    hidden = torch.randn(4, 3, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    weight = torch.randn(11, 3, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    labels = torch.randint(0, 11, (4,), device="cuda")
+    kernel_strides = []
+    original = chunked_lce._cuda_lce.inplace_gradient
+
+    def record_gradient(logits, target, grad_output, temperature):
+        kernel_strides.append(grad_output.stride())
+        return original(logits, target, grad_output, temperature)
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(chunked_lce._cuda_lce, "inplace_gradient", record_gradient)
+    try:
+        loss = chunked_vocab_parallel_linear_cross_entropy(
+            hidden, weight, labels, chunk_size=2
+        )
+        upstream = torch.ones(1, device="cuda").expand_as(loss)
+        assert upstream.stride() == (0,)
+        loss.backward(upstream)
+    finally:
+        monkeypatch.undo()
+
+    assert kernel_strides == [(1,), (1,)]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA Triton")
+@pytest.mark.parametrize("rows", [14135, 14136, 16384])
+def test_chunked_linear_cross_entropy_cuda_row_base_offsets_support_large_vocab_windows(
+    rows,
+):
+    vocab = 151936
+    logits = torch.zeros((rows, vocab), device="cuda", dtype=torch.bfloat16)
+    target = torch.zeros(rows, device="cuda", dtype=torch.long)
+
+    loss = chunked_lce._cuda_lce.token_loss(logits, target)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(loss, torch.full_like(loss, math.log(vocab)))
+
+    if rows == 16384:
+        grad_output = torch.ones(rows, device="cuda", dtype=torch.float32)
+        grad_logits = chunked_lce._cuda_lce.inplace_gradient(
+            logits, target, grad_output, 1.0
+        )
+        torch.cuda.synchronize()
+        assert grad_logits.data_ptr() == logits.data_ptr()
+        torch.testing.assert_close(
+            grad_logits[:, 0].float(),
+            torch.full((rows,), -(1.0 - 1.0 / vocab), device="cuda"),
+            rtol=0.0,
+            atol=0.004,
+        )
+        torch.testing.assert_close(
+            grad_logits[:, 1].float(),
+            torch.full((rows,), 1.0 / vocab, device="cuda"),
+            rtol=0.0,
+            atol=0.004,
+        )
+
+
+def test_chunked_linear_cross_entropy_reuses_logits_storage_for_bf16_dlogits():
+    logits = torch.empty(3, 7, dtype=torch.bfloat16)
+    softmax = torch.rand(3, 7, dtype=torch.float32)
+
+    grad_logits = _reuse_logits_storage_for_grad_logits(logits, softmax)
+
+    assert grad_logits.dtype is torch.bfloat16
+    assert grad_logits.data_ptr() == logits.data_ptr()
+    torch.testing.assert_close(grad_logits.float(), softmax, rtol=0.0, atol=0.004)
+
+
+def test_chunked_linear_cross_entropy_releases_previous_softmax_before_next_window(
+    monkeypatch,
+):
+    torch.manual_seed(11)
+    hidden = torch.randn(6, 1, 4, dtype=torch.bfloat16, requires_grad=True)
+    weight = torch.randn(9, 4, dtype=torch.bfloat16, requires_grad=True)
+    labels = torch.randint(0, 9, (6, 1))
+    original = chunked_lce._chunk_loss_and_softmax
+    prior_softmax = []
+
+    def checked_chunk_loss(*args, **kwargs):
+        gc.collect()
+        assert all(ref() is None for ref in prior_softmax)
+        result = original(*args, **kwargs)
+        if result[1] is not None:
+            prior_softmax.append(weakref.ref(result[1]))
+        return result
+
+    monkeypatch.setattr(chunked_lce, "_chunk_loss_and_softmax", checked_chunk_loss)
+    chunked_vocab_parallel_linear_cross_entropy(
+        hidden, weight, labels, chunk_size=2
+    ).sum().backward()
+
+
+def test_chunked_linear_cross_entropy_releases_forward_logits_at_window_scope(
+    monkeypatch,
+):
+    torch.manual_seed(13)
+    hidden = torch.randn(6, 1, 4, dtype=torch.bfloat16, requires_grad=True)
+    weight = torch.randn(9, 4, dtype=torch.bfloat16, requires_grad=True)
+    labels = torch.randint(0, 9, (6, 1))
+    original = chunked_lce._chunk_loss_and_softmax
+    captured_logits = []
+
+    def checked_chunk_loss(logits, *args, **kwargs):
+        captured_logits.append(weakref.ref(logits))
+        return original(logits, *args, **kwargs)
+
+    monkeypatch.setattr(chunked_lce, "_chunk_loss_and_softmax", checked_chunk_loss)
+    with torch.no_grad():
+        _forward_chunk_loss(
+            hidden.reshape(-1, 4),
+            weight,
+            labels.reshape(-1),
+            0,
+            2,
+            None,
+            0,
+            9,
+            1.25,
+        )
+    gc.collect()
+    assert captured_logits[0]() is None
+
+
+def _reference_loss(hidden, weight, labels, temperature, group=None):
+    logits = hidden.matmul(weight.t())
+    if temperature != 1.0:
+        logits = logits / temperature
+    logits_fp32 = logits.float()
+    row_max = logits_fp32.max(dim=-1).values
+    if group is not None:
+        dist.all_reduce(row_max, op=dist.ReduceOp.MAX, group=group)
+    shifted = logits_fp32 - row_max.unsqueeze(-1)
+    exp_shifted = shifted.exp()
+    summed = exp_shifted.sum(dim=-1)
+    target = labels.clone()
+    local_vocab = weight.shape[0]
+    rank = dist.get_rank(group) if group is not None else 0
+    mask = (target < rank * local_vocab) | (target >= (rank + 1) * local_vocab)
+    target = (target - rank * local_vocab).masked_fill(mask, 0)
+    predicted = shifted.reshape(-1, local_vocab)[
+        torch.arange(target.numel()), target.reshape(-1)
+    ].reshape_as(labels)
+    predicted.masked_fill_(mask, 0.0)
+    if group is not None:
+        dist.all_reduce(summed, group=group)
+        dist.all_reduce(predicted, group=group)
+    return summed.log() - predicted
+
+
+def test_chunked_linear_cross_entropy_tp1_matches_matmul_ce_and_saves_no_logits():
+    torch.manual_seed(7)
+    hidden = torch.randn(5, 2, 4, dtype=torch.bfloat16, requires_grad=True)
+    weight = torch.randn(9, 4, dtype=torch.bfloat16, requires_grad=True)
+    labels = torch.randint(0, 9, (5, 2))
+    hidden_ref = hidden.detach().clone().requires_grad_()
+    weight_ref = weight.detach().clone().requires_grad_()
+    saved = []
+
+    with torch.autograd.graph.saved_tensors_hooks(
+        lambda tensor: (saved.append(tensor), tensor)[1], lambda tensor: tensor
+    ):
+        token_loss = chunked_vocab_parallel_linear_cross_entropy(
+            hidden, weight, labels, temperature=1.25, chunk_size=3
+        )
+    token_loss.sum().backward()
+
+    expected = _reference_loss(hidden_ref, weight_ref, labels, 1.25)
+    expected.sum().backward()
+
+    torch.testing.assert_close(token_loss, expected)
+    torch.testing.assert_close(hidden.grad, hidden_ref.grad, rtol=0.03, atol=0.003)
+    torch.testing.assert_close(weight.grad, weight_ref.grad, rtol=0.03, atol=0.003)
+    assert not any(tensor.shape == (5, 2, 9) for tensor in saved)
+
+
+def _tp_sp_worker(rank, world_size, port):
+    dist.init_process_group(
+        "gloo", init_method=f"tcp://127.0.0.1:{port}", rank=rank, world_size=world_size
+    )
+    try:
+        torch.manual_seed(17)
+        full_hidden = torch.randn(6, 1, 4, dtype=torch.bfloat16)
+        full_weight = torch.randn(10, 4, dtype=torch.bfloat16)
+        labels = torch.randint(0, 10, (6, 1))
+        hidden = full_hidden.chunk(world_size, dim=0)[rank].clone().requires_grad_()
+        weight = full_weight.chunk(world_size, dim=0)[rank].clone().requires_grad_()
+
+        actual = chunked_vocab_parallel_linear_cross_entropy(
+            hidden,
+            weight,
+            labels,
+            tp_group=dist.group.WORLD,
+            sequence_parallel=True,
+            chunk_size=2,
+        )
+        actual.sum().backward()
+
+        # Match _VanillaColParallelMatmulSP.backward exactly: each vocab shard
+        # forms a full-sequence dH contribution, then one reduce-scatter both
+        # sums TP contributions and returns the local SP sequence slice.
+        logits_ref = full_hidden.matmul(weight.detach().t()).requires_grad_()
+        expected = vocab_parallel_cross_entropy(logits_ref, labels, dist.group.WORLD)
+        expected.sum().backward()
+        grad_hidden = torch.empty_like(hidden)
+        dist.reduce_scatter_tensor(
+            grad_hidden,
+            logits_ref.grad.matmul(weight.detach()).contiguous(),
+            group=dist.group.WORLD,
+        )
+        grad_weight = (
+            logits_ref.grad.reshape(-1, weight.shape[0])
+            .t()
+            .matmul(full_hidden.reshape(-1, full_hidden.shape[-1]))
+        )
+        torch.testing.assert_close(actual, expected)
+        torch.testing.assert_close(hidden.grad, grad_hidden, rtol=0.03, atol=0.003)
+        torch.testing.assert_close(weight.grad, grad_weight, rtol=0.03, atol=0.003)
+    finally:
+        dist.destroy_process_group()
+
+
+def test_chunked_linear_cross_entropy_matches_two_rank_gloo_tp_sp():
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+    mp.spawn(_tp_sp_worker, args=(2, port), nprocs=2, join=True)
+
+
+@pytest.mark.parametrize(
+    ("labels", "use_fused_kernels", "calculate_entropy", "has_chunked_ep", "expected"),
+    [
+        (True, False, False, True, True),
+        (True, True, False, True, False),
+        (True, False, True, True, False),
+        (True, False, False, False, False),
+        (False, False, False, True, False),
+    ],
+)
+def test_qwen3_chunked_head_loss_selection_contract(
+    labels, use_fused_kernels, calculate_entropy, has_chunked_ep, expected
+):
+    from megatron.lite.model.qwen3_moe.lite.head_loss import use_chunked_head_loss
+
+    assert (
+        use_chunked_head_loss(
+            has_labels=labels,
+            use_fused_kernels=use_fused_kernels,
+            calculate_entropy=calculate_entropy,
+            has_chunked_ep=has_chunked_ep,
+        )
+        is expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("token_count", "chunk_count", "expected"),
+    [(1, 1, 1), (1025, 3, 342), (32768, 2, 16384)],
+)
+def test_qwen3_head_loss_balances_tokens_across_configured_ep_chunks(
+    token_count, chunk_count, expected
+):
+    from megatron.lite.model.qwen3_moe.lite.head_loss import (
+        balanced_head_loss_chunk_size,
+    )
+
+    assert balanced_head_loss_chunk_size(token_count, chunk_count) == expected

--- a/experimental/lite/tests/unit/primitive/test_init_device.py
+++ b/experimental/lite/tests/unit/primitive/test_init_device.py
@@ -29,7 +29,9 @@ def _build_fsdp2(monkeypatch, transformer_engine_import_stub):
     monkeypatch.setattr(protocol, "set_cross_entropy_fusion", lambda *_args: None)
     monkeypatch.setattr(protocol, "apply_qat_to_chunks", lambda *_args: None)
     monkeypatch.setattr(nn.Module, "cuda", lambda self: self)
-    cfg = SimpleNamespace(num_nextn_predict_layers=0)
+    # Use the real Qwen3-30B-A3B architecture defaults, including router top-k.
+    # Model construction is replaced above; this remains a device-policy test.
+    cfg = protocol.Qwen3MoEConfig()
     bundle = protocol.build_model(cfg, impl_cfg=protocol.ImplConfig(optimizer="fsdp2"))
     return seen, [param.device.type for param in bundle.chunks[0].parameters()]
 
@@ -272,3 +274,14 @@ def test_dispatcher_metadata_stays_materialized_in_meta_context() -> None:
 
     assert dispatcher._sort_by_experts == [0, 2, 1, 3]
     assert dispatcher._restore_by_ranks == [0, 2, 1, 3]
+
+
+def test_model_config_requires_router_topk(transformer_engine_import_stub):
+    transformer_engine_import_stub()
+    from megatron.lite.model.qwen3_moe.lite import protocol
+
+    with pytest.raises(ValueError, match="num_experts_per_tok"):
+        protocol.build_model(
+            SimpleNamespace(num_nextn_predict_layers=0),
+            impl_cfg=protocol.ImplConfig(optimizer="fsdp2"),
+        )

--- a/experimental/lite/tests/unit/primitive/test_moe_ep_chunk_overlap.py
+++ b/experimental/lite/tests/unit/primitive/test_moe_ep_chunk_overlap.py
@@ -1,0 +1,209 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from __future__ import annotations
+
+import inspect
+from types import MethodType, SimpleNamespace
+
+import pytest
+import torch
+
+from megatron.lite.primitive.modules.moe_ep_chunk_overlap_policy import (
+    ep_chunk_ranges,
+    validate_ep_chunk_overlap_config,
+)
+
+
+def test_fixed_two_chunk_ranges_cover_each_token_exactly_once():
+    ranges = ep_chunk_ranges(11)
+
+    assert ranges == [(0, 6), (6, 11)]
+    assert [token for start, end in ranges for token in range(start, end)] == list(
+        range(11)
+    )
+
+
+@pytest.mark.parametrize(
+    ("chunk_count", "expected"),
+    [
+        (2, [(0, 6), (6, 11)]),
+        (3, [(0, 4), (4, 8), (8, 11)]),
+        (4, [(0, 3), (3, 6), (6, 9), (9, 11)]),
+    ],
+)
+def test_parameterized_chunk_ranges_cover_odd_rows_once(chunk_count, expected):
+    ranges = ep_chunk_ranges(11, chunk_count=chunk_count)
+
+    assert ranges == expected
+    assert [token for start, end in ranges for token in range(start, end)] == list(
+        range(11)
+    )
+
+
+def test_parameterized_ranges_return_exact_chunk_count_when_rows_do_not_divide():
+    assert ep_chunk_ranges(6, chunk_count=4) == [(0, 2), (2, 4), (4, 5), (5, 6)]
+
+
+@pytest.mark.parametrize("tokens", [0, 1])
+def test_fixed_two_chunk_ranges_fail_loud_when_both_chunks_cannot_be_live(tokens):
+    with pytest.raises(ValueError, match="at least two tokens"):
+        ep_chunk_ranges(tokens)
+
+
+@pytest.mark.parametrize(
+    "enabled,use_deepep,ep_size,topk",
+    [(False, False, 1, 8), (False, True, 8, 8), (True, True, 8, 8)],
+)
+def test_qwen_model_contract_accepts_only_supported_combinations(
+    enabled, use_deepep, ep_size, topk
+):
+    assert (
+        validate_ep_chunk_overlap_config(
+            enabled,
+            use_deepep=use_deepep,
+            ep_size=ep_size,
+            topk=topk,
+            max_token_rows_per_rank=4096 if enabled else None,
+        )
+        is enabled
+    )
+
+
+@pytest.mark.parametrize(
+    "enabled,use_deepep,ep_size",
+    [(True, False, 8), (True, True, 1)],
+)
+def test_qwen_model_contract_fails_loud(enabled, use_deepep, ep_size):
+    with pytest.raises(ValueError):
+        validate_ep_chunk_overlap_config(
+            enabled, use_deepep=use_deepep, ep_size=ep_size, topk=1
+        )
+
+
+def test_fused_op_static_source_order_flushes_before_local_storage_overwrite(
+    transformer_engine_import_stub,
+):
+    """Static concurrency guard; this is not end-to-end DeepEP evidence."""
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import EPChunkBackwardOp
+
+    source = inspect.getsource(EPChunkBackwardOp._full_recompute_fused_backward_v6)
+
+    dgrad = source.index("expert_grads = torch.autograd.grad(")
+    dgrad_ready = source.index("dgrad_ready.record(compute_stream)", dgrad)
+    flushed = source.index("flush_delayed_weight_grads", dgrad_ready)
+    overwritten = source.index("_dispatch_local_backward", flushed)
+    local_ready = source.index("local_bwd_ready.record(wgrad_stream)", overwritten)
+    dispatched = source.index("submit_deepep_dispatch_backward", local_ready)
+
+    assert dgrad < dgrad_ready < flushed < overwritten < local_ready < dispatched
+    assert "num_contexts=1" in source[flushed:overwritten]
+    assert "compute_stream.wait_event(wgrad_done)" not in source
+    assert "torch.cuda.synchronize" not in source
+
+
+def test_three_ops_have_distinct_saved_context_and_recompute_contracts(
+    transformer_engine_import_stub,
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        EPChunkBackwardOp,
+        EPChunkForwardOp,
+        EPChunkFusedForwardBackwardOp,
+    )
+
+    forward_source = inspect.getsource(EPChunkForwardOp)
+    backward_source = inspect.getsource(EPChunkBackwardOp)
+    fused_source = inspect.getsource(EPChunkFusedForwardBackwardOp)
+    primitive_source = inspect.getsource(
+        inspect.getmodule(EPChunkFusedForwardBackwardOp)
+    )
+
+    assert "forward-only" not in forward_source
+    assert "_SavedContextEPChunkFunction.apply" in forward_source
+    assert "context" in inspect.signature(EPChunkBackwardOp.backward).parameters
+    assert "_full_recompute" not in backward_source
+    assert "backward_op" not in fused_source
+    assert "_full_recompute_fused_backward" in fused_source
+    assert "moe_act_recompute" not in primitive_source
+
+
+def test_three_ops_direct_behavior_contracts(transformer_engine_import_stub):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        EPChunkBackwardOp,
+        EPChunkForwardOp,
+        EPChunkFusedForwardBackwardOp,
+    )
+
+    def workspace(op):
+        dispatchers = [SimpleNamespace(use_deepep=True) for _ in range(2)]
+        return SimpleNamespace(
+            key=SimpleNamespace(
+                op=op, shape_profile=SimpleNamespace(chunk_count=2)
+            ),
+            dispatcher=lambda slot: dispatchers[slot],
+            reset_tensors=lambda **_kwargs: None,
+            park_expert_activations=lambda **_kwargs: None,
+        )
+
+    router = torch.nn.Identity()
+    experts = torch.nn.Identity()
+    backward = EPChunkBackwardOp(
+        router=router, experts=experts, workspace=workspace("backward")
+    )
+    calls = {"forward": 0, "backward": 0, "fused": 0}
+    marker = object()
+
+    def saved_forward(_self, x, _ranges, input_shape, _dtype):
+        calls["forward"] += 1
+        return (x * 2).view(input_shape), marker
+
+    def saved_backward(_self, context, grad):
+        assert context is marker
+        assert torch.is_grad_enabled() is True
+        calls["backward"] += 1
+        return grad * 2, [], []
+
+    backward._saved_context_backward = MethodType(saved_backward, backward)
+    forward = EPChunkForwardOp(
+        router=router,
+        experts=experts,
+        workspace=workspace("forward"),
+        backward_op=backward,
+    )
+    forward._forward_saved_context_async = MethodType(saved_forward, forward)
+    forward._forward_output_async = MethodType(
+        lambda _self, x, _ranges, input_shape, _dtype, **_kwargs: (x * 2).view(
+            input_shape
+        ),
+        forward,
+    )
+    value = torch.randn(2, 4, requires_grad=True)
+    output = forward(value)
+    output.sum().backward()
+    torch.testing.assert_close(output, value.detach() * 2)
+    torch.testing.assert_close(value.grad, torch.full_like(value, 2))
+    assert calls == {"forward": 1, "backward": 1, "fused": 0}
+    with torch.no_grad():
+        inference = forward(value.detach())
+    torch.testing.assert_close(inference, value.detach() * 2)
+
+    fused = EPChunkFusedForwardBackwardOp(
+        router=router,
+        experts=experts,
+        workspace=workspace("fused_forward_backward"),
+    )
+
+    def fused_forward_backward(_self, _x, grad):
+        calls["fused"] += 1
+        return grad * 3, [], []
+
+    fused._full_recompute_fused_backward = MethodType(fused_forward_backward, fused)
+    grad_x, router_grads, expert_grads = fused.forward_backward(
+        value.detach(), torch.ones_like(value)
+    )
+    torch.testing.assert_close(grad_x, torch.full_like(value, 3))
+    assert router_grads == []
+    assert expert_grads == []
+    assert calls["fused"] == 1

--- a/experimental/lite/tests/unit/primitive/test_moe_ep_chunk_overlap.py
+++ b/experimental/lite/tests/unit/primitive/test_moe_ep_chunk_overlap.py
@@ -207,3 +207,19 @@ def test_three_ops_direct_behavior_contracts(transformer_engine_import_stub):
     assert router_grads == []
     assert expert_grads == []
     assert calls["fused"] == 1
+
+
+@pytest.mark.parametrize("chunk_count", [True, 1.5, 0, 1, 9])
+def test_chunk_count_validated_against_capacity(chunk_count):
+    with pytest.raises((TypeError, ValueError), match="chunk|token"):
+        validate_ep_chunk_overlap_config(
+            True, use_deepep=True, ep_size=2, topk=2,
+            max_token_rows_per_rank=8, chunk_count=chunk_count,
+        )
+
+
+def test_chunk_count_supports_more_than_two_logical_chunks():
+    assert validate_ep_chunk_overlap_config(
+        True, use_deepep=True, ep_size=2, topk=2,
+        max_token_rows_per_rank=8, chunk_count=3,
+    )

--- a/experimental/lite/tests/unit/primitive/test_moe_ep_chunk_overlap_core.py
+++ b/experimental/lite/tests/unit/primitive/test_moe_ep_chunk_overlap_core.py
@@ -1,0 +1,2735 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from __future__ import annotations
+
+import ast
+import inspect
+from contextlib import nullcontext
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+
+SOURCE = (
+    Path(__file__).parents[3]
+    / "megatron/lite/primitive/modules/moe_ep_chunk_overlap.py"
+)
+
+
+def test_finished_deepep_dispatch_shape_contract_executes_with_fake_dispatcher(
+    transformer_engine_import_stub,
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        EPChunkShapeProfile,
+        _validate_finished_deepep_dispatch,
+    )
+
+    class FakeDispatcher:
+        @staticmethod
+        def finish(*, recv_rows, expert_rows):
+            state = {
+                "recv_hidden": torch.zeros(recv_rows, 4),
+                "recv_probs": torch.zeros(recv_rows, 2),
+            }
+            return state, torch.zeros(expert_rows, 4)
+
+    profile = EPChunkShapeProfile(
+        max_input_rows=4,
+        hidden_size=4,
+        topk=2,
+        ep_size=2,
+    )
+    dispatcher = FakeDispatcher()
+    state, dispatched = dispatcher.finish(recv_rows=4, expert_rows=8)
+    _validate_finished_deepep_dispatch(profile, state, dispatched)
+
+    state, dispatched = dispatcher.finish(recv_rows=5, expert_rows=8)
+    with pytest.raises(RuntimeError, match="recv rows"):
+        _validate_finished_deepep_dispatch(profile, state, dispatched)
+
+    state, dispatched = dispatcher.finish(recv_rows=4, expert_rows=9)
+    with pytest.raises(RuntimeError, match="expert rows"):
+        _validate_finished_deepep_dispatch(profile, state, dispatched)
+
+
+def test_fused_pending_retirement_releases_dispatch_lease_before_next_expert(
+    monkeypatch, transformer_engine_import_stub
+):
+    """CPU contract for dispatch-lease ordering, not physical allocator reuse."""
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules import moe_ep_chunk_overlap as overlap
+
+    events = []
+
+    class FakeEvent:
+        def record(self, _stream):
+            events.append("lease-release-event")
+
+    class FakeDispatcher:
+        def finish_deepep_dispatch_backward(self, _state):
+            events.append("retire-dispatch-bwd")
+            return torch.ones(1, 1), torch.ones(1, 1)
+
+    class FakeLease:
+        def release(self, _event):
+            events.append("lease-release")
+
+    monkeypatch.setattr(overlap.torch.cuda, "stream", lambda _stream: nullcontext())
+    monkeypatch.setattr(overlap.torch.cuda, "Event", FakeEvent)
+    x = torch.ones(1, 1, requires_grad=True)
+    scores = x * 2
+    chunk = overlap._BackwardChunk(
+        idx=0,
+        start=0,
+        end=1,
+        x=x,
+        scores=scores,
+        handle=None,
+        row_id_map=torch.zeros(1, dtype=torch.long),
+        prob_flat_indices=torch.zeros(1, dtype=torch.long),
+        recv_hidden_shape=torch.Size((1, 1)),
+        recv_hidden_dtype=torch.float32,
+        recv_probs_shape=torch.Size((1, 1)),
+        recv_probs_dtype=torch.float32,
+        recv_probs_base=None,
+        dispatched=None,
+        probs=None,
+        expert_out=None,
+        dispatcher=FakeDispatcher(),
+        workspace_lease=FakeLease(),
+        scores_shape=scores.shape,
+        scores_dtype=scores.dtype,
+    )
+    pending = [(chunk, {"dispatch_bwd_state": object()})]
+    grad_x_chunks = [None]
+
+    events.append("prefetch-next")
+    overlap._retire_one_fused_dispatch_bwd(
+        pending,
+        compute_stream=object(),
+        grad_2d=torch.ones(1, 1),
+        router_params=(),
+        grad_x_chunks=grad_x_chunks,
+        router_accum=[],
+    )
+    events.append("expert-start-next")
+
+    assert pending == []
+    torch.testing.assert_close(grad_x_chunks[0], torch.full((1, 1), 3.0))
+    assert events == [
+        "prefetch-next",
+        "retire-dispatch-bwd",
+        "lease-release-event",
+        "lease-release",
+        "expert-start-next",
+    ]
+
+
+@pytest.mark.parametrize(
+    "state,dispatched,error",
+    [
+        (
+            {"recv_hidden": torch.zeros(4), "recv_probs": torch.zeros(4, 2)},
+            torch.zeros(8, 4),
+            "recv_hidden must be a rank-2 tensor",
+        ),
+        (
+            {"recv_hidden": torch.zeros(4, 5), "recv_probs": torch.zeros(4, 2)},
+            torch.zeros(8, 4),
+            "recv hidden size 5.*profile 4",
+        ),
+        (
+            {"recv_hidden": torch.zeros(4, 4), "recv_probs": torch.zeros(4)},
+            torch.zeros(8, 4),
+            "recv_probs must be a rank-2 tensor",
+        ),
+        (
+            {"recv_hidden": torch.zeros(4, 4), "recv_probs": torch.zeros(3, 2)},
+            torch.zeros(8, 4),
+            "recv_hidden and recv_probs rows must match",
+        ),
+        (
+            {"recv_hidden": torch.zeros(4, 4), "recv_probs": torch.zeros(4, 3)},
+            torch.zeros(8, 4),
+            "recv_probs top-k 3.*profile 2",
+        ),
+        (
+            {"recv_hidden": torch.zeros(4, 4), "recv_probs": torch.zeros(4, 2)},
+            torch.zeros(8, 5),
+            "dispatched expert input must be rank-2",
+        ),
+    ],
+)
+def test_finished_deepep_dispatch_rejects_shape_contract_mismatch(
+    state, dispatched, error, transformer_engine_import_stub
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        EPChunkShapeProfile,
+        _validate_finished_deepep_dispatch,
+    )
+
+    profile = EPChunkShapeProfile(max_input_rows=4, hidden_size=4, topk=2, ep_size=2)
+    with pytest.raises(RuntimeError, match=error):
+        _validate_finished_deepep_dispatch(profile, state, dispatched)
+
+
+def test_all_three_dispatch_finish_paths_validate_before_expert_or_arena(
+    transformer_engine_import_stub,
+):
+    import inspect
+
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        _EPChunkOperationBase,
+    )
+
+    for method in (
+        _EPChunkOperationBase._forward_output_async,
+        _EPChunkOperationBase._forward_saved_context_async,
+        _EPChunkOperationBase._full_recompute_fused_backward_v6,
+    ):
+        source = inspect.getsource(method)
+        validated = source.index("_validate_finished_deepep_dispatch")
+        expert = source.index("self.experts(", validated)
+        assert validated < expert
+
+
+def test_three_ops_expose_bounded_nvtx_phase_ranges():
+    source = SOURCE.read_text()
+
+    for phase in (
+        "forward.dispatch",
+        "forward.expert",
+        "forward.combine",
+        "backward.dispatch",
+        "backward.expert",
+        "backward.combine",
+        "backward.wgrad",
+    ):
+        assert phase in source
+
+
+def test_experts_accept_te_dbias_placeholders_when_bias_is_disabled(
+    monkeypatch, transformer_engine_import_stub
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules import experts as experts_module
+
+    class FakeStore:
+        def __init__(self, linear):
+            self.linear = linear
+            self.pending = 1
+            self.context = SimpleNamespace(empty=lambda: self.pending == 0)
+
+        @staticmethod
+        def delay_wgrad_compute():
+            return True
+
+        def pop(self):
+            self.pending -= 1
+            grads = [
+                getattr(self.linear, f"weight{idx}").main_grad
+                for idx in range(self.linear.num_gemms)
+            ]
+            return (None, [torch.empty(0), torch.empty(0)], None), [None, None, grads]
+
+    class FakeGroupedLinear(torch.nn.Module):
+        def __init__(self, num_gemms, *_args, bias, **_kwargs):
+            super().__init__()
+            self.num_gemms = num_gemms
+            self.use_bias = bias
+            for idx in range(num_gemms):
+                param = torch.nn.Parameter(torch.zeros(2, 2))
+                param.main_grad = torch.ones(2, 2)
+                self.register_parameter(f"weight{idx}", param)
+            self.wgrad_store = FakeStore(self)
+
+    monkeypatch.setattr(
+        experts_module.te, "GroupedLinear", FakeGroupedLinear, raising=False
+    )
+    config = SimpleNamespace(
+        num_experts=2,
+        hidden_size=2,
+        moe_intermediate_size=2,
+        swiglu_limit=0.0,
+    )
+    ps = SimpleNamespace(ep_size=1, etp_size=1, tp_size=1, etp_group=None)
+    experts = experts_module.Experts(config, ps, delay_wgrad_compute=True)
+
+    experts.flush_delayed_weight_grads(num_contexts=1)
+
+    assert all(parameter.grad is None for parameter in experts.parameters())
+    for linear in (experts.fc1, experts.fc2):
+        linear.wgrad_store._mlite_immediate_wgrad_contexts = 1
+    experts.flush_delayed_weight_grads(num_contexts=1)
+    assert all(
+        linear.wgrad_store._mlite_immediate_wgrad_contexts == 0
+        for linear in (experts.fc1, experts.fc2)
+    )
+
+    for linear in (experts.fc1, experts.fc2):
+        linear.wgrad_store._mlite_immediate_wgrad_contexts = 2
+    with pytest.raises(RuntimeError, match="immediate/deferred context accounting"):
+        experts.flush_delayed_weight_grads(num_contexts=1)
+
+    for linear in (experts.fc1, experts.fc2):
+        linear.wgrad_store._mlite_immediate_wgrad_contexts = 1
+        linear.wgrad_store.pending = 1
+    with pytest.raises(RuntimeError, match="queue was not drained"):
+        experts.flush_delayed_weight_grads(num_contexts=1)
+
+
+def test_expert_wgrad_flush_records_nested_cuda_views_and_bases(
+    monkeypatch, transformer_engine_import_stub
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules import experts as experts_module
+
+    original_is_tensor = experts_module.torch.is_tensor
+    stream = object()
+    recorded = []
+
+    class FakeCudaTensor:
+        is_cuda = True
+
+        def __init__(self, name, *, base=None):
+            self.name = name
+            self._base = base
+
+        def record_stream(self, actual_stream):
+            recorded.append((self.name, actual_stream))
+
+    class FakeStore:
+        def __init__(self, linear, prefix):
+            self.linear = linear
+            self.pending = 1
+            self.context = SimpleNamespace(empty=lambda: self.pending == 0)
+            self.base = FakeCudaTensor(f"{prefix}.base")
+            self.view = FakeCudaTensor(f"{prefix}.view", base=self.base)
+
+        @staticmethod
+        def delay_wgrad_compute():
+            return True
+
+        def pop(self):
+            self.pending -= 1
+            grads = [
+                getattr(self.linear, f"weight{idx}").main_grad
+                for idx in range(self.linear.num_gemms)
+            ]
+            result = ({"result": (self.view,)}, None, None)
+            tensors = [{"input": self.view}, [self.view], grads]
+            return result, tensors
+
+    class FakeGroupedLinear(torch.nn.Module):
+        next_idx = 0
+
+        def __init__(self, num_gemms, *_args, bias, **_kwargs):
+            super().__init__()
+            self.num_gemms = num_gemms
+            self.use_bias = bias
+            prefix = f"linear{FakeGroupedLinear.next_idx}"
+            FakeGroupedLinear.next_idx += 1
+            for idx in range(num_gemms):
+                param = torch.nn.Parameter(torch.zeros(2, 2))
+                param.main_grad = torch.ones(2, 2)
+                self.register_parameter(f"weight{idx}", param)
+            self.wgrad_store = FakeStore(self, prefix)
+
+    monkeypatch.setattr(
+        experts_module.te, "GroupedLinear", FakeGroupedLinear, raising=False
+    )
+    monkeypatch.setattr(
+        experts_module.torch,
+        "is_tensor",
+        lambda value: isinstance(value, FakeCudaTensor) or original_is_tensor(value),
+    )
+    experts = experts_module.Experts(
+        SimpleNamespace(
+            num_experts=2,
+            hidden_size=2,
+            moe_intermediate_size=2,
+            swiglu_limit=0.0,
+        ),
+        SimpleNamespace(ep_size=1, etp_size=1, tp_size=1, etp_group=None),
+        delay_wgrad_compute=True,
+    )
+
+    experts.flush_delayed_weight_grads(num_contexts=1, stream=stream)
+
+    assert recorded == [
+        ("linear0.view", stream),
+        ("linear0.base", stream),
+        ("linear1.view", stream),
+        ("linear1.base", stream),
+    ]
+    assert experts.fc1.wgrad_store.context.empty()
+    assert experts.fc2.wgrad_store.context.empty()
+
+
+def test_delayed_expert_wgrads_request_fused_sink_reuse(
+    monkeypatch, transformer_engine_import_stub
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules import experts as experts_module
+
+    grouped_linear_kwargs = []
+
+    class FakeGroupedLinear(torch.nn.Module):
+        def __init__(self, num_gemms, *_args, bias, **kwargs):
+            super().__init__()
+            grouped_linear_kwargs.append(kwargs)
+            self.use_bias = bias
+            for idx in range(num_gemms):
+                self.register_parameter(
+                    f"weight{idx}", torch.nn.Parameter(torch.zeros(2, 2))
+                )
+
+    monkeypatch.setattr(
+        experts_module.te, "GroupedLinear", FakeGroupedLinear, raising=False
+    )
+    config = SimpleNamespace(
+        num_experts=2,
+        hidden_size=2,
+        moe_intermediate_size=2,
+        swiglu_limit=0.0,
+    )
+    ps = SimpleNamespace(ep_size=1, etp_size=1, tp_size=1, etp_group=None)
+
+    experts_module.Experts(config, ps, delay_wgrad_compute=True)
+
+    assert all(kwargs["delay_wgrad_compute"] for kwargs in grouped_linear_kwargs)
+    assert all(kwargs["fuse_wgrad_accumulation"] for kwargs in grouped_linear_kwargs)
+
+
+def _build_fake_delayed_grad_experts(monkeypatch, experts_module):
+    class FakeStore:
+        def __init__(self, linear):
+            self.linear = linear
+            self.pending = []
+            self.context = SimpleNamespace(empty=lambda: not self.pending)
+
+        @staticmethod
+        def delay_wgrad_compute():
+            return True
+
+        def queue(self, value):
+            sinks = [
+                getattr(self.linear, f"weight{idx}").main_grad
+                for idx in range(self.linear.num_gemms)
+            ]
+            self.pending.append((float(value), sinks))
+
+        def pop(self):
+            value, sinks = self.pending.pop(0)
+            for sink in sinks:
+                sink.add_(value)
+            return (None, [None] * self.linear.num_gemms, None), [None, None, sinks]
+
+    class FakeGroupedLinear(torch.nn.Module):
+        def __init__(
+            self,
+            num_gemms,
+            *_args,
+            bias,
+            fuse_wgrad_accumulation,
+            **_kwargs,
+        ):
+            super().__init__()
+            self.num_gemms = num_gemms
+            self.use_bias = bias
+            self.fuse_wgrad_accumulation = fuse_wgrad_accumulation
+            self.output_size = _args[1]
+            for idx in range(num_gemms):
+                self.register_parameter(
+                    f"weight{idx}", torch.nn.Parameter(torch.zeros(2, 2))
+                )
+            self.wgrad_store = FakeStore(self)
+
+        def forward(self, x, _m_splits):
+            return x.new_zeros((*x.shape[:-1], self.output_size))
+
+    monkeypatch.setattr(
+        experts_module.te, "GroupedLinear", FakeGroupedLinear, raising=False
+    )
+    return experts_module.Experts(
+        SimpleNamespace(
+            num_experts=2,
+            hidden_size=2,
+            moe_intermediate_size=2,
+            swiglu_limit=0.0,
+        ),
+        SimpleNamespace(ep_size=1, etp_size=1, tp_size=1, etp_group=None),
+        delay_wgrad_compute=True,
+    )
+
+
+@pytest.mark.parametrize("flush_schedule", ["normal", "full_fused"])
+def test_delayed_expert_standard_grads_match_native_accumulation_without_main_grad(
+    flush_schedule, monkeypatch, transformer_engine_import_stub
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules import experts as experts_module
+
+    experts = _build_fake_delayed_grad_experts(monkeypatch, experts_module)
+    params = tuple(experts.fc1.parameters()) + tuple(experts.fc2.parameters())
+    assert all(
+        param.grad is None and not hasattr(param, "main_grad") for param in params
+    )
+    assert experts._owned_main_grad_aliases == {}
+    native_params = [torch.nn.Parameter(torch.zeros_like(param)) for param in params]
+
+    grad_storage = None
+    for contribution in (1.25, 2.75):
+        sum((param * contribution).sum() for param in native_params).backward()
+        experts._prepare_delayed_weight_grad_sinks()
+        if grad_storage is None:
+            grad_storage = {id(param): param.grad for param in params}
+        else:
+            assert all(param.grad is grad_storage[id(param)] for param in params)
+        for linear in (experts.fc1, experts.fc2):
+            linear.wgrad_store.queue(contribution)
+        if flush_schedule == "full_fused":
+            experts.flush_delayed_weight_grads(num_contexts=1)
+    if flush_schedule == "normal":
+        experts.flush_delayed_weight_grads(num_contexts=2)
+
+    for param, native_param in zip(params, native_params, strict=True):
+        torch.testing.assert_close(param.grad, native_param.grad)
+        assert not hasattr(param, "main_grad")
+    assert experts._owned_main_grad_aliases == {}
+
+
+def test_delayed_expert_forward_keeps_gradient_sinks_lazy_until_backward(
+    monkeypatch, transformer_engine_import_stub
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules import experts as experts_module
+
+    experts = _build_fake_delayed_grad_experts(monkeypatch, experts_module)
+    monkeypatch.setattr(
+        experts_module,
+        "swiglu_with_probs",
+        lambda value, _probs, _limit: value[..., :2],
+    )
+    params = tuple(experts.fc1.parameters()) + tuple(experts.fc2.parameters())
+    x = torch.zeros(3, 2)
+
+    with torch.no_grad():
+        experts(x, None, tokens_per_expert_list=[1, 2])
+    assert all(
+        param.grad is None and not hasattr(param, "main_grad") for param in params
+    )
+
+    with torch.enable_grad():
+        experts(x.requires_grad_(), None, tokens_per_expert_list=[1, 2])
+    assert all(
+        param.grad is None and not hasattr(param, "main_grad") for param in params
+    )
+
+    experts._prepare_delayed_weight_grad_sinks()
+    assert all(param.main_grad is param.grad for param in params)
+    for linear in (experts.fc1, experts.fc2):
+        linear.wgrad_store.queue(2.0)
+    experts.flush_delayed_weight_grads(num_contexts=1)
+    assert all(torch.equal(param.grad, torch.full_like(param, 2.0)) for param in params)
+    assert all(not hasattr(param, "main_grad") for param in params)
+
+
+def test_chunked_ep_backward_phases_prepare_sinks_before_expert_autograd(
+    transformer_engine_import_stub,
+):
+    import inspect
+
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        _EPChunkOperationBase,
+    )
+
+    for method in (
+        _EPChunkOperationBase._full_recompute_fused_backward_v6,
+        _EPChunkOperationBase._saved_context_backward,
+    ):
+        source = inspect.getsource(method)
+        assert source.index("_prepare_delayed_weight_grad_sinks") < source.index(
+            "expert_grads = torch.autograd.grad"
+        )
+
+
+def test_delayed_expert_external_main_grad_stays_zero_copy_without_parameter_grad(
+    monkeypatch, transformer_engine_import_stub
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules import experts as experts_module
+
+    experts = _build_fake_delayed_grad_experts(monkeypatch, experts_module)
+    params = tuple(experts.fc1.parameters()) + tuple(experts.fc2.parameters())
+    external = {}
+    for param in params:
+        external[id(param)] = torch.zeros_like(param)
+        param.main_grad = external[id(param)]
+
+    experts._prepare_delayed_weight_grad_sinks()
+    for linear in (experts.fc1, experts.fc2):
+        linear.wgrad_store.queue(3.5)
+    experts.flush_delayed_weight_grads(num_contexts=1)
+
+    for param in params:
+        assert param.grad is None
+        assert param.main_grad is external[id(param)]
+        torch.testing.assert_close(param.main_grad, torch.full_like(param, 3.5))
+    assert experts._owned_main_grad_aliases == {}
+
+
+def test_delayed_expert_fsdp_accessor_is_resolved_by_te_at_pop(
+    monkeypatch, transformer_engine_import_stub
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules import experts as experts_module
+
+    experts = _build_fake_delayed_grad_experts(monkeypatch, experts_module)
+    params = tuple(experts.fc1.parameters()) + tuple(experts.fc2.parameters())
+    external = {id(param): torch.zeros_like(param) for param in params}
+    accessor_calls = []
+    for param in params:
+        param.__fsdp_param__ = True
+
+        def get_main_grad(p=param):
+            accessor_calls.append(id(p))
+            return external[id(p)]
+
+        param.get_main_grad = get_main_grad
+
+    experts._prepare_delayed_weight_grad_sinks()
+    assert accessor_calls == []
+    assert all(not hasattr(param, "main_grad") for param in params)
+
+    # Frozen TE resolves the saved accessor during delayed backward and writes the
+    # result back to origin_weight.main_grad before WeightGradStore.pop returns.
+    for linear in (experts.fc1, experts.fc2):
+        for idx in range(linear.num_gemms):
+            param = getattr(linear, f"weight{idx}")
+            param.main_grad = param.get_main_grad()
+        linear.wgrad_store.queue(4.5)
+    experts.flush_delayed_weight_grads(num_contexts=1)
+
+    assert sorted(accessor_calls) == sorted(id(param) for param in params)
+    for param in params:
+        assert param.grad is None
+        assert param.main_grad is external[id(param)]
+        torch.testing.assert_close(param.main_grad, torch.full_like(param, 4.5))
+
+
+def test_delayed_expert_fsdp_accessor_sink_is_validated_after_pop(
+    monkeypatch, transformer_engine_import_stub
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules import experts as experts_module
+
+    experts = _build_fake_delayed_grad_experts(monkeypatch, experts_module)
+    params = tuple(experts.fc1.parameters()) + tuple(experts.fc2.parameters())
+    for param in params:
+        param.__fsdp_param__ = True
+        param.get_main_grad = lambda: torch.zeros(1)
+
+    experts._prepare_delayed_weight_grad_sinks()
+    for linear in (experts.fc1, experts.fc2):
+        for idx in range(linear.num_gemms):
+            param = getattr(linear, f"weight{idx}")
+            param.main_grad = param.get_main_grad()
+        linear.wgrad_store.queue(1.0)
+
+    with pytest.raises(RuntimeError, match="matching shape and device"):
+        experts.flush_delayed_weight_grads(num_contexts=1)
+
+
+def test_callable_get_main_grad_without_fsdp_capability_uses_standard_grad(
+    monkeypatch, transformer_engine_import_stub
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules import experts as experts_module
+
+    experts = _build_fake_delayed_grad_experts(monkeypatch, experts_module)
+    params = tuple(experts.fc1.parameters()) + tuple(experts.fc2.parameters())
+    calls = []
+    for param in params:
+        param.get_main_grad = lambda: calls.append(True)
+
+    experts._prepare_delayed_weight_grad_sinks()
+
+    assert calls == []
+    assert all(param.main_grad is param.grad for param in params)
+
+
+def test_owned_standard_grad_alias_obeys_zero_grad_and_explicit_release(
+    monkeypatch, transformer_engine_import_stub
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules import experts as experts_module
+
+    experts = _build_fake_delayed_grad_experts(monkeypatch, experts_module)
+    params = tuple(experts.fc1.parameters()) + tuple(experts.fc2.parameters())
+
+    experts._prepare_delayed_weight_grad_sinks()
+    first_grads = {id(param): param.grad for param in params}
+    assert all(param.main_grad is param.grad for param in params)
+    experts.release_delayed_weight_grad_aliases()
+    assert all(param.grad is first_grads[id(param)] for param in params)
+    assert all(not hasattr(param, "main_grad") for param in params)
+
+    experts.zero_grad(set_to_none=False)
+    experts._prepare_delayed_weight_grad_sinks()
+    assert all(param.grad is first_grads[id(param)] for param in params)
+    for linear in (experts.fc1, experts.fc2):
+        linear.wgrad_store.queue(2.0)
+    experts.flush_delayed_weight_grads(num_contexts=1)
+    assert all(torch.equal(param.grad, torch.full_like(param, 2.0)) for param in params)
+
+    experts.zero_grad(set_to_none=True)
+    assert all(param.grad is None for param in params)
+    experts._prepare_delayed_weight_grad_sinks()
+    assert all(param.grad is not first_grads[id(param)] for param in params)
+    assert all(param.main_grad is param.grad for param in params)
+
+
+def test_chunked_ep_public_ops_have_no_optimizer_or_recompute_policy_knowledge(
+    transformer_engine_import_stub,
+):
+    import inspect
+
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        EPChunkBackwardOp,
+        EPChunkForwardOp,
+        EPChunkFusedForwardBackwardOp,
+    )
+
+    for op in (EPChunkForwardOp, EPChunkBackwardOp, EPChunkFusedForwardBackwardOp):
+        public_contract = str(inspect.signature(op.__init__))
+        for name, member in inspect.getmembers(op, predicate=inspect.isfunction):
+            if not name.startswith("_"):
+                public_contract += str(inspect.signature(member))
+        assert "optimizer" not in public_contract
+        assert "recompute_modules" not in public_contract
+        assert "ep_chunk_full_recompute" not in public_contract
+
+
+def test_pending_combine_guards_are_fail_loud_under_python_optimized_mode():
+    source = SOURCE.read_text()
+
+    assert "assert pending_combine is not None" not in source
+    assert source.count("EP chunk combine pipeline produced no pending output") == 2
+
+
+def test_experts_accept_host_splits_without_a_device_count_tensor(
+    monkeypatch, transformer_engine_import_stub
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules import experts as experts_module
+
+    seen_splits = []
+
+    class FakeGroupedLinear(torch.nn.Module):
+        def __init__(self, _num_gemms, _in_features, out_features, **_kwargs):
+            super().__init__()
+            self.out_features = out_features
+
+        def forward(self, x, splits):
+            seen_splits.append(splits)
+            return x.new_ones((x.size(0), self.out_features))
+
+    monkeypatch.setattr(
+        experts_module.te, "GroupedLinear", FakeGroupedLinear, raising=False
+    )
+    monkeypatch.setattr(
+        experts_module, "bias_swiglu_impl", lambda x, bias=None: x[:, :2]
+    )
+    config = SimpleNamespace(
+        num_experts=2,
+        hidden_size=2,
+        moe_intermediate_size=2,
+        swiglu_limit=0.0,
+    )
+    ps = SimpleNamespace(ep_size=1, etp_size=1, tp_size=1, etp_group=None)
+    experts = experts_module.Experts(config, ps)
+
+    out = experts(
+        torch.ones(3, 2),
+        None,
+        None,
+        tokens_per_expert_list=[1, 2],
+    )
+
+    assert out.shape == (3, 2)
+    assert seen_splits == [[1, 2], [1, 2]]
+
+
+def test_dispatch_local_backward_accumulates_duplicate_rows_in_workspace(
+    transformer_engine_import_stub,
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        EPChunkShapeProfile,
+        EPChunkWorkspaceKey,
+        EPChunkWorkspaceRegistry,
+        _dispatch_local_backward,
+    )
+
+    key = EPChunkWorkspaceKey(
+        op="backward",
+        device_type="cpu",
+        device_index=None,
+        ep_group_id=1,
+        dtype=torch.float32,
+        shape_profile=EPChunkShapeProfile(
+            max_input_rows=3,
+            hidden_size=2,
+            topk=2,
+            ep_size=2,
+        ),
+    )
+    workspace = EPChunkWorkspaceRegistry().get_or_create(key, lambda slot: slot)
+    lease = workspace.acquire(0)
+    dispatched_base = torch.full((4, 2), 17.0)
+    recv_probs_base = torch.full((3, 2), 19.0)
+    chunk = SimpleNamespace(
+        idx=0,
+        workspace_lease=lease,
+        recv_probs_base=recv_probs_base,
+        row_id_map=torch.tensor([0, 0, 2]),
+        prob_flat_indices=torch.tensor([1, 3, 5]),
+        recv_hidden_shape=torch.Size((3, 2)),
+        recv_hidden_dtype=torch.float32,
+        recv_probs_shape=torch.Size((3, 2)),
+        recv_probs_dtype=torch.float32,
+    )
+
+    grad_hidden, grad_probs = _dispatch_local_backward(
+        chunk,
+        torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]),
+        torch.tensor([0.25, 0.5, 0.75]),
+        hidden_reuse_base=dispatched_base,
+    )
+
+    assert grad_hidden.data_ptr() == dispatched_base.data_ptr()
+    assert grad_probs.data_ptr() == recv_probs_base.data_ptr()
+    assert workspace.metrics()["runtime_allocations"] == 0
+
+    torch.testing.assert_close(
+        grad_hidden, torch.tensor([[4.0, 6.0], [0.0, 0.0], [5.0, 6.0]])
+    )
+    torch.testing.assert_close(
+        grad_probs,
+        torch.tensor([[0.0, 0.25], [0.0, 0.5], [0.0, 0.75]]),
+    )
+
+
+def test_dispatch_local_backward_clears_reused_scratch_before_sparse_writes(
+    transformer_engine_import_stub,
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        _dispatch_local_backward,
+    )
+
+    expert_out_base = torch.full((4, 2), 17.0)
+    recv_probs_base = torch.full((3, 2), 19.0)
+
+    chunk = SimpleNamespace(
+        recv_probs_base=recv_probs_base,
+        row_id_map=torch.tensor([0, 2]),
+        prob_flat_indices=torch.tensor([1, 5]),
+        recv_hidden_shape=torch.Size((3, 2)),
+        recv_hidden_dtype=torch.float32,
+        recv_probs_shape=torch.Size((3, 2)),
+        recv_probs_dtype=torch.float32,
+    )
+
+    grad_hidden, grad_probs = _dispatch_local_backward(
+        chunk,
+        torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
+        torch.tensor([0.25, 0.75]),
+        hidden_reuse_base=expert_out_base,
+    )
+    torch.testing.assert_close(
+        grad_hidden, torch.tensor([[1.0, 2.0], [0.0, 0.0], [3.0, 4.0]])
+    )
+    torch.testing.assert_close(
+        grad_probs,
+        torch.tensor([[0.0, 0.25], [0.0, 0.0], [0.0, 0.75]]),
+    )
+
+    expert_out_base.fill_(23.0)
+    recv_probs_base.fill_(29.0)
+    _grad_hidden, grad_probs_none = _dispatch_local_backward(
+        chunk,
+        torch.tensor([[5.0, 6.0], [7.0, 8.0]]),
+        None,
+        hidden_reuse_base=expert_out_base,
+    )
+    torch.testing.assert_close(grad_probs_none, torch.zeros_like(grad_probs_none))
+
+
+def test_dispatch_local_backward_fails_loud_for_invalid_hidden_reuse_storage(
+    transformer_engine_import_stub,
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        _dispatch_local_backward,
+    )
+
+    chunk = SimpleNamespace(
+        recv_probs_base=torch.empty(3, 2),
+        row_id_map=torch.tensor([0, 2]),
+        prob_flat_indices=torch.tensor([1, 5]),
+        recv_hidden_shape=torch.Size((3, 2)),
+        recv_hidden_dtype=torch.float32,
+        recv_probs_shape=torch.Size((3, 2)),
+        recv_probs_dtype=torch.float32,
+    )
+    grad_dispatched = torch.ones(2, 2)
+    invalid_bases = (
+        torch.empty(2, 2),
+        torch.empty(2, 4).t(),
+        torch.empty(3, 2, dtype=torch.float64),
+    )
+
+    for hidden_reuse_base in invalid_bases:
+        with pytest.raises(RuntimeError, match="hidden reuse storage"):
+            _dispatch_local_backward(
+                chunk,
+                grad_dispatched,
+                None,
+                hidden_reuse_base=hidden_reuse_base,
+            )
+
+
+def test_accumulate_reuses_first_chunk_gradient_storage(
+    transformer_engine_import_stub,
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import _accumulate
+
+    parameter = torch.nn.Parameter(torch.zeros(2, 2))
+    accum = [None]
+    _accumulate(accum, (parameter,), (torch.ones(2, 2),))
+    storage = accum[0].data_ptr()
+    _accumulate(accum, (parameter,), (torch.full((2, 2), 2.0),))
+
+    assert accum[0].data_ptr() == storage
+    torch.testing.assert_close(accum[0], torch.full((2, 2), 3.0))
+
+
+def test_core_contains_forward_backward_deepep_pipeline():
+    tree = ast.parse(SOURCE.read_text())
+    calls = {
+        node.func.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+    }
+
+    assert {
+        "submit_deepep_dispatch",
+        "finish_deepep_dispatch",
+        "submit_deepep_combine_prepared",
+        "finish_deepep_combine",
+        "submit_deepep_combine_backward",
+        "finish_deepep_combine_backward",
+        "submit_deepep_dispatch_backward",
+        "finish_deepep_dispatch_backward",
+    } <= calls
+
+
+def test_all_chunked_async_deepep_allocations_are_owned_by_comm_stream():
+    tree = ast.parse(SOURCE.read_text())
+    submit_names = {
+        "submit_deepep_dispatch",
+        "submit_deepep_combine_prepared",
+        "submit_deepep_combine_backward",
+        "submit_deepep_dispatch_backward",
+    }
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in submit_names
+    ]
+
+    assert calls
+    for call in calls:
+        keywords = {keyword.arg: keyword.value for keyword in call.keywords}
+        assert isinstance(keywords.get("allocate_on_comm_stream"), ast.Constant)
+        assert keywords["allocate_on_comm_stream"].value is True
+        if call.func.attr in {
+            "submit_deepep_dispatch",
+            "submit_deepep_combine_prepared",
+        }:
+            assert isinstance(keywords.get("async_finish"), ast.Constant)
+            assert keywords["async_finish"].value is True
+
+
+def test_only_deepep_recv_dispatch_uses_the_persistent_slot_mem_pool():
+    tree = ast.parse(SOURCE.read_text())
+    submit_names = {
+        "submit_deepep_dispatch",
+        "submit_deepep_combine_prepared",
+        "submit_deepep_combine_backward",
+        "submit_deepep_dispatch_backward",
+    }
+    submissions = []
+
+    def visit(node, in_pool=False):
+        if isinstance(node, ast.With):
+            in_pool = in_pool or any(
+                isinstance(item.context_expr, ast.Call)
+                and isinstance(item.context_expr.func, ast.Attribute)
+                and item.context_expr.func.attr == "deepep_recv_allocation"
+                for item in node.items
+            )
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in submit_names
+        ):
+            submissions.append((node.func.attr, in_pool))
+        for child in ast.iter_child_nodes(node):
+            visit(child, in_pool)
+
+    visit(tree)
+    assert submissions
+    assert all(
+        in_pool for name, in_pool in submissions if name == "submit_deepep_dispatch"
+    )
+    assert all(
+        not in_pool for name, in_pool in submissions if name != "submit_deepep_dispatch"
+    )
+
+
+def test_production_path_has_no_global_cuda_sync_or_allocator_fallback():
+    source = SOURCE.read_text()
+    tree = ast.parse(source)
+    cuda_calls = {
+        node.func.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Attribute)
+        and isinstance(node.func.value.value, ast.Name)
+        and node.func.value.value.id == "torch"
+        and node.func.value.attr == "cuda"
+    }
+
+    assert "synchronize" not in cuda_calls
+    assert "empty_cache" not in cuda_calls
+    assert "oversize_fallback" not in source
+    assert "in_use_fallback" not in source
+    assert "slot_grow" not in source
+
+
+def test_deepep_state_tensors_record_the_consumer_stream(
+    monkeypatch, transformer_engine_import_stub
+):
+    transformer_engine_import_stub()
+    import megatron.lite.primitive.modules.moe_ep_chunk_overlap as overlap
+
+    class FakeTensor:
+        is_cuda = True
+        device = torch.device("cuda", 0)
+
+        def __init__(self):
+            self.recorded_stream = None
+
+        def record_stream(self, stream):
+            self.recorded_stream = stream
+
+    stream = object()
+    outer = FakeTensor()
+    nested = FakeTensor()
+    monkeypatch.setattr(
+        overlap.torch, "is_tensor", lambda value: isinstance(value, FakeTensor)
+    )
+    monkeypatch.setattr(overlap.torch.cuda, "current_stream", lambda _device: stream)
+
+    overlap._record_state_tensors_current_stream(
+        {"recv_hidden": outer, "metadata": {"recv_probs": nested}, "handle": object()}
+    )
+
+    assert outer.recorded_stream is stream
+    assert nested.recorded_stream is stream
+
+
+def test_chunked_forward_enqueues_experts_before_lifetime_bookkeeping():
+    tree = ast.parse(SOURCE.read_text())
+    forward_names = {"_forward_output_async", "_forward_saved_context_async"}
+
+    for function in (
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name in forward_names
+    ):
+        expert_calls = [
+            node
+            for node in ast.walk(function)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "experts"
+        ]
+        record_calls = [
+            node
+            for node in ast.walk(function)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "_record_state_tensors_current_stream"
+        ]
+        assert len(expert_calls) == len(record_calls) == 1
+        assert expert_calls[0].lineno < record_calls[0].lineno
+
+
+def test_recv_telemetry_is_cold_unless_explicitly_enabled(
+    monkeypatch, transformer_engine_import_stub
+):
+    transformer_engine_import_stub()
+    import megatron.lite.primitive.modules.moe_ep_chunk_overlap as overlap
+
+    overlap._EP_CHUNK_RECV_ACTIVE.clear()
+    overlap._EP_CHUNK_RECV_STATS.clear()
+    monkeypatch.delenv("MEGATRON_LITE_EP_CHUNK_SCRATCH_TRACE", raising=False)
+
+    overlap._record_ep_chunk_recv_tensors(
+        action="acquire",
+        phase="forward",
+        workspace="forward",
+        chunk_idx=0,
+        recv_hidden=torch.zeros(2, 3),
+        recv_probs=torch.zeros(2, 1),
+    )
+
+    assert overlap._EP_CHUNK_RECV_ACTIVE == {}
+    assert overlap._EP_CHUNK_RECV_STATS == {}
+
+
+def test_chunked_forward_submits_next_dispatch_before_expert_host_setup():
+    tree = ast.parse(SOURCE.read_text())
+    forward_names = {"_forward_output_async", "_forward_saved_context_async"}
+
+    for function in (
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name in forward_names
+    ):
+        nested_names = {
+            node.name for node in function.body if isinstance(node, ast.FunctionDef)
+        }
+        assert {"finish_dispatch", "run_expert"} <= nested_names
+        loop = next(node for node in ast.walk(function) if isinstance(node, ast.For))
+        calls = {
+            node.func.id: node.lineno
+            for node in ast.walk(loop)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        }
+        assert calls["finish_dispatch"] < calls["submit_dispatch"] < calls["run_expert"]
+
+
+@pytest.mark.parametrize("chunk_count", [3, 4])
+@pytest.mark.parametrize("saved_context", [False, True])
+def test_logical_chunk_slot_reuse_finishes_combine_before_dispatch_reacquire(
+    chunk_count, saved_context, monkeypatch, transformer_engine_import_stub
+):
+    """Exercise both forward pipelines with two strictly leased physical slots."""
+    import gc
+    import weakref
+
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules import moe_ep_chunk_overlap as overlap
+
+    events = []
+
+    class FakeEvent:
+        def record(self, _stream):
+            pass
+
+    class FakeStream:
+        device = torch.device("cpu")
+
+        def wait_event(self, _event):
+            pass
+
+    class FakeDispatcher:
+        moe_permute_fusion = False
+
+        def submit_deepep_dispatch(self, x, _scores, _indices, **_kwargs):
+            return {
+                "chunk_idx": int(x[0, 0]),
+                "recv_hidden": x.clone(),
+                "recv_probs": torch.ones(x.size(0), 1),
+                "handle": object(),
+            }
+
+        def finish_deepep_dispatch(self, state, **_kwargs):
+            gc.collect()
+            chunk_idx = state["chunk_idx"] // 2
+            events.append(f"finish:{chunk_idx}")
+            dispatched = state["recv_hidden"].clone()
+            weakref.finalize(
+                dispatched, events.append, f"retire_dispatched:{chunk_idx}"
+            )
+            return (
+                dispatched,
+                [state["recv_hidden"].size(0)],
+                state["recv_probs"],
+            )
+
+        def finish_deepep_dispatch_external_with_options(self, state, **_kwargs):
+            return (
+                state["recv_hidden"],
+                [state["recv_hidden"].size(0)],
+                state["recv_probs"],
+                {
+                    "local_tpe_list": [state["recv_hidden"].size(0)],
+                    "manual_row_id_map": torch.arange(state["recv_hidden"].size(0)),
+                    "manual_prob_flat_indices": torch.arange(
+                        state["recv_hidden"].size(0)
+                    ),
+                },
+            )
+
+        def prepare_deepep_combine(self, expert_out):
+            return expert_out, object()
+
+        def submit_deepep_combine_prepared(self, rank_grouped, handle, **_kwargs):
+            return rank_grouped, handle
+
+        def finish_deepep_combine(self, state):
+            return state[0]
+
+    class FakeLease:
+        def __init__(self, workspace, slot):
+            self.workspace = workspace
+            self.slot = slot
+            self.dispatcher = FakeDispatcher()
+            self.allocation_arena = SimpleNamespace(allocate=lambda: nullcontext())
+
+        def deepep_recv_allocation(self):
+            return nullcontext()
+
+        def release(self, _event):
+            events.append(f"release:{self.slot}")
+            self.workspace.leased.remove(self.slot)
+
+    class FakeActivationLease:
+        def tensor(self, _name, shape, *, dtype, device):
+            return torch.empty(shape, dtype=dtype, device=device)
+
+        def allocate(self):
+            return nullcontext()
+
+        def release(self, _event):
+            pass
+
+    class FakeWorkspace:
+        def __init__(self):
+            self.key = SimpleNamespace(
+                op="forward",
+                shape_profile=SimpleNamespace(
+                    chunk_count=chunk_count, validate_input=lambda _value: None
+                ),
+            )
+            self.leased = set()
+
+        def acquire(self, slot, **_kwargs):
+            if slot in self.leased:
+                raise RuntimeError(f"slot {slot} already leased")
+            self.leased.add(slot)
+            events.append(f"acquire:{slot}")
+            return FakeLease(self, slot)
+
+        def acquire_expert_activation(self, **_kwargs):
+            return FakeActivationLease()
+
+    compute_stream = FakeStream()
+    workspace = FakeWorkspace()
+    operation = overlap._EPChunkOperationBase(
+        router=lambda x: (x * 2, torch.zeros(x.size(0), 1, dtype=torch.long)),
+        experts=lambda x, *_args, **_kwargs: x + 1,
+        workspace=workspace,
+    )
+    monkeypatch.setattr(
+        operation, "_streams", lambda _device: (compute_stream, FakeStream())
+    )
+    monkeypatch.setattr(overlap.torch.cuda, "Event", FakeEvent)
+    monkeypatch.setattr(overlap.torch.cuda, "stream", lambda _stream: nullcontext())
+    monkeypatch.setattr(
+        overlap.torch.cuda, "current_stream", lambda _device=None: compute_stream
+    )
+    monkeypatch.setattr(
+        overlap, "_validate_finished_deepep_dispatch", lambda *_args: None
+    )
+    monkeypatch.setattr(
+        overlap, "_record_state_tensors_current_stream", lambda _state: None
+    )
+    monkeypatch.setattr(
+        overlap, "_record_ep_chunk_recv_tensors", lambda **_kwargs: None
+    )
+    monkeypatch.setattr(
+        overlap, "unpermute", lambda expert_out, *_args, **_kwargs: expert_out
+    )
+
+    x = (
+        torch.arange(chunk_count * 2, dtype=torch.float32)
+        .view(-1, 1)
+        .requires_grad_(True)
+    )
+    ranges = [(2 * index, 2 * index + 2) for index in range(chunk_count)]
+    if saved_context:
+        output, context = operation._forward_saved_context_async(
+            x, ranges, x.shape, x.dtype
+        )
+        assert len(context.chunks) == chunk_count
+    else:
+        output = operation._forward_output_async(x, ranges, x.shape, x.dtype)
+
+    assert output.shape == x.shape
+    assert workspace.leased == set()
+    if not saved_context:
+        assert events.index("retire_dispatched:0") < events.index("finish:1"), events
+    for slot in range(2):
+        acquires = [
+            index for index, event in enumerate(events) if event == f"acquire:{slot}"
+        ]
+        assert len(acquires) == (chunk_count + 1 - slot) // 2
+        for reused in acquires[1:]:
+            assert any(event == f"release:{slot}" for event in events[:reused]), events
+
+
+def test_two_chunk_forward_keeps_next_dispatch_ahead_of_first_combine_release(
+    transformer_engine_import_stub,
+):
+    """The n=2 schedule retains its existing dispatch/expert/combine overlap."""
+    # The n=3/4 executable harness above would be redundant here; this source
+    # order pins the n=2 fast path, where no physical slot is reused in-loop.
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        _EPChunkOperationBase,
+    )
+
+    for method in (
+        _EPChunkOperationBase._forward_output_async,
+        _EPChunkOperationBase._forward_saved_context_async,
+    ):
+        source = inspect.getsource(method)
+        first_dispatch = source.index("current_state = submit_dispatch(0)")
+        next_dispatch = source.index("current_state = submit_dispatch(loop_idx + 1)")
+        first_combine = source.index("finish_combine(pending_combine)", next_dispatch)
+        assert first_dispatch < next_dispatch < first_combine
+
+
+def test_saved_forward_routes_on_compute_then_hands_off_dispatch_to_comm_stream():
+    tree = ast.parse(SOURCE.read_text())
+    function = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_forward_saved_context_async"
+    )
+    submit = next(
+        node
+        for node in function.body
+        if isinstance(node, ast.FunctionDef) and node.name == "submit_dispatch"
+    )
+    stream_contexts = [
+        item.context_expr.args[0].id
+        for node in ast.walk(submit)
+        if isinstance(node, ast.With)
+        for item in node.items
+        if isinstance(item.context_expr, ast.Call)
+        and isinstance(item.context_expr.func, ast.Attribute)
+        and item.context_expr.func.attr == "stream"
+        and isinstance(item.context_expr.args[0], ast.Name)
+    ]
+
+    assert stream_contexts == ["compute_stream", "comm_stream"]
+    source = ast.unparse(submit)
+    assert source.index("scores, indices = self._route") < source.index(
+        "route_ready.record(compute_stream)"
+    )
+    assert source.index("route_ready.record(compute_stream)") < source.index(
+        "comm_stream.wait_event(route_ready)"
+    ) < source.index("dispatcher.submit_deepep_dispatch")
+
+
+def test_saved_backward_chains_first_combine_to_caller_grad_readiness(
+    transformer_engine_import_stub,
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        _EPChunkOperationBase,
+    )
+
+    import inspect
+
+    source = inspect.getsource(_EPChunkOperationBase._saved_context_backward)
+
+    assert "caller_stream = torch.cuda.current_stream(grad_2d.device)" in source
+    assert "grad_ready = torch.cuda.Event()" in source
+    assert "grad_ready.record(caller_stream)" in source
+    assert "last_deepep_event: Any | None = grad_ready" in source
+    assert source.index("grad_ready.record(caller_stream)") < source.index(
+        "submit_deepep_combine_backward"
+    )
+    assert "torch.cuda.synchronize" not in source
+
+
+def test_saved_backward_uses_its_own_manual_unpermute_arena_after_recv_event(
+    transformer_engine_import_stub,
+):
+    import inspect
+
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        _EPChunkOperationBase,
+        _ForwardChunkContext,
+    )
+
+    fields = _ForwardChunkContext.__dataclass_fields__
+    forward_source = inspect.getsource(
+        _EPChunkOperationBase._forward_saved_context_async
+    )
+    backward_source = inspect.getsource(_EPChunkOperationBase._saved_context_backward)
+
+    assert "allocation_arena" not in fields
+    assert "forward_workspace_lease" not in fields
+    assert "recv_consumed_event" in fields
+    assert "allocation_arena=lease.allocation_arena" not in forward_source
+    assert "recv_consumed_event.record(compute_stream)" in forward_source
+    assert forward_source.index("recv_consumed_event.record(compute_stream)") < (
+        forward_source.index("state.clear()")
+    )
+    assert "allocation_arena=saved.allocation_arena" not in backward_source
+    assert "forward_workspace_lease=lease" not in forward_source
+    assert "lease.release(consumed)" in forward_source
+    assert "forward_workspace_lease" not in backward_source
+    assert "compute_stream.wait_event(saved.recv_consumed_event)" in backward_source
+    assert backward_source.index(
+        "compute_stream.wait_event(saved.recv_consumed_event)"
+    ) < backward_source.index("_dispatch_local_backward(")
+    assert "cuda.synchronize" not in backward_source
+
+
+def test_saved_context_wrapper_keeps_scratch_until_explicit_lifecycle_reset(
+    transformer_engine_import_stub,
+):
+    import inspect
+
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        _SavedContextEPChunkFunction,
+    )
+
+    source = inspect.getsource(_SavedContextEPChunkFunction.backward)
+
+    assert "ctx.backward_op.backward(" in source
+    assert "ctx.backward_op.workspace.reset_tensors(" not in source
+    assert "cuda.synchronize" not in source
+
+
+def test_fused_backward_leaves_parking_to_qwen_composition(
+    transformer_engine_import_stub,
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        EPChunkFusedForwardBackwardOp,
+        _EPChunkOperationBase,
+    )
+
+    fused_source = inspect.getsource(EPChunkFusedForwardBackwardOp.forward_backward)
+    backward_source = inspect.getsource(
+        _EPChunkOperationBase._full_recompute_fused_backward_v6
+    )
+
+    assert "torch.cuda.current_stream(grad_2d.device).wait_event(done)" in backward_source
+    assert backward_source.index("wait_event(done)") < backward_source.index(
+        "router_grads_out = _materialize"
+    )
+    assert fused_source.index("_full_recompute_fused_backward(") < fused_source.index(
+        "grad_x = grad_x.view_as(x_saved)"
+    )
+    assert "self.workspace.park_expert_activations(" not in fused_source
+    assert "reset_tensors" not in fused_source
+    assert "synchronize" not in fused_source
+
+
+def test_fused_backward_does_not_park_per_layer(
+    transformer_engine_import_stub,
+):
+    """Primitive fused recompute leaves the composition boundary to park once."""
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        EPChunkFusedForwardBackwardOp,
+    )
+
+    class Workspace:
+        def __init__(self):
+            self.park_calls = 0
+
+        def park_expert_activations(self, **_kwargs):
+            self.park_calls += 1
+
+    workspace = Workspace()
+    op = EPChunkFusedForwardBackwardOp(
+        router=torch.nn.Identity(),
+        experts=object(),
+        workspace=workspace,
+    )
+    op._full_recompute_fused_backward = lambda x, grad: (grad.clone(), [], [])
+    x = torch.ones(2, 3)
+    grad = torch.full_like(x, 2)
+
+    for _ in range(2):
+        grad_x, router_grads, expert_grads = op.forward_backward(x, grad)
+        torch.testing.assert_close(grad_x, grad)
+        assert router_grads == expert_grads == []
+    assert workspace.park_calls == 0
+
+
+def test_saved_backward_reuses_manual_unpermute_storage_only_after_wgrad_flush(
+    transformer_engine_import_stub,
+):
+    import inspect
+
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        _EPChunkOperationBase,
+    )
+
+    source = inspect.getsource(_EPChunkOperationBase._saved_context_backward)
+    grad_complete = source.index("expert_grads = torch.autograd.grad(")
+    flushed = source.index("flush_delayed_weight_grads")
+    flush_waited = source.index("compute_stream.wait_event(wgrad_done)")
+    alias_saved = source.index('local_state["hidden_reuse_base"] = dispatched.detach()')
+    alias_taken = source.index(
+        'hidden_reuse_base = local_state.pop("hidden_reuse_base")', flush_waited
+    )
+    storage_overwritten = source.index("_dispatch_local_backward(", alias_taken)
+    dispatch_submitted = source.index(
+        "submit_deepep_dispatch_backward(", storage_overwritten
+    )
+    queued = source.index("pending_dispatch_bwd.append", grad_complete)
+
+    assert grad_complete < alias_saved < queued < flushed < flush_waited < alias_taken
+    assert alias_taken < storage_overwritten < dispatch_submitted
+    assert 'local_state["hidden_reuse_base"] = dispatched.detach()' in source
+    assert "Delayed grouped-linear Wgrad retains FC1 input" in source
+    for assignment in (
+        "saved.dispatched = None",
+        "saved.probs = None",
+        "saved.expert_out = None",
+        "saved.expert_out_edge = None",
+        "chunk.dispatched = None",
+        "chunk.probs = None",
+        "chunk.expert_out = None",
+        "chunk.expert_out_edge = None",
+    ):
+        assert assignment in source
+    assert "saved.scores = None" not in source
+    assert "saved.x = None" not in source
+    assert "cuda.synchronize" not in source
+
+
+def test_normal_and_fused_backward_reuse_manual_unpermute_workspace_storage(
+    transformer_engine_import_stub,
+):
+    import inspect
+
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        _BackwardChunk,
+        _EPChunkOperationBase,
+        _ForwardChunkContext,
+        _dispatch_local_backward,
+        _manual_unpermute_backward,
+    )
+
+    assert "recv_probs_base" in _BackwardChunk.__dataclass_fields__
+    assert "recv_probs_base" in _ForwardChunkContext.__dataclass_fields__
+    assert "recv_hidden_base" not in _BackwardChunk.__dataclass_fields__
+    assert "recv_hidden_base" not in _ForwardChunkContext.__dataclass_fields__
+    saved_source = inspect.getsource(_EPChunkOperationBase._forward_saved_context_async)
+    normal_backward_source = inspect.getsource(
+        _EPChunkOperationBase._saved_context_backward
+    )
+    fused_source = inspect.getsource(
+        _EPChunkOperationBase._full_recompute_fused_backward_v6
+    )
+    helper_source = inspect.getsource(_dispatch_local_backward)
+    unpermute_source = inspect.getsource(_manual_unpermute_backward)
+
+    for source in (saved_source, fused_source):
+        assert 'recv_hidden_base=state["recv_hidden"]' not in source
+        assert 'recv_probs_base=state["recv_probs"]' in source
+    assert (
+        'local_state["hidden_reuse_base"] = dispatched.detach()'
+        in normal_backward_source
+    )
+    assert (
+        'hidden_reuse_base = local_state.pop("hidden_reuse_base")'
+        in normal_backward_source
+    )
+    assert "out=chunk.expert_out.detach()" in fused_source
+    assert "hidden_reuse_base = expert_dispatched.detach()" in fused_source
+    assert "chunk.workspace_lease.tensor(" in unpermute_source
+    assert '"grad_expert_out"' in unpermute_source
+    assert "torch.index_select(" in unpermute_source
+    assert "out=grad_expert_out" in unpermute_source
+    assert "chunk.workspace_lease.tensor(" not in helper_source
+    assert "hidden_reuse_base.detach()" in helper_source
+    assert ".view(-1)[:required_hidden_numel]" in helper_source
+    assert "grad_recv_probs = chunk.recv_probs_base" in helper_source
+    assert "cuda.synchronize" not in helper_source
+
+
+def test_fused_flushes_each_chunk_before_reusing_delayed_wgrad_storage(
+    transformer_engine_import_stub,
+):
+    import inspect
+
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        _EPChunkOperationBase,
+    )
+
+    source = inspect.getsource(_EPChunkOperationBase._full_recompute_fused_backward_v6)
+    autograd = source.index("expert_grads = torch.autograd.grad(")
+    direct_unpermute = source.index("out=chunk.expert_out.detach()")
+    next_dispatch = source.index(
+        "next_state = submit_recompute_dispatch", direct_unpermute
+    )
+    dgrad_ready = source.index("dgrad_ready.record(compute_stream)", autograd)
+    per_chunk_flush = source.index("flush_delayed_weight_grads", dgrad_ready)
+    activation_release = source.index(
+        "expert_activation_lease.release(local_bwd_ready)", per_chunk_flush
+    )
+    alias_taken = source.index(
+        "hidden_reuse_base = expert_dispatched.detach()", autograd
+    )
+    graph_clear = source.index("chunk.expert_out = None", alias_taken)
+    locals_clear = source.index("del expert_dispatched", graph_clear)
+    overwrite = source.index("_dispatch_local_backward(", per_chunk_flush)
+    local_ready = source.index("local_bwd_ready.record(wgrad_stream)", overwrite)
+    dispatch = source.index("submit_deepep_dispatch_backward(", overwrite)
+    pending_append = source.index("pending_dispatch_bwd.append", dispatch)
+
+    assert direct_unpermute < next_dispatch < autograd < alias_taken
+    assert alias_taken < graph_clear < locals_clear < dgrad_ready < per_chunk_flush
+    assert per_chunk_flush < overwrite < local_ready < activation_release
+    assert activation_release < dispatch < pending_append
+    assert "num_contexts=1" in source[per_chunk_flush:overwrite]
+    assert "stream=wgrad_stream" in source[per_chunk_flush:overwrite]
+    activation_backward = source.rindex(
+        "with expert_activation_lease.allocate():", 0, autograd
+    )
+    assert activation_backward < autograd < dgrad_ready
+    assert "num_contexts=len(pending_dispatch_bwd)" not in source
+    assert "compute_stream.wait_event(wgrad_done)" not in source
+    assert "pending_local_bwd" not in source
+    assert "_queue_backward_stream_wait(last_wgrad_done" in source
+    assert "del expert_input, expert_probs, metadata" in source
+    assert "state.clear()" in source
+    assert "del expert_dispatched, expert_probs_input" in source
+    assert "del expert_inputs, expert_grads, expert_output" in source
+    for name in (
+        "grad_dispatched",
+        "grad_probs",
+        "hidden_reuse_base",
+        "chunk.recv_probs_base",
+        "chunk.row_id_map",
+        "chunk.prob_flat_indices",
+    ):
+        assert name in source[per_chunk_flush:overwrite]
+    assert "cuda.synchronize" not in source
+
+
+def test_dispatch_local_backward_rejects_source_destination_storage_alias(
+    transformer_engine_import_stub,
+):
+    """The FC1-input reuse slot must not alias autograd's FC1 dgrad source."""
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        _dispatch_local_backward,
+    )
+
+    shared = torch.empty(3, 2)
+    chunk = SimpleNamespace(
+        recv_probs_base=torch.empty(3, 2),
+        row_id_map=torch.tensor([0, 2]),
+        prob_flat_indices=torch.tensor([1, 5]),
+        recv_hidden_shape=torch.Size((3, 2)),
+        recv_hidden_dtype=torch.float32,
+        recv_probs_shape=torch.Size((3, 2)),
+        recv_probs_dtype=torch.float32,
+    )
+
+    with pytest.raises(RuntimeError, match="source and destination storage overlap"):
+        _dispatch_local_backward(
+            chunk,
+            shared[:2],
+            None,
+            hidden_reuse_base=shared,
+        )
+
+
+def test_dispatch_local_backward_rejects_partial_byte_range_overlap(
+    transformer_engine_import_stub,
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        _dispatch_local_backward,
+    )
+
+    shared = torch.empty(4, 2)
+    chunk = SimpleNamespace(
+        recv_probs_base=torch.empty(3, 2),
+        row_id_map=torch.tensor([0, 2]),
+        prob_flat_indices=torch.tensor([1, 5]),
+        recv_hidden_shape=torch.Size((3, 2)),
+        recv_hidden_dtype=torch.float32,
+        recv_probs_shape=torch.Size((3, 2)),
+        recv_probs_dtype=torch.float32,
+    )
+
+    with pytest.raises(RuntimeError, match="source and destination storage overlap"):
+        _dispatch_local_backward(
+            chunk,
+            shared[:2],
+            None,
+            hidden_reuse_base=shared[1:],
+        )
+
+
+def test_dispatch_local_backward_accepts_adjacent_nonoverlapping_ranges(
+    transformer_engine_import_stub,
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        _dispatch_local_backward,
+    )
+
+    shared = torch.empty(5, 2)
+    grad_dispatched = shared[:2]
+    grad_dispatched.copy_(torch.tensor([[1.0, 2.0], [3.0, 4.0]]))
+    hidden_reuse_base = shared[2:]
+    chunk = SimpleNamespace(
+        recv_probs_base=torch.empty(3, 2),
+        row_id_map=torch.tensor([0, 2]),
+        prob_flat_indices=torch.tensor([1, 5]),
+        recv_hidden_shape=torch.Size((3, 2)),
+        recv_hidden_dtype=torch.float32,
+        recv_probs_shape=torch.Size((3, 2)),
+        recv_probs_dtype=torch.float32,
+    )
+
+    grad_hidden, _ = _dispatch_local_backward(
+        chunk, grad_dispatched, None, hidden_reuse_base=hidden_reuse_base
+    )
+
+    assert grad_hidden.data_ptr() != grad_dispatched.data_ptr()
+    torch.testing.assert_close(
+        grad_hidden, torch.tensor([[1.0, 2.0], [0.0, 0.0], [3.0, 4.0]])
+    )
+
+
+def test_dispatch_local_backward_rejects_noncontiguous_gradient_source(
+    transformer_engine_import_stub,
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        _dispatch_local_backward,
+    )
+
+    chunk = SimpleNamespace(
+        recv_probs_base=torch.empty(3, 2),
+        row_id_map=torch.tensor([0, 2]),
+        prob_flat_indices=torch.tensor([1, 5]),
+        recv_hidden_shape=torch.Size((3, 2)),
+        recv_hidden_dtype=torch.float32,
+        recv_probs_shape=torch.Size((3, 2)),
+        recv_probs_dtype=torch.float32,
+    )
+    noncontiguous_source = torch.empty(2, 3)[:, :2]
+
+    assert not noncontiguous_source.is_contiguous()
+    with pytest.raises(RuntimeError, match="gradient source must be contiguous"):
+        _dispatch_local_backward(
+            chunk,
+            noncontiguous_source,
+            None,
+            hidden_reuse_base=torch.empty(3, 2),
+        )
+
+
+def test_autograd_flush_then_local_scatter_reuses_distinct_fc1_input_storage(
+    transformer_engine_import_stub,
+):
+    """CPU model of the fused FC1-dgrad/FC2-output coloring boundary."""
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        _dispatch_local_backward,
+    )
+
+    events = []
+
+    class CallerOwnedDgrad(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, value, dgrad_out):
+            ctx.dgrad_out = dgrad_out
+            return value * 2
+
+        @staticmethod
+        def backward(ctx, grad_output):
+            events.append("autograd writes fc1_dgrad")
+            ctx.dgrad_out.copy_(grad_output * 3)
+            return ctx.dgrad_out, None
+
+    # This is the physical FC2-output/FC1-dgrad color from the production
+    # arena. FC1 input deliberately has a different physical address.
+    fc2_output_and_fc1_dgrad = torch.empty(3, 2)
+    expert_dispatched = torch.tensor([[2.0, 3.0], [5.0, 7.0]], requires_grad=True)
+    expert_output = CallerOwnedDgrad.apply(
+        expert_dispatched, fc2_output_and_fc1_dgrad[:2]
+    )
+    grad_dispatched = torch.autograd.grad(
+        expert_output,
+        expert_dispatched,
+        torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
+    )[0]
+    hidden_reuse_base = expert_dispatched.detach()
+
+    assert grad_dispatched.data_ptr() == fc2_output_and_fc1_dgrad.data_ptr()
+    assert grad_dispatched.data_ptr() != hidden_reuse_base.data_ptr()
+
+    class DelayedWgradQueue:
+        def flush(self):
+            events.append("flush delayed wgrad")
+
+    # The delayed FC1 Wgrad still reads expert_dispatched, so this real queue
+    # flush is the final operation before zero/scatter overwrites that storage.
+    delayed_wgrad = DelayedWgradQueue()
+    delayed_wgrad.flush()
+    chunk = SimpleNamespace(
+        recv_probs_base=torch.empty(2, 1),
+        row_id_map=torch.tensor([1, 0]),
+        prob_flat_indices=torch.tensor([0, 1]),
+        recv_hidden_shape=torch.Size((2, 2)),
+        recv_hidden_dtype=torch.float32,
+        recv_probs_shape=torch.Size((2, 1)),
+        recv_probs_dtype=torch.float32,
+    )
+
+    def dispatch_after_flush():
+        events.append("zero/scatter fc1_input")
+        return _dispatch_local_backward(
+            chunk,
+            grad_dispatched,
+            None,
+            hidden_reuse_base=hidden_reuse_base,
+        )
+
+    grad_hidden, _ = dispatch_after_flush()
+
+    assert events == [
+        "autograd writes fc1_dgrad",
+        "flush delayed wgrad",
+        "zero/scatter fc1_input",
+    ]
+    assert grad_hidden.data_ptr() == expert_dispatched.data_ptr()
+    torch.testing.assert_close(grad_hidden, torch.tensor([[9.0, 12.0], [3.0, 6.0]]))
+
+
+def test_fused_autograd_context_is_only_source_level_pool_routing_evidence(
+    transformer_engine_import_stub,
+):
+    import inspect
+
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        _EPChunkOperationBase,
+    )
+
+    source = inspect.getsource(_EPChunkOperationBase._full_recompute_fused_backward_v6)
+    tree = ast.parse(inspect.cleandoc(source))
+    activation_scopes = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.With)
+        and any(
+            isinstance(item.context_expr, ast.Call)
+            and isinstance(item.context_expr.func, ast.Attribute)
+            and isinstance(item.context_expr.func.value, ast.Name)
+            and item.context_expr.func.value.id == "expert_activation_lease"
+            and item.context_expr.func.attr == "allocate"
+            for item in node.items
+        )
+    ]
+    assert any(
+        any(
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Attribute)
+            and isinstance(node.func.value.value, ast.Name)
+            and node.func.value.value.id == "torch"
+            and node.func.value.attr == "autograd"
+            and node.func.attr == "grad"
+            for node in ast.walk(scope)
+        )
+        for scope in activation_scopes
+    )
+    # use_mem_pool is current-thread scoped; GPU allocator history must prove
+    # whether autograd engine worker allocations actually use this pool.
+
+
+def test_saved_backward_owns_one_activation_lease_until_all_local_backward_reads(
+    transformer_engine_import_stub,
+):
+    import inspect
+
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        _EPChunkOperationBase,
+    )
+
+    source = inspect.getsource(_EPChunkOperationBase._saved_context_backward)
+    acquire = source.index("acquire_expert_activation(")
+    chunk_loop = source.index("for saved in reversed(context.chunks):")
+    activation_scope = source.index(
+        "with expert_activation_lease.allocate():", chunk_loop
+    )
+    autograd = source.index("expert_grads = torch.autograd.grad(", activation_scope)
+    pending = source.index("pending_dispatch_bwd.append", autograd)
+    local_backward = source.index("_dispatch_local_backward(", pending)
+    activation_done = source.index(
+        "backward_activation_done.record(compute_stream)", local_backward
+    )
+    release = source.index(
+        "expert_activation_lease.release(backward_activation_done)", activation_done
+    )
+    finish_dispatch = source.index("finish_deepep_dispatch_backward(", release)
+
+    assert acquire < chunk_loop < activation_scope < autograd < pending
+    assert pending < local_backward < activation_done < release < finish_dispatch
+    assert "cuda.synchronize" not in source
+
+
+def test_forward_and_fused_split_expert_activation_from_slot_output_arenas(
+    transformer_engine_import_stub,
+):
+    import inspect
+
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        _EPChunkOperationBase,
+    )
+
+    forward_source = inspect.getsource(_EPChunkOperationBase._forward_output_async)
+    saved_forward_source = inspect.getsource(
+        _EPChunkOperationBase._forward_saved_context_async
+    )
+    fused_source = inspect.getsource(
+        _EPChunkOperationBase._full_recompute_fused_backward_v6
+    )
+
+    forward_acquire = forward_source.index("acquire_expert_activation(")
+    forward_expert = forward_source.index("expert_out = self.experts(", forward_acquire)
+    forward_release = forward_source.index(
+        "expert_activation_lease.release(expert_ready)", forward_expert
+    )
+    fused_acquire = fused_source.index("acquire_expert_activation(")
+    fused_dispatch_finish = fused_source.index(
+        "finish_deepep_dispatch_external_with_options("
+    )
+    fused_expert = fused_source.index("expert_out = self.experts(", fused_acquire)
+
+    assert forward_acquire < forward_expert < forward_release
+    assert "activation_allocation=expert_activation_lease.allocate" in forward_source
+    assert (
+        'expert_activation_lease.tensor(\n                        "fc1_input"'
+        in forward_source
+    )
+    assert "output_allocation=_expert_activation_output_allocation(" in forward_source
+    assert "wgrad_done" not in forward_source
+    assert "allocation_arena" not in saved_forward_source
+    assert "activation_allocation=" not in saved_forward_source
+    assert fused_dispatch_finish < fused_acquire < fused_expert
+    assert "activation_allocation=expert_activation_lease.allocate" in fused_source
+    assert (
+        'expert_activation_lease.tensor(\n                    "fc1_input"'
+        in fused_source
+    )
+    assert "expert_input = fc1_input.requires_grad_(True)" in fused_source
+    assert "output_allocation=_expert_activation_output_allocation(" in fused_source
+    no_grad_finish = forward_source.index("finish_deepep_combine(state)")
+    no_grad_release = forward_source.index("lease.release(consumed)", no_grad_finish)
+    assert no_grad_finish < no_grad_release
+    assert "cuda.synchronize" not in forward_source
+    assert "cuda.synchronize" not in saved_forward_source
+    assert "cuda.synchronize" not in fused_source
+
+
+def test_expert_activation_output_allocation_returns_owned_tensor(
+    transformer_engine_import_stub,
+):
+    """Both no-grad forward and fused use the same Tensor-returning callback."""
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        _expert_activation_output_allocation,
+    )
+
+    class FakeLease:
+        def __init__(self):
+            self.calls = []
+
+        def tensor(self, name, shape, *, dtype, device):
+            self.calls.append((name, shape, dtype, device))
+            return torch.empty(shape, dtype=dtype, device=device)
+
+    lease = FakeLease()
+    input_tensor = torch.empty((3, 2), dtype=torch.bfloat16)
+
+    allocation = _expert_activation_output_allocation(lease, input_tensor)
+    output = allocation("fc1_output", (5, 4))
+
+    assert isinstance(output, torch.Tensor)
+    assert output.shape == (5, 4)
+    assert output.dtype is input_tensor.dtype
+    assert output.device == input_tensor.device
+    assert lease.calls == [
+        ("fc1_output", (5, 4), input_tensor.dtype, input_tensor.device)
+    ]
+
+
+def test_no_grad_and_fused_expert_compute_do_not_nest_slot_and_activation_arenas(
+    transformer_engine_import_stub,
+):
+    """DeepEP receives use a slot pool; owned expert activations use one other pool."""
+    import inspect
+
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        _EPChunkOperationBase,
+    )
+
+    forward_source = inspect.getsource(_EPChunkOperationBase._forward_output_async)
+    forward_expert = forward_source[
+        forward_source.index("def run_expert") : forward_source.index(
+            "def submit_combine"
+        )
+    ]
+    fused_source = inspect.getsource(
+        _EPChunkOperationBase._full_recompute_fused_backward_v6
+    )
+    fused_expert = fused_source[
+        fused_source.index("def finish_recompute_expert") : fused_source.index(
+            "def retire_pending_dispatch_bwd"
+        )
+    ]
+
+    assert "allocation_arena.allocate" not in forward_expert
+    assert "allocation_arena.allocate" not in fused_expert
+
+
+def test_experts_split_fc1_and_swiglu_forward_activation_from_fc2_output(
+    monkeypatch, transformer_engine_import_stub
+):
+    from contextlib import contextmanager
+
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules import experts as experts_module
+
+    active = []
+    calls = []
+    constructed = []
+
+    @contextmanager
+    def stage(name):
+        active.append(name)
+        try:
+            yield
+        finally:
+            assert active.pop() == name
+
+    class FakeGroupedLinear(torch.nn.Module):
+        def __init__(self, _num_gemms, _in_features, out_features, **_kwargs):
+            super().__init__()
+            self.name = "fc1" if not constructed else "fc2"
+            self.out_features = out_features
+            constructed.append(self)
+
+        def forward(self, x, _splits):
+            calls.append((self.name, tuple(active)))
+            return x.new_ones((x.size(0), self.out_features))
+
+    def weighted(value, _probs, _limit):
+        calls.append(("weighted_swiglu", tuple(active)))
+        return value[:, :2]
+
+    monkeypatch.setattr(
+        experts_module.te, "GroupedLinear", FakeGroupedLinear, raising=False
+    )
+    monkeypatch.setattr(experts_module, "swiglu_with_probs", weighted)
+    experts = experts_module.Experts(
+        SimpleNamespace(
+            num_experts=2,
+            hidden_size=2,
+            moe_intermediate_size=2,
+            swiglu_limit=0.0,
+        ),
+        SimpleNamespace(ep_size=1, etp_size=1, tp_size=1, etp_group=None),
+    )
+
+    with stage("slot"):
+        experts(
+            torch.ones(3, 2),
+            None,
+            torch.ones(3),
+            tokens_per_expert_list=[1, 2],
+            activation_allocation=lambda: stage("activation"),
+        )
+
+    assert calls == [
+        ("fc1", ("slot", "activation")),
+        ("weighted_swiglu", ("slot", "activation")),
+        ("fc2", ("slot",)),
+    ]
+
+
+def test_experts_owned_outputs_only_request_dgrad_for_each_grad_input(
+    monkeypatch, transformer_engine_import_stub
+):
+    """The production adapter must not allocate FC1 dgrad for wgrad-only input."""
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules import experts as experts_module
+
+    constructed = []
+    adapter_calls = []
+    allocated = []
+
+    class FakeGroupedLinear(torch.nn.Module):
+        def __init__(self, _num_gemms, _in_features, out_features, **_kwargs):
+            super().__init__()
+            self.name = "fc1" if not constructed else "fc2"
+            self.out_features = out_features
+            constructed.append(self)
+
+    def fake_owned_linear(linear, x, _m_splits, out, dgrad_out):
+        adapter_calls.append((linear.name, x.requires_grad, dgrad_out is not None))
+        if linear.name == "fc1":
+            # FC1 parameter gradients make its output an autograd input to FC2,
+            # even though the original expert input needs no dgrad.
+            return out.requires_grad_(True)
+        return out
+
+    def allocation(name, shape):
+        allocated.append(name)
+        return torch.empty(shape, dtype=torch.bfloat16)
+
+    monkeypatch.setattr(
+        experts_module.te, "GroupedLinear", FakeGroupedLinear, raising=False
+    )
+    monkeypatch.setattr(
+        experts_module, "_caller_owned_grouped_linear", fake_owned_linear
+    )
+    monkeypatch.setattr(experts_module, "swiglu_with_probs", lambda y, *_args: y[:, :2])
+    experts = experts_module.Experts(
+        SimpleNamespace(
+            num_experts=2,
+            hidden_size=2,
+            moe_intermediate_size=2,
+            swiglu_limit=0.0,
+        ),
+        SimpleNamespace(ep_size=1, etp_size=1, tp_size=1, etp_group=None),
+        delay_wgrad_compute=True,
+    )
+
+    with torch.enable_grad():
+        output = experts(
+            torch.ones(3, 2, dtype=torch.bfloat16),
+            None,
+            tokens_per_expert_list=[1, 2],
+            output_allocation=allocation,
+        )
+
+    assert output.shape == (3, 2)
+    assert adapter_calls == [("fc1", False, False), ("fc2", True, True)]
+    assert allocated == ["fc1_output", "fc2_output", "fc2_dgrad"]
+
+
+def test_caller_owned_grouped_linear_keeps_te_delayed_wgrad_contract(
+    transformer_engine_import_stub,
+):
+    """The output adapter is narrow: it must not silently become generic TE."""
+    import inspect
+
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules import experts as experts_module
+
+    source = inspect.getsource(experts_module._CallerOwnedGroupedLinear)
+    wrapper_source = inspect.getsource(experts_module._caller_owned_grouped_linear)
+    assert "general_grouped_gemm" in source
+    assert "wgrad_store.put" in source
+    assert "main_grad sinks" in source
+    assert "grad_added_to_main_grad" in source
+    assert "overwrite_main_grad" in source
+    assert "_2X_ACC_FPROP" in source
+    assert "_2X_ACC_DGRAD" in source
+    assert "_2X_ACC_WGRAD" in source
+    assert "prepare_forward" in wrapper_source
+    assert "end_forward" in wrapper_source
+    assert "_get_weight_tensors" in wrapper_source
+    assert "_get_quantizers" in wrapper_source
+    assert "torch.bfloat16" in source
+    assert "dgrad_out" in source
+    assert "torch.empty_like(inp)" not in source
+
+
+def test_caller_owned_dummy_wgrad_is_eager_scoped_and_capture_stable(
+    monkeypatch, transformer_engine_import_stub
+):
+    """Eager dummies must not become TE's process-global allocation cache."""
+    transformer_engine_import_stub()
+    import gc
+    import sys
+    import weakref
+
+    from megatron.lite.primitive.modules import experts as experts_module
+
+    base = sys.modules["transformer_engine.pytorch.module.base"]
+    cached = torch.full((2, 3), 9.0, dtype=torch.bfloat16)
+    cache_calls = []
+
+    def fake_te_dummy(shape, dtype, zero=False):
+        cache_calls.append((shape, dtype, zero))
+        if zero:
+            cached.zero_()
+        return cached
+
+    monkeypatch.setattr(base, "get_dummy_wgrad", fake_te_dummy, raising=False)
+    main_grad = torch.ones(2, 3, dtype=torch.float32)
+    weight = torch.nn.Parameter(torch.ones(2, 3, dtype=torch.bfloat16))
+
+    monkeypatch.setattr(experts_module, "_caller_owned_dummy_is_capturing", lambda _x: False)
+    first = experts_module._caller_owned_dummy_wgrad(main_grad, weight, zero=True)
+    second = experts_module._caller_owned_dummy_wgrad(main_grad, weight, zero=False)
+
+    assert first is not None and second is not None
+    assert first.shape == main_grad.shape == second.shape
+    assert first.dtype == weight.dtype == second.dtype
+    assert torch.count_nonzero(first) == 0
+    assert first.data_ptr() != second.data_ptr()
+    assert cache_calls == []
+    first_ref, second_ref = weakref.ref(first), weakref.ref(second)
+    del first, second
+    gc.collect()
+    assert first_ref() is None and second_ref() is None
+
+    monkeypatch.setattr(experts_module, "_caller_owned_dummy_is_capturing", lambda _x: True)
+    captured_first = experts_module._caller_owned_dummy_wgrad(main_grad, weight, zero=False)
+    captured_second = experts_module._caller_owned_dummy_wgrad(main_grad, weight, zero=True)
+
+    assert captured_first.data_ptr() == captured_second.data_ptr()
+    assert torch.count_nonzero(captured_second) == 0
+    assert cache_calls == [([2, 3], torch.bfloat16, False), ([2, 3], torch.bfloat16, True)]
+
+
+def test_caller_owned_grouped_linear_executes_te_lifecycle_and_partial_overlap_wgrad(
+    monkeypatch, transformer_engine_import_stub
+):
+    """CPU fake of TE2.15's narrow adapter: buffers, hooks, and delayed GEMM execute."""
+    transformer_engine_import_stub()
+    import sys
+
+    base = sys.modules["transformer_engine.pytorch.module.base"]
+    base._2X_ACC_FPROP = False
+    base._2X_ACC_DGRAD = False
+    base._2X_ACC_WGRAD = False
+    base.get_dummy_wgrad = lambda shape, dtype, zero=False: (
+        torch.zeros(shape, dtype=dtype) if zero else torch.ones(shape, dtype=dtype)
+    )
+    cpp = sys.modules["transformer_engine.pytorch.cpp_extensions"]
+    trace = {
+        "fc1_dgrad_ptr": None,
+        "overlap_dgrad_ptr": None,
+        "overlap_dgrad_end": None,
+        "events": [],
+    }
+
+    def fake_grouped_gemm(
+        weights, inputs, outputs, quantization_params=None, out_dtype=None, **kwargs
+    ):
+        if kwargs.get("layout") == "NN":
+            pieces = [inp @ weight for weight, inp in zip(weights, inputs)]
+        elif kwargs.get("layout") == "NT":
+            if any(
+                trace["overlap_dgrad_ptr"] < grad.data_ptr() + grad.nbytes
+                and grad.data_ptr() < trace["overlap_dgrad_end"]
+                for grad in inputs
+                if trace["overlap_dgrad_ptr"] is not None
+            ):
+                trace["events"].append("overlap wgrad reads grad_output")
+            pieces = [grad.T @ inp for inp, grad in zip(weights, inputs)]
+            for dst, piece in zip(outputs, pieces, strict=True):
+                if kwargs.get("accumulate"):
+                    dst.add_(piece)
+                else:
+                    dst.copy_(piece)
+            if (
+                trace["events"]
+                and trace["events"][-1] == "overlap wgrad reads grad_output"
+            ):
+                trace["events"].append("overlap wgrad completes")
+            return None, [None] * len(pieces), None
+        else:
+            pieces = [inp @ weight.T for weight, inp in zip(weights, inputs)]
+        outputs[0].copy_(torch.cat(pieces, dim=0))
+        if (
+            trace["overlap_dgrad_ptr"] is not None
+            and trace["overlap_dgrad_ptr"] < outputs[0].data_ptr() + outputs[0].nbytes
+            and outputs[0].data_ptr() < trace["overlap_dgrad_end"]
+        ):
+            trace["events"].append("overlap dgrad first write")
+        if (
+            kwargs.get("layout") == "NN"
+            and outputs[0].data_ptr() == trace["fc1_dgrad_ptr"]
+        ):
+            trace["events"].append(
+                "fc2_dgrad_first_write"
+                if outputs[0].shape[1] == 3
+                else "fc1_dgrad_first_write"
+            )
+        return None, [None] * len(pieces), None
+
+    cpp.general_grouped_gemm = fake_grouped_gemm
+    from megatron.lite.primitive.modules import experts as experts_module
+
+    class Store:
+        def __init__(self):
+            self.entries = []
+            self.context = SimpleNamespace(empty=lambda: not self.entries)
+
+        @staticmethod
+        def delay_wgrad_compute():
+            return True
+
+        def put(self, tensors, fn):
+            self.entries.append((tensors, fn))
+
+        def pop(self):
+            tensors, fn = self.entries.pop(0)
+            return fn(*tensors), tensors
+
+    class Linear:
+        def __init__(self):
+            self.num_gemms = 2
+            self.fp8 = False
+            self.use_bias = False
+            self.return_bias = False
+            self.save_original_input = False
+            self.fuse_wgrad_accumulation = True
+            self.wgrad_store = Store()
+            self.activation_dtype = torch.bfloat16
+            self.weight0 = torch.nn.Parameter(
+                torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=torch.bfloat16)
+            )
+            self.weight1 = torch.nn.Parameter(
+                torch.tensor(
+                    [[2.0, -1.0], [0.0, 3.0], [4.0, 1.0]], dtype=torch.bfloat16
+                )
+            )
+            for weight in (self.weight0, self.weight1):
+                weight.main_grad = torch.zeros_like(weight, dtype=torch.float32)
+                weight.grad_added_to_main_grad = False
+                weight.zero_out_wgrad = True
+            self.calls = []
+
+        def prepare_forward(self, value, *, num_gemms):
+            self.calls.append(("prepare", num_gemms))
+            return value
+
+        def end_forward(self):
+            self.calls.append(("end",))
+
+        def _get_weight_tensors(self):
+            self.calls.append(("weights",))
+            return [self.weight0, self.weight1]
+
+        def _get_bias_tensors(self):
+            self.calls.append(("biases",))
+            return []
+
+        def _get_quantizers(self):
+            self.calls.append(("quantizers",))
+            return tuple([None, None] for _ in range(6))
+
+    linear = Linear()
+    x = torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.bfloat16, requires_grad=True)
+    out = torch.empty(2, 3, dtype=torch.bfloat16)
+    dgrad = torch.empty_like(x)
+    result = experts_module._caller_owned_grouped_linear(linear, x, [1, 1], out, dgrad)
+    assert result.data_ptr() == out.data_ptr()
+    result.float().sum().backward()
+    assert x.grad.data_ptr() == dgrad.data_ptr()
+    torch.testing.assert_close(
+        x.grad,
+        torch.tensor([[9.0, 12.0], [6.0, 3.0]], dtype=torch.bfloat16),
+    )
+    assert linear.calls == [
+        ("prepare", 2),
+        ("weights",),
+        ("biases",),
+        ("quantizers",),
+        ("end",),
+    ]
+    assert len(linear.wgrad_store.entries) == 1
+    tensors, delayed = linear.wgrad_store.entries.pop()
+    delayed(*tensors)
+    assert all(
+        weight.grad_added_to_main_grad for weight in (linear.weight0, linear.weight1)
+    )
+    assert all(
+        torch.count_nonzero(weight.main_grad)
+        for weight in (linear.weight0, linear.weight1)
+    )
+    torch.testing.assert_close(
+        linear.weight0.main_grad,
+        torch.tensor([[1.0, 2.0], [1.0, 2.0], [1.0, 2.0]]),
+    )
+    torch.testing.assert_close(
+        linear.weight1.main_grad,
+        torch.tensor([[3.0, 4.0], [3.0, 4.0], [3.0, 4.0]]),
+    )
+
+    # Fused 3-slot mode may use the FC2 output bytes as the FC2 dgrad output.
+    # The explicit grad_output and dgrad_out below are different contiguous
+    # views with a partial byte-range overlap, not a same-data_ptr shortcut.
+    # Wgrad must execute before Dgrad overwrites the shared bytes, rather than
+    # enqueueing a deferred callback that would read corruption during flush.
+    overlap_linear = Linear()
+    overlap_linear.weight0 = torch.nn.Parameter(
+        torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=torch.bfloat16)
+    )
+    overlap_linear.weight1 = torch.nn.Parameter(
+        torch.tensor([[2.0, -1.0, 4.0], [0.0, 3.0, 5.0]], dtype=torch.bfloat16)
+    )
+    for weight in (overlap_linear.weight0, overlap_linear.weight1):
+        weight.main_grad = torch.zeros_like(weight, dtype=torch.float32)
+        weight.grad_added_to_main_grad = False
+        weight.zero_out_wgrad = True
+    overlap_x = torch.tensor(
+        [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
+        dtype=torch.bfloat16,
+        requires_grad=True,
+    )
+    overlap_out = torch.empty(2, 2, dtype=torch.bfloat16)
+    overlap_raw = torch.empty(8, dtype=torch.bfloat16)
+    overlap_grad_output = overlap_raw[:4].view(2, 2)
+    overlap_dgrad_out = overlap_raw[2:].view(2, 3)
+    assert overlap_grad_output.data_ptr() != overlap_dgrad_out.data_ptr()
+    overlap_result = experts_module._caller_owned_grouped_linear(
+        overlap_linear,
+        overlap_x,
+        [1, 1],
+        overlap_out,
+        overlap_dgrad_out,
+    )
+    overlap_grad_output.copy_(
+        torch.tensor([[2.0, 3.0], [5.0, 7.0]], dtype=torch.bfloat16)
+    )
+    trace["overlap_dgrad_ptr"] = overlap_dgrad_out.data_ptr()
+    trace["overlap_dgrad_end"] = overlap_dgrad_out.data_ptr() + overlap_dgrad_out.nbytes
+    overlap_dgrad = torch.autograd.grad(overlap_result, overlap_x, overlap_grad_output)[
+        0
+    ]
+
+    assert overlap_dgrad.data_ptr() == overlap_dgrad_out.data_ptr()
+    torch.testing.assert_close(
+        overlap_dgrad,
+        torch.tensor([[14.0, 19.0, 24.0], [10.0, 16.0, 55.0]], dtype=torch.bfloat16),
+    )
+    assert overlap_linear.wgrad_store.entries == []
+    assert trace["events"] == [
+        "overlap wgrad reads grad_output",
+        "overlap wgrad completes",
+        "overlap dgrad first write",
+    ]
+    assert all(
+        weight.grad_added_to_main_grad
+        for weight in (overlap_linear.weight0, overlap_linear.weight1)
+    )
+    torch.testing.assert_close(
+        overlap_linear.weight0.main_grad,
+        torch.tensor([[2.0, 4.0, 6.0], [3.0, 6.0, 9.0]]),
+    )
+    torch.testing.assert_close(
+        overlap_linear.weight1.main_grad,
+        torch.tensor([[20.0, 25.0, 30.0], [28.0, 35.0, 42.0]]),
+    )
+    trace["events"].clear()
+    trace["overlap_dgrad_ptr"] = None
+    trace["overlap_dgrad_end"] = None
+
+    no_dgrad_x = torch.tensor([[2.0, 1.0], [4.0, 3.0]], dtype=torch.bfloat16)
+    no_dgrad_out = torch.empty(2, 3, dtype=torch.bfloat16)
+    no_dgrad_result = experts_module._caller_owned_grouped_linear(
+        linear, no_dgrad_x, [1, 1], no_dgrad_out, None
+    )
+    assert no_dgrad_result.requires_grad
+    no_dgrad_result.float().sum().backward()
+    assert len(linear.wgrad_store.entries) == 1
+    tensors, delayed = linear.wgrad_store.entries.pop()
+    delayed(*tensors)
+
+    # Full two-linear CPU probe: use the fused FC2 raw-byte coloring, run fake
+    # grouped GEMMs, and prove that the colliding FC2 Wgrad is immediate while
+    # FC1 remains deferred when SwiGLU supplies it a non-overlapping gradient.
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        EPChunkShapeProfile,
+        EPChunkWorkspaceKey,
+        EPChunkWorkspaceRegistry,
+    )
+
+    workspace = EPChunkWorkspaceRegistry().get_or_create(
+        EPChunkWorkspaceKey(
+            op="fused_forward_backward",
+            device_type="cpu",
+            device_index=None,
+            ep_group_id=101,
+            dtype=torch.bfloat16,
+            shape_profile=EPChunkShapeProfile(
+                max_input_rows=8, hidden_size=2, topk=2, ep_size=2
+            ),
+        ),
+        lambda slot: SimpleNamespace(slot=slot, use_deepep=True),
+    )
+    lease = workspace.acquire_expert_activation()
+    colored_fc1_out = lease.tensor(
+        "fc1_output", (2, 3), dtype=torch.bfloat16, device="cpu"
+    )
+    colored_fc2_out = lease.tensor(
+        "fc2_output", (2, 2), dtype=torch.bfloat16, device="cpu"
+    )
+    colored_fc1_dgrad = lease.tensor(
+        "fc1_dgrad", (2, 2), dtype=torch.bfloat16, device="cpu"
+    )
+    colored_fc2_dgrad = lease.tensor(
+        "fc2_dgrad", (2, 3), dtype=torch.bfloat16, device="cpu"
+    )
+    assert colored_fc2_out.data_ptr() == colored_fc1_dgrad.data_ptr()
+    assert colored_fc2_dgrad.data_ptr() == colored_fc1_dgrad.data_ptr()
+    # This isolated adapter probe keeps FC1's caller-owned dgrad separate so
+    # the non-overlap/deferred branch remains executable alongside FC2's
+    # fused collision. Dedicated workspace tests retain the production 3-slot map.
+    colored_fc1_dgrad = torch.empty_like(colored_fc1_dgrad)
+
+    fc1 = Linear()
+    fc2 = Linear()
+    fc2.weight0 = torch.nn.Parameter(
+        torch.tensor([[1.0, 0.0, 1.0], [0.0, 1.0, 1.0]], dtype=torch.bfloat16)
+    )
+    fc2.weight1 = torch.nn.Parameter(
+        torch.tensor([[2.0, 0.0, 0.0], [0.0, 3.0, 0.0]], dtype=torch.bfloat16)
+    )
+    for weight in (fc2.weight0, fc2.weight1):
+        weight.main_grad = torch.zeros_like(weight, dtype=torch.float32)
+        weight.grad_added_to_main_grad = False
+        weight.zero_out_wgrad = True
+    colored_x = torch.tensor(
+        [[1.0, 2.0], [3.0, 4.0]], dtype=torch.bfloat16, requires_grad=True
+    )
+    trace["fc1_dgrad_ptr"] = colored_fc1_dgrad.data_ptr()
+    colored_fc1 = experts_module._caller_owned_grouped_linear(
+        fc1, colored_x, [1, 1], colored_fc1_out, colored_fc1_dgrad
+    )
+
+    class FakeSwiGLU(torch.autograd.Function):
+        """CPU stand-in that records FC2-dgrad's final intermediate consumer."""
+
+        @staticmethod
+        def forward(ctx, value):
+            return value.clone()
+
+        @staticmethod
+        def backward(ctx, grad):
+            trace["events"].append("swiglu_intermediate_consumer")
+            return grad.clone()
+
+    colored_fc2 = experts_module._caller_owned_grouped_linear(
+        fc2,
+        FakeSwiGLU.apply(colored_fc1),
+        [1, 1],
+        colored_fc2_out,
+        colored_fc2_dgrad,
+    )
+    # Match the fused production path: obtain the custom-Function edge before
+    # writing the same FC2-output bytes used as the incoming gradient source.
+    expert_out_edge = torch.autograd.graph.get_gradient_edge(colored_fc2)
+    colored_fc2_grad = colored_fc2.detach()
+    colored_fc2_grad.copy_(torch.tensor([[2.0, 3.0], [5.0, 7.0]], dtype=torch.bfloat16))
+    trace["overlap_dgrad_ptr"] = colored_fc2_dgrad.data_ptr()
+    trace["overlap_dgrad_end"] = colored_fc2_dgrad.data_ptr() + colored_fc2_dgrad.nbytes
+    colored_x_dgrad = torch.autograd.grad(expert_out_edge, colored_x, colored_fc2_grad)[
+        0
+    ]
+    assert trace["events"] == [
+        "overlap wgrad reads grad_output",
+        "overlap wgrad completes",
+        "overlap dgrad first write",
+        "swiglu_intermediate_consumer",
+        "fc1_dgrad_first_write",
+    ]
+    assert colored_x_dgrad.data_ptr() == colored_fc1_dgrad.data_ptr()
+    torch.testing.assert_close(
+        colored_x_dgrad,
+        torch.tensor([[36.0, 46.0], [20.0, 53.0]], dtype=torch.bfloat16),
+    )
+    assert fc2.wgrad_store.entries == []
+    assert getattr(fc2.wgrad_store, "_mlite_immediate_wgrad_contexts", 0) == 1
+    assert len(fc1.wgrad_store.entries) == 1
+    assert getattr(fc1.wgrad_store, "_mlite_immediate_wgrad_contexts", 0) == 0
+
+    flush_owner = SimpleNamespace(
+        fc1=fc1,
+        fc2=fc2,
+        _validate_weight_grad_sink=experts_module.Experts._validate_weight_grad_sink,
+        release_delayed_weight_grad_aliases=lambda: None,
+    )
+    experts_module.Experts.flush_delayed_weight_grads(flush_owner, num_contexts=1)
+    assert fc1.wgrad_store.context.empty()
+    assert fc2.wgrad_store.context.empty()
+    assert fc1.wgrad_store._mlite_immediate_wgrad_contexts == 0
+    assert fc2.wgrad_store._mlite_immediate_wgrad_contexts == 0
+    torch.testing.assert_close(
+        fc1.weight0.main_grad,
+        torch.tensor([[2.0, 4.0], [3.0, 6.0], [5.0, 10.0]]),
+    )
+    torch.testing.assert_close(
+        fc1.weight1.main_grad,
+        torch.tensor([[30.0, 40.0], [63.0, 84.0], [0.0, 0.0]]),
+    )
+    torch.testing.assert_close(
+        fc2.weight0.main_grad,
+        torch.tensor([[10.0, 22.0, 34.0], [15.0, 33.0, 51.0]]),
+    )
+    torch.testing.assert_close(
+        fc2.weight1.main_grad,
+        torch.tensor([[10.0, 60.0, 80.0], [14.0, 84.0, 112.0]]),
+    )
+    trace["overlap_dgrad_ptr"] = None
+    trace["overlap_dgrad_end"] = None
+
+    class ReadyEvent:
+        @staticmethod
+        def query():
+            return True
+
+    lease.release(ReadyEvent())
+
+    # TE2.15 must defer MCore-FSDP main_grad lookup until backward, after the
+    # framework has materialized the sink.  The saved weight Tensor is not the
+    # source of these Python-side hook attributes.
+    for weight in (linear.weight0, linear.weight1):
+        sink = weight.main_grad
+        del weight.main_grad
+        weight.__fsdp_param__ = True
+        weight.get_main_grad = lambda sink=sink: sink
+    fsdp_x = torch.tensor(
+        [[1.0, 1.0], [2.0, 2.0]], dtype=torch.bfloat16, requires_grad=True
+    )
+    fsdp_out = torch.empty(2, 3, dtype=torch.bfloat16)
+    fsdp_dgrad = torch.empty_like(fsdp_x)
+    experts_module._caller_owned_grouped_linear(
+        linear, fsdp_x, [1, 1], fsdp_out, fsdp_dgrad
+    ).float().sum().backward()
+    tensors, delayed = linear.wgrad_store.entries.pop()
+    delayed(*tensors)
+    assert fsdp_x.grad.data_ptr() == fsdp_dgrad.data_ptr()
+
+    with pytest.raises(RuntimeError, match="non-grad"):
+        experts_module._caller_owned_grouped_linear(
+            linear, x, [1, 1], out.detach().requires_grad_(), dgrad
+        )
+    assert linear.calls[-1] == ("end",)
+
+
+def test_manual_unpermute_writes_into_stable_workspace_slot(
+    transformer_engine_import_stub,
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        _manual_unpermute_backward,
+    )
+
+    class StableLease:
+        def __init__(self):
+            self.storage = None
+            self.names = []
+
+        def tensor(self, name, shape, *, dtype, device):
+            self.names.append(name)
+            if self.storage is None:
+                self.storage = torch.empty(shape, dtype=dtype, device=device)
+            return self.storage
+
+    lease = StableLease()
+    chunk = SimpleNamespace(
+        expert_out_shape=torch.Size((4, 2)),
+        expert_out_dtype=torch.float32,
+        row_id_map=torch.tensor([2, 0, 3, 1]),
+        workspace_lease=lease,
+    )
+    first_input = torch.arange(8, dtype=torch.float32).view(4, 2)
+    first = _manual_unpermute_backward(chunk, first_input)
+    first_ptr = first.data_ptr()
+    second_input = first_input + 10
+    second = _manual_unpermute_backward(chunk, second_input)
+
+    assert first_ptr == second.data_ptr()
+    assert lease.names == ["grad_expert_out", "grad_expert_out"]
+    torch.testing.assert_close(second, second_input.index_select(0, chunk.row_id_map))
+
+
+def test_fused_manual_unpermute_reuses_expert_output_without_workspace_scratch(
+    transformer_engine_import_stub,
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        _manual_unpermute_backward,
+    )
+
+    class NoScratchLease:
+        def tensor(self, *args, **kwargs):
+            raise AssertionError(
+                "fused manual unpermute must not allocate workspace scratch"
+            )
+
+    expert_out = torch.full((4, 2), -1.0)
+    chunk = SimpleNamespace(
+        expert_out_shape=torch.Size((4, 2)),
+        expert_out_dtype=torch.float32,
+        row_id_map=torch.tensor([2, 0, 3, 1]),
+        workspace_lease=NoScratchLease(),
+    )
+    grad_rank_grouped = torch.arange(8, dtype=torch.float32).view(4, 2)
+
+    grad_expert_out = _manual_unpermute_backward(
+        chunk,
+        grad_rank_grouped,
+        out=expert_out.detach(),
+    )
+
+    assert grad_expert_out.data_ptr() == expert_out.data_ptr()
+    torch.testing.assert_close(
+        grad_expert_out,
+        grad_rank_grouped.index_select(0, chunk.row_id_map),
+    )

--- a/experimental/lite/tests/unit/primitive/test_moe_ep_chunk_workspace.py
+++ b/experimental/lite/tests/unit/primitive/test_moe_ep_chunk_workspace.py
@@ -1,0 +1,2829 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from __future__ import annotations
+
+import inspect
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+
+class _FakeEvent:
+    def __init__(self, ready: bool = False):
+        self.ready = ready
+
+    def query(self) -> bool:
+        return self.ready
+
+
+class _FakeStream:
+    def __init__(self):
+        self.waited = []
+
+    def wait_event(self, event) -> None:
+        self.waited.append(event)
+
+
+class _RecordableCudaTensor:
+    is_cuda = True
+
+    def __init__(self):
+        self.recorded_streams = []
+
+    def record_stream(self, stream) -> None:
+        self.recorded_streams.append(stream)
+
+
+def test_owned_expert_tensor_uses_the_default_allocator(
+    monkeypatch, transformer_engine_import_stub
+):
+    """Caller-owned eager activations do not enter a private CUDA pool."""
+    transformer_engine_import_stub()
+    import megatron.lite.primitive.modules.moe_ep_chunk_overlap as overlap
+
+    entered = []
+
+    @contextmanager
+    def use_device(_device):
+        yield
+
+    @contextmanager
+    def use_pool(pool, device=None):
+        entered.append((pool, device))
+        yield
+
+    monkeypatch.setattr(overlap.torch.cuda, "device", use_device)
+    monkeypatch.setattr(overlap.torch.cuda, "use_mem_pool", use_pool)
+    profile = overlap.EPChunkShapeProfile(
+        max_input_rows=8, hidden_size=4, topk=2, ep_size=2
+    )
+    workspace = overlap.EPChunkWorkspaceRegistry().get_or_create(
+        overlap.EPChunkWorkspaceKey(
+            op="forward",
+            device_type="cuda",
+            device_index=0,
+            ep_group_id=1,
+            dtype=torch.bfloat16,
+            shape_profile=profile,
+        ),
+        lambda slot: SimpleNamespace(slot=slot, use_deepep=True),
+    )
+    workspace.materialize()
+    lease = workspace.acquire_expert_activation(
+        stream=SimpleNamespace(device=torch.device("cuda", 0))
+    )
+    with lease.allocate():
+        tensor = lease.tensor(
+            "fc1_input", (3, 4), dtype=torch.bfloat16, device=torch.device("cpu")
+        )
+
+    assert tuple(tensor.shape) == (3, 4)
+    assert entered == []
+    assert workspace.evidence()["expert_activation_pool_count"] == 0
+    lease.release(_FakeEvent(ready=True))
+
+
+def test_eager_workspace_never_uses_a_private_cuda_pool(
+    monkeypatch, transformer_engine_import_stub
+):
+    """Eager ChunkedEP must leave reusable blocks in PyTorch's default allocator."""
+    transformer_engine_import_stub()
+    import megatron.lite.primitive.modules.moe_ep_chunk_overlap as overlap
+
+    @contextmanager
+    def use_device(_device):
+        yield
+
+    def private_pool_forbidden(*_args, **_kwargs):
+        raise AssertionError("eager ChunkedEP must not instantiate torch.cuda.MemPool")
+
+    @contextmanager
+    def private_scope_forbidden(*_args, **_kwargs):
+        raise AssertionError("eager ChunkedEP must not enter torch.cuda.use_mem_pool")
+        yield
+
+    monkeypatch.setattr(overlap.torch.cuda, "device", use_device)
+    monkeypatch.setattr(overlap.torch.cuda, "MemPool", private_pool_forbidden)
+    monkeypatch.setattr(overlap.torch.cuda, "use_mem_pool", private_scope_forbidden)
+    monkeypatch.setattr(overlap.torch.cuda, "is_current_stream_capturing", lambda: False)
+    monkeypatch.setattr(overlap, "_EXPERT_ACTIVATION_SIZE_CLASS_BYTES", 1)
+    profile = overlap.EPChunkShapeProfile(
+        max_input_rows=8,
+        hidden_size=4,
+        topk=2,
+        ep_size=2,
+        expert_intermediate_size=3,
+    )
+    registry = overlap.EPChunkWorkspaceRegistry()
+    workspace = registry.get_or_create(
+        overlap.EPChunkWorkspaceKey(
+            op="forward",
+            device_type="cuda",
+            device_index=0,
+            ep_group_id=700,
+            dtype=torch.float32,
+            shape_profile=profile,
+        ),
+        lambda slot: SimpleNamespace(slot=slot, use_deepep=True),
+    )
+    stream = SimpleNamespace(device=torch.device("cuda", 0))
+    workspace.materialize()
+    workspace.reserve_expert_activations(max_expert_rows=3, device=stream.device)
+    scratch = workspace.acquire(0, stream=stream)
+    with scratch.deepep_recv_allocation():
+        first_scratch = scratch.tensor(
+            "grad_expert_out", (3, 4), dtype=torch.float32, device="cpu"
+        )
+    first_scratch_ptr = first_scratch.data_ptr()
+    scratch.release(_FakeEvent(ready=True))
+    reacquired_scratch = workspace.acquire(0, stream=stream)
+    with reacquired_scratch.deepep_recv_allocation():
+        second_scratch = reacquired_scratch.tensor(
+            "grad_expert_out", (3, 4), dtype=torch.float32, device="cpu"
+        )
+    assert second_scratch.data_ptr() == first_scratch_ptr
+    reacquired_scratch.release(_FakeEvent(ready=True))
+    first = workspace.acquire_expert_activation(stream=stream)
+    first.tensor("fc1_input", (3, 4), dtype=torch.float32, device="cpu")
+    first.release(_FakeEvent(ready=True))
+    workspace.park_expert_activations(stream=stream)
+    second = workspace.acquire_expert_activation(stream=stream)
+    second.tensor("fc1_input", (3, 4), dtype=torch.float32, device="cpu")
+    second.release(_FakeEvent(ready=True))
+    workspace.close(stream=stream)
+    registry.release(workspace.key, stream=stream)
+
+    evidence = workspace.evidence()
+    assert evidence["allocation_pool_count"] == 0
+    assert evidence["allocation_pool_ids"] == {}
+    assert evidence["expert_activation_pool_count"] == 0
+    assert evidence["expert_activation_pool_id"] is None
+    assert workspace._expert_activation_owner.coordinator.capacity_bytes == {}
+
+
+def test_explicit_frozen_activation_reservation_eager_park_releases_backing(
+    monkeypatch, transformer_engine_import_stub
+):
+    """Eager park drops views and backing but retains frozen capacity metadata."""
+    transformer_engine_import_stub()
+    import megatron.lite.primitive.modules.moe_ep_chunk_overlap as overlap
+
+    @contextmanager
+    def use_device(_device):
+        yield
+
+    monkeypatch.setattr(overlap.torch.cuda, "device", use_device)
+    monkeypatch.setattr(overlap.torch.cuda, "is_current_stream_capturing", lambda: False)
+    monkeypatch.setattr(overlap, "_EXPERT_ACTIVATION_SIZE_CLASS_BYTES", 1)
+    profile = overlap.EPChunkShapeProfile(
+        max_input_rows=8,
+        hidden_size=4,
+        topk=2,
+        ep_size=2,
+        expert_intermediate_size=3,
+    )
+    registry = overlap.EPChunkWorkspaceRegistry()
+
+    def workspace(op):
+        return registry.get_or_create(
+            overlap.EPChunkWorkspaceKey(
+                op=op,
+                device_type="cuda",
+                device_index=0,
+                ep_group_id=991,
+                dtype=torch.float32,
+                shape_profile=profile,
+            ),
+            lambda slot: SimpleNamespace(slot=slot, use_deepep=True),
+        )
+
+    forward, fused = workspace("forward"), workspace("fused_forward_backward")
+    stream = SimpleNamespace(device=torch.device("cuda", 0))
+    forward.reserve_expert_activations(max_expert_rows=3, device=stream.device)
+    coordinator = forward._expert_activation_owner.coordinator
+
+    assert coordinator.frozen
+    assert coordinator.arena.tensors == {}
+
+    first = forward.acquire_expert_activation(stream=stream)
+    first.tensor("fc1_input", (3, 4), dtype=torch.float32, device="cpu")
+    assert set(coordinator.arena.tensors) == {"fc1_input"}
+    assert coordinator.backing_tensors == {}
+    first.release(_FakeEvent(ready=True))
+    forward.reset_tensors()
+    assert coordinator.arena.tensors == {}
+    assert coordinator.backing_tensors == {}
+    assert coordinator.capacity_bytes == {
+        "fc1_input": 48,
+        "fc1_output": 72,
+        "fc2_output": 48,
+        "fc2_dgrad": 48,
+    }
+
+    rehydrated = forward.acquire_expert_activation(stream=stream)
+    rehydrated_input = rehydrated.tensor(
+        "fc1_input", (3, 4), dtype=torch.float32, device="cpu"
+    )
+    rehydrated.tensor("fc1_output", (3, 6), dtype=torch.float32, device="cpu")
+    rehydrated_fc2 = rehydrated.tensor(
+        "fc2_output", (3, 4), dtype=torch.float32, device="cpu"
+    )
+    assert rehydrated_fc2.data_ptr() == rehydrated_input.data_ptr()
+    rehydrated.release(_FakeEvent(ready=True))
+    forward.reset_tensors()
+    assert coordinator.arena.tensors == {}
+    assert coordinator.backing_tensors == {}
+
+    second = fused.acquire_expert_activation(stream=stream)
+    fused_fc1_input = second.tensor(
+        "fc1_input", (3, 4), dtype=torch.float32, device="cpu"
+    )
+    second.tensor("fc1_output", (3, 6), dtype=torch.float32, device="cpu")
+    second.tensor("fc2_output", (3, 4), dtype=torch.float32, device="cpu")
+    second.release(_FakeEvent(ready=True))
+    assert fused.evidence()["expert_activation_pool_id"] == forward.evidence()["expert_activation_pool_id"]
+    assert fused_fc1_input.data_ptr() != 0
+    assert coordinator.grows == 0
+    fused.reset_tensors()
+    assert coordinator.backing_tensors == {}
+
+    third = forward.acquire_expert_activation(stream=stream)
+    third.tensor("fc1_input", (3, 4), dtype=torch.float32, device="cpu")
+    third.tensor("fc1_output", (3, 6), dtype=torch.float32, device="cpu")
+    third.tensor("fc2_output", (3, 4), dtype=torch.float32, device="cpu")
+    with pytest.raises(RuntimeError, match="Frozen EP chunk expert activation"):
+        third.tensor("fc1_input", (4, 4), dtype=torch.float32, device="cpu")
+    third.release(_FakeEvent(ready=True))
+    forward.reset_tensors()
+
+    registry.release(forward.key)
+    registry.release(fused.key)
+    assert coordinator.capacity_bytes == {}
+    assert coordinator.pointer_signatures_by_op == {}
+    assert coordinator.backing_tensors == {}
+    assert not coordinator.frozen
+
+
+@pytest.mark.parametrize(("hidden_size", "expert_intermediate_size"), [(4, 7), (7, 4)])
+def test_frozen_normal_backward_reserves_widest_fc2_dgrad_alias(
+    hidden_size, expert_intermediate_size, transformer_engine_import_stub
+):
+    """Normal backward's shared dgrad slot must fit both logical widths."""
+    transformer_engine_import_stub()
+    import megatron.lite.primitive.modules.moe_ep_chunk_overlap as overlap
+
+    profile = overlap.EPChunkShapeProfile(
+        max_input_rows=8,
+        hidden_size=hidden_size,
+        topk=2,
+        ep_size=2,
+        expert_intermediate_size=expert_intermediate_size,
+    )
+    registry = overlap.EPChunkWorkspaceRegistry()
+    workspace = registry.get_or_create(
+        overlap.EPChunkWorkspaceKey(
+            op="backward",
+            device_type="cpu",
+            device_index=None,
+            ep_group_id=993,
+            dtype=torch.float32,
+            shape_profile=profile,
+        ),
+        lambda slot: SimpleNamespace(slot=slot, use_deepep=True),
+    )
+    workspace.reserve_expert_activations(max_expert_rows=3, device="cpu")
+    coordinator = workspace._expert_activation_owner.coordinator
+    assert coordinator.capacity_bytes["fc2_dgrad"] == (
+        overlap._expert_activation_capacity_bytes(
+            3
+            * max(hidden_size, expert_intermediate_size)
+            * torch.empty((), dtype=torch.float32).element_size()
+        )
+    )
+
+    lease = workspace.acquire_expert_activation()
+    fc2_dgrad = lease.tensor(
+        "fc2_dgrad", (3, expert_intermediate_size), dtype=torch.float32, device="cpu"
+    )
+    fc1_dgrad = lease.tensor(
+        "fc1_dgrad", (3, hidden_size), dtype=torch.float32, device="cpu"
+    )
+    assert fc2_dgrad.data_ptr() == fc1_dgrad.data_ptr()
+    assert workspace._expert_activation_owner.grows == 0
+    lease.release(_FakeEvent(ready=True))
+    registry.release(workspace.key)
+
+
+def test_fused_training_reuses_backing_until_explicit_reset(
+    transformer_engine_import_stub,
+):
+    """Fused-step releases retain event-guarded backing for the next step."""
+    transformer_engine_import_stub()
+    import megatron.lite.primitive.modules.moe_ep_chunk_overlap as overlap
+
+    profile = overlap.EPChunkShapeProfile(
+        max_input_rows=8,
+        hidden_size=4,
+        topk=2,
+        ep_size=2,
+        expert_intermediate_size=7,
+    )
+    registry = overlap.EPChunkWorkspaceRegistry()
+    workspace = registry.get_or_create(
+        overlap.EPChunkWorkspaceKey(
+            op="fused_forward_backward",
+            device_type="cpu",
+            device_index=None,
+            ep_group_id=994,
+            dtype=torch.float32,
+            shape_profile=profile,
+        ),
+        lambda slot: SimpleNamespace(slot=slot, use_deepep=True),
+    )
+    workspace.reserve_expert_activations(max_expert_rows=3, device="cpu")
+    coordinator = workspace._expert_activation_owner.coordinator
+
+    first = workspace.acquire_expert_activation()
+    first_tensor = first.tensor("fc1_input", (3, 4), dtype=torch.float32, device="cpu")
+    first.release(_FakeEvent(ready=True))
+    allocations, rehydrates = coordinator.allocations, coordinator.rehydrates
+
+    second = workspace.acquire_expert_activation()
+    second_tensor = second.tensor("fc1_input", (3, 4), dtype=torch.float32, device="cpu")
+    assert second_tensor.data_ptr() == first_tensor.data_ptr()
+    assert (coordinator.allocations, coordinator.rehydrates) == (allocations, rehydrates)
+    second.release(_FakeEvent(ready=True))
+
+    workspace.reset_tensors()
+    assert coordinator.arena.tensors == {}
+    assert coordinator.backing_tensors == {}
+    rebuilt = workspace.acquire_expert_activation()
+    rebuilt.tensor("fc1_input", (3, 4), dtype=torch.float32, device="cpu")
+    assert coordinator.rehydrates == rehydrates + 1
+    rebuilt.release(_FakeEvent(ready=True))
+    registry.release(workspace.key)
+
+
+def test_zero_row_activation_is_a_non_allocating_logical_view(
+    transformer_engine_import_stub,
+):
+    """Zero-token experts must not materialize a capacity-sized activation."""
+    transformer_engine_import_stub()
+    import megatron.lite.primitive.modules.moe_ep_chunk_overlap as overlap
+
+    profile = overlap.EPChunkShapeProfile(
+        max_input_rows=8, hidden_size=4, topk=2, ep_size=2
+    )
+    coordinator = overlap._EPChunkExpertActivationArenaCoordinator(
+        overlap._EPChunkExpertActivationArenaKey(
+            device_type="cpu",
+            device_index=None,
+            ep_group_id=998,
+            dtype=torch.float32,
+            shape_profile=profile,
+        )
+    )
+    zero = coordinator.tensor("fc1_input", (0, 4), dtype=torch.float32, device="cpu")
+    assert zero.shape == (0, 4) and zero.dtype == torch.float32
+    assert not zero.requires_grad
+    assert coordinator.arena.tensors == {}
+    assert coordinator.capacity_bytes == {}
+    assert coordinator.issued_storage_slots == set()
+    assert coordinator.rehydrates == coordinator.grows == coordinator.allocations == 0
+
+    # Zero access is not a lease claim: the later nonzero alias can allocate normally.
+    nonzero = coordinator.tensor("fc1_input", (2, 4), dtype=torch.float32, device="cpu")
+    assert nonzero.shape == (2, 4)
+    assert coordinator.issued_storage_slots == {"fc1_input"}
+
+    coordinator.arena.tensors.clear()
+    coordinator.issued_storage_slots.clear()
+    coordinator.frozen = True
+    coordinator.capacity_bytes["fc1_input"] = 32
+    parked_zero = coordinator.tensor(
+        "fc1_input", (0, 4), dtype=torch.float32, device="cpu"
+    )
+    assert parked_zero.numel() == 0
+    assert coordinator.arena.tensors == {}
+    assert coordinator.rehydrates == 0
+    assert coordinator.capacity_bytes == {"fc1_input": 32}
+    with pytest.raises(RuntimeError, match="shape"):
+        coordinator.tensor("fc1_input", (0, 5), dtype=torch.float32, device="cpu")
+    with pytest.raises(RuntimeError, match="dtype"):
+        coordinator.tensor("fc1_input", (0, 4), dtype=torch.bfloat16, device="cpu")
+
+
+def test_capture_signature_rejects_only_a_changed_backing_slot(
+    transformer_engine_import_stub,
+):
+    """Slot-set growth is valid; an existing storage name may never move."""
+    transformer_engine_import_stub()
+    import megatron.lite.primitive.modules.moe_ep_chunk_overlap as overlap
+
+    coordinator = overlap._EPChunkExpertActivationArenaCoordinator(
+        overlap._EPChunkExpertActivationArenaKey(
+            device_type="cpu",
+            device_index=None,
+            ep_group_id=992,
+            dtype=torch.float32,
+            shape_profile=overlap.EPChunkShapeProfile(
+                max_input_rows=8, hidden_size=4, topk=2, ep_size=2
+            ),
+        )
+    )
+    coordinator.frozen = True
+    coordinator.graph_backing_owned = True
+    coordinator._record_pointer_signature("forward", {"fc1_input": 101})
+    coordinator._record_pointer_signature(
+        "forward", {"fc1_input": 101, "fc1_output": 202}
+    )
+    with pytest.raises(RuntimeError, match=r"fc1_input.*previous=101.*current=303"):
+        coordinator._record_pointer_signature("forward", {"fc1_input": 303})
+
+
+def test_capture_owned_backing_survives_park_and_close_releases_everything(
+    monkeypatch, transformer_engine_import_stub
+):
+    """Capture ownership retains stable backing across replay, unlike eager park."""
+    transformer_engine_import_stub()
+    import megatron.lite.primitive.modules.moe_ep_chunk_overlap as overlap
+
+    @contextmanager
+    def use_device(_device):
+        yield
+
+    @contextmanager
+    def use_pool(_pool, device=None):
+        raise AssertionError(f"capture must not enter eager MemPool: {device}")
+
+    capturing = {"value": True}
+    monkeypatch.setattr(overlap.torch.cuda, "device", use_device)
+    monkeypatch.setattr(
+        overlap.torch.cuda,
+        "MemPool",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("capture must not instantiate an eager MemPool")
+        ),
+    )
+    monkeypatch.setattr(overlap.torch.cuda, "use_mem_pool", use_pool)
+    monkeypatch.setattr(overlap.torch.cuda, "is_current_stream_capturing", lambda: capturing["value"])
+    monkeypatch.setattr(overlap, "_EXPERT_ACTIVATION_SIZE_CLASS_BYTES", 1)
+    profile = overlap.EPChunkShapeProfile(
+        max_input_rows=8,
+        hidden_size=4,
+        topk=2,
+        ep_size=2,
+        expert_intermediate_size=3,
+    )
+    registry = overlap.EPChunkWorkspaceRegistry()
+
+    def workspace(op):
+        return registry.get_or_create(
+            overlap.EPChunkWorkspaceKey(
+                op=op,
+                device_type="cuda",
+                device_index=0,
+                ep_group_id=993,
+                dtype=torch.float32,
+                shape_profile=profile,
+            ),
+            lambda slot: SimpleNamespace(slot=slot, use_deepep=True),
+        )
+
+    forward, fused = workspace("forward"), workspace("fused_forward_backward")
+    stream = SimpleNamespace(device=torch.device("cuda", 0))
+    forward.reserve_expert_activations(max_expert_rows=3, device=stream.device)
+    coordinator = forward._expert_activation_owner.coordinator
+
+    # Both allocation paths must defer to the outer graph allocator.  This is
+    # intentionally stronger than inspecting activation storage alone.
+    scratch = forward.acquire(0, stream=stream)
+    with scratch.deepep_recv_allocation():
+        scratch_tensor = scratch.tensor(
+            "grad_expert_out", (3, 4), dtype=torch.float32, device="cpu"
+        )
+    scratch_ptr = scratch_tensor.data_ptr()
+    scratch.release(_FakeEvent(ready=True))
+
+    capture = forward.acquire_expert_activation(stream=stream)
+    initial = capture.tensor("fc1_input", (3, 4), dtype=torch.float32, device="cpu")
+    initial_ptr = initial.data_ptr()
+    capture.release(_FakeEvent(ready=True))
+    forward.park_expert_activations(stream=stream)
+    assert coordinator.arena.tensors == {}
+    assert coordinator.graph_backing_owned
+    assert set(coordinator.backing_tensors) == {"fc1_input"}
+    assert forward._slots[0].tensors["grad_expert_out"].data_ptr() == scratch_ptr
+
+    capturing["value"] = False
+    replay = fused.acquire_expert_activation(stream=stream)
+    replay_input = replay.tensor("fc1_input", (3, 4), dtype=torch.float32, device="cpu")
+    assert replay_input.data_ptr() == initial_ptr
+    replay.release(_FakeEvent(ready=True))
+    fused.park_expert_activations(stream=stream)
+    assert set(coordinator.backing_tensors) == {"fc1_input"}
+
+    registry.release(forward.key)
+    registry.release(fused.key)
+    assert coordinator.arena.tensors == {}
+    assert coordinator.backing_tensors == {}
+    assert coordinator.capacity_bytes == {}
+    assert not coordinator.graph_backing_owned
+
+
+def test_eager_park_waits_then_records_reset_stream_before_releasing_views(
+    transformer_engine_import_stub,
+):
+    """A cross-stream reset cannot make a pending expert allocation reusable."""
+    transformer_engine_import_stub()
+    import megatron.lite.primitive.modules.moe_ep_chunk_overlap as overlap
+
+    coordinator = overlap._EPChunkExpertActivationArenaCoordinator(
+        overlap._EPChunkExpertActivationArenaKey(
+            device_type="cuda",
+            device_index=0,
+            ep_group_id=994,
+            dtype=torch.float32,
+            shape_profile=overlap.EPChunkShapeProfile(
+                max_input_rows=8, hidden_size=4, topk=2, ep_size=2
+            ),
+        )
+    )
+    tensor = _RecordableCudaTensor()
+    event = _FakeEvent(ready=False)
+    stream = _FakeStream()
+    coordinator.arena.tensors["fc1_input"] = tensor
+    coordinator.consumer_event = event
+
+    coordinator.park(stream=stream)
+
+    assert stream.waited == [event]
+    assert tensor.recorded_streams == [stream]
+    assert coordinator.arena.tensors == {}
+    assert coordinator.backing_tensors == {}
+
+
+def test_graph_owned_park_drops_views_without_eager_allocator_marking(
+    transformer_engine_import_stub,
+):
+    """Graph replay retains backing and must not take the eager release path."""
+    transformer_engine_import_stub()
+    import megatron.lite.primitive.modules.moe_ep_chunk_overlap as overlap
+
+    coordinator = overlap._EPChunkExpertActivationArenaCoordinator(
+        overlap._EPChunkExpertActivationArenaKey(
+            device_type="cuda",
+            device_index=0,
+            ep_group_id=995,
+            dtype=torch.float32,
+            shape_profile=overlap.EPChunkShapeProfile(
+                max_input_rows=8, hidden_size=4, topk=2, ep_size=2
+            ),
+        )
+    )
+    tensor = _RecordableCudaTensor()
+    event = _FakeEvent(ready=False)
+    stream = _FakeStream()
+    coordinator.graph_backing_owned = True
+    coordinator.arena.tensors["fc1_input"] = tensor
+    coordinator.backing_tensors["fc1_input"] = tensor
+    coordinator.consumer_event = event
+
+    coordinator.park(stream=stream)
+
+    assert stream.waited == [event]
+    assert tensor.recorded_streams == []
+    assert coordinator.arena.tensors == {}
+    assert coordinator.backing_tensors == {"fc1_input": tensor}
+
+
+def test_activation_only_park_preserves_workspace_slots_and_deepep_state(
+    transformer_engine_import_stub,
+):
+    """Fused lifecycle parking must not reset dispatcher slots or their scratch."""
+    transformer_engine_import_stub()
+    import megatron.lite.primitive.modules.moe_ep_chunk_overlap as overlap
+
+    profile = overlap.EPChunkShapeProfile(
+        max_input_rows=8, hidden_size=4, topk=2, ep_size=2
+    )
+    workspace = overlap.EPChunkWorkspaceRegistry().get_or_create(
+        overlap.EPChunkWorkspaceKey(
+            op="fused_forward_backward",
+            device_type="cuda",
+            device_index=0,
+            ep_group_id=996,
+            dtype=torch.float32,
+            shape_profile=profile,
+        ),
+        lambda slot: SimpleNamespace(slot=slot, use_deepep=True),
+    )
+    workspace._materialized = True
+    coordinator = workspace._expert_activation_owner.coordinator
+    activation = _RecordableCudaTensor()
+    pending = _FakeEvent(ready=False)
+    stream = _FakeStream()
+    slot = workspace._slots[0]
+    dispatcher = object()
+    scratch = object()
+    slot.dispatcher = dispatcher
+    slot.tensors["scratch"] = scratch
+    coordinator.arena.tensors["fc1_input"] = activation
+    coordinator.backing_tensors["fc1_input"] = activation
+    coordinator.consumer_event = pending
+
+    workspace.park_expert_activations(stream=stream)
+
+    assert stream.waited == [pending]
+    assert activation.recorded_streams == [stream]
+    assert coordinator.arena.tensors == {}
+    assert coordinator.backing_tensors == {}
+    assert slot.dispatcher is dispatcher
+    assert slot.tensors == {"scratch": scratch}
+
+
+def test_activation_only_park_keeps_capture_owned_backing(
+    transformer_engine_import_stub,
+):
+    """The public lifecycle facade retains capture/replay backing."""
+    transformer_engine_import_stub()
+    import megatron.lite.primitive.modules.moe_ep_chunk_overlap as overlap
+
+    profile = overlap.EPChunkShapeProfile(
+        max_input_rows=8, hidden_size=4, topk=2, ep_size=2
+    )
+    workspace = overlap.EPChunkWorkspaceRegistry().get_or_create(
+        overlap.EPChunkWorkspaceKey(
+            op="fused_forward_backward",
+            device_type="cuda",
+            device_index=0,
+            ep_group_id=997,
+            dtype=torch.float32,
+            shape_profile=profile,
+        ),
+        lambda slot: SimpleNamespace(slot=slot, use_deepep=True),
+    )
+    workspace._materialized = True
+    coordinator = workspace._expert_activation_owner.coordinator
+    activation = _RecordableCudaTensor()
+    stream = _FakeStream()
+    coordinator.graph_backing_owned = True
+    coordinator.arena.tensors["fc1_input"] = activation
+    coordinator.backing_tensors["fc1_input"] = activation
+    coordinator.consumer_event = _FakeEvent(ready=False)
+
+    workspace.park_expert_activations(stream=stream)
+
+    assert coordinator.arena.tensors == {}
+    assert coordinator.backing_tensors == {"fc1_input": activation}
+    assert activation.recorded_streams == []
+
+
+def test_activation_arena_parks_between_ops_at_observed_high_watermark(
+    monkeypatch, transformer_engine_import_stub
+):
+    """Only explicit park hands compatible logical storage to the next OP."""
+    transformer_engine_import_stub()
+    import megatron.lite.primitive.modules.moe_ep_chunk_overlap as overlap
+
+    @contextmanager
+    def use_device(_device):
+        yield
+
+    monkeypatch.setattr(overlap.torch.cuda, "device", use_device)
+    profile = overlap.EPChunkShapeProfile(
+        max_input_rows=32, hidden_size=4, topk=2, ep_size=2
+    )
+    registry = overlap.EPChunkWorkspaceRegistry()
+
+    def workspace(op):
+        return registry.get_or_create(
+            overlap.EPChunkWorkspaceKey(
+                op=op,
+                device_type="cuda",
+                device_index=0,
+                ep_group_id=11,
+                dtype=torch.float32,
+                shape_profile=profile,
+            ),
+            lambda slot: SimpleNamespace(slot=slot, use_deepep=True),
+        )
+
+    backward, fused = workspace("backward"), workspace("fused_forward_backward")
+    stream = _FakeStream()
+    stream.device = torch.device("cuda", 0)
+    names = ("fc1_input", "fc1_output", "fc2_output")
+    first = backward.acquire_expert_activation(stream=stream)
+    for name in names:
+        first.tensor(name, (16, 4), dtype=torch.float32, device="cpu")
+    first.release(_FakeEvent(ready=True))
+    # The active lease retains its three logical storage references.
+    repeated = backward.acquire_expert_activation(stream=stream)
+    for name in names:
+        repeated.tensor(name, (3, 4), dtype=torch.float32, device="cpu")
+    pending = _FakeEvent(ready=False)
+    repeated.release(pending)
+    coordinator = backward._expert_activation_owner.coordinator
+    capacity = coordinator.capacity_bytes["fc1_input"]
+    assert coordinator.arena.tensors
+    assert coordinator.rehydrates == 0
+    scratch_lease = backward.acquire(0, require_dispatcher=False)
+    scratch_lease.tensor(
+        "grad_expert_out", (3, 4), dtype=torch.float32, device="cpu"
+    )
+    scratch_lease.release(_FakeEvent(ready=True))
+    backward.reset_tensors(stream=stream)
+    assert stream.waited == [pending]
+    assert coordinator.arena.tensors == {}
+    assert coordinator.parks == 1
+    assert backward.evidence()["data_ptrs"] == {}
+
+    second = fused.acquire_expert_activation(stream=stream)
+    smaller = {
+        name: second.tensor(name, (3, 4), dtype=torch.float32, device="cpu")
+        for name in names
+    }
+    assert stream.waited == [pending]
+    assert all(tensor.numel() == 12 for tensor in smaller.values())
+    assert coordinator.capacity_bytes["fc1_input"] == capacity
+    assert coordinator.rehydrates == 3
+    second.release(_FakeEvent(ready=True))
+    assert coordinator.arena.tensors
+
+    registry.release(backward.key)
+    registry.release(fused.key)
+    assert coordinator.capacity_bytes == {}
+    assert coordinator.parks == coordinator.rehydrates == 0
+
+
+def _symbols(transformer_engine_import_stub):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        EP_CHUNK_COUNT,
+        EPChunkBackwardOp,
+        EPChunkForwardOp,
+        EPChunkFusedForwardBackwardOp,
+        EPChunkShapeProfile,
+        EPChunkWorkspaceKey,
+        EPChunkWorkspaceRegistry,
+        _SavedContextEPChunkFunction,
+    )
+
+    return (
+        EP_CHUNK_COUNT,
+        EPChunkForwardOp,
+        EPChunkBackwardOp,
+        EPChunkFusedForwardBackwardOp,
+        EPChunkShapeProfile,
+        EPChunkWorkspaceKey,
+        EPChunkWorkspaceRegistry,
+        _SavedContextEPChunkFunction,
+    )
+
+
+def test_three_explicit_ops_have_fixed_two_chunk_contract(
+    transformer_engine_import_stub,
+):
+    (
+        chunk_count,
+        forward_op,
+        backward_op,
+        fused_op,
+        _profile,
+        _key,
+        _registry,
+        _function,
+    ) = _symbols(transformer_engine_import_stub)
+
+    assert chunk_count == 2
+    assert tuple(inspect.signature(forward_op.forward).parameters) == (
+        "self",
+        "x",
+        "routing_input",
+    )
+    assert tuple(inspect.signature(backward_op.backward).parameters) == (
+        "self",
+        "context",
+        "grad_output",
+    )
+    assert tuple(inspect.signature(fused_op.forward_backward).parameters) == (
+        "self",
+        "x_saved",
+        "grad_output",
+        "routing_input",
+    )
+
+
+@pytest.mark.parametrize("chunk_count", [2, 3, 4])
+def test_logical_chunk_count_is_profile_contract_but_workspace_stays_two_slots(
+    chunk_count, transformer_engine_import_stub
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        EP_CHUNK_COUNT,
+        EPChunkShapeProfile,
+        EPChunkWorkspaceKey,
+        EPChunkWorkspaceRegistry,
+    )
+
+    profile = EPChunkShapeProfile(
+        max_input_rows=17, hidden_size=4, topk=2, ep_size=4, chunk_count=chunk_count
+    )
+    workspace = EPChunkWorkspaceRegistry().get_or_create(
+        EPChunkWorkspaceKey(
+            op="forward",
+            device_type="cpu",
+            device_index=None,
+            ep_group_id=31,
+            dtype=torch.float32,
+            shape_profile=profile,
+        ),
+        lambda slot: f"dispatcher-{slot}",
+    )
+    workspace.materialize(device="cpu")
+
+    assert profile.chunk_count == chunk_count
+    assert EP_CHUNK_COUNT == 2
+    assert workspace.evidence()["dispatcher_count"] == 2
+    assert workspace.metrics()["fallbacks"] == 0
+
+
+def test_three_ops_get_independent_cross_layer_workspaces(
+    transformer_engine_import_stub,
+):
+    (
+        _chunk_count,
+        _forward_op,
+        _backward_op,
+        _fused_op,
+        profile_type,
+        key_type,
+        registry_type,
+        _function,
+    ) = _symbols(transformer_engine_import_stub)
+    registry = registry_type()
+    created = []
+
+    def factory(slot: int):
+        dispatcher = object()
+        created.append((slot, dispatcher))
+        return dispatcher
+
+    profile = profile_type(max_input_rows=128, hidden_size=64, topk=8, ep_size=8)
+    common = dict(
+        device_type="cpu",
+        device_index=None,
+        ep_group_id=7,
+        dtype=torch.bfloat16,
+        shape_profile=profile,
+    )
+    forward_key = key_type(op="forward", **common)
+    backward_key = key_type(op="backward", **common)
+    fused_key = key_type(op="fused_forward_backward", **common)
+
+    forward_layer_0 = registry.get_or_create(forward_key, factory)
+    forward_layer_47 = registry.get_or_create(forward_key, factory)
+    backward = registry.get_or_create(backward_key, factory)
+    fused = registry.get_or_create(fused_key, factory)
+
+    assert forward_layer_0 is forward_layer_47
+    assert forward_layer_0 is not backward
+    assert backward is not fused
+    assert created == []
+    forward_layer_0.materialize(device="cpu")
+    backward.materialize(device="cpu")
+    fused.materialize(device="cpu")
+    assert len(created) == 6
+    assert [slot for slot, _ in created] == [0, 1, 0, 1, 0, 1]
+    assert "layer" not in key_type.__dataclass_fields__
+    assert "chunk" not in key_type.__dataclass_fields__
+
+
+def test_workspace_slots_are_stable_and_consumer_event_guarded(
+    transformer_engine_import_stub,
+):
+    (
+        _chunk_count,
+        _forward_op,
+        _backward_op,
+        _fused_op,
+        profile_type,
+        key_type,
+        registry_type,
+        _function,
+    ) = _symbols(transformer_engine_import_stub)
+    key = key_type(
+        op="forward",
+        device_type="cpu",
+        device_index=None,
+        ep_group_id=3,
+        dtype=torch.float32,
+        shape_profile=profile_type(max_input_rows=8, hidden_size=4, topk=2, ep_size=4),
+    )
+    workspace = registry_type().get_or_create(key, lambda slot: f"dispatcher-{slot}")
+
+    first = workspace.acquire(0)
+    before = first.tensor(
+        "output", (8, 4), dtype=torch.float32, device="cpu"
+    ).data_ptr()
+    allocation_count = workspace.metrics()["allocations"]
+    with pytest.raises(RuntimeError, match="already leased"):
+        workspace.acquire(0)
+    pending = _FakeEvent(ready=False)
+    first.release(pending)
+
+    stream = _FakeStream()
+    second = workspace.acquire(0, stream=stream)
+    assert stream.waited == [pending]
+    after = second.tensor(
+        "output", (8, 4), dtype=torch.float32, device="cpu"
+    ).data_ptr()
+    second.release(_FakeEvent(ready=True))
+
+    metrics = workspace.metrics()
+    assert after == before
+    assert metrics["allocations"] == allocation_count
+    assert metrics["grows"] == 0
+    assert metrics["fallbacks"] == 0
+
+
+def test_expert_scratch_can_exceed_recv_rows_but_not_expert_row_capacity(
+    transformer_engine_import_stub,
+):
+    (
+        _chunk_count,
+        _forward_op,
+        _backward_op,
+        _fused_op,
+        profile_type,
+        key_type,
+        registry_type,
+        _function,
+    ) = _symbols(transformer_engine_import_stub)
+    key = key_type(
+        op="backward",
+        device_type="cpu",
+        device_index=None,
+        ep_group_id=5,
+        dtype=torch.float32,
+        shape_profile=profile_type(max_input_rows=8, hidden_size=4, topk=2, ep_size=4),
+    )
+    workspace = registry_type().get_or_create(key, lambda slot: slot)
+    workspace.materialize(device="cpu")
+    assert workspace.evidence()["data_ptrs"] == {}
+    lease = workspace.acquire(0)
+    assert key.shape_profile.max_recv_rows == 16
+    first = lease.tensor("grad_expert_out", (16, 4), dtype=torch.float32, device="cpu")
+    grown = lease.tensor("grad_expert_out", (17, 4), dtype=torch.float32, device="cpu")
+
+    assert grown.shape == (17, 4)
+    assert grown.data_ptr() != first.data_ptr()
+    assert workspace.metrics()["grows"] == 1
+
+    with pytest.raises(RuntimeError, match="exceeds fixed profile capacity"):
+        lease.tensor("grad_expert_out", (33, 4), dtype=torch.float32, device="cpu")
+
+    assert workspace.metrics()["fallbacks"] == 0
+
+
+@pytest.mark.parametrize("op", ["backward", "fused_forward_backward"])
+def test_op_scratch_is_actual_shape_lazy_then_steady_state_stable(
+    op, transformer_engine_import_stub
+):
+    (
+        _chunk_count,
+        _forward_op,
+        _backward_op,
+        _fused_op,
+        profile_type,
+        key_type,
+        registry_type,
+        _function,
+    ) = _symbols(transformer_engine_import_stub)
+    profile = profile_type(max_input_rows=8, hidden_size=4, topk=2, ep_size=4)
+    workspace = registry_type().get_or_create(
+        key_type(
+            op=op,
+            device_type="cpu",
+            device_index=None,
+            ep_group_id=11,
+            dtype=torch.float32,
+            shape_profile=profile,
+        ),
+        lambda slot: slot,
+    )
+
+    workspace.materialize(device="cpu")
+    assert workspace.metrics()["allocations"] == 0
+    assert workspace.evidence()["data_ptrs"] == {}
+
+    first_ptrs = {}
+    for slot in range(2):
+        lease = workspace.acquire(slot)
+        first_ptrs[(slot, "grad_expert_out")] = lease.tensor(
+            "grad_expert_out", (9, 4), dtype=torch.float32, device="cpu"
+        ).data_ptr()
+        lease.release(_FakeEvent(ready=True))
+
+    first_metrics = workspace.metrics().copy()
+    assert first_metrics["allocations"] == 2
+    assert first_metrics["runtime_allocations"] == 2
+
+    second_ptrs = {}
+    for slot in range(2):
+        lease = workspace.acquire(slot)
+        second_ptrs[(slot, "grad_expert_out")] = lease.tensor(
+            "grad_expert_out", (9, 4), dtype=torch.float32, device="cpu"
+        ).data_ptr()
+        lease.release(_FakeEvent(ready=True))
+
+    assert second_ptrs == first_ptrs
+    assert workspace.metrics() == first_metrics
+
+
+def test_backward_scratch_only_lease_does_not_materialize_dispatchers_or_pools(
+    transformer_engine_import_stub,
+):
+    (
+        _chunk_count,
+        _forward_op,
+        _backward_op,
+        _fused_op,
+        profile_type,
+        key_type,
+        registry_type,
+        _function,
+    ) = _symbols(transformer_engine_import_stub)
+    created = []
+    workspace = registry_type().get_or_create(
+        key_type(
+            op="backward",
+            device_type="cpu",
+            device_index=None,
+            ep_group_id=17,
+            dtype=torch.float32,
+            shape_profile=profile_type(
+                max_input_rows=8, hidden_size=4, topk=2, ep_size=4
+            ),
+        ),
+        lambda slot: created.append(slot) or f"dispatcher-{slot}",
+    )
+
+    lease = workspace.acquire(0, require_dispatcher=False)
+    scratch = lease.tensor("grad_expert_out", (9, 4), dtype=torch.float32, device="cpu")
+
+    assert scratch.shape == (9, 4)
+    assert created == []
+    assert workspace.evidence()["dispatcher_count"] == 0
+    assert workspace.evidence()["allocation_pool_count"] == 0
+    with pytest.raises(RuntimeError, match="scratch-only lease has no dispatcher"):
+        _ = lease.dispatcher
+    lease.release(_FakeEvent(ready=True))
+
+
+def test_dispatcher_backed_lease_still_materializes_two_dispatchers(
+    transformer_engine_import_stub,
+):
+    (
+        _chunk_count,
+        _forward_op,
+        _backward_op,
+        _fused_op,
+        profile_type,
+        key_type,
+        registry_type,
+        _function,
+    ) = _symbols(transformer_engine_import_stub)
+    created = []
+    workspace = registry_type().get_or_create(
+        key_type(
+            op="fused_forward_backward",
+            device_type="cpu",
+            device_index=None,
+            ep_group_id=19,
+            dtype=torch.float32,
+            shape_profile=profile_type(
+                max_input_rows=8, hidden_size=4, topk=2, ep_size=4
+            ),
+        ),
+        lambda slot: created.append(slot) or f"dispatcher-{slot}",
+    )
+
+    lease = workspace.acquire(0)
+
+    assert lease.dispatcher == "dispatcher-0"
+    assert created == [0, 1]
+    assert workspace.evidence()["dispatcher_count"] == 2
+    lease.release(_FakeEvent(ready=True))
+
+
+def test_reset_tensors_waits_for_consumers_and_keeps_dispatchers(
+    transformer_engine_import_stub,
+):
+    (
+        _chunk_count,
+        _forward_op,
+        _backward_op,
+        _fused_op,
+        profile_type,
+        key_type,
+        registry_type,
+        _function,
+    ) = _symbols(transformer_engine_import_stub)
+    workspace = registry_type().get_or_create(
+        key_type(
+            op="backward",
+            device_type="cpu",
+            device_index=None,
+            ep_group_id=23,
+            dtype=torch.float32,
+            shape_profile=profile_type(
+                max_input_rows=8, hidden_size=4, topk=2, ep_size=4
+            ),
+        ),
+        lambda slot: f"dispatcher-{slot}",
+    )
+    lease = workspace.acquire(0)
+    tensor = lease.tensor("grad_expert_out", (9, 4), dtype=torch.float32, device="cpu")
+    lease.release(_FakeEvent(ready=False))
+
+    with pytest.raises(RuntimeError, match="pending consumer event"):
+        workspace.reset_tensors()
+
+    stream = _FakeStream()
+    workspace.reset_tensors(stream=stream)
+
+    evidence = workspace.evidence()
+    assert len(stream.waited) == 1
+    assert evidence["dispatcher_count"] == 2
+    assert evidence["data_ptrs"] == {}
+    assert evidence["tensor_details"] == {}
+    assert tensor.shape == (9, 4)
+
+
+@pytest.mark.parametrize("failure", ["leased_slot", "pending_slot"])
+def test_reset_preflight_failure_preserves_activation_arena_atomically(
+    failure, transformer_engine_import_stub
+):
+    """A rejected reset must not park activation state before slot preflight passes."""
+    (
+        _chunk_count,
+        _forward_op,
+        _backward_op,
+        _fused_op,
+        profile_type,
+        key_type,
+        registry_type,
+        _function,
+    ) = _symbols(transformer_engine_import_stub)
+    workspace = registry_type().get_or_create(
+        key_type(
+            op="backward",
+            device_type="cpu",
+            device_index=None,
+            ep_group_id=230,
+            dtype=torch.float32,
+            shape_profile=profile_type(
+                max_input_rows=8, hidden_size=4, topk=2, ep_size=2
+            ),
+        ),
+        lambda slot: f"dispatcher-{slot}",
+    )
+    activation = workspace.acquire_expert_activation()
+    activation.tensor("fc1_input", (4, 4), dtype=torch.float32, device="cpu")
+    activation_event = _FakeEvent(ready=True)
+    activation.release(activation_event)
+    coordinator = workspace._expert_activation_owner.coordinator
+    tensors_before = dict(coordinator.arena.tensors)
+    counters_before = (coordinator.parks, coordinator.rehydrates)
+
+    slot = workspace.acquire(0, require_dispatcher=False)
+    if failure == "pending_slot":
+        slot.release(_FakeEvent(ready=False))
+        expected = "pending consumer event"
+    else:
+        expected = "slot 0 is leased"
+
+    with pytest.raises(RuntimeError, match=expected):
+        workspace.reset_tensors()
+
+    assert coordinator.arena.tensors == tensors_before
+    assert coordinator.consumer_event is activation_event
+    assert (coordinator.parks, coordinator.rehydrates) == counters_before
+    if failure == "leased_slot":
+        slot.release(_FakeEvent(ready=True))
+
+
+def test_workspace_evidence_reports_actual_scratch_shape_dtype_and_bytes(
+    transformer_engine_import_stub,
+):
+    (
+        _chunk_count,
+        _forward_op,
+        _backward_op,
+        _fused_op,
+        profile_type,
+        key_type,
+        registry_type,
+        _function,
+    ) = _symbols(transformer_engine_import_stub)
+    workspace = registry_type().get_or_create(
+        key_type(
+            op="backward",
+            device_type="cpu",
+            device_index=None,
+            ep_group_id=29,
+            dtype=torch.float32,
+            shape_profile=profile_type(
+                max_input_rows=8, hidden_size=4, topk=2, ep_size=4
+            ),
+        ),
+        lambda slot: f"dispatcher-{slot}",
+    )
+    lease = workspace.acquire(0, require_dispatcher=False)
+    lease.tensor("grad_expert_out", (9, 4), dtype=torch.float32, device="cpu")
+    lease.release(_FakeEvent(ready=True))
+
+    details = workspace.evidence()["tensor_details"]
+    assert details == {
+        "0:grad_expert_out": {
+            "shape": (9, 4),
+            "dtype": "torch.float32",
+            "nbytes": 9 * 4 * 4,
+        }
+    }
+
+
+def test_scratch_only_lease_allocates_from_its_own_backward_slot(
+    transformer_engine_import_stub,
+):
+    (
+        _chunk_count,
+        _forward_op,
+        _backward_op,
+        _fused_op,
+        profile_type,
+        key_type,
+        registry_type,
+        _function,
+    ) = _symbols(transformer_engine_import_stub)
+    workspace = registry_type().get_or_create(
+        key_type(
+            op="backward",
+            device_type="cpu",
+            device_index=None,
+            ep_group_id=31,
+            dtype=torch.float32,
+            shape_profile=profile_type(
+                max_input_rows=8, hidden_size=4, topk=2, ep_size=4
+            ),
+        ),
+        lambda slot: f"unused-{slot}",
+    )
+    lease = workspace.acquire(0, require_dispatcher=False)
+    lease.tensor("grad_expert_out", (9, 4), dtype=torch.float32, device="cpu")
+
+    assert workspace.evidence()["dispatcher_count"] == 0
+    assert "grad_expert_out" in workspace._slots[0].tensors
+    lease.release(_FakeEvent(ready=True))
+
+
+def test_fused_dispatcher_lease_allocates_scratch_from_its_own_slot(
+    transformer_engine_import_stub,
+):
+    (
+        _chunk_count,
+        _forward_op,
+        _backward_op,
+        _fused_op,
+        profile_type,
+        key_type,
+        registry_type,
+        _function,
+    ) = _symbols(transformer_engine_import_stub)
+    workspace = registry_type().get_or_create(
+        key_type(
+            op="fused_forward_backward",
+            device_type="cpu",
+            device_index=None,
+            ep_group_id=41,
+            dtype=torch.float32,
+            shape_profile=profile_type(
+                max_input_rows=8, hidden_size=4, topk=2, ep_size=4
+            ),
+        ),
+        lambda slot: f"fused-{slot}",
+    )
+    lease = workspace.acquire(0)
+    lease.tensor("grad_expert_out", (9, 4), dtype=torch.float32, device="cpu")
+
+    assert "grad_expert_out" in workspace._slots[0].tensors
+    lease.release(_FakeEvent(ready=True))
+
+
+def test_profile_rejects_input_rows_beyond_qwen_capacity(
+    transformer_engine_import_stub,
+):
+    (
+        _chunk_count,
+        _forward_op,
+        _backward_op,
+        _fused_op,
+        profile_type,
+        _key,
+        _registry,
+        _function,
+    ) = _symbols(transformer_engine_import_stub)
+    profile = profile_type(max_input_rows=8, hidden_size=4, topk=2, ep_size=4)
+
+    with pytest.raises(RuntimeError, match="exceeds two-slot profile"):
+        profile.validate_input_rows(9)
+
+
+def test_workspace_reports_deepep_buffer_count_and_resident_bytes(
+    transformer_engine_import_stub,
+):
+    (
+        _chunk_count,
+        _forward_op,
+        _backward_op,
+        _fused_op,
+        profile_type,
+        key_type,
+        registry_type,
+        _function,
+    ) = _symbols(transformer_engine_import_stub)
+    profile = profile_type(max_input_rows=8, hidden_size=4, topk=2, ep_size=2)
+
+    def dispatcher(_slot):
+        return SimpleNamespace(buffer=object(), deepep_buffer_resident_bytes=1024)
+
+    workspace = registry_type().get_or_create(
+        key_type(
+            op="forward",
+            device_type="cpu",
+            device_index=None,
+            ep_group_id=19,
+            dtype=torch.float32,
+            shape_profile=profile,
+        ),
+        dispatcher,
+    )
+    workspace.materialize(device="cpu")
+
+    evidence = workspace.evidence()
+    assert evidence["dispatcher_count"] == 2
+    assert evidence["deepep_buffer_count"] == 2
+    assert evidence["deepep_buffer_resident_bytes"] == 2048
+
+
+def test_workspace_uses_default_allocator_for_comm_and_activation_storage(
+    monkeypatch, transformer_engine_import_stub
+):
+    transformer_engine_import_stub()
+    import megatron.lite.primitive.modules.moe_ep_chunk_overlap as overlap
+
+    (
+        _chunk_count,
+        _forward_op,
+        _backward_op,
+        _fused_op,
+        profile_type,
+        key_type,
+        registry_type,
+        _function,
+    ) = _symbols(transformer_engine_import_stub)
+    creation_devices = []
+
+    @contextmanager
+    def use_device(device):
+        creation_devices.append(device)
+        yield
+
+    monkeypatch.setattr(overlap.torch.cuda, "device", use_device)
+    workspace = registry_type().get_or_create(
+        key_type(
+            op="forward",
+            device_type="cuda",
+            device_index=3,
+            ep_group_id=31,
+            dtype=torch.bfloat16,
+            shape_profile=profile_type(
+                max_input_rows=8, hidden_size=4, topk=2, ep_size=2
+            ),
+        ),
+        lambda slot: SimpleNamespace(slot=slot, use_deepep=True),
+    )
+    workspace.materialize()
+    assert creation_devices == [torch.device("cuda", 3)]
+    evidence = workspace.evidence()
+    assert evidence["allocation_pool_count"] == 0
+    assert evidence["allocation_pool_ids"] == {}
+    assert evidence["expert_activation_pool_count"] == 0
+    assert evidence["expert_activation_pool_id"] is None
+    assert evidence["recv_observer_enabled"] is False
+    monkeypatch.setenv("MEGATRON_LITE_EP_CHUNK_SCRATCH_TRACE", "1")
+    assert workspace.evidence()["recv_observer_enabled"] is True
+
+    lease0 = workspace.acquire(0)
+    assert workspace.evidence()["active_lease_count"] == 1
+    with lease0.deepep_recv_allocation():
+        pass
+    with lease0.deepep_recv_allocation():
+        pass
+    lease0.release(_FakeEvent(ready=True))
+    assert workspace.evidence()["consumer_event_guard_count"] == 1
+
+    activation = workspace.acquire_expert_activation(
+        stream=SimpleNamespace(device=torch.device("cuda", 3))
+    )
+    activation.release(_FakeEvent(ready=True))
+    assert workspace.evidence()["expert_activation_pool_count"] == 0
+    assert workspace.evidence()["expert_activation_pool_id"] is None
+
+    lease1 = workspace.acquire(1)
+    with lease1.deepep_recv_allocation():
+        pass
+    lease1.release(_FakeEvent(ready=True))
+    assert workspace.evidence()["allocation_pool_count"] == 0
+
+    workspace.release()
+    assert workspace.evidence()["allocation_pool_count"] == 0
+    assert workspace.evidence()["expert_activation_pool_count"] == 0
+    assert workspace._registry is not None
+    workspace._registry.release(workspace.key)
+    assert workspace.evidence()["expert_activation_pool_count"] == 0
+
+
+def test_compatible_three_ops_keep_logical_owners_without_eager_private_pools(
+    monkeypatch, transformer_engine_import_stub
+):
+    transformer_engine_import_stub()
+    import megatron.lite.primitive.modules.moe_ep_chunk_overlap as overlap
+
+    (
+        _chunk_count,
+        _forward_op,
+        _backward_op,
+        _fused_op,
+        profile_type,
+        key_type,
+        registry_type,
+        _function,
+    ) = _symbols(transformer_engine_import_stub)
+
+    @contextmanager
+    def use_device(_device):
+        yield
+
+    monkeypatch.setattr(overlap.torch.cuda, "device", use_device)
+    registry = registry_type()
+    profile = profile_type(max_input_rows=8, hidden_size=4, topk=2, ep_size=2)
+    workspaces = []
+    for op in ("forward", "backward", "fused_forward_backward"):
+        workspace = registry.get_or_create(
+            key_type(
+                op=op,
+                device_type="cuda",
+                device_index=3,
+                ep_group_id=43,
+                dtype=torch.bfloat16,
+                shape_profile=profile,
+            ),
+            lambda slot: SimpleNamespace(slot=slot, use_deepep=True),
+        )
+        if op == "backward":
+            workspace.prepare_scratch(device=torch.device("cuda", 3))
+            assert workspace.evidence()["dispatcher_count"] == 0
+            assert workspace.evidence()["allocation_pool_count"] == 0
+            assert workspace.evidence()["expert_activation_pool_count"] == 0
+            lease = workspace.acquire_expert_activation(
+                stream=SimpleNamespace(device=torch.device("cuda", 3))
+            )
+            lease.release(_FakeEvent(ready=True))
+            assert workspace.evidence()["dispatcher_count"] == 0
+            assert workspace.evidence()["allocation_pool_count"] == 0
+        else:
+            workspace.materialize()
+        workspaces.append(workspace)
+
+    comm_ids = {
+        pool_id
+        for workspace in workspaces
+        for pool_id in workspace.evidence()["allocation_pool_ids"].values()
+    }
+    assert {workspace.evidence()["expert_activation_pool_id"] for workspace in workspaces} == {None}
+    assert [workspace.evidence()["allocation_pool_count"] for workspace in workspaces] == [0, 0, 0]
+    assert comm_ids == set()
+    assert len({id(workspace._expert_activation_owner) for workspace in workspaces}) == 3
+    assert len(
+        {id(workspace._expert_activation_owner.coordinator) for workspace in workspaces}
+    ) == 1
+
+
+def test_eager_private_pool_is_absent_through_release_and_rematerialize(
+    monkeypatch, transformer_engine_import_stub
+):
+    """Release and rematerialize keep eager allocation on the default allocator."""
+    transformer_engine_import_stub()
+    import megatron.lite.primitive.modules.moe_ep_chunk_overlap as overlap
+
+    @contextmanager
+    def use_device(_device):
+        yield
+
+    monkeypatch.setattr(overlap.torch.cuda, "device", use_device)
+    profile = overlap.EPChunkShapeProfile(max_input_rows=8, hidden_size=4, topk=2, ep_size=2)
+    registry = overlap.EPChunkWorkspaceRegistry()
+
+    def get(op):
+        return registry.get_or_create(
+            overlap.EPChunkWorkspaceKey(op, "cuda", 0, 71, torch.bfloat16, profile),
+            lambda slot: SimpleNamespace(slot=slot, use_deepep=True),
+        )
+
+    forward, fused = get("forward"), get("fused_forward_backward")
+    forward.materialize()
+    fused.materialize()
+    assert forward.evidence()["expert_activation_pool_id"] is None
+    assert fused.evidence()["expert_activation_pool_id"] is None
+    registry.release(forward.key)
+    assert fused.evidence()["expert_activation_pool_id"] is None
+    registry.release(fused.key)
+    assert not hasattr(registry, "_eager_physical_pools")
+
+    rematerialized = get("forward")
+    rematerialized.materialize()
+
+
+def test_expert_activation_arena_waits_only_for_its_consumer_event(
+    transformer_engine_import_stub,
+):
+    (
+        _chunk_count,
+        _forward_op,
+        _backward_op,
+        _fused_op,
+        profile_type,
+        key_type,
+        registry_type,
+        _function,
+    ) = _symbols(transformer_engine_import_stub)
+    workspace = registry_type().get_or_create(
+        key_type(
+            op="fused_forward_backward",
+            device_type="cpu",
+            device_index=None,
+            ep_group_id=41,
+            dtype=torch.bfloat16,
+            shape_profile=profile_type(
+                max_input_rows=8, hidden_size=4, topk=2, ep_size=2
+            ),
+        ),
+        lambda slot: SimpleNamespace(slot=slot, use_deepep=True),
+    )
+    stream = _FakeStream()
+    first = workspace.acquire_expert_activation(stream=stream)
+    with pytest.raises(RuntimeError, match="expert activation arena is already leased"):
+        workspace.acquire_expert_activation(stream=stream)
+
+    pending = _FakeEvent(ready=False)
+    first.release(pending)
+    second = workspace.acquire_expert_activation(stream=stream)
+
+    assert stream.waited == [pending]
+    assert workspace.evidence()["expert_activation_waits"] == 1
+    assert workspace.metrics()["runtime_allocations"] == 0
+    assert workspace.metrics()["grows"] == 0
+    second.release(_FakeEvent(ready=True))
+
+
+def test_expert_activation_lease_size_classes_adjacent_rows_without_growth(
+    transformer_engine_import_stub,
+):
+    (
+        _chunk_count,
+        _forward_op,
+        _backward_op,
+        _fused_op,
+        profile_type,
+        key_type,
+        registry_type,
+        _function,
+    ) = _symbols(transformer_engine_import_stub)
+    workspace = registry_type().get_or_create(
+        key_type(
+            op="fused_forward_backward",
+            device_type="cpu",
+            device_index=None,
+            ep_group_id=43,
+            dtype=torch.float32,
+            shape_profile=profile_type(
+                max_input_rows=8, hidden_size=4, topk=2, ep_size=2
+            ),
+        ),
+        lambda slot: SimpleNamespace(slot=slot, use_deepep=True),
+    )
+    stream = _FakeStream()
+    first = workspace.acquire_expert_activation(stream=stream)
+    first_tensor = first.tensor("fc1_input", (5, 4), dtype=torch.float32, device="cpu")
+    # A caller-owned autograd output can require gradients for one invocation;
+    # the persistent base must stay non-grad when its next lease aliases it.
+    first_tensor.requires_grad_(True)
+    first_ptr = first_tensor.data_ptr()
+    pending = _FakeEvent(ready=False)
+    first.release(pending)
+
+    second = workspace.acquire_expert_activation(stream=stream)
+    second_tensor = second.tensor(
+        "fc1_input", (3, 4), dtype=torch.float32, device="cpu"
+    )
+
+    assert stream.waited == [pending]
+    assert second_tensor.data_ptr() == first_ptr
+    assert not second_tensor.requires_grad
+    evidence = workspace.evidence()["expert_activation_tensors"]["fc1_input"]
+    assert evidence["shape"][0] >= 5
+    assert (
+        evidence["nbytes"] - first_tensor.numel() * first_tensor.element_size()
+        < 8 * 1024 * 1024
+    )
+    assert evidence["data_ptr"] == first_ptr
+    grow_guard = _FakeEvent(ready=False)
+    second.release(grow_guard)
+
+    third = workspace.acquire_expert_activation(stream=stream)
+    grown_tensor = third.tensor("fc1_input", (7, 4), dtype=torch.float32, device="cpu")
+
+    assert stream.waited == [pending, grow_guard]
+    grown_evidence = workspace.evidence()["expert_activation_tensors"]["fc1_input"]
+    assert grown_evidence["data_ptr"] == first_ptr
+    assert grown_tensor.data_ptr() == first_ptr
+    assert workspace._expert_activation_owner.grows == 0
+    third.release(_FakeEvent(ready=True))
+
+
+def test_multilayer_microbatch_probe_separates_owner_lifetime_from_slot_growth(
+    monkeypatch, transformer_engine_import_stub
+):
+    """Trace 48 layer references and eight microbatches through real workspace APIs.
+
+    The deliberately small class is a CPU-only boundary witness, not a claim
+    about job15448830's CUDA routing shapes.  It exercises the workspace/owner
+    lifecycle APIs.  Each logical EP op owns an independent
+    event-guarded arena; the trace separately exposes exact-shape slot growth.
+    """
+    transformer_engine_import_stub()
+    import megatron.lite.primitive.modules.moe_ep_chunk_overlap as overlap
+
+    monkeypatch.setattr(overlap, "_EXPERT_ACTIVATION_SIZE_CLASS_BYTES", 64)
+    profile = overlap.EPChunkShapeProfile(
+        max_input_rows=64, hidden_size=4, topk=2, ep_size=2
+    )
+    registry = overlap.EPChunkWorkspaceRegistry()
+    workspaces = {
+        op: registry.get_or_create(
+            overlap.EPChunkWorkspaceKey(
+                op=op,
+                device_type="cpu",
+                device_index=None,
+                ep_group_id=4808,
+                dtype=torch.float32,
+                shape_profile=profile,
+            ),
+            lambda slot: SimpleNamespace(slot=slot, use_deepep=True),
+        )
+        for op in ("forward", "backward", "fused_forward_backward")
+    }
+    layers = [workspaces for _ in range(48)]
+    assert {layer["forward"].key for layer in layers} == {workspaces["forward"].key}
+    assert {layer["backward"].key for layer in layers} == {workspaces["backward"].key}
+    assert {layer["fused_forward_backward"].key for layer in layers} == {
+        workspaces["fused_forward_backward"].key
+    }
+    assert len({id(workspace._expert_activation_owner) for workspace in workspaces.values()}) == 3
+    assert len(
+        {id(workspace._expert_activation_owner.coordinator) for workspace in workspaces.values()}
+    ) == 1
+
+    trace = []
+
+    def request(workspace, *, microbatch, rows, slot):
+        slot_lease = workspace.acquire(slot, require_dispatcher=False)
+        scratch = slot_lease.tensor(
+            "grad_expert_out", (rows, 4), dtype=torch.float32, device="cpu"
+        )
+        slot_lease.release(_FakeEvent(ready=True))
+        activation_lease = workspace.acquire_expert_activation()
+        activations = {
+            name: activation_lease.tensor(
+                name, (rows, 4), dtype=torch.float32, device="cpu"
+            )
+            for name in ("fc1_input", "fc1_output", "fc2_output")
+        }
+        activation_lease.release(_FakeEvent(ready=True))
+        evidence = workspace.evidence()
+        trace.append(
+            {
+                "op": workspace.key.op,
+                "workspace_key": workspace.key,
+                "activation_owner": id(workspace._expert_activation_owner),
+                "microbatch": microbatch,
+                "slot": slot,
+                "requested_shape": tuple(scratch.shape),
+                "rounded_capacity": {
+                    name: overlap._expert_activation_capacity_bytes(
+                        tensor.numel() * tensor.element_size()
+                    )
+                    for name, tensor in activations.items()
+                },
+                "scratch_ptr": scratch.data_ptr(),
+                "activation_ptrs": {
+                    name: tensor.data_ptr() for name, tensor in activations.items()
+                },
+                "grows": evidence["grows"],
+                "activation_grows": evidence["expert_activation_grows"],
+                "active_leases": evidence["active_lease_count"],
+                "slot_release_event": True,
+                "slot_event_guards": evidence["consumer_event_guard_count"],
+                "activation_release_event": evidence[
+                    "expert_activation_event_guarded"
+                ],
+            }
+        )
+
+    # Five and seven rows share the 128-byte bucket; nine crosses once into
+    # 192 bytes.  Later microbatches repeat the warmed maximum.  The owner
+    # trace therefore distinguishes a bucket transition from concurrent lease
+    # pressure without claiming these CPU rows are the CUDA routing rows.
+    for microbatch, rows in enumerate((5, 7, 9, 9, 9, 9, 9, 9)):
+        for workspace in workspaces.values():
+            for slot in range(2):
+                request(workspace, microbatch=microbatch, rows=rows, slot=slot)
+
+    assert len(trace) == 48
+    assert {entry["op"] for entry in trace} == set(workspaces)
+    assert {entry["workspace_key"] for entry in trace} == {
+        workspace.key for workspace in workspaces.values()
+    }
+    assert len({entry["activation_owner"] for entry in trace}) == 3
+    assert all(entry["active_leases"] == 0 for entry in trace)
+    assert all(entry["slot_release_event"] for entry in trace)
+    assert all(0 <= entry["slot_event_guards"] <= 2 for entry in trace)
+    assert all(entry["activation_release_event"] for entry in trace)
+    assert [
+        set(entry["rounded_capacity"].values()) for entry in trace[:18:6]
+    ] == [{128}, {128}, {192}]
+    for workspace in workspaces.values():
+        assert workspace.metrics()["grows"] == 4
+        assert workspace._expert_activation_owner.coordinator.grows == 3
+        for slot in range(2):
+            ptrs = [
+                entry["scratch_ptr"]
+                for entry in trace
+                if entry["op"] == workspace.key.op and entry["slot"] == slot
+            ]
+            assert len(set(ptrs)) == 3
+        for name in ("fc1_input", "fc1_output", "fc2_output"):
+            activation_ptrs = [
+                entry["activation_ptrs"][name]
+                for entry in trace
+                if entry["op"] == workspace.key.op
+            ]
+            assert len(set(activation_ptrs[4:])) == 1
+    # The forward-only FC2 output reuses FC1-input raw storage; backward and
+    # fused retain their own lifetimes, so same-named logical tensors need not
+    # share one pointer across OPs.
+    forward_trace = [entry for entry in trace if entry["op"] == "forward"]
+    assert all(
+        entry["activation_ptrs"]["fc1_input"]
+        == entry["activation_ptrs"]["fc2_output"]
+        for entry in forward_trace
+    )
+    coordinator = workspaces["forward"]._expert_activation_owner.coordinator
+    assert coordinator.max_requested_bytes == {
+        "fc1_input": 144,
+        "fc1_output": 144,
+        "fc2_output": 144,
+    }
+    assert coordinator.capacity_bytes == {
+        "fc1_input": 192,
+        "fc1_output": 192,
+        "fc2_output": 192,
+    }
+
+    forward_held = workspaces["forward"].acquire_expert_activation()
+    with pytest.raises(RuntimeError, match="coordinator is already claimed"):
+        workspaces["fused_forward_backward"].acquire_expert_activation()
+    pending = _FakeEvent(ready=False)
+    forward_held.release(pending)
+    handoff_stream = _FakeStream()
+    fused_held = workspaces["fused_forward_backward"].acquire_expert_activation(
+        stream=handoff_stream
+    )
+    assert handoff_stream.waited == [pending]
+    fused_held.release(_FakeEvent(ready=True))
+    owners = tuple(workspace._expert_activation_owner for workspace in workspaces.values())
+    for workspace in workspaces.values():
+        registry.release(workspace.key)
+    assert not registry._expert_activation_owners
+    assert all(not owner.arena.tensors for owner in owners)
+
+
+def test_each_op_reuses_its_own_large_activation_names_across_layers(
+    transformer_engine_import_stub,
+):
+    """Adjacent routed row counts must not cold-grow five live activation names."""
+    (
+        _chunk_count,
+        _forward_op,
+        _backward_op,
+        _fused_op,
+        profile_type,
+        key_type,
+        registry_type,
+        _function,
+    ) = _symbols(transformer_engine_import_stub)
+    registry = registry_type()
+    profile = profile_type(max_input_rows=131963, hidden_size=16, topk=2, ep_size=2)
+
+    def make_workspace(op):
+        return registry.get_or_create(
+            key_type(
+                op=op,
+                device_type="cpu",
+                device_index=None,
+                ep_group_id=97,
+                dtype=torch.float32,
+                shape_profile=profile,
+            ),
+            lambda slot: SimpleNamespace(slot=slot, use_deepep=True),
+        )
+
+    forward, fused = make_workspace("forward"), make_workspace("fused_forward_backward")
+    assert forward._expert_activation_owner is not fused._expert_activation_owner
+    assert forward._expert_activation_owner.coordinator is fused._expert_activation_owner.coordinator
+    names = ("fc1_input", "fc1_output", "fc2_output", "fc1_dgrad", "fc2_dgrad")
+    first = forward.acquire_expert_activation()
+    first_ptrs = {
+        name: first.tensor(
+            name, (131750, 16), dtype=torch.float32, device="cpu"
+        ).data_ptr()
+        for name in names
+    }
+    # No-grad forward recycles FC1 input for FC2 output, while preserving the
+    # normal dgrad alias.  It therefore owns three physical slots.
+    assert first_ptrs["fc1_input"] == first_ptrs["fc2_output"]
+    assert first_ptrs["fc1_dgrad"] == first_ptrs["fc2_dgrad"]
+    assert first_ptrs["fc2_output"] != first_ptrs["fc2_dgrad"]
+    assert len(set(first_ptrs.values())) == 3
+    owner = forward._expert_activation_owner
+    assert set(owner.arena.tensors) == {
+        "fc1_input",
+        "fc1_output",
+        "fc2_dgrad",
+    }
+    pending = _FakeEvent(ready=False)
+    first.release(pending)
+    stream = _FakeStream()
+    second = fused.acquire_expert_activation(stream=stream)
+    second_ptrs = {
+        name: second.tensor(
+            name, (131963, 16), dtype=torch.float32, device="cpu"
+        ).data_ptr()
+        for name in names
+    }
+    assert stream.waited == [pending]
+    # Fused has an independent logical owner, but handoff preserves the three
+    # physical base addresses after the forward lease's consumer event.
+    assert second_ptrs["fc1_input"] == first_ptrs["fc1_input"]
+    assert second_ptrs["fc1_output"] == first_ptrs["fc1_output"]
+    assert second_ptrs["fc2_output"] != first_ptrs["fc2_output"]
+    assert second_ptrs["fc2_dgrad"] == second_ptrs["fc2_output"]
+    assert second_ptrs["fc1_dgrad"] == second_ptrs["fc2_output"]
+    assert forward._expert_activation_owner.grows == 0
+    assert fused._expert_activation_owner.grows == 0
+    for tensor in fused._expert_activation_owner.arena.tensors.values():
+        requested_bytes = 131963 * 16 * tensor.element_size()
+        assert (
+            tensor.numel() * tensor.element_size() - requested_bytes < 8 * 1024 * 1024
+        )
+    second.release(_FakeEvent(ready=True))
+
+    isolated = registry.get_or_create(
+        key_type(
+            op="forward",
+            device_type="cpu",
+            device_index=None,
+            ep_group_id=98,
+            dtype=torch.float32,
+            shape_profile=profile,
+        ),
+        lambda slot: SimpleNamespace(slot=slot, use_deepep=True),
+    )
+    assert isolated._expert_activation_owner is not forward._expert_activation_owner
+    registry.release(forward.key, stream=stream)
+    assert not fused._expert_activation_owner.arena.tensors
+    assert not forward._expert_activation_owner.arena.tensors
+    registry.release(fused.key)
+    assert not fused._expert_activation_owner.arena.tensors
+
+
+def test_per_op_phase_handoff_keeps_one_physical_arena_until_final_release(
+    transformer_engine_import_stub,
+):
+    """Logical OP releases do not clear shared physical graph-address storage."""
+    (
+        _chunk_count,
+        _forward_op,
+        _backward_op,
+        _fused_op,
+        profile_type,
+        key_type,
+        registry_type,
+        _function,
+    ) = _symbols(transformer_engine_import_stub)
+    registry = registry_type()
+    profile = profile_type(max_input_rows=16, hidden_size=4, topk=2, ep_size=2)
+
+    def get(op):
+        return registry.get_or_create(
+            key_type(
+                op=op,
+                device_type="cpu",
+                device_index=None,
+                ep_group_id=4816,
+                dtype=torch.float32,
+                shape_profile=profile,
+            ),
+            lambda slot: SimpleNamespace(slot=slot, use_deepep=True),
+        )
+
+    forward = get("forward")
+    fused = get("fused_forward_backward")
+    forward_lease = forward.acquire_expert_activation()
+    forward_tensor = forward_lease.tensor(
+        "fc1_input", (5, 4), dtype=torch.float32, device="cpu"
+    )
+    pending = _FakeEvent(ready=False)
+    forward_lease.release(pending)
+    stream = _FakeStream()
+    fused_lease = fused.acquire_expert_activation(stream=stream)
+    fused_tensor = fused_lease.tensor(
+        "fc1_input", (5, 4), dtype=torch.float32, device="cpu"
+    )
+    fused_lease.release(_FakeEvent(ready=True))
+
+    assert stream.waited == [pending]
+    assert forward_tensor.data_ptr() == fused_tensor.data_ptr()
+    assert forward._expert_activation_owner.arena.tensors
+    assert fused._expert_activation_owner.arena.tensors
+    assert forward._expert_activation_owner is not fused._expert_activation_owner
+    assert forward._expert_activation_owner.coordinator is fused._expert_activation_owner.coordinator
+    coordinator = forward._expert_activation_owner.coordinator
+    registry.release(forward.key, stream=stream)
+    assert not coordinator.arena.tensors
+    assert not fused._expert_activation_owner.arena.tensors
+    next_forward_lease = forward.acquire_expert_activation()
+    next_forward_tensor = next_forward_lease.tensor(
+        "fc1_input", (5, 4), dtype=torch.float32, device="cpu"
+    )
+    next_forward_lease.release(_FakeEvent(ready=True))
+    assert next_forward_tensor.data_ptr() != 0
+    assert coordinator.rehydrates == 1
+    registry.release(forward.key)
+    registry.release(fused.key)
+    assert not coordinator.arena.tensors
+    assert not registry._expert_activation_arenas
+
+
+def test_all_caller_owned_activations_bound_rows_and_bind_logical_trailing_shape(
+    transformer_engine_import_stub,
+):
+    (
+        _chunk_count,
+        _forward_op,
+        _backward_op,
+        _fused_op,
+        profile_type,
+        key_type,
+        registry_type,
+        _function,
+    ) = _symbols(transformer_engine_import_stub)
+    profile = profile_type(max_input_rows=4, hidden_size=2, topk=2, ep_size=2)
+    registry = registry_type()
+    workspace = registry.get_or_create(
+        key_type(
+            op="backward",
+            device_type="cpu",
+            device_index=None,
+            ep_group_id=4818,
+            dtype=torch.float32,
+            shape_profile=profile,
+        ),
+        lambda slot: SimpleNamespace(slot=slot, use_deepep=True),
+    )
+    names = ("fc1_output", "fc2_output", "fc2_dgrad", "fc1_dgrad")
+    lease = workspace.acquire_expert_activation()
+    with pytest.raises(RuntimeError, match="Unknown EP chunk expert activation"):
+        lease.tensor("unknown", (1, 5), dtype=torch.float32, device="cpu")
+    with pytest.raises(RuntimeError, match="exceeds profile ceiling"):
+        lease.tensor(
+            "fc1_output",
+            (profile.max_expert_rows, 5, 1),
+            dtype=torch.float32,
+            device="cpu",
+        )
+    with pytest.raises(RuntimeError, match="exceeds profile ceiling"):
+        lease.tensor(
+            "fc1_output",
+            (profile.max_expert_rows, 5),
+            dtype=torch.float64,
+            device="cpu",
+        )
+    for name in names:
+        lease.tensor(
+            name,
+            (profile.max_expert_rows, 5),
+            dtype=torch.float32,
+            device="cpu",
+        )
+    for name in names:
+        with pytest.raises(RuntimeError, match="exceeds profile ceiling"):
+            lease.tensor(
+                name,
+                (profile.max_expert_rows + 1, 5),
+                dtype=torch.float32,
+                device="cpu",
+            )
+    with pytest.raises(RuntimeError, match="exceeds profile ceiling"):
+        lease.tensor(
+            "fc1_input",
+            (profile.max_expert_rows, profile.hidden_size + 1),
+            dtype=torch.float32,
+            device="cpu",
+        )
+    with pytest.raises(RuntimeError, match="exceeds profile ceiling"):
+        lease.tensor(
+            "fc1_input",
+            (profile.max_expert_rows + 1, profile.hidden_size),
+            dtype=torch.float32,
+            device="cpu",
+        )
+    lease.release(_FakeEvent(ready=True))
+
+    rebound = workspace.acquire_expert_activation()
+    with pytest.raises(RuntimeError, match="trailing shape"):
+        rebound.tensor(
+            "fc1_output",
+            (profile.max_expert_rows, 6),
+            dtype=torch.float32,
+            device="cpu",
+        )
+    rebound.release(_FakeEvent(ready=True))
+
+    fused = registry.get_or_create(
+        key_type(
+            op="fused_forward_backward",
+            device_type="cpu",
+            device_index=None,
+            ep_group_id=4819,
+            dtype=torch.float32,
+            shape_profile=profile,
+        ),
+        lambda slot: SimpleNamespace(slot=slot, use_deepep=True),
+    )
+    fused_lease = fused.acquire_expert_activation()
+    fc2_output = fused_lease.tensor(
+        "fc2_output", (profile.max_expert_rows, 6), dtype=torch.float32, device="cpu"
+    )
+    fc2_dgrad = fused_lease.tensor(
+        "fc2_dgrad", (profile.max_expert_rows, 5), dtype=torch.float32, device="cpu"
+    )
+    fc1_dgrad = fused_lease.tensor(
+        "fc1_dgrad", (profile.max_expert_rows, 4), dtype=torch.float32, device="cpu"
+    )
+    assert fc2_output.data_ptr() == fc2_dgrad.data_ptr() == fc1_dgrad.data_ptr()
+    fused_lease.release(_FakeEvent(ready=True))
+
+    coordinator = workspace._expert_activation_owner.coordinator
+    registry.release(workspace.key)
+    assert not coordinator.logical_trailing_shapes
+    fused_coordinator = fused._expert_activation_owner.coordinator
+    registry.release(fused.key)
+    assert not fused_coordinator.logical_trailing_shapes
+
+
+def test_expert_activation_growth_uses_requested_size_class_not_geometric_headroom(
+    monkeypatch, transformer_engine_import_stub
+):
+    """A grown arena retains only the requested 8-MiB size class."""
+    transformer_engine_import_stub()
+    import megatron.lite.primitive.modules.moe_ep_chunk_overlap as overlap
+
+    monkeypatch.setattr(overlap, "_EXPERT_ACTIVATION_SIZE_CLASS_BYTES", 64)
+    registry = overlap.EPChunkWorkspaceRegistry()
+    profile = overlap.EPChunkShapeProfile(
+        max_input_rows=16, hidden_size=4, topk=2, ep_size=2
+    )
+    workspace = registry.get_or_create(
+        overlap.EPChunkWorkspaceKey(
+            op="fused_forward_backward",
+            device_type="cpu",
+            device_index=None,
+            ep_group_id=4817,
+            dtype=torch.float32,
+            shape_profile=profile,
+        ),
+        lambda slot: SimpleNamespace(slot=slot, use_deepep=True),
+    )
+    first = workspace.acquire_expert_activation()
+    first.tensor("fc1_input", (16, 4), dtype=torch.float32, device="cpu")
+    first.release(_FakeEvent(ready=True))
+
+    second = workspace.acquire_expert_activation()
+    second.tensor("fc1_input", (17, 4), dtype=torch.float32, device="cpu")
+    second.release(_FakeEvent(ready=True))
+
+    evidence = workspace.evidence()["expert_activation_tensors"]["fc1_input"]
+    assert workspace._expert_activation_owner.grows == 1
+    assert evidence["nbytes"] == overlap._expert_activation_capacity_bytes(17 * 4 * 4)
+    assert evidence["nbytes"] <= overlap._expert_activation_capacity_bytes(
+        profile.max_expert_rows * profile.hidden_size * 4
+    )
+
+
+def test_delayed_fc2_wgrad_reads_output_before_safe_dgrad_slot_reuse(
+    transformer_engine_import_stub,
+):
+    """FC2 output must survive until its delayed Wgrad callback consumes it."""
+    (
+        _chunk_count,
+        _forward_op,
+        _backward_op,
+        _fused_op,
+        profile_type,
+        key_type,
+        registry_type,
+        _function,
+    ) = _symbols(transformer_engine_import_stub)
+    workspace = registry_type().get_or_create(
+        key_type(
+            # Normal/deferred Wgrad must retain FC2 output separately.
+            op="backward",
+            device_type="cpu",
+            device_index=None,
+            ep_group_id=100,
+            dtype=torch.float32,
+            shape_profile=profile_type(
+                max_input_rows=8, hidden_size=2, topk=2, ep_size=2
+            ),
+        ),
+        lambda slot: SimpleNamespace(slot=slot, use_deepep=True),
+    )
+    lease = workspace.acquire_expert_activation()
+    fc2_output = lease.tensor("fc2_output", (2, 2), dtype=torch.float32, device="cpu")
+    fc2_dgrad = lease.tensor("fc2_dgrad", (2, 2), dtype=torch.float32, device="cpu")
+    expected_fc2_output = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    fc2_output.copy_(expected_fc2_output)
+    delayed_wgrad_read = torch.empty_like(fc2_output)
+
+    # This is the production ordering bug: FC2 dgrad is written before the
+    # delayed FC2 Wgrad callback reads its saved forward input.
+    fc2_dgrad.fill_(17.0)
+    delayed_wgrad_read.copy_(fc2_output)
+
+    assert fc2_output.data_ptr() != fc2_dgrad.data_ptr()
+    torch.testing.assert_close(delayed_wgrad_read, expected_fc2_output)
+    lease.release(_FakeEvent(ready=True))
+
+
+def test_forward_reuses_fc1_input_only_while_backward_and_fused_keep_their_contracts(
+    transformer_engine_import_stub,
+):
+    """Only no-grad forward may recycle its dead FC1-input raw storage for FC2."""
+    (
+        _chunk_count,
+        _forward_op,
+        _backward_op,
+        _fused_op,
+        profile_type,
+        key_type,
+        registry_type,
+        _function,
+    ) = _symbols(transformer_engine_import_stub)
+    registry = registry_type()
+    profile = profile_type(max_input_rows=8, hidden_size=2, topk=2, ep_size=2)
+
+    def workspace(op):
+        return registry.get_or_create(
+            key_type(
+                op=op,
+                device_type="cpu",
+                device_index=None,
+                ep_group_id=102,
+                dtype=torch.float32,
+                shape_profile=profile,
+            ),
+            lambda slot: SimpleNamespace(slot=slot, use_deepep=True),
+        )
+
+    names = ("fc1_input", "fc1_output", "fc2_output", "fc2_dgrad", "fc1_dgrad")
+    forward = workspace("forward")
+    forward_lease = forward.acquire_expert_activation()
+    forward_ptrs = {
+        name: forward_lease.tensor(
+            name, (2, 2), dtype=torch.float32, device="cpu"
+        ).data_ptr()
+        for name in names
+    }
+    assert forward_ptrs["fc1_input"] == forward_ptrs["fc2_output"]
+    assert forward_ptrs["fc2_output"] != forward_ptrs["fc2_dgrad"]
+    assert forward_ptrs["fc2_dgrad"] == forward_ptrs["fc1_dgrad"]
+    forward_lease.release(_FakeEvent(ready=True))
+
+    fused = workspace("fused_forward_backward")
+    fused_lease = fused.acquire_expert_activation()
+    fused_ptrs = {
+        name: fused_lease.tensor(
+            name, (2, 2), dtype=torch.float32, device="cpu"
+        ).data_ptr()
+        for name in names
+    }
+    assert fused_ptrs["fc2_output"] == fused_ptrs["fc2_dgrad"]
+    assert fused_ptrs["fc2_dgrad"] == fused_ptrs["fc1_dgrad"]
+    assert fused_ptrs["fc1_input"] != fused_ptrs["fc2_output"]
+    assert len(set(fused_ptrs.values())) == 3
+    fused_lease.release(_FakeEvent(ready=True))
+
+    normal = workspace("backward")
+    normal_lease = normal.acquire_expert_activation()
+    normal_ptrs = {
+        name: normal_lease.tensor(
+            name, (2, 2), dtype=torch.float32, device="cpu"
+        ).data_ptr()
+        for name in names
+    }
+    assert normal_ptrs["fc2_output"] != normal_ptrs["fc2_dgrad"]
+    assert normal_ptrs["fc2_dgrad"] == normal_ptrs["fc1_dgrad"]
+    assert normal_ptrs["fc1_input"] != normal_ptrs["fc2_output"]
+    normal_lease.release(_FakeEvent(ready=True))
+
+
+def test_fc1_dgrad_reuses_fc2_dgrad_only_after_swiglu_consumes_it(
+    transformer_engine_import_stub,
+):
+    """The shared dgrad slot is overwritten only after its SwiGLU consumer."""
+    (
+        _chunk_count,
+        _forward_op,
+        _backward_op,
+        _fused_op,
+        profile_type,
+        key_type,
+        registry_type,
+        _function,
+    ) = _symbols(transformer_engine_import_stub)
+    workspace = registry_type().get_or_create(
+        key_type(
+            op="fused_forward_backward",
+            device_type="cpu",
+            device_index=None,
+            ep_group_id=101,
+            dtype=torch.float32,
+            shape_profile=profile_type(
+                max_input_rows=8, hidden_size=2, topk=2, ep_size=2
+            ),
+        ),
+        lambda slot: SimpleNamespace(slot=slot, use_deepep=True),
+    )
+    lease = workspace.acquire_expert_activation()
+    fc2_dgrad = lease.tensor("fc2_dgrad", (2, 2), dtype=torch.float32, device="cpu")
+    fc1_dgrad = lease.tensor("fc1_dgrad", (2, 2), dtype=torch.float32, device="cpu")
+    expected_fc2_dgrad = torch.tensor([[2.0, 3.0], [5.0, 7.0]])
+    fc2_dgrad.copy_(expected_fc2_dgrad)
+    events = []
+    consumed = torch.empty_like(fc2_dgrad)
+
+    class SwiGLUConsumer(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, value):
+            return value
+
+        @staticmethod
+        def backward(ctx, grad_output):
+            events.append("swiglu consumes fc2_dgrad")
+            consumed.copy_(grad_output)
+            return grad_output
+
+    input_value = torch.ones_like(fc2_dgrad, requires_grad=True)
+    torch.autograd.grad(SwiGLUConsumer.apply(input_value), input_value, fc2_dgrad)
+    assert events == ["swiglu consumes fc2_dgrad"]
+    fc1_dgrad.fill_(19.0)
+    events.append("fc1 writes shared dgrad")
+
+    assert fc1_dgrad.data_ptr() == fc2_dgrad.data_ptr()
+    assert events == ["swiglu consumes fc2_dgrad", "fc1 writes shared dgrad"]
+    torch.testing.assert_close(consumed, expected_fc2_dgrad)
+    lease.release(_FakeEvent(ready=True))
+
+
+def test_failed_colored_alias_grow_does_not_bind_or_raise_high_watermark(
+    transformer_engine_import_stub,
+):
+    """A failed new logical alias request must not become a sticky binding."""
+    (
+        _chunk_count,
+        _forward_op,
+        _backward_op,
+        _fused_op,
+        profile_type,
+        key_type,
+        registry_type,
+        _function,
+    ) = _symbols(transformer_engine_import_stub)
+    workspace = registry_type().get_or_create(
+        key_type(
+            op="fused_forward_backward",
+            device_type="cpu",
+            device_index=None,
+            ep_group_id=99,
+            dtype=torch.float32,
+            shape_profile=profile_type(
+                max_input_rows=8, hidden_size=4, topk=2, ep_size=2
+            ),
+        ),
+        lambda slot: SimpleNamespace(slot=slot, use_deepep=True),
+    )
+    first_width = 2 * 1024 * 1024
+    first = workspace.acquire_expert_activation()
+    first_view = first.tensor(
+        "fc2_dgrad", (1, first_width), dtype=torch.float32, device="cpu"
+    )
+    first_ptr = first_view.data_ptr()
+    with pytest.raises(RuntimeError, match="during an active lease"):
+        first.tensor(
+            "fc1_dgrad", (1, first_width + 1), dtype=torch.float32, device="cpu"
+        )
+    assert first_view.data_ptr() == first_ptr
+    coordinator = workspace._expert_activation_owner.coordinator
+    assert "fc1_dgrad" not in coordinator.logical_trailing_shapes
+    assert coordinator.max_requested_bytes["fc2_output"] == first_width * 4
+    first.release(_FakeEvent(ready=True))
+
+    # The failed width must not bind fc1_dgrad: the next lease can issue its
+    # smaller, compatible logical view from the already allocated raw slot.
+    second = workspace.acquire_expert_activation()
+    second_view = second.tensor(
+        "fc1_dgrad", (1, first_width), dtype=torch.float32, device="cpu"
+    )
+    assert second_view.data_ptr() == first_ptr
+    second.release(_FakeEvent(ready=True))
+
+
+@pytest.mark.parametrize(
+    ("requested_bytes", "capacity_bytes"),
+    [
+        (532_676_608, 536_870_912),
+        (530_579_456, 536_870_912),
+        (534_773_760, 536_870_912),
+    ],
+)
+def test_expert_activation_rounds_real_32k_requests_to_8mib_classes(
+    requested_bytes, capacity_bytes, transformer_engine_import_stub
+):
+    """32K Qwen3 records remain in one 8 MiB class without cold growth."""
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        _EXPERT_ACTIVATION_SIZE_CLASS_BYTES,
+        _expert_activation_capacity_bytes,
+    )
+
+    assert _EXPERT_ACTIVATION_SIZE_CLASS_BYTES == 8 * 1024 * 1024
+    assert _expert_activation_capacity_bytes(requested_bytes) == capacity_bytes
+    # The next routed block may request the full 512 MiB; it must reuse this
+    # class rather than cold-grow a second persistent buffer.
+    assert _expert_activation_capacity_bytes(536_870_912) == capacity_bytes
+    assert capacity_bytes - requested_bytes < _EXPERT_ACTIVATION_SIZE_CLASS_BYTES
+
+
+def test_unbound_workspace_binds_to_first_runtime_stream_device(
+    monkeypatch, transformer_engine_import_stub
+):
+    transformer_engine_import_stub()
+    import megatron.lite.primitive.modules.moe_ep_chunk_overlap as overlap
+
+    (
+        _chunk_count,
+        _forward_op,
+        _backward_op,
+        _fused_op,
+        profile_type,
+        key_type,
+        registry_type,
+        _function,
+    ) = _symbols(transformer_engine_import_stub)
+    device_contexts = []
+
+    @contextmanager
+    def use_device(device):
+        device_contexts.append(torch.device(device))
+        yield
+
+    monkeypatch.setattr(overlap.torch.cuda, "device", use_device)
+    workspace = registry_type().get_or_create(
+        key_type(
+            op="forward",
+            device_type="cuda",
+            device_index=None,
+            ep_group_id=37,
+            dtype=torch.bfloat16,
+            shape_profile=profile_type(
+                max_input_rows=8, hidden_size=4, topk=2, ep_size=2
+            ),
+        ),
+        lambda slot: SimpleNamespace(slot=slot, use_deepep=True),
+    )
+    stream = SimpleNamespace(device=torch.device("cuda", 5))
+
+    lease = workspace.acquire(0, stream=stream)
+
+    assert device_contexts == [torch.device("cuda", 5)]
+    assert workspace.evidence()["materialized_device"] == "cuda:5"
+    lease.release(_FakeEvent(ready=True))
+
+    with pytest.raises(RuntimeError, match="already materialized on cuda:5"):
+        workspace.acquire(1, stream=SimpleNamespace(device=torch.device("cuda", 6)))
+
+    workspace.release()
+    rebound = workspace.acquire(
+        0, stream=SimpleNamespace(device=torch.device("cuda", 6))
+    )
+    assert device_contexts == [torch.device("cuda", 5), torch.device("cuda", 6)]
+    assert workspace.evidence()["materialized_device"] == "cuda:6"
+    rebound.release(_FakeEvent(ready=True))
+
+
+def test_workspace_is_lazy_and_registry_release_rebuilds_without_old_state(
+    transformer_engine_import_stub,
+):
+    (
+        _chunk_count,
+        _forward_op,
+        _backward_op,
+        _fused_op,
+        profile_type,
+        key_type,
+        registry_type,
+        _function,
+    ) = _symbols(transformer_engine_import_stub)
+    key = key_type(
+        op="backward",
+        device_type="cpu",
+        device_index=None,
+        ep_group_id=23,
+        dtype=torch.float32,
+        shape_profile=profile_type(max_input_rows=8, hidden_size=4, topk=2, ep_size=2),
+    )
+    created = []
+
+    def factory(slot):
+        dispatcher = SimpleNamespace(
+            slot=slot,
+            use_deepep=True,
+            buffer=object(),
+            deepep_buffer_resident_bytes=256,
+        )
+        created.append(dispatcher)
+        return dispatcher
+
+    registry = registry_type()
+    workspace = registry.get_or_create(key, factory)
+    assert workspace.evidence() == {
+        "allocations": 0,
+        "runtime_allocations": 0,
+        "waits": 0,
+        "grows": 0,
+        "fallbacks": 0,
+        "data_ptrs": {},
+        "tensor_details": {},
+        "dispatcher_count": 0,
+        "deepep_buffer_count": 0,
+        "deepep_buffer_resident_bytes": 0,
+        "allocation_pool_count": 0,
+        "allocation_pool_ids": {},
+        "expert_activation_pool_count": 0,
+        "expert_activation_pool_id": None,
+        "expert_activation_tensors": {},
+        "expert_activation_waits": 0,
+        "expert_activation_allocations": 0,
+        "expert_activation_grows": 0,
+        "expert_activation_parks": 0,
+        "expert_activation_rehydrates": 0,
+        "expert_activation_in_use": False,
+        "expert_activation_event_guarded": False,
+        "expert_activation_arena_id": id(
+            workspace._expert_activation_owner.coordinator
+        ),
+        "expert_activation_arena_claimed_op": None,
+        "expert_activation_max_requested_bytes": {},
+        "expert_activation_capacity_bytes": {},
+        "active_lease_count": 0,
+        "consumer_event_guard_count": 0,
+        "recv_observer_enabled": False,
+        "materialized_device": None,
+        "materialized": False,
+    }
+    assert created == []
+
+    workspace.materialize(device="cpu")
+    first_dispatchers = tuple(created)
+    assert workspace.evidence()["data_ptrs"] == {}
+    for slot in range(2):
+        lease = workspace.acquire(slot)
+        lease.tensor("grad_expert_out", (4, 4), dtype=torch.float32, device="cpu")
+        lease.release(_FakeEvent(ready=True))
+    activation = workspace.acquire_expert_activation()
+    activation.tensor("fc1_input", (4, 4), dtype=torch.float32, device="cpu")
+    activation.release(_FakeEvent(ready=True))
+    assert workspace.evidence()["dispatcher_count"] == 2
+
+    registry.release(key)
+    assert workspace.evidence()["dispatcher_count"] == 0
+    assert workspace.evidence()["deepep_buffer_resident_bytes"] == 0
+    assert workspace.evidence()["data_ptrs"] == {}
+    assert not workspace._expert_activation_owner.arena.tensors
+    registry.release(key)
+
+    workspace.materialize(device="cpu")
+    assert registry.get_or_create(key, factory) is workspace
+    assert workspace.evidence()["data_ptrs"] == {}
+    for slot in range(2):
+        lease = workspace.acquire(slot)
+        lease.tensor("grad_expert_out", (4, 4), dtype=torch.float32, device="cpu")
+        lease.release(_FakeEvent(ready=True))
+    assert workspace.evidence()["data_ptrs"]
+    activation = workspace.acquire_expert_activation()
+    activation.tensor("fc1_input", (4, 4), dtype=torch.float32, device="cpu")
+    activation.release(_FakeEvent(ready=True))
+    registry.release(key)
+    assert not workspace._expert_activation_owner.arena.tensors
+
+    rebuilt = registry.get_or_create(key, factory)
+    assert rebuilt is not workspace
+    rebuilt.materialize(device="cpu")
+    for slot in range(2):
+        lease = rebuilt.acquire(slot)
+        lease.tensor("grad_expert_out", (4, 4), dtype=torch.float32, device="cpu")
+        lease.release(_FakeEvent(ready=True))
+    assert all(
+        rebuilt.dispatcher(slot) is not first_dispatchers[slot] for slot in range(2)
+    )
+    assert rebuilt.evidence()["data_ptrs"]
+    registry.release(key)
+    registry._expert_activation_owners[workspace._expert_activation_owner.key] = (
+        object()
+    )
+    with pytest.raises(RuntimeError, match="replaced activation owner"):
+        workspace.materialize(device="cpu")
+
+
+def test_workspace_release_rejects_active_lease_and_pending_event(
+    transformer_engine_import_stub,
+):
+    (
+        _chunk_count,
+        _forward_op,
+        _backward_op,
+        _fused_op,
+        profile_type,
+        key_type,
+        registry_type,
+        _function,
+    ) = _symbols(transformer_engine_import_stub)
+    key = key_type(
+        op="forward",
+        device_type="cpu",
+        device_index=None,
+        ep_group_id=29,
+        dtype=torch.float32,
+        shape_profile=profile_type(max_input_rows=8, hidden_size=4, topk=2, ep_size=2),
+    )
+    registry = registry_type()
+    workspace = registry.get_or_create(key, lambda slot: SimpleNamespace(slot=slot))
+    lease = workspace.acquire(0)
+    with pytest.raises(RuntimeError, match="slot 0 is leased"):
+        registry.release(key)
+
+    event = _FakeEvent(ready=False)
+    lease.release(event)
+    with pytest.raises(RuntimeError, match="pending consumer event"):
+        registry.release(key)
+
+    stream = _FakeStream()
+    registry.release(key, stream=stream)
+    assert stream.waited == [event]
+    assert workspace.evidence()["dispatcher_count"] == 0
+
+
+def test_workspace_release_never_uses_device_wide_synchronize(
+    transformer_engine_import_stub,
+):
+    (
+        _chunk_count,
+        _forward_op,
+        _backward_op,
+        _fused_op,
+        _profile,
+        _key,
+        registry_type,
+        _function,
+    ) = _symbols(transformer_engine_import_stub)
+
+    assert "synchronize" not in inspect.getsource(registry_type.release)
+
+
+@pytest.mark.parametrize("shape", [(2, 5, 4), (10, 4)], ids=["bshd", "thd-packed"])
+def test_profile_checks_actual_flattened_rows_for_batched_and_packed_inputs(
+    shape, transformer_engine_import_stub
+):
+    (
+        _chunk_count,
+        _forward_op,
+        _backward_op,
+        _fused_op,
+        profile_type,
+        _key,
+        _registry,
+        _function,
+    ) = _symbols(transformer_engine_import_stub)
+    profile = profile_type.for_two_slot_chunked_ep(
+        max_input_rows=9, hidden_size=4, topk=2, ep_size=8
+    )
+
+    with pytest.raises(RuntimeError, match="input rows 10"):
+        profile.validate_input(torch.empty(shape))
+
+
+def test_qwen3_profile_freezes_deepep_worst_case_receive_capacity(
+    transformer_engine_import_stub,
+):
+    (
+        _chunk_count,
+        _forward_op,
+        _backward_op,
+        _fused_op,
+        profile_type,
+        _key,
+        _registry,
+        _function,
+    ) = _symbols(transformer_engine_import_stub)
+
+    profile = profile_type.for_two_slot_chunked_ep(
+        max_input_rows=17, hidden_size=64, topk=8, ep_size=8
+    )
+
+    assert profile.max_recv_rows == 9 * 8
+    assert profile.max_expert_rows == 9 * 8 * 8
+    assert profile.topk == 8
+
+
+@pytest.mark.parametrize("rows", [0, 1, 72])
+def test_shape_profile_accepts_recv_rows_at_or_below_capacity(
+    rows, transformer_engine_import_stub
+):
+    profile = _symbols(transformer_engine_import_stub)[4](
+        max_input_rows=17, hidden_size=4, topk=8, ep_size=8
+    )
+
+    profile.validate_recv_rows(rows)
+
+
+def test_shape_profile_rejects_recv_rows_above_capacity(transformer_engine_import_stub):
+    profile = _symbols(transformer_engine_import_stub)[4](
+        max_input_rows=17, hidden_size=4, topk=8, ep_size=8
+    )
+
+    with pytest.raises(RuntimeError, match="recv rows 73.*capacity 72"):
+        profile.validate_recv_rows(73)
+
+
+@pytest.mark.parametrize("rows", [0, 73, 576])
+def test_shape_profile_accepts_expert_rows_at_or_below_capacity(
+    rows, transformer_engine_import_stub
+):
+    profile = _symbols(transformer_engine_import_stub)[4](
+        max_input_rows=17, hidden_size=4, topk=8, ep_size=8
+    )
+
+    profile.validate_expert_rows(rows)
+
+
+def test_shape_profile_rejects_expert_rows_above_capacity(
+    transformer_engine_import_stub,
+):
+    profile = _symbols(transformer_engine_import_stub)[4](
+        max_input_rows=17, hidden_size=4, topk=8, ep_size=8
+    )
+
+    with pytest.raises(RuntimeError, match="expert rows 577.*capacity 576"):
+        profile.validate_expert_rows(577)
+
+
+def test_saved_context_autograd_keeps_forward_context_for_backward(
+    transformer_engine_import_stub,
+):
+    (
+        _chunk_count,
+        _forward_op,
+        _backward_op,
+        _fused_op,
+        _profile,
+        _key,
+        _registry,
+        function,
+    ) = _symbols(transformer_engine_import_stub)
+    source = inspect.getsource(function)
+
+    assert "ctx.saved_forward_context = saved_context" in source
+    assert "ctx.backward_op = forward_op.backward_op" in source
+    assert "ctx.backward_op.backward(" in source
+    assert "synchronize" not in source
+
+
+def test_saved_context_backward_uses_the_dispatcher_that_created_its_handle(
+    transformer_engine_import_stub,
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        _EPChunkOperationBase,
+        _ForwardChunkContext,
+    )
+
+    fields = _ForwardChunkContext.__dataclass_fields__
+    forward_source = inspect.getsource(
+        _EPChunkOperationBase._forward_saved_context_async
+    )
+    backward_source = inspect.getsource(_EPChunkOperationBase._saved_context_backward)
+
+    assert "dispatcher" in fields
+    assert "dispatcher=dispatcher" in forward_source
+    assert "dispatcher=saved.dispatcher" in backward_source
+    assert "dispatcher=lease.dispatcher" not in backward_source
+    assert "require_dispatcher=False" in backward_source
+
+
+def test_saved_forward_context_does_not_pin_two_shared_slots_across_layers(
+    transformer_engine_import_stub,
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        _EPChunkOperationBase,
+        _ForwardChunkContext,
+    )
+
+    fields = _ForwardChunkContext.__dataclass_fields__
+    forward_source = inspect.getsource(
+        _EPChunkOperationBase._forward_saved_context_async
+    )
+
+    assert "forward_workspace_lease" not in fields
+    assert "lease.release(consumed)" in forward_source
+    expert_finished = forward_source.index("expert_out = self.experts(")
+    context_saved = forward_source.index("saved_chunks[chunk_idx] =")
+    slot_released = forward_source.index("lease.release(consumed)")
+    assert expert_finished < context_saved < slot_released
+    for saved_tensor in ("recv_probs_base", "dispatched", "probs", "expert_out_edge"):
+        assert saved_tensor in fields
+    assert 'handle=state["handle"]' in forward_source
+
+
+def test_forward_router_runs_on_compute_stream_before_comm_dispatch(
+    transformer_engine_import_stub,
+):
+    """Routing stays on the caller stream; comm only consumes its ready event."""
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe_ep_chunk_overlap import (
+        _EPChunkOperationBase,
+    )
+
+    for method in (
+        _EPChunkOperationBase._forward_output_async,
+        _EPChunkOperationBase._forward_saved_context_async,
+    ):
+        source = inspect.getsource(method)
+        compute_route = source.index("with torch.cuda.stream(compute_stream):")
+        route = source.index("scores, indices = self._route", compute_route)
+        route_ready = source.index("route_ready.record(compute_stream)", route)
+        comm_dispatch = source.index("with torch.cuda.stream(comm_stream):", route_ready)
+        comm_wait = source.index("comm_stream.wait_event(route_ready)", comm_dispatch)
+        dispatch = source.index("dispatcher.submit_deepep_dispatch(", comm_wait)
+
+        assert compute_route < route < route_ready < comm_dispatch < comm_wait < dispatch
+        handoff = source[route_ready:dispatch]
+        assert "x_chunk.record_stream(comm_stream)" in handoff
+        assert "scores.record_stream(comm_stream)" in handoff
+        assert "indices.record_stream(comm_stream)" in handoff
+        assert "synchronize" not in source

--- a/experimental/lite/tests/unit/runtime/backends/mlite/test_runtime_backend_unit.py
+++ b/experimental/lite/tests/unit/runtime/backends/mlite/test_runtime_backend_unit.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
+import subprocess
 import sys
 import types
 from dataclasses import dataclass
@@ -10,7 +12,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 import torch.nn as nn
-
 from megatron.lite.runtime import create_runtime
 from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig
 from megatron.lite.runtime.backends.mlite.runtime import (
@@ -20,9 +21,17 @@ from megatron.lite.runtime.backends.mlite.runtime import (
     _pipeline_callbacks,
     _reset_parameters,
 )
-from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig, RuntimeConfig
+from megatron.lite.runtime.contracts.config import (
+    OptimizerConfig,
+    ParallelConfig,
+    RuntimeConfig,
+)
 from megatron.lite.runtime.contracts.handle import ModelHandle
-from megatron.lite.runtime.contracts.loss import LossContext, get_loss_context, use_loss_context
+from megatron.lite.runtime.contracts.loss import (
+    LossContext,
+    get_loss_context,
+    use_loss_context,
+)
 
 
 def test_runtime_returns_loss_separately_from_microbatch_metrics():
@@ -50,7 +59,10 @@ def test_pipeline_callbacks_accept_wrapped_and_presplit_context():
     forward, loss = _pipeline_callbacks(
         lambda _model, batch: seen.append((batch, get_loss_context()))
         or {"loss": torch.tensor(1.0)},
-        lambda out, batch, ctx: (out["loss"], {"batch": batch, "source": ctx.source_batch}),
+        lambda out, batch, ctx: (
+            out["loss"],
+            {"batch": batch, "source": ctx.source_batch},
+        ),
     )
 
     output = forward(None, ("wrapped", context))
@@ -84,7 +96,8 @@ def test_runtime_config_accepts_mlite_backend_cfg():
 
 def test_mlite_config_defaults_and_parallel_fields():
     cfg = MegatronLiteConfig(
-        model_name="qwen3_moe", parallel=ParallelConfig(tp=4, etp=1, ep=8, pp=2, vpp=2, cp=2)
+        model_name="qwen3_moe",
+        parallel=ParallelConfig(tp=4, etp=1, ep=8, pp=2, vpp=2, cp=2),
     )
 
     assert cfg.model_name == "qwen3_moe"
@@ -353,7 +366,9 @@ class HookedOptimizer:
 
 def test_runtime_to_prefers_optimizer_specific_offload_hooks():
     optimizer = HookedOptimizer()
-    handle = ModelHandle(model=nn.Linear(2, 2), optimizer=optimizer, _extras={"model_chunks": []})
+    handle = ModelHandle(
+        model=nn.Linear(2, 2), optimizer=optimizer, _extras={"model_chunks": []}
+    )
     runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
 
     runtime.to(handle, "cpu", model=False, optimizer=True, grad=False)
@@ -397,9 +412,7 @@ def test_training_transfer_parks_optimizer_and_releases_scratch(monkeypatch):
     monkeypatch.setattr(torch.cuda, "empty_cache", lambda: events.append("empty-cache"))
     chunk = Chunk()
     handle = ModelHandle(
-        model=chunk,
-        optimizer=Optimizer(),
-        _extras={"model_chunks": [chunk]},
+        model=chunk, optimizer=Optimizer(), _extras={"model_chunks": [chunk]}
     )
     runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
 
@@ -418,12 +431,65 @@ def test_training_transfer_parks_optimizer_and_releases_scratch(monkeypatch):
     ]
 
 
+def test_training_transfer_releases_unique_ep_workspaces_before_model_offload(
+    monkeypatch,
+):
+    events = []
+
+    class Module:
+        def release_ep_chunk_workspaces(self, *, phase, stream):
+            assert phase is None and stream == "stream"
+            events.append("release-ep")
+
+    class Chunk:
+        def __init__(self, modules):
+            self._modules = modules
+
+        def modules(self):
+            return iter(self._modules)
+
+        def release_export_scratch(self):
+            events.append("release-scratch")
+
+    import megatron.lite.runtime.megatron_utils as megatron_utils
+
+    monkeypatch.setattr(
+        megatron_utils, "offload_model_to_cpu", lambda _: events.append("offload-model")
+    )
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "current_stream", lambda: "stream")
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda: events.append("sync"))
+    monkeypatch.setattr(
+        "megatron.lite.runtime.backends.mlite.runtime.gc.collect",
+        lambda: events.append("gc"),
+    )
+    monkeypatch.setattr(torch.cuda, "empty_cache", lambda: events.append("empty"))
+    module = Module()
+    chunks = [Chunk([module, module]), Chunk([module])]
+    handle = ModelHandle(model=chunks[0], _extras={"model_chunks": chunks})
+    MegatronLiteRuntime.__new__(MegatronLiteRuntime).to(
+        handle, "cpu", optimizer=False, grad=True
+    )
+    assert events == [
+        "release-ep",
+        "offload-model",
+        "release-scratch",
+        "release-scratch",
+        "sync",
+        "gc",
+        "empty",
+    ]
+
+
 def test_export_transfer_does_not_move_optimizer_or_release_scratch(monkeypatch):
     events = []
 
     class Chunk:
         def release_export_scratch(self):
             events.append("release-scratch")
+
+        def release_ep_chunk_workspaces(self, *, phase, stream):
+            events.append("release-ep")
 
     import megatron.lite.runtime.megatron_utils as megatron_utils
 
@@ -434,9 +500,7 @@ def test_export_transfer_does_not_move_optimizer_or_release_scratch(monkeypatch)
     )
     chunk = Chunk()
     handle = ModelHandle(
-        model=chunk,
-        optimizer=HookedOptimizer(),
-        _extras={"model_chunks": [chunk]},
+        model=chunk, optimizer=HookedOptimizer(), _extras={"model_chunks": [chunk]}
     )
 
     MegatronLiteRuntime.__new__(MegatronLiteRuntime).to(
@@ -444,6 +508,37 @@ def test_export_transfer_does_not_move_optimizer_or_release_scratch(monkeypatch)
     )
 
     assert events == ["offload-model"]
+
+
+def test_training_transfer_uses_no_ep_stream_without_cuda(monkeypatch):
+    events = []
+
+    class Chunk:
+        def release_ep_chunk_workspaces(self, *, phase, stream):
+            assert phase is None
+            assert stream is None
+            events.append("release-ep")
+
+        def release_export_scratch(self):
+            events.append("release-scratch")
+
+    import megatron.lite.runtime.megatron_utils as megatron_utils
+
+    monkeypatch.setattr(
+        megatron_utils, "offload_model_to_cpu", lambda _: events.append("offload-model")
+    )
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(
+        torch.cuda, "current_stream", lambda: pytest.fail("unexpected stream")
+    )
+    chunk = Chunk()
+    MegatronLiteRuntime.__new__(MegatronLiteRuntime).to(
+        ModelHandle(model=chunk, _extras={"model_chunks": [chunk]}),
+        "cpu",
+        optimizer=False,
+        grad=True,
+    )
+    assert events == ["release-ep", "offload-model", "release-scratch"]
 
 
 class _FakeStorage:
@@ -552,7 +647,10 @@ def test_megatron_ddp_detection_accepts_ddp_and_subclasses(monkeypatch):
 
 @pytest.mark.parametrize("model_cls", [_FakeMegatronDDP, _FakeMegatronDDPSubclass])
 def test_megatron_ddp_model_move_helpers_use_buffer_path(monkeypatch, model_cls):
-    from megatron.lite.runtime.megatron_utils import load_model_to_gpu, offload_model_to_cpu
+    from megatron.lite.runtime.megatron_utils import (
+        load_model_to_gpu,
+        offload_model_to_cpu,
+    )
 
     _install_fake_megatron_ddp(monkeypatch)
     model = model_cls()
@@ -579,7 +677,10 @@ def test_megatron_ddp_model_move_helpers_use_buffer_path(monkeypatch, model_cls)
 
 
 def test_native_model_move_helpers_do_not_require_megatron_core(monkeypatch):
-    from megatron.lite.runtime.megatron_utils import load_model_to_gpu, offload_model_to_cpu
+    from megatron.lite.runtime.megatron_utils import (
+        load_model_to_gpu,
+        offload_model_to_cpu,
+    )
 
     monkeypatch.setitem(sys.modules, "megatron.core", None)
     monkeypatch.setitem(sys.modules, "megatron.core.distributed", None)
@@ -638,7 +739,9 @@ def test_model_handle_dp_from_parallel_state():
 def test_model_handle_cp_range_and_config_properties():
     cfg = {"tp": 8, "ep": 4}
     default_handle = ModelHandle(model=MagicMock())
-    configured_handle = ModelHandle(model=MagicMock(), config=cfg, _extras={"cp_range": (1, 8)})
+    configured_handle = ModelHandle(
+        model=MagicMock(), config=cfg, _extras={"cp_range": (1, 8)}
+    )
 
     assert default_handle.cp_range == (1, 1)
     assert configured_handle.cp_range == (1, 8)
@@ -652,7 +755,9 @@ def test_runtime_dispatch_creates_mlite_backend():
 
         runtime = create_runtime(
             RuntimeConfig(
-                backend="mlite", hf_path="/models/test", backend_cfg={"model_name": "qwen3"}
+                backend="mlite",
+                hf_path="/models/test",
+                backend_cfg={"model_name": "qwen3"},
             )
         )
 
@@ -663,3 +768,111 @@ def test_runtime_dispatch_creates_mlite_backend():
 def test_runtime_dispatch_unknown_backend_raises():
     with pytest.raises(KeyError):
         create_runtime(RuntimeConfig(backend="nonexistent"))
+
+
+def _run_verl_sft_dry_run(script: Path, tmp_path: Path, **env_overrides: str) -> str:
+    env = {
+        **os.environ,
+        "MODEL_PATH": "/tmp/mlite-model",
+        "TRAIN_FILES": "/tmp/mlite-train.parquet",
+        "OUTPUT_ROOT": str(tmp_path),
+        "DRY_RUN": "1",
+        "NUM_GPUS": "1",
+        "NPROC_PER_NODE": "1",
+        "TP_SIZE": "1",
+        "PP_SIZE": "1",
+        "CP_SIZE": "1",
+        "EP_SIZE": "1",
+        "ETP_SIZE": "1",
+        **env_overrides,
+    }
+    completed = subprocess.run(
+        [str(script)], env=env, text=True, capture_output=True, check=True
+    )
+    return completed.stdout
+
+
+def test_verl_sft_script_maps_offload_env_to_backend_args(tmp_path):
+    script = (
+        Path(__file__).resolve().parents[5]
+        / "examples"
+        / "verl"
+        / "scripts"
+        / "run_qwen3moe_sft.sh"
+    )
+
+    command = _run_verl_sft_dry_run(
+        script,
+        tmp_path,
+        PARAM_OFFLOAD="True",
+        OPTIMIZER_OFFLOAD="True",
+        OPTIMIZER_STATE_OFFLOAD_FRACTION="0.75",
+    )
+
+    assert "engine.param_offload=True" in command
+    assert "engine.optimizer_offload=True" in command
+    assert "+optim.override_optimizer_config.offload_fraction=0.75" in command
+    assert (
+        "+optim.override_optimizer_config.use_precision_aware_optimizer=True" in command
+    )
+
+
+def test_verl_sft_script_does_not_emit_optimizer_state_offload_when_disabled(tmp_path):
+    script = (
+        Path(__file__).resolve().parents[5]
+        / "examples"
+        / "verl"
+        / "scripts"
+        / "run_qwen3moe_sft.sh"
+    )
+
+    command = _run_verl_sft_dry_run(
+        script, tmp_path, PARAM_OFFLOAD="False", OPTIMIZER_OFFLOAD="False"
+    )
+
+    assert "engine.param_offload=False" in command
+    assert "engine.optimizer_offload=False" in command
+    assert "override_optimizer_config.offload_fraction" not in command
+
+
+def test_verl_sft_script_emits_explicit_dynamic_cp_switch_when_disabled(tmp_path):
+    script = (
+        Path(__file__).resolve().parents[5]
+        / "examples"
+        / "verl"
+        / "scripts"
+        / "run_qwen3moe_sft.sh"
+    )
+
+    command = _run_verl_sft_dry_run(script, tmp_path, DYNAMIC_CONTEXT_PARALLEL="False")
+
+    assert (
+        "+engine.impl_cfg.runtime_plugins.dynamic_context_parallel.enabled=False"
+        in command
+    )
+
+
+def test_verl_sft_dynamic_cp_acceptance_requires_full_cp_size_coverage(tmp_path):
+    script = (
+        Path(__file__).resolve().parents[5]
+        / "examples"
+        / "verl"
+        / "scripts"
+        / "run_qwen3moe_sft.sh"
+    )
+
+    command = _run_verl_sft_dry_run(
+        script,
+        tmp_path,
+        DYNAMIC_CONTEXT_PARALLEL="True",
+        MAX_SEQLEN_PER_DP_CP_RANK="4096",
+    )
+
+    assert (
+        "+engine.impl_cfg.runtime_plugins.dynamic_context_parallel."
+        "require_full_cp_size_coverage=True"
+    ) in command
+    assert (
+        "+engine.impl_cfg.runtime_plugins.dynamic_context_parallel.enabled=True"
+        in command
+    )


### PR DESCRIPTION
## Summary

Add token-wise expert-parallel overlap within each Qwen3 MoE microbatch. The enabled path defaults to two logical chunks and uses independent forward, backward, and fused forward-backward operators, with reusable activation workspaces and event-ordered DeepEP dispatch/combine.

The default remains the native MoE path. Enabling overlap requires DeepEP and EP greater than one. Full recomputation belongs to the transformer layer; the primitive preserves delayed-weight-gradient ordering. Chunked head cross entropy bounds the shared vocabulary-logit peak in the full-model workload.

Rebased onto `d8e010069`, preserving FSDP2 meta initialization, the shared Transformer Engine adapter, and duplicate-expert probability accumulation. A behavioral regression verifies duplicate routing weights and gradients.

## Validation

The GPU measurements below remain pinned to `33be6f1ef`; they were not rerun for the construction-time rejection below.

Validation is pinned to `33be6f1ef746f6c9dc889a76c6eb174318f6f02c`. Both A/B arms use the same tensor shapes and full-recomputation contract, fresh processes, three warmups, and ten measured iterations. These measurements cover forward/backward with no optimizer update and randomly initialized weights.

| Qwen3 MoE configuration | Native max-rank median | Chunked max-rank median | Speedup | Peak allocated change | Peak reserved change | Loss max abs |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| EP8, top-k8, 1 layer, 32K tokens, mb1 | 450.770 ms | 326.005 ms | 1.3827x | -56.673% | -12.935% | 9.54e-7 |
| EP8, top-k8, 48 layers, 16K tokens, mb8 | 33,514.279 ms | 29,613.317 ms | 1.1317x | -9.809% | -13.355% | 5.72e-5 |

Both configurations completed without allocator retries or OOMs. All eight ranks retained stable post-warm activation allocation/growth counters, one shared arena, and zero runtime workspace allocations; release, rematerialization, and recovery checks passed.

CPU coverage includes ChunkedEP workspaces/operators/dispatch, model configuration, checkpoint/QAT integration, cross entropy, and runtime behavior. The expanded local run reported 284 passed, four failed, and four skipped: the two socket-restricted Gloo failures passed in the permitted CPU/Gloo rerun (28 passed); the two missing-Transformer-Engine runtime failures passed in the GPU container; all four CUDA skips passed in that container. Additional MoE/checkpoint/QAT coverage passed 24 tests. Ruff and whitespace checks passed; both modified skill contracts passed structural checks.

GPU runtime coverage is limited to Qwen3 MoE. These results do not establish FP8 parity or throughput parity with Megatron FP8, or runtime support for other model families.

## Review revision: reject unsupported MTP composition

Revision `255b48f3b13c17ce55c1f70f6ed692755354b4f6` rejects `enable_ep_chunk_overlap=True` together with `mtp_enable=True` in both the protocol and direct model constructor, before parallel/model/workspace allocation. This applies with either value of `mtp_enable_train`. Disable one feature to proceed. MTP auxiliary losses also materialize full-vocabulary logits before the main head branch, so removing the main-head MTP condition alone would not make this combination memory-bounded. Supporting it requires separate validation of shifted labels, masking, and auxiliary gradients.

`ep_chunk_count` now reaches shared configuration validation and the MoE configuration contract; logical chunk count is configurable (default 2), subject to token capacity. Legacy allocation-pool fields explicitly describe only private pools owned by the workspace; outer graph pool identity remains a documented TODO and those fields are not total-allocator telemetry.

Validation for this revision: four constructor/protocol rejection cases failed before the fix and passed afterward; the complete six-file ChunkedEP/model/dispatcher/workspace suite passed **231 tests** (14 warnings, exit 0). Ruff, whitespace checks, and the modified MoE skill structural check passed. No new GPU or numerical MTP support is claimed.

Remaining review caveats are recorded without expanding this revision: invalid configured capacity is rejected at construction; runtime token counts below the configured chunk count are handled by the small-batch revision below; the non-CUDA BF16 dlogits path has bounded numerical error; CUDA fast-path/ChunkedEP/head numerical end-to-end coverage and broader benchmark/skill documentation gaps remain.

## Small per-rank batch correction

Revision `ce65889962771ab6fe903760a3975b26a1576425` handles runtime row counts below the configured logical chunk count in ordinary forward, saved-context forward, and fused recomputation. The number of nonempty compute chunks reduces to the local token count (one for a singleton, zero for an empty input). Zero-token communication slots remain so every EP rank performs the same dispatch/combine sequence. Rank-local removal of those collectives would be unsafe when other ranks have larger inputs; an empty source rank can still receive remote expert work. No dummy tokens or new per-step global synchronization are introduced. Construction-time validation remains strict.

The real `EPChunkForwardOp.forward` is exercised with CPU stream/transport doubles, both with and without saved-context autograd, chunk counts 2 and 4, local rows 0/1/3, and zero or two simulated remote expert rows. All 24 cases match an ordinary unchunked router-dispatch-expert-combine path exactly. Deleting the small-input fallback branch produces **20 failures and 4 passes** (exit 1); restoring it yields **255 passed** across the complete seven-file related suite (14 warnings, exit 0). Ruff, whitespace, and the modified MoE skill structural checks passed. This is forward schedule evidence, not actual distributed DeepEP GPU parity; no new GPU performance numbers are claimed.

Head-selection documentation now states that fused cross entropy may coexist with ChunkedEP and takes precedence; entropy output without fusion uses the full-vocabulary fallback. Neither selection rejects MoE composition, unlike the explicitly rejected MTP/recompute combinations.

Known gaps retained for the merge decision: entropy's full-vocabulary fallback (CR-2); BF16 roughly one-ULP error (CR-3); static-substring coverage limitations (EVID-1); incomplete CUDA fast-path GPU parity evidence (EVID-2); and the README's cited runs being non-ChunkedEP runs without in-repository artifacts (EVID-3). These are not addressed by this revision.

## Meta-initialization regression correction

Revision `7e572b842e3e64f8dcf27b036f9decbb354fc7bb` only changes the Qwen3 protocol and its existing initialization-device test. Missing `num_experts_per_tok` now raises a descriptive configuration error rather than an incidental AttributeError. The meta-init test uses the real `Qwen3MoEConfig`, whose Qwen3-30B-A3B architecture defaults supply router top-k=8; it no longer uses an incomplete namespace or an arbitrary test-only value. Both earlier blocker fixes and their tests are unchanged.

Fresh full-unit comparison against merge-base `d8e010069fef5c6da3690d008b899d480864a8de` used the same container and dependency environment. The selector was every `tests/unit/**/test_*.py` file in each tree, with no `-k`, no `-m`, and no selection override. Pytest arguments: `-v -rs -p no:cacheprovider --maxfail=200 --continue-on-collection-errors`, plus JUnit output.

| Tree | Selected files | Collected items | Deselected | Passed | Failed | Skipped | Errors | Extracted failures + errors |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Head `7e572b842` | 80 | 999 | 0 | 959 | 20 | 22 | 5 | 25 |
| Main `d8e010069` | 72 | 722 | 0 | 682 | 20 | 22 | 5 | 25 |

Each collection reports five errors and two collection-time skips separately from collected items; the final 22 skips include those two collection-time skips. JUnit counts match every terminal-summary category, and each extracted set contains exactly `20 + 5 = 25` unique failure/error identities. **Added failures: 0; removed failures: 0.** The meta-init test passes in both trees. Both full-suite runs exit 1 because the shared baseline failures remain; this is a clean regression delta, not an all-green suite. The two exact targeted tests also passed (2 collected, 0 deselected).
