### PR TITLE
Add a shared KDA training operator

### DIFF
--- a/experimental/lite/docs/porting.md
+++ b/experimental/lite/docs/porting.md
@@ -41,3 +41,33 @@ export PYTHONPATH=/path/to/Megatron-LM/experimental/lite:$PYTHONPATH
 
 A future integration step can decide whether to keep the experimental location
 or move the tree into the final package location.
+
+## KDA Operator
+
+External hybrid-model packages can reuse the model-independent Kimi Delta
+Attention recurrence without moving model configuration or layer schedules into
+Megatron Lite:
+
+```python
+from megatron.lite.primitive.ops.kda import kda
+
+output, final_state = kda(
+    q,
+    k,
+    v,
+    gate_logits,
+    beta_logits,
+    a_log=a_log,
+    dt_bias=dt_bias,
+    lower_bound=-5.0,
+    backend="auto",
+)
+```
+
+The tensors use `[batch, sequence, heads, head_dim]`; `beta_logits` omits the
+last dimension. CPU dispatch is a bounded differentiable oracle for tiny
+correctness tests. CUDA dispatch calls FLA `chunk_kda`, which provides the
+training-capable forward and backward path. Megatron Lite does not call the
+forward-only FlashKDA extension directly. Packed sequences are accepted only
+by the FLA backend; context-parallel state transfer is not implemented by this
+operator.

--- a/experimental/lite/megatron/lite/primitive/ops/kda.py
+++ b/experimental/lite/megatron/lite/primitive/ops/kda.py
@@ -1,0 +1,157 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Kimi Delta Attention recurrence and training-backend dispatch."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import torch
+import torch.nn.functional as F
+
+KDABackend = Literal["auto", "torch", "fla"]
+
+
+def _validate_kda_inputs(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate_logits: torch.Tensor,
+    beta_logits: torch.Tensor,
+    a_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    lower_bound: float,
+    initial_state: torch.Tensor | None,
+) -> None:
+    if q.ndim != 4:
+        raise ValueError("KDA q must have shape [batch, sequence, heads, head_dim]")
+    if q.shape != k.shape or q.shape != v.shape or q.shape != gate_logits.shape:
+        raise ValueError("KDA q, k, v, and gate_logits must have the same shape")
+    if beta_logits.shape != q.shape[:-1]:
+        raise ValueError("KDA beta_logits must have shape [batch, sequence, heads]")
+    heads, head_dim = q.shape[-2:]
+    if a_log.shape != (heads,):
+        raise ValueError(f"KDA a_log must have shape [{heads}]")
+    if dt_bias.shape != (heads, head_dim):
+        raise ValueError(f"KDA dt_bias must have shape [{heads}, {head_dim}]")
+    if initial_state is not None:
+        expected_state = (q.shape[0], heads, head_dim, v.shape[-1])
+        if initial_state.shape != expected_state:
+            raise ValueError(f"KDA initial_state must have shape {expected_state}")
+    if not -5.0 <= lower_bound < 0.0:
+        raise ValueError("KDA lower_bound must be in the FLA safe range [-5, 0)")
+
+
+def torch_recurrent_kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate_logits: torch.Tensor,
+    beta_logits: torch.Tensor,
+    *,
+    a_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    lower_bound: float = -5.0,
+    initial_state: torch.Tensor | None = None,
+    scale: float | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Differentiable bounded recurrence for tiny correctness references."""
+    _validate_kda_inputs(
+        q, k, v, gate_logits, beta_logits, a_log, dt_bias, lower_bound, initial_state
+    )
+    output_dtype = v.dtype
+    batch, sequence, heads, head_dim = q.shape
+    scale = head_dim**-0.5 if scale is None else scale
+    q = F.normalize(q.float(), p=2, dim=-1)
+    k = F.normalize(k.float(), p=2, dim=-1)
+    v = v.float()
+    gate = lower_bound * torch.sigmoid(
+        a_log.float().exp().view(1, 1, heads, 1)
+        * (gate_logits.float() + dt_bias.float().view(1, 1, heads, head_dim))
+    )
+    beta = torch.sigmoid(beta_logits.float())
+    state = (
+        q.new_zeros(batch, heads, head_dim, v.shape[-1])
+        if initial_state is None
+        else initial_state.float()
+    )
+    outputs = []
+    for token in range(sequence):
+        state = state * gate[:, token].exp().unsqueeze(-1)
+        prediction = torch.einsum("bhd,bhdv->bhv", k[:, token], state)
+        update = beta[:, token].unsqueeze(-1) * (v[:, token] - prediction)
+        state = state + torch.einsum("bhd,bhv->bhdv", k[:, token], update)
+        outputs.append(torch.einsum("bhd,bhdv->bhv", q[:, token], state) * scale)
+    return torch.stack(outputs, dim=1).to(output_dtype), state
+
+
+def kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate_logits: torch.Tensor,
+    beta_logits: torch.Tensor,
+    *,
+    a_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    lower_bound: float = -5.0,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = True,
+    scale: float | None = None,
+    cu_seqlens: torch.Tensor | None = None,
+    backend: KDABackend = "auto",
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Execute KDA through a tiny torch oracle or FLA's trainable chunk kernel."""
+    _validate_kda_inputs(
+        q, k, v, gate_logits, beta_logits, a_log, dt_bias, lower_bound, initial_state
+    )
+    if backend not in {"auto", "torch", "fla"}:
+        raise ValueError(f"unsupported KDA backend: {backend!r}")
+    selected = "fla" if backend == "auto" and q.is_cuda else backend
+    if selected in {"auto", "torch"}:
+        if cu_seqlens is not None:
+            raise NotImplementedError(
+                "the torch KDA oracle accepts equal-length batches only"
+            )
+        output, final_state = torch_recurrent_kda(
+            q,
+            k,
+            v,
+            gate_logits,
+            beta_logits,
+            a_log=a_log,
+            dt_bias=dt_bias,
+            lower_bound=lower_bound,
+            initial_state=initial_state,
+            scale=scale,
+        )
+        return output, final_state if output_final_state else None
+
+    try:
+        from fla.ops.kda import chunk_kda
+    except ImportError as error:
+        raise ImportError(
+            "FLA KDA requires flash-linear-attention with fla.ops.kda.chunk_kda"
+        ) from error
+
+    return chunk_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=gate_logits,
+        beta=beta_logits,
+        scale=q.shape[-1] ** -0.5 if scale is None else scale,
+        A_log=a_log,
+        dt_bias=dt_bias,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        use_qk_l2norm_in_kernel=True,
+        use_gate_in_kernel=True,
+        use_beta_sigmoid_in_kernel=True,
+        safe_gate=True,
+        lower_bound=lower_bound,
+        state_v_first=True,
+        cu_seqlens=cu_seqlens,
+    )
+
+
+__all__ = ["KDABackend", "kda", "torch_recurrent_kda"]

--- a/experimental/lite/tests/unit/primitive/test_kda_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_kda_unit.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.mlite
+
+
+def _kda_ops():
+    from megatron.lite.primitive.ops.kda import kda, torch_recurrent_kda
+
+    return kda, torch_recurrent_kda
+
+
+def _inputs(*, requires_grad: bool = False):
+    torch.manual_seed(7)
+    shape = (2, 3, 2, 4)
+    q = torch.randn(shape, requires_grad=requires_grad)
+    k = torch.randn(shape, requires_grad=requires_grad)
+    v = torch.randn(shape, requires_grad=requires_grad)
+    gate = torch.randn(shape, requires_grad=requires_grad)
+    beta = torch.randn(shape[:-1], requires_grad=requires_grad)
+    a_log = torch.randn(shape[2], requires_grad=requires_grad)
+    dt_bias = torch.randn(shape[2:], requires_grad=requires_grad)
+    return q, k, v, gate, beta, a_log, dt_bias
+
+
+def test_kda_cpu_auto_matches_recurrent_reference():
+    kda, torch_recurrent_kda = _kda_ops()
+    q, k, v, gate, beta, a_log, dt_bias = _inputs()
+    kwargs = {
+        "a_log": a_log,
+        "dt_bias": dt_bias,
+        "lower_bound": -5.0,
+        "scale": q.shape[-1] ** -0.5,
+    }
+
+    actual, actual_state = kda(q, k, v, gate, beta, backend="auto", **kwargs)
+    expected, expected_state = torch_recurrent_kda(q, k, v, gate, beta, **kwargs)
+
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+    torch.testing.assert_close(actual_state, expected_state, atol=0, rtol=0)
+
+
+def test_kda_recurrent_reference_is_differentiable():
+    _kda, torch_recurrent_kda = _kda_ops()
+    inputs = _inputs(requires_grad=True)
+
+    output, final_state = torch_recurrent_kda(
+        *inputs[:5], a_log=inputs[5], dt_bias=inputs[6], lower_bound=-5.0, scale=0.5
+    )
+    (output.square().mean() + final_state.square().mean()).backward()
+
+    for tensor in inputs:
+        assert tensor.grad is not None
+        assert torch.isfinite(tensor.grad).all()
+
+
+@pytest.mark.parametrize("backend", ["auto", "torch", "fla"])
+def test_kda_rejects_invalid_parameter_shapes_before_backend_dispatch(backend):
+    kda, _torch_recurrent_kda = _kda_ops()
+    q, k, v, gate, beta, a_log, dt_bias = _inputs()
+
+    with pytest.raises(ValueError, match="dt_bias"):
+        kda(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            a_log=a_log,
+            dt_bias=dt_bias[:, :-1],
+            lower_bound=-5.0,
+            backend=backend,
+        )
+
+
+def test_kda_rejects_unsafe_gate_bound():
+    kda, _torch_recurrent_kda = _kda_ops()
+    q, k, v, gate, beta, a_log, dt_bias = _inputs()
+
+    with pytest.raises(ValueError, match="lower_bound"):
+        kda(q, k, v, gate, beta, a_log=a_log, dt_bias=dt_bias, lower_bound=0.0)
+
+
+def test_kda_fla_backend_uses_trainable_chunk_contract(monkeypatch):
+    kda, _torch_recurrent_kda = _kda_ops()
+    q, k, v, gate, beta, a_log, dt_bias = _inputs()
+    calls = []
+    module = ModuleType("fla.ops.kda")
+
+    def chunk_kda(**kwargs):
+        calls.append(kwargs)
+        return kwargs["v"] + 1, None
+
+    module.chunk_kda = chunk_kda
+    monkeypatch.setitem(sys.modules, "fla", ModuleType("fla"))
+    monkeypatch.setitem(sys.modules, "fla.ops", ModuleType("fla.ops"))
+    monkeypatch.setitem(sys.modules, "fla.ops.kda", module)
+
+    output, final_state = kda(
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        a_log=a_log,
+        dt_bias=dt_bias,
+        lower_bound=-5.0,
+        output_final_state=False,
+        backend="fla",
+    )
+
+    torch.testing.assert_close(output, v + 1)
+    assert final_state is None
+    assert calls[0]["use_qk_l2norm_in_kernel"] is True
+    assert calls[0]["use_gate_in_kernel"] is True
+    assert calls[0]["use_beta_sigmoid_in_kernel"] is True
+    assert calls[0]["safe_gate"] is True
+    assert calls[0]["state_v_first"] is True


### PR DESCRIPTION
## Summary

- add a model-independent KDA operator with explicit tensor and gate contracts
- use a differentiable bounded PyTorch recurrence for tiny CPU correctness checks
- route the CUDA training path through FLA `chunk_kda` without calling the forward-only FlashKDA extension directly
- document the external-model usage contract and current packed/CP boundary

## Validation

- `7 passed` in the focused CPU KDA suite
- pinned `isort==5.13.2` and `black==24.4.2` hooks passed for both added Python files
- Ruff format/check and `git diff --check` passed

## Scope

This PR provides the shared primitive needed by external hybrid-model packages. It does not claim GPU execution evidence, FlashKDA-direct validation, context-parallel state transfer, or distributed Kimi K3 support.