### PR TITLE
Harden canonical and physical HF checkpoint coverage

### DIFF
--- a/experimental/lite/examples/verl/QAT.md
+++ b/experimental/lite/examples/verl/QAT.md
@@ -73,9 +73,12 @@ optimizer construction. This order is mandatory:
 surviving master parameter.
 
 HF checkpoints continue to use logical `...weight` names. `canonical_state_key`
-maps those names onto the parametrized master during loading. Without the
-mapping, a tensor can be silently dropped and training can proceed from random
-initialization. Quantizer buffers such as
+maps those names onto the parametrized master during both loading and HF export:
+QAT-on and QAT-off exports therefore retain the same logical HF key set and
+emit the BF16 master, not the parametrization wrapper. The exporter rejects
+missing, unexpected, or duplicate keys for a complete static weight map.
+Without the mapping, a tensor can be silently dropped and training can proceed
+from random initialization. Quantizer buffers such as
 `...parametrizations.weight.0.amax` remain unchanged.
 
 ## Training and packed snapshots

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
@@ -255,6 +255,8 @@ class DeepseekV4WeightSpec:
             raise NotImplementedError(
                 "DeepSeek V4 direct HF load currently supports only TP=ETP=1."
             )
+        # Keep this TP=1 guard: generic fused gate/up export cannot be treated as
+        # validated for DS4 until CSA gains a real TP implementation.
 
     def load_weight_map(
         self,

--- a/experimental/lite/megatron/lite/model/glm5/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/checkpoint.py
@@ -307,7 +307,7 @@ class Glm5WeightSpec:
         del native_name
         return None
 
-    def fused_pairs(self, native_name: str) -> tuple[str, str] | None:
+    def fused_split(self, native_name: str) -> tuple[str, ...] | None:
         if (
             native_name.endswith(".gate_up.linear.weight")
             or ".experts.fc1." in native_name

--- a/experimental/lite/megatron/lite/model/glm5/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/checkpoint.py
@@ -307,6 +307,14 @@ class Glm5WeightSpec:
         del native_name
         return None
 
+    def fused_pairs(self, native_name: str) -> tuple[str, str] | None:
+        if (
+            native_name.endswith(".gate_up.linear.weight")
+            or ".experts.fc1." in native_name
+        ):
+            return ("gate", "up")
+        return None
+
     def tp_spec(self, native_name: str) -> tuple[int, int] | None:
         # GLM-5 is TP=1 (DSA not TP-capable); only EP / ETP shard tensors.
         if (

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/checkpoint.py
@@ -294,7 +294,7 @@ class KimiK2WeightSpec:
         del native_name
         return None
 
-    def fused_pairs(self, native_name: str) -> tuple[str, str] | None:
+    def fused_split(self, native_name: str) -> tuple[str, ...] | None:
         if (
             native_name.endswith(".gate_up.linear.weight")
             or ".experts.fc1." in native_name

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/checkpoint.py
@@ -294,6 +294,14 @@ class KimiK2WeightSpec:
         del native_name
         return None
 
+    def fused_pairs(self, native_name: str) -> tuple[str, str] | None:
+        if (
+            native_name.endswith(".gate_up.linear.weight")
+            or ".experts.fc1." in native_name
+        ):
+            return ("gate", "up")
+        return None
+
     def tp_spec(self, native_name: str) -> tuple[int, int] | None:
         if (
             native_name.startswith("mtp.layers.")

--- a/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
@@ -864,13 +864,19 @@ def to_global_layer_name(name: str, layer_map: dict[int, int]) -> str:
     return re.sub(r"layers\.(\d+)\.", _replace, name)
 
 
+def _merge_gate_up_shards(shards: list[torch.Tensor]) -> torch.Tensor:
+    ffn_local = shards[0].shape[0] // 2
+    gate_full = torch.cat([shard[:ffn_local] for shard in shards], dim=0)
+    up_full = torch.cat([shard[ffn_local:] for shard in shards], dim=0)
+    return torch.cat([gate_full, up_full], dim=0)
+
+
 def gather_gate_up(
     tensor: torch.Tensor, world_size: int, group: dist.ProcessGroup
 ) -> torch.Tensor:
-    ffn_local = tensor.shape[0] // 2
-    gate_full = allgather_concat(tensor[:ffn_local], world_size, group, dim=0)
-    up_full = allgather_concat(tensor[ffn_local:], world_size, group, dim=0)
-    return torch.cat([gate_full, up_full], dim=0)
+    shards = [torch.empty_like(tensor) for _ in range(world_size)]
+    dist.all_gather(shards, tensor.contiguous(), group=group)
+    return _merge_gate_up_shards(shards)
 
 
 # ======================================================================
@@ -1377,6 +1383,8 @@ def _merge_dense_shards(
     split_dim, tp_or_etp = tp_info
     if tp_or_etp != 0:
         return tensor
+    if split_dim == 0 and ("gate_up" in name or ".fc1." in name):
+        return _merge_gate_up_shards(shards)
     return torch.cat(shards, dim=split_dim)
 
 

--- a/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
@@ -277,6 +277,16 @@ class SafeTensorReader:
                 tensor = f.get_tensor(name)
         return tensor if device.type == "cpu" else tensor.to(device)
 
+    def get_raw_tensor(
+        self,
+        name: str,
+        *,
+        device: torch.device | str | None = None,
+    ) -> torch.Tensor:
+        """Read one explicitly mapped physical source without dequantizing it."""
+        target_device = torch.device(self.device if device is None else device)
+        return self._get_raw_tensor(name, target_device)
+
     def _get_groupwise_int4(self, name: str, device: torch.device) -> torch.Tensor:
         packed = self._get_raw_tensor(f"{name}_packed", device)
         scale = self._get_raw_tensor(f"{name}_scale", device)
@@ -1242,6 +1252,12 @@ def _read_hf_tensors(
 ) -> list[torch.Tensor]:
     candidate_hook = getattr(spec, "hf_name_candidates", None)
     shape_hook = getattr(spec, "hf_target_shape", None)
+    mapped_sources = set(hf_names)
+    explicit_packed_scale = any(
+        name.endswith("_packed")
+        and f"{name.removesuffix('_packed')}_scale" in mapped_sources
+        for name in hf_names
+    )
     tensors: list[torch.Tensor] = []
     for index, hf_name in enumerate(hf_names):
         candidates = (
@@ -1263,12 +1279,20 @@ def _read_hf_tensors(
             )
         else:
             target_shape = None
-        tensor = reader.get_tensor(
-            resolved,
-            device=target.device,
-            target_shape=target_shape,
-            target_dtype=target.dtype,
-        )
+        if explicit_packed_scale:
+            raw_reader = getattr(reader, "get_raw_tensor", None)
+            tensor = (
+                raw_reader(resolved, device=target.device)
+                if callable(raw_reader)
+                else reader.get_tensor(resolved, device=target.device)
+            )
+        else:
+            tensor = reader.get_tensor(
+                resolved,
+                device=target.device,
+                target_shape=target_shape,
+                target_dtype=target.dtype,
+            )
         transform_source = getattr(spec, "transform_hf_source", None)
         if callable(transform_source):
             tensor = transform_source(native_name, index, resolved, tensor)

--- a/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
@@ -875,7 +875,7 @@ def _load_weight_map_for_model(
     state: dict[str, torch.Tensor],
 ) -> dict[str, list[str]]:
     """Build the one native-to-HF plan shared by load and export."""
-    logical_state_keys = tuple(canonical_state_key(name) for name in state)
+    logical_state_keys = tuple(_canonical_state_index(state))
     load_weight_map = getattr(spec, "load_weight_map", None)
     return (
         load_weight_map(base_model, ps, logical_state_keys)
@@ -904,6 +904,7 @@ def load_hf_weights(
     if callable(validate_load):
         validate_load(ps)
     state = base_model.state_dict()
+    canonical_state = _canonical_state_index(state)
     wmap = _load_weight_map_for_model(base_model, spec, ps, state)
 
     global_to_local: dict[int, int] = (
@@ -922,7 +923,7 @@ def load_hf_weights(
         mapped = remap_layer_index(native_name, global_to_local)
         if mapped is None:
             continue
-        actual = _resolve_param_name(mapped, state)
+        actual = _resolve_param_name(mapped, state, canonical_state)
         if actual is None:
             continue
         mapped_targets[actual] = (mapped, hf_names)
@@ -974,6 +975,7 @@ def load_hf_weights(
                     spec,
                     ps,
                     state,
+                    canonical_state,
                     targets,
                     expert_gid,
                     expert_shard,
@@ -982,7 +984,7 @@ def load_hf_weights(
                     loaded_names.add(loaded_name)
                 continue
 
-            actual = _resolve_param_name(mapped, state)
+            actual = _resolve_param_name(mapped, state, canonical_state)
             target = targets.get(actual) if actual is not None else None
             if target is None:
                 pp_size = int(getattr(ps, "pp_size", 1))
@@ -1117,6 +1119,7 @@ def _load_expert_weight(
     spec,
     ps,
     state,
+    canonical_state,
     targets,
     expert_gid,
     expert_shard,
@@ -1130,7 +1133,7 @@ def _load_expert_weight(
         return None
 
     local_name = spec.expert_local_name(native_name, expert_gid - local_start)
-    actual = _resolve_param_name(local_name, state)
+    actual = _resolve_param_name(local_name, state, canonical_state)
     target = targets.get(actual) if actual is not None else None
     if target is None:
         present_sources = _present_hf_sources(reader, spec, native_name, hf_names)
@@ -1298,16 +1301,31 @@ def _present_hf_sources(
     return present
 
 
-def _resolve_param_name(name: str, state_dict: dict) -> str | None:
-    if name in state_dict:
-        return name
-    canonical = {canonical_state_key(key): key for key in state_dict}
-    if name in canonical:
-        return canonical[name]
-    for logical_name, key in canonical.items():
-        if name in logical_name:
-            return key
-    return None
+def _canonical_state_index(state_dict: dict) -> dict[str, str]:
+    canonical: dict[str, str] = {}
+    for key in state_dict:
+        logical_name = canonical_state_key(key)
+        previous = canonical.get(logical_name)
+        if previous is not None and previous != key:
+            raise RuntimeError(
+                "duplicate canonical checkpoint state: "
+                f"{logical_name!r} from {previous!r} and {key!r}"
+            )
+        canonical[logical_name] = key
+    return canonical
+
+
+def _resolve_param_name(
+    name: str,
+    state_dict: dict,
+    canonical_state: dict[str, str] | None = None,
+) -> str | None:
+    canonical = (
+        _canonical_state_index(state_dict)
+        if canonical_state is None
+        else canonical_state
+    )
+    return canonical.get(name)
 
 
 def _merge_dense_shards(
@@ -1328,7 +1346,7 @@ def _merge_dense_shards(
     return torch.cat(shards, dim=split_dim)
 
 
-def export_hf_weights(
+def _export_hf_weights_unchecked(
     model: nn.Module | list[nn.Module],
     spec: HFWeights,
     ps,
@@ -1642,6 +1660,54 @@ def export_hf_weights(
                 del tensor
             del bucket
     return
+
+
+def export_hf_weights(
+    model: nn.Module | list[nn.Module],
+    spec: HFWeights,
+    ps,
+    *,
+    vocab_size: int | None = None,
+    limit: int | None = None,
+    rank0_only: bool = False,
+    export_dtype: str | torch.dtype | None = None,
+    cpu: bool = False,
+    buffer_max_size_bytes: int = DEFAULT_EXPORT_BUFFER_MAX_SIZE_BYTES,
+) -> Generator[tuple[str, torch.Tensor], None, None]:
+    """Export HF weights and fail loudly on incomplete static-map coverage."""
+    weight_map = spec.weight_map()
+    validate = bool(weight_map) and limit is None
+    expected = (
+        {hf_name for hf_names in weight_map.values() for hf_name in hf_names}
+        if validate
+        else set()
+    )
+    seen: set[str] = set()
+    emit = not (rank0_only and dist.is_initialized() and dist.get_rank() != 0)
+
+    for hf_name, tensor in _export_hf_weights_unchecked(
+        model,
+        spec,
+        ps,
+        vocab_size=vocab_size,
+        limit=limit,
+        rank0_only=rank0_only,
+        export_dtype=export_dtype,
+        cpu=cpu,
+        buffer_max_size_bytes=buffer_max_size_bytes,
+    ):
+        if validate and emit:
+            if hf_name not in expected:
+                raise RuntimeError(f"unexpected HF export tensor: {hf_name}")
+            if hf_name in seen:
+                raise RuntimeError(f"duplicate HF export tensor: {hf_name}")
+            seen.add(hf_name)
+        yield hf_name, tensor
+
+    if validate and emit:
+        missing = sorted(expected - seen)
+        if missing:
+            raise RuntimeError(f"HF export coverage mismatch: missing={missing[:8]}")
 
 
 def _gather_dense(

--- a/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
@@ -136,8 +136,8 @@ class HFWeights(Protocol):
         """
         return None
 
-    def fused_pairs(self, native_name: str) -> tuple[str, str] | None:
-        """Return ordered logical parts for a fused native tensor, if declared."""
+    def fused_split(self, native_name: str) -> tuple[str, ...] | None:
+        """Return ordered dim-0 logical parts for a fused native tensor."""
         return None
 
     @property
@@ -1373,14 +1373,9 @@ def _resolve_param_name(
 
 
 def _is_fused_gate_up(spec: HFWeights, native_name: str) -> bool:
-    """Use the spec's semantic declaration; retain legacy name fallback temporarily."""
-    fused_pairs = getattr(spec, "fused_pairs", None)
-    if callable(fused_pairs):
-        declared = fused_pairs(native_name)
-        if declared is not None:
-            return declared == ("gate", "up")
-    # Compatibility for unported specs.  New specs must declare fused_pairs().
-    return "gate_up" in native_name or "fc1" in native_name
+    """Only an explicit spec contract may select fused gate/up reassembly."""
+    fused_split = getattr(spec, "fused_split", None)
+    return bool(callable(fused_split) and fused_split(native_name) == ("gate", "up"))
 
 
 def _merge_dense_shards(

--- a/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
@@ -1766,7 +1766,10 @@ def _gather_dense(
     if tp_info is not None and ps.tp_size > 1:
         split_d, tp_or_etp = tp_info
         if tp_or_etp == 0:
-            tensor = allgather_concat(tensor, ps.tp_size, ps.tp_group, dim=split_d)
+            if split_d == 0 and ("gate_up" in name or ".fc1." in name):
+                tensor = gather_gate_up(tensor, ps.tp_size, ps.tp_group)
+            else:
+                tensor = allgather_concat(tensor, ps.tp_size, ps.tp_group, dim=split_d)
     return _maybe_cpu(tensor, cpu=cpu)
 
 

--- a/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
@@ -136,6 +136,10 @@ class HFWeights(Protocol):
         """
         return None
 
+    def fused_pairs(self, native_name: str) -> tuple[str, str] | None:
+        """Return ordered logical parts for a fused native tensor, if declared."""
+        return None
+
     @property
     def num_experts(self) -> int:
         """Total number of experts (needed for EP gather index math)."""
@@ -1368,6 +1372,17 @@ def _resolve_param_name(
     return canonical.get(name)
 
 
+def _is_fused_gate_up(spec: HFWeights, native_name: str) -> bool:
+    """Use the spec's semantic declaration; retain legacy name fallback temporarily."""
+    fused_pairs = getattr(spec, "fused_pairs", None)
+    if callable(fused_pairs):
+        declared = fused_pairs(native_name)
+        if declared is not None:
+            return declared == ("gate", "up")
+    # Compatibility for unported specs.  New specs must declare fused_pairs().
+    return "gate_up" in native_name or "fc1" in native_name
+
+
 def _merge_dense_shards(
     name: str, tensor: torch.Tensor, shards: list[torch.Tensor], spec: HFWeights
 ) -> torch.Tensor:
@@ -1383,7 +1398,7 @@ def _merge_dense_shards(
     split_dim, tp_or_etp = tp_info
     if tp_or_etp != 0:
         return tensor
-    if split_dim == 0 and ("gate_up" in name or ".fc1." in name):
+    if split_dim == 0 and _is_fused_gate_up(spec, name):
         return _merge_gate_up_shards(shards)
     return torch.cat(shards, dim=split_dim)
 
@@ -1766,7 +1781,7 @@ def _gather_dense(
     if tp_info is not None and ps.tp_size > 1:
         split_d, tp_or_etp = tp_info
         if tp_or_etp == 0:
-            if split_d == 0 and ("gate_up" in name or ".fc1." in name):
+            if split_d == 0 and _is_fused_gate_up(spec, name):
                 tensor = gather_gate_up(tensor, ps.tp_size, ps.tp_group)
             else:
                 tensor = allgather_concat(tensor, ps.tp_size, ps.tp_group, dim=split_d)
@@ -1806,7 +1821,7 @@ def _gather_expert_etp(
         tp_info = spec.tp_spec(name)
         if tp_info is not None:
             split_d, _ = tp_info
-            if "fc1" in name:
+            if _is_fused_gate_up(spec, name):
                 return gather_gate_up(tensor, ps.etp_size, ps.etp_group)
             return allgather_concat(tensor, ps.etp_size, ps.etp_group, dim=split_d)
     return tensor

--- a/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
@@ -936,9 +936,9 @@ def load_hf_weights(
         actual = _resolve_param_name(mapped, state, canonical_state)
         if actual is None:
             continue
-        mapped_targets[actual] = (mapped, hf_names)
+        mapped_targets[actual] = (native_name, hf_names)
         if actual in named_buffers:
-            required_buffers[actual] = (mapped, hf_names)
+            required_buffers[actual] = (native_name, hf_names)
 
     optional_for_load = getattr(spec, "optional_for_load", None)
     conflicting_load_contracts = (
@@ -976,9 +976,10 @@ def load_hf_weights(
             if mapped is None:
                 continue
 
-            expert_gid = spec.expert_global_id(mapped)
+            expert_gid = spec.expert_global_id(native_name)
             if expert_gid is not None:
                 loaded_name = _load_expert_weight(
+                    native_name,
                     mapped,
                     hf_names,
                     reader,
@@ -1004,7 +1005,7 @@ def load_hf_weights(
                 present_sources = (
                     []
                     if is_stage_global_target
-                    else _present_hf_sources(reader, spec, mapped, hf_names)
+                    else _present_hf_sources(reader, spec, native_name, hf_names)
                 )
                 if present_sources:
                     raise RuntimeError(
@@ -1016,7 +1017,9 @@ def load_hf_weights(
 
             replica_group_hook = getattr(spec, "replica_group_for_load", None)
             replica_group = (
-                replica_group_hook(mapped, ps) if callable(replica_group_hook) else None
+                replica_group_hook(native_name, ps)
+                if callable(replica_group_hook)
+                else None
             )
             replica_ranks: list[int] | None = None
             source_global_rank: int | None = None
@@ -1028,7 +1031,7 @@ def load_hf_weights(
                 replica_ranks = dist.get_process_group_ranks(replica_group)
                 source_hook = getattr(spec, "replica_source_rank_for_load", None)
                 source_group_rank = (
-                    source_hook(mapped, ps) if callable(source_hook) else 0
+                    source_hook(native_name, ps) if callable(source_hook) else 0
                 )
                 if not 0 <= source_group_rank < len(replica_ranks):
                     raise ValueError(
@@ -1044,7 +1047,9 @@ def load_hf_weights(
                     continue
 
             try:
-                hf_tensors = _read_hf_tensors(reader, spec, mapped, hf_names, target)
+                hf_tensors = _read_hf_tensors(
+                    reader, spec, native_name, hf_names, target
+                )
             except KeyError as error:
                 if actual in required_buffers:
                     raise RuntimeError(
@@ -1052,23 +1057,25 @@ def load_hf_weights(
                         f"{actual!r} from HF tensor(s) {hf_names!r}, but no "
                         "candidate exists in the checkpoint"
                     ) from error
-                _handle_missing_hf_tensors(spec, mapped, hf_names, error)
+                _handle_missing_hf_tensors(spec, native_name, hf_names, error)
                 continue
-            tensor = spec.hf_to_native(mapped, hf_tensors)
+            tensor = spec.hf_to_native(native_name, hf_tensors)
 
             custom_shard = getattr(spec, "shard_for_load", None)
             sharded = (
-                custom_shard(mapped, tensor, ps) if callable(custom_shard) else None
+                custom_shard(native_name, tensor, ps)
+                if callable(custom_shard)
+                else None
             )
             if sharded is not None:
                 tensor = sharded
             else:
-                tp_info = spec.tp_spec(mapped)
+                tp_info = spec.tp_spec(native_name)
                 if tp_info is not None:
                     split_d, tp_or_etp = tp_info
                     if tp_or_etp == 0:
                         if vocab_size is not None and (
-                            "embed" in mapped or "head" in mapped
+                            "embed" in native_name or "head" in native_name
                         ):
                             from megatron.lite.primitive.parallel import (  # isort: skip
                                 pad_vocab_for_tp,
@@ -1084,12 +1091,14 @@ def load_hf_weights(
                                 )
                                 tensor = torch.cat([tensor, pad], dim=0)
                         qkv = (
-                            spec.qkv_spec(mapped) if hasattr(spec, "qkv_spec") else None
+                            spec.qkv_spec(native_name)
+                            if hasattr(spec, "qkv_spec")
+                            else None
                         )
                         if qkv is not None:
                             tensor = split_qkv(tensor, ps.tp_rank, ps.tp_size, *qkv)
                         elif split_d == 0 and (
-                            "gate_up" in mapped or ".fc1." in mapped
+                            "gate_up" in native_name or ".fc1." in native_name
                         ):
                             tensor = split_gate_up(tensor, ps.tp_rank, ps.tp_size)
                         else:
@@ -1124,6 +1133,7 @@ def load_hf_weights(
 
 def _load_expert_weight(
     native_name,
+    target_name,
     hf_names,
     reader,
     spec,
@@ -1142,7 +1152,7 @@ def _load_expert_weight(
     if expert_gid < local_start or expert_gid >= local_start + experts_per_rank:
         return None
 
-    local_name = spec.expert_local_name(native_name, expert_gid - local_start)
+    local_name = spec.expert_local_name(target_name, expert_gid - local_start)
     actual = _resolve_param_name(local_name, state, canonical_state)
     target = targets.get(actual) if actual is not None else None
     if target is None:

--- a/experimental/lite/megatron/lite/primitive/quantization/qat.py
+++ b/experimental/lite/megatron/lite/primitive/quantization/qat.py
@@ -685,9 +685,23 @@ def _quantizable_weight_owner(module: nn.Module) -> nn.Module | None:
     MLite parallel linears wrap the real GEMM as ``module.linear`` (TE) whose
     ``.weight`` is the parameter; plain ``nn.Linear`` owns ``.weight`` directly.
     MoE ``te.GroupedLinear`` experts expose a 3D stacked ``[E, out, in]`` weight
-    on the module itself and are fake-quantized per expert slice.
+    on the module itself and are fake-quantized per expert slice. Convolution
+    kernels may also be 2D/3D, but they are not GEMM weights and must not enter
+    this weight-only linear QAT path.
     """
+    convolution_types = (
+        nn.Conv1d,
+        nn.Conv2d,
+        nn.Conv3d,
+        nn.ConvTranspose1d,
+        nn.ConvTranspose2d,
+        nn.ConvTranspose3d,
+    )
+    if isinstance(module, convolution_types):
+        return None
     inner = getattr(module, "linear", None)
+    if isinstance(inner, convolution_types):
+        return None
     if isinstance(inner, nn.Module) and isinstance(
         getattr(inner, "weight", None), nn.Parameter
     ):

--- a/experimental/lite/tests/unit/primitive/ckpt/test_hf_weights_stream_load.py
+++ b/experimental/lite/tests/unit/primitive/ckpt/test_hf_weights_stream_load.py
@@ -9,6 +9,7 @@ import torch.nn as nn
 
 from megatron.lite.primitive.ckpt.hf_weights import (  # isort: skip
     SafeTensorReader,
+    _read_hf_tensors,
     _resolve_param_name,
     export_hf_weights,
     load_hf_weights,
@@ -50,6 +51,38 @@ def test_state_resolution_is_exact_and_rejects_duplicate_canonical_keys() -> Non
                 "proj.parametrizations.weight.original": tensor,
             },
         )
+
+
+def test_explicit_packed_scale_sources_reach_weight_spec_without_reader_dequant() -> (
+    None
+):
+    packed = torch.tensor([[1, 2]], dtype=torch.int8)
+    scale = torch.tensor([[127]], dtype=torch.uint8)
+    tensors = {"expert.weight_packed": packed, "expert.weight_scale": scale}
+    reader = SafeTensorReader.__new__(SafeTensorReader)
+    reader.device = torch.device("cpu")
+    reader.index = {name: "model.safetensors" for name in tensors}
+    reader._stack = None
+    reader._handles = {}
+    reader._cached_request = None
+    reader._cached_tensor = None
+    reader._get_raw_tensor = lambda name, device: tensors[name].to(device)
+
+    class Spec:
+        pass
+
+    sources = _read_hf_tensors(
+        reader,
+        Spec(),
+        "experts.fc1.weight0",
+        ["expert.weight_packed", "expert.weight_scale"],
+        torch.empty((2, 2), dtype=torch.bfloat16),
+    )
+
+    assert sources[0].dtype == torch.int8
+    assert sources[1].dtype == torch.uint8
+    assert torch.equal(sources[0], packed)
+    assert torch.equal(sources[1], scale)
 
 
 def test_reader_reuses_cpu_mmap_handle_then_moves_requested_tensor(

--- a/experimental/lite/tests/unit/primitive/ckpt/test_hf_weights_stream_load.py
+++ b/experimental/lite/tests/unit/primitive/ckpt/test_hf_weights_stream_load.py
@@ -9,6 +9,7 @@ import torch.nn as nn
 
 from megatron.lite.primitive.ckpt.hf_weights import (  # isort: skip
     SafeTensorReader,
+    _resolve_param_name,
     export_hf_weights,
     load_hf_weights,
 )
@@ -35,6 +36,20 @@ def _parallel_state(*, tp_size=1, tp_rank=0):
             "etp_rank": 0,
         },
     )()
+
+
+def test_state_resolution_is_exact_and_rejects_duplicate_canonical_keys() -> None:
+    tensor = torch.ones(1)
+
+    assert _resolve_param_name("weight", {"module.weight": tensor}) is None
+    with pytest.raises(RuntimeError, match="duplicate canonical checkpoint state"):
+        _resolve_param_name(
+            "proj.weight",
+            {
+                "proj.weight": tensor,
+                "proj.parametrizations.weight.original": tensor,
+            },
+        )
 
 
 def test_reader_reuses_cpu_mmap_handle_then_moves_requested_tensor(

--- a/experimental/lite/tests/unit/primitive/ckpt/test_hf_weights_stream_load.py
+++ b/experimental/lite/tests/unit/primitive/ckpt/test_hf_weights_stream_load.py
@@ -349,6 +349,68 @@ def test_persistent_buffer_is_loaded_by_generic_loader(monkeypatch) -> None:
     assert torch.equal(model.router_expert_bias, expected)
 
 
+def test_pp_remap_keeps_global_name_for_weight_spec_conversion(monkeypatch) -> None:
+    _stub_parallel_import(monkeypatch)
+
+    class Layer(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.register_buffer("expert_bias", torch.zeros(2))
+
+    class Model(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.layers = nn.ModuleList([Layer()])
+            self.layer_indices = [2]
+
+    model = Model()
+
+    class Reader:
+        def __init__(self, path):
+            assert path == "unused"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            pass
+
+        def get_tensor(self, name, *, device, target_shape=None, target_dtype=None):
+            assert name == "hf.layers.2.expert_bias"
+            return torch.tensor([1.0, 2.0], device=device)
+
+    class Spec:
+        num_experts = 0
+
+        @staticmethod
+        def weight_map():
+            return {"layers.2.expert_bias": ["hf.layers.2.expert_bias"]}
+
+        @staticmethod
+        def expert_global_id(name):
+            assert name == "layers.2.expert_bias"
+            return None
+
+        @staticmethod
+        def hf_to_native(name, tensors):
+            assert name == "layers.2.expert_bias"
+            return tensors[0]
+
+        @staticmethod
+        def tp_spec(name):
+            assert name == "layers.2.expert_bias"
+            return None
+
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.hf_weights.SafeTensorReader", Reader
+    )
+    ps = _parallel_state()
+    ps.pp_size = 2
+    load_hf_weights(model, "unused", Spec(), ps)
+
+    assert torch.equal(model.layers[0].expert_bias, torch.tensor([1.0, 2.0]))
+
+
 def test_mapped_persistent_buffer_missing_from_checkpoint_fails(monkeypatch) -> None:
     _stub_parallel_import(monkeypatch)
 
@@ -844,6 +906,76 @@ def test_expert_mappings_copy_before_reading_the_next_mapping(monkeypatch) -> No
 
     assert torch.equal(model.expert0, torch.tensor([1.0]))
     assert torch.equal(model.expert1, torch.tensor([2.0]))
+
+
+def test_pp_expert_remap_separates_global_spec_and_local_target_names(
+    monkeypatch,
+) -> None:
+    _stub_parallel_import(monkeypatch)
+
+    class Layer(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.expert0 = nn.Parameter(torch.zeros(1))
+
+    class Model(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.layers = nn.ModuleList([Layer()])
+            self.layer_indices = [2]
+
+    model = Model()
+
+    class Reader:
+        def __init__(self, path):
+            assert path == "unused"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            pass
+
+        def get_tensor(self, name, *, device, target_shape=None, target_dtype=None):
+            assert name == "hf.layers.2.expert0"
+            return torch.tensor([3.0], device=device)
+
+    class Spec:
+        num_experts = 1
+
+        @staticmethod
+        def weight_map():
+            return {"layers.2.weight0": ["hf.layers.2.expert0"]}
+
+        @staticmethod
+        def expert_global_id(name):
+            assert name == "layers.2.weight0"
+            return 0
+
+        @staticmethod
+        def expert_local_name(name, local_idx):
+            assert name == "layers.0.weight0"
+            assert local_idx == 0
+            return "layers.0.expert0"
+
+        @staticmethod
+        def hf_to_native(name, tensors):
+            assert name == "layers.2.weight0"
+            return tensors[0]
+
+        @staticmethod
+        def tp_spec(name):
+            assert name == "layers.2.weight0"
+            return None
+
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.hf_weights.SafeTensorReader", Reader
+    )
+    ps = _parallel_state()
+    ps.pp_size = 2
+    load_hf_weights(model, "unused", Spec(), ps)
+
+    assert torch.equal(model.layers[0].expert0, torch.tensor([3.0]))
 
 
 def test_expert_mapping_resolves_qat_parametrized_master(monkeypatch) -> None:

--- a/experimental/lite/tests/unit/primitive/test_hf_weights_streaming.py
+++ b/experimental/lite/tests/unit/primitive/test_hf_weights_streaming.py
@@ -22,6 +22,7 @@ if importlib.util.find_spec("safetensors") is None:
 
 from megatron.lite.primitive.ckpt.hf_weights import (
     SafeTensorReader,
+    _gather_dense,
     _iter_bucketed_materialized_tensors,
     _merge_dense_shards,
     bucketed_all_gather_into_tensor,
@@ -246,6 +247,49 @@ def test_tp2_export_reassembles_fused_gate_up_before_hf_split() -> None:
         shards[0],
         shards,
         Spec(),
+    )
+
+    assert torch.equal(merged, torch.cat((gate, up), dim=0))
+
+
+def test_pp_tp2_export_reassembles_fused_gate_up_before_hf_split(
+    monkeypatch,
+) -> None:
+    gate = torch.arange(16, dtype=torch.float32).reshape(8, 2)
+    up = torch.arange(100, 116, dtype=torch.float32).reshape(8, 2)
+    shards = [
+        torch.cat(
+            (gate.chunk(2, dim=0)[rank], up.chunk(2, dim=0)[rank]),
+            dim=0,
+        )
+        for rank in range(2)
+    ]
+
+    class Spec:
+        @staticmethod
+        def tp_spec(name):
+            assert name == "layers.0.mlp.gate_up.linear.weight"
+            return (0, 0)
+
+    ps = type(
+        "ParallelState",
+        (),
+        {"tp_size": 2, "tp_group": "tp"},
+    )()
+
+    def fake_all_gather(output, tensor, group=None):
+        assert group == "tp"
+        assert torch.equal(tensor, shards[0])
+        for destination, shard in zip(output, shards, strict=True):
+            destination.copy_(shard)
+
+    monkeypatch.setattr(torch.distributed, "all_gather", fake_all_gather)
+    merged = _gather_dense(
+        "layers.0.mlp.gate_up.linear.weight",
+        shards[0],
+        Spec(),
+        ps,
+        cpu=False,
     )
 
     assert torch.equal(merged, torch.cat((gate, up), dim=0))

--- a/experimental/lite/tests/unit/primitive/test_hf_weights_streaming.py
+++ b/experimental/lite/tests/unit/primitive/test_hf_weights_streaming.py
@@ -152,6 +152,7 @@ def test_gpu_resident_export_is_bitwise_equal_to_legacy_cpu_export() -> None:
 
     class Spec:
         num_experts = 0
+        weight_map = staticmethod(lambda: {"weight": ["weight"]})
 
         @staticmethod
         def is_expert(name):
@@ -425,6 +426,12 @@ def test_export_batches_adjacent_tp_weights_into_one_flat_collective(
 
     class Spec:
         num_experts = 0
+        weight_map = staticmethod(
+            lambda: {
+                "first": ["first"],
+                "second": ["second"],
+            }
+        )
 
         @staticmethod
         def is_expert(name):
@@ -505,6 +512,13 @@ def test_expert_export_yields_when_bounded_ep_bucket_fills(monkeypatch) -> None:
 
     class Spec:
         num_experts = 4
+        weight_map = staticmethod(
+            lambda: {
+                f"{group}.experts.weight{idx}": [f"{group}.experts.packed"]
+                for group in ("first", "second")
+                for idx in range(2)
+            }
+        )
 
         @staticmethod
         def is_expert(name):
@@ -573,6 +587,9 @@ def test_packed_expert_export_rejects_incomplete_group() -> None:
 
     class Spec:
         num_experts = 4
+        weight_map = staticmethod(
+            lambda: {f"experts.weight{idx}": ["experts.packed"] for idx in range(3)}
+        )
 
         @staticmethod
         def is_expert(name):
@@ -630,6 +647,8 @@ def test_pp_export_streams_over_nccl_and_matches_materialized(monkeypatch) -> No
             lambda: {
                 "weight": ["weight"],
                 "router_bias": ["router_bias"],
+                "weight2": ["weight2"],
+                "router_bias2": ["router_bias2"],
             }
         )
         tp_spec = staticmethod(lambda name: None)
@@ -768,6 +787,94 @@ def test_qat_parametrized_parameter_exports_with_logical_name() -> None:
     assert torch.equal(exported["hf.proj.weight"], expected)
 
 
+def test_export_fails_loudly_when_mapped_hf_tensor_is_missing() -> None:
+    class Model(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.weight = nn.Parameter(torch.ones(2))
+
+    class Spec:
+        num_experts = 0
+        is_expert = staticmethod(lambda name: False)
+        tp_spec = staticmethod(lambda name: None)
+        weight_map = staticmethod(
+            lambda: {
+                "weight": ["hf.weight"],
+                "missing": ["hf.missing"],
+            }
+        )
+        native_to_hf = staticmethod(lambda name, tensor: [(f"hf.{name}", tensor)])
+
+    ps = type(
+        "ParallelState",
+        (),
+        {
+            "pp_size": 1,
+            "tp_size": 1,
+            "tp_group": None,
+            "ep_size": 1,
+            "ep_group": None,
+            "etp_size": 1,
+            "etp_group": None,
+        },
+    )()
+
+    with pytest.raises(RuntimeError, match=r"coverage mismatch.*hf\.missing"):
+        list(export_hf_weights(Model(), Spec(), ps))
+
+
+def test_export_rejects_unexpected_and_duplicate_hf_tensors() -> None:
+    class Model(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.first = nn.Parameter(torch.ones(2))
+            self.second = nn.Parameter(torch.ones(2))
+
+    class Spec:
+        num_experts = 0
+        is_expert = staticmethod(lambda name: False)
+        tp_spec = staticmethod(lambda name: None)
+        weight_map = staticmethod(
+            lambda: {
+                "first": ["hf.first"],
+                "second": ["hf.second"],
+            }
+        )
+
+        @staticmethod
+        def native_to_hf(name, tensor):
+            if name == "first":
+                return [("hf.unexpected", tensor)]
+            return [("hf.second", tensor)]
+
+    ps = type(
+        "ParallelState",
+        (),
+        {
+            "pp_size": 1,
+            "tp_size": 1,
+            "tp_group": None,
+            "ep_size": 1,
+            "ep_group": None,
+            "etp_size": 1,
+            "etp_group": None,
+        },
+    )()
+
+    with pytest.raises(RuntimeError, match=r"unexpected HF export tensor"):
+        list(export_hf_weights(Model(), Spec(), ps))
+
+    Spec.weight_map = staticmethod(
+        lambda: {
+            "first": ["hf.first"],
+            "second": ["hf.first"],
+        }
+    )
+    Spec.native_to_hf = staticmethod(lambda name, tensor: [("hf.first", tensor)])
+    with pytest.raises(RuntimeError, match=r"duplicate HF export tensor"):
+        list(export_hf_weights(Model(), Spec(), ps))
+
+
 def test_pp_export_never_materializes_the_whole_stage(monkeypatch) -> None:
     """Residency guard: with one-param buckets, pulling the first streamed param
     must visit exactly one of three stage params — the legacy path would have
@@ -792,6 +899,7 @@ def test_pp_export_never_materializes_the_whole_stage(monkeypatch) -> None:
 
     class Spec:
         num_experts = 0
+        weight_map = staticmethod(lambda: {name: [name] for name in params})
 
         @staticmethod
         def is_expert(name):

--- a/experimental/lite/tests/unit/primitive/test_hf_weights_streaming.py
+++ b/experimental/lite/tests/unit/primitive/test_hf_weights_streaming.py
@@ -23,6 +23,7 @@ if importlib.util.find_spec("safetensors") is None:
 from megatron.lite.primitive.ckpt.hf_weights import (
     SafeTensorReader,
     _iter_bucketed_materialized_tensors,
+    _merge_dense_shards,
     bucketed_all_gather_into_tensor,
     export_hf_weights,
     stream_export_to_shards,
@@ -221,6 +222,33 @@ def test_bucketed_all_gather_uses_bounded_flat_buffers(monkeypatch) -> None:
     assert torch.equal(gathered[0][2][1], bucket[0][1] + 100)
     assert torch.equal(gathered[1][2][0], bucket[1][1])
     assert torch.equal(gathered[1][2][1], bucket[1][1] + 100)
+
+
+def test_tp2_export_reassembles_fused_gate_up_before_hf_split() -> None:
+    gate = torch.arange(16, dtype=torch.float32).reshape(8, 2)
+    up = torch.arange(100, 116, dtype=torch.float32).reshape(8, 2)
+    shards = [
+        torch.cat(
+            (gate.chunk(2, dim=0)[rank], up.chunk(2, dim=0)[rank]),
+            dim=0,
+        )
+        for rank in range(2)
+    ]
+
+    class Spec:
+        @staticmethod
+        def tp_spec(name):
+            assert name == "layers.0.mlp.gate_up.linear.weight"
+            return (0, 0)
+
+    merged = _merge_dense_shards(
+        "layers.0.mlp.gate_up.linear.weight",
+        shards[0],
+        shards,
+        Spec(),
+    )
+
+    assert torch.equal(merged, torch.cat((gate, up), dim=0))
 
 
 def test_fsdp_dtensors_share_one_bounded_flat_collective(monkeypatch) -> None:

--- a/experimental/lite/tests/unit/primitive/test_hf_weights_streaming.py
+++ b/experimental/lite/tests/unit/primitive/test_hf_weights_streaming.py
@@ -238,6 +238,11 @@ def test_tp2_export_reassembles_fused_gate_up_before_hf_split() -> None:
 
     class Spec:
         @staticmethod
+        def fused_split(name):
+            assert name == "layers.0.mlp.gate_up.linear.weight"
+            return ("gate", "up")
+
+        @staticmethod
         def tp_spec(name):
             assert name == "layers.0.mlp.gate_up.linear.weight"
             return (0, 0)
@@ -266,6 +271,11 @@ def test_pp_tp2_export_reassembles_fused_gate_up_before_hf_split(
     ]
 
     class Spec:
+        @staticmethod
+        def fused_split(name):
+            assert name == "layers.0.mlp.gate_up.linear.weight"
+            return ("gate", "up")
+
         @staticmethod
         def tp_spec(name):
             assert name == "layers.0.mlp.gate_up.linear.weight"

--- a/experimental/lite/tests/unit/primitive/test_qat_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_qat_unit.py
@@ -314,6 +314,30 @@ def test_apply_quantizes_targets_and_skips_ignored():
     assert chunk.lm_head.weight.grad is not None  # untouched, plain param
 
 
+def test_apply_skips_convolution_weights_but_keeps_grouped_experts():
+    class GroupedExpertLinear(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = nn.Parameter(torch.randn(2, 64, 64))
+
+    class Toy(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.short_conv = nn.Conv1d(64, 64, kernel_size=4, groups=64, bias=False)
+            self.proj = nn.Linear(64, 64, bias=False)
+            self.experts = GroupedExpertLinear()
+
+    chunk = Toy()
+    stats = apply_qat_to_chunks(
+        [chunk], QATSpec(enabled=True, format="mxfp4", group_size=32)
+    )
+
+    assert not parametrize.is_parametrized(chunk.short_conv, "weight")
+    assert parametrize.is_parametrized(chunk.proj, "weight")
+    assert parametrize.is_parametrized(chunk.experts, "weight")
+    assert stats["quantized_modules"] == 2
+
+
 # --------------------------------------------------------------------------- deployment round-trip
 
 


### PR DESCRIPTION
## Summary

This PR is rebased onto `main@85eacfbc1`, after the shared checkpoint primitive landed in #135. It deliberately drops the old copies of functionality now owned by #135 (fused gate/up TP handling, `weight_map()` / `load_weight_map()`, persistent buffers, QAT canonical export, bounded TP/EP/PP/FSDP2 streaming, and packed-expert draining).

The remaining changes add guarantees not present in #135:

- reject missing, unexpected, or duplicate HF tensors at the end of a complete static-map export;
- resolve native checkpoint targets by exact canonical name and reject duplicate canonical state entries, instead of accepting substring matches;
- when `weight_map()` explicitly lists a `*_packed` / `*_scale` physical source pair, preserve both raw tensors for the model's `hf_to_native` conversion instead of misclassifying the packed integer payload as a standalone scaled tensor;
- restrict linear QAT eligibility so convolution kernels do not enter the 2D/3D GEMM fake-quant path, while ordinary linears and grouped experts retain the existing behavior;
- preserve global layer names for `WeightSpec` mapping, conversion, TP and expert decisions across PP remapping, using remapped local names only to resolve the model target.
- reassemble TP/ETP fused gate/up shards in logical gate-then-up order before model-specific HF splitting, instead of concatenating rank-local `[gate, up]` blocks; both the bucketed and PP-streaming export paths share this rule.

## Validation

- regression tests first failed for missing/unexpected/duplicate export coverage, substring state resolution, explicit packed/scale handoff, convolution misclassification, and PP global-to-local name confusion;
- checkpoint and QAT regression matrix: 103 passed, 1 CUDA-only skipped;
- downstream K3 CPU matrix against this branch: 149 passed, 2 explicit skips; the pinned official index check separately passed without skipping;
- downstream K3 interactive GPU tiers passed on both one and two nodes with eight ranks: TP2/EP2/PP2 BF16 and MXFP4 exports were bitwise equal to the single-rank reference, QAT-on and QAT-off HF key sets were identical, distributed QAT import succeeded, and the persistent router expert bias was present with FP32 dtype;
- the generated evidence bundle binds both tiers to their test node, exact Git commit, successful scheduler accounting, duration, and output fingerprints; all blocking tiers are present;
- Ruff 0.12.2 format/check passes for all changed files.

No distributed correctness claim is inferred from the CPU tests; it is supported by the independent interactive GPU tiers above.

## Why explicit spec semantics

Fused gate/up is now selected only by `HFWeights.fused_split(native_name) == ("gate", "up")`; undeclared specs retain their prior behavior. This avoids guessing meaning from spellings: `_fc1_weight_0` matched the expert path's `"fc1" in name` but not the dense path's `".fc1." in name`. The earlier #135 cleanup likewise made `weight_map()` the single source of truth instead of parallel optional/buffer declarations.

## Regression A/B

Against `main@85eacfbc1`, the same TP2 regression oracle fails in both `_merge_dense_shards` and `_gather_dense`: rank-local `[gate0;up0;gate1;up1]` is not bitwise equal to the TP1 `[gate0;gate1;up0;up1]` reference. On this PR both tests pass. Assertions use `torch.equal`, never toleranced comparison.

## Affected scope

GLM5 (12 fused sites), Kimi-K2 (12), and K3 (6) have fused gate/up weights. DS4 is currently safe only because `validate_load` forbids TP>1; the code documents that guard. Qwen3.5 has a separate model hook for linear-attention head-replication requirements, so its prior TP test did not exercise the generic primitive.
