### PR TITLE
Add Hy3 support through shared HF weight loading

### DIFF
--- a/experimental/lite/README.md
+++ b/experimental/lite/README.md
@@ -18,7 +18,7 @@ This initial drop contains:
 
 - A lightweight runtime API in `megatron.lite.runtime`.
 - Common training primitives in `megatron.lite.primitive`.
-- Lite-only native model implementations for Qwen3 MoE and Qwen3.5 MoE.
+- Lite-only native model implementations for Qwen3 MoE, Qwen3.5 MoE, and Tencent Hy3.
 - Hugging Face safetensors load/export helpers for the included models.
 - Megatron-Core optimizer wrapping for the lite runtime.
 - FSDP2 optimizer primitives for supported lite model protocols.
@@ -98,6 +98,8 @@ Canonical model names currently registered by default:
 
 - `qwen3_moe`: Qwen3 MoE lite implementation. Use this name in new configs.
 - `qwen3_5`: Qwen3.5 MoE lite implementation.
+- `hy3`: Tencent Hy3 native lite implementation. HF `model_type=hy_v3`
+  resolves to this model name.
 
 Compatibility names:
 
@@ -129,6 +131,7 @@ bash experimental/lite/examples/bench/scripts/run_qwen35_correctness_pair.sh
 - [Architecture](docs/architecture.md)
 - [Runtime](docs/runtime.md)
 - [Models](docs/models.md)
+- [Hy3 Architecture Mapping](docs/hy3_architecture.md)
 - [Porting Notes](docs/porting.md)
 - [Skills](skills/README.md)
 - [Bench Example](examples/bench/README.md)

--- a/experimental/lite/docs/hy3_architecture.md
+++ b/experimental/lite/docs/hy3_architecture.md
@@ -1,0 +1,73 @@
+# Hy3 architecture and Megatron Lite mapping
+
+This document freezes the public `tencent/Hy3` architecture before the native
+Megatron Lite implementation is changed.  It follows the staged model-porting
+workflow used by the existing Qwen3 MoE implementation: establish an
+independent reference, map capabilities to reusable primitives, then implement
+weights and distributed validation.
+
+## Reference freeze
+
+| Input | Revision or digest |
+| --- | --- |
+| Hugging Face repository | `tencent/Hy3@716aa7241bd6d95896be4ebfc761162a9c4d49ef` |
+| `config.json` SHA-256 | `663036ceca3d8a178cd772739566c262caffdecebaed6c1d76b464d729bb2951` |
+| `model.safetensors.index.json` SHA-256 | `9594f1a9419e62ca7afca51bb644f38ef19039374f7812449381ccf42f0ef79b` |
+| Reference implementation | Transformers `hy_v3` (`transformers_version=5.6.0`) |
+
+Only the public configuration and weight index are needed for the structural
+contract.  The 598 GB checkpoint is deliberately not copied into the source
+tree.
+
+## Architecture manifest
+
+| Area | Hy3 contract |
+| --- | --- |
+| Decoder | 80 causal decoder layers plus one MTP layer; layer 0 is dense and layers 1-79 are sparse |
+| Hidden/normalization | hidden size 4096; RMSNorm epsilon `1e-5`; untied embedding and LM head |
+| Attention | GQA with 64 query heads, 8 KV heads and head dimension 128; bias-free projections; Q/K RMSNorm before RoPE |
+| Position | default RoPE, theta `11158840`, maximum sequence length 262144 |
+| Dense MLP | SwiGLU, intermediate size 13312, no bias |
+| Routed MoE | 192 experts, top-8, expert intermediate size 1536, SwiGLU |
+| Router | fp32 logits, sigmoid scores; add persistent `expert_bias` only for expert selection; gather un-biased sigmoid scores, normalize selected scores, then multiply by 2.826; no auxiliary loss in the Transformers reference |
+| Shared expert | one always-on, ungated SwiGLU MLP with intermediate size 1536; add to routed output (the released config disables fp32 combination) |
+| MTP | one layer at checkpoint layer index 80 with `enorm`, `hnorm`, `eh_proj`, a sparse decoder layer and `final_layernorm` |
+| Vocabulary | 120832 tokens; separate embedding and output head |
+
+The checkpoint index contains 47,138 tensors.  Sparse layers use
+`mlp.router.gate.weight`, `mlp.expert_bias`, `mlp.shared_mlp.*` and per-expert
+`gate_proj`/`up_proj`/`down_proj`; layer 0 instead has the three dense MLP
+weights.  The MTP layer has the same attention and sparse-MoE names plus its
+four MTP-specific tensors.
+
+## Primitive mapping
+
+| Hy3 capability | Megatron Lite implementation | Decision |
+| --- | --- | --- |
+| GQA, Q/K norm, RoPE, TP/CP/THD | `primitive.modules.GQAttention` | Reuse directly |
+| Routed expert compute | `primitive.modules.Experts` | Reuse directly |
+| EP/DeepEP dispatch and combine | `primitive.modules.TokenDispatcher` | Reuse directly |
+| Sigmoid top-k selection | `primitive.modules.SigmoidTopKRouter` | Extend its generic contract to persist checkpoint expert bias and accept Hy3 field names |
+| Dense/shared SwiGLU | `primitive.modules.SwiGLUMLP` | New generic primitive; no Hy3-specific behavior |
+| MTP mechanics | `primitive.modules.MTPBlock` and `MTPDecoderLayer` | Reuse directly |
+| TP/SP/CP/EP/PP/VPP and THD | `primitive.parallel` and the Qwen3-MoE protocol shape | Reuse directly |
+| HF/DCP checkpoint machinery | `primitive.ckpt` | Reuse; Hy3 contributes only its WeightSpec |
+
+No MLA, GDN, DSA, attention sink, attention gate, or KV-mirror behavior is
+present in the released architecture.  Model code therefore only selects the
+dense/sparse layer type and composes the primitives above; it must not contain
+its own attention, router, dispatch, or parallel communication implementation.
+
+## Staged validation
+
+1. CPU/static: config invariants, registry resolution, exact router semantics,
+   layer-type selection, WeightSpec coverage, and synthetic HF/native/HF tensor
+   round-trip.
+2. Single GPU (Slurm): a tiny Transformers `HYV3ForCausalLM` reference versus
+   the native model, checking router choices, each layer output, logits, loss,
+   and gradients.
+3. Distributed (Slurm): TP2, EP2, CP2+THD, PP2 and a CP2xEP2 combination, with
+   explicit assertions that routed experts and the requested communication
+   paths did not fall back.
+4. Training/IO (Slurm): checkpoint load/export/reload, DCP resume, deterministic
+   optimizer steps, and a short loss-decreasing SFT run.

--- a/experimental/lite/docs/models.md
+++ b/experimental/lite/docs/models.md
@@ -33,6 +33,16 @@ and `qwen2_moe` currently resolve through this compatibility path.
 megatron.lite.model.qwen3_5.lite.protocol
 ```
 
+`hy3` maps Hugging Face `model_type=hy_v3` to the native Tencent Hy3 lite
+implementation:
+
+```text
+megatron.lite.model.hy3.lite.protocol
+```
+
+Its architecture and primitive decisions are frozen in
+[`hy3_architecture.md`](hy3_architecture.md).
+
 ## Acknowledgements
 
 The Qwen3 MoE LoRA adapter support follows Mind-Lab's PEFT/Mint-compatible

--- a/experimental/lite/megatron/lite/model/hy3/__init__.py
+++ b/experimental/lite/megatron/lite/model/hy3/__init__.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Tencent Hy3 model package."""
 
 from megatron.lite.model.hy3.config import Hy3Config

--- a/experimental/lite/megatron/lite/model/hy3/__init__.py
+++ b/experimental/lite/megatron/lite/model/hy3/__init__.py
@@ -1,0 +1,5 @@
+"""Tencent Hy3 model package."""
+
+from megatron.lite.model.hy3.config import Hy3Config
+
+__all__ = ["Hy3Config"]

--- a/experimental/lite/megatron/lite/model/hy3/config.py
+++ b/experimental/lite/megatron/lite/model/hy3/config.py
@@ -51,6 +51,11 @@ class Hy3Config:
     def shared_expert_intermediate_size(self) -> int:
         return self.moe_intermediate_size * self.num_shared_experts
 
+    @property
+    def n_routed_experts(self) -> int:
+        """Compatibility view consumed by the model-agnostic router primitive."""
+        return self.num_experts
+
     def _validate(self) -> None:
         errors: list[str] = []
 
@@ -65,19 +70,37 @@ class Hy3Config:
             "num_attention_heads must be divisible by num_key_value_heads",
         )
         check(self.head_dim > 0, "head_dim must be positive")
-        check(0 <= self.first_k_dense_replace <= self.num_hidden_layers, "first_k_dense_replace is out of range")
-        check(len(self.layer_types) == self.num_hidden_layers, "layer_types length must equal num_hidden_layers")
-        check(all(kind in {"dense", "sparse"} for kind in self.layer_types), "layer_types must contain dense or sparse")
+        check(
+            0 <= self.first_k_dense_replace <= self.num_hidden_layers,
+            "first_k_dense_replace is out of range",
+        )
+        check(
+            len(self.layer_types) == self.num_hidden_layers,
+            "layer_types length must equal num_hidden_layers",
+        )
+        check(
+            all(kind in {"dense", "sparse"} for kind in self.layer_types),
+            "layer_types must contain dense or sparse",
+        )
         check(self.num_experts > 0, "num_experts must be positive")
-        check(1 <= self.num_experts_per_tok <= self.num_experts, "num_experts_per_tok is out of range")
+        check(
+            1 <= self.num_experts_per_tok <= self.num_experts,
+            "num_experts_per_tok is out of range",
+        )
         check(self.num_shared_experts == 1, "num_shared_experts must be 1")
         check(self.hidden_act == "silu", "hidden_act must be silu")
         check(self.qk_norm, "qk_norm must be enabled")
         check(self.moe_router_use_sigmoid, "moe_router_use_sigmoid must be enabled")
-        check(self.moe_router_enable_expert_bias, "moe_router_enable_expert_bias must be enabled")
+        check(
+            self.moe_router_enable_expert_bias,
+            "moe_router_enable_expert_bias must be enabled",
+        )
         check(self.route_norm, "route_norm must be enabled")
         check(self.router_scaling_factor > 0, "router_scaling_factor must be positive")
-        check(self.num_nextn_predict_layers >= 0, "num_nextn_predict_layers must be non-negative")
+        check(
+            self.num_nextn_predict_layers >= 0,
+            "num_nextn_predict_layers must be non-negative",
+        )
         if errors:
             raise ValueError("Invalid Hy3Config:\n  " + "\n  ".join(errors))
 
@@ -87,13 +110,17 @@ class Hy3Config:
 
     @classmethod
     def from_hf_config(cls, hf_config, **overrides) -> "Hy3Config":
-        source = hf_config.to_dict() if hasattr(hf_config, "to_dict") else vars(hf_config)
+        source = (
+            hf_config.to_dict() if hasattr(hf_config, "to_dict") else vars(hf_config)
+        )
         return cls._from_hf_dict(source, **overrides)
 
     @classmethod
     def _from_hf_dict(cls, hf: dict[str, Any], **overrides) -> "Hy3Config":
         if hf.get("model_type", "hy_v3") != "hy_v3":
-            raise ValueError(f"model_type must be 'hy_v3', got {hf.get('model_type')!r}")
+            raise ValueError(
+                f"model_type must be 'hy_v3', got {hf.get('model_type')!r}"
+            )
         valid = {item.name for item in dc_fields(cls)}
         kwargs = {key: value for key, value in hf.items() if key in valid}
         rope = hf.get("rope_parameters")

--- a/experimental/lite/megatron/lite/model/hy3/config.py
+++ b/experimental/lite/megatron/lite/model/hy3/config.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Tencent Hy3 architecture configuration."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/model/hy3/config.py
+++ b/experimental/lite/megatron/lite/model/hy3/config.py
@@ -1,0 +1,107 @@
+"""Tencent Hy3 architecture configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, fields as dc_fields
+from typing import Any
+
+from megatron.lite.primitive.config import load_hf_config_dict
+
+
+@dataclass
+class Hy3Config:
+    num_hidden_layers: int = 80
+    hidden_size: int = 4096
+    num_attention_heads: int = 64
+    num_key_value_heads: int = 8
+    head_dim: int = 128
+    vocab_size: int = 120832
+    intermediate_size: int = 13312
+    moe_intermediate_size: int = 1536
+    num_experts: int = 192
+    num_experts_per_tok: int = 8
+    num_shared_experts: int = 1
+    first_k_dense_replace: int = 1
+    router_scaling_factor: float = 2.826
+    rms_norm_eps: float = 1e-5
+    rope_theta: float = 11_158_840.0
+    max_position_embeddings: int = 262144
+    hidden_act: str = "silu"
+    qk_norm: bool = True
+    moe_router_use_sigmoid: bool = True
+    moe_router_enable_expert_bias: bool = True
+    route_norm: bool = True
+    enable_moe_fp32_combine: bool = False
+    router_aux_loss_coef: float = 0.0
+    num_nextn_predict_layers: int = 1
+    mtp_loss_scaling_factor: float = 0.1
+    mtp_use_repeated_layer: bool = False
+    layer_types: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if not self.layer_types:
+            self.layer_types = [
+                "dense" if index < self.first_k_dense_replace else "sparse"
+                for index in range(self.num_hidden_layers)
+            ]
+        self._validate()
+
+    @property
+    def shared_expert_intermediate_size(self) -> int:
+        return self.moe_intermediate_size * self.num_shared_experts
+
+    def _validate(self) -> None:
+        errors: list[str] = []
+
+        def check(condition: bool, message: str) -> None:
+            if not condition:
+                errors.append(message)
+
+        check(self.hidden_size > 0, "hidden_size must be positive")
+        check(self.num_hidden_layers > 0, "num_hidden_layers must be positive")
+        check(
+            self.num_attention_heads % self.num_key_value_heads == 0,
+            "num_attention_heads must be divisible by num_key_value_heads",
+        )
+        check(self.head_dim > 0, "head_dim must be positive")
+        check(0 <= self.first_k_dense_replace <= self.num_hidden_layers, "first_k_dense_replace is out of range")
+        check(len(self.layer_types) == self.num_hidden_layers, "layer_types length must equal num_hidden_layers")
+        check(all(kind in {"dense", "sparse"} for kind in self.layer_types), "layer_types must contain dense or sparse")
+        check(self.num_experts > 0, "num_experts must be positive")
+        check(1 <= self.num_experts_per_tok <= self.num_experts, "num_experts_per_tok is out of range")
+        check(self.num_shared_experts == 1, "num_shared_experts must be 1")
+        check(self.hidden_act == "silu", "hidden_act must be silu")
+        check(self.qk_norm, "qk_norm must be enabled")
+        check(self.moe_router_use_sigmoid, "moe_router_use_sigmoid must be enabled")
+        check(self.moe_router_enable_expert_bias, "moe_router_enable_expert_bias must be enabled")
+        check(self.route_norm, "route_norm must be enabled")
+        check(self.router_scaling_factor > 0, "router_scaling_factor must be positive")
+        check(self.num_nextn_predict_layers >= 0, "num_nextn_predict_layers must be non-negative")
+        if errors:
+            raise ValueError("Invalid Hy3Config:\n  " + "\n  ".join(errors))
+
+    @classmethod
+    def from_hf(cls, path_or_name: str, **overrides) -> "Hy3Config":
+        return cls._from_hf_dict(load_hf_config_dict(path_or_name), **overrides)
+
+    @classmethod
+    def from_hf_config(cls, hf_config, **overrides) -> "Hy3Config":
+        source = hf_config.to_dict() if hasattr(hf_config, "to_dict") else vars(hf_config)
+        return cls._from_hf_dict(source, **overrides)
+
+    @classmethod
+    def _from_hf_dict(cls, hf: dict[str, Any], **overrides) -> "Hy3Config":
+        if hf.get("model_type", "hy_v3") != "hy_v3":
+            raise ValueError(f"model_type must be 'hy_v3', got {hf.get('model_type')!r}")
+        valid = {item.name for item in dc_fields(cls)}
+        kwargs = {key: value for key, value in hf.items() if key in valid}
+        rope = hf.get("rope_parameters")
+        if isinstance(rope, dict):
+            if rope.get("rope_type", "default") != "default":
+                raise ValueError("rope_parameters.rope_type must be default")
+            kwargs["rope_theta"] = float(rope.get("rope_theta", cls.rope_theta))
+        kwargs.update(overrides)
+        return cls(**kwargs)
+
+
+__all__ = ["Hy3Config"]

--- a/experimental/lite/megatron/lite/model/hy3/lite/__init__.py
+++ b/experimental/lite/megatron/lite/model/hy3/lite/__init__.py
@@ -1,0 +1,1 @@
+"""Native Megatron Lite implementation of Hy3."""

--- a/experimental/lite/megatron/lite/model/hy3/lite/__init__.py
+++ b/experimental/lite/megatron/lite/model/hy3/lite/__init__.py
@@ -1,1 +1,2 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Native Megatron Lite implementation of Hy3."""

--- a/experimental/lite/megatron/lite/model/hy3/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/hy3/lite/checkpoint.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import re
+
 import torch
 from torch.distributed.tensor import Replicate, Shard
 
@@ -30,7 +32,9 @@ class Hy3WeightSpec:
         attention = f"{hf_prefix}.self_attn"
         weight_map.update(
             {
-                f"{native_prefix}.attn.qkv.linear.layer_norm_weight": [f"{hf_prefix}.input_layernorm.weight"],
+                f"{native_prefix}.attn.qkv.linear.layer_norm_weight": [
+                    f"{hf_prefix}.input_layernorm.weight"
+                ],
                 f"{native_prefix}.attn.qkv.linear.weight": [
                     f"{attention}.q_proj.weight",
                     f"{attention}.k_proj.weight",
@@ -38,8 +42,12 @@ class Hy3WeightSpec:
                 ],
                 f"{native_prefix}.attn.q_norm.weight": [f"{attention}.q_norm.weight"],
                 f"{native_prefix}.attn.k_norm.weight": [f"{attention}.k_norm.weight"],
-                f"{native_prefix}.attn.proj.linear.weight": [f"{attention}.o_proj.weight"],
-                f"{native_prefix}.mlp_norm.weight": [f"{hf_prefix}.post_attention_layernorm.weight"],
+                f"{native_prefix}.attn.proj.linear.weight": [
+                    f"{attention}.o_proj.weight"
+                ],
+                f"{native_prefix}.mlp_norm.weight": [
+                    f"{hf_prefix}.post_attention_layernorm.weight"
+                ],
             }
         )
 
@@ -52,13 +60,17 @@ class Hy3WeightSpec:
         mlp = f"{hf_prefix}.mlp"
         weight_map.update(
             {
-                f"{native_prefix}.moe.router.gate.weight": [f"{mlp}.router.gate.weight"],
+                f"{native_prefix}.moe.router.gate.weight": [
+                    f"{mlp}.router.gate.weight"
+                ],
                 f"{native_prefix}.moe.router.expert_bias": [f"{mlp}.expert_bias"],
                 f"{native_prefix}.moe.shared_mlp.gate_up.linear.weight": [
                     f"{mlp}.shared_mlp.gate_proj.weight",
                     f"{mlp}.shared_mlp.up_proj.weight",
                 ],
-                f"{native_prefix}.moe.shared_mlp.down.linear.weight": [f"{mlp}.shared_mlp.down_proj.weight"],
+                f"{native_prefix}.moe.shared_mlp.down.linear.weight": [
+                    f"{mlp}.shared_mlp.down_proj.weight"
+                ],
             }
         )
         for expert in range(self.config.num_experts):
@@ -87,7 +99,9 @@ class Hy3WeightSpec:
                     f"{hf}.mlp.gate_proj.weight",
                     f"{hf}.mlp.up_proj.weight",
                 ]
-                result[f"{native}.mlp.down.linear.weight"] = [f"{hf}.mlp.down_proj.weight"]
+                result[f"{native}.mlp.down.linear.weight"] = [
+                    f"{hf}.mlp.down_proj.weight"
+                ]
             else:
                 self._add_sparse_mlp(result, native, hf)
         for mtp_index in range(config.num_nextn_predict_layers):
@@ -100,14 +114,18 @@ class Hy3WeightSpec:
                     f"{native}.enorm.weight": [f"{hf}.enorm.weight"],
                     f"{native}.hnorm.weight": [f"{hf}.hnorm.weight"],
                     f"{native}.eh_proj.linear.weight": [f"{hf}.eh_proj.weight"],
-                    f"{native}.final_layernorm.weight": [f"{hf}.final_layernorm.weight"],
+                    f"{native}.final_layernorm.weight": [
+                        f"{hf}.final_layernorm.weight"
+                    ],
                 }
             )
             self._add_attention(result, transformer, hf)
             self._add_sparse_mlp(result, transformer, hf)
         return result
 
-    def hf_to_native(self, native_name: str, tensors: list[torch.Tensor]) -> torch.Tensor:
+    def hf_to_native(
+        self, native_name: str, tensors: list[torch.Tensor]
+    ) -> torch.Tensor:
         if len(tensors) == 3:
             return pack_grouped_query_qkv(
                 *tensors,
@@ -119,7 +137,19 @@ class Hy3WeightSpec:
             return torch.cat(tensors, dim=0)
         return tensors[0]
 
-    def native_to_hf(self, native_name: str, tensor: torch.Tensor) -> list[tuple[str, torch.Tensor]]:
+    @staticmethod
+    def _canonical_expert_name(native_name: str) -> str:
+        """Restore GroupedLinear's local name to the shared weight-map key."""
+        return re.sub(
+            r"(\.moe\.experts)\.(fc[12])\.weight(\d+)$",
+            r"\1._\2_weight_\3",
+            native_name,
+        )
+
+    def native_to_hf(
+        self, native_name: str, tensor: torch.Tensor
+    ) -> list[tuple[str, torch.Tensor]]:
+        native_name = self._canonical_expert_name(native_name)
         if native_name == "mtp_embed.embedding.weight":
             return []
         targets = self.weight_map().get(native_name)
@@ -165,6 +195,7 @@ class Hy3WeightSpec:
         return ".experts." in native_name and ".router." not in native_name
 
     def expert_global_id(self, native_name: str) -> int | None:
+        native_name = self._canonical_expert_name(native_name)
         if "_fc1_weight_" in native_name or "_fc2_weight_" in native_name:
             return int(native_name.rsplit("_", 1)[1])
         return None
@@ -203,7 +234,9 @@ def load_hf_weights(model, path: str, config: Hy3Config, ps) -> None:
 def export_hf_weights(model, config: Hy3Config, ps, **kwargs):
     from megatron.lite.primitive.ckpt.hf_weights import export_hf_weights as export
 
-    yield from export(model, Hy3WeightSpec(config), ps, vocab_size=config.vocab_size, **kwargs)
+    yield from export(
+        model, Hy3WeightSpec(config), ps, vocab_size=config.vocab_size, **kwargs
+    )
 
 
 def save_hf_weights(model, path: str, config: Hy3Config, ps) -> None:

--- a/experimental/lite/megatron/lite/model/hy3/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/hy3/lite/checkpoint.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Hy3 HF/native checkpoint mapping."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/model/hy3/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/hy3/lite/checkpoint.py
@@ -1,0 +1,221 @@
+"""Hy3 HF/native checkpoint mapping."""
+
+from __future__ import annotations
+
+import torch
+from torch.distributed.tensor import Replicate, Shard
+
+from megatron.lite.model.hy3.config import Hy3Config
+from megatron.lite.primitive.checkpoint_transforms import (
+    pack_grouped_query_qkv,
+    unpack_grouped_query_qkv,
+)
+
+
+class Hy3WeightSpec:
+    def __init__(self, config: Hy3Config):
+        self.config = config
+
+    @property
+    def num_experts(self) -> int:
+        return self.config.num_experts
+
+    def _add_attention(
+        self,
+        weight_map: dict[str, list[str]],
+        native_prefix: str,
+        hf_prefix: str,
+    ) -> None:
+        attention = f"{hf_prefix}.self_attn"
+        weight_map.update(
+            {
+                f"{native_prefix}.attn.qkv.linear.layer_norm_weight": [f"{hf_prefix}.input_layernorm.weight"],
+                f"{native_prefix}.attn.qkv.linear.weight": [
+                    f"{attention}.q_proj.weight",
+                    f"{attention}.k_proj.weight",
+                    f"{attention}.v_proj.weight",
+                ],
+                f"{native_prefix}.attn.q_norm.weight": [f"{attention}.q_norm.weight"],
+                f"{native_prefix}.attn.k_norm.weight": [f"{attention}.k_norm.weight"],
+                f"{native_prefix}.attn.proj.linear.weight": [f"{attention}.o_proj.weight"],
+                f"{native_prefix}.mlp_norm.weight": [f"{hf_prefix}.post_attention_layernorm.weight"],
+            }
+        )
+
+    def _add_sparse_mlp(
+        self,
+        weight_map: dict[str, list[str]],
+        native_prefix: str,
+        hf_prefix: str,
+    ) -> None:
+        mlp = f"{hf_prefix}.mlp"
+        weight_map.update(
+            {
+                f"{native_prefix}.moe.router.gate.weight": [f"{mlp}.router.gate.weight"],
+                f"{native_prefix}.moe.router.expert_bias": [f"{mlp}.expert_bias"],
+                f"{native_prefix}.moe.shared_mlp.gate_up.linear.weight": [
+                    f"{mlp}.shared_mlp.gate_proj.weight",
+                    f"{mlp}.shared_mlp.up_proj.weight",
+                ],
+                f"{native_prefix}.moe.shared_mlp.down.linear.weight": [f"{mlp}.shared_mlp.down_proj.weight"],
+            }
+        )
+        for expert in range(self.config.num_experts):
+            weight_map[f"{native_prefix}.moe.experts._fc1_weight_{expert}"] = [
+                f"{mlp}.experts.{expert}.gate_proj.weight",
+                f"{mlp}.experts.{expert}.up_proj.weight",
+            ]
+            weight_map[f"{native_prefix}.moe.experts._fc2_weight_{expert}"] = [
+                f"{mlp}.experts.{expert}.down_proj.weight"
+            ]
+
+    def weight_map(self) -> dict[str, list[str]]:
+        config = self.config
+        result: dict[str, list[str]] = {
+            "embed.embedding.weight": ["model.embed_tokens.weight"],
+            "mtp_embed.embedding.weight": ["model.embed_tokens.weight"],
+            "norm.weight": ["model.norm.weight"],
+            "head.col.linear.weight": ["lm_head.weight"],
+        }
+        for layer in range(config.num_hidden_layers):
+            native = f"layers.{layer}"
+            hf = f"model.layers.{layer}"
+            self._add_attention(result, native, hf)
+            if config.layer_types[layer] == "dense":
+                result[f"{native}.mlp.gate_up.linear.weight"] = [
+                    f"{hf}.mlp.gate_proj.weight",
+                    f"{hf}.mlp.up_proj.weight",
+                ]
+                result[f"{native}.mlp.down.linear.weight"] = [f"{hf}.mlp.down_proj.weight"]
+            else:
+                self._add_sparse_mlp(result, native, hf)
+        for mtp_index in range(config.num_nextn_predict_layers):
+            hf_layer = config.num_hidden_layers + mtp_index
+            native = f"mtp.layers.{mtp_index}"
+            transformer = f"{native}.transformer_layer"
+            hf = f"model.layers.{hf_layer}"
+            result.update(
+                {
+                    f"{native}.enorm.weight": [f"{hf}.enorm.weight"],
+                    f"{native}.hnorm.weight": [f"{hf}.hnorm.weight"],
+                    f"{native}.eh_proj.linear.weight": [f"{hf}.eh_proj.weight"],
+                    f"{native}.final_layernorm.weight": [f"{hf}.final_layernorm.weight"],
+                }
+            )
+            self._add_attention(result, transformer, hf)
+            self._add_sparse_mlp(result, transformer, hf)
+        return result
+
+    def hf_to_native(self, native_name: str, tensors: list[torch.Tensor]) -> torch.Tensor:
+        if len(tensors) == 3:
+            return pack_grouped_query_qkv(
+                *tensors,
+                num_attention_heads=self.config.num_attention_heads,
+                num_key_value_heads=self.config.num_key_value_heads,
+                head_dim=self.config.head_dim,
+            )
+        if len(tensors) == 2:
+            return torch.cat(tensors, dim=0)
+        return tensors[0]
+
+    def native_to_hf(self, native_name: str, tensor: torch.Tensor) -> list[tuple[str, torch.Tensor]]:
+        if native_name == "mtp_embed.embedding.weight":
+            return []
+        targets = self.weight_map().get(native_name)
+        if targets is None:
+            return [(native_name, tensor)]
+        if len(targets) == 3:
+            tensors = unpack_grouped_query_qkv(
+                tensor,
+                num_attention_heads=self.config.num_attention_heads,
+                num_key_value_heads=self.config.num_key_value_heads,
+                head_dim=self.config.head_dim,
+            )
+            return list(zip(targets, tensors))
+        if len(targets) == 2:
+            return list(zip(targets, tensor.chunk(2, dim=0)))
+        return [(targets[0], tensor)]
+
+    def qkv_spec(self, native_name: str) -> tuple[int, int, int] | None:
+        return None
+
+    def tp_spec(self, native_name: str) -> tuple[int, int] | None:
+        if self.is_expert(native_name):
+            if "fc1" in native_name:
+                return (0, 1)
+            if "fc2" in native_name:
+                return (1, 1)
+            return None
+        if "eh_proj" in native_name:
+            return (0, 0)
+        if "qkv" in native_name and "layer_norm" not in native_name:
+            return (0, 0)
+        if "attn.proj" in native_name:
+            return (1, 0)
+        if "gate_up" in native_name:
+            return (0, 0)
+        if ".down." in native_name:
+            return (1, 0)
+        if "embed" in native_name or "head" in native_name:
+            return (0, 0)
+        return None
+
+    def is_expert(self, native_name: str) -> bool:
+        return ".experts." in native_name and ".router." not in native_name
+
+    def expert_global_id(self, native_name: str) -> int | None:
+        if "_fc1_weight_" in native_name or "_fc2_weight_" in native_name:
+            return int(native_name.rsplit("_", 1)[1])
+        return None
+
+    def expert_local_name(self, native_name: str, local_idx: int) -> str:
+        prefix = native_name.rsplit("._fc", 1)[0]
+        fc_tag = "fc1" if "_fc1_weight_" in native_name else "fc2"
+        return f"{prefix}.{fc_tag}.weight{local_idx}"
+
+
+def EXPERT_CLASSIFIER(name: str) -> bool:
+    return ".experts." in name and ".router." not in name
+
+
+def PLACEMENT_FN(param_name: str) -> list:
+    if EXPERT_CLASSIFIER(param_name):
+        if "fc1" in param_name:
+            return [Replicate(), Replicate(), Shard(0), Shard(0)]
+        if "fc2" in param_name:
+            return [Replicate(), Replicate(), Shard(0), Shard(1)]
+    if "qkv" in param_name and "layer_norm" not in param_name:
+        return [Replicate(), Replicate(), Replicate(), Shard(0)]
+    if "attn.proj" in param_name or ".down." in param_name:
+        return [Replicate(), Replicate(), Replicate(), Shard(1)]
+    if "gate_up" in param_name or "embed" in param_name or "head" in param_name:
+        return [Replicate(), Replicate(), Replicate(), Shard(0)]
+    return [Replicate(), Replicate(), Replicate(), Replicate()]
+
+
+def load_hf_weights(model, path: str, config: Hy3Config, ps) -> None:
+    from megatron.lite.primitive.ckpt.hf_weights import load_hf_weights as load
+
+    load(model, path, Hy3WeightSpec(config), ps, vocab_size=config.vocab_size)
+
+
+def export_hf_weights(model, config: Hy3Config, ps, **kwargs):
+    from megatron.lite.primitive.ckpt.hf_weights import export_hf_weights as export
+
+    yield from export(model, Hy3WeightSpec(config), ps, vocab_size=config.vocab_size, **kwargs)
+
+
+def save_hf_weights(model, path: str, config: Hy3Config, ps) -> None:
+    from megatron.lite.primitive.ckpt.hf_weights import save_hf_weights as save
+
+    save(model, path, Hy3WeightSpec(config), ps, vocab_size=config.vocab_size)
+
+
+__all__ = [
+    "EXPERT_CLASSIFIER",
+    "Hy3WeightSpec",
+    "PLACEMENT_FN",
+    "export_hf_weights",
+    "load_hf_weights",
+    "save_hf_weights",
+]

--- a/experimental/lite/megatron/lite/model/hy3/lite/model.py
+++ b/experimental/lite/megatron/lite/model/hy3/lite/model.py
@@ -14,7 +14,11 @@ from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
 from megatron.lite.primitive.modules.experts import Experts
 from megatron.lite.primitive.modules.gqa import GQAttention
 from megatron.lite.primitive.modules.mlp import SwiGLUMLP
-from megatron.lite.primitive.modules.mtp import MTPBlock, MTPDecoderLayer, MTPLossAutoScaler
+from megatron.lite.primitive.modules.mtp import (
+    MTPBlock,
+    MTPDecoderLayer,
+    MTPLossAutoScaler,
+)
 from megatron.lite.primitive.modules.router import SigmoidTopKRouter
 from megatron.lite.primitive.ops.cross_entropy import vocab_parallel_cross_entropy
 from megatron.lite.primitive.ops.linear_cross_entropy import linear_cross_entropy
@@ -49,7 +53,7 @@ class Hy3MoELayer(nn.Module):
             config,
             ps,
             compute_aux_loss=False,
-            persistent_expert_bias=True,
+            expert_bias_persistent=True,
         )
         self.experts = Experts(
             config,
@@ -66,7 +70,6 @@ class Hy3MoELayer(nn.Module):
         self.shared_mlp = SwiGLUMLP(
             config.hidden_size,
             config.shared_expert_intermediate_size,
-            ps,
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -123,7 +126,7 @@ class Hy3TransformerLayer(nn.Module):
         self.mlp: SwiGLUMLP | None = None
         self.moe: Hy3MoELayer | None = None
         if self.layer_type == "dense":
-            self.mlp = SwiGLUMLP(config.hidden_size, config.intermediate_size, ps)
+            self.mlp = SwiGLUMLP(config.hidden_size, config.intermediate_size)
         elif self.layer_type == "sparse":
             self.moe = Hy3MoELayer(
                 config,
@@ -214,7 +217,11 @@ class Hy3Model(nn.Module):
                 for index in self.layer_indices
             ]
         )
-        self.norm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps) if layout.has_head else None
+        self.norm = (
+            te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+            if layout.has_head
+            else None
+        )
         self.head = (
             VocabParallelOutput(config.vocab_size, config.hidden_size, ps)
             if layout.has_head
@@ -225,7 +232,9 @@ class Hy3Model(nn.Module):
         if mtp_enable and config.num_nextn_predict_layers > 0 and self.head is not None:
             mtp_embedding = self.embed
             if mtp_embedding is None:
-                mtp_embedding = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
+                mtp_embedding = VocabParallelEmbedding(
+                    config.vocab_size, config.hidden_size, ps
+                )
                 self.mtp_embed = mtp_embedding
 
             def make_mtp_layer(index: int) -> MTPDecoderLayer:
@@ -284,10 +293,18 @@ class Hy3Model(nn.Module):
             hidden = hidden_states if hidden_states is not None else self._input_tensor
             if hidden is None:
                 raise ValueError("hidden states are required on a non-embedding stage")
-        context = te.fp8_autocast(enabled=True, fp8_recipe=build_fp8_recipe()) if self.fp8 else nullcontext()
+        context = (
+            te.fp8_autocast(enabled=True, fp8_recipe=build_fp8_recipe())
+            if self.fp8
+            else nullcontext()
+        )
         with context:
             for layer in self.layers:
-                hidden = layer(hidden, position_ids=position_ids, packed_seq_params=packed_seq_params)
+                hidden = layer(
+                    hidden,
+                    position_ids=position_ids,
+                    packed_seq_params=packed_seq_params,
+                )
         output = {"hidden_states": hidden}
         if self.head is None:
             return output
@@ -296,7 +313,11 @@ class Hy3Model(nn.Module):
         if labels is None:
             output["logits"] = self.head.gather(self.head(hidden_for_head))
             return output
-        temperature_value = float(temperature.detach().float().item()) if isinstance(temperature, torch.Tensor) else float(temperature)
+        temperature_value = (
+            float(temperature.detach().float().item())
+            if isinstance(temperature, torch.Tensor)
+            else float(temperature)
+        )
         mtp_result = self._apply_mtp_loss(
             hidden_for_head,
             input_ids=input_ids,
@@ -324,9 +345,15 @@ class Hy3Model(nn.Module):
             logits = self.head(hidden_for_head)
             if temperature_value != 1.0:
                 logits = logits / temperature_value
-            token_loss = vocab_parallel_cross_entropy(logits, labels_sb, self.ps.tp_group)
+            token_loss = vocab_parallel_cross_entropy(
+                logits, labels_sb, self.ps.tp_group
+            )
             log_probs = -token_loss
-            entropy = vocab_parallel_entropy(logits, self.ps.tp_group) if calculate_entropy else None
+            entropy = (
+                vocab_parallel_entropy(logits, self.ps.tp_group)
+                if calculate_entropy
+                else None
+            )
         output["loss"] = token_loss.mean()
         if return_log_probs:
             output["log_probs"] = log_probs.transpose(0, 1).contiguous()
@@ -355,7 +382,11 @@ class Hy3Model(nn.Module):
             return None
         if input_ids is None:
             raise ValueError("MTP training requires input_ids")
-        mask = torch.ones_like(labels, dtype=torch.float32) if loss_mask is None else loss_mask.float()
+        mask = (
+            torch.ones_like(labels, dtype=torch.float32)
+            if loss_mask is None
+            else loss_mask.float()
+        )
         mtp_hidden_states = self.mtp(
             input_ids=input_ids,
             position_ids=position_ids,
@@ -368,12 +399,18 @@ class Hy3Model(nn.Module):
             shifted_labels, _ = roll_packed_thd_left(
                 shifted_labels, packed_seq_params=packed_seq_params, dims=-1
             )
-            mask, num_tokens = roll_packed_thd_left(mask, packed_seq_params=packed_seq_params, dims=-1)
+            mask, num_tokens = roll_packed_thd_left(
+                mask, packed_seq_params=packed_seq_params, dims=-1
+            )
             labels_sb = shifted_labels.transpose(0, 1).contiguous()
             if use_fused_kernels:
                 hidden_full = gather_from_sequence_parallel(mtp_hidden, self.ps)
                 log_probs, _ = linear_cross_entropy(
-                    hidden_full, self._head_weight(hidden_full), labels_sb, temperature, self.ps.tp_group
+                    hidden_full,
+                    self._head_weight(hidden_full),
+                    labels_sb,
+                    temperature,
+                    self.ps.tp_group,
                 )
                 token_loss = -log_probs
             else:
@@ -388,8 +425,12 @@ class Hy3Model(nn.Module):
             denominator = num_tokens.to(token_loss.dtype).clamp_min(1.0)
             losses.append(token_loss.sum() / denominator)
             scale = self.mtp_loss_scaling_factor / max(len(mtp_hidden_states), 1)
-            hidden_states = MTPLossAutoScaler.apply(hidden_states, scale * token_loss / denominator)
-        return hidden_states, torch.stack([loss.detach().float() for loss in losses]).mean()
+            hidden_states = MTPLossAutoScaler.apply(
+                hidden_states, scale * token_loss / denominator
+            )
+        return hidden_states, torch.stack(
+            [loss.detach().float() for loss in losses]
+        ).mean()
 
 
 __all__ = ["Hy3MoELayer", "Hy3Model", "Hy3TransformerLayer"]

--- a/experimental/lite/megatron/lite/model/hy3/lite/model.py
+++ b/experimental/lite/megatron/lite/model/hy3/lite/model.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Native Hy3 composition over Megatron Lite primitives."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/model/hy3/lite/model.py
+++ b/experimental/lite/megatron/lite/model/hy3/lite/model.py
@@ -1,0 +1,394 @@
+"""Native Hy3 composition over Megatron Lite primitives."""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+
+import torch
+import torch.nn as nn
+import transformer_engine.pytorch as te
+
+from megatron.lite.model.hy3.config import Hy3Config
+from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
+from megatron.lite.primitive.modules.experts import Experts
+from megatron.lite.primitive.modules.gqa import GQAttention
+from megatron.lite.primitive.modules.mlp import SwiGLUMLP
+from megatron.lite.primitive.modules.mtp import MTPBlock, MTPDecoderLayer, MTPLossAutoScaler
+from megatron.lite.primitive.modules.router import SigmoidTopKRouter
+from megatron.lite.primitive.ops.cross_entropy import vocab_parallel_cross_entropy
+from megatron.lite.primitive.ops.linear_cross_entropy import linear_cross_entropy
+from megatron.lite.primitive.ops.logprob import vocab_parallel_entropy
+from megatron.lite.primitive.parallel import (
+    ParallelState,
+    VocabParallelEmbedding,
+    VocabParallelOutput,
+    build_pipeline_chunk_layout,
+    gather_from_sequence_parallel,
+    roll_packed_thd_left,
+    scatter_to_sequence_parallel,
+)
+from megatron.lite.primitive.utils import build_fp8_recipe
+
+
+class Hy3MoELayer(nn.Module):
+    """Hy3-specific composition of generic routing, expert and MLP primitives."""
+
+    def __init__(
+        self,
+        config: Hy3Config,
+        ps: ParallelState,
+        *,
+        use_deepep: bool,
+        fp8: bool,
+        moe_act_recompute: bool,
+    ) -> None:
+        super().__init__()
+        self.combine_in_fp32 = config.enable_moe_fp32_combine
+        self.router = SigmoidTopKRouter(
+            config,
+            ps,
+            compute_aux_loss=False,
+            persistent_expert_bias=True,
+        )
+        self.experts = Experts(
+            config,
+            ps,
+            fp8=fp8,
+            moe_act_recompute=moe_act_recompute,
+        )
+        self.dispatcher = TokenDispatcher(
+            config.num_experts,
+            config.hidden_size,
+            ps,
+            use_deepep=use_deepep,
+        )
+        self.shared_mlp = SwiGLUMLP(
+            config.hidden_size,
+            config.shared_expert_intermediate_size,
+            ps,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        input_shape = x.shape
+        tokens = x.reshape(-1, x.size(-1))
+        shared = self.shared_mlp(tokens)
+        scores, indices = self.router(tokens)
+        dispatched, tokens_per_expert, permuted_probs = self.dispatcher.dispatch(
+            tokens, scores, indices
+        )
+        self.dispatcher.wait_dispatch_event()
+        expert_output = self.experts(
+            dispatched,
+            tokens_per_expert,
+            permuted_probs,
+            tokens_per_expert_list=getattr(self.dispatcher, "_local_tpe_list", None),
+        )
+        routed = self.dispatcher.combine(expert_output)
+        if self.combine_in_fp32:
+            output = (routed.float() + shared.float()).to(x.dtype)
+        else:
+            output = routed + shared
+        return output.reshape(input_shape).to(x.dtype)
+
+
+class Hy3TransformerLayer(nn.Module):
+    def __init__(
+        self,
+        config: Hy3Config,
+        ps: ParallelState,
+        layer_idx: int,
+        *,
+        layer_type: str | None = None,
+        use_deepep: bool = False,
+        fp8: bool = False,
+        moe_act_recompute: bool = False,
+        use_thd: bool = False,
+    ) -> None:
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.layer_type = layer_type or config.layer_types[layer_idx]
+        self.attn = GQAttention(
+            hidden_size=config.hidden_size,
+            num_attention_heads=config.num_attention_heads,
+            num_key_value_heads=config.num_key_value_heads,
+            head_dim=config.head_dim,
+            ps=ps,
+            rms_norm_eps=config.rms_norm_eps,
+            rope_theta=config.rope_theta,
+            use_thd=use_thd,
+            qkv_layout="mcore",
+        )
+        self.mlp_norm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.mlp: SwiGLUMLP | None = None
+        self.moe: Hy3MoELayer | None = None
+        if self.layer_type == "dense":
+            self.mlp = SwiGLUMLP(config.hidden_size, config.intermediate_size, ps)
+        elif self.layer_type == "sparse":
+            self.moe = Hy3MoELayer(
+                config,
+                ps,
+                use_deepep=use_deepep,
+                fp8=fp8,
+                moe_act_recompute=moe_act_recompute,
+            )
+        else:
+            raise ValueError(f"Unsupported Hy3 layer type: {self.layer_type!r}")
+
+    def forward(self, x, position_ids=None, packed_seq_params=None):
+        x = x + self.attn(
+            x,
+            position_ids=position_ids,
+            packed_seq_params=packed_seq_params,
+        )
+        normalized = self.mlp_norm(x)
+        feed_forward = self.mlp if self.mlp is not None else self.moe
+        assert feed_forward is not None
+        return x + feed_forward(normalized)
+
+
+def _collect_sp_grad_params(model: nn.Module) -> list[nn.Parameter]:
+    suffixes = (
+        ".attn.qkv.linear.layer_norm_weight",
+        ".attn.q_norm.weight",
+        ".attn.k_norm.weight",
+        ".mlp_norm.weight",
+        ".moe.router.gate.weight",
+        ".moe.router.expert_bias",
+        ".enorm.weight",
+        ".hnorm.weight",
+        ".final_layernorm.weight",
+    )
+    return [
+        parameter
+        for name, parameter in model.named_parameters()
+        if name == "norm.weight" or any(name.endswith(suffix) for suffix in suffixes)
+    ]
+
+
+class Hy3Model(nn.Module):
+    def __init__(
+        self,
+        config: Hy3Config,
+        ps: ParallelState,
+        vpp: int | None = None,
+        vpp_chunk_id: int | None = None,
+        *,
+        use_deepep: bool = False,
+        fp8: bool = False,
+        recompute_modules: list[str] | None = None,
+        use_thd: bool = False,
+        mtp_enable: bool = False,
+        mtp_enable_train: bool = False,
+        mtp_detach_encoder: bool = False,
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.ps = ps
+        self.fp8 = fp8
+        self.mtp_enable_train = mtp_enable and mtp_enable_train
+        self.mtp_loss_scaling_factor = config.mtp_loss_scaling_factor
+        self._input_tensor: torch.Tensor | None = None
+        layout = build_pipeline_chunk_layout(
+            config.num_hidden_layers, ps, vpp, vpp_chunk_id
+        )
+        self.layer_indices = layout.layer_indices
+        self.embed = (
+            VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
+            if layout.has_embed
+            else None
+        )
+        recompute = recompute_modules or []
+        moe_act_recompute = "moe_act" in recompute and "moe" not in recompute
+        self.layers = nn.ModuleList(
+            [
+                Hy3TransformerLayer(
+                    config,
+                    ps,
+                    index,
+                    use_deepep=use_deepep,
+                    fp8=fp8,
+                    moe_act_recompute=moe_act_recompute,
+                    use_thd=use_thd,
+                )
+                for index in self.layer_indices
+            ]
+        )
+        self.norm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps) if layout.has_head else None
+        self.head = (
+            VocabParallelOutput(config.vocab_size, config.hidden_size, ps)
+            if layout.has_head
+            else None
+        )
+        self.mtp_embed: VocabParallelEmbedding | None = None
+        self.mtp: MTPBlock | None = None
+        if mtp_enable and config.num_nextn_predict_layers > 0 and self.head is not None:
+            mtp_embedding = self.embed
+            if mtp_embedding is None:
+                mtp_embedding = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
+                self.mtp_embed = mtp_embedding
+
+            def make_mtp_layer(index: int) -> MTPDecoderLayer:
+                transformer = Hy3TransformerLayer(
+                    config,
+                    ps,
+                    config.num_hidden_layers + index,
+                    layer_type="sparse",
+                    use_deepep=use_deepep,
+                    fp8=fp8,
+                    moe_act_recompute=moe_act_recompute,
+                    use_thd=use_thd,
+                )
+                return MTPDecoderLayer(
+                    hidden_size=config.hidden_size,
+                    rms_norm_eps=config.rms_norm_eps,
+                    ps=ps,
+                    embedding=mtp_embedding,
+                    transformer_layer=transformer,
+                    detach_encoder=mtp_detach_encoder,
+                    zero_centered_gamma=False,
+                )
+
+            self.mtp = MTPBlock(
+                num_layers=config.num_nextn_predict_layers,
+                repeated_layer=config.mtp_use_repeated_layer,
+                layer_factory=make_mtp_layer,
+            )
+        self.sp_params = _collect_sp_grad_params(self) if ps.tp_size > 1 else []
+
+    def set_input_tensor(self, input_tensor) -> None:
+        if isinstance(input_tensor, list):
+            if len(input_tensor) > 1:
+                raise ValueError("Hy3Model expects one pipeline input tensor")
+            input_tensor = input_tensor[0] if input_tensor else None
+        self._input_tensor = input_tensor
+
+    def forward(
+        self,
+        input_ids=None,
+        hidden_states=None,
+        position_ids=None,
+        packed_seq_params=None,
+        labels=None,
+        loss_mask=None,
+        temperature: float | torch.Tensor = 1.0,
+        use_fused_kernels: bool = False,
+        calculate_entropy: bool = False,
+        return_log_probs: bool = True,
+    ) -> dict:
+        if self.embed is not None:
+            if input_ids is None:
+                raise ValueError("input_ids are required on the embedding stage")
+            hidden = scatter_to_sequence_parallel(self.embed(input_ids), self.ps)
+        else:
+            hidden = hidden_states if hidden_states is not None else self._input_tensor
+            if hidden is None:
+                raise ValueError("hidden states are required on a non-embedding stage")
+        context = te.fp8_autocast(enabled=True, fp8_recipe=build_fp8_recipe()) if self.fp8 else nullcontext()
+        with context:
+            for layer in self.layers:
+                hidden = layer(hidden, position_ids=position_ids, packed_seq_params=packed_seq_params)
+        output = {"hidden_states": hidden}
+        if self.head is None:
+            return output
+        assert self.norm is not None
+        hidden_for_head = self.norm(hidden)
+        if labels is None:
+            output["logits"] = self.head.gather(self.head(hidden_for_head))
+            return output
+        temperature_value = float(temperature.detach().float().item()) if isinstance(temperature, torch.Tensor) else float(temperature)
+        mtp_result = self._apply_mtp_loss(
+            hidden_for_head,
+            input_ids=input_ids,
+            position_ids=position_ids,
+            labels=labels,
+            loss_mask=loss_mask,
+            packed_seq_params=packed_seq_params,
+            temperature=temperature_value,
+            use_fused_kernels=use_fused_kernels,
+        )
+        if mtp_result is not None:
+            hidden_for_head, output["mtp_loss"] = mtp_result
+        labels_sb = labels.transpose(0, 1).contiguous()
+        if use_fused_kernels:
+            hidden_full = gather_from_sequence_parallel(hidden_for_head, self.ps)
+            log_probs, entropy = linear_cross_entropy(
+                hidden_full,
+                self._head_weight(hidden_full),
+                labels_sb,
+                temperature_value,
+                self.ps.tp_group,
+            )
+            token_loss = -log_probs
+        else:
+            logits = self.head(hidden_for_head)
+            if temperature_value != 1.0:
+                logits = logits / temperature_value
+            token_loss = vocab_parallel_cross_entropy(logits, labels_sb, self.ps.tp_group)
+            log_probs = -token_loss
+            entropy = vocab_parallel_entropy(logits, self.ps.tp_group) if calculate_entropy else None
+        output["loss"] = token_loss.mean()
+        if return_log_probs:
+            output["log_probs"] = log_probs.transpose(0, 1).contiguous()
+        if calculate_entropy and entropy is not None:
+            output["entropy"] = entropy.transpose(0, 1).contiguous()
+        return output
+
+    def _head_weight(self, hidden: torch.Tensor) -> torch.Tensor:
+        assert self.head is not None
+        weight = self.head.col.linear.weight
+        return weight if weight.dtype == hidden.dtype else weight.to(hidden.dtype)
+
+    def _apply_mtp_loss(
+        self,
+        hidden_states,
+        *,
+        input_ids,
+        position_ids,
+        labels,
+        loss_mask,
+        packed_seq_params,
+        temperature,
+        use_fused_kernels,
+    ):
+        if self.mtp is None or not self.mtp_enable_train:
+            return None
+        if input_ids is None:
+            raise ValueError("MTP training requires input_ids")
+        mask = torch.ones_like(labels, dtype=torch.float32) if loss_mask is None else loss_mask.float()
+        mtp_hidden_states = self.mtp(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            hidden_states=hidden_states,
+            packed_seq_params=packed_seq_params,
+        )
+        shifted_labels = labels.clone()
+        losses = []
+        for mtp_hidden in mtp_hidden_states:
+            shifted_labels, _ = roll_packed_thd_left(
+                shifted_labels, packed_seq_params=packed_seq_params, dims=-1
+            )
+            mask, num_tokens = roll_packed_thd_left(mask, packed_seq_params=packed_seq_params, dims=-1)
+            labels_sb = shifted_labels.transpose(0, 1).contiguous()
+            if use_fused_kernels:
+                hidden_full = gather_from_sequence_parallel(mtp_hidden, self.ps)
+                log_probs, _ = linear_cross_entropy(
+                    hidden_full, self._head_weight(hidden_full), labels_sb, temperature, self.ps.tp_group
+                )
+                token_loss = -log_probs
+            else:
+                assert self.head is not None
+                logits = self.head(mtp_hidden)
+                token_loss = vocab_parallel_cross_entropy(
+                    logits / temperature if temperature != 1.0 else logits,
+                    labels_sb,
+                    self.ps.tp_group,
+                )
+            token_loss = token_loss * mask.transpose(0, 1).to(token_loss.dtype)
+            denominator = num_tokens.to(token_loss.dtype).clamp_min(1.0)
+            losses.append(token_loss.sum() / denominator)
+            scale = self.mtp_loss_scaling_factor / max(len(mtp_hidden_states), 1)
+            hidden_states = MTPLossAutoScaler.apply(hidden_states, scale * token_loss / denominator)
+        return hidden_states, torch.stack([loss.detach().float() for loss in losses]).mean()
+
+
+__all__ = ["Hy3MoELayer", "Hy3Model", "Hy3TransformerLayer"]

--- a/experimental/lite/megatron/lite/model/hy3/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/hy3/lite/protocol.py
@@ -20,6 +20,11 @@ from megatron.lite.model.hy3.lite.model import Hy3Model, Hy3TransformerLayer
 from megatron.lite.primitive.bundle import ModelBundle
 from megatron.lite.primitive.modules.mtp import MTPLossAutoScaler
 from megatron.lite.primitive.parallel import ParallelState, init_parallel
+from megatron.lite.primitive.quantization import (
+    QATSpec,
+    apply_qat_to_chunks,
+    normalize_qat_spec,
+)
 from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec
 from megatron.lite.runtime.contracts import OptimizerConfig, ParallelConfig
 
@@ -38,6 +43,7 @@ class ImplConfig:
     mtp_detach_encoder: bool = False
     mtp_loss_scaling_factor: float = 0.1
     deterministic: bool = True
+    qat: QATSpec | dict | None = None
 
 
 MODULE_MAP = {
@@ -108,7 +114,9 @@ def build_model(model_cfg: Hy3Config, *, impl_cfg: ImplConfig) -> ModelBundle:
             vpp=vpp,
             vpp_chunk_id=index if vpp is not None else None,
             **model_kwargs,
-        ).to(torch.bfloat16).cuda()
+        )
+        .to(torch.bfloat16)
+        .cuda()
         for index in range(vpp or 1)
     ]
     if recompute:
@@ -120,11 +128,16 @@ def build_model(model_cfg: Hy3Config, *, impl_cfg: ImplConfig) -> ModelBundle:
         for chunk in chunks:
             apply_offload(chunk.layers, impl_cfg.offload, MODULE_MAP)
 
+    # Parametrize before optimizer construction so it captures the BF16 master.
+    apply_qat_to_chunks(chunks, normalize_qat_spec(impl_cfg.qat))
+
     optimizer = None
     finalize_grads = None
     post_model_load_hook = None
     if impl_cfg.optimizer == "mc":
-        from megatron.lite.primitive.optimizers.megatron_wrap import build_mc_training_optimizer
+        from megatron.lite.primitive.optimizers.megatron_wrap import (
+            build_mc_training_optimizer,
+        )
 
         optimizer, finalize_grads = build_mc_training_optimizer(
             chunks,
@@ -140,7 +153,9 @@ def build_model(model_cfg: Hy3Config, *, impl_cfg: ImplConfig) -> ModelBundle:
         optimizer_backend = "fsdp2"
 
         def build_optimizer_after_load():
-            from megatron.lite.primitive.optimizers.fsdp2 import build_fsdp2_training_optimizer
+            from megatron.lite.primitive.optimizers.fsdp2 import (
+                build_fsdp2_training_optimizer,
+            )
 
             return {
                 "optimizer": build_fsdp2_training_optimizer(

--- a/experimental/lite/megatron/lite/model/hy3/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/hy3/lite/protocol.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Megatron Lite model protocol for native Tencent Hy3."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/model/hy3/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/hy3/lite/protocol.py
@@ -1,0 +1,208 @@
+"""Megatron Lite model protocol for native Tencent Hy3."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from megatron.lite.model.hy3.config import Hy3Config
+from megatron.lite.model.hy3.lite.checkpoint import (
+    EXPERT_CLASSIFIER,
+    PLACEMENT_FN,
+    load_hf_weights as _load_hf_weights,
+)
+from megatron.lite.model.hy3.lite.model import Hy3Model, Hy3TransformerLayer
+from megatron.lite.primitive.bundle import ModelBundle
+from megatron.lite.primitive.modules.mtp import MTPLossAutoScaler
+from megatron.lite.primitive.parallel import ParallelState, init_parallel
+from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec
+from megatron.lite.runtime.contracts import OptimizerConfig, ParallelConfig
+
+
+@dataclass(frozen=True)
+class ImplConfig:
+    parallel: ParallelConfig = field(default_factory=ParallelConfig)
+    optimizer: str | None = "mc"
+    recompute: list[str] = field(default_factory=list)
+    offload: list[str] = field(default_factory=list)
+    use_deepep: bool = False
+    use_thd: bool = False
+    optimizer_config: OptimizerConfig | None = None
+    mtp_enable: bool = False
+    mtp_enable_train: bool = False
+    mtp_detach_encoder: bool = False
+    mtp_loss_scaling_factor: float = 0.1
+    deterministic: bool = True
+
+
+MODULE_MAP = {
+    "core_attn": lambda layer: layer.attn.core_attn,
+    "mlp": lambda layer: layer.mlp,
+    "experts": lambda layer: layer.moe.experts if layer.moe is not None else None,
+    "moe": lambda layer: layer.moe,
+    "router": lambda layer: layer.moe.router if layer.moe is not None else None,
+    "mlp_norm": lambda layer: layer.mlp_norm,
+    "attn_proj": lambda layer: layer.attn.proj,
+}
+
+
+def build_model_config(source: str | Path | dict, **overrides) -> Hy3Config:
+    config = (
+        Hy3Config._from_hf_dict(source, **overrides)
+        if isinstance(source, dict)
+        else Hy3Config.from_hf(str(source), **overrides)
+    )
+    return config
+
+
+def _forward_step(model: nn.Module, batch: dict) -> dict:
+    kwargs = {"input_ids": batch["input_ids"], "labels": batch["labels"]}
+    for key in (
+        "packed_seq_params",
+        "position_ids",
+        "loss_mask",
+        "temperature",
+        "use_fused_kernels",
+        "calculate_entropy",
+        "return_log_probs",
+    ):
+        if key in batch:
+            kwargs[key] = batch[key]
+    if kwargs["input_ids"].dim() == 1:
+        kwargs["input_ids"] = kwargs["input_ids"].unsqueeze(0)
+    return model(**kwargs)
+
+
+def build_model(model_cfg: Hy3Config, *, impl_cfg: ImplConfig) -> ModelBundle:
+    parallel = impl_cfg.parallel
+    if impl_cfg.use_deepep and parallel.etp is not None and parallel.etp > 1:
+        raise ValueError("use_deepep and etp>1 are mutually exclusive")
+    if impl_cfg.mtp_enable:
+        if model_cfg.num_nextn_predict_layers <= 0:
+            raise ValueError("mtp_enable=True but the HF config has no MTP layer")
+        model_cfg.mtp_loss_scaling_factor = impl_cfg.mtp_loss_scaling_factor
+    else:
+        model_cfg.num_nextn_predict_layers = 0
+
+    ps = init_parallel(parallel)
+    recompute = parse_recompute_spec(impl_cfg.recompute)
+    model_kwargs: dict[str, Any] = {
+        "use_deepep": impl_cfg.use_deepep,
+        "fp8": False,
+        "recompute_modules": recompute,
+        "use_thd": impl_cfg.use_thd,
+        "mtp_enable": impl_cfg.mtp_enable,
+        "mtp_enable_train": impl_cfg.mtp_enable and impl_cfg.mtp_enable_train,
+        "mtp_detach_encoder": impl_cfg.mtp_detach_encoder,
+    }
+    vpp = None if parallel.vpp == 1 else parallel.vpp
+    chunks = [
+        Hy3Model(
+            model_cfg,
+            ps,
+            vpp=vpp,
+            vpp_chunk_id=index if vpp is not None else None,
+            **model_kwargs,
+        ).to(torch.bfloat16).cuda()
+        for index in range(vpp or 1)
+    ]
+    if recompute:
+        for chunk in chunks:
+            apply_recompute(chunk.layers, recompute, MODULE_MAP)
+    if impl_cfg.offload:
+        from megatron.lite.primitive.recompute import apply_offload
+
+        for chunk in chunks:
+            apply_offload(chunk.layers, impl_cfg.offload, MODULE_MAP)
+
+    optimizer = None
+    finalize_grads = None
+    post_model_load_hook = None
+    if impl_cfg.optimizer == "mc":
+        from megatron.lite.primitive.optimizers.megatron_wrap import build_mc_training_optimizer
+
+        optimizer, finalize_grads = build_mc_training_optimizer(
+            chunks,
+            model_cfg=model_cfg,
+            impl_cfg=impl_cfg,
+            ps=ps,
+            model_name="hy3",
+            is_expert=EXPERT_CLASSIFIER,
+            deterministic=impl_cfg.deterministic,
+        )
+        optimizer_backend = "mc"
+    elif impl_cfg.optimizer == "fsdp2":
+        optimizer_backend = "fsdp2"
+
+        def build_optimizer_after_load():
+            from megatron.lite.primitive.optimizers.fsdp2 import build_fsdp2_training_optimizer
+
+            return {
+                "optimizer": build_fsdp2_training_optimizer(
+                    chunks,
+                    impl_cfg.optimizer_config,
+                    ps,
+                    unit_modules=(Hy3TransformerLayer,),
+                    expert_classifier=EXPERT_CLASSIFIER,
+                    deterministic=impl_cfg.deterministic,
+                    vpp=parallel.vpp,
+                    leaf_module_names=(),
+                )
+            }
+
+        post_model_load_hook = build_optimizer_after_load
+    elif impl_cfg.optimizer is None:
+        optimizer_backend = "none"
+    else:
+        raise ValueError(f"Unknown Hy3 lite optimizer: {impl_cfg.optimizer!r}")
+
+    return ModelBundle(
+        chunks=chunks,
+        parallel_state=ps,
+        optimizer=optimizer,
+        finalize_grads=finalize_grads,
+        forward_step=_forward_step,
+        extras={
+            "model_cfg": model_cfg,
+            "pre_forward_hook": MTPLossAutoScaler.set_loss_scale,
+            "optimizer_backend": optimizer_backend,
+            "post_model_load_hook": post_model_load_hook,
+        },
+    )
+
+
+def load_hf_weights(
+    chunk: nn.Module,
+    hf_path: str,
+    model_cfg: Hy3Config,
+    ps: ParallelState,
+) -> None:
+    if hf_path:
+        _load_hf_weights(chunk, hf_path, model_cfg, ps)
+
+
+def export_hf_weights(chunks, model_cfg: Hy3Config, ps: ParallelState, **kwargs):
+    from megatron.lite.model.hy3.lite.checkpoint import export_hf_weights as export
+
+    for chunk in chunks:
+        yield from export(chunk, model_cfg, ps, **kwargs)
+
+
+def vocab_size(model_cfg: Hy3Config) -> int:
+    return model_cfg.vocab_size
+
+
+__all__ = [
+    "ImplConfig",
+    "MODULE_MAP",
+    "PLACEMENT_FN",
+    "build_model",
+    "build_model_config",
+    "export_hf_weights",
+    "load_hf_weights",
+    "vocab_size",
+]

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/checkpoint.py
@@ -25,25 +25,25 @@ from torch.distributed.tensor import Replicate, Shard
 def _pack_mcore_qkv(
     q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, config: Qwen3MoEConfig
 ) -> torch.Tensor:
-    q_per_group = config.num_attention_heads // config.num_key_value_heads
-    q = q.view(config.num_key_value_heads, q_per_group * config.head_dim, -1)
-    k = k.view(config.num_key_value_heads, config.head_dim, -1)
-    v = v.view(config.num_key_value_heads, config.head_dim, -1)
-    return torch.cat([q, k, v], dim=1).reshape(-1, q.shape[-1]).contiguous()
+    return pack_grouped_query_qkv(
+        q,
+        k,
+        v,
+        num_attention_heads=config.num_attention_heads,
+        num_key_value_heads=config.num_key_value_heads,
+        head_dim=config.head_dim,
+    )
 
 
 def _unpack_mcore_qkv(
     tensor: torch.Tensor, config: Qwen3MoEConfig
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    q_per_group = config.num_attention_heads // config.num_key_value_heads
-    group_width = (q_per_group + 2) * config.head_dim
-    packed = tensor.view(config.num_key_value_heads, group_width, -1)
-    q_end = q_per_group * config.head_dim
-    k_end = q_end + config.head_dim
-    q = packed[:, :q_end].reshape(config.num_attention_heads * config.head_dim, -1)
-    k = packed[:, q_end:k_end].reshape(config.num_key_value_heads * config.head_dim, -1)
-    v = packed[:, k_end:].reshape(config.num_key_value_heads * config.head_dim, -1)
-    return q, k, v
+    return unpack_grouped_query_qkv(
+        tensor,
+        num_attention_heads=config.num_attention_heads,
+        num_key_value_heads=config.num_key_value_heads,
+        head_dim=config.head_dim,
+    )
 
 
 class Qwen3MoEWeightSpec:

--- a/experimental/lite/megatron/lite/model/registry.py
+++ b/experimental/lite/megatron/lite/model/registry.py
@@ -82,7 +82,9 @@ register_model(
 )
 
 register_model(
-    "qwen3_moe", package="megatron.lite.model.qwen3_moe", impls={"lite": _QWEN3_MOE_LITE}
+    "qwen3_moe",
+    package="megatron.lite.model.qwen3_moe",
+    impls={"lite": _QWEN3_MOE_LITE},
 )
 
 register_model(
@@ -90,6 +92,13 @@ register_model(
     package="megatron.lite.model.qwen3_5",
     hf_model_types=["qwen3_5_moe"],
     impls={"lite": "megatron.lite.model.qwen3_5.lite.protocol"},
+)
+
+register_model(
+    "hy3",
+    package="megatron.lite.model.hy3",
+    hf_model_types=["hy_v3"],
+    impls={"lite": "megatron.lite.model.hy3.lite.protocol"},
 )
 
 register_model(
@@ -121,7 +130,9 @@ register_model(
 
 def get_model_package(model_name: str):
     if model_name not in MODEL_PACKAGES:
-        raise ValueError(f"Unknown model: {model_name!r}. Available: {list(MODEL_PACKAGES)}")
+        raise ValueError(
+            f"Unknown model: {model_name!r}. Available: {list(MODEL_PACKAGES)}"
+        )
     return importlib.import_module(MODEL_PACKAGES[model_name])
 
 
@@ -135,7 +146,8 @@ def resolve_runtime_model_name(model_name: str, impl: str) -> str:
     key = (model_name, impl)
     if key not in _IMPL_TO_RUNTIME_MODEL:
         raise ValueError(
-            f"No runtime for ({model_name!r}, {impl!r}). " f"Known: {list(_IMPL_TO_RUNTIME_MODEL)}"
+            f"No runtime for ({model_name!r}, {impl!r}). "
+            f"Known: {list(_IMPL_TO_RUNTIME_MODEL)}"
         )
     return _IMPL_TO_RUNTIME_MODEL[key]
 

--- a/experimental/lite/megatron/lite/primitive/checkpoint_transforms.py
+++ b/experimental/lite/megatron/lite/primitive/checkpoint_transforms.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Reusable checkpoint tensor layout transforms without I/O dependencies."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/primitive/checkpoint_transforms.py
+++ b/experimental/lite/megatron/lite/primitive/checkpoint_transforms.py
@@ -1,0 +1,64 @@
+"""Reusable checkpoint tensor layout transforms without I/O dependencies."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+from collections.abc import Generator, Mapping
+
+
+def pack_grouped_query_qkv(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    *,
+    num_attention_heads: int,
+    num_key_value_heads: int,
+    head_dim: int,
+) -> torch.Tensor:
+    """Pack separate HF Q/K/V weights into MCore grouped-query order."""
+    q_per_group = num_attention_heads // num_key_value_heads
+    query = query.view(num_key_value_heads, q_per_group * head_dim, -1)
+    key = key.view(num_key_value_heads, head_dim, -1)
+    value = value.view(num_key_value_heads, head_dim, -1)
+    return torch.cat([query, key, value], dim=1).reshape(-1, query.shape[-1]).contiguous()
+
+
+def unpack_grouped_query_qkv(
+    tensor: torch.Tensor,
+    *,
+    num_attention_heads: int,
+    num_key_value_heads: int,
+    head_dim: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Unpack an MCore grouped-query QKV weight into separate HF tensors."""
+    q_per_group = num_attention_heads // num_key_value_heads
+    group_width = (q_per_group + 2) * head_dim
+    packed = tensor.view(num_key_value_heads, group_width, -1)
+    q_end = q_per_group * head_dim
+    k_end = q_end + head_dim
+    query = packed[:, :q_end].reshape(num_attention_heads * head_dim, -1)
+    key = packed[:, q_end:k_end].reshape(num_key_value_heads * head_dim, -1)
+    value = packed[:, k_end:].reshape(num_key_value_heads * head_dim, -1)
+    return query, key, value
+
+
+def iter_checkpoint_tensors(
+    model: nn.Module,
+    weight_map: Mapping[str, list[str]],
+) -> Generator[tuple[str, torch.Tensor], None, None]:
+    """Yield parameters plus mapped persistent buffers for checkpoint I/O."""
+    yield from model.named_parameters()
+    parameter_names = {name for name, _parameter in model.named_parameters()}
+    state_names = set(model.state_dict())
+    mapped_names = set(weight_map)
+    for name, buffer in model.named_buffers():
+        if name in state_names and name in mapped_names and name not in parameter_names:
+            yield name, buffer
+
+
+__all__ = [
+    "iter_checkpoint_tensors",
+    "pack_grouped_query_qkv",
+    "unpack_grouped_query_qkv",
+]

--- a/experimental/lite/megatron/lite/primitive/modules/mtp.py
+++ b/experimental/lite/megatron/lite/primitive/modules/mtp.py
@@ -66,18 +66,27 @@ class MTPDecoderLayer(nn.Module):
         embedding: VocabParallelEmbedding,
         transformer_layer: nn.Module,
         detach_encoder: bool,
+        zero_centered_gamma: bool = True,
     ):
         super().__init__()
         self.ps = ps
         self.embedding = embedding
         self.detach_encoder = detach_encoder
-        self.enorm = te.RMSNorm(hidden_size, eps=rms_norm_eps, zero_centered_gamma=True)
-        self.hnorm = te.RMSNorm(hidden_size, eps=rms_norm_eps, zero_centered_gamma=True)
+        self.enorm = te.RMSNorm(
+            hidden_size, eps=rms_norm_eps, zero_centered_gamma=zero_centered_gamma
+        )
+        self.hnorm = te.RMSNorm(
+            hidden_size, eps=rms_norm_eps, zero_centered_gamma=zero_centered_gamma
+        )
         self.eh_proj = VanillaColumnParallelLinear(
             hidden_size * 2, hidden_size, ps, sp=ps.tp_size > 1, gather_output=True
         )
         self.transformer_layer = transformer_layer
-        self.final_layernorm = te.RMSNorm(hidden_size, eps=rms_norm_eps, zero_centered_gamma=True)
+        self.final_layernorm = te.RMSNorm(
+            hidden_size,
+            eps=rms_norm_eps,
+            zero_centered_gamma=zero_centered_gamma,
+        )
 
     def forward(
         self,

--- a/experimental/lite/megatron/lite/primitive/modules/router.py
+++ b/experimental/lite/megatron/lite/primitive/modules/router.py
@@ -201,7 +201,7 @@ class SigmoidTopKRouter(nn.Module):
         self.router_dtype = router_dtype
         self.router_replay: RouterReplay | None = None
 
-        self.gate = nn.Linear(config.hidden_size, config.n_routed_experts, bias=False)
+        self.gate = nn.Linear(config.hidden_size, self.num_experts, bias=False)
         self.register_buffer(
             "expert_bias",
             torch.zeros(config.n_routed_experts, dtype=torch.float32),

--- a/experimental/lite/tests/README.md
+++ b/experimental/lite/tests/README.md
@@ -43,5 +43,6 @@ Current matrix:
 | Optimizer update-state offload fraction | `unit/primitive/test_runtime_config_unit.py` and single-process CUDA coverage in `unit/primitive/test_fsdp2_offload_gpu.py` | multi-rank offloaded grad clipping is checked against the non-offloaded baseline in `smoke/primitive/test_fsdp2_offload_checkpoint_smoke.py` |
 | Qwen3 MoE lite config/build/forward | `unit/model/test_qwen_config_unit.py` | `smoke/model/test_qwen_lite_forward_smoke.py` |
 | Qwen3.5 MoE lite config/build/forward | `unit/model/test_qwen_config_unit.py` | `smoke/model/test_qwen_lite_forward_smoke.py` |
+| Hy3 config/weights/native forward | `unit/model/test_qwen_config_unit.py`, `unit/model/test_hy3_checkpoint_unit.py` | `smoke/model/test_qwen_lite_forward_smoke.py` |
 
 Classic FSDP is not a separate MLite primitive in the current source tree; MLite's native sharded optimizer coverage is FSDP2 plus Megatron DDP/distopt.

--- a/experimental/lite/tests/smoke/model/test_hy3_acceptance_smoke.py
+++ b/experimental/lite/tests/smoke/model/test_hy3_acceptance_smoke.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+import torch
+import torch.distributed as dist
+
+
+pytestmark = [
+    pytest.mark.mlite,
+    pytest.mark.smoke,
+    pytest.mark.gpu,
+    pytest.mark.distributed,
+]
+
+
+def _require_cuda_and_te() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for Hy3 acceptance smoke tests.")
+    pytest.importorskip("transformer_engine.pytorch")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _cuda_dist():
+    _require_cuda_and_te()
+    os.environ.setdefault("RANK", "0")
+    os.environ.setdefault("WORLD_SIZE", "1")
+    os.environ.setdefault("LOCAL_RANK", "0")
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29631")
+    torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
+    created = False
+    if not dist.is_initialized():
+        dist.init_process_group("nccl", init_method="env://")
+        created = True
+    yield
+    if created and dist.is_initialized():
+        dist.destroy_process_group()
+
+
+def _config():
+    from megatron.lite.model.hy3.config import Hy3Config
+
+    return Hy3Config(
+        num_hidden_layers=2,
+        hidden_size=32,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        vocab_size=128,
+        intermediate_size=48,
+        num_experts=4,
+        num_experts_per_tok=2,
+        moe_intermediate_size=16,
+        first_k_dense_replace=1,
+        max_position_embeddings=32,
+        num_nextn_predict_layers=0,
+    )
+
+
+def _build(*, tp: int = 1, ep: int = 1, cp: int = 1, use_thd: bool = False):
+    from megatron.lite.model.hy3.lite import protocol
+    from megatron.lite.runtime.contracts.config import ParallelConfig
+
+    impl = protocol.ImplConfig(
+        parallel=ParallelConfig(tp=tp, ep=ep, etp=1, pp=1, cp=cp),
+        optimizer=None,
+        use_deepep=False,
+        use_thd=use_thd,
+        deterministic=True,
+    )
+    return protocol.build_model(_config(), impl_cfg=impl), protocol
+
+
+def _named_state(model: torch.nn.Module) -> dict[str, torch.Tensor]:
+    return {
+        name: tensor.detach().float().cpu().clone()
+        for name, tensor in model.state_dict().items()
+    }
+
+
+def test_hy3_real_hf_file_save_load_export_reload(tmp_path: Path):
+    if dist.get_world_size() != 1:
+        pytest.skip("HF file IO acceptance runs on one rank.")
+    from safetensors import safe_open
+
+    from megatron.lite.model.hy3.lite.checkpoint import load_hf_weights, save_hf_weights
+
+    torch.manual_seed(101)
+    first, _ = _build()
+    torch.manual_seed(202)
+    second, _ = _build()
+    first_model, second_model = first.chunks[0], second.chunks[0]
+    first_before = _named_state(first_model)
+    second_before = _named_state(second_model)
+    assert any(not torch.equal(first_before[name], second_before[name]) for name in first_before)
+
+    first_dir = tmp_path / "first_hf"
+    first_dir.mkdir()
+    save_hf_weights(first_model, str(first_dir), _config(), first.parallel_state)
+    load_hf_weights(second_model, str(first_dir), _config(), second.parallel_state)
+
+    second_dir = tmp_path / "reexported_hf"
+    second_dir.mkdir()
+    save_hf_weights(second_model, str(second_dir), _config(), second.parallel_state)
+
+    def read_all(root: Path) -> dict[str, torch.Tensor]:
+        tensors: dict[str, torch.Tensor] = {}
+        for file in sorted(root.glob("*.safetensors")):
+            with safe_open(file, framework="pt") as handle:
+                tensors.update({name: handle.get_tensor(name) for name in handle.keys()})
+        return tensors
+
+    original = read_all(first_dir)
+    reexported = read_all(second_dir)
+    assert original
+    assert original.keys() == reexported.keys()
+    mismatches = [
+        name
+        for name in original
+        if not torch.equal(original[name], reexported[name])
+    ]
+    assert not mismatches, "HF load/export/reload changed tensors: " + ", ".join(mismatches)
+
+
+def test_hy3_short_train_reduces_fixed_batch_loss():
+    if dist.get_world_size() != 1:
+        pytest.skip("short-train acceptance runs on one rank.")
+    torch.manual_seed(303)
+    bundle, _ = _build()
+    model = bundle.chunks[0]
+    optimizer = torch.optim.AdamW(model.parameters(), lr=3e-2, weight_decay=0.0)
+    input_ids = torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8]], device="cuda")
+    labels = torch.tensor([[2, 3, 4, 5, 6, 7, 8, 9]], device="cuda")
+    losses = []
+    for _ in range(12):
+        optimizer.zero_grad(set_to_none=True)
+        loss = model(input_ids=input_ids, labels=labels)["loss"]
+        assert torch.isfinite(loss)
+        losses.append(float(loss.detach()))
+        loss.backward()
+        optimizer.step()
+    assert losses[-1] < losses[0] * 0.5, losses
+
+
+@pytest.mark.parametrize("topology", [os.environ.get("HY3_TOPOLOGY", "ep2")])
+def test_hy3_distributed_forward_backward_uses_requested_paths(topology: str):
+    expected_world = {"ep2": 2, "cp2_thd": 2, "cp2_ep2": 4}[topology]
+    assert dist.get_world_size() == expected_world
+    ep = 2 if topology in {"ep2", "cp2_ep2"} else 1
+    cp = 2 if topology in {"cp2_thd", "cp2_ep2"} else 1
+    use_thd = cp > 1
+    torch.manual_seed(404)
+    bundle, _ = _build(ep=ep, cp=cp, use_thd=use_thd)
+    model = bundle.chunks[0]
+    ps = bundle.parallel_state
+    assert (ps.ep_size, ps.cp_size) == (ep, cp)
+
+    sparse = model.layers[1].moe
+    assert sparse is not None
+    assert sparse.dispatcher.ep_size == ep
+    assert not sparse.dispatcher.use_deepep
+    path_calls = {"alltoall": 0}
+    if ep > 1:
+        original = sparse.dispatcher._dispatch_alltoall
+
+        def counted(*args, **kwargs):
+            path_calls["alltoall"] += 1
+            return original(*args, **kwargs)
+
+        sparse.dispatcher._dispatch_alltoall = counted
+
+    if use_thd:
+        from megatron.lite.primitive.parallel import pack_nested_thd
+
+        sequences = [
+            torch.tensor([1, 2, 3, 4, 5, 6, 7, 8], device="cuda"),
+            torch.tensor([9, 10, 11, 12], device="cuda"),
+        ]
+        labels = [
+            torch.tensor([2, 3, 4, 5, 6, 7, 8, 9], device="cuda"),
+            torch.tensor([10, 11, 12, 13], device="cuda"),
+        ]
+        packed = pack_nested_thd(
+            torch.nested.nested_tensor(sequences, layout=torch.jagged),
+            cp_size=cp,
+            cp_rank=ps.cp_rank,
+            cp_group=ps.cp_group,
+            labels=torch.nested.nested_tensor(labels, layout=torch.jagged),
+        )
+        assert packed.packed_seq_params.qkv_format == "thd"
+        assert packed.packed_seq_params.local_cp_size == cp
+        output = model(
+            input_ids=packed.input_ids,
+            labels=packed.labels,
+            position_ids=packed.position_ids,
+            packed_seq_params=packed.packed_seq_params,
+        )
+    else:
+        input_ids = torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8]], device="cuda")
+        labels = torch.tensor([[2, 3, 4, 5, 6, 7, 8, 9]], device="cuda")
+        output = model(input_ids=input_ids, labels=labels)
+
+    loss = output["loss"]
+    assert torch.isfinite(loss)
+    loss.backward()
+    assert any(
+        parameter.grad is not None and torch.isfinite(parameter.grad.float()).all()
+        for parameter in model.parameters()
+    )
+    if ep > 1:
+        assert path_calls["alltoall"] == 1
+    marker = torch.tensor([1], device="cuda")
+    dist.all_reduce(marker)
+    assert marker.item() == expected_world
+

--- a/experimental/lite/tests/smoke/model/test_hy3_acceptance_smoke.py
+++ b/experimental/lite/tests/smoke/model/test_hy3_acceptance_smoke.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from __future__ import annotations
 
 import os
@@ -215,4 +216,3 @@ def test_hy3_distributed_forward_backward_uses_requested_paths(topology: str):
     marker = torch.tensor([1], device="cuda")
     dist.all_reduce(marker)
     assert marker.item() == expected_world
-

--- a/experimental/lite/tests/smoke/model/test_hy3_hf_parity_smoke.py
+++ b/experimental/lite/tests/smoke/model/test_hy3_hf_parity_smoke.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from __future__ import annotations
 
 import os

--- a/experimental/lite/tests/smoke/model/test_hy3_hf_parity_smoke.py
+++ b/experimental/lite/tests/smoke/model/test_hy3_hf_parity_smoke.py
@@ -167,6 +167,10 @@ def _batch_first(tensor: torch.Tensor, batch: int) -> torch.Tensor:
     return tensor.transpose(0, 1).contiguous()
 
 
+def _router_batch_first(tensor: torch.Tensor, batch: int, sequence: int) -> torch.Tensor:
+    return tensor.reshape(sequence, batch, -1).transpose(0, 1).reshape(batch * sequence, -1)
+
+
 def _assert_close(name: str, actual: torch.Tensor, expected: torch.Tensor, atol=3e-2):
     actual_f = actual.detach().float()
     expected_f = expected.detach().float()
@@ -220,6 +224,8 @@ def test_hy3_transformers_5_6_layer_router_logits_loss_and_gradient_parity():
     assert len(hf_router) == len(native_router) == 1
     hf_scores, hf_indices = hf_router[0]
     native_scores, native_indices = native_router[0]
+    native_scores = _router_batch_first(native_scores, *input_ids.shape)
+    native_indices = _router_batch_first(native_indices, *input_ids.shape)
     assert torch.equal(native_indices, hf_indices)
     _assert_close("router_scores", native_scores, hf_scores, atol=2e-3)
     _assert_close("logits", native_logits, hf_logits)
@@ -257,4 +263,3 @@ def test_hy3_transformers_5_6_layer_router_logits_loss_and_gradient_parity():
     for name, (native_grad, hf_grad) in gradient_pairs.items():
         assert native_grad is not None and hf_grad is not None
         _assert_close(name, native_grad, hf_grad, atol=8e-2)
-

--- a/experimental/lite/tests/smoke/model/test_hy3_hf_parity_smoke.py
+++ b/experimental/lite/tests/smoke/model/test_hy3_hf_parity_smoke.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+
+
+pytestmark = [
+    pytest.mark.mlite,
+    pytest.mark.smoke,
+    pytest.mark.gpu,
+    pytest.mark.distributed,
+]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _single_cuda_rank():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for Hy3 HF parity.")
+    pytest.importorskip("transformer_engine.pytorch")
+    transformers = pytest.importorskip("transformers")
+    if transformers.__version__ != "5.6.0" or not hasattr(transformers, "HYV3ForCausalLM"):
+        pytest.skip("Hy3 parity requires Transformers 5.6.0 with HYV3ForCausalLM.")
+    assert int(os.environ.get("WORLD_SIZE", "1")) == 1
+    os.environ.setdefault("RANK", "0")
+    os.environ.setdefault("WORLD_SIZE", "1")
+    os.environ.setdefault("LOCAL_RANK", "0")
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29632")
+    torch.cuda.set_device(0)
+    created = False
+    if not dist.is_initialized():
+        dist.init_process_group("nccl", init_method="env://")
+        created = True
+    yield
+    if created and dist.is_initialized():
+        dist.destroy_process_group()
+
+
+def _configs():
+    from transformers import HYV3Config
+
+    from megatron.lite.model.hy3.config import Hy3Config
+
+    common = dict(
+        num_hidden_layers=2,
+        hidden_size=32,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        vocab_size=128,
+        intermediate_size=48,
+        num_experts=4,
+        num_experts_per_tok=2,
+        num_shared_experts=1,
+        moe_intermediate_size=16,
+        router_scaling_factor=2.826,
+        rms_norm_eps=1e-5,
+        max_position_embeddings=32,
+        enable_moe_fp32_combine=False,
+    )
+    hf = HYV3Config(
+        **common,
+        mlp_layer_types=["dense", "sparse"],
+        use_cache=False,
+        rope_parameters={"rope_type": "default", "rope_theta": 11_158_840.0},
+    )
+    native = Hy3Config(
+        **common,
+        first_k_dense_replace=1,
+        num_nextn_predict_layers=0,
+    )
+    return hf, native
+
+
+def _build_models():
+    from transformers import HYV3ForCausalLM
+
+    from megatron.lite.model.hy3.lite import protocol
+    from megatron.lite.runtime.contracts.config import ParallelConfig
+
+    hf_config, native_config = _configs()
+    hf_config._attn_implementation = "eager"
+    torch.manual_seed(711)
+    hf_model = HYV3ForCausalLM(hf_config).cuda().to(torch.bfloat16)
+    impl = protocol.ImplConfig(
+        parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, cp=1),
+        optimizer=None,
+        use_deepep=False,
+        deterministic=True,
+    )
+    native_bundle = protocol.build_model(native_config, impl_cfg=impl)
+    native_model = native_bundle.chunks[0]
+    _copy_hf_to_native(hf_model, native_model, native_config)
+    return hf_model, native_model, native_config
+
+
+def _copy(target: torch.Tensor, source: torch.Tensor) -> None:
+    assert target.shape == source.shape, (target.shape, source.shape)
+    target.copy_(source.to(device=target.device, dtype=target.dtype))
+
+
+@torch.no_grad()
+def _copy_hf_to_native(hf_model, native_model, config) -> None:
+    from megatron.lite.model.hy3.lite.checkpoint import Hy3WeightSpec
+
+    spec = Hy3WeightSpec(config)
+    _copy(native_model.embed.embedding.weight, hf_model.model.embed_tokens.weight)
+    _copy(native_model.norm.weight, hf_model.model.norm.weight)
+    _copy(native_model.head.col.linear.weight, hf_model.lm_head.weight)
+    for index, (hf_layer, native_layer) in enumerate(
+        zip(hf_model.model.layers, native_model.layers, strict=True)
+    ):
+        _copy(
+            native_layer.attn.qkv.linear.layer_norm_weight,
+            hf_layer.input_layernorm.weight,
+        )
+        packed_qkv = spec.hf_to_native(
+            f"layers.{index}.attn.qkv.linear.weight",
+            [
+                hf_layer.self_attn.q_proj.weight,
+                hf_layer.self_attn.k_proj.weight,
+                hf_layer.self_attn.v_proj.weight,
+            ],
+        )
+        _copy(native_layer.attn.qkv.linear.weight, packed_qkv)
+        _copy(native_layer.attn.q_norm.weight, hf_layer.self_attn.q_norm.weight)
+        _copy(native_layer.attn.k_norm.weight, hf_layer.self_attn.k_norm.weight)
+        _copy(native_layer.attn.proj.linear.weight, hf_layer.self_attn.o_proj.weight)
+        _copy(native_layer.mlp_norm.weight, hf_layer.post_attention_layernorm.weight)
+        if native_layer.mlp is not None:
+            _copy(
+                native_layer.mlp.gate_up.linear.weight,
+                torch.cat([hf_layer.mlp.gate_proj.weight, hf_layer.mlp.up_proj.weight]),
+            )
+            _copy(native_layer.mlp.down.linear.weight, hf_layer.mlp.down_proj.weight)
+            continue
+        assert native_layer.moe is not None
+        native_moe, hf_moe = native_layer.moe, hf_layer.mlp
+        _copy(native_moe.router.gate.weight, hf_moe.gate.weight)
+        _copy(native_moe.router.expert_bias, hf_moe.e_score_correction_bias)
+        _copy(
+            native_moe.shared_mlp.gate_up.linear.weight,
+            torch.cat(
+                [hf_moe.shared_experts.gate_proj.weight, hf_moe.shared_experts.up_proj.weight]
+            ),
+        )
+        _copy(native_moe.shared_mlp.down.linear.weight, hf_moe.shared_experts.down_proj.weight)
+        for expert in range(config.num_experts):
+            _copy(
+                getattr(native_moe.experts.fc1, f"weight{expert}"),
+                hf_moe.experts.gate_up_proj[expert],
+            )
+            _copy(
+                getattr(native_moe.experts.fc2, f"weight{expert}"),
+                hf_moe.experts.down_proj[expert],
+            )
+
+
+def _batch_first(tensor: torch.Tensor, batch: int) -> torch.Tensor:
+    if tensor.shape[0] == batch:
+        return tensor
+    assert tensor.shape[1] == batch
+    return tensor.transpose(0, 1).contiguous()
+
+
+def _assert_close(name: str, actual: torch.Tensor, expected: torch.Tensor, atol=3e-2):
+    actual_f = actual.detach().float()
+    expected_f = expected.detach().float()
+    assert actual_f.shape == expected_f.shape, (name, actual_f.shape, expected_f.shape)
+    max_abs = float((actual_f - expected_f).abs().max())
+    assert torch.allclose(actual_f, expected_f, atol=atol, rtol=atol), (
+        f"{name} mismatch: max_abs={max_abs}"
+    )
+
+
+def test_hy3_transformers_5_6_layer_router_logits_loss_and_gradient_parity():
+    hf_model, native_model, config = _build_models()
+    hf_model.train()
+    native_model.train()
+    input_ids = torch.tensor(
+        [[1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12]],
+        device="cuda",
+    )
+    labels = torch.tensor(
+        [[2, 3, 4, 5, 6, 7], [8, 9, 10, 11, 12, 13]],
+        device="cuda",
+    )
+    hf_layers: list[torch.Tensor] = []
+    native_layers: list[torch.Tensor] = []
+    hf_router: list[tuple[torch.Tensor, torch.Tensor]] = []
+    native_router: list[tuple[torch.Tensor, torch.Tensor]] = []
+    hooks = []
+    for layer in hf_model.model.layers:
+        hooks.append(layer.register_forward_hook(lambda _m, _i, out: hf_layers.append(out)))
+    for layer in native_model.layers:
+        hooks.append(layer.register_forward_hook(lambda _m, _i, out: native_layers.append(out)))
+    hooks.append(
+        hf_model.model.layers[1].mlp.gate.register_forward_hook(
+            lambda _m, _i, out: hf_router.append((out[1], out[2]))
+        )
+    )
+    hooks.append(
+        native_model.layers[1].moe.router.register_forward_hook(
+            lambda _m, _i, out: native_router.append((out[0], out[1]))
+        )
+    )
+
+    hf_logits = hf_model(input_ids=input_ids, use_cache=False).logits
+    native_logits = _batch_first(native_model(input_ids=input_ids)["logits"], input_ids.shape[0])
+    for hook in hooks:
+        hook.remove()
+
+    assert len(hf_layers) == len(native_layers) == config.num_hidden_layers
+    for index, (native_layer, hf_layer) in enumerate(zip(native_layers, hf_layers, strict=True)):
+        _assert_close(f"layer_{index}", _batch_first(native_layer, input_ids.shape[0]), hf_layer)
+    assert len(hf_router) == len(native_router) == 1
+    hf_scores, hf_indices = hf_router[0]
+    native_scores, native_indices = native_router[0]
+    assert torch.equal(native_indices, hf_indices)
+    _assert_close("router_scores", native_scores, hf_scores, atol=2e-3)
+    _assert_close("logits", native_logits, hf_logits)
+
+    hf_loss = F.cross_entropy(hf_logits.flatten(0, 1).float(), labels.flatten())
+    native_loss = F.cross_entropy(native_logits.flatten(0, 1).float(), labels.flatten())
+    _assert_close("loss", native_loss, hf_loss, atol=2e-3)
+    hf_loss.backward()
+    native_loss.backward()
+
+    from megatron.lite.model.hy3.lite.checkpoint import Hy3WeightSpec
+
+    spec = Hy3WeightSpec(config)
+    native_qkv_grad = native_model.layers[0].attn.qkv.linear.weight.grad
+    hf_qkv_grad = spec.hf_to_native(
+        "layers.0.attn.qkv.linear.weight",
+        [
+            hf_model.model.layers[0].self_attn.q_proj.weight.grad,
+            hf_model.model.layers[0].self_attn.k_proj.weight.grad,
+            hf_model.model.layers[0].self_attn.v_proj.weight.grad,
+        ],
+    )
+    gradient_pairs = {
+        "embedding_grad": (
+            native_model.embed.embedding.weight.grad,
+            hf_model.model.embed_tokens.weight.grad,
+        ),
+        "qkv_grad": (native_qkv_grad, hf_qkv_grad),
+        "router_grad": (
+            native_model.layers[1].moe.router.gate.weight.grad,
+            hf_model.model.layers[1].mlp.gate.weight.grad,
+        ),
+        "head_grad": (native_model.head.col.linear.weight.grad, hf_model.lm_head.weight.grad),
+    }
+    for name, (native_grad, hf_grad) in gradient_pairs.items():
+        assert native_grad is not None and hf_grad is not None
+        _assert_close(name, native_grad, hf_grad, atol=8e-2)
+

--- a/experimental/lite/tests/smoke/model/test_qwen_lite_forward_smoke.py
+++ b/experimental/lite/tests/smoke/model/test_qwen_lite_forward_smoke.py
@@ -29,6 +29,14 @@ def _qwen35_symbols():
     return Qwen35Config, Qwen35Model
 
 
+def _hy3_symbols():
+    pytest.importorskip("transformer_engine.pytorch")
+    from megatron.lite.model.hy3.config import Hy3Config
+    from megatron.lite.model.hy3.lite.model import Hy3Model
+
+    return Hy3Config, Hy3Model
+
+
 @pytest.fixture(scope="module", autouse=True)
 def _single_node_cuda_dist():
     if not torch.cuda.is_available():
@@ -91,6 +99,25 @@ def _tiny_qwen35_config():
         partial_rotary_factor=1.0,
         mrope_section=[1, 1, 0],
         layer_types=["linear_attention"],
+    )
+
+
+def _tiny_hy3_config():
+    Hy3Config, _Hy3Model = _hy3_symbols()
+    return Hy3Config(
+        num_hidden_layers=2,
+        hidden_size=16,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=4,
+        vocab_size=64,
+        intermediate_size=24,
+        num_experts=2,
+        num_experts_per_tok=1,
+        moe_intermediate_size=8,
+        first_k_dense_replace=1,
+        max_position_embeddings=16,
+        num_nextn_predict_layers=0,
     )
 
 

--- a/experimental/lite/tests/unit/model/test_hy3_checkpoint_unit.py
+++ b/experimental/lite/tests/unit/model/test_hy3_checkpoint_unit.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from __future__ import annotations
 
 import torch

--- a/experimental/lite/tests/unit/model/test_hy3_checkpoint_unit.py
+++ b/experimental/lite/tests/unit/model/test_hy3_checkpoint_unit.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import torch
 import torch.nn as nn
+import pytest
+from types import SimpleNamespace
 
 from megatron.lite.model.hy3.config import Hy3Config
 from megatron.lite.model.hy3.lite.checkpoint import Hy3WeightSpec
@@ -82,3 +84,44 @@ def test_checkpoint_tensor_iterator_includes_only_mapped_persistent_buffers():
     weight_map = {"weight": ["weight"], "expert_bias": ["expert_bias"]}
     tensors = dict(iter_checkpoint_tensors(Module(), weight_map))
     assert set(tensors) == {"weight", "expert_bias"}
+
+
+def test_hy3_export_translates_grouped_linear_local_expert_names():
+    pytest.importorskip("safetensors")
+    from megatron.lite.primitive.ckpt.hf_weights import export_hf_weights
+
+    class Experts(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.fc1 = nn.Module()
+            self.fc1.register_parameter("weight0", nn.Parameter(torch.arange(64).reshape(8, 8).float()))
+
+    class Sparse(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.moe = nn.Module()
+            self.moe.experts = Experts()
+
+    class Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layers = nn.ModuleList([nn.Identity(), Sparse()])
+            self.layer_indices = [0, 1]
+
+    ps = SimpleNamespace(
+        pp_size=1,
+        tp_size=1,
+        tp_rank=0,
+        tp_group=None,
+        etp_size=1,
+        etp_rank=0,
+        etp_group=None,
+        ep_size=1,
+        ep_rank=0,
+        ep_group=None,
+    )
+    exported = dict(export_hf_weights(Model(), Hy3WeightSpec(_config()), ps))
+    assert set(exported) == {
+        "model.layers.1.mlp.experts.0.gate_proj.weight",
+        "model.layers.1.mlp.experts.0.up_proj.weight",
+    }

--- a/experimental/lite/tests/unit/model/test_hy3_checkpoint_unit.py
+++ b/experimental/lite/tests/unit/model/test_hy3_checkpoint_unit.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+from megatron.lite.model.hy3.config import Hy3Config
+from megatron.lite.model.hy3.lite.checkpoint import Hy3WeightSpec
+
+
+def _config() -> Hy3Config:
+    return Hy3Config(
+        hidden_size=8,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=4,
+        num_hidden_layers=2,
+        vocab_size=16,
+        intermediate_size=12,
+        num_experts=2,
+        num_experts_per_tok=1,
+        moe_intermediate_size=4,
+        num_nextn_predict_layers=1,
+    )
+
+
+def test_hy3_weight_spec_maps_dense_sparse_shared_bias_and_mtp_names():
+    spec = Hy3WeightSpec(_config())
+    weight_map = spec.weight_map()
+
+    assert weight_map["layers.0.mlp.gate_up.linear.weight"] == [
+        "model.layers.0.mlp.gate_proj.weight",
+        "model.layers.0.mlp.up_proj.weight",
+    ]
+    assert weight_map["layers.1.moe.router.expert_bias"] == [
+        "model.layers.1.mlp.expert_bias"
+    ]
+    assert weight_map["layers.1.moe.shared_mlp.down.linear.weight"] == [
+        "model.layers.1.mlp.shared_mlp.down_proj.weight"
+    ]
+    assert weight_map["mtp.layers.0.enorm.weight"] == ["model.layers.2.enorm.weight"]
+    assert weight_map["mtp.layers.0.final_layernorm.weight"] == [
+        "model.layers.2.final_layernorm.weight"
+    ]
+
+
+def test_hy3_weight_spec_round_trips_qkv_dense_and_shared_swiglu():
+    config = _config()
+    spec = Hy3WeightSpec(config)
+    hidden = config.hidden_size
+
+    q = torch.arange(8 * hidden).reshape(8, hidden)
+    k = torch.arange(4 * hidden).reshape(4, hidden) + 1000
+    v = torch.arange(4 * hidden).reshape(4, hidden) + 2000
+    packed = spec.hf_to_native("layers.0.attn.qkv.linear.weight", [q, k, v])
+    qkv = dict(spec.native_to_hf("layers.0.attn.qkv.linear.weight", packed))
+    assert torch.equal(qkv["model.layers.0.self_attn.q_proj.weight"], q)
+    assert torch.equal(qkv["model.layers.0.self_attn.k_proj.weight"], k)
+    assert torch.equal(qkv["model.layers.0.self_attn.v_proj.weight"], v)
+
+    gate = torch.arange(12 * hidden).reshape(12, hidden)
+    up = gate + 1000
+    for native_name in (
+        "layers.0.mlp.gate_up.linear.weight",
+        "layers.1.moe.shared_mlp.gate_up.linear.weight",
+    ):
+        packed = spec.hf_to_native(native_name, [gate, up])
+        exported = dict(spec.native_to_hf(native_name, packed))
+        assert any(torch.equal(value, gate) for name, value in exported.items() if "gate_proj" in name)
+        assert any(torch.equal(value, up) for name, value in exported.items() if "up_proj" in name)
+
+
+def test_checkpoint_tensor_iterator_includes_only_mapped_persistent_buffers():
+    from megatron.lite.primitive.checkpoint_transforms import iter_checkpoint_tensors
+
+    class Module(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = nn.Parameter(torch.ones(1))
+            self.register_buffer("expert_bias", torch.zeros(1), persistent=True)
+            self.register_buffer("scratch", torch.zeros(1), persistent=False)
+
+    weight_map = {"weight": ["weight"], "expert_bias": ["expert_bias"]}
+    tensors = dict(iter_checkpoint_tensors(Module(), weight_map))
+    assert set(tensors) == {"weight", "expert_bias"}

--- a/experimental/lite/tests/unit/model/test_qat_all_model_wiring.py
+++ b/experimental/lite/tests/unit/model/test_qat_all_model_wiring.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 
 MODEL_ROOT = Path(__file__).parents[3] / "megatron" / "lite" / "model"
-MODEL_NAMES = ("qwen3_moe", "qwen3_5", "deepseek_v4", "glm5", "kimi_k2")
+MODEL_NAMES = ("qwen3_moe", "qwen3_5", "deepseek_v4", "glm5", "kimi_k2", "hy3")
 
 
 @pytest.mark.parametrize("model_name", MODEL_NAMES)

--- a/experimental/lite/tests/unit/model/test_qwen_config_unit.py
+++ b/experimental/lite/tests/unit/model/test_qwen_config_unit.py
@@ -8,7 +8,11 @@ import pytest
 
 from megatron.lite.model.qwen3_5.config import Qwen35Config
 from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
-from megatron.lite.model.registry import resolve_model_type_from_hf, resolve_runtime_model_name
+from megatron.lite.model.hy3.config import Hy3Config
+from megatron.lite.model.registry import (
+    resolve_model_type_from_hf,
+    resolve_runtime_model_name,
+)
 
 pytestmark = pytest.mark.mlite
 
@@ -59,6 +63,63 @@ def test_registry_resolves_qwen_lite_model_names():
     assert resolve_runtime_model_name("qwen3", "lite") == "qwen3"
     assert resolve_runtime_model_name("qwen3_moe", "lite") == "qwen3_moe"
     assert resolve_runtime_model_name("qwen3_5", "lite") == "qwen3_5"
+
+
+def _tiny_hy3_hf_dict() -> dict:
+    return {
+        "model_type": "hy_v3",
+        "hidden_size": 16,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "head_dim": 4,
+        "num_hidden_layers": 3,
+        "vocab_size": 64,
+        "intermediate_size": 24,
+        "moe_intermediate_size": 8,
+        "num_experts": 4,
+        "num_experts_per_tok": 2,
+        "num_shared_experts": 1,
+        "first_k_dense_replace": 1,
+        "router_scaling_factor": 2.5,
+        "qk_norm": True,
+        "moe_router_use_sigmoid": True,
+        "moe_router_enable_expert_bias": True,
+        "route_norm": True,
+        "hidden_act": "silu",
+        "rope_parameters": {"rope_theta": 12345.0, "rope_type": "default"},
+        "num_nextn_predict_layers": 1,
+    }
+
+
+def test_hy3_registry_and_config_preserve_nonstandard_contract():
+    assert resolve_model_type_from_hf({"model_type": "hy_v3"}) == "hy3"
+    assert resolve_runtime_model_name("hy3", "lite") == "hy3"
+
+    cfg = Hy3Config._from_hf_dict(_tiny_hy3_hf_dict())
+
+    assert cfg.layer_types == ["dense", "sparse", "sparse"]
+    assert cfg.rope_theta == 12345.0
+    assert cfg.shared_expert_intermediate_size == 8
+    assert cfg.num_nextn_predict_layers == 1
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("qk_norm", False),
+        ("moe_router_use_sigmoid", False),
+        ("moe_router_enable_expert_bias", False),
+        ("route_norm", False),
+        ("num_shared_experts", 2),
+        ("hidden_act", "gelu"),
+    ],
+)
+def test_hy3_config_rejects_unsupported_architecture_drift(field, value):
+    hf = _tiny_hy3_hf_dict()
+    hf[field] = value
+
+    with pytest.raises(ValueError, match=field):
+        Hy3Config._from_hf_dict(hf)
 
 
 def test_qwen3_config_from_hf_dict_derives_head_dim_and_rope_theta():

--- a/experimental/lite/tests/unit/primitive/test_attention_moe_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_attention_moe_unit.py
@@ -34,6 +34,14 @@ def _router_and_parallel_state(monkeypatch):
     return TopKRouter, ParallelState
 
 
+def _sigmoid_router_and_parallel_state():
+    pytest.importorskip("transformer_engine.pytorch")
+    from megatron.lite.primitive.modules.router import SigmoidTopKRouter
+    from megatron.lite.primitive.parallel import ParallelState
+
+    return SigmoidTopKRouter, ParallelState
+
+
 def _router_config():
     return SimpleNamespace(
         hidden_size=4, num_experts=4, num_experts_per_tok=2, router_aux_loss_coef=0.1


### PR DESCRIPTION
## Summary
- Add native Tencent Hy3 composition, registry/config support, HF checkpoint mappings, and staged acceptance coverage.
- Reuse the shared HFWeights loading/export primitive introduced by #135; Hy3 supplies only model-specific mapping and format conversion.
- Preserve persistent router-bias loading, GroupedLinear expert-name canonicalization, and the standard QAT-before-optimizer switch.

## Validation
- `python -m pytest experimental/lite/tests/unit/model/test_qat_all_model_wiring.py experimental/lite/tests/unit/model/test_qwen_config_unit.py experimental/lite/tests/unit/model/test_hy3_checkpoint_unit.py experimental/lite/tests/unit/primitive/ckpt/test_hf_weights_stream_load.py -q` — 41 passed.
- `ruff format --check` and `ruff check` on the changed Hy3, registry, and QAT-wiring sources — passed.
- `git diff --check` — passed.

## Scope
22 files changed: 1,963 additions and 24 deletions. GPU staged smoke coverage is included but has not been run in this change.