### PR TITLE
Add controlled Qwen3 EP overlap probe

### DIFF
--- a/experimental/lite/examples/bench/README.md
+++ b/experimental/lite/examples/bench/README.md
@@ -75,10 +75,18 @@ DRY_RUN=1 \
 bash experimental/lite/examples/bench/scripts/run_qwen3_ep_overlap_pair.sh
 ```
 
-Set `DRY_RUN=0` inside an 8-GPU allocation to run the default EP=8 pair. The
-overlap arm sets only `overlap_moe_expert_parallel_comm=true`; the script writes
-separate JSON and log files for direct loss, gradient-norm, throughput, and
-memory comparison.
+Set `DRY_RUN=0` inside an 8-GPU allocation to run the EP=8 pair. This probe uses
+the complete model configuration: it rejects layer or expert truncation and
+records the realized layer count, expert count, and EP/TP/PP/CP topology in
+every rank summary. The overlap arm changes only
+`overlap_moe_expert_parallel_comm`. Each summary contains repeated global-step
+timings with a 95% confidence interval plus per-step and overall
+`max_memory_allocated`/`max_memory_reserved` evidence. Set `NSYS_PROFILE=1` to
+also capture CUDA/NVTX/OSRT traces for both arms; each measured step has an NVTX
+range. CSV, summary, allocator snapshot, log, and nsys outputs are kept under
+`OUTPUT_DIR`. Run the unprofiled measurement pair and the nsys pair in separate
+output directories; profiler timings are attribution evidence, not performance
+numbers.
 
 ## Validated Run
 

--- a/experimental/lite/examples/bench/README.md
+++ b/experimental/lite/examples/bench/README.md
@@ -62,6 +62,24 @@ Set `DRY_RUN=0` to run the benchmark under `torchrun`. Results are written to
 `experimental/lite/examples/bench/outputs/`. Set `REFERENCE_BACKEND=bridge` only
 when Megatron-Bridge is installed and `import megatron.bridge` succeeds.
 
+## Qwen3 EP-Overlap Pair
+
+The first combined-1F1B profile is deliberately narrow: Qwen3 MoE, PP=1,
+EP>1, the all-to-all dispatcher, at least two microbatches, no MTP, no
+recompute, and unfused permutation. Run the baseline and overlap arms with the
+same data and model shape:
+
+```bash
+HF_PATH=/models/Qwen3-30B-A3B \
+DRY_RUN=1 \
+bash experimental/lite/examples/bench/scripts/run_qwen3_ep_overlap_pair.sh
+```
+
+Set `DRY_RUN=0` inside an 8-GPU allocation to run the default EP=8 pair. The
+overlap arm sets only `overlap_moe_expert_parallel_comm=true`; the script writes
+separate JSON and log files for direct loss, gradient-norm, throughput, and
+memory comparison.
+
 ## Validated Run
 
 The following paired run completed on 2026-06-07 with 8x NVIDIA H100 80GB GPUs:

--- a/experimental/lite/examples/bench/bench.py
+++ b/experimental/lite/examples/bench/bench.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import random
 import sys
 from dataclasses import dataclass, fields, is_dataclass, replace
 from pathlib import Path
@@ -371,10 +372,19 @@ def _step_reporter(trace: StepTrace) -> None:
     print(" ".join(parts), flush=True)
 
 
+def _seed_benchmark(seed: int) -> None:
+    """Replay model initialization and data setup across separate A/B processes."""
+    import torch
+
+    random.seed(seed)
+    torch.manual_seed(seed)
+
+
 def run(cfg: BenchCliConfig) -> dict[str, Any]:
     if cfg.dry_run:
         return build_dry_run_plan(cfg)
 
+    _seed_benchmark(cfg.seed)
     rt_cfg = build_runtime_config(cfg)
     rt = create_runtime(rt_cfg)
     handle = rt.build_model()

--- a/experimental/lite/examples/bench/cycle_memory_probe.py
+++ b/experimental/lite/examples/bench/cycle_memory_probe.py
@@ -34,9 +34,17 @@ def sample_cuda_memory() -> dict[str, int]:
     return {
         "allocated_bytes": allocated,
         "reserved_bytes": reserved,
+        "peak_allocated_bytes": torch.cuda.max_memory_allocated(),
+        "peak_reserved_bytes": torch.cuda.max_memory_reserved(),
         "reserved_minus_allocated_bytes": reserved - allocated,
         "inactive_split_bytes": int(stats.get("inactive_split_bytes.all.current", 0)),
     }
+
+
+def reset_peak_memory() -> None:
+    import torch
+
+    torch.cuda.reset_peak_memory_stats()
 
 
 def dump_snapshot(path: Path) -> None:
@@ -134,5 +142,6 @@ __all__ = [
     "live_allocation_stacks",
     "per_cycle_retention",
     "record_memory_history",
+    "reset_peak_memory",
     "sample_cuda_memory",
 ]

--- a/experimental/lite/examples/bench/cycle_memory_probe.py
+++ b/experimental/lite/examples/bench/cycle_memory_probe.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Shared per-cycle CUDA memory evidence helpers.
+
+The sampling, snapshot fail-loud behavior, live-stack aggregation, and
+least-squares retention calculation are ported from the validated per-cycle
+memory harness. Workload adapters should only define their controlled arms and
+lifecycle; they must not carry private copies of this evidence logic.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+
+def record_memory_history(max_entries: int = 200000) -> None:
+    import torch
+
+    try:
+        torch.cuda.memory._record_memory_history(
+            enabled="all", stacks="all", max_entries=max_entries
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise RuntimeError(f"_record_memory_history failed: {exc}") from exc
+
+
+def sample_cuda_memory() -> dict[str, int]:
+    import torch
+
+    stats = torch.cuda.memory_stats()
+    allocated = torch.cuda.memory_allocated()
+    reserved = torch.cuda.memory_reserved()
+    return {
+        "allocated_bytes": allocated,
+        "reserved_bytes": reserved,
+        "reserved_minus_allocated_bytes": reserved - allocated,
+        "inactive_split_bytes": int(stats.get("inactive_split_bytes.all.current", 0)),
+    }
+
+
+def dump_snapshot(path: Path) -> None:
+    import torch
+
+    try:
+        torch.cuda.memory._dump_snapshot(path)
+    except Exception as exc:  # noqa: BLE001
+        raise RuntimeError(f"_dump_snapshot failed for {path}: {exc}") from exc
+
+
+def current_snapshot() -> dict[str, Any]:
+    import torch
+
+    try:
+        return torch.cuda.memory._snapshot()
+    except Exception as exc:  # noqa: BLE001
+        raise RuntimeError(f"_snapshot failed: {exc}") from exc
+
+
+def live_allocation_stacks(
+    snapshot: Mapping[str, object], top_n: int = 15
+) -> list[dict[str, Any]]:
+    grouped: dict[tuple[str, ...], list[int]] = {}
+    for segment in snapshot.get("segments", []) or []:
+        for block in segment.get("blocks", []) or []:
+            if block.get("state") not in {"active_allocated", "allocated"}:
+                continue
+            frames = block.get("frames") or []
+            if not frames and (history := block.get("history") or []):
+                frames = history[0].get("frames") or []
+            key = tuple(
+                f"{frame.get('filename', '?')}:{frame.get('line', '?')}:{frame.get('name', '?')}"
+                for frame in frames
+            )[:6]
+            if not key:
+                continue
+            entry = grouped.setdefault(key, [0, 0])
+            entry[0] += int(block.get("size", block.get("requested_size", 0)) or 0)
+            entry[1] += 1
+    return [
+        {"frames": list(key), "retained_bytes": value[0], "num_blocks": value[1]}
+        for key, value in sorted(
+            grouped.items(), key=lambda item: item[1][0], reverse=True
+        )[:top_n]
+    ]
+
+
+def _least_squares_slope(xs: Sequence[float], ys: Sequence[float]) -> float:
+    if len(xs) < 2:
+        return 0.0
+    mean_x = sum(xs) / len(xs)
+    mean_y = sum(ys) / len(ys)
+    denominator = sum((x - mean_x) ** 2 for x in xs)
+    if denominator == 0.0:
+        return 0.0
+    return (
+        sum((x - mean_x) * (y - mean_y) for x, y in zip(xs, ys, strict=True))
+        / denominator
+    )
+
+
+def per_cycle_retention(
+    samples: Iterable[Mapping[str, object]],
+    *,
+    phase: str,
+    metric: str,
+    warmup_cycles: int,
+) -> dict[str, float | int | None]:
+    rows = [
+        row
+        for row in samples
+        if str(row.get("phase")) == phase and int(row["cycle"]) >= warmup_cycles
+    ]
+    rows.sort(key=lambda row: int(row["cycle"]))
+    if len(rows) < 2:
+        return {
+            "slope_bytes_per_cycle": 0.0,
+            "net_delta_bytes": 0.0,
+            "first_cycle": int(rows[0]["cycle"]) if rows else None,
+            "last_cycle": int(rows[-1]["cycle"]) if rows else None,
+            "n_points": len(rows),
+        }
+    xs = [float(int(row["cycle"])) for row in rows]
+    ys = [float(row[metric]) for row in rows]
+    return {
+        "slope_bytes_per_cycle": _least_squares_slope(xs, ys),
+        "net_delta_bytes": ys[-1] - ys[0],
+        "first_cycle": int(rows[0]["cycle"]),
+        "last_cycle": int(rows[-1]["cycle"]),
+        "n_points": len(rows),
+    }
+
+
+__all__ = [
+    "current_snapshot",
+    "dump_snapshot",
+    "live_allocation_stacks",
+    "per_cycle_retention",
+    "record_memory_history",
+    "sample_cuda_memory",
+]

--- a/experimental/lite/examples/bench/cycle_memory_probe.py
+++ b/experimental/lite/examples/bench/cycle_memory_probe.py
@@ -113,13 +113,10 @@ def per_cycle_retention(
     ]
     rows.sort(key=lambda row: int(row["cycle"]))
     if len(rows) < 2:
-        return {
-            "slope_bytes_per_cycle": 0.0,
-            "net_delta_bytes": 0.0,
-            "first_cycle": int(rows[0]["cycle"]) if rows else None,
-            "last_cycle": int(rows[-1]["cycle"]) if rows else None,
-            "n_points": len(rows),
-        }
+        raise ValueError(
+            "per-cycle retention requires at least 2 samples: "
+            f"phase={phase!r}, metric={metric!r}, n_points={len(rows)}"
+        )
     xs = [float(int(row["cycle"])) for row in rows]
     ys = [float(row[metric]) for row in rows]
     return {

--- a/experimental/lite/examples/bench/qwen3_ep_overlap_probe.py
+++ b/experimental/lite/examples/bench/qwen3_ep_overlap_probe.py
@@ -1,0 +1,277 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Controlled two-arm configuration gate for Qwen3 EP overlap."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import time
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from examples.bench.bench import (
+    BenchCliConfig,
+    build_dry_run_plan,
+    build_runtime_config,
+)
+
+_OVERLAP_KEY = "overlap_moe_expert_parallel_comm"
+_SHARED_IMPL_CFG: dict[str, Any] = {"use_deepep": False, "recompute": []}
+
+
+def build_arm_configs() -> tuple[dict[str, Any], dict[str, Any]]:
+    baseline = deepcopy(_SHARED_IMPL_CFG)
+    overlap = deepcopy(_SHARED_IMPL_CFG)
+    baseline[_OVERLAP_KEY] = False
+    overlap[_OVERLAP_KEY] = True
+    assert_only_overlap_diff(baseline, overlap)
+    return baseline, overlap
+
+
+def assert_only_overlap_diff(baseline: dict[str, Any], overlap: dict[str, Any]) -> None:
+    if set(baseline) != set(overlap):
+        raise ValueError(
+            f"impl_cfg keys differ: baseline={sorted(baseline)}, overlap={sorted(overlap)}"
+        )
+    for key in sorted(baseline):
+        if key == _OVERLAP_KEY:
+            if baseline[key] is not False or overlap[key] is not True:
+                raise ValueError(f"{_OVERLAP_KEY} must be False/True")
+        elif baseline[key] != overlap[key]:
+            raise ValueError(f"controlled A/B differs outside {_OVERLAP_KEY}: {key}")
+
+
+def build_config_only_plans(hf_path: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    baseline, overlap = build_arm_configs()
+    common = dict(
+        backend="mlite",
+        hf_path=hf_path,
+        model_name="qwen3_moe",
+        tp=1,
+        etp=1,
+        ep=8,
+        pp=1,
+        cp=1,
+        steps=4,
+        warmup=1,
+        num_microbatches=4,
+        seq_len=256,
+        truncate_layers=2,
+        keep_experts=8,
+        disable_mtp=True,
+        same_data_across_dp=True,
+        skip_load_hf_weights=True,
+        dry_run=True,
+    )
+    baseline_plan = build_dry_run_plan(
+        BenchCliConfig(**common, impl_cfg_json=json.dumps(baseline))
+    )
+    overlap_plan = build_dry_run_plan(
+        BenchCliConfig(**common, impl_cfg_json=json.dumps(overlap))
+    )
+    assert_only_overlap_diff(
+        baseline_plan["runtime"]["backend_cfg"]["impl_cfg"],
+        overlap_plan["runtime"]["backend_cfg"]["impl_cfg"],
+    )
+    return baseline_plan, overlap_plan
+
+
+def _sample_cuda_memory() -> dict[str, int]:
+    """Reuse the established probe's reserved/allocated/inactive-split evidence."""
+    import torch
+
+    stats = torch.cuda.memory_stats()
+    allocated = torch.cuda.memory_allocated()
+    reserved = torch.cuda.memory_reserved()
+    return {
+        "allocated_bytes": allocated,
+        "reserved_bytes": reserved,
+        "reserved_minus_allocated_bytes": reserved - allocated,
+        "inactive_split_bytes": int(stats.get("inactive_split_bytes.all.current", 0)),
+    }
+
+
+def _live_stacks(snapshot: dict[str, Any], top_n: int) -> list[dict[str, Any]]:
+    """Existing probe's live allocation-stack aggregation, unchanged in criterion."""
+    grouped: dict[tuple[str, ...], list[int]] = {}
+    for segment in snapshot.get("segments", []) or []:
+        for block in segment.get("blocks", []) or []:
+            if block.get("state") not in {"active_allocated", "allocated"}:
+                continue
+            frames = block.get("frames") or []
+            if not frames and (history := block.get("history") or []):
+                frames = history[0].get("frames") or []
+            key = tuple(
+                f"{frame.get('filename', '?')}:{frame.get('line', '?')}:{frame.get('name', '?')}"
+                for frame in frames
+            )[:6]
+            if not key:
+                continue
+            entry = grouped.setdefault(key, [0, 0])
+            entry[0] += int(block.get("size", block.get("requested_size", 0)) or 0)
+            entry[1] += 1
+    return [
+        {"frames": list(key), "retained_bytes": value[0], "num_blocks": value[1]}
+        for key, value in sorted(
+            grouped.items(), key=lambda item: item[1][0], reverse=True
+        )[:top_n]
+    ]
+
+
+def _gpu_arm(
+    name: str, cfg: BenchCliConfig, out_dir: Path, cycles: int, warmup: int
+) -> None:
+    """One arm of the copied per-cycle CSV/snapshot lifecycle."""
+    import torch
+
+    from examples.bench.session import PretrainSessionConfig, _make_data_iter
+    from megatron.lite.runtime import create_runtime
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA unavailable; refusing to emit CPU proxy evidence")
+    rank = int(os.environ.get("RANK", "0"))
+    torch.cuda.set_device(int(os.environ.get("LOCAL_RANK", "0")))
+    torch.manual_seed(cfg.seed)
+    torch.cuda.manual_seed_all(cfg.seed)
+    try:
+        torch.cuda.memory._record_memory_history(
+            enabled="all", stacks="all", max_entries=200000
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise RuntimeError(f"_record_memory_history failed: {exc}") from exc
+    runtime = create_runtime(build_runtime_config(cfg))
+    handle = runtime.build_model()
+    session = PretrainSessionConfig(
+        steps=cycles + warmup,
+        warmup=warmup,
+        num_microbatches=cfg.num_microbatches,
+        seq_len=cfg.seq_len,
+        seed=cfg.seed,
+        device="cuda",
+        same_data_across_dp=True,
+    )
+    rows: list[dict[str, Any]] = []
+    path = out_dir / f"{name}-rank{rank}.csv"
+    with path.open("w", newline="", encoding="utf-8") as fh, runtime.train_mode(handle):
+        fields = [
+            "cycle",
+            "phase",
+            "allocated_bytes",
+            "reserved_bytes",
+            "reserved_minus_allocated_bytes",
+            "inactive_split_bytes",
+            "step_ms",
+        ]
+        writer = csv.DictWriter(fh, fieldnames=fields)
+        writer.writeheader()
+        data = _make_data_iter(handle, session)
+        for cycle in range(cycles + warmup):
+            runtime.zero_grad(handle)
+            torch.cuda.synchronize()
+            before = {
+                "cycle": cycle,
+                "phase": "before",
+                **_sample_cuda_memory(),
+                "step_ms": 0.0,
+            }
+            writer.writerow(before)
+            rows.append(before)
+            started = time.perf_counter()
+            runtime.forward_backward(
+                handle, data, loss_fn=None, num_microbatches=cfg.num_microbatches
+            )
+            runtime.optimizer_step(handle)
+            runtime.lr_scheduler_step(handle)
+            torch.cuda.synchronize()
+            after = {
+                "cycle": cycle,
+                "phase": "after",
+                **_sample_cuda_memory(),
+                "step_ms": round((time.perf_counter() - started) * 1000, 3),
+            }
+            writer.writerow(after)
+            rows.append(after)
+            if cycle >= warmup:
+                try:
+                    torch.cuda.memory._dump_snapshot(
+                        out_dir / f"{name}-rank{rank}-cycle{cycle}.pickle"
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    raise RuntimeError(
+                        f"_dump_snapshot cycle {cycle} failed: {exc}"
+                    ) from exc
+    stacks = _live_stacks(torch.cuda.memory._snapshot(), top_n=15)
+    if not stacks:
+        raise RuntimeError(
+            "snapshot yielded no live allocation stacks; attribution evidence missing"
+        )
+    (out_dir / f"{name}-rank{rank}-summary.json").write_text(
+        json.dumps(
+            {
+                "arm": name,
+                "impl_cfg": json.loads(cfg.impl_cfg_json),
+                "rows": rows,
+                "live_stacks": stacks,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--hf-path", required=True)
+    parser.add_argument("--config-only", action="store_true")
+    parser.add_argument("--out-dir", default=".")
+    parser.add_argument("--cycles", type=int, default=4)
+    parser.add_argument("--warmup", type=int, default=1)
+    args = parser.parse_args(argv)
+    baseline, overlap = build_config_only_plans(args.hf_path)
+    if args.config_only:
+        print(
+            json.dumps(
+                {
+                    "baseline": baseline["runtime"]["backend_cfg"]["impl_cfg"],
+                    "overlap": overlap["runtime"]["backend_cfg"]["impl_cfg"],
+                },
+                sort_keys=True,
+            )
+        )
+        print("QWEN3_EP_OVERLAP_CONFIG_ONLY_OK", flush=True)
+        return 0
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    arm_configs = build_arm_configs()
+    for name, impl_cfg in zip(("baseline", "overlap"), arm_configs, strict=True):
+        cfg = BenchCliConfig(
+            backend="mlite",
+            hf_path=args.hf_path,
+            model_name="qwen3_moe",
+            tp=1,
+            etp=1,
+            ep=8,
+            pp=1,
+            cp=1,
+            steps=args.cycles + args.warmup,
+            warmup=args.warmup,
+            num_microbatches=4,
+            seq_len=256,
+            truncate_layers=2,
+            keep_experts=8,
+            disable_mtp=True,
+            same_data_across_dp=True,
+            skip_load_hf_weights=True,
+            impl_cfg_json=json.dumps(impl_cfg, sort_keys=True),
+        )
+        _gpu_arm(name, cfg, out_dir, args.cycles, args.warmup)
+    print("QWEN3_EP_OVERLAP_PROBE_OK", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experimental/lite/examples/bench/qwen3_ep_overlap_probe.py
+++ b/experimental/lite/examples/bench/qwen3_ep_overlap_probe.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+import math
 import os
+import statistics
 import time
 from copy import deepcopy
 from pathlib import Path
@@ -23,10 +25,129 @@ dump_snapshot = cycle_memory_probe.dump_snapshot
 live_allocation_stacks = cycle_memory_probe.live_allocation_stacks
 per_cycle_retention = cycle_memory_probe.per_cycle_retention
 record_memory_history = cycle_memory_probe.record_memory_history
+reset_peak_memory = cycle_memory_probe.reset_peak_memory
 sample_cuda_memory = cycle_memory_probe.sample_cuda_memory
 
 _OVERLAP_KEY = "overlap_moe_expert_parallel_comm"
 _SHARED_IMPL_CFG: dict[str, Any] = {"use_deepep": False, "recompute": []}
+_PARALLEL_EVIDENCE = {"ep": 8, "tp": 1, "pp": 1, "cp": 1}
+
+
+def _config_root(config: Any) -> Any:
+    if isinstance(config, dict):
+        return config.get("text_config", config)
+    return getattr(config, "text_config", config)
+
+
+def load_source_model_evidence(hf_path: str) -> dict[str, int | bool]:
+    config_path = Path(hf_path) / "config.json"
+    if not config_path.is_file():
+        raise ValueError(f"model evidence requires {config_path}")
+    source = _config_root(json.loads(config_path.read_text(encoding="utf-8")))
+    if isinstance(source, dict):
+        layers = source.get("num_hidden_layers")
+        experts = source.get("num_experts")
+    else:
+        layers = getattr(source, "num_hidden_layers", None)
+        experts = getattr(source, "num_experts", None)
+    if not isinstance(layers, int) or layers <= 2:
+        raise ValueError(
+            f"full multi-layer evidence requires >2 layers, got {layers!r}"
+        )
+    if not isinstance(experts, int) or experts <= 0:
+        raise ValueError(f"MoE evidence requires num_experts > 0, got {experts!r}")
+    return {"num_hidden_layers": layers, "truncated": False, "num_experts": experts}
+
+
+def build_model_evidence(cfg: BenchCliConfig, model_cfg: Any) -> dict[str, int | bool]:
+    if cfg.truncate_layers is not None or cfg.keep_experts is not None:
+        raise ValueError("probe evidence forbids truncated layers or experts")
+    root = _config_root(model_cfg)
+    evidence = {
+        "num_hidden_layers": int(getattr(root, "num_hidden_layers")),
+        "truncated": False,
+        "num_experts": int(getattr(root, "num_experts")),
+    }
+    source = load_source_model_evidence(cfg.hf_path)
+    if evidence != source:
+        raise ValueError(
+            f"built model differs from source model: built={evidence}, source={source}"
+        )
+    return evidence
+
+
+def build_parallel_evidence(cfg: BenchCliConfig) -> dict[str, int]:
+    evidence = {"ep": cfg.ep, "tp": cfg.tp, "pp": cfg.pp, "cp": cfg.cp}
+    if evidence != _PARALLEL_EVIDENCE:
+        raise ValueError(
+            f"probe requires {_PARALLEL_EVIDENCE}, got parallel topology {evidence}"
+        )
+    return evidence
+
+
+def _performance_summary(rows: list[dict[str, Any]], warmup: int) -> dict[str, Any]:
+    measured = [
+        row for row in rows if row["phase"] == "after" and int(row["cycle"]) >= warmup
+    ]
+    step_ms = [float(row["step_ms"]) for row in measured]
+    if len(step_ms) < 2:
+        raise ValueError(
+            f"performance evidence requires >=2 repeats, got {len(step_ms)}"
+        )
+    mean = statistics.fmean(step_ms)
+    sem = statistics.stdev(step_ms) / math.sqrt(len(step_ms))
+    return {
+        "repeat_count": len(step_ms),
+        "step_ms": {
+            "mean": mean,
+            "median": statistics.median(step_ms),
+            "ci95_low": mean - 1.96 * sem,
+            "ci95_high": mean + 1.96 * sem,
+            "samples": step_ms,
+        },
+        "throughput_tokens_per_second": {
+            "mean": statistics.fmean(
+                float(row["throughput_tokens_per_second"]) for row in measured
+            ),
+            "samples": [float(row["throughput_tokens_per_second"]) for row in measured],
+        },
+    }
+
+
+def validate_probe_summary(summary: dict[str, Any], *, warmup: int) -> None:
+    model = summary.get("model") or {}
+    if model.get("truncated") is not False:
+        raise ValueError("probe evidence must declare truncated=false")
+    if int(model.get("num_hidden_layers", 0)) <= 2:
+        raise ValueError("probe evidence requires full multi-layer model")
+    if int(model.get("num_experts", 0)) <= 0:
+        raise ValueError("probe evidence requires num_experts")
+    if summary.get("parallel") != _PARALLEL_EVIDENCE:
+        raise ValueError(f"unexpected parallel topology: {summary.get('parallel')!r}")
+    measured = [
+        row
+        for row in summary.get("rows", [])
+        if row.get("phase") == "after" and int(row.get("cycle", -1)) >= warmup
+    ]
+    peak_fields = ("peak_allocated_bytes", "peak_reserved_bytes")
+    if len(measured) < 2 or any(
+        not isinstance(row.get(field), int) or int(row[field]) <= 0
+        for row in measured
+        for field in peak_fields
+    ):
+        raise ValueError("peak memory evidence missing or invalid")
+    expected_peak = {
+        "max_memory_allocated_bytes": max(
+            int(row["peak_allocated_bytes"]) for row in measured
+        ),
+        "max_memory_reserved_bytes": max(
+            int(row["peak_reserved_bytes"]) for row in measured
+        ),
+    }
+    if summary.get("peak_memory") != expected_peak:
+        raise ValueError("peak memory aggregate missing or inconsistent")
+    if summary.get("performance", {}).get("repeat_count") != len(measured):
+        raise ValueError("performance repeat evidence missing or inconsistent")
 
 
 def build_arm_configs() -> tuple[dict[str, Any], dict[str, Any]]:
@@ -67,27 +188,35 @@ def build_config_only_plans(hf_path: str) -> tuple[dict[str, Any], dict[str, Any
         ep=8,
         pp=1,
         cp=1,
-        steps=4,
-        warmup=1,
+        steps=13,
+        warmup=3,
         num_microbatches=4,
         seq_len=256,
-        truncate_layers=2,
-        keep_experts=8,
         disable_mtp=True,
         same_data_across_dp=True,
         skip_load_hf_weights=True,
         dry_run=True,
     )
-    baseline_plan = build_dry_run_plan(
-        BenchCliConfig(**common, impl_cfg_json=json.dumps(baseline))
-    )
-    overlap_plan = build_dry_run_plan(
-        BenchCliConfig(**common, impl_cfg_json=json.dumps(overlap))
-    )
+    baseline_cfg = BenchCliConfig(**common, impl_cfg_json=json.dumps(baseline))
+    overlap_cfg = BenchCliConfig(**common, impl_cfg_json=json.dumps(overlap))
+    baseline_plan = build_dry_run_plan(baseline_cfg)
+    overlap_plan = build_dry_run_plan(overlap_cfg)
     assert_only_overlap_diff(
         baseline_plan["runtime"]["backend_cfg"]["impl_cfg"],
         overlap_plan["runtime"]["backend_cfg"]["impl_cfg"],
     )
+    evidence_contract = {
+        "model": load_source_model_evidence(hf_path),
+        "parallel": build_parallel_evidence(baseline_cfg),
+        "required_metrics": [
+            "step_ms",
+            "throughput_tokens_per_second",
+            "peak_allocated_bytes",
+            "peak_reserved_bytes",
+        ],
+    }
+    baseline_plan["evidence_contract"] = deepcopy(evidence_contract)
+    overlap_plan["evidence_contract"] = deepcopy(evidence_contract)
     return baseline_plan, overlap_plan
 
 
@@ -130,6 +259,8 @@ def _gpu_arm(
     record_memory_history()
     runtime = create_runtime(build_runtime_config(cfg))
     handle = runtime.build_model()
+    model_evidence = build_model_evidence(cfg, handle._extras.get("model_cfg"))
+    parallel_evidence = build_parallel_evidence(cfg)
     session = PretrainSessionConfig(
         steps=cycles + warmup,
         warmup=warmup,
@@ -147,9 +278,12 @@ def _gpu_arm(
             "phase",
             "allocated_bytes",
             "reserved_bytes",
+            "peak_allocated_bytes",
+            "peak_reserved_bytes",
             "reserved_minus_allocated_bytes",
             "inactive_split_bytes",
             "step_ms",
+            "throughput_tokens_per_second",
         ]
         writer = csv.DictWriter(fh, fieldnames=fields)
         writer.writeheader()
@@ -157,26 +291,40 @@ def _gpu_arm(
         for cycle in range(cycles + warmup):
             runtime.zero_grad(handle)
             torch.cuda.synchronize()
+            reset_peak_memory()
             before = {
                 "cycle": cycle,
                 "phase": "before",
                 **sample_cuda_memory(),
                 "step_ms": 0.0,
+                "throughput_tokens_per_second": 0.0,
             }
             writer.writerow(before)
             rows.append(before)
             started = time.perf_counter()
-            runtime.forward_backward(
-                handle, data, loss_fn=None, num_microbatches=cfg.num_microbatches
-            )
-            runtime.optimizer_step(handle)
-            runtime.lr_scheduler_step(handle)
-            torch.cuda.synchronize()
+            torch.cuda.nvtx.range_push(f"qwen3_ep_{name}_step_{cycle}")
+            try:
+                runtime.forward_backward(
+                    handle, data, loss_fn=None, num_microbatches=cfg.num_microbatches
+                )
+                runtime.optimizer_step(handle)
+                runtime.lr_scheduler_step(handle)
+                torch.cuda.synchronize()
+            finally:
+                torch.cuda.nvtx.range_pop()
+            elapsed_ms = (time.perf_counter() - started) * 1000
+            step_memory = sample_cuda_memory()
+            if torch.distributed.is_initialized():
+                elapsed = torch.tensor(elapsed_ms, dtype=torch.float64, device="cuda")
+                torch.distributed.all_reduce(elapsed, op=torch.distributed.ReduceOp.MAX)
+                elapsed_ms = float(elapsed.item())
+            tokens_per_step = cfg.num_microbatches * cfg.seq_len * handle.dp_size
             after = {
                 "cycle": cycle,
                 "phase": "after",
-                **sample_cuda_memory(),
-                "step_ms": round((time.perf_counter() - started) * 1000, 3),
+                **step_memory,
+                "step_ms": round(elapsed_ms, 3),
+                "throughput_tokens_per_second": tokens_per_step / (elapsed_ms / 1000),
             }
             writer.writerow(after)
             rows.append(after)
@@ -187,27 +335,36 @@ def _gpu_arm(
         raise RuntimeError(
             "snapshot yielded no live allocation stacks; attribution evidence missing"
         )
+    summary = {
+        "arm": name,
+        "impl_cfg": json.loads(cfg.impl_cfg_json),
+        "model": model_evidence,
+        "parallel": parallel_evidence,
+        "rows": rows,
+        "performance": _performance_summary(rows, warmup),
+        "peak_memory": {
+            "max_memory_allocated_bytes": max(
+                int(row["peak_allocated_bytes"])
+                for row in rows
+                if row["phase"] == "after" and int(row["cycle"]) >= warmup
+            ),
+            "max_memory_reserved_bytes": max(
+                int(row["peak_reserved_bytes"])
+                for row in rows
+                if row["phase"] == "after" and int(row["cycle"]) >= warmup
+            ),
+        },
+        "retention": {
+            metric: per_cycle_retention(
+                rows, phase="after", metric=metric, warmup_cycles=warmup
+            )
+            for metric in ("reserved_minus_allocated_bytes", "inactive_split_bytes")
+        },
+        "live_stacks": stacks,
+    }
+    validate_probe_summary(summary, warmup=warmup)
     (out_dir / f"{name}-rank{rank}-summary.json").write_text(
-        json.dumps(
-            {
-                "arm": name,
-                "impl_cfg": json.loads(cfg.impl_cfg_json),
-                "rows": rows,
-                "retention": {
-                    metric: per_cycle_retention(
-                        rows, phase="after", metric=metric, warmup_cycles=warmup
-                    )
-                    for metric in (
-                        "reserved_minus_allocated_bytes",
-                        "inactive_split_bytes",
-                    )
-                },
-                "live_stacks": stacks,
-            },
-            indent=2,
-        )
-        + "\n",
-        encoding="utf-8",
+        json.dumps(summary, indent=2) + "\n", encoding="utf-8"
     )
 
 
@@ -217,8 +374,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--config-only", action="store_true")
     parser.add_argument("--arm", choices=("baseline", "overlap"))
     parser.add_argument("--out-dir", default=".")
-    parser.add_argument("--cycles", type=int, default=4)
-    parser.add_argument("--warmup", type=int, default=1)
+    parser.add_argument("--cycles", type=int, default=10)
+    parser.add_argument("--warmup", type=int, default=3)
     args = parser.parse_args(argv)
     baseline, overlap = build_config_only_plans(args.hf_path)
     if args.config_only:
@@ -227,6 +384,7 @@ def main(argv: list[str] | None = None) -> int:
                 {
                     "baseline": baseline["runtime"]["backend_cfg"]["impl_cfg"],
                     "overlap": overlap["runtime"]["backend_cfg"]["impl_cfg"],
+                    "evidence_contract": baseline["evidence_contract"],
                 },
                 sort_keys=True,
             )
@@ -250,8 +408,6 @@ def main(argv: list[str] | None = None) -> int:
         warmup=args.warmup,
         num_microbatches=4,
         seq_len=256,
-        truncate_layers=2,
-        keep_experts=8,
         disable_mtp=True,
         same_data_across_dp=True,
         skip_load_hf_weights=True,

--- a/experimental/lite/examples/bench/qwen3_ep_overlap_probe.py
+++ b/experimental/lite/examples/bench/qwen3_ep_overlap_probe.py
@@ -38,6 +38,11 @@ def build_arm_configs() -> tuple[dict[str, Any], dict[str, Any]]:
     return baseline, overlap
 
 
+def select_arm_config(arm: str) -> dict[str, Any]:
+    baseline, overlap = build_arm_configs()
+    return {"baseline": baseline, "overlap": overlap}[arm]
+
+
 def assert_only_overlap_diff(baseline: dict[str, Any], overlap: dict[str, Any]) -> None:
     if set(baseline) != set(overlap):
         raise ValueError(
@@ -188,6 +193,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--hf-path", required=True)
     parser.add_argument("--config-only", action="store_true")
+    parser.add_argument("--arm", choices=("baseline", "overlap"))
     parser.add_argument("--out-dir", default=".")
     parser.add_argument("--cycles", type=int, default=4)
     parser.add_argument("--warmup", type=int, default=1)
@@ -205,31 +211,31 @@ def main(argv: list[str] | None = None) -> int:
         )
         print("QWEN3_EP_OVERLAP_CONFIG_ONLY_OK", flush=True)
         return 0
+    if args.arm is None:
+        parser.error("--arm is required unless --config-only")
     out_dir = Path(args.out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
-    arm_configs = build_arm_configs()
-    for name, impl_cfg in zip(("baseline", "overlap"), arm_configs, strict=True):
-        cfg = BenchCliConfig(
-            backend="mlite",
-            hf_path=args.hf_path,
-            model_name="qwen3_moe",
-            tp=1,
-            etp=1,
-            ep=8,
-            pp=1,
-            cp=1,
-            steps=args.cycles + args.warmup,
-            warmup=args.warmup,
-            num_microbatches=4,
-            seq_len=256,
-            truncate_layers=2,
-            keep_experts=8,
-            disable_mtp=True,
-            same_data_across_dp=True,
-            skip_load_hf_weights=True,
-            impl_cfg_json=json.dumps(impl_cfg, sort_keys=True),
-        )
-        _gpu_arm(name, cfg, out_dir, args.cycles, args.warmup)
+    cfg = BenchCliConfig(
+        backend="mlite",
+        hf_path=args.hf_path,
+        model_name="qwen3_moe",
+        tp=1,
+        etp=1,
+        ep=8,
+        pp=1,
+        cp=1,
+        steps=args.cycles + args.warmup,
+        warmup=args.warmup,
+        num_microbatches=4,
+        seq_len=256,
+        truncate_layers=2,
+        keep_experts=8,
+        disable_mtp=True,
+        same_data_across_dp=True,
+        skip_load_hf_weights=True,
+        impl_cfg_json=json.dumps(select_arm_config(args.arm), sort_keys=True),
+    )
+    _gpu_arm(args.arm, cfg, out_dir, args.cycles, args.warmup)
     print("QWEN3_EP_OVERLAP_PROBE_OK", flush=True)
     return 0
 

--- a/experimental/lite/examples/bench/qwen3_ep_overlap_probe.py
+++ b/experimental/lite/examples/bench/qwen3_ep_overlap_probe.py
@@ -12,11 +12,18 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
-from examples.bench.bench import (
-    BenchCliConfig,
-    build_dry_run_plan,
-    build_runtime_config,
-)
+from examples.bench import bench as bench_module
+from examples.bench import cycle_memory_probe
+
+BenchCliConfig = bench_module.BenchCliConfig
+build_dry_run_plan = bench_module.build_dry_run_plan
+build_runtime_config = bench_module.build_runtime_config
+current_snapshot = cycle_memory_probe.current_snapshot
+dump_snapshot = cycle_memory_probe.dump_snapshot
+live_allocation_stacks = cycle_memory_probe.live_allocation_stacks
+per_cycle_retention = cycle_memory_probe.per_cycle_retention
+record_memory_history = cycle_memory_probe.record_memory_history
+sample_cuda_memory = cycle_memory_probe.sample_cuda_memory
 
 _OVERLAP_KEY = "overlap_moe_expert_parallel_comm"
 _SHARED_IMPL_CFG: dict[str, Any] = {"use_deepep": False, "recompute": []}
@@ -79,54 +86,11 @@ def build_config_only_plans(hf_path: str) -> tuple[dict[str, Any], dict[str, Any
     return baseline_plan, overlap_plan
 
 
-def _sample_cuda_memory() -> dict[str, int]:
-    """Reuse the established probe's reserved/allocated/inactive-split evidence."""
-    import torch
-
-    stats = torch.cuda.memory_stats()
-    allocated = torch.cuda.memory_allocated()
-    reserved = torch.cuda.memory_reserved()
-    return {
-        "allocated_bytes": allocated,
-        "reserved_bytes": reserved,
-        "reserved_minus_allocated_bytes": reserved - allocated,
-        "inactive_split_bytes": int(stats.get("inactive_split_bytes.all.current", 0)),
-    }
-
-
-def _live_stacks(snapshot: dict[str, Any], top_n: int) -> list[dict[str, Any]]:
-    """Existing probe's live allocation-stack aggregation, unchanged in criterion."""
-    grouped: dict[tuple[str, ...], list[int]] = {}
-    for segment in snapshot.get("segments", []) or []:
-        for block in segment.get("blocks", []) or []:
-            if block.get("state") not in {"active_allocated", "allocated"}:
-                continue
-            frames = block.get("frames") or []
-            if not frames and (history := block.get("history") or []):
-                frames = history[0].get("frames") or []
-            key = tuple(
-                f"{frame.get('filename', '?')}:{frame.get('line', '?')}:{frame.get('name', '?')}"
-                for frame in frames
-            )[:6]
-            if not key:
-                continue
-            entry = grouped.setdefault(key, [0, 0])
-            entry[0] += int(block.get("size", block.get("requested_size", 0)) or 0)
-            entry[1] += 1
-    return [
-        {"frames": list(key), "retained_bytes": value[0], "num_blocks": value[1]}
-        for key, value in sorted(
-            grouped.items(), key=lambda item: item[1][0], reverse=True
-        )[:top_n]
-    ]
-
-
 def _gpu_arm(
     name: str, cfg: BenchCliConfig, out_dir: Path, cycles: int, warmup: int
 ) -> None:
     """One arm of the copied per-cycle CSV/snapshot lifecycle."""
     import torch
-
     from examples.bench.session import PretrainSessionConfig, _make_data_iter
     from megatron.lite.runtime import create_runtime
 
@@ -136,12 +100,7 @@ def _gpu_arm(
     torch.cuda.set_device(int(os.environ.get("LOCAL_RANK", "0")))
     torch.manual_seed(cfg.seed)
     torch.cuda.manual_seed_all(cfg.seed)
-    try:
-        torch.cuda.memory._record_memory_history(
-            enabled="all", stacks="all", max_entries=200000
-        )
-    except Exception as exc:  # noqa: BLE001
-        raise RuntimeError(f"_record_memory_history failed: {exc}") from exc
+    record_memory_history()
     runtime = create_runtime(build_runtime_config(cfg))
     handle = runtime.build_model()
     session = PretrainSessionConfig(
@@ -174,7 +133,7 @@ def _gpu_arm(
             before = {
                 "cycle": cycle,
                 "phase": "before",
-                **_sample_cuda_memory(),
+                **sample_cuda_memory(),
                 "step_ms": 0.0,
             }
             writer.writerow(before)
@@ -189,21 +148,14 @@ def _gpu_arm(
             after = {
                 "cycle": cycle,
                 "phase": "after",
-                **_sample_cuda_memory(),
+                **sample_cuda_memory(),
                 "step_ms": round((time.perf_counter() - started) * 1000, 3),
             }
             writer.writerow(after)
             rows.append(after)
             if cycle >= warmup:
-                try:
-                    torch.cuda.memory._dump_snapshot(
-                        out_dir / f"{name}-rank{rank}-cycle{cycle}.pickle"
-                    )
-                except Exception as exc:  # noqa: BLE001
-                    raise RuntimeError(
-                        f"_dump_snapshot cycle {cycle} failed: {exc}"
-                    ) from exc
-    stacks = _live_stacks(torch.cuda.memory._snapshot(), top_n=15)
+                dump_snapshot(out_dir / f"{name}-rank{rank}-cycle{cycle}.pickle")
+    stacks = live_allocation_stacks(current_snapshot(), top_n=15)
     if not stacks:
         raise RuntimeError(
             "snapshot yielded no live allocation stacks; attribution evidence missing"
@@ -214,6 +166,15 @@ def _gpu_arm(
                 "arm": name,
                 "impl_cfg": json.loads(cfg.impl_cfg_json),
                 "rows": rows,
+                "retention": {
+                    metric: per_cycle_retention(
+                        rows, phase="after", metric=metric, warmup_cycles=warmup
+                    )
+                    for metric in (
+                        "reserved_minus_allocated_bytes",
+                        "inactive_split_bytes",
+                    )
+                },
                 "live_stacks": stacks,
             },
             indent=2,

--- a/experimental/lite/examples/bench/qwen3_ep_overlap_probe.py
+++ b/experimental/lite/examples/bench/qwen3_ep_overlap_probe.py
@@ -91,6 +91,28 @@ def build_config_only_plans(hf_path: str) -> tuple[dict[str, Any], dict[str, Any
     return baseline_plan, overlap_plan
 
 
+def require_probe_artifacts(
+    out_dir: Path, arm: str, rank: int, cycles: int, warmup: int
+) -> list[Path]:
+    expected = [
+        out_dir / f"{arm}-rank{rank}.csv",
+        out_dir / f"{arm}-rank{rank}-summary.json",
+        *[
+            out_dir / f"{arm}-rank{rank}-cycle{cycle}.pickle"
+            for cycle in range(warmup, cycles + warmup)
+        ],
+    ]
+    missing = [
+        path for path in expected if not path.is_file() or path.stat().st_size == 0
+    ]
+    if missing:
+        raise RuntimeError(
+            "probe evidence missing or empty: "
+            + ", ".join(str(path) for path in missing)
+        )
+    return expected
+
+
 def _gpu_arm(
     name: str, cfg: BenchCliConfig, out_dir: Path, cycles: int, warmup: int
 ) -> None:
@@ -236,6 +258,13 @@ def main(argv: list[str] | None = None) -> int:
         impl_cfg_json=json.dumps(select_arm_config(args.arm), sort_keys=True),
     )
     _gpu_arm(args.arm, cfg, out_dir, args.cycles, args.warmup)
+    require_probe_artifacts(
+        out_dir=out_dir,
+        arm=args.arm,
+        rank=int(os.environ.get("RANK", "0")),
+        cycles=args.cycles,
+        warmup=args.warmup,
+    )
     print("QWEN3_EP_OVERLAP_PROBE_OK", flush=True)
     return 0
 

--- a/experimental/lite/examples/bench/scripts/run_qwen3_ep_overlap_pair.sh
+++ b/experimental/lite/examples/bench/scripts/run_qwen3_ep_overlap_pair.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HF_PATH=${HF_PATH:?set HF_PATH to a HuggingFace Qwen3 MoE model directory}
+REPO_ROOT=${REPO_ROOT:-$(pwd)}
+OUTPUT_DIR=${OUTPUT_DIR:-"${REPO_ROOT}/experimental/lite/examples/bench/outputs"}
+PYTHON_BIN=${PYTHON_BIN:-python}
+NPROC=${NPROC:-8}
+DRY_RUN=${DRY_RUN:-1}
+
+export PYTHONPATH="${REPO_ROOT}/experimental/lite:${REPO_ROOT}${PYTHONPATH:+:${PYTHONPATH}}"
+export MEGATRON_LITE_MOE_PERMUTE_FUSION=0
+
+COMMON_ARGS=(
+  --backend mlite
+  --hf-path "${HF_PATH}"
+  --model-name qwen3_moe
+  --tp "${TP:-1}"
+  --etp "${ETP:-1}"
+  --ep "${EP:-8}"
+  --pp 1
+  --cp 1
+  --steps "${STEPS:-12}"
+  --warmup "${WARMUP:-4}"
+  --num-microbatches "${NUM_MICROBATCHES:-4}"
+  --seq-len "${SEQ_LEN:-1024}"
+  --truncate-layers "${TRUNCATE_LAYERS:-8}"
+  --keep-experts "${KEEP_EXPERTS:-8}"
+  --disable-mtp
+  --same-data-across-dp
+  --skip-load-hf-weights
+)
+
+run_arm() {
+  local arm=$1
+  local impl_cfg=$2
+  local port=$3
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    "${PYTHON_BIN}" "${REPO_ROOT}/experimental/lite/examples/bench/bench.py" \
+      "${COMMON_ARGS[@]}" \
+      --impl-cfg-json "${impl_cfg}" \
+      --dry-run
+    return
+  fi
+
+  mkdir -p "${OUTPUT_DIR}"
+  torchrun --nproc_per_node "${NPROC}" --master_port "${port}" \
+    "${REPO_ROOT}/experimental/lite/examples/bench/bench.py" \
+    "${COMMON_ARGS[@]}" \
+    --impl-cfg-json "${impl_cfg}" \
+    --output-json "${OUTPUT_DIR}/qwen3_ep_${arm}.json" \
+    2>&1 | tee "${OUTPUT_DIR}/qwen3_ep_${arm}.log"
+}
+
+run_arm baseline '{}' "${MASTER_PORT_BASELINE:-31851}"
+run_arm overlap \
+  '{"overlap_moe_expert_parallel_comm":true,"use_deepep":false,"recompute":[]}' \
+  "${MASTER_PORT_OVERLAP:-31852}"

--- a/experimental/lite/examples/bench/scripts/run_qwen3_ep_overlap_pair.sh
+++ b/experimental/lite/examples/bench/scripts/run_qwen3_ep_overlap_pair.sh
@@ -7,52 +7,38 @@ OUTPUT_DIR=${OUTPUT_DIR:-"${REPO_ROOT}/experimental/lite/examples/bench/outputs"
 PYTHON_BIN=${PYTHON_BIN:-python}
 NPROC=${NPROC:-8}
 DRY_RUN=${DRY_RUN:-1}
+NSYS_PROFILE=${NSYS_PROFILE:-0}
+CYCLES=${CYCLES:-10}
+WARMUP=${WARMUP:-3}
 
 export PYTHONPATH="${REPO_ROOT}/experimental/lite:${REPO_ROOT}${PYTHONPATH:+:${PYTHONPATH}}"
 export MEGATRON_LITE_MOE_PERMUTE_FUSION=0
 
-COMMON_ARGS=(
-  --backend mlite
-  --hf-path "${HF_PATH}"
-  --model-name qwen3_moe
-  --tp "${TP:-1}"
-  --etp "${ETP:-1}"
-  --ep "${EP:-8}"
-  --pp 1
-  --cp 1
-  --steps "${STEPS:-12}"
-  --warmup "${WARMUP:-4}"
-  --num-microbatches "${NUM_MICROBATCHES:-4}"
-  --seq-len "${SEQ_LEN:-1024}"
-  --truncate-layers "${TRUNCATE_LAYERS:-8}"
-  --keep-experts "${KEEP_EXPERTS:-8}"
-  --disable-mtp
-  --same-data-across-dp
-  --skip-load-hf-weights
-)
-
 run_arm() {
   local arm=$1
-  local impl_cfg=$2
-  local port=$3
+  local port=$2
   if [[ "${DRY_RUN}" == "1" ]]; then
-    "${PYTHON_BIN}" "${REPO_ROOT}/experimental/lite/examples/bench/bench.py" \
-      "${COMMON_ARGS[@]}" \
-      --impl-cfg-json "${impl_cfg}" \
-      --dry-run
+    "${PYTHON_BIN}" \
+      "${REPO_ROOT}/experimental/lite/examples/bench/qwen3_ep_overlap_probe.py" \
+      --hf-path "${HF_PATH}" --config-only
     return
   fi
 
   mkdir -p "${OUTPUT_DIR}"
-  torchrun --nproc_per_node "${NPROC}" --master_port "${port}" \
-    "${REPO_ROOT}/experimental/lite/examples/bench/bench.py" \
-    "${COMMON_ARGS[@]}" \
-    --impl-cfg-json "${impl_cfg}" \
-    --output-json "${OUTPUT_DIR}/qwen3_ep_${arm}.json" \
-    2>&1 | tee "${OUTPUT_DIR}/qwen3_ep_${arm}.log"
+  local command=(
+    torchrun --nproc_per_node "${NPROC}" --master_port "${port}"
+    "${REPO_ROOT}/experimental/lite/examples/bench/qwen3_ep_overlap_probe.py"
+    --hf-path "${HF_PATH}" --out-dir "${OUTPUT_DIR}"
+    --cycles "${CYCLES}" --warmup "${WARMUP}" --arm "${arm}"
+  )
+  if [[ "${NSYS_PROFILE}" == "1" ]]; then
+    nsys profile --force-overwrite=true --trace=cuda,nvtx,osrt --sample=none \
+      --output "${OUTPUT_DIR}/qwen3_ep_${arm}" "${command[@]}" \
+      2>&1 | tee "${OUTPUT_DIR}/qwen3_ep_${arm}.log"
+  else
+    "${command[@]}" 2>&1 | tee "${OUTPUT_DIR}/qwen3_ep_${arm}.log"
+  fi
 }
 
-run_arm baseline '{}' "${MASTER_PORT_BASELINE:-31851}"
-run_arm overlap \
-  '{"overlap_moe_expert_parallel_comm":true,"use_deepep":false,"recompute":[]}' \
-  "${MASTER_PORT_OVERLAP:-31852}"
+run_arm baseline "${MASTER_PORT_BASELINE:-31851}"
+run_arm overlap "${MASTER_PORT_OVERLAP:-31852}"

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
@@ -101,8 +101,9 @@ class MoELayer(nn.Module):
             )
 
         def preprocess(x):
-            scores, indices = self.router(x)
-            return self.dispatcher.alltoall_dispatch_preprocess(x, scores, indices)
+            x_2d = x.view(-1, x.size(-1)) if x.dim() == 3 else x
+            scores, indices = self.router(x_2d)
+            return self.dispatcher.alltoall_dispatch_preprocess(x_2d, scores, indices)
 
         def communicate(permuted, permuted_probs, tokens_per_expert):
             return self.dispatcher.alltoall_dispatch_communicate(
@@ -226,12 +227,12 @@ class TransformerLayer(nn.Module):
             x = residual + h
             residual = x
             h = self.mlp_norm(x)
-            permuted, permuted_probs = moe_preprocess(h)
-            return residual, permuted, permuted_probs
+            permuted, permuted_probs, tokens_per_expert = moe_preprocess(h)
+            return residual, permuted, permuted_probs, tokens_per_expert
 
-        def dispatch_node(residual, permuted, permuted_probs):
+        def dispatch_node(residual, permuted, permuted_probs, tokens_per_expert):
             dispatched, tokens_per_expert, permuted_probs = dispatch(
-                permuted, permuted_probs
+                permuted, permuted_probs, tokens_per_expert
             )
             return residual, dispatched, tokens_per_expert, permuted_probs
 
@@ -239,7 +240,8 @@ class TransformerLayer(nn.Module):
             return residual, experts(dispatched, tokens_per_expert, permuted_probs)
 
         def combine_node(residual, expert_output):
-            return residual + combine(expert_output)
+            combined = combine(expert_output).view_as(residual).to(residual.dtype)
+            return residual + combined
 
         return pre_dispatch, dispatch_node, experts_node, combine_node
 

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
@@ -13,7 +13,6 @@ from contextlib import nullcontext
 import torch
 import torch.nn as nn
 import transformer_engine.pytorch as te
-
 from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
 from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
 from megatron.lite.primitive.modules.experts import Experts
@@ -24,6 +23,7 @@ from megatron.lite.primitive.ops.cross_entropy import vocab_parallel_cross_entro
 from megatron.lite.primitive.ops.linear_cross_entropy import linear_cross_entropy
 from megatron.lite.primitive.ops.logprob import vocab_parallel_entropy
 from megatron.lite.primitive.parallel import (
+    Combined1F1BModelPlan,
     ParallelState,
     VanillaColumnParallelLinear,
     VocabParallelEmbedding,
@@ -58,7 +58,11 @@ class MoELayer(nn.Module):
             config, ps, router_bias_rate=router_bias_rate, compute_aux_loss=False
         )
         self.experts = Experts(
-            config, ps, fp8=fp8, moe_act_recompute=moe_act_recompute, lora_config=lora_config
+            config,
+            ps,
+            fp8=fp8,
+            moe_act_recompute=moe_act_recompute,
+            lora_config=lora_config,
         )
         self.dispatcher = TokenDispatcher(
             config.num_experts, config.hidden_size, ps, use_deepep=use_deepep
@@ -72,7 +76,9 @@ class MoELayer(nn.Module):
             x_2d = x
 
         scores, indices = self.router(x_2d)
-        dispatched, tpe, permuted_probs = self.dispatcher.dispatch(x_2d, scores, indices)
+        dispatched, tpe, permuted_probs = self.dispatcher.dispatch(
+            x_2d, scores, indices
+        )
         del scores, indices
         self.dispatcher.wait_dispatch_event()
         expert_out = self.experts(
@@ -86,6 +92,37 @@ class MoELayer(nn.Module):
         del expert_out
 
         return combined.view(input_shape).to(x.dtype)
+
+    def combined_1f1b_callables(self):
+        """Return the all-to-all MoE nodes used by the combined schedule."""
+        if self.dispatcher.ep_size <= 1 or self.dispatcher.use_deepep:
+            raise RuntimeError(
+                "combined-1F1B requires EP > 1 with the alltoall dispatcher"
+            )
+
+        def preprocess(x):
+            scores, indices = self.router(x)
+            return self.dispatcher.alltoall_dispatch_preprocess(x, scores, indices)
+
+        def communicate(permuted, permuted_probs):
+            return self.dispatcher.alltoall_dispatch_communicate(
+                permuted, permuted_probs
+            )
+
+        def experts(dispatched, tokens_per_expert, permuted_probs):
+            return self.experts(
+                dispatched,
+                tokens_per_expert,
+                permuted_probs,
+                tokens_per_expert_list=None,
+            )
+
+        return (
+            preprocess,
+            communicate,
+            experts,
+            self.dispatcher.alltoall_combine_communicate,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -159,7 +196,10 @@ class TransformerLayer(nn.Module):
         )
 
     def forward(
-        self, x: torch.Tensor, position_ids: torch.Tensor | None = None, packed_seq_params=None
+        self,
+        x: torch.Tensor,
+        position_ids: torch.Tensor | None = None,
+        packed_seq_params=None,
     ) -> torch.Tensor:
         residual = x
         h = self.attn(x, position_ids=position_ids, packed_seq_params=packed_seq_params)
@@ -171,6 +211,37 @@ class TransformerLayer(nn.Module):
         x = residual + moe_out
 
         return x
+
+    def combined_1f1b_callables(
+        self, *, position_ids: torch.Tensor | None, packed_seq_params
+    ):
+        """Split the layer at EP communication boundaries, matching Megatron."""
+        moe_preprocess, dispatch, experts, combine = self.moe.combined_1f1b_callables()
+
+        def pre_dispatch(x):
+            residual = x
+            h = self.attn(
+                x, position_ids=position_ids, packed_seq_params=packed_seq_params
+            )
+            x = residual + h
+            residual = x
+            h = self.mlp_norm(x)
+            permuted, permuted_probs = moe_preprocess(h)
+            return residual, permuted, permuted_probs
+
+        def dispatch_node(residual, permuted, permuted_probs):
+            dispatched, tokens_per_expert, permuted_probs = dispatch(
+                permuted, permuted_probs
+            )
+            return residual, dispatched, tokens_per_expert, permuted_probs
+
+        def experts_node(residual, dispatched, tokens_per_expert, permuted_probs):
+            return residual, experts(dispatched, tokens_per_expert, permuted_probs)
+
+        def combine_node(residual, expert_output):
+            return residual + combine(expert_output)
+
+        return pre_dispatch, dispatch_node, experts_node, combine_node
 
 
 class MTPLossAutoScaler(torch.autograd.Function):
@@ -186,7 +257,9 @@ class MTPLossAutoScaler(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad_output: torch.Tensor):
         (mtp_loss,) = ctx.saved_tensors
-        scaled_mtp_grad = torch.ones_like(mtp_loss) * MTPLossAutoScaler.main_loss_backward_scale
+        scaled_mtp_grad = (
+            torch.ones_like(mtp_loss) * MTPLossAutoScaler.main_loss_backward_scale
+        )
         return grad_output, scaled_mtp_grad
 
     @staticmethod
@@ -221,7 +294,11 @@ class MultiTokenPredictionLayer(nn.Module):
         self.enorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.hnorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.eh_proj = VanillaColumnParallelLinear(
-            config.hidden_size * 2, config.hidden_size, ps, sp=ps.tp_size > 1, gather_output=True
+            config.hidden_size * 2,
+            config.hidden_size,
+            ps,
+            sp=ps.tp_size > 1,
+            gather_output=True,
         )
         self.transformer_layer = TransformerLayer(
             config,
@@ -248,7 +325,9 @@ class MultiTokenPredictionLayer(nn.Module):
         attention_position_ids = (
             rotary_position_ids if rotary_position_ids is not None else position_ids
         )
-        input_ids, _ = roll_packed_thd_left(input_ids, packed_seq_params=packed_seq_params, dims=-1)
+        input_ids, _ = roll_packed_thd_left(
+            input_ids, packed_seq_params=packed_seq_params, dims=-1
+        )
         if position_ids is not None:
             position_ids, _ = roll_packed_thd_left(
                 position_ids, packed_seq_params=packed_seq_params, dims=-1
@@ -266,7 +345,9 @@ class MultiTokenPredictionLayer(nn.Module):
         hidden_states = self.eh_proj(hidden_states)
         hidden_states = scatter_to_sequence_parallel(hidden_states, self.ps)
         hidden_states = self.transformer_layer(
-            hidden_states, position_ids=attention_position_ids, packed_seq_params=packed_seq_params
+            hidden_states,
+            position_ids=attention_position_ids,
+            packed_seq_params=packed_seq_params,
         )
         hidden_states = self.final_layernorm(hidden_states)
         return hidden_states, input_ids, position_ids
@@ -369,7 +450,9 @@ class Qwen3MoEModel(nn.Module):
         self.mtp_enable_train = bool(mtp_enable and mtp_enable_train)
         self.mtp_loss_scaling_factor = config.mtp_loss_scaling_factor
         self._input_tensor: torch.Tensor | None = None
-        layout = build_pipeline_chunk_layout(config.num_hidden_layers, ps, vpp, vpp_chunk_id)
+        layout = build_pipeline_chunk_layout(
+            config.num_hidden_layers, ps, vpp, vpp_chunk_id
+        )
         self.layer_indices = layout.layer_indices
         has_embed = layout.has_embed
         has_head = layout.has_head
@@ -379,7 +462,9 @@ class Qwen3MoEModel(nn.Module):
 
         self.embed: VocabParallelEmbedding | None = None
         if has_embed:
-            self.embed = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
+            self.embed = VocabParallelEmbedding(
+                config.vocab_size, config.hidden_size, ps
+            )
 
         _recompute = recompute_modules or []
         moe_act_recompute = "moe_act" in _recompute and "moe" not in _recompute
@@ -411,7 +496,9 @@ class Qwen3MoEModel(nn.Module):
         if mtp_enable and config.num_nextn_predict_layers > 0 and self.head is not None:
             mtp_embedding = self.embed
             if mtp_embedding is None:
-                mtp_embedding = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
+                mtp_embedding = VocabParallelEmbedding(
+                    config.vocab_size, config.hidden_size, ps
+                )
                 self.mtp_embed = mtp_embedding
             self.mtp = MultiTokenPredictionBlock(
                 config,
@@ -434,9 +521,93 @@ class Qwen3MoEModel(nn.Module):
     def set_input_tensor(self, input_tensor):
         if isinstance(input_tensor, list):
             if len(input_tensor) > 1:
-                raise ValueError("Qwen3MoEModel expects a single pipeline input tensor.")
+                raise ValueError(
+                    "Qwen3MoEModel expects a single pipeline input tensor."
+                )
             input_tensor = input_tensor[0] if input_tensor else None
         self._input_tensor = input_tensor
+
+    def _preprocess_hidden(
+        self, *, input_ids: torch.Tensor | None, hidden_states: torch.Tensor | None
+    ) -> torch.Tensor:
+        if self.embed is not None:
+            if input_ids is None:
+                raise ValueError("input_ids are required on the embedding stage")
+            hidden = self.embed(input_ids)
+            return scatter_to_sequence_parallel(hidden, self.ps)
+        if hidden_states is None:
+            hidden_states = self._input_tensor
+        if hidden_states is None:
+            raise ValueError("hidden_states are required without an embedding")
+        return hidden_states
+
+    def _postprocess_hidden(
+        self,
+        hidden: torch.Tensor,
+        *,
+        input_ids: torch.Tensor | None,
+        position_ids: torch.Tensor | None,
+        packed_seq_params,
+        labels: torch.Tensor | None,
+        loss_mask: torch.Tensor | None,
+        temperature: float | torch.Tensor,
+        use_fused_kernels: bool,
+        calculate_entropy: bool,
+        return_log_probs: bool,
+    ) -> dict:
+        output = {"hidden_states": hidden}
+        if self.head is None:
+            return output
+
+        hidden_for_head = self.norm(hidden)
+        if labels is not None:
+            temperature_value = _temperature_to_float(temperature)
+            mtp_result = self._apply_mtp_loss(
+                hidden_for_head,
+                input_ids=input_ids,
+                position_ids=position_ids,
+                labels=labels,
+                loss_mask=loss_mask,
+                packed_seq_params=packed_seq_params,
+                temperature=temperature_value,
+                use_fused_kernels=use_fused_kernels,
+            )
+            if mtp_result is not None:
+                hidden_for_head, mtp_loss = mtp_result
+                output["mtp_loss"] = mtp_loss
+            labels_sb = labels.transpose(0, 1).contiguous()
+            if use_fused_kernels:
+                hidden_full = gather_from_sequence_parallel(hidden_for_head, self.ps)
+                log_probs, entropy = linear_cross_entropy(
+                    hidden_full,
+                    self._head_weight_for_fused_ce(hidden_full),
+                    labels_sb,
+                    temperature_value,
+                    self.ps.tp_group,
+                )
+                token_loss = -log_probs
+                output["loss"] = token_loss.mean()
+                if return_log_probs:
+                    output["log_probs"] = log_probs.transpose(0, 1).contiguous()
+                if calculate_entropy:
+                    output["entropy"] = entropy.transpose(0, 1).contiguous()
+            else:
+                logits = self.head(hidden_for_head)
+                if temperature_value != 1.0:
+                    logits = logits / temperature_value
+                token_loss = vocab_parallel_cross_entropy(
+                    logits, labels_sb, self.ps.tp_group
+                )
+                output["loss"] = token_loss.mean()
+                if return_log_probs:
+                    output["log_probs"] = (-token_loss).transpose(0, 1).contiguous()
+                if calculate_entropy:
+                    entropy = vocab_parallel_entropy(logits, self.ps.tp_group)
+                    output["entropy"] = entropy.transpose(0, 1).contiguous()
+        else:
+            logits = self.head(hidden_for_head)
+            output["logits"] = self.head.gather(logits)
+        return output
 
     def forward(
         self,
@@ -451,14 +622,7 @@ class Qwen3MoEModel(nn.Module):
         calculate_entropy: bool = False,
         return_log_probs: bool = True,
     ) -> dict:
-        if self.embed is not None:
-            assert input_ids is not None
-            h = self.embed(input_ids)
-        else:
-            if hidden_states is None:
-                hidden_states = self._input_tensor
-            assert hidden_states is not None
-            h = hidden_states
+        h = self._preprocess_hidden(input_ids=input_ids, hidden_states=hidden_states)
 
         fp8_ctx = (
             te.fp8_autocast(enabled=True, fp8_recipe=build_fp8_recipe())
@@ -467,67 +631,89 @@ class Qwen3MoEModel(nn.Module):
         )
 
         with fp8_ctx:
-            if self.embed is not None:
-                h = scatter_to_sequence_parallel(h, self.ps)
             for layer in self.layers:
-                h = layer(h, position_ids=position_ids, packed_seq_params=packed_seq_params)
+                h = layer(
+                    h, position_ids=position_ids, packed_seq_params=packed_seq_params
+                )
             # Head path is SP-aware: norm runs on SP-sharded [S/tp, B, H] and
             # head's internal all-gather happens inside VocabParallelOutput.
             # Mirrors MC GPTModel's final_layernorm → output_layer(sp=True).
 
-        output = {"hidden_states": h}
+        return self._postprocess_hidden(
+            h,
+            input_ids=input_ids,
+            position_ids=position_ids,
+            packed_seq_params=packed_seq_params,
+            labels=labels,
+            loss_mask=loss_mask,
+            temperature=temperature,
+            use_fused_kernels=use_fused_kernels,
+            calculate_entropy=calculate_entropy,
+            return_log_probs=return_log_probs,
+        )
 
-        if self.head is not None:
-            hidden_for_head = self.norm(h)
+    def build_combined_1f1b_plan(
+        self,
+        *,
+        input_ids: torch.Tensor | None = None,
+        hidden_states: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        packed_seq_params=None,
+        labels: torch.Tensor | None = None,
+        loss_mask: torch.Tensor | None = None,
+        temperature: float | torch.Tensor = 1.0,
+        use_fused_kernels: bool = False,
+        calculate_entropy: bool = False,
+        return_log_probs: bool = True,
+        num_microbatches: int,
+        external_loss=None,
+    ) -> Combined1F1BModelPlan:
+        """Build the narrow PP=1 all-to-all plan consumed by the scheduler."""
+        if self.embed is None or self.head is None:
+            raise ValueError("combined-1F1B first profile requires PP=1")
+        if self.mtp is not None:
+            raise ValueError("combined-1F1B first profile does not support MTP")
 
-            if labels is not None:
-                temperature_value = _temperature_to_float(temperature)
-                mtp_result = self._apply_mtp_loss(
-                    hidden_for_head,
-                    input_ids=input_ids,
-                    position_ids=position_ids,
-                    labels=labels,
-                    loss_mask=loss_mask,
-                    packed_seq_params=packed_seq_params,
-                    temperature=temperature_value,
-                    use_fused_kernels=use_fused_kernels,
-                )
-                if mtp_result is not None:
-                    hidden_for_head, mtp_loss = mtp_result
-                    output["mtp_loss"] = mtp_loss
-                labels_sb = labels.transpose(0, 1).contiguous()
-                if use_fused_kernels:
-                    hidden_full = gather_from_sequence_parallel(hidden_for_head, self.ps)
-                    log_probs, entropy = linear_cross_entropy(
-                        hidden_full,
-                        self._head_weight_for_fused_ce(hidden_full),
-                        labels_sb,
-                        temperature_value,
-                        self.ps.tp_group,
-                    )
-                    token_loss = -log_probs
-                    output["loss"] = token_loss.mean()
-                    if return_log_probs:
-                        output["log_probs"] = log_probs.transpose(0, 1).contiguous()
-                    if calculate_entropy:
-                        output["entropy"] = entropy.transpose(0, 1).contiguous()
-                else:
-                    logits = self.head(hidden_for_head)
-                    if temperature_value != 1.0:
-                        logits = logits / temperature_value
-                    token_loss = vocab_parallel_cross_entropy(logits, labels_sb, self.ps.tp_group)
-                    output["loss"] = token_loss.mean()
-                    if return_log_probs:
-                        output["log_probs"] = (-token_loss).transpose(0, 1).contiguous()
-                    if calculate_entropy:
-                        entropy = vocab_parallel_entropy(logits, self.ps.tp_group)
-                        output["entropy"] = entropy.transpose(0, 1).contiguous()
+        layer_callables = [
+            layer.combined_1f1b_callables(
+                position_ids=position_ids, packed_seq_params=packed_seq_params
+            )
+            for layer in self.layers
+        ]
+        if self.fp8:
 
-            if labels is None:
-                logits = self.head(hidden_for_head)
-                output["logits"] = self.head.gather(logits)
+            def with_fp8(fn):
+                def wrapped(*args):
+                    with te.fp8_autocast(enabled=True, fp8_recipe=build_fp8_recipe()):
+                        return fn(*args)
 
-        return output
+                return wrapped
+
+            layer_callables = [
+                tuple(with_fp8(fn) for fn in callables) for callables in layer_callables
+            ]
+
+        return Combined1F1BModelPlan(
+            preprocess=lambda: self._preprocess_hidden(
+                input_ids=input_ids, hidden_states=hidden_states
+            ),
+            layer_callables=layer_callables,
+            postprocess=lambda hidden: self._postprocess_hidden(
+                hidden,
+                input_ids=input_ids,
+                position_ids=position_ids,
+                packed_seq_params=packed_seq_params,
+                labels=labels,
+                loss_mask=loss_mask,
+                temperature=temperature,
+                use_fused_kernels=use_fused_kernels,
+                calculate_entropy=calculate_entropy,
+                return_log_probs=return_log_probs,
+            ),
+            num_microbatches=num_microbatches,
+            external_loss=external_loss,
+            use_cuda=True,
+        )
 
     def _apply_mtp_loss(
         self,
@@ -586,12 +772,16 @@ class Qwen3MoEModel(nn.Module):
                 logits = self.head(mtp_hidden)
                 if temperature != 1.0:
                     logits = logits / temperature
-                token_loss = vocab_parallel_cross_entropy(logits, labels_sb, self.ps.tp_group)
+                token_loss = vocab_parallel_cross_entropy(
+                    logits, labels_sb, self.ps.tp_group
+                )
             token_loss = token_loss * mask_sb.to(dtype=token_loss.dtype)
             num_tokens = num_tokens.to(dtype=token_loss.dtype).clamp_min(1.0)
             mtp_loss_values.append(token_loss.sum() / num_tokens)
 
-            mtp_loss_scale = self.mtp_loss_scaling_factor / max(len(mtp_hidden_states), 1)
+            mtp_loss_scale = self.mtp_loss_scaling_factor / max(
+                len(mtp_hidden_states), 1
+            )
             hidden_states = MTPLossAutoScaler.apply(
                 hidden_states, mtp_loss_scale * token_loss / num_tokens
             )

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
@@ -104,9 +104,9 @@ class MoELayer(nn.Module):
             scores, indices = self.router(x)
             return self.dispatcher.alltoall_dispatch_preprocess(x, scores, indices)
 
-        def communicate(permuted, permuted_probs):
+        def communicate(permuted, permuted_probs, tokens_per_expert):
             return self.dispatcher.alltoall_dispatch_communicate(
-                permuted, permuted_probs
+                permuted, permuted_probs, tokens_per_expert
             )
 
         def experts(dispatched, tokens_per_expert, permuted_probs):

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
@@ -35,8 +35,13 @@ from megatron.lite.model.protocol_utils import (
 )
 from megatron.lite.model.qwen3_moe.common import is_expert_param
 from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
-from megatron.lite.model.qwen3_moe.lite.checkpoint import EXPERT_CLASSIFIER, PLACEMENT_FN
-from megatron.lite.model.qwen3_moe.lite.checkpoint import load_hf_weights as _load_hf_weights_impl
+from megatron.lite.model.qwen3_moe.lite.checkpoint import (
+    EXPERT_CLASSIFIER,
+    PLACEMENT_FN,
+)
+from megatron.lite.model.qwen3_moe.lite.checkpoint import (
+    load_hf_weights as _load_hf_weights_impl,
+)
 from megatron.lite.model.qwen3_moe.lite.model import MTPLossAutoScaler, Qwen3MoEModel
 from megatron.lite.primitive.bundle import ModelBundle
 from megatron.lite.primitive.modules.lora import (
@@ -76,6 +81,7 @@ class ImplConfig:
     recompute: list[str] = field(default_factory=list)
     offload: list[str] = field(default_factory=list)
     use_deepep: bool = False
+    overlap_moe_expert_parallel_comm: bool = False
     use_thd: bool = False
     cross_entropy_fusion: bool = False
     router_aux_loss_coef: float | None = None
@@ -136,7 +142,46 @@ def _forward_step(model: nn.Module, batch: PackedBatch) -> dict:
 
 def _forward_step_bshd(model: nn.Module, batch: PackedBatch) -> dict:
     labels = batch.labels.reshape(1, -1) if batch.labels is not None else None
-    return model(input_ids=batch.input_ids.reshape(1, -1), labels=labels, packed_seq_params=None)
+    return model(
+        input_ids=batch.input_ids.reshape(1, -1), labels=labels, packed_seq_params=None
+    )
+
+
+def _build_combined_plan(
+    model: nn.Module,
+    batch: PackedBatch,
+    *,
+    num_microbatches: int,
+    loss_fn,
+    loss_context,
+    use_thd: bool,
+):
+    from megatron.lite.runtime.contracts.loss import use_loss_context
+
+    with use_loss_context(loss_context):
+        if use_thd:
+            kwargs = pack_thd_forward_kwargs(model, batch)
+            add_loss_context_kwargs(kwargs, include_return_log_probs=True)
+            add_cross_entropy_fusion(kwargs, model)
+        else:
+            labels = batch.labels.reshape(1, -1) if batch.labels is not None else None
+            kwargs = {
+                "input_ids": batch.input_ids.reshape(1, -1),
+                "labels": labels,
+                "packed_seq_params": None,
+            }
+
+    external_loss = None
+    if loss_fn is not None:
+
+        def external_loss(output):
+            if loss_context is None:
+                return loss_fn(output, batch)
+            return loss_fn(output, batch, loss_context)
+
+    return model.build_combined_1f1b_plan(
+        **kwargs, num_microbatches=num_microbatches, external_loss=external_loss
+    )
 
 
 def unpack_forward_output(model: nn.Module, batch: PackedBatch, output) -> Any:
@@ -154,6 +199,23 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
     # ── validation ──
     if impl_cfg.use_deepep and (p.etp is not None and p.etp > 1):
         raise ValueError("use_deepep and etp>1 are mutually exclusive")
+    if impl_cfg.overlap_moe_expert_parallel_comm:
+        if p.ep <= 1:
+            raise ValueError("combined-1F1B requires EP > 1")
+        if p.pp != 1:
+            raise ValueError("combined-1F1B first profile requires PP=1")
+        if impl_cfg.use_deepep:
+            raise ValueError("combined-1F1B first profile requires alltoall")
+        if impl_cfg.recompute:
+            raise ValueError("combined-1F1B does not support recompute")
+        if impl_cfg.offload:
+            raise ValueError("combined-1F1B first profile does not support offload")
+        if impl_cfg.mtp_enable:
+            raise ValueError("combined-1F1B first profile does not support MTP")
+        if impl_cfg.optimizer != "dist_opt":
+            raise ValueError(
+                "combined-1F1B first profile requires the distributed optimizer"
+            )
 
     # ── override model config from impl_cfg ──
     if impl_cfg.router_aux_loss_coef is not None:
@@ -162,7 +224,9 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
     mtp_enable_train = mtp_enable and bool(impl_cfg.mtp_enable_train)
     if mtp_enable:
         if model_cfg.num_nextn_predict_layers <= 0:
-            raise ValueError("mtp_enable=True but HF config has no num_nextn_predict_layers.")
+            raise ValueError(
+                "mtp_enable=True but HF config has no num_nextn_predict_layers."
+            )
         model_cfg.mtp_loss_scaling_factor = impl_cfg.mtp_loss_scaling_factor
         if impl_cfg.mtp_use_repeated_layer is not None:
             model_cfg.mtp_use_repeated_layer = impl_cfg.mtp_use_repeated_layer
@@ -189,7 +253,9 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
 
     vpp = None if p.vpp == 1 else p.vpp
     if vpp is None:
-        chunks = [Qwen3MoEModel(model_cfg, ps, **model_kwargs).to(torch.bfloat16).cuda()]
+        chunks = [
+            Qwen3MoEModel(model_cfg, ps, **model_kwargs).to(torch.bfloat16).cuda()
+        ]
     else:
         chunks = []
         for i in range(vpp):
@@ -250,7 +316,9 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
 
         def _post_model_load_hook():
             from megatron.lite.model.qwen3_moe.lite.model import TransformerLayer
-            from megatron.lite.primitive.optimizers.fsdp2 import build_fsdp2_training_optimizer
+            from megatron.lite.primitive.optimizers.fsdp2 import (
+                build_fsdp2_training_optimizer,
+            )
 
             return {
                 "optimizer": build_fsdp2_training_optimizer(
@@ -295,6 +363,16 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
             "post_model_load_hook": post_model_load_hook,
             "lora_config": lora_config,
             "lora_stats": lora_stats,
+            "combined_1f1b_plan": (
+                (
+                    lambda model, batch, **kwargs: _build_combined_plan(
+                        model, batch, use_thd=impl_cfg.use_thd, **kwargs
+                    )
+                )
+                if impl_cfg.overlap_moe_expert_parallel_comm
+                else None
+            ),
+            "combined_1f1b_recompute": tuple(recompute_spec),
         },
     )
 
@@ -317,17 +395,16 @@ def export_hf_weights(
     chunks: list[nn.Module], model_cfg: Qwen3MoEConfig, ps: ParallelState, **kwargs
 ):
     """Export HF weights from model chunks."""
-    from megatron.lite.model.qwen3_moe.lite.checkpoint import export_hf_weights as _export
+    from megatron.lite.model.qwen3_moe.lite.checkpoint import (
+        export_hf_weights as _export,
+    )
 
     for chunk in chunks:
         yield from _export(chunk, model_cfg, ps, **kwargs)
 
 
 def save_hf_weights(
-    chunks: list[nn.Module],
-    path: str,
-    model_cfg: Qwen3MoEConfig,
-    ps: ParallelState,
+    chunks: list[nn.Module], path: str, model_cfg: Qwen3MoEConfig, ps: ParallelState
 ) -> None:
     from megatron.lite.model.qwen3_moe.lite.checkpoint import save_hf_weights as _save
 

--- a/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
+++ b/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
@@ -7,7 +7,6 @@ import os
 
 import torch  # pyright: ignore[reportMissingImports]
 import torch.distributed as dist  # pyright: ignore[reportMissingImports]
-
 from megatron.lite.primitive.modules.moe import _AllToAll
 from megatron.lite.primitive.parallel import ParallelState
 from megatron.lite.primitive.utils import ensure_divisible
@@ -15,7 +14,10 @@ from megatron.lite.primitive.utils.moe import permute, unpermute
 
 try:
     import deep_ep  # pyright: ignore[reportMissingImports]
-    from deep_ep.utils import EventHandle, EventOverlap  # pyright: ignore[reportMissingImports]
+    from deep_ep.utils import (  # pyright: ignore[reportMissingImports]
+        EventHandle,
+        EventOverlap,
+    )
 except ImportError:
     deep_ep = None  # type: ignore
     EventHandle = None  # type: ignore
@@ -46,7 +48,9 @@ def _build_deepep_buffer(group: dist.ProcessGroup, hidden_size: int):
             config.get_rdma_buffer_size_hint(hidden_bytes, group_size), num_rdma_bytes
         )
 
-    return deep_ep.Buffer(group=group, num_nvl_bytes=num_nvl_bytes, num_rdma_bytes=num_rdma_bytes)
+    return deep_ep.Buffer(
+        group=group, num_nvl_bytes=num_nvl_bytes, num_rdma_bytes=num_rdma_bytes
+    )
 
 
 def _use_moe_permute_fusion() -> bool:
@@ -87,19 +91,24 @@ class _DeepEPDispatch(torch.autograd.Function):
             async_finish=async_finish,
             allocate_on_comm_stream=allocate_on_comm_stream,
         )
-        (recv_hidden, recv_indices, recv_probs, recv_per_expert, handle, after_event) = (
-            buffer.dispatch(
-                hidden_states.contiguous(),
-                topk_idx=topk_indices,
-                topk_weights=topk_scores.float(),
-                num_tokens_per_rank=num_tokens_per_rank,
-                num_tokens_per_rdma_rank=num_tokens_per_rdma_rank,
-                is_token_in_rank=is_token_in_rank,
-                num_tokens_per_expert=num_tokens_per_expert,
-                previous_event=event,
-                async_finish=async_finish,
-                allocate_on_comm_stream=allocate_on_comm_stream,
-            )
+        (
+            recv_hidden,
+            recv_indices,
+            recv_probs,
+            recv_per_expert,
+            handle,
+            after_event,
+        ) = buffer.dispatch(
+            hidden_states.contiguous(),
+            topk_idx=topk_indices,
+            topk_weights=topk_scores.float(),
+            num_tokens_per_rank=num_tokens_per_rank,
+            num_tokens_per_rdma_rank=num_tokens_per_rdma_rank,
+            is_token_in_rank=is_token_in_rank,
+            num_tokens_per_expert=num_tokens_per_expert,
+            previous_event=event,
+            async_finish=async_finish,
+            allocate_on_comm_stream=allocate_on_comm_stream,
         )
         if async_finish:
             after_event.current_stream_wait()
@@ -115,7 +124,12 @@ class _DeepEPDispatch(torch.autograd.Function):
 
     @staticmethod
     def backward(
-        ctx, grad_recv_hidden, grad_recv_indices, grad_recv_probs, grad_recv_per_expert, grad_handle
+        ctx,
+        grad_recv_hidden,
+        grad_recv_indices,
+        grad_recv_probs,
+        grad_recv_per_expert,
+        grad_handle,
     ):
         del grad_recv_indices, grad_recv_per_expert, grad_handle
         previous_event = (
@@ -202,7 +216,9 @@ class TokenDispatcher:
         self.ep_size = ps.ep_size
         self.num_local_experts = ensure_divisible(num_experts, ps.ep_size)
         self.moe_permute_fusion = (
-            _use_moe_permute_fusion() if moe_permute_fusion is None else bool(moe_permute_fusion)
+            _use_moe_permute_fusion()
+            if moe_permute_fusion is None
+            else bool(moe_permute_fusion)
         )
 
         self.use_deepep = use_deepep and deep_ep is not None and ps.ep_size > 1
@@ -214,20 +230,28 @@ class TokenDispatcher:
         self._restore_shape: tuple | None = None
         self._input_splits: list[int] | None = None
         self._output_splits: list[int] | None = None
+        self._recv_tpe_2d: torch.Tensor | None = None
         self._handle = None
         self._deepep_event = None
 
         if self.ep_size > 1 and self.num_local_experts > 1:
             chunk_idxs = torch.arange(self.ep_size * self.num_local_experts)
             self._sort_by_experts = (
-                chunk_idxs.reshape(self.ep_size, self.num_local_experts).T.ravel().tolist()
+                chunk_idxs.reshape(self.ep_size, self.num_local_experts)
+                .T.ravel()
+                .tolist()
             )
             self._restore_by_ranks = (
-                chunk_idxs.reshape(self.num_local_experts, self.ep_size).T.ravel().tolist()
+                chunk_idxs.reshape(self.num_local_experts, self.ep_size)
+                .T.ravel()
+                .tolist()
             )
 
     def dispatch(
-        self, hidden_states: torch.Tensor, topk_scores: torch.Tensor, topk_indices: torch.Tensor
+        self,
+        hidden_states: torch.Tensor,
+        topk_scores: torch.Tensor,
+        topk_indices: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
         if self.ep_size <= 1:
             return self._dispatch_local(hidden_states, topk_scores, topk_indices)
@@ -295,7 +319,9 @@ class TokenDispatcher:
         routing_map.scatter_(1, topk_indices, True)
         num_out = int(routing_map.sum().item())
 
-        probs_2d = torch.zeros(t, e, dtype=topk_scores.dtype, device=hidden_states.device)
+        probs_2d = torch.zeros(
+            t, e, dtype=topk_scores.dtype, device=hidden_states.device
+        )
         probs_2d.scatter_(1, topk_indices, topk_scores)
 
         permuted, permuted_probs, sorted_indices = permute(
@@ -324,6 +350,23 @@ class TokenDispatcher:
         return result
 
     def _dispatch_alltoall(self, hidden_states, topk_scores, topk_indices):
+        permuted, permuted_probs = self.alltoall_dispatch_preprocess(
+            hidden_states, topk_scores, topk_indices
+        )
+        return self.alltoall_dispatch_communicate(permuted, permuted_probs)
+
+    def alltoall_dispatch_preprocess(self, hidden_states, topk_scores, topk_indices):
+        """Prepare deterministic all-to-all metadata without issuing token exchange.
+
+        The combined-1F1B scheduler runs this compute-heavy portion on its
+        computation stream, then schedules :meth:`alltoall_dispatch_communicate`
+        on the communication stream. The ordinary dispatcher calls the same two
+        methods back-to-back, so the split does not create a second EP behavior.
+        """
+        if self.ep_size <= 1 or self.use_deepep:
+            raise RuntimeError(
+                "alltoall dispatch splitting requires EP > 1 with DeepEP disabled"
+            )
         t, h = hidden_states.shape
         e = self.num_experts
 
@@ -337,7 +380,9 @@ class TokenDispatcher:
         # so this is a no-op for them.
         num_out = int(routing_map.sum().item())
 
-        probs_2d = torch.zeros(t, e, dtype=topk_scores.dtype, device=hidden_states.device)
+        probs_2d = torch.zeros(
+            t, e, dtype=topk_scores.dtype, device=hidden_states.device
+        )
         probs_2d.scatter_(1, topk_indices, topk_scores)
 
         permuted, permuted_probs, sorted_indices = permute(
@@ -351,22 +396,45 @@ class TokenDispatcher:
         self._restore_shape = hidden_states.shape
 
         tokens_per_expert = routing_map.sum(dim=0).to(torch.int64)
-        tpe_by_rank = tokens_per_expert.view(self.ep_size, self.num_local_experts).sum(dim=1)
+        tpe_by_rank = tokens_per_expert.view(self.ep_size, self.num_local_experts).sum(
+            dim=1
+        )
         self._input_splits = tpe_by_rank.tolist()
 
         global_tpe_flat = tokens_per_expert.new_empty(self.ep_size * e)
-        dist.all_gather_into_tensor(global_tpe_flat, tokens_per_expert, group=self.ps.ep_group)
+        dist.all_gather_into_tensor(
+            global_tpe_flat, tokens_per_expert, group=self.ps.ep_group
+        )
         global_tpe_2d = global_tpe_flat.view(self.ep_size, e)
         ep_rank = dist.get_rank(group=self.ps.ep_group)
         my_start = ep_rank * self.num_local_experts
-        recv_tpe_2d = global_tpe_2d[:, my_start : my_start + self.num_local_experts].contiguous()
+        recv_tpe_2d = global_tpe_2d[
+            :, my_start : my_start + self.num_local_experts
+        ].contiguous()
         self._output_splits = recv_tpe_2d.sum(dim=1).tolist()
+        self._recv_tpe_2d = recv_tpe_2d
+        return permuted, permuted_probs
+
+    def alltoall_dispatch_communicate(self, permuted, permuted_probs):
+        """Exchange prepared token/probability buffers on the caller's stream."""
+        if (
+            self._input_splits is None
+            or self._output_splits is None
+            or self._recv_tpe_2d is None
+        ):
+            raise RuntimeError(
+                "alltoall_dispatch_preprocess must run before communication"
+            )
+        recv_tpe_2d = self._recv_tpe_2d
 
         recv_flat = _AllToAll.apply(
             permuted, self._input_splits, self._output_splits, self.ps.ep_group
         )
         recv_scores = _AllToAll.apply(
-            permuted_probs.unsqueeze(-1), self._input_splits, self._output_splits, self.ps.ep_group
+            permuted_probs.unsqueeze(-1),
+            self._input_splits,
+            self._output_splits,
+            self.ps.ep_group,
         )
 
         if self.num_local_experts > 1:
@@ -386,9 +454,14 @@ class TokenDispatcher:
             self._combine_restore_idxs = None
 
         recv_tpe = recv_tpe_2d.sum(dim=0)
+        self._recv_tpe_2d = None
         return dispatched, recv_tpe, permuted_probs_out.squeeze(-1)
 
     def _combine_alltoall(self, expert_output):
+        return self.alltoall_combine_communicate(expert_output)
+
+    def alltoall_combine_communicate(self, expert_output):
+        """Run combine exchange and restore original token order."""
         if self._combine_chunk_sizes is not None:
             chunks = torch.split(expert_output, self._combine_chunk_sizes, dim=0)
             restore_idxs = (
@@ -415,11 +488,17 @@ class TokenDispatcher:
         self._output_splits = None
         self._combine_chunk_sizes = None
         self._combine_restore_idxs = None
+        self._recv_tpe_2d = None
         self._local_tpe_list = None
         return result
 
     def submit_deepep_dispatch(
-        self, hidden_states, topk_scores, topk_indices, *, allocate_on_comm_stream: bool = False
+        self,
+        hidden_states,
+        topk_scores,
+        topk_indices,
+        *,
+        allocate_on_comm_stream: bool = False,
     ):
         if not self.use_deepep:
             raise RuntimeError("submit_deepep_dispatch requires DeepEP dispatch.")
@@ -489,16 +568,23 @@ class TokenDispatcher:
         if isinstance(recv_per_expert, torch.Tensor):
             recv_per_expert = [int(x) for x in recv_per_expert.detach().cpu().tolist()]
         local_tpe = torch.tensor(
-            recv_per_expert[: self.num_local_experts], dtype=torch.int64, device=recv_hidden.device
+            recv_per_expert[: self.num_local_experts],
+            dtype=torch.int64,
+            device=recv_hidden.device,
         )
-        self._local_tpe_list = [int(x) for x in recv_per_expert[: self.num_local_experts]]
+        self._local_tpe_list = [
+            int(x) for x in recv_per_expert[: self.num_local_experts]
+        ]
         rows = recv_hidden.size(0)
         recv_indices = recv_indices.to(torch.long)
         routing_map = torch.zeros(
             rows, self.num_local_experts, dtype=torch.bool, device=recv_hidden.device
         )
         probs_2d = torch.zeros(
-            rows, self.num_local_experts, dtype=recv_probs.dtype, device=recv_hidden.device
+            rows,
+            self.num_local_experts,
+            dtype=recv_probs.dtype,
+            device=recv_hidden.device,
         )
         valid = recv_indices >= 0
         row_ids = torch.arange(rows, device=recv_hidden.device).unsqueeze(1)
@@ -529,9 +615,9 @@ class TokenDispatcher:
                 f"local_tpe_sum={int(local_tpe.sum().item())}",
                 flush=True,
             )
-        if os.environ.get("MEGATRON_LITE_DEEPEP_SKIP_DISPATCH_METADATA_CHECK") != "1" and int(
-            local_tpe.sum().item()
-        ) != int(dispatched.shape[0]):
+        if os.environ.get(
+            "MEGATRON_LITE_DEEPEP_SKIP_DISPATCH_METADATA_CHECK"
+        ) != "1" and int(local_tpe.sum().item()) != int(dispatched.shape[0]):
             ep_rank = dist.get_rank(group=self.ps.ep_group)
             raise RuntimeError(
                 "DeepEP dispatch metadata mismatch: "
@@ -542,14 +628,16 @@ class TokenDispatcher:
 
     def _dispatch_deepep(self, hidden_states, topk_scores, topk_indices):
         if torch.is_grad_enabled():
-            recv_hidden, recv_indices, recv_probs, recv_per_expert, handle = _DeepEPDispatch.apply(
-                self.buffer,
-                hidden_states,
-                topk_indices,
-                topk_scores.float(),
-                self.num_experts,
-                False,
-                False,
+            recv_hidden, recv_indices, recv_probs, recv_per_expert, handle = (
+                _DeepEPDispatch.apply(
+                    self.buffer,
+                    hidden_states,
+                    topk_indices,
+                    topk_scores.float(),
+                    self.num_experts,
+                    False,
+                    False,
+                )
             )
             self._handle = handle
             self._deepep_event = None
@@ -574,7 +662,9 @@ class TokenDispatcher:
             fused=self.moe_permute_fusion,
         )
         if torch.is_grad_enabled():
-            combined = _DeepEPCombine.apply(self.buffer, rank_grouped, self._handle, False, False)
+            combined = _DeepEPCombine.apply(
+                self.buffer, rank_grouped, self._handle, False, False
+            )
         else:
             combined = self.buffer.combine(rank_grouped, self._handle)
         if isinstance(combined, tuple):

--- a/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
+++ b/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
@@ -350,10 +350,12 @@ class TokenDispatcher:
         return result
 
     def _dispatch_alltoall(self, hidden_states, topk_scores, topk_indices):
-        permuted, permuted_probs = self.alltoall_dispatch_preprocess(
+        permuted, permuted_probs, tokens_per_expert = self.alltoall_dispatch_preprocess(
             hidden_states, topk_scores, topk_indices
         )
-        return self.alltoall_dispatch_communicate(permuted, permuted_probs)
+        return self.alltoall_dispatch_communicate(
+            permuted, permuted_probs, tokens_per_expert
+        )
 
     def alltoall_dispatch_preprocess(self, hidden_states, topk_scores, topk_indices):
         """Prepare deterministic all-to-all metadata without issuing token exchange.
@@ -396,16 +398,24 @@ class TokenDispatcher:
         self._restore_shape = hidden_states.shape
 
         tokens_per_expert = routing_map.sum(dim=0).to(torch.int64)
-        tpe_by_rank = tokens_per_expert.view(self.ep_size, self.num_local_experts).sum(
-            dim=1
-        )
+        return permuted, permuted_probs, tokens_per_expert
+
+    def alltoall_dispatch_communicate(
+        self, permuted, permuted_probs, tokens_per_expert
+    ):
+        """Exchange layout metadata and prepared token/probability buffers."""
+        tpe_by_rank = tokens_per_expert.view(
+            self.ep_size, self.num_local_experts
+        ).sum(dim=1)
         self._input_splits = tpe_by_rank.tolist()
 
-        global_tpe_flat = tokens_per_expert.new_empty(self.ep_size * e)
+        global_tpe_flat = tokens_per_expert.new_empty(
+            self.ep_size * self.num_experts
+        )
         dist.all_gather_into_tensor(
             global_tpe_flat, tokens_per_expert, group=self.ps.ep_group
         )
-        global_tpe_2d = global_tpe_flat.view(self.ep_size, e)
+        global_tpe_2d = global_tpe_flat.view(self.ep_size, self.num_experts)
         ep_rank = dist.get_rank(group=self.ps.ep_group)
         my_start = ep_rank * self.num_local_experts
         recv_tpe_2d = global_tpe_2d[
@@ -413,10 +423,6 @@ class TokenDispatcher:
         ].contiguous()
         self._output_splits = recv_tpe_2d.sum(dim=1).tolist()
         self._recv_tpe_2d = recv_tpe_2d
-        return permuted, permuted_probs
-
-    def alltoall_dispatch_communicate(self, permuted, permuted_probs):
-        """Exchange prepared token/probability buffers on the caller's stream."""
         if (
             self._input_splits is None
             or self._output_splits is None

--- a/experimental/lite/megatron/lite/primitive/parallel/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/__init__.py
@@ -4,13 +4,7 @@
 from __future__ import annotations
 
 from megatron.lite.primitive.parallel.combined_1f1b import (
-    Combined1F1BConfig,
-    Combined1F1BLayerPlan,
     Combined1F1BModelPlan,
-    Combined1F1BNode,
-    Combined1F1BPlan,
-    build_combined_1f1b_trace,
-    run_combined_1f1b,
 )
 from megatron.lite.primitive.parallel.cp import (
     contiguous_to_zigzag_chunks,
@@ -67,11 +61,7 @@ def __getattr__(name: str):
 
 __all__ = [
     "ColumnParallelLinear",
-    "Combined1F1BConfig",
-    "Combined1F1BLayerPlan",
     "Combined1F1BModelPlan",
-    "Combined1F1BNode",
-    "Combined1F1BPlan",
     "contiguous_to_zigzag_chunks",
     "PackedSeqParams",
     "PackedTHDBatch",
@@ -82,7 +72,6 @@ __all__ = [
     "VocabParallelEmbedding",
     "VocabParallelOutput",
     "all_gather_last_dim_with_grad_reduce",
-    "build_combined_1f1b_trace",
     "build_pipeline_chunk_layout",
     "forward_backward_pipelining",
     "gather_for_non_sp_head",
@@ -96,7 +85,6 @@ __all__ = [
     "prepare_packed_thd_kwargs_for_context_parallel",
     "reconstruct_packed_from_cp_parts",
     "roll_packed_thd_left",
-    "run_combined_1f1b",
     "scatter_to_sequence_parallel",
     "split_packed_to_cp_local",
     "split_packed_for_cp",

--- a/experimental/lite/megatron/lite/primitive/parallel/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/__init__.py
@@ -3,6 +3,15 @@
 
 from __future__ import annotations
 
+from megatron.lite.primitive.parallel.combined_1f1b import (
+    Combined1F1BConfig,
+    Combined1F1BLayerPlan,
+    Combined1F1BModelPlan,
+    Combined1F1BNode,
+    Combined1F1BPlan,
+    build_combined_1f1b_trace,
+    run_combined_1f1b,
+)
 from megatron.lite.primitive.parallel.cp import (
     contiguous_to_zigzag_chunks,
     split_packed_for_cp,
@@ -58,6 +67,11 @@ def __getattr__(name: str):
 
 __all__ = [
     "ColumnParallelLinear",
+    "Combined1F1BConfig",
+    "Combined1F1BLayerPlan",
+    "Combined1F1BModelPlan",
+    "Combined1F1BNode",
+    "Combined1F1BPlan",
     "contiguous_to_zigzag_chunks",
     "PackedSeqParams",
     "PackedTHDBatch",
@@ -68,6 +82,7 @@ __all__ = [
     "VocabParallelEmbedding",
     "VocabParallelOutput",
     "all_gather_last_dim_with_grad_reduce",
+    "build_combined_1f1b_trace",
     "build_pipeline_chunk_layout",
     "forward_backward_pipelining",
     "gather_for_non_sp_head",
@@ -81,6 +96,7 @@ __all__ = [
     "prepare_packed_thd_kwargs_for_context_parallel",
     "reconstruct_packed_from_cp_parts",
     "roll_packed_thd_left",
+    "run_combined_1f1b",
     "scatter_to_sequence_parallel",
     "split_packed_to_cp_local",
     "split_packed_for_cp",

--- a/experimental/lite/megatron/lite/primitive/parallel/combined_1f1b.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/combined_1f1b.py
@@ -1,0 +1,359 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Combined-1F1B driver for batch-level expert-parallel overlap.
+
+The driver owns only the adjacent-microbatch phase order. Models expose a
+fine-grained plan whose implementation keeps model composition out of this
+parallel primitive.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager, nullcontext
+from dataclasses import dataclass
+from typing import Any, Callable, Protocol, Sequence
+
+import torch
+
+
+class Combined1F1BPlan(Protocol):
+    """Fine-grained model plan consumed by the combined-1F1B driver."""
+
+    def forward(self) -> dict[str, Any]: ...
+
+    def combined_forward_backward(
+        self, backward_plan: Combined1F1BPlan
+    ) -> dict[str, Any]: ...
+
+    def backward(self) -> None: ...
+
+
+_COMM_STREAM = None
+
+
+def _get_comm_stream():
+    global _COMM_STREAM
+    if _COMM_STREAM is None:
+        _COMM_STREAM = torch.cuda.Stream(device=torch.cuda.current_device())
+    return _COMM_STREAM
+
+
+class _ScheduleContext:
+    """Per-microbatch dependency event with a process-wide ordered comm stream."""
+
+    def __init__(self, *, use_cuda: bool):
+        self.use_cuda = use_cuda
+        self.event = torch.cuda.Event() if use_cuda else None
+        self.compute_stream = torch.cuda.current_stream() if use_cuda else None
+        self.comm_stream = _get_comm_stream() if use_cuda else None
+
+    def record_current(self) -> None:
+        if self.use_cuda:
+            self.event.record(torch.cuda.current_stream())
+
+    def wait_current(self) -> None:
+        if self.use_cuda:
+            self.event.wait(torch.cuda.current_stream())
+
+    @contextmanager
+    def acquire(self, stream_name: str, nvtx_name: str):
+        if not self.use_cuda:
+            with nullcontext():
+                yield
+            return
+        stream = self.compute_stream if stream_name == "compute" else self.comm_stream
+        self.event.wait(stream)
+        with torch.cuda.stream(stream):
+            with torch.cuda.nvtx.range(nvtx_name):
+                yield
+        self.event.record(stream)
+
+
+def _as_tuple(value):
+    return value if isinstance(value, tuple) else (value,)
+
+
+def _from_tuple(value):
+    return value[0] if len(value) == 1 else value
+
+
+class Combined1F1BNode:
+    """Autograd boundary for one fine-grained compute or communication node."""
+
+    def __init__(
+        self, forward_fn: Callable, *, context: _ScheduleContext, stream: str, name: str
+    ):
+        self.forward_fn = forward_fn
+        self.context = context
+        self.stream = stream
+        self.name = name
+        self.inputs: tuple[torch.Tensor, ...] | None = None
+        self.outputs: tuple[torch.Tensor, ...] | None = None
+
+    def forward(self, inputs):
+        raw_inputs = _as_tuple(inputs)
+        detached = tuple(
+            value.detach().requires_grad_(value.requires_grad) for value in raw_inputs
+        )
+        with self.context.acquire(
+            self.stream, f"combined_1f1b.forward.{self.name}"
+        ):
+            outputs = _as_tuple(self.forward_fn(*detached))
+        if not all(isinstance(value, torch.Tensor) for value in outputs):
+            raise TypeError(f"{self.name} must return only tensors")
+        self.inputs = detached
+        self.outputs = outputs
+        return _from_tuple(outputs)
+
+    def backward(self, output_grads):
+        if self.inputs is None or self.outputs is None:
+            raise RuntimeError(f"{self.name} backward called before forward")
+        grads = _as_tuple(output_grads)
+        if len(grads) != len(self.outputs):
+            raise RuntimeError(
+                f"{self.name} got {len(grads)} grads for {len(self.outputs)} outputs"
+            )
+        tensors = []
+        grad_tensors = []
+        for output, grad in zip(self.outputs, grads, strict=True):
+            if output.requires_grad and grad is not None:
+                tensors.append(output)
+                grad_tensors.append(grad)
+        with self.context.acquire(
+            self.stream, f"combined_1f1b.backward.{self.name}"
+        ):
+            if tensors:
+                torch.autograd.backward(tensors, grad_tensors)
+        input_grads = tuple(value.grad for value in self.inputs)
+        self.inputs = None
+        self.outputs = None
+        return _from_tuple(input_grads)
+
+
+class Combined1F1BLayerPlan:
+    """Four-node Megatron ordering for one MoE transformer layer."""
+
+    def __init__(self, callables: Sequence[Callable], *, context: _ScheduleContext):
+        if len(callables) != 4:
+            raise ValueError("combined-1F1B layers require exactly four callables")
+        names = ("pre_dispatch", "dispatch", "experts", "combine")
+        streams = ("compute", "comm", "compute", "comm")
+        self.nodes = tuple(
+            Combined1F1BNode(fn, context=context, stream=stream, name=name)
+            for fn, stream, name in zip(callables, streams, names, strict=True)
+        )
+
+    def forward(self, inputs):
+        for node in self.nodes:
+            inputs = node.forward(inputs)
+        return inputs
+
+    def backward(self, grads):
+        for node in reversed(self.nodes):
+            grads = node.backward(grads)
+        return grads
+
+    @staticmethod
+    def combined(
+        forward_plan: Combined1F1BLayerPlan,
+        backward_plan: Combined1F1BLayerPlan,
+        forward_inputs,
+        backward_grads,
+    ):
+        f_pre, f_dispatch, f_experts, f_combine = forward_plan.nodes
+        b_pre, b_dispatch, b_experts, b_combine = backward_plan.nodes
+
+        forward_inputs = f_pre.forward(forward_inputs)
+        backward_grads = b_combine.backward(backward_grads)
+        forward_inputs = f_dispatch.forward(forward_inputs)
+        backward_grads = b_experts.backward(backward_grads)
+        forward_inputs = f_experts.forward(forward_inputs)
+        backward_grads = b_dispatch.backward(backward_grads)
+        forward_inputs = f_combine.forward(forward_inputs)
+        backward_grads = b_pre.backward(backward_grads)
+        return forward_inputs, backward_grads
+
+
+class Combined1F1BModelPlan:
+    """Model-agnostic fine-grained plan used by the adjacent-microbatch driver."""
+
+    def __init__(
+        self,
+        *,
+        preprocess: Callable[[], torch.Tensor],
+        layer_callables: Sequence[Sequence[Callable]],
+        postprocess: Callable[[torch.Tensor], dict[str, Any]],
+        num_microbatches: int,
+        external_loss: (
+            Callable[[dict[str, Any]], tuple[torch.Tensor, dict]] | None
+        ) = None,
+        use_cuda: bool,
+    ):
+        self.preprocess = preprocess
+        self.postprocess = postprocess
+        self.num_microbatches = num_microbatches
+        self.external_loss = external_loss
+        self.context = _ScheduleContext(use_cuda=use_cuda)
+        self.layers = [
+            Combined1F1BLayerPlan(callables, context=self.context)
+            for callables in layer_callables
+        ]
+        self.preprocess_output = None
+        self.postprocess_input = None
+        self.output: dict[str, Any] | None = None
+        self.loss = None
+
+    def _start_forward(self):
+        self.preprocess_output = self.preprocess()
+        self.context.record_current()
+        return self.preprocess_output
+
+    def _finish_forward(self, hidden):
+        self.context.wait_current()
+        self.postprocess_input = hidden.detach().requires_grad_(hidden.requires_grad)
+        self.output = self.postprocess(self.postprocess_input)
+        if self.external_loss is None:
+            self.loss = self.output.get("loss")
+            if self.loss is None:
+                raise ValueError("combined-1F1B postprocess output has no loss")
+        else:
+            self.loss, metrics = self.external_loss(self.output)
+            self.output["loss"] = self.loss
+            self.output["_loss_fn_metrics"] = metrics
+        self.context.record_current()
+        return self.output
+
+    def _start_backward(self):
+        if self.loss is None or self.postprocess_input is None:
+            raise RuntimeError("combined-1F1B backward called before forward")
+        self.context.wait_current()
+        (self.loss / self.num_microbatches).backward()
+        grad = self.postprocess_input.grad
+        if grad is None:
+            raise RuntimeError(
+                "combined-1F1B postprocess produced no hidden-state gradient"
+            )
+        self.context.record_current()
+        return grad
+
+    def _finish_backward(self, grad) -> None:
+        if self.preprocess_output is None:
+            raise RuntimeError("combined-1F1B backward has no preprocess output")
+        self.context.wait_current()
+        if self.preprocess_output.requires_grad and grad is not None:
+            torch.autograd.backward(self.preprocess_output, grad)
+        self.context.record_current()
+        if self.output is not None:
+            for key, value in self.output.items():
+                if isinstance(value, torch.Tensor):
+                    self.output[key] = value.detach()
+        self.loss = None
+        self.postprocess_input = None
+        self.preprocess_output = None
+
+    def forward(self) -> dict[str, Any]:
+        hidden = self._start_forward()
+        for layer in self.layers:
+            hidden = layer.forward(hidden)
+        return self._finish_forward(hidden)
+
+    def combined_forward_backward(
+        self, backward_plan: Combined1F1BModelPlan
+    ) -> dict[str, Any]:
+        forward_hidden = self._start_forward()
+        backward_grad = backward_plan._start_backward()
+        overlap = min(len(self.layers), len(backward_plan.layers))
+        for index in range(overlap):
+            forward_hidden, backward_grad = Combined1F1BLayerPlan.combined(
+                self.layers[index],
+                backward_plan.layers[-1 - index],
+                forward_hidden,
+                backward_grad,
+            )
+        for layer in backward_plan.layers[: len(backward_plan.layers) - overlap][::-1]:
+            backward_grad = layer.backward(backward_grad)
+        for layer in self.layers[overlap:]:
+            forward_hidden = layer.forward(forward_hidden)
+        output = self._finish_forward(forward_hidden)
+        backward_plan._finish_backward(backward_grad)
+        return output
+
+    def backward(self) -> None:
+        grad = self._start_backward()
+        for layer in reversed(self.layers):
+            grad = layer.backward(grad)
+        self._finish_backward(grad)
+
+
+@dataclass(frozen=True)
+class Combined1F1BConfig:
+    """Closed first profile for the 8-GPU all-to-all proxy."""
+
+    num_microbatches: int
+    ep_size: int
+    pp_size: int
+    use_deepep: bool
+    recompute: tuple[str, ...]
+    moe_permute_fusion: bool
+
+    def validate(self) -> None:
+        if self.num_microbatches < 2:
+            raise ValueError("combined-1F1B requires at least 2 microbatches")
+        if self.ep_size <= 1:
+            raise ValueError("combined-1F1B requires EP > 1")
+        if self.pp_size != 1:
+            raise ValueError("the first combined-1F1B profile requires PP=1")
+        if self.use_deepep:
+            raise ValueError(
+                "the first combined-1F1B profile uses alltoall, not DeepEP"
+            )
+        if self.recompute:
+            raise ValueError("combined-1F1B does not support recompute")
+        if self.moe_permute_fusion:
+            raise ValueError("the first combined-1F1B profile disables permute fusion")
+
+
+def build_combined_1f1b_trace(
+    num_microbatches: int,
+) -> list[tuple[int | None, int | None]]:
+    """Return ``(forward_mb, backward_mb)`` for every schedule phase."""
+    if num_microbatches < 1:
+        raise ValueError("num_microbatches must be positive")
+    trace: list[tuple[int | None, int | None]] = [(0, None)]
+    trace.extend((i, i - 1) for i in range(1, num_microbatches))
+    trace.append((None, num_microbatches - 1))
+    return trace
+
+
+def run_combined_1f1b(
+    plans: Sequence[Combined1F1BPlan],
+    *,
+    before_last_backward: Callable[[], None] | None = None,
+) -> list[dict[str, Any]]:
+    """Run Megatron-style adjacent-microbatch combined-1F1B phases."""
+    if len(plans) < 2:
+        raise ValueError("combined-1F1B requires at least 2 microbatches")
+
+    outputs = []
+    for forward_mb, backward_mb in build_combined_1f1b_trace(len(plans)):
+        if backward_mb is None:
+            outputs.append(plans[forward_mb].forward())
+        elif forward_mb is None:
+            if before_last_backward is not None:
+                before_last_backward()
+            plans[backward_mb].backward()
+        else:
+            outputs.append(
+                plans[forward_mb].combined_forward_backward(plans[backward_mb])
+            )
+    return outputs
+
+
+__all__ = [
+    "Combined1F1BConfig",
+    "Combined1F1BLayerPlan",
+    "Combined1F1BModelPlan",
+    "Combined1F1BNode",
+    "Combined1F1BPlan",
+    "build_combined_1f1b_trace",
+    "run_combined_1f1b",
+]

--- a/experimental/lite/megatron/lite/primitive/parallel/combined_1f1b.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/combined_1f1b.py
@@ -37,6 +37,12 @@ def _get_comm_stream():
     return _COMM_STREAM
 
 
+def _join_comm_stream() -> None:
+    """Make subsequent optimizer work wait for all scheduled EP communication."""
+    if _COMM_STREAM is not None:
+        torch.cuda.current_stream().wait_stream(_COMM_STREAM)
+
+
 class _ScheduleContext:
     """Per-microbatch dependency event with a process-wide ordered comm stream."""
 
@@ -345,6 +351,7 @@ def run_combined_1f1b(
             outputs.append(
                 plans[forward_mb].combined_forward_backward(plans[backward_mb])
             )
+    _join_comm_stream()
     return outputs
 
 

--- a/experimental/lite/megatron/lite/primitive/parallel/combined_1f1b.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/combined_1f1b.py
@@ -162,12 +162,12 @@ class Combined1F1BLayerPlan:
         f_pre, f_dispatch, f_experts, f_combine = forward_plan.nodes
         b_pre, b_dispatch, b_experts, b_combine = backward_plan.nodes
 
-        forward_inputs = f_pre.forward(forward_inputs)
         backward_grads = b_combine.backward(backward_grads)
-        forward_inputs = f_dispatch.forward(forward_inputs)
+        forward_inputs = f_pre.forward(forward_inputs)
         backward_grads = b_experts.backward(backward_grads)
-        forward_inputs = f_experts.forward(forward_inputs)
+        forward_inputs = f_dispatch.forward(forward_inputs)
         backward_grads = b_dispatch.backward(backward_grads)
+        forward_inputs = f_experts.forward(forward_inputs)
         forward_inputs = f_combine.forward(forward_inputs)
         backward_grads = b_pre.backward(backward_grads)
         return forward_inputs, backward_grads

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -15,9 +15,17 @@ import torch
 import torch.distributed as dist
 from megatron.lite.runtime.backends import Runtime as RuntimeBase
 from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig
-from megatron.lite.runtime.contracts.data import ForwardResult, ModelOutputs, PackedBatch
+from megatron.lite.runtime.contracts.data import (
+    ForwardResult,
+    ModelOutputs,
+    PackedBatch,
+)
 from megatron.lite.runtime.contracts.handle import ModelHandle
-from megatron.lite.runtime.contracts.loss import get_loss_context, split_loss_context, use_loss_context
+from megatron.lite.runtime.contracts.loss import (
+    get_loss_context,
+    split_loss_context,
+    use_loss_context,
+)
 
 
 def _build_impl_cfg(proto, rt_cfg: MegatronLiteConfig):
@@ -25,20 +33,28 @@ def _build_impl_cfg(proto, rt_cfg: MegatronLiteConfig):
     init_fields = {f.name for f in dc_fields(proto.ImplConfig) if f.init}
     # Only forward impl_cfg keys this model's ImplConfig declares: the connector
     # may pass knobs (e.g. cross_entropy_fusion) that some models don't model.
-    impl_cfg_kwargs = {key: value for key, value in rt_cfg.impl_cfg.items() if key in init_fields}
+    impl_cfg_kwargs = {
+        key: value for key, value in rt_cfg.impl_cfg.items() if key in init_fields
+    }
     impl_cfg_kwargs["parallel"] = rt_cfg.parallel
     if (
         "attention_backend_override" in init_fields
         and impl_cfg_kwargs.get("attention_backend_override") is None
     ):
-        impl_cfg_kwargs["attention_backend_override"] = rt_cfg.attention_backend_override
+        impl_cfg_kwargs["attention_backend_override"] = (
+            rt_cfg.attention_backend_override
+        )
     if (
         "router_aux_loss_coef" in init_fields
         and impl_cfg_kwargs.get("router_aux_loss_coef") is None
         and rt_cfg.router_aux_loss_coef is not None
     ):
         impl_cfg_kwargs["router_aux_loss_coef"] = rt_cfg.router_aux_loss_coef
-    if "hf_path" in init_fields and impl_cfg_kwargs.get("hf_path") in (None, "") and rt_cfg.hf_path:
+    if (
+        "hf_path" in init_fields
+        and impl_cfg_kwargs.get("hf_path") in (None, "")
+        and rt_cfg.hf_path
+    ):
         impl_cfg_kwargs["hf_path"] = rt_cfg.hf_path
     # Thread the user-level OptimizerConfig so the protocol can pass it to
     # optimizer primitives without reading runtime internals.
@@ -74,9 +90,13 @@ def _apply_attention_backend_env(backend: str | None, *, tag: str) -> None:
     os.environ["NVTE_UNFUSED_ATTN"] = unfused
 
 
-def _infer_pipeline_tensor_shape(batch: PackedBatch, model_cfg: Any, ps) -> tuple[int, int, int]:
+def _infer_pipeline_tensor_shape(
+    batch: PackedBatch, model_cfg: Any, ps
+) -> tuple[int, int, int]:
     if model_cfg is None or not hasattr(model_cfg, "hidden_size"):
-        raise ValueError("Megatron Lite pipeline runtime requires model_cfg.hidden_size.")
+        raise ValueError(
+            "Megatron Lite pipeline runtime requires model_cfg.hidden_size."
+        )
     if not isinstance(batch, PackedBatch):
         raise TypeError("Megatron Lite pipeline runtime requires PackedBatch inputs.")
 
@@ -88,7 +108,9 @@ def _infer_pipeline_tensor_shape(batch: PackedBatch, model_cfg: Any, ps) -> tupl
         batch_size = int(input_ids.size(0))
         local_seq_len = int(input_ids.size(1))
     else:
-        raise ValueError(f"Unsupported input_ids rank for pipeline runtime: {input_ids.dim()}.")
+        raise ValueError(
+            f"Unsupported input_ids rank for pipeline runtime: {input_ids.dim()}."
+        )
 
     if local_seq_len < 1:
         raise ValueError("Pipeline tensor shape requires non-empty sequence.")
@@ -102,7 +124,11 @@ def _infer_pipeline_tensor_shape(batch: PackedBatch, model_cfg: Any, ps) -> tupl
     # (each sequence padded to align = tp * (2*cp if cp>1 else 1)) then divide by CP*TP.
     seq_lens = getattr(batch, "seq_lens", None)
     if seq_lens is not None and cp_size * tp_size > 1:
-        sl = seq_lens if isinstance(seq_lens, torch.Tensor) else torch.as_tensor(seq_lens)
+        sl = (
+            seq_lens
+            if isinstance(seq_lens, torch.Tensor)
+            else torch.as_tensor(seq_lens)
+        )
         sl = sl.to(torch.int64).reshape(-1)
         align = tp_size * (2 * cp_size if cp_size > 1 else 1)
         padded = sl + (align - sl % align) % align
@@ -217,9 +243,15 @@ class MegatronLiteRuntime(RuntimeBase):
 
         # ── load HF weights (optional) ──
         loaded_hf_weights = False
-        if rt_cfg.load_hf_weights and rt_cfg.hf_path and hasattr(proto, "load_hf_weights"):
+        if (
+            rt_cfg.load_hf_weights
+            and rt_cfg.hf_path
+            and hasattr(proto, "load_hf_weights")
+        ):
             for chunk in bundle.chunks:
-                proto.load_hf_weights(chunk, rt_cfg.hf_path, model_cfg, bundle.parallel_state)
+                proto.load_hf_weights(
+                    chunk, rt_cfg.hf_path, model_cfg, bundle.parallel_state
+                )
             loaded_hf_weights = True
 
         post_load_hook = bundle.extras.pop("post_model_load_hook", None)
@@ -235,7 +267,9 @@ class MegatronLiteRuntime(RuntimeBase):
                 extra_updates = post_load_updates.get("extras")
                 if extra_updates:
                     if not isinstance(extra_updates, dict):
-                        raise TypeError("post_model_load_hook extras update must be a dict.")
+                        raise TypeError(
+                            "post_model_load_hook extras update must be a dict."
+                        )
                     bundle.extras.update(extra_updates)
 
         if loaded_hf_weights and bundle.optimizer is not None:
@@ -244,7 +278,9 @@ class MegatronLiteRuntime(RuntimeBase):
                 reload_model_params()
 
         if bundle.forward_step is None:
-            raise ValueError("Megatron Lite model bundles must provide a typed forward_step.")
+            raise ValueError(
+                "Megatron Lite model bundles must provide a typed forward_step."
+            )
 
         p = rt_cfg.parallel
         model = bundle.chunks[0] if len(bundle.chunks) == 1 else bundle.chunks
@@ -268,7 +304,10 @@ class MegatronLiteRuntime(RuntimeBase):
 
     def _load_protocol(self, rt_cfg: MegatronLiteConfig):
         """Load and return the model protocol module."""
-        from megatron.lite.model.registry import TRAIN_RUNTIME_MODULES, resolve_runtime_model_name
+        from megatron.lite.model.registry import (
+            TRAIN_RUNTIME_MODULES,
+            resolve_runtime_model_name,
+        )
 
         try:
             runtime_key = resolve_runtime_model_name(rt_cfg.model_name, rt_cfg.impl)
@@ -288,7 +327,9 @@ class MegatronLiteRuntime(RuntimeBase):
 
         for fn_name in ("build_model_config", "build_model"):
             if not callable(getattr(proto, fn_name, None)):
-                raise ValueError(f"Protocol module {mod_path} missing required function: {fn_name}")
+                raise ValueError(
+                    f"Protocol module {mod_path} missing required function: {fn_name}"
+                )
         if not hasattr(proto, "ImplConfig"):
             raise ValueError(f"Protocol module {mod_path} missing ImplConfig class")
 
@@ -351,7 +392,9 @@ class MegatronLiteRuntime(RuntimeBase):
             **kwargs,
         )
 
-    def export_weights(self, handle: ModelHandle, **kwargs) -> Iterator[tuple[str, torch.Tensor]]:
+    def export_weights(
+        self, handle: ModelHandle, **kwargs
+    ) -> Iterator[tuple[str, torch.Tensor]]:
         model_chunks = handle._extras.get("model_chunks", [handle._model])
         proto = handle._extras.get("protocol")
         model_cfg = handle._extras.get("model_cfg")
@@ -447,7 +490,9 @@ class MegatronLiteRuntime(RuntimeBase):
         router_replay: Any = None,
     ) -> ForwardResult:
         from megatron.lite.primitive.train_step import run_microbatch_loop
-        from megatron.lite.runtime.backends.mlite.router_replay import RouterReplayDriver
+        from megatron.lite.runtime.backends.mlite.router_replay import (
+            RouterReplayDriver,
+        )
 
         forward_step = handle._extras["forward_step"]
         if num_microbatches < 1:
@@ -466,11 +511,66 @@ class MegatronLiteRuntime(RuntimeBase):
             forward_step = replay_driver.wrap(forward_step)
 
         ps = handle._parallel_state
-        if ps.pp_size > 1:
+        combined_plan_factory = handle._extras.get("combined_1f1b_plan")
+        combined_outputs = None
+        if combined_plan_factory is not None and not forward_only:
+            if replay_driver is not None:
+                replay_driver.end()
+                raise ValueError("combined-1F1B does not yet support router replay")
+            from megatron.lite.primitive.ckpt.hf_weights import unwrap_model
+            from megatron.lite.primitive.parallel.combined_1f1b import (
+                Combined1F1BConfig,
+                run_combined_1f1b,
+            )
+
+            Combined1F1BConfig(
+                num_microbatches=num_microbatches,
+                ep_size=ps.ep_size,
+                pp_size=ps.pp_size,
+                use_deepep=False,
+                recompute=handle._extras.get("combined_1f1b_recompute", ()),
+                moe_permute_fusion=(
+                    os.environ.get("MEGATRON_LITE_MOE_PERMUTE_FUSION", "0") == "1"
+                ),
+            ).validate()
+            model = unwrap_model(handle._model)
+            plans = []
+            pre_forward_hook = handle._extras.get("pre_forward_hook")
+            for _ in range(num_microbatches):
+                batch, loss_context = split_loss_context(next(data_iter))
+                if pre_forward_hook is not None:
+                    pre_forward_hook(
+                        torch.tensor(1.0 / num_microbatches, device="cuda")
+                    )
+                plans.append(
+                    combined_plan_factory(
+                        model,
+                        batch,
+                        num_microbatches=num_microbatches,
+                        loss_fn=loss_fn,
+                        loss_context=loss_context,
+                    )
+                )
+
+            def _enable_last_grad_sync():
+                if handle._optimizer is not None:
+                    handle._optimizer.grad_sync_enabled = True
+
+            try:
+                combined_outputs = run_combined_1f1b(
+                    plans, before_last_backward=_enable_last_grad_sync
+                )
+            finally:
+                if replay_driver is not None:
+                    replay_driver.end()
+            out = combined_outputs[-1]
+        elif ps.pp_size > 1:
             from types import SimpleNamespace
 
             from megatron.lite.primitive.ckpt.hf_weights import unwrap_model
-            from megatron.lite.primitive.parallel.pipeline import forward_backward_pipelining
+            from megatron.lite.primitive.parallel.pipeline import (
+                forward_backward_pipelining,
+            )
 
             first_item = next(data_iter)
             first_batch, _loss_context = split_loss_context(first_item)
@@ -484,7 +584,9 @@ class MegatronLiteRuntime(RuntimeBase):
 
             model_chunks = handle._extras.get("model_chunks", [handle._model])
             pipeline_chunks = [unwrap_model(chunk) for chunk in model_chunks]
-            pipeline_forward_step, pipeline_loss_fn = _pipeline_callbacks(forward_step, loss_fn)
+            pipeline_forward_step, pipeline_loss_fn = _pipeline_callbacks(
+                forward_step, loss_fn
+            )
             try:
                 outputs = forward_backward_pipelining(
                     pipeline_forward_step,
@@ -512,7 +614,9 @@ class MegatronLiteRuntime(RuntimeBase):
                 dtype=torch.float32,
             )
             if ps.pp_group is not None and ps.pp_global_ranks is not None:
-                dist.broadcast(loss_payload, src=ps.pp_global_ranks[-1], group=ps.pp_group)
+                dist.broadcast(
+                    loss_payload, src=ps.pp_global_ranks[-1], group=ps.pp_group
+                )
             out = {"loss": loss_payload[1]} if bool(loss_payload[0].item()) else {}
         else:
             try:
@@ -538,8 +642,16 @@ class MegatronLiteRuntime(RuntimeBase):
 
         loss_tensor = out.get("loss") if out else None
         metric_rows = out.get("_loss_fn_metrics", []) if out else []
+        if isinstance(metric_rows, dict):
+            metric_rows = [metric_rows]
         if ps.pp_size > 1:
             metric_rows += [item["metrics"] for item in outputs if item.get("metrics")]
+        if combined_outputs is not None:
+            metric_rows = [
+                item["_loss_fn_metrics"]
+                for item in combined_outputs
+                if item.get("_loss_fn_metrics")
+            ]
         metrics: dict = {}
         for row in metric_rows:
             for key, value in row.items():
@@ -628,7 +740,10 @@ def _checkpoint_model(handle: ModelHandle, *, use_dcp: bool):
 
 
 def _checkpoint_hooks(handle: ModelHandle):
-    from megatron.lite.primitive.protocols import default_expert_classifier, default_placement_fn
+    from megatron.lite.primitive.protocols import (
+        default_expert_classifier,
+        default_placement_fn,
+    )
 
     proto = handle._extras.get("protocol")
     return (

--- a/experimental/lite/tests/unit/examples/test_bench_example.py
+++ b/experimental/lite/tests/unit/examples/test_bench_example.py
@@ -46,6 +46,17 @@ def test_bench_builds_mlite_runtime_config_with_model_hook():
     assert model_cfg.num_nextn_predict_layers == 0
 
 
+def test_bench_seed_replays_cpu_model_initialization():
+    from examples.bench.bench import _seed_benchmark
+
+    _seed_benchmark(42)
+    first = torch.rand(8)
+    _seed_benchmark(42)
+    second = torch.rand(8)
+
+    torch.testing.assert_close(first, second, rtol=0, atol=0)
+
+
 def test_bench_mlite_deterministic_mounts_native_vision_not_mbridge(monkeypatch):
     from examples.bench.bench import BenchCliConfig, build_runtime_config
 

--- a/experimental/lite/tests/unit/examples/test_cycle_memory_probe.py
+++ b/experimental/lite/tests/unit/examples/test_cycle_memory_probe.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""CPU contracts for shared per-cycle CUDA memory evidence helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_LITE_ROOT = str(Path(__file__).resolve().parents[3])
+sys.path = [path for path in sys.path if path != _LITE_ROOT]
+sys.path.insert(0, _LITE_ROOT)
+
+
+def test_per_cycle_retention_rejects_a_single_post_warmup_sample():
+    from examples.bench.cycle_memory_probe import per_cycle_retention
+
+    rows = [{"cycle": 1, "phase": "after", "reserved_minus_allocated_bytes": 100}]
+
+    with pytest.raises(ValueError, match="at least 2 samples"):
+        per_cycle_retention(
+            rows,
+            phase="after",
+            metric="reserved_minus_allocated_bytes",
+            warmup_cycles=1,
+        )
+
+
+def test_per_cycle_retention_calculates_known_two_point_slope():
+    from examples.bench.cycle_memory_probe import per_cycle_retention
+
+    rows = [
+        {"cycle": 2, "phase": "after", "allocated_bytes": 120},
+        {"cycle": 5, "phase": "after", "allocated_bytes": 180},
+    ]
+
+    retention = per_cycle_retention(
+        rows, phase="after", metric="allocated_bytes", warmup_cycles=1
+    )
+
+    assert retention["slope_bytes_per_cycle"] == 20
+    assert retention["net_delta_bytes"] == 60
+    assert retention["n_points"] == 2

--- a/experimental/lite/tests/unit/examples/test_cycle_memory_probe.py
+++ b/experimental/lite/tests/unit/examples/test_cycle_memory_probe.py
@@ -42,3 +42,23 @@ def test_per_cycle_retention_calculates_known_two_point_slope():
     assert retention["slope_bytes_per_cycle"] == 20
     assert retention["net_delta_bytes"] == 60
     assert retention["n_points"] == 2
+
+
+def test_cuda_memory_sample_includes_allocated_and_reserved_peaks(monkeypatch):
+    import torch
+    from examples.bench.cycle_memory_probe import sample_cuda_memory
+
+    monkeypatch.setattr(torch.cuda, "memory_stats", lambda: {})
+    monkeypatch.setattr(torch.cuda, "memory_allocated", lambda: 10)
+    monkeypatch.setattr(torch.cuda, "memory_reserved", lambda: 20)
+    monkeypatch.setattr(torch.cuda, "max_memory_allocated", lambda: 30)
+    monkeypatch.setattr(torch.cuda, "max_memory_reserved", lambda: 40)
+
+    assert sample_cuda_memory() == {
+        "allocated_bytes": 10,
+        "reserved_bytes": 20,
+        "peak_allocated_bytes": 30,
+        "peak_reserved_bytes": 40,
+        "reserved_minus_allocated_bytes": 10,
+        "inactive_split_bytes": 0,
+    }

--- a/experimental/lite/tests/unit/examples/test_qwen3_ep_overlap_probe.py
+++ b/experimental/lite/tests/unit/examples/test_qwen3_ep_overlap_probe.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""CPU contracts for the two-arm Qwen3 EP-overlap probe."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_LITE_ROOT = str(Path(__file__).resolve().parents[3])
+sys.path = [path for path in sys.path if path != _LITE_ROOT]
+sys.path.insert(0, _LITE_ROOT)
+
+
+def test_overlap_probe_arms_differ_only_in_overlap_knob():
+    from examples.bench.qwen3_ep_overlap_probe import (
+        build_arm_configs,
+        assert_only_overlap_diff,
+    )
+
+    baseline, overlap = build_arm_configs()
+    assert baseline["overlap_moe_expert_parallel_comm"] is False
+    assert overlap["overlap_moe_expert_parallel_comm"] is True
+    assert_only_overlap_diff(baseline, overlap)
+
+
+def test_overlap_probe_rejects_non_overlap_difference():
+    from examples.bench.qwen3_ep_overlap_probe import assert_only_overlap_diff
+
+    with pytest.raises(ValueError, match="use_deepep"):
+        assert_only_overlap_diff(
+            {"overlap_moe_expert_parallel_comm": False, "use_deepep": False},
+            {"overlap_moe_expert_parallel_comm": True, "use_deepep": True},
+        )
+
+
+def test_overlap_probe_config_only_builds_both_runtime_configs():
+    from examples.bench.qwen3_ep_overlap_probe import build_config_only_plans
+
+    baseline, overlap = build_config_only_plans(hf_path="/tmp/hf")
+    assert (
+        baseline["runtime"]["backend_cfg"]["impl_cfg"][
+            "overlap_moe_expert_parallel_comm"
+        ]
+        is False
+    )
+    assert (
+        overlap["runtime"]["backend_cfg"]["impl_cfg"][
+            "overlap_moe_expert_parallel_comm"
+        ]
+        is True
+    )

--- a/experimental/lite/tests/unit/examples/test_qwen3_ep_overlap_probe.py
+++ b/experimental/lite/tests/unit/examples/test_qwen3_ep_overlap_probe.py
@@ -22,6 +22,16 @@ def test_overlap_probe_arms_differ_only_in_overlap_knob():
     probe.assert_only_overlap_diff(baseline, overlap)
 
 
+def test_overlap_probe_selects_exactly_one_arm_per_process():
+    from examples.bench import qwen3_ep_overlap_probe as probe
+
+    baseline = probe.select_arm_config("baseline")
+    overlap = probe.select_arm_config("overlap")
+    assert baseline["overlap_moe_expert_parallel_comm"] is False
+    assert overlap["overlap_moe_expert_parallel_comm"] is True
+    assert baseline is not overlap
+
+
 def test_overlap_probe_rejects_non_overlap_difference():
     from examples.bench.qwen3_ep_overlap_probe import assert_only_overlap_diff
 

--- a/experimental/lite/tests/unit/examples/test_qwen3_ep_overlap_probe.py
+++ b/experimental/lite/tests/unit/examples/test_qwen3_ep_overlap_probe.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -42,10 +43,35 @@ def test_overlap_probe_rejects_non_overlap_difference():
         )
 
 
-def test_overlap_probe_config_only_builds_both_runtime_configs():
+def test_overlap_probe_rejects_wrong_parallel_topology():
+    from examples.bench import qwen3_ep_overlap_probe as probe
+
+    with pytest.raises(ValueError, match="parallel topology"):
+        probe.build_parallel_evidence(probe.BenchCliConfig(ep=4, tp=1, pp=1, cp=1))
+
+
+def _write_qwen3_moe_config(path: Path) -> Path:
+    path.mkdir()
+    (path / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "qwen3_moe",
+                "num_hidden_layers": 48,
+                "num_experts": 128,
+                "num_experts_per_tok": 8,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_overlap_probe_config_only_builds_full_model_runtime_configs(tmp_path):
     from examples.bench.qwen3_ep_overlap_probe import build_config_only_plans
 
-    baseline, overlap = build_config_only_plans(hf_path="/tmp/hf")
+    baseline, overlap = build_config_only_plans(
+        hf_path=str(_write_qwen3_moe_config(tmp_path / "hf"))
+    )
     assert (
         baseline["runtime"]["backend_cfg"]["impl_cfg"][
             "overlap_moe_expert_parallel_comm"
@@ -58,6 +84,63 @@ def test_overlap_probe_config_only_builds_both_runtime_configs():
         ]
         is True
     )
+    for plan in (baseline, overlap):
+        assert plan["evidence_contract"]["model"] == {
+            "num_hidden_layers": 48,
+            "truncated": False,
+            "num_experts": 128,
+        }
+        assert plan["evidence_contract"]["parallel"] == {
+            "ep": 8,
+            "tp": 1,
+            "pp": 1,
+            "cp": 1,
+        }
+
+
+def test_overlap_probe_rejects_truncated_model_evidence():
+    from examples.bench.qwen3_ep_overlap_probe import validate_probe_summary
+
+    with pytest.raises(ValueError, match="truncated"):
+        validate_probe_summary(
+            {
+                "model": {
+                    "num_hidden_layers": 2,
+                    "truncated": True,
+                    "num_experts": 128,
+                },
+                "parallel": {"ep": 8, "tp": 1, "pp": 1, "cp": 1},
+                "rows": [],
+            },
+            warmup=1,
+        )
+
+
+def test_overlap_probe_rejects_missing_peak_memory_evidence():
+    from examples.bench.qwen3_ep_overlap_probe import validate_probe_summary
+
+    with pytest.raises(ValueError, match="peak memory"):
+        validate_probe_summary(
+            {
+                "model": {
+                    "num_hidden_layers": 48,
+                    "truncated": False,
+                    "num_experts": 128,
+                },
+                "parallel": {"ep": 8, "tp": 1, "pp": 1, "cp": 1},
+                "rows": [
+                    {
+                        "cycle": cycle,
+                        "phase": "after",
+                        "step_ms": 10.0,
+                        "peak_allocated_bytes": 100,
+                        "peak_reserved_bytes": 200,
+                    }
+                    for cycle in (1, 2)
+                ],
+            },
+            warmup=1,
+        )
 
 
 def test_overlap_probe_reuses_shared_cycle_memory_harness():
@@ -76,11 +159,7 @@ def test_overlap_probe_success_requires_all_rank_artifacts(tmp_path):
 
     with pytest.raises(RuntimeError, match="probe evidence missing"):
         require_probe_artifacts(
-            out_dir=tmp_path,
-            arm="baseline",
-            rank=3,
-            cycles=2,
-            warmup=1,
+            out_dir=tmp_path, arm="baseline", rank=3, cycles=2, warmup=1
         )
 
     expected = [
@@ -94,11 +173,7 @@ def test_overlap_probe_success_requires_all_rank_artifacts(tmp_path):
 
     assert (
         require_probe_artifacts(
-            out_dir=tmp_path,
-            arm="baseline",
-            rank=3,
-            cycles=2,
-            warmup=1,
+            out_dir=tmp_path, arm="baseline", rank=3, cycles=2, warmup=1
         )
         == expected
     )

--- a/experimental/lite/tests/unit/examples/test_qwen3_ep_overlap_probe.py
+++ b/experimental/lite/tests/unit/examples/test_qwen3_ep_overlap_probe.py
@@ -14,15 +14,12 @@ sys.path.insert(0, _LITE_ROOT)
 
 
 def test_overlap_probe_arms_differ_only_in_overlap_knob():
-    from examples.bench.qwen3_ep_overlap_probe import (
-        build_arm_configs,
-        assert_only_overlap_diff,
-    )
+    from examples.bench import qwen3_ep_overlap_probe as probe
 
-    baseline, overlap = build_arm_configs()
+    baseline, overlap = probe.build_arm_configs()
     assert baseline["overlap_moe_expert_parallel_comm"] is False
     assert overlap["overlap_moe_expert_parallel_comm"] is True
-    assert_only_overlap_diff(baseline, overlap)
+    probe.assert_only_overlap_diff(baseline, overlap)
 
 
 def test_overlap_probe_rejects_non_overlap_difference():
@@ -51,3 +48,36 @@ def test_overlap_probe_config_only_builds_both_runtime_configs():
         ]
         is True
     )
+
+
+def test_overlap_probe_reuses_shared_cycle_memory_harness():
+    from examples.bench import cycle_memory_probe
+    from examples.bench import qwen3_ep_overlap_probe as probe
+
+    assert probe.sample_cuda_memory is cycle_memory_probe.sample_cuda_memory
+    assert probe.live_allocation_stacks is cycle_memory_probe.live_allocation_stacks
+    assert probe.per_cycle_retention is cycle_memory_probe.per_cycle_retention
+    assert not hasattr(probe, "_sample_cuda_memory")
+    assert not hasattr(probe, "_live_stacks")
+
+
+def test_cycle_memory_retention_separates_fragmentation_from_inactive_split():
+    from examples.bench.cycle_memory_probe import per_cycle_retention
+
+    rows = [
+        {
+            "cycle": cycle,
+            "phase": "after",
+            "reserved_minus_allocated_bytes": 100 + 9 * cycle,
+            "inactive_split_bytes": 10 + 7 * cycle,
+        }
+        for cycle in range(5)
+    ]
+    fragmentation = per_cycle_retention(
+        rows, phase="after", metric="reserved_minus_allocated_bytes", warmup_cycles=1
+    )
+    inactive_split = per_cycle_retention(
+        rows, phase="after", metric="inactive_split_bytes", warmup_cycles=1
+    )
+    assert fragmentation["slope_bytes_per_cycle"] == 9
+    assert inactive_split["slope_bytes_per_cycle"] == 7

--- a/experimental/lite/tests/unit/examples/test_qwen3_ep_overlap_probe.py
+++ b/experimental/lite/tests/unit/examples/test_qwen3_ep_overlap_probe.py
@@ -71,6 +71,39 @@ def test_overlap_probe_reuses_shared_cycle_memory_harness():
     assert not hasattr(probe, "_live_stacks")
 
 
+def test_overlap_probe_success_requires_all_rank_artifacts(tmp_path):
+    from examples.bench.qwen3_ep_overlap_probe import require_probe_artifacts
+
+    with pytest.raises(RuntimeError, match="probe evidence missing"):
+        require_probe_artifacts(
+            out_dir=tmp_path,
+            arm="baseline",
+            rank=3,
+            cycles=2,
+            warmup=1,
+        )
+
+    expected = [
+        tmp_path / "baseline-rank3.csv",
+        tmp_path / "baseline-rank3-summary.json",
+        tmp_path / "baseline-rank3-cycle1.pickle",
+        tmp_path / "baseline-rank3-cycle2.pickle",
+    ]
+    for path in expected:
+        path.write_bytes(b"evidence")
+
+    assert (
+        require_probe_artifacts(
+            out_dir=tmp_path,
+            arm="baseline",
+            rank=3,
+            cycles=2,
+            warmup=1,
+        )
+        == expected
+    )
+
+
 def test_cycle_memory_retention_separates_fragmentation_from_inactive_split():
     from examples.bench.cycle_memory_probe import per_cycle_retention
 

--- a/experimental/lite/tests/unit/model/test_qwen_config_unit.py
+++ b/experimental/lite/tests/unit/model/test_qwen_config_unit.py
@@ -9,6 +9,7 @@ import pytest
 from megatron.lite.model.qwen3_5.config import Qwen35Config
 from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
 from megatron.lite.model.registry import resolve_model_type_from_hf, resolve_runtime_model_name
+from megatron.lite.runtime.contracts.config import ParallelConfig
 
 pytestmark = pytest.mark.mlite
 
@@ -101,6 +102,20 @@ def test_qwen_lite_protocols_build_configs_from_hf_dicts(transformer_engine_impo
     )
 
     assert qwen3_cfg.vocab_size == 128
+    overlap_cfg = qwen3_protocol.ImplConfig(
+        parallel=ParallelConfig(ep=8),
+        overlap_moe_expert_parallel_comm=True,
+    )
+    assert overlap_cfg.overlap_moe_expert_parallel_comm is True
+    with pytest.raises(ValueError, match="alltoall"):
+        qwen3_protocol.build_model(
+            qwen3_cfg,
+            impl_cfg=qwen3_protocol.ImplConfig(
+                parallel=ParallelConfig(ep=8),
+                overlap_moe_expert_parallel_comm=True,
+                use_deepep=True,
+            ),
+        )
     assert qwen35_cfg.vocab_size == 128
     assert qwen35_cfg.layer_type_at(0) == "linear_attention"
     assert qwen35_cfg.layer_type_at(1) == "full_attention"

--- a/experimental/lite/tests/unit/model/test_qwen_config_unit.py
+++ b/experimental/lite/tests/unit/model/test_qwen_config_unit.py
@@ -5,6 +5,8 @@ import ast
 from pathlib import Path
 
 import pytest
+import torch
+from torch import nn
 
 from megatron.lite.model.qwen3_5.config import Qwen35Config
 from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
@@ -119,6 +121,68 @@ def test_qwen_lite_protocols_build_configs_from_hf_dicts(transformer_engine_impo
     assert qwen35_cfg.vocab_size == 128
     assert qwen35_cfg.layer_type_at(0) == "linear_attention"
     assert qwen35_cfg.layer_type_at(1) == "full_attention"
+
+
+def test_qwen3_combined_1f1b_flattens_moe_tokens_and_restores_layer_shape(
+    transformer_engine_import_stub,
+):
+    transformer_engine_import_stub()
+
+    from megatron.lite.model.qwen3_moe.lite.model import MoELayer, TransformerLayer
+
+    class _Router(nn.Module):
+        def forward(self, hidden):
+            assert hidden.shape == (6, 4)
+            return hidden.new_ones(6, 1), torch.zeros(
+                6, 1, dtype=torch.long, device=hidden.device
+            )
+
+    class _Dispatcher:
+        ep_size = 2
+        use_deepep = False
+
+        def alltoall_dispatch_preprocess(self, hidden, scores, indices):
+            assert hidden.shape == (6, 4)
+            assert scores.shape == indices.shape == (6, 1)
+            return hidden, scores, torch.tensor([3, 3])
+
+        def alltoall_dispatch_communicate(self, hidden, scores, tokens_per_expert):
+            return hidden, tokens_per_expert, scores
+
+        def alltoall_combine_communicate(self, expert_output):
+            return expert_output
+
+    class _Attention(nn.Module):
+        def forward(self, hidden, **_kwargs):
+            return torch.zeros_like(hidden)
+
+    class _Experts(nn.Module):
+        def forward(self, hidden, *_args, **_kwargs):
+            return hidden
+
+    moe = MoELayer.__new__(MoELayer)
+    nn.Module.__init__(moe)
+    moe.router = _Router()
+    moe.experts = _Experts()
+    moe.dispatcher = _Dispatcher()
+
+    layer = TransformerLayer.__new__(TransformerLayer)
+    nn.Module.__init__(layer)
+    layer.attn = _Attention()
+    layer.mlp_norm = nn.Identity()
+    layer.moe = moe
+
+    pre_dispatch, dispatch, experts, combine = layer.combined_1f1b_callables(
+        position_ids=None, packed_seq_params=None
+    )
+    hidden = torch.randn(3, 2, 4)
+    residual, permuted, probs, tokens_per_expert = pre_dispatch(hidden)
+    residual, dispatched, tokens_per_expert, probs = dispatch(
+        residual, permuted, probs, tokens_per_expert
+    )
+    residual, expert_output = experts(residual, dispatched, tokens_per_expert, probs)
+
+    assert combine(residual, expert_output).shape == hidden.shape
 
 
 def test_qwen_lite_protocols_reexport_checkpoint_hook_names():

--- a/experimental/lite/tests/unit/primitive/test_combined_1f1b_dispatcher_gloo.py
+++ b/experimental/lite/tests/unit/primitive/test_combined_1f1b_dispatcher_gloo.py
@@ -91,11 +91,13 @@ def _dispatcher_worker(rank, world_size, port, results):
         split = TokenDispatcher(
             num_experts=4, hidden_size=2, ps=ps, use_deepep=False
         )
-        permuted, permuted_probs = split.alltoall_dispatch_preprocess(
-            split_hidden, split_scores, indices_by_rank[rank]
+        permuted, permuted_probs, tokens_per_expert = (
+            split.alltoall_dispatch_preprocess(
+                split_hidden, split_scores, indices_by_rank[rank]
+            )
         )
         dispatched, split_tpe, split_probs = split.alltoall_dispatch_communicate(
-            permuted, permuted_probs
+            permuted, permuted_probs, tokens_per_expert
         )
         split_output = split.alltoall_combine_communicate(
             dispatched * split_probs.unsqueeze(-1)

--- a/experimental/lite/tests/unit/primitive/test_combined_1f1b_dispatcher_gloo.py
+++ b/experimental/lite/tests/unit/primitive/test_combined_1f1b_dispatcher_gloo.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Real two-rank gloo proof for the split all-to-all dispatcher path."""
+
+import multiprocessing
+import os
+import sys
+import types
+
+import pytest
+import torch
+import torch.distributed as dist
+
+
+def _install_te_import_stub():
+    """Provide import-only TE symbols; this test exercises the unfused path."""
+
+    def unavailable(*_args, **_kwargs):
+        raise RuntimeError("fused Transformer Engine path was unexpectedly used")
+
+    root = types.ModuleType("transformer_engine")
+    pytorch = types.ModuleType("transformer_engine.pytorch")
+    cpp_extensions = types.ModuleType("transformer_engine.pytorch.cpp_extensions")
+    module = types.ModuleType("transformer_engine.pytorch.module")
+    module_base = types.ModuleType("transformer_engine.pytorch.module.base")
+    permutation = types.ModuleType("transformer_engine.pytorch.permutation")
+    router = types.ModuleType("transformer_engine.pytorch.router")
+    cpp_extensions.general_gemm = unavailable
+    module_base.get_workspace = unavailable
+    module.base = module_base
+    permutation.moe_permute = unavailable
+    permutation.moe_permute_and_pad_with_probs = unavailable
+    permutation.moe_permute_with_probs = unavailable
+    permutation.moe_unpermute = unavailable
+    router.fused_compute_score_for_moe_aux_loss = unavailable
+    router.fused_moe_aux_loss = unavailable
+    router.fused_topk_with_score_function = unavailable
+    root.pytorch = pytorch
+    for name, value in {
+        "transformer_engine": root,
+        "transformer_engine.pytorch": pytorch,
+        "transformer_engine.pytorch.cpp_extensions": cpp_extensions,
+        "transformer_engine.pytorch.module": module,
+        "transformer_engine.pytorch.module.base": module_base,
+        "transformer_engine.pytorch.permutation": permutation,
+        "transformer_engine.pytorch.router": router,
+    }.items():
+        sys.modules[name] = value
+
+
+def _dispatcher_worker(rank, world_size, port, results):
+    _install_te_import_stub()
+    from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
+    from megatron.lite.primitive.parallel.state import ParallelState
+
+    os.environ.update(
+        MASTER_ADDR="127.0.0.1",
+        MASTER_PORT=str(port),
+        RANK=str(rank),
+        WORLD_SIZE=str(world_size),
+        MEGATRON_LITE_MOE_PERMUTE_FUSION="0",
+    )
+    dist.init_process_group("gloo", rank=rank, world_size=world_size)
+    try:
+        ps = ParallelState(
+            ep_group=dist.group.WORLD, ep_size=world_size, ep_rank=rank
+        )
+        indices_by_rank = (
+            torch.tensor([[0], [0], [2]]),
+            torch.tensor([[1], [3], [3]]),
+        )
+        hidden = (
+            torch.arange(6, dtype=torch.float32).reshape(3, 2) + rank * 10
+        )
+        scores = torch.tensor([[0.5], [0.75], [1.0]])
+
+        baseline_hidden = hidden.clone().requires_grad_(True)
+        baseline_scores = scores.clone().requires_grad_(True)
+        baseline = TokenDispatcher(
+            num_experts=4, hidden_size=2, ps=ps, use_deepep=False
+        )
+        dispatched, baseline_tpe, baseline_probs = baseline.dispatch(
+            baseline_hidden, baseline_scores, indices_by_rank[rank]
+        )
+        baseline_output = baseline.combine(
+            dispatched * baseline_probs.unsqueeze(-1)
+        )
+        baseline_output.sum().backward()
+
+        split_hidden = hidden.clone().requires_grad_(True)
+        split_scores = scores.clone().requires_grad_(True)
+        split = TokenDispatcher(
+            num_experts=4, hidden_size=2, ps=ps, use_deepep=False
+        )
+        permuted, permuted_probs = split.alltoall_dispatch_preprocess(
+            split_hidden, split_scores, indices_by_rank[rank]
+        )
+        dispatched, split_tpe, split_probs = split.alltoall_dispatch_communicate(
+            permuted, permuted_probs
+        )
+        split_output = split.alltoall_combine_communicate(
+            dispatched * split_probs.unsqueeze(-1)
+        )
+        split_output.sum().backward()
+
+        results.append(
+            (
+                rank,
+                bool(torch.equal(split_tpe, baseline_tpe)),
+                bool(torch.equal(split_output, baseline_output)),
+                bool(torch.equal(split_hidden.grad, baseline_hidden.grad)),
+                bool(torch.equal(split_scores.grad, baseline_scores.grad)),
+            )
+        )
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.distributed
+def test_split_alltoall_matches_existing_dispatcher_with_zero_expert_splits():
+    import torch.multiprocessing as mp
+
+    results = multiprocessing.Manager().list()
+    mp.spawn(_dispatcher_worker, args=(2, 29675, results), nprocs=2, join=True)
+
+    assert sorted(results) == [
+        (0, True, True, True, True),
+        (1, True, True, True, True),
+    ]

--- a/experimental/lite/tests/unit/primitive/test_combined_1f1b_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_combined_1f1b_unit.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""CPU contract tests for the combined-1F1B EP-overlap driver."""
+
+from copy import deepcopy
+from dataclasses import dataclass
+
+import pytest
+import torch
+from megatron.lite.primitive.parallel.combined_1f1b import (
+    Combined1F1BConfig,
+    Combined1F1BModelPlan,
+    build_combined_1f1b_trace,
+    run_combined_1f1b,
+)
+from torch import nn
+
+
+@dataclass
+class _FakePlan:
+    microbatch: int
+    calls: list[tuple]
+
+    def forward(self):
+        self.calls.append(("forward", self.microbatch))
+        return {"loss": self.microbatch}
+
+    def combined_forward_backward(self, backward_plan):
+        self.calls.append(("combined", self.microbatch, backward_plan.microbatch))
+        return {"loss": self.microbatch}
+
+    def backward(self):
+        self.calls.append(("backward", self.microbatch))
+
+
+def test_combined_1f1b_trace_matches_megatron_phase_order():
+    assert build_combined_1f1b_trace(4) == [
+        (0, None),
+        (1, 0),
+        (2, 1),
+        (3, 2),
+        (None, 3),
+    ]
+
+
+def test_combined_1f1b_driver_runs_adjacent_microbatches():
+    calls = []
+    plans = [_FakePlan(i, calls) for i in range(4)]
+
+    outputs = run_combined_1f1b(plans)
+
+    assert calls == [
+        ("forward", 0),
+        ("combined", 1, 0),
+        ("combined", 2, 1),
+        ("combined", 3, 2),
+        ("backward", 3),
+    ]
+    assert outputs == [{"loss": 0}, {"loss": 1}, {"loss": 2}, {"loss": 3}]
+
+
+class _TinyModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layers = nn.ModuleList(
+            [nn.ModuleList([nn.Linear(4, 4) for _ in range(4)]) for _ in range(2)]
+        )
+        self.head = nn.Linear(4, 1)
+
+    def forward(self, x):
+        for layer in self.layers:
+            for node in layer:
+                x = torch.tanh(node(x))
+        return self.head(x)
+
+
+def _model_plan(model, x, target, num_microbatches):
+    layer_callables = [
+        [lambda value, node=node: torch.tanh(node(value)) for node in layer]
+        for layer in model.layers
+    ]
+    return Combined1F1BModelPlan(
+        preprocess=lambda: x,
+        layer_callables=layer_callables,
+        postprocess=lambda hidden: {
+            "loss": torch.nn.functional.mse_loss(model.head(hidden), target)
+        },
+        num_microbatches=num_microbatches,
+        use_cuda=False,
+    )
+
+
+def test_combined_1f1b_gradients_match_sequential_microbatch_backward():
+    torch.manual_seed(123)
+    reference = _TinyModel()
+    combined = deepcopy(reference)
+    batches = [
+        (torch.randn(3, 4), torch.randn(3, 1)),
+        (torch.randn(3, 4), torch.randn(3, 1)),
+        (torch.randn(3, 4), torch.randn(3, 1)),
+    ]
+
+    for x, target in batches:
+        (torch.nn.functional.mse_loss(reference(x), target) / len(batches)).backward()
+
+    run_combined_1f1b(
+        [_model_plan(combined, x, target, len(batches)) for x, target in batches]
+    )
+
+    for ref_param, combined_param in zip(
+        reference.parameters(), combined.parameters(), strict=True
+    ):
+        torch.testing.assert_close(combined_param.grad, ref_param.grad)
+
+
+@pytest.mark.parametrize(
+    ("override", "message"),
+    [
+        ({"num_microbatches": 1}, "at least 2 microbatches"),
+        ({"ep_size": 1}, "EP > 1"),
+        ({"pp_size": 2}, "PP=1"),
+        ({"use_deepep": True}, "alltoall"),
+        ({"recompute": ("full",)}, "recompute"),
+        ({"moe_permute_fusion": True}, "permute fusion"),
+    ],
+)
+def test_combined_1f1b_config_fails_loud_outside_first_profile(override, message):
+    values = {
+        "num_microbatches": 2,
+        "ep_size": 8,
+        "pp_size": 1,
+        "use_deepep": False,
+        "recompute": (),
+        "moe_permute_fusion": False,
+    }
+    values.update(override)
+
+    with pytest.raises(ValueError, match=message):
+        Combined1F1BConfig(**values).validate()

--- a/experimental/lite/tests/unit/primitive/test_combined_1f1b_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_combined_1f1b_unit.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 from megatron.lite.primitive.parallel.combined_1f1b import (
     Combined1F1BConfig,
+    Combined1F1BLayerPlan,
     Combined1F1BModelPlan,
     build_combined_1f1b_trace,
     run_combined_1f1b,
@@ -56,6 +57,47 @@ def test_combined_1f1b_driver_runs_adjacent_microbatches():
         ("backward", 3),
     ]
     assert outputs == [{"loss": 0}, {"loss": 1}, {"loss": 2}, {"loss": 3}]
+
+
+class _TraceNode:
+    def __init__(self, name, calls):
+        self.name = name
+        self.calls = calls
+
+    def forward(self, value):
+        self.calls.append(("forward", self.name))
+        return value
+
+    def backward(self, value):
+        self.calls.append(("backward", self.name))
+        return value
+
+
+def test_layer_pair_matches_megatron_combined_node_order():
+    calls = []
+    forward = Combined1F1BLayerPlan.__new__(Combined1F1BLayerPlan)
+    backward = Combined1F1BLayerPlan.__new__(Combined1F1BLayerPlan)
+    forward.nodes = tuple(
+        _TraceNode(f"f_{name}", calls)
+        for name in ("pre_dispatch", "dispatch", "experts", "combine")
+    )
+    backward.nodes = tuple(
+        _TraceNode(f"b_{name}", calls)
+        for name in ("pre_dispatch", "dispatch", "experts", "combine")
+    )
+
+    Combined1F1BLayerPlan.combined(forward, backward, object(), object())
+
+    assert calls == [
+        ("backward", "b_combine"),
+        ("forward", "f_pre_dispatch"),
+        ("backward", "b_experts"),
+        ("forward", "f_dispatch"),
+        ("backward", "b_dispatch"),
+        ("forward", "f_experts"),
+        ("forward", "f_combine"),
+        ("backward", "b_pre_dispatch"),
+    ]
 
 
 class _TinyModel(nn.Module):

--- a/experimental/lite/tests/unit/primitive/test_combined_1f1b_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_combined_1f1b_unit.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 
 import pytest
 import torch
+from megatron.lite.primitive.parallel import combined_1f1b
 from megatron.lite.primitive.parallel.combined_1f1b import (
     Combined1F1BConfig,
     Combined1F1BLayerPlan,
@@ -57,6 +58,19 @@ def test_combined_1f1b_driver_runs_adjacent_microbatches():
         ("backward", 3),
     ]
     assert outputs == [{"loss": 0}, {"loss": 1}, {"loss": 2}, {"loss": 3}]
+
+
+def test_combined_1f1b_driver_joins_comm_stream_before_return(monkeypatch):
+    calls = []
+    plans = [_FakePlan(i, calls) for i in range(2)]
+    joins = []
+    monkeypatch.setattr(
+        combined_1f1b, "_join_comm_stream", lambda: joins.append("joined")
+    )
+
+    run_combined_1f1b(plans)
+
+    assert joins == ["joined"]
 
 
 class _TraceNode:

--- a/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
+++ b/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
@@ -12,7 +12,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 import torch.nn as nn
-
 from megatron.lite.runtime import create_runtime
 from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig
 from megatron.lite.runtime.backends.mlite.runtime import (
@@ -21,9 +20,17 @@ from megatron.lite.runtime.backends.mlite.runtime import (
     _build_impl_cfg,
     _pipeline_callbacks,
 )
-from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig, RuntimeConfig
+from megatron.lite.runtime.contracts.config import (
+    OptimizerConfig,
+    ParallelConfig,
+    RuntimeConfig,
+)
 from megatron.lite.runtime.contracts.handle import ModelHandle
-from megatron.lite.runtime.contracts.loss import LossContext, get_loss_context, use_loss_context
+from megatron.lite.runtime.contracts.loss import (
+    LossContext,
+    get_loss_context,
+    use_loss_context,
+)
 
 pytestmark = pytest.mark.mlite
 
@@ -47,13 +54,65 @@ def test_runtime_returns_loss_separately_from_microbatch_metrics():
     assert result.model_output.loss is not None
 
 
+def test_runtime_combined_1f1b_path_is_production_reachable():
+    calls = []
+
+    class Plan:
+        def __init__(self, microbatch):
+            self.microbatch = microbatch
+
+        def forward(self):
+            calls.append(("forward", self.microbatch))
+            return {"loss": torch.tensor(float(self.microbatch))}
+
+        def combined_forward_backward(self, backward_plan):
+            calls.append(("combined", self.microbatch, backward_plan.microbatch))
+            return {"loss": torch.tensor(float(self.microbatch))}
+
+        def backward(self):
+            calls.append(("backward", self.microbatch))
+
+    def factory(_model, batch, **_kwargs):
+        return Plan(batch["micro"])
+
+    handle = ModelHandle(
+        model=nn.Linear(1, 1, bias=False),
+        parallel_state=types.SimpleNamespace(pp_size=1, ep_size=8),
+        _extras={
+            "forward_step": MagicMock(
+                side_effect=AssertionError("sequential path used")
+            ),
+            "combined_1f1b_plan": factory,
+            "combined_1f1b_recompute": (),
+        },
+    )
+
+    result = MegatronLiteRuntime.__new__(MegatronLiteRuntime).forward_backward(
+        handle,
+        iter([{"micro": 0}, {"micro": 1}, {"micro": 2}]),
+        None,
+        num_microbatches=3,
+    )
+
+    assert calls == [
+        ("forward", 0),
+        ("combined", 1, 0),
+        ("combined", 2, 1),
+        ("backward", 2),
+    ]
+    assert result.model_output.loss.item() == 2.0
+
+
 def test_pipeline_callbacks_accept_wrapped_and_presplit_context():
     context = LossContext(source_batch="source")
     seen = []
     forward, loss = _pipeline_callbacks(
         lambda _model, batch: seen.append((batch, get_loss_context()))
         or {"loss": torch.tensor(1.0)},
-        lambda out, batch, ctx: (out["loss"], {"batch": batch, "source": ctx.source_batch}),
+        lambda out, batch, ctx: (
+            out["loss"],
+            {"batch": batch, "source": ctx.source_batch},
+        ),
     )
 
     output = forward(None, ("wrapped", context))
@@ -87,7 +146,8 @@ def test_runtime_config_accepts_mlite_backend_cfg():
 
 def test_mlite_config_defaults_and_parallel_fields():
     cfg = MegatronLiteConfig(
-        model_name="qwen3_moe", parallel=ParallelConfig(tp=4, etp=1, ep=8, pp=2, vpp=2, cp=2)
+        model_name="qwen3_moe",
+        parallel=ParallelConfig(tp=4, etp=1, ep=8, pp=2, vpp=2, cp=2),
     )
 
     assert cfg.model_name == "qwen3_moe"
@@ -216,7 +276,9 @@ class HookedOptimizer:
 
 def test_runtime_to_prefers_optimizer_specific_offload_hooks():
     optimizer = HookedOptimizer()
-    handle = ModelHandle(model=nn.Linear(2, 2), optimizer=optimizer, _extras={"model_chunks": []})
+    handle = ModelHandle(
+        model=nn.Linear(2, 2), optimizer=optimizer, _extras={"model_chunks": []}
+    )
     runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
 
     runtime.to(handle, "cpu", model=False, optimizer=True, grad=False)
@@ -260,9 +322,7 @@ def test_training_transfer_parks_optimizer_and_releases_scratch(monkeypatch):
     monkeypatch.setattr(torch.cuda, "empty_cache", lambda: events.append("empty-cache"))
     chunk = Chunk()
     handle = ModelHandle(
-        model=chunk,
-        optimizer=Optimizer(),
-        _extras={"model_chunks": [chunk]},
+        model=chunk, optimizer=Optimizer(), _extras={"model_chunks": [chunk]}
     )
     runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
 
@@ -297,9 +357,7 @@ def test_export_transfer_does_not_move_optimizer_or_release_scratch(monkeypatch)
     )
     chunk = Chunk()
     handle = ModelHandle(
-        model=chunk,
-        optimizer=HookedOptimizer(),
-        _extras={"model_chunks": [chunk]},
+        model=chunk, optimizer=HookedOptimizer(), _extras={"model_chunks": [chunk]}
     )
 
     MegatronLiteRuntime.__new__(MegatronLiteRuntime).to(
@@ -415,7 +473,10 @@ def test_megatron_ddp_detection_accepts_ddp_and_subclasses(monkeypatch):
 
 @pytest.mark.parametrize("model_cls", [_FakeMegatronDDP, _FakeMegatronDDPSubclass])
 def test_megatron_ddp_model_move_helpers_use_buffer_path(monkeypatch, model_cls):
-    from megatron.lite.runtime.megatron_utils import load_model_to_gpu, offload_model_to_cpu
+    from megatron.lite.runtime.megatron_utils import (
+        load_model_to_gpu,
+        offload_model_to_cpu,
+    )
 
     _install_fake_megatron_ddp(monkeypatch)
     model = model_cls()
@@ -442,7 +503,10 @@ def test_megatron_ddp_model_move_helpers_use_buffer_path(monkeypatch, model_cls)
 
 
 def test_native_model_move_helpers_do_not_require_megatron_core(monkeypatch):
-    from megatron.lite.runtime.megatron_utils import load_model_to_gpu, offload_model_to_cpu
+    from megatron.lite.runtime.megatron_utils import (
+        load_model_to_gpu,
+        offload_model_to_cpu,
+    )
 
     monkeypatch.setitem(sys.modules, "megatron.core", None)
     monkeypatch.setitem(sys.modules, "megatron.core.distributed", None)
@@ -501,7 +565,9 @@ def test_model_handle_dp_from_parallel_state():
 def test_model_handle_cp_range_and_config_properties():
     cfg = {"tp": 8, "ep": 4}
     default_handle = ModelHandle(model=MagicMock())
-    configured_handle = ModelHandle(model=MagicMock(), config=cfg, _extras={"cp_range": (1, 8)})
+    configured_handle = ModelHandle(
+        model=MagicMock(), config=cfg, _extras={"cp_range": (1, 8)}
+    )
 
     assert default_handle.cp_range == (1, 1)
     assert configured_handle.cp_range == (1, 8)
@@ -515,7 +581,9 @@ def test_runtime_dispatch_creates_mlite_backend():
 
         runtime = create_runtime(
             RuntimeConfig(
-                backend="mlite", hf_path="/models/test", backend_cfg={"model_name": "qwen3"}
+                backend="mlite",
+                hf_path="/models/test",
+                backend_cfg={"model_name": "qwen3"},
             )
         )
 
@@ -544,7 +612,9 @@ def _run_verl_sft_dry_run(script: Path, tmp_path: Path, **env_overrides: str) ->
         "ETP_SIZE": "1",
         **env_overrides,
     }
-    completed = subprocess.run([str(script)], env=env, text=True, capture_output=True, check=True)
+    completed = subprocess.run(
+        [str(script)], env=env, text=True, capture_output=True, check=True
+    )
     return completed.stdout
 
 
@@ -568,7 +638,9 @@ def test_verl_sft_script_maps_offload_env_to_backend_args(tmp_path):
     assert "engine.param_offload=True" in command
     assert "engine.optimizer_offload=True" in command
     assert "+optim.override_optimizer_config.offload_fraction=0.75" in command
-    assert "+optim.override_optimizer_config.use_precision_aware_optimizer=True" in command
+    assert (
+        "+optim.override_optimizer_config.use_precision_aware_optimizer=True" in command
+    )
 
 
 def test_verl_sft_script_does_not_emit_optimizer_state_offload_when_disabled(tmp_path):


### PR DESCRIPTION
## Summary
- add a controlled baseline/overlap Qwen3 MoE probe whose runtime configs differ only in `overlap_moe_expert_parallel_comm`
- run each arm in a separate torchrun process so allocator and runtime state cannot contaminate the comparison
- record full-model identity and parallelism in every summary, including layer count, truncation status, expert count, and EP/TP/PP/CP sizes
- measure per-step throughput plus `torch.cuda.max_memory_allocated` and `max_memory_reserved`, while retaining allocator snapshots as secondary evidence
- fail loudly on truncated-model evidence, missing peak fields, insufficient post-warmup samples, or incomplete rank artifacts

## Validation
- focused benchmark contracts: 26 passed
- negative contracts: the previous implementation failed all three new checks for truncation, missing peak metrics, and incomplete full-model evidence
- repository-pinned isort and Black: passed on all changed Python files
- zero-GPU Slurm gate: full dependency closure passed; the runtime plan resolved to 48 layers, 128 experts, no truncation, EP=8, TP=PP=CP=1, and all required performance/peak fields
- single-node 8-GPU full-model run: completed with exit code 0 in 11 minutes 43 seconds; baseline and overlap each produced 8 rank summaries for 3 warmup plus 10 measured steps, followed by separate two-step Nsight Systems profiles

## Full-model 8-GPU results

The workload used the Qwen3-30B-A3B configuration with 48 layers, 128 experts, no layer truncation, EP=8, TP=PP=CP=1, `use_deepep=false`, and `recompute=[]`. The only configuration difference was `overlap_moe_expert_parallel_comm=false/true`. Reported 95% confidence intervals use ten paired measured cycles after three warmup cycles; step and throughput values first aggregate across ranks per distributed step, while peak memory uses the maximum rank per step.

- Step time was 2758.173 ± 612.038 ms for baseline and 3168.205 ± 259.187 ms for overlap. The paired overlap-minus-baseline difference was +410.032 ms (95% CI -286.732 to +1106.797), a 14.866% slower point estimate with an interval crossing zero.
- Throughput was 3216.504 ± 640.639 tokens/s for baseline and 2618.399 ± 229.273 tokens/s for overlap. The paired difference was -598.105 tokens/s (95% CI -1317.608 to +121.398), an 18.595% lower point estimate with an interval crossing zero.
- Peak allocated memory was 68489.524 ± 55.427 MiB for baseline and 69444.892 ± 81.602 MiB for overlap. The paired difference was **+955.368 MiB** (95% CI +928.690 to +982.046), or +1.395%.
- Peak reserved memory was 71704.400 ± 30.765 MiB for baseline and 73295.800 ± 107.352 MiB for overlap. The paired difference was **+1591.400 MiB** (95% CI +1499.334 to +1683.466), or +2.219%.
- As secondary allocator evidence, `reserved - allocated` increased by 1664.528 MiB (95% CI +1619.961 to +1709.094), while `inactive_split` decreased by only 3.347 MiB (95% CI -4.533 to -2.162). The full-model run therefore does not demonstrate lower peak memory or reduced allocator pressure.

These results do **not** satisfy the intended speed or memory acceptance criteria. They replace the earlier two-layer proxy numbers, which must not be used as evidence for full-model behavior.

## Nsight Systems attribution

Separate profiles used one warmup plus two measured steps so profiler overhead did not contaminate the ten-repeat performance run. Both reports were generated successfully.

- Aggregated `ncclDevKernel_AllGather_RING_LL` GPU-kernel time increased from 13.669 s to 238.334 s (17.4x), while `ncclDevKernel_SendRecv` decreased from 130.486 s to 26.915 s.
- Aggregated `cudaMemcpyAsync` API time increased from 14.252 s to 239.552 s (16.8x).
- Median per-rank NVTX step time increased from 3.148 s to 3.405 s on measured step 1 (+8.2%) and from 3.150 s to 3.670 s on measured step 2 (+16.5%).
- The overlap trace attributes the dominant added wait to `combined_1f1b.forward.dispatch`; this is consistent with the split all-to-all path's metadata all-gather running on the shared communication stream. This attribution is diagnostic, not a claim that the exact profiled timing equals the unprofiled timing.

## Known limitations and status
- This probe uses random weights and does not establish loss or gradient parity; it is a runtime, memory, and short-run performance gate.
- The current implementation fails the full-model speed and lower-peak-memory goals and should not be merged until the communication-stream/all-gather regression is fixed and the same protocol is rerun.
- Existing training evidence should account for the current `loss_mask` versus `response_mask` fallback mismatch before using loss comparisons.
- Qwen3 MoE pack geometry/protocol hooks remain under-documented, the protocol loader does not validate `unpack_forward_output`, and combined-1F1B step-level loss currently reflects only the last microbatch.
- Recorded protocol data currently has no consumer before end-of-step cleanup.
- The MLite skill set does not yet have a dedicated `lint_skill` CI check.
