### PR TITLE
[lite] feat: declarative fused weight layout primitive

### DIFF
--- a/experimental/lite/megatron/lite/primitive/ckpt/fused_weights.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/fused_weights.py
@@ -1,0 +1,234 @@
+"""Declarative fused checkpoint tensor layouts.
+
+Model code declares semantic segments and their head geometry. This primitive
+owns concatenation, splitting, tensor-parallel slicing, and quantized
+packed/scale pairing so callers never infer layout from parameter names.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass(frozen=True, slots=True)
+class WeightSegment:
+    """One semantic row segment in a fused projection."""
+
+    name: str
+    heads: int
+    head_dim: int
+    replicated: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("weight segment name must not be empty")
+        if self.heads <= 0:
+            raise ValueError(f"{self.name!r} heads must be positive")
+        if self.head_dim <= 0:
+            raise ValueError(f"{self.name!r} head_dim must be positive")
+
+    @property
+    def rows(self) -> int:
+        return self.heads * self.head_dim
+
+    def local_rows(self, world_size: int) -> int:
+        """Return local rows, validating head divisibility for sharded segments."""
+        if world_size <= 0:
+            raise ValueError("world_size must be positive")
+        if self.replicated or world_size == 1:
+            return self.rows
+        if self.heads % world_size:
+            raise ValueError(
+                f"{self.name!r} heads={self.heads} must be divisible by TP={world_size}"
+            )
+        return self.heads // world_size * self.head_dim
+
+
+@dataclass(frozen=True, slots=True)
+class QuantizedWeight:
+    """A packed tensor and its scale, kept together as one semantic value."""
+
+    packed: torch.Tensor
+    scale: torch.Tensor
+
+
+@dataclass(frozen=True, slots=True)
+class FusedWeightLayout:
+    """Ordered, fail-loud layout for a fused projection's output rows."""
+
+    name: str
+    segments: tuple[WeightSegment, ...]
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("fused weight layout name must not be empty")
+        if not self.segments:
+            raise ValueError(f"{self.name!r} requires at least one segment")
+        names = tuple(segment.name for segment in self.segments)
+        if len(names) != len(set(names)):
+            raise ValueError(f"{self.name!r} has duplicate segment names")
+
+    @property
+    def rows(self) -> int:
+        return sum(segment.rows for segment in self.segments)
+
+    def _ordered(self, tensors: Mapping[str, torch.Tensor]) -> list[torch.Tensor]:
+        expected = {segment.name for segment in self.segments}
+        actual = set(tensors)
+        if actual != expected:
+            raise ValueError(
+                f"{self.name!r} segment set mismatch: "
+                f"missing={sorted(expected - actual)}, unexpected={sorted(actual - expected)}"
+            )
+        ordered = []
+        trailing_shape = None
+        dtype = None
+        device = None
+        for segment in self.segments:
+            tensor = tensors[segment.name]
+            if tensor.ndim < 1:
+                raise ValueError(
+                    f"{self.name!r}.{segment.name} must have at least one dimension"
+                )
+            if tensor.size(0) != segment.rows:
+                raise ValueError(
+                    f"{self.name!r}.{segment.name} requires {segment.rows} rows "
+                    f"from {segment.heads} heads x {segment.head_dim}, got {tensor.size(0)}"
+                )
+            current_trailing = tuple(tensor.shape[1:])
+            if trailing_shape is None:
+                trailing_shape = current_trailing
+                dtype = tensor.dtype
+                device = tensor.device
+            elif current_trailing != trailing_shape:
+                raise ValueError(
+                    f"{self.name!r}.{segment.name} trailing shape {current_trailing} "
+                    f"does not match {trailing_shape}"
+                )
+            elif tensor.dtype != dtype or tensor.device != device:
+                raise ValueError(
+                    f"{self.name!r}.{segment.name} dtype/device must match earlier segments"
+                )
+            ordered.append(tensor)
+        return ordered
+
+    def fuse(self, tensors: Mapping[str, torch.Tensor]) -> torch.Tensor:
+        """Fuse semantic tensors in declared order after validating geometry."""
+        return torch.cat(self._ordered(tensors), dim=0).contiguous()
+
+    def fuse_ordered(self, tensors: Sequence[tuple[str, torch.Tensor]]) -> torch.Tensor:
+        """Fuse an ordered source stream, rejecting swapped semantic segments."""
+        expected = tuple(segment.name for segment in self.segments)
+        actual = tuple(name for name, _ in tensors)
+        if actual != expected:
+            raise ValueError(
+                f"{self.name!r} segment order mismatch: "
+                f"expected={expected}, actual={actual}"
+            )
+        return self.fuse(dict(tensors))
+
+    def split(self, tensor: torch.Tensor) -> dict[str, torch.Tensor]:
+        """Split one fused tensor using the same declaration used to fuse it."""
+        if tensor.ndim < 1 or tensor.size(0) != self.rows:
+            got = tensor.size(0) if tensor.ndim else 0
+            raise ValueError(
+                f"{self.name!r} requires {self.rows} fused rows, got {got}"
+            )
+        return dict(
+            zip(
+                (segment.name for segment in self.segments),
+                tensor.split([segment.rows for segment in self.segments], dim=0),
+                strict=True,
+            )
+        )
+
+    def tp_shard(
+        self, tensor: torch.Tensor, *, rank: int, world_size: int
+    ) -> torch.Tensor:
+        """Shard each head-based segment independently, preserving replicas."""
+        if world_size <= 0 or not 0 <= rank < world_size:
+            raise ValueError("rank must be within a positive world_size")
+        parts = self.split(tensor)
+        local = {}
+        local_segments = []
+        for segment in self.segments:
+            part = parts[segment.name]
+            if segment.replicated or world_size == 1:
+                local[segment.name] = part
+                local_segments.append(segment)
+                continue
+            segment.local_rows(world_size)
+            headed = part.reshape(segment.heads, segment.head_dim, *part.shape[1:])
+            local[segment.name] = headed.chunk(world_size, dim=0)[rank].reshape(
+                -1, *part.shape[1:]
+            )
+            local_segments.append(
+                WeightSegment(
+                    segment.name,
+                    segment.heads // world_size,
+                    segment.head_dim,
+                )
+            )
+        return FusedWeightLayout(self.name, tuple(local_segments)).fuse(local)
+
+    def fuse_quantized(
+        self,
+        tensors: Mapping[str, QuantizedWeight],
+        *,
+        materialize: Callable[[QuantizedWeight], torch.Tensor],
+    ) -> torch.Tensor:
+        """Validate packed/scale pairing, materialize, then fuse by declaration."""
+        expected = {segment.name for segment in self.segments}
+        actual = set(tensors)
+        if actual != expected:
+            raise ValueError(
+                f"{self.name!r} quantized segment set mismatch: "
+                f"missing={sorted(expected - actual)}, unexpected={sorted(actual - expected)}"
+            )
+        materialized = {}
+        for segment in self.segments:
+            pair = tensors[segment.name]
+            for label, value in (("packed", pair.packed), ("scale", pair.scale)):
+                if value.ndim < 1 or value.size(0) != segment.rows:
+                    got = value.size(0) if value.ndim else 0
+                    raise ValueError(
+                        f"{self.name!r}.{segment.name} {label} requires "
+                        f"{segment.rows} rows, got {got}"
+                    )
+            materialized[segment.name] = materialize(pair)
+        return self.fuse(materialized)
+
+    def fuse_quantized_ordered(
+        self,
+        tensors: Sequence[tuple[str, QuantizedWeight]],
+        *,
+        materialize: Callable[[QuantizedWeight], torch.Tensor],
+    ) -> torch.Tensor:
+        """Materialize an ordered quantized stream with fail-loud semantics."""
+        expected = tuple(segment.name for segment in self.segments)
+        actual = tuple(name for name, _ in tensors)
+        if actual != expected:
+            raise ValueError(
+                f"{self.name!r} quantized segment order mismatch: "
+                f"expected={expected}, actual={actual}"
+            )
+        return self.fuse_quantized(dict(tensors), materialize=materialize)
+
+    def split_quantized(
+        self, packed: torch.Tensor, scale: torch.Tensor
+    ) -> dict[str, QuantizedWeight]:
+        """Split packed weights and scales through identical semantic boundaries."""
+        packed_parts = self.split(packed)
+        scale_parts = self.split(scale)
+        return {
+            segment.name: QuantizedWeight(
+                packed=packed_parts[segment.name], scale=scale_parts[segment.name]
+            )
+            for segment in self.segments
+        }
+
+
+__all__ = ["FusedWeightLayout", "QuantizedWeight", "WeightSegment"]

--- a/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
@@ -226,6 +226,12 @@ class SafeTensorReader:
             return tensor
 
         tensor = self._get_raw_tensor(name, target_device)
+        if name.endswith(("_packed", "_scale")):
+            # Explicit physical quantization components are consumed together
+            # by the model weight spec.  They are not standalone one-byte
+            # weights for this generic reader to dequantize.
+            self._cached_request, self._cached_tensor = request, tensor
+            return tensor
         scaled_quantized = isinstance(
             tensor, torch.Tensor
         ) and _is_scaled_quantized_dtype(tensor.dtype)

--- a/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
@@ -35,6 +35,10 @@ except Exception:  # pragma: no cover - older torch without DTensor
 from megatron.lite.primitive.ckpt.weight_sync_probe import (  # isort: skip
     get_weight_sync_probe,
 )
+from megatron.lite.primitive.ckpt.fused_weights import (  # isort: skip
+    FusedWeightLayout,
+    WeightSegment,
+)
 
 
 def _tensor_nbytes(tensor: torch.Tensor) -> int:
@@ -492,26 +496,26 @@ def split_qkv(
     Naive ``split_dim`` would slice across the Q/K/V boundary incorrectly
     when num_q_heads != num_kv_heads (GQA).
     """
-    if world <= 1:
-        return tensor
-    q_size = num_q_heads * head_dim
-    kv_size = num_kv_heads * head_dim
-    q = tensor[:q_size]
-    k = tensor[q_size : q_size + kv_size]
-    v = tensor[q_size + kv_size :]
-    q_shard = q.chunk(world, dim=0)[rank]
-    k_shard = k.chunk(world, dim=0)[rank]
-    v_shard = v.chunk(world, dim=0)[rank]
-    return torch.cat([q_shard, k_shard, v_shard], dim=0).contiguous()
+    layout = FusedWeightLayout(
+        name="qkv",
+        segments=(
+            WeightSegment("q", num_q_heads, head_dim),
+            WeightSegment("k", num_kv_heads, head_dim),
+            WeightSegment("v", num_kv_heads, head_dim),
+        ),
+    )
+    return layout.tp_shard(tensor, rank=rank, world_size=world)
 
 
 def split_gate_up(tensor: torch.Tensor, rank: int, world: int) -> torch.Tensor:
-    if world <= 1:
-        return tensor
+    if tensor.size(0) % 2:
+        raise ValueError("gate_up tensor must contain equal gate and up rows")
     ffn = tensor.shape[0] // 2
-    gate = tensor[:ffn].chunk(world, dim=0)[rank]
-    up = tensor[ffn:].chunk(world, dim=0)[rank]
-    return torch.cat([gate, up], dim=0).contiguous()
+    layout = FusedWeightLayout(
+        name="gate_up",
+        segments=(WeightSegment("gate", ffn, 1), WeightSegment("up", ffn, 1)),
+    )
+    return layout.tp_shard(tensor, rank=rank, world_size=world)
 
 
 def allgather_concat(
@@ -857,10 +861,29 @@ def to_global_layer_name(name: str, layer_map: dict[int, int]) -> str:
 def gather_gate_up(
     tensor: torch.Tensor, world_size: int, group: dist.ProcessGroup
 ) -> torch.Tensor:
+    if tensor.size(0) % 2:
+        raise ValueError("gate_up tensor must contain equal gate and up rows")
     ffn_local = tensor.shape[0] // 2
-    gate_full = allgather_concat(tensor[:ffn_local], world_size, group, dim=0)
-    up_full = allgather_concat(tensor[ffn_local:], world_size, group, dim=0)
-    return torch.cat([gate_full, up_full], dim=0)
+    local_layout = FusedWeightLayout(
+        name="gate_up",
+        segments=(
+            WeightSegment("gate", ffn_local, 1),
+            WeightSegment("up", ffn_local, 1),
+        ),
+    )
+    local = local_layout.split(tensor)
+    full = {
+        name: allgather_concat(part, world_size, group, dim=0)
+        for name, part in local.items()
+    }
+    full_layout = FusedWeightLayout(
+        name="gate_up",
+        segments=(
+            WeightSegment("gate", ffn_local * world_size, 1),
+            WeightSegment("up", ffn_local * world_size, 1),
+        ),
+    )
+    return full_layout.fuse(full)
 
 
 # ======================================================================

--- a/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
@@ -178,7 +178,7 @@ class SafeTensorReader:
         self._stack: ExitStack | None = None
         self._handles: dict[Path, Any] = {}
         self._cached_request: (
-            tuple[str, torch.device, torch.Size | None, torch.dtype | None] | None
+            tuple[str, torch.device, torch.Size | None, torch.dtype | None, bool] | None
         ) = None
         self._cached_tensor: torch.Tensor | None = None
 
@@ -214,9 +214,10 @@ class SafeTensorReader:
         device: torch.device | str | None = None,
         target_shape: torch.Size | None = None,
         target_dtype: torch.dtype | None = None,
+        raw: bool = False,
     ) -> torch.Tensor:
         target_device = torch.device(self.device if device is None else device)
-        request = (name, target_device, target_shape, target_dtype)
+        request = (name, target_device, target_shape, target_dtype, raw)
         if request == self._cached_request:
             assert self._cached_tensor is not None
             return self._cached_tensor
@@ -226,10 +227,7 @@ class SafeTensorReader:
             return tensor
 
         tensor = self._get_raw_tensor(name, target_device)
-        if name.endswith(("_packed", "_scale")):
-            # Explicit physical quantization components are consumed together
-            # by the model weight spec.  They are not standalone one-byte
-            # weights for this generic reader to dequantize.
+        if raw:
             self._cached_request, self._cached_tensor = request, tensor
             return tensor
         scaled_quantized = isinstance(
@@ -1289,12 +1287,16 @@ def _read_hf_tensors(
             )
         else:
             target_shape = None
-        tensor = reader.get_tensor(
-            resolved,
-            device=target.device,
-            target_shape=target_shape,
-            target_dtype=target.dtype,
-        )
+        raw_source = getattr(spec, "raw_hf_source", None)
+        if callable(raw_source) and raw_source(native_name, index, resolved):
+            tensor = reader.get_tensor(resolved, device=target.device, raw=True)
+        else:
+            tensor = reader.get_tensor(
+                resolved,
+                device=target.device,
+                target_shape=target_shape,
+                target_dtype=target.dtype,
+            )
         transform_source = getattr(spec, "transform_hf_source", None)
         if callable(transform_source):
             tensor = transform_source(native_name, index, resolved, tensor)

--- a/experimental/lite/tests/unit/primitive/ckpt/test_hf_weights_fp8_scale.py
+++ b/experimental/lite/tests/unit/primitive/ckpt/test_hf_weights_fp8_scale.py
@@ -62,18 +62,42 @@ def test_safe_tensor_reader_rejects_one_byte_quantized_weight_without_scale(
         )
 
 
-@pytest.mark.parametrize("suffix", ["packed", "scale"])
-def test_safe_tensor_reader_preserves_explicit_quantization_components(suffix) -> None:
-    name = f"expert.weight_{suffix}"
-    physical = torch.tensor([[0, 127, 255]], dtype=torch.uint8)
-    actual = _reader({name: physical}).get_tensor(
-        name,
-        target_shape=physical.shape,
-        target_dtype=torch.bfloat16,
+def test_explicit_packed_component_without_plan_context_still_fails_loudly() -> None:
+    name = "expert.weight_packed"
+    with pytest.raises(RuntimeError, match=r"expert\.weight_packed.*missing scale"):
+        _reader({name: torch.ones((2, 2), dtype=torch.uint8)}).get_tensor(
+            name,
+            target_shape=torch.Size((2, 4)),
+            target_dtype=torch.bfloat16,
+        )
+
+
+def test_load_plan_can_request_paired_physical_quantization_components() -> None:
+    packed = torch.tensor([[0, 127, 255]], dtype=torch.uint8)
+    scale = torch.tensor([[121, 122, 123]], dtype=torch.uint8)
+    tensors = {
+        "expert.weight_packed": packed,
+        "expert.weight_scale": scale,
+    }
+
+    class Spec:
+        @staticmethod
+        def raw_hf_source(native_name, index, resolved_name):
+            assert native_name == "expert.weight"
+            assert resolved_name in tensors
+            return index in (0, 1)
+
+    actual = _read_hf_tensors(
+        _reader(tensors),
+        Spec(),
+        "expert.weight",
+        ["expert.weight_packed", "expert.weight_scale"],
+        torch.empty((2, 4), dtype=torch.bfloat16),
     )
 
-    assert actual.dtype == torch.uint8
-    assert torch.equal(actual, physical)
+    assert [tensor.dtype for tensor in actual] == [torch.uint8, torch.uint8]
+    assert torch.equal(actual[0], packed)
+    assert torch.equal(actual[1], scale)
 
 
 def test_multi_source_mapping_dequantizes_each_fp8_block_scaled_source() -> None:

--- a/experimental/lite/tests/unit/primitive/ckpt/test_hf_weights_fp8_scale.py
+++ b/experimental/lite/tests/unit/primitive/ckpt/test_hf_weights_fp8_scale.py
@@ -62,6 +62,20 @@ def test_safe_tensor_reader_rejects_one_byte_quantized_weight_without_scale(
         )
 
 
+@pytest.mark.parametrize("suffix", ["packed", "scale"])
+def test_safe_tensor_reader_preserves_explicit_quantization_components(suffix) -> None:
+    name = f"expert.weight_{suffix}"
+    physical = torch.tensor([[0, 127, 255]], dtype=torch.uint8)
+    actual = _reader({name: physical}).get_tensor(
+        name,
+        target_shape=physical.shape,
+        target_dtype=torch.bfloat16,
+    )
+
+    assert actual.dtype == torch.uint8
+    assert torch.equal(actual, physical)
+
+
 def test_multi_source_mapping_dequantizes_each_fp8_block_scaled_source() -> None:
     if not hasattr(torch, "float8_e4m3fn"):
         pytest.skip("torch float8_e4m3fn is required")

--- a/experimental/lite/tests/unit/primitive/test_fused_weights.py
+++ b/experimental/lite/tests/unit/primitive/test_fused_weights.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from megatron.lite.primitive.ckpt.fused_weights import (
+    FusedWeightLayout,
+    QuantizedWeight,
+    WeightSegment,
+)
+from megatron.lite.primitive.ckpt.hf_weights import split_gate_up, split_qkv
+
+
+def _kda_layout(*, q_heads: int = 6) -> FusedWeightLayout:
+    return FusedWeightLayout(
+        name="in_proj_qkvgfab",
+        segments=(
+            WeightSegment("q", q_heads, 4),
+            WeightSegment("k", 6, 4),
+            WeightSegment("v", 6, 4),
+            WeightSegment("g", 6, 4),
+            WeightSegment("f_a", 1, 4, replicated=True),
+            WeightSegment("b", 6, 1),
+        ),
+    )
+
+
+def _parts(layout: FusedWeightLayout) -> dict[str, torch.Tensor]:
+    offset = 0
+    parts = {}
+    for segment in layout.segments:
+        numel = segment.rows * 3
+        parts[segment.name] = torch.arange(offset, offset + numel).reshape(
+            segment.rows, 3
+        )
+        offset += numel
+    return parts
+
+
+def test_layout_fuses_and_splits_against_an_independent_reference() -> None:
+    layout = _kda_layout()
+    parts = _parts(layout)
+    reference = torch.cat(
+        [parts[name] for name in ("q", "k", "v", "g", "f_a", "b")], dim=0
+    )
+
+    fused = layout.fuse(parts)
+    restored = layout.split(fused)
+
+    assert torch.equal(fused, reference)
+    assert tuple(restored) == ("q", "k", "v", "g", "f_a", "b")
+    assert all(torch.equal(restored[name], parts[name]) for name in restored)
+
+
+def test_layout_rejects_a_declared_head_count_mismatch() -> None:
+    layout = _kda_layout(q_heads=7)
+    parts = _parts(_kda_layout())
+
+    with pytest.raises(ValueError, match=r"q.*28 rows.*got 24"):
+        layout.fuse(parts)
+
+
+def test_layout_rejects_components_in_the_wrong_declared_order() -> None:
+    layout = _kda_layout()
+    parts = _parts(layout)
+    wrong_order = [("q", parts["q"]), ("v", parts["v"]), ("k", parts["k"])] + [
+        (name, parts[name]) for name in ("g", "f_a", "b")
+    ]
+
+    with pytest.raises(ValueError, match=r"segment order mismatch.*k.*v"):
+        layout.fuse_ordered(wrong_order)
+
+
+def test_tp_shard_matches_independent_mixed_shard_and_replica_semantics() -> None:
+    layout = _kda_layout()
+    parts = _parts(layout)
+
+    actual = layout.tp_shard(layout.fuse(parts), rank=1, world_size=2)
+    expected = torch.cat(
+        [parts[name].chunk(2, dim=0)[1] for name in ("q", "k", "v", "g")]
+        + [parts["f_a"], parts["b"].chunk(2, dim=0)[1]],
+        dim=0,
+    )
+
+    assert torch.equal(actual, expected)
+
+
+def test_quantized_fusion_keeps_each_scale_attached_to_its_segment() -> None:
+    layout = FusedWeightLayout(
+        name="gate_up",
+        segments=(WeightSegment("gate", 2, 1), WeightSegment("up", 2, 1)),
+    )
+    gate = QuantizedWeight(
+        packed=torch.full((2, 2), 1, dtype=torch.uint8),
+        scale=torch.full((2, 1), 11, dtype=torch.uint8),
+    )
+    up = QuantizedWeight(
+        packed=torch.full((2, 2), 2, dtype=torch.uint8),
+        scale=torch.full((2, 1), 22, dtype=torch.uint8),
+    )
+
+    fused = layout.fuse_quantized(
+        {"gate": gate, "up": up}, materialize=lambda pair: pair.scale.expand(-1, 2)
+    )
+
+    assert torch.equal(
+        fused,
+        torch.tensor([[11, 11], [11, 11], [22, 22], [22, 22]], dtype=torch.uint8),
+    )
+
+
+def test_quantized_split_checks_each_scale_and_round_trips_exactly() -> None:
+    layout = _kda_layout()
+    parts = _parts(layout)
+    scales = {
+        segment.name: torch.full((segment.rows, 1), index, dtype=torch.uint8)
+        for index, segment in enumerate(layout.segments, start=1)
+    }
+    packed = layout.fuse(parts)
+    fused_scales = layout.fuse(scales)
+
+    restored = layout.split_quantized(packed, fused_scales)
+
+    for segment in layout.segments:
+        assert torch.equal(restored[segment.name].packed, parts[segment.name])
+        assert torch.equal(restored[segment.name].scale, scales[segment.name])
+
+
+def test_shared_hf_qkv_and_gate_up_sharding_use_declared_segment_boundaries() -> None:
+    q = torch.arange(0, 16).reshape(8, 2)
+    k = torch.arange(100, 108).reshape(4, 2)
+    v = torch.arange(200, 208).reshape(4, 2)
+    qkv = torch.cat((q, k, v), dim=0)
+    gate = torch.arange(300, 316).reshape(8, 2)
+    up = torch.arange(400, 416).reshape(8, 2)
+
+    assert torch.equal(
+        split_qkv(qkv, rank=1, world=2, num_q_heads=4, num_kv_heads=2, head_dim=2),
+        torch.cat((q.chunk(2)[1], k.chunk(2)[1], v.chunk(2)[1]), dim=0),
+    )
+    assert torch.equal(
+        split_gate_up(torch.cat((gate, up)), rank=1, world=2),
+        torch.cat((gate.chunk(2)[1], up.chunk(2)[1]), dim=0),
+    )


### PR DESCRIPTION
### What

Adds a shared primitive for declaring and slicing fused attention input projections, so models stop hand-rolling `torch.cat` over the fused axis and stop deriving per-projection semantics from weight-name string parsing.

- `primitive/ckpt/fused_weights.py` (new): a model declares each projection of a fused weight by name, head count, head dim and order; the primitive derives the offsets and performs fuse/split.
- `primitive/ckpt/hf_weights.py`: consumes the declaration instead of ad-hoc concatenation.
- `tests/unit/primitive/test_fused_weights.py`: CPU unit tests.

### Why

A seven-way fused projection (`q/k/v/g/f/a/b`) was being concatenated with self-computed offsets and split by matching on substrings of the parameter name. That produced a deterministic, silent corruption of one segment after weight synchronisation: the same element index and the same bad-element count reproduced byte-for-byte across independent runs, while the source-side tensor was entirely finite.

Declaring the layout once and deriving offsets from the declaration removes the class of bug rather than one instance of it, and makes the same code path reusable by other models with fused projections.

### Test

CPU unit tests cover fuse/split round-trip per projection with element-wise equality, and a negative case where a declared head count disagrees with the tensor, which must fail loudly rather than silently mis-slice.
