### PR TITLE
Decouple FSDP2 parameter and gradient storage

### DIFF
--- a/experimental/lite/examples/verl/README.md
+++ b/experimental/lite/examples/verl/README.md
@@ -69,6 +69,28 @@ sets `optim.override_optimizer_config.offload_fraction=1.0` by default, which
 keeps FSDP2 optimizer update state on CPU during forward/backward to reduce GPU
 memory pressure.
 
+The FSDP2 recipe independently controls persistent parameter and gradient
+storage through `optim.override_optimizer_config.fsdp2_param_dtype` (default
+`bfloat16`) and `fsdp2_grad_dtype` (default `float32`). FSDP2 still computes
+with BF16 materialized parameters and reduces in FP32. A FP32 grad setting
+makes MLite retain the reduced FP32 shard as `main_grad`; PyTorch's transient
+BF16 `.grad` is cleared before the optimizer step. `main_grad`, the FP32
+optimizer master parameter, and both Adam moments use separate storage. This
+mode therefore requires `fsdp2_use_fp32_master=True` and does not support TE
+FusedAdam. With CPU optimizer offload enabled, the FP32 master and Adam moments
+remain on CPU. The removed `use_fp32_shards` API and
+`fsdp2_use_fp32_shards` optimizer option fail with a migration error instead
+of being silently ignored; replace old `True` with `float32` for both new keys,
+or old `False` with `bfloat16` for both. The DeepSeek V4 DAPO launcher is a
+complete example of the current configuration:
+
+```bash
+MODEL_PATH=/path/to/deepseek-v4-hf \
+TRAIN_FILES=/path/to/train.parquet \
+VAL_FILES=/path/to/validation.parquet \
+bash experimental/lite/examples/verl/scripts/run_deepseek_v4_dapo.sh
+```
+
 Example dry run:
 
 ```bash

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
@@ -467,7 +467,6 @@ def build_model(model_cfg: DeepseekV4Config, *, impl_cfg: ImplConfig) -> ModelBu
                     deterministic=impl_cfg.deterministic,
                     vpp=impl_cfg.parallel.vpp,
                     leaf_module_names=(),
-                    use_fp32_shards=False,
                 )
             }
 

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/__init__.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+# isort: off
 from megatron.lite.primitive.optimizers.fsdp2.grad_clip import (
     all_reduce_scalar_,
     clip_grads_with_sharded_norm_,
@@ -24,11 +25,13 @@ from megatron.lite.primitive.optimizers.fsdp2.wrap import (
     build_fsdp2_process_group_mesh,
     build_fsdp2_shard_placement_fn,
     fsdp2_available,
-    promote_fsdp2_trainable_params_to_fp32,
+    register_fsdp2_main_grad_hooks,
     set_fsdp2_requires_gradient_sync,
     wrap_fsdp2,
     wrap_fsdp2_module,
 )
+
+# isort: on
 
 __all__ = [
     "BACKEND",
@@ -43,7 +46,7 @@ __all__ = [
     "build_fsdp2_shard_placement_fn",
     "clip_grads_with_sharded_norm_",
     "fsdp2_available",
-    "promote_fsdp2_trainable_params_to_fp32",
+    "register_fsdp2_main_grad_hooks",
     "resolve_torch_dtype",
     "set_fsdp2_requires_gradient_sync",
     "sharded_grad_abs_max",

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/adamw.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/adamw.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+# isort: off
 import inspect
 from collections.abc import Callable, Iterable
 from typing import Any
@@ -10,6 +11,9 @@ from typing import Any
 import torch
 import torch.distributed as dist
 import torch.nn as nn
+from megatron.lite.primitive.optimizers.fsdp2.main_grad import get_param_grad
+
+# isort: on
 
 
 def local_grad_sq_sum(
@@ -20,7 +24,7 @@ def local_grad_sq_sum(
 ) -> torch.Tensor:
     total: torch.Tensor | None = None
     for param in params:
-        grad = param.grad
+        grad = get_param_grad(param)
         if grad is None:
             continue
         grad = to_local_tensor(grad)
@@ -28,7 +32,9 @@ def local_grad_sq_sum(
             total = torch.zeros((), device=grad.device, dtype=dtype)
         total += grad.detach().to(dtype).pow(2).sum()
     if total is None:
-        return torch.zeros((), device=default_device or torch.device("cpu"), dtype=dtype)
+        return torch.zeros(
+            (), device=default_device or torch.device("cpu"), dtype=dtype
+        )
     return total
 
 
@@ -42,13 +48,8 @@ def to_local_tensor(tensor):
     return tensor
 
 
-def fsdp2_model_param_dtype(param: nn.Parameter) -> torch.dtype | None:
-    dtype = getattr(param, "_fsdp2_model_param_dtype", None)
-    return dtype if isinstance(dtype, torch.dtype) else None
-
-
 def has_dtensor_grad_or_param(param: nn.Parameter) -> bool:
-    grad = param.grad
+    grad = get_param_grad(param)
     return is_dtensor_like(param) or (grad is not None and is_dtensor_like(grad))
 
 
@@ -60,7 +61,9 @@ def is_dtensor_like(tensor: Any) -> bool:
     )
 
 
-def copy_local_tensor_to_param_(param: nn.Parameter, local_tensor: torch.Tensor) -> None:
+def copy_local_tensor_to_param_(
+    param: nn.Parameter, local_tensor: torch.Tensor
+) -> None:
     if not is_dtensor_like(param):
         param.detach().copy_(local_tensor.to(device=param.device, dtype=param.dtype))
         return
@@ -70,7 +73,9 @@ def copy_local_tensor_to_param_(param: nn.Parameter, local_tensor: torch.Tensor)
     # local * mesh, e.g. a (3,) param over 8 ranks -> 0 or 8), so copy local->local
     # (master is init'd from this same local shard, so shapes match).
     local_param = to_local_tensor(param)
-    local_param.copy_(local_tensor.to(device=local_param.device, dtype=local_param.dtype))
+    local_param.copy_(
+        local_tensor.to(device=local_param.device, dtype=local_param.dtype)
+    )
 
 
 def all_reduce_grad_(grad: torch.Tensor, *, group: dist.ProcessGroup) -> None:
@@ -108,9 +113,13 @@ class ChainedOptimizer:
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
         optimizer_states = state_dict.get("optimizers")
-        if not isinstance(optimizer_states, list) or len(optimizer_states) != len(self.optimizers):
+        if not isinstance(optimizer_states, list) or len(optimizer_states) != len(
+            self.optimizers
+        ):
             raise ValueError("Invalid chained torch optimizer state_dict.")
-        for optimizer, optimizer_state in zip(self.optimizers, optimizer_states, strict=True):
+        for optimizer, optimizer_state in zip(
+            self.optimizers, optimizer_states, strict=True
+        ):
             optimizer.load_state_dict(optimizer_state)
 
 
@@ -126,9 +135,10 @@ class FP32AdamW:
         betas: tuple[float, float],
         eps: float,
         cpu_update: bool = False,
-        model_param_dtypes: dict[int, torch.dtype] | None = None,
     ):
-        self.param_groups = normalize_param_groups(params, default_weight_decay=weight_decay)
+        self.param_groups = normalize_param_groups(
+            params, default_weight_decay=weight_decay
+        )
         self.params: list[nn.Parameter] = []
         self.lr = lr
         self.weight_decay = weight_decay
@@ -138,8 +148,6 @@ class FP32AdamW:
         self.step_count = 0
         self.state: dict[nn.Parameter, dict[str, torch.Tensor]] = {}
         self._master_for_param: dict[nn.Parameter, torch.Tensor] = {}
-        self._model_param_dtypes_by_id = dict(model_param_dtypes or {})
-        self._model_dtype_for_param: dict[nn.Parameter, torch.dtype] = {}
 
         for group in self.param_groups:
             group.setdefault("lr", lr)
@@ -148,9 +156,6 @@ class FP32AdamW:
             group["weight_decay"] = group_weight_decay
             for param in group["params"]:
                 self.params.append(param)
-                model_dtype = self._model_param_dtypes_by_id.get(id(param))
-                if model_dtype is not None:
-                    self._model_dtype_for_param[param] = model_dtype
                 master = self._init_master_param(param)
                 self.state[param] = {
                     "master_param": master,
@@ -164,16 +169,11 @@ class FP32AdamW:
         if self.cpu_update:
             local_param = to_local_tensor(param.detach())
             return local_param.detach().to(device="cpu", dtype=torch.float32).clone()
-        if self._model_param_dtype(param) is not None:
-            return param.detach().to(dtype=torch.float32).clone()
         return (
             param.detach()
             if param.dtype is torch.float32
             else param.detach().to(dtype=torch.float32).clone()
         )
-
-    def _model_param_dtype(self, param: nn.Parameter) -> torch.dtype | None:
-        return self._model_dtype_for_param.get(param) or fsdp2_model_param_dtype(param)
 
     def zero_grad(self, *args, **kwargs) -> None:
         set_to_none = kwargs.get("set_to_none", False)
@@ -197,7 +197,7 @@ class FP32AdamW:
             group_lr = float(group.get("lr", self.lr))
             group_weight_decay = float(group.get("weight_decay", self.weight_decay))
             for param in group["params"]:
-                grad = param.grad
+                grad = get_param_grad(param)
                 if grad is None:
                     continue
                 state = self.state[param]
@@ -215,19 +215,20 @@ class FP32AdamW:
                 exp_avg.mul_(beta1).add_(grad, alpha=1.0 - beta1)
                 exp_avg_sq.mul_(beta2).addcmul_(grad, grad, value=1.0 - beta2)
                 denom = exp_avg_sq.sqrt().div_(bias_correction2_sqrt).add_(self.eps)
-                master.addcdiv_(exp_avg.to(dtype=torch.float32), denom, value=-group_step_size)
+                master.addcdiv_(
+                    exp_avg.to(dtype=torch.float32), denom, value=-group_step_size
+                )
                 self._copy_master_to_param(param, master)
 
     def _prepare_grad(self, grad: torch.Tensor, master: torch.Tensor) -> torch.Tensor:
         if self.cpu_update:
             grad = to_local_tensor(grad)
             return grad.detach().to(device=master.device, dtype=torch.float32)
+        if grad.dtype is torch.float32:
+            return grad.detach()
         return grad.detach().to(dtype=torch.float32)
 
     def _copy_master_to_param(self, param: nn.Parameter, master: torch.Tensor) -> None:
-        model_dtype = self._model_param_dtype(param)
-        if model_dtype is not None:
-            master = master.to(dtype=model_dtype).to(dtype=param.dtype)
         if not self.cpu_update:
             param.detach().copy_(master.to(dtype=param.dtype))
             return
@@ -237,7 +238,9 @@ class FP32AdamW:
         return {
             "type": "fp32_adamw",
             "step_count": self.step_count,
-            "master_params": [self.state[param]["master_param"] for param in self.params],
+            "master_params": [
+                self.state[param]["master_param"] for param in self.params
+            ],
             "exp_avgs": [self.state[param]["exp_avg"] for param in self.params],
             "exp_avg_sqs": [self.state[param]["exp_avg_sq"] for param in self.params],
             "steps": [int(self.state[param]["step"]) for param in self.params],
@@ -269,7 +272,9 @@ class FP32AdamW:
                 local_target.copy_(local_src)
         loaded_steps = state_dict.get("steps")
         if loaded_steps is not None:
-            if not isinstance(loaded_steps, list) or len(loaded_steps) != len(self.params):
+            if not isinstance(loaded_steps, list) or len(loaded_steps) != len(
+                self.params
+            ):
                 raise ValueError("Invalid FP32 AdamW steps state.")
             for param, step in zip(self.params, loaded_steps, strict=True):
                 self.state[param]["step"] = int(step)
@@ -278,9 +283,9 @@ class FP32AdamW:
                 self.state[param]["step"] = self.step_count
         loaded_weight_decays = state_dict.get("weight_decays")
         if loaded_weight_decays is not None:
-            if not isinstance(loaded_weight_decays, list) or len(loaded_weight_decays) != len(
-                self.params
-            ):
+            if not isinstance(loaded_weight_decays, list) or len(
+                loaded_weight_decays
+            ) != len(self.params):
                 raise ValueError("Invalid FP32 AdamW weight_decay state.")
             idx = 0
             for group in self.param_groups:
@@ -304,7 +309,6 @@ def build_adamw_optimizer(
     foreach: bool | str,
     use_fp32_master: bool,
     cpu_update: bool,
-    model_param_dtypes: dict[int, torch.dtype] | None,
     opt,
 ) -> Any:
     param_groups = normalize_param_groups(params, default_weight_decay=weight_decay)
@@ -328,22 +332,35 @@ def build_adamw_optimizer(
             betas=betas,
             eps=eps,
             cpu_update=cpu_update,
-            model_param_dtypes=model_param_dtypes,
         )
     if foreach not in {True, False, "auto"}:
-        raise ValueError(f"adamw_foreach must be True, False, or 'auto', got {foreach!r}.")
+        raise ValueError(
+            f"adamw_foreach must be True, False, or 'auto', got {foreach!r}."
+        )
     if foreach is False:
         return torch.optim.AdamW(
-            param_groups, lr=lr, weight_decay=weight_decay, betas=betas, eps=eps, foreach=False
+            param_groups,
+            lr=lr,
+            weight_decay=weight_decay,
+            betas=betas,
+            eps=eps,
+            foreach=False,
         )
 
     dtensor_param_groups, tensor_param_groups = split_dtensor_and_tensor_param_groups(
         param_groups, default_weight_decay=weight_decay
     )
-    split_param_groups = [group for group in (dtensor_param_groups, tensor_param_groups) if group]
+    split_param_groups = [
+        group for group in (dtensor_param_groups, tensor_param_groups) if group
+    ]
     if foreach == "auto" and not dtensor_param_groups:
         return torch.optim.AdamW(
-            param_groups, lr=lr, weight_decay=weight_decay, betas=betas, eps=eps, foreach=False
+            param_groups,
+            lr=lr,
+            weight_decay=weight_decay,
+            betas=betas,
+            eps=eps,
+            foreach=False,
         )
     if len(split_param_groups) <= 1:
         return torch.optim.AdamW(
@@ -379,7 +396,9 @@ def maybe_build_te_fused_adam_optimizer(
 
     all_param_list = list(all_params)
     master_weights = get_bool_opt(
-        opt, "master_weights", default=use_fp32_master and should_use_master_weights(all_param_list)
+        opt,
+        "master_weights",
+        default=use_fp32_master and should_use_master_weights(all_param_list),
     )
     kwargs = dict(
         lr=lr,
@@ -388,15 +407,23 @@ def maybe_build_te_fused_adam_optimizer(
         eps=eps,
         adam_w_mode=True,
         master_weights=master_weights,
-        master_weight_dtype=get_dtype_opt(opt, "master_weight_dtype", default=torch.float32),
-        store_param_remainders=get_bool_opt(opt, "store_param_remainders", default=master_weights),
+        master_weight_dtype=get_dtype_opt(
+            opt, "master_weight_dtype", default=torch.float32
+        ),
+        store_param_remainders=get_bool_opt(
+            opt, "store_param_remainders", default=master_weights
+        ),
         exp_avg_dtype=get_dtype_opt(opt, "exp_avg_dtype", default=torch.float32),
         exp_avg_sq_dtype=get_dtype_opt(opt, "exp_avg_sq_dtype", default=torch.float32),
     )
-    return FusedAdam(param_groups, **filter_supported_kwargs(FusedAdam.__init__, kwargs))
+    return FusedAdam(
+        param_groups, **filter_supported_kwargs(FusedAdam.__init__, kwargs)
+    )
 
 
-def filter_supported_kwargs(fn: Callable[..., Any], kwargs: dict[str, Any]) -> dict[str, Any]:
+def filter_supported_kwargs(
+    fn: Callable[..., Any], kwargs: dict[str, Any]
+) -> dict[str, Any]:
     try:
         params = inspect.signature(fn).parameters
     except (TypeError, ValueError):
@@ -407,7 +434,10 @@ def filter_supported_kwargs(fn: Callable[..., Any], kwargs: dict[str, Any]) -> d
 
 
 def should_use_master_weights(params: Iterable[nn.Parameter]) -> bool:
-    return any(param.is_floating_point() and param.dtype is not torch.float32 for param in params)
+    return any(
+        param.is_floating_point() and param.dtype is not torch.float32
+        for param in params
+    )
 
 
 def get_bool_opt(opt, attr: str, *, default: bool) -> bool:
@@ -451,7 +481,9 @@ def get_opt_value(opt, attr: str):
 
 
 def normalize_param_groups(
-    params: Iterable[nn.Parameter] | Iterable[dict[str, Any]], *, default_weight_decay: float
+    params: Iterable[nn.Parameter] | Iterable[dict[str, Any]],
+    *,
+    default_weight_decay: float,
 ) -> list[dict[str, Any]]:
     items = list(params)
     if not items:
@@ -533,7 +565,6 @@ __all__ = [
     "copy_local_tensor_to_param_",
     "dtensor_from_local",
     "filter_supported_kwargs",
-    "fsdp2_model_param_dtype",
     "get_bool_opt",
     "get_dtype_opt",
     "get_opt_value",

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/grad_clip.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/grad_clip.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+# isort: off
 import math
 from collections import defaultdict
 from collections.abc import Callable, Iterable
@@ -11,6 +12,9 @@ from typing import Any
 import torch
 import torch.distributed as dist
 import torch.nn as nn
+from megatron.lite.primitive.optimizers.fsdp2.main_grad import get_param_grad
+
+# isort: on
 
 try:  # pragma: no cover - import availability is PyTorch-version dependent.
     from torch.distributed.tensor import DTensor, Partial, Replicate
@@ -40,16 +44,27 @@ def sharded_grad_sq_sum(
     groups = _group_grads(params)
     total: torch.Tensor | None = None
     for group in groups.values():
-        local_sq = _group_local_sq_sum(group, dtype=dtype, chunk_size_numel=chunk_size_numel)
+        local_sq = _group_local_sq_sum(
+            group, dtype=dtype, chunk_size_numel=chunk_size_numel
+        )
         meta = group[0][2]
-        if meta is not None and not _has_partial_placement(meta) and dist.is_initialized():
+        if (
+            meta is not None
+            and not _has_partial_placement(meta)
+            and dist.is_initialized()
+        ):
             _reduce_dtensor_scalar_(
-                local_sq, meta, op=dist.ReduceOp.SUM, scalar_all_reduce=scalar_all_reduce
+                local_sq,
+                meta,
+                op=dist.ReduceOp.SUM,
+                scalar_all_reduce=scalar_all_reduce,
             )
         total = local_sq if total is None else total.to(local_sq.device) + local_sq
 
     if total is None:
-        return torch.zeros((), device=default_device or torch.device("cpu"), dtype=dtype)
+        return torch.zeros(
+            (), device=default_device or torch.device("cpu"), dtype=dtype
+        )
     return total
 
 
@@ -70,13 +85,24 @@ def sharded_grad_norm(
 
     if math.isinf(float(norm_type)):
         total = sharded_grad_abs_max(
-            params, pp_group=pp_group, accum_dtype=accum_dtype, default_device=default_device
+            params,
+            pp_group=pp_group,
+            accum_dtype=accum_dtype,
+            default_device=default_device,
         )
         return total
     if float(norm_type) != 2.0:
-        raise ValueError(f"sharded_grad_norm supports norm_type=2.0 or inf, got {norm_type!r}.")
-    sq_sum = sharded_grad_sq_sum(params, accum_dtype=accum_dtype, default_device=default_device)
-    if pp_group is not None and dist.is_initialized() and dist.get_world_size(pp_group) > 1:
+        raise ValueError(
+            f"sharded_grad_norm supports norm_type=2.0 or inf, got {norm_type!r}."
+        )
+    sq_sum = sharded_grad_sq_sum(
+        params, accum_dtype=accum_dtype, default_device=default_device
+    )
+    if (
+        pp_group is not None
+        and dist.is_initialized()
+        and dist.get_world_size(pp_group) > 1
+    ):
         all_reduce_scalar_(sq_sum, op=dist.ReduceOp.SUM, group=pp_group)
     return sq_sum.sqrt()
 
@@ -96,22 +122,33 @@ def sharded_grad_abs_max(
     for group in groups.values():
         local_max = _group_local_abs_max(group, dtype=dtype)
         meta = group[0][2]
-        if meta is not None and not _has_partial_placement(meta) and dist.is_initialized():
+        if (
+            meta is not None
+            and not _has_partial_placement(meta)
+            and dist.is_initialized()
+        ):
             _reduce_dtensor_scalar_(local_max, meta, op=dist.ReduceOp.MAX)
-        total = local_max if total is None else torch.maximum(total.to(local_max.device), local_max)
+        total = (
+            local_max
+            if total is None
+            else torch.maximum(total.to(local_max.device), local_max)
+        )
 
     if total is None:
-        total = torch.zeros((), device=default_device or torch.device("cpu"), dtype=dtype)
-    if pp_group is not None and dist.is_initialized() and dist.get_world_size(pp_group) > 1:
+        total = torch.zeros(
+            (), device=default_device or torch.device("cpu"), dtype=dtype
+        )
+    if (
+        pp_group is not None
+        and dist.is_initialized()
+        and dist.get_world_size(pp_group) > 1
+    ):
         all_reduce_scalar_(total, op=dist.ReduceOp.MAX, group=pp_group)
     return total
 
 
 def all_reduce_scalar_(
-    value: torch.Tensor,
-    *,
-    op: dist.ReduceOp,
-    group: dist.ProcessGroup,
+    value: torch.Tensor, *, op: dist.ReduceOp, group: dist.ProcessGroup
 ) -> None:
     """All-reduce a scalar on a device compatible with the process group backend."""
 
@@ -144,8 +181,9 @@ def clip_grads_with_sharded_norm_(
         if clip_coef >= 1.0:
             return
     for param in params:
-        if param.grad is not None:
-            _scale_grad_(param.grad, clip_coef)
+        grad = get_param_grad(param)
+        if grad is not None:
+            _scale_grad_(grad, clip_coef)
 
 
 def resolve_torch_dtype(dtype: str | torch.dtype) -> torch.dtype:
@@ -155,20 +193,24 @@ def resolve_torch_dtype(dtype: str | torch.dtype) -> torch.dtype:
         name = dtype.removeprefix("torch.")
         resolved = getattr(torch, name, None)
     if not isinstance(resolved, torch.dtype):
-        raise ValueError(f"Unsupported torch dtype for grad norm accumulation: {dtype!r}")
+        raise ValueError(
+            f"Unsupported torch dtype for grad norm accumulation: {dtype!r}"
+        )
     if not torch.empty((), dtype=resolved).is_floating_point():
-        raise ValueError(f"Grad norm accumulation dtype must be floating point: {dtype!r}")
+        raise ValueError(
+            f"Grad norm accumulation dtype must be floating point: {dtype!r}"
+        )
     return resolved
 
 
 def _group_grads(
     params: Iterable[nn.Parameter],
 ) -> dict[tuple[Any, ...], list[tuple[nn.Parameter, torch.Tensor, Any | None]]]:
-    groups: dict[tuple[Any, ...], list[tuple[nn.Parameter, torch.Tensor, Any | None]]] = (
-        defaultdict(list)
-    )
+    groups: dict[
+        tuple[Any, ...], list[tuple[nn.Parameter, torch.Tensor, Any | None]]
+    ] = defaultdict(list)
     for param in params:
-        grad = param.grad
+        grad = get_param_grad(param)
         if grad is None:
             continue
         meta = _dtensor_meta(param, grad)
@@ -178,7 +220,10 @@ def _group_grads(
             key = (
                 "dtensor",
                 id(meta.device_mesh),
-                tuple((type(placement).__name__, repr(placement)) for placement in meta.placements),
+                tuple(
+                    (type(placement).__name__, repr(placement))
+                    for placement in meta.placements
+                ),
             )
         groups[key].append((param, grad, meta))
     return groups
@@ -194,7 +239,9 @@ def _group_local_sq_sum(
     total = torch.zeros((), device=device, dtype=dtype)
     for _param, grad, meta in group:
         local_grad = _local_grad(grad, meta)
-        total += _tensor_sq_sum(local_grad.detach(), dtype=dtype, chunk_size_numel=chunk_size_numel)
+        total += _tensor_sq_sum(
+            local_grad.detach(), dtype=dtype, chunk_size_numel=chunk_size_numel
+        )
     return total
 
 
@@ -266,7 +313,9 @@ def _is_dtensor_like(tensor: Any) -> bool:
 
 
 def _has_partial_placement(dtensor: Any) -> bool:
-    return any(_placement_name(placement) == "Partial" for placement in dtensor.placements)
+    return any(
+        _placement_name(placement) == "Partial" for placement in dtensor.placements
+    )
 
 
 def _is_replicate_placement(placement: Any) -> bool:

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/main_grad.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/main_grad.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""MLite-owned gradient accessors for the FSDP2 optimizer primitive."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+_MAIN_GRAD_STATE_ATTR = "_mlite_fsdp2_main_grad_state"
+
+
+def get_param_grad(param: nn.Parameter) -> torch.Tensor | None:
+    """Return the active MLite main gradient, otherwise PyTorch's gradient."""
+
+    state = getattr(param, _MAIN_GRAD_STATE_ATTR, None)
+    if state is None:
+        return param.grad
+    if not bool(getattr(state, "active", False)):
+        return None
+    main_grad = getattr(param, "main_grad", None)
+    if not isinstance(main_grad, torch.Tensor):
+        raise RuntimeError("FSDP2 main_grad state is active but its view is missing.")
+    if main_grad.dtype is not torch.float32:
+        raise RuntimeError(f"FSDP2 main_grad must be float32, got {main_grad.dtype}.")
+    return main_grad
+
+
+def zero_main_grads(params: Iterable[nn.Parameter]) -> None:
+    """Zero each unique flat main-gradient buffer exactly once."""
+
+    states: dict[int, Any] = {}
+    for param in params:
+        state = getattr(param, _MAIN_GRAD_STATE_ATTR, None)
+        if state is not None:
+            states[id(state)] = state
+    for state in states.values():
+        state.zero()
+
+
+__all__ = ["get_param_grad", "zero_main_grads"]

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/optimizer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/optimizer.py
@@ -13,11 +13,12 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 
+# isort: off
 from megatron.lite.primitive.optimizers.fsdp2.adamw import (
     all_reduce_grad_,
     build_adamw_optimizer,
-    fsdp2_model_param_dtype,
     get_bool_opt,
+    get_opt_value,
     has_dtensor_grad_or_param,
     local_grad_sq_sum,
 )
@@ -26,6 +27,10 @@ from megatron.lite.primitive.optimizers.fsdp2.grad_clip import (
     clip_grads_with_sharded_norm_,
     resolve_torch_dtype,
     sharded_grad_sq_sum,
+)
+from megatron.lite.primitive.optimizers.fsdp2.main_grad import (
+    get_param_grad,
+    zero_main_grads,
 )
 from megatron.lite.primitive.optimizers.fsdp2.state import (
     OffloadedStateEntry,
@@ -36,11 +41,14 @@ from megatron.lite.primitive.optimizers.fsdp2.wrap import (
     FSDP2Config,
     build_fsdp2_process_group_mesh,
     build_fsdp2_shard_placement_fn,
-    promote_fsdp2_trainable_params_to_fp32,
+    register_fsdp2_main_grad_hooks,
+    set_fsdp2_requires_gradient_sync,
     wrap_fsdp2,
     wrap_fsdp2_module,
 )
 from megatron.lite.primitive.parallel.state import ParallelState
+
+# isort: on
 
 _DEFAULT_RESHARD_AFTER_FORWARD: bool | int | None = True
 _DEFAULT_WRAP_ROOT = True
@@ -49,7 +57,8 @@ _DEFAULT_FORWARD_PREFETCH_DEPTH = 1
 _DEFAULT_BACKWARD_PREFETCH_DEPTH = 0
 _DEFAULT_PARAM_DTYPE: str | None = "bfloat16"
 _DEFAULT_REDUCE_DTYPE: str | None = "float32"
-_DEFAULT_USE_FP32_SHARDS = True
+_DEFAULT_SHARD_PARAM_DTYPE: str = "bfloat16"
+_DEFAULT_GRAD_DTYPE: str = "float32"
 _DEFAULT_USE_FP32_MASTER = True
 _DEFAULT_ADAMW_FOREACH: bool | str = "auto"
 
@@ -77,6 +86,7 @@ class FSDP2Optimizer:
         tp_replicated_grad_sync_group: dist.ProcessGroup | None = None,
         grad_norm_accum_dtype: str | torch.dtype = torch.float32,
         param_names: dict[int, str] | None = None,
+        fsdp_modules: Iterable[nn.Module] | None = None,
     ):
         self.optimizer = optimizer
         self.params = list(params)
@@ -85,7 +95,9 @@ class FSDP2Optimizer:
         self.clip_grad = float(clip_grad)
         self.grad_norm_accum_dtype = resolve_torch_dtype(grad_norm_accum_dtype)
         self.replicated_grad_params = list(replicated_grad_params or ())
-        self._replicated_grad_param_ids = {id(param) for param in self.replicated_grad_params}
+        self._replicated_grad_param_ids = {
+            id(param) for param in self.replicated_grad_params
+        }
         self.replicated_grad_sync_group = replicated_grad_sync_group
         self.replicated_grad_sync_divisor = replicated_grad_sync_divisor
         self.replicated_grad_norm_group = replicated_grad_norm_group
@@ -94,14 +106,29 @@ class FSDP2Optimizer:
             id(param) for param in self.expert_sharded_grad_params
         }
         self.expert_sharded_grad_scale = (
-            1.0 if expert_sharded_grad_scale is None else float(expert_sharded_grad_scale)
+            1.0
+            if expert_sharded_grad_scale is None
+            else float(expert_sharded_grad_scale)
         )
         self.expert_sharded_grad_norm_group = expert_sharded_grad_norm_group
         self.tp_replicated_grad_params = list(tp_replicated_grad_params or ())
-        self._tp_replicated_grad_param_ids = {id(param) for param in self.tp_replicated_grad_params}
+        self._tp_replicated_grad_param_ids = {
+            id(param) for param in self.tp_replicated_grad_params
+        }
         self.tp_replicated_grad_sync_group = tp_replicated_grad_sync_group
         self._cpu_offloaded_state: dict[tuple[int, str], OffloadedStateEntry] = {}
-        self.grad_sync_enabled = False
+        self.fsdp_modules = list(fsdp_modules or ())
+        self._grad_sync_enabled = False
+
+    @property
+    def grad_sync_enabled(self) -> bool:
+        return self._grad_sync_enabled
+
+    @grad_sync_enabled.setter
+    def grad_sync_enabled(self, enabled: bool) -> None:
+        self._grad_sync_enabled = bool(enabled)
+        for module in self.fsdp_modules:
+            set_fsdp2_requires_gradient_sync(module, self._grad_sync_enabled)
 
     @property
     def param_groups(self):
@@ -110,6 +137,7 @@ class FSDP2Optimizer:
     def zero_grad(self) -> None:
         self.grad_sync_enabled = False
         self.optimizer.zero_grad(set_to_none=True)
+        zero_main_grads(self.params)
 
     def step(self) -> tuple[bool, float, int]:
         self.sync_tp_replicated_grads()
@@ -136,7 +164,7 @@ class FSDP2Optimizer:
         if divisor is None:
             divisor = float(group_size)
         for param in self.replicated_grad_params:
-            grad = param.grad
+            grad = get_param_grad(param)
             if grad is None:
                 continue
             if group is not None and dist.is_initialized() and group_size > 1:
@@ -148,10 +176,14 @@ class FSDP2Optimizer:
         group = self.tp_replicated_grad_sync_group
         if not self.tp_replicated_grad_params:
             return
-        if group is None or not dist.is_initialized() or dist.get_world_size(group) <= 1:
+        if (
+            group is None
+            or not dist.is_initialized()
+            or dist.get_world_size(group) <= 1
+        ):
             return
         for param in self.tp_replicated_grad_params:
-            grad = param.grad
+            grad = get_param_grad(param)
             if grad is not None:
                 all_reduce_grad_(grad, group=group)
 
@@ -159,7 +191,7 @@ class FSDP2Optimizer:
         if not self.expert_sharded_grad_params or self.expert_sharded_grad_scale == 1.0:
             return
         for param in self.expert_sharded_grad_params:
-            grad = param.grad
+            grad = get_param_grad(param)
             if grad is not None:
                 grad.mul_(self.expert_sharded_grad_scale)
 
@@ -170,7 +202,9 @@ class FSDP2Optimizer:
             | self._expert_sharded_grad_param_ids
         )
         sharded_params = [
-            param for param in self.params if id(param) not in excluded_sharded_param_ids
+            param
+            for param in self.params
+            if id(param) not in excluded_sharded_param_ids
         ]
         dtensor_sharded_params = [
             param for param in sharded_params if has_dtensor_grad_or_param(param)
@@ -194,7 +228,9 @@ class FSDP2Optimizer:
             and dist.is_initialized()
             and dist.get_world_size(plain_sharded_group) > 1
         ):
-            all_reduce_scalar_(plain_sharded_sq, op=dist.ReduceOp.SUM, group=plain_sharded_group)
+            all_reduce_scalar_(
+                plain_sharded_sq, op=dist.ReduceOp.SUM, group=plain_sharded_group
+            )
         total_sq = total_sq.to(plain_sharded_sq.device) + plain_sharded_sq
         if (
             self.ps is not None
@@ -220,7 +256,9 @@ class FSDP2Optimizer:
             and dist.get_world_size(self.replicated_grad_norm_group) > 1
         ):
             all_reduce_scalar_(
-                replicated_sq, op=dist.ReduceOp.SUM, group=self.replicated_grad_norm_group
+                replicated_sq,
+                op=dist.ReduceOp.SUM,
+                group=self.replicated_grad_norm_group,
             )
 
         expert_sharded_sq = sharded_grad_sq_sum(
@@ -270,7 +308,9 @@ class FSDP2Optimizer:
         )
 
     def load_state_to_device(self) -> None:
-        move_offloaded_optimizer_state_to_device(self.optimizer, self._cpu_offloaded_state)
+        move_offloaded_optimizer_state_to_device(
+            self.optimizer, self._cpu_offloaded_state
+        )
 
 
 def build_fsdp2_adamw(
@@ -290,7 +330,6 @@ def build_fsdp2_adamw(
     grad_norm_accum_dtype: str | torch.dtype = torch.float32,
     adamw_foreach: bool | str = "auto",
     use_fp32_master: bool = False,
-    model_param_dtypes: dict[tuple[int, str], torch.dtype] | None = None,
 ) -> FSDP2Optimizer:
     """Build AdamW from Megatron Lite's shared OptimizerConfig-like object."""
 
@@ -298,11 +337,10 @@ def build_fsdp2_adamw(
     if optimizer_name not in {"adam", "adamw"}:
         raise ValueError(f"fsdp2 supports adam/adamw, got {optimizer_name!r}.")
 
-    params, param_groups, param_names, param_model_dtypes = _build_adamw_param_groups(
+    params, param_groups, param_names = _build_adamw_param_groups(
         model_chunks,
         weight_decay=float(getattr(opt, "weight_decay", 0.01)),
         apply_wd_to_qk_layernorm=bool(getattr(opt, "apply_wd_to_qk_layernorm", False)),
-        model_param_dtypes=model_param_dtypes,
     )
     beta1 = getattr(opt, "adam_beta1", None)
     beta2 = getattr(opt, "adam_beta2", None)
@@ -318,7 +356,6 @@ def build_fsdp2_adamw(
         foreach=adamw_foreach,
         use_fp32_master=use_fp32_master,
         cpu_update=use_fp32_master and float(offload_fraction) > 0.0,
-        model_param_dtypes=param_model_dtypes,
         opt=opt,
     )
     return FSDP2Optimizer(
@@ -337,6 +374,7 @@ def build_fsdp2_adamw(
         tp_replicated_grad_sync_group=tp_replicated_grad_sync_group,
         grad_norm_accum_dtype=grad_norm_accum_dtype,
         param_names=param_names,
+        fsdp_modules=model_chunks,
     )
 
 
@@ -357,21 +395,44 @@ def build_fsdp2_training_optimizer(
     backward_prefetch_depth: int = _DEFAULT_BACKWARD_PREFETCH_DEPTH,
     param_dtype: str | torch.dtype | None = _DEFAULT_PARAM_DTYPE,
     reduce_dtype: str | torch.dtype | None = _DEFAULT_REDUCE_DTYPE,
-    use_fp32_shards: bool | None = None,
+    grad_dtype: str | torch.dtype | None = None,
     use_fp32_master: bool | None = None,
     adamw_foreach: bool | str = _DEFAULT_ADAMW_FOREACH,
+    **removed_options: Any,
 ) -> FSDP2Optimizer:
     """Wrap model chunks with FSDP2 and build the matching AdamW adapter."""
+
+    if "use_fp32_shards" in removed_options:
+        raise ValueError(
+            "use_fp32_shards has been removed; use fsdp2_param_dtype and "
+            "fsdp2_grad_dtype instead."
+        )
+    if removed_options:
+        unexpected = next(iter(removed_options))
+        raise TypeError(
+            "build_fsdp2_training_optimizer() got an unexpected keyword argument "
+            f"{unexpected!r}"
+        )
+    if get_opt_value(opt, "fsdp2_use_fp32_shards") is not None:
+        raise ValueError(
+            "fsdp2_use_fp32_shards has been removed; use fsdp2_param_dtype and "
+            "fsdp2_grad_dtype instead."
+        )
 
     if (vpp or 1) > 1 and ps.pp_size <= 1:
         raise ValueError("optimizer='fsdp2' requires pp>1 when vpp>1.")
 
     expert_params = _collect_expert_params(model_chunks, ps, expert_classifier)
     expert_modules = _collect_expert_modules(
-        model_chunks, ps, expert_classifier, expert_module_leaf_name=expert_module_leaf_name
+        model_chunks,
+        ps,
+        expert_classifier,
+        expert_module_leaf_name=expert_module_leaf_name,
     )
     if expert_params and not expert_modules:
-        raise RuntimeError("FSDP2 expert parameters were found but no expert module was found.")
+        raise RuntimeError(
+            "FSDP2 expert parameters were found but no expert module was found."
+        )
 
     if opt is None:
         opt = SimpleNamespace(
@@ -384,19 +445,51 @@ def build_fsdp2_training_optimizer(
             adam_eps=None,
         )
     if deterministic is None:
+        # isort: off
         from megatron.lite.primitive.deterministic import deterministic_requested
 
+        # isort: on
+
         deterministic = deterministic_requested()
-    effective_use_fp32_shards = (
-        bool(use_fp32_shards)
-        if use_fp32_shards is not None
-        else get_bool_opt(opt, "fsdp2_use_fp32_shards", default=_DEFAULT_USE_FP32_SHARDS)
-    )
     effective_use_fp32_master = (
         bool(use_fp32_master)
         if use_fp32_master is not None
-        else get_bool_opt(opt, "fsdp2_use_fp32_master", default=_DEFAULT_USE_FP32_MASTER)
+        else get_bool_opt(
+            opt, "fsdp2_use_fp32_master", default=_DEFAULT_USE_FP32_MASTER
+        )
     )
+    has_config_grad_dtype, configured_grad_dtype = _get_opt_value_with_presence(
+        opt, "fsdp2_grad_dtype"
+    )
+    effective_grad_dtype = (
+        grad_dtype
+        if grad_dtype is not None
+        else configured_grad_dtype if has_config_grad_dtype else _DEFAULT_GRAD_DTYPE
+    )
+    has_shard_param_dtype, configured_shard_param_dtype = _get_opt_value_with_presence(
+        opt, "fsdp2_param_dtype"
+    )
+    effective_shard_param_dtype = (
+        configured_shard_param_dtype
+        if has_shard_param_dtype
+        else _DEFAULT_SHARD_PARAM_DTYPE
+    )
+    _validate_fsdp2_storage_dtype("fsdp2_param_dtype", effective_shard_param_dtype)
+    resolved_grad_dtype = _validate_fsdp2_storage_dtype(
+        "fsdp2_grad_dtype", effective_grad_dtype
+    )
+    if _resolve_fsdp2_dtype(reduce_dtype) is not torch.float32:
+        raise ValueError("FSDP2 reduce_dtype must be float32.")
+    if resolved_grad_dtype is torch.float32 and not effective_use_fp32_master:
+        raise ValueError(
+            "FSDP2 float32 main_grad currently requires fsdp2_use_fp32_master=True."
+        )
+    if resolved_grad_dtype is torch.float32 and get_bool_opt(
+        opt, "fsdp2_use_te_fused_adam", default=False
+    ):
+        raise ValueError("FSDP2 float32 main_grad is not supported by TE FusedAdam.")
+
+    _cast_trainable_floating_params_(model_chunks, effective_shard_param_dtype)
 
     unit_reshard_after_forward = _fsdp2_unit_reshard_after_forward(
         ps, reshard_after_forward=reshard_after_forward
@@ -408,28 +501,33 @@ def build_fsdp2_training_optimizer(
         last_unit_reshard_after_forward=unit_reshard_after_forward,
         root_reshard_after_forward=False,
         wrap_root=wrap_root,
-        forward_prefetch_depth=_fsdp2_prefetch_depth(ps, default_depth=forward_prefetch_depth),
-        backward_prefetch_depth=_fsdp2_prefetch_depth(ps, default_depth=backward_prefetch_depth),
+        forward_prefetch_depth=_fsdp2_prefetch_depth(
+            ps, default_depth=forward_prefetch_depth
+        ),
+        backward_prefetch_depth=_fsdp2_prefetch_depth(
+            ps, default_depth=backward_prefetch_depth
+        ),
         param_dtype=param_dtype,
         reduce_dtype=reduce_dtype,
+        grad_dtype=effective_grad_dtype,
     )
-    if effective_use_fp32_shards:
-        model_param_dtypes = _collect_model_param_dtypes(model_chunks)
-        for chunk in model_chunks:
-            promote_fsdp2_trainable_params_to_fp32(chunk)
-    else:
-        model_param_dtypes = {}
 
-    tp_replicated_grad_param_names = _collect_tp_replicated_grad_param_names(model_chunks)
+    tp_replicated_grad_param_names = _collect_tp_replicated_grad_param_names(
+        model_chunks
+    )
 
     dense_shard_placement_fn = build_fsdp2_shard_placement_fn(ps.dp_cp_size)
     expert_shard_placement_fn = build_fsdp2_shard_placement_fn(ps.expert_dp_size)
 
     if expert_modules:
         if ps.ep_dp_group is None:
-            raise RuntimeError("FSDP2 expert sharding requires ParallelState.ep_dp_group.")
+            raise RuntimeError(
+                "FSDP2 expert sharding requires ParallelState.ep_dp_group."
+            )
         expert_mesh = build_fsdp2_process_group_mesh(
-            ps.ep_dp_group, mesh_dim_name="expert_dp", device_type=fsdp2_config.device_type
+            ps.ep_dp_group,
+            mesh_dim_name="expert_dp",
+            device_type=fsdp2_config.device_type,
         )
         for module in expert_modules:
             wrap_fsdp2_module(
@@ -450,9 +548,7 @@ def build_fsdp2_training_optimizer(
             ignored_params=ignored_expert_params or None,
             shard_placement_fn=dense_shard_placement_fn,
         )
-    if model_param_dtypes:
-        _restore_model_param_dtypes(model_chunks, model_param_dtypes)
-
+        register_fsdp2_main_grad_hooks(chunk, fsdp2_config.grad_dtype)
     tp_replicated_grad_params = _collect_tp_replicated_grad_params(
         model_chunks, param_names=tp_replicated_grad_param_names
     )
@@ -462,20 +558,25 @@ def build_fsdp2_training_optimizer(
         ps,
         expert_sharded_grad_params=list(ignored_expert_params),
         expert_sharded_grad_scale=(
-            float(ps.expert_dp_size) / float(ps.dp_cp_size) if ignored_expert_params else None
+            float(ps.expert_dp_size) / float(ps.dp_cp_size)
+            if ignored_expert_params
+            else None
         ),
         expert_sharded_grad_norm_group=ps.ep_group if ignored_expert_params else None,
         tp_replicated_grad_params=tp_replicated_grad_params,
-        tp_replicated_grad_sync_group=ps.tp_group if tp_replicated_grad_params else None,
+        tp_replicated_grad_sync_group=(
+            ps.tp_group if tp_replicated_grad_params else None
+        ),
         grad_norm_accum_dtype="float32",
         adamw_foreach=False if deterministic else adamw_foreach,
         use_fp32_master=effective_use_fp32_master,
-        model_param_dtypes=model_param_dtypes,
     )
 
 
 def _collect_expert_params(
-    chunks: Iterable[nn.Module], ps: ParallelState, expert_classifier: Callable[[str], bool] | None
+    chunks: Iterable[nn.Module],
+    ps: ParallelState,
+    expert_classifier: Callable[[str], bool] | None,
 ) -> set[nn.Parameter]:
     if ps.ep_size <= 1 or expert_classifier is None:
         return set()
@@ -519,26 +620,65 @@ def _collect_module_params(modules: Iterable[nn.Module]) -> set[nn.Parameter]:
     return {param for module in modules for param in module.parameters()}
 
 
-def _collect_model_param_dtypes(chunks: Iterable[nn.Module]) -> dict[tuple[int, str], torch.dtype]:
-    return {
-        (chunk_idx, name): param.dtype
-        for chunk_idx, chunk in enumerate(chunks)
-        for name, param in chunk.named_parameters()
-        if param.requires_grad and param.is_floating_point() and param.dtype != torch.float32
-    }
+def _resolve_fsdp2_dtype(dtype: str | torch.dtype | None) -> torch.dtype | None:
+    if dtype is None or isinstance(dtype, torch.dtype):
+        return dtype
+    resolved = getattr(torch, dtype.removeprefix("torch."), None)
+    if not isinstance(resolved, torch.dtype):
+        raise ValueError(f"Unsupported FSDP2 dtype: {dtype!r}")
+    return resolved
 
 
-def _restore_model_param_dtypes(
-    chunks: Iterable[nn.Module], model_param_dtypes: dict[tuple[int, str], torch.dtype]
+def _validate_fsdp2_storage_dtype(name: str, dtype: str | torch.dtype) -> torch.dtype:
+    try:
+        resolved = _resolve_fsdp2_dtype(dtype)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be bfloat16 or float32.") from exc
+    if resolved not in {torch.bfloat16, torch.float32}:
+        raise ValueError(f"{name} must be bfloat16 or float32.")
+    return resolved
+
+
+def _get_opt_value_with_presence(opt: Any, attr: str) -> tuple[bool, Any]:
+    """Read an optimizer setting while distinguishing absent from explicit ``None``."""
+
+    if isinstance(opt, dict):
+        if attr in opt:
+            return True, opt[attr]
+        override = opt.get("override_optimizer_config")
+    else:
+        if hasattr(opt, attr):
+            return True, getattr(opt, attr)
+        override = getattr(opt, "override_optimizer_config", None)
+    if isinstance(override, dict) and attr in override:
+        return True, override[attr]
+    return False, None
+
+
+def _cast_trainable_floating_params_(
+    model_chunks: Iterable[nn.Module], dtype: str | torch.dtype
 ) -> None:
-    for chunk_idx, chunk in enumerate(chunks):
-        for name, param in chunk.named_parameters():
-            model_dtype = model_param_dtypes.get((chunk_idx, name))
-            if model_dtype is not None:
-                param._fsdp2_model_param_dtype = model_dtype
+    """Set persistent parameter storage dtype before FSDP2 captures it.
+
+    Buffers and frozen parameters deliberately retain their model-defined dtype;
+    only trainable floating-point parameter storage belongs to this knob.
+    """
+
+    resolved = _validate_fsdp2_storage_dtype("fsdp2_param_dtype", dtype)
+    seen: set[int] = set()
+    with torch.no_grad():
+        for chunk in model_chunks:
+            for param in chunk.parameters():
+                if id(param) in seen:
+                    continue
+                seen.add(id(param))
+                if param.requires_grad and torch.is_floating_point(param):
+                    param.data = param.data.to(dtype=resolved)
 
 
-def _collect_tp_replicated_grad_param_names(chunks: Iterable[nn.Module]) -> list[tuple[int, str]]:
+def _collect_tp_replicated_grad_param_names(
+    chunks: Iterable[nn.Module],
+) -> list[tuple[int, str]]:
     names: list[tuple[int, str]] = []
     for chunk_idx, chunk in enumerate(chunks):
         sp_param_ids = {id(param) for param in getattr(chunk, "sp_params", ())}
@@ -594,13 +734,11 @@ def _build_adamw_param_groups(
     *,
     weight_decay: float,
     apply_wd_to_qk_layernorm: bool,
-    model_param_dtypes: dict[tuple[int, str], torch.dtype] | None = None,
-) -> tuple[list[nn.Parameter], list[dict[str, Any]], dict[int, str], dict[int, torch.dtype]]:
+) -> tuple[list[nn.Parameter], list[dict[str, Any]], dict[int, str]]:
     params: list[nn.Parameter] = []
     decay_params: list[nn.Parameter] = []
     no_decay_params: list[nn.Parameter] = []
     param_names: dict[int, str] = {}
-    param_model_dtypes: dict[int, torch.dtype] = {}
     seen_param_ids: set[int] = set()
 
     for chunk_idx, chunk in enumerate(model_chunks):
@@ -610,13 +748,6 @@ def _build_adamw_param_groups(
             seen_param_ids.add(id(param))
             params.append(param)
             param_names[id(param)] = f"chunk{chunk_idx}.{name}"
-            model_dtype = None
-            if model_param_dtypes is not None:
-                model_dtype = model_param_dtypes.get((chunk_idx, name))
-            if model_dtype is None:
-                model_dtype = fsdp2_model_param_dtype(param)
-            if model_dtype is not None:
-                param_model_dtypes[id(param)] = model_dtype
             if _matches_megatron_no_weight_decay(name, param, apply_wd_to_qk_layernorm):
                 no_decay_params.append(param)
             else:
@@ -626,10 +757,14 @@ def _build_adamw_param_groups(
     # 1D params and bias skip AdamW decay unless the Q/K layernorm override is set.
     param_groups: list[dict[str, Any]] = []
     if decay_params:
-        param_groups.append({"params": decay_params, "weight_decay": weight_decay, "wd_mult": 1.0})
+        param_groups.append(
+            {"params": decay_params, "weight_decay": weight_decay, "wd_mult": 1.0}
+        )
     if no_decay_params:
-        param_groups.append({"params": no_decay_params, "weight_decay": 0.0, "wd_mult": 0.0})
-    return params, param_groups, param_names, param_model_dtypes
+        param_groups.append(
+            {"params": no_decay_params, "weight_decay": 0.0, "wd_mult": 0.0}
+        )
+    return params, param_groups, param_names
 
 
 def _matches_megatron_no_weight_decay(
@@ -640,7 +775,10 @@ def _matches_megatron_no_weight_decay(
     if not apply_wd_to_qk_layernorm:
         return True
     return not (
-        "q_layernorm." in name or "k_layernorm." in name or "q_norm." in name or "k_norm." in name
+        "q_layernorm." in name
+        or "k_layernorm." in name
+        or "q_norm." in name
+        or "k_norm." in name
     )
 
 

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/wrap.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/wrap.py
@@ -18,11 +18,15 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 
+# isort: off
 from megatron.lite.primitive.parallel.state import ParallelState
+
+# isort: on
 
 UnitModule = type[nn.Module] | str
 
 _WARNED_TP_NOT_RECOMMENDED = False
+_MAIN_GRAD_STATE_ATTR = "_mlite_fsdp2_main_grad_state"
 
 
 @dataclass(frozen=True)
@@ -42,6 +46,7 @@ class FSDP2Config:
     device_type: str = "cuda"
     param_dtype: str | torch.dtype | None = None
     reduce_dtype: str | torch.dtype | None = None
+    grad_dtype: str | torch.dtype = "float32"
     output_dtype: str | torch.dtype | None = None
     cast_forward_inputs: bool | None = True
 
@@ -64,6 +69,9 @@ class FSDP2Config:
             raise ValueError("forward_prefetch_depth must be >= 0.")
         if self.backward_prefetch_depth < 0:
             raise ValueError("backward_prefetch_depth must be >= 0.")
+        object.__setattr__(
+            self, "grad_dtype", _resolve_fsdp2_grad_dtype(self.grad_dtype)
+        )
 
 
 def fsdp2_available() -> bool:
@@ -77,7 +85,9 @@ def fsdp2_available() -> bool:
     return True
 
 
-def build_fsdp2_device_mesh(ps: ParallelState, config: FSDP2Config | None = None) -> Any:
+def build_fsdp2_device_mesh(
+    ps: ParallelState, config: FSDP2Config | None = None
+) -> Any:
     """Build the default one-dimensional FSDP2 DeviceMesh from ``ParallelState``."""
 
     cfg = config or FSDP2Config()
@@ -111,7 +121,9 @@ def build_fsdp2_process_group_mesh(
 
     from torch.distributed import DeviceMesh
 
-    return DeviceMesh.from_group(group, device_type=device_type, mesh_dim_names=(mesh_dim_name,))
+    return DeviceMesh.from_group(
+        group, device_type=device_type, mesh_dim_names=(mesh_dim_name,)
+    )
 
 
 def build_fsdp2_shard_placement_fn(fsdp_size: int) -> Callable[[nn.Parameter], Any]:
@@ -169,7 +181,9 @@ def wrap_fsdp2(
     )
 
     wrapped_units: list[nn.Module] = []
-    unit_modules = list(_iter_fsdp2_unit_modules(model, unit_types, cfg.leaf_module_names))
+    unit_modules = list(
+        _iter_fsdp2_unit_modules(model, unit_types, cfg.leaf_module_names)
+    )
     for idx, sub_module in enumerate(unit_modules):
         kwargs = dict(common_kwargs)
         _set_optional_reshard_after_forward(
@@ -253,35 +267,6 @@ def _warn_tp_not_recommended(ps: ParallelState) -> None:
     )
 
 
-def promote_fsdp2_trainable_params_to_fp32(
-    model: nn.Module, *, ignored_params: set[nn.Parameter] | None = None
-) -> int:
-    """Promote FSDP2-owned trainable floating parameters to FP32 shards.
-
-    Model protocols still use ``FSDP2Config.param_dtype`` to run compute in
-    BF16. Keeping the sharded parameters in FP32 makes the torch optimizer path
-    closer to MCore dist-opt's main-param semantics and avoids BF16 grad-norm
-    and update drift before FSDP2 wrapping.
-    """
-
-    ignored_param_ids = {id(param) for param in ignored_params or ()}
-    promoted = 0
-    with torch.no_grad():
-        for param in model.parameters():
-            if id(param) in ignored_param_ids:
-                continue
-            if not param.requires_grad or not param.is_floating_point():
-                continue
-            if param.dtype == torch.float32:
-                continue
-            param._fsdp2_model_param_dtype = param.dtype
-            param.data = param.data.to(torch.float32)
-            if param.grad is not None:
-                param.grad = param.grad.to(torch.float32)
-            promoted += 1
-    return promoted
-
-
 def set_fsdp2_requires_gradient_sync(
     module: nn.Module, requires_gradient_sync: bool, *, recurse: bool = True
 ) -> int:
@@ -305,6 +290,143 @@ def set_fsdp2_requires_gradient_sync(
     return touched
 
 
+def register_fsdp2_main_grad_hooks(
+    module: nn.Module, grad_dtype: str | torch.dtype, *, recurse: bool = True
+) -> int:
+    """Capture reduced FP32 shards in MLite-owned ``main_grad`` buffers.
+
+    PyTorch 2.11 calls ``FSDPModule.set_all_reduce_hook`` after reduce-scatter
+    (and HSDP all-reduce) but before casting the result back to the persistent
+    parameter dtype. For FP32 gradients, this installs one hook per FSDP
+    parameter group and exposes per-parameter views through ``param.main_grad``.
+    PyTorch remains the sole owner of ``param.grad`` and its lazy-init methods.
+    """
+
+    if not torch.__version__.startswith("2.11."):
+        raise RuntimeError("FSDP2 main_grad hooks require pinned PyTorch 2.11.x.")
+    resolved_dtype = _resolve_fsdp2_grad_dtype(grad_dtype)
+    if resolved_dtype is torch.bfloat16:
+        return 0
+    modules = (module, *tuple(module.modules())) if recurse else (module,)
+    touched = 0
+    seen: set[int] = set()
+    for candidate in modules:
+        getter = getattr(candidate, "_get_fsdp_state", None)
+        setter = getattr(candidate, "set_all_reduce_hook", None)
+        if not callable(getter) or not callable(setter):
+            continue
+        state = getter()
+        if hasattr(state, "_fsdp_param_groups"):
+            raise RuntimeError(
+                "Installed PyTorch FSDP2 state shape does not match pinned 2.11.x."
+            )
+        param_group = getattr(state, "_fsdp_param_group", None)
+        if param_group is None or id(param_group) in seen:
+            continue
+        seen.add(id(param_group))
+        if getattr(param_group, "_all_reduce_hook", None) is not None:
+            raise RuntimeError("FSDP2 parameter group already has an all-reduce hook.")
+        if bool(getattr(param_group, "force_sum_reduction_for_comms", False)):
+            raise RuntimeError(
+                "FSDP2 FP32 main_grad does not support post-hook gradient division."
+            )
+        main_grad_state = _FSDP2MainGradState(param_group, resolved_dtype)
+        setter(main_grad_state.capture)
+        setattr(candidate, _MAIN_GRAD_STATE_ATTR, main_grad_state)
+        touched += 1
+    if touched == 0:
+        raise RuntimeError(
+            "FSDP2 FP32 main_grad registration found no parameter groups."
+        )
+    return touched
+
+
+class _FSDP2MainGradState:
+    """Own one flat FP32 reduced-gradient buffer and its parameter views."""
+
+    def __init__(self, param_group: Any, dtype: torch.dtype) -> None:
+        fsdp_params = tuple(getattr(param_group, "fsdp_params", ()))
+        self.fsdp_params = tuple(
+            fsdp_param
+            for fsdp_param in fsdp_params
+            if getattr(fsdp_param, "sharded_param", None) is not None
+            and fsdp_param.sharded_param.requires_grad
+        )
+        if not self.fsdp_params:
+            raise RuntimeError(
+                "FSDP2 main_grad found an empty trainable parameter group."
+            )
+        self.dtype = dtype
+        self.buffer: torch.Tensor | None = None
+        self.active = False
+        for fsdp_param in self.fsdp_params:
+            sharded_param = fsdp_param.sharded_param
+            setattr(sharded_param, _MAIN_GRAD_STATE_ATTR, self)
+            hook = sharded_param.register_post_accumulate_grad_hook(
+                self._clear_torch_landed_grad
+            )
+            setattr(sharded_param, "_mlite_fsdp2_landed_grad_hook", hook)
+
+    @property
+    def expected_numel(self) -> int:
+        return sum(
+            int(fsdp_param.padded_sharded_param_size.numel())
+            for fsdp_param in self.fsdp_params
+        )
+
+    def capture(self, reduce_output: torch.Tensor) -> None:
+        if reduce_output.dtype is not self.dtype:
+            raise RuntimeError(
+                f"FSDP2 main_grad expected {self.dtype} reduce output, "
+                f"got {reduce_output.dtype}."
+            )
+        if reduce_output.numel() != self.expected_numel:
+            raise RuntimeError(
+                f"FSDP2 main_grad expected {self.expected_numel} elements from "
+                f"the complete parameter group, got {reduce_output.numel()}."
+            )
+        if self.buffer is None:
+            # Take ownership of the already-reduced FP32 allocation. PyTorch's
+            # following dtype cast allocates its own BF16 landed-grad tensor.
+            self.buffer = reduce_output.detach()
+        elif (
+            self.buffer.shape != reduce_output.shape
+            or self.buffer.device != reduce_output.device
+        ):
+            raise RuntimeError(
+                "FSDP2 main_grad buffer layout changed after registration."
+            )
+        else:
+            self.buffer.add_(reduce_output)
+        self.active = True
+
+        offset = 0
+        for fsdp_param in self.fsdp_params:
+            main_grad = torch.as_strided(
+                self.buffer,
+                size=fsdp_param.sharded_size,
+                stride=fsdp_param.contiguous_sharded_stride,
+                storage_offset=offset,
+            )
+            to_sharded_dtensor = getattr(fsdp_param, "to_sharded_dtensor", None)
+            if callable(to_sharded_dtensor):
+                main_grad = to_sharded_dtensor(main_grad)
+            fsdp_param.sharded_param.main_grad = main_grad
+            offset += int(fsdp_param.padded_sharded_param_size.numel())
+
+    def zero(self) -> None:
+        self.buffer = None
+        self.active = False
+        for fsdp_param in self.fsdp_params:
+            sharded_param = fsdp_param.sharded_param
+            if hasattr(sharded_param, "main_grad"):
+                delattr(sharded_param, "main_grad")
+
+    def _clear_torch_landed_grad(self, param: torch.Tensor) -> None:
+        if self.active:
+            param.grad = None
+
+
 def _load_fully_shard():
     try:
         from torch.distributed.fsdp import fully_shard
@@ -316,7 +438,9 @@ def _load_fully_shard():
     return fully_shard
 
 
-def _resolve_unit_module_types(unit_modules: Iterable[UnitModule]) -> tuple[type[nn.Module], ...]:
+def _resolve_unit_module_types(
+    unit_modules: Iterable[UnitModule],
+) -> tuple[type[nn.Module], ...]:
     resolved: list[type[nn.Module]] = []
     for item in unit_modules:
         if isinstance(item, str):
@@ -336,12 +460,16 @@ def _import_module_type(path: str) -> type[nn.Module]:
     module = importlib.import_module(module_name)
     obj = getattr(module, attr_name)
     if not isinstance(obj, type) or not issubclass(obj, nn.Module):
-        raise TypeError(f"FSDP2 unit module path does not resolve to nn.Module: {path!r}")
+        raise TypeError(
+            f"FSDP2 unit module path does not resolve to nn.Module: {path!r}"
+        )
     return obj
 
 
 def _iter_fsdp2_unit_modules(
-    root: nn.Module, unit_types: tuple[type[nn.Module], ...], leaf_module_names: tuple[str, ...]
+    root: nn.Module,
+    unit_types: tuple[type[nn.Module], ...],
+    leaf_module_names: tuple[str, ...],
 ) -> Iterable[nn.Module]:
     leaf_names = set(leaf_module_names)
     if not unit_types and not leaf_names:
@@ -387,7 +515,11 @@ def _is_fsdp2_module(module: nn.Module) -> bool:
 
 
 def _apply_fsdp2_prefetch(
-    root: nn.Module, wrapped_units: list[nn.Module], *, forward_depth: int, backward_depth: int
+    root: nn.Module,
+    wrapped_units: list[nn.Module],
+    *,
+    forward_depth: int,
+    backward_depth: int,
 ) -> None:
     fsdp_units = [module for module in wrapped_units if _is_fsdp2_module(module)]
     fsdp_root = root if _is_fsdp2_module(root) else None
@@ -408,7 +540,9 @@ def _apply_fsdp2_prefetch(
                 fsdp_units[idx].set_modules_to_backward_prefetch(targets)
 
 
-def _unit_reshard_after_forward(cfg: FSDP2Config, idx: int, total_units: int) -> bool | int | None:
+def _unit_reshard_after_forward(
+    cfg: FSDP2Config, idx: int, total_units: int
+) -> bool | int | None:
     if total_units > 0 and idx == total_units - 1:
         return cfg.last_unit_reshard_after_forward
     return cfg.reshard_after_forward
@@ -445,7 +579,11 @@ def _fully_shard_kwargs(
 
 
 def _mixed_precision_policy_from_config(cfg: FSDP2Config) -> Any | None:
-    if cfg.param_dtype is None and cfg.reduce_dtype is None and cfg.output_dtype is None:
+    if (
+        cfg.param_dtype is None
+        and cfg.reduce_dtype is None
+        and cfg.output_dtype is None
+    ):
         return None
     try:
         from torch.distributed.fsdp import MixedPrecisionPolicy
@@ -471,7 +609,16 @@ def _resolve_torch_dtype(dtype: str | torch.dtype | None) -> torch.dtype | None:
     name = dtype.removeprefix("torch.")
     resolved = getattr(torch, name, None)
     if not isinstance(resolved, torch.dtype):
-        raise ValueError(f"Unsupported torch dtype for FSDP2 mixed precision: {dtype!r}")
+        raise ValueError(
+            f"Unsupported torch dtype for FSDP2 mixed precision: {dtype!r}"
+        )
+    return resolved
+
+
+def _resolve_fsdp2_grad_dtype(dtype: str | torch.dtype) -> torch.dtype:
+    resolved = _resolve_torch_dtype(dtype)
+    if resolved not in {torch.bfloat16, torch.float32}:
+        raise ValueError("FSDP2 grad_dtype must be bfloat16 or float32.")
     return resolved
 
 
@@ -479,7 +626,9 @@ def _save_param_attrs(module: nn.Module) -> dict[str, dict[str, Any]]:
     return {name: dict(vars(param)) for name, param in module.named_parameters()}
 
 
-def _restore_param_attrs(module: nn.Module, saved_attrs: dict[str, dict[str, Any]]) -> None:
+def _restore_param_attrs(
+    module: nn.Module, saved_attrs: dict[str, dict[str, Any]]
+) -> None:
     for name, param in module.named_parameters():
         for attr_name, attr_value in saved_attrs.get(name, {}).items():
             setattr(param, attr_name, attr_value)
@@ -491,7 +640,7 @@ __all__ = [
     "build_fsdp2_process_group_mesh",
     "build_fsdp2_shard_placement_fn",
     "fsdp2_available",
-    "promote_fsdp2_trainable_params_to_fp32",
+    "register_fsdp2_main_grad_hooks",
     "set_fsdp2_requires_gradient_sync",
     "wrap_fsdp2",
     "wrap_fsdp2_module",

--- a/experimental/lite/tests/unit/primitive/test_fsdp2_main_grad_torch211.py
+++ b/experimental/lite/tests/unit/primitive/test_fsdp2_main_grad_torch211.py
@@ -1,0 +1,230 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from __future__ import annotations
+
+import multiprocessing
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+
+# isort: off
+from megatron.lite.primitive.optimizers.fsdp2.adamw import FP32AdamW
+from megatron.lite.primitive.optimizers.fsdp2.optimizer import FSDP2Optimizer
+from megatron.lite.primitive.optimizers.fsdp2 import wrap as fsdp2_wrap
+from megatron.lite.primitive.optimizers.fsdp2.wrap import (
+    FSDP2Config,
+    build_fsdp2_process_group_mesh,
+    wrap_fsdp2,
+    wrap_fsdp2_module,
+)
+from megatron.lite.primitive.parallel.state import ParallelState
+
+# isort: on
+
+pytestmark = [pytest.mark.mlite, pytest.mark.distributed]
+_TORCH_211_COMMIT = "70d99e998b4955e0049d13a98d77ae1b14db1f45"
+
+
+def _get_main_grad(param: nn.Parameter) -> torch.Tensor | None:
+    main_grad = getattr(param, "main_grad", None)
+    return main_grad if isinstance(main_grad, torch.Tensor) else None
+
+
+class TinyExperts(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.randn(2, 4, 4))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.einsum("bd,edh->beh", x, self.weight).mean(dim=1)
+
+
+class TinyTransformerLayer(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.dense = nn.Linear(4, 4, bias=False)
+        self.experts = TinyExperts()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.tanh(self.dense(x) + self.experts(x))
+
+
+class TinyQwen3MoE(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.layers = nn.ModuleList([TinyTransformerLayer(), TinyTransformerLayer()])
+        self.out = nn.Linear(4, 2, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        for layer in self.layers:
+            x = layer(x)
+        return self.out(x)
+
+
+def _main_grad_worker(rank: int, world: int, port: int, results) -> None:
+    os.environ.update(
+        MASTER_ADDR="127.0.0.1",
+        MASTER_PORT=str(port),
+        RANK=str(rank),
+        WORLD_SIZE=str(world),
+    )
+    dist.init_process_group("gloo", rank=rank, world_size=world)
+    try:
+        torch.manual_seed(1234)
+        model = TinyQwen3MoE().to(dtype=torch.bfloat16)
+        ps = ParallelState(dp_cp_size=world, expert_dp_size=world)
+        dense_mesh = build_fsdp2_process_group_mesh(
+            dist.group.WORLD, mesh_dim_name="dp", device_type="cpu"
+        )
+        expert_mesh = build_fsdp2_process_group_mesh(
+            dist.group.WORLD, mesh_dim_name="expert_dp", device_type="cpu"
+        )
+        config = FSDP2Config(
+            unit_modules=(TinyTransformerLayer,),
+            device_type="cpu",
+            param_dtype="bfloat16",
+            reduce_dtype="float32",
+            grad_dtype="float32",
+            forward_prefetch_depth=0,
+        )
+        for layer in model.layers:
+            wrap_fsdp2_module(layer.experts, ps, config, mesh=expert_mesh)
+        expert_params = {
+            param for layer in model.layers for param in layer.experts.parameters()
+        }
+        wrap_fsdp2(model, ps, config, mesh=dense_mesh, ignored_params=expert_params)
+
+        groups = []
+        lazy_init_impls = []
+        for module in model.modules():
+            getter = getattr(module, "_get_fsdp_state", None)
+            if not callable(getter):
+                continue
+            group = getter()._fsdp_param_group
+            if group is not None and id(group) not in {id(item) for item in groups}:
+                groups.append(group)
+                lazy_init_impls.append(
+                    getattr(group.lazy_init, "__func__", group.lazy_init)
+                )
+
+        register = getattr(fsdp2_wrap, "register_fsdp2_main_grad_hooks", None)
+        if callable(register):
+            touched = register(model, torch.float32)
+        else:
+            # Run this exact carrier against 4e683aa08: its plural-state scan
+            # returns zero on the production pin and leaves the real BF16 grad.
+            touched = fsdp2_wrap.set_fsdp2_gradient_dtype(model, torch.float32)
+        params = list(model.parameters())
+        torch_optimizer = FP32AdamW(
+            params, lr=1.0e-3, weight_decay=0.0, betas=(0.9, 0.95), eps=1.0e-8
+        )
+        optimizer = FSDP2Optimizer(torch_optimizer, params, clip_grad=1.0e9)
+        x = torch.arange(12, dtype=torch.bfloat16).view(3, 4) / 8
+        model(x).float().square().mean().backward()
+        first_main_grads = [
+            (
+                main_grad.clone()
+                if (main_grad := _get_main_grad(param)) is not None
+                else None
+            )
+            for param in params
+        ]
+        model(x).float().square().mean().backward()
+
+        landed_grads_cleared = all(param.grad is None for param in params)
+        landed_dtypes = {
+            param.grad.to_local().dtype for param in params if param.grad is not None
+        }
+        main_dtypes = {
+            main_grad.dtype
+            for param in params
+            if (main_grad := _get_main_grad(param)) is not None
+        }
+        accumulated = all(
+            first is not None and torch.equal(_get_main_grad(param), first * 2)
+            for param, first in zip(params, first_main_grads, strict=True)
+        )
+        independent = True
+        for param in params:
+            state = torch_optimizer.state[param]
+            main_grad = _get_main_grad(param)
+            if main_grad is None:
+                independent = False
+                continue
+            pointers = {
+                tensor.untyped_storage().data_ptr()
+                for tensor in (
+                    param.to_local(),
+                    main_grad.to_local(),
+                    state["master_param"].to_local(),
+                    state["exp_avg"].to_local(),
+                    state["exp_avg_sq"].to_local(),
+                )
+            }
+            independent = independent and len(pointers) == 5
+
+        current_lazy_init_impls = [
+            getattr(group.lazy_init, "__func__", group.lazy_init) for group in groups
+        ]
+        main_grad_bytes = sum(
+            main_grad.to_local().numel() * 4
+            for param in params
+            if (main_grad := _get_main_grad(param)) is not None
+        )
+        bf16_param_bytes = sum(param.to_local().numel() * 2 for param in params)
+        optimizer.step()
+        optimizer_consumed = all(
+            torch.equal(
+                torch_optimizer.state[param]["exp_avg"].to_local(),
+                _get_main_grad(param).to_local() * 0.1,
+            )
+            for param in params
+            if _get_main_grad(param) is not None
+        ) and all(_get_main_grad(param) is not None for param in params)
+        optimizer.zero_grad()
+        results.append(
+            {
+                "touched": touched,
+                "group_count": len(groups),
+                "landed_grads_cleared": landed_grads_cleared,
+                "landed_dtypes": landed_dtypes,
+                "main_dtypes": main_dtypes,
+                "accumulated": accumulated,
+                "independent": independent,
+                "optimizer_consumed": optimizer_consumed,
+                "lazy_init_unchanged": current_lazy_init_impls == lazy_init_impls,
+                "cleared": all(_get_main_grad(param) is None for param in params),
+                "main_grad_bytes": main_grad_bytes,
+                "bf16_param_bytes": bf16_param_bytes,
+            }
+        )
+    finally:
+        dist.destroy_process_group()
+
+
+def test_torch211_nested_moe_main_grad_contract() -> None:
+    if (
+        not torch.__version__.startswith("2.11.")
+        or torch.version.git_version != _TORCH_211_COMMIT
+    ):
+        pytest.skip(f"requires production PyTorch 2.11 pin {_TORCH_211_COMMIT}")
+    manager = multiprocessing.Manager()
+    results = manager.list()
+    torch.multiprocessing.spawn(
+        _main_grad_worker, args=(2, 29711, results), nprocs=2, join=True
+    )
+
+    assert len(results) == 2
+    for result in results:
+        assert result["touched"] == result["group_count"] == 5, result
+        assert result["landed_grads_cleared"], result
+        assert result["landed_dtypes"] == set(), result
+        assert result["main_dtypes"] == {torch.float32}, result
+        assert result["accumulated"], result
+        assert result["independent"], result
+        assert result["optimizer_consumed"], result
+        assert result["lazy_init_unchanged"], result
+        assert result["cleared"], result
+        assert result["main_grad_bytes"] == 2 * result["bf16_param_bytes"], result

--- a/experimental/lite/tests/unit/primitive/test_fsdp2_offload_gpu.py
+++ b/experimental/lite/tests/unit/primitive/test_fsdp2_offload_gpu.py
@@ -266,7 +266,6 @@ def test_fsdp2_pp_edp_reshard_and_offload_roundtrip_eight_gpus():
         reshard_after_forward=True,
         forward_prefetch_depth=0,
         backward_prefetch_depth=0,
-        use_fp32_shards=False,
         use_fp32_master=True,
     )
 
@@ -348,7 +347,6 @@ def test_fsdp2_pp_edp_reshard_and_offload_roundtrip_eight_gpus():
         reshard_after_forward=True,
         forward_prefetch_depth=0,
         backward_prefetch_depth=0,
-        use_fp32_shards=False,
         use_fp32_master=False,
     )
     del stress_optimizer
@@ -424,7 +422,6 @@ def test_fsdp2_pp_edp_reshard_and_offload_roundtrip_eight_gpus():
         reshard_after_forward=False,
         forward_prefetch_depth=0,
         backward_prefetch_depth=0,
-        use_fp32_shards=False,
         use_fp32_master=False,
     )
     x = torch.randn(2, 512, device="cuda", dtype=torch.bfloat16)

--- a/experimental/lite/tests/unit/primitive/test_fsdp2_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_fsdp2_unit.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import copy
 import importlib
+import multiprocessing
+import os
 from types import SimpleNamespace
 
 import pytest
@@ -10,6 +12,7 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 
+# isort: off
 from megatron.lite.primitive.optimizers.fsdp2 import (
     FSDP2Config,
     FSDP2Optimizer,
@@ -17,15 +20,26 @@ from megatron.lite.primitive.optimizers.fsdp2 import (
     clip_grads_with_sharded_norm_,
     fsdp2_available,
 )
-from megatron.lite.primitive.optimizers.fsdp2.adamw import build_adamw_optimizer
+from megatron.lite.primitive.optimizers.fsdp2.adamw import (
+    FP32AdamW,
+    build_adamw_optimizer,
+    to_local_tensor,
+)
+from megatron.lite.primitive.optimizers.fsdp2.main_grad import get_param_grad
 from megatron.lite.primitive.optimizers.fsdp2.wrap import build_fsdp2_shard_placement_fn
 from megatron.lite.primitive.parallel.state import ParallelState
+
+# isort: on
 
 pytestmark = pytest.mark.mlite
 
 fsdp2_wrap = importlib.import_module("megatron.lite.primitive.optimizers.fsdp2.wrap")
-fsdp2_optimizer = importlib.import_module("megatron.lite.primitive.optimizers.fsdp2.optimizer")
-fsdp2_grad_clip = importlib.import_module("megatron.lite.primitive.optimizers.fsdp2.grad_clip")
+fsdp2_optimizer = importlib.import_module(
+    "megatron.lite.primitive.optimizers.fsdp2.optimizer"
+)
+fsdp2_grad_clip = importlib.import_module(
+    "megatron.lite.primitive.optimizers.fsdp2.grad_clip"
+)
 
 
 class ToyBlock(nn.Module):
@@ -83,6 +97,20 @@ class ToyMoEBlock(nn.Module):
         return self.experts(self.dense(x))
 
 
+def _assert_loss_and_gradients_bitwise_equal(
+    actual_loss: torch.Tensor,
+    expected_loss: torch.Tensor,
+    actual_model: nn.Module,
+    expected_model: nn.Module,
+) -> None:
+    assert torch.equal(actual_loss, expected_loss)
+    actual_grads = dict(actual_model.named_parameters())
+    expected_grads = dict(expected_model.named_parameters())
+    assert actual_grads.keys() == expected_grads.keys()
+    for name in actual_grads:
+        assert torch.equal(actual_grads[name].grad, expected_grads[name].grad), name
+
+
 def test_fsdp2_config_validates_empty_wrap_surface():
     with pytest.raises(ValueError, match="wrap_root=True"):
         FSDP2Config(wrap_root=False)
@@ -106,11 +134,7 @@ def test_fsdp2_pipeline_wraps_dense_and_experts_with_reshard(monkeypatch):
     expert_mesh = SimpleNamespace(name="expert_dp")
     optimizer = object()
     ps = ParallelState(
-        pp_size=2,
-        ep_size=2,
-        dp_cp_size=4,
-        expert_dp_size=2,
-        ep_dp_group=object(),
+        pp_size=2, ep_size=2, dp_cp_size=4, expert_dp_size=2, ep_dp_group=object()
     )
 
     def fake_wrap_expert(module, _ps, config, **kwargs):
@@ -129,9 +153,10 @@ def test_fsdp2_pipeline_wraps_dense_and_experts_with_reshard(monkeypatch):
     monkeypatch.setattr(fsdp2_optimizer, "wrap_fsdp2_module", fake_wrap_expert)
     monkeypatch.setattr(fsdp2_optimizer, "wrap_fsdp2", fake_wrap_dense)
     monkeypatch.setattr(
-        fsdp2_optimizer,
-        "build_fsdp2_adamw",
-        lambda *args, **kwargs: optimizer,
+        fsdp2_optimizer, "register_fsdp2_main_grad_hooks", lambda *_args, **_kwargs: 1
+    )
+    monkeypatch.setattr(
+        fsdp2_optimizer, "build_fsdp2_adamw", lambda *args, **kwargs: optimizer
     )
 
     result = fsdp2_optimizer.build_fsdp2_training_optimizer(
@@ -141,7 +166,7 @@ def test_fsdp2_pipeline_wraps_dense_and_experts_with_reshard(monkeypatch):
         unit_modules=(ToyMoEBlock,),
         expert_classifier=lambda name: ".experts." in f".{name}",
         reshard_after_forward=True,
-        use_fp32_shards=False,
+        grad_dtype="bfloat16",
         use_fp32_master=False,
     )
 
@@ -159,6 +184,443 @@ def test_fsdp2_pipeline_wraps_dense_and_experts_with_reshard(monkeypatch):
     assert dense_config.reshard_after_forward is True
     assert dense_config.last_unit_reshard_after_forward is True
     assert dense_kwargs["ignored_params"] == set(model.experts.parameters())
+
+
+@pytest.mark.parametrize("removed_value", [False, True])
+def test_fsdp2_rejects_removed_use_fp32_shards_keyword(removed_value: bool):
+    with pytest.raises(
+        ValueError, match="use_fp32_shards has been removed; use fsdp2_param_dtype"
+    ):
+        fsdp2_optimizer.build_fsdp2_training_optimizer(
+            [ToyModel()],
+            None,
+            ParallelState(),
+            unit_modules=(ToyBlock,),
+            use_fp32_shards=removed_value,
+        )
+
+
+@pytest.mark.parametrize(
+    "opt",
+    [
+        SimpleNamespace(fsdp2_use_fp32_shards=False),
+        {"fsdp2_use_fp32_shards": True},
+        SimpleNamespace(override_optimizer_config={"fsdp2_use_fp32_shards": False}),
+    ],
+)
+def test_fsdp2_rejects_removed_use_fp32_shards_config(opt):
+    with pytest.raises(
+        ValueError,
+        match="fsdp2_use_fp32_shards has been removed; use fsdp2_param_dtype",
+    ):
+        fsdp2_optimizer.build_fsdp2_training_optimizer(
+            [ToyModel()], opt, ParallelState(), unit_modules=(ToyBlock,)
+        )
+
+
+def test_fsdp2_default_mixed_precision_policy_keeps_bf16_params_fp32_reductions():
+    policy = fsdp2_wrap._mixed_precision_policy_from_config(
+        FSDP2Config(param_dtype="bfloat16", reduce_dtype="float32")
+    )
+
+    assert policy.param_dtype is torch.bfloat16
+    assert policy.reduce_dtype is torch.float32
+
+
+def test_fsdp2_config_defaults_to_fp32_grad_and_accepts_only_storage_dtypes():
+    assert FSDP2Config().grad_dtype is torch.float32
+    assert FSDP2Config(grad_dtype="bfloat16").grad_dtype is torch.bfloat16
+    assert FSDP2Config(grad_dtype=torch.float32).grad_dtype is torch.float32
+    with pytest.raises(ValueError, match="grad_dtype"):
+        FSDP2Config(grad_dtype="float16")
+
+
+def test_fsdp2_fp32_main_grad_captures_post_reduce_output_without_changing_landed_grad(
+    monkeypatch,
+):
+    monkeypatch.setattr(fsdp2_wrap.torch, "__version__", "2.11.0")
+    sharded_param = nn.Parameter(torch.zeros(2, dtype=torch.bfloat16))
+    sharded_param.grad = torch.ones_like(sharded_param)
+    fsdp_param = SimpleNamespace(
+        sharded_param=sharded_param,
+        sharded_size=torch.Size((2,)),
+        contiguous_sharded_stride=(1,),
+        padded_sharded_param_size=torch.Size((2,)),
+    )
+    param_group = SimpleNamespace(
+        fsdp_params=[fsdp_param],
+        _all_reduce_hook=None,
+        gradient_divide_factor=None,
+        force_sum_reduction_for_comms=False,
+    )
+    module = ToyModel()
+    module._get_fsdp_state = lambda: SimpleNamespace(  # type: ignore[attr-defined]
+        _fsdp_param_group=param_group
+    )
+    module.set_all_reduce_hook = lambda hook: setattr(  # type: ignore[attr-defined]
+        param_group, "_all_reduce_hook", hook
+    )
+
+    touched = fsdp2_wrap.register_fsdp2_main_grad_hooks(
+        module, torch.float32, recurse=False
+    )
+    param_group._all_reduce_hook(torch.tensor([1.25, 2.5], dtype=torch.float32))
+
+    assert touched == 1
+    assert sharded_param.dtype is torch.bfloat16
+    assert sharded_param.grad.dtype is torch.bfloat16
+    assert sharded_param.main_grad.dtype is torch.float32
+    assert torch.equal(sharded_param.main_grad, torch.tensor([1.25, 2.5]))
+    assert (
+        to_local_tensor(sharded_param.main_grad).untyped_storage().data_ptr()
+        != sharded_param.grad.untyped_storage().data_ptr()
+    )
+    state = sharded_param._mlite_fsdp2_main_grad_state
+    state._clear_torch_landed_grad(sharded_param)
+    assert sharded_param.grad is None
+
+    param_group._all_reduce_hook(torch.tensor([0.75, 0.5], dtype=torch.float32))
+    assert torch.equal(sharded_param.main_grad, torch.tensor([2.0, 3.0]))
+
+
+def test_fsdp2_fp32_main_grad_rejects_incomplete_flat_group(monkeypatch):
+    monkeypatch.setattr(fsdp2_wrap.torch, "__version__", "2.11.0")
+    sharded_param = nn.Parameter(torch.zeros(2, dtype=torch.bfloat16))
+    fsdp_param = SimpleNamespace(
+        sharded_param=sharded_param,
+        sharded_size=torch.Size((2,)),
+        contiguous_sharded_stride=(1,),
+        padded_sharded_param_size=torch.Size((2,)),
+    )
+    param_group = SimpleNamespace(
+        fsdp_params=[fsdp_param],
+        _all_reduce_hook=None,
+        gradient_divide_factor=None,
+        force_sum_reduction_for_comms=False,
+    )
+    module = ToyModel()
+    module._get_fsdp_state = lambda: SimpleNamespace(  # type: ignore[attr-defined]
+        _fsdp_param_group=param_group
+    )
+    module.set_all_reduce_hook = lambda hook: setattr(  # type: ignore[attr-defined]
+        param_group, "_all_reduce_hook", hook
+    )
+
+    fsdp2_wrap.register_fsdp2_main_grad_hooks(module, torch.float32, recurse=False)
+
+    with pytest.raises(RuntimeError, match="expected 2 elements"):
+        param_group._all_reduce_hook(torch.ones(1, dtype=torch.float32))
+
+
+def test_fsdp2_optimizer_consumes_and_clears_main_grad_independent_of_state():
+    param = nn.Parameter(torch.tensor([1.0, -2.0], dtype=torch.bfloat16))
+    fsdp_param = SimpleNamespace(
+        sharded_param=param,
+        sharded_size=torch.Size((2,)),
+        contiguous_sharded_stride=(1,),
+        padded_sharded_param_size=torch.Size((2,)),
+    )
+    state = fsdp2_wrap._FSDP2MainGradState(
+        SimpleNamespace(fsdp_params=[fsdp_param]), torch.float32
+    )
+    param.grad = torch.full_like(param, 100.0)
+    state.capture(torch.tensor([0.25, -0.5], dtype=torch.float32))
+    state._clear_torch_landed_grad(param)
+    torch_optimizer = FP32AdamW(
+        [param], lr=1.0e-3, weight_decay=0.0, betas=(0.9, 0.95), eps=1.0e-8
+    )
+    optimizer = FSDP2Optimizer(torch_optimizer, [param], clip_grad=1.0e9)
+    master = torch_optimizer.state[param]["master_param"]
+    exp_avg = torch_optimizer.state[param]["exp_avg"]
+    exp_avg_sq = torch_optimizer.state[param]["exp_avg_sq"]
+    storages = {
+        tensor.untyped_storage().data_ptr()
+        for tensor in (param, param.main_grad, master, exp_avg, exp_avg_sq)
+    }
+
+    assert len(storages) == 5
+    assert param.grad is None
+    assert torch.equal(get_param_grad(param), torch.tensor([0.25, -0.5]))
+    assert optimizer.step()[0]
+    assert torch.equal(exp_avg, torch.tensor([0.025, -0.05]))
+
+    optimizer.zero_grad()
+    assert get_param_grad(param) is None
+    assert not hasattr(param, "main_grad")
+
+
+def test_fsdp2_gradient_dtype_rejects_unsupported_dtype(monkeypatch):
+    monkeypatch.setattr(fsdp2_wrap.torch, "__version__", "2.11.0")
+    with pytest.raises(ValueError, match="grad_dtype"):
+        fsdp2_wrap.register_fsdp2_main_grad_hooks(ToyModel(), torch.float16)
+
+
+def _fsdp2_gradient_landing_worker(rank, world, grad_dtype, port, results):
+    os.environ.update(
+        MASTER_ADDR="127.0.0.1",
+        MASTER_PORT=str(port),
+        RANK=str(rank),
+        WORLD_SIZE=str(world),
+    )
+    dist.init_process_group("gloo", rank=rank, world_size=world)
+    try:
+        from torch.distributed import init_device_mesh
+
+        model = nn.Linear(4, 2, bias=False).to(dtype=torch.bfloat16)
+        mesh = init_device_mesh("cpu", (world,), mesh_dim_names=("dp",))
+        policy = fsdp2_wrap._mixed_precision_policy_from_config(
+            FSDP2Config(
+                param_dtype="bfloat16", reduce_dtype="float32", device_type="cpu"
+            )
+        )
+        fsdp2_wrap._load_fully_shard()(model, mesh=mesh, mp_policy=policy)
+        param_group = model._get_fsdp_state()._fsdp_param_group
+        lazy_init = param_group.lazy_init
+        lazy_init_impl = getattr(lazy_init, "__func__", lazy_init)
+        try:
+            fsdp2_wrap.register_fsdp2_main_grad_hooks(model, grad_dtype)
+        except RuntimeError as exc:
+            results.append(("unsupported", str(exc)))
+            return
+        model(torch.ones(3, 4, dtype=torch.bfloat16)).float().square().mean().backward()
+        param = next(model.parameters())
+        current_lazy_init = param_group.lazy_init
+        current_lazy_init_impl = getattr(
+            current_lazy_init, "__func__", current_lazy_init
+        )
+        results.append(
+            (
+                param.dtype,
+                param.grad.to_local().dtype,
+                (
+                    getattr(param, "main_grad", None).dtype
+                    if hasattr(param, "main_grad")
+                    else None
+                ),
+                current_lazy_init_impl is lazy_init_impl,
+            )
+        )
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.distributed
+@pytest.mark.parametrize(
+    ("grad_dtype", "port"), [(torch.bfloat16, 29671), (torch.float32, 29672)]
+)
+def test_fsdp2_gradient_dtype_lands_real_gloo_grad(grad_dtype, port):
+    if not fsdp2_available():
+        pytest.skip("Installed PyTorch does not expose FSDP2 fully_shard.")
+    manager = multiprocessing.Manager()
+    results = manager.list()
+    torch.multiprocessing.spawn(
+        _fsdp2_gradient_landing_worker,
+        args=(2, grad_dtype, port, results),
+        nprocs=2,
+        join=True,
+    )
+    if torch.__version__.startswith("2.11."):
+        expected_main_grad = torch.float32 if grad_dtype is torch.float32 else None
+        assert (
+            list(results)
+            == [(torch.bfloat16, torch.bfloat16, expected_main_grad, True)] * 2
+        )
+    else:
+        assert (
+            list(results)
+            == [("unsupported", "FSDP2 main_grad hooks require pinned PyTorch 2.11.x.")]
+            * 2
+        )
+
+
+def test_fsdp2_training_optimizer_threads_independent_grad_dtype(monkeypatch):
+    model = ToyModel()
+    seen_grad_dtypes = []
+    monkeypatch.setattr(
+        fsdp2_optimizer, "wrap_fsdp2", lambda model, *_args, **_kwargs: model
+    )
+    monkeypatch.setattr(
+        fsdp2_optimizer,
+        "register_fsdp2_main_grad_hooks",
+        lambda module, dtype: seen_grad_dtypes.append((module, dtype)),
+    )
+    monkeypatch.setattr(
+        fsdp2_optimizer, "build_fsdp2_adamw", lambda *_args, **_kwargs: object()
+    )
+
+    fsdp2_optimizer.build_fsdp2_training_optimizer(
+        [model], None, ParallelState(), unit_modules=(ToyBlock,), grad_dtype="float32"
+    )
+
+    assert seen_grad_dtypes == [(model, torch.float32)]
+
+
+@pytest.mark.parametrize(
+    ("param_dtype", "grad_dtype"),
+    [
+        ("bfloat16", "bfloat16"),
+        ("bfloat16", "float32"),
+        ("float32", "bfloat16"),
+        ("float32", "float32"),
+    ],
+)
+def test_fsdp2_training_optimizer_applies_orthogonal_storage_dtypes(
+    monkeypatch, param_dtype, grad_dtype
+):
+    model = ToyModel().to(dtype=torch.float32)
+    seen_grad_dtypes = []
+    monkeypatch.setattr(
+        fsdp2_optimizer, "wrap_fsdp2", lambda model, *_args, **_kwargs: model
+    )
+    monkeypatch.setattr(
+        fsdp2_optimizer,
+        "register_fsdp2_main_grad_hooks",
+        lambda _module, dtype: seen_grad_dtypes.append(dtype),
+    )
+    monkeypatch.setattr(
+        fsdp2_optimizer, "build_fsdp2_adamw", lambda *_args, **_kwargs: object()
+    )
+
+    fsdp2_optimizer.build_fsdp2_training_optimizer(
+        [model],
+        SimpleNamespace(fsdp2_param_dtype=param_dtype, fsdp2_grad_dtype=grad_dtype),
+        ParallelState(),
+        unit_modules=(ToyBlock,),
+    )
+
+    expected_param_dtype = getattr(torch, param_dtype)
+    expected_grad_dtype = getattr(torch, grad_dtype)
+    assert {param.dtype for param in model.parameters()} == {expected_param_dtype}
+    assert seen_grad_dtypes == [expected_grad_dtype]
+
+
+@pytest.mark.parametrize("invalid", [None, "float16", "not-a-dtype"])
+def test_fsdp2_training_optimizer_rejects_invalid_storage_dtype(monkeypatch, invalid):
+    model = ToyModel()
+    monkeypatch.setattr(
+        fsdp2_optimizer, "wrap_fsdp2", lambda model, *_args, **_kwargs: model
+    )
+    with pytest.raises(ValueError, match="fsdp2_param_dtype"):
+        fsdp2_optimizer.build_fsdp2_training_optimizer(
+            [model],
+            SimpleNamespace(fsdp2_param_dtype=invalid),
+            ParallelState(),
+            unit_modules=(ToyBlock,),
+        )
+
+
+def test_fsdp2_training_optimizer_rejects_non_fp32_reduce_dtype():
+    with pytest.raises(ValueError, match="reduce_dtype must be float32"):
+        fsdp2_optimizer.build_fsdp2_training_optimizer(
+            [ToyModel()],
+            None,
+            ParallelState(),
+            unit_modules=(ToyBlock,),
+            reduce_dtype="bfloat16",
+        )
+
+
+def test_fsdp2_fp32_main_grad_requires_fp32_master(monkeypatch):
+    monkeypatch.setattr(
+        fsdp2_optimizer, "wrap_fsdp2", lambda model, *_args, **_kwargs: model
+    )
+    with pytest.raises(ValueError, match="requires fsdp2_use_fp32_master=True"):
+        fsdp2_optimizer.build_fsdp2_training_optimizer(
+            [ToyModel()],
+            None,
+            ParallelState(),
+            unit_modules=(ToyBlock,),
+            grad_dtype="float32",
+            use_fp32_master=False,
+        )
+
+
+def test_removed_fp32_shards_path_preserves_loss_and_gradients_bitwise_cpu(monkeypatch):
+    monkeypatch.setattr(
+        fsdp2_optimizer, "wrap_fsdp2", lambda model, *_args, **_kwargs: model
+    )
+    monkeypatch.setattr(
+        fsdp2_optimizer, "register_fsdp2_main_grad_hooks", lambda *_args, **_kwargs: 1
+    )
+    torch.manual_seed(1234)
+    actual_model = ToyModel().to(dtype=torch.bfloat16)
+    expected_model = copy.deepcopy(actual_model)
+    opt = SimpleNamespace(
+        optimizer="adam",
+        lr=1.0e-3,
+        weight_decay=0.0,
+        adam_beta1=0.9,
+        adam_beta2=0.95,
+        adam_eps=1.0e-8,
+        clip_grad=1.0e9,
+        offload_fraction=0.0,
+    )
+    actual_optimizer = fsdp2_optimizer.build_fsdp2_training_optimizer(
+        [actual_model],
+        opt,
+        ParallelState(),
+        unit_modules=(ToyBlock,),
+        use_fp32_master=True,
+        adamw_foreach=False,
+    )
+    # This is the old use_fp32_shards=False path: wrapping leaves BF16 model
+    # parameters intact, then the optimizer owns the only FP32 parameter copy.
+    expected_optimizer = fsdp2_optimizer.build_fsdp2_adamw(
+        [expected_model],
+        opt,
+        ParallelState(),
+        use_fp32_master=True,
+        adamw_foreach=False,
+    )
+    actual_params = list(actual_model.parameters())
+    actual_masters = actual_optimizer.optimizer.state_dict()["master_params"]
+    assert all(
+        param.dtype is torch.bfloat16 and param.element_size() == 2
+        for param in actual_params
+    )
+    assert all(
+        master.dtype is torch.float32 and master.element_size() == 4
+        for master in actual_masters
+    )
+    assert all(
+        param.untyped_storage().data_ptr() != master.untyped_storage().data_ptr()
+        for param, master in zip(actual_params, actual_masters, strict=True)
+    )
+    inputs = [
+        torch.randn(
+            3, 4, dtype=torch.bfloat16, generator=torch.Generator().manual_seed(seed)
+        )
+        for seed in range(5)
+    ]
+
+    for x in inputs:
+        actual_optimizer.zero_grad()
+        expected_optimizer.zero_grad()
+        actual_loss = actual_model(x).float().square().mean()
+        expected_loss = expected_model(x).float().square().mean()
+        actual_loss.backward()
+        expected_loss.backward()
+        _assert_loss_and_gradients_bitwise_equal(
+            actual_loss, expected_loss, actual_model, expected_model
+        )
+        assert actual_optimizer.step()[0]
+        assert expected_optimizer.step()[0]
+        for actual_param, expected_param in zip(
+            actual_model.parameters(), expected_model.parameters(), strict=True
+        ):
+            assert torch.equal(actual_param, expected_param)
+
+
+def test_bitwise_loss_and_gradient_check_detects_perturbation():
+    actual_model = nn.Linear(2, 1, bias=False)
+    expected_model = copy.deepcopy(actual_model)
+    actual_model.weight.grad = torch.tensor([[1.0, 2.0]])
+    expected_model.weight.grad = torch.tensor([[1.0, 2.5]])
+
+    with pytest.raises(AssertionError):
+        _assert_loss_and_gradients_bitwise_equal(
+            torch.tensor(1.0), torch.tensor(1.0), actual_model, expected_model
+        )
 
 
 @pytest.mark.parametrize("depth", [0, 1, 2])
@@ -188,7 +650,9 @@ def test_fsdp2_optimizer_offloads_dtensor_state_without_extra_knob(monkeypatch):
     optimizer = FSDP2Optimizer(torch_optimizer, model.parameters())
     calls: list[bool] = []
 
-    def fake_move_optimizer_state_to_cpu(_optimizer, _offloaded_state, *, include_dtensor_state):
+    def fake_move_optimizer_state_to_cpu(
+        _optimizer, _offloaded_state, *, include_dtensor_state
+    ):
         calls.append(include_dtensor_state)
 
     monkeypatch.setattr(
@@ -199,6 +663,29 @@ def test_fsdp2_optimizer_offloads_dtensor_state_without_extra_knob(monkeypatch):
 
     assert calls == [True]
     assert not hasattr(optimizer, "optimizer_offload_dtensor_state")
+
+
+def test_fsdp2_grad_sync_enabled_propagates_to_fsdp2_roots():
+    class FakeFSDP2Root(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.calls: list[tuple[bool, bool]] = []
+
+        def set_requires_gradient_sync(
+            self, requires_gradient_sync: bool, *, recurse: bool
+        ) -> None:
+            self.calls.append((requires_gradient_sync, recurse))
+
+    param = nn.Parameter(torch.tensor([1.0]))
+    root = FakeFSDP2Root()
+    optimizer = FSDP2Optimizer(
+        torch.optim.SGD([param], lr=0.0), [param], fsdp_modules=[root]
+    )
+
+    optimizer.grad_sync_enabled = True
+    optimizer.grad_sync_enabled = False
+
+    assert root.calls == [(True, True), (False, True)]
 
 
 def test_fsdp2_shard_placement_prefers_first_divisible_dimension():
@@ -225,7 +712,9 @@ def test_fsdp2_rejects_non_module_unit_path():
 
 
 def test_wrap_fsdp2_requires_distributed_when_mesh_is_not_provided(monkeypatch):
-    monkeypatch.setattr(fsdp2_wrap, "_load_fully_shard", lambda: lambda module, **kwargs: module)
+    monkeypatch.setattr(
+        fsdp2_wrap, "_load_fully_shard", lambda: lambda module, **kwargs: module
+    )
 
     with pytest.raises(RuntimeError, match="torch.distributed"):
         fsdp2_wrap.wrap_fsdp2(ToyModel(), ParallelState(), FSDP2Config())
@@ -281,7 +770,9 @@ def test_wrap_fsdp2_accepts_unit_module_import_paths(monkeypatch):
 
 def test_wrap_fsdp2_uses_container_order_without_nested_unit_duplicates(monkeypatch):
     model = nn.Module()
-    model.layers = nn.ModuleDict({"10": NestedToyBlock(), "2": ToyBlock(), "11": ToyBlock()})
+    model.layers = nn.ModuleDict(
+        {"10": NestedToyBlock(), "2": ToyBlock(), "11": ToyBlock()}
+    )
     calls: list[nn.Module] = []
 
     def fake_fully_shard(module, **kwargs):
@@ -391,7 +882,9 @@ def test_clip_grads_with_sharded_norm_scales_cpu_grads_once():
     torch.testing.assert_close(p1.grad, torch.tensor([0.0, 12.0]) * scale)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for NCCL scalar test.")
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA is required for NCCL scalar test."
+)
 def test_all_reduce_scalar_moves_cpu_value_to_nccl_device(monkeypatch):
     group = object()
     reduced_devices: list[str] = []
@@ -416,11 +909,7 @@ def test_all_reduce_scalar_moves_cpu_value_to_nccl_device(monkeypatch):
 
 def test_fsdp2_optimizer_uses_scalar_all_reduce_for_all_norm_groups(monkeypatch):
     groups = SimpleNamespace(
-        dp_cp=object(),
-        tp=object(),
-        replicated=object(),
-        expert=object(),
-        pp=object(),
+        dp_cp=object(), tp=object(), replicated=object(), expert=object(), pp=object()
     )
     reduced_groups: list[object] = []
 
@@ -445,11 +934,7 @@ def test_fsdp2_optimizer_uses_scalar_all_reduce_for_all_norm_groups(monkeypatch)
     optimizer = FSDP2Optimizer(
         torch.optim.SGD([sharded, replicated, expert, tp_replicated], lr=0.0),
         [sharded, replicated, expert, tp_replicated],
-        ParallelState(
-            dp_cp_group=groups.dp_cp,
-            tp_group=groups.tp,
-            pp_group=groups.pp,
-        ),
+        ParallelState(dp_cp_group=groups.dp_cp, tp_group=groups.tp, pp_group=groups.pp),
         clip_grad=100.0,
         replicated_grad_params=[replicated],
         replicated_grad_norm_group=groups.replicated,
@@ -482,13 +967,15 @@ def test_fp32_adamw_state_dict_roundtrip_cpu():
         foreach=False,
         use_fp32_master=True,
         cpu_update=False,
-        model_param_dtypes={id(param): torch.bfloat16},
         opt=SimpleNamespace(),
     )
     param.grad = torch.tensor([0.5, -0.25], dtype=torch.bfloat16)
     optimizer.step()
     state = optimizer.state_dict()
-    expected = {key: state[key][0].clone() for key in ("master_params", "exp_avgs", "exp_avg_sqs")}
+    expected = {
+        key: state[key][0].clone()
+        for key in ("master_params", "exp_avgs", "exp_avg_sqs")
+    }
     for key, value in expected.items():
         state[key][0] = SimpleNamespace(_local_tensor=value)
 
@@ -503,14 +990,15 @@ def test_fp32_adamw_state_dict_roundtrip_cpu():
         foreach=False,
         use_fp32_master=True,
         cpu_update=False,
-        model_param_dtypes={id(loaded_param): torch.bfloat16},
         opt=SimpleNamespace(),
     )
     loaded_optimizer.load_state_dict(state)
     loaded_state = loaded_optimizer.state_dict()
 
     assert loaded_state["step_count"] == state["step_count"]
-    torch.testing.assert_close(loaded_param, expected["master_params"].to(torch.bfloat16))
+    torch.testing.assert_close(
+        loaded_param, expected["master_params"].to(torch.bfloat16)
+    )
     for key, value in expected.items():
         torch.testing.assert_close(loaded_state[key][0], value)
     assert loaded_state["steps"] == state["steps"]
@@ -530,7 +1018,6 @@ def test_fp32_adamw_load_matches_uninterrupted_next_step_cpu(cpu_update: bool):
             foreach=False,
             use_fp32_master=True,
             cpu_update=cpu_update,
-            model_param_dtypes={id(param): torch.bfloat16},
             opt=SimpleNamespace(),
         )
         return param, optimizer
@@ -565,5 +1052,7 @@ def test_fp32_adamw_load_matches_uninterrupted_next_step_cpu(cpu_update: bool):
     loaded_state = loaded_optimizer.state_dict()
     assert loaded_state["step_count"] == direct_state["step_count"]
     for key in ("master_params", "exp_avgs", "exp_avg_sqs"):
-        torch.testing.assert_close(loaded_state[key][0], direct_state[key][0], atol=0.0, rtol=0.0)
+        torch.testing.assert_close(
+            loaded_state[key][0], direct_state[key][0], atol=0.0, rtol=0.0
+        )
     assert loaded_state["steps"] == direct_state["steps"]


### PR DESCRIPTION
## Summary

- replace the removed `use_fp32_shards` path with independent `fsdp2_param_dtype` and `fsdp2_grad_dtype` settings
- retain the post-reduce FP32 shard as an MLite-owned `main_grad`, while leaving PyTorch in charge of FSDP2 lazy initialization and `.grad` writeback
- make gradient norm, clipping, TP/EP synchronization, and `FP32AdamW` consume `main_grad`; release the flat buffer from `zero_grad()`
- reject unsupported FP32-main-grad combinations without an FP32 master or with TE FusedAdam

## Precision and storage contract

The capture hook runs after reduce-scatter (and HSDP all-reduce) in FP32 and before PyTorch casts the result to the persistent parameter dtype. The first reduced allocation becomes the flat `main_grad` buffer directly; later microbatches accumulate into it in FP32. A post-accumulate hook clears PyTorch's transient BF16 `.grad`.

The BF16 parameter shard, FP32 `main_grad`, FP32 master, `exp_avg`, and `exp_avg_sq` use five independent storages. Persistent optimizer-side storage changes from 20 to 18 bytes per local parameter element versus the previous FP32-shard path: the only net saving is the parameter shard changing from 4 to 2 bytes. The transient BF16 landed gradient may still keep backward peak memory unchanged, so this PR makes no peak-memory claim.

## Validation

- production-pinned PyTorch `2.11.0+cu130` at `70d99e998b4955e0049d13a98d77ae1b14db1f45`, two-rank Gloo, nested tiny MoE with five FSDP groups: previous implementation reproduced `touched=0`, BF16 landed gradients, and no `main_grad`; this commit passed the same carrier without skips
- contract checks cover two-backward FP32 accumulation, actual optimizer consumption, five-way storage independence, unchanged `lazy_init`, and buffer release
- FSDP2 unit suite: 51 passed, 1 skipped locally because the local interpreter is not the production PyTorch pin
- layering contracts: 6 passed
- repository-pinned Black 24.4.2 and isort 5.13.2: all 8 changed Python files passed

The PR contains one Yan Bai commit based on `main`, with implementation, tests, and usage documentation only.