### PR TITLE
Enable native FP32 fused wgrad accumulation for M-FSDP

### DIFF
--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
@@ -379,7 +379,13 @@ class ParamBucket:
             )
         )
         self.full_buffer = torch.empty(0, dtype=compute_dtype, device=self.device)
+        self.full_main_grad_buffer = torch.empty(
+            0,
+            dtype=self.policy.main_grads_dtype,
+            device=self.device,
+        )
         self._full_lease: BufferLease | None = None
+        self._full_main_grad_lease: BufferLease | None = None
         self._grad_lease: BufferLease | None = None
         self._param_gather_work: Any | None = None
         self._grad_reduce_work: Any | None = None
@@ -412,6 +418,9 @@ class ParamBucket:
                 _copy_parameter_metadata(spec.full_param, shard_param)
                 shard_param._mfsdp_original_ndim = spec.full_param.ndim
                 spec.shard_param = shard_param
+                # TE returns a dummy ``.grad`` when its wgrad GEMM writes the
+                # real gradient directly into ``main_grad``.
+                spec.full_param.grad_added_to_main_grad = False
                 spec.full_param.register_post_accumulate_grad_hook(
                     self._make_grad_ready_hook(spec)
                 )
@@ -431,6 +440,39 @@ class ParamBucket:
             spec.full_param.data = view
             for binding in spec.bindings:
                 setattr(binding.module, binding.attribute, spec.full_param)
+
+    def prepare_main_grads(self) -> None:
+        """Attach bounded FP32 views for fused wgrad accumulation."""
+        if self._full_main_grad_lease is None:
+            self._full_main_grad_lease = self.allocator.allocate(
+                self.full_numel,
+                dtype=self.policy.main_grads_dtype,
+                device=self.device,
+                group=self.process_group,
+                key=(
+                    "main_grad",
+                    id(self.process_group),
+                    self.allocator_layout_key,
+                ),
+            )
+            self.full_main_grad_buffer = self._full_main_grad_lease.tensor
+            self.full_main_grad_buffer.zero_()
+        for spec in self.specs:
+            spec.full_param.main_grad = self.full_main_grad_buffer.narrow(
+                0, spec.full_offset, spec.numel
+            ).view(spec.shape)
+
+    def _release_full_main_grads(self) -> None:
+        if self._full_main_grad_lease is not None:
+            self._full_main_grad_lease.release()
+            self._full_main_grad_lease = None
+        self.full_main_grad_buffer = torch.empty(
+            0,
+            dtype=self.policy.main_grads_dtype,
+            device=self.device,
+        )
+        for spec in self.specs:
+            spec.full_param.main_grad = self.full_main_grad_buffer
 
     def prepare_param_gather(self) -> tuple[torch.Tensor, torch.Tensor]:
         if self._full_lease is None:
@@ -505,6 +547,8 @@ class ParamBucket:
         self.discard_full_parameter_views()
         if self._grad_reduce_launched:
             self.wait_grad_reduce()
+        else:
+            self._release_full_main_grads()
         self.allocator.release_cached()
 
         grad_present = {
@@ -525,6 +569,11 @@ class ParamBucket:
         self.full_buffer = torch.empty(
             0,
             dtype=self.policy.compute_dtype,
+            device=device,
+        )
+        self.full_main_grad_buffer = torch.empty(
+            0,
+            dtype=self.policy.main_grads_dtype,
             device=device,
         )
 
@@ -563,6 +612,8 @@ class ParamBucket:
         self.discard_full_parameter_views()
         if self._grad_reduce_launched:
             self.wait_grad_reduce()
+        else:
+            self._release_full_main_grads()
         self.allocator.release_cached()
 
     def prepare_grad_reduce(
@@ -573,23 +624,27 @@ class ParamBucket:
         if not force and len(self._grad_ready_ids) != len(self.specs):
             return None
         self._grad_reduce_launched = True
-        self._grad_lease = self.allocator.allocate(
-            self.full_numel,
-            dtype=self.policy.grad_comm_dtype,
-            device=self.device,
-            group=self.process_group,
-            key=(
-                "grad",
-                id(self.process_group),
-                self.allocator_layout_key,
-            ),
-        )
-        grad_input = self._grad_lease.tensor
-        grad_input.zero_()
+        self.prepare_main_grads()
+        if self.policy.grad_comm_dtype == self.policy.main_grads_dtype:
+            grad_input = self.full_main_grad_buffer
+        else:
+            self._grad_lease = self.allocator.allocate(
+                self.full_numel,
+                dtype=self.policy.grad_comm_dtype,
+                device=self.device,
+                group=self.process_group,
+                key=(
+                    "grad",
+                    id(self.process_group),
+                    self.allocator_layout_key,
+                ),
+            )
+            grad_input = self._grad_lease.tensor
+            grad_input.copy_(self.full_main_grad_buffer)
         with torch.no_grad():
             for spec in self.specs:
                 grad = spec.full_param.grad
-                if grad is not None:
+                if grad is not None and not spec.full_param.grad_added_to_main_grad:
                     grad_input.narrow(0, spec.full_offset, spec.numel).copy_(
                         grad.reshape(-1)
                     )
@@ -628,6 +683,7 @@ class ParamBucket:
         if self._grad_lease is not None:
             self._grad_lease.release()
             self._grad_lease = None
+        self._release_full_main_grads()
 
     def copy_full_parameters_to_shards(self) -> None:
         self.wait_param_gather()
@@ -646,8 +702,10 @@ class ParamBucket:
         self.main_grad_buffer.zero_()
         for spec in self.specs:
             spec.full_param.grad = None
+            spec.full_param.grad_added_to_main_grad = False
             if spec.shard_param is not None:
                 spec.shard_param.grad = None
+        self._release_full_main_grads()
 
     def set_grad_sync_enabled(self, enabled: bool) -> None:
         enabled = bool(enabled)
@@ -982,6 +1040,7 @@ class AllGatherPipeline:
         bucket_id = bucket.bucket_id
         self.wait_bucket_ready(bucket_id, bwd=True)
         bucket.install_full_parameters()
+        bucket.prepare_main_grads()
         self._backward_cursor = min(self._backward_cursor, bucket_id - 1)
         if self.overlap and self._backward_cursor >= 0:
             self.async_bucket_gather(self._backward_cursor, bwd=True)

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
@@ -625,6 +625,12 @@ class ParamBucket:
             return None
         self._grad_reduce_launched = True
         self.prepare_main_grads()
+        with torch.no_grad():
+            for spec in self.specs:
+                grad = spec.full_param.grad
+                if grad is not None and not spec.full_param.grad_added_to_main_grad:
+                    spec.full_param.main_grad.add_(grad)
+                spec.full_param.grad = None
         if self.policy.grad_comm_dtype == self.policy.main_grads_dtype:
             grad_input = self.full_main_grad_buffer
         else:
@@ -641,14 +647,6 @@ class ParamBucket:
             )
             grad_input = self._grad_lease.tensor
             grad_input.copy_(self.full_main_grad_buffer)
-        with torch.no_grad():
-            for spec in self.specs:
-                grad = spec.full_param.grad
-                if grad is not None and not spec.full_param.grad_added_to_main_grad:
-                    grad_input.narrow(0, spec.full_offset, spec.numel).copy_(
-                        grad.reshape(-1)
-                    )
-                spec.full_param.grad = None
         return self.local_grad_comm_buffer, grad_input
 
     def mark_grad_reduce_launched(self, work: Any | None) -> None:
@@ -740,6 +738,10 @@ class ParamBucket:
                 return
             self._grad_ready_ids.add(id(spec))
             if param.grad_added_to_main_grad:
+                param.grad = None
+            else:
+                with torch.no_grad():
+                    param.main_grad.add_(param.grad)
                 param.grad = None
             if len(self._grad_ready_ids) != len(self.specs):
                 return

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
@@ -739,6 +739,8 @@ class ParamBucket:
             if param.grad is None:
                 return
             self._grad_ready_ids.add(id(spec))
+            if param.grad_added_to_main_grad:
+                param.grad = None
             if len(self._grad_ready_ids) != len(self.specs):
                 return
             if self.grad_sync_enabled and self.grad_ready_callback is not None:

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/wrapper.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/wrapper.py
@@ -97,6 +97,7 @@ class MegatronFSDP(nn.Module):
             is_expert=is_expert,
             unit_modules=unit_modules,
         )
+        _enable_fused_wgrad_accumulation(module)
         self.param_sync = CommunicationPipelines(self.param_and_grad_buffer.buckets)
         self.all_gather_pipeline: AllGatherPipeline = self.param_sync.all_gather
         self.grad_reduce_pipeline: GradReducePipeline = self.param_sync.grad_reduce
@@ -270,6 +271,13 @@ def _module_by_id(root: nn.Module, module_id: int) -> nn.Module:
         if id(module) == module_id:
             return module
     raise RuntimeError("M-FSDP bucket owner is no longer part of the wrapped module.")
+
+
+def _enable_fused_wgrad_accumulation(module: nn.Module) -> None:
+    """Enable TE-style fused wgrad only inside the M-FSDP ownership boundary."""
+    for child in module.modules():
+        if hasattr(child, "fuse_wgrad_accumulation"):
+            child.fuse_wgrad_accumulation = True
 
 
 __all__ = ["MFSdpModule", "MegatronFSDP", "mark_optimizer_built"]

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -1024,6 +1024,7 @@ def test_mfsdp_non_fused_wgrad_accumulates_in_fp32_per_microbatch():
     assert not hasattr(model.linear, "fuse_wgrad_accumulation")
     chunks = [model]
     optimizer_config = _optimizer_cfg(use_fused_optimizer=False)
+    optimizer_config.clip_grad = 10000.0
     impl_cfg = SimpleNamespace(
         parallel=parallel,
         optimizer_config=optimizer_config,

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -100,6 +100,63 @@ class TinyParallelModel(nn.Module):
         return self.out(self.experts(hidden))
 
 
+class TinyTELinear(nn.Module):
+    def __init__(self, in_features: int, out_features: int):
+        super().__init__()
+        import transformer_engine.pytorch as te
+
+        self.linear = te.Linear(
+            in_features,
+            out_features,
+            bias=False,
+            params_dtype=torch.bfloat16,
+        )
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+class TinyTETransformerLayer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.dense = TinyTELinear(8, 8)
+        self.expert = TinyTELinear(8, 8)
+
+    def forward(self, x):
+        return torch.tanh(self.dense(x) + self.expert(x))
+
+
+class TinyTEQwen3MoE(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layers = nn.ModuleList(
+            [TinyTETransformerLayer(), TinyTETransformerLayer()]
+        )
+        self.out = TinyTELinear(8, 4)
+
+    def forward(self, x):
+        for layer in self.layers:
+            x = layer(x)
+        return self.out(x)
+
+
+class RecordingSGD(torch.optim.SGD):
+    def __init__(self, param_groups):
+        super().__init__(param_groups, lr=0.0)
+        self.consumed_grad_groups: list[list[torch.Tensor]] = []
+
+    def step(self, closure=None):
+        self.consumed_grad_groups = [
+            [
+                param.grad.detach().clone()
+                for param in group["params"]
+                if param.grad is not None
+            ]
+            for group in self.param_groups
+        ]
+        return super().step(closure)
+
+
 class BenchmarkUnit(nn.Module):
     def __init__(self, hidden_size: int):
         super().__init__()
@@ -309,6 +366,14 @@ def _memory_triple() -> dict[str, float]:
             strict=True,
         )
     )
+
+
+def _bf16_roundtrip_difference_fraction(tensors: list[torch.Tensor]) -> float:
+    values = torch.cat([tensor.detach().float().reshape(-1) for tensor in tensors])
+    assert values.numel() > 0
+    rounded = values.to(torch.bfloat16).to(torch.float32)
+    assert not torch.equal(values, rounded)
+    return float((values != rounded).float().mean().item())
 
 
 def _memory_delta(
@@ -674,6 +739,102 @@ def _tp_ep_parallel_config() -> ParallelConfig:
 
 def _is_tiny_expert(name: str) -> bool:
     return name.startswith("experts.")
+
+
+def test_mfsdp_native_fp32_fused_wgrad_reaches_optimizer_groups():
+    parallel = _dense_parallel_config()
+    ps = _parallel_state(parallel)
+    chunks = [_new_model(7319, TinyTEQwen3MoE)]
+    optimizer_config = _optimizer_cfg(use_fused_optimizer=False)
+    impl_cfg = SimpleNamespace(
+        parallel=parallel,
+        optimizer_config=optimizer_config,
+    )
+
+    def build_recording_optimizer(param_groups, _optimizer_config):
+        params = [param for group in param_groups for param in group["params"]]
+        assert len(params) == 5
+        return RecordingSGD(
+            [
+                {"params": params[::2], "weight_decay": 0.0},
+                {"params": params[1::2], "weight_decay": 0.0},
+            ]
+        )
+
+    optimizer, finalize = build_mfsdp_training_optimizer(
+        chunks,
+        impl_cfg=impl_cfg,
+        ps=ps,
+        is_expert=lambda name: ".expert." in name,
+        fsdp_unit_modules=(TinyTETransformerLayer,),
+        optimizer_factory=build_recording_optimizer,
+    )
+    chunk = chunks[0]
+    assert len(chunk.param_sync.buckets) == 5
+    assert len(optimizer.param_groups) == 2
+
+    optimizer.zero_grad()
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(8107 + dist.get_rank())
+    value = torch.randn(
+        64,
+        8,
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    chunk(value).float().square().mean().backward()
+
+    main_grad_by_shard = {}
+    for bucket in chunk.param_sync.buckets:
+        for spec in bucket.specs:
+            assert spec.shard_param is not None
+            assert spec.full_param.grad_added_to_main_grad is True
+            assert spec.full_param.main_grad.dtype is torch.float32
+            main_grad_by_shard[id(spec.shard_param)] = (
+                spec.full_param.main_grad.detach().clone()
+            )
+    main_grad_fractions = [
+        _bf16_roundtrip_difference_fraction(
+            [main_grad_by_shard[id(param)] for param in group["params"]]
+        )
+        for group in optimizer.param_groups
+    ]
+
+    finalize()
+    optimizer_grad_fractions = [
+        _bf16_roundtrip_difference_fraction(
+            [param.grad for param in group["params"] if param.grad is not None]
+        )
+        for group in optimizer.param_groups
+    ]
+    success, _grad_norm, _num_zeros = optimizer.step()
+    recording_optimizer = optimizer._inner_optimizer.optimizer
+    consumed_grad_fractions = [
+        _bf16_roundtrip_difference_fraction(group)
+        for group in recording_optimizer.consumed_grad_groups
+    ]
+
+    assert success
+    assert all(fraction > 0.0 for fraction in main_grad_fractions)
+    assert all(fraction > 0.0 for fraction in optimizer_grad_fractions)
+    assert all(fraction > 0.0 for fraction in consumed_grad_fractions)
+    if dist.get_rank() == 0:
+        print(
+            "[MFSDP_NATIVE_FP32_WGRAD] "
+            + json.dumps(
+                {
+                    "world_size": dist.get_world_size(),
+                    "bucket_count": len(chunk.param_sync.buckets),
+                    "optimizer_group_count": len(optimizer.param_groups),
+                    "main_grad_low_bit_fractions": main_grad_fractions,
+                    "optimizer_grad_low_bit_fractions": optimizer_grad_fractions,
+                    "consumed_grad_low_bit_fractions": consumed_grad_fractions,
+                },
+                sort_keys=True,
+            ),
+            flush=True,
+        )
 
 
 def test_mfsdp_precision_curve_matches_fsdp2():

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -176,6 +176,17 @@ class TinyTEGroupedMoE(nn.Module):
         return self.out(x)
 
 
+class TinyNonFusedLinear(nn.Module):
+    """Regular autograd linear covering M-FSDP's non-TE gradient path."""
+
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(4, 4, bias=False, dtype=torch.bfloat16)
+
+    def forward(self, x):
+        return self.linear(x)
+
+
 class RecordingSGD(torch.optim.SGD):
     def __init__(self, param_groups):
         super().__init__(param_groups, lr=0.0)
@@ -417,6 +428,11 @@ def _bf16_roundtrip_difference_fraction(tensors: list[torch.Tensor]) -> float:
     rounded = values.to(torch.bfloat16).to(torch.float32)
     assert not torch.equal(values, rounded)
     return float((values != rounded).float().mean().item())
+
+
+def _is_bf16_roundtrip_exact(tensor: torch.Tensor) -> bool:
+    values = tensor.detach().float()
+    return torch.equal(values, values.to(torch.bfloat16).to(torch.float32))
 
 
 def _memory_delta(
@@ -843,6 +859,7 @@ def test_mfsdp_native_fp32_fused_wgrad_reaches_optimizer_groups():
         for spec in bucket.specs:
             assert spec.shard_param is not None
             assert spec.full_param.grad_added_to_main_grad is True
+            assert spec.full_param.grad is None
             assert spec.full_param.main_grad.dtype is torch.float32
             main_grad_by_shard[id(spec.shard_param)] = (
                 spec.full_param.main_grad.detach().clone()
@@ -991,6 +1008,87 @@ def test_mfsdp_native_fp32_grouped_expert_wgrad_reaches_optimizer():
                     "main_grad_low_bit_fractions": main_grad_fractions,
                     "optimizer_grad_low_bit_fractions": optimizer_grad_fractions,
                     "consumed_grad_low_bit_fractions": consumed_grad_fractions,
+                },
+                sort_keys=True,
+            ),
+            flush=True,
+        )
+
+
+def test_mfsdp_non_fused_wgrad_accumulates_in_fp32_per_microbatch():
+    parallel = _dense_parallel_config()
+    ps = _parallel_state(parallel)
+    torch.manual_seed(10103)
+    torch.cuda.manual_seed_all(10103)
+    chunks = [TinyNonFusedLinear().cuda()]
+    optimizer_config = _optimizer_cfg(use_fused_optimizer=False)
+    impl_cfg = SimpleNamespace(
+        parallel=parallel,
+        optimizer_config=optimizer_config,
+    )
+
+    def build_recording_optimizer(param_groups, _optimizer_config):
+        return RecordingSGD(param_groups)
+
+    optimizer, finalize = build_mfsdp_training_optimizer(
+        chunks,
+        impl_cfg=impl_cfg,
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(TinyNonFusedLinear,),
+        optimizer_factory=build_recording_optimizer,
+    )
+    chunk = chunks[0]
+    assert not hasattr(chunk.linear, "fuse_wgrad_accumulation")
+    assert len(chunk.param_sync.buckets) == 1
+    spec = chunk.param_sync.buckets[0].specs[0]
+    assert spec.shard_param is not None
+    assert spec.full_param.grad_added_to_main_grad is False
+
+    optimizer.zero_grad()
+    chunk(torch.ones(1, 4, device="cuda", dtype=torch.bfloat16)).sum().backward()
+    single_backward_grad = spec.full_param.main_grad.detach().clone()
+    assert spec.full_param.grad is None
+    assert spec.full_param.main_grad.dtype is torch.float32
+    assert torch.equal(single_backward_grad, torch.ones(4, 4, device="cuda"))
+    assert _is_bf16_roundtrip_exact(single_backward_grad)
+
+    optimizer.zero_grad()
+    chunk(
+        torch.full((1, 4), 256.0, device="cuda", dtype=torch.bfloat16)
+    ).sum().backward()
+    assert spec.full_param.grad is None
+    assert torch.equal(
+        spec.full_param.main_grad,
+        torch.full((4, 4), 256.0, device="cuda"),
+    )
+    assert _is_bf16_roundtrip_exact(spec.full_param.main_grad)
+
+    chunk(torch.ones(1, 4, device="cuda", dtype=torch.bfloat16)).sum().backward()
+    expected = torch.full((4, 4), 257.0, device="cuda")
+    assert spec.full_param.grad is None
+    assert torch.equal(spec.full_param.main_grad, expected)
+    assert not _is_bf16_roundtrip_exact(spec.full_param.main_grad)
+
+    finalize()
+    expected_shard = expected.reshape(-1).chunk(dist.get_world_size())[dist.get_rank()]
+    assert spec.shard_param.grad is not None
+    assert spec.shard_param.grad.dtype is torch.float32
+    assert torch.equal(spec.shard_param.grad, expected_shard)
+    success, _grad_norm, _num_zeros = optimizer.step()
+    recording_optimizer = optimizer._inner_optimizer.optimizer
+    consumed_grad = recording_optimizer.consumed_grad_by_param[id(spec.shard_param)]
+    assert success
+    assert torch.equal(consumed_grad, expected_shard)
+    if dist.get_rank() == 0:
+        print(
+            "[MFSDP_NON_FUSED_FP32_ACCUMULATION] "
+            + json.dumps(
+                {
+                    "world_size": dist.get_world_size(),
+                    "single_backward_bf16_roundtrip_exact": True,
+                    "multi_microbatch_value": float(consumed_grad[0]),
+                    "multi_microbatch_bf16_roundtrip_exact": False,
                 },
                 sort_keys=True,
             ),

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -17,6 +17,7 @@ import torch.distributed as dist
 import torch.nn as nn
 from torch.utils._python_dispatch import TorchDispatchMode
 
+from megatron.lite.primitive.modules.experts import Experts
 from megatron.lite.primitive.optimizers.fsdp2 import (
     build_fsdp2_training_optimizer,
     fsdp2_available,
@@ -140,10 +141,46 @@ class TinyTEQwen3MoE(nn.Module):
         return self.out(x)
 
 
+class TinyTEGroupedExpertLayer(nn.Module):
+    def __init__(self, ps):
+        super().__init__()
+        config = SimpleNamespace(
+            num_experts=2,
+            hidden_size=8,
+            moe_intermediate_size=16,
+            swiglu_limit=0.0,
+        )
+        self.experts = Experts(config, ps)
+
+    def forward(self, x):
+        first_expert_tokens = x.shape[0] // 2
+        tokens_per_expert = torch.tensor(
+            [first_expert_tokens, x.shape[0] - first_expert_tokens],
+            device=x.device,
+            dtype=torch.int64,
+        )
+        return torch.tanh(self.experts(x, tokens_per_expert))
+
+
+class TinyTEGroupedMoE(nn.Module):
+    def __init__(self, ps):
+        super().__init__()
+        self.layers = nn.ModuleList(
+            [TinyTEGroupedExpertLayer(ps), TinyTEGroupedExpertLayer(ps)]
+        )
+        self.out = TinyTELinear(8, 4)
+
+    def forward(self, x):
+        for layer in self.layers:
+            x = layer(x)
+        return self.out(x)
+
+
 class RecordingSGD(torch.optim.SGD):
     def __init__(self, param_groups):
         super().__init__(param_groups, lr=0.0)
         self.consumed_grad_groups: list[list[torch.Tensor]] = []
+        self.consumed_grad_by_param: dict[int, torch.Tensor] = {}
 
     def step(self, closure=None):
         self.consumed_grad_groups = [
@@ -154,6 +191,12 @@ class RecordingSGD(torch.optim.SGD):
             ]
             for group in self.param_groups
         ]
+        self.consumed_grad_by_param = {
+            id(param): param.grad.detach().clone()
+            for group in self.param_groups
+            for param in group["params"]
+            if param.grad is not None
+        }
         return super().step(closure)
 
 
@@ -741,6 +784,16 @@ def _is_tiny_expert(name: str) -> bool:
     return name.startswith("experts.")
 
 
+def _grouped_expert_key(name: str) -> str | None:
+    layer_name, marker, parameter_name = name.partition("experts.")
+    if not marker:
+        return None
+    weight_name = parameter_name.rsplit(".", 1)[-1]
+    if not weight_name.startswith("weight") or not weight_name[6:].isdigit():
+        return None
+    return f"{layer_name}expert{weight_name[6:]}"
+
+
 def test_mfsdp_native_fp32_fused_wgrad_reaches_optimizer_groups():
     parallel = _dense_parallel_config()
     ps = _parallel_state(parallel)
@@ -827,6 +880,114 @@ def test_mfsdp_native_fp32_fused_wgrad_reaches_optimizer_groups():
                     "world_size": dist.get_world_size(),
                     "bucket_count": len(chunk.param_sync.buckets),
                     "optimizer_group_count": len(optimizer.param_groups),
+                    "main_grad_low_bit_fractions": main_grad_fractions,
+                    "optimizer_grad_low_bit_fractions": optimizer_grad_fractions,
+                    "consumed_grad_low_bit_fractions": consumed_grad_fractions,
+                },
+                sort_keys=True,
+            ),
+            flush=True,
+        )
+
+
+def test_mfsdp_native_fp32_grouped_expert_wgrad_reaches_optimizer():
+    parallel = _dense_parallel_config()
+    ps = _parallel_state(parallel)
+    torch.manual_seed(9127)
+    torch.cuda.manual_seed_all(9127)
+    chunks = [TinyTEGroupedMoE(ps).cuda().to(torch.bfloat16)]
+    optimizer_config = _optimizer_cfg(use_fused_optimizer=False)
+    impl_cfg = SimpleNamespace(
+        parallel=parallel,
+        optimizer_config=optimizer_config,
+    )
+
+    def build_recording_optimizer(param_groups, _optimizer_config):
+        params = [param for group in param_groups for param in group["params"]]
+        return RecordingSGD(
+            [{"params": [param], "weight_decay": 0.0} for param in params]
+        )
+
+    optimizer, finalize = build_mfsdp_training_optimizer(
+        chunks,
+        impl_cfg=impl_cfg,
+        ps=ps,
+        is_expert=lambda name: "experts." in name,
+        fsdp_unit_modules=(TinyTEGroupedExpertLayer,),
+        optimizer_factory=build_recording_optimizer,
+    )
+    chunk = chunks[0]
+    grouped_linear_modules = [
+        module for module in chunk.modules() if type(module).__name__ == "GroupedLinear"
+    ]
+    assert len(grouped_linear_modules) == 4
+    assert all(module.fuse_wgrad_accumulation for module in grouped_linear_modules)
+
+    expert_specs = {}
+    for bucket in chunk.param_sync.buckets:
+        for spec in bucket.specs:
+            expert_key = _grouped_expert_key(spec.name)
+            if expert_key is not None:
+                expert_specs.setdefault(expert_key, []).append(spec)
+    assert len(expert_specs) == 4
+    assert all(len(specs) == 2 for specs in expert_specs.values())
+
+    optimizer.zero_grad()
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(9131 + dist.get_rank())
+    value = torch.randn(
+        64,
+        8,
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    chunk(value).float().square().mean().backward()
+
+    main_grad_fractions = {}
+    for expert_key, specs in expert_specs.items():
+        main_grads = []
+        for spec in specs:
+            assert spec.shard_param is not None
+            assert spec.full_param.grad_added_to_main_grad is True
+            assert spec.full_param.main_grad.dtype is torch.float32
+            assert spec.full_param.grad is None
+            main_grads.append(spec.full_param.main_grad)
+        main_grad_fractions[expert_key] = _bf16_roundtrip_difference_fraction(
+            main_grads
+        )
+
+    finalize()
+    optimizer_grad_fractions = {
+        expert_key: _bf16_roundtrip_difference_fraction(
+            [spec.shard_param.grad for spec in specs]
+        )
+        for expert_key, specs in expert_specs.items()
+    }
+    success, _grad_norm, _num_zeros = optimizer.step()
+    recording_optimizer = optimizer._inner_optimizer.optimizer
+    consumed_grad_fractions = {
+        expert_key: _bf16_roundtrip_difference_fraction(
+            [
+                recording_optimizer.consumed_grad_by_param[id(spec.shard_param)]
+                for spec in specs
+            ]
+        )
+        for expert_key, specs in expert_specs.items()
+    }
+
+    assert success
+    assert all(fraction > 0.0 for fraction in main_grad_fractions.values())
+    assert all(fraction > 0.0 for fraction in optimizer_grad_fractions.values())
+    assert all(fraction > 0.0 for fraction in consumed_grad_fractions.values())
+    if dist.get_rank() == 0:
+        print(
+            "[MFSDP_NATIVE_FP32_GROUPED_EXPERT_WGRAD] "
+            + json.dumps(
+                {
+                    "world_size": dist.get_world_size(),
+                    "expert_group_count": len(expert_specs),
+                    "grouped_linear_count": len(grouped_linear_modules),
                     "main_grad_low_bit_fractions": main_grad_fractions,
                     "optimizer_grad_low_bit_fractions": optimizer_grad_fractions,
                     "consumed_grad_low_bit_fractions": consumed_grad_fractions,

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -1020,7 +1020,9 @@ def test_mfsdp_non_fused_wgrad_accumulates_in_fp32_per_microbatch():
     ps = _parallel_state(parallel)
     torch.manual_seed(10103)
     torch.cuda.manual_seed_all(10103)
-    chunks = [TinyNonFusedLinear().cuda()]
+    model = TinyNonFusedLinear().cuda()
+    assert not hasattr(model.linear, "fuse_wgrad_accumulation")
+    chunks = [model]
     optimizer_config = _optimizer_cfg(use_fused_optimizer=False)
     impl_cfg = SimpleNamespace(
         parallel=parallel,
@@ -1039,7 +1041,6 @@ def test_mfsdp_non_fused_wgrad_accumulates_in_fp32_per_microbatch():
         optimizer_factory=build_recording_optimizer,
     )
     chunk = chunks[0]
-    assert not hasattr(chunk.linear, "fuse_wgrad_accumulation")
     assert len(chunk.param_sync.buckets) == 1
     spec = chunk.param_sync.buckets[0].specs[0]
     assert spec.shard_param is not None

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -64,8 +64,11 @@ class _FusedMainGradLinearFunction(torch.autograd.Function):
     def backward(ctx, grad_output):
         value, weight = ctx.saved_tensors
         grad_input = grad_output.matmul(weight)
-        grad_weight = grad_output.float().reshape(-1, grad_output.shape[-1]).t().matmul(
-            value.float().reshape(-1, value.shape[-1])
+        grad_weight = (
+            grad_output.float()
+            .reshape(-1, grad_output.shape[-1])
+            .t()
+            .matmul(value.float().reshape(-1, value.shape[-1]))
         )
         if ctx.fuse_wgrad_accumulation:
             ctx.weight.main_grad.add_(grad_weight)
@@ -1490,6 +1493,7 @@ def test_mfsdp_routes_fused_wgrad_through_bucketed_fp32_main_grad():
     spec = bucket.specs[0]
     assert model.fuse_wgrad_accumulation is True
     assert spec.full_param.grad_added_to_main_grad is True
+    assert spec.full_param.grad is None
     assert spec.full_param.main_grad.dtype is torch.float32
     assert spec.full_param.main_grad.untyped_storage().data_ptr() == (
         bucket.full_main_grad_buffer.untyped_storage().data_ptr()
@@ -1503,6 +1507,7 @@ def test_mfsdp_routes_fused_wgrad_through_bucketed_fp32_main_grad():
 
     second_value = torch.randn(8, 4, dtype=torch.bfloat16)
     chunk(second_value).float().sum().backward()
+    assert spec.full_param.grad is None
     second_expected = second_value.float().sum(dim=0).repeat(4, 1)
     assert spec.full_param.main_grad.untyped_storage().data_ptr() == main_grad_storage
     assert torch.equal(spec.full_param.main_grad, first_main_grad + second_expected)

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -52,6 +52,44 @@ class _DirectParamModel(torch.nn.Module):
         return torch.nn.functional.linear(hidden, self.projection.weight)
 
 
+class _FusedMainGradLinearFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, value, weight, fuse_wgrad_accumulation):
+        ctx.save_for_backward(value, weight)
+        ctx.weight = weight
+        ctx.fuse_wgrad_accumulation = fuse_wgrad_accumulation
+        return torch.nn.functional.linear(value, weight)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        value, weight = ctx.saved_tensors
+        grad_input = grad_output.matmul(weight)
+        grad_weight = grad_output.float().reshape(-1, grad_output.shape[-1]).t().matmul(
+            value.float().reshape(-1, value.shape[-1])
+        )
+        if ctx.fuse_wgrad_accumulation:
+            ctx.weight.main_grad.add_(grad_weight)
+            ctx.weight.grad_added_to_main_grad = True
+            grad_weight = torch.zeros_like(weight)
+        return grad_input, grad_weight, None
+
+
+class _FusedMainGradLinear(torch.nn.Module):
+    """CPU stand-in for TE's dynamic ``weight.main_grad`` backward contract."""
+
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.randn(4, 4, dtype=torch.bfloat16))
+        self.fuse_wgrad_accumulation = False
+
+    def forward(self, value):
+        return _FusedMainGradLinearFunction.apply(
+            value,
+            self.weight,
+            self.fuse_wgrad_accumulation,
+        )
+
+
 def _optimizer_params(optimizer) -> list[torch.nn.Parameter]:
     return optimizer._inner_optimizer.params
 
@@ -1410,6 +1448,93 @@ def test_mfsdp_keeps_fp32_shards_for_bfloat16_compute_parameters():
     assert all(param.dtype is torch.float32 for param in optimizer_params)
     assert any(not torch.equal(old, new) for old, new in zip(before, optimizer_params))
     assert torch.isfinite(chunks[0](value).float()).all()
+
+
+def test_mfsdp_routes_fused_wgrad_through_bucketed_fp32_main_grad():
+    model = _FusedMainGradLinear()
+    ps = SimpleNamespace(
+        dp_cp_group=None,
+        dp_group=None,
+        ep_dp_group=None,
+        ep_group=None,
+        etp_group=None,
+        tp_group=None,
+        pp_group=None,
+        dp_cp_size=1,
+        expert_dp_size=1,
+    )
+    opt = SimpleNamespace(
+        optimizer="sgd",
+        lr=0.0,
+        weight_decay=0.0,
+        clip_grad=0.0,
+        override_optimizer_config={"mfsdp_sharding_strategy": "optim_grads_params"},
+    )
+    chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [model],
+        engine_cfg=SimpleNamespace(
+            parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1),
+            optimizer=opt,
+        ),
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_FusedMainGradLinear,),
+    )
+
+    chunk = chunks[0]
+    bucket = chunk.param_sync.buckets[0]
+    optimizer.zero_grad()
+    value = torch.randn(8, 4, dtype=torch.bfloat16)
+    chunk(value).float().sum().backward()
+
+    spec = bucket.specs[0]
+    assert model.fuse_wgrad_accumulation is True
+    assert spec.full_param.grad_added_to_main_grad is True
+    assert spec.full_param.main_grad.dtype is torch.float32
+    assert spec.full_param.main_grad.untyped_storage().data_ptr() == (
+        bucket.full_main_grad_buffer.untyped_storage().data_ptr()
+    )
+    assert not torch.equal(
+        spec.full_param.main_grad,
+        spec.full_param.main_grad.to(torch.bfloat16).to(torch.float32),
+    )
+    first_main_grad = spec.full_param.main_grad.detach().clone()
+    main_grad_storage = spec.full_param.main_grad.untyped_storage().data_ptr()
+
+    second_value = torch.randn(8, 4, dtype=torch.bfloat16)
+    chunk(second_value).float().sum().backward()
+    second_expected = second_value.float().sum(dim=0).repeat(4, 1)
+    assert spec.full_param.main_grad.untyped_storage().data_ptr() == main_grad_storage
+    assert torch.equal(spec.full_param.main_grad, first_main_grad + second_expected)
+    expected_main_grad = spec.full_param.main_grad.detach().reshape(-1).clone()
+
+    optimizer.finish_grad_sync()
+    consumed_grad = _optimizer_params(optimizer)[0].grad
+    assert consumed_grad is not None
+    assert consumed_grad.dtype is torch.float32
+    assert torch.equal(consumed_grad, expected_main_grad)
+    assert not torch.equal(
+        consumed_grad,
+        consumed_grad.to(torch.bfloat16).to(torch.float32),
+    )
+
+
+def test_mfsdp_keeps_regular_autograd_grad_as_main_grad_fallback():
+    chunk, optimizer = _single_rank_mfsdp_stack()
+    optimizer.zero_grad()
+    value = torch.randn(3, 4)
+    chunk(value).square().mean().backward()
+    expected = {
+        spec.name: spec.full_param.grad.detach().float().clone()
+        for bucket in chunk.param_sync.buckets
+        for spec in bucket.specs
+    }
+
+    optimizer.finish_grad_sync()
+
+    for name, shard in _optimizer_named_shards(optimizer).items():
+        assert shard.grad is not None
+        assert torch.equal(shard.grad.reshape(-1), expected[name].reshape(-1))
 
 
 def _run_mfsdp_gloo_parity(rank: int, world_size: int, init_file: str) -> None:

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -93,6 +93,17 @@ class _FusedMainGradLinear(torch.nn.Module):
         )
 
 
+class _RegularMainGradLinear(torch.nn.Module):
+    """Non-TE linear used to exercise the autograd gradient fallback."""
+
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.ones(4, 4, dtype=torch.bfloat16))
+
+    def forward(self, value):
+        return torch.nn.functional.linear(value, self.weight)
+
+
 def _optimizer_params(optimizer) -> list[torch.nn.Parameter]:
     return optimizer._inner_optimizer.params
 
@@ -1524,22 +1535,82 @@ def test_mfsdp_routes_fused_wgrad_through_bucketed_fp32_main_grad():
     )
 
 
-def test_mfsdp_keeps_regular_autograd_grad_as_main_grad_fallback():
+def test_mfsdp_routes_regular_autograd_grad_through_fp32_main_grad():
     chunk, optimizer = _single_rank_mfsdp_stack()
     optimizer.zero_grad()
     value = torch.randn(3, 4)
     chunk(value).square().mean().backward()
     expected = {
-        spec.name: spec.full_param.grad.detach().float().clone()
+        spec.name: spec.full_param.main_grad.detach().clone()
         for bucket in chunk.param_sync.buckets
         for spec in bucket.specs
     }
+    for bucket in chunk.param_sync.buckets:
+        for spec in bucket.specs:
+            assert spec.full_param.grad is None
+            assert spec.full_param.main_grad.dtype is torch.float32
 
     optimizer.finish_grad_sync()
 
     for name, shard in _optimizer_named_shards(optimizer).items():
         assert shard.grad is not None
         assert torch.equal(shard.grad.reshape(-1), expected[name].reshape(-1))
+
+
+def test_mfsdp_accumulates_regular_wgrad_in_fp32_per_microbatch():
+    model = _RegularMainGradLinear()
+    ps = SimpleNamespace(
+        dp_cp_group=None,
+        dp_group=None,
+        ep_dp_group=None,
+        ep_group=None,
+        etp_group=None,
+        tp_group=None,
+        pp_group=None,
+        dp_cp_size=1,
+        expert_dp_size=1,
+    )
+    opt = SimpleNamespace(
+        optimizer="sgd",
+        lr=0.0,
+        weight_decay=0.0,
+        clip_grad=0.0,
+        override_optimizer_config={"mfsdp_sharding_strategy": "optim_grads_params"},
+    )
+    chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [model],
+        engine_cfg=SimpleNamespace(
+            parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1),
+            optimizer=opt,
+        ),
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_RegularMainGradLinear,),
+    )
+
+    chunk = chunks[0]
+    bucket = chunk.param_sync.buckets[0]
+    spec = bucket.specs[0]
+    optimizer.zero_grad()
+
+    chunk(torch.full((1, 4), 256.0, dtype=torch.bfloat16)).sum().backward()
+    assert spec.full_param.grad is None
+    assert torch.equal(spec.full_param.main_grad, torch.full((4, 4), 256.0))
+
+    chunk(torch.ones(1, 4, dtype=torch.bfloat16)).sum().backward()
+    assert spec.full_param.grad is None
+    expected = torch.full((4, 4), 257.0)
+    assert torch.equal(spec.full_param.main_grad, expected)
+    assert not torch.equal(
+        spec.full_param.main_grad,
+        spec.full_param.main_grad.to(torch.bfloat16).to(torch.float32),
+    )
+
+    optimizer.finish_grad_sync()
+    consumed_grad = _optimizer_params(optimizer)[0].grad
+    assert consumed_grad is not None
+    assert consumed_grad.dtype is torch.float32
+    assert torch.equal(consumed_grad, expected.reshape(-1))
 
 
 def _run_mfsdp_gloo_parity(rank: int, world_size: int, init_file: str) -> None:


### PR DESCRIPTION
## Summary

This PR is stacked on #89 and must merge after it. Its diff is intentionally limited to native FP32 gradient accumulation:

- attach bucket-scoped FP32 `param.main_grad` views for Transformer Engine fused wgrad GEMMs
- enable `fuse_wgrad_accumulation` only within the M-FSDP ownership boundary
- accumulate non-fused autograd gradients into `main_grad` after every backward and clear the BF16 `.grad` before the next microbatch
- reduce from `main_grad` for both fused and non-fused parameters, including when the communication dtype differs from the main-gradient dtype
- discard Transformer Engine's dummy BF16 `.grad` after it signals fused-wgrad readiness
- release the full-gradient lease after reduction and cover both fused and fallback paths with contract tests

This keeps custom Linear implementations unchanged while preventing cross-microbatch accumulation in BF16. It addresses the accumulation gap documented in #153. It does not address the existing host-memory, optimizer-offload, or repeated-forward issues tracked separately for #89.

## Validation

- Full M-FSDP CPU unit suite: 42 passed, including the two-rank Gloo parity test
- Non-fused microbatch regression: BF16 per-backward gradients of 256 and 1 accumulated to exactly 257 in FP32 `main_grad`; a BF16 round trip produces 256, proving the low bit would otherwise be lost
- Focused CPU contracts cover both native fused-wgrad routing and regular-autograd FP32 fallback
- Post-fallback real two-GPU Transformer Engine Linear smoke at `0b0952fe923e0692dc4def02153a449e96308eb2`: both ranks reported 2 passed with no skips ([W&B run](https://wandb.ai/megatron-core-moe-dev/mlite-mfsdp-validation/runs/cwr3a581))
- The Linear smoke covered 5 M-FSDP buckets and 2 optimizer parameter groups. For every group, the fraction of values not preserved by a BF16 round trip was exactly 1.0 for `main_grad`, the optimizer-visible reduced gradient, and the exact gradient tensor consumed by `optimizer.step()`; fused parameters had `grad_added_to_main_grad=True` and no retained `.grad`
- Post-fallback real two-GPU Transformer Engine GroupedLinear smoke at the same commit: both ranks reported 2 passed with no skips ([W&B run](https://wandb.ai/megatron-core-moe-dev/mlite-mfsdp-validation/runs/4y9siyw5))
- The production `Experts` primitive exercised 4 GroupedLinear modules across 2 layers and 2 local experts. For all 4 layer/expert groups, the BF16-round-trip difference fraction was exactly 1.0 for `main_grad`, the optimizer-visible reduced gradient, and the tensor consumed by `optimizer.step()`; fused parameters had `grad_added_to_main_grad=True` and no retained `.grad`
- Both GPU jobs also exercised a regular non-fused `nn.Linear`: one backward produced a gradient exactly representable after a BF16 round trip, while two microbatches of 256 and 1 accumulated to exactly 257.0 in FP32 `main_grad`, were not preserved by a BF16 round trip, and remained exactly 257.0 in both the reduced shard and the tensor consumed by `optimizer.step()`
- GPU environment: Torch 2.11.0, Transformer Engine 2.15.0, NCCL 2.30.7
- Ruff 0.15.17 format/check, focused Python compilation, and `git diff --check` passed

The broader local primitive validation entrypoint could not collect because that environment lacks optional Transformer Engine and VERL dependencies; the real TE paths above were therefore run in the project GPU container rather than reported as local passes.
