### PR TITLE
Align Lite isort and Black formatting

### DIFF
--- a/experimental/lite/.pre-commit-config.yaml
+++ b/experimental/lite/.pre-commit-config.yaml
@@ -7,10 +7,12 @@ repos:
     language: python
     additional_dependencies: ["isort==5.13.2"]
     files: ^experimental/lite/.*\.py$
+    require_serial: true
   - id: black
     name: black
     entry: black
     language: python
     additional_dependencies: ["black==24.4.2"]
     files: ^experimental/lite/.*\.py$
-    args: ["--skip-magic-trailing-comma", "--skip-string-normalization"]
+    require_serial: true
+    args: ["--skip-magic-trailing-comma", "--skip-string-normalization", "--workers", "1"]

--- a/experimental/lite/examples/bench/bench.py
+++ b/experimental/lite/examples/bench/bench.py
@@ -79,7 +79,9 @@ def _json_mapping(raw: str, *, name: str) -> dict[str, Any]:
 
 
 def _parallel_config(cfg: BenchCliConfig) -> ParallelConfig:
-    return ParallelConfig(tp=cfg.tp, etp=cfg.etp, ep=cfg.ep, pp=cfg.pp, vpp=cfg.vpp, cp=cfg.cp)
+    return ParallelConfig(
+        tp=cfg.tp, etp=cfg.etp, ep=cfg.ep, pp=cfg.pp, vpp=cfg.vpp, cp=cfg.cp
+    )
 
 
 def _optimizer_config(cfg: BenchCliConfig) -> OptimizerConfig:
@@ -142,11 +144,17 @@ def _make_mlite_model_config_hook(cfg: BenchCliConfig):
             old_num = getattr(model_cfg, "num_experts", None)
             old_topk = getattr(model_cfg, "num_experts_per_tok", None)
             if old_num is None or old_topk is None:
-                raise ValueError("keep_experts requires model config with MoE expert metadata.")
+                raise ValueError(
+                    "keep_experts requires model config with MoE expert metadata."
+                )
             if keep_experts <= 0 or keep_experts > old_num:
-                raise ValueError(f"keep_experts must be in [1, {old_num}], got {keep_experts}.")
+                raise ValueError(
+                    f"keep_experts must be in [1, {old_num}], got {keep_experts}."
+                )
             return replace(
-                model_cfg, num_experts=keep_experts, num_experts_per_tok=min(old_topk, keep_experts)
+                model_cfg,
+                num_experts=keep_experts,
+                num_experts_per_tok=min(old_topk, keep_experts),
             )
 
         hooks.append(keep_experts_hook)
@@ -195,9 +203,13 @@ def _make_bridge_post_init_hook(cfg: BenchCliConfig):
             old_num = getattr(hf_cfg, "num_experts", None)
             old_topk = getattr(hf_cfg, "num_experts_per_tok", None)
             if old_num is None or old_topk is None:
-                raise ValueError("keep_experts requires HF config with MoE expert metadata.")
+                raise ValueError(
+                    "keep_experts requires HF config with MoE expert metadata."
+                )
             if keep_experts <= 0 or keep_experts > old_num:
-                raise ValueError(f"keep_experts must be in [1, {old_num}], got {keep_experts}.")
+                raise ValueError(
+                    f"keep_experts must be in [1, {old_num}], got {keep_experts}."
+                )
             hf_cfg.num_experts = keep_experts
             hf_cfg.num_experts_per_tok = min(old_topk, keep_experts)
             _refresh_bridge_config(bridge)
@@ -221,7 +233,9 @@ def _make_bridge_post_init_hook(cfg: BenchCliConfig):
             hf_cfg = _get_bridge_config_root(bridge)
             old_layers = getattr(hf_cfg, "num_hidden_layers", None)
             if old_layers is None:
-                raise ValueError("truncate_layers requires HF config with num_hidden_layers.")
+                raise ValueError(
+                    "truncate_layers requires HF config with num_hidden_layers."
+                )
             if keep_layers <= 0 or keep_layers > old_layers:
                 raise ValueError(
                     f"truncate_layers must be in [1, {old_layers}], got {keep_layers}."
@@ -259,7 +273,9 @@ def _make_bridge_post_init_hook(cfg: BenchCliConfig):
 def build_runtime_config(cfg: BenchCliConfig) -> RuntimeConfig:
     parallel = _parallel_config(cfg)
     optimizer = _optimizer_config(cfg)
-    optimizer_overrides = _json_mapping(cfg.override_optimizer_json, name="override_optimizer_json")
+    optimizer_overrides = _json_mapping(
+        cfg.override_optimizer_json, name="override_optimizer_json"
+    )
 
     if cfg.backend == "mlite":
         for key, value in optimizer_overrides.items():
@@ -292,7 +308,9 @@ def build_runtime_config(cfg: BenchCliConfig) -> RuntimeConfig:
             use_thd=cfg.use_thd,
             load_hf_weights=not cfg.skip_load_hf_weights,
             build_optimizer=not cfg.skip_optimizer_build,
-            override_ddp_config=_json_mapping(cfg.override_ddp_json, name="override_ddp_json"),
+            override_ddp_config=_json_mapping(
+                cfg.override_ddp_json, name="override_ddp_json"
+            ),
             override_transformer_config=_json_mapping(
                 cfg.override_transformer_json, name="override_transformer_json"
             ),
@@ -300,9 +318,13 @@ def build_runtime_config(cfg: BenchCliConfig) -> RuntimeConfig:
             bridge_post_init=_make_bridge_post_init_hook(cfg),
         )
     else:
-        raise ValueError(f"backend must be 'mlite', 'bridge', or 'mbridge', got {cfg.backend!r}.")
+        raise ValueError(
+            f"backend must be 'mlite', 'bridge', or 'mbridge', got {cfg.backend!r}."
+        )
 
-    return RuntimeConfig(backend=cfg.backend, hf_path=cfg.hf_path, backend_cfg=backend_cfg)
+    return RuntimeConfig(
+        backend=cfg.backend, hf_path=cfg.hf_path, backend_cfg=backend_cfg
+    )
 
 
 def build_session_config(cfg: BenchCliConfig) -> PretrainSessionConfig:
@@ -321,7 +343,10 @@ def build_session_config(cfg: BenchCliConfig) -> PretrainSessionConfig:
 
 def _to_jsonable(value: Any) -> Any:
     if is_dataclass(value):
-        return {field.name: _to_jsonable(getattr(value, field.name)) for field in fields(value)}
+        return {
+            field.name: _to_jsonable(getattr(value, field.name))
+            for field in fields(value)
+        }
     if isinstance(value, dict):
         return {str(k): _to_jsonable(v) for k, v in value.items()}
     if isinstance(value, (list, tuple)):
@@ -386,7 +411,9 @@ def run(cfg: BenchCliConfig) -> dict[str, Any]:
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--backend", choices=["mlite", "bridge", "mbridge"], default="mlite")
+    parser.add_argument(
+        "--backend", choices=["mlite", "bridge", "mbridge"], default="mlite"
+    )
     parser.add_argument("--hf-path", default="")
     parser.add_argument("--model-name", default="qwen3_moe")
     parser.add_argument("--impl", default="lite")

--- a/experimental/lite/examples/bench/correctness.py
+++ b/experimental/lite/examples/bench/correctness.py
@@ -22,12 +22,15 @@ if str(_EXPERIMENTAL_LITE_ROOT) not in sys.path:
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(1, str(_REPO_ROOT))
 
-from megatron.lite.primitive.deterministic import set_deterministic
-from megatron.lite.runtime import create_runtime
-
-from examples.bench.bench import BenchCliConfig, build_runtime_config, build_session_config
+from examples.bench.bench import (
+    BenchCliConfig,
+    build_runtime_config,
+    build_session_config,
+)
 from examples.bench.results import compare_correctness_artifacts, load_result_artifact
 from examples.bench.session import _make_data_iter
+from megatron.lite.primitive.deterministic import set_deterministic
+from megatron.lite.runtime import create_runtime
 
 
 def _distributed_rank() -> int:
@@ -145,7 +148,9 @@ def _resolve_probe_module(modules: dict[str, Any], name: str) -> tuple[str, Any]
 
 
 @contextmanager
-def _activation_probe_context(handle, probe_names: list[str], *, record_grad: bool = False):
+def _activation_probe_context(
+    handle, probe_names: list[str], *, record_grad: bool = False
+):
     records: list[dict[str, Any]] = []
     hooks = []
     tensor_hooks = []
@@ -182,12 +187,18 @@ def _activation_probe_context(handle, probe_names: list[str], *, record_grad: bo
                         record_grad=record_grad,
                         tensor_hooks=tensor_hooks,
                     )
-                    records[-1]["resolved_name"] = f"{_resolved_name}::{_method_name}:input"
+                    records[-1][
+                        "resolved_name"
+                    ] = f"{_resolved_name}::{_method_name}:input"
                     records[-1]["module_type"] = _module_type
                     return _original(*args, **kwargs)
                 output = _original(*args, **kwargs)
                 _record_activation_probe(
-                    records, _probe_name, output, record_grad=record_grad, tensor_hooks=tensor_hooks
+                    records,
+                    _probe_name,
+                    output,
+                    record_grad=record_grad,
+                    tensor_hooks=tensor_hooks,
                 )
                 records[-1]["resolved_name"] = f"{_resolved_name}::{_method_name}"
                 records[-1]["module_type"] = _module_type
@@ -205,9 +216,15 @@ def _activation_probe_context(handle, probe_names: list[str], *, record_grad: bo
 
         if record_input:
 
-            def _pre_hook(_module, args, probe_name=name, resolved_probe_name=resolved_name):
+            def _pre_hook(
+                _module, args, probe_name=name, resolved_probe_name=resolved_name
+            ):
                 _record_activation_probe(
-                    records, probe_name, args, record_grad=record_grad, tensor_hooks=tensor_hooks
+                    records,
+                    probe_name,
+                    args,
+                    record_grad=record_grad,
+                    tensor_hooks=tensor_hooks,
                 )
                 records[-1]["resolved_name"] = f"{resolved_probe_name}:input"
                 records[-1]["module_type"] = (
@@ -217,12 +234,20 @@ def _activation_probe_context(handle, probe_names: list[str], *, record_grad: bo
             hooks.append(module.register_forward_pre_hook(_pre_hook))
             continue
 
-        def _hook(_module, _args, output, probe_name=name, resolved_probe_name=resolved_name):
+        def _hook(
+            _module, _args, output, probe_name=name, resolved_probe_name=resolved_name
+        ):
             _record_activation_probe(
-                records, probe_name, output, record_grad=record_grad, tensor_hooks=tensor_hooks
+                records,
+                probe_name,
+                output,
+                record_grad=record_grad,
+                tensor_hooks=tensor_hooks,
             )
             records[-1]["resolved_name"] = resolved_probe_name
-            records[-1]["module_type"] = type(_module).__module__ + "." + type(_module).__qualname__
+            records[-1]["module_type"] = (
+                type(_module).__module__ + "." + type(_module).__qualname__
+            )
 
         hooks.append(module.register_forward_hook(_hook))
     try:
@@ -306,14 +331,14 @@ def _weight_fingerprint(rt, handle) -> dict[str, Any]:
 
 def _forward_logits(rt, handle, batch: Any) -> torch.Tensor | None:
     result = rt.forward_backward(
-        handle,
-        iter([batch]),
-        loss_fn=None,
-        num_microbatches=1,
-        forward_only=True,
+        handle, iter([batch]), loss_fn=None, num_microbatches=1, forward_only=True
     )
     output = result.model_output
-    return output.vocab_parallel_logits if output.vocab_parallel_logits is not None else (-output.log_probs if output.log_probs is not None else None)
+    return (
+        output.vocab_parallel_logits
+        if output.vocab_parallel_logits is not None
+        else (-output.log_probs if output.log_probs is not None else None)
+    )
 
 
 def run_backend(
@@ -347,11 +372,18 @@ def run_backend(
                 rt.zero_grad(handle)
                 _sync(session_cfg.device)
                 result = rt.forward_backward(
-                    handle, data_iter, loss_fn=None, num_microbatches=session_cfg.num_microbatches
+                    handle,
+                    data_iter,
+                    loss_fn=None,
+                    num_microbatches=session_cfg.num_microbatches,
                 )
                 _sync(session_cfg.device)
                 output = result.model_output
-                logits = _hash_tensor(output.vocab_parallel_logits if output.vocab_parallel_logits is not None else (-output.log_probs if output.log_probs is not None else None))
+                logits = _hash_tensor(
+                    output.vocab_parallel_logits
+                    if output.vocab_parallel_logits is not None
+                    else (-output.log_probs if output.log_probs is not None else None)
+                )
                 grads = _grad_fingerprint(handle)
 
                 if session_cfg.no_optimizer:
@@ -373,7 +405,9 @@ def run_backend(
                     "grad_norm": _scalar(grad_norm),
                     "update_successful": bool(update_successful),
                     "num_zeros": None if num_zeros is None else int(num_zeros),
-                    "post_step_weights": _weight_fingerprint(rt, handle) if hash_weights else None,
+                    "post_step_weights": (
+                        _weight_fingerprint(rt, handle) if hash_weights else None
+                    ),
                     "train_activation_probes": train_activation_probes,
                 }
             )
@@ -398,7 +432,9 @@ def run_backend(
 
 
 def _add_run_args(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument("--backend", choices=["mlite", "bridge", "mbridge"], required=True)
+    parser.add_argument(
+        "--backend", choices=["mlite", "bridge", "mbridge"], required=True
+    )
     parser.add_argument("--hf-path", required=True)
     parser.add_argument("--model-name", default="qwen3_5")
     parser.add_argument("--impl", default="lite")
@@ -441,15 +477,21 @@ def _activation_probe_names(raw: str, backend: str) -> list[str]:
     if isinstance(value, dict):
         selected = value.get(backend, [])
         if not isinstance(selected, list):
-            raise ValueError(f"activation probe list for {backend!r} must be a JSON list.")
+            raise ValueError(
+                f"activation probe list for {backend!r} must be a JSON list."
+            )
         return [str(item) for item in selected]
-    raise ValueError("activation_probes_json must be a JSON list or backend-to-list mapping.")
+    raise ValueError(
+        "activation_probes_json must be a JSON list or backend-to-list mapping."
+    )
 
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     sub = parser.add_subparsers(dest="command", required=True)
-    run_p = sub.add_parser("run", help="run one backend and write a correctness artifact")
+    run_p = sub.add_parser(
+        "run", help="run one backend and write a correctness artifact"
+    )
     _add_run_args(run_p)
 
     cmp_p = sub.add_parser("compare", help="strictly compare two correctness artifacts")
@@ -488,12 +530,18 @@ def main(argv: list[str] | None = None) -> dict[str, Any]:
         return result
 
     cfg = BenchCliConfig(
-        **{k: v for k, v in vars(ns).items() if k in BenchCliConfig.__dataclass_fields__}
+        **{
+            k: v
+            for k, v in vars(ns).items()
+            if k in BenchCliConfig.__dataclass_fields__
+        }
     )
     artifact = run_backend(
         cfg,
         hash_weights=not ns.skip_weight_hash,
-        activation_probe_names=_activation_probe_names(ns.activation_probes_json, cfg.backend),
+        activation_probe_names=_activation_probe_names(
+            ns.activation_probes_json, cfg.backend
+        ),
     )
     if _distributed_rank() == 0:
         text = json.dumps(artifact, indent=2, sort_keys=True)

--- a/experimental/lite/examples/bench/results.py
+++ b/experimental/lite/examples/bench/results.py
@@ -128,7 +128,11 @@ def result_summary(artifact: dict[str, Any]) -> dict[str, Any]:
 
 
 def compare_step_traces(
-    baseline: dict[str, Any], candidate: dict[str, Any], *, atol: float = 1e-4, rtol: float = 1e-4
+    baseline: dict[str, Any],
+    candidate: dict[str, Any],
+    *,
+    atol: float = 1e-4,
+    rtol: float = 1e-4,
 ) -> dict[str, Any]:
     """Compare loss and grad-norm traces from two benchmark artifacts."""
     base_steps = baseline.get("result", {}).get("step_traces", [])
@@ -145,12 +149,16 @@ def compare_step_traces(
         )
 
     lengths_match = sample_count == len(base_steps) == len(cand_steps)
-    loss_ref_max = max([abs(float(step["loss"])) for step in base_steps[:sample_count]] + [0.0])
+    loss_ref_max = max(
+        [abs(float(step["loss"])) for step in base_steps[:sample_count]] + [0.0]
+    )
     grad_norm_ref_max = max(
         [abs(float(step["grad_norm"])) for step in base_steps[:sample_count]] + [0.0]
     )
     loss_passed = lengths_match and max_loss_abs <= atol + rtol * loss_ref_max
-    grad_norm_passed = lengths_match and max_grad_norm_abs <= atol + rtol * grad_norm_ref_max
+    grad_norm_passed = (
+        lengths_match and max_grad_norm_abs <= atol + rtol * grad_norm_ref_max
+    )
 
     return {
         "samples": sample_count,
@@ -225,7 +233,9 @@ def compare_correctness_artifacts(
         base = base_steps[idx]
         cand = cand_steps[idx]
         loss_abs = abs(float(base["loss"]["value"]) - float(cand["loss"]["value"]))
-        grad_abs = abs(float(base["grad_norm"]["value"]) - float(cand["grad_norm"]["value"]))
+        grad_abs = abs(
+            float(base["grad_norm"]["value"]) - float(cand["grad_norm"]["value"])
+        )
         if math.isfinite(loss_abs):
             max_loss_abs = max(max_loss_abs, loss_abs)
         if math.isfinite(grad_abs):

--- a/experimental/lite/examples/bench/session.py
+++ b/experimental/lite/examples/bench/session.py
@@ -65,9 +65,7 @@ def _resolve_vocab_size(handle: ModelHandle) -> int:
     return 151936
 
 
-def _infinite_packed_batches(
-    vocab_size: int, seq_len: int, *, device: str, seed: int
-):
+def _infinite_packed_batches(vocab_size: int, seq_len: int, *, device: str, seed: int):
     """Yield raw, model-agnostic :class:`PackedBatch` objects for the bench.
 
     The bench is the single source of truth for one unpadded packed batch (1-D
@@ -82,7 +80,9 @@ def _infinite_packed_batches(
     seq_lens = torch.tensor([seq_len], dtype=torch.int64, device=device)
     while True:
         yield PackedBatch(
-            input_ids=torch.randint(0, vocab_size, (seq_len,), device=device, generator=g),
+            input_ids=torch.randint(
+                0, vocab_size, (seq_len,), device=device, generator=g
+            ),
             labels=torch.randint(0, vocab_size, (seq_len,), device=device, generator=g),
             seq_lens=seq_lens.clone(),
         )
@@ -91,7 +91,9 @@ def _infinite_packed_batches(
 def _make_data_iter(handle: ModelHandle, cfg: PretrainSessionConfig):
     data_seed = cfg.seed if cfg.same_data_across_dp else cfg.seed + handle.dp_rank
     vocab_size = _resolve_vocab_size(handle)
-    return _infinite_packed_batches(vocab_size, cfg.seq_len, device=cfg.device, seed=data_seed)
+    return _infinite_packed_batches(
+        vocab_size, cfg.seq_len, device=cfg.device, seed=data_seed
+    )
 
 
 def _calc_tflops_per_gpu(
@@ -239,7 +241,11 @@ def run_pretrain_session(
         impl=getattr(config, "impl", "bridge"),
         optimizer_backend=handle._extras.get(
             "optimizer_backend",
-            getattr(handle._optimizer, "name", "none") if handle._optimizer is not None else "none",
+            (
+                getattr(handle._optimizer, "name", "none")
+                if handle._optimizer is not None
+                else "none"
+            ),
         ),
         tp=parallel.tp,
         etp=parallel.etp,

--- a/experimental/lite/examples/miles/miles_mlite/arguments.py
+++ b/experimental/lite/examples/miles/miles_mlite/arguments.py
@@ -3,10 +3,7 @@
 
 from __future__ import annotations
 
-_OPTIMIZER_BACKEND_TO_IMPL = {
-    "dist_opt": "dist_opt",
-    "fsdp2": "fsdp2",
-}
+_OPTIMIZER_BACKEND_TO_IMPL = {"dist_opt": "dist_opt", "fsdp2": "fsdp2"}
 
 
 def optimizer_backend_to_impl(backend: str) -> str:
@@ -76,7 +73,9 @@ def add_mlite_arguments(parser):
 
 def validate_mlite_args(args) -> None:
     if not getattr(args, "hf_checkpoint", None):
-        raise ValueError("--hf-checkpoint is required for the Megatron Lite backend patch.")
+        raise ValueError(
+            "--hf-checkpoint is required for the Megatron Lite backend patch."
+        )
     args.variable_seq_lengths = True
     if not hasattr(args, "calculate_per_token_loss"):
         args.calculate_per_token_loss = False

--- a/experimental/lite/examples/miles/miles_mlite/backend_patch.py
+++ b/experimental/lite/examples/miles/miles_mlite/backend_patch.py
@@ -124,12 +124,24 @@ def _install_miles_parallel_state(ps) -> None:
         return
     state = parallel_mod.ParallelState(
         intra_dp=_group(ps.dp_rank, ps.dp_size, ps.dp_group),
-        intra_dp_cp=_group(getattr(ps, "dp_cp_rank", ps.dp_rank), getattr(ps, "dp_cp_size", ps.dp_size), getattr(ps, "dp_cp_group", ps.dp_group)),
+        intra_dp_cp=_group(
+            getattr(ps, "dp_cp_rank", ps.dp_rank),
+            getattr(ps, "dp_cp_size", ps.dp_size),
+            getattr(ps, "dp_cp_group", ps.dp_group),
+        ),
         cp=_group(ps.cp_rank, ps.cp_size, ps.cp_group),
         tp=_group(ps.tp_rank, ps.tp_size, ps.tp_group),
         pp=_group(ps.pp_rank, ps.pp_size, ps.pp_group),
-        ep=_group(getattr(ps, "ep_rank", 0), getattr(ps, "ep_size", 1), getattr(ps, "ep_group", None)),
-        etp=_group(getattr(ps, "etp_rank", 0), getattr(ps, "etp_size", 1), getattr(ps, "etp_group", None)),
+        ep=_group(
+            getattr(ps, "ep_rank", 0),
+            getattr(ps, "ep_size", 1),
+            getattr(ps, "ep_group", None),
+        ),
+        etp=_group(
+            getattr(ps, "etp_rank", 0),
+            getattr(ps, "etp_size", 1),
+            getattr(ps, "etp_group", None),
+        ),
         cp_comm_type=getattr(ps, "cp_comm_type", None),
         is_pp_last_stage=ps.pp_rank == ps.pp_size - 1,
         vpp_size=1,
@@ -141,7 +153,10 @@ def _install_miles_parallel_state(ps) -> None:
 class _MLiteTrainRayActorMixin:
     def _build_mlite_config(self, args: Namespace):
         from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig
-        from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
+        from megatron.lite.runtime.contracts.config import (
+            OptimizerConfig,
+            ParallelConfig,
+        )
 
         validate_mlite_args(args)
         parallel = ParallelConfig(
@@ -197,9 +212,13 @@ class _MLiteTrainRayActorMixin:
     ) -> int | None:
         super().init(args, role, with_ref, with_opd_teacher=with_opd_teacher)
         if role != "actor":
-            raise NotImplementedError("Megatron Lite miles backend supports actor training only.")
+            raise NotImplementedError(
+                "Megatron Lite miles backend supports actor training only."
+            )
         if with_ref or with_opd_teacher:
-            raise NotImplementedError("Reference/teacher model swapping is not implemented for the MLite patch.")
+            raise NotImplementedError(
+                "Reference/teacher model swapping is not implemented for the MLite patch."
+            )
 
         if args.debug_rollout_only:
             self.args = args
@@ -209,7 +228,9 @@ class _MLiteTrainRayActorMixin:
 
         self._cfg = self._build_mlite_config(args)
         self.runtime = create_runtime(
-            RuntimeConfig(backend="mlite", hf_path=args.hf_checkpoint, backend_cfg=self._cfg)
+            RuntimeConfig(
+                backend="mlite", hf_path=args.hf_checkpoint, backend_cfg=self._cfg
+            )
         )
         self.handle = self.runtime.build_model()
         _install_set_input_tensor_proxy(self.handle)
@@ -251,18 +272,32 @@ class _MLiteTrainRayActorMixin:
                         args.load,
                     )
 
-        if getattr(args, "offload_train", False) or getattr(args, "mlite_param_offload", False):
+        if getattr(args, "offload_train", False) or getattr(
+            args, "mlite_param_offload", False
+        ):
             self.sleep()
         return start_rollout_id
 
     def _process_rollout_data(self, rollout_data_ref):
         data_mod = importlib.import_module("miles.utils.data")
         ps = self.handle._parallel_state
-        rollout_data = data_mod.process_rollout_data(self.args, rollout_data_ref, ps.dp_rank, ps.dp_size)
-        rollout_data["tokens"] = [torch.as_tensor(t, dtype=torch.long) for t in rollout_data["tokens"]]
-        rollout_data["loss_masks"] = [torch.as_tensor(t, dtype=torch.float32) for t in rollout_data["loss_masks"]]
+        rollout_data = data_mod.process_rollout_data(
+            self.args, rollout_data_ref, ps.dp_rank, ps.dp_size
+        )
+        rollout_data["tokens"] = [
+            torch.as_tensor(t, dtype=torch.long) for t in rollout_data["tokens"]
+        ]
+        rollout_data["loss_masks"] = [
+            torch.as_tensor(t, dtype=torch.float32) for t in rollout_data["loss_masks"]
+        ]
         device = torch.device("cuda", torch.cuda.current_device())
-        for key in ("rollout_log_probs", "log_probs", "ref_log_probs", "advantages", "returns"):
+        for key in (
+            "rollout_log_probs",
+            "log_probs",
+            "ref_log_probs",
+            "advantages",
+            "returns",
+        ):
             if key in rollout_data and rollout_data[key] is not None:
                 rollout_data[key] = [
                     torch.as_tensor(t, dtype=torch.float32, device=device).reshape(-1)
@@ -311,7 +346,9 @@ class _MLiteTrainRayActorMixin:
 
     def train(self, rollout_id: int, rollout_data_ref) -> None:
         self._last_rollout_id = rollout_id
-        if getattr(self.args, "offload_train", False) or getattr(self.args, "mlite_param_offload", False):
+        if getattr(self.args, "offload_train", False) or getattr(
+            self.args, "mlite_param_offload", False
+        ):
             self.wake_up()
 
         rollout_data = self._process_rollout_data(rollout_data_ref)
@@ -319,8 +356,12 @@ class _MLiteTrainRayActorMixin:
             return None
 
         loss_type = getattr(self.args, "loss_type", "sft_loss")
-        if loss_type == "policy_loss" and getattr(self.args, "compute_advantages_and_returns", True):
-            if not getattr(self.args, "use_rollout_logprobs", False) or getattr(self.args, "get_mismatch_metrics", False):
+        if loss_type == "policy_loss" and getattr(
+            self.args, "compute_advantages_and_returns", True
+        ):
+            if not getattr(self.args, "use_rollout_logprobs", False) or getattr(
+                self.args, "get_mismatch_metrics", False
+            ):
                 log_probs = self._compute_log_probs(rollout_data)
                 if log_probs is not None:
                     rollout_data["log_probs"] = log_probs
@@ -391,15 +432,14 @@ class _MLiteTrainRayActorMixin:
         loaded = None
         if verify_load:
             loaded = self.runtime.load_checkpoint(
-                self.handle,
-                save_dir,
-                load_optimizer=save_optimizer,
-                load_rng=save_rng,
+                self.handle, save_dir, load_optimizer=save_optimizer, load_rng=save_rng
             )
             if probe_key is not None and before is not None:
                 after_param = _find_local_parameter(self.handle, probe_key)
                 if after_param is None:
-                    raise RuntimeError(f"checkpoint load probe parameter missing after load: {probe_key}")
+                    raise RuntimeError(
+                        f"checkpoint load probe parameter missing after load: {probe_key}"
+                    )
                 after = after_param.detach().float().cpu()
                 max_abs = float(torch.max(torch.abs(after - before)).item())
                 if max_abs != 0.0:
@@ -430,8 +470,12 @@ class _MLiteTrainRayActorMixin:
         if self.args.debug_train_only or self.args.debug_rollout_only:
             return
         if info is None:
-            raise ValueError("update_weights requires rollout engine info from the miles rollout manager.")
-        if getattr(self.args, "offload_train", False) or getattr(self.args, "mlite_param_offload", False):
+            raise ValueError(
+                "update_weights requires rollout engine info from the miles rollout manager."
+            )
+        if getattr(self.args, "offload_train", False) or getattr(
+            self.args, "mlite_param_offload", False
+        ):
             self.wake_up()
 
         rollout_engines = info.rollout_engines
@@ -454,22 +498,32 @@ class _MLiteTrainRayActorMixin:
                 ray.get(self.rollout_manager.clear_updatable_has_new_engines.remote())
 
         if getattr(self.args, "debug_skip_weight_update", False):
-            logger.warning("Skipping MLite actor-to-rollout weight update because --debug-skip-weight-update is set.")
+            logger.warning(
+                "Skipping MLite actor-to-rollout weight update because --debug-skip-weight-update is set."
+            )
             return
         self.weight_updater.update_weights()
 
     def sleep(self, *args, **kwargs) -> None:
-        if not (getattr(self.args, "offload_train", False) or getattr(self.args, "mlite_param_offload", False)):
+        if not (
+            getattr(self.args, "offload_train", False)
+            or getattr(self.args, "mlite_param_offload", False)
+        ):
             return
         self.runtime.to(self.handle, "cpu")
 
     def wake_up(self, *args, **kwargs) -> None:
-        if not (getattr(self.args, "offload_train", False) or getattr(self.args, "mlite_param_offload", False)):
+        if not (
+            getattr(self.args, "offload_train", False)
+            or getattr(self.args, "mlite_param_offload", False)
+        ):
             return
         self.runtime.to(self.handle, "cuda")
 
     def connect_actor_critic(self, critic_group=None, **kwargs):
-        raise NotImplementedError("Megatron Lite miles backend does not support critic training yet.")
+        raise NotImplementedError(
+            "Megatron Lite miles backend does not support critic training yet."
+        )
 
     def _get_parallel_config(self):
         return self.train_parallel_config
@@ -488,7 +542,11 @@ def _load_or_synthesize_actor_module(import_error: ImportError) -> ModuleType:
 
     parent_mod = importlib.import_module(actor_mod.__package__)
     setattr(parent_mod, "actor", actor_mod)
-    logger.warning("Using synthetic %s because the original module failed to import: %s", module_name, import_error)
+    logger.warning(
+        "Using synthetic %s because the original module failed to import: %s",
+        module_name,
+        import_error,
+    )
     return actor_mod
 
 

--- a/experimental/lite/examples/miles/miles_mlite/data.py
+++ b/experimental/lite/examples/miles/miles_mlite/data.py
@@ -33,7 +33,9 @@ def _as_tensor_list(values, *, dtype, device) -> list[torch.Tensor]:
     return [torch.as_tensor(v, dtype=dtype, device=device).reshape(-1) for v in values]
 
 
-def _optional_tensor_list(data: dict[str, Any], key: str, *, dtype, device) -> list[torch.Tensor] | None:
+def _optional_tensor_list(
+    data: dict[str, Any], key: str, *, dtype, device
+) -> list[torch.Tensor] | None:
     if key not in data or data[key] is None:
         return None
     return _as_tensor_list(data[key], dtype=dtype, device=device)
@@ -51,7 +53,10 @@ def _group_microbatches(
         return []
     if not use_dynamic_batch_size:
         mbs = max(int(micro_batch_size), 1)
-        return [list(range(i, min(i + mbs, num_samples))) for i in range(0, num_samples, mbs)]
+        return [
+            list(range(i, min(i + mbs, num_samples)))
+            for i in range(0, num_samples, mbs)
+        ]
 
     budget = max(int(max_tokens_per_gpu), 1)
     groups: list[list[int]] = []
@@ -70,7 +75,9 @@ def _group_microbatches(
     return groups
 
 
-def response_mask_to_full(loss_mask: torch.Tensor, total_length: int, response_length: int) -> torch.Tensor:
+def response_mask_to_full(
+    loss_mask: torch.Tensor, total_length: int, response_length: int
+) -> torch.Tensor:
     prompt_length = total_length - response_length
     if loss_mask.numel() != response_length:
         raise ValueError(
@@ -94,7 +101,9 @@ def _select(values: list[Any] | None, group: list[int]) -> list[Any] | None:
     return [values[i] for i in group]
 
 
-def _put_if_present(batch: dict[str, Any], key: str, values: list[Any] | None, group: list[int]) -> None:
+def _put_if_present(
+    batch: dict[str, Any], key: str, values: list[Any] | None, group: list[int]
+) -> None:
     selected = _select(values, group)
     if selected is not None:
         batch[key] = selected
@@ -112,12 +121,24 @@ def build_runtime_microbatches(
     """Build model-agnostic PackedBatch items plus loss-side source metadata."""
     device = torch.device("cuda", torch.cuda.current_device())
     tokens = _as_tensor_list(rollout_data["tokens"], dtype=torch.long, device=device)
-    response_loss_masks = _as_tensor_list(rollout_data["loss_masks"], dtype=torch.float32, device=device)
-    rollout_log_probs = _optional_tensor_list(rollout_data, "rollout_log_probs", dtype=torch.float32, device=device)
-    old_log_probs = _optional_tensor_list(rollout_data, "log_probs", dtype=torch.float32, device=device)
-    ref_log_probs = _optional_tensor_list(rollout_data, "ref_log_probs", dtype=torch.float32, device=device)
-    advantages = _optional_tensor_list(rollout_data, "advantages", dtype=torch.float32, device=device)
-    returns = _optional_tensor_list(rollout_data, "returns", dtype=torch.float32, device=device)
+    response_loss_masks = _as_tensor_list(
+        rollout_data["loss_masks"], dtype=torch.float32, device=device
+    )
+    rollout_log_probs = _optional_tensor_list(
+        rollout_data, "rollout_log_probs", dtype=torch.float32, device=device
+    )
+    old_log_probs = _optional_tensor_list(
+        rollout_data, "log_probs", dtype=torch.float32, device=device
+    )
+    ref_log_probs = _optional_tensor_list(
+        rollout_data, "ref_log_probs", dtype=torch.float32, device=device
+    )
+    advantages = _optional_tensor_list(
+        rollout_data, "advantages", dtype=torch.float32, device=device
+    )
+    returns = _optional_tensor_list(
+        rollout_data, "returns", dtype=torch.float32, device=device
+    )
 
     total_lengths = [int(x) for x in rollout_data["total_lengths"]]
     response_lengths = [int(x) for x in rollout_data["response_lengths"]]
@@ -139,13 +160,19 @@ def build_runtime_microbatches(
         full_masks = [
             response_mask_to_full(mask, total, response)
             for mask, total, response in zip(
-                group_response_masks, group_total_lengths, group_response_lengths, strict=True
+                group_response_masks,
+                group_total_lengths,
+                group_response_lengths,
+                strict=True,
             )
         ]
         aligned_masks = [
             response_mask_to_aligned_full(mask, total, response)
             for mask, total, response in zip(
-                group_response_masks, group_total_lengths, group_response_lengths, strict=True
+                group_response_masks,
+                group_total_lengths,
+                group_response_lengths,
+                strict=True,
             )
         ]
 
@@ -154,7 +181,9 @@ def build_runtime_microbatches(
             input_ids=flat_tokens,
             labels=flat_tokens,
             loss_mask=torch.cat(full_masks, dim=0).contiguous(),
-            seq_lens=torch.tensor(group_total_lengths, dtype=torch.int64, device=device),
+            seq_lens=torch.tensor(
+                group_total_lengths, dtype=torch.int64, device=device
+            ),
         )
 
         source_batch: dict[str, Any] = {

--- a/experimental/lite/examples/miles/miles_mlite/loss.py
+++ b/experimental/lite/examples/miles/miles_mlite/loss.py
@@ -29,18 +29,26 @@ def _unpack_output(handle, runtime_batch, output: torch.Tensor) -> list[torch.Te
     proto = handle._extras.get("protocol")
     unpack = getattr(proto, "unpack_forward_output", None)
     if unpack is None:
-        raise ValueError("Model protocol must expose unpack_forward_output for miles losses.")
-    model = handle._model[0] if isinstance(handle._model, list | tuple) else handle._model
+        raise ValueError(
+            "Model protocol must expose unpack_forward_output for miles losses."
+        )
+    model = (
+        handle._model[0] if isinstance(handle._model, list | tuple) else handle._model
+    )
     return _nested_to_list(unpack(model, runtime_batch, output), runtime_batch.seq_lens)
 
 
-def extract_response_log_probs(raw_output: dict[str, torch.Tensor], runtime_batch, source_batch, handle):
+def extract_response_log_probs(
+    raw_output: dict[str, torch.Tensor], runtime_batch, source_batch, handle
+):
     log_probs = raw_output.get("log_probs")
     if log_probs is None:
         raise ValueError("Megatron Lite model output must contain token log_probs.")
     full_log_probs = _unpack_output(handle, runtime_batch, log_probs)
     response_log_probs = []
-    for values, mask in zip(full_log_probs, source_batch["aligned_loss_masks"], strict=True):
+    for values, mask in zip(
+        full_log_probs, source_batch["aligned_loss_masks"], strict=True
+    ):
         active = mask.to(device=values.device).bool()
         if values.numel() != active.numel():
             raise ValueError(
@@ -62,11 +70,13 @@ def _mean_scalars(values: list[torch.Tensor], device) -> torch.Tensor:
 
 
 def _policy_loss(
-    args,
-    current: list[torch.Tensor],
-    source_batch: dict[str, Any],
+    args, current: list[torch.Tensor], source_batch: dict[str, Any]
 ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
-    old = source_batch.get("rollout_log_probs") if getattr(args, "use_rollout_logprobs", False) else None
+    old = (
+        source_batch.get("rollout_log_probs")
+        if getattr(args, "use_rollout_logprobs", False)
+        else None
+    )
     if old is None:
         old = source_batch.get("log_probs")
     if old is None:
@@ -80,7 +90,9 @@ def _policy_loss(
     losses = []
     clipfracs = []
     kls = []
-    for cur, old_lp, adv, mask in zip(current, old, advantages, source_batch["loss_masks"], strict=True):
+    for cur, old_lp, adv, mask in zip(
+        current, old, advantages, source_batch["loss_masks"], strict=True
+    ):
         cur = cur.float()
         old_lp = old_lp.to(device=cur.device, dtype=cur.dtype)
         adv = adv.to(device=cur.device, dtype=cur.dtype)
@@ -116,7 +128,9 @@ def _policy_loss(
     return loss, metrics
 
 
-def _sft_loss(current: list[torch.Tensor], source_batch: dict[str, Any]) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+def _sft_loss(
+    current: list[torch.Tensor], source_batch: dict[str, Any]
+) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
     losses = []
     for log_probs, mask in zip(current, source_batch["loss_masks"], strict=True):
         mask = mask.to(device=log_probs.device, dtype=log_probs.dtype)
@@ -144,15 +158,21 @@ def make_runtime_loss_fn(
         try:
             return next(loss_context_iter)
         except StopIteration as exc:
-            raise RuntimeError("MLite miles loss context iterator ended before loss_fn calls.") from exc
+            raise RuntimeError(
+                "MLite miles loss context iterator ended before loss_fn calls."
+            ) from exc
 
     def _loss_fn(raw_output: dict[str, torch.Tensor], runtime_batch, loss_context=None):
         if loss_context is None:
             loss_context = _next_loss_context()
         if loss_context is None or loss_context.source_batch is None:
-            raise ValueError("MLite miles loss_fn requires a LossContext with source_batch.")
+            raise ValueError(
+                "MLite miles loss_fn requires a LossContext with source_batch."
+            )
         source_batch = loss_context.source_batch
-        current = extract_response_log_probs(raw_output, runtime_batch, source_batch, handle)
+        current = extract_response_log_probs(
+            raw_output, runtime_batch, source_batch, handle
+        )
         if forward_store is not None:
             forward_store.append({"log_probs": [x.detach() for x in current]})
             zero = torch.zeros((), device=current[0].device, dtype=torch.float32)
@@ -163,6 +183,8 @@ def make_runtime_loss_fn(
             return _sft_loss(current, source_batch)
         if loss_type == "policy_loss":
             return _policy_loss(args, current, source_batch)
-        raise NotImplementedError(f"Megatron Lite miles actor does not support loss_type={loss_type!r}.")
+        raise NotImplementedError(
+            f"Megatron Lite miles actor does not support loss_type={loss_type!r}."
+        )
 
     return _loss_fn

--- a/experimental/lite/examples/miles/miles_mlite/reward_log.py
+++ b/experimental/lite/examples/miles/miles_mlite/reward_log.py
@@ -19,7 +19,9 @@ from miles.utils.metric_utils import compute_pass_rate
 logger = logging.getLogger(__name__)
 
 
-def log_rollout_data(rollout_id, args, samples, rollout_extra_metrics, rollout_time) -> bool:
+def log_rollout_data(
+    rollout_id, args, samples, rollout_extra_metrics, rollout_time
+) -> bool:
     rewards = [float(sample.get_reward_value(args)) for sample in samples]
     if not rewards:
         return False

--- a/experimental/lite/examples/miles/miles_mlite/weight_update.py
+++ b/experimental/lite/examples/miles/miles_mlite/weight_update.py
@@ -3,10 +3,10 @@
 
 from __future__ import annotations
 
-import logging
 import importlib
-from dataclasses import replace
+import logging
 from collections.abc import Sequence
+from dataclasses import replace
 
 import ray
 import torch
@@ -57,14 +57,20 @@ class RawHFWeightUpdater:
         broadcast = importlib.import_module(
             "miles.backends.megatron_utils.update_weight.update_weight_from_distributed.broadcast"
         )
-        connect_rollout_engines_from_distributed = broadcast.connect_rollout_engines_from_distributed
-        disconnect_rollout_engines_from_distributed = broadcast.disconnect_rollout_engines_from_distributed
+        connect_rollout_engines_from_distributed = (
+            broadcast.connect_rollout_engines_from_distributed
+        )
+        disconnect_rollout_engines_from_distributed = (
+            broadcast.disconnect_rollout_engines_from_distributed
+        )
 
         self.rollout_engines = list(rollout_engines)
         self.rollout_engine_lock = rollout_engine_lock
 
         if engine_gpu_counts is None:
-            engine_gpu_counts = [self.args.rollout_num_gpus_per_engine] * len(rollout_engines)
+            engine_gpu_counts = [self.args.rollout_num_gpus_per_engine] * len(
+                rollout_engines
+            )
         if engine_gpu_offsets is None:
             engine_gpu_offsets = []
             offset = 0
@@ -75,9 +81,13 @@ class RawHFWeightUpdater:
         if not getattr(self.args, "colocate", False):
             colocate_engine_nums = 0
         else:
-            total_actor_gpus = self.args.actor_num_nodes * self.args.actor_num_gpus_per_node
+            total_actor_gpus = (
+                self.args.actor_num_nodes * self.args.actor_num_gpus_per_node
+            )
             colocate_engine_nums = 0
-            for gpu_offset, gpu_count in zip(engine_gpu_offsets, engine_gpu_counts, strict=True):
+            for gpu_offset, gpu_count in zip(
+                engine_gpu_offsets, engine_gpu_counts, strict=True
+            ):
                 if gpu_offset + gpu_count > total_actor_gpus:
                     break
                 colocate_engine_nums += 1
@@ -102,7 +112,10 @@ class RawHFWeightUpdater:
                 engine_gpu_counts=engine_gpu_counts[colocate_engine_nums:],
             )
 
-        self._connect_colocated_groups(engine_gpu_counts[:colocate_engine_nums], engine_gpu_offsets[:colocate_engine_nums])
+        self._connect_colocated_groups(
+            engine_gpu_counts[:colocate_engine_nums],
+            engine_gpu_offsets[:colocate_engine_nums],
+        )
 
     @property
     def _active_rollout_engines(self):
@@ -114,7 +127,9 @@ class RawHFWeightUpdater:
         self._ipc_gather_src = None
         self._ipc_engine = None
 
-        for engine_idx, (offset, count) in enumerate(zip(engine_gpu_offsets, engine_gpu_counts, strict=True)):
+        for engine_idx, (offset, count) in enumerate(
+            zip(engine_gpu_offsets, engine_gpu_counts, strict=True)
+        ):
             group_ranks = list(range(offset, offset + count))
             new_group = dist.new_group(ranks=group_ranks, backend="gloo")
             if rank in group_ranks:
@@ -123,7 +138,9 @@ class RawHFWeightUpdater:
                 self._ipc_engine = self.rollout_engines[engine_idx]
 
     def update_weights(self) -> None:
-        common = importlib.import_module("miles.backends.megatron_utils.update_weight.common")
+        common = importlib.import_module(
+            "miles.backends.megatron_utils.update_weight.common"
+        )
         broadcast = importlib.import_module(
             "miles.backends.megatron_utils.update_weight.update_weight_from_distributed.broadcast"
         )
@@ -140,8 +157,15 @@ class RawHFWeightUpdater:
         rank = dist.get_rank()
         if rank == 0:
             mode = self.args.pause_generation_mode
-            ray.get([engine.pause_generation.remote(mode=mode) for engine in self._active_rollout_engines])
-            ray.get([engine.flush_cache.remote() for engine in self._active_rollout_engines])
+            ray.get(
+                [
+                    engine.pause_generation.remote(mode=mode)
+                    for engine in self._active_rollout_engines
+                ]
+            )
+            ray.get(
+                [engine.flush_cache.remote() for engine in self._active_rollout_engines]
+            )
         dist.barrier(group=get_gloo_group())
 
         refs = []
@@ -178,7 +202,12 @@ class RawHFWeightUpdater:
                 restore_weights_before_load=False,
                 post_process_quantization=True,
             )
-            ray.get([engine.continue_generation.remote() for engine in self._active_rollout_engines])
+            ray.get(
+                [
+                    engine.continue_generation.remote()
+                    for engine in self._active_rollout_engines
+                ]
+            )
         dist.barrier(group=get_gloo_group())
 
     def _export_weight_chunks(self):
@@ -200,7 +229,9 @@ class RawHFWeightUpdater:
                 continue
             tensor = tensor.detach()
             if not tensor.is_cuda:
-                tensor = tensor.to(device=torch.cuda.current_device(), non_blocking=True)
+                tensor = tensor.to(
+                    device=torch.cuda.current_device(), non_blocking=True
+                )
             item_bytes = tensor.numel() * tensor.element_size()
             if chunk and chunk_bytes + item_bytes > limit:
                 torch.cuda.synchronize()
@@ -241,7 +272,9 @@ class RawHFWeightUpdater:
                 pp_next_rank=-1,
                 pp_prev_rank=-1,
             )
-            yield from proto.export_hf_weights(model_chunks, model_cfg, local_pp_ps, **export_kwargs)
+            yield from proto.export_hf_weights(
+                model_chunks, model_cfg, local_pp_ps, **export_kwargs
+            )
             return
 
         for chunk in model_chunks:
@@ -266,9 +299,12 @@ def _send_to_colocated_engine_direct(
 
     is_gather_src = dist.get_rank() == ipc_gather_src
     serialized_tensors = [
-        (name, MultiprocessingSerializer.serialize(tensor)) for name, tensor in hf_named_tensors
+        (name, MultiprocessingSerializer.serialize(tensor))
+        for name, tensor in hf_named_tensors
     ]
-    serialized_named_tensors = [None] * dist.get_world_size(ipc_gather_group) if is_gather_src else None
+    serialized_named_tensors = (
+        [None] * dist.get_world_size(ipc_gather_group) if is_gather_src else None
+    )
     dist.gather_object(
         serialized_tensors,
         object_gather_list=serialized_named_tensors,
@@ -282,10 +318,17 @@ def _send_to_colocated_engine_direct(
         for tensor_group in zip(*serialized_named_tensors, strict=True):
             names = {name for name, _ in tensor_group}
             if len(names) != 1:
-                raise RuntimeError(f"Mismatched TP tensor names during weight sync: {sorted(names)}")
+                raise RuntimeError(
+                    f"Mismatched TP tensor names during weight sync: {sorted(names)}"
+                )
             name = tensor_group[0][0]
             named_tensors.append(
-                (name, LocalSerializedTensor(values=[rank_part[1] for rank_part in tensor_group]))
+                (
+                    name,
+                    LocalSerializedTensor(
+                        values=[rank_part[1] for rank_part in tensor_group]
+                    ),
+                )
             )
         payload = [
             MultiprocessingSerializer.serialize(named_tensors, output_str=True)
@@ -293,8 +336,7 @@ def _send_to_colocated_engine_direct(
         ]
         refs.append(
             ipc_engine.update_weights_from_tensor.remote(
-                serialized_named_tensors=payload,
-                weight_version=str(weight_version),
+                serialized_named_tensors=payload, weight_version=str(weight_version)
             )
         )
 

--- a/experimental/lite/examples/verl/scripts/validate_deepseek_v4_dapo.py
+++ b/experimental/lite/examples/verl/scripts/validate_deepseek_v4_dapo.py
@@ -16,7 +16,6 @@ from pathlib import Path
 
 from packaging.version import Version
 
-
 EXACT_DEPENDENCIES = {
     "vllm": "0.25.1",
     "flashinfer-python": "0.6.13",
@@ -102,9 +101,10 @@ def validate_environment() -> None:
             "DS4 requires PyTorch 2.12 nv26.05 / CUDA 13.2, "
             f"got torch={torch.__version__} cuda={torch.version.cuda}"
         )
-    if "q_causal_offsets" not in inspect.signature(
-        DSA.indexer_forward_wrapper
-    ).parameters:
+    if (
+        "q_causal_offsets"
+        not in inspect.signature(DSA.indexer_forward_wrapper).parameters
+    ):
         raise SystemExit(
             "nvidia-cudnn-frontend lacks q_causal_offsets required by fused DSA CP"
         )

--- a/experimental/lite/examples/verl/verl_mlite/compat.py
+++ b/experimental/lite/examples/verl/verl_mlite/compat.py
@@ -18,18 +18,15 @@ from functools import wraps
 from pathlib import Path
 from typing import Any
 
-_VLLM_ASYNC_SERVER_MODULE = (
-    "verl.workers.rollout.vllm_rollout.vllm_async_server"
-)
-_VLLM_ROLLOUT_CONSUMER_MODULE = (
-    "verl.workers.rollout.vllm_rollout.vllm_rollout"
-)
+_VLLM_ASYNC_SERVER_MODULE = "verl.workers.rollout.vllm_rollout.vllm_async_server"
+_VLLM_ROLLOUT_CONSUMER_MODULE = "verl.workers.rollout.vllm_rollout.vllm_rollout"
 _REGISTERED_HF_CONFIG_TYPES: set[str] = set()
 
 _VLLM_IMPORTABLE: bool | None = None
 
 
 _BUCKETED_SENDER_MODULE = "verl.workers.rollout.vllm_rollout.bucketed_weight_transfer"
+
 
 def _vllm_importable() -> bool:
     """Whether ``import vllm`` succeeds in THIS process.
@@ -73,9 +70,7 @@ def _register_opaque_hf_config() -> bool:
     from transformers import AutoConfig, PretrainedConfig
 
     config_cls = type(
-        "MLiteOpaqueConfig",
-        (PretrainedConfig,),
-        {"model_type": model_type},
+        "MLiteOpaqueConfig", (PretrainedConfig,), {"model_type": model_type}
     )
     try:
         AutoConfig.register(model_type, config_cls)
@@ -254,7 +249,9 @@ def _vllm_server_profile_env() -> dict[str, str]:
     shim = os.environ.get("VERL_MLITE_VLLM_LD_PRELOAD", "").strip()
     existing_preload = os.environ.get("LD_PRELOAD", "").strip()
     if shim:
-        result["LD_PRELOAD"] = f"{shim}:{existing_preload}" if existing_preload else shim
+        result["LD_PRELOAD"] = (
+            f"{shim}:{existing_preload}" if existing_preload else shim
+        )
     elif existing_preload:
         result["LD_PRELOAD"] = existing_preload
     return result
@@ -288,11 +285,7 @@ def _patch_verl_vllm_headless_api_server_count() -> bool:
 
     server_module = importlib.import_module(_VLLM_ASYNC_SERVER_MODULE)
     original_run_headless = server_module.run_headless
-    if getattr(
-        original_run_headless,
-        "_verl_mlite_api_server_count_patch",
-        False,
-    ):
+    if getattr(original_run_headless, "_verl_mlite_api_server_count_patch", False):
         return False
 
     @wraps(original_run_headless)
@@ -359,6 +352,7 @@ def _patch_verl_vllm_device_uuid() -> bool:
     if getattr(original_get_device_uuid, "_verl_mlite_visible_device_patch", False):
         patched_get_device_uuid = original_get_device_uuid
     else:
+
         @wraps(original_get_device_uuid)
         def patched_get_device_uuid(device_id: int) -> str:
             return original_get_device_uuid(
@@ -398,7 +392,9 @@ def _patch_transformers_rope_ignore_keys() -> None:
 
         is_staticmethod = isinstance(descriptor, staticmethod)
         is_classmethod = isinstance(descriptor, classmethod)
-        original = descriptor.__func__ if is_staticmethod or is_classmethod else descriptor
+        original = (
+            descriptor.__func__ if is_staticmethod or is_classmethod else descriptor
+        )
 
         def build_wrapper(check_received_keys: Any) -> Any:
             @wraps(check_received_keys)
@@ -485,14 +481,10 @@ def _trace_runtime_patch(stage: str, result: Any = None) -> None:
         return missing, "absent"
 
     alias, alias_source = raw_binding("AutoModelForVision2Seq")
-    replacement, replacement_source = raw_binding(
-        "AutoModelForImageTextToText"
-    )
+    replacement, replacement_source = raw_binding("AutoModelForImageTextToText")
     payload = {
         "alias_is_replacement": (
-            alias is not missing
-            and replacement is not missing
-            and alias is replacement
+            alias is not missing and replacement is not missing and alias is replacement
         ),
         "alias_source": alias_source,
         "changed": result,
@@ -505,8 +497,7 @@ def _trace_runtime_patch(stage: str, result: Any = None) -> None:
         "transformers_loaded": transformers is not None,
     }
     sys.stderr.write(
-        "VERL_MLITE_RUNTIME_PATCH_TRACE "
-        f"{json.dumps(payload, sort_keys=True)}\n"
+        "VERL_MLITE_RUNTIME_PATCH_TRACE " f"{json.dumps(payload, sort_keys=True)}\n"
     )
     sys.stderr.flush()
 
@@ -574,7 +565,11 @@ def _restore_dsv4_attn_sink_padding(model: Any) -> int:
         sink = getattr(module, "attn_sink", None)
         real_heads = getattr(module, "n_local_heads", None)
         padded_heads = getattr(module, "padded_heads", None)
-        if sink is None or not isinstance(real_heads, int) or not isinstance(padded_heads, int):
+        if (
+            sink is None
+            or not isinstance(real_heads, int)
+            or not isinstance(padded_heads, int)
+        ):
             continue
         if sink.ndim != 1 or sink.numel() != padded_heads:
             continue
@@ -628,6 +623,7 @@ def _recreate_dense_fp8_linear_params(model) -> int:
     the single post-load process_weights_after_loading matches cold load bit-for-bit
     (see module block above). Returns the count recreated."""
     import torch
+
     try:
         from vllm.model_executor.layers.linear import LinearBase
         from vllm.model_executor.layers.quantization.fp8 import Fp8LinearMethod
@@ -635,8 +631,10 @@ def _recreate_dense_fp8_linear_params(model) -> int:
         return 0
     recreated = 0
     for _name, layer in model.named_modules():
-        if not (isinstance(layer, LinearBase)
-                and isinstance(getattr(layer, "quant_method", None), Fp8LinearMethod)):
+        if not (
+            isinstance(layer, LinearBase)
+            and isinstance(getattr(layer, "quant_method", None), Fp8LinearMethod)
+        ):
             continue
         qm = layer.quant_method
         if not getattr(qm, "block_quant", False):
@@ -696,7 +694,8 @@ def _patch_verl_dsv4_prepare_recreates_dense() -> bool:
                 if n:
                     sys.stderr.write(
                         f"VERL_MLITE_DENSE_RECREATE recreated {n} dense FP8 linear "
-                        "param set(s) to checkpoint layout before resync load\n")
+                        "param set(s) to checkpoint layout before resync load\n"
+                    )
                     sys.stderr.flush()
         except Exception as exc:
             sys.stderr.write(f"VERL_MLITE_DENSE_RECREATE error: {exc!r}\n")
@@ -825,13 +824,14 @@ def _patch_verl_dsv4_native_layerwise_reload() -> bool:
         if reload_state is not _DSV4_LAYERWISE_RELOAD_STATE:
             return original_process(model_runner, reload_state)
         from vllm.config import set_current_vllm_config
-        from vllm.model_executor.model_loader.reload import finalize_layerwise_processing
+        from vllm.model_executor.model_loader.reload import (
+            finalize_layerwise_processing,
+        )
 
         try:
             with set_current_vllm_config(model_runner.vllm_config):
                 finalize_layerwise_processing(
-                    model_runner.model,
-                    model_runner.vllm_config.model_config,
+                    model_runner.model, model_runner.vllm_config.model_config
                 )
         finally:
             model_runner.model._verl_mlite_ds4_layerwise_reload_active = False
@@ -892,7 +892,9 @@ def _patch_verl_dsv4_native_layerwise_reload() -> bool:
     process_quanted_weights_after_loading._verl_mlite_ds4_layerwise = True
     load_quanted_weights._verl_mlite_ds4_layerwise = True
     fp8_utils.prepare_quanted_weights_for_loading = prepare_quanted_weights_for_loading
-    fp8_utils.process_quanted_weights_after_loading = process_quanted_weights_after_loading
+    fp8_utils.process_quanted_weights_after_loading = (
+        process_quanted_weights_after_loading
+    )
     fp8_utils.load_quanted_weights = load_quanted_weights
     # ``utils.py`` imports this function at module import time, so replacing the
     # defining module alone would leave the live rollout callback on the stale
@@ -912,9 +914,7 @@ def _patch_verl_dsv4_fp8_process_weights() -> bool:
     if not _vllm_importable():
         return False
     try:
-        utils = importlib.import_module(
-            "verl.workers.rollout.vllm_rollout.utils"
-        )
+        utils = importlib.import_module("verl.workers.rollout.vllm_rollout.utils")
     except Exception:
         return False
     ext_cls = getattr(utils, "vLLMColocateWorkerExtension", None)
@@ -1061,7 +1061,11 @@ def _install_bucketed_sender_prefetch(sender_cls: type) -> bool:
     async def prefetched_async_send_weights(self, weights):
         import torch
 
-        if not isinstance(weights, Iterable) or hasattr(weights, "__aiter__") or self.use_shm:
+        if (
+            not isinstance(weights, Iterable)
+            or hasattr(weights, "__aiter__")
+            or self.use_shm
+        ):
             return await original_async_send_weights(self, weights)
 
         executor = None
@@ -1083,7 +1087,9 @@ def _install_bucketed_sender_prefetch(sender_cls: type) -> bool:
             ready_results = queue.Queue(maxsize=2)
             for slot_index in range(2):
                 free_slots.put_nowait(slot_index)
-            executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="mlite-weight-prefetch")
+            executor = ThreadPoolExecutor(
+                max_workers=1, thread_name_prefix="mlite-weight-prefetch"
+            )
 
             def put_ready(result):
                 while not stop.is_set():
@@ -1120,12 +1126,20 @@ def _install_bucketed_sender_prefetch(sender_cls: type) -> bool:
                 except queue.Empty:
                     if worker_future.done():
                         worker_future.result()
-                        raise RuntimeError("MLite weight prefetch stopped without a terminal result")
+                        raise RuntimeError(
+                            "MLite weight prefetch stopped without a terminal result"
+                        )
                     continue
 
-                kind, metadata_or_name, direct_weight, used_bytes, ready, is_last, held_slot = (
-                    result
-                )
+                (
+                    kind,
+                    metadata_or_name,
+                    direct_weight,
+                    used_bytes,
+                    ready,
+                    is_last,
+                    held_slot,
+                ) = result
                 if kind == "error":
                     raise metadata_or_name
                 if kind == "eof":
@@ -1196,12 +1210,11 @@ def _instrument_bucketed_weight_sender(sender_cls: type) -> bool:
 
     import torch
     import torch.distributed as dist
-    from torch.utils._python_dispatch import TorchDispatchMode
-
     from megatron.lite.primitive.ckpt.weight_sync_probe import (
         get_weight_sync_probe,
         weight_sync_probe_session,
     )
+    from torch.utils._python_dispatch import TorchDispatchMode
 
     probe = get_weight_sync_probe()
     original_init_socket = sender_cls._init_socket
@@ -1261,13 +1274,17 @@ def _instrument_bucketed_weight_sender(sender_cls: type) -> bool:
         original_all_gather_into_tensor = dist.all_gather_into_tensor
 
         def profiled_all_gather_into_tensor(output, tensor, *args, **kwargs):
-            with probe.measure("mbridge_gather", nbytes=output.nbytes, device=tensor.device):
+            with probe.measure(
+                "mbridge_gather", nbytes=output.nbytes, device=tensor.device
+            ):
                 return original_all_gather_into_tensor(output, tensor, *args, **kwargs)
 
         with weight_sync_probe_session(backend), _H2DCopyMode():
             dist.all_gather_into_tensor = profiled_all_gather_into_tensor
             try:
-                result = await original_async_send_weights(self, fingerprinted_weights())
+                result = await original_async_send_weights(
+                    self, fingerprinted_weights()
+                )
                 if weight_sync_fingerprint_enabled():
                     rank = dist.get_rank() if dist.is_initialized() else 0
                     report_stream_fingerprint("sender", rank, fingerprint_records)
@@ -1315,7 +1332,10 @@ def _patch_bucketed_weight_transfer() -> bool:
     module = sys.modules.get(_BUCKETED_SENDER_MODULE)
     if module is not None:
         return _install_bucketed_sender_prefetch(module.BucketedWeightSender)
-    if any(getattr(finder, "_mlite_weight_sync_probe_finder", False) for finder in sys.meta_path):
+    if any(
+        getattr(finder, "_mlite_weight_sync_probe_finder", False)
+        for finder in sys.meta_path
+    ):
         return False
     sys.meta_path.insert(0, _SenderPatchFinder())
     return True
@@ -1329,7 +1349,9 @@ def _patch_bucketed_weight_sender() -> bool:
 
     module = sys.modules.get(_BUCKETED_SENDER_MODULE)
     if module is not None:
-        changed = _instrument_bucketed_weight_sender(module.BucketedWeightSender) or changed
+        changed = (
+            _instrument_bucketed_weight_sender(module.BucketedWeightSender) or changed
+        )
     else:
         finder = next(
             finder
@@ -1397,14 +1419,25 @@ def load_verl_engine_api():
     # only a fallback for environments where verl isn't importable as a package.
     try:
         from verl.workers.engine.base import BaseEngine, BaseEngineCtx, EngineRegistry
-        from verl.workers.engine.utils import postprocess_batch_func, prepare_micro_batches
+        from verl.workers.engine.utils import (
+            postprocess_batch_func,
+            prepare_micro_batches,
+        )
     except (ModuleNotFoundError, ImportError):
         base = _load_verl_file("workers/engine/base.py", "_verl_mlite_verl_engine_base")
-        utils = _load_verl_file("workers/engine/utils.py", "_verl_mlite_verl_engine_utils")
+        utils = _load_verl_file(
+            "workers/engine/utils.py", "_verl_mlite_verl_engine_utils"
+        )
         BaseEngine = base.BaseEngine
         BaseEngineCtx = base.BaseEngineCtx
         EngineRegistry = base.EngineRegistry
         postprocess_batch_func = utils.postprocess_batch_func
         prepare_micro_batches = utils.prepare_micro_batches
 
-    return BaseEngine, BaseEngineCtx, EngineRegistry, postprocess_batch_func, prepare_micro_batches
+    return (
+        BaseEngine,
+        BaseEngineCtx,
+        EngineRegistry,
+        postprocess_batch_func,
+        prepare_micro_batches,
+    )

--- a/experimental/lite/examples/verl/verl_mlite/compat.py
+++ b/experimental/lite/examples/verl/verl_mlite/compat.py
@@ -1210,11 +1210,16 @@ def _instrument_bucketed_weight_sender(sender_cls: type) -> bool:
 
     import torch
     import torch.distributed as dist
+
+    # Check the private API before checkpoint imports initialize global state.
+    # isort: off
+    from torch.utils._python_dispatch import TorchDispatchMode
     from megatron.lite.primitive.ckpt.weight_sync_probe import (
         get_weight_sync_probe,
         weight_sync_probe_session,
     )
-    from torch.utils._python_dispatch import TorchDispatchMode
+
+    # isort: on
 
     probe = get_weight_sync_probe()
     original_init_socket = sender_cls._init_socket

--- a/experimental/lite/examples/verl/verl_mlite/engine/config.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/config.py
@@ -50,9 +50,7 @@ class MegatronLiteEngineConfig(EngineConfig):
             from megatron.lite.runtime.contracts.weights import ResyncFormat
 
             object.__setattr__(
-                self,
-                "resync_format",
-                ResyncFormat.parse(self.resync_format).value,
+                self, "resync_format", ResyncFormat.parse(self.resync_format).value
             )
         if not isinstance(self.resync_config, Mapping):
             raise TypeError("resync_config must be a mapping")

--- a/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
@@ -13,16 +13,23 @@ from typing import Any
 import torch
 import torch.distributed as dist
 from megatron.lite.model import resolve_model_type_from_hf
-from megatron.lite.primitive.ckpt import load_training_checkpoint, save_training_checkpoint
+from megatron.lite.primitive.ckpt import (
+    load_training_checkpoint,
+    save_training_checkpoint,
+)
 from megatron.lite.primitive.modules import router_replay
-from megatron.lite.primitive.protocols import default_expert_classifier, default_placement_fn
+from megatron.lite.primitive.protocols import (
+    default_expert_classifier,
+    default_placement_fn,
+)
 from megatron.lite.runtime import create_runtime
 from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig
 from megatron.lite.runtime.contracts import LossContext, PackedBatch
-from megatron.lite.runtime.contracts.config import OptimizerConfig as MegatronLiteOptimizerConfig
+from megatron.lite.runtime.contracts.config import (
+    OptimizerConfig as MegatronLiteOptimizerConfig,
+)
 from megatron.lite.runtime.contracts.config import ParallelConfig, RuntimeConfig
 from tensordict import TensorDict
-
 from verl.trainer.config import CheckpointConfig
 from verl.utils import tensordict_utils as tu
 from verl.utils.device import get_device_id, get_device_name
@@ -42,9 +49,13 @@ from .config import MegatronLiteEngineConfig
 
 _patch_bucketed_weight_sender()
 
-BaseEngine, BaseEngineCtx, EngineRegistry, postprocess_batch_func, prepare_micro_batches = (
-    load_verl_engine_api()
-)
+(
+    BaseEngine,
+    BaseEngineCtx,
+    EngineRegistry,
+    postprocess_batch_func,
+    prepare_micro_batches,
+) = load_verl_engine_api()
 
 try:
     from verl.utils.dataset.dataset_utils import DatasetPadMode
@@ -349,7 +360,9 @@ class MegatronLiteEngine(BaseEngine):
 
         tu.assign_non_tensor(data, sp_size=self.engine_config.cp)
 
-        token_mask = data["loss_mask"] if "loss_mask" in data.keys() else data["response_mask"]
+        token_mask = (
+            data["loss_mask"] if "loss_mask" in data.keys() else data["response_mask"]
+        )
         batch_num_tokens = token_mask.sum().to(get_device_id())
         torch.distributed.all_reduce(
             batch_num_tokens,
@@ -360,7 +373,9 @@ class MegatronLiteEngine(BaseEngine):
         tu.assign_non_tensor(data, dp_size=self.get_data_parallel_size())
 
         micro_batches, indices = prepare_micro_batches(
-            data=data, dp_group=self.get_data_parallel_group(), same_micro_num_in_dp=True
+            data=data,
+            dp_group=self.get_data_parallel_group(),
+            same_micro_num_in_dp=True,
         )
 
         # Megatron drives every forward through the runtime's forward_backward
@@ -385,10 +400,7 @@ class MegatronLiteEngine(BaseEngine):
             for key in ("limit", "include_mtp_only", "include_local_prefixes")
             if key in kwargs
         }
-        export_kwargs.update(
-            buffer_max_size_bytes=2 * 1024**3,
-            cpu=False,
-        )
+        export_kwargs.update(buffer_max_size_bytes=2 * 1024**3, cpu=False)
         if self.engine_config.resync_format is not None:
             export_kwargs["target"] = self.engine_config.resync_format
             if self.engine_config.resync_config:
@@ -432,11 +444,15 @@ class MegatronLiteEngine(BaseEngine):
             return None
         return self.handle.dp_group
 
-    def to(self, device: str, model: bool = True, optimizer: bool = True, grad: bool = True):
+    def to(
+        self, device: str, model: bool = True, optimizer: bool = True, grad: bool = True
+    ):
         self._require_initialized()
         if model or not (optimizer or grad):
             super().to(device=device, model=model, optimizer=optimizer, grad=grad)
-        self.runtime.to(self.handle, device, model=model, optimizer=optimizer, grad=grad)
+        self.runtime.to(
+            self.handle, device, model=model, optimizer=optimizer, grad=grad
+        )
 
     def save_checkpoint(
         self,
@@ -532,7 +548,9 @@ class MegatronLiteEngine(BaseEngine):
             if hf_config is not None:
                 auto_map = getattr(hf_config, "auto_map", None)
                 if isinstance(auto_map, dict) and None in auto_map:
-                    hf_config.auto_map = {k: v for k, v in auto_map.items() if k is not None}
+                    hf_config.auto_map = {
+                        k: v for k, v in auto_map.items() if k is not None
+                    }
                 hf_config.save_pretrained(hf_local_path)
             tokenizer = getattr(self.model_config, "tokenizer", None)
             if tokenizer is not None:
@@ -572,7 +590,9 @@ class MegatronLiteEngine(BaseEngine):
             )
             scheduler_path = os.path.join(local_path, _LR_SCHEDULER_STATE)
             if self.handle._lr_scheduler is not None and os.path.exists(scheduler_path):
-                state = torch.load(scheduler_path, map_location="cpu", weights_only=False)
+                state = torch.load(
+                    scheduler_path, map_location="cpu", weights_only=False
+                )
                 self.handle._lr_scheduler.load_state_dict(state)
             if dist.is_initialized():
                 dist.barrier()
@@ -587,7 +607,9 @@ class MegatronLiteEngine(BaseEngine):
             tp_rank = rank % self.engine_config.tp
             cp_rank = (rank // self.engine_config.tp) % self.engine_config.cp
             pp_rank = rank // (self.engine_config.tp * self.engine_config.cp * dense_dp)
-            return tp_rank == 0 and cp_rank == 0 and pp_rank == self.engine_config.pp - 1
+            return (
+                tp_rank == 0 and cp_rank == 0 and pp_rank == self.engine_config.pp - 1
+            )
         return self.runtime.is_mp_src_rank_with_outputs(self.handle)
 
     def _require_initialized(self) -> None:
@@ -637,15 +659,21 @@ class MegatronLiteEngine(BaseEngine):
         impl_cfg["use_thd"] = True
         cross_entropy_fusion = getattr(self.engine_config, "cross_entropy_fusion", None)
         if cross_entropy_fusion is None:
-            cross_entropy_fusion = getattr(self.engine_config, "use_fused_kernels", False)
+            cross_entropy_fusion = getattr(
+                self.engine_config, "use_fused_kernels", False
+            )
         impl_cfg.setdefault("cross_entropy_fusion", bool(cross_entropy_fusion))
         mtp_cfg = getattr(self.model_config, "mtp", None)
         if mtp_cfg is not None:
             mtp_enable = bool(getattr(mtp_cfg, "enable", False))
-            mtp_enable_train = mtp_enable and bool(getattr(mtp_cfg, "enable_train", False))
+            mtp_enable_train = mtp_enable and bool(
+                getattr(mtp_cfg, "enable_train", False)
+            )
             impl_cfg["mtp_enable"] = mtp_enable
             impl_cfg["mtp_enable_train"] = mtp_enable_train
-            impl_cfg["mtp_detach_encoder"] = bool(getattr(mtp_cfg, "detach_encoder", False))
+            impl_cfg["mtp_detach_encoder"] = bool(
+                getattr(mtp_cfg, "detach_encoder", False)
+            )
             impl_cfg["mtp_loss_scaling_factor"] = float(
                 getattr(mtp_cfg, "mtp_loss_scaling_factor", 0.1)
             )
@@ -670,11 +698,15 @@ class MegatronLiteEngine(BaseEngine):
         min_lr = getattr(self.optimizer_config, "min_lr", None)
         min_lr_ratio = getattr(self.optimizer_config, "min_lr_ratio", None)
         if min_lr is None:
-            min_lr = 0.0 if min_lr_ratio is None else self.optimizer_config.lr * min_lr_ratio
+            min_lr = (
+                0.0 if min_lr_ratio is None else self.optimizer_config.lr * min_lr_ratio
+            )
 
         lr_decay_style = getattr(self.optimizer_config, "lr_decay_style", None)
         if lr_decay_style is None:
-            lr_decay_style = getattr(self.optimizer_config, "lr_scheduler_type", "constant")
+            lr_decay_style = getattr(
+                self.optimizer_config, "lr_scheduler_type", "constant"
+            )
 
         return MegatronLiteOptimizerConfig(
             optimizer=optimizer_name,
@@ -691,8 +723,12 @@ class MegatronLiteEngine(BaseEngine):
             weight_decay_incr_style=getattr(
                 self.optimizer_config, "weight_decay_incr_style", "constant"
             ),
-            lr_wsd_decay_style=getattr(self.optimizer_config, "lr_wsd_decay_style", "exponential"),
-            lr_wsd_decay_steps=getattr(self.optimizer_config, "lr_wsd_decay_steps", None),
+            lr_wsd_decay_style=getattr(
+                self.optimizer_config, "lr_wsd_decay_style", "exponential"
+            ),
+            lr_wsd_decay_steps=getattr(
+                self.optimizer_config, "lr_wsd_decay_steps", None
+            ),
             use_checkpoint_opt_param_scheduler=getattr(
                 self.optimizer_config, "use_checkpoint_opt_param_scheduler", False
             ),
@@ -718,7 +754,9 @@ class MegatronLiteEngine(BaseEngine):
         model = self.handle._model
         if isinstance(model, list | tuple):
             if not model:
-                raise RuntimeError("Megatron Lite runtime returned an empty model chunk list.")
+                raise RuntimeError(
+                    "Megatron Lite runtime returned an empty model chunk list."
+                )
             if len(model) > 1:
                 return torch.nn.ModuleList(model)
             return model[0]
@@ -735,14 +773,20 @@ class MegatronLiteEngine(BaseEngine):
     ) -> dict[str, Any]:
         runtime_batches = []
         num_micro_batches = len(micro_batches)
-        batch_num_tokens = tu.get_non_tensor_data(data=data, key="batch_num_tokens", default=None)
+        batch_num_tokens = tu.get_non_tensor_data(
+            data=data, key="batch_num_tokens", default=None
+        )
         if batch_num_tokens is None:
             raise ValueError(
                 "MegatronLiteEngine PP/CP SFT requires batch_num_tokens for VERL-compatible loss scaling."
             )
         if batch_num_tokens <= 0:
-            raise ValueError(f"batch_num_tokens must be positive, got {batch_num_tokens}.")
-        loss_scale = self.get_data_parallel_size() * num_micro_batches / float(batch_num_tokens)
+            raise ValueError(
+                f"batch_num_tokens must be positive, got {batch_num_tokens}."
+            )
+        loss_scale = (
+            self.get_data_parallel_size() * num_micro_batches / float(batch_num_tokens)
+        )
         for micro_idx, micro_batch in enumerate(micro_batches):
             tu.assign_non_tensor(micro_batch, micro_batch_idx=micro_idx)
             micro_batch = micro_batch.to(get_device_id())
@@ -754,9 +798,16 @@ class MegatronLiteEngine(BaseEngine):
             )
 
         runtime_loss_fn = None
-        reduced_outputs = [] if (loss_function is not None or forward_only) and self.is_mp_src_rank_with_outputs() else None
+        reduced_outputs = (
+            []
+            if (loss_function is not None or forward_only)
+            and self.is_mp_src_rank_with_outputs()
+            else None
+        )
         if loss_function is not None or forward_only:
-            runtime_loss_fn = self._make_runtime_loss_fn(loss_function, num_micro_batches, reduced_outputs)
+            runtime_loss_fn = self._make_runtime_loss_fn(
+                loss_function, num_micro_batches, reduced_outputs
+            )
 
         replay_specs = [
             runtime_batch.routed_experts is not None
@@ -777,20 +828,28 @@ class MegatronLiteEngine(BaseEngine):
             router_replay={"action": "replay"} if replay_enabled else None,
         )
         if reduced_outputs is not None:
-            return postprocess_batch_func(output_lst=reduced_outputs, indices=indices, data=data)
+            return postprocess_batch_func(
+                output_lst=reduced_outputs, indices=indices, data=data
+            )
         metrics = dict(result.metrics)
         loss = result.model_output.loss
-        losses = [] if loss is None else torch.as_tensor(loss).detach().flatten().cpu().tolist()
+        losses = (
+            []
+            if loss is None
+            else torch.as_tensor(loss).detach().flatten().cpu().tolist()
+        )
         return {
             "model_output": {},
             "loss": losses,
             # Pass Metric aggregators through unchanged (reduce_metrics folds them);
             # list-wrap plain scalars as the legacy contract expects.
             "metrics": {
-                key: value
-                if isinstance(value, list)
-                or (_VerlMetric is not None and isinstance(value, _VerlMetric))
-                else [value]
+                key: (
+                    value
+                    if isinstance(value, list)
+                    or (_VerlMetric is not None and isinstance(value, _VerlMetric))
+                    else [value]
+                )
                 for key, value in metrics.items()
             },
         }
@@ -812,7 +871,9 @@ class MegatronLiteEngine(BaseEngine):
         if self.engine_config.router_replay_mode == "R3":
             r3_replay_mask = self._r3_replay_mask_for_packing(micro_batch, input_ids)
         routed_experts = micro_batch.get("routed_experts", None)
-        if routed_experts is not None and not getattr(routed_experts, "is_nested", False):
+        if routed_experts is not None and not getattr(
+            routed_experts, "is_nested", False
+        ):
             raise ValueError(
                 "R3 routed_experts must use VERL's jagged no-padding layout; "
                 f"got shape {tuple(routed_experts.shape)}."
@@ -820,7 +881,9 @@ class MegatronLiteEngine(BaseEngine):
         return PackedBatch(
             input_ids=input_ids.values().contiguous(),
             labels=input_ids.values().contiguous(),
-            loss_mask=None if loss_mask is None else loss_mask.values().contiguous().float(),
+            loss_mask=(
+                None if loss_mask is None else loss_mask.values().contiguous().float()
+            ),
             seq_lens=input_ids.offsets().diff().to(dtype=torch.int64),
             routed_experts=routed_experts,
             r3_replay_mask=(
@@ -829,15 +892,14 @@ class MegatronLiteEngine(BaseEngine):
         )
 
     def _make_runtime_loss_context(
-        self,
-        micro_batch: TensorDict,
-        *,
-        loss_scale: float,
+        self, micro_batch: TensorDict, *, loss_scale: float
     ) -> LossContext:
         return LossContext(
             temperature=float(self._scalar_temperature(micro_batch)),
             calculate_entropy=bool(
-                tu.get_non_tensor_data(data=micro_batch, key="calculate_entropy", default=False)
+                tu.get_non_tensor_data(
+                    data=micro_batch, key="calculate_entropy", default=False
+                )
             ),
             return_log_probs=True,
             loss_scale=loss_scale,
@@ -894,7 +956,9 @@ class MegatronLiteEngine(BaseEngine):
                 raise ValueError(
                     f"response loss mask has {response_tokens} tokens but packed input sequence has {seq_len} tokens"
                 )
-            full_mask = torch.zeros(seq_len, dtype=row_mask.dtype, device=row_mask.device)
+            full_mask = torch.zeros(
+                seq_len, dtype=row_mask.dtype, device=row_mask.device
+            )
             if response_tokens:
                 full_mask[-response_tokens:] = row_mask[:response_tokens]
             rows.append(full_mask)
@@ -910,14 +974,13 @@ class MegatronLiteEngine(BaseEngine):
         )
 
     def _build_verl_model_output(
-        self,
-        *,
-        raw_output: dict[str, torch.Tensor],
-        runtime_batch: PackedBatch,
+        self, *, raw_output: dict[str, torch.Tensor], runtime_batch: PackedBatch
     ) -> dict[str, torch.Tensor]:
         log_probs = raw_output.get("log_probs")
         if log_probs is None:
-            raise ValueError("Megatron Lite THD model output must contain token log_probs.")
+            raise ValueError(
+                "Megatron Lite THD model output must contain token log_probs."
+            )
         proto = self.handle._extras.get("protocol")
         unpack = getattr(proto, "unpack_forward_output", None)
         if unpack is None:
@@ -930,7 +993,9 @@ class MegatronLiteEngine(BaseEngine):
             output["entropy"] = unpack(self.module, runtime_batch, entropy)
         return output
 
-    def _make_runtime_loss_fn(self, loss_function, num_microbatches: int, output_lst=None):
+    def _make_runtime_loss_fn(
+        self, loss_function, num_microbatches: int, output_lst=None
+    ):
         loss_fn_ref = None
 
         def _loss_fn(
@@ -957,7 +1022,9 @@ class MegatronLiteEngine(BaseEngine):
                 metrics = dict(metrics)
                 mtp_loss = self._reduce_mtp_metric(raw_output["mtp_loss"])
                 metrics["mtp_losses/mtp_1_loss"] = (
-                    float(mtp_loss.item()) if mtp_loss.numel() == 1 else mtp_loss.cpu().tolist()
+                    float(mtp_loss.item())
+                    if mtp_loss.numel() == 1
+                    else mtp_loss.cpu().tolist()
                 )
 
             raw_output["_verl_metrics"] = metrics
@@ -976,7 +1043,9 @@ class MegatronLiteEngine(BaseEngine):
                         "metrics": metrics,
                     }
                 )
-            return (loss * num_microbatches if loss_function is not None else loss), metrics
+            return (
+                loss * num_microbatches if loss_function is not None else loss
+            ), metrics
 
         # Avoid a strong self-reference while preserving the runtime hook attributes.
         loss_fn_ref = weakref.ref(_loss_fn)
@@ -1027,5 +1096,7 @@ class MegatronLiteEngine(BaseEngine):
     def _checkpoint_hooks(self):
         proto = self.handle._extras.get("protocol")
         placement_fn = getattr(proto, "PLACEMENT_FN", default_placement_fn)
-        expert_classifier = getattr(proto, "EXPERT_CLASSIFIER", default_expert_classifier)
+        expert_classifier = getattr(
+            proto, "EXPERT_CLASSIFIER", default_expert_classifier
+        )
         return placement_fn, expert_classifier

--- a/experimental/lite/examples/verl/verl_mlite/qat_export.py
+++ b/experimental/lite/examples/verl/verl_mlite/qat_export.py
@@ -20,11 +20,7 @@ from megatron.lite.primitive.quantization.mxfp4 import MXFP4_BLOCK_SIZE, quantiz
 # ``ignore_patterns`` must still leave fragile output, embedding, and router
 # tensors in BF16; callers can explicitly provide a different list when their
 # checkpoint naming requires it.
-_DEFAULT_IGNORE_PATTERNS = (
-    "lm_head",
-    "embed_tokens",
-    "re:.*mlp.gate$",
-)
+_DEFAULT_IGNORE_PATTERNS = ("lm_head", "embed_tokens", "re:.*mlp.gate$")
 
 
 def _get_field(config: Any, name: str, default: Any) -> Any:

--- a/experimental/lite/examples/verl/verl_mlite/rollout/layer_cluster.py
+++ b/experimental/lite/examples/verl/verl_mlite/rollout/layer_cluster.py
@@ -15,30 +15,20 @@ _LAYER_INDEX_RE = re.compile(
 _MTP_INDEX_RE = re.compile(r"(?:^|\.)(?:(?:model\.)?mtp\.(?P<mtp>\d+))(?:\.|$)")
 
 _EMBED_NAMES = frozenset(
-    {
-        "embed.weight",
-        "model.embed.weight",
-        "model.embed_tokens.weight",
-    }
+    {"embed.weight", "model.embed.weight", "model.embed_tokens.weight"}
 )
 _NORM_NAMES = frozenset({"norm.weight", "model.norm.weight"})
-_HEAD_NAMES = frozenset(
-    {
-        "head.weight",
-        "lm_head.weight",
-        "model.lm_head.weight",
-    }
-)
+_HEAD_NAMES = frozenset({"head.weight", "lm_head.weight", "model.lm_head.weight"})
 
 
 def resync_layer_cluster_key(name: str) -> tuple[int, int]:
     """Return a stable sortable key that groups checkpoint tensors by decoder layer.
 
-    Tensors that belong to the same HF decoder layer (weights and their ``.scale``
-  companions) must be loaded in one contiguous ``load_weights`` batch while the
-    vLLM layerwise-reload lifecycle is active. Otherwise multiple submodules stay
-    in the deferred ``online_process_loader`` state and staging memory accumulates
-    across layers (observed as the 53-58 GiB receiver peak in r1-r11).
+      Tensors that belong to the same HF decoder layer (weights and their ``.scale``
+    companions) must be loaded in one contiguous ``load_weights`` batch while the
+      vLLM layerwise-reload lifecycle is active. Otherwise multiple submodules stay
+      in the deferred ``online_process_loader`` state and staging memory accumulates
+      across layers (observed as the 53-58 GiB receiver peak in r1-r11).
     """
     if name in _EMBED_NAMES:
         return (0, 0)
@@ -84,7 +74,7 @@ class LayerClusterBuffer:
 
 
 def iter_layer_clustered_weights(
-    weights: Iterable[tuple[str, Any]],
+    weights: Iterable[tuple[str, Any]]
 ) -> Iterator[tuple[str, Any]]:
     """Reorder a flat export stream so each HF layer cluster is contiguous."""
     current_key: tuple[int, int] | None = None

--- a/experimental/lite/megatron/lite/__init__.py
+++ b/experimental/lite/megatron/lite/__init__.py
@@ -8,8 +8,15 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from megatron.lite.runtime.backends.bridge.config import BridgeConfig
-    from megatron.lite.runtime.backends.mlite.config import DebugConfig, MegatronLiteConfig
-    from megatron.lite.runtime.contracts import OptimizerConfig, ParallelConfig, RuntimeConfig
+    from megatron.lite.runtime.backends.mlite.config import (
+        DebugConfig,
+        MegatronLiteConfig,
+    )
+    from megatron.lite.runtime.contracts import (
+        OptimizerConfig,
+        ParallelConfig,
+        RuntimeConfig,
+    )
 
 __all__ = [
     "BridgeConfig",

--- a/experimental/lite/megatron/lite/model/deepseek_v4/config.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/config.py
@@ -65,13 +65,22 @@ class DeepseekV4Config:
     @classmethod
     def _from_hf_dict(cls, hf: dict[str, Any], **overrides) -> DeepseekV4Config:
         hf_fields = {item.name for item in fields(cls)}
-        kwargs = {key: value for key, value in hf.items() if key in hf_fields and value is not None}
-        if "num_nextn_predict_layers" not in kwargs and hf.get("num_nextn_predict") is not None:
+        kwargs = {
+            key: value
+            for key, value in hf.items()
+            if key in hf_fields and value is not None
+        }
+        if (
+            "num_nextn_predict_layers" not in kwargs
+            and hf.get("num_nextn_predict") is not None
+        ):
             kwargs["num_nextn_predict_layers"] = int(hf["num_nextn_predict"])
         rope_parameters = hf.get("rope_parameters")
         if isinstance(rope_parameters, dict):
             if "rope_theta" not in kwargs:
-                kwargs["rope_theta"] = float(rope_parameters.get("rope_theta", cls.rope_theta))
+                kwargs["rope_theta"] = float(
+                    rope_parameters.get("rope_theta", cls.rope_theta)
+                )
         rope_scaling = hf.get("rope_scaling")
         if isinstance(rope_scaling, dict):
             if rope_scaling.get("factor") is not None:

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/model.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/model.py
@@ -36,10 +36,9 @@ from typing import Any
 
 import torch
 import torch.nn as nn
-
-from megatron.lite.primitive import transformer_engine as te
 from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
 from megatron.lite.model.deepseek_v4.lite.moe import DeepseekV4MoE
+from megatron.lite.primitive import transformer_engine as te
 from megatron.lite.primitive.modules.attention.csa import CompressedSparseAttention
 from megatron.lite.primitive.modules.attention.hca import HyperConnection
 from megatron.lite.primitive.modules.attention.mhc import MultiHeadHyperConnectionHead
@@ -66,10 +65,7 @@ from megatron.lite.primitive.utils import build_fp8_recipe
 
 
 def _roll_mtp_left(
-    tensor: torch.Tensor,
-    *,
-    packed_seq_params=None,
-    dims: int = -1,
+    tensor: torch.Tensor, *, packed_seq_params=None, dims: int = -1
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Shift labels/ids one position left (next-token target for MTP depth d).
 
@@ -78,13 +74,19 @@ def _roll_mtp_left(
     per-sequence THD-aware roll (contiguous cu_seqlens at CP==1, where DS4 MTP
     runs) when packed_seq_params is available; fall back to plain roll otherwise.
     """
-    cu_seqlens = None if packed_seq_params is None else getattr(packed_seq_params, "cu_seqlens_q", None)
+    cu_seqlens = (
+        None
+        if packed_seq_params is None
+        else getattr(packed_seq_params, "cu_seqlens_q", None)
+    )
     if cu_seqlens is not None:
         # DS4 uses a CONTIGUOUS THD/CP layout (not TE/Megatron zigzag), so roll
         # per-sequence via cu_seqlens directly -- never the zigzag reconstruction
         # in roll_packed_thd_left (which GLM/Kimi use for their zigzag layout).
         dim = dims if dims >= 0 else tensor.dim() + dims
-        return _roll_packed_thd_left_local(tensor, cu_seqlens_padded=cu_seqlens, dims=dim)
+        return _roll_packed_thd_left_local(
+            tensor, cu_seqlens_padded=cu_seqlens, dims=dim
+        )
     dim = dims if dims >= 0 else tensor.dim() + dims
     rolled = torch.roll(tensor, shifts=-1, dims=dim)
     rolled.select(dim, -1).zero_()
@@ -112,7 +114,11 @@ class DeepseekV4CSAAttention(nn.Module):
         self.self_attn = CompressedSparseAttention(config, layer_idx=layer_idx, ps=ps)
 
     def forward(
-        self, x: torch.Tensor, *, position_ids: torch.Tensor, packed_seq_params: Any = None
+        self,
+        x: torch.Tensor,
+        *,
+        position_ids: torch.Tensor,
+        packed_seq_params: Any = None,
     ) -> torch.Tensor:
         # Skeleton feeds SBHD [S, B, H]; CSA needs batch-first [B, S, H].
         # packed_seq_params (cu_seqlens etc.) passes through unchanged: the THD
@@ -152,7 +158,9 @@ class DeepseekV4Layer(nn.Module):
         self.layer_idx = layer_idx
         self.ps = ps
         self.input_layernorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.post_attention_layernorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = te.RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
         # DS4 ONLY: CSA attention behind the SBHD shim (Kimi builds MLA here).
         self.self_attn = DeepseekV4CSAAttention(config, layer_idx=layer_idx, ps=ps)
         # DS4 ONLY: hash-routed MoE family (shared Experts/Router/dispatcher).
@@ -191,8 +199,12 @@ class DeepseekV4Layer(nn.Module):
         # align with the flattened hidden.  The skeleton is SBHD, so the FFN
         # input flattens in (S, B) order; transpose input_ids [B, S] -> [S, B]
         # so its flatten matches.  (No-op semantics for non-hash layers.)
-        mlp_input_ids = None if input_ids is None else input_ids.transpose(0, 1).contiguous()
-        ffn_out = self.mlp(self.post_attention_layernorm(ffn_in), input_ids=mlp_input_ids)
+        mlp_input_ids = (
+            None if input_ids is None else input_ids.transpose(0, 1).contiguous()
+        )
+        ffn_out = self.mlp(
+            self.post_attention_layernorm(ffn_in), input_ids=mlp_input_ids
+        )
         return HyperConnection.post(ffn_out, residual, post, comb)
 
 
@@ -226,7 +238,9 @@ class DeepseekV4MTPLayer(DeepseekV4Layer):
         self.enorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.hnorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.norm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.hc_head = MultiHeadHyperConnectionHead(config.hidden_size, config.hc_mult, config.hc_eps)
+        self.hc_head = MultiHeadHyperConnectionHead(
+            config.hidden_size, config.hc_mult, config.hc_eps
+        )
 
     def forward(
         self,
@@ -244,8 +258,12 @@ class DeepseekV4MTPLayer(DeepseekV4Layer):
         embedded = self.enorm(embedded)
         # e_proj on the [S, B, H] embedding, broadcast across the hc_mult streams;
         # h_proj on the normed mHC hidden keeps the per-stream state.
-        projected = self.e_proj(embedded).unsqueeze(2) + self.h_proj(self.hnorm(hidden_states))
-        return super().forward(projected, position_ids=position_ids, input_ids=input_ids)
+        projected = self.e_proj(embedded).unsqueeze(2) + self.h_proj(
+            self.hnorm(hidden_states)
+        )
+        return super().forward(
+            projected, position_ids=position_ids, input_ids=input_ids
+        )
 
     def contract(self, x: torch.Tensor) -> torch.Tensor:
         # Collapse the hc_mult streams [S, B, hc_mult, H] -> [S, B, H].
@@ -340,7 +358,9 @@ class DeepseekV4Model(nn.Module):
 
         self.embed_tokens: VocabParallelEmbedding | None = None
         if layout.has_embed:
-            self.embed_tokens = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
+            self.embed_tokens = VocabParallelEmbedding(
+                config.vocab_size, config.hidden_size, ps
+            )
 
         # Key by LOCAL pipeline-stage position (0..len-1), not the global layer id,
         # so parameter names ("layers.{local}.…") follow the same convention as the
@@ -352,7 +372,9 @@ class DeepseekV4Model(nn.Module):
         # for its dense-vs-MoE / per-layer logic.
         self.layers = nn.ModuleDict(
             {
-                str(local): DeepseekV4Layer(config, ps, global_idx, use_deepep=use_deepep)
+                str(local): DeepseekV4Layer(
+                    config, ps, global_idx, use_deepep=use_deepep
+                )
                 for local, global_idx in enumerate(self.layer_indices)
             }
         )
@@ -365,14 +387,18 @@ class DeepseekV4Model(nn.Module):
             self.hc_head = MultiHeadHyperConnectionHead(
                 config.hidden_size, config.hc_mult, config.hc_eps
             )
-            self.lm_head = VocabParallelOutput(config.vocab_size, config.hidden_size, ps)
+            self.lm_head = VocabParallelOutput(
+                config.vocab_size, config.hidden_size, ps
+            )
 
         self.mtp_embed: VocabParallelEmbedding | None = None
         self.mtp: nn.ModuleList = nn.ModuleList()
         if mtp_enable and config.num_nextn_predict_layers > 0 and layout.has_mtp:
             mtp_embedding = self.embed_tokens
             if mtp_embedding is None:
-                mtp_embedding = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
+                mtp_embedding = VocabParallelEmbedding(
+                    config.vocab_size, config.hidden_size, ps
+                )
                 self.mtp_embed = mtp_embedding
             self.mtp = nn.ModuleList(
                 [
@@ -391,7 +417,9 @@ class DeepseekV4Model(nn.Module):
     def set_input_tensor(self, input_tensor):
         if isinstance(input_tensor, list):
             if len(input_tensor) > 1:
-                raise ValueError("DeepseekV4Model expects a single pipeline input tensor.")
+                raise ValueError(
+                    "DeepseekV4Model expects a single pipeline input tensor."
+                )
             input_tensor = input_tensor[0] if input_tensor else None
         self._input_tensor = input_tensor
 
@@ -453,7 +481,9 @@ class DeepseekV4Model(nn.Module):
             )
 
         fp8_ctx = (
-            te.fp8_autocast(enabled=True, fp8_recipe=build_fp8_recipe(self.train_config))
+            te.fp8_autocast(
+                enabled=True, fp8_recipe=build_fp8_recipe(self.train_config)
+            )
             if self.train_config.fp8
             else nullcontext()
         )
@@ -476,7 +506,9 @@ class DeepseekV4Model(nn.Module):
         # Last stage: contract the mHC streams, then run head / MTP / loss
         # exactly as the Kimi skeleton does.
         mtp_source = h
-        hidden_for_head = contract_mhc_hidden_for_pipeline(h, norm=self.norm, head=self.hc_head)
+        hidden_for_head = contract_mhc_hidden_for_pipeline(
+            h, norm=self.norm, head=self.hc_head
+        )
 
         # MTP runs on the head stage (where self.mtp is built with a valid bound
         # embedding -- self.embed_tokens when present, else the self.mtp_embed
@@ -489,7 +521,10 @@ class DeepseekV4Model(nn.Module):
             and self.ps.cp_size == 1
         )
         mtp_hidden_states = self._apply_mtp(
-            mtp_source, input_ids=input_ids, position_ids=position_ids, run_mtp=run_mtp,
+            mtp_source,
+            input_ids=input_ids,
+            position_ids=position_ids,
+            run_mtp=run_mtp,
             packed_seq_params=packed_seq_params,
         )
         if mtp_hidden_states is not None:
@@ -538,7 +573,9 @@ class DeepseekV4Model(nn.Module):
             output["logits"] = self.lm_head.gather(logits).transpose(0, 1).contiguous()
             if mtp_hidden_states is not None:
                 output["mtp_logits"] = [
-                    self.lm_head.gather(self.lm_head(mtp_hidden)).transpose(0, 1).contiguous()
+                    self.lm_head.gather(self.lm_head(mtp_hidden))
+                    .transpose(0, 1)
+                    .contiguous()
                     for mtp_hidden in mtp_hidden_states
                 ]
         return output
@@ -562,11 +599,11 @@ class DeepseekV4Model(nn.Module):
         source = mtp_source
         outputs: list[torch.Tensor] = []
         for mtp_layer in self.mtp:
-            mtp_input_ids, _ = _roll_mtp_left(mtp_input_ids, packed_seq_params=packed_seq_params, dims=-1)
+            mtp_input_ids, _ = _roll_mtp_left(
+                mtp_input_ids, packed_seq_params=packed_seq_params, dims=-1
+            )
             source = mtp_layer(
-                input_ids=mtp_input_ids,
-                hidden_states=source,
-                position_ids=position_ids,
+                input_ids=mtp_input_ids, hidden_states=source, position_ids=position_ids
             )
             outputs.append(mtp_layer.contract(source))
         return outputs
@@ -592,8 +629,12 @@ class DeepseekV4Model(nn.Module):
 
         mtp_loss_values = []
         for mtp_hidden in mtp_hidden_states:
-            mtp_labels, _ = _roll_mtp_left(mtp_labels, packed_seq_params=packed_seq_params, dims=-1)
-            mtp_loss_mask, num_tokens = _roll_mtp_left(mtp_loss_mask, packed_seq_params=packed_seq_params, dims=-1)
+            mtp_labels, _ = _roll_mtp_left(
+                mtp_labels, packed_seq_params=packed_seq_params, dims=-1
+            )
+            mtp_loss_mask, num_tokens = _roll_mtp_left(
+                mtp_loss_mask, packed_seq_params=packed_seq_params, dims=-1
+            )
             labels_sb = mtp_labels.transpose(0, 1).contiguous()
             mask_sb = mtp_loss_mask.transpose(0, 1).contiguous()
 
@@ -611,16 +652,19 @@ class DeepseekV4Model(nn.Module):
                 logits = self.lm_head(mtp_hidden)
                 if temperature != 1.0:
                     logits = logits / temperature
-                token_loss = vocab_parallel_cross_entropy(logits, labels_sb, self.ps.tp_group)
+                token_loss = vocab_parallel_cross_entropy(
+                    logits, labels_sb, self.ps.tp_group
+                )
 
             token_loss = token_loss * mask_sb.to(dtype=token_loss.dtype)
             num_tokens = num_tokens.to(dtype=token_loss.dtype).clamp_min(1.0)
             mtp_loss_values.append(token_loss.sum() / num_tokens)
 
-            mtp_loss_scale = self.mtp_loss_scaling_factor / max(len(mtp_hidden_states), 1)
+            mtp_loss_scale = self.mtp_loss_scaling_factor / max(
+                len(mtp_hidden_states), 1
+            )
             hidden_states = MTPLossAutoScaler.apply(
-                hidden_states,
-                mtp_loss_scale * token_loss / num_tokens,
+                hidden_states, mtp_loss_scale * token_loss / num_tokens
             )
 
         if not mtp_loss_values:
@@ -634,7 +678,9 @@ class DeepseekV4Model(nn.Module):
         assert self.lm_head is not None
         weight = self.lm_head.col.linear.weight
         return (
-            weight if weight.dtype == hidden_states.dtype else weight.to(dtype=hidden_states.dtype)
+            weight
+            if weight.dtype == hidden_states.dtype
+            else weight.to(dtype=hidden_states.dtype)
         )
 
 

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/model.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/model.py
@@ -36,9 +36,14 @@ from typing import Any
 
 import torch
 import torch.nn as nn
+
+# Initialize TE before MoE imports attempt optional DeepEP initialization.
+# isort: off
+from megatron.lite.primitive import transformer_engine as te
 from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
 from megatron.lite.model.deepseek_v4.lite.moe import DeepseekV4MoE
-from megatron.lite.primitive import transformer_engine as te
+
+# isort: on
 from megatron.lite.primitive.modules.attention.csa import CompressedSparseAttention
 from megatron.lite.primitive.modules.attention.hca import HyperConnection
 from megatron.lite.primitive.modules.attention.mhc import MultiHeadHyperConnectionHead

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/moe.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/moe.py
@@ -2,7 +2,6 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-
 from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
 from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
 from megatron.lite.primitive.modules.experts import Experts
@@ -51,16 +50,11 @@ class DeepseekV4MoE(nn.Module):
             else None
         )
         self.dispatcher = TokenDispatcher(
-            config.n_routed_experts,
-            config.hidden_size,
-            ps,
-            use_deepep=use_deepep,
+            config.n_routed_experts, config.hidden_size, ps, use_deepep=use_deepep
         )
 
     def _hash_route(
-        self,
-        x: torch.Tensor,
-        input_ids: torch.Tensor,
+        self, x: torch.Tensor, input_ids: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor]:
         logits = self.gate.gate(x).view(-1, self.gate.num_experts)
         if self.gate.score_function == "sqrtsoftplus":
@@ -80,14 +74,18 @@ class DeepseekV4MoE(nn.Module):
             weights = weights / (weights.sum(dim=-1, keepdim=True) + 1e-20)
         return (weights * self.route_scale).to(dtype=x.dtype), indices
 
-    def forward(self, x: torch.Tensor, *, input_ids: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(
+        self, x: torch.Tensor, *, input_ids: torch.Tensor | None = None
+    ) -> torch.Tensor:
         shape = x.shape
         x_flat = x.reshape(-1, self.hidden_size)
         if self.is_hash_layer and input_ids is not None:
             weights, indices = self._hash_route(x_flat, input_ids)
         else:
             weights, indices = self.gate(x_flat)
-        dispatched, tpe, permuted_probs = self.dispatcher.dispatch(x_flat, weights, indices)
+        dispatched, tpe, permuted_probs = self.dispatcher.dispatch(
+            x_flat, weights, indices
+        )
         del weights, indices
         self.dispatcher.wait_dispatch_event()
         out = self.experts(

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
@@ -6,20 +6,31 @@ from typing import Any
 
 import torch
 import torch.nn as nn
-
 from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
 from megatron.lite.model.deepseek_v4.lite.checkpoint import (
     EXPERT_CLASSIFIER,
     PLACEMENT_FN,
+)
+from megatron.lite.model.deepseek_v4.lite.checkpoint import (
     export_hf_weights as _export_hf_weights_impl,
+)
+from megatron.lite.model.deepseek_v4.lite.checkpoint import (
     load_hf_weights as _load_hf_weights_impl,
+)
+from megatron.lite.model.deepseek_v4.lite.checkpoint import (
     save_hf_weights as _save_hf_weights_impl,
 )
 from megatron.lite.model.protocol_utils import (
     add_loss_context_kwargs,
     nested_from_packed,
+)
+from megatron.lite.model.protocol_utils import (
     pack_r3_replay_mask as _pack_r3_replay_mask,
+)
+from megatron.lite.model.protocol_utils import (
     pack_routed_experts as _pack_routed_experts,
+)
+from megatron.lite.model.protocol_utils import (
     router_replay_roots as router_replay_roots,
 )
 from megatron.lite.primitive.bundle import ModelBundle
@@ -36,12 +47,12 @@ from megatron.lite.primitive.parallel.thd import (
     thd_pack_meta,
     unpack_thd_to_nested,
 )
-from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec
 from megatron.lite.primitive.quantization import (
     QATSpec,
     apply_qat_to_chunks,
     normalize_qat_spec,
 )
+from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec
 from megatron.lite.runtime.contracts import OptimizerConfig, PackedBatch, ParallelConfig
 
 
@@ -125,16 +136,14 @@ def _as_batch_row(tensor):
     return tensor
 
 
-def _infer_cp_local_seq_len(
-    *,
-    input_ids,
-    position_ids,
-    cp_size,
-):
+def _infer_cp_local_seq_len(*, input_ids, position_ids, cp_size):
     seq_len = input_ids.size(1)
     if cp_size <= 1:
         return seq_len
-    if position_ids is not None and position_ids.size(-1) in (seq_len, seq_len * cp_size):
+    if position_ids is not None and position_ids.size(-1) in (
+        seq_len,
+        seq_len * cp_size,
+    ):
         return seq_len
     return seq_len // cp_size if seq_len % cp_size == 0 else seq_len
 
@@ -194,7 +203,9 @@ def _prepare_packed_contiguous_cp_kwargs(model, kwargs):
     for key in ("input_ids", "labels", "loss_mask", "position_ids"):
         tensor = kwargs.get(key)
         if tensor is not None:
-            kwargs[key] = contiguous_slice_for_cp(tensor, ps.cp_rank, ps.cp_size, seq_dim=1)
+            kwargs[key] = contiguous_slice_for_cp(
+                tensor, ps.cp_rank, ps.cp_size, seq_dim=1
+            )
     return kwargs
 
 
@@ -247,7 +258,9 @@ def _prepare_model_forward_kwargs(model, batch: PackedBatch):
     # split per row under contiguous CP, where contiguous_position_ids_for_cp rebuilds
     # the per-rank global position ids.
     input_ids = batch.input_ids
-    is_thd_packed = input_ids.dim() == 1 or (input_ids.dim() == 2 and input_ids.size(0) == 1)
+    is_thd_packed = input_ids.dim() == 1 or (
+        input_ids.dim() == 2 and input_ids.size(0) == 1
+    )
     if is_thd_packed:
         return _prepare_packed_batch_kwargs(model, batch)
     kwargs = _base_model_forward_kwargs(batch)
@@ -294,11 +307,15 @@ def _apply_mtp_config(model_cfg: DeepseekV4Config, impl_cfg: ImplConfig) -> None
         override = impl_cfg.mtp_num_layers
     if override is not None:
         if override < 0:
-            raise ValueError(f"DeepSeek V4 MTP layer count must be >=0, got {override}.")
+            raise ValueError(
+                f"DeepSeek V4 MTP layer count must be >=0, got {override}."
+            )
         model_cfg.num_nextn_predict_layers = int(override)
     if impl_cfg.mtp_enable:
         if model_cfg.num_nextn_predict_layers <= 0:
-            raise ValueError("mtp_enable=True but DeepSeek V4 config has no MTP layers.")
+            raise ValueError(
+                "mtp_enable=True but DeepSeek V4 config has no MTP layers."
+            )
         model_cfg.mtp_loss_scaling_factor = impl_cfg.mtp_loss_scaling_factor
     else:
         model_cfg.num_nextn_predict_layers = 0
@@ -330,7 +347,9 @@ def _optimizer_backend_name(optimizer: Any) -> str | None:
     return optimizer
 
 
-def _configure_attention_backend(chunks: list[nn.Module], *, backend: str | None) -> None:
+def _configure_attention_backend(
+    chunks: list[nn.Module], *, backend: str | None
+) -> None:
     backend_name = backend or "torch"
     for chunk in chunks:
         for module in chunk.modules():
@@ -455,7 +474,9 @@ def build_model(model_cfg: DeepseekV4Config, *, impl_cfg: ImplConfig) -> ModelBu
 
         def _post_model_load_hook():
             from megatron.lite.model.deepseek_v4.lite.model import DeepseekV4Layer
-            from megatron.lite.primitive.optimizers.fsdp2 import build_fsdp2_training_optimizer
+            from megatron.lite.primitive.optimizers.fsdp2 import (
+                build_fsdp2_training_optimizer,
+            )
 
             return {
                 "optimizer": build_fsdp2_training_optimizer(
@@ -507,7 +528,11 @@ def export_hf_weights(
 
 
 def save_hf_weights(
-    chunks: list[nn.Module], path: str, model_cfg: DeepseekV4Config, ps: ParallelState, **kwargs
+    chunks: list[nn.Module],
+    path: str,
+    model_cfg: DeepseekV4Config,
+    ps: ParallelState,
+    **kwargs,
 ) -> None:
     _save_hf_weights_impl(chunks, path, model_cfg, ps, **kwargs)
 

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/resync.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/resync.py
@@ -7,7 +7,6 @@ from collections.abc import Iterable, Iterator, Mapping
 from typing import Any
 
 import torch
-
 from megatron.lite.primitive.quantization.block_fp8 import quantize_block_fp8
 from megatron.lite.primitive.quantization.mxfp4 import quantize_mxfp4
 
@@ -118,8 +117,4 @@ def export_resync_weights(
         yield _scale_name(name), scale
 
 
-__all__ = [
-    "export_resync_weights",
-    "is_release_unquantized_weight",
-    "is_routed_expert",
-]
+__all__ = ["export_resync_weights", "is_release_unquantized_weight", "is_routed_expert"]

--- a/experimental/lite/megatron/lite/model/glm5/config.py
+++ b/experimental/lite/megatron/lite/model/glm5/config.py
@@ -63,14 +63,18 @@ _HF_FIELDS = frozenset(
 _INDEXER_TYPES = frozenset({"full", "shared"})
 
 
-def _infer_dsa_indexer_type(layer_number: int, *, topk_freq: int, skip_topk_offset: int) -> str:
+def _infer_dsa_indexer_type(
+    layer_number: int, *, topk_freq: int, skip_topk_offset: int
+) -> str:
     if topk_freq <= 1:
         return "full"
     skip_topk = (max(layer_number - skip_topk_offset, 0) % topk_freq) != 0
     return "shared" if skip_topk else "full"
 
 
-def _source_dsa_compute_layer(layer_number: int, *, topk_freq: int, skip_topk_offset: int) -> int:
+def _source_dsa_compute_layer(
+    layer_number: int, *, topk_freq: int, skip_topk_offset: int
+) -> int:
     if (
         _infer_dsa_indexer_type(
             layer_number, topk_freq=topk_freq, skip_topk_offset=skip_topk_offset
@@ -199,22 +203,23 @@ class Glm5Config:
             "index_head_dim must be >= qk_rope_head_dim",
         )
         check(self.index_topk_freq >= 1, "index_topk_freq must be >= 1")
-        check(
-            self.index_skip_topk_offset >= 0,
-            "index_skip_topk_offset must be >= 0",
-        )
+        check(self.index_skip_topk_offset >= 0, "index_skip_topk_offset must be >= 0")
         check(
             self.num_key_value_heads == self.num_attention_heads,
             "initial GLM5 native path expects MLA heads to be ungrouped",
         )
         check(self.vocab_size > 0, "vocab_size must be > 0")
-        check(self.num_nextn_predict_layers >= 0, "num_nextn_predict_layers must be >= 0")
+        check(
+            self.num_nextn_predict_layers >= 0, "num_nextn_predict_layers must be >= 0"
+        )
         check(self.n_routed_experts >= 1, "n_routed_experts must be >= 1")
         check(
             1 <= self.num_experts_per_tok <= self.n_routed_experts,
             "num_experts_per_tok must be in [1, n_routed_experts]",
         )
-        check(1 <= self.topk_group <= self.n_group, "topk_group must be in [1, n_group]")
+        check(
+            1 <= self.topk_group <= self.n_group, "topk_group must be in [1, n_group]"
+        )
         if self.mlp_layer_types is not None:
             expected_layer_type_lengths = {
                 self.num_hidden_layers,
@@ -254,7 +259,10 @@ class Glm5Config:
                 except ValueError as exc:
                     check(False, str(exc))
 
-            if self.indexer_types is not None and len(self.indexer_types) == self.num_hidden_layers:
+            if (
+                self.indexer_types is not None
+                and len(self.indexer_types) == self.num_hidden_layers
+            ):
                 for idx, indexer_type in enumerate(self.indexer_types):
                     expected = _infer_dsa_indexer_type(
                         idx + 1,
@@ -288,12 +296,19 @@ class Glm5Config:
     @classmethod
     def _from_hf_dict(cls, hf: dict[str, Any], **overrides) -> Glm5Config:
         kwargs = {
-            key: value for key, value in hf.items() if key in _HF_FIELDS and value is not None
+            key: value
+            for key, value in hf.items()
+            if key in _HF_FIELDS and value is not None
         }
-        if "num_nextn_predict_layers" not in kwargs and hf.get("num_nextn_predict") is not None:
+        if (
+            "num_nextn_predict_layers" not in kwargs
+            and hf.get("num_nextn_predict") is not None
+        ):
             kwargs["num_nextn_predict_layers"] = int(hf["num_nextn_predict"])
         rope_parameters = hf.get("rope_parameters")
         if isinstance(rope_parameters, dict) and "rope_theta" not in kwargs:
-            kwargs["rope_theta"] = float(rope_parameters.get("rope_theta", cls.rope_theta))
+            kwargs["rope_theta"] = float(
+                rope_parameters.get("rope_theta", cls.rope_theta)
+            )
         kwargs.update(overrides)
         return cls(**kwargs)

--- a/experimental/lite/megatron/lite/model/glm5/lite/model.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/model.py
@@ -30,9 +30,8 @@ from contextlib import nullcontext
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-
-from megatron.lite.primitive import transformer_engine as te
 from megatron.lite.model.glm5.config import Glm5Config
+from megatron.lite.primitive import transformer_engine as te
 from megatron.lite.primitive.kernels.swiglu import bias_swiglu_impl
 from megatron.lite.primitive.modules.attention import (
     DSAIndexShareState,
@@ -86,7 +85,8 @@ def _collect_sp_grad_params(model: nn.Module) -> list[nn.Parameter]:
     return [
         param
         for name, param in model.named_parameters()
-        if any(name.endswith(suffix) for suffix in _SP_GRAD_SUFFIXES) or name == "norm.weight"
+        if any(name.endswith(suffix) for suffix in _SP_GRAD_SUFFIXES)
+        or name == "norm.weight"
     ]
 
 
@@ -97,7 +97,9 @@ def _swiglu(x: torch.Tensor) -> torch.Tensor:
     return F.silu(x1) * x2
 
 
-def _reduce_scatter_to_sequence_parallel(x: torch.Tensor, ps: ParallelState) -> torch.Tensor:
+def _reduce_scatter_to_sequence_parallel(
+    x: torch.Tensor, ps: ParallelState
+) -> torch.Tensor:
     if ps.tp_size == 1:
         return x
     return ReduceScatterDim0.apply(x, ps.tp_size, ps.tp_rank, ps.tp_group)
@@ -238,7 +240,9 @@ class DenseMLP(nn.Module):
             normalization="RMSNorm",
             eps=config.rms_norm_eps,
         )
-        self.down = RowParallelLinear(config.intermediate_size, config.hidden_size, ps, bias=False)
+        self.down = RowParallelLinear(
+            config.intermediate_size, config.hidden_size, ps, bias=False
+        )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.down(_swiglu(self.gate_up(x)))
@@ -270,10 +274,7 @@ class _LocalLinear(nn.Module):
     def __init__(self, in_features: int, out_features: int):
         super().__init__()
         self.linear = te.Linear(
-            in_features,
-            out_features,
-            bias=False,
-            params_dtype=torch.bfloat16,
+            in_features, out_features, bias=False, params_dtype=torch.bfloat16
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -293,7 +294,9 @@ class MoELayer(nn.Module):
     ):
         super().__init__()
         if fp8:
-            raise NotImplementedError("GLM-5 lite MoE fp8 training is not implemented yet.")
+            raise NotImplementedError(
+                "GLM-5 lite MoE fp8 training is not implemented yet."
+            )
         self.router = SigmoidTopKRouter(
             config,
             ps,
@@ -303,17 +306,9 @@ class MoELayer(nn.Module):
             router_dtype=torch.float32,
             expert_bias_persistent=True,
         )
-        self.experts = Experts(
-            config,
-            ps,
-            fp8=fp8,
-            moe_act_recompute=moe_act_recompute,
-        )
+        self.experts = Experts(config, ps, fp8=fp8, moe_act_recompute=moe_act_recompute)
         self.dispatcher = TokenDispatcher(
-            config.num_experts,
-            config.hidden_size,
-            ps,
-            use_deepep=use_deepep,
+            config.num_experts, config.hidden_size, ps, use_deepep=use_deepep
         )
         self.shared_expert = SharedExpert(config, ps)
 
@@ -322,7 +317,9 @@ class MoELayer(nn.Module):
 
         flat_x = x.view(-1, x.size(-1))
         scores, indices = self.router(flat_x)
-        dispatched, tpe, permuted_probs = self.dispatcher.dispatch(flat_x, scores, indices)
+        dispatched, tpe, permuted_probs = self.dispatcher.dispatch(
+            flat_x, scores, indices
+        )
         del scores, indices
         self.dispatcher.wait_dispatch_event()
         expert_out = self.experts(
@@ -411,13 +408,12 @@ class Glm5Layer(nn.Module):
 
 
 def _roll_mtp_left(
-    tensor: torch.Tensor,
-    *,
-    packed_seq_params=None,
-    dims: int = -1,
+    tensor: torch.Tensor, *, packed_seq_params=None, dims: int = -1
 ) -> tuple[torch.Tensor, torch.Tensor]:
     if packed_seq_params is not None:
-        return roll_packed_thd_left(tensor, packed_seq_params=packed_seq_params, dims=dims)
+        return roll_packed_thd_left(
+            tensor, packed_seq_params=packed_seq_params, dims=dims
+        )
     dim = dims if dims >= 0 else tensor.dim() + dims
     rolled = torch.roll(tensor, shifts=-1, dims=dim)
     rolled.select(dim, -1).zero_()
@@ -485,7 +481,9 @@ class Glm5MTPLayer(nn.Module):
         attention_position_ids = (
             rotary_position_ids if rotary_position_ids is not None else position_ids
         )
-        input_ids, _ = _roll_mtp_left(input_ids, packed_seq_params=packed_seq_params, dims=-1)
+        input_ids, _ = _roll_mtp_left(
+            input_ids, packed_seq_params=packed_seq_params, dims=-1
+        )
         if position_ids is not None:
             position_ids, _ = _roll_mtp_left(
                 position_ids, packed_seq_params=packed_seq_params, dims=-1
@@ -701,7 +699,9 @@ class Glm5Model(nn.Module):
 
         self.embed: VocabParallelEmbedding | None = None
         if layout.has_embed:
-            self.embed = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
+            self.embed = VocabParallelEmbedding(
+                config.vocab_size, config.hidden_size, ps
+            )
 
         recompute_modules = getattr(train_config, "recompute_modules", [])
         offload_modules = getattr(train_config, "offload_modules", [])
@@ -709,7 +709,9 @@ class Glm5Model(nn.Module):
             {"full", "core_attn", "self_attn", "dsa"}
             & set([*recompute_modules, *offload_modules])
         )
-        moe_act_recompute = "moe_act" in recompute_modules and "moe" not in recompute_modules
+        moe_act_recompute = (
+            "moe_act" in recompute_modules and "moe" not in recompute_modules
+        )
         self.layers = nn.ModuleList(
             [
                 Glm5Layer(
@@ -741,7 +743,9 @@ class Glm5Model(nn.Module):
         if mtp_enable and config.num_nextn_predict_layers > 0 and layout.has_mtp:
             mtp_embedding = self.embed
             if mtp_embedding is None:
-                mtp_embedding = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
+                mtp_embedding = VocabParallelEmbedding(
+                    config.vocab_size, config.hidden_size, ps
+                )
                 self.mtp_embed = mtp_embedding
             self.mtp = Glm5MTPBlock(
                 config,
@@ -793,7 +797,9 @@ class Glm5Model(nn.Module):
             h = hidden_states
 
         fp8_ctx = (
-            te.fp8_autocast(enabled=True, fp8_recipe=build_fp8_recipe(self.train_config))
+            te.fp8_autocast(
+                enabled=True, fp8_recipe=build_fp8_recipe(self.train_config)
+            )
             if self.train_config.fp8
             else nullcontext()
         )
@@ -844,7 +850,9 @@ class Glm5Model(nn.Module):
                     output["mtp_loss"] = mtp_loss
                 labels_sb = labels.transpose(0, 1).contiguous()
                 if use_fused_kernels:
-                    hidden_full = gather_from_sequence_parallel(hidden_for_head, self.ps)
+                    hidden_full = gather_from_sequence_parallel(
+                        hidden_for_head, self.ps
+                    )
                     log_probs, entropy = linear_cross_entropy(
                         hidden_full,
                         self._head_weight_for_fused_ce(hidden_full),
@@ -860,7 +868,9 @@ class Glm5Model(nn.Module):
                     logits = self.head(hidden_for_head)
                     if temperature_value != 1.0:
                         logits = logits / temperature_value
-                    loss = vocab_parallel_cross_entropy(logits, labels_sb, self.ps.tp_group)
+                    loss = vocab_parallel_cross_entropy(
+                        logits, labels_sb, self.ps.tp_group
+                    )
                     output["loss"] = loss.mean()
                     output["log_probs"] = (-loss).transpose(0, 1).contiguous()
                     if calculate_entropy:
@@ -871,7 +881,9 @@ class Glm5Model(nn.Module):
                 output["logits"] = self.head.gather(logits).transpose(0, 1).contiguous()
                 if mtp_hidden_states is not None:
                     output["mtp_logits"] = [
-                        self.head.gather(self.head(mtp_hidden)).transpose(0, 1).contiguous()
+                        self.head.gather(self.head(mtp_hidden))
+                        .transpose(0, 1)
+                        .contiguous()
                         for mtp_hidden in mtp_hidden_states
                     ]
         if dsa_index_share_state is not None:
@@ -925,14 +937,10 @@ class Glm5Model(nn.Module):
         mtp_loss_values = []
         for mtp_hidden in mtp_hidden_states:
             mtp_labels, _ = _roll_mtp_left(
-                mtp_labels,
-                packed_seq_params=packed_seq_params,
-                dims=-1,
+                mtp_labels, packed_seq_params=packed_seq_params, dims=-1
             )
             mtp_loss_mask, num_tokens = _roll_mtp_left(
-                mtp_loss_mask,
-                packed_seq_params=packed_seq_params,
-                dims=-1,
+                mtp_loss_mask, packed_seq_params=packed_seq_params, dims=-1
             )
             labels_sb = mtp_labels.transpose(0, 1).contiguous()
             mask_sb = mtp_loss_mask.transpose(0, 1).contiguous()
@@ -951,16 +959,19 @@ class Glm5Model(nn.Module):
                 logits = self.head(mtp_hidden)
                 if temperature != 1.0:
                     logits = logits / temperature
-                token_loss = vocab_parallel_cross_entropy(logits, labels_sb, self.ps.tp_group)
+                token_loss = vocab_parallel_cross_entropy(
+                    logits, labels_sb, self.ps.tp_group
+                )
 
             token_loss = token_loss * mask_sb.to(dtype=token_loss.dtype)
             num_tokens = num_tokens.to(dtype=token_loss.dtype).clamp_min(1.0)
             mtp_loss_values.append(token_loss.sum() / num_tokens)
 
-            mtp_loss_scale = self.mtp_loss_scaling_factor / max(len(mtp_hidden_states), 1)
+            mtp_loss_scale = self.mtp_loss_scaling_factor / max(
+                len(mtp_hidden_states), 1
+            )
             hidden_states = MTPLossAutoScaler.apply(
-                hidden_states,
-                mtp_loss_scale * token_loss / num_tokens,
+                hidden_states, mtp_loss_scale * token_loss / num_tokens
             )
 
         if not mtp_loss_values:
@@ -974,7 +985,9 @@ class Glm5Model(nn.Module):
         assert self.head is not None
         weight = self.head.col.linear.weight
         return (
-            weight if weight.dtype == hidden_states.dtype else weight.to(dtype=hidden_states.dtype)
+            weight
+            if weight.dtype == hidden_states.dtype
+            else weight.to(dtype=hidden_states.dtype)
         )
 
 

--- a/experimental/lite/megatron/lite/model/glm5/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/protocol.py
@@ -28,11 +28,17 @@ from megatron.lite.model.protocol_utils import (
     add_cross_entropy_fusion,
     add_loss_context_kwargs,
     nested_from_packed,
-    pack_r3_replay_mask as _pack_r3_replay_mask,
-    pack_routed_experts as _pack_routed_experts,
-    router_replay_roots as router_replay_roots,
-    set_cross_entropy_fusion,
 )
+from megatron.lite.model.protocol_utils import (
+    pack_r3_replay_mask as _pack_r3_replay_mask,
+)
+from megatron.lite.model.protocol_utils import (
+    pack_routed_experts as _pack_routed_experts,
+)
+from megatron.lite.model.protocol_utils import (
+    router_replay_roots as router_replay_roots,
+)
+from megatron.lite.model.protocol_utils import set_cross_entropy_fusion
 from megatron.lite.primitive.bundle import ModelBundle
 from megatron.lite.primitive.parallel import ParallelState, init_parallel
 from megatron.lite.primitive.parallel.cp import contiguous_slice_for_cp
@@ -42,12 +48,12 @@ from megatron.lite.primitive.parallel.thd import (
     thd_pack_meta,
     unpack_thd_to_nested,
 )
-from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec
 from megatron.lite.primitive.quantization import (
     QATSpec,
     apply_qat_to_chunks,
     normalize_qat_spec,
 )
+from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec
 from megatron.lite.runtime.contracts import OptimizerConfig, ParallelConfig
 from megatron.lite.runtime.contracts.data import PackedBatch
 
@@ -324,13 +330,7 @@ def build_model(model_cfg: Glm5Config, *, impl_cfg: ImplConfig) -> ModelBundle:
         ]
     else:
         chunks = [
-            Glm5Model(
-                model_cfg,
-                train_cfg,
-                ps,
-                vpp_chunk_id=i,
-                **model_kwargs,
-            )
+            Glm5Model(model_cfg, train_cfg, ps, vpp_chunk_id=i, **model_kwargs)
             .to(torch.bfloat16)
             .cuda()
             for i in range(vpp)

--- a/experimental/lite/megatron/lite/model/kimi_k2/config.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/config.py
@@ -137,13 +137,21 @@ class KimiK2Config:
             )
             if self.n_group is not None and self.topk_group is not None:
                 _check(self.n_group >= 1, "n_group must be >= 1")
-                _check(1 <= self.topk_group <= self.n_group, "topk_group must be in [1, n_group]")
+                _check(
+                    1 <= self.topk_group <= self.n_group,
+                    "topk_group must be in [1, n_group]",
+                )
                 _check(
                     self.n_routed_experts % self.n_group == 0,
                     "n_routed_experts must be divisible by n_group",
                 )
-        _check(0 <= self.first_k_dense_replace <= self.num_hidden_layers, "bad dense prefix")
-        _check(self.num_nextn_predict_layers >= 0, "num_nextn_predict_layers must be >= 0")
+        _check(
+            0 <= self.first_k_dense_replace <= self.num_hidden_layers,
+            "bad dense prefix",
+        )
+        _check(
+            self.num_nextn_predict_layers >= 0, "num_nextn_predict_layers must be >= 0"
+        )
         if errors:
             raise ValueError("Invalid KimiK2Config:\n  " + "\n  ".join(errors))
 

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/model.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/model.py
@@ -11,7 +11,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 from megatron.lite.model.kimi_k2.config import KimiK2Config
 from megatron.lite.primitive import transformer_engine as te
-from megatron.lite.primitive.kernels.swiglu import bias_swiglu_impl
 from megatron.lite.primitive.modules.attention import MultiLatentAttention
 from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
 from megatron.lite.primitive.modules.experts import Experts
@@ -21,6 +20,12 @@ from megatron.lite.primitive.ops.cross_entropy import vocab_parallel_cross_entro
 from megatron.lite.primitive.ops.linear_cross_entropy import linear_cross_entropy
 from megatron.lite.primitive.ops.logprob import vocab_parallel_entropy
 from megatron.lite.primitive.ops.sp_ops import ReduceScatterDim0
+
+# Keep SwiGLU JIT initialization after attention/expert module initialization.
+# isort: off
+from megatron.lite.primitive.kernels.swiglu import bias_swiglu_impl
+
+# isort: on
 from megatron.lite.primitive.parallel import (
     ColumnParallelLinear,
     ParallelState,

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/model.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/model.py
@@ -9,9 +9,9 @@ from contextlib import nullcontext
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-
-from megatron.lite.primitive import transformer_engine as te
 from megatron.lite.model.kimi_k2.config import KimiK2Config
+from megatron.lite.primitive import transformer_engine as te
+from megatron.lite.primitive.kernels.swiglu import bias_swiglu_impl
 from megatron.lite.primitive.modules.attention import MultiLatentAttention
 from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
 from megatron.lite.primitive.modules.experts import Experts
@@ -21,7 +21,6 @@ from megatron.lite.primitive.ops.cross_entropy import vocab_parallel_cross_entro
 from megatron.lite.primitive.ops.linear_cross_entropy import linear_cross_entropy
 from megatron.lite.primitive.ops.logprob import vocab_parallel_entropy
 from megatron.lite.primitive.ops.sp_ops import ReduceScatterDim0
-from megatron.lite.primitive.kernels.swiglu import bias_swiglu_impl
 from megatron.lite.primitive.parallel import (
     ColumnParallelLinear,
     ParallelState,
@@ -53,7 +52,8 @@ def _collect_sp_grad_params(model: nn.Module) -> list[nn.Parameter]:
     return [
         param
         for name, param in model.named_parameters()
-        if any(name.endswith(suffix) for suffix in _SP_GRAD_SUFFIXES) or name == "norm.weight"
+        if any(name.endswith(suffix) for suffix in _SP_GRAD_SUFFIXES)
+        or name == "norm.weight"
     ]
 
 
@@ -64,7 +64,9 @@ def _swiglu(x: torch.Tensor) -> torch.Tensor:
     return F.silu(x1) * x2
 
 
-def _reduce_scatter_to_sequence_parallel(x: torch.Tensor, ps: ParallelState) -> torch.Tensor:
+def _reduce_scatter_to_sequence_parallel(
+    x: torch.Tensor, ps: ParallelState
+) -> torch.Tensor:
     if ps.tp_size == 1:
         return x
     return ReduceScatterDim0.apply(x, ps.tp_size, ps.tp_rank, ps.tp_group)
@@ -81,7 +83,9 @@ class DenseMLP(nn.Module):
             normalization="RMSNorm",
             eps=config.rms_norm_eps,
         )
-        self.down = RowParallelLinear(config.intermediate_size, config.hidden_size, ps, bias=False)
+        self.down = RowParallelLinear(
+            config.intermediate_size, config.hidden_size, ps, bias=False
+        )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.down(_swiglu(self.gate_up(x)))
@@ -111,10 +115,7 @@ class _LocalLinear(nn.Module):
     def __init__(self, in_features: int, out_features: int):
         super().__init__()
         self.linear = te.Linear(
-            in_features,
-            out_features,
-            bias=False,
-            params_dtype=torch.bfloat16,
+            in_features, out_features, bias=False, params_dtype=torch.bfloat16
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -134,7 +135,9 @@ class MoELayer(nn.Module):
     ):
         super().__init__()
         if fp8:
-            raise NotImplementedError("Kimi K2 lite MoE fp8 training is not implemented yet.")
+            raise NotImplementedError(
+                "Kimi K2 lite MoE fp8 training is not implemented yet."
+            )
         self.router = SigmoidTopKRouter(
             config,
             ps,
@@ -144,17 +147,9 @@ class MoELayer(nn.Module):
             router_dtype=torch.float32,
             expert_bias_persistent=True,
         )
-        self.experts = Experts(
-            config,
-            ps,
-            fp8=fp8,
-            moe_act_recompute=moe_act_recompute,
-        )
+        self.experts = Experts(config, ps, fp8=fp8, moe_act_recompute=moe_act_recompute)
         self.dispatcher = TokenDispatcher(
-            config.num_experts,
-            config.hidden_size,
-            ps,
-            use_deepep=use_deepep,
+            config.num_experts, config.hidden_size, ps, use_deepep=use_deepep
         )
         self.shared_expert = SharedExpert(config, ps)
 
@@ -163,7 +158,9 @@ class MoELayer(nn.Module):
 
         flat_x = x.view(-1, x.size(-1))
         scores, indices = self.router(flat_x)
-        dispatched, tpe, permuted_probs = self.dispatcher.dispatch(flat_x, scores, indices)
+        dispatched, tpe, permuted_probs = self.dispatcher.dispatch(
+            flat_x, scores, indices
+        )
         del scores, indices
         self.dispatcher.wait_dispatch_event()
         expert_out = self.experts(
@@ -228,7 +225,9 @@ class KimiK2Layer(nn.Module):
             self.mlp = DenseMLP(config, ps)
 
     def forward(self, x: torch.Tensor, packed_seq_params=None) -> torch.Tensor:
-        x = x + self.self_attention(self.input_layernorm(x), packed_seq_params=packed_seq_params)
+        x = x + self.self_attention(
+            self.input_layernorm(x), packed_seq_params=packed_seq_params
+        )
         if self.moe is not None:
             assert self.mlp_norm is not None
             mlp_input = self.mlp_norm(x)
@@ -238,13 +237,12 @@ class KimiK2Layer(nn.Module):
 
 
 def _roll_mtp_left(
-    tensor: torch.Tensor,
-    *,
-    packed_seq_params=None,
-    dims: int = -1,
+    tensor: torch.Tensor, *, packed_seq_params=None, dims: int = -1
 ) -> tuple[torch.Tensor, torch.Tensor]:
     if packed_seq_params is not None:
-        return roll_packed_thd_left(tensor, packed_seq_params=packed_seq_params, dims=dims)
+        return roll_packed_thd_left(
+            tensor, packed_seq_params=packed_seq_params, dims=dims
+        )
     dim = dims if dims >= 0 else tensor.dim() + dims
     rolled = torch.roll(tensor, shifts=-1, dims=dim)
     rolled.select(dim, -1).zero_()
@@ -301,7 +299,9 @@ class KimiK2MTPLayer(nn.Module):
         packed_seq_params=None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
         del rotary_position_ids
-        input_ids, _ = _roll_mtp_left(input_ids, packed_seq_params=packed_seq_params, dims=-1)
+        input_ids, _ = _roll_mtp_left(
+            input_ids, packed_seq_params=packed_seq_params, dims=-1
+        )
         if position_ids is not None:
             position_ids, _ = _roll_mtp_left(
                 position_ids, packed_seq_params=packed_seq_params, dims=-1
@@ -318,7 +318,9 @@ class KimiK2MTPLayer(nn.Module):
         hidden_states = torch.cat((decoder_input, hidden_states), dim=-1)
         hidden_states = self.eh_proj(hidden_states)
         hidden_states = scatter_to_sequence_parallel(hidden_states, self.ps)
-        hidden_states = self.transformer_layer(hidden_states, packed_seq_params=packed_seq_params)
+        hidden_states = self.transformer_layer(
+            hidden_states, packed_seq_params=packed_seq_params
+        )
         hidden_states = self.final_layernorm(hidden_states)
         return hidden_states, input_ids, position_ids
 
@@ -454,10 +456,14 @@ class KimiK2Model(nn.Module):
 
         self.embed: VocabParallelEmbedding | None = None
         if layout.has_embed:
-            self.embed = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
+            self.embed = VocabParallelEmbedding(
+                config.vocab_size, config.hidden_size, ps
+            )
 
         recompute_modules = getattr(train_config, "recompute_modules", [])
-        moe_act_recompute = "moe_act" in recompute_modules and "moe" not in recompute_modules
+        moe_act_recompute = (
+            "moe_act" in recompute_modules and "moe" not in recompute_modules
+        )
         self.layers = nn.ModuleList(
             [
                 KimiK2Layer(
@@ -485,7 +491,9 @@ class KimiK2Model(nn.Module):
         if mtp_enable and config.num_nextn_predict_layers > 0 and layout.has_mtp:
             mtp_embedding = self.embed
             if mtp_embedding is None:
-                mtp_embedding = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
+                mtp_embedding = VocabParallelEmbedding(
+                    config.vocab_size, config.hidden_size, ps
+                )
                 self.mtp_embed = mtp_embedding
             self.mtp = KimiK2MTPBlock(
                 config,
@@ -533,7 +541,9 @@ class KimiK2Model(nn.Module):
             h = hidden_states
 
         fp8_ctx = (
-            te.fp8_autocast(enabled=True, fp8_recipe=build_fp8_recipe(self.train_config))
+            te.fp8_autocast(
+                enabled=True, fp8_recipe=build_fp8_recipe(self.train_config)
+            )
             if self.train_config.fp8
             else nullcontext()
         )
@@ -571,7 +581,9 @@ class KimiK2Model(nn.Module):
                     output["mtp_loss"] = mtp_loss
                 labels_sb = labels.transpose(0, 1).contiguous()
                 if use_fused_kernels:
-                    hidden_full = gather_from_sequence_parallel(hidden_for_head, self.ps)
+                    hidden_full = gather_from_sequence_parallel(
+                        hidden_for_head, self.ps
+                    )
                     log_probs, entropy = linear_cross_entropy(
                         hidden_full,
                         self._head_weight_for_fused_ce(hidden_full),
@@ -587,7 +599,9 @@ class KimiK2Model(nn.Module):
                     logits = self.head(hidden_for_head)
                     if temperature_value != 1.0:
                         logits = logits / temperature_value
-                    loss = vocab_parallel_cross_entropy(logits, labels_sb, self.ps.tp_group)
+                    loss = vocab_parallel_cross_entropy(
+                        logits, labels_sb, self.ps.tp_group
+                    )
                     output["loss"] = loss.mean()
                     output["log_probs"] = (-loss).transpose(0, 1).contiguous()
                     if calculate_entropy:
@@ -598,7 +612,9 @@ class KimiK2Model(nn.Module):
                 output["logits"] = self.head.gather(logits).transpose(0, 1).contiguous()
                 if mtp_hidden_states is not None:
                     output["mtp_logits"] = [
-                        self.head.gather(self.head(mtp_hidden)).transpose(0, 1).contiguous()
+                        self.head.gather(self.head(mtp_hidden))
+                        .transpose(0, 1)
+                        .contiguous()
                         for mtp_hidden in mtp_hidden_states
                     ]
         return output
@@ -648,14 +664,10 @@ class KimiK2Model(nn.Module):
         mtp_loss_values = []
         for mtp_hidden in mtp_hidden_states:
             mtp_labels, _ = _roll_mtp_left(
-                mtp_labels,
-                packed_seq_params=packed_seq_params,
-                dims=-1,
+                mtp_labels, packed_seq_params=packed_seq_params, dims=-1
             )
             mtp_loss_mask, num_tokens = _roll_mtp_left(
-                mtp_loss_mask,
-                packed_seq_params=packed_seq_params,
-                dims=-1,
+                mtp_loss_mask, packed_seq_params=packed_seq_params, dims=-1
             )
             labels_sb = mtp_labels.transpose(0, 1).contiguous()
             mask_sb = mtp_loss_mask.transpose(0, 1).contiguous()
@@ -674,16 +686,19 @@ class KimiK2Model(nn.Module):
                 logits = self.head(mtp_hidden)
                 if temperature != 1.0:
                     logits = logits / temperature
-                token_loss = vocab_parallel_cross_entropy(logits, labels_sb, self.ps.tp_group)
+                token_loss = vocab_parallel_cross_entropy(
+                    logits, labels_sb, self.ps.tp_group
+                )
 
             token_loss = token_loss * mask_sb.to(dtype=token_loss.dtype)
             num_tokens = num_tokens.to(dtype=token_loss.dtype).clamp_min(1.0)
             mtp_loss_values.append(token_loss.sum() / num_tokens)
 
-            mtp_loss_scale = self.mtp_loss_scaling_factor / max(len(mtp_hidden_states), 1)
+            mtp_loss_scale = self.mtp_loss_scaling_factor / max(
+                len(mtp_hidden_states), 1
+            )
             hidden_states = MTPLossAutoScaler.apply(
-                hidden_states,
-                mtp_loss_scale * token_loss / num_tokens,
+                hidden_states, mtp_loss_scale * token_loss / num_tokens
             )
 
         if not mtp_loss_values:
@@ -697,7 +712,9 @@ class KimiK2Model(nn.Module):
         assert self.head is not None
         weight = self.head.col.linear.weight
         return (
-            weight if weight.dtype == hidden_states.dtype else weight.to(dtype=hidden_states.dtype)
+            weight
+            if weight.dtype == hidden_states.dtype
+            else weight.to(dtype=hidden_states.dtype)
         )
 
 

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/protocol.py
@@ -15,18 +15,22 @@ from megatron.lite.model.protocol_utils import (
     add_cross_entropy_fusion,
     add_loss_context_kwargs,
     pack_thd_forward_kwargs,
+)
+from megatron.lite.model.protocol_utils import (
     router_replay_roots as router_replay_roots,
+)
+from megatron.lite.model.protocol_utils import (
     set_cross_entropy_fusion,
     unpack_thd_forward_output,
 )
 from megatron.lite.primitive.bundle import ModelBundle
 from megatron.lite.primitive.parallel import ParallelState, init_parallel
-from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec
 from megatron.lite.primitive.quantization import (
     QATSpec,
     apply_qat_to_chunks,
     normalize_qat_spec,
 )
+from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec
 from megatron.lite.runtime.contracts import OptimizerConfig, ParallelConfig
 from megatron.lite.runtime.contracts.data import PackedBatch
 
@@ -132,7 +136,9 @@ def _make_aux_loss_hook():
 def _build_dist_opt_optimizer(
     chunks, model_cfg: KimiK2Config, impl_cfg: ImplConfig, ps: ParallelState
 ):
-    from megatron.lite.primitive.optimizers.megatron_wrap import build_dist_opt_training_optimizer
+    from megatron.lite.primitive.optimizers.megatron_wrap import (
+        build_dist_opt_training_optimizer,
+    )
 
     return build_dist_opt_training_optimizer(
         chunks,
@@ -155,7 +161,9 @@ def build_model(model_cfg: KimiK2Config, *, impl_cfg: ImplConfig) -> ModelBundle
     mtp_enable_train = mtp_enable and bool(impl_cfg.mtp_enable_train)
     if mtp_enable:
         if model_cfg.num_nextn_predict_layers <= 0:
-            raise ValueError("mtp_enable=True but HF config has no num_nextn_predict_layers.")
+            raise ValueError(
+                "mtp_enable=True but HF config has no num_nextn_predict_layers."
+            )
         model_cfg.mtp_loss_scaling_factor = impl_cfg.mtp_loss_scaling_factor
         if impl_cfg.mtp_use_repeated_layer is not None:
             model_cfg.mtp_use_repeated_layer = impl_cfg.mtp_use_repeated_layer
@@ -190,16 +198,14 @@ def build_model(model_cfg: KimiK2Config, *, impl_cfg: ImplConfig) -> ModelBundle
     )
 
     if vpp is None:
-        chunks = [KimiK2Model(model_cfg, train_cfg, ps, **model_kwargs).to(torch.bfloat16).cuda()]
+        chunks = [
+            KimiK2Model(model_cfg, train_cfg, ps, **model_kwargs)
+            .to(torch.bfloat16)
+            .cuda()
+        ]
     else:
         chunks = [
-            KimiK2Model(
-                model_cfg,
-                train_cfg,
-                ps,
-                vpp_chunk_id=i,
-                **model_kwargs,
-            )
+            KimiK2Model(model_cfg, train_cfg, ps, vpp_chunk_id=i, **model_kwargs)
             .to(torch.bfloat16)
             .cuda()
             for i in range(vpp)
@@ -224,7 +230,9 @@ def build_model(model_cfg: KimiK2Config, *, impl_cfg: ImplConfig) -> ModelBundle
     post_model_load_hook = None
     optimizer_backend = "none"
     if impl_cfg.optimizer == "dist_opt":
-        optimizer, finalize_grads = _build_dist_opt_optimizer(chunks, model_cfg, impl_cfg, ps)
+        optimizer, finalize_grads = _build_dist_opt_optimizer(
+            chunks, model_cfg, impl_cfg, ps
+        )
         from megatron.lite.primitive.ckpt import attach_model_sharded_state_dict
         from megatron.lite.runtime.megatron_utils import register_training_hooks
 
@@ -238,7 +246,9 @@ def build_model(model_cfg: KimiK2Config, *, impl_cfg: ImplConfig) -> ModelBundle
 
         def _post_model_load_hook():
             from megatron.lite.model.kimi_k2.lite.model import KimiK2Layer
-            from megatron.lite.primitive.optimizers.fsdp2 import build_fsdp2_training_optimizer
+            from megatron.lite.primitive.optimizers.fsdp2 import (
+                build_fsdp2_training_optimizer,
+            )
 
             return {
                 "optimizer": build_fsdp2_training_optimizer(
@@ -283,12 +293,16 @@ def load_hf_weights(
 
 
 def export_hf_weights(chunks, model_cfg: KimiK2Config, ps: ParallelState, **kwargs):
-    from megatron.lite.model.kimi_k2.lite.checkpoint import export_hf_weights as export_impl
+    from megatron.lite.model.kimi_k2.lite.checkpoint import (
+        export_hf_weights as export_impl,
+    )
 
     yield from export_impl(chunks, model_cfg, ps, **kwargs)
 
 
-def save_hf_weights(chunks, path: str, model_cfg: KimiK2Config, ps: ParallelState, **kwargs) -> None:
+def save_hf_weights(
+    chunks, path: str, model_cfg: KimiK2Config, ps: ParallelState, **kwargs
+) -> None:
     from megatron.lite.model.kimi_k2.lite.checkpoint import save_hf_weights as save_impl
 
     save_impl(chunks, path, model_cfg, ps, **kwargs)

--- a/experimental/lite/megatron/lite/model/qwen3_5/config.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/config.py
@@ -67,7 +67,13 @@ class Qwen35Config:
     linear_conv_kernel_dim: int = 4
     layer_types: list[str] = field(
         default_factory=lambda: (
-            ["linear_attention", "linear_attention", "linear_attention", "full_attention"] * 10
+            [
+                "linear_attention",
+                "linear_attention",
+                "linear_attention",
+                "full_attention",
+            ]
+            * 10
         )
     )
     partial_rotary_factor: float = 0.25
@@ -108,7 +114,8 @@ class Qwen35Config:
         if (
             self.num_nextn_predict_layers > 0
             and not self.mtp_layer_types
-            and len(self.layer_types) == self.num_hidden_layers + self.num_nextn_predict_layers
+            and len(self.layer_types)
+            == self.num_hidden_layers + self.num_nextn_predict_layers
         ):
             self.mtp_layer_types = self.layer_types[self.num_hidden_layers :]
             self.layer_types = self.layer_types[: self.num_hidden_layers]
@@ -171,7 +178,10 @@ class Qwen35Config:
             f"num_key_value_heads({self.num_key_value_heads})",
         )
         if self.is_moe:
-            _check(self.num_experts >= 1, f"num_experts must be >= 1, got {self.num_experts}")
+            _check(
+                self.num_experts >= 1,
+                f"num_experts must be >= 1, got {self.num_experts}",
+            )
             _check(
                 1 <= self.num_experts_per_tok <= self.num_experts,
                 f"num_experts_per_tok({self.num_experts_per_tok}) must be in "
@@ -228,10 +238,14 @@ class Qwen35Config:
             )
         valid_types = {"linear_attention", "full_attention"}
         for i, lt in enumerate(self.layer_types):
-            _check(lt in valid_types, f"layer_types[{i}] must be one of {valid_types}, got '{lt}'")
+            _check(
+                lt in valid_types,
+                f"layer_types[{i}] must be one of {valid_types}, got '{lt}'",
+            )
         for i, lt in enumerate(self.mtp_layer_types):
             _check(
-                lt in valid_types, f"mtp_layer_types[{i}] must be one of {valid_types}, got '{lt}'"
+                lt in valid_types,
+                f"mtp_layer_types[{i}] must be one of {valid_types}, got '{lt}'",
             )
 
         if errors:
@@ -267,7 +281,10 @@ class Qwen35Config:
         kwargs["model_type"] = model_type
         kwargs["hf_text_prefix"] = "model.language_model" if is_composite else "model"
         mtp_num_hidden_layers = kwargs.pop("mtp_num_hidden_layers", None)
-        if kwargs.get("num_nextn_predict_layers") is None and mtp_num_hidden_layers is not None:
+        if (
+            kwargs.get("num_nextn_predict_layers") is None
+            and mtp_num_hidden_layers is not None
+        ):
             kwargs["num_nextn_predict_layers"] = int(mtp_num_hidden_layers)
         if "rope_parameters" in hf and isinstance(hf["rope_parameters"], dict):
             rp = hf["rope_parameters"]

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/checkpoint.py
@@ -20,7 +20,6 @@ from megatron.lite.primitive.utils import ensure_divisible
 from megatron.lite.runtime.contracts.weights import ResyncFormat
 from torch.distributed.tensor import Replicate, Shard
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -353,7 +352,9 @@ class Qwen35WeightSpec:
                         f"{local_prefix}.mlp_norm.weight": [
                             f"{hf_prefix}.post_attention_layernorm.weight"
                         ],
-                        f"{local_prefix}.moe.router.gate.weight": [f"{mlp}.gate.weight"],
+                        f"{local_prefix}.moe.router.gate.weight": [
+                            f"{mlp}.gate.weight"
+                        ],
                         f"{local_prefix}.moe.shared_expert.gate_up.linear.weight": [
                             f"{mlp}.shared_expert.gate_proj.weight",
                             f"{mlp}.shared_expert.up_proj.weight",
@@ -476,10 +477,7 @@ class Qwen35WeightSpec:
                 return shards[0]
             return torch.cat(shards, dim=0).contiguous()
         if native_name.endswith(
-            (
-                ".mlp.gate_up.linear.weight",
-                ".moe.shared_expert.gate_up.linear.weight",
-            )
+            (".mlp.gate_up.linear.weight", ".moe.shared_expert.gate_up.linear.weight")
         ):
             return _merge_gate_up_tp_shards(_allgather_tp_shards(tensor, ps))
         return None
@@ -496,10 +494,7 @@ class Qwen35WeightSpec:
                 return shards[0]
             return torch.cat(shards, dim=0).contiguous()
         if native_name.endswith(
-            (
-                ".mlp.gate_up.linear.weight",
-                ".moe.shared_expert.gate_up.linear.weight",
-            )
+            (".mlp.gate_up.linear.weight", ".moe.shared_expert.gate_up.linear.weight")
         ):
             return _merge_gate_up_tp_shards(shards)
         return None
@@ -835,11 +830,7 @@ def export_hf_weights(
         return
     yield from _export_mxfp4_weights(
         _export(
-            model,
-            Qwen35WeightSpec(config),
-            ps,
-            vocab_size=config.vocab_size,
-            **kwargs,
+            model, Qwen35WeightSpec(config), ps, vocab_size=config.vocab_size, **kwargs
         )
     )
 
@@ -875,9 +866,7 @@ def save_hf_weights(
     ps: ParallelState,
     **kwargs,
 ) -> None:
-    from megatron.lite.primitive.ckpt.hf_weights import (  # isort: skip
-        save_hf_weights as _save,
-    )
+    from megatron.lite.primitive.ckpt.hf_weights import save_hf_weights as _save
 
     # Qwen3.5 has no MXFP4/block-FP8 save-time resync path, so the engine-level
     # export kwargs are accepted for signature-compatibility but not consumed.

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
@@ -13,15 +13,18 @@ from contextlib import nullcontext
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-
-from megatron.lite.primitive import transformer_engine as te
 from megatron.lite.model.qwen3_5.config import Qwen35Config
+from megatron.lite.primitive import transformer_engine as te
 from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
 from megatron.lite.primitive.modules.experts import Experts, swiglu_with_probs
 from megatron.lite.primitive.modules.gated_delta_net import GatedDeltaNet
 from megatron.lite.primitive.modules.gqa import GQAttention as FullAttention
-from megatron.lite.primitive.modules.gqa import split_grouped_qkvg as _split_grouped_qkvg
-from megatron.lite.primitive.modules.mrope import MultimodalRotaryEmbedding as Qwen35MRoPE
+from megatron.lite.primitive.modules.gqa import (
+    split_grouped_qkvg as _split_grouped_qkvg,
+)
+from megatron.lite.primitive.modules.mrope import (
+    MultimodalRotaryEmbedding as Qwen35MRoPE,
+)
 from megatron.lite.primitive.modules.mtp import (
     MTPBlock,
     MTPDecoderLayer,
@@ -136,7 +139,11 @@ class SharedExpert(nn.Module):
             return self.linear(x)
 
     def __init__(
-        self, config: Qwen35Config, ps: ParallelState, *, use_plain_te_linear: bool = False
+        self,
+        config: Qwen35Config,
+        ps: ParallelState,
+        *,
+        use_plain_te_linear: bool = False,
     ):
         super().__init__()
         ffn = config.shared_expert_intermediate_size
@@ -144,7 +151,9 @@ class SharedExpert(nn.Module):
             self.gate_up = self._PlainTELinear(config.hidden_size, ffn * 2)
             self.down = self._PlainTELinear(ffn, config.hidden_size)
         else:
-            self.gate_up = ColumnParallelLinear(config.hidden_size, ffn * 2, ps, bias=False)
+            self.gate_up = ColumnParallelLinear(
+                config.hidden_size, ffn * 2, ps, bias=False
+            )
             self.down = RowParallelLinear(ffn, config.hidden_size, ps, bias=False)
         self.shared_gate = nn.Linear(config.hidden_size, 1, bias=False)
         self.tp_group = ps.tp_group
@@ -207,7 +216,9 @@ class MoELayer(nn.Module):
             use_deepep=use_deepep,
             moe_permute_fusion=moe_permute_fusion,
         )
-        self.shared_expert = SharedExpert(config, ps, use_plain_te_linear=shared_expert_plain_te)
+        self.shared_expert = SharedExpert(
+            config, ps, use_plain_te_linear=shared_expert_plain_te
+        )
         self.preserve_3d_graph = bool(preserve_3d_graph)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -224,7 +235,9 @@ class MoELayer(nn.Module):
             with torch.cuda.stream(side_stream):
                 shared_out = self.shared_expert(shared_input)
         scores, indices = self.router(router_input)
-        dispatched, tpe, permuted_probs = self.dispatcher.dispatch(x_2d, scores, indices)
+        dispatched, tpe, permuted_probs = self.dispatcher.dispatch(
+            x_2d, scores, indices
+        )
         del scores, indices
         self.dispatcher.wait_dispatch_event()
         expert_out = self.experts(
@@ -319,14 +332,21 @@ class Qwen35Layer(nn.Module):
             self.mlp = DenseMLP(config, ps)
 
     def forward(
-        self, x: torch.Tensor, position_ids: torch.Tensor | None = None, packed_seq_params=None
+        self,
+        x: torch.Tensor,
+        position_ids: torch.Tensor | None = None,
+        packed_seq_params=None,
     ) -> torch.Tensor:
         residual = x
         if self.full_attn is not None:
-            h = self.full_attn(x, position_ids=position_ids, packed_seq_params=packed_seq_params)
+            h = self.full_attn(
+                x, position_ids=position_ids, packed_seq_params=packed_seq_params
+            )
         else:
             assert self.linear_attn is not None
-            h = self.linear_attn(x, position_ids=position_ids, packed_seq_params=packed_seq_params)
+            h = self.linear_attn(
+                x, position_ids=position_ids, packed_seq_params=packed_seq_params
+            )
         x = residual + h
         residual = x
         if self.moe is not None:
@@ -339,12 +359,16 @@ class Qwen35Layer(nn.Module):
 def _temperature_to_float(temperature: float | torch.Tensor) -> float:
     if isinstance(temperature, torch.Tensor):
         if temperature.numel() != 1:
-            raise ValueError("Qwen35Model fused/MTP SFT supports scalar temperature only.")
+            raise ValueError(
+                "Qwen35Model fused/MTP SFT supports scalar temperature only."
+            )
         return float(temperature.detach().float().item())
     return float(temperature)
 
 
-def _ensure_mrope_position_ids(position_ids: torch.Tensor | None) -> torch.Tensor | None:
+def _ensure_mrope_position_ids(
+    position_ids: torch.Tensor | None,
+) -> torch.Tensor | None:
     if position_ids is None:
         return None
     if position_ids.dim() == 2:
@@ -354,7 +378,9 @@ def _ensure_mrope_position_ids(position_ids: torch.Tensor | None) -> torch.Tenso
             return position_ids.expand(3, -1, -1).contiguous()
         if position_ids.shape[0] == 3:
             return position_ids
-    raise ValueError("Qwen3.5 MRoPE expects position_ids shape (B,S), (1,B,S), or (3,B,S).")
+    raise ValueError(
+        "Qwen3.5 MRoPE expects position_ids shape (B,S), (1,B,S), or (3,B,S)."
+    )
 
 
 def _apply_attention_backend_override(backend: str | None) -> None:
@@ -419,15 +445,21 @@ class Qwen35Model(nn.Module):
         self.post_process = has_head
         self.share_embeddings_and_output_weights = False
         self.vision_model: nn.Module | None = (
-            _build_native_vision_model(hf_path) if has_embed and mount_vision_model else None
+            _build_native_vision_model(hf_path)
+            if has_embed and mount_vision_model
+            else None
         )
 
         self.embed: VocabParallelEmbedding | None = None
         if has_embed:
-            self.embed = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
+            self.embed = VocabParallelEmbedding(
+                config.vocab_size, config.hidden_size, ps
+            )
 
         recompute_modules = getattr(train_config, "recompute_modules", [])
-        moe_act_recompute = "moe_act" in recompute_modules and "moe" not in recompute_modules
+        moe_act_recompute = (
+            "moe_act" in recompute_modules and "moe" not in recompute_modules
+        )
         self.layers = nn.ModuleList(
             [
                 Qwen35Layer(
@@ -459,7 +491,9 @@ class Qwen35Model(nn.Module):
         if mtp_enable and config.num_nextn_predict_layers > 0 and self.head is not None:
             mtp_embedding = self.embed
             if mtp_embedding is None:
-                mtp_embedding = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
+                mtp_embedding = VocabParallelEmbedding(
+                    config.vocab_size, config.hidden_size, ps
+                )
                 self.mtp_embed = mtp_embedding
 
             def make_mtp_layer(layer_idx: int) -> MTPDecoderLayer:
@@ -522,17 +556,25 @@ class Qwen35Model(nn.Module):
             h = hidden_states
 
         if packed_seq_params is not None:
-            assert position_ids is not None, "THD path requires caller-supplied MRoPE position_ids."
+            assert (
+                position_ids is not None
+            ), "THD path requires caller-supplied MRoPE position_ids."
         elif position_ids is None and input_ids is not None:
             if self.ps.cp_size > 1:
-                raise ValueError("CP>1 requires caller-supplied FULL position_ids (3,B,S).")
+                raise ValueError(
+                    "CP>1 requires caller-supplied FULL position_ids (3,B,S)."
+                )
             batch, seq = input_ids.shape
             pos = torch.arange(seq, device=input_ids.device, dtype=torch.long)
-            position_ids = pos.unsqueeze(0).unsqueeze(0).expand(3, batch, seq).contiguous()
+            position_ids = (
+                pos.unsqueeze(0).unsqueeze(0).expand(3, batch, seq).contiguous()
+            )
         position_ids = _ensure_mrope_position_ids(position_ids)
 
         fp8_ctx = (
-            te.fp8_autocast(enabled=True, fp8_recipe=build_fp8_recipe(self.train_config))
+            te.fp8_autocast(
+                enabled=True, fp8_recipe=build_fp8_recipe(self.train_config)
+            )
             if self.train_config.fp8
             else nullcontext()
         )
@@ -540,7 +582,9 @@ class Qwen35Model(nn.Module):
             if self.embed is not None:
                 h = scatter_to_sequence_parallel(h, self.ps)
             for layer in self.layers:
-                h = layer(h, position_ids=position_ids, packed_seq_params=packed_seq_params)
+                h = layer(
+                    h, position_ids=position_ids, packed_seq_params=packed_seq_params
+                )
 
         output = {"hidden_states": h}
         if self.head is not None:
@@ -563,7 +607,9 @@ class Qwen35Model(nn.Module):
                     output["mtp_loss"] = mtp_loss
                 labels_sb = labels.transpose(0, 1).contiguous()
                 if use_fused_kernels:
-                    hidden_full = gather_from_sequence_parallel(hidden_for_head, self.ps)
+                    hidden_full = gather_from_sequence_parallel(
+                        hidden_for_head, self.ps
+                    )
                     log_probs, entropy = linear_cross_entropy(
                         hidden_full,
                         self._head_weight_for_fused_ce(hidden_full),
@@ -579,7 +625,9 @@ class Qwen35Model(nn.Module):
                     logits = self.head(hidden_for_head)
                     if temperature_value != 1.0:
                         logits = logits / temperature_value
-                    loss = vocab_parallel_cross_entropy(logits, labels_sb, self.ps.tp_group)
+                    loss = vocab_parallel_cross_entropy(
+                        logits, labels_sb, self.ps.tp_group
+                    )
                     output["loss"] = loss.mean()
                     output["log_probs"] = (-loss).transpose(0, 1).contiguous()
                     if calculate_entropy:
@@ -644,11 +692,15 @@ class Qwen35Model(nn.Module):
                 logits = self.head(mtp_hidden)
                 if temperature != 1.0:
                     logits = logits / temperature
-                token_loss = vocab_parallel_cross_entropy(logits, labels_sb, self.ps.tp_group)
+                token_loss = vocab_parallel_cross_entropy(
+                    logits, labels_sb, self.ps.tp_group
+                )
             token_loss = token_loss * mask_sb.to(dtype=token_loss.dtype)
             num_tokens = num_tokens.to(dtype=token_loss.dtype).clamp_min(1.0)
             mtp_loss_values.append(token_loss.sum() / num_tokens)
-            mtp_loss_scale = self.mtp_loss_scaling_factor / max(len(mtp_hidden_states), 1)
+            mtp_loss_scale = self.mtp_loss_scaling_factor / max(
+                len(mtp_hidden_states), 1
+            )
             hidden_states = MTPLossAutoScaler.apply(
                 hidden_states, mtp_loss_scale * token_loss / num_tokens
             )
@@ -664,7 +716,9 @@ class Qwen35Model(nn.Module):
         assert self.head is not None
         weight = self.head.col.linear.weight
         return (
-            weight if weight.dtype == hidden_states.dtype else weight.to(dtype=hidden_states.dtype)
+            weight
+            if weight.dtype == hidden_states.dtype
+            else weight.to(dtype=hidden_states.dtype)
         )
 
 
@@ -697,7 +751,9 @@ def _resolve_hf_vision_cls(hf_config, hf_path: str) -> type:
     errors: list[str] = []
     for class_ref in _iter_auto_model_class_refs(hf_config):
         try:
-            model_cls = get_class_from_dynamic_module(class_ref, hf_path, trust_remote_code=True)
+            model_cls = get_class_from_dynamic_module(
+                class_ref, hf_path, trust_remote_code=True
+            )
         except Exception as exc:
             errors.append(f"{class_ref}: {exc}")
             continue
@@ -705,19 +761,27 @@ def _resolve_hf_vision_cls(hf_config, hf_path: str) -> type:
         if vision_cls is not None:
             return vision_cls
         errors.append(f"{class_ref}: missing HfVisionClass")
-    detail = "; ".join(errors) if errors else "config auto_map has no supported AutoModel entry"
+    detail = (
+        "; ".join(errors)
+        if errors
+        else "config auto_map has no supported AutoModel entry"
+    )
     raise RuntimeError(f"Cannot resolve native HF vision class for Qwen3.5: {detail}.")
 
 
 def _hook_fp32_rotary_emb(module: nn.Module) -> None:
     for submodule in module.modules():
         if hasattr(submodule, "inv_freq") and submodule.inv_freq is not None:
-            submodule._inv_freq_fp32_original = submodule.inv_freq.detach().clone().float()
+            submodule._inv_freq_fp32_original = (
+                submodule.inv_freq.detach().clone().float()
+            )
 
             def _hook(mod, args):
                 del args
                 if hasattr(mod, "_inv_freq_fp32_original"):
-                    mod.inv_freq = mod._inv_freq_fp32_original.to(device=mod.inv_freq.device)
+                    mod.inv_freq = mod._inv_freq_fp32_original.to(
+                        device=mod.inv_freq.device
+                    )
 
             submodule.register_forward_pre_hook(_hook)
 

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
@@ -15,15 +15,25 @@ from megatron.lite.model.protocol_utils import (
     add_cross_entropy_fusion,
     add_loss_context_kwargs,
     pack_thd_forward_kwargs,
+)
+from megatron.lite.model.protocol_utils import (
     router_replay_roots as router_replay_roots,
+)
+from megatron.lite.model.protocol_utils import (
     set_cross_entropy_fusion,
     unpack_thd_forward_output,
 )
 from megatron.lite.model.qwen3_5.config import Qwen35Config
 from megatron.lite.model.qwen3_5.lite.checkpoint import EXPERT_CLASSIFIER, PLACEMENT_FN
-from megatron.lite.model.qwen3_5.lite.checkpoint import export_hf_weights as _export_hf_weights_impl
-from megatron.lite.model.qwen3_5.lite.checkpoint import load_hf_weights as _load_hf_weights_impl
-from megatron.lite.model.qwen3_5.lite.checkpoint import save_hf_weights as _save_hf_weights_impl
+from megatron.lite.model.qwen3_5.lite.checkpoint import (
+    export_hf_weights as _export_hf_weights_impl,
+)
+from megatron.lite.model.qwen3_5.lite.checkpoint import (
+    load_hf_weights as _load_hf_weights_impl,
+)
+from megatron.lite.model.qwen3_5.lite.checkpoint import (
+    save_hf_weights as _save_hf_weights_impl,
+)
 from megatron.lite.primitive.bundle import ModelBundle
 from megatron.lite.primitive.parallel import ParallelState, init_parallel
 from megatron.lite.primitive.quantization import (
@@ -142,7 +152,11 @@ def _forward_step_bshd(model: nn.Module, batch: PackedBatch) -> dict:
     """
     input_ids = batch.input_ids.reshape(1, -1)
     labels = batch.labels.reshape(1, -1) if batch.labels is not None else None
-    kwargs: dict[str, Any] = {"input_ids": input_ids, "labels": labels, "packed_seq_params": None}
+    kwargs: dict[str, Any] = {
+        "input_ids": input_ids,
+        "labels": labels,
+        "packed_seq_params": None,
+    }
     add_cross_entropy_fusion(kwargs, model)
     return model(**kwargs)
 
@@ -195,7 +209,9 @@ def build_model(model_cfg: Qwen35Config, *, impl_cfg: ImplConfig) -> ModelBundle
     mtp_enable_train = mtp_enable and bool(impl_cfg.mtp_enable_train)
     if mtp_enable:
         if model_cfg.num_nextn_predict_layers <= 0:
-            raise ValueError("mtp_enable=True but HF config has no num_nextn_predict_layers.")
+            raise ValueError(
+                "mtp_enable=True but HF config has no num_nextn_predict_layers."
+            )
         model_cfg.mtp_loss_scaling_factor = impl_cfg.mtp_loss_scaling_factor
         if impl_cfg.mtp_use_repeated_layer is not None:
             model_cfg.mtp_use_repeated_layer = impl_cfg.mtp_use_repeated_layer
@@ -206,7 +222,11 @@ def build_model(model_cfg: Qwen35Config, *, impl_cfg: ImplConfig) -> ModelBundle
     recompute_spec = parse_recompute_spec(impl_cfg.recompute)
     vpp = None if p.vpp == 1 else p.vpp
     deterministic = impl_cfg.deterministic
-    if impl_cfg.use_thd and deterministic and "linear_attention" in model_cfg.layer_types:
+    if (
+        impl_cfg.use_thd
+        and deterministic
+        and "linear_attention" in model_cfg.layer_types
+    ):
         deterministic = False
     train_cfg = SimpleNamespace(
         tp=ps.tp_size,
@@ -233,7 +253,11 @@ def build_model(model_cfg: Qwen35Config, *, impl_cfg: ImplConfig) -> ModelBundle
     )
 
     if vpp is None:
-        chunks = [Qwen35Model(model_cfg, train_cfg, ps, **model_kwargs).to(torch.bfloat16).cuda()]
+        chunks = [
+            Qwen35Model(model_cfg, train_cfg, ps, **model_kwargs)
+            .to(torch.bfloat16)
+            .cuda()
+        ]
     else:
         chunks = [
             Qwen35Model(model_cfg, train_cfg, ps, vpp_chunk_id=i, **model_kwargs)
@@ -269,7 +293,9 @@ def build_model(model_cfg: Qwen35Config, *, impl_cfg: ImplConfig) -> ModelBundle
     post_model_load_hook = None
     optimizer_backend = "none"
     if impl_cfg.optimizer == "dist_opt":
-        optimizer, finalize_grads = _build_dist_opt_optimizer(chunks, model_cfg, impl_cfg, ps)
+        optimizer, finalize_grads = _build_dist_opt_optimizer(
+            chunks, model_cfg, impl_cfg, ps
+        )
         from megatron.lite.primitive.ckpt import attach_model_sharded_state_dict
         from megatron.lite.runtime.megatron_utils import register_training_hooks
 
@@ -283,7 +309,9 @@ def build_model(model_cfg: Qwen35Config, *, impl_cfg: ImplConfig) -> ModelBundle
 
         def _post_model_load_hook():
             from megatron.lite.model.qwen3_5.lite.model import Qwen35Layer
-            from megatron.lite.primitive.optimizers.fsdp2 import build_fsdp2_training_optimizer
+            from megatron.lite.primitive.optimizers.fsdp2 import (
+                build_fsdp2_training_optimizer,
+            )
 
             return {
                 "optimizer": build_fsdp2_training_optimizer(
@@ -332,7 +360,11 @@ def export_hf_weights(
 
 
 def save_hf_weights(
-    chunks: list[nn.Module], path: str, model_cfg: Qwen35Config, ps: ParallelState, **kwargs
+    chunks: list[nn.Module],
+    path: str,
+    model_cfg: Qwen35Config,
+    ps: ParallelState,
+    **kwargs,
 ) -> None:
     _save_hf_weights_impl(chunks, path, model_cfg, ps, **kwargs)
 

--- a/experimental/lite/megatron/lite/model/qwen3_5/stats.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/stats.py
@@ -38,7 +38,11 @@ def num_floating_point_operations(
             if full_attention_interval <= 0:
                 return None
             layer_types = [
-                "full_attention" if (i + 1) % full_attention_interval == 0 else "linear_attention"
+                (
+                    "full_attention"
+                    if (i + 1) % full_attention_interval == 0
+                    else "linear_attention"
+                )
                 for i in range(num_hidden_layers)
             ]
 
@@ -99,7 +103,10 @@ def num_floating_point_operations(
             18
             * total_tokens
             * hidden_size
-            * (moe_intermediate_size * num_experts_per_tok + shared_expert_intermediate_size)
+            * (
+                moe_intermediate_size * num_experts_per_tok
+                + shared_expert_intermediate_size
+            )
             * num_hidden_layers
         )
 
@@ -145,7 +152,9 @@ def activated_params(model_cfg: Qwen35Config) -> int | None:
         num_key_value_heads = int(_get("num_key_value_heads"))
         head_dim = int(_get("head_dim"))
         full_qkv_dim = (num_attention_heads + 2 * num_key_value_heads) * head_dim
-        full_attention = hidden_size * full_qkv_dim + (num_attention_heads * head_dim) * hidden_size
+        full_attention = (
+            hidden_size * full_qkv_dim + (num_attention_heads * head_dim) * hidden_size
+        )
 
         linear_num_key_heads = int(_get("linear_num_key_heads"))
         linear_key_head_dim = int(_get("linear_key_head_dim"))
@@ -170,7 +179,8 @@ def activated_params(model_cfg: Qwen35Config) -> int | None:
         shared_expert_intermediate_size = int(_get("shared_expert_intermediate_size"))
         router = hidden_size * num_experts
         routed_expert = (
-            hidden_size * (2 * moe_intermediate_size) + moe_intermediate_size * hidden_size
+            hidden_size * (2 * moe_intermediate_size)
+            + moe_intermediate_size * hidden_size
         )
         shared_expert = (
             hidden_size * (2 * shared_expert_intermediate_size)

--- a/experimental/lite/megatron/lite/model/qwen3_moe/config.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/config.py
@@ -55,7 +55,9 @@ class Qwen3MoEConfig:
             f"num_attention_heads({self.num_attention_heads}) % num_key_value_heads({self.num_key_value_heads}) != 0",
         )
         _check(self.head_dim > 0, f"head_dim must be > 0, got {self.head_dim}")
-        _check(self.num_experts >= 1, f"num_experts must be >= 1, got {self.num_experts}")
+        _check(
+            self.num_experts >= 1, f"num_experts must be >= 1, got {self.num_experts}"
+        )
         _check(
             1 <= self.num_experts_per_tok <= self.num_experts,
             f"num_experts_per_tok({self.num_experts_per_tok}) not in [1, {self.num_experts}]",
@@ -63,7 +65,9 @@ class Qwen3MoEConfig:
         _check(self.moe_intermediate_size > 0, "moe_intermediate_size must be > 0")
         _check(self.vocab_size > 0, "vocab_size must be > 0")
         _check(self.num_hidden_layers >= 1, "num_hidden_layers must be >= 1")
-        _check(self.num_nextn_predict_layers >= 0, "num_nextn_predict_layers must be >= 0")
+        _check(
+            self.num_nextn_predict_layers >= 0, "num_nextn_predict_layers must be >= 0"
+        )
         _check(
             len(self.layer_types) == self.num_hidden_layers,
             f"len(layer_types)={len(self.layer_types)} != "
@@ -71,11 +75,15 @@ class Qwen3MoEConfig:
         )
         valid_types = {"full_attention"}
         for i, lt in enumerate(self.layer_types):
-            _check(lt in valid_types, f"layer_types[{i}] must be one of {valid_types}, got '{lt}'")
+            _check(
+                lt in valid_types,
+                f"layer_types[{i}] must be one of {valid_types}, got '{lt}'",
+            )
 
         if errors:
             raise ValueError(
-                f"Invalid Qwen3MoEConfig ({len(errors)} errors):\n  " + "\n  ".join(errors)
+                f"Invalid Qwen3MoEConfig ({len(errors)} errors):\n  "
+                + "\n  ".join(errors)
             )
 
     @property
@@ -92,7 +100,9 @@ class Qwen3MoEConfig:
 
     @classmethod
     def from_hf_config(cls, hf_config, **overrides) -> Qwen3MoEConfig:
-        hf_dict = hf_config.to_dict() if hasattr(hf_config, "to_dict") else vars(hf_config)
+        hf_dict = (
+            hf_config.to_dict() if hasattr(hf_config, "to_dict") else vars(hf_config)
+        )
         return cls._from_hf_dict(hf_dict, **overrides)
 
     @classmethod
@@ -102,7 +112,9 @@ class Qwen3MoEConfig:
 
         if "rope_theta" not in kwargs:
             if "rope_parameters" in hf and isinstance(hf["rope_parameters"], dict):
-                kwargs["rope_theta"] = float(hf["rope_parameters"].get("rope_theta", 1_000_000.0))
+                kwargs["rope_theta"] = float(
+                    hf["rope_parameters"].get("rope_theta", 1_000_000.0)
+                )
 
         if "head_dim" not in kwargs or kwargs["head_dim"] is None:
             hs = kwargs.get("hidden_size", 2048)
@@ -112,6 +124,8 @@ class Qwen3MoEConfig:
             kwargs["num_nextn_predict_layers"] = 0
 
         if "layer_types" not in kwargs:
-            kwargs["layer_types"] = ["full_attention"] * kwargs.get("num_hidden_layers", 48)
+            kwargs["layer_types"] = ["full_attention"] * kwargs.get(
+                "num_hidden_layers", 48
+            )
         kwargs.update(overrides)
         return cls(**kwargs)

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/checkpoint.py
@@ -23,7 +23,6 @@ from megatron.lite.primitive.quantization.mxfp4 import MXFP4_BLOCK_SIZE, quantiz
 from megatron.lite.runtime.contracts.weights import ResyncFormat
 from torch.distributed.tensor import Replicate, Shard
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -281,11 +280,7 @@ def export_hf_weights(model, config: Qwen3MoEConfig, ps, **kwargs):
     target = kwargs.pop("target", "hf")
     resync_config = kwargs.pop("resync_config", None)
     weights = _export(
-        model,
-        Qwen3MoEWeightSpec(config),
-        ps,
-        vocab_size=config.vocab_size,
-        **kwargs,
+        model, Qwen3MoEWeightSpec(config), ps, vocab_size=config.vocab_size, **kwargs
     )
     if target in {"hf", ResyncFormat.BF16.value}:
         if resync_config:

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/lora_adapter.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/lora_adapter.py
@@ -10,7 +10,6 @@ from typing import Any
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-
 from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
 from megatron.lite.primitive.modules.lora import LoraConfig, normalize_lora_config
 from megatron.lite.primitive.parallel import ParallelState
@@ -44,7 +43,9 @@ def _unwrap_model(module: nn.Module) -> nn.Module:
     return current
 
 
-def _iter_qwen_chunks(chunks: list[nn.Module] | tuple[nn.Module, ...]) -> list[nn.Module]:
+def _iter_qwen_chunks(
+    chunks: list[nn.Module] | tuple[nn.Module, ...]
+) -> list[nn.Module]:
     return [_unwrap_model(chunk) for chunk in chunks]
 
 
@@ -71,7 +72,9 @@ def _is_rank_partitioned_lora_a(lora: Any, ps: ParallelState) -> bool:
     return ps.tp_size > 1 and lora.lora_a.shape[0] != rank
 
 
-def _gather_lora_rank_partition(tensor: torch.Tensor, ps: ParallelState) -> torch.Tensor:
+def _gather_lora_rank_partition(
+    tensor: torch.Tensor, ps: ParallelState
+) -> torch.Tensor:
     return _all_gather_cat(tensor, ps.tp_group, dim=0)
 
 
@@ -79,7 +82,9 @@ def _slice_lora_rank_partition(tensor: torch.Tensor, ps: ParallelState) -> torch
     if ps.tp_size == 1:
         return tensor.contiguous()
     if tensor.shape[0] % ps.tp_size != 0:
-        raise ValueError(f"Cannot shard LoRA rank dim {tensor.shape[0]} over TP={ps.tp_size}.")
+        raise ValueError(
+            f"Cannot shard LoRA rank dim {tensor.shape[0]} over TP={ps.tp_size}."
+        )
     local_rank = tensor.shape[0] // ps.tp_size
     start = ps.tp_rank * local_rank
     return tensor[start : start + local_rank].contiguous()
@@ -88,7 +93,9 @@ def _slice_lora_rank_partition(tensor: torch.Tensor, ps: ParallelState) -> torch
 def _is_output_partitioned_lora_b(lora: Any, ps: ParallelState) -> bool:
     if getattr(lora, "output_partitioned_b", False):
         return True
-    return ps.tp_size > 1 and lora.lora_b.shape[0] * ps.tp_size == getattr(lora, "out_features", -1)
+    return ps.tp_size > 1 and lora.lora_b.shape[0] * ps.tp_size == getattr(
+        lora, "out_features", -1
+    )
 
 
 def _expert_lora_is_shared(lora: Any) -> bool:
@@ -100,8 +107,14 @@ def _expand_shared_expert_lora(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     if _expert_lora_is_shared(lora):
         return (
-            lora.lora_a.detach().unsqueeze(0).expand(num_local_experts, -1, -1).contiguous(),
-            lora.lora_b.detach().unsqueeze(0).expand(num_local_experts, -1, -1).contiguous(),
+            lora.lora_a.detach()
+            .unsqueeze(0)
+            .expand(num_local_experts, -1, -1)
+            .contiguous(),
+            lora.lora_b.detach()
+            .unsqueeze(0)
+            .expand(num_local_experts, -1, -1)
+            .contiguous(),
         )
     return lora.lora_a.detach(), lora.lora_b.detach()
 
@@ -145,7 +158,9 @@ def _attn_key(layer_idx: int, module: str, suffix: str) -> str:
 
 
 def _expert_key(layer_idx: int, expert_idx: int, module: str, suffix: str) -> str:
-    return f"{_layer_prefix(layer_idx)}.mlp.experts.{expert_idx}.{module}.{suffix}.weight"
+    return (
+        f"{_layer_prefix(layer_idx)}.mlp.experts.{expert_idx}.{module}.{suffix}.weight"
+    )
 
 
 def _target_modules_from_lora_config(lora_config: LoraConfig) -> list[str]:
@@ -248,11 +263,17 @@ def _validate_adapter_config(
 ) -> None:
     peft_type = adapter_config.get("peft_type")
     if peft_type is not None and str(peft_type).upper() != "LORA":
-        raise ValueError(f"Expected PEFT adapter_config peft_type='LORA', got {peft_type!r}.")
+        raise ValueError(
+            f"Expected PEFT adapter_config peft_type='LORA', got {peft_type!r}."
+        )
 
     state_rank = _infer_state_rank(state)
     config_rank = adapter_config.get("r")
-    if config_rank is not None and state_rank is not None and int(config_rank) != state_rank:
+    if (
+        config_rank is not None
+        and state_rank is not None
+        and int(config_rank) != state_rank
+    ):
         raise ValueError(
             f"Adapter config rank r={config_rank} does not match tensor rank {state_rank}."
         )
@@ -267,7 +288,11 @@ def _validate_adapter_config(
 
     config_alpha = adapter_config.get("lora_alpha")
     native_alpha = _infer_native_alpha(chunks)
-    if config_alpha is not None and native_alpha is not None and int(config_alpha) != native_alpha:
+    if (
+        config_alpha is not None
+        and native_alpha is not None
+        and int(config_alpha) != native_alpha
+    ):
         raise ValueError(
             f"Adapter config lora_alpha={config_alpha} does not match native model alpha={native_alpha}."
         )
@@ -279,7 +304,9 @@ def _validate_adapter_config(
             raise ValueError(
                 f"Adapter config rank r={config_rank} does not match expected rank {expected.rank}."
             )
-        if config_alpha is not None and int(config_alpha) != _effective_lora_alpha(expected):
+        if config_alpha is not None and int(config_alpha) != _effective_lora_alpha(
+            expected
+        ):
             raise ValueError(
                 "Adapter config lora_alpha="
                 f"{config_alpha} does not match expected alpha {_effective_lora_alpha(expected)}."
@@ -348,7 +375,9 @@ def export_lora_adapter_state(
 
             if attn.qkv_lora is not None:
                 if _is_rank_partitioned_lora_a(attn.qkv_lora, ps):
-                    qkv_a = _gather_lora_rank_partition(attn.qkv_lora.lora_a.detach(), ps)
+                    qkv_a = _gather_lora_rank_partition(
+                        attn.qkv_lora.lora_a.detach(), ps
+                    )
                 else:
                     qkv_a = _select_tp_replicated(attn.qkv_lora.lora_a.detach(), ps)
                 q_b_local, k_b_local, v_b_local = _split_local_mcore_qkv_b(
@@ -369,9 +398,13 @@ def export_lora_adapter_state(
                     state[_attn_key(layer_idx, "v_proj", "lora_B")] = v_b
 
             if attn.proj_lora is not None:
-                proj_a = _all_gather_cat(attn.proj_lora.lora_a.detach(), ps.tp_group, dim=1)
+                proj_a = _all_gather_cat(
+                    attn.proj_lora.lora_a.detach(), ps.tp_group, dim=1
+                )
                 if _is_output_partitioned_lora_b(attn.proj_lora, ps):
-                    proj_b = _all_gather_cat(attn.proj_lora.lora_b.detach(), ps.tp_group, dim=0)
+                    proj_b = _all_gather_cat(
+                        attn.proj_lora.lora_b.detach(), ps.tp_group, dim=0
+                    )
                 else:
                     proj_b = _select_tp_replicated(attn.proj_lora.lora_b.detach(), ps)
                 if _rank() == 0:
@@ -388,18 +421,18 @@ def export_lora_adapter_state(
                 gate_b, up_b = fc1_b.chunk(2, dim=1)
                 if _rank() == 0:
                     for expert_idx in range(model_cfg.num_experts):
-                        state[_expert_key(layer_idx, expert_idx, "gate_proj", "lora_A")] = fc1_a[
-                            expert_idx
-                        ]
-                        state[_expert_key(layer_idx, expert_idx, "gate_proj", "lora_B")] = gate_b[
-                            expert_idx
-                        ]
-                        state[_expert_key(layer_idx, expert_idx, "up_proj", "lora_A")] = fc1_a[
-                            expert_idx
-                        ].clone()
-                        state[_expert_key(layer_idx, expert_idx, "up_proj", "lora_B")] = up_b[
-                            expert_idx
-                        ]
+                        state[
+                            _expert_key(layer_idx, expert_idx, "gate_proj", "lora_A")
+                        ] = fc1_a[expert_idx]
+                        state[
+                            _expert_key(layer_idx, expert_idx, "gate_proj", "lora_B")
+                        ] = gate_b[expert_idx]
+                        state[
+                            _expert_key(layer_idx, expert_idx, "up_proj", "lora_A")
+                        ] = fc1_a[expert_idx].clone()
+                        state[
+                            _expert_key(layer_idx, expert_idx, "up_proj", "lora_B")
+                        ] = up_b[expert_idx]
 
             if experts.fc2_lora is not None:
                 fc2_a_local, fc2_b_local = _expand_shared_expert_lora(
@@ -409,17 +442,19 @@ def export_lora_adapter_state(
                 fc2_b = _all_gather_cat(fc2_b_local, ps.ep_group, dim=0)
                 if _rank() == 0:
                     for expert_idx in range(model_cfg.num_experts):
-                        state[_expert_key(layer_idx, expert_idx, "down_proj", "lora_A")] = fc2_a[
-                            expert_idx
-                        ]
-                        state[_expert_key(layer_idx, expert_idx, "down_proj", "lora_B")] = fc2_b[
-                            expert_idx
-                        ]
+                        state[
+                            _expert_key(layer_idx, expert_idx, "down_proj", "lora_A")
+                        ] = fc2_a[expert_idx]
+                        state[
+                            _expert_key(layer_idx, expert_idx, "down_proj", "lora_B")
+                        ] = fc2_b[expert_idx]
 
     if _rank() != 0:
         return {}
     if cpu:
-        return {name: tensor.detach().cpu().contiguous() for name, tensor in state.items()}
+        return {
+            name: tensor.detach().cpu().contiguous() for name, tensor in state.items()
+        }
     return {name: tensor.detach().contiguous() for name, tensor in state.items()}
 
 
@@ -438,7 +473,9 @@ def save_lora_adapter(
     from safetensors.torch import save_file
 
     if lora_config is None:
-        raise ValueError("save_lora_adapter requires the LoRA config used to build the model.")
+        raise ValueError(
+            "save_lora_adapter requires the LoRA config used to build the model."
+        )
     lora = normalize_lora_config(lora_config)
     if not lora.enabled:
         raise ValueError("save_lora_adapter requires an enabled LoRA config.")
@@ -477,7 +514,12 @@ def save_lora_adapter(
             ),
             "num_tensors": len(state),
             "num_parameters": int(sum(t.numel() for t in state.values())),
-            "parallel": {"tp": ps.tp_size, "ep": ps.ep_size, "etp": ps.etp_size, "pp": ps.pp_size},
+            "parallel": {
+                "tp": ps.tp_size,
+                "ep": ps.ep_size,
+                "etp": ps.etp_size,
+                "pp": ps.pp_size,
+            },
             "model": {
                 "num_hidden_layers": model_cfg.num_hidden_layers,
                 "hidden_size": model_cfg.hidden_size,
@@ -489,7 +531,9 @@ def save_lora_adapter(
             },
             "metadata": metadata or {},
         }
-        (output / "megatron.lite_adapter_meta.json").write_text(json.dumps(meta, indent=2) + "\n")
+        (output / "megatron.lite_adapter_meta.json").write_text(
+            json.dumps(meta, indent=2) + "\n"
+        )
         result = {
             "path": str(output),
             "adapter_model": str(output / "adapter_model.safetensors"),
@@ -510,12 +554,16 @@ def _require_tensor(state: dict[str, torch.Tensor], key: str) -> torch.Tensor:
         raise KeyError(f"Missing adapter tensor {key!r}") from exc
 
 
-def _slice_tp_output(tensor: torch.Tensor, local_width: int, ps: ParallelState) -> torch.Tensor:
+def _slice_tp_output(
+    tensor: torch.Tensor, local_width: int, ps: ParallelState
+) -> torch.Tensor:
     start = ps.tp_rank * local_width
     return tensor[start : start + local_width].contiguous()
 
 
-def _slice_tp_input(tensor: torch.Tensor, local_width: int, ps: ParallelState) -> torch.Tensor:
+def _slice_tp_input(
+    tensor: torch.Tensor, local_width: int, ps: ParallelState
+) -> torch.Tensor:
     start = ps.tp_rank * local_width
     return tensor[:, start : start + local_width].contiguous()
 
@@ -548,11 +596,17 @@ def load_lora_adapter_state(
             layer_idx = int(layer.layer_idx)
             attn = layer.attn
             if attn.qkv_lora is not None:
-                q_a = _require_tensor(state, _attn_key(layer_idx, "q_proj", "lora_A")).to(
+                q_a = _require_tensor(
+                    state, _attn_key(layer_idx, "q_proj", "lora_A")
+                ).to(
                     device=attn.qkv_lora.lora_a.device, dtype=attn.qkv_lora.lora_a.dtype
                 )
-                k_a = _require_tensor(state, _attn_key(layer_idx, "k_proj", "lora_A")).to(q_a)
-                v_a = _require_tensor(state, _attn_key(layer_idx, "v_proj", "lora_A")).to(q_a)
+                k_a = _require_tensor(
+                    state, _attn_key(layer_idx, "k_proj", "lora_A")
+                ).to(q_a)
+                v_a = _require_tensor(
+                    state, _attn_key(layer_idx, "v_proj", "lora_A")
+                ).to(q_a)
                 if strict and (not torch.equal(q_a, k_a) or not torch.equal(q_a, v_a)):
                     raise ValueError(
                         "Megatron Lite fused qkv_lora requires q/k/v lora_A tensors to match."
@@ -564,21 +618,24 @@ def load_lora_adapter_state(
                 )
                 q_b = _slice_tp_output(
                     _require_tensor(state, _attn_key(layer_idx, "q_proj", "lora_B")).to(
-                        device=attn.qkv_lora.lora_b.device, dtype=attn.qkv_lora.lora_b.dtype
+                        device=attn.qkv_lora.lora_b.device,
+                        dtype=attn.qkv_lora.lora_b.dtype,
                     ),
                     q_width_local,
                     ps,
                 )
                 k_b = _slice_tp_output(
                     _require_tensor(state, _attn_key(layer_idx, "k_proj", "lora_B")).to(
-                        device=attn.qkv_lora.lora_b.device, dtype=attn.qkv_lora.lora_b.dtype
+                        device=attn.qkv_lora.lora_b.device,
+                        dtype=attn.qkv_lora.lora_b.dtype,
                     ),
                     kv_width_local,
                     ps,
                 )
                 v_b = _slice_tp_output(
                     _require_tensor(state, _attn_key(layer_idx, "v_proj", "lora_B")).to(
-                        device=attn.qkv_lora.lora_b.device, dtype=attn.qkv_lora.lora_b.dtype
+                        device=attn.qkv_lora.lora_b.device,
+                        dtype=attn.qkv_lora.lora_b.dtype,
                     ),
                     kv_width_local,
                     ps,
@@ -599,16 +656,22 @@ def load_lora_adapter_state(
             if attn.proj_lora is not None:
                 proj_a = _slice_tp_input(
                     _require_tensor(state, _attn_key(layer_idx, "o_proj", "lora_A")).to(
-                        device=attn.proj_lora.lora_a.device, dtype=attn.proj_lora.lora_a.dtype
+                        device=attn.proj_lora.lora_a.device,
+                        dtype=attn.proj_lora.lora_a.dtype,
                     ),
                     attn_in_width_local,
                     ps,
                 )
-                proj_b = _require_tensor(state, _attn_key(layer_idx, "o_proj", "lora_B")).to(
-                    device=attn.proj_lora.lora_b.device, dtype=attn.proj_lora.lora_b.dtype
+                proj_b = _require_tensor(
+                    state, _attn_key(layer_idx, "o_proj", "lora_B")
+                ).to(
+                    device=attn.proj_lora.lora_b.device,
+                    dtype=attn.proj_lora.lora_b.dtype,
                 )
                 if _is_output_partitioned_lora_b(attn.proj_lora, ps):
-                    proj_b = _slice_tp_output(proj_b, attn.proj_lora.lora_b.shape[0], ps)
+                    proj_b = _slice_tp_output(
+                        proj_b, attn.proj_lora.lora_b.shape[0], ps
+                    )
                 attn.proj_lora.lora_a.data.copy_(proj_a)
                 attn.proj_lora.lora_b.data.copy_(proj_b)
                 loaded += 2
@@ -623,13 +686,15 @@ def load_lora_adapter_state(
                     local_up_b = []
                     for expert_idx in range(expert_start, expert_stop):
                         gate_a = _require_tensor(
-                            state, _expert_key(layer_idx, expert_idx, "gate_proj", "lora_A")
+                            state,
+                            _expert_key(layer_idx, expert_idx, "gate_proj", "lora_A"),
                         ).to(
                             device=experts.fc1_lora.lora_a.device,
                             dtype=experts.fc1_lora.lora_a.dtype,
                         )
                         up_a = _require_tensor(
-                            state, _expert_key(layer_idx, expert_idx, "up_proj", "lora_A")
+                            state,
+                            _expert_key(layer_idx, expert_idx, "up_proj", "lora_A"),
                         ).to(gate_a)
                         if strict and not torch.equal(gate_a, up_a):
                             raise ValueError(
@@ -638,7 +703,10 @@ def load_lora_adapter_state(
                         local_gate_a.append(gate_a)
                         local_gate_b.append(
                             _require_tensor(
-                                state, _expert_key(layer_idx, expert_idx, "gate_proj", "lora_B")
+                                state,
+                                _expert_key(
+                                    layer_idx, expert_idx, "gate_proj", "lora_B"
+                                ),
                             ).to(
                                 device=experts.fc1_lora.lora_b.device,
                                 dtype=experts.fc1_lora.lora_b.dtype,
@@ -646,7 +714,8 @@ def load_lora_adapter_state(
                         )
                         local_up_b.append(
                             _require_tensor(
-                                state, _expert_key(layer_idx, expert_idx, "up_proj", "lora_B")
+                                state,
+                                _expert_key(layer_idx, expert_idx, "up_proj", "lora_B"),
                             ).to(
                                 device=experts.fc1_lora.lora_b.device,
                                 dtype=experts.fc1_lora.lora_b.dtype,
@@ -654,20 +723,25 @@ def load_lora_adapter_state(
                         )
                     if strict:
                         if any(
-                            not torch.equal(local_gate_a[0], value) for value in local_gate_a[1:]
+                            not torch.equal(local_gate_a[0], value)
+                            for value in local_gate_a[1:]
                         ):
                             raise ValueError(
                                 "Megatron Lite shared expert fc1_lora can only import PEFT adapters "
                                 "whose local expert gate lora_A tensors are identical."
                             )
                         if any(
-                            not torch.equal(local_gate_b[0], value) for value in local_gate_b[1:]
+                            not torch.equal(local_gate_b[0], value)
+                            for value in local_gate_b[1:]
                         ):
                             raise ValueError(
                                 "Megatron Lite shared expert fc1_lora can only import PEFT adapters "
                                 "whose local expert gate lora_B tensors are identical."
                             )
-                        if any(not torch.equal(local_up_b[0], value) for value in local_up_b[1:]):
+                        if any(
+                            not torch.equal(local_up_b[0], value)
+                            for value in local_up_b[1:]
+                        ):
                             raise ValueError(
                                 "Megatron Lite shared expert fc1_lora can only import PEFT adapters "
                                 "whose local expert up lora_B tensors are identical."
@@ -678,28 +752,34 @@ def load_lora_adapter_state(
                     )
                     loaded += 2
                 else:
-                    for local_idx, expert_idx in enumerate(range(expert_start, expert_stop)):
+                    for local_idx, expert_idx in enumerate(
+                        range(expert_start, expert_stop)
+                    ):
                         gate_a = _require_tensor(
-                            state, _expert_key(layer_idx, expert_idx, "gate_proj", "lora_A")
+                            state,
+                            _expert_key(layer_idx, expert_idx, "gate_proj", "lora_A"),
                         ).to(
                             device=experts.fc1_lora.lora_a.device,
                             dtype=experts.fc1_lora.lora_a.dtype,
                         )
                         up_a = _require_tensor(
-                            state, _expert_key(layer_idx, expert_idx, "up_proj", "lora_A")
+                            state,
+                            _expert_key(layer_idx, expert_idx, "up_proj", "lora_A"),
                         ).to(gate_a)
                         if strict and not torch.equal(gate_a, up_a):
                             raise ValueError(
                                 "Megatron Lite fused fc1_lora requires gate/up lora_A tensors to match."
                             )
                         gate_b = _require_tensor(
-                            state, _expert_key(layer_idx, expert_idx, "gate_proj", "lora_B")
+                            state,
+                            _expert_key(layer_idx, expert_idx, "gate_proj", "lora_B"),
                         ).to(
                             device=experts.fc1_lora.lora_b.device,
                             dtype=experts.fc1_lora.lora_b.dtype,
                         )
                         up_b = _require_tensor(
-                            state, _expert_key(layer_idx, expert_idx, "up_proj", "lora_B")
+                            state,
+                            _expert_key(layer_idx, expert_idx, "up_proj", "lora_B"),
                         ).to(
                             device=experts.fc1_lora.lora_b.device,
                             dtype=experts.fc1_lora.lora_b.dtype,
@@ -717,7 +797,10 @@ def load_lora_adapter_state(
                     for expert_idx in range(expert_start, expert_stop):
                         local_a.append(
                             _require_tensor(
-                                state, _expert_key(layer_idx, expert_idx, "down_proj", "lora_A")
+                                state,
+                                _expert_key(
+                                    layer_idx, expert_idx, "down_proj", "lora_A"
+                                ),
                             ).to(
                                 device=experts.fc2_lora.lora_a.device,
                                 dtype=experts.fc2_lora.lora_a.dtype,
@@ -725,19 +808,26 @@ def load_lora_adapter_state(
                         )
                         local_b.append(
                             _require_tensor(
-                                state, _expert_key(layer_idx, expert_idx, "down_proj", "lora_B")
+                                state,
+                                _expert_key(
+                                    layer_idx, expert_idx, "down_proj", "lora_B"
+                                ),
                             ).to(
                                 device=experts.fc2_lora.lora_b.device,
                                 dtype=experts.fc2_lora.lora_b.dtype,
                             )
                         )
                     if strict:
-                        if any(not torch.equal(local_a[0], value) for value in local_a[1:]):
+                        if any(
+                            not torch.equal(local_a[0], value) for value in local_a[1:]
+                        ):
                             raise ValueError(
                                 "Megatron Lite shared expert fc2_lora can only import PEFT adapters "
                                 "whose local expert down lora_A tensors are identical."
                             )
-                        if any(not torch.equal(local_b[0], value) for value in local_b[1:]):
+                        if any(
+                            not torch.equal(local_b[0], value) for value in local_b[1:]
+                        ):
                             raise ValueError(
                                 "Megatron Lite shared expert fc2_lora can only import PEFT adapters "
                                 "whose local expert down lora_B tensors are identical."
@@ -746,10 +836,15 @@ def load_lora_adapter_state(
                     experts.fc2_lora.lora_b.data.copy_(local_b[0])
                     loaded += 2
                 else:
-                    for local_idx, expert_idx in enumerate(range(expert_start, expert_stop)):
+                    for local_idx, expert_idx in enumerate(
+                        range(expert_start, expert_stop)
+                    ):
                         experts.fc2_lora.lora_a.data[local_idx].copy_(
                             _require_tensor(
-                                state, _expert_key(layer_idx, expert_idx, "down_proj", "lora_A")
+                                state,
+                                _expert_key(
+                                    layer_idx, expert_idx, "down_proj", "lora_A"
+                                ),
                             ).to(
                                 device=experts.fc2_lora.lora_a.device,
                                 dtype=experts.fc2_lora.lora_a.dtype,
@@ -757,7 +852,10 @@ def load_lora_adapter_state(
                         )
                         experts.fc2_lora.lora_b.data[local_idx].copy_(
                             _require_tensor(
-                                state, _expert_key(layer_idx, expert_idx, "down_proj", "lora_B")
+                                state,
+                                _expert_key(
+                                    layer_idx, expert_idx, "down_proj", "lora_B"
+                                ),
                             ).to(
                                 device=experts.fc2_lora.lora_b.device,
                                 dtype=experts.fc2_lora.lora_b.dtype,

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
@@ -12,9 +12,8 @@ from contextlib import nullcontext
 
 import torch
 import torch.nn as nn
-
-from megatron.lite.primitive import transformer_engine as te
 from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
+from megatron.lite.primitive import transformer_engine as te
 from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
 from megatron.lite.primitive.modules.experts import Experts
 from megatron.lite.primitive.modules.gqa import GQAttention
@@ -58,7 +57,11 @@ class MoELayer(nn.Module):
             config, ps, router_bias_rate=router_bias_rate, compute_aux_loss=False
         )
         self.experts = Experts(
-            config, ps, fp8=fp8, moe_act_recompute=moe_act_recompute, lora_config=lora_config
+            config,
+            ps,
+            fp8=fp8,
+            moe_act_recompute=moe_act_recompute,
+            lora_config=lora_config,
         )
         self.dispatcher = TokenDispatcher(
             config.num_experts, config.hidden_size, ps, use_deepep=use_deepep
@@ -72,7 +75,9 @@ class MoELayer(nn.Module):
             x_2d = x
 
         scores, indices = self.router(x_2d)
-        dispatched, tpe, permuted_probs = self.dispatcher.dispatch(x_2d, scores, indices)
+        dispatched, tpe, permuted_probs = self.dispatcher.dispatch(
+            x_2d, scores, indices
+        )
         del scores, indices
         self.dispatcher.wait_dispatch_event()
         expert_out = self.experts(
@@ -159,7 +164,10 @@ class TransformerLayer(nn.Module):
         )
 
     def forward(
-        self, x: torch.Tensor, position_ids: torch.Tensor | None = None, packed_seq_params=None
+        self,
+        x: torch.Tensor,
+        position_ids: torch.Tensor | None = None,
+        packed_seq_params=None,
     ) -> torch.Tensor:
         residual = x
         h = self.attn(x, position_ids=position_ids, packed_seq_params=packed_seq_params)
@@ -186,7 +194,9 @@ class MTPLossAutoScaler(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad_output: torch.Tensor):
         (mtp_loss,) = ctx.saved_tensors
-        scaled_mtp_grad = torch.ones_like(mtp_loss) * MTPLossAutoScaler.main_loss_backward_scale
+        scaled_mtp_grad = (
+            torch.ones_like(mtp_loss) * MTPLossAutoScaler.main_loss_backward_scale
+        )
         return grad_output, scaled_mtp_grad
 
     @staticmethod
@@ -221,7 +231,11 @@ class MultiTokenPredictionLayer(nn.Module):
         self.enorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.hnorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.eh_proj = VanillaColumnParallelLinear(
-            config.hidden_size * 2, config.hidden_size, ps, sp=ps.tp_size > 1, gather_output=True
+            config.hidden_size * 2,
+            config.hidden_size,
+            ps,
+            sp=ps.tp_size > 1,
+            gather_output=True,
         )
         self.transformer_layer = TransformerLayer(
             config,
@@ -248,7 +262,9 @@ class MultiTokenPredictionLayer(nn.Module):
         attention_position_ids = (
             rotary_position_ids if rotary_position_ids is not None else position_ids
         )
-        input_ids, _ = roll_packed_thd_left(input_ids, packed_seq_params=packed_seq_params, dims=-1)
+        input_ids, _ = roll_packed_thd_left(
+            input_ids, packed_seq_params=packed_seq_params, dims=-1
+        )
         if position_ids is not None:
             position_ids, _ = roll_packed_thd_left(
                 position_ids, packed_seq_params=packed_seq_params, dims=-1
@@ -266,7 +282,9 @@ class MultiTokenPredictionLayer(nn.Module):
         hidden_states = self.eh_proj(hidden_states)
         hidden_states = scatter_to_sequence_parallel(hidden_states, self.ps)
         hidden_states = self.transformer_layer(
-            hidden_states, position_ids=attention_position_ids, packed_seq_params=packed_seq_params
+            hidden_states,
+            position_ids=attention_position_ids,
+            packed_seq_params=packed_seq_params,
         )
         hidden_states = self.final_layernorm(hidden_states)
         return hidden_states, input_ids, position_ids
@@ -369,7 +387,9 @@ class Qwen3MoEModel(nn.Module):
         self.mtp_enable_train = bool(mtp_enable and mtp_enable_train)
         self.mtp_loss_scaling_factor = config.mtp_loss_scaling_factor
         self._input_tensor: torch.Tensor | None = None
-        layout = build_pipeline_chunk_layout(config.num_hidden_layers, ps, vpp, vpp_chunk_id)
+        layout = build_pipeline_chunk_layout(
+            config.num_hidden_layers, ps, vpp, vpp_chunk_id
+        )
         self.layer_indices = layout.layer_indices
         has_embed = layout.has_embed
         has_head = layout.has_head
@@ -379,7 +399,9 @@ class Qwen3MoEModel(nn.Module):
 
         self.embed: VocabParallelEmbedding | None = None
         if has_embed:
-            self.embed = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
+            self.embed = VocabParallelEmbedding(
+                config.vocab_size, config.hidden_size, ps
+            )
 
         _recompute = recompute_modules or []
         moe_act_recompute = "moe_act" in _recompute and "moe" not in _recompute
@@ -411,7 +433,9 @@ class Qwen3MoEModel(nn.Module):
         if mtp_enable and config.num_nextn_predict_layers > 0 and self.head is not None:
             mtp_embedding = self.embed
             if mtp_embedding is None:
-                mtp_embedding = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
+                mtp_embedding = VocabParallelEmbedding(
+                    config.vocab_size, config.hidden_size, ps
+                )
                 self.mtp_embed = mtp_embedding
             self.mtp = MultiTokenPredictionBlock(
                 config,
@@ -434,7 +458,9 @@ class Qwen3MoEModel(nn.Module):
     def set_input_tensor(self, input_tensor):
         if isinstance(input_tensor, list):
             if len(input_tensor) > 1:
-                raise ValueError("Qwen3MoEModel expects a single pipeline input tensor.")
+                raise ValueError(
+                    "Qwen3MoEModel expects a single pipeline input tensor."
+                )
             input_tensor = input_tensor[0] if input_tensor else None
         self._input_tensor = input_tensor
 
@@ -470,7 +496,9 @@ class Qwen3MoEModel(nn.Module):
             if self.embed is not None:
                 h = scatter_to_sequence_parallel(h, self.ps)
             for layer in self.layers:
-                h = layer(h, position_ids=position_ids, packed_seq_params=packed_seq_params)
+                h = layer(
+                    h, position_ids=position_ids, packed_seq_params=packed_seq_params
+                )
             # Head path is SP-aware: norm runs on SP-sharded [S/tp, B, H] and
             # head's internal all-gather happens inside VocabParallelOutput.
             # Mirrors MC GPTModel's final_layernorm → output_layer(sp=True).
@@ -497,7 +525,9 @@ class Qwen3MoEModel(nn.Module):
                     output["mtp_loss"] = mtp_loss
                 labels_sb = labels.transpose(0, 1).contiguous()
                 if use_fused_kernels:
-                    hidden_full = gather_from_sequence_parallel(hidden_for_head, self.ps)
+                    hidden_full = gather_from_sequence_parallel(
+                        hidden_for_head, self.ps
+                    )
                     log_probs, entropy = linear_cross_entropy(
                         hidden_full,
                         self._head_weight_for_fused_ce(hidden_full),
@@ -515,7 +545,9 @@ class Qwen3MoEModel(nn.Module):
                     logits = self.head(hidden_for_head)
                     if temperature_value != 1.0:
                         logits = logits / temperature_value
-                    token_loss = vocab_parallel_cross_entropy(logits, labels_sb, self.ps.tp_group)
+                    token_loss = vocab_parallel_cross_entropy(
+                        logits, labels_sb, self.ps.tp_group
+                    )
                     output["loss"] = token_loss.mean()
                     if return_log_probs:
                         output["log_probs"] = (-token_loss).transpose(0, 1).contiguous()
@@ -586,12 +618,16 @@ class Qwen3MoEModel(nn.Module):
                 logits = self.head(mtp_hidden)
                 if temperature != 1.0:
                     logits = logits / temperature
-                token_loss = vocab_parallel_cross_entropy(logits, labels_sb, self.ps.tp_group)
+                token_loss = vocab_parallel_cross_entropy(
+                    logits, labels_sb, self.ps.tp_group
+                )
             token_loss = token_loss * mask_sb.to(dtype=token_loss.dtype)
             num_tokens = num_tokens.to(dtype=token_loss.dtype).clamp_min(1.0)
             mtp_loss_values.append(token_loss.sum() / num_tokens)
 
-            mtp_loss_scale = self.mtp_loss_scaling_factor / max(len(mtp_hidden_states), 1)
+            mtp_loss_scale = self.mtp_loss_scaling_factor / max(
+                len(mtp_hidden_states), 1
+            )
             hidden_states = MTPLossAutoScaler.apply(
                 hidden_states, mtp_loss_scale * token_loss / num_tokens
             )

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
@@ -31,14 +31,23 @@ from megatron.lite.model.protocol_utils import (
     add_cross_entropy_fusion,
     add_loss_context_kwargs,
     pack_thd_forward_kwargs,
+)
+from megatron.lite.model.protocol_utils import (
     router_replay_roots as router_replay_roots,
+)
+from megatron.lite.model.protocol_utils import (
     set_cross_entropy_fusion,
     unpack_thd_forward_output,
 )
 from megatron.lite.model.qwen3_moe.common import is_expert_param
 from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
-from megatron.lite.model.qwen3_moe.lite.checkpoint import EXPERT_CLASSIFIER, PLACEMENT_FN
-from megatron.lite.model.qwen3_moe.lite.checkpoint import load_hf_weights as _load_hf_weights_impl
+from megatron.lite.model.qwen3_moe.lite.checkpoint import (
+    EXPERT_CLASSIFIER,
+    PLACEMENT_FN,
+)
+from megatron.lite.model.qwen3_moe.lite.checkpoint import (
+    load_hf_weights as _load_hf_weights_impl,
+)
 from megatron.lite.model.qwen3_moe.lite.model import MTPLossAutoScaler, Qwen3MoEModel
 from megatron.lite.primitive.bundle import ModelBundle
 from megatron.lite.primitive.modules.lora import (
@@ -113,7 +122,9 @@ def _validate_meta_parameters(model: torch.nn.Module) -> None:
             )
     if non_meta:
         details = "\n".join(non_meta)
-        raise RuntimeError(f"FSDP2 meta initialization left materialized parameters:\n{details}")
+        raise RuntimeError(
+            f"FSDP2 meta initialization left materialized parameters:\n{details}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -161,7 +172,9 @@ def _forward_step(model: nn.Module, batch: PackedBatch) -> dict:
 
 def _forward_step_bshd(model: nn.Module, batch: PackedBatch) -> dict:
     labels = batch.labels.reshape(1, -1) if batch.labels is not None else None
-    return model(input_ids=batch.input_ids.reshape(1, -1), labels=labels, packed_seq_params=None)
+    return model(
+        input_ids=batch.input_ids.reshape(1, -1), labels=labels, packed_seq_params=None
+    )
 
 
 def unpack_forward_output(model: nn.Module, batch: PackedBatch, output) -> Any:
@@ -187,7 +200,9 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
     mtp_enable_train = mtp_enable and bool(impl_cfg.mtp_enable_train)
     if mtp_enable:
         if model_cfg.num_nextn_predict_layers <= 0:
-            raise ValueError("mtp_enable=True but HF config has no num_nextn_predict_layers.")
+            raise ValueError(
+                "mtp_enable=True but HF config has no num_nextn_predict_layers."
+            )
         model_cfg.mtp_loss_scaling_factor = impl_cfg.mtp_loss_scaling_factor
         if impl_cfg.mtp_use_repeated_layer is not None:
             model_cfg.mtp_use_repeated_layer = impl_cfg.mtp_use_repeated_layer
@@ -217,7 +232,9 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
 
     def build_chunk(**kwargs):
         with torch.device("meta") if meta_init else nullcontext():
-            chunk = Qwen3MoEModel(model_cfg, ps, **kwargs, **model_kwargs).to(torch.bfloat16)
+            chunk = Qwen3MoEModel(model_cfg, ps, **kwargs, **model_kwargs).to(
+                torch.bfloat16
+            )
         if meta_init:
             _validate_meta_parameters(chunk)
         chunk._mlite_meta_init = meta_init
@@ -283,7 +300,9 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
 
         def _post_model_load_hook():
             from megatron.lite.model.qwen3_moe.lite.model import TransformerLayer
-            from megatron.lite.primitive.optimizers.fsdp2 import build_fsdp2_training_optimizer
+            from megatron.lite.primitive.optimizers.fsdp2 import (
+                build_fsdp2_training_optimizer,
+            )
 
             return {
                 "optimizer": build_fsdp2_training_optimizer(
@@ -350,7 +369,9 @@ def export_hf_weights(
     chunks: list[nn.Module], model_cfg: Qwen3MoEConfig, ps: ParallelState, **kwargs
 ):
     """Export HF weights from model chunks."""
-    from megatron.lite.model.qwen3_moe.lite.checkpoint import export_hf_weights as _export
+    from megatron.lite.model.qwen3_moe.lite.checkpoint import (
+        export_hf_weights as _export,
+    )
 
     for chunk in chunks:
         yield from _export(chunk, model_cfg, ps, **kwargs)

--- a/experimental/lite/megatron/lite/model/registry.py
+++ b/experimental/lite/megatron/lite/model/registry.py
@@ -82,7 +82,9 @@ register_model(
 )
 
 register_model(
-    "qwen3_moe", package="megatron.lite.model.qwen3_moe", impls={"lite": _QWEN3_MOE_LITE}
+    "qwen3_moe",
+    package="megatron.lite.model.qwen3_moe",
+    impls={"lite": _QWEN3_MOE_LITE},
 )
 
 register_model(
@@ -121,7 +123,9 @@ register_model(
 
 def get_model_package(model_name: str):
     if model_name not in MODEL_PACKAGES:
-        raise ValueError(f"Unknown model: {model_name!r}. Available: {list(MODEL_PACKAGES)}")
+        raise ValueError(
+            f"Unknown model: {model_name!r}. Available: {list(MODEL_PACKAGES)}"
+        )
     return importlib.import_module(MODEL_PACKAGES[model_name])
 
 
@@ -135,7 +139,8 @@ def resolve_runtime_model_name(model_name: str, impl: str) -> str:
     key = (model_name, impl)
     if key not in _IMPL_TO_RUNTIME_MODEL:
         raise ValueError(
-            f"No runtime for ({model_name!r}, {impl!r}). " f"Known: {list(_IMPL_TO_RUNTIME_MODEL)}"
+            f"No runtime for ({model_name!r}, {impl!r}). "
+            f"Known: {list(_IMPL_TO_RUNTIME_MODEL)}"
         )
     return _IMPL_TO_RUNTIME_MODEL[key]
 

--- a/experimental/lite/megatron/lite/primitive/bundle.py
+++ b/experimental/lite/megatron/lite/primitive/bundle.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import torch.nn as nn
-
 from megatron.lite.primitive.parallel.state import ParallelState
 
 

--- a/experimental/lite/megatron/lite/primitive/ckpt/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/__init__.py
@@ -1,7 +1,10 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Checkpoint helpers."""
 
-from megatron.lite.primitive.ckpt.dcp import load_training_checkpoint, save_training_checkpoint
+from megatron.lite.primitive.ckpt.dcp import (
+    load_training_checkpoint,
+    save_training_checkpoint,
+)
 from megatron.lite.primitive.ckpt.hf_weights import HFWeights
 
 __all__ = [
@@ -14,7 +17,9 @@ __all__ = [
 
 def __getattr__(name: str):
     if name == "attach_model_sharded_state_dict":
-        from megatron.lite.primitive.ckpt.distckpt import attach_model_sharded_state_dict
+        from megatron.lite.primitive.ckpt.distckpt import (
+            attach_model_sharded_state_dict,
+        )
 
         return attach_model_sharded_state_dict
     raise AttributeError(name)

--- a/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
@@ -19,9 +19,6 @@ import torch  # pyright: ignore[reportMissingImports]
 import torch.distributed as dist  # pyright: ignore[reportMissingImports]
 import torch.distributed.checkpoint as dcp  # pyright: ignore[reportMissingImports]
 import torch.nn as nn  # pyright: ignore[reportMissingImports]
-from torch.distributed.device_mesh import DeviceMesh  # pyright: ignore[reportMissingImports]
-from torch.distributed.tensor import DTensor  # pyright: ignore[reportMissingImports]
-
 from megatron.lite.primitive.parallel import ParallelState
 from megatron.lite.primitive.protocols import (
     ExpertClassifierFn,
@@ -29,6 +26,10 @@ from megatron.lite.primitive.protocols import (
     default_expert_classifier,
     default_placement_fn,
 )
+from torch.distributed.device_mesh import (
+    DeviceMesh,  # pyright: ignore[reportMissingImports]
+)
+from torch.distributed.tensor import DTensor  # pyright: ignore[reportMissingImports]
 
 
 def save_training_checkpoint(
@@ -62,7 +63,12 @@ def save_training_checkpoint(
         ckpt_path = os.path.join(path, f"step_{step}")
         os.makedirs(ckpt_path, exist_ok=True)
         _save_dist_opt_checkpoint(
-            model, optimizer, step, ckpt_path, save_model=save_model, save_optimizer=save_optimizer
+            model,
+            optimizer,
+            step,
+            ckpt_path,
+            save_model=save_model,
+            save_optimizer=save_optimizer,
         )
         if save_rng:
             _save_rng_sidecar(ckpt_path)
@@ -84,7 +90,9 @@ def save_training_checkpoint(
         for name, param in model.named_parameters():
             placements = get_placements(name)
             mesh = expert_mesh if is_expert(name) else dense_mesh
-            state_dict[f"{model_prefix}.{name}"] = _dcp_tensor_from_param(param, mesh, placements)
+            state_dict[f"{model_prefix}.{name}"] = _dcp_tensor_from_param(
+                param, mesh, placements
+            )
 
     ckpt_path = os.path.join(path, f"step_{step}")
     os.makedirs(ckpt_path, exist_ok=True)
@@ -125,7 +133,11 @@ def load_training_checkpoint(
     ckpt_path = _resolve_step_checkpoint_path(path)
     if _supports_dist_opt_distckpt(model, optimizer):
         step = _load_dist_opt_checkpoint(
-            model, optimizer, ckpt_path, load_model=load_model, load_optimizer=load_optimizer
+            model,
+            optimizer,
+            ckpt_path,
+            load_model=load_model,
+            load_optimizer=load_optimizer,
         )
         if load_rng:
             _load_rng_sidecar(ckpt_path)
@@ -175,14 +187,17 @@ def _resolve_step_checkpoint_path(path: str) -> str:
         return path
 
     step_dirs = sorted(
-        [d for d in os.listdir(path) if d.startswith("step_")], key=lambda d: int(d.split("_")[1])
+        [d for d in os.listdir(path) if d.startswith("step_")],
+        key=lambda d: int(d.split("_")[1]),
     )
     if step_dirs:
         return os.path.join(path, step_dirs[-1])
     return path
 
 
-def _supports_dist_opt_distckpt(model: nn.Module | Iterable[nn.Module], optimizer) -> bool:
+def _supports_dist_opt_distckpt(
+    model: nn.Module | Iterable[nn.Module], optimizer
+) -> bool:
     try:
         from megatron.lite.primitive.ckpt.distckpt import supports_dist_opt_distckpt
     except ModuleNotFoundError as exc:
@@ -205,7 +220,12 @@ def _save_dist_opt_checkpoint(
     from megatron.lite.primitive.ckpt.distckpt import save_dist_opt_checkpoint
 
     save_dist_opt_checkpoint(
-        model, optimizer, step, path, save_model=save_model, save_optimizer=save_optimizer
+        model,
+        optimizer,
+        step,
+        path,
+        save_model=save_model,
+        save_optimizer=save_optimizer,
     )
 
 
@@ -235,7 +255,9 @@ def _save_optimizer_checkpoint(optimizer, path: str) -> None:
         return
     state_dict_fn = getattr(optimizer, "state_dict", None)
     if not callable(state_dict_fn):
-        raise TypeError(f"Optimizer {type(optimizer).__name__} does not provide state_dict().")
+        raise TypeError(
+            f"Optimizer {type(optimizer).__name__} does not provide state_dict()."
+        )
     torch.save(state_dict_fn(), _optimizer_checkpoint_path(path))
 
 
@@ -245,11 +267,15 @@ def _load_optimizer_checkpoint(optimizer, path: str) -> None:
         return
     ckpt_path = _optimizer_checkpoint_path(path)
     if not os.path.exists(ckpt_path):
-        log_rank0(f"No optimizer checkpoint found at {ckpt_path}; loading model state only")
+        log_rank0(
+            f"No optimizer checkpoint found at {ckpt_path}; loading model state only"
+        )
         return
     load_state_dict_fn = getattr(optimizer, "load_state_dict", None)
     if not callable(load_state_dict_fn):
-        raise TypeError(f"Optimizer {type(optimizer).__name__} does not provide load_state_dict().")
+        raise TypeError(
+            f"Optimizer {type(optimizer).__name__} does not provide load_state_dict()."
+        )
     state = torch.load(ckpt_path, map_location="cpu", weights_only=False)
     load_state_dict_fn(state)
 
@@ -281,7 +307,9 @@ def _is_dtensor_like(tensor: Any) -> bool:
     )
 
 
-def _dcp_tensor_from_param(param: torch.Tensor, mesh: DeviceMesh, placements: list) -> DTensor:
+def _dcp_tensor_from_param(
+    param: torch.Tensor, mesh: DeviceMesh, placements: list
+) -> DTensor:
     if _is_dtensor_like(param):
         return _dtensor_from_dtensor_like_param(param, _to_local_tensor(param).detach())
     return DTensor.from_local(_to_local_tensor(param).detach(), mesh, placements)
@@ -291,11 +319,17 @@ def _empty_dcp_tensor_like_param(
     param: torch.Tensor, mesh: DeviceMesh, placements: list
 ) -> DTensor:
     if _is_dtensor_like(param):
-        return _dtensor_from_dtensor_like_param(param, torch.empty_like(_to_local_tensor(param)))
-    return DTensor.from_local(torch.empty_like(_to_local_tensor(param)), mesh, placements)
+        return _dtensor_from_dtensor_like_param(
+            param, torch.empty_like(_to_local_tensor(param))
+        )
+    return DTensor.from_local(
+        torch.empty_like(_to_local_tensor(param)), mesh, placements
+    )
 
 
-def _dtensor_from_dtensor_like_param(param: torch.Tensor, local_tensor: torch.Tensor) -> DTensor:
+def _dtensor_from_dtensor_like_param(
+    param: torch.Tensor, local_tensor: torch.Tensor
+) -> DTensor:
     return DTensor.from_local(
         local_tensor,
         param.device_mesh,
@@ -307,7 +341,9 @@ def _dtensor_from_dtensor_like_param(param: torch.Tensor, local_tensor: torch.Te
 
 def _copy_tensor_(target: torch.Tensor, src: torch.Tensor) -> None:
     local_target = _to_local_tensor(target)
-    local_src = _to_local_tensor(src).to(device=local_target.device, dtype=local_target.dtype)
+    local_src = _to_local_tensor(src).to(
+        device=local_target.device, dtype=local_target.dtype
+    )
     if isinstance(local_target, torch.Tensor) and local_target is not target:
         local_target.copy_(local_src)
     else:
@@ -351,7 +387,9 @@ def _local_checkpoint_file(path: str | os.PathLike[str]) -> Path:
 
 
 def _local_optimizer_parameter_state_file(ckpt_file: Path) -> Path:
-    return ckpt_file.with_name(f"{ckpt_file.stem}.optimizer_parameter_state{ckpt_file.suffix}")
+    return ckpt_file.with_name(
+        f"{ckpt_file.stem}.optimizer_parameter_state{ckpt_file.suffix}"
+    )
 
 
 def _rank_suffix() -> str:
@@ -387,7 +425,9 @@ def _get_cuda_rng_tracker_states() -> dict[str, torch.Tensor]:
     from megatron.core import tensor_parallel
 
     states = tensor_parallel.get_cuda_rng_tracker().get_states()
-    return {name: _cpu_clone(state) for name, state in states.items() if state is not None}
+    return {
+        name: _cpu_clone(state) for name, state in states.items() if state is not None
+    }
 
 
 def _get_rng_state() -> dict[str, Any]:
@@ -414,7 +454,9 @@ def _restore_cuda_rng_tracker_states(states: dict[str, torch.Tensor]) -> None:
         }
         tracker.set_states(restored)
     except Exception as exc:
-        raise RuntimeError("Failed to restore Megatron tensor-parallel RNG tracker state.") from exc
+        raise RuntimeError(
+            "Failed to restore Megatron tensor-parallel RNG tracker state."
+        ) from exc
 
 
 def _restore_rng_state(state: dict[str, Any] | None) -> None:
@@ -456,7 +498,9 @@ def _save_local_training_checkpoint(
     ckpt_file.parent.mkdir(parents=True, exist_ok=True)
     save_parameter_state = getattr(optimizer, "save_parameter_state", None)
     optimizer_parameter_state_file = (
-        _local_optimizer_parameter_state_file(ckpt_file) if callable(save_parameter_state) else None
+        _local_optimizer_parameter_state_file(ckpt_file)
+        if callable(save_parameter_state)
+        else None
     )
     state = {
         "format": "megatron_lite.local_training.v1",
@@ -556,7 +600,9 @@ def _ag(data, size, group, dim=0):
     return allgather_concat(data, size, group, dim)
 
 
-def canonicalize_qkv_for_dcp(model, num_attention_heads, num_key_value_heads, head_dim, ps):
+def canonicalize_qkv_for_dcp(
+    model, num_attention_heads, num_key_value_heads, head_dim, ps
+):
     """Rearrange fused QKV from interleaved-TP to canonical (Q|K|V) for DCP save."""
     if ps.tp_size <= 1:
         return
@@ -579,7 +625,9 @@ def canonicalize_qkv_for_dcp(model, num_attention_heads, num_key_value_heads, he
         param.data.copy_(canon.chunk(ps.tp_size, dim=0)[ps.tp_rank])
 
 
-def decanon_qkv_after_dcp(model, num_attention_heads, num_key_value_heads, head_dim, ps):
+def decanon_qkv_after_dcp(
+    model, num_attention_heads, num_key_value_heads, head_dim, ps
+):
     """Reverse of canonicalize_qkv_for_dcp."""
     if ps.tp_size <= 1:
         return

--- a/experimental/lite/megatron/lite/primitive/ckpt/distckpt.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/distckpt.py
@@ -11,7 +11,6 @@ from typing import Any
 
 import torch
 import torch.nn as nn
-
 from megatron.core import dist_checkpointing
 from megatron.core.dist_checkpointing.mapping import ShardedTensor
 from megatron.lite.primitive.parallel import ParallelState
@@ -46,10 +45,14 @@ def attach_model_sharded_state_dict(
         chunk._mlite_dist_opt_parallel_state = ps  # type: ignore[attr-defined]
 
 
-def supports_dist_opt_distckpt(model: nn.Module | Iterable[nn.Module], optimizer: Any) -> bool:
+def supports_dist_opt_distckpt(
+    model: nn.Module | Iterable[nn.Module], optimizer: Any
+) -> bool:
     """Return whether this model/optimizer pair can use mcore dist_checkpointing."""
 
-    if optimizer is not None and not callable(getattr(optimizer, "sharded_state_dict", None)):
+    if optimizer is not None and not callable(
+        getattr(optimizer, "sharded_state_dict", None)
+    ):
         return False
     return all(
         bool(getattr(chunk, "_mlite_dist_opt_sharded_state_dict", False))
@@ -77,7 +80,9 @@ def save_dist_opt_checkpoint(
         state_dict.update(model_sd)
     if save_optimizer and optimizer is not None:
         _synchronize_native_optimizer_steps(optimizer)
-        patches = _patch_empty_native_optimizer_state_dicts(optimizer, fallback_step=step)
+        patches = _patch_empty_native_optimizer_state_dicts(
+            optimizer, fallback_step=step
+        )
         try:
             state_dict["optimizer"] = optimizer.sharded_state_dict(
                 _single_or_all_model_state(model_sd), metadata=metadata
@@ -180,7 +185,9 @@ def _patch_empty_native_optimizer_state_dicts(
         original_state_dict = dist_opt.state_dict
 
         def patched_state_dict(
-            original_state_dict=original_state_dict, dist_opt=dist_opt, fallback_step=fallback_step
+            original_state_dict=original_state_dict,
+            dist_opt=dist_opt,
+            fallback_step=fallback_step,
         ):
             try:
                 return original_state_dict()
@@ -203,9 +210,14 @@ def _patch_native_optimizer_step_load(optimizer: Any) -> list[tuple[Any, Any]]:
         original_set_state = dist_opt._set_main_param_and_optimizer_states
 
         def patched_set_state(
-            model_param, tensors, dist_opt=dist_opt, original_set_state=original_set_state
+            model_param,
+            tensors,
+            dist_opt=dist_opt,
+            original_set_state=original_set_state,
         ):
-            removed_step = _pop_optimizer_step_for_model_param(dist_opt, model_param, tensors)
+            removed_step = _pop_optimizer_step_for_model_param(
+                dist_opt, model_param, tensors
+            )
             try:
                 return original_set_state(model_param, tensors)
             finally:
@@ -267,11 +279,17 @@ def _dist_opt_checkpoint_metadata(optimizer: Any) -> dict[str, Any]:
     dist_opts = tuple(_iter_distributed_optimizers(optimizer))
     return {
         **_DISTOPT_METADATA,
-        "distrib_optim_fully_reshardable_mem_efficient": bool(dist_opts) and all(getattr(opt, "data_parallel_group_gloo", None) is not None for opt in dist_opts),
+        "distrib_optim_fully_reshardable_mem_efficient": bool(dist_opts)
+        and all(
+            getattr(opt, "data_parallel_group_gloo", None) is not None
+            for opt in dist_opts
+        ),
     }
 
 
-def _iter_optimizer_children(obj: Any, *, known_inner: Any | None = None) -> Iterable[Any]:
+def _iter_optimizer_children(
+    obj: Any, *, known_inner: Any | None = None
+) -> Iterable[Any]:
     chained = getattr(obj, "chained_optimizers", None)
     if isinstance(chained, Iterable):
         yield from chained
@@ -294,7 +312,9 @@ def _safe_inner_optimizer(obj: Any) -> Any | None:
     return getattr(obj, "optimizer", None)
 
 
-def _empty_native_optimizer_state_dict(dist_opt: Any, fallback_step: int) -> dict[str, Any]:
+def _empty_native_optimizer_state_dict(
+    dist_opt: Any, fallback_step: int
+) -> dict[str, Any]:
     inner_state_dict = dist_opt.optimizer.state_dict()
     optimizer_state = {
         key: ([group.copy() for group in value] if key == "param_groups" else value)
@@ -398,7 +418,9 @@ def _make_sharded_tensor(
     expert: bool,
     sharded_offsets: tuple[tuple[int, int, int], ...] = (),
 ) -> ShardedTensor:
-    rank_offsets, replica_id = _rank_offsets_and_replica_id(placements, ps, expert=expert)
+    rank_offsets, replica_id = _rank_offsets_and_replica_id(
+        placements, ps, expert=expert
+    )
     return ShardedTensor.from_rank_offsets(
         key, tensor, *sharded_offsets, *rank_offsets, replica_id=replica_id
     )
@@ -413,14 +435,20 @@ def _rank_offsets_and_replica_id(
         if _is_shard_placement(placement):
             dim = _shard_dim(placement)
             if dim is None:
-                raise ValueError(f"Unsupported Shard placement without dim: {placement!r}.")
+                raise ValueError(
+                    f"Unsupported Shard placement without dim: {placement!r}."
+                )
             prev_rank, prev_size = axis_fragments.get(dim, (0, 1))
             axis_fragments[dim] = (prev_rank * size + rank, prev_size * size)
-    rank_offsets = tuple((dim, rank, size) for dim, (rank, size) in axis_fragments.items())
+    rank_offsets = tuple(
+        (dim, rank, size) for dim, (rank, size) in axis_fragments.items()
+    )
     return rank_offsets, _replica_id(placements, ps, expert=expert)
 
 
-def _replica_id(placements: list, ps: ParallelState, *, expert: bool) -> tuple[int, int, int]:
+def _replica_id(
+    placements: list, ps: ParallelState, *, expert: bool
+) -> tuple[int, int, int]:
     # PP stages own different parameters. They are not replicas of one
     # another, so PP rank must not make a shard non-main.
     if expert:
@@ -445,7 +473,9 @@ def _placement_is_sharded(placements: list, axis: int) -> bool:
     return axis < len(placements) and _is_shard_placement(placements[axis])
 
 
-def _mesh_ranks_and_sizes(ps: ParallelState, *, expert: bool) -> tuple[list[int], list[int]]:
+def _mesh_ranks_and_sizes(
+    ps: ParallelState, *, expert: bool
+) -> tuple[list[int], list[int]]:
     if expert:
         return (
             [ps.pp_rank, ps.expert_dp_rank, ps.ep_rank, ps.etp_rank],
@@ -490,7 +520,9 @@ def _model_chunk_key(ps: ParallelState | None, idx: int, num_chunks: int) -> str
     return f"model{idx}"
 
 
-def _model_chunk_sharded_key_prefix(ps: ParallelState | None, idx: int, num_chunks: int) -> str:
+def _model_chunk_sharded_key_prefix(
+    ps: ParallelState | None, idx: int, num_chunks: int
+) -> str:
     if ps is None and num_chunks == 1:
         return ""
     if ps is not None and ps.pp_size <= 1 and num_chunks == 1:
@@ -498,7 +530,9 @@ def _model_chunk_sharded_key_prefix(ps: ParallelState | None, idx: int, num_chun
     return f"{_model_chunk_key(ps, idx, num_chunks)}."
 
 
-def _chunk_sharded_state_dict(chunk: nn.Module, sharded_key_prefix: str) -> dict[str, Any]:
+def _chunk_sharded_state_dict(
+    chunk: nn.Module, sharded_key_prefix: str
+) -> dict[str, Any]:
     chunk_sd = chunk.sharded_state_dict()  # type: ignore[attr-defined]
     if not sharded_key_prefix:
         return chunk_sd

--- a/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
@@ -47,7 +47,9 @@ def _local_source(target, source):
         shape, offset = compute_local_shape_and_global_offset(
             target.shape, target.device_mesh, target.placements
         )
-        return source[tuple(slice(start, start + size) for start, size in zip(offset, shape))]
+        return source[
+            tuple(slice(start, start + size) for start, size in zip(offset, shape))
+        ]
     return source
 
 
@@ -582,7 +584,8 @@ def bucketed_all_gather_into_tensor(
                 tensor,
                 [
                     recv_buffer[
-                        rank * total_numel + offsets[idx] : rank * total_numel
+                        rank * total_numel
+                        + offsets[idx] : rank * total_numel
                         + offsets[idx]
                         + numel_per_tensor[idx]
                     ].view_as(tensor)
@@ -879,10 +882,7 @@ def gather_gate_up(
 
 
 def _load_weight_map_for_model(
-    base_model: nn.Module,
-    spec: HFWeights,
-    ps,
-    state: dict[str, torch.Tensor],
+    base_model: nn.Module, spec: HFWeights, ps, state: dict[str, torch.Tensor]
 ) -> dict[str, list[str]]:
     """Build the one native-to-HF plan shared by load and export."""
     logical_state_keys = tuple(
@@ -1103,8 +1103,12 @@ def load_hf_weights(
                             tensor, ps.etp_rank, ps.etp_size, dim=split_d
                         )
 
-            converted = _local_source(target, tensor).to(device=target.device, dtype=target.dtype)
-            (target.to_local().data if isinstance(target, DTensor) else target.data).copy_(converted)
+            converted = _local_source(target, tensor).to(
+                device=target.device, dtype=target.dtype
+            )
+            (
+                target.to_local().data if isinstance(target, DTensor) else target.data
+            ).copy_(converted)
             if replica_ranks is not None:
                 assert source_global_rank is not None
                 dist.broadcast(target.data, src=source_global_rank, group=replica_group)
@@ -1115,7 +1119,9 @@ def load_hf_weights(
         if name in loaded_names or "lora" in name.lower() or "adapter" in name.lower():
             continue
         elif getattr(base_model, "_mlite_meta_init", False):
-            raise RuntimeError(f"Deferred parameter {name!r} was not filled by the checkpoint")
+            raise RuntimeError(
+                f"Deferred parameter {name!r} was not filled by the checkpoint"
+            )
         else:
             log_rank0(f"WARNING: {name} not loaded from checkpoint")
     missing_expected_buffers = required_buffers.keys() - loaded_names
@@ -1127,15 +1133,7 @@ def load_hf_weights(
 
 
 def _load_expert_weight(
-    native_name,
-    hf_names,
-    reader,
-    spec,
-    ps,
-    state,
-    targets,
-    expert_gid,
-    expert_shard,
+    native_name, hf_names, reader, spec, ps, state, targets, expert_gid, expert_shard
 ) -> str | None:
     if expert_shard is None:
         raise RuntimeError(
@@ -1202,8 +1200,12 @@ def _load_expert_weight(
             else:
                 tensor = split_dim(tensor, ps.etp_rank, ps.etp_size, dim=split_d)
 
-    converted = _local_source(target, tensor).to(device=target.device, dtype=target.dtype)
-    (target.to_local().data if isinstance(target, DTensor) else target.data).copy_(converted)
+    converted = _local_source(target, tensor).to(
+        device=target.device, dtype=target.dtype
+    )
+    (target.to_local().data if isinstance(target, DTensor) else target.data).copy_(
+        converted
+    )
     if replica_ranks is not None:
         assert source_global_rank is not None
         dist.broadcast(target.data, src=source_global_rank, group=replica_group)
@@ -1212,10 +1214,7 @@ def _load_expert_weight(
 
 
 def _handle_missing_hf_tensors(
-    spec: HFWeights,
-    native_name: str,
-    hf_names: list[str],
-    error: KeyError,
+    spec: HFWeights, native_name: str, hf_names: list[str], error: KeyError
 ) -> None:
     """Fail on required HF sources and explain every optional fallback.
 
@@ -1290,10 +1289,7 @@ def _read_hf_tensors(
 
 
 def _present_hf_sources(
-    reader: SafeTensorReader,
-    spec: HFWeights,
-    native_name: str,
-    hf_names: list[str],
+    reader: SafeTensorReader, spec: HFWeights, native_name: str, hf_names: list[str]
 ) -> list[str]:
     """Return mapped checkpoint sources that exist without loading payloads."""
     resolve = getattr(reader, "first_available", None)
@@ -1494,9 +1490,9 @@ def export_hf_weights(
                     if packed_name is None:
                         yield from _iter_mapped({global_name: export_shard})
                         continue
-                    packed_expert_buffers.setdefault(packed_name, {})[global_idx] = (
-                        export_shard
-                    )
+                    packed_expert_buffers.setdefault(packed_name, {})[
+                        global_idx
+                    ] = export_shard
                 if packed_name is not None:
                     packed = packed_expert_buffers[packed_name]
                     if len(packed) == spec.num_experts:

--- a/experimental/lite/megatron/lite/primitive/ckpt/weight_sync_fingerprint.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/weight_sync_fingerprint.py
@@ -45,7 +45,9 @@ def _sample_payload(name: str, tensor: torch.Tensor) -> tuple[bool, bytes]:
 
 def _sample_indices(numel: int, count: int, *, device=None) -> torch.Tensor:
     if not 1 <= count <= numel:
-        raise ValueError(f"expected 1 <= count <= numel, got count={count}, numel={numel}")
+        raise ValueError(
+            f"expected 1 <= count <= numel, got count={count}, numel={numel}"
+        )
     if count == 1:
         return torch.zeros(1, dtype=torch.int64, device=device)
     positions = torch.arange(count, dtype=torch.int64, device=device)

--- a/experimental/lite/megatron/lite/primitive/data.py
+++ b/experimental/lite/megatron/lite/primitive/data.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import os
 
 import torch  # pyright: ignore[reportMissingImports]
-
 from megatron.lite.primitive.utils.packed_seq import PackedSeqParams
 
 _TRUE_ENV_VALUES = {"1", "true", "yes", "on"}
@@ -36,7 +35,9 @@ def _resolve_thd_padding(seq_len: int, cp_size: int) -> tuple[int, int, bool]:
     if pad_to_alignment is None:
         pad_to_alignment = cp_size > 1
 
-    pad_multiple_env = os.environ.get("MEGATRON_LITE_THD_PAD_MULTIPLE", "auto").strip().lower()
+    pad_multiple_env = (
+        os.environ.get("MEGATRON_LITE_THD_PAD_MULTIPLE", "auto").strip().lower()
+    )
     if pad_multiple_env in ("", "auto", "cp", "min_cp"):
         align_size = cp_size * 2 if cp_size > 1 else 1
     else:
@@ -72,14 +73,22 @@ def fixed_batches(
     g = torch.Generator().manual_seed(seed)
     batches = []
     for _ in range(num_steps):
-        ids = torch.randint(0, vocab_size, (batch_size, seq_len), generator=g).to(device)
-        labels = torch.randint(0, vocab_size, (batch_size, seq_len), generator=g).to(device)
+        ids = torch.randint(0, vocab_size, (batch_size, seq_len), generator=g).to(
+            device
+        )
+        labels = torch.randint(0, vocab_size, (batch_size, seq_len), generator=g).to(
+            device
+        )
         batches.append((ids, labels))
     return batches
 
 
 def infinite_batches(
-    vocab_size: int, seq_len: int, batch_size: int = 1, device: str = "cuda", seed: int = 42
+    vocab_size: int,
+    seq_len: int,
+    batch_size: int = 1,
+    device: str = "cuda",
+    seed: int = 42,
 ):
     """Infinite deterministic batch generator (for throughput benchmarks)."""
     g = torch.Generator(device=device).manual_seed(seed)
@@ -122,7 +131,9 @@ def infinite_batches_thd(
         raise ValueError(f"cp_rank must be in [0, {cp_size}), got {cp_rank}")
 
     g = torch.Generator(device=device).manual_seed(seed)
-    seq_len_padded, _align_size, _pad_to_alignment = _resolve_thd_padding(seq_len, cp_size)
+    seq_len_padded, _align_size, _pad_to_alignment = _resolve_thd_padding(
+        seq_len, cp_size
+    )
 
     # position_ids always stay full length; RoPE auto-slices for CP.
     position_ids = (
@@ -132,10 +143,14 @@ def infinite_batches_thd(
         .contiguous()
     )
     cu_seqlens = torch.tensor([0, seq_len], dtype=torch.int32, device=device)
-    cu_seqlens_padded = torch.tensor([0, seq_len_padded], dtype=torch.int32, device=device)
+    cu_seqlens_padded = torch.tensor(
+        [0, seq_len_padded], dtype=torch.int32, device=device
+    )
 
     if cp_size > 1:
-        from megatron.lite.primitive.parallel.cp import zigzag_split_for_cp  # noqa: I001
+        from megatron.lite.primitive.parallel.cp import (  # noqa: I001
+            zigzag_split_for_cp,
+        )
 
         # cu_seqlens stays full; MC GDN internally divides by cp_size.
         packed_seq_params = PackedSeqParams(
@@ -148,11 +163,19 @@ def infinite_batches_thd(
             cu_seqlens_kv_padded=cu_seqlens_padded,
         )
         while True:
-            ids_full = torch.randint(0, vocab_size, (seq_len,), device=device, generator=g)
-            lbl_full = torch.randint(0, vocab_size, (seq_len,), device=device, generator=g)
+            ids_full = torch.randint(
+                0, vocab_size, (seq_len,), device=device, generator=g
+            )
+            lbl_full = torch.randint(
+                0, vocab_size, (seq_len,), device=device, generator=g
+            )
             if seq_len_padded != seq_len:
-                ids_padded = torch.zeros(seq_len_padded, dtype=ids_full.dtype, device=device)
-                lbl_padded = torch.zeros(seq_len_padded, dtype=lbl_full.dtype, device=device)
+                ids_padded = torch.zeros(
+                    seq_len_padded, dtype=ids_full.dtype, device=device
+                )
+                lbl_padded = torch.zeros(
+                    seq_len_padded, dtype=lbl_full.dtype, device=device
+                )
                 ids_padded[:seq_len] = ids_full
                 lbl_padded[:seq_len] = lbl_full
             else:
@@ -177,7 +200,9 @@ def infinite_batches_thd(
             cu_seqlens_kv_padded=cu_seqlens_padded,
         )
         while True:
-            input_ids = torch.zeros((1, seq_len_padded), dtype=torch.long, device=device)
+            input_ids = torch.zeros(
+                (1, seq_len_padded), dtype=torch.long, device=device
+            )
             labels = torch.zeros((1, seq_len_padded), dtype=torch.long, device=device)
             input_ids[:, :seq_len] = torch.randint(
                 0, vocab_size, (1, seq_len), device=device, generator=g

--- a/experimental/lite/megatron/lite/primitive/kernels/dsa_kernels.py
+++ b/experimental/lite/megatron/lite/primitive/kernels/dsa_kernels.py
@@ -193,7 +193,9 @@ def _load_indexer_fwd_sm100():
     global _indexer_fwd_sm100
     if _indexer_fwd_sm100 is None:
         try:
-            module = import_module("cudnn.deepseek_sparse_attention.indexer_forward._interface")
+            module = import_module(
+                "cudnn.deepseek_sparse_attention.indexer_forward._interface"
+            )
             _indexer_fwd_sm100 = module.indexer_fwd
         except (AttributeError, ImportError) as exc:
             raise ImportError(
@@ -337,7 +339,9 @@ def build_flat_topk_idxs(
             # CUDA still work. Production callers always go through the CUDA
             # path above.
             valid_mask = global_idxs >= 0
-            sorted_indices = valid_mask.int().argsort(dim=-1, descending=True, stable=True)
+            sorted_indices = valid_mask.int().argsort(
+                dim=-1, descending=True, stable=True
+            )
             global_idxs = global_idxs.gather(-1, sorted_indices)
             topk_length_flat = valid_mask.sum(dim=-1).int()
 
@@ -443,7 +447,14 @@ def dsa_sparse_attn(
     kv_flat = kv.reshape(skv * b, d)
 
     out_flat, _lse, _lse_indexer = SparseAttnFunc.apply(
-        q_flat, kv_flat, attn_sink, topk_idxs, topk_length, softmax_scale, indexer_topk, value_dim
+        q_flat,
+        kv_flat,
+        attn_sink,
+        topk_idxs,
+        topk_length,
+        softmax_scale,
+        indexer_topk,
+        value_dim,
     )
 
     d_v = out_flat.shape[-1]
@@ -574,7 +585,9 @@ def indexer_topk(
     q_bshd, k_bsd, _w_bsh_raw, w_bsh_scaled = _sbhd_to_bshd_indexer_inputs(
         q_indexer, k_indexer, weights, indexer_softmax_scale
     )
-    topk_indices, topk_length, _ = _indexer_topk_bshd(q_bshd, k_bsd, w_bsh_scaled, topk, ratio)
+    topk_indices, topk_length, _ = _indexer_topk_bshd(
+        q_bshd, k_bsd, w_bsh_scaled, topk, ratio
+    )
     return topk_indices, topk_length
 
 
@@ -608,11 +621,7 @@ def _cudnn_topk_block(
             f"seq_lens range=[{min_seq_len}, {max_seq_len}], num_cols={num_cols}."
         )
     result = dsa_namespace.indexer_top_k_wrapper(
-        scores,
-        seq_lens,
-        top_k=width,
-        next_n=next_n,
-        return_val=False,
+        scores, seq_lens, top_k=width, next_n=next_n, return_val=False
     )
     indices = result["indices"]
     valid = (indices >= 0) & (indices < num_cols)
@@ -654,18 +663,16 @@ def indexer_topk_with_mask(
     block_size = 2048
     for start in range(0, sk, block_size):
         end = min(start + block_size, sk)
-        scores = torch.einsum("bqhd,bkd->bqhk", q_bshd.float(), k_bsd[:, start:end].float())
+        scores = torch.einsum(
+            "bqhd,bkd->bqhk", q_bshd.float(), k_bsd[:, start:end].float()
+        )
         scores = torch.relu(scores).mul(w_bsh_scaled.float().unsqueeze(-1)).sum(dim=2)
         scores = scores + mask[:, start:end].unsqueeze(0)
         block_width = min(width, end - start)
         if scores.is_cuda:
             _ensure_dsa_namespace()
             flat_scores = scores.reshape(b * sq, end - start).contiguous()
-            values, indices = _cudnn_topk_block(
-                _DSA,
-                flat_scores,
-                block_width,
-            )
+            values, indices = _cudnn_topk_block(_DSA, flat_scores, block_width)
             values = values.view(b, sq, block_width)
             indices = indices.view(b, sq, block_width)
         else:
@@ -680,7 +687,9 @@ def indexer_topk_with_mask(
         best_values, best_indices = values, indices
     assert best_values is not None and best_indices is not None
     values, indices = best_values, best_indices
-    indices = torch.where(torch.isfinite(values), indices, torch.full_like(indices, -1)).int()
+    indices = torch.where(
+        torch.isfinite(values), indices, torch.full_like(indices, -1)
+    ).int()
     if width < topk:
         indices = torch.nn.functional.pad(indices, (0, topk - width), value=-1)
     return q_bshd.new_empty(0), indices
@@ -732,7 +741,9 @@ def cp_indexer_loss(
             2,
             safe.unsqueeze(-1).expand(-1, -1, -1, k_bsd.shape[-1]),
         )
-        index_logits = torch.einsum("bqhd,bqtd->bqht", q_bshd.float(), selected_k.float())
+        index_logits = torch.einsum(
+            "bqhd,bqtd->bqht", q_bshd.float(), selected_k.float()
+        )
         index_logits = torch.relu(index_logits).mul(w_scaled.unsqueeze(-1)).sum(dim=2)
         selected_kv = torch.gather(
             kv_bkd.unsqueeze(1).expand(-1, sq, -1, -1),
@@ -743,11 +754,15 @@ def cp_indexer_loss(
         attn_logits = attn_logits * float(softmax_scale)
         selected_valid = topk_indices >= 0
         row_valid = selected_valid.any(dim=-1, keepdim=True)
-        index_logits = torch.where(row_valid, index_logits, torch.zeros_like(index_logits))
+        index_logits = torch.where(
+            row_valid, index_logits, torch.zeros_like(index_logits)
+        )
         attn_logits = torch.where(
             row_valid.unsqueeze(2), attn_logits, torch.zeros_like(attn_logits)
         )
-        index_logits = index_logits.masked_fill(~selected_valid & row_valid, float("-inf"))
+        index_logits = index_logits.masked_fill(
+            ~selected_valid & row_valid, float("-inf")
+        )
         attn_logits = attn_logits.masked_fill(
             ((~selected_valid) & row_valid).unsqueeze(2), float("-inf")
         )
@@ -797,7 +812,9 @@ def cp_indexer_loss(
             idx = idx.masked_fill(~block_valid, float("-inf"))
             attn = attn.masked_fill(~block_valid.unsqueeze(2), float("-inf"))
             predict_log = idx - safe_index_lse.unsqueeze(-1)
-            predict_log = torch.where(block_valid, predict_log, torch.zeros_like(predict_log))
+            predict_log = torch.where(
+                block_valid, predict_log, torch.zeros_like(predict_log)
+            )
             target = torch.exp(attn - safe_attn_lse.unsqueeze(-1)).mean(dim=2)
             target = torch.where(block_valid, target, torch.zeros_like(target))
             term = target * (torch.log(target + 1.0e-10) - predict_log)
@@ -1014,7 +1031,9 @@ def _kl_loss_from_dense_scores(
     # ``0 · log(0/p) = 0`` convention. Without this gate, the eps-clamp
     # on target makes the term ``eps · (log eps - (-inf)) = +inf``.
     position_valid = torch.isfinite(index_score)
-    safe_index_score = torch.where(position_valid, index_score, torch.zeros_like(index_score))
+    safe_index_score = torch.where(
+        position_valid, index_score, torch.zeros_like(index_score)
+    )
     log_predict = safe_index_score - safe_lse.unsqueeze(-1)
 
     kl_terms = target_clamped * (torch.log(target_clamped) - log_predict)
@@ -1088,7 +1107,9 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
         )  # topk_indices_cmp: (b, sq, effective_topk) int32; indexer_scores: (b, sq, n_comp) fp32
 
         # ---- 3. Combine indices (indexer first, then window). --------------
-        compress_topk_idxs = torch.where(topk_indices_cmp >= 0, topk_indices_cmp + kv_offset, -1)
+        compress_topk_idxs = torch.where(
+            topk_indices_cmp >= 0, topk_indices_cmp + kv_offset, -1
+        )
         if requested_topk > effective_topk:
             pad = torch.full(
                 (b, sq, requested_topk - effective_topk),
@@ -1117,7 +1138,9 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
         # ---- 5. Derive predict from indexer_scores, compute target. --------
         # Attention-path tensors (detached — loss is not differentiable through them).
         q_attn_bshd = query.detach().permute(1, 0, 2, 3).contiguous()
-        k_attn_compressed_bsd = kv_full[kv_offset:].detach().permute(1, 0, 2).contiguous()
+        k_attn_compressed_bsd = (
+            kv_full[kv_offset:].detach().permute(1, 0, 2).contiguous()
+        )
         lse_indexer_bsqh = lse_indexer.reshape(sq, b, np_).permute(1, 0, 2)
 
         if sparse_loss:
@@ -1140,7 +1163,11 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
 
             if loss_coeff > 0:
                 indexer_loss = _kl_loss_from_target_predict(
-                    target, predict, topk_indices_cmp, loss_coeff, calculate_per_token_loss
+                    target,
+                    predict,
+                    topk_indices_cmp,
+                    loss_coeff,
+                    calculate_per_token_loss,
                 )
             else:
                 indexer_loss = torch.zeros((), device=query.device, dtype=torch.float32)
@@ -1213,7 +1240,9 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
                     block_I=128,
                 )
             # BSHD -> SBHD (match input layout).
-            precomputed_grad_q_indexer = ig["d_index_q"].permute(1, 0, 2, 3).contiguous()
+            precomputed_grad_q_indexer = (
+                ig["d_index_q"].permute(1, 0, 2, 3).contiguous()
+            )
             precomputed_grad_k_indexer = ig["d_index_k"].permute(1, 0, 2).contiguous()
             precomputed_grad_weights = ig["d_weights"].permute(1, 0, 2).contiguous()
         else:

--- a/experimental/lite/megatron/lite/primitive/kernels/grouped_gemm.py
+++ b/experimental/lite/megatron/lite/primitive/kernels/grouped_gemm.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 
 try:
     import grouped_gemm  # pyright: ignore[reportMissingImports]
-except Exception:  # pragma: no cover - optional fused kernel or missing shared libraries.
+except (
+    Exception
+):  # pragma: no cover - optional fused kernel or missing shared libraries.
     grouped_gemm = None  # type: ignore[assignment]
 
 

--- a/experimental/lite/megatron/lite/primitive/kernels/swiglu.py
+++ b/experimental/lite/megatron/lite/primitive/kernels/swiglu.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import torch
 import torch.nn.functional as F
-
 from megatron.lite.primitive.kernels.jit import jit_fuser
 
 
@@ -32,7 +31,11 @@ def weighted_swiglu(y, weights):
 def swiglu_back(g, y):
     y_1, y_2 = torch.chunk(y, 2, -1)
     return torch.cat(
-        (g * torch.sigmoid(y_1) * (1 + y_1 * (1 - torch.sigmoid(y_1))) * y_2, g * F.silu(y_1)), -1
+        (
+            g * torch.sigmoid(y_1) * (1 + y_1 * (1 - torch.sigmoid(y_1))) * y_2,
+            g * F.silu(y_1),
+        ),
+        -1,
     )
 
 
@@ -114,7 +117,9 @@ def bias_swiglu_impl(input, bias, fp8_input_store=False, cpu_offload_input=False
     assert len(original_shape) in [2, 3]
     input = input.view(-1, original_shape[-1])
     if bias is not None:
-        output = BiasSwiGLUFunction.apply(input, bias, fp8_input_store, cpu_offload_input)
+        output = BiasSwiGLUFunction.apply(
+            input, bias, fp8_input_store, cpu_offload_input
+        )
     else:
         output = SwiGLUFunction.apply(input, fp8_input_store, cpu_offload_input)
     return (

--- a/experimental/lite/megatron/lite/primitive/modules/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/modules/__init__.py
@@ -5,22 +5,37 @@ from __future__ import annotations
 
 _EXPORTS = {
     "Experts": ("megatron.lite.primitive.modules.experts", "Experts"),
-    "GatedDeltaNet": ("megatron.lite.primitive.modules.gated_delta_net", "GatedDeltaNet"),
+    "GatedDeltaNet": (
+        "megatron.lite.primitive.modules.gated_delta_net",
+        "GatedDeltaNet",
+    ),
     "GQAttention": ("megatron.lite.primitive.modules.gqa", "GQAttention"),
     "MTPBlock": ("megatron.lite.primitive.modules.mtp", "MTPBlock"),
     "MTPDecoderLayer": ("megatron.lite.primitive.modules.mtp", "MTPDecoderLayer"),
     "MTPLossAutoScaler": ("megatron.lite.primitive.modules.mtp", "MTPLossAutoScaler"),
-    "MoEAuxLossAutoScaler": ("megatron.lite.primitive.modules.moe", "MoEAuxLossAutoScaler"),
+    "MoEAuxLossAutoScaler": (
+        "megatron.lite.primitive.modules.moe",
+        "MoEAuxLossAutoScaler",
+    ),
     "MultimodalRotaryEmbedding": (
         "megatron.lite.primitive.modules.mrope",
         "MultimodalRotaryEmbedding",
     ),
-    "SigmoidTopKRouter": ("megatron.lite.primitive.modules.router", "SigmoidTopKRouter"),
+    "SigmoidTopKRouter": (
+        "megatron.lite.primitive.modules.router",
+        "SigmoidTopKRouter",
+    ),
     "SwiGLUMLP": ("megatron.lite.primitive.modules.mlp", "SwiGLUMLP"),
-    "TokenDispatcher": ("megatron.lite.primitive.modules.dispatcher", "TokenDispatcher"),
+    "TokenDispatcher": (
+        "megatron.lite.primitive.modules.dispatcher",
+        "TokenDispatcher",
+    ),
     "TopKRouter": ("megatron.lite.primitive.modules.router", "TopKRouter"),
     "_AllToAll": ("megatron.lite.primitive.modules.moe", "_AllToAll"),
-    "split_grouped_qkvg": ("megatron.lite.primitive.modules.gqa_utils", "split_grouped_qkvg"),
+    "split_grouped_qkvg": (
+        "megatron.lite.primitive.modules.gqa_utils",
+        "split_grouped_qkvg",
+    ),
 }
 
 

--- a/experimental/lite/megatron/lite/primitive/modules/attention/cp.py
+++ b/experimental/lite/megatron/lite/primitive/modules/attention/cp.py
@@ -6,7 +6,9 @@ import torch.distributed as dist
 from torch.distributed.nn.functional import all_gather
 
 
-def _all_gather_cp(tensor: torch.Tensor, group: dist.ProcessGroup) -> list[torch.Tensor]:
+def _all_gather_cp(
+    tensor: torch.Tensor, group: dist.ProcessGroup
+) -> list[torch.Tensor]:
     return list(all_gather(tensor.contiguous(), group=group))
 
 
@@ -15,10 +17,14 @@ def iter_cp_sources(tensor, position_ids, *, cp_rank, cp_size, cp_group):
         yield cp_rank, tensor, position_ids
         return
     if cp_group is None:
-        raise RuntimeError("CP source iteration requires a context-parallel process group.")
+        raise RuntimeError(
+            "CP source iteration requires a context-parallel process group."
+        )
     tensor_parts = _all_gather_cp(tensor, cp_group)
     position_parts = _all_gather_cp(position_ids.to(dtype=torch.long), cp_group)
-    for rank, (source_tensor, source_positions) in enumerate(zip(tensor_parts, position_parts)):
+    for rank, (source_tensor, source_positions) in enumerate(
+        zip(tensor_parts, position_parts)
+    ):
         yield rank, source_tensor, source_positions
 
 
@@ -26,9 +32,13 @@ def _gather_contiguous_tail(tensor, *, tail_len, cp_size, cp_group, seq_dim):
     if cp_size <= 1 or tail_len <= 0:
         return None
     if cp_group is None:
-        raise RuntimeError("CP chunk-tail gather requires a context-parallel process group.")
+        raise RuntimeError(
+            "CP chunk-tail gather requires a context-parallel process group."
+        )
     if tensor.size(seq_dim) < tail_len:
-        raise ValueError(f"CP chunk tail needs len >= {tail_len}, got {tensor.size(seq_dim)}.")
+        raise ValueError(
+            f"CP chunk tail needs len >= {tail_len}, got {tensor.size(seq_dim)}."
+        )
     tail = tensor.narrow(seq_dim, tensor.size(seq_dim) - tail_len, tail_len)
     return _all_gather_cp(tail.contiguous(), cp_group)
 

--- a/experimental/lite/megatron/lite/primitive/modules/attention/csa.py
+++ b/experimental/lite/megatron/lite/primitive/modules/attention/csa.py
@@ -5,7 +5,6 @@ from typing import Any
 import torch
 import torch.nn as nn
 
-from megatron.lite.primitive import transformer_engine as te
 # Zero-copy imports of the DSv4 THD-CP helpers that live in Megatron Core. The
 # lite CSA module reuses Core's differentiable kernels, CP row-mapping utilities,
 # and CuTeDSL layout kernels rather than vendoring them; see the module docstring
@@ -13,12 +12,16 @@ from megatron.lite.primitive import transformer_engine as te
 from megatron.core.tensor_parallel.mappings import gather_from_sequence_parallel_region
 from megatron.core.transformer.experimental_attention_variant import (
     csa_cp_layout_kernels,
+)
+from megatron.core.transformer.experimental_attention_variant import (
     csa_cp_utils as cp_utils,
 )
 from megatron.core.transformer.experimental_attention_variant.csa import (
     _unfused_indexer_sparse_attn_from_topk,
     unfused_compressed_sparse_attn,
 )
+from megatron.lite.primitive import transformer_engine as te
+
 # MCore moved the fused CSA entry points in the development branch. Keep the
 # Lite adapter compatible with both layouts while downstream snapshots migrate.
 try:
@@ -31,6 +34,7 @@ except ImportError:
         FusedCSAIndexerSparseAttnFromTopkFunc,
         csa_sparse_attn,
     )
+
 from megatron.core.transformer.experimental_attention_variant.dsa import (
     DSAIndexerLossAutoScaler,
     DSAIndexerLossLoggingHelper,
@@ -57,7 +61,9 @@ class GroupedLinear(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         out_per_group = self.out_features // self.n_groups
-        weight = self.weight.view(self.n_groups, out_per_group, self.in_features_per_group)
+        weight = self.weight.view(
+            self.n_groups, out_per_group, self.in_features_per_group
+        )
         return torch.einsum("...gd,god->...go", x, weight)
 
 
@@ -71,7 +77,10 @@ def build_rope_cos_sin(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     inv_freq = 1.0 / (
         rope_theta
-        ** (torch.arange(0, rope_head_dim, 2, device=device, dtype=torch.float32) / rope_head_dim)
+        ** (
+            torch.arange(0, rope_head_dim, 2, device=device, dtype=torch.float32)
+            / rope_head_dim
+        )
     )
     freqs = torch.einsum("bs,d->bsd", position_ids.to(torch.float32), inv_freq)
     emb = torch.cat([freqs, freqs], dim=-1)
@@ -89,11 +98,13 @@ def build_yarn_rope_cos_sin(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     dim = rope_head_dim
     inv_freq_extra = 1.0 / (
-        rope_theta ** (torch.arange(0, dim, 2, device=device, dtype=torch.float32) / dim)
+        rope_theta
+        ** (torch.arange(0, dim, 2, device=device, dtype=torch.float32) / dim)
     )
     inv_freq_inter = 1.0 / (
         config.rotary_scaling_factor
-        * rope_theta ** (torch.arange(0, dim, 2, device=device, dtype=torch.float32) / dim)
+        * rope_theta
+        ** (torch.arange(0, dim, 2, device=device, dtype=torch.float32) / dim)
     )
     low, high = _yarn_find_correction_range(
         config.beta_fast,
@@ -128,7 +139,9 @@ def build_compressed_rope_cos_sin(
             device=device,
             dtype=dtype,
         )
-    return build_rope_cos_sin(position_ids, rope_head_dim, rope_theta, device=device, dtype=dtype)
+    return build_rope_cos_sin(
+        position_ids, rope_head_dim, rope_theta, device=device, dtype=dtype
+    )
 
 
 def apply_partial_rope(
@@ -152,7 +165,9 @@ def apply_partial_rope(
 
 
 class CompressedSequenceCompressor(nn.Module):
-    def __init__(self, config: Any, compress_ratio: int, head_dim: int, *, rotate: bool = False):
+    def __init__(
+        self, config: Any, compress_ratio: int, head_dim: int, *, rotate: bool = False
+    ):
         super().__init__()
         self.config = config
         self.compress_ratio = compress_ratio
@@ -173,7 +188,9 @@ class CompressedSequenceCompressor(nn.Module):
     def reset_parameters(self) -> None:
         nn.init.normal_(self.ape, mean=0.0, std=self.initializer_range)
 
-    def _overlap_transform(self, tensor: torch.Tensor, fill_value: float) -> torch.Tensor:
+    def _overlap_transform(
+        self, tensor: torch.Tensor, fill_value: float
+    ) -> torch.Tensor:
         bsz, n_blocks, ratio, _, head_dim = tensor.shape
         out = tensor.new_full((bsz, n_blocks, 2 * ratio, head_dim), fill_value)
         out[:, :, ratio:] = tensor[:, :, :, 1]
@@ -193,7 +210,9 @@ class CompressedSequenceCompressor(nn.Module):
         gate = self.wgate(x[:, :cutoff])
         content = content.view(bsz, n_blocks, ratio, self.coff, self.head_dim)
         gate = gate.view_as(content)
-        gate = gate + self.ape.view(1, 1, ratio, self.coff, self.head_dim).to(gate.device)
+        gate = gate + self.ape.view(1, 1, ratio, self.coff, self.head_dim).to(
+            gate.device
+        )
         if self.overlap:
             content = self._overlap_transform(content, 0.0)
             gate = self._overlap_transform(gate, float("-inf"))
@@ -269,17 +288,23 @@ class CompressedSequenceCompressor(nn.Module):
         gate = self.wgate(hidden_compact)
         kv_grouped = kv.reshape(total_comp, ratio, 1, -1)
         gate_grouped = gate.reshape(total_comp, ratio, 1, -1)
-        gate_grouped = gate_grouped + self.ape.view(1, ratio, 1, -1).to(gate_grouped.device)
+        gate_grouped = gate_grouped + self.ape.view(1, ratio, 1, -1).to(
+            gate_grouped.device
+        )
         if self.overlap:
             is_first = compressed_group_ids[:total_comp] == 0
             kv_grouped = self._overlap_transform_thd(kv_grouped, is_first, 0.0)
-            gate_grouped = self._overlap_transform_thd(gate_grouped, is_first, float("-inf"))
+            gate_grouped = self._overlap_transform_thd(
+                gate_grouped, is_first, float("-inf")
+            )
         # Non-overlap (coff == 1): kv_grouped/gate_grouped are already
         # (total_comp, ratio, 1, head_dim); no windowing needed.
         weights = torch.softmax(gate_grouped.float(), dim=1).to(kv_grouped.dtype)
         compressed = (kv_grouped * weights).sum(dim=1)  # (total_comp, 1, head_dim)
         compressed = self.norm(compressed)
-        positions = compressed_group_ids[:total_comp].clamp_min(0).to(torch.long) * ratio
+        positions = (
+            compressed_group_ids[:total_comp].clamp_min(0).to(torch.long) * ratio
+        )
         cos, sin = build_compressed_rope_cos_sin(
             positions.view(1, total_comp),
             self.rope_head_dim,
@@ -327,7 +352,9 @@ class CompressedSparseAttentionIndexer(nn.Module):
         self.wq_b = nn.Linear(
             config.q_lora_rank, config.index_n_heads * config.index_head_dim, bias=False
         )
-        self.weights_proj = nn.Linear(config.hidden_size, config.index_n_heads, bias=False)
+        self.weights_proj = nn.Linear(
+            config.hidden_size, config.index_n_heads, bias=False
+        )
         self.compressor = CompressedSequenceCompressor(
             config, compress_ratio, config.index_head_dim, rotate=True
         )
@@ -374,7 +401,9 @@ class CompressedSparseAttention(nn.Module):
             self.compress_ratio = 0
         self.wq_a = nn.Linear(config.hidden_size, config.q_lora_rank, bias=False)
         self.q_norm = te.RMSNorm(config.q_lora_rank, eps=config.rms_norm_eps)
-        self.wq_b = nn.Linear(config.q_lora_rank, self.num_heads * self.head_dim, bias=False)
+        self.wq_b = nn.Linear(
+            config.q_lora_rank, self.num_heads * self.head_dim, bias=False
+        )
         self.wkv = nn.Linear(config.hidden_size, self.head_dim, bias=False)
         self.kv_norm = te.RMSNorm(config.head_dim, eps=config.rms_norm_eps)
         self.wo_a = GroupedLinear(
@@ -382,7 +411,9 @@ class CompressedSparseAttention(nn.Module):
             config.o_groups * config.o_lora_rank,
             config.o_groups,
         )
-        self.wo_b = nn.Linear(config.o_groups * config.o_lora_rank, config.hidden_size, bias=False)
+        self.wo_b = nn.Linear(
+            config.o_groups * config.o_lora_rank, config.hidden_size, bias=False
+        )
         self.sinks = nn.Parameter(torch.zeros(self.num_heads))
         self.compressor = (
             CompressedSequenceCompressor(config, self.compress_ratio, self.head_dim)
@@ -413,10 +444,14 @@ class CompressedSparseAttention(nn.Module):
                 )
             return self._forward_thd_packed(x, position_ids, packed_seq_params)
         if self.ps.cp_size > 1 and attention_mask is not None:
-            raise ValueError("CP expects attention_mask=None; masks are derived from position_ids.")
+            raise ValueError(
+                "CP expects attention_mask=None; masks are derived from position_ids."
+            )
         batch, seq_len, _ = x.shape
         attention_rope_theta = (
-            self.config.compress_rope_theta if self.compress_ratio > 1 else self.config.rope_theta
+            self.config.compress_rope_theta
+            if self.compress_ratio > 1
+            else self.config.rope_theta
         )
         cos, sin = build_compressed_rope_cos_sin(
             position_ids,
@@ -428,11 +463,19 @@ class CompressedSparseAttention(nn.Module):
             dtype=x.dtype,
         )
         q_low = self.q_norm(self.wq_a(x))
-        q = self.wq_b(q_low).view(batch, seq_len, self.num_heads, self.head_dim).transpose(1, 2)
+        q = (
+            self.wq_b(q_low)
+            .view(batch, seq_len, self.num_heads, self.head_dim)
+            .transpose(1, 2)
+        )
         q = q * torch.rsqrt(
             q.float().pow(2).mean(dim=-1, keepdim=True) + self.config.rms_norm_eps
         ).to(dtype=q.dtype)
-        kv = self.kv_norm(self.wkv(x)).view(batch, seq_len, 1, self.head_dim).transpose(1, 2)
+        kv = (
+            self.kv_norm(self.wkv(x))
+            .view(batch, seq_len, 1, self.head_dim)
+            .transpose(1, 2)
+        )
         q = apply_partial_rope(q, cos, sin, self.rope_head_dim)
         kv = apply_partial_rope(kv, cos, sin, self.rope_head_dim)
         use_sparse_backend = self.attention_backend not in {"local", "eager", "torch"}
@@ -455,12 +498,7 @@ class CompressedSparseAttention(nn.Module):
             )
         if use_sparse_backend and self.ps.cp_size == 1 and attention_mask is None:
             return self._forward_fused_sparse_no_indexer_cp1(
-                x,
-                q,
-                kv,
-                position_ids=position_ids,
-                cos=cos,
-                sin=sin,
+                x, q, kv, position_ids=position_ids, cos=cos, sin=sin
             )
 
         # The BSHD dense-softmax fallback (and its CP all-gather loop) has been
@@ -476,10 +514,15 @@ class CompressedSparseAttention(nn.Module):
     def _project_context(
         self, context: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor
     ) -> torch.Tensor:
-        context = apply_partial_rope(context, cos, -sin, self.rope_head_dim).transpose(1, 2)
+        context = apply_partial_rope(context, cos, -sin, self.rope_head_dim).transpose(
+            1, 2
+        )
         batch, seq_len = context.shape[:2]
         grouped = context.reshape(
-            batch, seq_len, self.config.o_groups, self.num_heads_per_group * self.head_dim
+            batch,
+            seq_len,
+            self.config.o_groups,
+            self.num_heads_per_group * self.head_dim,
         )
         return self.wo_b(self.wo_a(grouped).flatten(2))
 
@@ -499,22 +542,19 @@ class CompressedSparseAttention(nn.Module):
         kv_full = kv.squeeze(1)
         kv_full = kv_full.transpose(0, 1).contiguous()
         window_idxs = _window_topk_indices(
-            batch,
-            seq_len,
-            self.config.sliding_window,
-            device=x.device,
+            batch, seq_len, self.config.sliding_window, device=x.device
         )
 
         compressed = None
         if self.compressor is not None and self.compress_ratio > 1:
             compressed = self.compressor(
-                x,
-                position_ids=position_ids,
-                rope_theta=self.config.compress_rope_theta,
+                x, position_ids=position_ids, rope_theta=self.config.compress_rope_theta
             )
             if compressed is not None:
                 compressed_kv = compressed.squeeze(1)
-                kv_full = torch.cat([kv_full, compressed_kv.transpose(0, 1).contiguous()], dim=0)
+                kv_full = torch.cat(
+                    [kv_full, compressed_kv.transpose(0, 1).contiguous()], dim=0
+                )
 
         if compressed is not None:
             n_compressed = compressed.size(2)
@@ -538,20 +578,16 @@ class CompressedSparseAttention(nn.Module):
             )
         else:
             flat_idxs, _flat_tlen = dsa_kernels.build_flat_topk_idxs(
-                window_idxs,
-                batch_size=batch,
-                seqlen_kv=kv_full.size(0),
+                window_idxs, batch_size=batch, seqlen_kv=kv_full.size(0)
             )
 
         out = dsa_kernels.dsa_sparse_attn(
-            query,
-            kv_full,
-            self.sinks.float(),
-            flat_idxs,
-            self.head_dim**-0.5,
+            query, kv_full, self.sinks.float(), flat_idxs, self.head_dim**-0.5
         )
         context = (
-            out.view(seq_len, batch, self.num_heads, self.head_dim).permute(1, 2, 0, 3).contiguous()
+            out.view(seq_len, batch, self.num_heads, self.head_dim)
+            .permute(1, 2, 0, 3)
+            .contiguous()
         )
         return self._project_context(context, cos, sin)
 
@@ -568,7 +604,9 @@ class CompressedSparseAttention(nn.Module):
         attention_mask: torch.Tensor | None,
     ) -> torch.Tensor:
         if self.ps.cp_size != 1:
-            raise NotImplementedError("DeepSeek V4 fused DSA path currently supports CP=1 only.")
+            raise NotImplementedError(
+                "DeepSeek V4 fused DSA path currently supports CP=1 only."
+            )
         if attention_mask is not None:
             raise NotImplementedError(
                 "DeepSeek V4 fused DSA path currently supports causal masking only."
@@ -593,17 +631,15 @@ class CompressedSparseAttention(nn.Module):
             kv = torch.nn.functional.pad(kv, (0, 0, 0, pad))
         batch, seq_len, _ = x.shape
         compressed = self.compressor(
-            x,
-            position_ids=position_ids,
-            rope_theta=self.config.compress_rope_theta,
+            x, position_ids=position_ids, rope_theta=self.config.compress_rope_theta
         )
         index_comp = self.indexer.compressor(
-            x,
-            position_ids=position_ids,
-            rope_theta=self.config.compress_rope_theta,
+            x, position_ids=position_ids, rope_theta=self.config.compress_rope_theta
         )
         if compressed is None or index_comp is None:
-            raise RuntimeError("DeepSeek V4 fused DSA requires at least one compressed KV entry.")
+            raise RuntimeError(
+                "DeepSeek V4 fused DSA requires at least one compressed KV entry."
+            )
         compressed_kv = compressed.squeeze(1)
         index_k = index_comp.squeeze(1).transpose(0, 1).contiguous()
         kv_full = torch.cat([kv.squeeze(1), compressed_kv], dim=1)
@@ -622,11 +658,16 @@ class CompressedSparseAttention(nn.Module):
             batch, seq_len, self.indexer.index_n_heads, self.indexer.index_head_dim
         )
         q_indexer = q_indexer.transpose(1, 2)
-        q_indexer = apply_partial_rope(q_indexer, idx_cos, idx_sin, self.indexer.rope_head_dim)
+        q_indexer = apply_partial_rope(
+            q_indexer, idx_cos, idx_sin, self.indexer.rope_head_dim
+        )
         q_indexer = rotate_activation(q_indexer)
         q_indexer = q_indexer.transpose(1, 2).transpose(0, 1).contiguous()
         weights_indexer = (
-            (self.indexer.weights_proj(x).to(dtype=x.dtype) * (self.indexer.index_n_heads**-0.5))
+            (
+                self.indexer.weights_proj(x).to(dtype=x.dtype)
+                * (self.indexer.index_n_heads**-0.5)
+            )
             .transpose(0, 1)
             .contiguous()
         )
@@ -634,10 +675,7 @@ class CompressedSparseAttention(nn.Module):
         if indexer_topk <= 0:
             raise RuntimeError("DeepSeek V4 fused DSA requires positive indexer_topk.")
         window_idxs = _window_topk_indices(
-            batch,
-            seq_len,
-            self.config.sliding_window,
-            device=x.device,
+            batch, seq_len, self.config.sliding_window, device=x.device
         )
         query = q.transpose(1, 2).transpose(0, 1).contiguous()
         sink = self.sinks.float()
@@ -670,9 +708,7 @@ class CompressedSparseAttention(nn.Module):
                 indexer_softmax_scale=self.indexer.softmax_scale,
             )
             topk_indices = torch.where(
-                topk_indices >= 0,
-                topk_indices + seq_len,
-                topk_indices,
+                topk_indices >= 0, topk_indices + seq_len, topk_indices
             ).to(torch.int32)
             flat_idxs, flat_tlen = dsa_kernels.build_flat_topk_idxs(
                 window_idxs,
@@ -691,7 +727,9 @@ class CompressedSparseAttention(nn.Module):
             )
 
         context = (
-            out.view(seq_len, batch, self.num_heads, self.head_dim).permute(1, 2, 0, 3).contiguous()
+            out.view(seq_len, batch, self.num_heads, self.head_dim)
+            .permute(1, 2, 0, 3)
+            .contiguous()
         )
         if pad:
             context = context[:, :, :orig_seq_len, :].contiguous()
@@ -726,8 +764,12 @@ class CompressedSparseAttention(nn.Module):
         ``boundary_kv.squeeze(-2).squeeze(1)`` contract in ``_forward_thd_cp``.
         """
         d_window = boundary_hidden.shape[0]
-        bkv = self.kv_norm(self.wkv(boundary_hidden.reshape(d_window, -1)))  # (d_window, head_dim)
-        b_pos = cp_utils._thd_cp_position_ids(cu_seqlens, int(global_start) - d_window, d_window)
+        bkv = self.kv_norm(
+            self.wkv(boundary_hidden.reshape(d_window, -1))
+        )  # (d_window, head_dim)
+        b_pos = cp_utils._thd_cp_position_ids(
+            cu_seqlens, int(global_start) - d_window, d_window
+        )
         cos, sin = build_compressed_rope_cos_sin(
             b_pos.view(1, d_window).long(),
             self.rope_head_dim,
@@ -737,15 +779,14 @@ class CompressedSparseAttention(nn.Module):
             device=bkv.device,
             dtype=bkv.dtype,
         )
-        bkv = bkv.view(1, 1, d_window, self.head_dim)  # (batch=1, head=1, seq=d_window, hd)
+        bkv = bkv.view(
+            1, 1, d_window, self.head_dim
+        )  # (batch=1, head=1, seq=d_window, hd)
         bkv = apply_partial_rope(bkv, cos, sin, self.rope_head_dim)
         return bkv.permute(2, 0, 1, 3).contiguous()  # (d_window, 1, 1, head_dim)
 
     def _forward_thd_packed(
-        self,
-        x: torch.Tensor,
-        position_ids: torch.Tensor,
-        packed_seq_params: Any,
+        self, x: torch.Tensor, position_ids: torch.Tensor, packed_seq_params: Any
     ) -> torch.Tensor:
         """Build THD-packed q/key/x/qr, exchange boundaries, and run CP attention.
 
@@ -765,13 +806,17 @@ class CompressedSparseAttention(nn.Module):
         global_start = cp_rank * seq_len
 
         attention_rope_theta = (
-            self.config.compress_rope_theta if self.compress_ratio > 1 else self.config.rope_theta
+            self.config.compress_rope_theta
+            if self.compress_ratio > 1
+            else self.config.rope_theta
         )
         # Positions come from cu_seqlens + this rank's global offset (CP-correct
         # within-sequence positions), not the raw position_ids tensor, so the
         # mapping is identical to the unsharded reference at cp_size == 1.
         del position_ids
-        local_pos = cp_utils._thd_cp_position_ids(cu_seqlens, global_start, seq_len).view(1, seq_len)
+        local_pos = cp_utils._thd_cp_position_ids(
+            cu_seqlens, global_start, seq_len
+        ).view(1, seq_len)
         cos, sin = build_compressed_rope_cos_sin(
             local_pos.long(),
             self.rope_head_dim,
@@ -782,11 +827,19 @@ class CompressedSparseAttention(nn.Module):
             dtype=x.dtype,
         )
         q_low = self.q_norm(self.wq_a(x))
-        q = self.wq_b(q_low).view(batch, seq_len, self.num_heads, self.head_dim).transpose(1, 2)
+        q = (
+            self.wq_b(q_low)
+            .view(batch, seq_len, self.num_heads, self.head_dim)
+            .transpose(1, 2)
+        )
         q = q * torch.rsqrt(
             q.float().pow(2).mean(dim=-1, keepdim=True) + self.config.rms_norm_eps
         ).to(dtype=q.dtype)
-        kv = self.kv_norm(self.wkv(x)).view(batch, seq_len, 1, self.head_dim).transpose(1, 2)
+        kv = (
+            self.kv_norm(self.wkv(x))
+            .view(batch, seq_len, 1, self.head_dim)
+            .transpose(1, 2)
+        )
         q = apply_partial_rope(q, cos, sin, self.rope_head_dim)
         kv = apply_partial_rope(kv, cos, sin, self.rope_head_dim)
 
@@ -807,7 +860,9 @@ class CompressedSparseAttention(nn.Module):
             # through the same method, so materialize the zero boundary directly
             # (matching ``cp_utils.exchange_cp_boundary_hidden``'s D_window sizing).
             d_comp = (
-                8 if self.compress_ratio == 4 else self.compress_ratio if self.compress_ratio > 1 else 0
+                8
+                if self.compress_ratio == 4
+                else self.compress_ratio if self.compress_ratio > 1 else 0
             )
             d_window = max(int(self.config.sliding_window), d_comp)
             boundary_hidden = x_thd.new_zeros((d_window,) + tuple(x_thd.shape[1:]))
@@ -816,7 +871,13 @@ class CompressedSparseAttention(nn.Module):
         )
 
         context = self._forward_thd_cp(
-            query_thd, key_thd, x_thd, qr_thd, boundary_hidden, boundary_kv, packed_seq_params
+            query_thd,
+            key_thd,
+            x_thd,
+            qr_thd,
+            boundary_hidden,
+            boundary_kv,
+            packed_seq_params,
         )
         # context: (total, 1, np * hn). Reshape to (1, np, total, hn) for the shared
         # output projection (inverse RoPE + wo), then return (1, total, hidden).
@@ -855,7 +916,9 @@ class CompressedSparseAttention(nn.Module):
 
         l_local = query.shape[0]
         if l_local != key.shape[0]:
-            raise RuntimeError("DSv4 THD CP path currently supports self-attention only.")
+            raise RuntimeError(
+                "DSv4 THD CP path currently supports self-attention only."
+            )
         cu_seqlens = self._thd_cu_seqlens(packed_seq_params)
         max_seqlen_q = int(packed_seq_params.max_seqlen_q)
 
@@ -912,7 +975,9 @@ class CompressedSparseAttention(nn.Module):
                 q_indexer_cp = indexer.wq_b(indexer_qr.squeeze(1)).view(
                     l_local, indexer.index_n_heads, indexer.index_head_dim
                 )
-                idx_pos = cp_utils._thd_cp_position_ids(cu_seqlens, global_start, l_local)
+                idx_pos = cp_utils._thd_cp_position_ids(
+                    cu_seqlens, global_start, l_local
+                )
                 idx_cos, idx_sin = build_compressed_rope_cos_sin(
                     idx_pos.view(1, l_local).long(),
                     indexer.rope_head_dim,
@@ -924,7 +989,9 @@ class CompressedSparseAttention(nn.Module):
                 )
                 # lite RoPE wants the sequence axis at dim -2: (1, n_heads, l_local, hd).
                 q_rope = q_indexer_cp.permute(1, 0, 2).unsqueeze(0)
-                q_rope = apply_partial_rope(q_rope, idx_cos, idx_sin, indexer.rope_head_dim)
+                q_rope = apply_partial_rope(
+                    q_rope, idx_cos, idx_sin, indexer.rope_head_dim
+                )
                 q_indexer_cp = q_rope.squeeze(0).permute(1, 0, 2).contiguous()
                 q_indexer_cp = rotate_activation(q_indexer_cp)
                 weights_indexer_cp = indexer.weights_proj(indexer_x.squeeze(1)) * (
@@ -967,9 +1034,13 @@ class CompressedSparseAttention(nn.Module):
                 compressed_kv_local.squeeze(1), group=cp_group
             )
 
-        kv_full_thd = torch.cat((boundary_kv, kv_local, compressed_kv_rank_major), dim=0)
+        kv_full_thd = torch.cat(
+            (boundary_kv, kv_local, compressed_kv_rank_major), dim=0
+        )
         use_indexer_loss = (
-            training_with_grad and indexer_loss_coeff > 0 and compressed_topk is not None
+            training_with_grad
+            and indexer_loss_coeff > 0
+            and compressed_topk is not None
         )
         compressed_width = (
             compressed_topk.shape[-1]

--- a/experimental/lite/megatron/lite/primitive/modules/attention/csa.py
+++ b/experimental/lite/megatron/lite/primitive/modules/attention/csa.py
@@ -5,6 +5,10 @@ from typing import Any
 import torch
 import torch.nn as nn
 
+# Initialize TE before Core imports and its optional-kernel fallback.
+# isort: off
+from megatron.lite.primitive import transformer_engine as te
+
 # Zero-copy imports of the DSv4 THD-CP helpers that live in Megatron Core. The
 # lite CSA module reuses Core's differentiable kernels, CP row-mapping utilities,
 # and CuTeDSL layout kernels rather than vendoring them; see the module docstring
@@ -12,15 +16,14 @@ import torch.nn as nn
 from megatron.core.tensor_parallel.mappings import gather_from_sequence_parallel_region
 from megatron.core.transformer.experimental_attention_variant import (
     csa_cp_layout_kernels,
-)
-from megatron.core.transformer.experimental_attention_variant import (
     csa_cp_utils as cp_utils,
 )
 from megatron.core.transformer.experimental_attention_variant.csa import (
     _unfused_indexer_sparse_attn_from_topk,
     unfused_compressed_sparse_attn,
 )
-from megatron.lite.primitive import transformer_engine as te
+
+# isort: on
 
 # MCore moved the fused CSA entry points in the development branch. Keep the
 # Lite adapter compatible with both layouts while downstream snapshots migrate.

--- a/experimental/lite/megatron/lite/primitive/modules/attention/dsa.py
+++ b/experimental/lite/megatron/lite/primitive/modules/attention/dsa.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING
 
 import torch
 import torch.nn as nn
-
 from megatron.lite.primitive import transformer_engine as te
 from megatron.lite.primitive.kernels import dsa_kernels as _dsa_kernels
 from megatron.lite.primitive.modules.attention.cp import iter_cp_sources
@@ -258,11 +257,7 @@ def _dense_cp_layout(
 
 
 def _packed_cp_layout(
-    cu_seqlens: torch.Tensor,
-    *,
-    cp_size: int,
-    cp_rank: int,
-    device: torch.device,
+    cu_seqlens: torch.Tensor, *, cp_size: int, cp_rank: int, device: torch.device
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Return contiguous THD local-query positions and global KV order."""
     cu_seqlens = cu_seqlens.to(device=device, dtype=torch.long)
@@ -280,8 +275,7 @@ def _packed_cp_layout(
 
 
 def _pad_cp_projected_kv(
-    kv: torch.Tensor,
-    index_k: torch.Tensor | None,
+    kv: torch.Tensor, index_k: torch.Tensor | None
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Physically align gathered CP KV for cuDNN top-k score loads."""
     logical_rows = kv.shape[0]
@@ -332,12 +326,7 @@ def _index_scores_and_topk(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Kernel-routed CP indexer over local Q and gathered projected K."""
     result = _dsa_kernels.indexer_topk_with_mask(
-        q,
-        k,
-        weights,
-        topk,
-        mask,
-        indexer_softmax_scale=scale,
+        q, k, weights, topk, mask, indexer_softmax_scale=scale
     )
     if q.is_cuda:
         # cuDNN FE 1.27's decode-varlen wrapper owns an asynchronous scratch
@@ -865,11 +854,7 @@ class DynamicSparseAttention(nn.Module):
 
         if self.cp_size > 1 and self.cp_mode == "native":
             return self._forward_dense_cp_native(
-                x,
-                cos,
-                sin,
-                position_ids,
-                index_share_state=index_share_state,
+                x, cos, sin, position_ids, index_share_state=index_share_state
             )
 
         cp_restore = self.cp_size > 1
@@ -949,16 +934,11 @@ class DynamicSparseAttention(nn.Module):
         contiguous: bool = False,
     ) -> torch.Tensor:
         if not contiguous:
-            parts = _all_gather_cp(
-                tensor, cp_size=self.cp_size, cp_group=self.cp_group
-            )
+            parts = _all_gather_cp(tensor, cp_size=self.cp_size, cp_group=self.cp_group)
             rank_major = torch.cat(parts, dim=0)
             return rank_major.index_select(0, kv_reorder)
         local_positions = contiguous_position_ids_for_cp(
-            tensor.shape[0] * self.cp_size,
-            self.cp_rank,
-            self.cp_size,
-            tensor.device,
+            tensor.shape[0] * self.cp_size, self.cp_rank, self.cp_size, tensor.device
         )
         parts = [
             source
@@ -1011,16 +991,11 @@ class DynamicSparseAttention(nn.Module):
             )
             if self.index_share_enabled and index_share_state is not None:
                 index_share_state.save_topk(
-                    self.layer_number,
-                    topk_indices,
-                    sequence_key=index_share_cache_key,
+                    self.layer_number, topk_indices, sequence_key=index_share_cache_key
                 )
 
         flat_idxs, flat_tlen = _dsa_kernels.build_flat_topk_idxs(
-            topk_indices,
-            batch_size=batch,
-            seqlen_kv=kv.shape[0],
-            compact=True,
+            topk_indices, batch_size=batch, seqlen_kv=kv.shape[0], compact=True
         )
         out = _dsa_kernels.dsa_sparse_attn(
             query,
@@ -1085,8 +1060,7 @@ class DynamicSparseAttention(nn.Module):
         if kv.is_cuda and not self.skip_topk:
             kv, k_idx = _pad_cp_projected_kv(kv, k_idx)
         mask = _build_cp_causal_mask(
-            query_pos,
-            torch.arange(kv.shape[0], device=x.device),
+            query_pos, torch.arange(kv.shape[0], device=x.device)
         )
         out = self._run_cp_sparse_segment(
             query,
@@ -1122,10 +1096,7 @@ class DynamicSparseAttention(nn.Module):
                 f"got {cp_layout!r}."
             )
         query_pos, kv_reorder = _packed_cp_layout(
-            cu_seqlens,
-            cp_size=self.cp_size,
-            cp_rank=self.cp_rank,
-            device=x.device,
+            cu_seqlens, cp_size=self.cp_size, cp_rank=self.cp_rank, device=x.device
         )
         if query_pos.numel() != x.shape[1]:
             raise RuntimeError(
@@ -1144,11 +1115,7 @@ class DynamicSparseAttention(nn.Module):
         if kv.is_cuda and not self.skip_topk:
             kv, k_idx = _pad_cp_projected_kv(kv, k_idx)
         key_pos = torch.arange(kv.shape[0], device=x.device, dtype=torch.long)
-        mask = _build_cp_causal_mask(
-            query_pos,
-            key_pos,
-            cu_seqlens=cu_seqlens,
-        )
+        mask = _build_cp_causal_mask(query_pos, key_pos, cu_seqlens=cu_seqlens)
         out = self._run_cp_sparse_segment(
             query,
             kv,
@@ -1412,10 +1379,7 @@ class DynamicSparseAttention(nn.Module):
             )
         cos_parts = _all_gather_cp(cos, cp_size=self.cp_size, cp_group=self.cp_group)
         sin_parts = _all_gather_cp(sin, cp_size=self.cp_size, cp_group=self.cp_group)
-        return (
-            torch.cat(cos_parts, dim=1),
-            torch.cat(sin_parts, dim=1),
-        )
+        return (torch.cat(cos_parts, dim=1), torch.cat(sin_parts, dim=1))
 
     def _full_cp_position_ids(
         self,

--- a/experimental/lite/megatron/lite/primitive/modules/attention/hca.py
+++ b/experimental/lite/megatron/lite/primitive/modules/attention/hca.py
@@ -16,13 +16,15 @@ def split_sinkhorn(
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     split_sizes = [hc_mult, hc_mult, hc_mult * hc_mult]
     pre_mix, post_mix, comb_mix = mixes.split(split_sizes, dim=-1)
-    base_pre, base_post, base_comb = hc_base.to(dtype=mixes.dtype, device=mixes.device).split(
-        split_sizes, dim=-1
-    )
+    base_pre, base_post, base_comb = hc_base.to(
+        dtype=mixes.dtype, device=mixes.device
+    ).split(split_sizes, dim=-1)
     scale = hc_scale.to(dtype=mixes.dtype, device=mixes.device)
     pre = torch.sigmoid(pre_mix * scale[0] + base_pre)
     post = 2 * torch.sigmoid(post_mix * scale[1] + base_post)
-    comb_logits = (comb_mix * scale[2] + base_comb).view(*comb_mix.shape[:-1], hc_mult, hc_mult)
+    comb_logits = (comb_mix * scale[2] + base_comb).view(
+        *comb_mix.shape[:-1], hc_mult, hc_mult
+    )
     comb = torch.exp(comb_logits - comb_logits.max(dim=-1, keepdim=True).values)
     for _ in range(iters):
         comb = comb / comb.sum(dim=-1, keepdim=True).clamp(min=eps)
@@ -38,7 +40,9 @@ class HyperConnection(nn.Module):
         self.hc_mult = hc_mult
         self.sinkhorn_iters = sinkhorn_iters
         self.eps = eps
-        self.fn = nn.Parameter(torch.empty(mix, hc_mult * hidden_size, dtype=torch.float32))
+        self.fn = nn.Parameter(
+            torch.empty(mix, hc_mult * hidden_size, dtype=torch.float32)
+        )
         self.base = nn.Parameter(torch.empty(mix, dtype=torch.float32))
         self.scale = nn.Parameter(torch.empty(3, dtype=torch.float32))
         self.reset_parameters()
@@ -48,12 +52,16 @@ class HyperConnection(nn.Module):
         nn.init.zeros_(self.base)
         nn.init.ones_(self.scale)
 
-    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    def forward(
+        self, x: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         if x.dim() == 3:
             x = x.unsqueeze(2).expand(*x.shape[:2], self.hc_mult, x.size(-1))
         shape, dtype = x.shape, x.dtype
         xf = x.flatten(2)
-        rms_inv = 1.0 / (xf.norm(dim=-1, keepdim=True) / math.sqrt(xf.shape[-1]) + self.eps)
+        rms_inv = 1.0 / (
+            xf.norm(dim=-1, keepdim=True) / math.sqrt(xf.shape[-1]) + self.eps
+        )
         mixes = F.linear(xf, self.fn.to(device=x.device, dtype=dtype)) * rms_inv
         pre, post, comb = split_sinkhorn(
             mixes, self.scale, self.base, self.hc_mult, self.sinkhorn_iters, self.eps

--- a/experimental/lite/megatron/lite/primitive/modules/attention/mhc.py
+++ b/experimental/lite/megatron/lite/primitive/modules/attention/mhc.py
@@ -10,7 +10,9 @@ class MultiHeadHyperConnectionHead(nn.Module):
         self.hidden_size = hidden_size
         self.hc_mult = hc_mult
         self.eps = eps
-        self.hc_fn = nn.Parameter(torch.empty(hc_mult, hc_mult * hidden_size, dtype=torch.float32))
+        self.hc_fn = nn.Parameter(
+            torch.empty(hc_mult, hc_mult * hidden_size, dtype=torch.float32)
+        )
         self.hc_base = nn.Parameter(torch.empty(hc_mult, dtype=torch.float32))
         self.hc_scale = nn.Parameter(torch.empty(1, dtype=torch.float32))
         self.reset_parameters()
@@ -27,6 +29,9 @@ class MultiHeadHyperConnectionHead(nn.Module):
         xf = x.flatten(2).float()
         rsqrt = torch.rsqrt(xf.square().mean(-1, keepdim=True) + self.eps)
         mixes = F.linear(xf, self.hc_fn.float()) * rsqrt
-        pre = torch.sigmoid(mixes * self.hc_scale.float() + self.hc_base.float()) + self.eps
+        pre = (
+            torch.sigmoid(mixes * self.hc_scale.float() + self.hc_base.float())
+            + self.eps
+        )
         y = torch.sum(pre.unsqueeze(-1) * xf.view(shape), dim=2)
         return y.to(dtype)

--- a/experimental/lite/megatron/lite/primitive/modules/attention/mla.py
+++ b/experimental/lite/megatron/lite/primitive/modules/attention/mla.py
@@ -8,18 +8,7 @@ import math
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-
 from megatron.lite.primitive import transformer_engine as te
-from megatron.lite.primitive.utils.rope import (
-    _apply_rotary_pos_emb_bshd,
-    _apply_rotary_pos_emb_thd,
-)
-from megatron.lite.primitive.utils.rotary import (
-    RotaryEmbedding,
-    YarnRotaryEmbedding,
-    _yarn_get_mscale,
-)
-
 from megatron.lite.primitive.parallel import (
     ColumnParallelLinear,
     ParallelState,
@@ -34,6 +23,15 @@ from megatron.lite.primitive.parallel.thd import (
     reconstruct_packed_from_cp_parts,
     split_packed_to_cp_local,
 )
+from megatron.lite.primitive.utils.rope import (
+    _apply_rotary_pos_emb_bshd,
+    _apply_rotary_pos_emb_thd,
+)
+from megatron.lite.primitive.utils.rotary import (
+    RotaryEmbedding,
+    YarnRotaryEmbedding,
+    _yarn_get_mscale,
+)
 
 _KEPT_PSP_FIELDS = (
     "qkv_format",
@@ -46,7 +44,9 @@ _KEPT_PSP_FIELDS = (
 )
 
 
-def _apply_mla_rope_bshd(t: torch.Tensor, freqs: torch.Tensor, *, mscale: float) -> torch.Tensor:
+def _apply_mla_rope_bshd(
+    t: torch.Tensor, freqs: torch.Tensor, *, mscale: float
+) -> torch.Tensor:
     return _apply_rotary_pos_emb_bshd(
         t, freqs, rotary_interleaved=False, mscale=mscale, mla_rotary_interleaved=True
     )
@@ -94,7 +94,9 @@ class MultiLatentAttention(nn.Module):
     ):
         super().__init__()
         if num_attention_heads % ps.tp_size != 0:
-            raise ValueError("num_attention_heads must be divisible by tensor parallel size")
+            raise ValueError(
+                "num_attention_heads must be divisible by tensor parallel size"
+            )
         self.ps = ps
         self.num_heads_local = num_attention_heads // ps.tp_size
         self.q_lora_rank = q_lora_rank
@@ -105,10 +107,7 @@ class MultiLatentAttention(nn.Module):
         self.q_head_dim = qk_nope_head_dim + qk_rope_head_dim
 
         self.linear_proj = RowParallelLinear(
-            num_attention_heads * v_head_dim,
-            hidden_size,
-            ps,
-            bias=False,
+            num_attention_heads * v_head_dim, hidden_size, ps, bias=False
         )
         self.linear_q_down_proj = nn.Linear(hidden_size, q_lora_rank, bias=False)
         self.linear_q_up_proj = ColumnParallelLinear(
@@ -120,9 +119,7 @@ class MultiLatentAttention(nn.Module):
             eps=rms_norm_eps,
         )
         self.linear_kv_down_proj = nn.Linear(
-            hidden_size,
-            kv_lora_rank + qk_rope_head_dim,
-            bias=False,
+            hidden_size, kv_lora_rank + qk_rope_head_dim, bias=False
         )
         self.linear_kv_up_proj = ColumnParallelLinear(
             kv_lora_rank,
@@ -150,7 +147,9 @@ class MultiLatentAttention(nn.Module):
                 mscale_all_dim=float(rope_scaling.get("mscale_all_dim", 1.0)),
                 cp_group=ps.cp_group if ps.cp_size > 1 else None,
             )
-            attn_mscale = _yarn_get_mscale(factor, float(rope_scaling.get("mscale_all_dim", 1.0)))
+            attn_mscale = _yarn_get_mscale(
+                factor, float(rope_scaling.get("mscale_all_dim", 1.0))
+            )
         elif rope_type == "rope":
             self.rotary = RotaryEmbedding(
                 kv_channels=qk_rope_head_dim,
@@ -178,7 +177,9 @@ class MultiLatentAttention(nn.Module):
         if not self._use_torch_core:
             dpa_kwargs = dict(cp_kwargs, softmax_scale=self._softmax_scale)
             kv_channels = (
-                (self.q_head_dim, v_head_dim) if v_head_dim != self.q_head_dim else self.q_head_dim
+                (self.q_head_dim, v_head_dim)
+                if v_head_dim != self.q_head_dim
+                else self.q_head_dim
             )
             self.core_attn = te.DotProductAttention(
                 num_attention_heads=self.num_heads_local,
@@ -193,18 +194,13 @@ class MultiLatentAttention(nn.Module):
         q_compressed = self.linear_q_down_proj(x)
         kv_combined = self.linear_kv_down_proj(x)
         kv_compressed, k_pos_emb = kv_combined.split(
-            [self.kv_lora_rank, self.qk_rope_head_dim],
-            dim=-1,
+            [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1
         )
         if self.ps.tp_size > 1:
             k_pos_emb = gather_from_sequence_parallel(k_pos_emb, self.ps)
 
         q_proj = self.linear_q_up_proj(q_compressed)
-        q = q_proj.view(
-            *q_proj.shape[:-1],
-            self.num_heads_local,
-            self.q_head_dim,
-        )
+        q = q_proj.view(*q_proj.shape[:-1], self.num_heads_local, self.q_head_dim)
         kv_proj = self.linear_kv_up_proj(kv_compressed)
         kv = kv_proj.view(
             *kv_proj.shape[:-1],
@@ -237,10 +233,7 @@ class MultiLatentAttention(nn.Module):
         if is_thd:
             if self._use_torch_core:
                 out = self._torch_core_attention_thd(
-                    query,
-                    key,
-                    value,
-                    packed_seq_params=packed_seq_params,
+                    query, key, value, packed_seq_params=packed_seq_params
                 ).reshape(query.size(0), 1, -1)
             else:
                 psp_kwargs = {
@@ -262,16 +255,17 @@ class MultiLatentAttention(nn.Module):
                 out = self._torch_core_attention(query, key, value)
             else:
                 assert self.core_attn is not None
-                out = self.core_attn(query, key, value, core_attention_bias_type="no_bias")
+                out = self.core_attn(
+                    query, key, value, core_attention_bias_type="no_bias"
+                )
             if out.dim() > x.dim():
-                out = out.reshape(*out.shape[:-2], self.num_heads_local * self.v_head_dim)
+                out = out.reshape(
+                    *out.shape[:-2], self.num_heads_local * self.v_head_dim
+                )
         return self.linear_proj(out)
 
     def _torch_core_attention(
-        self,
-        query: torch.Tensor,
-        key: torch.Tensor,
-        value: torch.Tensor,
+        self, query: torch.Tensor, key: torch.Tensor, value: torch.Tensor
     ) -> torch.Tensor:
         local_seq = query.size(0)
         if self.ps.cp_size > 1:
@@ -289,18 +283,15 @@ class MultiLatentAttention(nn.Module):
         v = value.permute(1, 2, 0, 3)
         scale = self._softmax_scale if self._query_scale == 1.0 else None
         out = F.scaled_dot_product_attention(
-            q,
-            k,
-            v,
-            dropout_p=0.0,
-            is_causal=True,
-            scale=scale,
+            q, k, v, dropout_p=0.0, is_causal=True, scale=scale
         )
         out = out.permute(2, 0, 1, 3).contiguous()
         if self.ps.cp_size > 1:
             out = zigzag_slice_for_cp(out, self.ps.cp_rank, self.ps.cp_size, seq_dim=0)
             if out.size(0) != local_seq:
-                raise RuntimeError("CP MLA output shard has unexpected sequence length.")
+                raise RuntimeError(
+                    "CP MLA output shard has unexpected sequence length."
+                )
         return out
 
     def _torch_core_attention_thd(
@@ -351,15 +342,12 @@ class MultiLatentAttention(nn.Module):
             k = key[start:end].permute(1, 0, 2).unsqueeze(0)
             v = value[start:end].permute(1, 0, 2).unsqueeze(0)
             out = F.scaled_dot_product_attention(
-                q,
-                k,
-                v,
-                dropout_p=0.0,
-                is_causal=True,
-                scale=scale,
+                q, k, v, dropout_p=0.0, is_causal=True, scale=scale
             )
             outputs.append(out.squeeze(0).permute(1, 0, 2).contiguous())
-        full_out = torch.cat(outputs, dim=0) if outputs else value.new_empty(value.shape)
+        full_out = (
+            torch.cat(outputs, dim=0) if outputs else value.new_empty(value.shape)
+        )
         if self.ps.cp_size <= 1:
             return full_out
         local_out = split_packed_to_cp_local(

--- a/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
+++ b/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
@@ -7,7 +7,6 @@ import os
 
 import torch  # pyright: ignore[reportMissingImports]
 import torch.distributed as dist  # pyright: ignore[reportMissingImports]
-
 from megatron.lite.primitive.modules.moe import _AllToAll
 from megatron.lite.primitive.parallel import ParallelState
 from megatron.lite.primitive.utils import ensure_divisible
@@ -15,7 +14,10 @@ from megatron.lite.primitive.utils.moe import permute, unpermute
 
 try:
     import deep_ep  # pyright: ignore[reportMissingImports]
-    from deep_ep.utils import EventHandle, EventOverlap  # pyright: ignore[reportMissingImports]
+    from deep_ep.utils import (  # pyright: ignore[reportMissingImports]
+        EventHandle,
+        EventOverlap,
+    )
 except ImportError:
     deep_ep = None  # type: ignore
     EventHandle = None  # type: ignore
@@ -46,7 +48,9 @@ def _build_deepep_buffer(group: dist.ProcessGroup, hidden_size: int):
             config.get_rdma_buffer_size_hint(hidden_bytes, group_size), num_rdma_bytes
         )
 
-    return deep_ep.Buffer(group=group, num_nvl_bytes=num_nvl_bytes, num_rdma_bytes=num_rdma_bytes)
+    return deep_ep.Buffer(
+        group=group, num_nvl_bytes=num_nvl_bytes, num_rdma_bytes=num_rdma_bytes
+    )
 
 
 def _use_moe_permute_fusion() -> bool:
@@ -87,19 +91,24 @@ class _DeepEPDispatch(torch.autograd.Function):
             async_finish=async_finish,
             allocate_on_comm_stream=allocate_on_comm_stream,
         )
-        (recv_hidden, recv_indices, recv_probs, recv_per_expert, handle, after_event) = (
-            buffer.dispatch(
-                hidden_states.contiguous(),
-                topk_idx=topk_indices,
-                topk_weights=topk_scores.float(),
-                num_tokens_per_rank=num_tokens_per_rank,
-                num_tokens_per_rdma_rank=num_tokens_per_rdma_rank,
-                is_token_in_rank=is_token_in_rank,
-                num_tokens_per_expert=num_tokens_per_expert,
-                previous_event=event,
-                async_finish=async_finish,
-                allocate_on_comm_stream=allocate_on_comm_stream,
-            )
+        (
+            recv_hidden,
+            recv_indices,
+            recv_probs,
+            recv_per_expert,
+            handle,
+            after_event,
+        ) = buffer.dispatch(
+            hidden_states.contiguous(),
+            topk_idx=topk_indices,
+            topk_weights=topk_scores.float(),
+            num_tokens_per_rank=num_tokens_per_rank,
+            num_tokens_per_rdma_rank=num_tokens_per_rdma_rank,
+            is_token_in_rank=is_token_in_rank,
+            num_tokens_per_expert=num_tokens_per_expert,
+            previous_event=event,
+            async_finish=async_finish,
+            allocate_on_comm_stream=allocate_on_comm_stream,
         )
         if async_finish:
             after_event.current_stream_wait()
@@ -115,7 +124,12 @@ class _DeepEPDispatch(torch.autograd.Function):
 
     @staticmethod
     def backward(
-        ctx, grad_recv_hidden, grad_recv_indices, grad_recv_probs, grad_recv_per_expert, grad_handle
+        ctx,
+        grad_recv_hidden,
+        grad_recv_indices,
+        grad_recv_probs,
+        grad_recv_per_expert,
+        grad_handle,
     ):
         del grad_recv_indices, grad_recv_per_expert, grad_handle
         previous_event = (
@@ -202,7 +216,9 @@ class TokenDispatcher:
         self.ep_size = ps.ep_size
         self.num_local_experts = ensure_divisible(num_experts, ps.ep_size)
         self.moe_permute_fusion = (
-            _use_moe_permute_fusion() if moe_permute_fusion is None else bool(moe_permute_fusion)
+            _use_moe_permute_fusion()
+            if moe_permute_fusion is None
+            else bool(moe_permute_fusion)
         )
 
         self.use_deepep = use_deepep and deep_ep is not None and ps.ep_size > 1
@@ -218,16 +234,25 @@ class TokenDispatcher:
         self._deepep_event = None
 
         if self.ep_size > 1 and self.num_local_experts > 1:
-            chunk_idxs = torch.arange(self.ep_size * self.num_local_experts, device="cpu")
+            chunk_idxs = torch.arange(
+                self.ep_size * self.num_local_experts, device="cpu"
+            )
             self._sort_by_experts = (
-                chunk_idxs.reshape(self.ep_size, self.num_local_experts).T.ravel().tolist()
+                chunk_idxs.reshape(self.ep_size, self.num_local_experts)
+                .T.ravel()
+                .tolist()
             )
             self._restore_by_ranks = (
-                chunk_idxs.reshape(self.num_local_experts, self.ep_size).T.ravel().tolist()
+                chunk_idxs.reshape(self.num_local_experts, self.ep_size)
+                .T.ravel()
+                .tolist()
             )
 
     def dispatch(
-        self, hidden_states: torch.Tensor, topk_scores: torch.Tensor, topk_indices: torch.Tensor
+        self,
+        hidden_states: torch.Tensor,
+        topk_scores: torch.Tensor,
+        topk_indices: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
         if self.ep_size <= 1:
             return self._dispatch_local(hidden_states, topk_scores, topk_indices)
@@ -295,7 +320,9 @@ class TokenDispatcher:
         routing_map.scatter_(1, topk_indices, True)
         num_out = int(routing_map.sum().item())
 
-        probs_2d = torch.zeros(t, e, dtype=topk_scores.dtype, device=hidden_states.device)
+        probs_2d = torch.zeros(
+            t, e, dtype=topk_scores.dtype, device=hidden_states.device
+        )
         probs_2d.scatter_add_(1, topk_indices, topk_scores)
 
         permuted, permuted_probs, sorted_indices = permute(
@@ -337,7 +364,9 @@ class TokenDispatcher:
         # so this is a no-op for them.
         num_out = int(routing_map.sum().item())
 
-        probs_2d = torch.zeros(t, e, dtype=topk_scores.dtype, device=hidden_states.device)
+        probs_2d = torch.zeros(
+            t, e, dtype=topk_scores.dtype, device=hidden_states.device
+        )
         probs_2d.scatter_add_(1, topk_indices, topk_scores)
 
         permuted, permuted_probs, sorted_indices = permute(
@@ -351,22 +380,31 @@ class TokenDispatcher:
         self._restore_shape = hidden_states.shape
 
         tokens_per_expert = routing_map.sum(dim=0).to(torch.int64)
-        tpe_by_rank = tokens_per_expert.view(self.ep_size, self.num_local_experts).sum(dim=1)
+        tpe_by_rank = tokens_per_expert.view(self.ep_size, self.num_local_experts).sum(
+            dim=1
+        )
         self._input_splits = tpe_by_rank.tolist()
 
         global_tpe_flat = tokens_per_expert.new_empty(self.ep_size * e)
-        dist.all_gather_into_tensor(global_tpe_flat, tokens_per_expert, group=self.ps.ep_group)
+        dist.all_gather_into_tensor(
+            global_tpe_flat, tokens_per_expert, group=self.ps.ep_group
+        )
         global_tpe_2d = global_tpe_flat.view(self.ep_size, e)
         ep_rank = dist.get_rank(group=self.ps.ep_group)
         my_start = ep_rank * self.num_local_experts
-        recv_tpe_2d = global_tpe_2d[:, my_start : my_start + self.num_local_experts].contiguous()
+        recv_tpe_2d = global_tpe_2d[
+            :, my_start : my_start + self.num_local_experts
+        ].contiguous()
         self._output_splits = recv_tpe_2d.sum(dim=1).tolist()
 
         recv_flat = _AllToAll.apply(
             permuted, self._input_splits, self._output_splits, self.ps.ep_group
         )
         recv_scores = _AllToAll.apply(
-            permuted_probs.unsqueeze(-1), self._input_splits, self._output_splits, self.ps.ep_group
+            permuted_probs.unsqueeze(-1),
+            self._input_splits,
+            self._output_splits,
+            self.ps.ep_group,
         )
 
         if self.num_local_experts > 1:
@@ -419,7 +457,12 @@ class TokenDispatcher:
         return result
 
     def submit_deepep_dispatch(
-        self, hidden_states, topk_scores, topk_indices, *, allocate_on_comm_stream: bool = False
+        self,
+        hidden_states,
+        topk_scores,
+        topk_indices,
+        *,
+        allocate_on_comm_stream: bool = False,
     ):
         if not self.use_deepep:
             raise RuntimeError("submit_deepep_dispatch requires DeepEP dispatch.")
@@ -489,16 +532,23 @@ class TokenDispatcher:
         if isinstance(recv_per_expert, torch.Tensor):
             recv_per_expert = [int(x) for x in recv_per_expert.detach().cpu().tolist()]
         local_tpe = torch.tensor(
-            recv_per_expert[: self.num_local_experts], dtype=torch.int64, device=recv_hidden.device
+            recv_per_expert[: self.num_local_experts],
+            dtype=torch.int64,
+            device=recv_hidden.device,
         )
-        self._local_tpe_list = [int(x) for x in recv_per_expert[: self.num_local_experts]]
+        self._local_tpe_list = [
+            int(x) for x in recv_per_expert[: self.num_local_experts]
+        ]
         rows = recv_hidden.size(0)
         recv_indices = recv_indices.to(torch.long)
         routing_map = torch.zeros(
             rows, self.num_local_experts, dtype=torch.bool, device=recv_hidden.device
         )
         probs_2d = torch.zeros(
-            rows, self.num_local_experts, dtype=recv_probs.dtype, device=recv_hidden.device
+            rows,
+            self.num_local_experts,
+            dtype=recv_probs.dtype,
+            device=recv_hidden.device,
         )
         valid = recv_indices >= 0
         row_ids = torch.arange(rows, device=recv_hidden.device).unsqueeze(1)
@@ -529,9 +579,9 @@ class TokenDispatcher:
                 f"local_tpe_sum={int(local_tpe.sum().item())}",
                 flush=True,
             )
-        if os.environ.get("MEGATRON_LITE_DEEPEP_SKIP_DISPATCH_METADATA_CHECK") != "1" and int(
-            local_tpe.sum().item()
-        ) != int(dispatched.shape[0]):
+        if os.environ.get(
+            "MEGATRON_LITE_DEEPEP_SKIP_DISPATCH_METADATA_CHECK"
+        ) != "1" and int(local_tpe.sum().item()) != int(dispatched.shape[0]):
             ep_rank = dist.get_rank(group=self.ps.ep_group)
             raise RuntimeError(
                 "DeepEP dispatch metadata mismatch: "
@@ -542,14 +592,16 @@ class TokenDispatcher:
 
     def _dispatch_deepep(self, hidden_states, topk_scores, topk_indices):
         if torch.is_grad_enabled():
-            recv_hidden, recv_indices, recv_probs, recv_per_expert, handle = _DeepEPDispatch.apply(
-                self.buffer,
-                hidden_states,
-                topk_indices,
-                topk_scores.float(),
-                self.num_experts,
-                False,
-                False,
+            recv_hidden, recv_indices, recv_probs, recv_per_expert, handle = (
+                _DeepEPDispatch.apply(
+                    self.buffer,
+                    hidden_states,
+                    topk_indices,
+                    topk_scores.float(),
+                    self.num_experts,
+                    False,
+                    False,
+                )
             )
             self._handle = handle
             self._deepep_event = None
@@ -574,7 +626,9 @@ class TokenDispatcher:
             fused=self.moe_permute_fusion,
         )
         if torch.is_grad_enabled():
-            combined = _DeepEPCombine.apply(self.buffer, rank_grouped, self._handle, False, False)
+            combined = _DeepEPCombine.apply(
+                self.buffer, rank_grouped, self._handle, False, False
+            )
         else:
             combined = self.buffer.combine(rank_grouped, self._handle)
         if isinstance(combined, tuple):

--- a/experimental/lite/megatron/lite/primitive/modules/experts.py
+++ b/experimental/lite/megatron/lite/primitive/modules/experts.py
@@ -10,9 +10,11 @@ from typing import Any
 import torch  # pyright: ignore[reportMissingImports]
 import torch.distributed as dist  # pyright: ignore[reportMissingImports]
 import torch.nn as nn  # pyright: ignore[reportMissingImports]
-
 from megatron.lite.primitive import transformer_engine as te
-from megatron.lite.primitive.kernels.swiglu import bias_swiglu_impl, weighted_bias_swiglu_impl
+from megatron.lite.primitive.kernels.swiglu import (
+    bias_swiglu_impl,
+    weighted_bias_swiglu_impl,
+)
 from megatron.lite.primitive.modules.lora import (
     LoraConfig,
     SharedGroupedLinearLoRA,
@@ -27,7 +29,10 @@ __all__ = ["Experts", "_AllReduceETP"]
 
 @contextmanager
 def _expert_nvtx_range(name: str):
-    if os.environ.get("MEGATRON_LITE_EP_EXPERT_NVTX") != "1" or not torch.cuda.is_available():
+    if (
+        os.environ.get("MEGATRON_LITE_EP_EXPERT_NVTX") != "1"
+        or not torch.cuda.is_available()
+    ):
         yield
         return
     torch.cuda.nvtx.range_push(name)
@@ -147,7 +152,9 @@ class Experts(nn.Module):
         )
         pad_mask = None
         if self.fp8:
-            x, permuted_probs, m_splits, pad_mask = self._fp8_pad(x, permuted_probs, m_splits)
+            x, permuted_probs, m_splits, pad_mask = self._fp8_pad(
+                x, permuted_probs, m_splits
+            )
 
         etp_real_len = x.shape[0]
         if self.etp_group is not None:
@@ -159,7 +166,10 @@ class Experts(nn.Module):
                     [
                         x,
                         torch.zeros(
-                            max_len - etp_real_len, x.shape[1], dtype=x.dtype, device=x.device
+                            max_len - etp_real_len,
+                            x.shape[1],
+                            dtype=x.dtype,
+                            device=x.device,
                         ),
                     ],
                     dim=0,
@@ -169,7 +179,9 @@ class Experts(nn.Module):
                         [
                             permuted_probs,
                             torch.zeros(
-                                max_len - etp_real_len, dtype=permuted_probs.dtype, device=x.device
+                                max_len - etp_real_len,
+                                dtype=permuted_probs.dtype,
+                                device=x.device,
                             ),
                         ],
                         dim=0,
@@ -184,7 +196,9 @@ class Experts(nn.Module):
                 fc1_out = self.fc1(x, m_splits)
                 if self.fc1_lora is not None:
                     fc1_out = fc1_out + self.fc1_lora(x, m_splits)
-                h = act_ckpt.checkpoint(swiglu_with_probs, fc1_out, probs, self.swiglu_limit)
+                h = act_ckpt.checkpoint(
+                    swiglu_with_probs, fc1_out, probs, self.swiglu_limit
+                )
                 out = self.fc2(h, m_splits)
                 if self.fc2_lora is not None:
                     out = out + self.fc2_lora(h, m_splits)
@@ -217,13 +231,17 @@ class Experts(nn.Module):
         mask = torch.zeros(total_padded, dtype=torch.bool, device=device)
         probs_pad = None
         if permuted_probs is not None:
-            probs_pad = torch.zeros(total_padded, device=device, dtype=permuted_probs.dtype)
+            probs_pad = torch.zeros(
+                total_padded, device=device, dtype=permuted_probs.dtype
+            )
         src_off, dst_off = 0, 0
         for real, pad in zip(m_splits, padded, strict=True):
             x_pad[dst_off : dst_off + real] = x[src_off : src_off + real]
             mask[dst_off : dst_off + real] = True
             if probs_pad is not None:
-                probs_pad[dst_off : dst_off + real] = permuted_probs[src_off : src_off + real]
+                probs_pad[dst_off : dst_off + real] = permuted_probs[
+                    src_off : src_off + real
+                ]
             src_off += real
             dst_off += pad
         return x_pad, probs_pad, padded, mask

--- a/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
@@ -36,7 +36,6 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
-
 from megatron.lite.primitive import transformer_engine as te
 from megatron.lite.primitive.kernels.jit import jit_fuser
 from megatron.lite.primitive.ops.gated_delta_rule import (
@@ -63,7 +62,6 @@ from megatron.lite.primitive.parallel.thd import (
     split_packed_to_cp_local,
 )
 from megatron.lite.primitive.utils import ensure_divisible
-
 
 try:
     from fla.modules.convolution import (
@@ -210,7 +208,11 @@ class GatedDeltaNet(nn.Module):
         agree.  HF loading already provides identical state; this closes the
         random-initialization path used by correctness and scratch training.
         """
-        if not self._replicate_heads or self.ps.tp_group is None or self.ps.tp_size <= 1:
+        if (
+            not self._replicate_heads
+            or self.ps.tp_group is None
+            or self.ps.tp_size <= 1
+        ):
             return
         if not dist.is_initialized() or dist.get_world_size(self.ps.tp_group) <= 1:
             return
@@ -234,7 +236,10 @@ class GatedDeltaNet(nn.Module):
         return [self.qk_dim_local, self.qk_dim_local, self.v_dim_local]
 
     def forward(
-        self, x: torch.Tensor, position_ids: torch.Tensor | None = None, packed_seq_params=None
+        self,
+        x: torch.Tensor,
+        position_ids: torch.Tensor | None = None,
+        packed_seq_params=None,
     ) -> torch.Tensor:
         del position_ids
         is_packed = packed_seq_params is not None
@@ -263,7 +268,9 @@ class GatedDeltaNet(nn.Module):
                 # Packed THD reshuffles with the global cu_seqlens (packing-aware); the
                 # non-packed path is a plain two-chunk swap (``cu_seqlens is None``).
                 reshuffle_cu = cu_seqlens if is_packed else None
-                qkvzba = self._chunkwise_reshuffle(qkvzba, reshuffle_cu, to_contiguous=True)
+                qkvzba = self._chunkwise_reshuffle(
+                    qkvzba, reshuffle_cu, to_contiguous=True
+                )
                 chunkwise = True
             else:  # headwise
                 if not is_packed and qkvzba.shape[0] > 1:
@@ -359,14 +366,14 @@ class GatedDeltaNet(nn.Module):
     def _state_parameters_for_tp(self) -> tuple[torch.Tensor, torch.Tensor]:
         """Return replicated GDN state with a TP gradient all-reduce."""
         A_log = _ReplicatedParameterWithGradReduce.apply(self.A_log, self.ps.tp_group)
-        dt_bias = _ReplicatedParameterWithGradReduce.apply(self.dt_bias, self.ps.tp_group)
+        dt_bias = _ReplicatedParameterWithGradReduce.apply(
+            self.dt_bias, self.ps.tp_group
+        )
         return A_log, dt_bias
 
     # ------------------------------------------------------------------ CP: headwise
     def _headwise_cp2hp(
-        self,
-        qkvzba: torch.Tensor,
-        cu_seqlens: torch.Tensor | None,
+        self, qkvzba: torch.Tensor, cu_seqlens: torch.Tensor | None
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """Zigzag-sharded ``[b, s_local, h]`` -> contiguous full-seq ``[b, s_global, h/cp]``.
 
@@ -381,26 +388,25 @@ class GatedDeltaNet(nn.Module):
         qkvzba = qkvzba.index_select(-1, perm)
         h = qkvzba.shape[-1]
         hpc = h // cp_size
-        send_parts = [qkvzba[..., k * hpc : (k + 1) * hpc].contiguous() for k in range(cp_size)]
+        send_parts = [
+            qkvzba[..., k * hpc : (k + 1) * hpc].contiguous() for k in range(cp_size)
+        ]
         recv = all_to_all_hidden_shards(send_parts, self.ps.cp_group)
         if cu_seqlens is None:
             full = zigzag_reconstruct_from_cp_parts(recv, seq_dim=1)
             return full.contiguous(), None
         if qkvzba.shape[0] != 1:
-            raise ValueError("Packed THD GatedDeltaNet expects a single packed batch row.")
+            raise ValueError(
+                "Packed THD GatedDeltaNet expects a single packed batch row."
+            )
         parts = [p[0].contiguous() for p in recv]
         full = reconstruct_packed_from_cp_parts(
-            parts,
-            cu_seqlens_padded=cu_seqlens,
-            cp_size=cp_size,
-            dim=0,
+            parts, cu_seqlens_padded=cu_seqlens, cp_size=cp_size, dim=0
         )
         return full.unsqueeze(0).contiguous(), cu_seqlens
 
     def _headwise_hp2cp(
-        self,
-        out: torch.Tensor,
-        cu_seqlens: torch.Tensor | None,
+        self, out: torch.Tensor, cu_seqlens: torch.Tensor | None
     ) -> torch.Tensor:
         """Inverse of :meth:`_headwise_cp2hp` for the value output.
 
@@ -418,15 +424,13 @@ class GatedDeltaNet(nn.Module):
             recv = all_to_all_hidden_shards(send_parts, self.ps.cp_group)
             return torch.cat(recv, dim=-1).contiguous()
         if out.shape[0] != 1:
-            raise ValueError("Packed THD GatedDeltaNet expects a single packed batch row.")
+            raise ValueError(
+                "Packed THD GatedDeltaNet expects a single packed batch row."
+            )
         base = out[0].contiguous()
         send_parts = [
             split_packed_to_cp_local(
-                base,
-                cu_seqlens_padded=cu_seqlens,
-                cp_size=cp_size,
-                cp_rank=j,
-                dim=0,
+                base, cu_seqlens_padded=cu_seqlens, cp_size=cp_size, cp_rank=j, dim=0
             ).contiguous()
             for j in range(cp_size)
         ]
@@ -458,10 +462,7 @@ class GatedDeltaNet(nn.Module):
         return cu_seqlens
 
     def _build_chunkwise_cp_context(
-        self,
-        qkvzba: torch.Tensor,
-        cu_seqlens: torch.Tensor | None,
-        is_packed: bool,
+        self, qkvzba: torch.Tensor, cu_seqlens: torch.Tensor | None, is_packed: bool
     ) -> tuple[object, torch.Tensor]:
         """Build the FLA ring ``cp_context`` and resolve the global cu_seqlens.
 
@@ -480,9 +481,7 @@ class GatedDeltaNet(nn.Module):
         if is_packed:
             cu = self._resolve_cu_seqlens(cu_seqlens, seq_len_global)
             cp_context = _fla_build_cp_context(
-                cu_seqlens=cu,
-                group=self.ps.cp_group,
-                conv1d_kernel_size=conv_kernel,
+                cu_seqlens=cu, group=self.ps.cp_group, conv1d_kernel_size=conv_kernel
             )
             return cp_context, cu
 
@@ -515,7 +514,11 @@ class GatedDeltaNet(nn.Module):
         ``cu_seqlens`` (the global packed layout) selects the packing-aware THD swap;
         ``None`` selects the plain two-chunk SBHD swap. Shape is preserved either way.
         """
-        swap = zigzag_to_contiguous_chunks if to_contiguous else contiguous_to_zigzag_chunks
+        swap = (
+            zigzag_to_contiguous_chunks
+            if to_contiguous
+            else contiguous_to_zigzag_chunks
+        )
         return swap(tensor, self.ps.cp_group, seq_dim=1, cu_seqlens=cu_seqlens)
 
     # ------------------------------------------------------------------ compute
@@ -532,11 +535,15 @@ class GatedDeltaNet(nn.Module):
         # ``conv_weight`` is the (headwise) per-rank slice; None means use the full module.
         weight = self.conv1d.weight if conv_weight is None else conv_weight
         groups = self.conv_dim_local // cp_div
-        if _HAS_FLA and (cp_context is not None or cu_seqlens is not None or not self.deterministic):
+        if _HAS_FLA and (
+            cp_context is not None or cu_seqlens is not None or not self.deterministic
+        ):
             orig_seq_len = qkv.shape[1]
             # Chunkwise CP must not pad conv inputs: padding chunk-local causal-conv
             # inputs would change later chunk numerics across the ring.
-            pad_n = 0 if cp_context is not None else (-orig_seq_len % _CONV_PAD_ALIGNMENT)
+            pad_n = (
+                0 if cp_context is not None else (-orig_seq_len % _CONV_PAD_ALIGNMENT)
+            )
             conv_input = qkv
             conv_cu_seqlens = cu_seqlens
             if pad_n > 0:
@@ -582,7 +589,9 @@ class GatedDeltaNet(nn.Module):
         cu_seqlens: torch.Tensor | None,
         cp_context=None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        if _HAS_FLA and (cp_context is not None or cu_seqlens is not None or not self.deterministic):
+        if _HAS_FLA and (
+            cp_context is not None or cu_seqlens is not None or not self.deterministic
+        ):
             kwargs = {}
             if cp_context is not None:
                 kwargs["cp_context"] = cp_context
@@ -643,7 +652,14 @@ class GatedDeltaNet(nn.Module):
 
     @jit_fuser
     def _prepare_qkv(
-        self, qkv: torch.Tensor, gate, beta, alpha, batch: int, seq_len: int, cp_div: int
+        self,
+        qkv: torch.Tensor,
+        gate,
+        beta,
+        alpha,
+        batch: int,
+        seq_len: int,
+        cp_div: int,
     ):
         qk = self.qk_dim_local // cp_div
         nkh = self.num_k_heads_local // cp_div

--- a/experimental/lite/megatron/lite/primitive/modules/gqa.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gqa.py
@@ -9,13 +9,16 @@ from __future__ import annotations
 
 import torch
 import torch.nn as nn
-
 from megatron.lite.primitive import transformer_engine as te
 from megatron.lite.primitive.modules.gqa_utils import (
     split_grouped_qkvg,
     split_grouped_qkvg_for_tp,
 )
-from megatron.lite.primitive.modules.lora import LinearLoRA, LoraConfig, normalize_lora_config
+from megatron.lite.primitive.modules.lora import (
+    LinearLoRA,
+    LoraConfig,
+    normalize_lora_config,
+)
 from megatron.lite.primitive.modules.mrope import MultimodalRotaryEmbedding
 from megatron.lite.primitive.parallel import (
     ColumnParallelLinear,
@@ -24,7 +27,10 @@ from megatron.lite.primitive.parallel import (
     all_gather_last_dim_with_grad_reduce,
 )
 from megatron.lite.primitive.utils import ensure_divisible
-from megatron.lite.primitive.utils.rope import _apply_rotary_pos_emb_bshd, _apply_rotary_pos_emb_thd
+from megatron.lite.primitive.utils.rope import (
+    _apply_rotary_pos_emb_bshd,
+    _apply_rotary_pos_emb_thd,
+)
 from megatron.lite.primitive.utils.rotary import RotaryEmbedding
 
 # Whitelist of MC PackedSeqParams fields accepted by TE DotProductAttention.forward().
@@ -96,7 +102,9 @@ class GQAttention(nn.Module):
         # Mismatched order would put bucket boundaries in different places,
         # producing different per-rank fp32 master shard layouts and
         # non-bitwise step-1 divergence.
-        self.proj = RowParallelLinear(num_attention_heads * head_dim, hidden_size, ps, bias=False)
+        self.proj = RowParallelLinear(
+            num_attention_heads * head_dim, hidden_size, ps, bias=False
+        )
         q_cols = num_attention_heads * (2 if output_gate else 1)
         qkv_size = (q_cols + 2 * num_key_value_heads) * head_dim
         self.qkv = ColumnParallelLinear(
@@ -108,8 +116,12 @@ class GQAttention(nn.Module):
             eps=rms_norm_eps,
             zero_centered_gamma=zero_centered_gamma,
         )
-        self.q_norm = te.RMSNorm(head_dim, eps=rms_norm_eps, zero_centered_gamma=zero_centered_gamma)
-        self.k_norm = te.RMSNorm(head_dim, eps=rms_norm_eps, zero_centered_gamma=zero_centered_gamma)
+        self.q_norm = te.RMSNorm(
+            head_dim, eps=rms_norm_eps, zero_centered_gamma=zero_centered_gamma
+        )
+        self.k_norm = te.RMSNorm(
+            head_dim, eps=rms_norm_eps, zero_centered_gamma=zero_centered_gamma
+        )
 
         lora = normalize_lora_config(lora_config)
         self.qkv_lora: LinearLoRA | None = None
@@ -182,7 +194,10 @@ class GQAttention(nn.Module):
         )
 
     def forward(
-        self, x: torch.Tensor, position_ids: torch.Tensor | None = None, packed_seq_params=None
+        self,
+        x: torch.Tensor,
+        position_ids: torch.Tensor | None = None,
+        packed_seq_params=None,
     ) -> torch.Tensor:
         qkv = self.qkv(x)
         if self.qkv_lora is not None:
@@ -246,8 +261,12 @@ class GQAttention(nn.Module):
             local_seq_len = q.size(0)
             seq_len_for_rope = local_seq_len * self.ps.cp_size
             freqs = self.rotary(seq_len_for_rope)
-            q = _apply_rotary_pos_emb_bshd(q, freqs, rotary_interleaved=False, mscale=1.0)
-            k = _apply_rotary_pos_emb_bshd(k, freqs, rotary_interleaved=False, mscale=1.0)
+            q = _apply_rotary_pos_emb_bshd(
+                q, freqs, rotary_interleaved=False, mscale=1.0
+            )
+            k = _apply_rotary_pos_emb_bshd(
+                k, freqs, rotary_interleaved=False, mscale=1.0
+            )
         if self._use_fp32_rope:
             q, k = q.to(orig_dtype), k.to(orig_dtype)
 
@@ -270,7 +289,9 @@ class GQAttention(nn.Module):
             attn_out = self.core_attn(q, k, v, core_attention_bias_type="no_bias")
             if attn_out.dim() > x.dim():
                 shape = attn_out.shape
-                attn_out = attn_out.reshape(*shape[:-2], self.num_heads_local * self.head_dim)
+                attn_out = attn_out.reshape(
+                    *shape[:-2], self.num_heads_local * self.head_dim
+                )
 
         if gate is not None:
             gate_fp32 = gate.reshape(attn_out.shape).float().sigmoid()
@@ -322,7 +343,9 @@ class GQAttention(nn.Module):
 
             q_per_group = ensure_divisible(nq, nkv)
             if self._output_gate:
-                return split_grouped_qkvg(qkv, num_heads=nq, num_kv_heads=nkv, head_dim=hd)
+                return split_grouped_qkvg(
+                    qkv, num_heads=nq, num_kv_heads=nkv, head_dim=hd
+                )
 
             qkv = qkv.view(*lead, nkv, (q_per_group + 2) * hd)
             q = qkv[..., : q_per_group * hd].reshape(*lead, nq, hd)

--- a/experimental/lite/megatron/lite/primitive/modules/gqa_utils.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gqa_utils.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import torch
-
 from megatron.lite.primitive.utils import ensure_divisible
 
 
@@ -16,7 +15,13 @@ def split_grouped_qkvg(
     group_width = (2 * q_heads_per_group + 2) * head_dim
     grouped = qkv.reshape(*lead, num_kv_heads, group_width)
     query, gate, key, value = grouped.split(
-        [q_heads_per_group * head_dim, q_heads_per_group * head_dim, head_dim, head_dim], dim=-1
+        [
+            q_heads_per_group * head_dim,
+            q_heads_per_group * head_dim,
+            head_dim,
+            head_dim,
+        ],
+        dim=-1,
     )
     return (
         query.reshape(*lead, num_heads, head_dim),
@@ -44,10 +49,7 @@ def split_grouped_qkvg_for_tp(
     q_rank_in_group = tp_rank % replicas_per_kv_head
     local_group = qkv.narrow(-1, kv_group_rank * group_width, group_width)
     query, gate, key, value = split_grouped_qkvg(
-        local_group,
-        num_heads=q_heads_per_group,
-        num_kv_heads=1,
-        head_dim=head_dim,
+        local_group, num_heads=q_heads_per_group, num_kv_heads=1, head_dim=head_dim
     )
     q_start = q_rank_in_group * q_heads_per_rank
     q_end = q_start + q_heads_per_rank

--- a/experimental/lite/megatron/lite/primitive/modules/lora.py
+++ b/experimental/lite/megatron/lite/primitive/modules/lora.py
@@ -29,7 +29,9 @@ class LoraConfig:
     rank: int = 0
     alpha: int | None = None
     dropout: float = 0.0
-    target_modules: tuple[str, ...] = field(default_factory=lambda: _DEFAULT_TARGET_MODULES)
+    target_modules: tuple[str, ...] = field(
+        default_factory=lambda: _DEFAULT_TARGET_MODULES
+    )
 
     @property
     def enabled(self) -> bool:
@@ -56,7 +58,9 @@ def normalize_lora_config(config: LoraConfig | dict[str, Any] | None) -> LoraCon
     if isinstance(config, LoraConfig):
         return config
     if not isinstance(config, dict):
-        raise TypeError(f"LoRA config must be LoraConfig, dict, or None, got {type(config)!r}.")
+        raise TypeError(
+            f"LoRA config must be LoraConfig, dict, or None, got {type(config)!r}."
+        )
     values = dict(config)
     enabled = values.pop("enabled", None)
     if enabled is False:
@@ -134,13 +138,17 @@ class _AllGatherSequence(torch.autograd.Function):
         world_size = dist.get_world_size(group)
         ctx.group = group
         ctx.local_seq = x.shape[0]
-        out = torch.empty((x.shape[0] * world_size, *x.shape[1:]), dtype=x.dtype, device=x.device)
+        out = torch.empty(
+            (x.shape[0] * world_size, *x.shape[1:]), dtype=x.dtype, device=x.device
+        )
         dist.all_gather_into_tensor(out, x.contiguous(), group=group)
         return out
 
     @staticmethod
     def backward(ctx, grad: torch.Tensor):
-        out = torch.empty((ctx.local_seq, *grad.shape[1:]), dtype=grad.dtype, device=grad.device)
+        out = torch.empty(
+            (ctx.local_seq, *grad.shape[1:]), dtype=grad.dtype, device=grad.device
+        )
         dist.reduce_scatter_tensor(out, grad.contiguous(), group=ctx.group)
         return out, None
 
@@ -155,14 +163,18 @@ class _ReduceScatterSequence(torch.autograd.Function):
             )
         ctx.group = group
         ctx.world_size = world_size
-        out = torch.empty((x.shape[0] // world_size, *x.shape[1:]), dtype=x.dtype, device=x.device)
+        out = torch.empty(
+            (x.shape[0] // world_size, *x.shape[1:]), dtype=x.dtype, device=x.device
+        )
         dist.reduce_scatter_tensor(out, x.contiguous(), group=group)
         return out
 
     @staticmethod
     def backward(ctx, grad: torch.Tensor):
         out = torch.empty(
-            (grad.shape[0] * ctx.world_size, *grad.shape[1:]), dtype=grad.dtype, device=grad.device
+            (grad.shape[0] * ctx.world_size, *grad.shape[1:]),
+            dtype=grad.dtype,
+            device=grad.device,
         )
         dist.all_gather_into_tensor(out, grad.contiguous(), group=ctx.group)
         return out, None
@@ -173,7 +185,9 @@ class _ScatterSequence(torch.autograd.Function):
     def forward(ctx, x: torch.Tensor, group, group_rank: int) -> torch.Tensor:
         world_size = dist.get_world_size(group)
         if x.shape[0] % world_size != 0:
-            raise ValueError(f"Cannot scatter sequence dim {x.shape[0]} over TP={world_size}.")
+            raise ValueError(
+                f"Cannot scatter sequence dim {x.shape[0]} over TP={world_size}."
+            )
         ctx.group = group
         ctx.world_size = world_size
         local_seq = x.shape[0] // world_size
@@ -183,7 +197,9 @@ class _ScatterSequence(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad: torch.Tensor):
         out = torch.empty(
-            (grad.shape[0] * ctx.world_size, *grad.shape[1:]), dtype=grad.dtype, device=grad.device
+            (grad.shape[0] * ctx.world_size, *grad.shape[1:]),
+            dtype=grad.dtype,
+            device=grad.device,
         )
         dist.all_gather_into_tensor(out, grad.contiguous(), group=ctx.group)
         return out, None, None
@@ -204,7 +220,9 @@ class _AllReduceSum(torch.autograd.Function):
         return out, None
 
 
-def _all_gather_last_dim(x: torch.Tensor, group, *, reduce_backward: bool = False) -> torch.Tensor:
+def _all_gather_last_dim(
+    x: torch.Tensor, group, *, reduce_backward: bool = False
+) -> torch.Tensor:
     if group is None or dist.get_world_size(group) == 1:
         return x
     return _AllGatherLastDim.apply(x, group, reduce_backward)
@@ -222,11 +240,15 @@ class _AllGatherLastDim(torch.autograd.Function):
         ctx.reduce_backward = bool(reduce_backward)
         flat = x.movedim(-1, 0).contiguous().view(ctx.local_width, -1)
         gathered = torch.empty(
-            (ctx.local_width * world_size, flat.shape[1]), dtype=x.dtype, device=x.device
+            (ctx.local_width * world_size, flat.shape[1]),
+            dtype=x.dtype,
+            device=x.device,
         )
         dist.all_gather_into_tensor(gathered, flat, group=group)
         return (
-            gathered.view(ctx.local_width * world_size, *x.shape[:-1]).movedim(0, -1).contiguous()
+            gathered.view(ctx.local_width * world_size, *x.shape[:-1])
+            .movedim(0, -1)
+            .contiguous()
         )
 
     @staticmethod
@@ -236,7 +258,11 @@ class _AllGatherLastDim(torch.autograd.Function):
         out = flat.narrow(0, start, ctx.local_width).contiguous()
         if ctx.reduce_backward:
             dist.all_reduce(out, op=dist.ReduceOp.SUM, group=ctx.group)
-        return out.view(ctx.local_width, *grad.shape[:-1]).movedim(0, -1).contiguous(), None, None
+        return (
+            out.view(ctx.local_width, *grad.shape[:-1]).movedim(0, -1).contiguous(),
+            None,
+            None,
+        )
 
 
 class _SequenceParallelRankPartitionedLoRA(torch.autograd.Function):
@@ -251,7 +277,12 @@ class _SequenceParallelRankPartitionedLoRA(torch.autograd.Function):
 
     @staticmethod
     def forward(
-        ctx, x: torch.Tensor, lora_a: torch.Tensor, lora_b: torch.Tensor, scale: float, group
+        ctx,
+        x: torch.Tensor,
+        lora_a: torch.Tensor,
+        lora_b: torch.Tensor,
+        scale: float,
+        group,
     ):
         world_size = dist.get_world_size(group) if group is not None else 1
         if world_size > 1:
@@ -302,25 +333,35 @@ class _SequenceParallelRankPartitionedLoRA(torch.autograd.Function):
         )
         grad_gathered = grad_hidden_local.matmul(lora_a)
         if world_size > 1:
-            grad_x = _reduce_scatter_sequence_forward(grad_gathered, group, ctx.local_seq)
+            grad_x = _reduce_scatter_sequence_forward(
+                grad_gathered, group, ctx.local_seq
+            )
         else:
             grad_x = grad_gathered
         return grad_x, grad_a, grad_b, None, None
 
 
-def _all_gather_sequence_forward(x: torch.Tensor, group, world_size: int) -> torch.Tensor:
-    out = torch.empty((x.shape[0] * world_size, *x.shape[1:]), dtype=x.dtype, device=x.device)
+def _all_gather_sequence_forward(
+    x: torch.Tensor, group, world_size: int
+) -> torch.Tensor:
+    out = torch.empty(
+        (x.shape[0] * world_size, *x.shape[1:]), dtype=x.dtype, device=x.device
+    )
     dist.all_gather_into_tensor(out, x.contiguous(), group=group)
     return out
 
 
-def _reduce_scatter_sequence_forward(x: torch.Tensor, group, local_seq: int) -> torch.Tensor:
+def _reduce_scatter_sequence_forward(
+    x: torch.Tensor, group, local_seq: int
+) -> torch.Tensor:
     out = torch.empty((local_seq, *x.shape[1:]), dtype=x.dtype, device=x.device)
     dist.reduce_scatter_tensor(out, x.contiguous(), group=group)
     return out
 
 
-def _all_gather_last_dim_forward(x: torch.Tensor, group, world_size: int) -> torch.Tensor:
+def _all_gather_last_dim_forward(
+    x: torch.Tensor, group, world_size: int
+) -> torch.Tensor:
     if world_size == 1:
         return x
     local_width = x.shape[-1]
@@ -329,7 +370,11 @@ def _all_gather_last_dim_forward(x: torch.Tensor, group, world_size: int) -> tor
         (local_width * world_size, flat.shape[1]), dtype=x.dtype, device=x.device
     )
     dist.all_gather_into_tensor(gathered, flat, group=group)
-    return gathered.view(local_width * world_size, *x.shape[:-1]).movedim(0, -1).contiguous()
+    return (
+        gathered.view(local_width * world_size, *x.shape[:-1])
+        .movedim(0, -1)
+        .contiguous()
+    )
 
 
 def _split_last_dim(x: torch.Tensor, group_rank: int, local_width: int) -> torch.Tensor:
@@ -429,7 +474,11 @@ class LinearLoRA(nn.Module):
         nn.init.zeros_(self.lora_b)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        if self.sequence_parallel_input and self.rank_partitioned_a and not self.training:
+        if (
+            self.sequence_parallel_input
+            and self.rank_partitioned_a
+            and not self.training
+        ):
             # Keep eval/inference on the simple path; the memory optimization
             # matters only when autograd needs to retain forward activations.
             pass
@@ -447,7 +496,11 @@ class LinearLoRA(nn.Module):
             )
         if self.sequence_parallel_input:
             x = _gather_sequence_parallel(x, self.tp_group)
-        dropped = F.dropout(x, p=self.dropout_p, training=self.training) if self.dropout_p else x
+        dropped = (
+            F.dropout(x, p=self.dropout_p, training=self.training)
+            if self.dropout_p
+            else x
+        )
         hidden = dropped.matmul(self.lora_a.t())
         if self.rank_partitioned_a:
             hidden = _all_gather_last_dim(hidden, self.tp_group, reduce_backward=True)
@@ -511,7 +564,11 @@ class GroupedLinearLoRA(nn.Module):
                 h_i = dropped.matmul(self.lora_a[expert_idx].t())
                 outputs.append(h_i.matmul(self.lora_b[expert_idx].t()) * self.scale)
             offset += size
-        return torch.cat(outputs, dim=0) if outputs else x.new_empty((0, self.lora_b.shape[1]))
+        return (
+            torch.cat(outputs, dim=0)
+            if outputs
+            else x.new_empty((0, self.lora_b.shape[1]))
+        )
 
 
 class SharedGroupedLinearLoRA(nn.Module):
@@ -550,7 +607,11 @@ class SharedGroupedLinearLoRA(nn.Module):
             raise ValueError(
                 f"SharedGroupedLinearLoRA expected {self.num_local_experts} splits, got {len(splits)}."
             )
-        dropped = F.dropout(x, p=self.dropout_p, training=self.training) if self.dropout_p else x
+        dropped = (
+            F.dropout(x, p=self.dropout_p, training=self.training)
+            if self.dropout_p
+            else x
+        )
         return dropped.matmul(self.lora_a.t()).matmul(self.lora_b.t()) * self.scale
 
 

--- a/experimental/lite/megatron/lite/primitive/modules/mlp.py
+++ b/experimental/lite/megatron/lite/primitive/modules/mlp.py
@@ -1,17 +1,12 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 import torch
 import torch.nn as nn
-
 from megatron.lite.primitive.modules.experts import swiglu_with_probs
 
 
 class SwiGLUMLP(nn.Module):
     def __init__(
-        self,
-        hidden_size: int,
-        intermediate_size: int,
-        *,
-        swiglu_limit: float = 0.0,
+        self, hidden_size: int, intermediate_size: int, *, swiglu_limit: float = 0.0
     ):
         super().__init__()
         self.gate_up = nn.Linear(hidden_size, 2 * intermediate_size, bias=False)

--- a/experimental/lite/megatron/lite/primitive/modules/moe.py
+++ b/experimental/lite/megatron/lite/primitive/modules/moe.py
@@ -53,7 +53,9 @@ class _AllToAll(torch.autograd.Function):
         ctx.output_splits = output_splits
         ctx.group = group
         input_tensor = input_tensor.contiguous()
-        output = input_tensor.new_empty([sum(output_splits)] + list(input_tensor.shape[1:]))
+        output = input_tensor.new_empty(
+            [sum(output_splits)] + list(input_tensor.shape[1:])
+        )
         dist.all_to_all_single(
             output,
             input_tensor,
@@ -66,7 +68,9 @@ class _AllToAll(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad_output):
         grad_output = grad_output.contiguous()
-        grad_input = grad_output.new_empty([sum(ctx.input_splits)] + list(grad_output.shape[1:]))
+        grad_input = grad_output.new_empty(
+            [sum(ctx.input_splits)] + list(grad_output.shape[1:])
+        )
         dist.all_to_all_single(
             grad_input,
             grad_output,

--- a/experimental/lite/megatron/lite/primitive/modules/mrope.py
+++ b/experimental/lite/megatron/lite/primitive/modules/mrope.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-
 from megatron.lite.primitive.utils.rope import get_pos_emb_on_this_cp_rank
 
 __all__ = ["MultimodalRotaryEmbedding"]
@@ -25,12 +24,16 @@ class MultimodalRotaryEmbedding(nn.Module):
     ):
         super().__init__()
         dim = int(kv_channels * rotary_percent)
-        inv_freq = 1.0 / (rotary_base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        inv_freq = 1.0 / (
+            rotary_base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim)
+        )
         self.register_buffer("inv_freq", inv_freq, persistent=False)
         self.cp_group = cp_group
 
     @staticmethod
-    def _apply_interleaved_mrope(freqs: torch.Tensor, mrope_section: list[int]) -> torch.Tensor:
+    def _apply_interleaved_mrope(
+        freqs: torch.Tensor, mrope_section: list[int]
+    ) -> torch.Tensor:
         freqs_t = freqs[0].clone()
         for dim, offset in enumerate((1, 2), start=1):
             length = mrope_section[dim] * 3
@@ -38,7 +41,11 @@ class MultimodalRotaryEmbedding(nn.Module):
         return freqs_t
 
     def forward(
-        self, position_ids: torch.Tensor, mrope_section: list[int], *, packed_seq: bool = False
+        self,
+        position_ids: torch.Tensor,
+        mrope_section: list[int],
+        *,
+        packed_seq: bool = False,
     ) -> torch.Tensor:
         seq = position_ids.to(device=self.inv_freq.device)
         inv_freq = self.inv_freq.float()
@@ -48,6 +55,10 @@ class MultimodalRotaryEmbedding(nn.Module):
         freqs = self._apply_interleaved_mrope(freqs, mrope_section)
         emb = torch.cat((freqs, freqs), dim=-1)
         emb = emb[..., None, :].transpose(0, 1).contiguous()
-        if not packed_seq and self.cp_group is not None and dist.get_world_size(self.cp_group) > 1:
+        if (
+            not packed_seq
+            and self.cp_group is not None
+            and dist.get_world_size(self.cp_group) > 1
+        ):
             emb = get_pos_emb_on_this_cp_rank(emb, 0, self.cp_group)
         return emb

--- a/experimental/lite/megatron/lite/primitive/modules/mtp.py
+++ b/experimental/lite/megatron/lite/primitive/modules/mtp.py
@@ -7,7 +7,6 @@ from collections.abc import Callable
 
 import torch
 import torch.nn as nn
-
 from megatron.lite.primitive import transformer_engine as te
 from megatron.lite.primitive.parallel import (
     ParallelState,
@@ -25,7 +24,9 @@ def roll_mtp_tensor_left(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Roll MTP inputs/labels one token left for dense or packed THD batches."""
     if packed_seq_params is not None:
-        return roll_packed_thd_left(tensor, packed_seq_params=packed_seq_params, dims=dims)
+        return roll_packed_thd_left(
+            tensor, packed_seq_params=packed_seq_params, dims=dims
+        )
 
     dim = dims if dims >= 0 else tensor.dim() + dims
     rolled = torch.roll(tensor, shifts=-1, dims=dim)
@@ -46,7 +47,9 @@ class MTPLossAutoScaler(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad_output: torch.Tensor):
         (mtp_loss,) = ctx.saved_tensors
-        scaled_mtp_grad = torch.ones_like(mtp_loss) * MTPLossAutoScaler.main_loss_backward_scale
+        scaled_mtp_grad = (
+            torch.ones_like(mtp_loss) * MTPLossAutoScaler.main_loss_backward_scale
+        )
         return grad_output, scaled_mtp_grad
 
     @staticmethod
@@ -77,7 +80,9 @@ class MTPDecoderLayer(nn.Module):
             hidden_size * 2, hidden_size, ps, sp=ps.tp_size > 1, gather_output=True
         )
         self.transformer_layer = transformer_layer
-        self.final_layernorm = te.RMSNorm(hidden_size, eps=rms_norm_eps, zero_centered_gamma=True)
+        self.final_layernorm = te.RMSNorm(
+            hidden_size, eps=rms_norm_eps, zero_centered_gamma=True
+        )
 
     def forward(
         self,
@@ -91,7 +96,9 @@ class MTPDecoderLayer(nn.Module):
         attention_position_ids = (
             rotary_position_ids if rotary_position_ids is not None else position_ids
         )
-        input_ids, _ = roll_mtp_tensor_left(input_ids, packed_seq_params=packed_seq_params, dims=-1)
+        input_ids, _ = roll_mtp_tensor_left(
+            input_ids, packed_seq_params=packed_seq_params, dims=-1
+        )
         if position_ids is not None:
             position_ids, _ = roll_mtp_tensor_left(
                 position_ids, packed_seq_params=packed_seq_params, dims=-1
@@ -103,9 +110,13 @@ class MTPDecoderLayer(nn.Module):
         decoder_input = self.enorm(decoder_input)
         hidden_states = self.hnorm(hidden_states)
         hidden_states = torch.cat((decoder_input, hidden_states), dim=-1)
-        hidden_states = scatter_to_sequence_parallel(self.eh_proj(hidden_states), self.ps)
+        hidden_states = scatter_to_sequence_parallel(
+            self.eh_proj(hidden_states), self.ps
+        )
         hidden_states = self.transformer_layer(
-            hidden_states, position_ids=attention_position_ids, packed_seq_params=packed_seq_params
+            hidden_states,
+            position_ids=attention_position_ids,
+            packed_seq_params=packed_seq_params,
         )
         hidden_states = self.final_layernorm(hidden_states)
         return hidden_states, input_ids, position_ids
@@ -123,7 +134,9 @@ class MTPBlock(nn.Module):
         self.num_layers = num_layers
         self.repeated_layer = repeated_layer
         layers_to_build = 1 if repeated_layer else num_layers
-        self.layers = nn.ModuleList([layer_factory(idx) for idx in range(layers_to_build)])
+        self.layers = nn.ModuleList(
+            [layer_factory(idx) for idx in range(layers_to_build)]
+        )
 
     def forward(
         self,

--- a/experimental/lite/megatron/lite/primitive/modules/router.py
+++ b/experimental/lite/megatron/lite/primitive/modules/router.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 import torch  # pyright: ignore[reportMissingImports]
 import torch.distributed as dist  # pyright: ignore[reportMissingImports]
 import torch.nn as nn  # pyright: ignore[reportMissingImports]
-
 from megatron.lite.primitive.modules.moe import MoEAuxLossAutoScaler
 from megatron.lite.primitive.modules.router_replay import (
     RouterReplay,
@@ -43,10 +42,9 @@ def _ordered_topk_from_routing_map(
 
 
 def _reject_aux_loss_during_replay(router_replay: RouterReplay | None) -> None:
-    if (
-        router_replay is not None
-        and router_replay.router_replay_action
-        in (RouterReplayAction.REPLAY_FORWARD, RouterReplayAction.REPLAY_BACKWARD)
+    if router_replay is not None and router_replay.router_replay_action in (
+        RouterReplayAction.REPLAY_FORWARD,
+        RouterReplayAction.REPLAY_BACKWARD,
     ):
         raise RuntimeError(
             "R3 router aux loss must be disabled: replay dispatches the supplied "
@@ -87,7 +85,9 @@ class TopKRouter(nn.Module):
 
         self.gate = nn.Linear(config.hidden_size, config.num_experts, bias=False)
         self.register_buffer(
-            "expert_bias", torch.zeros(config.num_experts, dtype=torch.float32), persistent=False
+            "expert_bias",
+            torch.zeros(config.num_experts, dtype=torch.float32),
+            persistent=False,
         )
 
         self._aux_loss_group = ps.tp_group if ps.tp_size > 1 else None
@@ -142,13 +142,18 @@ class TopKRouter(nn.Module):
         if apply_aux_loss:
             _reject_aux_loss_during_replay(self.router_replay)
             routing_map, aux_scores = compute_routing_scores_for_aux_loss(
-                logits, self.topk, score_function="softmax", fused=self.moe_router_fusion
+                logits,
+                self.topk,
+                score_function="softmax",
+                fused=self.moe_router_fusion,
             )
             tokens_per_expert = routing_map.sum(dim=0).to(torch.int64)
             total_num_tokens = num_tokens
             if self._aux_loss_group is not None:
                 dist.all_reduce(tokens_per_expert, group=self._aux_loss_group)
-                total_num_tokens = num_tokens * dist.get_world_size(group=self._aux_loss_group)
+                total_num_tokens = num_tokens * dist.get_world_size(
+                    group=self._aux_loss_group
+                )
             aux_loss = switch_load_balancing_loss_func(
                 aux_scores,
                 tokens_per_expert,
@@ -219,12 +224,7 @@ class SigmoidTopKRouter(nn.Module):
         logits = (
             self.gate(x)
             if self.router_dtype is None
-            else router_gating_linear(
-                x,
-                self.gate.weight,
-                None,
-                self.router_dtype,
-            )
+            else router_gating_linear(x, self.gate.weight, None, self.router_dtype)
         )
         logits = logits.view(-1, self.num_experts)
         num_tokens = logits.size(0)
@@ -268,13 +268,18 @@ class SigmoidTopKRouter(nn.Module):
         if apply_aux_loss:
             _reject_aux_loss_during_replay(self.router_replay)
             _, aux_scores = compute_routing_scores_for_aux_loss(
-                logits, self.topk, score_function=self.score_function, fused=self.moe_router_fusion
+                logits,
+                self.topk,
+                score_function=self.score_function,
+                fused=self.moe_router_fusion,
             )
             tokens_per_expert = routing_map.sum(dim=0).to(torch.int64)
             total_num_tokens = num_tokens
             if self._aux_loss_group is not None:
                 dist.all_reduce(tokens_per_expert, group=self._aux_loss_group)
-                total_num_tokens = num_tokens * dist.get_world_size(group=self._aux_loss_group)
+                total_num_tokens = num_tokens * dist.get_world_size(
+                    group=self._aux_loss_group
+                )
             aux_loss = switch_load_balancing_loss_func(
                 aux_scores,
                 tokens_per_expert,

--- a/experimental/lite/megatron/lite/primitive/modules/router_replay.py
+++ b/experimental/lite/megatron/lite/primitive/modules/router_replay.py
@@ -166,7 +166,9 @@ class RouterReplay:
         else:
             return native_indices
         if target is None:
-            raise RuntimeError("router replay is active but no target indices were set.")
+            raise RuntimeError(
+                "router replay is active but no target indices were set."
+            )
 
         target = target.to(device=native_indices.device, dtype=torch.long)
         if target.shape != native_indices.shape:

--- a/experimental/lite/megatron/lite/primitive/ops/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/ops/__init__.py
@@ -2,7 +2,10 @@
 """Runtime math primitives for Megatron Lite."""
 
 from megatron.lite.primitive.ops.cross_entropy import vocab_parallel_cross_entropy
-from megatron.lite.primitive.ops.gated_delta_rule import l2norm, torch_chunk_gated_delta_rule
+from megatron.lite.primitive.ops.gated_delta_rule import (
+    l2norm,
+    torch_chunk_gated_delta_rule,
+)
 from megatron.lite.primitive.ops.logprob import (
     vocab_parallel_entropy,
     vocab_parallel_log_probs_from_logits,

--- a/experimental/lite/megatron/lite/primitive/ops/cross_entropy.py
+++ b/experimental/lite/megatron/lite/primitive/ops/cross_entropy.py
@@ -39,7 +39,9 @@ class _VocabParallelCrossEntropy(torch.autograd.Function):
         else:
             rank = 0
             world_size = 1
-        vocab_start_index, vocab_end_index = _vocab_range(partition_vocab_size, rank, world_size)
+        vocab_start_index, vocab_end_index = _vocab_range(
+            partition_vocab_size, rank, world_size
+        )
 
         # Mask targets outside this partition's vocab range.
         target_mask = (target < vocab_start_index) | (target >= vocab_end_index)

--- a/experimental/lite/megatron/lite/primitive/ops/gated_delta_rule.py
+++ b/experimental/lite/megatron/lite/primitive/ops/gated_delta_rule.py
@@ -7,7 +7,9 @@ import torch
 import torch.nn.functional as F
 
 try:
-    from fla.modules.l2norm import l2norm as _fla_l2norm  # pyright: ignore[reportMissingImports]
+    from fla.modules.l2norm import (
+        l2norm as _fla_l2norm,  # pyright: ignore[reportMissingImports]
+    )
 
     _HAS_FLA_L2NORM = True
 except ImportError:
@@ -39,7 +41,8 @@ def torch_chunk_gated_delta_rule(
         query = l2norm(query)
         key = l2norm(key)
     query, key, value, beta, g = [
-        x.transpose(1, 2).contiguous().to(torch.float32) for x in (query, key, value, beta, g)
+        x.transpose(1, 2).contiguous().to(torch.float32)
+        for x in (query, key, value, beta, g)
     ]
 
     batch_size, num_heads, sequence_length, key_dim = key.shape
@@ -63,7 +66,8 @@ def torch_chunk_gated_delta_rule(
     g = g.reshape(g.shape[0], g.shape[1], -1, chunk_size)
 
     mask = torch.triu(
-        torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=query.device), diagonal=0
+        torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=query.device),
+        diagonal=0,
     )
     g = g.cumsum(dim=-1)
     decay_mask = ((g.unsqueeze(-1) - g.unsqueeze(-2)).tril().exp().float()).tril()
@@ -83,7 +87,8 @@ def torch_chunk_gated_delta_rule(
     )
     core_attn_out = torch.zeros_like(value)
     mask = torch.triu(
-        torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=query.device), diagonal=1
+        torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=query.device),
+        diagonal=1,
     )
 
     for i in range(0, total_sequence_length // chunk_size):
@@ -95,7 +100,10 @@ def torch_chunk_gated_delta_rule(
         core_attn_out[:, :, i] = attn_inter + attn @ v_new
         last_recurrent_state = (
             last_recurrent_state * g[:, :, i, -1, None, None].exp()
-            + (k_i * (g[:, :, i, -1, None] - g[:, :, i]).exp()[..., None]).transpose(-1, -2) @ v_new
+            + (k_i * (g[:, :, i, -1, None] - g[:, :, i]).exp()[..., None]).transpose(
+                -1, -2
+            )
+            @ v_new
         )
 
     if not output_final_state:

--- a/experimental/lite/megatron/lite/primitive/ops/linear_cross_entropy.py
+++ b/experimental/lite/megatron/lite/primitive/ops/linear_cross_entropy.py
@@ -10,11 +10,12 @@ from __future__ import annotations
 
 import torch
 import torch.distributed as dist
-
 from megatron.lite.primitive.ops.cross_entropy import vocab_parallel_cross_entropy
 
 
-def _all_reduce_if_needed(tensor: torch.Tensor, group, op=dist.ReduceOp.SUM) -> torch.Tensor:
+def _all_reduce_if_needed(
+    tensor: torch.Tensor, group, op=dist.ReduceOp.SUM
+) -> torch.Tensor:
     if group is not None and dist.is_initialized() and dist.get_world_size(group) > 1:
         dist.all_reduce(tensor, op=op, group=group)
     return tensor
@@ -51,13 +52,19 @@ def linear_cross_entropy(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Return token log-probs and entropy without changing VERL's fused API."""
     try:
-        from verl.utils.kernel.linear_cross_entropy import linear_cross_entropy as _verl_lce
+        from verl.utils.kernel.linear_cross_entropy import (
+            linear_cross_entropy as _verl_lce,
+        )
     except Exception:
         _verl_lce = None
 
     if _verl_lce is not None and hidden.is_cuda:
-        log_probs, entropy = _verl_lce(hidden, weight, labels, float(temperature), "none", tp_group)
-        return _reshape_like_labels(log_probs, labels), _reshape_like_labels(entropy, labels)
+        log_probs, entropy = _verl_lce(
+            hidden, weight, labels, float(temperature), "none", tp_group
+        )
+        return _reshape_like_labels(log_probs, labels), _reshape_like_labels(
+            entropy, labels
+        )
 
     logits = torch.matmul(hidden, weight.t())
     if temperature != 1.0:

--- a/experimental/lite/megatron/lite/primitive/ops/logprob.py
+++ b/experimental/lite/megatron/lite/primitive/ops/logprob.py
@@ -27,7 +27,9 @@ def vocab_parallel_log_probs_from_logits(
     return gathered.transpose(0, 1).contiguous() if transposed else gathered
 
 
-def _all_reduce_if_needed(tensor: torch.Tensor, group=None, op=dist.ReduceOp.SUM) -> torch.Tensor:
+def _all_reduce_if_needed(
+    tensor: torch.Tensor, group=None, op=dist.ReduceOp.SUM
+) -> torch.Tensor:
     if group is not None and dist.is_initialized() and dist.get_world_size(group) > 1:
         dist.all_reduce(tensor, op=op, group=group)
     return tensor
@@ -70,4 +72,6 @@ def _align_labels_to_logits(
     ):
         return labels.transpose(0, 1).contiguous(), True
 
-    raise ValueError(f"Could not align labels {labels.shape} with logits {logits.shape}.")
+    raise ValueError(
+        f"Could not align labels {labels.shape} with logits {logits.shape}."
+    )

--- a/experimental/lite/megatron/lite/primitive/ops/sp_ops.py
+++ b/experimental/lite/megatron/lite/primitive/ops/sp_ops.py
@@ -14,7 +14,9 @@ import torch.distributed as dist  # pyright: ignore[reportMissingImports]
 
 def _ag_dim0(x: torch.Tensor, tp_size: int, group: dist.ProcessGroup) -> torch.Tensor:
     """AllGather on dim 0: [S/tp, B, H] → [S, B, H]."""
-    out = torch.empty(tp_size * x.shape[0], x.shape[1], x.shape[2], dtype=x.dtype, device=x.device)
+    out = torch.empty(
+        tp_size * x.shape[0], x.shape[1], x.shape[2], dtype=x.dtype, device=x.device
+    )
     dist.all_gather_into_tensor(out, x.contiguous(), group=group)
     return out
 
@@ -87,4 +89,9 @@ class ScatterToSP(torch.autograd.Function):
         return _ag_dim0(grad, ctx.tp_size, ctx.group), None, None, None
 
 
-__all__ = ["AllGatherDim0", "AllGatherDim0ForNonSPConsumer", "ReduceScatterDim0", "ScatterToSP"]
+__all__ = [
+    "AllGatherDim0",
+    "AllGatherDim0ForNonSPConsumer",
+    "ReduceScatterDim0",
+    "ScatterToSP",
+]

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/adamw.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/adamw.py
@@ -10,7 +10,6 @@ from typing import Any
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-
 from megatron.lite.primitive.optimizers.fsdp2.grad_clip import fused_sq_sum
 
 
@@ -31,7 +30,9 @@ def local_grad_sq_sum(
             device = grad.device
         grads.append(grad)
     if device is None:
-        return torch.zeros((), device=default_device or torch.device("cpu"), dtype=dtype)
+        return torch.zeros(
+            (), device=default_device or torch.device("cpu"), dtype=dtype
+        )
     return fused_sq_sum(grads, dtype=dtype, device=device)
 
 
@@ -63,7 +64,9 @@ def is_dtensor_like(tensor: Any) -> bool:
     )
 
 
-def copy_local_tensor_to_param_(param: nn.Parameter, local_tensor: torch.Tensor) -> None:
+def copy_local_tensor_to_param_(
+    param: nn.Parameter, local_tensor: torch.Tensor
+) -> None:
     if not is_dtensor_like(param):
         param.detach().copy_(local_tensor.to(device=param.device, dtype=param.dtype))
         return
@@ -73,7 +76,9 @@ def copy_local_tensor_to_param_(param: nn.Parameter, local_tensor: torch.Tensor)
     # local * mesh, e.g. a (3,) param over 8 ranks -> 0 or 8), so copy local->local
     # (master is init'd from this same local shard, so shapes match).
     local_param = to_local_tensor(param)
-    local_param.copy_(local_tensor.to(device=local_param.device, dtype=local_param.dtype))
+    local_param.copy_(
+        local_tensor.to(device=local_param.device, dtype=local_param.dtype)
+    )
 
 
 def all_reduce_grad_(grad: torch.Tensor, *, group: dist.ProcessGroup) -> None:
@@ -111,9 +116,13 @@ class ChainedOptimizer:
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
         optimizer_states = state_dict.get("optimizers")
-        if not isinstance(optimizer_states, list) or len(optimizer_states) != len(self.optimizers):
+        if not isinstance(optimizer_states, list) or len(optimizer_states) != len(
+            self.optimizers
+        ):
             raise ValueError("Invalid chained torch optimizer state_dict.")
-        for optimizer, optimizer_state in zip(self.optimizers, optimizer_states, strict=True):
+        for optimizer, optimizer_state in zip(
+            self.optimizers, optimizer_states, strict=True
+        ):
             optimizer.load_state_dict(optimizer_state)
 
 
@@ -131,7 +140,9 @@ class FP32AdamW:
         cpu_update: bool = False,
         model_param_dtypes: dict[int, torch.dtype] | None = None,
     ):
-        self.param_groups = normalize_param_groups(params, default_weight_decay=weight_decay)
+        self.param_groups = normalize_param_groups(
+            params, default_weight_decay=weight_decay
+        )
         self.params: list[nn.Parameter] = []
         self.lr = lr
         self.weight_decay = weight_decay
@@ -226,7 +237,9 @@ class FP32AdamW:
                 exp_avg.mul_(beta1).add_(grad, alpha=1.0 - beta1)
                 exp_avg_sq.mul_(beta2).addcmul_(grad, grad, value=1.0 - beta2)
                 denom = exp_avg_sq.sqrt().div_(bias_correction2_sqrt).add_(self.eps)
-                master.addcdiv_(exp_avg.to(dtype=torch.float32), denom, value=-group_step_size)
+                master.addcdiv_(
+                    exp_avg.to(dtype=torch.float32), denom, value=-group_step_size
+                )
                 self._copy_master_to_param(param, master)
 
     def _prepare_grad(self, grad: torch.Tensor, master: torch.Tensor) -> torch.Tensor:
@@ -249,7 +262,9 @@ class FP32AdamW:
         return {
             "type": "fp32_adamw",
             "step_count": self.step_count,
-            "master_params": [self.state[param]["master_param"] for param in self.params],
+            "master_params": [
+                self.state[param]["master_param"] for param in self.params
+            ],
             "exp_avgs": [self.state[param]["exp_avg"] for param in self.params],
             "exp_avg_sqs": [self.state[param]["exp_avg_sq"] for param in self.params],
             "steps": [int(self.state[param]["step"]) for param in self.params],
@@ -281,7 +296,9 @@ class FP32AdamW:
                 local_target.copy_(local_src)
         loaded_steps = state_dict.get("steps")
         if loaded_steps is not None:
-            if not isinstance(loaded_steps, list) or len(loaded_steps) != len(self.params):
+            if not isinstance(loaded_steps, list) or len(loaded_steps) != len(
+                self.params
+            ):
                 raise ValueError("Invalid FP32 AdamW steps state.")
             for param, step in zip(self.params, loaded_steps, strict=True):
                 self.state[param]["step"] = int(step)
@@ -290,9 +307,9 @@ class FP32AdamW:
                 self.state[param]["step"] = self.step_count
         loaded_weight_decays = state_dict.get("weight_decays")
         if loaded_weight_decays is not None:
-            if not isinstance(loaded_weight_decays, list) or len(loaded_weight_decays) != len(
-                self.params
-            ):
+            if not isinstance(loaded_weight_decays, list) or len(
+                loaded_weight_decays
+            ) != len(self.params):
                 raise ValueError("Invalid FP32 AdamW weight_decay state.")
             idx = 0
             for group in self.param_groups:
@@ -343,19 +360,33 @@ def build_adamw_optimizer(
             model_param_dtypes=model_param_dtypes,
         )
     if foreach not in {True, False, "auto"}:
-        raise ValueError(f"adamw_foreach must be True, False, or 'auto', got {foreach!r}.")
+        raise ValueError(
+            f"adamw_foreach must be True, False, or 'auto', got {foreach!r}."
+        )
     if foreach is False:
         return torch.optim.AdamW(
-            param_groups, lr=lr, weight_decay=weight_decay, betas=betas, eps=eps, foreach=False
+            param_groups,
+            lr=lr,
+            weight_decay=weight_decay,
+            betas=betas,
+            eps=eps,
+            foreach=False,
         )
 
     dtensor_param_groups, tensor_param_groups = split_dtensor_and_tensor_param_groups(
         param_groups, default_weight_decay=weight_decay
     )
-    split_param_groups = [group for group in (dtensor_param_groups, tensor_param_groups) if group]
+    split_param_groups = [
+        group for group in (dtensor_param_groups, tensor_param_groups) if group
+    ]
     if foreach == "auto" and not dtensor_param_groups:
         return torch.optim.AdamW(
-            param_groups, lr=lr, weight_decay=weight_decay, betas=betas, eps=eps, foreach=False
+            param_groups,
+            lr=lr,
+            weight_decay=weight_decay,
+            betas=betas,
+            eps=eps,
+            foreach=False,
         )
     if len(split_param_groups) <= 1:
         return torch.optim.AdamW(
@@ -391,7 +422,9 @@ def maybe_build_te_fused_adam_optimizer(
 
     all_param_list = list(all_params)
     master_weights = get_bool_opt(
-        opt, "master_weights", default=use_fp32_master and should_use_master_weights(all_param_list)
+        opt,
+        "master_weights",
+        default=use_fp32_master and should_use_master_weights(all_param_list),
     )
     kwargs = dict(
         lr=lr,
@@ -400,15 +433,23 @@ def maybe_build_te_fused_adam_optimizer(
         eps=eps,
         adam_w_mode=True,
         master_weights=master_weights,
-        master_weight_dtype=get_dtype_opt(opt, "master_weight_dtype", default=torch.float32),
-        store_param_remainders=get_bool_opt(opt, "store_param_remainders", default=master_weights),
+        master_weight_dtype=get_dtype_opt(
+            opt, "master_weight_dtype", default=torch.float32
+        ),
+        store_param_remainders=get_bool_opt(
+            opt, "store_param_remainders", default=master_weights
+        ),
         exp_avg_dtype=get_dtype_opt(opt, "exp_avg_dtype", default=torch.float32),
         exp_avg_sq_dtype=get_dtype_opt(opt, "exp_avg_sq_dtype", default=torch.float32),
     )
-    return FusedAdam(param_groups, **filter_supported_kwargs(FusedAdam.__init__, kwargs))
+    return FusedAdam(
+        param_groups, **filter_supported_kwargs(FusedAdam.__init__, kwargs)
+    )
 
 
-def filter_supported_kwargs(fn: Callable[..., Any], kwargs: dict[str, Any]) -> dict[str, Any]:
+def filter_supported_kwargs(
+    fn: Callable[..., Any], kwargs: dict[str, Any]
+) -> dict[str, Any]:
     try:
         params = inspect.signature(fn).parameters
     except (TypeError, ValueError):
@@ -419,7 +460,10 @@ def filter_supported_kwargs(fn: Callable[..., Any], kwargs: dict[str, Any]) -> d
 
 
 def should_use_master_weights(params: Iterable[nn.Parameter]) -> bool:
-    return any(param.is_floating_point() and param.dtype is not torch.float32 for param in params)
+    return any(
+        param.is_floating_point() and param.dtype is not torch.float32
+        for param in params
+    )
 
 
 def get_bool_opt(opt, attr: str, *, default: bool) -> bool:
@@ -463,7 +507,9 @@ def get_opt_value(opt, attr: str):
 
 
 def normalize_param_groups(
-    params: Iterable[nn.Parameter] | Iterable[dict[str, Any]], *, default_weight_decay: float
+    params: Iterable[nn.Parameter] | Iterable[dict[str, Any]],
+    *,
+    default_weight_decay: float,
 ) -> list[dict[str, Any]]:
     items = list(params)
     if not items:

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/grad_clip.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/grad_clip.py
@@ -11,7 +11,6 @@ from typing import Any
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-
 from transformer_engine.pytorch.optimizers import (  # pyright: ignore[reportMissingImports]
     multi_tensor_applier,
     multi_tensor_l2norm,
@@ -46,14 +45,23 @@ def sharded_grad_sq_sum(
     for group in groups.values():
         local_sq = _group_local_sq_sum(group, dtype=dtype)
         meta = group[0][2]
-        if meta is not None and not _has_partial_placement(meta) and dist.is_initialized():
+        if (
+            meta is not None
+            and not _has_partial_placement(meta)
+            and dist.is_initialized()
+        ):
             _reduce_dtensor_scalar_(
-                local_sq, meta, op=dist.ReduceOp.SUM, scalar_all_reduce=scalar_all_reduce
+                local_sq,
+                meta,
+                op=dist.ReduceOp.SUM,
+                scalar_all_reduce=scalar_all_reduce,
             )
         total = local_sq if total is None else total.to(local_sq.device) + local_sq
 
     if total is None:
-        return torch.zeros((), device=default_device or torch.device("cpu"), dtype=dtype)
+        return torch.zeros(
+            (), device=default_device or torch.device("cpu"), dtype=dtype
+        )
     return total
 
 
@@ -74,13 +82,24 @@ def sharded_grad_norm(
 
     if math.isinf(float(norm_type)):
         total = sharded_grad_abs_max(
-            params, pp_group=pp_group, accum_dtype=accum_dtype, default_device=default_device
+            params,
+            pp_group=pp_group,
+            accum_dtype=accum_dtype,
+            default_device=default_device,
         )
         return total
     if float(norm_type) != 2.0:
-        raise ValueError(f"sharded_grad_norm supports norm_type=2.0 or inf, got {norm_type!r}.")
-    sq_sum = sharded_grad_sq_sum(params, accum_dtype=accum_dtype, default_device=default_device)
-    if pp_group is not None and dist.is_initialized() and dist.get_world_size(pp_group) > 1:
+        raise ValueError(
+            f"sharded_grad_norm supports norm_type=2.0 or inf, got {norm_type!r}."
+        )
+    sq_sum = sharded_grad_sq_sum(
+        params, accum_dtype=accum_dtype, default_device=default_device
+    )
+    if (
+        pp_group is not None
+        and dist.is_initialized()
+        and dist.get_world_size(pp_group) > 1
+    ):
         all_reduce_scalar_(sq_sum, op=dist.ReduceOp.SUM, group=pp_group)
     return sq_sum.sqrt()
 
@@ -100,22 +119,33 @@ def sharded_grad_abs_max(
     for group in groups.values():
         local_max = _group_local_abs_max(group, dtype=dtype)
         meta = group[0][2]
-        if meta is not None and not _has_partial_placement(meta) and dist.is_initialized():
+        if (
+            meta is not None
+            and not _has_partial_placement(meta)
+            and dist.is_initialized()
+        ):
             _reduce_dtensor_scalar_(local_max, meta, op=dist.ReduceOp.MAX)
-        total = local_max if total is None else torch.maximum(total.to(local_max.device), local_max)
+        total = (
+            local_max
+            if total is None
+            else torch.maximum(total.to(local_max.device), local_max)
+        )
 
     if total is None:
-        total = torch.zeros((), device=default_device or torch.device("cpu"), dtype=dtype)
-    if pp_group is not None and dist.is_initialized() and dist.get_world_size(pp_group) > 1:
+        total = torch.zeros(
+            (), device=default_device or torch.device("cpu"), dtype=dtype
+        )
+    if (
+        pp_group is not None
+        and dist.is_initialized()
+        and dist.get_world_size(pp_group) > 1
+    ):
         all_reduce_scalar_(total, op=dist.ReduceOp.MAX, group=pp_group)
     return total
 
 
 def all_reduce_scalar_(
-    value: torch.Tensor,
-    *,
-    op: dist.ReduceOp,
-    group: dist.ProcessGroup,
+    value: torch.Tensor, *, op: dist.ReduceOp, group: dist.ProcessGroup
 ) -> None:
     """All-reduce a scalar on a device compatible with the process group backend."""
 
@@ -159,18 +189,22 @@ def resolve_torch_dtype(dtype: str | torch.dtype) -> torch.dtype:
         name = dtype.removeprefix("torch.")
         resolved = getattr(torch, name, None)
     if not isinstance(resolved, torch.dtype):
-        raise ValueError(f"Unsupported torch dtype for grad norm accumulation: {dtype!r}")
+        raise ValueError(
+            f"Unsupported torch dtype for grad norm accumulation: {dtype!r}"
+        )
     if not torch.empty((), dtype=resolved).is_floating_point():
-        raise ValueError(f"Grad norm accumulation dtype must be floating point: {dtype!r}")
+        raise ValueError(
+            f"Grad norm accumulation dtype must be floating point: {dtype!r}"
+        )
     return resolved
 
 
 def _group_grads(
     params: Iterable[nn.Parameter],
 ) -> dict[tuple[Any, ...], list[tuple[nn.Parameter, torch.Tensor, Any | None]]]:
-    groups: dict[tuple[Any, ...], list[tuple[nn.Parameter, torch.Tensor, Any | None]]] = (
-        defaultdict(list)
-    )
+    groups: dict[
+        tuple[Any, ...], list[tuple[nn.Parameter, torch.Tensor, Any | None]]
+    ] = defaultdict(list)
     for param in params:
         grad = param.grad
         if grad is None:
@@ -182,7 +216,10 @@ def _group_grads(
             key = (
                 "dtensor",
                 id(meta.device_mesh),
-                tuple((type(placement).__name__, repr(placement)) for placement in meta.placements),
+                tuple(
+                    (type(placement).__name__, repr(placement))
+                    for placement in meta.placements
+                ),
             )
         groups[key].append((param, grad, meta))
     return groups
@@ -195,14 +232,18 @@ def fused_sq_sum(
 
     total = torch.zeros((), device=device, dtype=dtype)
     # multi_tensor_applier dispatches on the list's scalar type, so bucket by dtype.
-    buckets: dict[tuple[torch.dtype, torch.device], list[torch.Tensor]] = defaultdict(list)
+    buckets: dict[tuple[torch.dtype, torch.device], list[torch.Tensor]] = defaultdict(
+        list
+    )
     for tensor in tensors:
         if tensor.numel() == 0:
             continue
         if _is_fused_eligible(tensor):
             buckets[(tensor.dtype, tensor.device)].append(tensor)
         else:
-            total += torch.linalg.vector_norm(tensor, 2.0, dtype=dtype).pow_(2).to(device)
+            total += (
+                torch.linalg.vector_norm(tensor, 2.0, dtype=dtype).pow_(2).to(device)
+            )
     for (_bucket_dtype, bucket_device), bucket in buckets.items():
         noop_flag = torch.zeros(1, dtype=torch.int, device=bucket_device)
         norm, _ = multi_tensor_applier(multi_tensor_l2norm, noop_flag, [bucket], False)
@@ -228,7 +269,9 @@ def _group_local_sq_sum(
             local = _local_grad(grad, grad_meta).detach()
             total += fused_sq_sum([local], dtype=dtype, device=device)
         return total
-    locals_ = [_local_grad(grad, grad_meta).detach() for _param, grad, grad_meta in group]
+    locals_ = [
+        _local_grad(grad, grad_meta).detach() for _param, grad, grad_meta in group
+    ]
     return fused_sq_sum(locals_, dtype=dtype, device=device)
 
 
@@ -241,7 +284,9 @@ def _group_local_abs_max(
         local_grad = _local_grad(grad, meta)
         if local_grad.numel() > 0:
             # vector_norm(inf) is abs().max() without the intermediate tensors.
-            local_max = torch.linalg.vector_norm(local_grad.detach(), float("inf"), dtype=dtype)
+            local_max = torch.linalg.vector_norm(
+                local_grad.detach(), float("inf"), dtype=dtype
+            )
             total = torch.maximum(total, local_max.to(device))
     return total
 
@@ -286,7 +331,9 @@ def _is_dtensor_like(tensor: Any) -> bool:
 
 
 def _has_partial_placement(dtensor: Any) -> bool:
-    return any(_placement_name(placement) == "Partial" for placement in dtensor.placements)
+    return any(
+        _placement_name(placement) == "Partial" for placement in dtensor.placements
+    )
 
 
 def _is_replicate_placement(placement: Any) -> bool:

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/optimizer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/optimizer.py
@@ -12,7 +12,6 @@ from typing import Any
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-
 from megatron.lite.primitive.optimizers.fsdp2.adamw import (
     all_reduce_grad_,
     build_adamw_optimizer,
@@ -85,7 +84,9 @@ class FSDP2Optimizer:
         self.clip_grad = float(clip_grad)
         self.grad_norm_accum_dtype = resolve_torch_dtype(grad_norm_accum_dtype)
         self.replicated_grad_params = list(replicated_grad_params or ())
-        self._replicated_grad_param_ids = {id(param) for param in self.replicated_grad_params}
+        self._replicated_grad_param_ids = {
+            id(param) for param in self.replicated_grad_params
+        }
         self.replicated_grad_sync_group = replicated_grad_sync_group
         self.replicated_grad_sync_divisor = replicated_grad_sync_divisor
         self.replicated_grad_norm_group = replicated_grad_norm_group
@@ -94,11 +95,15 @@ class FSDP2Optimizer:
             id(param) for param in self.expert_sharded_grad_params
         }
         self.expert_sharded_grad_scale = (
-            1.0 if expert_sharded_grad_scale is None else float(expert_sharded_grad_scale)
+            1.0
+            if expert_sharded_grad_scale is None
+            else float(expert_sharded_grad_scale)
         )
         self.expert_sharded_grad_norm_group = expert_sharded_grad_norm_group
         self.tp_replicated_grad_params = list(tp_replicated_grad_params or ())
-        self._tp_replicated_grad_param_ids = {id(param) for param in self.tp_replicated_grad_params}
+        self._tp_replicated_grad_param_ids = {
+            id(param) for param in self.tp_replicated_grad_params
+        }
         self.tp_replicated_grad_sync_group = tp_replicated_grad_sync_group
         self._cpu_offloaded_state: dict[tuple[int, str], OffloadedStateEntry] = {}
         self.grad_sync_enabled = False
@@ -148,7 +153,11 @@ class FSDP2Optimizer:
         group = self.tp_replicated_grad_sync_group
         if not self.tp_replicated_grad_params:
             return
-        if group is None or not dist.is_initialized() or dist.get_world_size(group) <= 1:
+        if (
+            group is None
+            or not dist.is_initialized()
+            or dist.get_world_size(group) <= 1
+        ):
             return
         for param in self.tp_replicated_grad_params:
             grad = param.grad
@@ -170,7 +179,9 @@ class FSDP2Optimizer:
             | self._expert_sharded_grad_param_ids
         )
         sharded_params = [
-            param for param in self.params if id(param) not in excluded_sharded_param_ids
+            param
+            for param in self.params
+            if id(param) not in excluded_sharded_param_ids
         ]
         dtensor_sharded_params = [
             param for param in sharded_params if has_dtensor_grad_or_param(param)
@@ -194,7 +205,9 @@ class FSDP2Optimizer:
             and dist.is_initialized()
             and dist.get_world_size(plain_sharded_group) > 1
         ):
-            all_reduce_scalar_(plain_sharded_sq, op=dist.ReduceOp.SUM, group=plain_sharded_group)
+            all_reduce_scalar_(
+                plain_sharded_sq, op=dist.ReduceOp.SUM, group=plain_sharded_group
+            )
         total_sq = total_sq.to(plain_sharded_sq.device) + plain_sharded_sq
         if (
             self.ps is not None
@@ -220,7 +233,9 @@ class FSDP2Optimizer:
             and dist.get_world_size(self.replicated_grad_norm_group) > 1
         ):
             all_reduce_scalar_(
-                replicated_sq, op=dist.ReduceOp.SUM, group=self.replicated_grad_norm_group
+                replicated_sq,
+                op=dist.ReduceOp.SUM,
+                group=self.replicated_grad_norm_group,
             )
 
         expert_sharded_sq = sharded_grad_sq_sum(
@@ -275,7 +290,9 @@ class FSDP2Optimizer:
         )
 
     def load_state_to_device(self) -> None:
-        move_offloaded_optimizer_state_to_device(self.optimizer, self._cpu_offloaded_state)
+        move_offloaded_optimizer_state_to_device(
+            self.optimizer, self._cpu_offloaded_state
+        )
 
 
 def build_fsdp2_adamw(
@@ -373,10 +390,15 @@ def build_fsdp2_training_optimizer(
 
     expert_params = _collect_expert_params(model_chunks, ps, expert_classifier)
     expert_modules = _collect_expert_modules(
-        model_chunks, ps, expert_classifier, expert_module_leaf_name=expert_module_leaf_name
+        model_chunks,
+        ps,
+        expert_classifier,
+        expert_module_leaf_name=expert_module_leaf_name,
     )
     if expert_params and not expert_modules:
-        raise RuntimeError("FSDP2 expert parameters were found but no expert module was found.")
+        raise RuntimeError(
+            "FSDP2 expert parameters were found but no expert module was found."
+        )
 
     if opt is None:
         opt = SimpleNamespace(
@@ -395,12 +417,16 @@ def build_fsdp2_training_optimizer(
     effective_use_fp32_shards = (
         bool(use_fp32_shards)
         if use_fp32_shards is not None
-        else get_bool_opt(opt, "fsdp2_use_fp32_shards", default=_DEFAULT_USE_FP32_SHARDS)
+        else get_bool_opt(
+            opt, "fsdp2_use_fp32_shards", default=_DEFAULT_USE_FP32_SHARDS
+        )
     )
     effective_use_fp32_master = (
         bool(use_fp32_master)
         if use_fp32_master is not None
-        else get_bool_opt(opt, "fsdp2_use_fp32_master", default=_DEFAULT_USE_FP32_MASTER)
+        else get_bool_opt(
+            opt, "fsdp2_use_fp32_master", default=_DEFAULT_USE_FP32_MASTER
+        )
     )
 
     unit_reshard_after_forward = _fsdp2_unit_reshard_after_forward(
@@ -413,8 +439,12 @@ def build_fsdp2_training_optimizer(
         last_unit_reshard_after_forward=unit_reshard_after_forward,
         root_reshard_after_forward=False,
         wrap_root=wrap_root,
-        forward_prefetch_depth=_fsdp2_prefetch_depth(ps, default_depth=forward_prefetch_depth),
-        backward_prefetch_depth=_fsdp2_prefetch_depth(ps, default_depth=backward_prefetch_depth),
+        forward_prefetch_depth=_fsdp2_prefetch_depth(
+            ps, default_depth=forward_prefetch_depth
+        ),
+        backward_prefetch_depth=_fsdp2_prefetch_depth(
+            ps, default_depth=backward_prefetch_depth
+        ),
         param_dtype=param_dtype,
         reduce_dtype=reduce_dtype,
     )
@@ -425,16 +455,22 @@ def build_fsdp2_training_optimizer(
     else:
         model_param_dtypes = {}
 
-    tp_replicated_grad_param_names = _collect_tp_replicated_grad_param_names(model_chunks)
+    tp_replicated_grad_param_names = _collect_tp_replicated_grad_param_names(
+        model_chunks
+    )
 
     dense_shard_placement_fn = build_fsdp2_shard_placement_fn(ps.dp_cp_size)
     expert_shard_placement_fn = build_fsdp2_shard_placement_fn(ps.expert_dp_size)
 
     if expert_modules:
         if ps.ep_dp_group is None:
-            raise RuntimeError("FSDP2 expert sharding requires ParallelState.ep_dp_group.")
+            raise RuntimeError(
+                "FSDP2 expert sharding requires ParallelState.ep_dp_group."
+            )
         expert_mesh = build_fsdp2_process_group_mesh(
-            ps.ep_dp_group, mesh_dim_name="expert_dp", device_type=fsdp2_config.device_type
+            ps.ep_dp_group,
+            mesh_dim_name="expert_dp",
+            device_type=fsdp2_config.device_type,
         )
         for module in expert_modules:
             wrap_fsdp2_module(
@@ -469,11 +505,15 @@ def build_fsdp2_training_optimizer(
         ps,
         expert_sharded_grad_params=list(ignored_expert_params),
         expert_sharded_grad_scale=(
-            float(ps.expert_dp_size) / float(ps.dp_cp_size) if ignored_expert_params else None
+            float(ps.expert_dp_size) / float(ps.dp_cp_size)
+            if ignored_expert_params
+            else None
         ),
         expert_sharded_grad_norm_group=ps.ep_group if ignored_expert_params else None,
         tp_replicated_grad_params=tp_replicated_grad_params,
-        tp_replicated_grad_sync_group=ps.tp_group if tp_replicated_grad_params else None,
+        tp_replicated_grad_sync_group=(
+            ps.tp_group if tp_replicated_grad_params else None
+        ),
         grad_norm_accum_dtype="float32",
         adamw_foreach=False if deterministic else adamw_foreach,
         use_fp32_master=effective_use_fp32_master,
@@ -482,7 +522,9 @@ def build_fsdp2_training_optimizer(
 
 
 def _collect_expert_params(
-    chunks: Iterable[nn.Module], ps: ParallelState, expert_classifier: Callable[[str], bool] | None
+    chunks: Iterable[nn.Module],
+    ps: ParallelState,
+    expert_classifier: Callable[[str], bool] | None,
 ) -> set[nn.Parameter]:
     if ps.ep_size <= 1 or expert_classifier is None:
         return set()
@@ -526,12 +568,16 @@ def _collect_module_params(modules: Iterable[nn.Module]) -> set[nn.Parameter]:
     return {param for module in modules for param in module.parameters()}
 
 
-def _collect_model_param_dtypes(chunks: Iterable[nn.Module]) -> dict[tuple[int, str], torch.dtype]:
+def _collect_model_param_dtypes(
+    chunks: Iterable[nn.Module],
+) -> dict[tuple[int, str], torch.dtype]:
     return {
         (chunk_idx, name): param.dtype
         for chunk_idx, chunk in enumerate(chunks)
         for name, param in chunk.named_parameters()
-        if param.requires_grad and param.is_floating_point() and param.dtype != torch.float32
+        if param.requires_grad
+        and param.is_floating_point()
+        and param.dtype != torch.float32
     }
 
 
@@ -545,7 +591,9 @@ def _restore_model_param_dtypes(
                 param._fsdp2_model_param_dtype = model_dtype
 
 
-def _collect_tp_replicated_grad_param_names(chunks: Iterable[nn.Module]) -> list[tuple[int, str]]:
+def _collect_tp_replicated_grad_param_names(
+    chunks: Iterable[nn.Module],
+) -> list[tuple[int, str]]:
     names: list[tuple[int, str]] = []
     for chunk_idx, chunk in enumerate(chunks):
         sp_param_ids = {id(param) for param in getattr(chunk, "sp_params", ())}
@@ -602,7 +650,9 @@ def _build_adamw_param_groups(
     weight_decay: float,
     apply_wd_to_qk_layernorm: bool,
     model_param_dtypes: dict[tuple[int, str], torch.dtype] | None = None,
-) -> tuple[list[nn.Parameter], list[dict[str, Any]], dict[int, str], dict[int, torch.dtype]]:
+) -> tuple[
+    list[nn.Parameter], list[dict[str, Any]], dict[int, str], dict[int, torch.dtype]
+]:
     params: list[nn.Parameter] = []
     decay_params: list[nn.Parameter] = []
     no_decay_params: list[nn.Parameter] = []
@@ -633,9 +683,13 @@ def _build_adamw_param_groups(
     # 1D params and bias skip AdamW decay unless the Q/K layernorm override is set.
     param_groups: list[dict[str, Any]] = []
     if decay_params:
-        param_groups.append({"params": decay_params, "weight_decay": weight_decay, "wd_mult": 1.0})
+        param_groups.append(
+            {"params": decay_params, "weight_decay": weight_decay, "wd_mult": 1.0}
+        )
     if no_decay_params:
-        param_groups.append({"params": no_decay_params, "weight_decay": 0.0, "wd_mult": 0.0})
+        param_groups.append(
+            {"params": no_decay_params, "weight_decay": 0.0, "wd_mult": 0.0}
+        )
     return params, param_groups, param_names, param_model_dtypes
 
 
@@ -647,7 +701,10 @@ def _matches_megatron_no_weight_decay(
     if not apply_wd_to_qk_layernorm:
         return True
     return not (
-        "q_layernorm." in name or "k_layernorm." in name or "q_norm." in name or "k_norm." in name
+        "q_layernorm." in name
+        or "k_layernorm." in name
+        or "q_norm." in name
+        or "k_norm." in name
     )
 
 

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/state.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/state.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from typing import Any
 
 import torch
-
 from megatron.lite.primitive.optimizers.fsdp2.adamw import (
     dtensor_from_local,
     is_dtensor_like,
@@ -45,7 +44,10 @@ def move_optimizer_state_to_cpu(
                     if not include_dtensor_state:
                         continue
                     local_value = value.to_local()
-                    if not isinstance(local_value, torch.Tensor) or not local_value.is_cuda:
+                    if (
+                        not isinstance(local_value, torch.Tensor)
+                        or not local_value.is_cuda
+                    ):
                         continue
                     offloaded[(id(param), key)] = OffloadedStateEntry(
                         device=local_value.device,

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/wrap.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/wrap.py
@@ -17,7 +17,6 @@ from typing import Any
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-
 from megatron.lite.primitive.parallel.state import ParallelState
 
 UnitModule = type[nn.Module] | str
@@ -77,7 +76,9 @@ def fsdp2_available() -> bool:
     return True
 
 
-def build_fsdp2_device_mesh(ps: ParallelState, config: FSDP2Config | None = None) -> Any:
+def build_fsdp2_device_mesh(
+    ps: ParallelState, config: FSDP2Config | None = None
+) -> Any:
     """Build the default one-dimensional FSDP2 DeviceMesh from ``ParallelState``."""
 
     cfg = config or FSDP2Config()
@@ -111,7 +112,9 @@ def build_fsdp2_process_group_mesh(
 
     from torch.distributed import DeviceMesh
 
-    return DeviceMesh.from_group(group, device_type=device_type, mesh_dim_names=(mesh_dim_name,))
+    return DeviceMesh.from_group(
+        group, device_type=device_type, mesh_dim_names=(mesh_dim_name,)
+    )
 
 
 def build_fsdp2_shard_placement_fn(fsdp_size: int) -> Callable[[nn.Parameter], Any]:
@@ -169,7 +172,9 @@ def wrap_fsdp2(
     )
 
     wrapped_units: list[nn.Module] = []
-    unit_modules = list(_iter_fsdp2_unit_modules(model, unit_types, cfg.leaf_module_names))
+    unit_modules = list(
+        _iter_fsdp2_unit_modules(model, unit_types, cfg.leaf_module_names)
+    )
     for idx, sub_module in enumerate(unit_modules):
         kwargs = dict(common_kwargs)
         _set_optional_reshard_after_forward(
@@ -316,7 +321,9 @@ def _load_fully_shard():
     return fully_shard
 
 
-def _resolve_unit_module_types(unit_modules: Iterable[UnitModule]) -> tuple[type[nn.Module], ...]:
+def _resolve_unit_module_types(
+    unit_modules: Iterable[UnitModule],
+) -> tuple[type[nn.Module], ...]:
     resolved: list[type[nn.Module]] = []
     for item in unit_modules:
         if isinstance(item, str):
@@ -336,12 +343,16 @@ def _import_module_type(path: str) -> type[nn.Module]:
     module = importlib.import_module(module_name)
     obj = getattr(module, attr_name)
     if not isinstance(obj, type) or not issubclass(obj, nn.Module):
-        raise TypeError(f"FSDP2 unit module path does not resolve to nn.Module: {path!r}")
+        raise TypeError(
+            f"FSDP2 unit module path does not resolve to nn.Module: {path!r}"
+        )
     return obj
 
 
 def _iter_fsdp2_unit_modules(
-    root: nn.Module, unit_types: tuple[type[nn.Module], ...], leaf_module_names: tuple[str, ...]
+    root: nn.Module,
+    unit_types: tuple[type[nn.Module], ...],
+    leaf_module_names: tuple[str, ...],
 ) -> Iterable[nn.Module]:
     leaf_names = set(leaf_module_names)
     if not unit_types and not leaf_names:
@@ -387,7 +398,11 @@ def _is_fsdp2_module(module: nn.Module) -> bool:
 
 
 def _apply_fsdp2_prefetch(
-    root: nn.Module, wrapped_units: list[nn.Module], *, forward_depth: int, backward_depth: int
+    root: nn.Module,
+    wrapped_units: list[nn.Module],
+    *,
+    forward_depth: int,
+    backward_depth: int,
 ) -> None:
     fsdp_units = [module for module in wrapped_units if _is_fsdp2_module(module)]
     fsdp_root = root if _is_fsdp2_module(root) else None
@@ -408,7 +423,9 @@ def _apply_fsdp2_prefetch(
                 fsdp_units[idx].set_modules_to_backward_prefetch(targets)
 
 
-def _unit_reshard_after_forward(cfg: FSDP2Config, idx: int, total_units: int) -> bool | int | None:
+def _unit_reshard_after_forward(
+    cfg: FSDP2Config, idx: int, total_units: int
+) -> bool | int | None:
     if total_units > 0 and idx == total_units - 1:
         return cfg.last_unit_reshard_after_forward
     return cfg.reshard_after_forward
@@ -445,7 +462,11 @@ def _fully_shard_kwargs(
 
 
 def _mixed_precision_policy_from_config(cfg: FSDP2Config) -> Any | None:
-    if cfg.param_dtype is None and cfg.reduce_dtype is None and cfg.output_dtype is None:
+    if (
+        cfg.param_dtype is None
+        and cfg.reduce_dtype is None
+        and cfg.output_dtype is None
+    ):
         return None
     try:
         from torch.distributed.fsdp import MixedPrecisionPolicy
@@ -471,7 +492,9 @@ def _resolve_torch_dtype(dtype: str | torch.dtype | None) -> torch.dtype | None:
     name = dtype.removeprefix("torch.")
     resolved = getattr(torch, name, None)
     if not isinstance(resolved, torch.dtype):
-        raise ValueError(f"Unsupported torch dtype for FSDP2 mixed precision: {dtype!r}")
+        raise ValueError(
+            f"Unsupported torch dtype for FSDP2 mixed precision: {dtype!r}"
+        )
     return resolved
 
 
@@ -479,7 +502,9 @@ def _save_param_attrs(module: nn.Module) -> dict[str, dict[str, Any]]:
     return {name: dict(vars(param)) for name, param in module.named_parameters()}
 
 
-def _restore_param_attrs(module: nn.Module, saved_attrs: dict[str, dict[str, Any]]) -> None:
+def _restore_param_attrs(
+    module: nn.Module, saved_attrs: dict[str, dict[str, Any]]
+) -> None:
     for name, param in module.named_parameters():
         for attr_name, attr_value in saved_attrs.get(name, {}).items():
             setattr(param, attr_name, attr_value)

--- a/experimental/lite/megatron/lite/primitive/optimizers/megatron_wrap.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/megatron_wrap.py
@@ -9,8 +9,10 @@ from typing import Any
 
 import torch  # pyright: ignore[reportMissingImports]
 import torch.nn as nn  # pyright: ignore[reportMissingImports]
-
-from megatron.lite.primitive.protocols import ExpertClassifierFn, default_expert_classifier
+from megatron.lite.primitive.protocols import (
+    ExpertClassifierFn,
+    default_expert_classifier,
+)
 
 
 def validate_dist_opt_config(engine_cfg) -> None:
@@ -30,7 +32,9 @@ def _effective_etp(parallel) -> int:
 def _ensure_dist_opt_mpu_parallel_state(engine_cfg) -> None:
     """Initialize Megatron-Core mpu globals when dist_opt fallback groups are used."""
 
-    from megatron.core import parallel_state as mpu  # pyright: ignore[reportMissingImports]
+    from megatron.core import (
+        parallel_state as mpu,  # pyright: ignore[reportMissingImports]
+    )
 
     p = engine_cfg.parallel
     expected = (int(p.tp), int(p.ep), _effective_etp(p), int(p.pp), int(p.cp))
@@ -123,7 +127,10 @@ def build_dist_opt_stack(
             influences optimizer master-grad sharding, so callers that prewrap
             chunks own the DDP config compatibility.
     """
-    from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig
+    from megatron.core.distributed import (
+        DistributedDataParallel,
+        DistributedDataParallelConfig,
+    )
     from megatron.core.distributed.finalize_model_grads import finalize_model_grads
     from megatron.core.optimizer import get_megatron_optimizer
     from megatron.core.transformer.enums import ModelType
@@ -153,7 +160,9 @@ def build_dist_opt_stack(
         wrapped_chunks = list(model_chunks)
     else:
         ddp_config = DistributedDataParallelConfig(
-            use_distributed_optimizer=True, overlap_grad_reduce=False, grad_reduce_in_fp32=True
+            use_distributed_optimizer=True,
+            overlap_grad_reduce=False,
+            grad_reduce_in_fp32=True,
         )
         wrapped_chunks = []
         for chunk_idx, chunk in enumerate(model_chunks):
@@ -180,8 +189,12 @@ def build_dist_opt_stack(
     # groups. Long term, this primitive should always pass its own
     # `pg_collection`.
     if skip_ddp_wrap or use_mpu_groups:
-        optimizer = get_megatron_optimizer(config=opt_config, model_chunks=wrapped_chunks)
-        optimizer._dist_opt_pg_collection = None  # pyright: ignore[reportAttributeAccessIssue]
+        optimizer = get_megatron_optimizer(
+            config=opt_config, model_chunks=wrapped_chunks
+        )
+        optimizer._dist_opt_pg_collection = (
+            None  # pyright: ignore[reportAttributeAccessIssue]
+        )
     else:
         optimizer = get_megatron_optimizer(
             config=opt_config,
@@ -320,7 +333,6 @@ def _mark_dist_opt_parallel_attrs(
 
 def _build_pg_collection(ps, engine_cfg):
     import torch.distributed as dist  # pyright: ignore[reportMissingImports]
-
     from megatron.core.process_groups_config import ProcessGroupCollection
 
     if ps.pp_group is None:
@@ -330,7 +342,9 @@ def _build_pg_collection(ps, engine_cfg):
         return ((pp_i * ps.dp_size + dp_i) * ps.cp_size + cp_i) * ps.tp_size + tp_i
 
     def _expert_rank(etp_i: int, ep_i: int, edp_i: int, pp_i: int) -> int:
-        return ((pp_i * ps.expert_dp_size + edp_i) * ps.ep_size + ep_i) * ps.etp_size + etp_i
+        return (
+            (pp_i * ps.expert_dp_size + edp_i) * ps.ep_size + ep_i
+        ) * ps.etp_size + etp_i
 
     rank = dist.get_rank()
     world = dist.get_world_size()
@@ -374,7 +388,9 @@ def _build_pg_collection(ps, engine_cfg):
                 tp_ep_pp_group = group
 
         if mp_group is None or tp_ep_pp_group is None:
-            raise RuntimeError("Failed to construct dist_opt pipeline-aware process groups.")
+            raise RuntimeError(
+                "Failed to construct dist_opt pipeline-aware process groups."
+            )
 
     pg_kwargs = dict(
         tp=ps.tp_group,
@@ -434,7 +450,9 @@ class DistOptBackend:
     def load_state_dict(self, optimizer: Any, state_dict: dict) -> None:
         optimizer.load_state_dict(state_dict)
 
-    def finalize_grads(self, finalize_fn, model_chunks: list[Any], optimizer: Any) -> None:
+    def finalize_grads(
+        self, finalize_fn, model_chunks: list[Any], optimizer: Any
+    ) -> None:
         finalize_fn(model_chunks, optimizer)
 
 

--- a/experimental/lite/megatron/lite/primitive/parallel/cp.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/cp.py
@@ -10,10 +10,7 @@ import torch.distributed as dist
 
 
 def zigzag_split_for_cp(
-    tensor: torch.Tensor,
-    cp_rank: int,
-    cp_size: int,
-    seq_dim: int = 1,
+    tensor: torch.Tensor, cp_rank: int, cp_size: int, seq_dim: int = 1
 ) -> torch.Tensor:
     """Split tensor along sequence dim using zigzag (striped) pattern for CP.
 
@@ -34,9 +31,7 @@ def zigzag_split_for_cp(
     shape[seq_dim : seq_dim + 1] = [2 * cp_size, seq_len // (2 * cp_size)]
     tensor = tensor.view(*shape)
     idx = torch.tensor(
-        [cp_rank, 2 * cp_size - cp_rank - 1],
-        dtype=torch.long,
-        device=tensor.device,
+        [cp_rank, 2 * cp_size - cp_rank - 1], dtype=torch.long, device=tensor.device
     )
     tensor = tensor.index_select(seq_dim, idx)
     shape[seq_dim : seq_dim + 2] = [seq_len // cp_size]
@@ -103,10 +98,7 @@ def contiguous_slice_for_cp(
 
 
 def contiguous_position_ids_for_cp(
-    seq_len: int,
-    cp_rank: int,
-    cp_size: int,
-    device: torch.device,
+    seq_len: int, cp_rank: int, cp_size: int, device: torch.device
 ) -> torch.Tensor:
     """Return global position IDs for this CP rank under contiguous splitting."""
     if cp_size <= 1:
@@ -190,7 +182,12 @@ def zigzag_to_contiguous_chunks(
     """
     if cu_seqlens is not None:
         return _zigzag_contiguous_thd_swap(
-            tensor, cp_group, seq_dim, cu_seqlens, source_layout="zigzag", target_layout="contiguous"
+            tensor,
+            cp_group,
+            seq_dim,
+            cu_seqlens,
+            source_layout="zigzag",
+            target_layout="contiguous",
         )
     return _zigzag_contiguous_chunk_swap(tensor, cp_group, seq_dim, to_contiguous=True)
 
@@ -204,7 +201,12 @@ def contiguous_to_zigzag_chunks(
     """Inverse of :func:`zigzag_to_contiguous_chunks`."""
     if cu_seqlens is not None:
         return _zigzag_contiguous_thd_swap(
-            tensor, cp_group, seq_dim, cu_seqlens, source_layout="contiguous", target_layout="zigzag"
+            tensor,
+            cp_group,
+            seq_dim,
+            cu_seqlens,
+            source_layout="contiguous",
+            target_layout="zigzag",
         )
     return _zigzag_contiguous_chunk_swap(tensor, cp_group, seq_dim, to_contiguous=False)
 
@@ -248,9 +250,13 @@ def _zigzag_contiguous_chunk_swap(
     target_in_zigzag = not to_contiguous
     local_chunks = [tensor[:chunk_len], tensor[chunk_len:]]
     local_chunk_indices = rank_to_chunks(cp_rank, source_in_zigzag)
-    local_dests = [chunk_to_dest(chunk_idx, target_in_zigzag) for chunk_idx in local_chunk_indices]
+    local_dests = [
+        chunk_to_dest(chunk_idx, target_in_zigzag) for chunk_idx in local_chunk_indices
+    ]
     local_slot_order = sorted(range(2), key=lambda slot: local_dests[slot])
-    send_buf = torch.cat([local_chunks[slot] for slot in local_slot_order], dim=0).contiguous()
+    send_buf = torch.cat(
+        [local_chunks[slot] for slot in local_slot_order], dim=0
+    ).contiguous()
 
     input_split_chunks = [0] * cp_size
     for dst_rank, _dst_slot in local_dests:
@@ -260,7 +266,9 @@ def _zigzag_contiguous_chunk_swap(
     recv_dst_slots_per_source: list[list[int]] = [[] for _ in range(cp_size)]
     for src_rank in range(cp_size):
         src_chunks = rank_to_chunks(src_rank, source_in_zigzag)
-        src_dests = [chunk_to_dest(chunk_idx, target_in_zigzag) for chunk_idx in src_chunks]
+        src_dests = [
+            chunk_to_dest(chunk_idx, target_in_zigzag) for chunk_idx in src_chunks
+        ]
         src_slot_order = sorted(range(2), key=lambda slot: src_dests[slot])
         for slot in src_slot_order:
             dst_rank, dst_slot = src_dests[slot]
@@ -320,7 +328,9 @@ def get_thd_context_parallel_rank_indices(
     if not 0 <= cp_rank < cp_size:
         raise ValueError(f"cp_rank must be in [0, {cp_size}), got {cp_rank}.")
     if cu_seqlens.dim() != 1:
-        raise ValueError(f"cu_seqlens must be 1-D, got shape {tuple(cu_seqlens.shape)}.")
+        raise ValueError(
+            f"cu_seqlens must be 1-D, got shape {tuple(cu_seqlens.shape)}."
+        )
 
     cu = cu_seqlens.to(dtype=torch.long)
     if cu.numel() == 0 or cu[0].item() != 0:
@@ -360,7 +370,9 @@ def get_thd_context_parallel_rank_indices(
     offset = pos_in_seq - chunk * chunk_lens
 
     owner = torch.where(chunk < cp_size, chunk, 2 * cp_size - chunk - 1)
-    local_slot = torch.where(chunk < cp_size, torch.zeros_like(chunk), torch.ones_like(chunk))
+    local_slot = torch.where(
+        chunk < cp_size, torch.zeros_like(chunk), torch.ones_like(chunk)
+    )
 
     local_starts = (global_starts // cp_size)[seq_idx]
     local_pos = local_starts + local_slot * chunk_lens + offset
@@ -480,10 +492,7 @@ def _zigzag_contiguous_thd_swap(
 
 
 def zigzag_position_ids_for_cp(
-    seq_len: int,
-    cp_rank: int,
-    cp_size: int,
-    device: torch.device,
+    seq_len: int, cp_rank: int, cp_size: int, device: torch.device
 ) -> torch.Tensor:
     """Return global position IDs for this CP rank under zigzag splitting.
 
@@ -549,9 +558,7 @@ def split_packed_for_cp(
 
 
 def build_headwise_section_perm(
-    split_sections: tuple[int, ...] | list[int],
-    cp_size: int,
-    device: torch.device,
+    split_sections: tuple[int, ...] | list[int], cp_size: int, device: torch.device
 ) -> torch.Tensor:
     """Permutation over the hidden dim so a single contiguous ``1/cp`` slice equals
     the concatenation of each section's ``k``-th contiguous block.
@@ -571,7 +578,9 @@ def build_headwise_section_perm(
     parts = []
     for s in split_sections:
         parts.append(
-            torch.arange(offset, offset + s, device=device, dtype=torch.long).view(cp_size, -1)
+            torch.arange(offset, offset + s, device=device, dtype=torch.long).view(
+                cp_size, -1
+            )
         )
         offset += s
     return torch.cat(parts, dim=-1).view(-1)
@@ -612,8 +621,7 @@ def get_parameter_local_cp_headwise(
 
 
 def all_to_all_hidden_shards(
-    send_parts: list[torch.Tensor],
-    cp_group: dist.ProcessGroup | None,
+    send_parts: list[torch.Tensor], cp_group: dist.ProcessGroup | None
 ) -> list[torch.Tensor]:
     """Even all-to-all over a CP group: ``send_parts[j]`` is delivered to rank ``j``;
     the returned ``recv[i]`` is the tensor rank ``i`` sent to this rank.

--- a/experimental/lite/megatron/lite/primitive/parallel/linear.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/linear.py
@@ -8,10 +8,8 @@ from typing import TYPE_CHECKING
 import torch  # pyright: ignore[reportMissingImports]
 import torch.distributed as dist  # pyright: ignore[reportMissingImports]
 import torch.nn as nn  # pyright: ignore[reportMissingImports]
-
 from megatron.lite.primitive import transformer_engine as te
 from megatron.lite.primitive.utils import ensure_divisible
-
 
 if TYPE_CHECKING:
     from megatron.lite.primitive.parallel.state import ParallelState
@@ -79,8 +77,12 @@ class _VanillaColParallelMatmulSP(torch.autograd.Function):
         if ws > 1:
             s_local = input_.shape[0]
             total_shape = (s_local * ws, *input_.shape[1:])
-            total_input = torch.empty(total_shape, dtype=input_.dtype, device=input_.device)
-            dist.all_gather_into_tensor(total_input, input_.contiguous(), group=tp_group)
+            total_input = torch.empty(
+                total_shape, dtype=input_.dtype, device=input_.device
+            )
+            dist.all_gather_into_tensor(
+                total_input, input_.contiguous(), group=tp_group
+            )
         else:
             total_input = input_
         ctx.save_for_backward(total_input, weight)
@@ -98,7 +100,9 @@ class _VanillaColParallelMatmulSP(torch.autograd.Function):
             grad_input = torch.empty(
                 out_shape, dtype=grad_input_full.dtype, device=grad_input_full.device
             )
-            dist.reduce_scatter_tensor(grad_input, grad_input_full.contiguous(), group=ctx.tp_group)
+            dist.reduce_scatter_tensor(
+                grad_input, grad_input_full.contiguous(), group=ctx.tp_group
+            )
         else:
             grad_input = grad_input_full
         gi = grad_output.reshape(-1, grad_output.shape[-1])
@@ -120,13 +124,22 @@ class _VanillaColLinear(nn.Module):
     `sp=False`, input is assumed replicated and grad_input is all-reduced.
     """
 
-    def __init__(self, in_features: int, out_features: int, ps: ParallelState, *, sp: bool = False):
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        ps: ParallelState,
+        *,
+        sp: bool = False,
+    ):
         super().__init__()
         self.tp_group = ps.tp_group
         self.tp_size = ps.tp_size
         self.sp = sp
         local_out = ensure_divisible(out_features, ps.tp_size)
-        self.weight = nn.Parameter(torch.empty(local_out, in_features, dtype=torch.bfloat16))
+        self.weight = nn.Parameter(
+            torch.empty(local_out, in_features, dtype=torch.bfloat16)
+        )
         self.reset_parameters()
 
     def reset_parameters(self) -> None:
@@ -188,7 +201,9 @@ class ColumnParallelLinear(nn.Module):
         self.tp_group = ps.tp_group
         self.local_out = ensure_divisible(out_features, ps.tp_size)
         self.use_sp = (
-            ps.tp_size > 1 and not gather_output if sequence_parallel is None else sequence_parallel
+            ps.tp_size > 1 and not gather_output
+            if sequence_parallel is None
+            else sequence_parallel
         )
         if normalization is not None:
             self.linear = te.LayerNormLinear(
@@ -278,7 +293,12 @@ class VocabParallelEmbedding(nn.Module):
     """Embedding table split across TP on the vocab dimension."""
 
     def __init__(
-        self, vocab_size: int, hidden_size: int, ps: ParallelState, *, deterministic: bool = False
+        self,
+        vocab_size: int,
+        hidden_size: int,
+        ps: ParallelState,
+        *,
+        deterministic: bool = False,
     ):
         super().__init__()
         self.tp_size = ps.tp_size
@@ -294,7 +314,9 @@ class VocabParallelEmbedding(nn.Module):
     def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
         # input_ids: [B, S] → out: [S, B, H]
         mask = (input_ids >= self.vocab_start) & (input_ids < self.vocab_end)
-        local_ids = (input_ids - self.vocab_start).clamp(min=0, max=self.local_vocab - 1)
+        local_ids = (input_ids - self.vocab_start).clamp(
+            min=0, max=self.local_vocab - 1
+        )
         if self.deterministic:
             out = self.embedding.weight[local_ids]
         else:
@@ -350,14 +372,21 @@ class VocabParallelOutput(nn.Module):
     """
 
     def __init__(
-        self, vocab_size: int, hidden_size: int, ps: ParallelState, *, backend: str = "vanilla"
+        self,
+        vocab_size: int,
+        hidden_size: int,
+        ps: ParallelState,
+        *,
+        backend: str = "vanilla",
     ):
         super().__init__()
         padded_vocab = pad_vocab_for_tp(vocab_size, ps.tp_size)
         # SP-aware head: when tp>1 we run on SP-sharded input (matches MC
         # GPTModel where final_layernorm runs on SP-sharded hiddens and
         # output_layer gathers internally + reduce-scatters on backward).
-        self.col = _ColForLMHead(hidden_size, padded_vocab, ps, backend=backend, sp=ps.tp_size > 1)
+        self.col = _ColForLMHead(
+            hidden_size, padded_vocab, ps, backend=backend, sp=ps.tp_size > 1
+        )
         self.padded_vocab = padded_vocab
         self.local_vocab = padded_vocab // ps.tp_size
         self.vocab_size = vocab_size
@@ -409,7 +438,9 @@ class _AllGatherLastDimWithGradReduce(torch.autograd.Function):
     def backward(ctx, grad_output: torch.Tensor):
         local_width = ensure_divisible(grad_output.shape[-1], ctx.tp_size)
         flat_grad = grad_output.reshape(-1, grad_output.shape[-1])
-        packed_grad = torch.cat(flat_grad.split(local_width, dim=-1), dim=0).contiguous()
+        packed_grad = torch.cat(
+            flat_grad.split(local_width, dim=-1), dim=0
+        ).contiguous()
         local_grad = torch.empty(
             (flat_grad.shape[0], local_width),
             dtype=grad_output.dtype,

--- a/experimental/lite/megatron/lite/primitive/parallel/mhc.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/mhc.py
@@ -4,7 +4,9 @@ from typing import Any
 import torch
 
 
-def expand_mhc_hidden_for_pipeline(hidden: torch.Tensor, *, hc_mult: int) -> torch.Tensor:
+def expand_mhc_hidden_for_pipeline(
+    hidden: torch.Tensor, *, hc_mult: int
+) -> torch.Tensor:
     if hidden.dim() == 3:
         return hidden.unsqueeze(2).expand(-1, -1, hc_mult, -1).contiguous()
     return hidden
@@ -22,7 +24,9 @@ def fold_mhc_hidden_for_pipeline(hidden: torch.Tensor) -> torch.Tensor:
     return hidden
 
 
-def unfold_mhc_hidden_from_pipeline(hidden: torch.Tensor, *, hc_mult: int) -> torch.Tensor:
+def unfold_mhc_hidden_from_pipeline(
+    hidden: torch.Tensor, *, hc_mult: int
+) -> torch.Tensor:
     """Inverse of :func:`fold_mhc_hidden_for_pipeline`: [B, S, hc_mult * H] -> [B, S, hc_mult, H].
 
     Used on non-first PP stages to restore the hc_mult streams received over P2P. No-op when the
@@ -35,11 +39,7 @@ def unfold_mhc_hidden_from_pipeline(hidden: torch.Tensor, *, hc_mult: int) -> to
 
 
 def contract_mhc_hidden_for_pipeline(
-    hidden: torch.Tensor,
-    *,
-    norm: Any,
-    head: Any,
-    return_source: bool = False,
+    hidden: torch.Tensor, *, norm: Any, head: Any, return_source: bool = False
 ):
     if head is None or norm is None:
         if return_source:

--- a/experimental/lite/megatron/lite/primitive/parallel/pipeline.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/pipeline.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING
 
 import torch  # pyright: ignore[reportMissingImports]
 import torch.distributed as dist  # pyright: ignore[reportMissingImports]
-
 from megatron.lite.primitive.utils import ensure_divisible
 from megatron.lite.runtime.contracts.loss import split_loss_context, use_loss_context
 
@@ -169,7 +168,9 @@ def _compact_pipeline_output(out: dict | None) -> dict:
         compact["model_output"] = out["model_output"]
     if "loss" in out and out["loss"] is not None:
         loss = out["loss"]
-        compact["loss"] = loss.detach().item() if isinstance(loss, torch.Tensor) else float(loss)
+        compact["loss"] = (
+            loss.detach().item() if isinstance(loss, torch.Tensor) else float(loss)
+        )
     if "_loss_fn_metrics" in out:
         compact["metrics"] = out["_loss_fn_metrics"]
     elif "metrics" in out:
@@ -208,7 +209,14 @@ def _no_pipeline(
 
 
 def _forward_only_no_pipeline(
-    forward_step_fn, model, data_iter, config, ps, *, pre_forward_hook=None, loss_fn=None
+    forward_step_fn,
+    model,
+    data_iter,
+    config,
+    ps,
+    *,
+    pre_forward_hook=None,
+    loss_fn=None,
 ):
     num_microbatches = _num_microbatches_from_config(config, ps)
     del ps
@@ -290,13 +298,7 @@ def _1f1b_schedule(
         # Megatron dynamic shape exchange: the recv buffer is sized from the shape
         # the sender transmits, so no per-mb shape has to be tracked here.
         return _send_recv_pipeline(
-            send_fwd,
-            send_bwd,
-            recv_fwd,
-            recv_bwd,
-            ps,
-            tensor_shape,
-            dynamic_shape=True,
+            send_fwd, send_bwd, recv_fwd, recv_bwd, ps, tensor_shape, dynamic_shape=True
         )
 
     # ── Warmup: pure forward passes ──
@@ -310,7 +312,9 @@ def _1f1b_schedule(
         current_input = fwd_input
         out = _run_forward(fwd_input, batch, loss_ctx)
         hidden = out.get("hidden_states")
-        loss_s = out["loss"] / num_microbatches if "loss" in out and ps.pp_is_last else None
+        loss_s = (
+            out["loss"] / num_microbatches if "loss" in out and ps.pp_is_last else None
+        )
 
         # Recv the next forward input for every remaining warmup mb AND — on the
         # last warmup step — for the first STEADY mb (num_steady > 0). Middle
@@ -341,7 +345,9 @@ def _1f1b_schedule(
         mb_idx += 1
         out = _run_forward(fwd_input, batch, loss_ctx)
         hidden = out.get("hidden_states")
-        loss_s = out["loss"] / num_microbatches if "loss" in out and ps.pp_is_last else None
+        loss_s = (
+            out["loss"] / num_microbatches if "loss" in out and ps.pp_is_last else None
+        )
 
         input_tensors.append(fwd_input if not ps.pp_is_first else None)
         output_hiddens.append(hidden)
@@ -431,10 +437,14 @@ def _communicate_shapes(
     """
     device = _pipeline_device()
     recv_fwd_t = (
-        torch.empty(_PIPELINE_SHAPE_NDIM, dtype=torch.int64, device=device) if recv_fwd else None
+        torch.empty(_PIPELINE_SHAPE_NDIM, dtype=torch.int64, device=device)
+        if recv_fwd
+        else None
     )
     recv_bwd_t = (
-        torch.empty(_PIPELINE_SHAPE_NDIM, dtype=torch.int64, device=device) if recv_bwd else None
+        torch.empty(_PIPELINE_SHAPE_NDIM, dtype=torch.int64, device=device)
+        if recv_bwd
+        else None
     )
     send_fwd_t = (
         torch.tensor(tuple(send_fwd.size()), dtype=torch.int64, device=device)
@@ -574,12 +584,18 @@ def _send_recv_pipeline(
         ops.append(dist.P2POp(dist.isend, t, ps.pp_next_rank, p2p_group))
     if recv_fwd:
         if dynamic_shape:
-            fwd_buf = torch.empty(recv_fwd_shape, dtype=_PIPELINE_TENSOR_DTYPE, device=_pipeline_device())
+            fwd_buf = torch.empty(
+                recv_fwd_shape, dtype=_PIPELINE_TENSOR_DTYPE, device=_pipeline_device()
+            )
         else:
             fwd_buf = (
                 fwd_recv_buf
                 if fwd_recv_buf is not None
-                else torch.empty(tensor_shape, dtype=_PIPELINE_TENSOR_DTYPE, device=_pipeline_device())
+                else torch.empty(
+                    tensor_shape,
+                    dtype=_PIPELINE_TENSOR_DTYPE,
+                    device=_pipeline_device(),
+                )
             )
         ops.append(dist.P2POp(dist.irecv, fwd_buf, ps.pp_prev_rank, p2p_group))
     if send_bwd is not None:
@@ -587,12 +603,18 @@ def _send_recv_pipeline(
         ops.append(dist.P2POp(dist.isend, t, ps.pp_prev_rank, p2p_group))
     if recv_bwd:
         if dynamic_shape:
-            bwd_buf = torch.empty(recv_bwd_shape, dtype=_PIPELINE_TENSOR_DTYPE, device=_pipeline_device())
+            bwd_buf = torch.empty(
+                recv_bwd_shape, dtype=_PIPELINE_TENSOR_DTYPE, device=_pipeline_device()
+            )
         else:
             bwd_buf = (
                 bwd_recv_buf
                 if bwd_recv_buf is not None
-                else torch.empty(tensor_shape, dtype=_PIPELINE_TENSOR_DTYPE, device=_pipeline_device())
+                else torch.empty(
+                    tensor_shape,
+                    dtype=_PIPELINE_TENSOR_DTYPE,
+                    device=_pipeline_device(),
+                )
             )
         ops.append(dist.P2POp(dist.irecv, bwd_buf, ps.pp_next_rank, p2p_group))
 
@@ -646,7 +668,9 @@ def _pipeline_stage_barrier(ps: ParallelState) -> None:
         dist.barrier(group=ps.pp_cpu_group)
 
 
-def _set_virtual_pipeline_rank(ps: ParallelState, chunk_id: int | None, num_chunks: int) -> None:
+def _set_virtual_pipeline_rank(
+    ps: ParallelState, chunk_id: int | None, num_chunks: int
+) -> None:
     if chunk_id is None or num_chunks <= 1:
         ps.virtual_pipeline_size = None
         ps.virtual_pipeline_rank = None
@@ -748,7 +772,9 @@ def _forward_only_pipeline_schedule(
                 if recv_next:
                     pending_activation = fwd_buf
 
-        outputs.append(_compact_pipeline_output(last_output) if last_output is not None else {})
+        outputs.append(
+            _compact_pipeline_output(last_output) if last_output is not None else {}
+        )
 
     _set_virtual_pipeline_rank(ps, None, num_chunks)
     return outputs
@@ -795,7 +821,8 @@ def _interleaved_1f1b_schedule(
         batch = next(data_iter)
         _set_aux_loss_scale(pre_forward_hook, num_microbatches)
         saved: dict[
-            int, tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None, dict]
+            int,
+            tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None, dict],
         ] = {}
         pending_activation: torch.Tensor | None = None
 
@@ -814,7 +841,9 @@ def _interleaved_1f1b_schedule(
                 activation = None if is_first_stage else pending_activation
                 pending_activation = None
                 if _dbg:
-                    activation_shape = None if activation is None else tuple(activation.shape)
+                    activation_shape = (
+                        None if activation is None else tuple(activation.shape)
+                    )
                     print(
                         f"[VPP r{rank}] mb={mb_id} fwd stage={stage_id} "
                         f"chunk={chunk_id} activation_shape={activation_shape}",
@@ -840,7 +869,11 @@ def _interleaved_1f1b_schedule(
                         f"chunk={chunk_id} hidden_shape={hidden_shape}",
                         flush=True,
                     )
-                loss = out["loss"] / num_microbatches if is_last_stage and "loss" in out else None
+                loss = (
+                    out["loss"] / num_microbatches
+                    if is_last_stage and "loss" in out
+                    else None
+                )
                 saved[stage_id] = (activation, hidden, loss, out)
 
                 if is_last_stage:

--- a/experimental/lite/megatron/lite/primitive/parallel/pp.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/pp.py
@@ -44,7 +44,12 @@ def _auto_layout(
     )
 
     if rows is None:
-        units = ["embedding"] + ["decoder"] * num_hidden_layers + ["mtp"] * max(num_mtp_layers, 0) + ["loss"]
+        units = (
+            ["embedding"]
+            + ["decoder"] * num_hidden_layers
+            + ["mtp"] * max(num_mtp_layers, 0)
+            + ["loss"]
+        )
         base, remainder = divmod(len(units), pp_size)
         rows, pos = [], 0
         for size in (base + (1 if s < remainder else 0) for s in range(pp_size)):
@@ -54,8 +59,7 @@ def _auto_layout(
 
 
 def _validate_decoder_layer_groups(
-    num_hidden_layers: int,
-    decoder_layer_groups: Sequence[Sequence[int]],
+    num_hidden_layers: int, decoder_layer_groups: Sequence[Sequence[int]]
 ) -> list[list[int]]:
     groups = [list(group) for group in decoder_layer_groups]
     if any(not group for group in groups):
@@ -102,12 +106,7 @@ def _auto_layout_with_decoder_groups(
     first: dict[int, tuple[int, int, int, int | None]] = {}
     for end in range(n_groups + 1):
         cells = overhead(0) + prefix[end]
-        first[end] = (
-            cells,
-            1 if end == 0 else 0,
-            abs(cells - target_cells[0]),
-            None,
-        )
+        first[end] = (cells, 1 if end == 0 else 0, abs(cells - target_cells[0]), None)
     dp.append(first)
 
     for stage in range(1, pp_size):
@@ -151,12 +150,7 @@ def _auto_layout_with_decoder_groups(
             row.extend(["mtp"] * max(num_mtp_layers, 0))
             row.append("loss")
         rows.append(row)
-    return _auto_layout(
-        num_hidden_layers,
-        pp_size,
-        num_mtp_layers,
-        rows=rows,
-    )
+    return _auto_layout(num_hidden_layers, pp_size, num_mtp_layers, rows=rows)
 
 
 def build_pipeline_chunk_layout(
@@ -170,9 +164,12 @@ def build_pipeline_chunk_layout(
 ) -> PipelineChunkLayout:
     """``layer_indices`` / ``has_embed`` / ``has_head`` / ``has_mtp`` for this PP rank,
     from ``ps.pp_layout`` (custom) or an auto-balanced layout. ``has_mtp`` follows the
-    layout's ``m`` placement, so MTP is built where the layout says, not a fixed rank."""
+    layout's ``m`` placement, so MTP is built where the layout says, not a fixed rank.
+    """
     if (vpp is not None and vpp > 1) or vpp_chunk_id is not None:
-        raise NotImplementedError("VPP / interleaved pipeline layout is not supported (use vpp=1).")
+        raise NotImplementedError(
+            "VPP / interleaved pipeline layout is not supported (use vpp=1)."
+        )
 
     if ps.pp_size <= 1:  # no pipeline: this stage owns everything
         return PipelineChunkLayout(
@@ -189,9 +186,13 @@ def build_pipeline_chunk_layout(
 
     pp_layout = getattr(ps, "pp_layout", None)
     if pp_layout is not None:
-        layout = PipelineParallelLayerLayout(pp_layout, pipeline_model_parallel_size=ps.pp_size)
+        layout = PipelineParallelLayerLayout(
+            pp_layout, pipeline_model_parallel_size=ps.pp_size
+        )
         if layout.virtual_pipeline_model_parallel_size > 1:
-            raise NotImplementedError("VPP pp_layout is not supported (one stage per pp rank).")
+            raise NotImplementedError(
+                "VPP pp_layout is not supported (one stage per pp rank)."
+            )
     elif decoder_layer_groups is not None:
         layout = _auto_layout_with_decoder_groups(
             num_hidden_layers, ps.pp_size, num_mtp_layers, decoder_layer_groups
@@ -208,10 +209,15 @@ def build_pipeline_chunk_layout(
             "layout (set only `pp`), or place `m` on the same stage as `L`."
         )
     return PipelineChunkLayout(
-        layer_indices=layout.get_layer_id_list(LayerType.decoder, vp_stage=0, pp_rank=ps.pp_rank),
+        layer_indices=layout.get_layer_id_list(
+            LayerType.decoder, vp_stage=0, pp_rank=ps.pp_rank
+        ),
         has_embed=ps.pp_is_first,
         has_head=ps.pp_is_last,
-        has_mtp=layout.get_num_layers_to_build(LayerType.mtp, vp_stage=0, pp_rank=ps.pp_rank) > 0,
+        has_mtp=layout.get_num_layers_to_build(
+            LayerType.mtp, vp_stage=0, pp_rank=ps.pp_rank
+        )
+        > 0,
     )
 
 

--- a/experimental/lite/megatron/lite/primitive/parallel/sp.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/sp.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch  # pyright: ignore[reportMissingImports]
-
 from megatron.lite.primitive.ops.sp_ops import (
     AllGatherDim0,
     AllGatherDim0ForNonSPConsumer,

--- a/experimental/lite/megatron/lite/primitive/parallel/state.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/state.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import torch.distributed as dist  # pyright: ignore[reportMissingImports]
-
 from megatron.lite.primitive.utils import ensure_divisible
 
 

--- a/experimental/lite/megatron/lite/primitive/parallel/thd.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/thd.py
@@ -9,7 +9,6 @@ from typing import Any
 
 import torch
 import torch.distributed as dist
-
 from megatron.lite.primitive.utils.packed_seq import PackedSeqParams
 
 
@@ -56,20 +55,29 @@ def _make_packed_seq_params(
     )
 
 
-def _slice_along_dim(tensor: torch.Tensor, dim: int, start: int, end: int) -> torch.Tensor:
+def _slice_along_dim(
+    tensor: torch.Tensor, dim: int, start: int, end: int
+) -> torch.Tensor:
     index = [slice(None)] * tensor.dim()
     index[dim] = slice(start, end)
     return tensor[tuple(index)]
 
 
-def _assign_along_dim(dst: torch.Tensor, dim: int, start: int, src: torch.Tensor) -> None:
+def _assign_along_dim(
+    dst: torch.Tensor, dim: int, start: int, src: torch.Tensor
+) -> None:
     index = [slice(None)] * dst.dim()
     index[dim] = slice(start, start + src.size(dim))
     dst[tuple(index)] = src
 
 
 def _split_full_to_cp_local(
-    tensor: torch.Tensor, *, cu_seqlens_padded: torch.Tensor, cp_size: int, cp_rank: int, dim: int
+    tensor: torch.Tensor,
+    *,
+    cu_seqlens_padded: torch.Tensor,
+    cp_size: int,
+    cp_rank: int,
+    dim: int,
 ) -> torch.Tensor:
     if cp_size <= 1:
         return tensor
@@ -89,7 +97,10 @@ def _split_full_to_cp_local(
         local_start = full_start // cp_size
 
         first = _slice_along_dim(
-            tensor, dim, full_start + cp_rank * chunk, full_start + (cp_rank + 1) * chunk
+            tensor,
+            dim,
+            full_start + cp_rank * chunk,
+            full_start + (cp_rank + 1) * chunk,
         )
         second = _slice_along_dim(
             tensor, dim, full_end - (cp_rank + 1) * chunk, full_end - cp_rank * chunk
@@ -101,7 +112,11 @@ def _split_full_to_cp_local(
 
 
 def _reconstruct_full_from_cp_parts(
-    parts: list[torch.Tensor], *, cu_seqlens_padded: torch.Tensor, cp_size: int, dim: int
+    parts: list[torch.Tensor],
+    *,
+    cu_seqlens_padded: torch.Tensor,
+    cp_size: int,
+    dim: int,
 ) -> torch.Tensor:
     if cp_size <= 1:
         return parts[0]
@@ -122,7 +137,9 @@ def _reconstruct_full_from_cp_parts(
 
         for rank, part in enumerate(parts):
             first = _slice_along_dim(part, dim, local_start, local_start + chunk)
-            second = _slice_along_dim(part, dim, local_start + chunk, local_start + 2 * chunk)
+            second = _slice_along_dim(
+                part, dim, local_start + chunk, local_start + 2 * chunk
+            )
             _assign_along_dim(full, dim, full_start + rank * chunk, first)
             _assign_along_dim(full, dim, full_end - (rank + 1) * chunk, second)
 
@@ -130,7 +147,11 @@ def _reconstruct_full_from_cp_parts(
 
 
 def reconstruct_packed_from_cp_parts(
-    parts: list[torch.Tensor], *, cu_seqlens_padded: torch.Tensor, cp_size: int, dim: int
+    parts: list[torch.Tensor],
+    *,
+    cu_seqlens_padded: torch.Tensor,
+    cp_size: int,
+    dim: int,
 ) -> torch.Tensor:
     """Reconstruct a full packed THD tensor from CP-local zigzag parts."""
     return _reconstruct_full_from_cp_parts(
@@ -139,11 +160,20 @@ def reconstruct_packed_from_cp_parts(
 
 
 def split_packed_to_cp_local(
-    tensor: torch.Tensor, *, cu_seqlens_padded: torch.Tensor, cp_size: int, cp_rank: int, dim: int
+    tensor: torch.Tensor,
+    *,
+    cu_seqlens_padded: torch.Tensor,
+    cp_size: int,
+    cp_rank: int,
+    dim: int,
 ) -> torch.Tensor:
     """Slice a full packed THD tensor back to one CP rank's zigzag shard."""
     return _split_full_to_cp_local(
-        tensor, cu_seqlens_padded=cu_seqlens_padded, cp_size=cp_size, cp_rank=cp_rank, dim=dim
+        tensor,
+        cu_seqlens_padded=cu_seqlens_padded,
+        cp_size=cp_size,
+        cp_rank=cp_rank,
+        dim=dim,
     )
 
 
@@ -164,7 +194,9 @@ def _sequence_dim(tensor: torch.Tensor) -> int:
     return tensor.dim() - 1 if tensor.dim() > 1 else 0
 
 
-def _with_cp_metadata(packed_seq_params: Any, *, cp_size: int, cp_rank: int, cp_group: Any):
+def _with_cp_metadata(
+    packed_seq_params: Any, *, cp_size: int, cp_rank: int, cp_group: Any
+):
     updated = copy(packed_seq_params)
     updated.local_cp_size = cp_size
     updated.cp_rank = cp_rank
@@ -216,7 +248,11 @@ def prepare_packed_thd_for_context_parallel(
         if tensor is None:
             local_tensors.append(None)
             continue
-        dim = _sequence_dim(tensor) if dims is None or dims[idx] is None else int(dims[idx])
+        dim = (
+            _sequence_dim(tensor)
+            if dims is None or dims[idx] is None
+            else int(dims[idx])
+        )
         local_tensors.append(
             _split_full_to_cp_local(
                 tensor,
@@ -227,7 +263,9 @@ def prepare_packed_thd_for_context_parallel(
             )
         )
     return (
-        _with_cp_metadata(packed_seq_params, cp_size=cp_size, cp_rank=cp_rank, cp_group=cp_group),
+        _with_cp_metadata(
+            packed_seq_params, cp_size=cp_size, cp_rank=cp_rank, cp_group=cp_group
+        ),
         tuple(local_tensors),
     )
 
@@ -313,12 +351,17 @@ def unpack_thd_to_nested(
         flat = output
 
     if meta.cp_size > 1:
-        parts = _all_gather_cp_tensor(flat, cp_size=meta.cp_size, cp_group=meta.cp_group)
+        parts = _all_gather_cp_tensor(
+            flat, cp_size=meta.cp_size, cp_group=meta.cp_group
+        )
         if contiguous:
             flat = torch.cat(parts, dim=0)
         else:
             flat = _reconstruct_full_from_cp_parts(
-                parts, cu_seqlens_padded=meta.cu_seqlens_padded, cp_size=meta.cp_size, dim=0
+                parts,
+                cu_seqlens_padded=meta.cu_seqlens_padded,
+                cp_size=meta.cp_size,
+                dim=0,
             )
 
     pieces = []
@@ -351,7 +394,9 @@ def _roll_packed_thd_left_local(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     dim = dims if dims >= 0 else tensor.dim() + dims
     if dim < 0 or dim >= tensor.dim():
-        raise ValueError(f"Invalid roll dim {dims} for tensor with {tensor.dim()} dims.")
+        raise ValueError(
+            f"Invalid roll dim {dims} for tensor with {tensor.dim()} dims."
+        )
 
     rolled = tensor.clone()
     for idx in range(int(cu_seqlens_padded.numel()) - 1):
@@ -394,7 +439,9 @@ def roll_packed_thd_left(
 
     dim = dims if dims >= 0 else tensor.dim() + dims
     if cp_size <= 1:
-        return _roll_packed_thd_left_local(tensor, cu_seqlens_padded=cu_seqlens_padded, dims=dim)
+        return _roll_packed_thd_left_local(
+            tensor, cu_seqlens_padded=cu_seqlens_padded, dims=dim
+        )
 
     parts = _all_gather_cp_tensor(tensor, cp_size=cp_size, cp_group=cp_group)
     full = _reconstruct_full_from_cp_parts(
@@ -404,7 +451,11 @@ def roll_packed_thd_left(
         full, cu_seqlens_padded=cu_seqlens_padded, dims=dim
     )
     local = _split_full_to_cp_local(
-        rolled_full, cu_seqlens_padded=cu_seqlens_padded, cp_size=cp_size, cp_rank=cp_rank, dim=dim
+        rolled_full,
+        cu_seqlens_padded=cu_seqlens_padded,
+        cp_size=cp_size,
+        cp_rank=cp_rank,
+        dim=dim,
     )
     return local, token_sum
 
@@ -455,7 +506,9 @@ def pack_nested_thd(
     pad_size = (align_size - lengths % align_size) % align_size
     padded_lengths = lengths + pad_size
 
-    cu_seqlens_padded = torch.zeros(lengths.numel() + 1, dtype=torch.int32, device=device)
+    cu_seqlens_padded = torch.zeros(
+        lengths.numel() + 1, dtype=torch.int32, device=device
+    )
     cu_seqlens_padded[1:] = torch.cumsum(padded_lengths, dim=0)
     total_padded = int(cu_seqlens_padded[-1].item())
     total_local = total_padded // cp_size if split_cp else total_padded
@@ -463,7 +516,9 @@ def pack_nested_thd(
 
     packed_input = torch.zeros(total_local, dtype=input_ids.dtype, device=device)
     packed_labels = (
-        torch.zeros(total_local, dtype=labels.dtype, device=device) if labels is not None else None
+        torch.zeros(total_local, dtype=labels.dtype, device=device)
+        if labels is not None
+        else None
     )
     packed_loss_mask = (
         torch.zeros(total_local, dtype=loss_mask.dtype, device=device)
@@ -493,10 +548,14 @@ def pack_nested_thd(
         seq_loss_mask = None
         if loss_mask is not None:
             assert packed_loss_mask is not None
-            seq_loss_mask = torch.zeros(padded_length, dtype=loss_mask.dtype, device=device)
+            seq_loss_mask = torch.zeros(
+                padded_length, dtype=loss_mask.dtype, device=device
+            )
             seq_loss_mask[:length] = loss_mask[idx]
             if roll_loss_mask and length > 0:
-                seq_loss_mask[:length] = torch.roll(seq_loss_mask[:length], shifts=-1, dims=0)
+                seq_loss_mask[:length] = torch.roll(
+                    seq_loss_mask[:length], shifts=-1, dims=0
+                )
                 seq_loss_mask[length - 1] = 0
         seq_positions = torch.zeros(padded_length, dtype=torch.long, device=device)
         seq_positions[:length] = torch.arange(length, dtype=torch.long, device=device)
@@ -530,7 +589,9 @@ def pack_nested_thd(
                 else seq_labels
             )
             assert packed_labels is not None
-            packed_labels[local_start : local_start + local_labels.numel()] = local_labels
+            packed_labels[local_start : local_start + local_labels.numel()] = (
+                local_labels
+            )
         if seq_loss_mask is not None:
             local_loss_mask = (
                 _split_full_to_cp_local(
@@ -546,13 +607,17 @@ def pack_nested_thd(
                 else seq_loss_mask
             )
             assert packed_loss_mask is not None
-            packed_loss_mask[local_start : local_start + local_loss_mask.numel()] = local_loss_mask
+            packed_loss_mask[local_start : local_start + local_loss_mask.numel()] = (
+                local_loss_mask
+            )
         position_ids[full_start : full_start + padded_length] = seq_positions
 
     return PackedTHDBatch(
         input_ids=packed_input.unsqueeze(0),
         labels=packed_labels.unsqueeze(0) if packed_labels is not None else None,
-        loss_mask=(packed_loss_mask.unsqueeze(0) if packed_loss_mask is not None else None),
+        loss_mask=(
+            packed_loss_mask.unsqueeze(0) if packed_loss_mask is not None else None
+        ),
         position_ids=position_ids.unsqueeze(0),
         packed_seq_params=_make_packed_seq_params(
             cu_seqlens_padded=cu_seqlens_padded,
@@ -570,7 +635,9 @@ def pack_nested_thd(
     )
 
 
-def unpack_packed_thd_to_nested(output: torch.Tensor, batch: PackedTHDBatch) -> torch.Tensor:
+def unpack_packed_thd_to_nested(
+    output: torch.Tensor, batch: PackedTHDBatch
+) -> torch.Tensor:
     """Unpack ``[1, total_padded, ...]`` THD model output back to jagged form."""
 
     if output.dim() >= 2 and output.shape[0] == 1:
@@ -582,9 +649,14 @@ def unpack_packed_thd_to_nested(output: torch.Tensor, batch: PackedTHDBatch) -> 
 
     if batch.cp_size > 1:
         dim = 0
-        parts = _all_gather_cp_tensor(flat, cp_size=batch.cp_size, cp_group=batch.cp_group)
+        parts = _all_gather_cp_tensor(
+            flat, cp_size=batch.cp_size, cp_group=batch.cp_group
+        )
         flat = _reconstruct_full_from_cp_parts(
-            parts, cu_seqlens_padded=batch.cu_seqlens_padded, cp_size=batch.cp_size, dim=dim
+            parts,
+            cu_seqlens_padded=batch.cu_seqlens_padded,
+            cp_size=batch.cp_size,
+            dim=dim,
         )
 
     pieces = []

--- a/experimental/lite/megatron/lite/primitive/protocols.py
+++ b/experimental/lite/megatron/lite/primitive/protocols.py
@@ -21,4 +21,9 @@ def default_placement_fn(name: str) -> list:
     return [Replicate(), Replicate(), Replicate(), Replicate()]
 
 
-__all__ = ["ExpertClassifierFn", "PlacementFn", "default_expert_classifier", "default_placement_fn"]
+__all__ = [
+    "ExpertClassifierFn",
+    "PlacementFn",
+    "default_expert_classifier",
+    "default_placement_fn",
+]

--- a/experimental/lite/megatron/lite/primitive/quantization/block_fp8.py
+++ b/experimental/lite/megatron/lite/primitive/quantization/block_fp8.py
@@ -69,9 +69,7 @@ def quantize_block_fp8(
 
 
 def dequantize_block_fp8(
-    tensor: torch.Tensor,
-    scale: torch.Tensor,
-    block_shape: tuple[int, int] = (128, 128),
+    tensor: torch.Tensor, scale: torch.Tensor, block_shape: tuple[int, int] = (128, 128)
 ) -> torch.Tensor:
     """Dequantize a tensor emitted by :func:`quantize_block_fp8`."""
     _validate(tensor, block_shape)

--- a/experimental/lite/megatron/lite/primitive/quantization/qat.py
+++ b/experimental/lite/megatron/lite/primitive/quantization/qat.py
@@ -49,18 +49,10 @@ import torch.nn.utils.parametrize as parametrize
 # and the element rounding are defined to be bit-identical to the ModelOpt
 # quantizer the rollout actually runs, so the error QAT compensates during
 # training is the error deployment actually makes.
-from megatron.lite.primitive.quantization.mxfp4 import (
-    E2M1_LEVELS as _E2M1_LEVELS,
-)
-from megatron.lite.primitive.quantization.mxfp4 import (
-    E2M1_MAX as _E2M1_MAX,
-)
-from megatron.lite.primitive.quantization.mxfp4 import (
-    E8M0_BIAS as _E8M0_BIAS,
-)
-from megatron.lite.primitive.quantization.mxfp4 import (
-    MXFP4_BLOCK_SIZE as _MXFP4_BLOCK,
-)
+from megatron.lite.primitive.quantization.mxfp4 import E2M1_LEVELS as _E2M1_LEVELS
+from megatron.lite.primitive.quantization.mxfp4 import E2M1_MAX as _E2M1_MAX
+from megatron.lite.primitive.quantization.mxfp4 import E8M0_BIAS as _E8M0_BIAS
+from megatron.lite.primitive.quantization.mxfp4 import MXFP4_BLOCK_SIZE as _MXFP4_BLOCK
 from megatron.lite.primitive.quantization.mxfp4 import (
     e2m1_round_index as _e2m1_round_index,
 )
@@ -73,12 +65,7 @@ from megatron.lite.primitive.quantization.mxfp4 import (
 
 # Supported formats -> nominal bit-width. Free-form strings are rejected; every
 # enum must map to an exact quant/dequant contract.
-_FORMAT_BITS: dict[str, int] = {
-    "int8": 8,
-    "int4": 4,
-    "fp8_e4m3": 8,
-    "mxfp4": 4,
-}
+_FORMAT_BITS: dict[str, int] = {"int8": 8, "int4": 4, "fp8_e4m3": 8, "mxfp4": 4}
 
 # Canonicalising aliases accepted from configs.
 _FORMAT_ALIASES: dict[str, str] = {"fp8": "fp8_e4m3"}
@@ -167,9 +154,7 @@ class QATSpec:
             object.__setattr__(self, "format", canonical)
         if self.group_size is None:
             object.__setattr__(
-                self,
-                "group_size",
-                _MXFP4_BLOCK if canonical == "mxfp4" else 0,
+                self, "group_size", _MXFP4_BLOCK if canonical == "mxfp4" else 0
             )
         if not self.enabled:
             return
@@ -626,8 +611,7 @@ def _compute_amax_tensor(weight: torch.Tensor, group_size: int) -> torch.Tensor:
     """Per-tensor or per-expert amax for 2D ``[out, in]`` or 3D ``[E, out, in]`` weights."""
     if weight.dim() == 3:
         return torch.stack(
-            [compute_amax(weight[i], group_size) for i in range(weight.shape[0])],
-            dim=0,
+            [compute_amax(weight[i], group_size) for i in range(weight.shape[0])], dim=0
         )
     if weight.dim() != 2:
         raise ValueError(

--- a/experimental/lite/megatron/lite/primitive/recompute.py
+++ b/experimental/lite/megatron/lite/primitive/recompute.py
@@ -65,7 +65,9 @@ class _CheckpointWithoutOutputFn(torch.autograd.Function):
             ctx.cpu_rng_state = torch.get_rng_state()
             ctx.cuda_rng_state = torch.cuda.get_rng_state()
 
-        ctx.tensor_indices = [i for i, a in enumerate(args) if isinstance(a, torch.Tensor)]
+        ctx.tensor_indices = [
+            i for i, a in enumerate(args) if isinstance(a, torch.Tensor)
+        ]
         ctx.non_tensor_args = [
             (i, a) for i, a in enumerate(args) if not isinstance(a, torch.Tensor)
         ]
@@ -87,7 +89,9 @@ class _CheckpointWithoutOutputFn(torch.autograd.Function):
         torch.autograd.backward(outputs, grad_outputs)
         ctx.outputs = None
         ctx.inputs = None
-        grads = tuple(inp.grad if isinstance(inp, torch.Tensor) else None for inp in inputs)
+        grads = tuple(
+            inp.grad if isinstance(inp, torch.Tensor) else None for inp in inputs
+        )
         return (None, None) + grads
 
 
@@ -124,7 +128,9 @@ class CheckpointWithoutOutput:
             self._cuda_rng = torch.cuda.get_rng_state()
 
         outputs = _CheckpointWithoutOutputFn.apply(run_function, self, *args)
-        self.outputs = (outputs,) if isinstance(outputs, torch.Tensor) else tuple(outputs)
+        self.outputs = (
+            (outputs,) if isinstance(outputs, torch.Tensor) else tuple(outputs)
+        )
         return outputs
 
     def _recompute(self, _) -> None:
@@ -207,17 +213,23 @@ def apply_recompute(
                 if mod_name in module_map:
                     submod = module_map[mod_name](layer)
                     if submod is not None:
-                        wrap_checkpoint(submod, preserve_rng_state=mod_name not in no_rng)
+                        wrap_checkpoint(
+                            submod, preserve_rng_state=mod_name not in no_rng
+                        )
 
 
-def apply_offload(layers: nn.ModuleList, module_names: list[str], module_map: ModuleMap) -> None:
+def apply_offload(
+    layers: nn.ModuleList, module_names: list[str], module_map: ModuleMap
+) -> None:
     """Wrap specified sub-modules with activation offloading to CPU."""
     if not module_names:
         return
     try:
         from torch.utils.checkpoint import CheckpointPolicy  # noqa: F401
     except ImportError:
-        log_rank0("WARNING: torch.utils.checkpoint policy_fn not available, skipping offload")
+        log_rank0(
+            "WARNING: torch.utils.checkpoint policy_fn not available, skipping offload"
+        )
         return
     for layer in layers:
         for mod_name in module_names:
@@ -274,7 +286,11 @@ class CheckpointFunction(torch.autograd.Function):
 
         # Recompute forward pass with gradients enabled.
         detached = tuple(
-            t.detach().requires_grad_(t.requires_grad) if isinstance(t, torch.Tensor) else t
+            (
+                t.detach().requires_grad_(t.requires_grad)
+                if isinstance(t, torch.Tensor)
+                else t
+            )
             for t in inputs
         )
         with torch.enable_grad():
@@ -299,7 +315,9 @@ class CheckpointFunction(torch.autograd.Function):
         if outputs_with_grad:
             torch.autograd.backward(outputs_with_grad, grad_for_outputs)
 
-        grads = tuple(inp.grad if isinstance(inp, torch.Tensor) else None for inp in detached)
+        grads = tuple(
+            inp.grad if isinstance(inp, torch.Tensor) else None for inp in detached
+        )
         # None for run_function, None for preserve_rng_state, then grads for each input.
         return (None, None) + grads
 

--- a/experimental/lite/megatron/lite/primitive/train_step.py
+++ b/experimental/lite/megatron/lite/primitive/train_step.py
@@ -8,7 +8,10 @@ from collections.abc import Callable
 import torch
 import torch.distributed as dist
 from megatron.lite.primitive.parallel import ParallelState
-from megatron.lite.primitive.protocols import ExpertClassifierFn, default_expert_classifier
+from megatron.lite.primitive.protocols import (
+    ExpertClassifierFn,
+    default_expert_classifier,
+)
 from megatron.lite.runtime.contracts.loss import split_loss_context, use_loss_context
 
 
@@ -101,7 +104,9 @@ def compute_and_clip_grad_norm(
     if report_global_norm:
         if ps is None:
             raise ValueError("`ps` is required when `report_global_norm=True`.")
-        report_norm = compute_global_grad_norm(model, ps, is_expert_param=is_expert_param)
+        report_norm = compute_global_grad_norm(
+            model, ps, is_expert_param=is_expert_param
+        )
     if use_dist_opt:
         optimizer.finish_grad_sync()
         return optimizer.clip_grad_norm()
@@ -110,7 +115,10 @@ def compute_and_clip_grad_norm(
 
 
 def compute_global_grad_norm(
-    model, ps: ParallelState, *, is_expert_param: ExpertClassifierFn = default_expert_classifier
+    model,
+    ps: ParallelState,
+    *,
+    is_expert_param: ExpertClassifierFn = default_expert_classifier,
 ) -> torch.Tensor:
     """Compute benchmark global grad norm with dist-opt-aligned reduction order."""
     dense_sq = _bucketed_grad_sq_sum(

--- a/experimental/lite/megatron/lite/primitive/utils/moe.py
+++ b/experimental/lite/megatron/lite/primitive/utils/moe.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from typing import Optional, Tuple
 
 import torch
-
 from transformer_engine.pytorch.cpp_extensions import general_gemm
 from transformer_engine.pytorch.module import base as te_module_base
 from transformer_engine.pytorch.permutation import moe_permute as fused_permute
@@ -132,7 +131,9 @@ def permute(
 
         if probs is not None:
             probs_t_1d = probs.T.contiguous().view(-1)
-            indices_dim0 = torch.arange(num_experts, device=routing_map.device).unsqueeze(-1)
+            indices_dim0 = torch.arange(
+                num_experts, device=routing_map.device
+            ).unsqueeze(-1)
             indices_dim1 = sorted_indices.view(num_experts, capacity)
             indices_1d = (indices_dim0 * num_tokens + indices_dim1).view(-1)
             permuted_probs = probs_t_1d.index_select(0, indices_1d)
@@ -190,12 +191,16 @@ def unpermute(
             capacity = num_permuted_tokens // num_experts
             num_unpermuted_tokens = probs.size(0)
             probs_t_1d = probs.T.contiguous().view(-1)
-            indices_dim0 = torch.arange(num_experts, device=routing_map.device).unsqueeze(-1)
+            indices_dim0 = torch.arange(
+                num_experts, device=routing_map.device
+            ).unsqueeze(-1)
             indices_dim1 = sorted_indices.view(num_experts, capacity)
             indices_1d = (indices_dim0 * num_unpermuted_tokens + indices_dim1).view(-1)
             permuted_probs = probs_t_1d.index_select(0, indices_1d)
         else:
-            permuted_probs = probs.T.contiguous().masked_select(routing_map.T.contiguous())
+            permuted_probs = probs.T.contiguous().masked_select(
+                routing_map.T.contiguous()
+            )
         permuted_tokens = permuted_tokens * permuted_probs.unsqueeze(-1)
 
     output_tokens = torch.zeros(
@@ -219,7 +224,9 @@ def group_limited_topk(
     group_topk: int,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     group_scores = (
-        scores.view(num_tokens, num_groups, -1).topk(topk // group_topk, dim=-1)[0].sum(dim=-1)
+        scores.view(num_tokens, num_groups, -1)
+        .topk(topk // group_topk, dim=-1)[0]
+        .sum(dim=-1)
     )
     group_idx = torch.topk(group_scores, k=group_topk, dim=-1, sorted=False)[1]
     group_mask = torch.zeros_like(group_scores)
@@ -245,7 +252,9 @@ def topk_routing_with_score_function(
     fused: bool = False,
     dense_output: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    assert logits.dim() == 2, f"Expected 2D logits [num_tokens, num_experts], got {logits.dim()}."
+    assert (
+        logits.dim() == 2
+    ), f"Expected 2D logits [num_tokens, num_experts], got {logits.dim()}."
     num_tokens, num_experts = logits.shape
     if fused:
         return fused_topk_with_score_function(
@@ -291,11 +300,15 @@ def topk_routing_with_score_function(
             scores = torch.nn.functional.softplus(logits.float()).sqrt()
         if expert_bias is not None:
             scores_for_routing = scores + expert_bias.float()
-            _, top_indices = compute_topk(scores_for_routing, topk, num_groups, group_topk)
+            _, top_indices = compute_topk(
+                scores_for_routing, topk, num_groups, group_topk
+            )
             scores = torch.gather(scores, dim=1, index=top_indices)
         else:
             scores, top_indices = compute_topk(scores, topk, num_groups, group_topk)
-        probs = scores / (scores.sum(dim=-1, keepdim=True) + 1e-20) if topk > 1 else scores
+        probs = (
+            scores / (scores.sum(dim=-1, keepdim=True) + 1e-20) if topk > 1 else scores
+        )
     else:
         raise ValueError(f"Invalid score_function: {score_function}")
 
@@ -312,7 +325,9 @@ def topk_routing_with_score_function(
         routing_probs.index_put_((rows, top_indices), probs, accumulate=False)
         routing_map = torch.zeros_like(logits, dtype=logits.dtype)
         routing_map.index_put_(
-            (rows, top_indices), torch.ones_like(probs, dtype=routing_map.dtype), accumulate=False
+            (rows, top_indices),
+            torch.ones_like(probs, dtype=routing_map.dtype),
+            accumulate=False,
         )
         routing_map = routing_map.bool()
     else:
@@ -372,7 +387,9 @@ class RouterGatingLinearFunction(torch.autograd.Function):
 
         gemm_out = None
         if router_dtype != torch.float64:
-            gemm_out = _te_general_gemm(weight, inp, router_dtype, layout="TN", bias=bias)
+            gemm_out = _te_general_gemm(
+                weight, inp, router_dtype, layout="TN", bias=bias
+            )
         if gemm_out is not None:
             output = gemm_out[0]
         elif bias is None:
@@ -394,23 +411,40 @@ class RouterGatingLinearFunction(torch.autograd.Function):
         grad_input_out = grad_weight_out = None
         if ctx.router_dtype != torch.float64:
             grad_input_out = _te_general_gemm(
-                weight.to(ctx.router_dtype), grad_output, ctx.router_dtype, layout="NN", grad=True
+                weight.to(ctx.router_dtype),
+                grad_output,
+                ctx.router_dtype,
+                layout="NN",
+                grad=True,
             )
             grad_weight_out = _te_general_gemm(
-                inp.to(ctx.router_dtype), grad_output, ctx.router_dtype, layout="NT", grad=True
+                inp.to(ctx.router_dtype),
+                grad_output,
+                ctx.router_dtype,
+                layout="NT",
+                grad=True,
             )
         if grad_input_out is not None and grad_weight_out is not None:
             grad_input = grad_input_out[0].to(ctx.input_dtype)
             grad_weight = grad_weight_out[0].to(ctx.weight_dtype)
         else:
-            grad_input = torch.mm(grad_output, weight.to(ctx.router_dtype)).to(ctx.input_dtype)
-            grad_weight = torch.mm(grad_output.t(), inp.to(ctx.router_dtype)).to(ctx.weight_dtype)
-        grad_bias = grad_output.sum(dim=0).to(ctx.weight_dtype) if bias is not None else None
+            grad_input = torch.mm(grad_output, weight.to(ctx.router_dtype)).to(
+                ctx.input_dtype
+            )
+            grad_weight = torch.mm(grad_output.t(), inp.to(ctx.router_dtype)).to(
+                ctx.weight_dtype
+            )
+        grad_bias = (
+            grad_output.sum(dim=0).to(ctx.weight_dtype) if bias is not None else None
+        )
         return grad_input.view(*inp_shape), grad_weight, grad_bias, None
 
 
 def router_gating_linear(
-    inp: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor | None, router_dtype: torch.dtype
+    inp: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    router_dtype: torch.dtype,
 ) -> torch.Tensor:
     return RouterGatingLinearFunction.apply(inp, weight, bias, router_dtype)
 

--- a/experimental/lite/megatron/lite/primitive/utils/packed_seq.py
+++ b/experimental/lite/megatron/lite/primitive/utils/packed_seq.py
@@ -29,17 +29,22 @@ class PackedSeqParams:
 
     def __post_init__(self) -> None:
         cu_seqlens = (
-            self.cu_seqlens_q_padded if self.cu_seqlens_q_padded is not None else self.cu_seqlens_q
+            self.cu_seqlens_q_padded
+            if self.cu_seqlens_q_padded is not None
+            else self.cu_seqlens_q
         )
         if isinstance(cu_seqlens, Tensor) and self.total_tokens is not None:
             total_tokens_tensor = torch.tensor(
                 [self.total_tokens], dtype=cu_seqlens.dtype, device=cu_seqlens.device
             )
             cu_seqlens_with_max = torch.cat([cu_seqlens, total_tokens_tensor])
-            seq_lengths = (cu_seqlens_with_max[1:] - cu_seqlens_with_max[:-1]).clamp(min=0)
+            seq_lengths = (cu_seqlens_with_max[1:] - cu_seqlens_with_max[:-1]).clamp(
+                min=0
+            )
             self.seq_idx = (
                 torch.repeat_interleave(
-                    torch.arange(seq_lengths.numel(), device=cu_seqlens.device), seq_lengths
+                    torch.arange(seq_lengths.numel(), device=cu_seqlens.device),
+                    seq_lengths,
                 )
                 .to(torch.int32)
                 .unsqueeze(0)

--- a/experimental/lite/megatron/lite/primitive/utils/rope.py
+++ b/experimental/lite/megatron/lite/primitive/utils/rope.py
@@ -14,7 +14,9 @@ def get_pos_emb_on_this_cp_rank(
     pos_emb: Tensor, seq_dim: int, cp_group: torch.distributed.ProcessGroup
 ) -> Tensor:
     if cp_group is None:
-        raise ValueError("cp_group must be provided to get positional embedding per CP rank")
+        raise ValueError(
+            "cp_group must be provided to get positional embedding per CP rank"
+        )
     cp_size = cp_group.size()
     cp_rank = cp_group.rank()
     cp_idx = torch.tensor(
@@ -118,12 +120,17 @@ def _apply_rotary_pos_emb_thd(
         for i, x in enumerate(sequence_splits):
             seq_start_offset = cu_seqlens[i].item()
             freq_slices.append(
-                _get_thd_freqs_on_this_cp_rank(cp_rank, cp_size, x, freqs, seq_start_offset)
+                _get_thd_freqs_on_this_cp_rank(
+                    cp_rank, cp_size, x, freqs, seq_start_offset
+                )
             )
         freqs_packed = torch.cat(freq_slices, dim=0)
     else:
         freqs_packed = torch.cat(
-            [_get_thd_freqs_on_this_cp_rank(cp_rank, cp_size, x, freqs) for x in sequence_splits],
+            [
+                _get_thd_freqs_on_this_cp_rank(cp_rank, cp_size, x, freqs)
+                for x in sequence_splits
+            ],
             dim=0,
         )
 

--- a/experimental/lite/megatron/lite/primitive/utils/rotary.py
+++ b/experimental/lite/megatron/lite/primitive/utils/rotary.py
@@ -8,9 +8,8 @@ from functools import lru_cache
 from typing import Optional
 
 import torch
-from torch import Tensor, nn
-
 from megatron.lite.primitive.utils.rope import get_pos_emb_on_this_cp_rank
+from torch import Tensor, nn
 
 
 def _default_rope_device(use_cpu_initialization: bool) -> str | torch.device:
@@ -42,10 +41,13 @@ class RotaryEmbedding(nn.Module):
         self.seq_len_interpolation_factor = seq_len_interpolation_factor
         device = _default_rope_device(use_cpu_initialization)
         self.inv_freq = 1.0 / (
-            rotary_base ** (torch.arange(0, dim, 2, dtype=torch.float32, device=device) / dim)
+            rotary_base
+            ** (torch.arange(0, dim, 2, dtype=torch.float32, device=device) / dim)
         )
         if rope_scaling:
-            self.inv_freq = self._apply_scaling(self.inv_freq, factor=rope_scaling_factor)
+            self.inv_freq = self._apply_scaling(
+                self.inv_freq, factor=rope_scaling_factor
+            )
         self.cp_group = cp_group
 
     def _apply_scaling(
@@ -61,9 +63,9 @@ class RotaryEmbedding(nn.Module):
 
         wavelen = 2 * math.pi / freqs
         inv_freq_llama = torch.where(wavelen > low_freq_wavelen, freqs / factor, freqs)
-        smooth_factor = (original_max_position_embeddings / wavelen - low_freq_factor) / (
-            high_freq_factor - low_freq_factor
-        )
+        smooth_factor = (
+            original_max_position_embeddings / wavelen - low_freq_factor
+        ) / (high_freq_factor - low_freq_factor)
         smoothed_inv_freq = (
             1 - smooth_factor
         ) * inv_freq_llama / factor + smooth_factor * inv_freq_llama
@@ -72,7 +74,9 @@ class RotaryEmbedding(nn.Module):
 
     def get_freqs_non_repeated(self, max_seq_len: int, offset: int = 0) -> Tensor:
         seq = (
-            torch.arange(max_seq_len, device=self.inv_freq.device, dtype=self.inv_freq.dtype)
+            torch.arange(
+                max_seq_len, device=self.inv_freq.device, dtype=self.inv_freq.dtype
+            )
             + offset
         )
         if self.seq_len_interpolation_factor is not None:
@@ -149,12 +153,18 @@ class YarnRotaryEmbedding(RotaryEmbedding):
         device = _default_rope_device(use_cpu_initialization)
         self.inv_freq_extra = 1.0 / (
             self.rotary_base
-            ** (torch.arange(0, self.dim, 2, dtype=torch.float32, device=device) / self.dim)
+            ** (
+                torch.arange(0, self.dim, 2, dtype=torch.float32, device=device)
+                / self.dim
+            )
         )
         self.inv_freq_inter = 1.0 / (
             self.scaling_factor
             * self.rotary_base
-            ** (torch.arange(0, self.dim, 2, dtype=torch.float32, device=device) / self.dim)
+            ** (
+                torch.arange(0, self.dim, 2, dtype=torch.float32, device=device)
+                / self.dim
+            )
         )
         super().__init__(
             kv_channels=kv_channels,
@@ -166,17 +176,25 @@ class YarnRotaryEmbedding(RotaryEmbedding):
             cp_group=cp_group,
         )
         self._set_cos_sin_cache(
-            self.original_max_position_embeddings, offset=0, dtype=torch.get_default_dtype()
+            self.original_max_position_embeddings,
+            offset=0,
+            dtype=torch.get_default_dtype(),
         )
         self.forward.cache_clear()
 
     def get_emb(self, max_seq_len: int, offset: int = 0) -> tuple[Tensor, float]:
         if self.rotary_interleaved:
-            raise AssertionError("YARN RoPE does not support interleaved rotary embeddings")
+            raise AssertionError(
+                "YARN RoPE does not support interleaved rotary embeddings"
+            )
         if self.inv_freq_extra.device.type == "cpu" and torch.cuda.is_available():
-            self.inv_freq_extra = self.inv_freq_extra.to(device=torch.cuda.current_device())
+            self.inv_freq_extra = self.inv_freq_extra.to(
+                device=torch.cuda.current_device()
+            )
         if self.inv_freq_inter.device.type == "cpu" and torch.cuda.is_available():
-            self.inv_freq_inter = self.inv_freq_inter.to(device=torch.cuda.current_device())
+            self.inv_freq_inter = self.inv_freq_inter.to(
+                device=torch.cuda.current_device()
+            )
 
         low, high = _yarn_find_correction_range(
             self.beta_fast,
@@ -189,10 +207,15 @@ class YarnRotaryEmbedding(RotaryEmbedding):
         inv_freq_mask = 1.0 - _yarn_linear_ramp_mask(
             low, high, self.dim // 2, device=self.inv_freq_extra.device
         ).to(dtype=torch.float32)
-        inv_freq = self.inv_freq_inter * (1 - inv_freq_mask) + self.inv_freq_extra * inv_freq_mask
+        inv_freq = (
+            self.inv_freq_inter * (1 - inv_freq_mask)
+            + self.inv_freq_extra * inv_freq_mask
+        )
         seq = (
             torch.arange(
-                max_seq_len, device=self.inv_freq_extra.device, dtype=self.inv_freq_extra.dtype
+                max_seq_len,
+                device=self.inv_freq_extra.device,
+                dtype=self.inv_freq_extra.dtype,
             )
             + offset
         )
@@ -218,21 +241,34 @@ class YarnRotaryEmbedding(RotaryEmbedding):
             emb = get_pos_emb_on_this_cp_rank(emb, 0, cp_group)
         return emb, concentration
 
-    def _set_cos_sin_cache(self, seq_len, offset, dtype, packed_seq=False, cp_group=None):
+    def _set_cos_sin_cache(
+        self, seq_len, offset, dtype, packed_seq=False, cp_group=None
+    ):
         self.max_seq_len_cached = seq_len
         self.offset_cached = offset
         self.dtype_cached = dtype
         self.packed_seq_cached = packed_seq
-        emb, concentration = self.forward(seq_len, offset, packed_seq=packed_seq, cp_group=cp_group)
-        self.register_buffer(
-            "cos_cached", (emb.cos() * concentration).to(dtype).contiguous(), persistent=False
+        emb, concentration = self.forward(
+            seq_len, offset, packed_seq=packed_seq, cp_group=cp_group
         )
         self.register_buffer(
-            "sin_cached", (emb.sin() * concentration).to(dtype).contiguous(), persistent=False
+            "cos_cached",
+            (emb.cos() * concentration).to(dtype).contiguous(),
+            persistent=False,
+        )
+        self.register_buffer(
+            "sin_cached",
+            (emb.sin() * concentration).to(dtype).contiguous(),
+            persistent=False,
         )
 
     def get_cached_cos_sin(
-        self, seq_len, offset=0, dtype=torch.get_default_dtype(), packed_seq=False, cp_group=None
+        self,
+        seq_len,
+        offset=0,
+        dtype=torch.get_default_dtype(),
+        packed_seq=False,
+        cp_group=None,
     ):
         if (
             seq_len > self.max_seq_len_cached
@@ -245,7 +281,10 @@ class YarnRotaryEmbedding(RotaryEmbedding):
 
 
 def _yarn_find_correction_dim(
-    num_rotations: float, dim: int, rotary_base: float = 10000, max_position_embeddings: int = 2048
+    num_rotations: float,
+    dim: int,
+    rotary_base: float = 10000,
+    max_position_embeddings: int = 2048,
 ) -> float:
     return (dim * math.log(max_position_embeddings / (num_rotations * 2 * math.pi))) / (
         2 * math.log(rotary_base)
@@ -261,7 +300,9 @@ def _yarn_find_correction_range(
     round_to_int: bool = True,
 ) -> tuple[int, int]:
     low = _yarn_find_correction_dim(low_rot, dim, rotary_base, max_position_embeddings)
-    high = _yarn_find_correction_dim(high_rot, dim, rotary_base, max_position_embeddings)
+    high = _yarn_find_correction_dim(
+        high_rot, dim, rotary_base, max_position_embeddings
+    )
     if round_to_int:
         low = math.floor(low)
         high = math.ceil(high)
@@ -292,7 +333,8 @@ def _yarn_get_concentration_factor(
     if mscale is None or mscale_all_dim is None:
         return _yarn_get_mscale(scaling_factor)
     return float(
-        _yarn_get_mscale(scaling_factor, mscale) / _yarn_get_mscale(scaling_factor, mscale_all_dim)
+        _yarn_get_mscale(scaling_factor, mscale)
+        / _yarn_get_mscale(scaling_factor, mscale_all_dim)
     )
 
 

--- a/experimental/lite/megatron/lite/runtime/backends/__init__.py
+++ b/experimental/lite/megatron/lite/runtime/backends/__init__.py
@@ -28,7 +28,6 @@ from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     import torch
-
     from megatron.lite.runtime.contracts.data import ForwardResult
     from megatron.lite.runtime.contracts.handle import ModelHandle
 
@@ -44,7 +43,9 @@ class Runtime(ABC):
     # Model lifecycle
 
     @abstractmethod
-    def build_model(self, hf_path: str | None = None, cfg: Any = None, **kwargs) -> ModelHandle:
+    def build_model(
+        self, hf_path: str | None = None, cfg: Any = None, **kwargs
+    ) -> ModelHandle:
         """Build model state for this runtime.
 
         Implementations should default to the ``hf_path`` / ``backend_cfg``
@@ -120,7 +121,9 @@ class Runtime(ABC):
 
     # ── L2: RL Ready (覆盖即解锁) ───────────────────────────────
 
-    def export_weights(self, handle: ModelHandle, **kwargs) -> Iterator[tuple[str, torch.Tensor]]:
+    def export_weights(
+        self, handle: ModelHandle, **kwargs
+    ) -> Iterator[tuple[str, torch.Tensor]]:
         """Iterate over (name, tensor) pairs for HF-compatible weight export.
 
         Required by RL frameworks to send weights to the inference engine.

--- a/experimental/lite/megatron/lite/runtime/backends/bridge/config.py
+++ b/experimental/lite/megatron/lite/runtime/backends/bridge/config.py
@@ -6,7 +6,11 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig, pick_fields
+from megatron.lite.runtime.contracts.config import (
+    OptimizerConfig,
+    ParallelConfig,
+    pick_fields,
+)
 
 
 @dataclass
@@ -53,7 +57,9 @@ class BridgeConfig:
 
         parallel_src = cfg.get("parallel")
         parallel_data = (
-            pick_fields(ParallelConfig, parallel_src) if isinstance(parallel_src, dict) else {}
+            pick_fields(ParallelConfig, parallel_src)
+            if isinstance(parallel_src, dict)
+            else {}
         )
         parallel_data.update(pick_fields(ParallelConfig, cfg))
         parallel = ParallelConfig(**parallel_data)

--- a/experimental/lite/megatron/lite/runtime/backends/bridge/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/bridge/runtime.py
@@ -11,10 +11,17 @@ from typing import Any
 
 import torch
 import torch.distributed as dist
-from megatron.lite.primitive.optimizers.megatron_wrap import build_dist_opt_optimizer_config
+from megatron.lite.primitive.optimizers.megatron_wrap import (
+    build_dist_opt_optimizer_config,
+)
 from megatron.lite.runtime.backends import Runtime as RuntimeBase
 from megatron.lite.runtime.backends.bridge.config import BridgeConfig
-from megatron.lite.runtime.contracts.data import Batch, ForwardResult, ModelOutputs, PackedBatch
+from megatron.lite.runtime.contracts.data import (
+    Batch,
+    ForwardResult,
+    ModelOutputs,
+    PackedBatch,
+)
 from megatron.lite.runtime.contracts.handle import ModelHandle
 from megatron.lite.runtime.megatron_utils import (
     build_sharded_state_dict,
@@ -128,7 +135,9 @@ def _configure_provider(provider, cfg: BridgeConfig) -> None:
 def _register_bridge_compat_aliases() -> None:
     """Register local Megatron-Bridge aliases for supported checkpoint variants."""
     from megatron.bridge.models.conversion import model_bridge
-    from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
+    from megatron.bridge.models.conversion.mapping_registry import (
+        MegatronMappingRegistry,
+    )
     from megatron.bridge.models.conversion.param_mapping import (
         AutoMapping,
         GatedMLPMapping,
@@ -148,7 +157,8 @@ def _register_bridge_compat_aliases() -> None:
 
         def __init__(self, megatron_param: str, qkv: str, z: str, b: str, a: str):
             super().__init__(
-                megatron_param=megatron_param, hf_param={"qkv": qkv, "z": z, "b": b, "a": a}
+                megatron_param=megatron_param,
+                hf_param={"qkv": qkv, "z": z, "b": b, "a": a},
             )
             self._tp_mapping = AutoMapping(megatron_param, megatron_param)
 
@@ -159,12 +169,16 @@ def _register_bridge_compat_aliases() -> None:
                 config = self._get_config(megatron_module)
                 qkvz = torch.cat([hf_weights["qkv"], hf_weights["z"]], dim=0)
                 ba = torch.cat([hf_weights["b"], hf_weights["a"]], dim=0)
-                merged = merge_gdn_linear_weights(config, qkvz, ba, tp_size=self.tp_size)
+                merged = merge_gdn_linear_weights(
+                    config, qkvz, ba, tp_size=self.tp_size
+                )
             else:
                 merged = None
             return self._tp_mapping.hf_to_megatron(merged, megatron_module)
 
-        def megatron_to_hf(self, megatron_weights, megatron_module) -> dict[str, torch.Tensor]:
+        def megatron_to_hf(
+            self, megatron_weights, megatron_module
+        ) -> dict[str, torch.Tensor]:
             if megatron_weights is not None:
                 megatron_weights = self.maybe_dequantize(megatron_weights)
 
@@ -174,7 +188,9 @@ def _register_bridge_compat_aliases() -> None:
                 config = self._get_config(megatron_module)
                 config = self.broadcast_obj_from_pp_rank(config)
 
-            packed_dict = self._tp_mapping.megatron_to_hf(megatron_weights, megatron_module)
+            packed_dict = self._tp_mapping.megatron_to_hf(
+                megatron_weights, megatron_module
+            )
             if not packed_dict:
                 return {}
 
@@ -194,7 +210,11 @@ def _register_bridge_compat_aliases() -> None:
         def resolve(self, captures):
             megatron_param, hf_param = self._resolve_names(captures)
             return type(self)(
-                megatron_param, hf_param["qkv"], hf_param["z"], hf_param["b"], hf_param["a"]
+                megatron_param,
+                hf_param["qkv"],
+                hf_param["z"],
+                hf_param["b"],
+                hf_param["a"],
             )
 
     class Qwen35PackedExpertDownMapping(AutoMapping):
@@ -202,16 +222,22 @@ def _register_bridge_compat_aliases() -> None:
 
         def __init__(self, megatron_param: str, hf_param: str, permute_dims=None):
             super().__init__(
-                megatron_param=megatron_param, hf_param=hf_param, permute_dims=permute_dims
+                megatron_param=megatron_param,
+                hf_param=hf_param,
+                permute_dims=permute_dims,
             )
             self.allow_hf_name_mismatch = True
 
-        def hf_to_megatron(self, hf_weights: torch.Tensor, megatron_module) -> torch.Tensor:
+        def hf_to_megatron(
+            self, hf_weights: torch.Tensor, megatron_module
+        ) -> torch.Tensor:
             expert_number = extract_expert_number_from_param(self.megatron_param)
             expert_weight = hf_weights[expert_number].contiguous()
             return super().hf_to_megatron(expert_weight, megatron_module)
 
-        def megatron_to_hf(self, megatron_weights, megatron_module) -> dict[str, torch.Tensor]:
+        def megatron_to_hf(
+            self, megatron_weights, megatron_module
+        ) -> dict[str, torch.Tensor]:
             converted = super().megatron_to_hf(megatron_weights, megatron_module)
             return converted
 
@@ -221,7 +247,9 @@ def _register_bridge_compat_aliases() -> None:
     class Qwen35RouterMapping(AutoMapping):
         """Bridge mapping for Qwen3.5 router weights with bench expert truncation."""
 
-        def hf_to_megatron(self, hf_weights: torch.Tensor, megatron_module) -> torch.Tensor:
+        def hf_to_megatron(
+            self, hf_weights: torch.Tensor, megatron_module
+        ) -> torch.Tensor:
             config = self._get_config(megatron_module)
             num_experts = getattr(config, "num_moe_experts", None)
             if num_experts is not None and hf_weights.shape[0] != num_experts:
@@ -233,7 +261,9 @@ def _register_bridge_compat_aliases() -> None:
 
         def __init__(self, megatron_param: str, hf_param: str, permute_dims=None):
             super().__init__(
-                megatron_param=megatron_param, hf_param=hf_param, permute_dims=permute_dims
+                megatron_param=megatron_param,
+                hf_param=hf_param,
+                permute_dims=permute_dims,
             )
             self.allow_hf_name_mismatch = True
             GatedMLPMapping._validate_patterns = lambda *args, **kwargs: None
@@ -243,14 +273,22 @@ def _register_bridge_compat_aliases() -> None:
                 up=f"{self.hf_param}.up",
             )
 
-        def hf_to_megatron(self, hf_weights: torch.Tensor, megatron_module) -> torch.Tensor:
+        def hf_to_megatron(
+            self, hf_weights: torch.Tensor, megatron_module
+        ) -> torch.Tensor:
             expert_number = extract_expert_number_from_param(self.megatron_param)
             expert_weight = hf_weights[expert_number].contiguous()
             gate, up = torch.chunk(expert_weight, 2, dim=0)
-            return self._gated_mapping.hf_to_megatron({"gate": gate, "up": up}, megatron_module)
+            return self._gated_mapping.hf_to_megatron(
+                {"gate": gate, "up": up}, megatron_module
+            )
 
-        def megatron_to_hf(self, megatron_weights, megatron_module) -> dict[str, torch.Tensor]:
-            converted = self._gated_mapping.megatron_to_hf(megatron_weights, megatron_module)
+        def megatron_to_hf(
+            self, megatron_weights, megatron_module
+        ) -> dict[str, torch.Tensor]:
+            converted = self._gated_mapping.megatron_to_hf(
+                megatron_weights, megatron_module
+            )
             if not converted:
                 return {}
 
@@ -472,7 +510,10 @@ def _build_ddp_config(cfg: BridgeConfig):
 
 def _resolve_benchmark_protocol(cfg: BridgeConfig, bridge) -> Any | None:
     """Best-effort protocol lookup for model stats used by bench examples."""
-    from megatron.lite.model.registry import get_train_runtime_module, resolve_model_type_from_hf
+    from megatron.lite.model.registry import (
+        get_train_runtime_module,
+        resolve_model_type_from_hf,
+    )
 
     model_name = cfg.model_name
     if model_name == "auto":
@@ -548,7 +589,9 @@ def _bridge_forward_kwargs_from_packed_batch(
         split_cp=False,
         labels=_nested_from_packed(batch.labels, seq_lens),
         roll_labels=batch.labels is not None,
-        loss_mask=_nested_from_packed(batch.loss_mask, seq_lens) if has_loss_mask else None,
+        loss_mask=(
+            _nested_from_packed(batch.loss_mask, seq_lens) if has_loss_mask else None
+        ),
         roll_loss_mask=has_loss_mask,
     )
     sample: dict[str, Any] = {
@@ -574,6 +617,8 @@ def _bridge_forward_kwargs_from_packed_batch(
             if tensor is not None or key in sample:
                 sample[key] = tensor
     return sample
+
+
 # MLITE_LAYERING_ALLOW_BRIDGE_FORWARD_METADATA_END
 
 
@@ -592,9 +637,13 @@ def _bridge_forward_kwargs_bshd(batch: PackedBatch) -> dict[str, Any]:
     return {
         "input_ids": batch.input_ids.reshape(1, total).contiguous(),
         "labels": (
-            batch.labels.reshape(1, total).contiguous() if batch.labels is not None else None
+            batch.labels.reshape(1, total).contiguous()
+            if batch.labels is not None
+            else None
         ),
-        "attention_mask": torch.ones((1, total), dtype=torch.long, device=batch.input_ids.device),
+        "attention_mask": torch.ones(
+            (1, total), dtype=torch.long, device=batch.input_ids.device
+        ),
     }
 
 
@@ -603,12 +652,17 @@ class BridgeRuntime(RuntimeBase):
 
     def __init__(self, hf_path: str, cfg: BridgeConfig | dict[str, Any]):
         self._hf_path = hf_path
-        self._cfg = cfg if isinstance(cfg, BridgeConfig) else BridgeConfig.from_dict(cfg)
+        self._cfg = (
+            cfg if isinstance(cfg, BridgeConfig) else BridgeConfig.from_dict(cfg)
+        )
         self._offload_param = self._cfg.param_offload
         self._offload_optimizer = self._cfg.optimizer_offload
 
     def build_model(
-        self, hf_path: str | None = None, cfg: BridgeConfig | dict[str, Any] | None = None, **kwargs
+        self,
+        hf_path: str | None = None,
+        cfg: BridgeConfig | dict[str, Any] | None = None,
+        **kwargs,
     ) -> ModelHandle:
         from megatron.core import parallel_state as mpu
         from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
@@ -644,7 +698,8 @@ class BridgeRuntime(RuntimeBase):
 
         bridge = _build_bridge(hf_path, rt_cfg)
         provider = bridge.to_megatron_provider(
-            load_weights=rt_cfg.load_hf_weights, hf_path=hf_path if rt_cfg.load_hf_weights else None
+            load_weights=rt_cfg.load_hf_weights,
+            hf_path=hf_path if rt_cfg.load_hf_weights else None,
         )
         _configure_provider(provider, rt_cfg)
         if hasattr(provider, "finalize"):
@@ -657,8 +712,12 @@ class BridgeRuntime(RuntimeBase):
             bf16=True,
         )
 
-        optimizer = _build_optimizer(model_list, rt_cfg) if rt_cfg.build_optimizer else None
-        lr_scheduler = _build_lr_scheduler(optimizer, rt_cfg) if optimizer is not None else None
+        optimizer = (
+            _build_optimizer(model_list, rt_cfg) if rt_cfg.build_optimizer else None
+        )
+        lr_scheduler = (
+            _build_lr_scheduler(optimizer, rt_cfg) if optimizer is not None else None
+        )
         register_training_hooks(model_list, optimizer)
 
         if self._offload_param:
@@ -666,7 +725,13 @@ class BridgeRuntime(RuntimeBase):
         if self._offload_optimizer and optimizer is not None:
             offload_optimizer(optimizer)
 
-        logger.info("BridgeRuntime: model built, tp=%d ep=%d pp=%d cp=%d", p.tp, p.ep, p.pp, p.cp)
+        logger.info(
+            "BridgeRuntime: model built, tp=%d ep=%d pp=%d cp=%d",
+            p.tp,
+            p.ep,
+            p.pp,
+            p.cp,
+        )
 
         return ModelHandle(
             model=model_list[0],
@@ -721,15 +786,14 @@ class BridgeRuntime(RuntimeBase):
             owns_transient_metadata = False
             if isinstance(sample, PackedBatch):
                 if self._cfg.use_thd:
-                    sample = _bridge_forward_kwargs_from_packed_batch(sample, **cp_kwargs)
+                    sample = _bridge_forward_kwargs_from_packed_batch(
+                        sample, **cp_kwargs
+                    )
                     owns_transient_metadata = True
                 else:
                     sample = _bridge_forward_kwargs_bshd(sample)
             elif isinstance(sample, Batch):
-                sample = {
-                    "input_ids": sample["input_ids"],
-                    "labels": sample["labels"],
-                }
+                sample = {"input_ids": sample["input_ids"], "labels": sample["labels"]}
             if not isinstance(sample, dict):
                 raise TypeError(
                     f"BridgeRuntime expected dict or Batch data, got {type(sample).__name__}."
@@ -761,7 +825,9 @@ class BridgeRuntime(RuntimeBase):
 
             def _bridge_loss_fn(output_tensor, non_loss_data=False):
                 if loss_fn is not None:
-                    loss, _metrics = loss_fn({"output_tensor": output_tensor}, loss_sample)
+                    loss, _metrics = loss_fn(
+                        {"output_tensor": output_tensor}, loss_sample
+                    )
                 else:
                     loss = output_tensor.mean()
                 last_loss[0] = float(loss.detach().item())
@@ -794,7 +860,9 @@ class BridgeRuntime(RuntimeBase):
 
         result_loss = torch.tensor(loss_val or 0.0)
         return ForwardResult(
-            model_output=ModelOutputs(loss=result_loss, vocab_parallel_logits=last_output[0]),
+            model_output=ModelOutputs(
+                loss=result_loss, vocab_parallel_logits=last_output[0]
+            ),
             metrics={"loss": loss_val if loss_val is not None else 0.0},
         )
 
@@ -844,7 +912,9 @@ class BridgeRuntime(RuntimeBase):
             if optimizer and opt is not None:
                 offload_optimizer(opt)
         else:
-            raise ValueError(f"BridgeRuntime.to supports only 'cpu' or 'cuda', got {device!r}.")
+            raise ValueError(
+                f"BridgeRuntime.to supports only 'cpu' or 'cuda', got {device!r}."
+            )
 
     def train_mode(self, handle: ModelHandle):
         return _BridgeTrainCtx(self, handle)
@@ -852,7 +922,9 @@ class BridgeRuntime(RuntimeBase):
     def eval_mode(self, handle: ModelHandle):
         return _BridgeEvalCtx(self, handle)
 
-    def export_weights(self, handle: ModelHandle, **kwargs) -> Iterator[tuple[str, torch.Tensor]]:
+    def export_weights(
+        self, handle: ModelHandle, **kwargs
+    ) -> Iterator[tuple[str, torch.Tensor]]:
         bridge = handle._extras["bridge"]
         model_list = handle._extras["model_list"]
         load_model_to_gpu(model_list, load_grad=False)
@@ -928,7 +1000,9 @@ class _BridgeEvalCtx:
 
     def __enter__(self):
         if self._runtime._offload_param:
-            self._runtime.to(self._handle, "cuda", model=True, optimizer=False, grad=False)
+            self._runtime.to(
+                self._handle, "cuda", model=True, optimizer=False, grad=False
+            )
         for model in self._handle._extras["model_list"]:
             model.eval()
         torch.set_grad_enabled(False)
@@ -937,7 +1011,9 @@ class _BridgeEvalCtx:
     def __exit__(self, *exc):
         torch.set_grad_enabled(self._prev_grad)
         if self._runtime._offload_param:
-            self._runtime.to(self._handle, "cpu", model=True, optimizer=False, grad=False)
+            self._runtime.to(
+                self._handle, "cpu", model=True, optimizer=False, grad=False
+            )
         return False
 
 

--- a/experimental/lite/megatron/lite/runtime/backends/mbridge/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mbridge/runtime.py
@@ -10,7 +10,6 @@ from typing import Any
 
 import torch
 import torch.distributed as dist
-
 from megatron.lite.runtime.backends.bridge.config import BridgeConfig
 from megatron.lite.runtime.backends.bridge.runtime import (
     BridgeRuntime,
@@ -33,7 +32,6 @@ logger = logging.getLogger(__name__)
 def _build_mbridge(hf_path: str, cfg: BridgeConfig):
     """Build the legacy mbridge AutoBridge lazily from an HF model path."""
     from mbridge import AutoBridge
-
     from megatron.lite.primitive.deterministic import deterministic_requested
 
     bridge = AutoBridge.from_pretrained(hf_path, trust_remote_code=True)
@@ -44,7 +42,9 @@ def _build_mbridge(hf_path: str, cfg: BridgeConfig):
         bridge.set_extra_args(**transformer_overrides)
 
     if not hasattr(bridge.hf_config, "rope_theta"):
-        bridge.hf_config.rope_theta = bridge.hf_config.to_dict().get("rope_theta", 1000000.0)
+        bridge.hf_config.rope_theta = bridge.hf_config.to_dict().get(
+            "rope_theta", 1000000.0
+        )
 
     bridge.set_extra_args(bf16=True, fp16=False)
 
@@ -61,7 +61,10 @@ def _build_mbridge(hf_path: str, cfg: BridgeConfig):
 
 def _resolve_mbridge_benchmark_protocol(cfg: BridgeConfig, bridge) -> Any | None:
     """Best-effort protocol lookup for model stats used by bench examples."""
-    from megatron.lite.model.registry import get_train_runtime_module, resolve_model_type_from_hf
+    from megatron.lite.model.registry import (
+        get_train_runtime_module,
+        resolve_model_type_from_hf,
+    )
 
     model_name = cfg.model_name
     if model_name == "auto":
@@ -80,7 +83,10 @@ class MBridgeRuntime(BridgeRuntime):
     """mbridge training backend using Megatron-Core optimizer state."""
 
     def build_model(
-        self, hf_path: str | None = None, cfg: BridgeConfig | dict[str, Any] | None = None, **kwargs
+        self,
+        hf_path: str | None = None,
+        cfg: BridgeConfig | dict[str, Any] | None = None,
+        **kwargs,
     ) -> ModelHandle:
         from megatron.core import parallel_state as mpu
         from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
@@ -124,13 +130,19 @@ class MBridgeRuntime(BridgeRuntime):
         ddp_config.update(rt_cfg.override_ddp_config)
 
         model_list = bridge.get_model(
-            model_type=ModelType.encoder_or_decoder, wrap_with_ddp=True, ddp_config=ddp_config
+            model_type=ModelType.encoder_or_decoder,
+            wrap_with_ddp=True,
+            ddp_config=ddp_config,
         )
         if rt_cfg.load_hf_weights:
             bridge.load_weights(model_list, hf_path, memory_efficient=True)
 
-        optimizer = _build_optimizer(model_list, rt_cfg) if rt_cfg.build_optimizer else None
-        lr_scheduler = _build_lr_scheduler(optimizer, rt_cfg) if optimizer is not None else None
+        optimizer = (
+            _build_optimizer(model_list, rt_cfg) if rt_cfg.build_optimizer else None
+        )
+        lr_scheduler = (
+            _build_lr_scheduler(optimizer, rt_cfg) if optimizer is not None else None
+        )
         register_training_hooks(model_list, optimizer)
 
         if self._offload_param:
@@ -138,7 +150,13 @@ class MBridgeRuntime(BridgeRuntime):
         if self._offload_optimizer and optimizer is not None:
             offload_optimizer(optimizer)
 
-        logger.info("MBridgeRuntime: model built, tp=%d ep=%d pp=%d cp=%d", p.tp, p.ep, p.pp, p.cp)
+        logger.info(
+            "MBridgeRuntime: model built, tp=%d ep=%d pp=%d cp=%d",
+            p.tp,
+            p.ep,
+            p.pp,
+            p.cp,
+        )
 
         return ModelHandle(
             model=model_list[0],
@@ -157,7 +175,9 @@ class MBridgeRuntime(BridgeRuntime):
             },
         )
 
-    def export_weights(self, handle: ModelHandle, **kwargs) -> Iterator[tuple[str, torch.Tensor]]:
+    def export_weights(
+        self, handle: ModelHandle, **kwargs
+    ) -> Iterator[tuple[str, torch.Tensor]]:
         bridge = handle._extras["bridge"]
         model_list = handle._extras["model_list"]
         load_model_to_gpu(model_list, load_grad=False)

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/config.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/config.py
@@ -6,7 +6,11 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig, pick_fields
+from megatron.lite.runtime.contracts.config import (
+    OptimizerConfig,
+    ParallelConfig,
+    pick_fields,
+)
 
 
 @dataclass(slots=True)
@@ -68,8 +72,12 @@ class MegatronLiteConfig:
             if isinstance(opt_d, dict)
             else OptimizerConfig()
         )
-        if isinstance(opt_d, dict) and isinstance(opt_d.get("override_optimizer_config"), dict):
-            optimizer.override_optimizer_config = dict(opt_d["override_optimizer_config"])
+        if isinstance(opt_d, dict) and isinstance(
+            opt_d.get("override_optimizer_config"), dict
+        ):
+            optimizer.override_optimizer_config = dict(
+                opt_d["override_optimizer_config"]
+            )
 
         # impl_cfg: merge nested dict + top-level overrides
         impl_cfg: dict[str, Any] = {}

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/dynamic_cp.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/dynamic_cp.py
@@ -305,17 +305,12 @@ def _select_context(
             "Dynamic CP cannot merge incompatible per-sample loss policies."
         )
     return replace(
-        first,
-        source_batch=_merge_source([source for _, source in selected], device),
+        first, source_batch=_merge_source([source for _, source in selected], device)
     )
 
 
 def _select_batch(
-    samples: list[dict[str, Any]],
-    ids: list[int],
-    *,
-    cp_size: int,
-    leader: bool,
+    samples: list[dict[str, Any]], ids: list[int], *, cp_size: int, leader: bool
 ) -> PackedBatch:
     selected = [samples[index] for index in ids]
 
@@ -372,12 +367,7 @@ def _context_parallel_modules(model: Any) -> list[Any]:
             setter = getattr(module, "set_context_parallel_group", None)
             if callable(setter) and all(
                 hasattr(module, name)
-                for name in (
-                    "cp_group",
-                    "cp_global_ranks",
-                    "cp_stream",
-                    "cp_comm_type",
-                )
+                for name in ("cp_group", "cp_global_ranks", "cp_stream", "cp_comm_type")
             ):
                 found.append(module)
                 seen.add(id(module))
@@ -655,9 +645,7 @@ class DynamicCPPlugin:
     """Runtime-instance sidecar implementing logical-DP=1 Dynamic CP."""
 
     def __init__(
-        self,
-        config: Mapping[str, Any],
-        create_groups: Callable | None = None,
+        self, config: Mapping[str, Any], create_groups: Callable | None = None
     ):
         if not isinstance(config, Mapping):
             raise TypeError("dynamic_context_parallel plugin config must be a mapping.")
@@ -666,8 +654,7 @@ class DynamicCPPlugin:
             raise ValueError("Dynamic CP requires max_seqlen_per_dp_cp_rank >= 1.")
         self.max_length = max_length
         self.minimum = _positive_power_of_two(
-            int(config.get("min_context_parallel_size", 1)),
-            "min_context_parallel_size",
+            int(config.get("min_context_parallel_size", 1)), "min_context_parallel_size"
         )
         require_coverage = config.get("require_full_cp_size_coverage", False)
         if type(require_coverage) is not bool:
@@ -724,11 +711,7 @@ class DynamicCPPlugin:
         return handle
 
     def _prepare(
-        self,
-        handle: Any,
-        data: Any,
-        loss_fn: Callable | None,
-        num_microbatches: int,
+        self, handle: Any, data: Any, loss_fn: Callable | None, num_microbatches: int
     ) -> _Prepared:
         if self._groups is None or self._pool is None:
             raise RuntimeError(
@@ -944,11 +927,7 @@ class DynamicCPPlugin:
                 if collect_outputs and bool(batch.extras[_GROUP_LEADER]):
                     records.append(
                         _record_output(
-                            output,
-                            batch,
-                            loss * output_loss_scale,
-                            metrics,
-                            extractor,
+                            output, batch, loss * output_loss_scale, metrics, extractor
                         )
                     )
                 # DDP still reduces over the physical pool. A sample computed by

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/router_replay.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/router_replay.py
@@ -70,7 +70,9 @@ class RouterReplayDriver:
             attach_router_replay(root, reset=False) for root in self._replay_roots()
         )
         if self._num_routers == 0:
-            raise RuntimeError("router replay requested but the model has no MoE routers.")
+            raise RuntimeError(
+                "router replay requested but the model has no MoE routers."
+            )
         self._ps = parallel_state_from_model(self._chunks[-1])
         self._compute_pp_layout()
         if self.action == "record":
@@ -81,7 +83,9 @@ class RouterReplayDriver:
         if ps is None or ps.pp_size <= 1:
             self._pp_total = self._num_routers
             return
-        counts = [torch.zeros(1, dtype=torch.long, device="cuda") for _ in range(ps.pp_size)]
+        counts = [
+            torch.zeros(1, dtype=torch.long, device="cuda") for _ in range(ps.pp_size)
+        ]
         dist.all_gather(
             counts,
             torch.tensor([self._num_routers], dtype=torch.long, device="cuda"),
@@ -110,15 +114,21 @@ class RouterReplayDriver:
                 raise ValueError("R3 router replay requires batch.routed_experts.")
             routed = self._select_local_layers(routed)
             pack_routes = _protocol_fn(
-                self._protocol, "pack_routed_experts", protocol_utils.pack_routed_experts
+                self._protocol,
+                "pack_routed_experts",
+                protocol_utils.pack_routed_experts,
             )
             pack_mask = _protocol_fn(
-                self._protocol, "pack_r3_replay_mask", protocol_utils.pack_r3_replay_mask
+                self._protocol,
+                "pack_r3_replay_mask",
+                protocol_utils.pack_r3_replay_mask,
             )
             targets = pack_routes(model, batch, routed)
             replay_mask = pack_mask(model, batch)
             RouterReplay.set_replay_data(targets, replay_mask=replay_mask)
-            RouterReplay.set_global_router_replay_action(RouterReplayAction.REPLAY_FORWARD)
+            RouterReplay.set_global_router_replay_action(
+                RouterReplayAction.REPLAY_FORWARD
+            )
             RouterReplay.reset_replay_stats()
             try:
                 return forward_step(model, batch)

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -13,12 +13,20 @@ from typing import Any
 
 import torch
 import torch.distributed as dist
-from torch.distributed.tensor import DTensor  # pyright: ignore[reportMissingImports]
 from megatron.lite.runtime.backends import Runtime as RuntimeBase
 from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig
-from megatron.lite.runtime.contracts.data import ForwardResult, ModelOutputs, PackedBatch
+from megatron.lite.runtime.contracts.data import (
+    ForwardResult,
+    ModelOutputs,
+    PackedBatch,
+)
 from megatron.lite.runtime.contracts.handle import ModelHandle
-from megatron.lite.runtime.contracts.loss import get_loss_context, split_loss_context, use_loss_context
+from megatron.lite.runtime.contracts.loss import (
+    get_loss_context,
+    split_loss_context,
+    use_loss_context,
+)
+from torch.distributed.tensor import DTensor  # pyright: ignore[reportMissingImports]
 
 
 def _build_impl_cfg(proto, rt_cfg: MegatronLiteConfig):
@@ -26,20 +34,28 @@ def _build_impl_cfg(proto, rt_cfg: MegatronLiteConfig):
     init_fields = {f.name for f in dc_fields(proto.ImplConfig) if f.init}
     # Only forward impl_cfg keys this model's ImplConfig declares: the connector
     # may pass knobs (e.g. cross_entropy_fusion) that some models don't model.
-    impl_cfg_kwargs = {key: value for key, value in rt_cfg.impl_cfg.items() if key in init_fields}
+    impl_cfg_kwargs = {
+        key: value for key, value in rt_cfg.impl_cfg.items() if key in init_fields
+    }
     impl_cfg_kwargs["parallel"] = rt_cfg.parallel
     if (
         "attention_backend_override" in init_fields
         and impl_cfg_kwargs.get("attention_backend_override") is None
     ):
-        impl_cfg_kwargs["attention_backend_override"] = rt_cfg.attention_backend_override
+        impl_cfg_kwargs["attention_backend_override"] = (
+            rt_cfg.attention_backend_override
+        )
     if (
         "router_aux_loss_coef" in init_fields
         and impl_cfg_kwargs.get("router_aux_loss_coef") is None
         and rt_cfg.router_aux_loss_coef is not None
     ):
         impl_cfg_kwargs["router_aux_loss_coef"] = rt_cfg.router_aux_loss_coef
-    if "hf_path" in init_fields and impl_cfg_kwargs.get("hf_path") in (None, "") and rt_cfg.hf_path:
+    if (
+        "hf_path" in init_fields
+        and impl_cfg_kwargs.get("hf_path") in (None, "")
+        and rt_cfg.hf_path
+    ):
         impl_cfg_kwargs["hf_path"] = rt_cfg.hf_path
     # Thread the user-level OptimizerConfig so the protocol can pass it to
     # optimizer primitives without reading runtime internals.
@@ -63,12 +79,18 @@ def _reset_parameters(module: torch.nn.Module) -> None:
         for name, original in original_parameters.items():
             replacement = module._parameters.get(name)
             if replacement is None:
-                raise RuntimeError(f"{type(module).__name__}.reset_parameters() removed {name!r}.")
+                raise RuntimeError(
+                    f"{type(module).__name__}.reset_parameters() removed {name!r}."
+                )
             if replacement is original:
                 continue
-            original_local = original.to_local() if isinstance(original, DTensor) else original
+            original_local = (
+                original.to_local() if isinstance(original, DTensor) else original
+            )
             replacement_local = (
-                replacement.to_local() if isinstance(replacement, DTensor) else replacement
+                replacement.to_local()
+                if isinstance(replacement, DTensor)
+                else replacement
             )
             if original_local.shape != replacement_local.shape:
                 raise RuntimeError(
@@ -78,8 +100,7 @@ def _reset_parameters(module: torch.nn.Module) -> None:
             if original_local.data_ptr() != replacement_local.data_ptr():
                 original_local.copy_(
                     replacement_local.to(
-                        device=original_local.device,
-                        dtype=original_local.dtype,
+                        device=original_local.device, dtype=original_local.dtype
                     )
                 )
             module._parameters[name] = original
@@ -108,9 +129,13 @@ def _apply_attention_backend_env(backend: str | None, *, tag: str) -> None:
     os.environ["NVTE_UNFUSED_ATTN"] = unfused
 
 
-def _infer_pipeline_tensor_shape(batch: PackedBatch, model_cfg: Any, ps) -> tuple[int, int, int]:
+def _infer_pipeline_tensor_shape(
+    batch: PackedBatch, model_cfg: Any, ps
+) -> tuple[int, int, int]:
     if model_cfg is None or not hasattr(model_cfg, "hidden_size"):
-        raise ValueError("Megatron Lite pipeline runtime requires model_cfg.hidden_size.")
+        raise ValueError(
+            "Megatron Lite pipeline runtime requires model_cfg.hidden_size."
+        )
     if not isinstance(batch, PackedBatch):
         raise TypeError("Megatron Lite pipeline runtime requires PackedBatch inputs.")
 
@@ -122,7 +147,9 @@ def _infer_pipeline_tensor_shape(batch: PackedBatch, model_cfg: Any, ps) -> tupl
         batch_size = int(input_ids.size(0))
         local_seq_len = int(input_ids.size(1))
     else:
-        raise ValueError(f"Unsupported input_ids rank for pipeline runtime: {input_ids.dim()}.")
+        raise ValueError(
+            f"Unsupported input_ids rank for pipeline runtime: {input_ids.dim()}."
+        )
 
     if local_seq_len < 1:
         raise ValueError("Pipeline tensor shape requires non-empty sequence.")
@@ -136,7 +163,11 @@ def _infer_pipeline_tensor_shape(batch: PackedBatch, model_cfg: Any, ps) -> tupl
     # (each sequence padded to align = tp * (2*cp if cp>1 else 1)) then divide by CP*TP.
     seq_lens = getattr(batch, "seq_lens", None)
     if seq_lens is not None and cp_size * tp_size > 1:
-        sl = seq_lens if isinstance(seq_lens, torch.Tensor) else torch.as_tensor(seq_lens)
+        sl = (
+            seq_lens
+            if isinstance(seq_lens, torch.Tensor)
+            else torch.as_tensor(seq_lens)
+        )
         sl = sl.to(torch.int64).reshape(-1)
         align = tp_size * (2 * cp_size if cp_size > 1 else 1)
         padded = sl + (align - sl % align) % align
@@ -267,9 +298,15 @@ class MegatronLiteRuntime(RuntimeBase):
 
         # ── load HF weights (optional) ──
         loaded_hf_weights = False
-        if rt_cfg.load_hf_weights and rt_cfg.hf_path and hasattr(proto, "load_hf_weights"):
+        if (
+            rt_cfg.load_hf_weights
+            and rt_cfg.hf_path
+            and hasattr(proto, "load_hf_weights")
+        ):
             for chunk in bundle.chunks:
-                proto.load_hf_weights(chunk, rt_cfg.hf_path, model_cfg, bundle.parallel_state)
+                proto.load_hf_weights(
+                    chunk, rt_cfg.hf_path, model_cfg, bundle.parallel_state
+                )
             loaded_hf_weights = True
 
         post_load_hook = bundle.extras.pop("post_model_load_hook", None)
@@ -285,7 +322,9 @@ class MegatronLiteRuntime(RuntimeBase):
                 extra_updates = post_load_updates.get("extras")
                 if extra_updates:
                     if not isinstance(extra_updates, dict):
-                        raise TypeError("post_model_load_hook extras update must be a dict.")
+                        raise TypeError(
+                            "post_model_load_hook extras update must be a dict."
+                        )
                     bundle.extras.update(extra_updates)
 
         if (loaded_hf_weights or meta_initialized) and bundle.optimizer is not None:
@@ -294,7 +333,9 @@ class MegatronLiteRuntime(RuntimeBase):
                 reload_model_params()
 
         if bundle.forward_step is None:
-            raise ValueError("Megatron Lite model bundles must provide a typed forward_step.")
+            raise ValueError(
+                "Megatron Lite model bundles must provide a typed forward_step."
+            )
 
         p = rt_cfg.parallel
         model = bundle.chunks[0] if len(bundle.chunks) == 1 else bundle.chunks
@@ -318,7 +359,10 @@ class MegatronLiteRuntime(RuntimeBase):
 
     def _load_protocol(self, rt_cfg: MegatronLiteConfig):
         """Load and return the model protocol module."""
-        from megatron.lite.model.registry import TRAIN_RUNTIME_MODULES, resolve_runtime_model_name
+        from megatron.lite.model.registry import (
+            TRAIN_RUNTIME_MODULES,
+            resolve_runtime_model_name,
+        )
 
         try:
             runtime_key = resolve_runtime_model_name(rt_cfg.model_name, rt_cfg.impl)
@@ -338,7 +382,9 @@ class MegatronLiteRuntime(RuntimeBase):
 
         for fn_name in ("build_model_config", "build_model"):
             if not callable(getattr(proto, fn_name, None)):
-                raise ValueError(f"Protocol module {mod_path} missing required function: {fn_name}")
+                raise ValueError(
+                    f"Protocol module {mod_path} missing required function: {fn_name}"
+                )
         if not hasattr(proto, "ImplConfig"):
             raise ValueError(f"Protocol module {mod_path} missing ImplConfig class")
 
@@ -401,7 +447,9 @@ class MegatronLiteRuntime(RuntimeBase):
             **kwargs,
         )
 
-    def export_weights(self, handle: ModelHandle, **kwargs) -> Iterator[tuple[str, torch.Tensor]]:
+    def export_weights(
+        self, handle: ModelHandle, **kwargs
+    ) -> Iterator[tuple[str, torch.Tensor]]:
         model_chunks = handle._extras.get("model_chunks", [handle._model])
         proto = handle._extras.get("protocol")
         model_cfg = handle._extras.get("model_cfg")
@@ -497,7 +545,9 @@ class MegatronLiteRuntime(RuntimeBase):
         router_replay: Any = None,
     ) -> ForwardResult:
         from megatron.lite.primitive.train_step import run_microbatch_loop
-        from megatron.lite.runtime.backends.mlite.router_replay import RouterReplayDriver
+        from megatron.lite.runtime.backends.mlite.router_replay import (
+            RouterReplayDriver,
+        )
 
         forward_step = handle._extras["forward_step"]
         if num_microbatches < 1:
@@ -520,7 +570,9 @@ class MegatronLiteRuntime(RuntimeBase):
             from types import SimpleNamespace
 
             from megatron.lite.primitive.ckpt.hf_weights import unwrap_model
-            from megatron.lite.primitive.parallel.pipeline import forward_backward_pipelining
+            from megatron.lite.primitive.parallel.pipeline import (
+                forward_backward_pipelining,
+            )
 
             first_item = next(data_iter)
             first_batch, _loss_context = split_loss_context(first_item)
@@ -534,7 +586,9 @@ class MegatronLiteRuntime(RuntimeBase):
 
             model_chunks = handle._extras.get("model_chunks", [handle._model])
             pipeline_chunks = [unwrap_model(chunk) for chunk in model_chunks]
-            pipeline_forward_step, pipeline_loss_fn = _pipeline_callbacks(forward_step, loss_fn)
+            pipeline_forward_step, pipeline_loss_fn = _pipeline_callbacks(
+                forward_step, loss_fn
+            )
             try:
                 outputs = forward_backward_pipelining(
                     pipeline_forward_step,
@@ -562,7 +616,9 @@ class MegatronLiteRuntime(RuntimeBase):
                 dtype=torch.float32,
             )
             if ps.pp_group is not None and ps.pp_global_ranks is not None:
-                dist.broadcast(loss_payload, src=ps.pp_global_ranks[-1], group=ps.pp_group)
+                dist.broadcast(
+                    loss_payload, src=ps.pp_global_ranks[-1], group=ps.pp_group
+                )
             out = {"loss": loss_payload[1]} if bool(loss_payload[0].item()) else {}
         else:
             try:
@@ -678,7 +734,10 @@ def _checkpoint_model(handle: ModelHandle, *, use_dcp: bool):
 
 
 def _checkpoint_hooks(handle: ModelHandle):
-    from megatron.lite.primitive.protocols import default_expert_classifier, default_placement_fn
+    from megatron.lite.primitive.protocols import (
+        default_expert_classifier,
+        default_placement_fn,
+    )
 
     proto = handle._extras.get("protocol")
     return (

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -13,6 +13,12 @@ from typing import Any
 
 import torch
 import torch.distributed as dist
+
+# Resolve DTensor before contract modules allocate their global context state.
+# isort: off
+from torch.distributed.tensor import DTensor  # pyright: ignore[reportMissingImports]
+
+# isort: on
 from megatron.lite.runtime.backends import Runtime as RuntimeBase
 from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig
 from megatron.lite.runtime.contracts.data import (
@@ -26,7 +32,6 @@ from megatron.lite.runtime.contracts.loss import (
     split_loss_context,
     use_loss_context,
 )
-from torch.distributed.tensor import DTensor  # pyright: ignore[reportMissingImports]
 
 
 def _build_impl_cfg(proto, rt_cfg: MegatronLiteConfig):

--- a/experimental/lite/megatron/lite/runtime/contracts/__init__.py
+++ b/experimental/lite/megatron/lite/runtime/contracts/__init__.py
@@ -13,7 +13,10 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from megatron.lite.runtime.backends.bridge.config import BridgeConfig
-    from megatron.lite.runtime.backends.mlite.config import DebugConfig, MegatronLiteConfig
+    from megatron.lite.runtime.backends.mlite.config import (
+        DebugConfig,
+        MegatronLiteConfig,
+    )
     from megatron.lite.runtime.contracts.config import (
         OptimizerConfig,
         ParallelConfig,

--- a/experimental/lite/megatron/lite/runtime/contracts/config.py
+++ b/experimental/lite/megatron/lite/runtime/contracts/config.py
@@ -82,7 +82,9 @@ class RuntimeConfig:
 
     backend: str = "mlite"
     hf_path: str = ""
-    backend_cfg: MegatronLiteConfig | BridgeConfig | dict[str, Any] = field(default_factory=dict)
+    backend_cfg: MegatronLiteConfig | BridgeConfig | dict[str, Any] = field(
+        default_factory=dict
+    )
 
 
 __all__ = ["OptimizerConfig", "ParallelConfig", "RuntimeConfig"]

--- a/experimental/lite/megatron/lite/runtime/contracts/data.py
+++ b/experimental/lite/megatron/lite/runtime/contracts/data.py
@@ -73,7 +73,10 @@ class PackedBatch(Batch):
         if self.position_ids is not None:
             return self.position_ids
         return torch.cat(
-            [torch.arange(s, device=self.seq_lens.device) for s in self.seq_lens.tolist()]
+            [
+                torch.arange(s, device=self.seq_lens.device)
+                for s in self.seq_lens.tolist()
+            ]
         )
 
 
@@ -114,10 +117,4 @@ class ForwardResult:
     metrics: dict[str, Any] = field(default_factory=dict)
 
 
-__all__ = [
-    "Batch",
-    "ForwardResult",
-    "ModelOutputs",
-    "PackedBatch",
-    "TrainBatch",
-]
+__all__ = ["Batch", "ForwardResult", "ModelOutputs", "PackedBatch", "TrainBatch"]

--- a/experimental/lite/megatron/lite/runtime/megatron_utils.py
+++ b/experimental/lite/megatron/lite/runtime/megatron_utils.py
@@ -59,7 +59,9 @@ def register_training_hooks(model_list: list, optimizer) -> None:
 
         optimizer_config = getattr(optimizer, "config", None)
         overlap_param_gather = getattr(optimizer_config, "overlap_param_gather", False)
-        overlap_grad_reduce = getattr(one_model.ddp_config, "overlap_grad_reduce", False)
+        overlap_grad_reduce = getattr(
+            one_model.ddp_config, "overlap_grad_reduce", False
+        )
         align_grad_reduce = True
         align_param_gather = getattr(one_model.ddp_config, "align_param_gather", False)
 
@@ -128,7 +130,9 @@ def offload_model_to_cpu(model_list: list) -> None:
             for buffers in all_buffers:
                 for buffer in buffers:
                     if buffer.param_data.storage().size() > 0:
-                        buffer.param_data.cpu_data = buffer.param_data.data.cpu().pin_memory()
+                        buffer.param_data.cpu_data = (
+                            buffer.param_data.data.cpu().pin_memory()
+                        )
                         buffer.param_data_size = buffer.param_data.storage().size()
                         buffer.param_data.storage().resize_(0)
 
@@ -161,7 +165,9 @@ def load_model_to_gpu(model_list: list, load_grad: bool = True) -> None:
 
                     if buffer.param_data.storage().size() == 0:
                         buffer.param_data.storage().resize_(buffer.param_data_size)
-                        buffer.param_data.copy_(buffer.param_data.cpu_data, non_blocking=True)
+                        buffer.param_data.copy_(
+                            buffer.param_data.cpu_data, non_blocking=True
+                        )
 
             for param in model_chunk.module.parameters():
                 if not param.requires_grad and param.device.type == "cpu":
@@ -183,7 +189,8 @@ def offload_optimizer(optimizer) -> None:
         if _opt.optimizer is not None:
             hdo = _opt.optimizer
             if all(
-                hasattr(hdo, a) for a in ("sub_optimizers", "inner_param_to_orig_param", "state")
+                hasattr(hdo, a)
+                for a in ("sub_optimizers", "inner_param_to_orig_param", "state")
             ):
                 for sub_opt in hdo.sub_optimizers:
                     for param, state in sub_opt.state.items():
@@ -248,7 +255,9 @@ def build_sharded_state_dict(
         sharded_state_dict.update(chunk_sd)
 
     if optimizer is not None:
-        opt_sd = optimizer.sharded_state_dict(model_sharded_state_dict=sharded_state_dict)
+        opt_sd = optimizer.sharded_state_dict(
+            model_sharded_state_dict=sharded_state_dict
+        )
         sharded_state_dict.update(opt_sd)
 
     if lr_scheduler is not None:

--- a/experimental/lite/tests/smoke/model/glm5/lite/test_glm5_lite_cp_smoke.py
+++ b/experimental/lite/tests/smoke/model/glm5/lite/test_glm5_lite_cp_smoke.py
@@ -4,10 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-pytestmark = [
-    pytest.mark.gpus(2),
-    pytest.mark.env(CUDA_DEVICE_MAX_CONNECTIONS="1"),
-]
+pytestmark = [pytest.mark.gpus(2), pytest.mark.env(CUDA_DEVICE_MAX_CONNECTIONS="1")]
 
 
 def _make_train_config(ps):
@@ -90,12 +87,16 @@ def _tiny_hf_parity_config_kwargs():
 def _fused_dsa_seq_len(world: int) -> int:
     seq = 512
     if seq % (2 * world) != 0:
-        pytest.skip(f"GLM5 fused DSA CP smoke requires seq={seq} divisible by 2*world={2 * world}.")
+        pytest.skip(
+            f"GLM5 fused DSA CP smoke requires seq={seq} divisible by 2*world={2 * world}."
+        )
     return seq
 
 
 def _to_hf_deepseek_v3_config(cfg):
-    from transformers.models.deepseek_v3.configuration_deepseek_v3 import DeepseekV3Config
+    from transformers.models.deepseek_v3.configuration_deepseek_v3 import (
+        DeepseekV3Config,
+    )
 
     return DeepseekV3Config(
         hidden_size=cfg.hidden_size,
@@ -140,7 +141,9 @@ def _distributed_diff_stats(actual, expected) -> tuple[float, float]:
 
     diff = (actual.float() - expected.float()).abs()
     max_abs = diff.max()
-    scale = torch.maximum(actual.float().abs().max(), expected.float().abs().max()).clamp_min(1e-6)
+    scale = torch.maximum(
+        actual.float().abs().max(), expected.float().abs().max()
+    ).clamp_min(1e-6)
     stats = torch.stack([max_abs, scale])
     if dist.is_initialized():
         dist.all_reduce(stats, op=dist.ReduceOp.MAX)
@@ -179,9 +182,11 @@ def _make_dsa(*, cp_size: int = 1, cp_rank: int = 0, cp_group=None):
 def test_glm5_dsa_cp2_matches_full_sequence_reference_forward_and_grad():
     import torch
     import torch.distributed as dist
-
     from megatron.lite.primitive.modules.attention import build_rope_cache
-    from megatron.lite.primitive.parallel.cp import zigzag_position_ids_for_cp, zigzag_slice_for_cp
+    from megatron.lite.primitive.parallel.cp import (
+        zigzag_position_ids_for_cp,
+        zigzag_slice_for_cp,
+    )
     from megatron.lite.primitive.parallel.state import ParallelState
 
     device = _init_dist_or_skip()
@@ -199,14 +204,22 @@ def test_glm5_dsa_cp2_matches_full_sequence_reference_forward_and_grad():
     batch, seq = 1, _fused_dsa_seq_len(world)
     torch.manual_seed(99)
     full_x = torch.randn(batch, seq, 128, device=device, dtype=torch.bfloat16)
-    local_x = zigzag_slice_for_cp(full_x, rank, world, seq_dim=1).detach().requires_grad_(True)
+    local_x = (
+        zigzag_slice_for_cp(full_x, rank, world, seq_dim=1)
+        .detach()
+        .requires_grad_(True)
+    )
     ref_x = full_x.detach().clone().requires_grad_(True)
 
     cos, sin = build_rope_cache(
         dim=64, max_position_embeddings=seq, rope_theta=1_000_000.0, device=device
     )
     local_pos = zigzag_position_ids_for_cp(seq, rank, world, device).expand(batch, -1)
-    full_pos = torch.arange(seq, device=device, dtype=torch.long).unsqueeze(0).expand(batch, -1)
+    full_pos = (
+        torch.arange(seq, device=device, dtype=torch.long)
+        .unsqueeze(0)
+        .expand(batch, -1)
+    )
 
     cp_out = cp_attn(local_x, cos=cos, sin=sin, position_ids=local_pos)
     ref_out = ref_attn(ref_x, cos=cos, sin=sin, position_ids=full_pos)
@@ -224,7 +237,6 @@ def test_glm5_dsa_cp2_matches_full_sequence_reference_forward_and_grad():
 def test_glm5_tiny_model_cp2_matches_full_sequence_reference_forward():
     import torch
     import torch.distributed as dist
-
     from megatron.lite.model.glm5.config import Glm5Config
     from megatron.lite.primitive.parallel.cp import zigzag_slice_for_cp
     from megatron.lite.primitive.parallel.state import ParallelState
@@ -247,7 +259,9 @@ def test_glm5_tiny_model_cp2_matches_full_sequence_reference_forward():
 
     batch, seq = 1, _fused_dsa_seq_len(world)
     torch.manual_seed(100)
-    full_hidden = torch.randn(batch, seq, cfg.hidden_size, device=device, dtype=torch.bfloat16)
+    full_hidden = torch.randn(
+        batch, seq, cfg.hidden_size, device=device, dtype=torch.bfloat16
+    )
     local_hidden = zigzag_slice_for_cp(full_hidden, rank, world, seq_dim=1).contiguous()
 
     with torch.no_grad():
@@ -262,7 +276,6 @@ def test_glm5_tiny_model_cp2_matches_full_sequence_reference_forward():
 def test_glm5_tiny_model_cp2_forward_backward_smoke():
     import torch
     import torch.distributed as dist
-
     from megatron.lite.model.glm5.config import Glm5Config
     from megatron.lite.primitive.parallel.cp import zigzag_slice_for_cp
     from megatron.lite.primitive.parallel.state import ParallelState
@@ -302,7 +315,6 @@ def test_glm5_tiny_model_cp2_forward_backward_smoke():
 def test_glm5_packed_thd_variable_sequence_cp2_forward_backward_smoke():
     import torch
     import torch.distributed as dist
-
     from megatron.lite.model.glm5.config import Glm5Config
     from megatron.lite.model.glm5.lite.protocol import (
         _forward_step,
@@ -316,9 +328,7 @@ def test_glm5_packed_thd_variable_sequence_cp2_forward_backward_smoke():
     rank = dist.get_rank()
     cfg_kwargs = _tiny_config_kwargs()
     cfg_kwargs.update(
-        max_position_embeddings=64,
-        num_hidden_layers=6,
-        num_nextn_predict_layers=1,
+        max_position_embeddings=64, num_hidden_layers=6, num_nextn_predict_layers=1
     )
     indexer_types = ["full", "full", "full", "shared", "shared", "shared"]
     cfg = Glm5Config(
@@ -392,13 +402,14 @@ def test_glm5_packed_thd_variable_sequence_cp2_forward_backward_smoke():
 def test_glm5_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
     import torch
     import torch.distributed as dist
-    from transformers.models.deepseek_v3.modeling_deepseek_v3 import DeepseekV3ForCausalLM
-
     from megatron.lite.model.glm5.config import Glm5Config
     from megatron.lite.model.glm5.lite.checkpoint import load_hf_weights
     from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
     from megatron.lite.primitive.parallel.cp import zigzag_slice_for_cp
     from megatron.lite.primitive.parallel.state import ParallelState
+    from transformers.models.deepseek_v3.modeling_deepseek_v3 import (
+        DeepseekV3ForCausalLM,
+    )
 
     device = _init_dist_or_skip()
     world = dist.get_world_size()
@@ -460,19 +471,26 @@ def test_glm5_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
     for layer_idx, (actual, full_expected) in enumerate(
         zip(native_layer_outputs, hf_layer_outputs, strict=True)
     ):
-        expected = zigzag_slice_for_cp(full_expected, rank, world, seq_dim=1).contiguous()
+        expected = zigzag_slice_for_cp(
+            full_expected, rank, world, seq_dim=1
+        ).contiguous()
         max_abs, max_rel = _distributed_diff_stats(actual, expected)
         if rank == 0:
             print(
                 f"glm5_hf_native_parity layer={layer_idx} "
                 f"max_abs_diff={max_abs:.6e} max_rel_diff={max_rel:.6e}"
             )
-        torch.testing.assert_close(actual.float(), expected.float(), atol=1.5e-1, rtol=1.5e-1)
+        torch.testing.assert_close(
+            actual.float(), expected.float(), atol=1.5e-1, rtol=1.5e-1
+        )
 
     expected = zigzag_slice_for_cp(hf_logits, rank, world, seq_dim=1).contiguous()
     max_abs, max_rel = _distributed_diff_stats(native_logits, expected)
     if rank == 0:
         print(
-            "glm5_hf_native_parity logits " f"max_abs_diff={max_abs:.6e} max_rel_diff={max_rel:.6e}"
+            "glm5_hf_native_parity logits "
+            f"max_abs_diff={max_abs:.6e} max_rel_diff={max_rel:.6e}"
         )
-    torch.testing.assert_close(native_logits.float(), expected.float(), atol=1.5e-1, rtol=1.5e-1)
+    torch.testing.assert_close(
+        native_logits.float(), expected.float(), atol=1.5e-1, rtol=1.5e-1
+    )

--- a/experimental/lite/tests/smoke/model/glm5/lite/test_glm5_lite_fsdp2_smoke.py
+++ b/experimental/lite/tests/smoke/model/glm5/lite/test_glm5_lite_fsdp2_smoke.py
@@ -67,7 +67,6 @@ def _tiny_config_kwargs():
 
 def test_glm5_tiny_model_builds_and_steps_with_fsdp2_backend(cuda_dist):
     import torch
-
     from megatron.lite.model.glm5.config import Glm5Config
     from megatron.lite.model.glm5.lite import protocol
     from megatron.lite.primitive.optimizers.fsdp2 import FSDP2Optimizer, fsdp2_available
@@ -82,7 +81,11 @@ def test_glm5_tiny_model_builds_and_steps_with_fsdp2_backend(cuda_dist):
         parallel=ParallelConfig(),
         optimizer="fsdp2",
         optimizer_config=OptimizerConfig(
-            optimizer="adam", lr=1.0e-3, weight_decay=0.0, clip_grad=1.0, offload_fraction=0.0
+            optimizer="adam",
+            lr=1.0e-3,
+            weight_decay=0.0,
+            clip_grad=1.0,
+            offload_fraction=0.0,
         ),
         deterministic=True,
     )

--- a/experimental/lite/tests/smoke/model/kimi_k2/lite/test_kimi_k2_lite_cp_smoke.py
+++ b/experimental/lite/tests/smoke/model/kimi_k2/lite/test_kimi_k2_lite_cp_smoke.py
@@ -5,10 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 
-pytestmark = [
-    pytest.mark.gpus(2),
-    pytest.mark.env(CUDA_DEVICE_MAX_CONNECTIONS="1"),
-]
+pytestmark = [pytest.mark.gpus(2), pytest.mark.env(CUDA_DEVICE_MAX_CONNECTIONS="1")]
 
 
 def _init_dist_or_skip():
@@ -119,7 +116,9 @@ def _train_cfg(cp: int):
 
 
 def _to_hf_deepseek_v3_config(cfg):
-    from transformers.models.deepseek_v3.configuration_deepseek_v3 import DeepseekV3Config
+    from transformers.models.deepseek_v3.configuration_deepseek_v3 import (
+        DeepseekV3Config,
+    )
 
     rope_scaling = dict(cfg.rope_scaling)
     rope_scaling.setdefault("rope_type", rope_scaling.get("type", "yarn"))
@@ -166,7 +165,9 @@ def _distributed_diff_stats(actual, expected) -> tuple[float, float]:
 
     diff = (actual.float() - expected.float()).abs()
     max_abs = diff.max()
-    scale = torch.maximum(actual.float().abs().max(), expected.float().abs().max()).clamp_min(1e-6)
+    scale = torch.maximum(
+        actual.float().abs().max(), expected.float().abs().max()
+    ).clamp_min(1e-6)
     stats = torch.stack([max_abs, scale])
     if dist.is_initialized():
         dist.all_reduce(stats, op=dist.ReduceOp.MAX)
@@ -185,8 +186,12 @@ def _hf_state_dict_for_kimi_loader(model):
         down = state.get(f"{prefix}.down_proj")
         gate, up = gate_up.chunk(2, dim=1)
         for expert_idx in range(gate_up.size(0)):
-            state[f"{prefix}.{expert_idx}.gate_proj.weight"] = gate[expert_idx].contiguous().clone()
-            state[f"{prefix}.{expert_idx}.up_proj.weight"] = up[expert_idx].contiguous().clone()
+            state[f"{prefix}.{expert_idx}.gate_proj.weight"] = (
+                gate[expert_idx].contiguous().clone()
+            )
+            state[f"{prefix}.{expert_idx}.up_proj.weight"] = (
+                up[expert_idx].contiguous().clone()
+            )
             if down is not None:
                 state[f"{prefix}.{expert_idx}.down_proj.weight"] = (
                     down[expert_idx].contiguous().clone()
@@ -224,17 +229,24 @@ def test_kimi_k2_mla_cp2_matches_full_sequence_reference_forward_and_grad():
         use_thd=False,
     )
     torch.manual_seed(20260531)
-    cp_layer = MultiLatentAttention(ps=ps, **kwargs).to(device=device, dtype=torch.bfloat16)
+    cp_layer = MultiLatentAttention(ps=ps, **kwargs).to(
+        device=device, dtype=torch.bfloat16
+    )
     torch.manual_seed(20260531)
     ref_layer = MultiLatentAttention(ps=ParallelState(), **kwargs).to(
-        device=device,
-        dtype=torch.bfloat16,
+        device=device, dtype=torch.bfloat16
     )
 
     seq, batch = 8 * world, 1
     torch.manual_seed(123)
-    full_x = torch.randn(seq, batch, cfg.hidden_size, device=device, dtype=torch.bfloat16)
-    local_x = zigzag_slice_for_cp(full_x, rank, world, seq_dim=0).detach().requires_grad_(True)
+    full_x = torch.randn(
+        seq, batch, cfg.hidden_size, device=device, dtype=torch.bfloat16
+    )
+    local_x = (
+        zigzag_slice_for_cp(full_x, rank, world, seq_dim=0)
+        .detach()
+        .requires_grad_(True)
+    )
     ref_x = full_x.detach().clone().requires_grad_(True)
 
     cp_out = cp_layer(local_x)
@@ -267,13 +279,11 @@ def test_kimi_k2_tiny_model_cp2_matches_full_sequence_reference_forward():
 
     torch.manual_seed(777)
     cp_model = KimiK2Model(cfg, _train_cfg(world), ps, use_thd=False).to(
-        device=device,
-        dtype=torch.bfloat16,
+        device=device, dtype=torch.bfloat16
     )
     torch.manual_seed(777)
     ref_model = KimiK2Model(cfg, _train_cfg(1), ParallelState(), use_thd=False).to(
-        device=device,
-        dtype=torch.bfloat16,
+        device=device, dtype=torch.bfloat16
     )
     cp_model.eval()
     ref_model.eval()
@@ -289,16 +299,26 @@ def test_kimi_k2_tiny_model_cp2_matches_full_sequence_reference_forward():
         cp_out = cp_model(input_ids=input_ids, labels=labels)
         ref_out = ref_model(input_ids=full_ids, labels=full_labels)
 
-    expected_hidden = zigzag_slice_for_cp(ref_out["hidden_states"], rank, world, seq_dim=0)
-    expected_log_probs = zigzag_slice_for_cp(ref_out["log_probs"], rank, world, seq_dim=1)
-    torch.testing.assert_close(cp_out["hidden_states"], expected_hidden, atol=1e-1, rtol=1e-1)
-    torch.testing.assert_close(cp_out["log_probs"], expected_log_probs, atol=1e-1, rtol=1e-1)
+    expected_hidden = zigzag_slice_for_cp(
+        ref_out["hidden_states"], rank, world, seq_dim=0
+    )
+    expected_log_probs = zigzag_slice_for_cp(
+        ref_out["log_probs"], rank, world, seq_dim=1
+    )
+    torch.testing.assert_close(
+        cp_out["hidden_states"], expected_hidden, atol=1e-1, rtol=1e-1
+    )
+    torch.testing.assert_close(
+        cp_out["log_probs"], expected_log_probs, atol=1e-1, rtol=1e-1
+    )
 
 
 def test_kimi_k2_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
     import torch
     import torch.distributed as dist
-    from transformers.models.deepseek_v3.modeling_deepseek_v3 import DeepseekV3ForCausalLM
+    from transformers.models.deepseek_v3.modeling_deepseek_v3 import (
+        DeepseekV3ForCausalLM,
+    )
 
     device = _init_dist_or_skip()
     from megatron.lite.model.kimi_k2.lite.checkpoint import load_hf_weights
@@ -314,20 +334,15 @@ def test_kimi_k2_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
 
     torch.manual_seed(20260610)
     hf_ref = DeepseekV3ForCausalLM(_to_hf_deepseek_v3_config(cfg)).to(
-        device=device,
-        dtype=torch.bfloat16,
+        device=device, dtype=torch.bfloat16
     )
     hf_ref.eval()
     rank_tmp_path = tmp_path / f"rank{rank}"
-    save_safetensors(
-        _hf_state_dict_for_kimi_loader(hf_ref),
-        str(rank_tmp_path),
-    )
+    save_safetensors(_hf_state_dict_for_kimi_loader(hf_ref), str(rank_tmp_path))
 
     ps = init_parallel(ParallelConfig(tp=1, ep=1, etp=1, cp=world, pp=1))
     native = KimiK2Model(cfg, _train_cfg(world), ps, use_thd=False).to(
-        device=device,
-        dtype=torch.bfloat16,
+        device=device, dtype=torch.bfloat16
     )
     native.eval()
     load_hf_weights(native, str(rank_tmp_path), cfg, ps)
@@ -383,10 +398,7 @@ def test_kimi_k2_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
                 f"max_abs_diff={max_abs:.6e} max_rel_diff={max_rel:.6e}"
             )
         torch.testing.assert_close(
-            actual.float(),
-            expected.float(),
-            atol=1.5e-1,
-            rtol=1.5e-1,
+            actual.float(), expected.float(), atol=1.5e-1, rtol=1.5e-1
         )
 
     expected = zigzag_slice_for_cp(hf_logits, rank, world, seq_dim=1).contiguous()
@@ -397,10 +409,7 @@ def test_kimi_k2_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
             f"max_abs_diff={max_abs:.6e} max_rel_diff={max_rel:.6e}"
         )
     torch.testing.assert_close(
-        native_logits.float(),
-        expected.float(),
-        atol=1.5e-1,
-        rtol=1.5e-1,
+        native_logits.float(), expected.float(), atol=1.5e-1, rtol=1.5e-1
     )
 
 
@@ -411,7 +420,10 @@ def test_kimi_k2_packed_thd_variable_sequence_cp2_smoke():
     device = _init_dist_or_skip()
     from megatron.lite.model.kimi_k2.lite.model import KimiK2Model
     from megatron.lite.primitive.parallel.state import init_parallel
-    from megatron.lite.primitive.parallel.thd import pack_nested_thd, unpack_packed_thd_to_nested
+    from megatron.lite.primitive.parallel.thd import (
+        pack_nested_thd,
+        unpack_packed_thd_to_nested,
+    )
     from megatron.lite.runtime.contracts import ParallelConfig
 
     world = dist.get_world_size()
@@ -421,8 +433,7 @@ def test_kimi_k2_packed_thd_variable_sequence_cp2_smoke():
 
     torch.manual_seed(20260614)
     model = KimiK2Model(cfg, _train_cfg(world), ps, use_thd=True).to(
-        device=device,
-        dtype=torch.bfloat16,
+        device=device, dtype=torch.bfloat16
     )
     model.train()
 

--- a/experimental/lite/tests/smoke/model/test_qwen_lite_forward_smoke.py
+++ b/experimental/lite/tests/smoke/model/test_qwen_lite_forward_smoke.py
@@ -10,10 +10,7 @@ import pytest
 import torch
 import torch.distributed as dist
 
-pytestmark = [
-    pytest.mark.gpus(1),
-    pytest.mark.env(CUDA_DEVICE_MAX_CONNECTIONS="1"),
-]
+pytestmark = [pytest.mark.gpus(1), pytest.mark.env(CUDA_DEVICE_MAX_CONNECTIONS="1")]
 
 
 def _qwen3_symbols():
@@ -117,7 +114,9 @@ def _assert_loss_and_backward(output: dict, model: torch.nn.Module):
     assert torch.isfinite(loss)
     loss.backward()
     grad_params = [
-        param for param in model.parameters() if param.requires_grad and param.grad is not None
+        param
+        for param in model.parameters()
+        if param.requires_grad and param.grad is not None
     ]
     assert grad_params
     assert all(
@@ -172,7 +171,9 @@ def test_qwen35_lite_tiny_forward_backward_smoke():
 @pytest.mark.gpus(4)
 def test_qwen35_tp2_tp4_mixed_attention_parity_and_backward():
     if dist.get_world_size() < 4 or dist.get_world_size() % 4 != 0:
-        pytest.skip("Qwen3.5 TP replication smoke requires a world size divisible by 4.")
+        pytest.skip(
+            "Qwen3.5 TP replication smoke requires a world size divisible by 4."
+        )
 
     Qwen35Config, Qwen35Model = _qwen35_symbols()
     from megatron.lite.model.qwen3_5.lite.checkpoint import (
@@ -206,9 +207,11 @@ def test_qwen35_tp2_tp4_mixed_attention_parity_and_backward():
     )
 
     path_box = [
-        tempfile.mkdtemp(prefix="mlite-qwen35-tp-replication-")
-        if dist.get_rank() == 0
-        else None
+        (
+            tempfile.mkdtemp(prefix="mlite-qwen35-tp-replication-")
+            if dist.get_rank() == 0
+            else None
+        )
     ]
     dist.broadcast_object_list(path_box, src=0)
     checkpoint_dir = path_box[0]
@@ -253,9 +256,13 @@ def test_qwen35_tp2_tp4_mixed_attention_parity_and_backward():
     if dist.get_rank() == 0:
         logits_max_abs = (tp4_logits - tp2_logits).abs().max().item()
         loss_abs = (tp4_output["loss"].float() - tp2_loss).abs().item()
-        print(f"QWEN35_TP_PARITY logits_max_abs={logits_max_abs:.8g} loss_abs={loss_abs:.8g}")
+        print(
+            f"QWEN35_TP_PARITY logits_max_abs={logits_max_abs:.8g} loss_abs={loss_abs:.8g}"
+        )
     torch.testing.assert_close(tp4_logits, tp2_logits, atol=1e-2, rtol=1e-2)
-    torch.testing.assert_close(tp4_output["loss"].float(), tp2_loss, atol=1e-3, rtol=1e-3)
+    torch.testing.assert_close(
+        tp4_output["loss"].float(), tp2_loss, atol=1e-3, rtol=1e-3
+    )
     tp4_output["loss"].backward()
 
     gdn = tp4_model.layers[0].linear_attn

--- a/experimental/lite/tests/smoke/primitive/parallel/test_parallel_topologies_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/parallel/test_parallel_topologies_smoke.py
@@ -7,7 +7,6 @@ from types import SimpleNamespace
 import pytest
 import torch
 import torch.distributed as dist
-
 from megatron.lite.primitive.parallel import (
     PackedSeqParams,
     ParallelState,
@@ -18,10 +17,7 @@ from megatron.lite.primitive.parallel import (
     zigzag_to_contiguous_chunks,
 )
 
-pytestmark = [
-    pytest.mark.gpus(2),
-    pytest.mark.env(CUDA_DEVICE_MAX_CONNECTIONS="1"),
-]
+pytestmark = [pytest.mark.gpus(2), pytest.mark.env(CUDA_DEVICE_MAX_CONNECTIONS="1")]
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -176,11 +172,7 @@ def test_gdn_packed_thd_cp2_matches_full_sequence_reference():
         -0.5, 0.5, steps=8 * 16, device="cuda", dtype=torch.bfloat16
     ).reshape(8, 1, 16)
     local_hidden = split_packed_to_cp_local(
-        full_hidden,
-        cu_seqlens_padded=cu_seqlens,
-        cp_size=2,
-        cp_rank=ps.cp_rank,
-        dim=0,
+        full_hidden, cu_seqlens_padded=cu_seqlens, cp_size=2, cp_rank=ps.cp_rank, dim=0
     )
 
     with torch.no_grad():

--- a/experimental/lite/tests/smoke/workflows/checkpoint/test_distopt_checkpoint_smoke.py
+++ b/experimental/lite/tests/smoke/workflows/checkpoint/test_distopt_checkpoint_smoke.py
@@ -8,25 +8,26 @@ import pytest
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-from torch.distributed.tensor import Replicate, Shard
-
 from megatron.core.dist_checkpointing import load_plain_tensors
 from megatron.core.dist_checkpointing.dict_utils import diff
-from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig
+from megatron.core.distributed import (
+    DistributedDataParallel,
+    DistributedDataParallelConfig,
+)
 from megatron.core.optimizer import OptimizerConfig, get_megatron_optimizer
 from megatron.core.transformer import TransformerConfig
 from megatron.lite.primitive.ckpt import attach_model_sharded_state_dict
 from megatron.lite.primitive.optimizers.megatron_wrap import build_dist_opt_stack
 from megatron.lite.primitive.parallel import ParallelState, init_parallel
 from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
-from megatron.lite.runtime.contracts.config import OptimizerConfig as LiteOptimizerConfig
+from megatron.lite.runtime.contracts.config import (
+    OptimizerConfig as LiteOptimizerConfig,
+)
 from megatron.lite.runtime.contracts.config import ParallelConfig
 from megatron.lite.runtime.contracts.handle import ModelHandle
+from torch.distributed.tensor import Replicate, Shard
 
-pytestmark = [
-    pytest.mark.gpus(2),
-    pytest.mark.env(CUDA_DEVICE_MAX_CONNECTIONS="1"),
-]
+pytestmark = [pytest.mark.gpus(2), pytest.mark.env(CUDA_DEVICE_MAX_CONNECTIONS="1")]
 
 
 class TinyDense(nn.Module):
@@ -46,12 +47,16 @@ class TinyTopologyAwareState(nn.Module):
     def __init__(self, ps: ParallelState):
         super().__init__()
         self.dense_weight = nn.Parameter(
-            _local_shard(_global_tensor(self.dense_shape, 1.0), 0, ps.tp_rank, ps.tp_size)
+            _local_shard(
+                _global_tensor(self.dense_shape, 1.0), 0, ps.tp_rank, ps.tp_size
+            )
             .cuda()
             .bfloat16()
         )
         self.experts_weight = nn.Parameter(
-            _local_shard(_global_tensor(self.expert_shape, 101.0), 0, ps.etp_rank, ps.etp_size)
+            _local_shard(
+                _global_tensor(self.expert_shape, 101.0), 0, ps.etp_rank, ps.etp_size
+            )
             .cuda()
             .bfloat16()
         )
@@ -100,7 +105,9 @@ def _single_node_cuda_dist_opt():
 
 
 def _global_tensor(shape: tuple[int, ...], offset: float) -> torch.Tensor:
-    return torch.arange(offset, offset + int(torch.tensor(shape).prod().item())).reshape(shape)
+    return torch.arange(
+        offset, offset + int(torch.tensor(shape).prod().item())
+    ).reshape(shape)
 
 
 def _local_shard(tensor: torch.Tensor, dim: int, rank: int, size: int) -> torch.Tensor:
@@ -138,11 +145,18 @@ def _build_sharded_model_and_dist_opt(parallel: ParallelConfig):
         deterministic=False,
     )
     wrapped_chunks, optimizer = build_dist_opt_stack(
-        [model], model_cfg=model_cfg, engine_cfg=engine_cfg, ps=ps, is_expert=_is_expert_param
+        [model],
+        model_cfg=model_cfg,
+        engine_cfg=engine_cfg,
+        ps=ps,
+        is_expert=_is_expert_param,
     )
     _seed_optimizer_state(optimizer)
     attach_model_sharded_state_dict(
-        wrapped_chunks, ps, get_placements=_topology_placements, is_expert=_is_expert_param
+        wrapped_chunks,
+        ps,
+        get_placements=_topology_placements,
+        is_expert=_is_expert_param,
     )
     return wrapped_chunks, optimizer, ps
 
@@ -172,7 +186,9 @@ def _inner_optimizers(optimizer):
         yield optimizer
 
 
-def _dist_opt_handle(wrapped_chunks, optimizer, ps: ParallelState, parallel: ParallelConfig):
+def _dist_opt_handle(
+    wrapped_chunks, optimizer, ps: ParallelState, parallel: ParallelConfig
+):
     return ModelHandle(
         model=wrapped_chunks,
         optimizer=optimizer,
@@ -195,7 +211,9 @@ def _build_model_and_dist_opt():
         TransformerConfig(num_attention_heads=1, num_layers=1), ddp_config, model
     )
     optimizer = get_megatron_optimizer(
-        OptimizerConfig(optimizer="adam", lr=1.0e-3, bf16=True, use_distributed_optimizer=True),
+        OptimizerConfig(
+            optimizer="adam", lr=1.0e-3, bf16=True, use_distributed_optimizer=True
+        ),
         [wrapped],
     )
     attach_model_sharded_state_dict([wrapped], _single_node_parallel_state())
@@ -226,7 +244,10 @@ def _train_step(model, optimizer, x: torch.Tensor):
 
 
 def _local_named_params(model) -> dict[str, torch.Tensor]:
-    return {name: param.detach().cpu().float().clone() for name, param in model.named_parameters()}
+    return {
+        name: param.detach().cpu().float().clone()
+        for name, param in model.named_parameters()
+    }
 
 
 def _assert_model_close(lhs, rhs):
@@ -234,7 +255,9 @@ def _assert_model_close(lhs, rhs):
     rhs_params = _local_named_params(rhs)
     assert lhs_params.keys() == rhs_params.keys()
     for name in lhs_params:
-        torch.testing.assert_close(lhs_params[name], rhs_params[name], atol=0.0, rtol=0.0)
+        torch.testing.assert_close(
+            lhs_params[name], rhs_params[name], atol=0.0, rtol=0.0
+        )
 
 
 def test_dist_opt_checkpoint_load_matches_uninterrupted_training_single_node(tmp_path):
@@ -289,7 +312,9 @@ def test_dist_opt_checkpoint_reshards_from_pp_ep_to_tp_pp_ep_etp(tmp_path):
     source_parallel = ParallelConfig(tp=1, ep=2, etp=1, pp=2, cp=1)
     target_parallel = ParallelConfig(tp=2, ep=2, etp=2, pp=2, cp=1)
 
-    source_chunks, source_optimizer, source_ps = _build_sharded_model_and_dist_opt(source_parallel)
+    source_chunks, source_optimizer, source_ps = _build_sharded_model_and_dist_opt(
+        source_parallel
+    )
     runtime.save_checkpoint(
         _dist_opt_handle(source_chunks, source_optimizer, source_ps, source_parallel),
         source_dir,
@@ -297,10 +322,14 @@ def test_dist_opt_checkpoint_reshards_from_pp_ep_to_tp_pp_ep_etp(tmp_path):
         save_rng=False,
     )
 
-    target_chunks, target_optimizer, target_ps = _build_sharded_model_and_dist_opt(target_parallel)
+    target_chunks, target_optimizer, target_ps = _build_sharded_model_and_dist_opt(
+        target_parallel
+    )
     assert (
         runtime.load_checkpoint(
-            _dist_opt_handle(target_chunks, target_optimizer, target_ps, target_parallel),
+            _dist_opt_handle(
+                target_chunks, target_optimizer, target_ps, target_parallel
+            ),
             source_dir,
             load_rng=False,
         )

--- a/experimental/lite/tests/smoke/workflows/checkpoint/test_fsdp2_offload_checkpoint_smoke.py
+++ b/experimental/lite/tests/smoke/workflows/checkpoint/test_fsdp2_offload_checkpoint_smoke.py
@@ -8,7 +8,6 @@ import pytest
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-
 from megatron.lite.primitive.optimizers.fsdp2 import (
     FSDP2Config,
     build_fsdp2_adamw,
@@ -16,7 +15,10 @@ from megatron.lite.primitive.optimizers.fsdp2 import (
     fsdp2_available,
     wrap_fsdp2,
 )
-from megatron.lite.primitive.optimizers.fsdp2.adamw import iter_torch_optimizers, to_local_tensor
+from megatron.lite.primitive.optimizers.fsdp2.adamw import (
+    iter_torch_optimizers,
+    to_local_tensor,
+)
 from megatron.lite.primitive.parallel.state import ParallelState
 from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
 from megatron.lite.runtime.contracts.config import ParallelConfig
@@ -94,7 +96,9 @@ def _checkpoint_config():
     return SimpleNamespace(parallel=ParallelConfig())
 
 
-def _build_fsdp2_model(dtype: torch.dtype = torch.bfloat16) -> tuple[nn.Module, ParallelState]:
+def _build_fsdp2_model(
+    dtype: torch.dtype = torch.bfloat16,
+) -> tuple[nn.Module, ParallelState]:
     torch.manual_seed(1234)
     model = TinyModel().cuda().to(dtype=dtype)
     ps = _parallel_state()
@@ -163,14 +167,19 @@ def _assert_local_params_close(lhs: nn.Module, rhs: nn.Module):
     rhs_params = _local_named_params(rhs)
     assert lhs_params.keys() == rhs_params.keys()
     for name in lhs_params:
-        torch.testing.assert_close(lhs_params[name], rhs_params[name], atol=0.0, rtol=0.0)
+        torch.testing.assert_close(
+            lhs_params[name], rhs_params[name], atol=0.0, rtol=0.0
+        )
 
 
 def test_fsdp2_runtime_model_and_optimizer_offload_roundtrip_single_node():
     model, ps = _build_fsdp2_model()
     optimizer = _build_optimizer(model, ps, offload_fraction=0.0)
     handle = ModelHandle(
-        model=model, optimizer=optimizer, parallel_state=ps, _extras={"model_chunks": [model]}
+        model=model,
+        optimizer=optimizer,
+        parallel_state=ps,
+        _extras={"model_chunks": [model]},
     )
     runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
 

--- a/experimental/lite/tests/smoke/workflows/checkpoint/test_qwen3_moe_distopt_checkpoint_smoke.py
+++ b/experimental/lite/tests/smoke/workflows/checkpoint/test_qwen3_moe_distopt_checkpoint_smoke.py
@@ -8,17 +8,13 @@ from typing import Any
 import pytest
 import torch
 import torch.distributed as dist
-
 from megatron.lite.primitive.deterministic import set_deterministic
 from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
 from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
 from megatron.lite.runtime.contracts.data import PackedBatch
 from megatron.lite.runtime.contracts.handle import ModelHandle
 
-pytestmark = [
-    pytest.mark.gpus(8),
-    pytest.mark.env(CUDA_DEVICE_MAX_CONNECTIONS="1"),
-]
+pytestmark = [pytest.mark.gpus(8), pytest.mark.env(CUDA_DEVICE_MAX_CONNECTIONS="1")]
 
 
 def _qwen3_moe_symbols():
@@ -26,7 +22,9 @@ def _qwen3_moe_symbols():
         "transformer_engine.pytorch",
         reason="Qwen3MoE dist_opt checkpoint smoke requires real Transformer Engine.",
     )
-    assert hasattr(te, "Linear"), "Qwen3MoE smoke requires real Transformer Engine Linear."
+    assert hasattr(
+        te, "Linear"
+    ), "Qwen3MoE smoke requires real Transformer Engine Linear."
     from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
     from megatron.lite.model.qwen3_moe.lite import protocol
 
@@ -148,7 +146,9 @@ def _assert_batch_equal(actual: PackedBatch, expected: PackedBatch) -> None:
     assert torch.equal(actual.labels, expected.labels)
 
 
-def _train_step(runtime: MegatronLiteRuntime, handle: ModelHandle, batch: dict[str, Any]) -> None:
+def _train_step(
+    runtime: MegatronLiteRuntime, handle: ModelHandle, batch: dict[str, Any]
+) -> None:
     runtime.zero_grad(handle)
     runtime.forward_backward(handle, iter([batch]), None, num_microbatches=1)
     runtime.optimizer_step(handle)
@@ -168,12 +168,18 @@ def _assert_params_bitwise_equal(lhs: ModelHandle, rhs: ModelHandle) -> None:
     rhs_params = _local_named_params(rhs)
     assert lhs_params.keys() == rhs_params.keys()
     for name in lhs_params:
-        torch.testing.assert_close(lhs_params[name], rhs_params[name], atol=0.0, rtol=0.0)
+        torch.testing.assert_close(
+            lhs_params[name], rhs_params[name], atol=0.0, rtol=0.0
+        )
 
 
-def test_qwen3_moe_dist_opt_checkpoint_restores_rng_and_continues_bitwise_tp2_pp2_ep2(tmp_path):
+def test_qwen3_moe_dist_opt_checkpoint_restores_rng_and_continues_bitwise_tp2_pp2_ep2(
+    tmp_path,
+):
     if dist.get_world_size() != 8:
-        pytest.skip("Qwen3MoE tp2/pp2/ep2 dist_opt checkpoint smoke requires exactly 8 GPUs.")
+        pytest.skip(
+            "Qwen3MoE tp2/pp2/ep2 dist_opt checkpoint smoke requires exactly 8 GPUs."
+        )
 
     set_deterministic(2026)
     model_cfg = _tiny_qwen3_moe_config()

--- a/experimental/lite/tests/smoke/workflows/checkpoint/test_save_load_export_smoke.py
+++ b/experimental/lite/tests/smoke/workflows/checkpoint/test_save_load_export_smoke.py
@@ -24,7 +24,6 @@ from types import SimpleNamespace
 import pytest
 import torch
 import torch.distributed as dist
-
 from megatron.lite.primitive.deterministic import set_deterministic
 from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
 from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
@@ -172,7 +171,9 @@ def _glm5():
 
 
 def _deepseek_v4():
-    pytest.importorskip("cudnn", reason="deepseek_v4 fused DSA needs the cudnn DSA stack.")
+    pytest.importorskip(
+        "cudnn", reason="deepseek_v4 fused DSA needs the cudnn DSA stack."
+    )
     _require_te()
     from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
     from megatron.lite.model.deepseek_v4.lite import protocol
@@ -451,7 +452,9 @@ def _local_named_params(handle: ModelHandle) -> dict[str, torch.Tensor]:
     params: dict[str, torch.Tensor] = {}
     for chunk_idx, chunk in enumerate(handle._extras["model_chunks"]):
         for name, param in chunk.named_parameters():
-            params[f"{chunk_idx}.{name}"] = to_local_tensor(param.detach()).cpu().float().clone()
+            params[f"{chunk_idx}.{name}"] = (
+                to_local_tensor(param.detach()).cpu().float().clone()
+            )
     return params
 
 
@@ -465,7 +468,9 @@ def _assert_params_bitwise_equal(lhs: ModelHandle, rhs: ModelHandle) -> None:
         if not torch.equal(lhs_params[name], rhs_params[name]):
             diff = (lhs_params[name] - rhs_params[name]).abs().max().item()
             mismatches.append(f"{name} (max_abs_diff={diff})")
-    assert not mismatches, "save/load not bitwise; mismatched params:\n" + "\n".join(mismatches)
+    assert not mismatches, "save/load not bitwise; mismatched params:\n" + "\n".join(
+        mismatches
+    )
 
 
 def _is_valid_hf_export_key(key: str, model_name: str) -> bool:
@@ -487,7 +492,9 @@ def _is_valid_hf_export_key(key: str, model_name: str) -> bool:
     return key.startswith("model.") or key in ("lm_head.weight",)
 
 
-def _export_and_reload(handle: ModelHandle, cfg, protocol, out_dir: str, model_name: str) -> None:
+def _export_and_reload(
+    handle: ModelHandle, cfg, protocol, out_dir: str, model_name: str
+) -> None:
     """Export HF weights (bf16) and assert the reloaded shards are valid.
 
     Prefer the model's ``save_hf_weights`` wrapper; some models only expose the
@@ -535,17 +542,21 @@ def _export_and_reload(handle: ModelHandle, cfg, protocol, out_dir: str, model_n
                         if key.endswith(".e_score_correction_bias")
                         else torch.bfloat16
                     )
-                    assert tensor.dtype == expected_dtype, (
-                        f"{key} exported as {tensor.dtype}, want {expected_dtype}"
-                    )
+                    assert (
+                        tensor.dtype == expected_dtype
+                    ), f"{key} exported as {tensor.dtype}, want {expected_dtype}"
                 else:
-                    assert tensor.dtype in (torch.int64, torch.int32, torch.bool), (
-                        f"{key} exported as unexpected non-float dtype {tensor.dtype}"
-                    )
-                assert torch.isfinite(tensor.float()).all(), f"{key} has non-finite values"
-                assert _is_valid_hf_export_key(key, model_name), (
-                    f"unexpected non-HF export key: {key}"
-                )
+                    assert tensor.dtype in (
+                        torch.int64,
+                        torch.int32,
+                        torch.bool,
+                    ), f"{key} exported as unexpected non-float dtype {tensor.dtype}"
+                assert torch.isfinite(
+                    tensor.float()
+                ).all(), f"{key} has non-finite values"
+                assert _is_valid_hf_export_key(
+                    key, model_name
+                ), f"unexpected non-HF export key: {key}"
                 keys.add(key)
     assert keys, "exported zero tensors"
     # PP-gather completeness: the rank-0 export must carry EVERY decoder layer's
@@ -671,7 +682,10 @@ def _iter_opt_state_tensors(handle: ModelHandle, backend: str):
 def _opt_state_devices(handle: ModelHandle, backend: str) -> set[str]:
     from megatron.lite.primitive.optimizers.fsdp2.adamw import to_local_tensor
 
-    return {to_local_tensor(v).device.type for _, v in _iter_opt_state_tensors(handle, backend)}
+    return {
+        to_local_tensor(v).device.type
+        for _, v in _iter_opt_state_tensors(handle, backend)
+    }
 
 
 def _opt_state_snapshot(handle: ModelHandle, backend: str) -> dict[str, torch.Tensor]:
@@ -700,7 +714,9 @@ def _assert_named_bitwise_equal(lhs: dict, rhs: dict, label: str) -> None:
         if not torch.equal(lhs[name], rhs[name]):
             diff = (lhs[name] - rhs[name]).abs().max().item()
             mismatches.append(f"{name} (max_abs_diff={diff})")
-    assert not mismatches, f"{label} not bitwise after offload/onload:\n" + "\n".join(mismatches)
+    assert not mismatches, f"{label} not bitwise after offload/onload:\n" + "\n".join(
+        mismatches
+    )
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
@@ -724,18 +740,24 @@ def test_offload_onload_roundtrip(model_name, backend, tmp_path):
     assert _opt_state_devices(handle, backend) == {"cuda"}
 
     runtime.to(handle, "cpu", model=True, optimizer=True, grad=True)
-    assert _opt_state_devices(handle, backend) == {"cpu"}, "optimizer state not offloaded to CPU."
+    assert _opt_state_devices(handle, backend) == {
+        "cpu"
+    }, "optimizer state not offloaded to CPU."
     if backend == "fsdp2":
         # fsdp2 moves params to CPU directly; dist_opt instead frees the GPU
         # buffer storage (params keep a 0-size cuda handle), so assert only fsdp2.
         assert _local_param_devices(handle) == {"cpu"}, "params not offloaded to CPU."
 
     runtime.to(handle, "cuda", model=True, optimizer=True, grad=True)
-    assert _opt_state_devices(handle, backend) == {"cuda"}, "optimizer state not back on GPU."
+    assert _opt_state_devices(handle, backend) == {
+        "cuda"
+    }, "optimizer state not back on GPU."
     assert _local_param_devices(handle) == {"cuda"}, "params not back on GPU."
 
     _assert_named_bitwise_equal(params_before, _local_named_params(handle), "param")
-    _assert_named_bitwise_equal(opt_before, _opt_state_snapshot(handle, backend), "optimizer-state")
+    _assert_named_bitwise_equal(
+        opt_before, _opt_state_snapshot(handle, backend), "optimizer-state"
+    )
 
     _train_step(handle, backend, cfg)  # continues training after onload
 
@@ -758,7 +780,7 @@ def test_offload_fraction_keeps_optimizer_state_on_cpu(model_name, backend, tmp_
         offload_fraction=1.0,
     )
     _train_step(handle, backend, cfg)
-    assert "cpu" in _opt_state_devices(handle, backend), (
-        "offload_fraction=1.0 should keep optimizer update state on CPU."
-    )
+    assert "cpu" in _opt_state_devices(
+        handle, backend
+    ), "offload_fraction=1.0 should keep optimizer update state on CPU."
     _train_step(handle, backend, cfg)  # trains with the offloaded update state

--- a/experimental/lite/tests/smoke/workflows/train_export/test_auto_pipeline_layout_smoke.py
+++ b/experimental/lite/tests/smoke/workflows/train_export/test_auto_pipeline_layout_smoke.py
@@ -31,10 +31,7 @@ from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
 from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
 from megatron.lite.runtime.contracts.data import PackedBatch
 
-pytestmark = [
-    pytest.mark.gpus(8),
-    pytest.mark.env(CUDA_DEVICE_MAX_CONNECTIONS="1"),
-]
+pytestmark = [pytest.mark.gpus(8), pytest.mark.env(CUDA_DEVICE_MAX_CONNECTIONS="1")]
 
 # 9 decoders over pp=4 is non-divisible; 9 is small enough to stay fast yet leaves no
 # empty stage even for the MTP model (deepseek_v4 adds a slot on the last stage).
@@ -442,11 +439,7 @@ def _build_handle_from_config(
 def _build_handle(model_name: str, *, seed: int, pp_layout=None):
     cfg, protocol = MODELS[model_name]()
     return _build_handle_from_config(
-        model_name,
-        cfg,
-        protocol,
-        seed=seed,
-        pp_layout=pp_layout,
+        model_name, cfg, protocol, seed=seed, pp_layout=pp_layout
     )
 
 
@@ -501,9 +494,9 @@ def test_uneven_pp_builds_trains_and_exports(model_name):
     result = runtime.forward_backward(handle, iter([batch]), None, num_microbatches=1)
     runtime.optimizer_step(handle)
     loss = result.model_output.loss
-    assert loss is not None and torch.isfinite(loss).all(), (
-        f"{model_name}: non-finite loss {loss} on uneven PP layout"
-    )
+    assert (
+        loss is not None and torch.isfinite(loss).all()
+    ), f"{model_name}: non-finite loss {loss} on uneven PP layout"
 
     # Export across the uneven PP split (every rank materializes the full HF state).
     protocol = handle._extras["protocol"]
@@ -516,7 +509,9 @@ def test_uneven_pp_builds_trains_and_exports(model_name):
         f"{sorted(expected - present)} (have {sorted(present)}); PP gather lost a stage"
     )
     for name, tensor in exported:
-        assert torch.isfinite(tensor.float()).all(), (
+        assert torch.isfinite(
+            tensor.float()
+        ).all(), (
             f"{model_name}: non-finite exported tensor {name} from uneven PP gather"
         )
     if dist.get_rank() == 0:
@@ -569,7 +564,9 @@ def test_glm52_indexshare_78_layer_uneven_pp_builds_trains_and_keeps_share_group
         for layer_idx in local
         if cfg.dsa_indexer_type(layer_idx) == "shared"
     ]
-    assert all(source_idx in local for _, source_idx in local_shared_sources), local_shared_sources
+    assert all(
+        source_idx in local for _, source_idx in local_shared_sources
+    ), local_shared_sources
 
     runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
     batch = _random_packed_batch(cfg.vocab_size, num_tokens=512)
@@ -577,15 +574,17 @@ def test_glm52_indexshare_78_layer_uneven_pp_builds_trains_and_keeps_share_group
     result = runtime.forward_backward(handle, iter([batch]), None, num_microbatches=1)
     runtime.optimizer_step(handle)
     loss = result.model_output.loss
-    assert loss is not None and torch.isfinite(loss).all(), (
-        f"glm52_indexshare: non-finite loss {loss} on 78-layer uneven PP layout"
-    )
+    assert (
+        loss is not None and torch.isfinite(loss).all()
+    ), f"glm52_indexshare: non-finite loss {loss} on 78-layer uneven PP layout"
 
     stage_info = {
         "pp_rank": ps.pp_rank,
         "layers": local,
         "shared_sources": local_shared_sources,
-        "has_mtp": bool(unwrap_model(handle._extras["model_chunks"][0]).mtp is not None),
+        "has_mtp": bool(
+            unwrap_model(handle._extras["model_chunks"][0]).mtp is not None
+        ),
     }
     gathered = [None for _ in range(dist.get_world_size())]
     dist.all_gather_object(gathered, stage_info)

--- a/experimental/lite/tests/unit/examples/test_bench_example.py
+++ b/experimental/lite/tests/unit/examples/test_bench_example.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 import pytest
 import torch
-
 from megatron.lite.runtime.contracts.config import ParallelConfig
 from megatron.lite.runtime.contracts.data import ForwardResult, ModelOutputs
 from megatron.lite.runtime.contracts.handle import ModelHandle
@@ -81,7 +80,9 @@ def test_bench_builds_bridge_dry_run_plan_without_bridge_import():
     assert plan["runtime"]["backend"] == "bridge"
     backend_cfg = plan["runtime"]["backend_cfg"]
     assert backend_cfg["model_name"] == "qwen3_5"
-    assert backend_cfg["override_transformer_config"] == {"attention_backend": "unfused"}
+    assert backend_cfg["override_transformer_config"] == {
+        "attention_backend": "unfused"
+    }
     assert backend_cfg["bridge_post_init"].startswith("<callable:")
 
 
@@ -103,7 +104,9 @@ def test_bench_builds_mbridge_dry_run_plan_without_mbridge_import():
     assert plan["runtime"]["backend"] == "mbridge"
     backend_cfg = plan["runtime"]["backend_cfg"]
     assert backend_cfg["model_name"] == "qwen3_5"
-    assert backend_cfg["override_transformer_config"] == {"attention_backend": "unfused"}
+    assert backend_cfg["override_transformer_config"] == {
+        "attention_backend": "unfused"
+    }
     assert backend_cfg["bridge_post_init"].startswith("<callable:")
 
 
@@ -141,7 +144,9 @@ class _FakeRuntime:
 
     def forward_backward(self, handle, data, loss_fn, *, num_microbatches: int = 1):
         self.loss += 1
-        return ForwardResult(model_output=ModelOutputs(loss=torch.tensor(float(self.loss))))
+        return ForwardResult(
+            model_output=ModelOutputs(loss=torch.tensor(float(self.loss)))
+        )
 
     def optimizer_step(self, handle):
         return True, 3.5, 0
@@ -158,7 +163,9 @@ def test_pretrain_session_runs_with_fake_runtime_on_cpu():
         optimizer=object(),
         parallel_state=None,
         config=type(
-            "Cfg", (), {"model_name": "fake", "impl": "lite", "parallel": ParallelConfig()}
+            "Cfg",
+            (),
+            {"model_name": "fake", "impl": "lite", "parallel": ParallelConfig()},
         )(),
         _extras={"optimizer_backend": "fake"},
     )
@@ -229,7 +236,11 @@ def test_bench_main_writes_output_json_only_on_rank_zero(tmp_path, monkeypatch):
 
 
 def test_result_artifact_summary_and_trace_compare(tmp_path):
-    from examples.bench.results import compare_step_traces, load_result_artifact, result_summary
+    from examples.bench.results import (
+        compare_step_traces,
+        load_result_artifact,
+        result_summary,
+    )
 
     baseline = {
         "summary": {
@@ -265,17 +276,25 @@ def test_result_artifact_summary_and_trace_compare(tmp_path):
     loaded = load_result_artifact(baseline_path)
 
     assert result_summary(loaded)["backend"] == "mlite"
-    assert compare_step_traces(baseline, candidate, atol=1e-3, rtol=0.0)["passed"] is True
+    assert (
+        compare_step_traces(baseline, candidate, atol=1e-3, rtol=0.0)["passed"] is True
+    )
 
 
 def test_result_trace_compare_reports_metric_level_failures():
     from examples.bench.results import compare_step_traces
 
     baseline = {
-        "result": {"step_traces": [{"step": 0, "loss": 1.0, "grad_norm": 2.0, "step_ms": 10.0}]}
+        "result": {
+            "step_traces": [{"step": 0, "loss": 1.0, "grad_norm": 2.0, "step_ms": 10.0}]
+        }
     }
     candidate = {
-        "result": {"step_traces": [{"step": 0, "loss": 1.00001, "grad_norm": 3.0, "step_ms": 10.0}]}
+        "result": {
+            "step_traces": [
+                {"step": 0, "loss": 1.00001, "grad_norm": 3.0, "step_ms": 10.0}
+            ]
+        }
     }
 
     comparison = compare_step_traces(baseline, candidate, atol=1e-3, rtol=0.0)
@@ -346,11 +365,7 @@ def test_correctness_compare_supports_explicit_numeric_tolerances():
     }
 
     comparison = compare_correctness_artifacts(
-        baseline,
-        candidate,
-        loss_atol=1e-5,
-        grad_atol=1e-4,
-        tensor_atol=3e-3,
+        baseline, candidate, loss_atol=1e-5, grad_atol=1e-4, tensor_atol=3e-3
     )
 
     assert comparison["passed"] is True

--- a/experimental/lite/tests/unit/examples/test_verl_compat_dense_recreate.py
+++ b/experimental/lite/tests/unit/examples/test_verl_compat_dense_recreate.py
@@ -47,9 +47,7 @@ def test_dense_recreate_runs_under_model_runner_vllm_config(monkeypatch) -> None
         original_calls.append(("prepare", model_runner.model))
         return "state"
 
-    fp8_utils, events = _install_fake_reload_modules(
-        monkeypatch, original
-    )
+    fp8_utils, events = _install_fake_reload_modules(monkeypatch, original)
     monkeypatch.setattr(
         compat,
         "_recreate_dense_fp8_linear_params",

--- a/experimental/lite/tests/unit/examples/test_verl_compat_fp8_prepare_state.py
+++ b/experimental/lite/tests/unit/examples/test_verl_compat_fp8_prepare_state.py
@@ -24,9 +24,7 @@ def test_pure_fp8_ds4_prepare_state_is_promoted(monkeypatch) -> None:
     dsv4_utils = ModuleType("verl.utils.vllm.vllm_dsv4_fp8_utils")
     dsv4_utils.is_deepseek_v4_model = lambda model: True
 
-    routed_module = ModuleType(
-        "vllm.model_executor.layers.fused_moe.routed_experts"
-    )
+    routed_module = ModuleType("vllm.model_executor.layers.fused_moe.routed_experts")
     fp8_module = ModuleType("vllm.model_executor.layers.quantization.fp8")
 
     class RoutedExperts:
@@ -58,9 +56,7 @@ def test_non_ds4_false_prepare_state_stays_false(monkeypatch) -> None:
     fp8_utils.prepare_quanted_weights_for_loading = lambda model_runner: False
     dsv4_utils = ModuleType("verl.utils.vllm.vllm_dsv4_fp8_utils")
     dsv4_utils.is_deepseek_v4_model = lambda model: False
-    routed_module = ModuleType(
-        "vllm.model_executor.layers.fused_moe.routed_experts"
-    )
+    routed_module = ModuleType("vllm.model_executor.layers.fused_moe.routed_experts")
     fp8_module = ModuleType("vllm.model_executor.layers.quantization.fp8")
     routed_module.RoutedExperts = type("RoutedExperts", (), {})
     fp8_module.Fp8MoEMethod = type("Fp8MoEMethod", (), {})

--- a/experimental/lite/tests/unit/examples/test_verl_compat_native_layerwise_reload.py
+++ b/experimental/lite/tests/unit/examples/test_verl_compat_native_layerwise_reload.py
@@ -47,11 +47,11 @@ def test_ds4_uses_native_vllm_layerwise_reload(monkeypatch) -> None:
             events.append(("exit-config", config))
 
     vllm_config.set_current_vllm_config = set_current_vllm_config
-    reload_api.initialize_layerwise_reload = (
-        lambda model: events.append(("initialize", model))
+    reload_api.initialize_layerwise_reload = lambda model: events.append(
+        ("initialize", model)
     )
-    reload_api.finalize_layerwise_processing = (
-        lambda model, config: events.append(("finalize", model, config))
+    reload_api.finalize_layerwise_processing = lambda model, config: events.append(
+        ("finalize", model, config)
     )
     rollout_utils.load_quanted_weights = fp8_utils.load_quanted_weights
     for module in (
@@ -85,7 +85,9 @@ def test_ds4_uses_native_vllm_layerwise_reload(monkeypatch) -> None:
     fp8_utils.process_quanted_weights_after_loading(runner, state)
     assert model._verl_mlite_ds4_layerwise_reload_active is False
     assert "legacy-prepare" not in events
-    assert not any(isinstance(event, tuple) and event[0] == "legacy-process" for event in events)
+    assert not any(
+        isinstance(event, tuple) and event[0] == "legacy-process" for event in events
+    )
     assert events == [
         ("enter-config", config),
         ("initialize", model),

--- a/experimental/lite/tests/unit/examples/test_verl_compat_post_reload_fixups.py
+++ b/experimental/lite/tests/unit/examples/test_verl_compat_post_reload_fixups.py
@@ -30,9 +30,7 @@ def test_post_reload_restores_attention_and_only_finalizes_moe(monkeypatch) -> N
     utils.vLLMColocateWorkerExtension = Extension
     dsv4_utils = ModuleType("verl.utils.vllm.vllm_dsv4_fp8_utils")
     dsv4_utils.is_deepseek_v4_model = lambda model: True
-    routed_experts = ModuleType(
-        "vllm.model_executor.layers.fused_moe.routed_experts"
-    )
+    routed_experts = ModuleType("vllm.model_executor.layers.fused_moe.routed_experts")
     fp8 = ModuleType("vllm.model_executor.layers.quantization.fp8")
 
     class RoutedExperts:
@@ -62,9 +60,7 @@ def test_post_reload_restores_attention_and_only_finalizes_moe(monkeypatch) -> N
     moe = RoutedExperts()
     moe.quant_method = Fp8MoEMethod()
     dense = SimpleNamespace(quant_method=DenseQuantMethod())
-    model = SimpleNamespace(
-        modules=lambda: iter((moe, dense)),
-    )
+    model = SimpleNamespace(modules=lambda: iter((moe, dense)))
     assert compat._patch_verl_dsv4_fp8_process_weights()
     assert Extension(model).update_weights_from_ipc() == "loaded"
     assert events == ["load", "restore-attention", "finalize-moe"]

--- a/experimental/lite/tests/unit/examples/test_verl_mlite_engine_config.py
+++ b/experimental/lite/tests/unit/examples/test_verl_mlite_engine_config.py
@@ -17,7 +17,9 @@ pytestmark = pytest.mark.optional
 
 @pytest.fixture(autouse=True)
 def _require_verl() -> None:
-    pytest.importorskip("verl", reason="VERL is required for this optional example test.")
+    pytest.importorskip(
+        "verl", reason="VERL is required for this optional example test."
+    )
 
 
 def _optimizer_config(**override_optimizer_config) -> SimpleNamespace:
@@ -73,7 +75,10 @@ def test_verl_loss_hook_preserves_gradient_and_micro_outputs(num_microbatches):
     engine.get_data_parallel_group = lambda: None
 
     hook = engine._make_runtime_loss_fn(
-        lambda model_output, **_kwargs: (model_output["log_probs"] / num_microbatches, {}),
+        lambda model_output, **_kwargs: (
+            model_output["log_probs"] / num_microbatches,
+            {},
+        ),
         num_microbatches=num_microbatches,
         output_lst=outputs,
     )
@@ -83,7 +88,9 @@ def test_verl_loss_hook_preserves_gradient_and_micro_outputs(num_microbatches):
         (loss / num_microbatches).backward()
 
     torch.testing.assert_close(weight.grad, torch.tensor(3.0))
-    assert [output["loss"] for output in outputs] == [3.0 / num_microbatches] * num_microbatches
+    assert [output["loss"] for output in outputs] == [
+        3.0 / num_microbatches
+    ] * num_microbatches
 
 
 def test_verl_loss_hook_has_no_strong_self_reference():

--- a/experimental/lite/tests/unit/examples/test_verl_mlite_engine_cp_smoke.py
+++ b/experimental/lite/tests/unit/examples/test_verl_mlite_engine_cp_smoke.py
@@ -193,10 +193,9 @@ def test_mlite_engine_runtime_thd_cp_uses_typed_packed_batch(
     from verl_mlite.compat import apply_runtime_patches
 
     apply_runtime_patches()
+    from megatron.lite.runtime.contracts import PackedBatch
     from verl_mlite.engine.config import MegatronLiteEngineConfig
     from verl_mlite.engine.mlite_engine import MegatronLiteEngine
-
-    from megatron.lite.runtime.contracts import PackedBatch
 
     device = _init_dist_or_skip()
     world = dist.get_world_size()
@@ -206,9 +205,7 @@ def test_mlite_engine_runtime_thd_cp_uses_typed_packed_batch(
 
     engine = MegatronLiteEngine(
         model_config=SimpleNamespace(
-            local_path=str(hf_path),
-            hf_config={"model_type": model_type},
-            mtp=None,
+            local_path=str(hf_path), hf_config={"model_type": model_type}, mtp=None
         ),
         engine_config=MegatronLiteEngineConfig(
             model_name=model_name,
@@ -231,7 +228,9 @@ def test_mlite_engine_runtime_thd_cp_uses_typed_packed_batch(
         config.load_hf_weights = False
         return config
 
-    engine._build_mlite_config = MethodType(_build_config_without_loading_weights, engine)
+    engine._build_mlite_config = MethodType(
+        _build_config_without_loading_weights, engine
+    )
     engine.initialize()
     engine.optimizer_zero_grad()
 

--- a/experimental/lite/tests/unit/examples/test_verl_mlite_engine_loss_mask_packing.py
+++ b/experimental/lite/tests/unit/examples/test_verl_mlite_engine_loss_mask_packing.py
@@ -35,7 +35,9 @@ pytestmark = pytest.mark.optional
 
 @pytest.fixture(autouse=True)
 def _require_verl() -> None:
-    pytest.importorskip("verl", reason="VERL is required for this optional example test.")
+    pytest.importorskip(
+        "verl", reason="VERL is required for this optional example test."
+    )
 
 
 def _tensor_dict(data, batch_size):
@@ -101,7 +103,8 @@ def test_full_length_nested_loss_mask_is_unchanged():
     response_lengths = [100, 100]
     input_ids = _full_input_ids(full_lengths)
     loss_mask = torch.nested.as_nested_tensor(
-        [torch.ones(r, dtype=torch.float32) for r in response_lengths], layout=torch.jagged
+        [torch.ones(r, dtype=torch.float32) for r in response_lengths],
+        layout=torch.jagged,
     )
     micro_batch = _tensor_dict(
         {"input_ids": input_ids, "loss_mask": loss_mask}, batch_size=[len(full_lengths)]
@@ -138,6 +141,8 @@ def test_response_longer_than_input_is_rejected():
     loss_mask = torch.nested.as_nested_tensor(
         [torch.ones(64, dtype=torch.float32)], layout=torch.jagged
     )
-    micro_batch = _tensor_dict({"input_ids": input_ids, "loss_mask": loss_mask}, batch_size=[1])
+    micro_batch = _tensor_dict(
+        {"input_ids": input_ids, "loss_mask": loss_mask}, batch_size=[1]
+    )
     with pytest.raises(ValueError, match="tokens but packed input"):
         _loss_mask_for_packing(micro_batch, input_ids)

--- a/experimental/lite/tests/unit/model/deepseek_v4/lite/test_deepseek_v4_hf_load_local_to_global.py
+++ b/experimental/lite/tests/unit/model/deepseek_v4/lite/test_deepseek_v4_hf_load_local_to_global.py
@@ -138,8 +138,7 @@ def test_ds4_load_hf_canonicalizes_qat_state_before_dynamic_mapping(tmp_path):
         linear,
         "weight",
         WeightFakeQuant(
-            QATSpec(enabled=True, format="int8", group_size=-1),
-            linear.weight.shape,
+            QATSpec(enabled=True, format="int8", group_size=-1), linear.weight.shape
         ),
     )
     master = linear.parametrizations.weight.original
@@ -182,16 +181,7 @@ def test_ds4_export_streams_router_buffers_from_every_pp_stage(monkeypatch):
 
     remote = torch.tensor([3, 1, 4], dtype=torch.int64)
     remote_headers = iter(
-        [
-            [
-                (
-                    "layers.0.mlp.gate.tid2eid",
-                    tuple(remote.shape),
-                    remote.dtype,
-                )
-            ],
-            [],
-        ]
+        [[("layers.0.mlp.gate.tid2eid", tuple(remote.shape), remote.dtype)], []]
     )
 
     def fake_broadcast_object_list(header, *, src, **_kwargs):

--- a/experimental/lite/tests/unit/model/deepseek_v4/lite/test_deepseek_v4_recompute_units.py
+++ b/experimental/lite/tests/unit/model/deepseek_v4/lite/test_deepseek_v4_recompute_units.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import torch.nn as nn
-
 from megatron.lite.model.deepseek_v4.lite.protocol import _iter_transformer_units
 
 

--- a/experimental/lite/tests/unit/model/deepseek_v4/lite/test_thd_packing_consistency.py
+++ b/experimental/lite/tests/unit/model/deepseek_v4/lite/test_thd_packing_consistency.py
@@ -15,14 +15,13 @@ from __future__ import annotations
 
 import pytest
 import torch
-
 from megatron.lite.model.deepseek_v4.lite.protocol import _nested_from_packed_tensor
 
 
 def test_reproduce_seqlen_exceeds_packed_tensor_206_over_128():
     """Packed tensor holds 128 tokens but seq_lens declares 206 -> narrow overruns."""
-    packed = torch.arange(128, dtype=torch.long)           # 128 tokens
-    seq_lens = torch.tensor([206], dtype=torch.long)        # declares 206 (> 128)
+    packed = torch.arange(128, dtype=torch.long)  # 128 tokens
+    seq_lens = torch.tensor([206], dtype=torch.long)  # declares 206 (> 128)
     with pytest.raises(RuntimeError) as ei:
         _nested_from_packed_tensor(packed, seq_lens)
     msg = str(ei.value).lower()
@@ -32,7 +31,7 @@ def test_reproduce_seqlen_exceeds_packed_tensor_206_over_128():
 def test_reproduce_multi_seq_second_overruns():
     """Multiple sequences: the second one pushes the cumulative offset past the end."""
     packed = torch.arange(128, dtype=torch.long)
-    seq_lens = torch.tensor([100, 128], dtype=torch.long)   # 100+128=228 > 128
+    seq_lens = torch.tensor([100, 128], dtype=torch.long)  # 100+128=228 > 128
     with pytest.raises(RuntimeError):
         _nested_from_packed_tensor(packed, seq_lens)
 
@@ -44,7 +43,7 @@ def test_sum_mismatch_underrun_raises_valueerror():
     underrun -> ValueError (the offset != numel sum check).
     """
     packed = torch.arange(128, dtype=torch.long)
-    seq_lens = torch.tensor([100], dtype=torch.long)        # 100 < 128
+    seq_lens = torch.tensor([100], dtype=torch.long)  # 100 < 128
     with pytest.raises(ValueError, match="sizes sum to 100"):
         _nested_from_packed_tensor(packed, seq_lens)
 
@@ -55,7 +54,7 @@ def test_consistent_packing_succeeds():
     Control case: proves the crash comes from the inconsistency, not the function.
     """
     packed = torch.arange(128, dtype=torch.long)
-    seq_lens = torch.tensor([50, 78], dtype=torch.long)     # 50+78=128
+    seq_lens = torch.tensor([50, 78], dtype=torch.long)  # 50+78=128
     out = _nested_from_packed_tensor(packed, seq_lens)
     assert out is not None
-    assert out.size(0) == 2                                  # 2 segments
+    assert out.size(0) == 2  # 2 segments

--- a/experimental/lite/tests/unit/model/qwen3_5/lite/test_qwen35_export.py
+++ b/experimental/lite/tests/unit/model/qwen3_5/lite/test_qwen35_export.py
@@ -4,7 +4,6 @@ from types import SimpleNamespace
 
 import torch
 import torch.nn as nn
-
 from megatron.lite.model.qwen3_5.config import Qwen35Config
 from megatron.lite.model.qwen3_5.lite.checkpoint import (
     PLACEMENT_FN,
@@ -19,7 +18,10 @@ from megatron.lite.model.qwen3_5.lite.checkpoint import (
     export_hf_weights,
 )
 from megatron.lite.model.qwen3_5.lite.protocol import ImplConfig
-from megatron.lite.model.registry import TRAIN_RUNTIME_MODULES, resolve_runtime_model_name
+from megatron.lite.model.registry import (
+    TRAIN_RUNTIME_MODULES,
+    resolve_runtime_model_name,
+)
 
 
 def _tiny_config() -> Qwen35Config:
@@ -45,16 +47,18 @@ def _tiny_config() -> Qwen35Config:
 
 
 def _tiny_dense_config() -> Qwen35Config:
-    return replace(
-        _tiny_config(),
-        model_type="qwen3_5",
-        intermediate_size=12,
-    )
+    return replace(_tiny_config(), model_type="qwen3_5", intermediate_size=12)
 
 
 def _single_rank_parallel_state() -> SimpleNamespace:
     return SimpleNamespace(
-        pp_size=1, tp_size=1, tp_group=None, ep_size=1, ep_group=None, etp_size=1, etp_group=None
+        pp_size=1,
+        tp_size=1,
+        tp_group=None,
+        ep_size=1,
+        ep_group=None,
+        etp_size=1,
+        etp_group=None,
     )
 
 
@@ -108,9 +112,9 @@ def test_qwen35_export_dtype_cast_is_opt_in() -> None:
 
             rows = config.moe_intermediate_size * 2
             for expert_idx in range(config.num_experts):
-                tensor = torch.arange(rows * config.hidden_size, dtype=torch.float32).reshape(
-                    rows, config.hidden_size
-                )
+                tensor = torch.arange(
+                    rows * config.hidden_size, dtype=torch.float32
+                ).reshape(rows, config.hidden_size)
                 tensor = tensor + expert_idx * 1000
                 self.layers[0].moe.experts.fc1.register_parameter(
                     f"weight{expert_idx}", nn.Parameter(tensor)
@@ -121,7 +125,9 @@ def test_qwen35_export_dtype_cast_is_opt_in() -> None:
 
     default_export = dict(export_hf_weights(model, cfg, _single_rank_parallel_state()))
     bf16_export = dict(
-        export_hf_weights(model, cfg, _single_rank_parallel_state(), export_dtype="bfloat16")
+        export_hf_weights(
+            model, cfg, _single_rank_parallel_state(), export_dtype="bfloat16"
+        )
     )
 
     assert default_export["model.language_model.norm.weight"].dtype == torch.float32
@@ -148,9 +154,9 @@ def test_qwen35_export_preserves_runtime_parameter_dtype_by_default() -> None:
 
             rows = config.moe_intermediate_size * 2
             for expert_idx in range(config.num_experts):
-                tensor = torch.arange(rows * config.hidden_size, dtype=torch.bfloat16).reshape(
-                    rows, config.hidden_size
-                )
+                tensor = torch.arange(
+                    rows * config.hidden_size, dtype=torch.bfloat16
+                ).reshape(rows, config.hidden_size)
                 tensor = tensor + expert_idx * 1000
                 self.layers[0].moe.experts.fc1.register_parameter(
                     f"weight{expert_idx}", nn.Parameter(tensor)
@@ -163,7 +169,8 @@ def test_qwen35_export_preserves_runtime_parameter_dtype_by_default() -> None:
 
     assert exported["model.language_model.norm.weight"].dtype == torch.bfloat16
     assert (
-        exported["model.language_model.layers.0.mlp.experts.gate_up_proj"].dtype == torch.bfloat16
+        exported["model.language_model.layers.0.mlp.experts.gate_up_proj"].dtype
+        == torch.bfloat16
     )
 
 
@@ -175,10 +182,7 @@ def test_qwen35_online_export_keeps_weights_on_the_source_device() -> None:
 
     exported = dict(
         export_hf_weights(
-            TinyQwen35Module(),
-            _tiny_config(),
-            _single_rank_parallel_state(),
-            cpu=False,
+            TinyQwen35Module(), _tiny_config(), _single_rank_parallel_state(), cpu=False
         )
     )
 
@@ -241,7 +245,9 @@ def test_qwen35_export_batches_ep_expert_gather(monkeypatch) -> None:
         for i in range(cfg.num_experts // ps.ep_size)
     ]
     expected = torch.stack(local_tensors + [tensor + 2000 for tensor in local_tensors])
-    assert torch.equal(exported["model.language_model.layers.0.mlp.experts.gate_up_proj"], expected)
+    assert torch.equal(
+        exported["model.language_model.layers.0.mlp.experts.gate_up_proj"], expected
+    )
     layer1_tensors = [
         getattr(model.layers[1].moe.experts.fc1, f"weight{i}").detach()
         for i in range(cfg.num_experts // ps.ep_size)
@@ -266,9 +272,9 @@ def test_qwen35_export_uses_packed_expert_group_names(monkeypatch) -> None:
 
             rows = config.moe_intermediate_size * 2
             for expert_idx in range(config.num_experts):
-                tensor = torch.arange(rows * config.hidden_size, dtype=torch.bfloat16).reshape(
-                    rows, config.hidden_size
-                )
+                tensor = torch.arange(
+                    rows * config.hidden_size, dtype=torch.bfloat16
+                ).reshape(rows, config.hidden_size)
                 tensor = tensor + expert_idx * 1000
                 self.layers[0].moe.experts.fc1.register_parameter(
                     f"weight{expert_idx}", nn.Parameter(tensor)
@@ -284,7 +290,9 @@ def test_qwen35_export_uses_packed_expert_group_names(monkeypatch) -> None:
 
     monkeypatch.setattr(Qwen35WeightSpec, "native_to_hf", spy_native_to_hf)
 
-    exported = dict(export_hf_weights(TinyQwen35Module(cfg), cfg, _single_rank_parallel_state()))
+    exported = dict(
+        export_hf_weights(TinyQwen35Module(cfg), cfg, _single_rank_parallel_state())
+    )
 
     assert seen_native_names == ["layers.0.moe.experts.fc1.packed"]
     assert set(exported) == {"model.language_model.layers.0.mlp.experts.gate_up_proj"}
@@ -301,7 +309,10 @@ def test_qwen35_export_rank0_only_still_participates_in_ep_gather(monkeypatch) -
 
             rows = config.moe_intermediate_size * 2
             for local_idx in range(config.num_experts // 2):
-                tensor = torch.zeros(rows, config.hidden_size, dtype=torch.bfloat16) + local_idx
+                tensor = (
+                    torch.zeros(rows, config.hidden_size, dtype=torch.bfloat16)
+                    + local_idx
+                )
                 self.layers[0].moe.experts.fc1.register_parameter(
                     f"weight{local_idx}", nn.Parameter(tensor)
                 )
@@ -324,8 +335,12 @@ def test_qwen35_export_rank0_only_still_participates_in_ep_gather(monkeypatch) -
         output[: tensor.numel()].copy_(tensor)
         output[tensor.numel() :].copy_(tensor + 2)
 
-    monkeypatch.setattr("megatron.lite.primitive.ckpt.hf_weights.dist.is_initialized", lambda: True)
-    monkeypatch.setattr("megatron.lite.primitive.ckpt.hf_weights.dist.get_rank", lambda: 1)
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.hf_weights.dist.is_initialized", lambda: True
+    )
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.hf_weights.dist.get_rank", lambda: 1
+    )
     monkeypatch.setattr(
         "megatron.lite.primitive.ckpt.hf_weights.dist.all_gather_into_tensor",
         fake_all_gather,
@@ -389,9 +404,7 @@ def test_qwen35_dense_load_and_export_map_gated_mlp_weights() -> None:
     assert torch.equal(
         exported["model.language_model.layers.0.mlp.gate_proj.weight"], gate
     )
-    assert torch.equal(
-        exported["model.language_model.layers.0.mlp.up_proj.weight"], up
-    )
+    assert torch.equal(exported["model.language_model.layers.0.mlp.up_proj.weight"], up)
     assert torch.equal(
         exported["model.language_model.layers.0.mlp.down_proj.weight"], down
     )
@@ -401,9 +414,7 @@ def test_qwen35_hf_text_prefix_selects_composite_and_standalone_names() -> None:
     composite = Qwen35WeightSpec(
         replace(_tiny_dense_config(), hf_text_prefix="model.language_model")
     )
-    standalone = Qwen35WeightSpec(
-        replace(_tiny_dense_config(), hf_text_prefix="model")
-    )
+    standalone = Qwen35WeightSpec(replace(_tiny_dense_config(), hf_text_prefix="model"))
     native_name = "layers.0.mlp.down.linear.weight"
     tensor = torch.arange(12)
 
@@ -428,8 +439,7 @@ def test_qwen35_dense_mlp_tp_specs_and_placements() -> None:
     gate = torch.arange(48).reshape(6, 8)
     up = gate + 1000
     shards = [
-        torch.cat([gate.chunk(2)[rank], up.chunk(2)[rank]], dim=0)
-        for rank in range(2)
+        torch.cat([gate.chunk(2)[rank], up.chunk(2)[rank]], dim=0) for rank in range(2)
     ]
 
     assert type(PLACEMENT_FN(gate_up)[-1]).__name__ == "Shard"
@@ -447,12 +457,15 @@ def test_qwen35_export_unpacks_full_attention_q_gate() -> None:
     cfg = _tiny_config()
     spec = Qwen35WeightSpec(cfg)
     hidden = cfg.hidden_size
-    q_gate = torch.arange(cfg.num_attention_heads * 2 * cfg.head_dim * hidden).reshape(-1, hidden)
+    q_gate = torch.arange(cfg.num_attention_heads * 2 * cfg.head_dim * hidden).reshape(
+        -1, hidden
+    )
     key = torch.arange(
         q_gate.numel(), q_gate.numel() + cfg.num_key_value_heads * cfg.head_dim * hidden
     ).reshape(-1, hidden)
     value = torch.arange(
-        key[-1, -1] + 1, key[-1, -1] + 1 + cfg.num_key_value_heads * cfg.head_dim * hidden
+        key[-1, -1] + 1,
+        key[-1, -1] + 1 + cfg.num_key_value_heads * cfg.head_dim * hidden,
     ).reshape(-1, hidden)
 
     packed = _merge_full_attn_qkvg(q_gate, key, value, cfg=cfg)
@@ -463,9 +476,15 @@ def test_qwen35_export_unpacks_full_attention_q_gate() -> None:
         "model.language_model.layers.0.self_attn.k_proj.weight",
         "model.language_model.layers.0.self_attn.v_proj.weight",
     }
-    assert torch.equal(exported["model.language_model.layers.0.self_attn.q_proj.weight"], q_gate)
-    assert torch.equal(exported["model.language_model.layers.0.self_attn.k_proj.weight"], key)
-    assert torch.equal(exported["model.language_model.layers.0.self_attn.v_proj.weight"], value)
+    assert torch.equal(
+        exported["model.language_model.layers.0.self_attn.q_proj.weight"], q_gate
+    )
+    assert torch.equal(
+        exported["model.language_model.layers.0.self_attn.k_proj.weight"], key
+    )
+    assert torch.equal(
+        exported["model.language_model.layers.0.self_attn.v_proj.weight"], value
+    )
 
 
 def test_qwen35_full_attention_tp4_shards_roundtrip_with_two_kv_heads() -> None:
@@ -513,7 +532,9 @@ def test_qwen35_export_maps_linear_attention_to_hf_checkpoint_names() -> None:
     rows = qk_dim * 2 + v_dim * 2 + cfg.linear_num_value_heads * 2
     tensor = torch.arange(rows * cfg.hidden_size).reshape(rows, cfg.hidden_size)
 
-    exported = dict(spec.native_to_hf("layers.0.linear_attn.in_proj.linear.weight", tensor))
+    exported = dict(
+        spec.native_to_hf("layers.0.linear_attn.in_proj.linear.weight", tensor)
+    )
 
     assert set(exported) == {
         "model.language_model.layers.0.linear_attn.in_proj_qkv.weight",
@@ -522,10 +543,15 @@ def test_qwen35_export_maps_linear_attention_to_hf_checkpoint_names() -> None:
         "model.language_model.layers.0.linear_attn.in_proj_a.weight",
     }
     assert (
-        exported["model.language_model.layers.0.linear_attn.in_proj_qkv.weight"].shape[0]
+        exported["model.language_model.layers.0.linear_attn.in_proj_qkv.weight"].shape[
+            0
+        ]
         == qk_dim * 2 + v_dim
     )
-    assert exported["model.language_model.layers.0.linear_attn.in_proj_z.weight"].shape[0] == v_dim
+    assert (
+        exported["model.language_model.layers.0.linear_attn.in_proj_z.weight"].shape[0]
+        == v_dim
+    )
     assert (
         exported["model.language_model.layers.0.linear_attn.in_proj_b.weight"].shape[0]
         == cfg.linear_num_value_heads
@@ -554,7 +580,10 @@ def test_qwen35_export_reorders_linear_attention_tp_shards_before_hf_split() -> 
         ),
     ]
     full = torch.cat(parts, dim=0)
-    shards = [torch.cat([part.chunk(2, dim=0)[rank] for part in parts], dim=0) for rank in range(2)]
+    shards = [
+        torch.cat([part.chunk(2, dim=0)[rank] for part in parts], dim=0)
+        for rank in range(2)
+    ]
 
     merged = _merge_linear_attn_in_proj_tp_shards(shards, cfg=cfg)
 
@@ -567,18 +596,21 @@ def test_qwen35_export_reorders_linear_attention_conv1d_tp_shards() -> None:
     v_dim = cfg.linear_num_value_heads * cfg.linear_value_head_dim
     trailing = (1, cfg.linear_conv_kernel_dim)
     parts = [
-        torch.arange(0, qk_dim * trailing[0] * trailing[1], dtype=torch.float32).reshape(
-            qk_dim, *trailing
-        ),
-        torch.arange(100, 100 + qk_dim * trailing[0] * trailing[1], dtype=torch.float32).reshape(
-            qk_dim, *trailing
-        ),
-        torch.arange(200, 200 + v_dim * trailing[0] * trailing[1], dtype=torch.float32).reshape(
-            v_dim, *trailing
-        ),
+        torch.arange(
+            0, qk_dim * trailing[0] * trailing[1], dtype=torch.float32
+        ).reshape(qk_dim, *trailing),
+        torch.arange(
+            100, 100 + qk_dim * trailing[0] * trailing[1], dtype=torch.float32
+        ).reshape(qk_dim, *trailing),
+        torch.arange(
+            200, 200 + v_dim * trailing[0] * trailing[1], dtype=torch.float32
+        ).reshape(v_dim, *trailing),
     ]
     full = torch.cat(parts, dim=0)
-    shards = [torch.cat([part.chunk(2, dim=0)[rank] for part in parts], dim=0) for rank in range(2)]
+    shards = [
+        torch.cat([part.chunk(2, dim=0)[rank] for part in parts], dim=0)
+        for rank in range(2)
+    ]
 
     merged = _merge_linear_attn_conv1d_tp_shards(shards, cfg=cfg)
 
@@ -594,7 +626,14 @@ def test_qwen35_linear_attention_tp4_replicated_heads_roundtrip() -> None:
         torch.arange(offset, offset + rows * hidden).reshape(rows, hidden)
         for offset, rows in zip(
             (0, 100, 200, 300, 400, 500),
-            (qk_dim, qk_dim, v_dim, v_dim, cfg.linear_num_value_heads, cfg.linear_num_value_heads),
+            (
+                qk_dim,
+                qk_dim,
+                v_dim,
+                v_dim,
+                cfg.linear_num_value_heads,
+                cfg.linear_num_value_heads,
+            ),
             strict=True,
         )
     ]
@@ -605,9 +644,9 @@ def test_qwen35_linear_attention_tp4_replicated_heads_roundtrip() -> None:
     ]
 
     conv_parts = [
-        torch.arange(offset, offset + rows * cfg.linear_conv_kernel_dim, dtype=torch.float32).reshape(
-            rows, 1, cfg.linear_conv_kernel_dim
-        )
+        torch.arange(
+            offset, offset + rows * cfg.linear_conv_kernel_dim, dtype=torch.float32
+        ).reshape(rows, 1, cfg.linear_conv_kernel_dim)
         for offset, rows in zip((0, 100, 200), (qk_dim, qk_dim, v_dim), strict=True)
     ]
     full_conv = torch.cat(conv_parts, dim=0)
@@ -619,7 +658,9 @@ def test_qwen35_linear_attention_tp4_replicated_heads_roundtrip() -> None:
     assert torch.equal(
         _merge_linear_attn_in_proj_tp_shards(in_proj_shards, cfg=cfg), full_in_proj
     )
-    assert all(shard.shape == (3, 1, cfg.linear_conv_kernel_dim) for shard in conv_shards)
+    assert all(
+        shard.shape == (3, 1, cfg.linear_conv_kernel_dim) for shard in conv_shards
+    )
     assert torch.equal(
         _merge_linear_attn_conv1d_tp_shards(conv_shards, cfg=cfg), full_conv
     )
@@ -628,7 +669,9 @@ def test_qwen35_linear_attention_tp4_replicated_heads_roundtrip() -> None:
 def test_qwen35_linear_attention_state_is_tp_replicated() -> None:
     spec = Qwen35WeightSpec(_tiny_config())
 
-    assert type(PLACEMENT_FN("layers.0.linear_attn.dt_bias")[-1]).__name__ == "Replicate"
+    assert (
+        type(PLACEMENT_FN("layers.0.linear_attn.dt_bias")[-1]).__name__ == "Replicate"
+    )
     assert type(PLACEMENT_FN("layers.0.linear_attn.A_log")[-1]).__name__ == "Replicate"
     assert spec.tp_spec("layers.0.linear_attn.dt_bias") is None
     assert spec.tp_spec("layers.0.linear_attn.A_log") is None
@@ -642,9 +685,7 @@ def test_qwen35_linear_attention_state_load_matches_head_layout() -> None:
     )
     ps = SimpleNamespace(tp_size=4, tp_rank=2)
 
-    assert torch.equal(
-        _tp_linear_attn_state(state, cfg=replicated_cfg, ps=ps), state
-    )
+    assert torch.equal(_tp_linear_attn_state(state, cfg=replicated_cfg, ps=ps), state)
     assert torch.equal(
         _tp_linear_attn_state(state, cfg=sharded_cfg, ps=ps), state.chunk(4)[2]
     )
@@ -666,18 +707,21 @@ def test_qwen35_export_uses_mbridge_conv1d_tp_gather(monkeypatch) -> None:
     v_dim = cfg.linear_num_value_heads * cfg.linear_value_head_dim
     trailing = (1, cfg.linear_conv_kernel_dim)
     parts = [
-        torch.arange(0, qk_dim * trailing[0] * trailing[1], dtype=torch.float32).reshape(
-            qk_dim, *trailing
-        ),
-        torch.arange(100, 100 + qk_dim * trailing[0] * trailing[1], dtype=torch.float32).reshape(
-            qk_dim, *trailing
-        ),
-        torch.arange(200, 200 + v_dim * trailing[0] * trailing[1], dtype=torch.float32).reshape(
-            v_dim, *trailing
-        ),
+        torch.arange(
+            0, qk_dim * trailing[0] * trailing[1], dtype=torch.float32
+        ).reshape(qk_dim, *trailing),
+        torch.arange(
+            100, 100 + qk_dim * trailing[0] * trailing[1], dtype=torch.float32
+        ).reshape(qk_dim, *trailing),
+        torch.arange(
+            200, 200 + v_dim * trailing[0] * trailing[1], dtype=torch.float32
+        ).reshape(v_dim, *trailing),
     ]
     full = torch.cat(parts, dim=0)
-    shards = [torch.cat([part.chunk(2, dim=0)[rank] for part in parts], dim=0) for rank in range(2)]
+    shards = [
+        torch.cat([part.chunk(2, dim=0)[rank] for part in parts], dim=0)
+        for rank in range(2)
+    ]
     ps = SimpleNamespace(
         pp_size=1,
         tp_size=2,
@@ -704,7 +748,9 @@ def test_qwen35_export_uses_mbridge_conv1d_tp_gather(monkeypatch) -> None:
 
     assert len(gather_calls) == 1
     assert torch.equal(gather_calls[0], shards[0])
-    assert torch.equal(exported["model.language_model.layers.0.linear_attn.conv1d.weight"], full)
+    assert torch.equal(
+        exported["model.language_model.layers.0.linear_attn.conv1d.weight"], full
+    )
 
 
 def test_qwen35_export_reorders_shared_expert_gate_up_tp_shards() -> None:
@@ -737,11 +783,13 @@ def test_qwen35_export_restores_zero_centered_linear_attention_norm() -> None:
 def test_qwen35_export_maps_shared_expert_to_hf_checkpoint_names() -> None:
     cfg = _tiny_config()
     spec = Qwen35WeightSpec(cfg)
-    tensor = torch.arange(cfg.shared_expert_intermediate_size * 2 * cfg.hidden_size).reshape(
-        -1, cfg.hidden_size
-    )
+    tensor = torch.arange(
+        cfg.shared_expert_intermediate_size * 2 * cfg.hidden_size
+    ).reshape(-1, cfg.hidden_size)
 
-    exported = dict(spec.native_to_hf("layers.0.moe.shared_expert.gate_up.linear.weight", tensor))
+    exported = dict(
+        spec.native_to_hf("layers.0.moe.shared_expert.gate_up.linear.weight", tensor)
+    )
 
     assert set(exported) == {
         "model.language_model.layers.0.mlp.shared_expert.gate_proj.weight",
@@ -749,7 +797,8 @@ def test_qwen35_export_maps_shared_expert_to_hf_checkpoint_names() -> None:
     }
     gate, up = tensor.chunk(2, dim=0)
     assert torch.equal(
-        exported["model.language_model.layers.0.mlp.shared_expert.gate_proj.weight"], gate
+        exported["model.language_model.layers.0.mlp.shared_expert.gate_proj.weight"],
+        gate,
     )
     assert torch.equal(
         exported["model.language_model.layers.0.mlp.shared_expert.up_proj.weight"], up
@@ -769,7 +818,11 @@ def test_qwen35_export_packs_base_expert_fc1_to_hf_gate_up_proj() -> None:
         tensor = base + expert_idx * 1000
         expert_tensors.append(tensor)
         exported.update(
-            dict(spec.native_to_hf(f"layers.0.moe.experts.fc1.weight{expert_idx}", tensor))
+            dict(
+                spec.native_to_hf(
+                    f"layers.0.moe.experts.fc1.weight{expert_idx}", tensor
+                )
+            )
         )
 
     assert set(exported) == {"model.language_model.layers.0.mlp.experts.gate_up_proj"}
@@ -784,14 +837,16 @@ def test_qwen35_export_matches_mbridge_qwen35_moe_packed_expert_contract() -> No
     spec = Qwen35WeightSpec(cfg)
     rows = cfg.moe_intermediate_size * 2
     fc1_tensors = [
-        torch.arange(rows * cfg.hidden_size, dtype=torch.bfloat16).reshape(rows, cfg.hidden_size)
+        torch.arange(rows * cfg.hidden_size, dtype=torch.bfloat16).reshape(
+            rows, cfg.hidden_size
+        )
         + expert_idx * 1000
         for expert_idx in range(cfg.num_experts)
     ]
     fc2_tensors = [
-        torch.arange(cfg.hidden_size * cfg.moe_intermediate_size, dtype=torch.bfloat16).reshape(
-            cfg.hidden_size, cfg.moe_intermediate_size
-        )
+        torch.arange(
+            cfg.hidden_size * cfg.moe_intermediate_size, dtype=torch.bfloat16
+        ).reshape(cfg.hidden_size, cfg.moe_intermediate_size)
         + expert_idx * 1000
         for expert_idx in range(cfg.num_experts)
     ]
@@ -806,7 +861,9 @@ def test_qwen35_export_matches_mbridge_qwen35_moe_packed_expert_contract() -> No
             dict(spec.native_to_hf(f"layers.0.moe.experts.fc2.weight{expert_idx}", fc2))
         )
 
-    assert set(fc1_exported) == {"model.language_model.layers.0.mlp.experts.gate_up_proj"}
+    assert set(fc1_exported) == {
+        "model.language_model.layers.0.mlp.experts.gate_up_proj"
+    }
     assert set(fc2_exported) == {"model.language_model.layers.0.mlp.experts.down_proj"}
     assert torch.equal(
         fc1_exported["model.language_model.layers.0.mlp.experts.gate_up_proj"],
@@ -818,7 +875,9 @@ def test_qwen35_export_matches_mbridge_qwen35_moe_packed_expert_contract() -> No
     )
 
 
-def test_qwen35_export_vllm_target_uses_runtime_prefix_and_packed_expert_names() -> None:
+def test_qwen35_export_vllm_target_uses_runtime_prefix_and_packed_expert_names() -> (
+    None
+):
     cfg = _tiny_config()
     spec = Qwen35WeightSpec(cfg, target="vllm")
     dense = torch.arange(cfg.hidden_size)
@@ -833,24 +892,29 @@ def test_qwen35_export_vllm_target_uses_runtime_prefix_and_packed_expert_names()
     assert set(exported_mlp_norm) == {
         "language_model.model.layers.0.post_attention_layernorm.weight"
     }
-    assert torch.equal(exported_embed["language_model.model.embed_tokens.weight"], dense)
+    assert torch.equal(
+        exported_embed["language_model.model.embed_tokens.weight"], dense
+    )
     assert torch.equal(exported_norm["language_model.model.norm.weight"], dense)
     assert torch.equal(exported_head["language_model.lm_head.weight"], dense)
     assert torch.equal(
-        exported_mlp_norm["language_model.model.layers.0.post_attention_layernorm.weight"], dense
+        exported_mlp_norm[
+            "language_model.model.layers.0.post_attention_layernorm.weight"
+        ],
+        dense,
     )
 
     fc1_tensors = [
-        torch.arange(cfg.moe_intermediate_size * 2 * cfg.hidden_size, dtype=torch.bfloat16).reshape(
-            -1, cfg.hidden_size
-        )
+        torch.arange(
+            cfg.moe_intermediate_size * 2 * cfg.hidden_size, dtype=torch.bfloat16
+        ).reshape(-1, cfg.hidden_size)
         + expert_idx * 1000
         for expert_idx in range(cfg.num_experts)
     ]
     fc2_tensors = [
-        torch.arange(cfg.hidden_size * cfg.moe_intermediate_size, dtype=torch.bfloat16).reshape(
-            cfg.hidden_size, cfg.moe_intermediate_size
-        )
+        torch.arange(
+            cfg.hidden_size * cfg.moe_intermediate_size, dtype=torch.bfloat16
+        ).reshape(cfg.hidden_size, cfg.moe_intermediate_size)
         + expert_idx * 2000
         for expert_idx in range(cfg.num_experts)
     ]
@@ -865,7 +929,9 @@ def test_qwen35_export_vllm_target_uses_runtime_prefix_and_packed_expert_names()
             dict(spec.native_to_hf(f"layers.0.moe.experts.fc2.weight{expert_idx}", fc2))
         )
 
-    assert set(fc1_exported) == {"language_model.model.layers.0.mlp.experts.gate_up_proj"}
+    assert set(fc1_exported) == {
+        "language_model.model.layers.0.mlp.experts.gate_up_proj"
+    }
     assert set(fc2_exported) == {"language_model.model.layers.0.mlp.experts.down_proj"}
     assert torch.equal(
         fc1_exported["language_model.model.layers.0.mlp.experts.gate_up_proj"],
@@ -889,12 +955,13 @@ def test_qwen35_export_vllm_target_packs_experts_with_runtime_prefix() -> None:
 
             rows = config.moe_intermediate_size * 2
             for expert_idx in range(config.num_experts):
-                fc1 = torch.arange(rows * config.hidden_size, dtype=torch.bfloat16).reshape(
-                    rows, config.hidden_size
-                )
+                fc1 = torch.arange(
+                    rows * config.hidden_size, dtype=torch.bfloat16
+                ).reshape(rows, config.hidden_size)
                 fc1 = fc1 + expert_idx * 1000
                 fc2 = torch.arange(
-                    config.hidden_size * config.moe_intermediate_size, dtype=torch.bfloat16
+                    config.hidden_size * config.moe_intermediate_size,
+                    dtype=torch.bfloat16,
                 ).reshape(config.hidden_size, config.moe_intermediate_size)
                 fc2 = fc2 + expert_idx * 2000
                 self.layers[0].moe.experts.fc1.register_parameter(
@@ -907,12 +974,18 @@ def test_qwen35_export_vllm_target_packs_experts_with_runtime_prefix() -> None:
     cfg = _tiny_config()
     model = TinyQwen35Module(cfg)
 
-    exported = dict(export_hf_weights(model, cfg, _single_rank_parallel_state(), target="vllm"))
+    exported = dict(
+        export_hf_weights(model, cfg, _single_rank_parallel_state(), target="vllm")
+    )
 
     assert "model.language_model.layers.0.mlp.experts.gate_up_proj" not in exported
     assert "model.language_model.layers.0.mlp.experts.down_proj" not in exported
-    assert "language_model.model.layers.0.mlp.experts.0.gate_proj.weight" not in exported
-    assert "language_model.model.layers.0.mlp.experts.0.down_proj.weight" not in exported
+    assert (
+        "language_model.model.layers.0.mlp.experts.0.gate_proj.weight" not in exported
+    )
+    assert (
+        "language_model.model.layers.0.mlp.experts.0.down_proj.weight" not in exported
+    )
     assert set(exported) == {
         "language_model.model.layers.0.mlp.experts.gate_up_proj",
         "language_model.model.layers.0.mlp.experts.down_proj",
@@ -950,7 +1023,11 @@ def test_qwen35_export_packs_base_expert_fc2_and_expert_metadata() -> None:
         tensor = base + expert_idx * 1000
         expert_tensors.append(tensor)
         exported.update(
-            dict(spec.native_to_hf(f"layers.0.moe.experts.fc2.weight{expert_idx}", tensor))
+            dict(
+                spec.native_to_hf(
+                    f"layers.0.moe.experts.fc2.weight{expert_idx}", tensor
+                )
+            )
         )
 
     assert set(exported) == {"model.language_model.layers.0.mlp.experts.down_proj"}

--- a/experimental/lite/tests/unit/model/test_all_model_qat_r3_contracts.py
+++ b/experimental/lite/tests/unit/model/test_all_model_qat_r3_contracts.py
@@ -111,11 +111,7 @@ class _CpuTERMSNorm(nn.Module):
     """State-dict-compatible TE RMSNorm stand-in for CPU-only construction."""
 
     def __init__(
-        self,
-        hidden_size: int,
-        *,
-        zero_centered_gamma: bool = False,
-        **_kwargs,
+        self, hidden_size: int, *, zero_centered_gamma: bool = False, **_kwargs
     ):
         super().__init__()
         self.weight = nn.Parameter(torch.zeros(hidden_size))
@@ -142,13 +138,11 @@ class _CpuTEGroupedLinear(nn.Module):
         super().__init__()
         for index in range(num_gemms):
             self.register_parameter(
-                f"weight{index}",
-                nn.Parameter(torch.empty(out_features, in_features)),
+                f"weight{index}", nn.Parameter(torch.empty(out_features, in_features))
             )
             if bias:
                 self.register_parameter(
-                    f"bias{index}",
-                    nn.Parameter(torch.zeros(out_features)),
+                    f"bias{index}", nn.Parameter(torch.zeros(out_features))
                 )
 
 
@@ -187,11 +181,7 @@ def _layers(chunk: _TinyChunk) -> list[nn.Module]:
 
 
 def _case(
-    model_name: str,
-    transformer_engine_import_stub,
-    monkeypatch,
-    *,
-    mtp_enabled: bool,
+    model_name: str, transformer_engine_import_stub, monkeypatch, *, mtp_enabled: bool
 ) -> _ModelCase:
     return _ModelCase(
         name=model_name,
@@ -437,8 +427,7 @@ R3_SUPPORTED_MODEL_NAMES = MODEL_NAMES
 
 
 def test_mapped_model_state_has_no_optional_override(
-    transformer_engine_import_stub,
-    monkeypatch,
+    transformer_engine_import_stub, monkeypatch
 ):
     for model_name, spec_name in (
         ("kimi_k2", "KimiK2WeightSpec"),
@@ -457,21 +446,13 @@ def test_mapped_model_state_has_no_optional_override(
 
 @pytest.mark.parametrize(
     ("model_name", "spec_name"),
-    [
-        ("kimi_k2", "KimiK2WeightSpec"),
-        ("glm5", "Glm5WeightSpec"),
-    ],
+    [("kimi_k2", "KimiK2WeightSpec"), ("glm5", "Glm5WeightSpec")],
 )
 def test_persistent_router_bias_is_required(
-    model_name,
-    spec_name,
-    tmp_path,
-    transformer_engine_import_stub,
-    monkeypatch,
+    model_name, spec_name, tmp_path, transformer_engine_import_stub, monkeypatch
 ):
-    from safetensors.torch import save_file
-
     from megatron.lite.primitive.ckpt.hf_weights import load_hf_weights
+    from safetensors.torch import save_file
 
     _protocol(model_name, transformer_engine_import_stub, monkeypatch)
     checkpoint = importlib.import_module(
@@ -505,35 +486,22 @@ def test_persistent_router_bias_is_required(
             "layers.0.moe.router.expert_bias": ["hf.router.expert_bias"],
         },
     )
-    save_file(
-        {"hf.required": torch.ones(1)},
-        str(tmp_path / "model.safetensors"),
-    )
+    save_file({"hf.required": torch.ones(1)}, str(tmp_path / "model.safetensors"))
     ps = types.SimpleNamespace(
-        ep_size=1,
-        ep_rank=0,
-        tp_size=1,
-        tp_rank=0,
-        etp_size=1,
-        etp_rank=0,
-        pp_size=1,
+        ep_size=1, ep_rank=0, tp_size=1, tp_rank=0, etp_size=1, etp_rank=0, pp_size=1
     )
 
     with pytest.raises(
-        RuntimeError,
-        match=rf"{spec_name}.*layers\.0\.moe\.router\.expert_bias",
+        RuntimeError, match=rf"{spec_name}.*layers\.0\.moe\.router\.expert_bias"
     ):
         load_hf_weights(model, str(tmp_path), spec, ps)
 
 
 def test_deepseek_v4_router_buffer_remains_required(
-    tmp_path,
-    transformer_engine_import_stub,
-    monkeypatch,
+    tmp_path, transformer_engine_import_stub, monkeypatch
 ):
-    from safetensors.torch import save_file
-
     from megatron.lite.primitive.ckpt.hf_weights import load_hf_weights
+    from safetensors.torch import save_file
 
     _protocol("deepseek_v4", transformer_engine_import_stub, monkeypatch)
     checkpoint = importlib.import_module(
@@ -559,17 +527,9 @@ def test_deepseek_v4_router_buffer_remains_required(
             super().__init__()
             self.layers = nn.ModuleList([Layer()])
 
-    save_file(
-        {"unrelated": torch.ones(1)},
-        str(tmp_path / "model.safetensors"),
-    )
+    save_file({"unrelated": torch.ones(1)}, str(tmp_path / "model.safetensors"))
     ps = types.SimpleNamespace(
-        ep_size=1,
-        ep_rank=0,
-        tp_size=1,
-        tp_rank=0,
-        etp_size=1,
-        etp_rank=0,
+        ep_size=1, ep_rank=0, tp_size=1, tp_rank=0, etp_size=1, etp_rank=0
     )
 
     with pytest.raises(
@@ -581,16 +541,13 @@ def test_deepseek_v4_router_buffer_remains_required(
 
 
 def test_kimi_router_bias_92_key_roundtrip_uses_weight_map(
-    tmp_path,
-    transformer_engine_import_stub,
-    monkeypatch,
+    tmp_path, transformer_engine_import_stub, monkeypatch
 ):
-    from safetensors.torch import save_file
-
     from megatron.lite.primitive.ckpt.hf_weights import (
         export_hf_weights,
         load_hf_weights,
     )
+    from safetensors.torch import save_file
 
     _protocol("kimi_k2", transformer_engine_import_stub, monkeypatch)
     checkpoint = importlib.import_module("megatron.lite.model.kimi_k2.lite.checkpoint")
@@ -599,10 +556,7 @@ def test_kimi_router_bias_92_key_roundtrip_uses_weight_map(
     class Router(nn.Module):
         def __init__(self, layer_idx):
             super().__init__()
-            self.register_buffer(
-                "expert_bias",
-                torch.full((2,), float(layer_idx)),
-            )
+            self.register_buffer("expert_bias", torch.full((2,), float(layer_idx)))
 
     class Layer(nn.Module):
         def __init__(self, layer_idx):
@@ -649,8 +603,7 @@ def test_kimi_router_bias_92_key_roundtrip_uses_weight_map(
 
     assert all(
         torch.equal(
-            loaded.layers[idx].moe.router.expert_bias,
-            torch.full((2,), float(idx)),
+            loaded.layers[idx].moe.router.expert_bias, torch.full((2,), float(idx))
         )
         for idx in range(92)
     )
@@ -658,9 +611,7 @@ def test_kimi_router_bias_92_key_roundtrip_uses_weight_map(
 
 @pytest.mark.parametrize("cp_rank", [0, 1])
 def test_glm5_r3_route_packing_matches_contiguous_forward_layout(
-    cp_rank,
-    transformer_engine_import_stub,
-    monkeypatch,
+    cp_rank, transformer_engine_import_stub, monkeypatch
 ):
     from megatron.lite.runtime.contracts import PackedBatch
 
@@ -668,11 +619,7 @@ def test_glm5_r3_route_packing_matches_contiguous_forward_layout(
     deepseek_v4 = _protocol("deepseek_v4", transformer_engine_import_stub, monkeypatch)
     model = nn.Module()
     model.ps = types.SimpleNamespace(
-        tp_size=1,
-        tp_rank=0,
-        cp_size=2,
-        cp_rank=cp_rank,
-        cp_group=None,
+        tp_size=1, tp_rank=0, cp_size=2, cp_rank=cp_rank, cp_group=None
     )
     batch = PackedBatch(
         input_ids=torch.arange(8),
@@ -701,16 +648,10 @@ def test_glm5_r3_route_packing_matches_contiguous_forward_layout(
 @pytest.mark.parametrize("model_name", R3_SUPPORTED_MODEL_NAMES)
 @pytest.mark.parametrize("mtp_enabled", [False, True], ids=["mtp-off", "mtp-on"])
 def test_supported_model_replay_roots_are_exact_decoder_layers(
-    model_name: str,
-    mtp_enabled: bool,
-    transformer_engine_import_stub,
-    monkeypatch,
+    model_name: str, mtp_enabled: bool, transformer_engine_import_stub, monkeypatch
 ):
     case = _case(
-        model_name,
-        transformer_engine_import_stub,
-        monkeypatch,
-        mtp_enabled=mtp_enabled,
+        model_name, transformer_engine_import_stub, monkeypatch, mtp_enabled=mtp_enabled
     )
     expected = _layers(case.chunk)
 
@@ -718,9 +659,9 @@ def test_supported_model_replay_roots_are_exact_decoder_layers(
 
     assert roots == expected
     assert len(roots) == len(case.chunk.model.layers)
-    assert roots != [case.chunk], (
-        "falling back to the whole chunk would include MTP routers"
-    )
+    assert roots != [
+        case.chunk
+    ], "falling back to the whole chunk would include MTP routers"
     if mtp_enabled:
         mtp_modules = set(case.chunk.model.mtp.modules())
         assert all(root not in mtp_modules for root in roots)
@@ -728,15 +669,10 @@ def test_supported_model_replay_roots_are_exact_decoder_layers(
 
 @pytest.mark.parametrize("model_name", R3_SUPPORTED_MODEL_NAMES)
 def test_supported_model_mtp_off_replay_attachment_count_is_unchanged(
-    model_name: str,
-    transformer_engine_import_stub,
-    monkeypatch,
+    model_name: str, transformer_engine_import_stub, monkeypatch
 ):
     case = _case(
-        model_name,
-        transformer_engine_import_stub,
-        monkeypatch,
-        mtp_enabled=False,
+        model_name, transformer_engine_import_stub, monkeypatch, mtp_enabled=False
     )
     old_count = attach_router_replay(case.chunk, reset=False)
     detach_router_replay(case.chunk)
@@ -753,15 +689,10 @@ def test_supported_model_mtp_off_replay_attachment_count_is_unchanged(
 
 @pytest.mark.parametrize("model_name", R3_SUPPORTED_MODEL_NAMES)
 def test_supported_model_attaches_replay_only_to_decoder_router_count(
-    model_name: str,
-    transformer_engine_import_stub,
-    monkeypatch,
+    model_name: str, transformer_engine_import_stub, monkeypatch
 ):
     case = _case(
-        model_name,
-        transformer_engine_import_stub,
-        monkeypatch,
-        mtp_enabled=True,
+        model_name, transformer_engine_import_stub, monkeypatch, mtp_enabled=True
     )
     roots = case.protocol.router_replay_roots(case.chunk)
 
@@ -781,9 +712,7 @@ def test_supported_model_attaches_replay_only_to_decoder_router_count(
 
 @pytest.mark.parametrize("model_name", MODEL_NAMES)
 def test_real_tiny_model_replay_attachment_count_matches_decoder_layers(
-    model_name: str,
-    transformer_engine_import_stub,
-    monkeypatch,
+    model_name: str, transformer_engine_import_stub, monkeypatch
 ):
     _install_cpu_te_construction_stubs(transformer_engine_import_stub, monkeypatch)
     model = _real_tiny_model(model_name, monkeypatch)
@@ -800,10 +729,7 @@ def test_real_tiny_model_replay_attachment_count_matches_decoder_layers(
     ("key", "expected"),
     [
         ("layers.0.mlp.weight", "layers.0.mlp.weight"),
-        (
-            "layers.0.mlp.parametrizations.weight.original",
-            "layers.0.mlp.weight",
-        ),
+        ("layers.0.mlp.parametrizations.weight.original", "layers.0.mlp.weight"),
         (
             "layers.0.mlp.parametrizations.weight.0.amax",
             "layers.0.mlp.parametrizations.weight.0.amax",
@@ -833,9 +759,7 @@ def test_every_model_uses_shared_canonical_state_key(
 
 @pytest.mark.parametrize("model_name", MODEL_NAMES)
 def test_every_model_qat_off_canonicalization_is_identity_for_all_real_state_keys(
-    model_name: str,
-    transformer_engine_import_stub,
-    monkeypatch,
+    model_name: str, transformer_engine_import_stub, monkeypatch
 ):
     _install_cpu_te_construction_stubs(transformer_engine_import_stub, monkeypatch)
     model = _real_tiny_model(model_name, monkeypatch)
@@ -851,15 +775,10 @@ def test_every_model_qat_off_canonicalization_is_identity_for_all_real_state_key
 
 @pytest.mark.parametrize("model_name", MODEL_NAMES)
 def test_every_model_qat_none_is_bitwise_inert(
-    model_name: str,
-    transformer_engine_import_stub,
-    monkeypatch,
+    model_name: str, transformer_engine_import_stub, monkeypatch
 ):
     case = _case(
-        model_name,
-        transformer_engine_import_stub,
-        monkeypatch,
-        mtp_enabled=False,
+        model_name, transformer_engine_import_stub, monkeypatch, mtp_enabled=False
     )
     implicit = copy.deepcopy(case.chunk)
     explicit = copy.deepcopy(case.chunk)
@@ -885,20 +804,14 @@ def test_every_model_qat_none_is_bitwise_inert(
 
 @pytest.mark.parametrize("model_name", MODEL_NAMES)
 def test_every_model_qat_quantizes_gate_up_but_not_router_gate(
-    model_name: str,
-    transformer_engine_import_stub,
-    monkeypatch,
+    model_name: str, transformer_engine_import_stub, monkeypatch
 ):
     case = _case(
-        model_name,
-        transformer_engine_import_stub,
-        monkeypatch,
-        mtp_enabled=False,
+        model_name, transformer_engine_import_stub, monkeypatch, mtp_enabled=False
     )
 
     stats = apply_qat_to_chunks(
-        [case.chunk],
-        QATSpec(enabled=True, format="int8", group_size=-1),
+        [case.chunk], QATSpec(enabled=True, format="int8", group_size=-1)
     )
 
     assert stats["quantized_modules"] > 0
@@ -910,15 +823,12 @@ def test_every_model_qat_quantizes_gate_up_but_not_router_gate(
 
 @pytest.mark.parametrize("model_name", MODEL_NAMES)
 def test_every_model_qat_expert_load_target_resolves_master_weight(
-    model_name: str,
-    transformer_engine_import_stub,
-    monkeypatch,
+    model_name: str, transformer_engine_import_stub, monkeypatch
 ):
     _install_cpu_te_construction_stubs(transformer_engine_import_stub, monkeypatch)
     model = _real_tiny_model(model_name, monkeypatch)
     stats = apply_qat_to_chunks(
-        [model],
-        QATSpec(enabled=True, format="int8", group_size=-1),
+        [model], QATSpec(enabled=True, format="int8", group_size=-1)
     )
     assert stats["quantized_modules"] > 0
 

--- a/experimental/lite/tests/unit/model/test_deepseek_v4_hf_export_dtype.py
+++ b/experimental/lite/tests/unit/model/test_deepseek_v4_hf_export_dtype.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import pytest
 import torch
 
-
 _CHECKPOINT_PATH = (
     Path(__file__).resolve().parents[3]
     / "megatron"

--- a/experimental/lite/tests/unit/model/test_deepseek_v4_resync.py
+++ b/experimental/lite/tests/unit/model/test_deepseek_v4_resync.py
@@ -6,7 +6,6 @@ from types import SimpleNamespace
 
 import torch
 
-
 _RESYNC_PATH = (
     Path(__file__).resolve().parents[3]
     / "megatron"
@@ -27,8 +26,7 @@ export_resync_weights = _MODULE.export_resync_weights
 
 def test_fp8_resync_exports_float32_block_scales() -> None:
     config = SimpleNamespace(
-        expert_dtype="fp8",
-        quantization_config={"weight_block_size": [128, 128]},
+        expert_dtype="fp8", quantization_config={"weight_block_size": [128, 128]}
     )
     source = torch.randn(128, 128, dtype=torch.bfloat16)
 
@@ -51,10 +49,7 @@ def test_fp4_resync_uses_mxfp4_only_for_routed_experts(monkeypatch) -> None:
         return tensor.to(torch.uint8), torch.ones(1, dtype=torch.uint8)
 
     def fake_block_fp8(
-        tensor: torch.Tensor,
-        _block_shape: tuple[int, int],
-        *,
-        scale_format: str,
+        tensor: torch.Tensor, _block_shape: tuple[int, int], *, scale_format: str
     ) -> tuple[torch.Tensor, torch.Tensor]:
         calls.append(("block_fp8", scale_format))
         return tensor.to(torch.float8_e4m3fn), torch.ones(1, dtype=torch.uint8)
@@ -62,8 +57,7 @@ def test_fp4_resync_uses_mxfp4_only_for_routed_experts(monkeypatch) -> None:
     monkeypatch.setattr(_MODULE, "quantize_mxfp4", fake_mxfp4)
     monkeypatch.setattr(_MODULE, "quantize_block_fp8", fake_block_fp8)
     config = SimpleNamespace(
-        expert_dtype="fp4",
-        quantization_config={"weight_block_size": [128, 128]},
+        expert_dtype="fp4", quantization_config={"weight_block_size": [128, 128]}
     )
     source = torch.randn(2, 2, dtype=torch.bfloat16)
 

--- a/experimental/lite/tests/unit/model/test_glm5_lite_static.py
+++ b/experimental/lite/tests/unit/model/test_glm5_lite_static.py
@@ -41,23 +41,20 @@ def _use_cpu_transformer_engine_stubs(monkeypatch):
     import transformer_engine.pytorch as te
 
     class _GroupedLinear(nn.Module):
-        def __init__(self, num_gemms, in_features, out_features, *, params_dtype=None, **_):
+        def __init__(
+            self, num_gemms, in_features, out_features, *, params_dtype=None, **_
+        ):
             super().__init__()
             dtype = params_dtype or torch.get_default_dtype()
             for index in range(num_gemms):
                 self.register_parameter(
-                    f"weight{index}", nn.Parameter(torch.empty(out_features, in_features, dtype=dtype))
+                    f"weight{index}",
+                    nn.Parameter(torch.empty(out_features, in_features, dtype=dtype)),
                 )
 
     class _LayerNormLinear(nn.Module):
         def __init__(
-            self,
-            in_features,
-            out_features,
-            *,
-            bias=True,
-            params_dtype=None,
-            **_,
+            self, in_features, out_features, *, bias=True, params_dtype=None, **_
         ):
             super().__init__()
             dtype = params_dtype or torch.get_default_dtype()
@@ -79,9 +76,7 @@ def _use_cpu_transformer_engine_stubs(monkeypatch):
 
     def _rms_norm(normalized_shape, *, eps=None, params_dtype=None, **_):
         return nn.RMSNorm(
-            normalized_shape,
-            eps=eps,
-            dtype=params_dtype or torch.get_default_dtype(),
+            normalized_shape, eps=eps, dtype=params_dtype or torch.get_default_dtype()
         )
 
     monkeypatch.setattr(te, "GroupedLinear", _GroupedLinear)
@@ -195,7 +190,6 @@ def test_glm5_config_ignores_null_hf_optional_fields():
 
 def test_glm52_config_validates_index_share_schedule():
     import pytest
-
     from megatron.lite.model.glm5.config import Glm5Config
 
     indexer_types = _glm52_indexer_types()
@@ -255,7 +249,14 @@ def test_glm5_config_preserves_mtp_aliases_and_layer_types():
 
 
 def test_glm5_lite_does_not_import_wrappers_or_sibling_models():
-    root = Path(__file__).resolve().parents[3] / "megatron" / "lite" / "model" / "glm5" / "lite"
+    root = (
+        Path(__file__).resolve().parents[3]
+        / "megatron"
+        / "lite"
+        / "model"
+        / "glm5"
+        / "lite"
+    )
     for path in root.glob("*.py"):
         text = path.read_text()
         assert "megatron.lite.model.qwen" not in text
@@ -267,7 +268,9 @@ def test_glm5_lite_does_not_import_wrappers_or_sibling_models():
 def test_glm5_lite_uses_shared_mla_and_dsa_primitive():
     root = Path(__file__).resolve().parents[3] / "megatron" / "lite"
     model_text = (root / "model" / "glm5" / "lite" / "model.py").read_text()
-    primitive_text = (root / "primitive" / "modules" / "attention" / "dsa.py").read_text()
+    primitive_text = (
+        root / "primitive" / "modules" / "attention" / "dsa.py"
+    ).read_text()
     kernel_text = (root / "primitive" / "kernels" / "dsa_kernels.py").read_text()
 
     assert "DynamicSparseAttention" in model_text
@@ -285,7 +288,9 @@ def test_glm5_lite_uses_shared_mla_and_dsa_primitive():
     assert "value_dim" in kernel_text
     assert "from cudnn.deepseek_sparse_attention import DSA" in kernel_text
     assert "from cudnn import DSA" in kernel_text
-    assert "cudnn.deepseek_sparse_attention.indexer_forward._interface_sm90" in kernel_text
+    assert (
+        "cudnn.deepseek_sparse_attention.indexer_forward._interface_sm90" in kernel_text
+    )
     assert "cudnn.deepseek_sparse_attention.indexer_forward._interface" in kernel_text
     assert "torch.cuda.get_device_capability(device)" in kernel_text
     assert "torch.topk" not in primitive_text
@@ -318,13 +323,19 @@ def test_glm5_dsa_kernel_routes_indexer_forward_by_sm(monkeypatch):
     monkeypatch.setattr(dsa_kernels, "_load_indexer_fwd_sm90", lambda: sm90_entry)
     monkeypatch.setattr(dsa_kernels, "_load_indexer_fwd_sm100", lambda: sm100_entry)
 
-    monkeypatch.setattr(dsa_kernels.torch.cuda, "get_device_capability", lambda device: (9, 0))
+    monkeypatch.setattr(
+        dsa_kernels.torch.cuda, "get_device_capability", lambda device: (9, 0)
+    )
     assert dsa_kernels._select_indexer_forward(None) is sm90_entry
 
-    monkeypatch.setattr(dsa_kernels.torch.cuda, "get_device_capability", lambda device: (10, 0))
+    monkeypatch.setattr(
+        dsa_kernels.torch.cuda, "get_device_capability", lambda device: (10, 0)
+    )
     assert dsa_kernels._select_indexer_forward(None) is sm100_entry
 
-    monkeypatch.setattr(dsa_kernels.torch.cuda, "get_device_capability", lambda device: (8, 0))
+    monkeypatch.setattr(
+        dsa_kernels.torch.cuda, "get_device_capability", lambda device: (8, 0)
+    )
     assert dsa_kernels._select_indexer_forward(None) is None
 
 
@@ -333,9 +344,11 @@ def test_glm5_dsa_kernel_routes_indexer_forward_by_sm(monkeypatch):
 def test_glm5_dsa_training_forward_uses_fused_kernel(monkeypatch):
     import pytest
     import torch
-
-    from megatron.lite.primitive.modules.attention import dsa
-    from megatron.lite.primitive.modules.attention import DynamicSparseAttention, build_rope_cache
+    from megatron.lite.primitive.modules.attention import (
+        DynamicSparseAttention,
+        build_rope_cache,
+        dsa,
+    )
 
     if not torch.cuda.is_available():
         pytest.skip("GLM-5 native attention requires CUDA (Transformer Engine RMSNorm)")
@@ -432,9 +445,11 @@ def test_glm5_dsa_training_forward_uses_fused_kernel(monkeypatch):
 def test_glm5_dsa_eval_forward_uses_fused_sparse_attention(monkeypatch):
     import pytest
     import torch
-
-    from megatron.lite.primitive.modules.attention import dsa
-    from megatron.lite.primitive.modules.attention import DynamicSparseAttention, build_rope_cache
+    from megatron.lite.primitive.modules.attention import (
+        DynamicSparseAttention,
+        build_rope_cache,
+        dsa,
+    )
 
     if not torch.cuda.is_available():
         pytest.skip("GLM-5 native attention requires CUDA (Transformer Engine RMSNorm)")
@@ -442,7 +457,9 @@ def test_glm5_dsa_eval_forward_uses_fused_sparse_attention(monkeypatch):
 
     calls = {}
 
-    def fake_indexer_topk(q_indexer, k_indexer, weights, topk, ratio, indexer_softmax_scale=1.0):
+    def fake_indexer_topk(
+        q_indexer, k_indexer, weights, topk, ratio, indexer_softmax_scale=1.0
+    ):
         del q_indexer, k_indexer, weights, indexer_softmax_scale
         calls["indexer"] = {"topk": topk, "ratio": ratio}
         idx = torch.zeros((1, 4, topk), dtype=torch.int32, device=device)
@@ -459,8 +476,13 @@ def test_glm5_dsa_eval_forward_uses_fused_sparse_attention(monkeypatch):
         value_dim=None,
     ):
         del kv_full, attn_sink, topk_idxs, softmax_scale, indexer_topk
-        calls["sparse"] = {"topk_length_is_set": topk_length is not None, "value_dim": value_dim}
-        return query.new_zeros(query.shape[0], query.shape[1], query.shape[2] * value_dim)
+        calls["sparse"] = {
+            "topk_length_is_set": topk_length is not None,
+            "value_dim": value_dim,
+        }
+        return query.new_zeros(
+            query.shape[0], query.shape[1], query.shape[2] * value_dim
+        )
 
     monkeypatch.setattr(dsa._dsa_kernels, "indexer_topk", fake_indexer_topk)
     monkeypatch.setattr(dsa._dsa_kernels, "dsa_sparse_attn", fake_dsa_sparse_attn)
@@ -552,21 +574,21 @@ def test_glm52_index_share_shared_layers_omit_indexer_modules(monkeypatch):
     assert "layers.2.self_attention.self_attention.indexer.wq_b.weight" in keys
     assert "layers.3.self_attention.self_attention.indexer.wq_b.weight" not in keys
     assert (
-        "mtp.layers.0.transformer_layer.self_attention.self_attention.indexer.wq_b.weight" in keys
+        "mtp.layers.0.transformer_layer.self_attention.self_attention.indexer.wq_b.weight"
+        in keys
     )
 
 
 @pytest.mark.gpus(1)
 def test_glm5_checkpoint_exports_and_saves_hf_style_weights(tmp_path):
     import torch
-    from safetensors import safe_open
-
     from megatron.lite.model.glm5.config import Glm5Config
     from megatron.lite.model.glm5.lite.checkpoint import (
         export_hf_weights,
         save_hf_weights,
     )
     from megatron.lite.primitive.parallel import ParallelState
+    from safetensors import safe_open
 
     cfg = Glm5Config(**_tiny_config_kwargs())
     ps = ParallelState()
@@ -578,7 +600,9 @@ def test_glm5_checkpoint_exports_and_saves_hf_style_weights(tmp_path):
 
     assert torch.equal(
         exported["model.layers.1.mlp.experts.2.gate_proj.weight"].detach().cpu(),
-        state["layers.1.moe.experts.fc1.weight2"][: cfg.moe_intermediate_size].detach().cpu(),
+        state["layers.1.moe.experts.fc1.weight2"][: cfg.moe_intermediate_size]
+        .detach()
+        .cpu(),
     )
     assert torch.equal(
         exported["model.layers.1.mlp.gate.e_score_correction_bias"].detach().cpu(),
@@ -588,7 +612,9 @@ def test_glm5_checkpoint_exports_and_saves_hf_style_weights(tmp_path):
 
     hf_dir = tmp_path / "hf"
     save_hf_weights(model, str(hf_dir), cfg, ps)
-    with safe_open(str(hf_dir / "model.safetensors"), framework="pt", device="cpu") as handle:
+    with safe_open(
+        str(hf_dir / "model.safetensors"), framework="pt", device="cpu"
+    ) as handle:
         assert torch.equal(
             handle.get_tensor("model.layers.1.mlp.experts.2.down_proj.weight"),
             state["layers.1.moe.experts.fc2.weight2"].detach().cpu(),
@@ -609,7 +635,9 @@ def test_glm5_checkpoint_exports_and_saves_hf_style_weights(tmp_path):
 
     hf_bf16_dir = tmp_path / "hf_bf16"
     save_hf_weights(model, str(hf_bf16_dir), cfg, ps, export_dtype=torch.bfloat16)
-    with safe_open(str(hf_bf16_dir / "model.safetensors"), framework="pt", device="cpu") as handle:
+    with safe_open(
+        str(hf_bf16_dir / "model.safetensors"), framework="pt", device="cpu"
+    ) as handle:
         floating_dtypes = {
             handle.get_tensor(key).dtype
             for key in handle.keys()
@@ -620,7 +648,9 @@ def test_glm5_checkpoint_exports_and_saves_hf_style_weights(tmp_path):
     loaded_bf16 = _make_glm5_model(cfg, ps=ps)
     load_hf_weights(loaded_bf16, str(hf_bf16_dir), cfg, ps)
     assert torch.equal(
-        loaded_bf16.state_dict()["layers.1.moe.experts.fc1.weight2"][cfg.moe_intermediate_size :]
+        loaded_bf16.state_dict()["layers.1.moe.experts.fc1.weight2"][
+            cfg.moe_intermediate_size :
+        ]
         .detach()
         .cpu(),
         state["layers.1.moe.experts.fc1.weight2"][cfg.moe_intermediate_size :]
@@ -642,9 +672,11 @@ def test_glm5_hf_export_rejects_missing_model_config():
 @pytest.mark.gpus(1)
 def test_glm5_checkpoint_exports_and_loads_mtp_layers(tmp_path):
     import torch
-
     from megatron.lite.model.glm5.config import Glm5Config
-    from megatron.lite.model.glm5.lite.checkpoint import export_hf_weights, load_hf_weights
+    from megatron.lite.model.glm5.lite.checkpoint import (
+        export_hf_weights,
+        load_hf_weights,
+    )
     from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
     from megatron.lite.primitive.parallel import ParallelState
 
@@ -675,8 +707,8 @@ def test_glm5_checkpoint_exports_and_loads_mtp_layers(tmp_path):
 
 def test_glm52_checkpoint_mapping_skips_shared_indexer_without_te():
     import importlib.util
-    import torch
 
+    import torch
     from megatron.lite.model.glm5.config import Glm5Config
 
     checkpoint_path = (
@@ -688,7 +720,9 @@ def test_glm52_checkpoint_mapping_skips_shared_indexer_without_te():
         / "lite"
         / "checkpoint.py"
     )
-    module_spec = importlib.util.spec_from_file_location("_glm5_checkpoint_test", checkpoint_path)
+    module_spec = importlib.util.spec_from_file_location(
+        "_glm5_checkpoint_test", checkpoint_path
+    )
     assert module_spec is not None and module_spec.loader is not None
     checkpoint_module = importlib.util.module_from_spec(module_spec)
     module_spec.loader.exec_module(checkpoint_module)
@@ -711,7 +745,9 @@ def test_glm52_checkpoint_mapping_skips_shared_indexer_without_te():
         "layers.2.self_attention.self_attention.indexer.wq_b.weight", tensor
     ) == [("model.layers.2.self_attn.indexer.wq_b.weight", tensor)]
     assert (
-        spec.native_to_hf("layers.3.self_attention.self_attention.indexer.wq_b.weight", tensor)
+        spec.native_to_hf(
+            "layers.3.self_attention.self_attention.indexer.wq_b.weight", tensor
+        )
         == []
     )
     assert spec.native_to_hf(
@@ -744,7 +780,10 @@ def test_glm52_checkpoint_skips_shared_indexer_weights_and_loads_full_layers(
         pytest.skip(f"Transformer Engine is not importable in this environment: {exc}")
 
     from megatron.lite.model.glm5.config import Glm5Config
-    from megatron.lite.model.glm5.lite.checkpoint import export_hf_weights, load_hf_weights
+    from megatron.lite.model.glm5.lite.checkpoint import (
+        export_hf_weights,
+        load_hf_weights,
+    )
     from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
     from megatron.lite.primitive.parallel import ParallelState
 
@@ -779,19 +818,22 @@ def test_glm52_checkpoint_skips_shared_indexer_weights_and_loads_full_layers(
         loaded_state["layers.2.self_attention.self_attention.indexer.wq_b.weight"],
         state["layers.2.self_attention.self_attention.indexer.wq_b.weight"],
     )
-    assert "layers.3.self_attention.self_attention.indexer.wq_b.weight" not in loaded_state
+    assert (
+        "layers.3.self_attention.self_attention.indexer.wq_b.weight" not in loaded_state
+    )
     assert torch.equal(
         loaded_state[
             "mtp.layers.0.transformer_layer.self_attention.self_attention.indexer.wq_b.weight"
         ],
-        state["mtp.layers.0.transformer_layer.self_attention.self_attention.indexer.wq_b.weight"],
+        state[
+            "mtp.layers.0.transformer_layer.self_attention.self_attention.indexer.wq_b.weight"
+        ],
     )
 
 
 @pytest.mark.gpus(1)
 def test_glm5_router_modules_use_current_names_and_bias_buffers():
     import torch
-
     from megatron.lite.model.glm5.config import Glm5Config
 
     model = _make_glm5_model(
@@ -812,7 +854,6 @@ def test_glm5_router_modules_use_current_names_and_bias_buffers():
 
 def test_glm5_protocol_allows_cp_only_parallel_scope():
     import pytest
-
     from megatron.lite.model.glm5.lite.protocol import _validate_parallel_scope
     from megatron.lite.runtime.contracts import ParallelConfig
 
@@ -858,19 +899,25 @@ def test_glm5_dsa_execution_policy_lives_in_impl_config_only(
     assert ImplConfig().dsa_indexer_loss_coeff == 0.0
     assert ImplConfig().dsa_indexer_use_sparse_loss is False
     assert ImplConfig().calculate_per_token_loss is False
-    assert ImplConfig(dsa_cp_mode="legacy_gather_all").dsa_cp_mode == "legacy_gather_all"
+    assert (
+        ImplConfig(dsa_cp_mode="legacy_gather_all").dsa_cp_mode == "legacy_gather_all"
+    )
 
 
 def test_glm5_production_cp_path_has_no_zigzag_layout():
     lite_root = Path(__file__).resolve().parents[3] / "megatron" / "lite"
     model_text = (lite_root / "model" / "glm5" / "lite" / "model.py").read_text()
-    dsa_text = (lite_root / "primitive" / "modules" / "attention" / "dsa.py").read_text()
+    dsa_text = (
+        lite_root / "primitive" / "modules" / "attention" / "dsa.py"
+    ).read_text()
 
     assert "zigzag" not in model_text
     assert "zigzag" not in dsa_text
 
 
-def test_glm5_attention_receives_impl_dsa_policy(monkeypatch, transformer_engine_import_stub):
+def test_glm5_attention_receives_impl_dsa_policy(
+    monkeypatch, transformer_engine_import_stub
+):
     import torch.nn as nn
 
     transformer_engine_import_stub()
@@ -925,7 +972,6 @@ def test_glm5_protocol_uses_mlite_optimizer_api():
 def test_glm5_lite_tiny_forward_backward(monkeypatch):
     import pytest
     import torch
-
     from megatron.lite.model.glm5.config import Glm5Config
     from megatron.lite.primitive.modules.attention import dsa
 
@@ -990,7 +1036,9 @@ def test_glm5_lite_tiny_forward_backward(monkeypatch):
     assert output["loss"].ndim == 0
     output["loss"].backward()
     grad_norm = sum(
-        param.grad.detach().float().norm() for param in model.parameters() if param.grad is not None
+        param.grad.detach().float().norm()
+        for param in model.parameters()
+        if param.grad is not None
     )
     assert torch.isfinite(grad_norm)
 
@@ -1003,16 +1051,26 @@ def test_glm5_lite_tiny_forward_backward(monkeypatch):
     mtp_infer = mtp_model(input_ids=input_ids)
     assert len(mtp_infer["mtp_hidden_states"]) == 1
     assert len(mtp_infer["mtp_logits"]) == 1
-    assert mtp_infer["mtp_hidden_states"][0].shape == (5, 2, mtp_model.config.hidden_size)
+    assert mtp_infer["mtp_hidden_states"][0].shape == (
+        5,
+        2,
+        mtp_model.config.hidden_size,
+    )
     assert mtp_infer["mtp_logits"][0].shape == (2, 5, mtp_model.config.vocab_size)
 
     # Training path (with labels) returns the MTP loss instead of logits.
     mtp_output = mtp_model(
-        input_ids=input_ids, labels=labels, loss_mask=torch.ones_like(labels, dtype=torch.float32)
+        input_ids=input_ids,
+        labels=labels,
+        loss_mask=torch.ones_like(labels, dtype=torch.float32),
     )
 
     assert len(mtp_output["mtp_hidden_states"]) == 1
-    assert mtp_output["mtp_hidden_states"][0].shape == (5, 2, mtp_model.config.hidden_size)
+    assert mtp_output["mtp_hidden_states"][0].shape == (
+        5,
+        2,
+        mtp_model.config.hidden_size,
+    )
     assert mtp_output["mtp_loss"].ndim == 0
     mtp_output["loss"].backward()
     mtp_grad_norm = sum(

--- a/experimental/lite/tests/unit/model/test_hf_save_protocol_contract.py
+++ b/experimental/lite/tests/unit/model/test_hf_save_protocol_contract.py
@@ -8,9 +8,7 @@ import importlib
 from pathlib import Path
 
 import pytest
-
 from megatron.lite.model.registry import TRAIN_RUNTIME_MODULES
-
 
 LITE_ROOT = Path(__file__).resolve().parents[3]
 _REGISTERED_PROTOCOLS = sorted(TRAIN_RUNTIME_MODULES.items())
@@ -32,9 +30,9 @@ def test_registered_protocol_exposes_hf_save(
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
     }
 
-    assert "save_hf_weights" in functions, (
-        f"{runtime_name} ({module_name}) cannot honor save_contents=['hf_model']"
-    )
+    assert (
+        "save_hf_weights" in functions
+    ), f"{runtime_name} ({module_name}) cannot honor save_contents=['hf_model']"
 
 
 @pytest.mark.parametrize("model_name", ["kimi_k2", "qwen3_moe"])
@@ -56,19 +54,9 @@ def test_new_hf_save_protocols_delegate_all_arguments(
     )
     chunks, model_cfg, parallel_state = object(), object(), object()
 
-    protocol.save_hf_weights(
-        chunks,
-        "/tmp/hf-save-contract",
-        model_cfg,
-        parallel_state,
-    )
+    protocol.save_hf_weights(chunks, "/tmp/hf-save-contract", model_cfg, parallel_state)
 
-    assert calls == [
-        (
-            (chunks, "/tmp/hf-save-contract", model_cfg, parallel_state),
-            {},
-        )
-    ]
+    assert calls == [((chunks, "/tmp/hf-save-contract", model_cfg, parallel_state), {})]
 
 
 # Engine-side ``save_contents=['hf_model']`` unconditionally forwards

--- a/experimental/lite/tests/unit/model/test_qat_mxfp4_model_export_unit.py
+++ b/experimental/lite/tests/unit/model/test_qat_mxfp4_model_export_unit.py
@@ -8,13 +8,11 @@ from types import SimpleNamespace
 
 import pytest
 import torch
-
 from megatron.lite.primitive.quantization.mxfp4 import (
     MXFP4_BLOCK_SIZE,
     dequantize_mxfp4,
     quantize_mxfp4,
 )
-
 
 pytestmark = pytest.mark.mlite
 
@@ -24,9 +22,13 @@ def test_mxfp4_resync_export_matches_primitive_and_skips_release_weights(
     monkeypatch, model_name, transformer_engine_import_stub
 ):
     transformer_engine_import_stub()
-    checkpoint = importlib.import_module(f"megatron.lite.model.{model_name}.lite.checkpoint")
+    checkpoint = importlib.import_module(
+        f"megatron.lite.model.{model_name}.lite.checkpoint"
+    )
     hf_weights = importlib.import_module("megatron.lite.primitive.ckpt.hf_weights")
-    weight = torch.linspace(-4, 4, MXFP4_BLOCK_SIZE * 2, dtype=torch.float32).reshape(2, -1)
+    weight = torch.linspace(-4, 4, MXFP4_BLOCK_SIZE * 2, dtype=torch.float32).reshape(
+        2, -1
+    )
     source = [
         ("model.layers.0.mlp.experts.0.up_proj.weight", weight),
         ("model.embed_tokens.weight", weight.clone()),
@@ -39,15 +41,32 @@ def test_mxfp4_resync_export_matches_primitive_and_skips_release_weights(
         yield from source
 
     monkeypatch.setattr(hf_weights, "export_hf_weights", fake_export)
-    exported = dict(checkpoint.export_hf_weights(object(), SimpleNamespace(vocab_size=128), object(), target="mxfp4"))
+    exported = dict(
+        checkpoint.export_hf_weights(
+            object(), SimpleNamespace(vocab_size=128), object(), target="mxfp4"
+        )
+    )
     prefix = "model.layers.0.mlp.experts.0.up_proj"
     packed, scale = quantize_mxfp4(weight)
     assert torch.equal(exported[f"{prefix}.weight"], packed.view(torch.uint8))
     assert torch.equal(exported[f"{prefix}.weight_scale"], scale.view(torch.uint8))
     assert exported[f"{prefix}.weight"].shape[-1] * 2 == weight.shape[-1]
-    assert exported[f"{prefix}.weight_scale"].shape[-1] == weight.shape[-1] // MXFP4_BLOCK_SIZE
-    assert torch.equal(dequantize_mxfp4(exported[f"{prefix}.weight"].view(torch.int8), exported[f"{prefix}.weight_scale"].view(torch.float8_e8m0fnu)), dequantize_mxfp4(packed, scale))
-    for ignored in ("model.embed_tokens.weight", "lm_head.weight", "model.layers.0.mlp.gate.weight"):
+    assert (
+        exported[f"{prefix}.weight_scale"].shape[-1]
+        == weight.shape[-1] // MXFP4_BLOCK_SIZE
+    )
+    assert torch.equal(
+        dequantize_mxfp4(
+            exported[f"{prefix}.weight"].view(torch.int8),
+            exported[f"{prefix}.weight_scale"].view(torch.float8_e8m0fnu),
+        ),
+        dequantize_mxfp4(packed, scale),
+    )
+    for ignored in (
+        "model.embed_tokens.weight",
+        "lm_head.weight",
+        "model.layers.0.mlp.gate.weight",
+    ):
         assert torch.equal(exported[ignored], dict(source)[ignored])
         assert f"{ignored[:-7]}.weight_scale" not in exported
 
@@ -57,8 +76,16 @@ def test_mxfp4_resync_export_rejects_unsupported_target(
     monkeypatch, model_name, transformer_engine_import_stub
 ):
     transformer_engine_import_stub()
-    checkpoint = importlib.import_module(f"megatron.lite.model.{model_name}.lite.checkpoint")
+    checkpoint = importlib.import_module(
+        f"megatron.lite.model.{model_name}.lite.checkpoint"
+    )
     hf_weights = importlib.import_module("megatron.lite.primitive.ckpt.hf_weights")
-    monkeypatch.setattr(hf_weights, "export_hf_weights", lambda *args, **kwargs: iter(()))
+    monkeypatch.setattr(
+        hf_weights, "export_hf_weights", lambda *args, **kwargs: iter(())
+    )
     with pytest.raises(ValueError, match="resync target"):
-        list(checkpoint.export_hf_weights(object(), SimpleNamespace(vocab_size=128), object(), target="block_fp8"))
+        list(
+            checkpoint.export_hf_weights(
+                object(), SimpleNamespace(vocab_size=128), object(), target="block_fp8"
+            )
+        )

--- a/experimental/lite/tests/unit/model/test_qat_qwen3_moe_unit.py
+++ b/experimental/lite/tests/unit/model/test_qat_qwen3_moe_unit.py
@@ -130,9 +130,7 @@ def test_qwen3_moe_canonical_state_key_maps_grouped_expert_master():
     )
 
 
-def test_qwen3_moe_mxfp4_resync_exports_compressed_tensors_stream(
-    monkeypatch,
-):
+def test_qwen3_moe_mxfp4_resync_exports_compressed_tensors_stream(monkeypatch):
     from megatron.lite.primitive.ckpt import hf_weights as hf_weights_module
 
     expert = torch.arange(64, dtype=torch.float32).reshape(2, 32) - 31
@@ -153,11 +151,7 @@ def test_qwen3_moe_mxfp4_resync_exports_compressed_tensors_stream(
 
     exported = dict(
         export_hf_weights(
-            object(),
-            SimpleNamespace(vocab_size=128),
-            object(),
-            target="mxfp4",
-            limit=4,
+            object(), SimpleNamespace(vocab_size=128), object(), target="mxfp4", limit=4
         )
     )
 
@@ -174,8 +168,7 @@ def test_qwen3_moe_mxfp4_resync_exports_compressed_tensors_stream(
     assert exported[f"{dense_prefix}.weight_scale"].shape == (2, 1)
     assert torch.equal(exported["model.layers.0.mlp.gate.weight"], router)
     assert torch.equal(
-        exported["model.layers.0.input_layernorm.weight"],
-        torch.ones(32),
+        exported["model.layers.0.input_layernorm.weight"], torch.ones(32)
     )
 
 

--- a/experimental/lite/tests/unit/model/test_qwen3_moe_checkpoint_spec.py
+++ b/experimental/lite/tests/unit/model/test_qwen3_moe_checkpoint_spec.py
@@ -15,18 +15,12 @@ def _config(*, num_nextn_predict_layers: int) -> Qwen3MoEConfig:
 
 
 def test_weight_map_omits_mtp_embedding_when_config_has_no_mtp() -> None:
-    weight_map = Qwen3MoEWeightSpec(
-        _config(num_nextn_predict_layers=0)
-    ).weight_map()
+    weight_map = Qwen3MoEWeightSpec(_config(num_nextn_predict_layers=0)).weight_map()
 
     assert "mtp_embed.embedding.weight" not in weight_map
 
 
 def test_weight_map_includes_mtp_embedding_when_config_has_mtp() -> None:
-    weight_map = Qwen3MoEWeightSpec(
-        _config(num_nextn_predict_layers=1)
-    ).weight_map()
+    weight_map = Qwen3MoEWeightSpec(_config(num_nextn_predict_layers=1)).weight_map()
 
-    assert weight_map["mtp_embed.embedding.weight"] == [
-        "model.embed_tokens.weight"
-    ]
+    assert weight_map["mtp_embed.embedding.weight"] == ["model.embed_tokens.weight"]

--- a/experimental/lite/tests/unit/model/test_qwen_config_unit.py
+++ b/experimental/lite/tests/unit/model/test_qwen_config_unit.py
@@ -7,10 +7,12 @@ from pathlib import Path
 
 import pytest
 import torch.nn as nn
-
 from megatron.lite.model.qwen3_5.config import Qwen35Config
 from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
-from megatron.lite.model.registry import resolve_model_type_from_hf, resolve_runtime_model_name
+from megatron.lite.model.registry import (
+    resolve_model_type_from_hf,
+    resolve_runtime_model_name,
+)
 
 LITE_ROOT = Path(__file__).resolve().parents[3]
 
@@ -166,7 +168,9 @@ def test_qwen35_dense_and_moe_layers_select_distinct_ffn_branches(
     monkeypatch.setattr(qwen35_model, "ColumnParallelLinear", Linear)
     monkeypatch.setattr(qwen35_model, "RowParallelLinear", Linear)
     monkeypatch.setattr(qwen35_model, "MoELayer", MoE)
-    monkeypatch.setattr(qwen35_model.te, "RMSNorm", lambda *args, **kwargs: nn.Identity())
+    monkeypatch.setattr(
+        qwen35_model.te, "RMSNorm", lambda *args, **kwargs: nn.Identity()
+    )
 
     ps = object()
     dense = Qwen35Config(
@@ -207,7 +211,9 @@ def test_qwen35_dense_and_moe_layers_select_distinct_ffn_branches(
     assert MODULE_MAP["experts"](dense_layer) is None
 
 
-def test_qwen_lite_protocols_build_configs_from_hf_dicts(transformer_engine_import_stub):
+def test_qwen_lite_protocols_build_configs_from_hf_dicts(
+    transformer_engine_import_stub,
+):
     transformer_engine_import_stub()
 
     from megatron.lite.model.qwen3_5.lite import protocol as qwen35_protocol
@@ -215,7 +221,8 @@ def test_qwen_lite_protocols_build_configs_from_hf_dicts(transformer_engine_impo
 
     qwen3_cfg = qwen3_protocol.build_model_config(_tiny_qwen3_hf_dict(), vocab_size=128)
     qwen35_cfg = qwen35_protocol.build_model_config(
-        {"model_type": "qwen3_5_moe", "text_config": _tiny_qwen35_text_config()}, vocab_size=128
+        {"model_type": "qwen3_5_moe", "text_config": _tiny_qwen35_text_config()},
+        vocab_size=128,
     )
 
     assert qwen3_cfg.vocab_size == 128
@@ -246,10 +253,13 @@ def test_qwen35_attention_backend_override_resets_te_environment(
 
     _apply_attention_backend_override(backend)
 
-    assert tuple(
-        os.environ[name]
-        for name in ("NVTE_FLASH_ATTN", "NVTE_FUSED_ATTN", "NVTE_UNFUSED_ATTN")
-    ) == expected
+    assert (
+        tuple(
+            os.environ[name]
+            for name in ("NVTE_FLASH_ATTN", "NVTE_FUSED_ATTN", "NVTE_UNFUSED_ATTN")
+        )
+        == expected
+    )
 
 
 def test_qwen35_attention_backend_override_rejects_unknown_value(
@@ -283,11 +293,16 @@ def _string_list_assignment(tree: ast.Module, name: str) -> set[str]:
     for node in tree.body:
         if not isinstance(node, ast.Assign):
             continue
-        if not any(isinstance(target, ast.Name) and target.id == name for target in node.targets):
+        if not any(
+            isinstance(target, ast.Name) and target.id == name
+            for target in node.targets
+        ):
             continue
         if not isinstance(node.value, (ast.List, ast.Tuple)):
             return set()
-        return {item.value for item in node.value.elts if isinstance(item, ast.Constant)}
+        return {
+            item.value for item in node.value.elts if isinstance(item, ast.Constant)
+        }
     return set()
 
 

--- a/experimental/lite/tests/unit/primitive/ckpt/test_hf_weights_fp8_scale.py
+++ b/experimental/lite/tests/unit/primitive/ckpt/test_hf_weights_fp8_scale.py
@@ -26,9 +26,7 @@ def test_safe_tensor_reader_dequantizes_fp8_weight_with_block_scale() -> None:
         "w.scale": torch.full((1, 1), 2.0, dtype=torch.float32),
     }
     actual = _reader(tensors).get_tensor(
-        "w.weight",
-        target_shape=torch.Size((2, 2)),
-        target_dtype=torch.bfloat16,
+        "w.weight", target_shape=torch.Size((2, 2)), target_dtype=torch.bfloat16
     )
 
     torch.testing.assert_close(actual, weight.float() * 2.0)
@@ -47,9 +45,7 @@ def test_safe_tensor_reader_rejects_one_byte_quantized_weight_without_scale(
     if source_dtype is None:
         pytest.skip("torch float8_e4m3fn is required")
 
-    tensors = {
-        "missing.weight": torch.ones((2, 2), dtype=source_dtype),
-    }
+    tensors = {"missing.weight": torch.ones((2, 2), dtype=source_dtype)}
 
     with pytest.raises(
         RuntimeError,
@@ -91,8 +87,7 @@ def test_multi_source_mapping_dequantizes_each_fp8_block_scaled_source() -> None
     actual = Spec.hf_to_native("fused.weight", sources)
 
     torch.testing.assert_close(
-        actual,
-        torch.cat([first.float() * 2.0, second.float() * 0.5], dim=0),
+        actual, torch.cat([first.float() * 2.0, second.float() * 0.5], dim=0)
     )
 
 
@@ -108,8 +103,7 @@ def test_multi_source_block_scale_rejects_shape_that_cannot_be_inferred() -> Non
     }
 
     with pytest.raises(
-        RuntimeError,
-        match=r"first\.weight.*target_shape is required.*first\.scale",
+        RuntimeError, match=r"first\.weight.*target_shape is required.*first\.scale"
     ):
         _read_hf_tensors(
             _reader(tensors),

--- a/experimental/lite/tests/unit/primitive/ckpt/test_hf_weights_gpu.py
+++ b/experimental/lite/tests/unit/primitive/ckpt/test_hf_weights_gpu.py
@@ -12,18 +12,13 @@ import pytest
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-from safetensors.torch import save_file
-
 from megatron.lite.model.kimi_k2.config import KimiK2Config
 from megatron.lite.model.kimi_k2.lite.checkpoint import KimiK2WeightSpec
 from megatron.lite.model.qwen3_5.config import Qwen35Config
 from megatron.lite.model.qwen3_5.lite.checkpoint import Qwen35WeightSpec
-from megatron.lite.primitive.ckpt.hf_weights import (
-    export_hf_weights,
-    load_hf_weights,
-)
+from megatron.lite.primitive.ckpt.hf_weights import export_hf_weights, load_hf_weights
 from megatron.lite.primitive.quantization.qat import QATSpec, apply_qat_to_chunks
-
+from safetensors.torch import save_file
 
 pytestmark = pytest.mark.mlite
 
@@ -105,9 +100,7 @@ def _shared_checkpoint(tensors: dict[str, torch.Tensor]) -> str:
         )
         paths[0] = path
     dist.broadcast_object_list(
-        paths,
-        src=0,
-        device=torch.device("cuda", torch.cuda.current_device()),
+        paths, src=0, device=torch.device("cuda", torch.cuda.current_device())
     )
     dist.barrier()
     assert isinstance(paths[0], str)
@@ -141,17 +134,13 @@ def test_ep2_export_gather_matches_single_rank_reference_bitwise() -> None:
             for local_idx in range(config.num_experts // 2):
                 global_idx = rank * (config.num_experts // 2) + local_idx
                 self.layers[0].moe.experts.fc1.register_parameter(
-                    f"weight{local_idx}",
-                    nn.Parameter(_expert_tensor(global_idx)),
+                    f"weight{local_idx}", nn.Parameter(_expert_tensor(global_idx))
                 )
 
     model = CudaMoE()
     exported = dict(
         export_hf_weights(
-            model,
-            Qwen35WeightSpec(config),
-            _parallel_state(ep_size=2),
-            cpu=False,
+            model, Qwen35WeightSpec(config), _parallel_state(ep_size=2), cpu=False
         )
     )
 
@@ -277,8 +266,7 @@ def test_incomplete_packed_expert_group_fails_loud_on_cuda_moe() -> None:
             self.layers[0].moe.experts.fc1 = nn.Module()
             for expert_idx in range(config.num_experts - 1):
                 self.layers[0].moe.experts.fc1.register_parameter(
-                    f"weight{expert_idx}",
-                    nn.Parameter(_expert_tensor(expert_idx)),
+                    f"weight{expert_idx}", nn.Parameter(_expert_tensor(expert_idx))
                 )
 
     model = IncompleteCudaMoE()
@@ -289,10 +277,7 @@ def test_incomplete_packed_expert_group_fails_loud_on_cuda_moe() -> None:
     ):
         list(
             export_hf_weights(
-                model,
-                Qwen35WeightSpec(config),
-                _parallel_state(),
-                cpu=False,
+                model, Qwen35WeightSpec(config), _parallel_state(), cpu=False
             )
         )
 
@@ -316,8 +301,7 @@ def test_qat_on_and_off_export_the_same_hf_keys_from_cuda_model() -> None:
     qat_on = SharedExpert()
     qat_on.load_state_dict(qat_off.state_dict())
     stats = apply_qat_to_chunks(
-        [qat_on],
-        QATSpec(enabled=True, format="int8", group_size=-1),
+        [qat_on], QATSpec(enabled=True, format="int8", group_size=-1)
     )
     assert stats["quantized_modules"] == 1
     master = qat_on.layers[

--- a/experimental/lite/tests/unit/primitive/ckpt/test_hf_weights_stream_load.py
+++ b/experimental/lite/tests/unit/primitive/ckpt/test_hf_weights_stream_load.py
@@ -291,18 +291,11 @@ def test_dense_fused_gate_up_uses_interleaved_tp2_shard(monkeypatch, tp_rank) ->
         "megatron.lite.primitive.ckpt.hf_weights.SafeTensorReader", Reader
     )
     load_hf_weights(
-        model,
-        "unused",
-        Spec(),
-        _parallel_state(tp_size=2, tp_rank=tp_rank),
+        model, "unused", Spec(), _parallel_state(tp_size=2, tp_rank=tp_rank)
     )
 
     expected = torch.cat(
-        [
-            gate.chunk(2, dim=0)[tp_rank],
-            up.chunk(2, dim=0)[tp_rank],
-        ],
-        dim=0,
+        [gate.chunk(2, dim=0)[tp_rank], up.chunk(2, dim=0)[tp_rank]], dim=0
     )
     assert torch.equal(model.gate_up.weight, expected)
 
@@ -398,8 +391,7 @@ def test_mapped_persistent_buffer_missing_from_checkpoint_fails(monkeypatch) -> 
     )
 
     with pytest.raises(
-        RuntimeError,
-        match=r"Spec.*router_expert_bias.*hf\.router_expert_bias",
+        RuntimeError, match=r"Spec.*router_expert_bias.*hf\.router_expert_bias"
     ):
         load_hf_weights(Model(), "unused", Spec(), _parallel_state())
 
@@ -426,7 +418,9 @@ def test_deferred_parameter_missing_from_checkpoint_fails(monkeypatch) -> None:
         def weight_map():
             return {}
 
-    monkeypatch.setattr("megatron.lite.primitive.ckpt.hf_weights.SafeTensorReader", Reader)
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.hf_weights.SafeTensorReader", Reader
+    )
     with pytest.raises(RuntimeError, match="Deferred parameter 'weight'"):
         load_hf_weights(model, "unused", Spec(), _parallel_state())
 
@@ -496,8 +490,7 @@ def test_checkpoint_source_without_model_target_fails(monkeypatch) -> None:
     )
 
     with pytest.raises(
-        RuntimeError,
-        match=r"Spec.*hf\.ghost\.weight.*ghost\.weight.*no model target",
+        RuntimeError, match=r"Spec.*hf\.ghost\.weight.*ghost\.weight.*no model target"
     ):
         load_hf_weights(nn.Module(), "unused", Spec(), _parallel_state())
 
@@ -541,8 +534,7 @@ def test_undeclared_buffer_adds_no_warning_or_failure(monkeypatch) -> None:
 
 
 def test_nonpersistent_primitive_router_bias_needs_no_checkpoint(
-    tmp_path,
-    transformer_engine_import_stub,
+    tmp_path, transformer_engine_import_stub
 ) -> None:
     from types import SimpleNamespace
 
@@ -647,16 +639,11 @@ def test_missing_required_hf_tensor_fails_with_spec_and_key_context(
         "megatron.lite.primitive.ckpt.hf_weights.SafeTensorReader", Reader
     )
 
-    with pytest.raises(
-        KeyError,
-        match=r"RequiredSpec.*weight.*required\.hf\.weight",
-    ):
+    with pytest.raises(KeyError, match=r"RequiredSpec.*weight.*required\.hf\.weight"):
         load_hf_weights(model, "unused", RequiredSpec(), _parallel_state())
 
 
-def test_mapped_parameter_cannot_be_optional(
-    monkeypatch,
-) -> None:
+def test_mapped_parameter_cannot_be_optional(monkeypatch) -> None:
     _stub_parallel_import(monkeypatch)
     model = nn.Linear(1, 1, bias=False)
     model.weight.data.fill_(11)
@@ -747,8 +734,7 @@ def test_missing_required_expert_hf_tensor_fails_with_context(monkeypatch) -> No
     )
 
     with pytest.raises(
-        KeyError,
-        match=r"RequiredExpertSpec.*expert0.*required\.hf\.expert0",
+        KeyError, match=r"RequiredExpertSpec.*expert0.*required\.hf\.expert0"
     ):
         load_hf_weights(Model(), "unused", RequiredExpertSpec(), _parallel_state())
 

--- a/experimental/lite/tests/unit/primitive/ckpt/test_hf_weights_streaming.py
+++ b/experimental/lite/tests/unit/primitive/ckpt/test_hf_weights_streaming.py
@@ -8,9 +8,9 @@ import sys
 import types
 from pathlib import Path
 
+import pytest
 import torch
 import torch.nn as nn
-import pytest
 
 if importlib.util.find_spec("safetensors") is None:
     safetensors = types.ModuleType("safetensors")
@@ -208,10 +208,7 @@ def test_bucketed_all_gather_uses_bounded_flat_buffers(monkeypatch) -> None:
     )
 
     gathered = bucketed_all_gather_into_tensor(
-        bucket,
-        group="tp",
-        group_size=2,
-        buffer_max_size_bytes=32,
+        bucket, group="tp", group_size=2, buffer_max_size_bytes=32
     )
 
     assert len(calls) == 3
@@ -255,19 +252,13 @@ def test_fsdp_dtensors_share_one_bounded_flat_collective(monkeypatch) -> None:
     equivalent_group = object()
     single_rank_group = object()
     first = FakeDTensor(
-        torch.arange(6, dtype=torch.float32).reshape(2, 3),
-        (4, 3),
-        0,
-        first_group,
+        torch.arange(6, dtype=torch.float32).reshape(2, 3), (4, 3), 0, first_group
     )
     single = FakeDTensor(
         torch.arange(3, dtype=torch.float32), (3,), 0, single_rank_group
     )
     second = FakeDTensor(
-        torch.arange(4, dtype=torch.float32).reshape(2, 2),
-        (2, 4),
-        1,
-        equivalent_group,
+        torch.arange(4, dtype=torch.float32).reshape(2, 2), (2, 4), 1, equivalent_group
     )
     calls = []
 
@@ -605,10 +596,7 @@ def test_packed_expert_export_rejects_incomplete_group() -> None:
         },
     )()
 
-    with pytest.raises(
-        RuntimeError,
-        match=r"experts\.packed.*3/4",
-    ):
+    with pytest.raises(RuntimeError, match=r"experts\.packed.*3/4"):
         list(export_hf_weights(Model(), Spec(), ps, cpu=True))
 
 
@@ -628,10 +616,7 @@ def test_pp_export_streams_over_nccl_and_matches_materialized(monkeypatch) -> No
         num_experts = 0
         is_expert = staticmethod(lambda name: False)
         weight_map = staticmethod(
-            lambda: {
-                "weight": ["weight"],
-                "router_bias": ["router_bias"],
-            }
+            lambda: {"weight": ["weight"], "router_bias": ["router_bias"]}
         )
         tp_spec = staticmethod(lambda name: None)
         native_to_hf = staticmethod(lambda name, tensor: [(name, tensor)])
@@ -721,8 +706,7 @@ def test_persistent_buffer_load_export_mapping_must_match() -> None:
     )()
 
     with pytest.raises(
-        RuntimeError,
-        match=r"Spec.*router_bias.*hf\.expected_bias.*hf\.different_bias",
+        RuntimeError, match=r"Spec.*router_bias.*hf\.expected_bias.*hf\.different_bias"
     ):
         dict(export_hf_weights(Model(), Spec(), ps))
 

--- a/experimental/lite/tests/unit/primitive/ckpt/test_weight_sync_fingerprint.py
+++ b/experimental/lite/tests/unit/primitive/ckpt/test_weight_sync_fingerprint.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import torch
-
 from megatron.lite.primitive.ckpt.weight_sync_fingerprint import (
     _sample_indices,
     stream_fingerprint,

--- a/experimental/lite/tests/unit/primitive/ckpt/test_weight_sync_probe.py
+++ b/experimental/lite/tests/unit/primitive/ckpt/test_weight_sync_probe.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from __future__ import annotations
 
-import json
 import importlib.util
+import json
 import sys
 import types
 

--- a/experimental/lite/tests/unit/primitive/modules/test_attention_moe_unit.py
+++ b/experimental/lite/tests/unit/primitive/modules/test_attention_moe_unit.py
@@ -83,7 +83,9 @@ def test_gqa_split_grouped_qkvg_preserves_q_gate_kv_order():
     split_grouped_qkvg = _split_grouped_qkvg()
     qkv = torch.arange(24).reshape(1, 24)
 
-    query, gate, key, value = split_grouped_qkvg(qkv, num_heads=4, num_kv_heads=2, head_dim=2)
+    query, gate, key, value = split_grouped_qkvg(
+        qkv, num_heads=4, num_kv_heads=2, head_dim=2
+    )
 
     assert query.shape == (1, 4, 2)
     assert gate.shape == (1, 4, 2)
@@ -130,12 +132,7 @@ def test_gqa_kv_replication_selects_distinct_queries_and_reuses_kv():
 
     per_rank = [
         split_grouped_qkvg_for_tp(
-            qkvg,
-            num_heads=8,
-            num_kv_heads=2,
-            head_dim=1,
-            tp_rank=rank,
-            tp_size=4,
+            qkvg, num_heads=8, num_kv_heads=2, head_dim=1, tp_rank=rank, tp_size=4
         )
         for rank in range(4)
     ]
@@ -306,8 +303,7 @@ def test_router_replay_rejects_nonzero_aux_loss(router_kind):
     router.router_replay = RouterReplay()
     router.train()
     RouterReplay.set_replay_data(
-        [torch.tensor([[0, 1], [1, 2]])],
-        replay_mask=torch.tensor([True, True]),
+        [torch.tensor([[0, 1], [1, 2]])], replay_mask=torch.tensor([True, True])
     )
     RouterReplay.set_global_router_replay_action(RouterReplayAction.REPLAY_FORWARD)
 
@@ -389,33 +385,17 @@ def test_dsa_index_share_pipeline_guard_rejects_cross_stage_sources():
     )
 
     validate_dsa_index_share_pipeline_split(
-        [0, 1, 2, 3],
-        topk_freq=4,
-        skip_topk_offset=3,
+        [0, 1, 2, 3], topk_freq=4, skip_topk_offset=3
     )
     with pytest.raises(ValueError, match="cannot cross pipeline stages"):
         validate_dsa_index_share_pipeline_split(
-            [3, 4, 5],
-            topk_freq=4,
-            skip_topk_offset=3,
+            [3, 4, 5], topk_freq=4, skip_topk_offset=3
         )
     with pytest.raises(ValueError, match="must execute before"):
-        validate_dsa_index_share_pipeline_split(
-            [3, 2],
-            topk_freq=4,
-            skip_topk_offset=3,
-        )
+        validate_dsa_index_share_pipeline_split([3, 2], topk_freq=4, skip_topk_offset=3)
     # Global layer index 3 is the first MTP layer for a 3-layer trunk in this
     # configuration.  It is shared from trunk layer 2 and must not sit alone on
     # the final pipeline stage.
     with pytest.raises(ValueError, match="cannot cross pipeline stages"):
-        validate_dsa_index_share_pipeline_split(
-            [3],
-            topk_freq=4,
-            skip_topk_offset=3,
-        )
-    validate_dsa_index_share_pipeline_split(
-        [2, 3],
-        topk_freq=4,
-        skip_topk_offset=3,
-    )
+        validate_dsa_index_share_pipeline_split([3], topk_freq=4, skip_topk_offset=3)
+    validate_dsa_index_share_pipeline_split([2, 3], topk_freq=4, skip_topk_offset=3)

--- a/experimental/lite/tests/unit/primitive/modules/test_module_primitives_independent_unit.py
+++ b/experimental/lite/tests/unit/primitive/modules/test_module_primitives_independent_unit.py
@@ -6,7 +6,6 @@ from types import SimpleNamespace
 import pytest
 import torch
 import torch.nn as nn
-
 from megatron.lite.primitive.modules.lora import (
     GroupedLinearLoRA,
     LinearLoRA,
@@ -18,7 +17,9 @@ from megatron.lite.primitive.modules.lora import (
 
 
 def test_lora_config_aliases_and_trainable_param_accounting():
-    cfg = normalize_lora_config({"enabled": True, "rank": 2, "alpha": 6, "targets": ["qkv", "fc2"]})
+    cfg = normalize_lora_config(
+        {"enabled": True, "rank": 2, "alpha": 6, "targets": ["qkv", "fc2"]}
+    )
 
     assert cfg.enabled
     assert cfg.scale == 3.0
@@ -44,7 +45,8 @@ def test_lora_config_aliases_and_trainable_param_accounting():
     assert model.lora_adapter.weight.requires_grad
     assert trainable_param_stats(model) == {
         "trainable_tensors": 2,
-        "trainable_numel": model.lora_adapter.weight.numel() + model.lora_adapter.bias.numel(),
+        "trainable_numel": model.lora_adapter.weight.numel()
+        + model.lora_adapter.bias.numel(),
     }
 
 
@@ -71,7 +73,9 @@ def test_grouped_lora_respects_per_expert_splits():
     x = torch.tensor([[2.0, 9.0], [4.0, 1.0], [6.0, 3.0]])
     output = layer(x, [1, 2])
 
-    torch.testing.assert_close(output, torch.tensor([[4.0, 6.0], [5.0, 7.0], [15.0, 21.0]]))
+    torch.testing.assert_close(
+        output, torch.tensor([[4.0, 6.0], [5.0, 7.0], [15.0, 21.0]])
+    )
     with pytest.raises(ValueError, match="expected 2 splits"):
         layer(x, [3])
 
@@ -92,7 +96,9 @@ def test_mrope_interleaves_text_height_and_width_sections():
 
     base = torch.arange(3 * 2 * 6, dtype=torch.float32).reshape(3, 2, 6)
 
-    interleaved = MultimodalRotaryEmbedding._apply_interleaved_mrope(base, mrope_section=[1, 1, 1])
+    interleaved = MultimodalRotaryEmbedding._apply_interleaved_mrope(
+        base, mrope_section=[1, 1, 1]
+    )
 
     expected = base[0].clone()
     expected[..., 1] = base[1, ..., 1]
@@ -100,7 +106,9 @@ def test_mrope_interleaves_text_height_and_width_sections():
     torch.testing.assert_close(interleaved, expected)
 
 
-def test_mtp_aux_loss_scaler_threads_independent_gradient(transformer_engine_import_stub):
+def test_mtp_aux_loss_scaler_threads_independent_gradient(
+    transformer_engine_import_stub,
+):
     transformer_engine_import_stub()
     from megatron.lite.primitive.modules.mtp import MTPLossAutoScaler
 
@@ -115,14 +123,18 @@ def test_mtp_aux_loss_scaler_threads_independent_gradient(transformer_engine_imp
     MTPLossAutoScaler.main_loss_backward_scale = 1.0
 
 
-def test_gated_delta_static_helpers_are_finite_and_shape_stable(transformer_engine_import_stub):
+def test_gated_delta_static_helpers_are_finite_and_shape_stable(
+    transformer_engine_import_stub,
+):
     transformer_engine_import_stub()
     from megatron.lite.primitive.modules.gated_delta_net import GatedDeltaNet
 
     alpha = torch.tensor([[[0.0, 1.0], [-1.0, 2.0]]])
     beta = torch.tensor([[[0.0, 2.0], [-2.0, 4.0]]])
 
-    g, beta_sigmoid = GatedDeltaNet._compute_g_and_beta(torch.zeros(2), torch.ones(2), alpha, beta)
+    g, beta_sigmoid = GatedDeltaNet._compute_g_and_beta(
+        torch.zeros(2), torch.ones(2), alpha, beta
+    )
 
     assert g.shape == alpha.shape
     assert beta_sigmoid.shape == beta.shape
@@ -157,12 +169,7 @@ def test_gated_delta_tp4_replicates_two_head_state(
     monkeypatch.setattr(gdn_module.te, "RMSNorm", _FakeRMSNorm)
 
     ps = SimpleNamespace(
-        tp_size=4,
-        tp_rank=0,
-        tp_group=object(),
-        cp_size=1,
-        cp_rank=0,
-        cp_group=None,
+        tp_size=4, tp_rank=0, tp_group=object(), cp_size=1, cp_rank=0, cp_group=None
     )
     gdn = gdn_module.GatedDeltaNet(
         hidden_size=8,
@@ -233,7 +240,9 @@ def test_gated_delta_syncs_replicated_state_from_tp_rank_zero(
     monkeypatch.setattr(gdn_module.te, "RMSNorm", _FakeRMSNorm)
     monkeypatch.setattr(gdn_module.dist, "is_initialized", lambda: True)
     monkeypatch.setattr(gdn_module.dist, "get_world_size", lambda _group: 4)
-    monkeypatch.setattr(gdn_module.dist, "get_process_group_ranks", lambda _group: (12, 13, 14, 15))
+    monkeypatch.setattr(
+        gdn_module.dist, "get_process_group_ranks", lambda _group: (12, 13, 14, 15)
+    )
     broadcasts = []
     monkeypatch.setattr(
         gdn_module.dist,

--- a/experimental/lite/tests/unit/primitive/modules/test_router_aux_loss_gate.py
+++ b/experimental/lite/tests/unit/primitive/modules/test_router_aux_loss_gate.py
@@ -10,10 +10,9 @@ gradient into every parameter below the router.
 
 from types import SimpleNamespace
 
+import megatron.lite.primitive.modules.router as router_module
 import pytest
 import torch
-
-import megatron.lite.primitive.modules.router as router_module
 from megatron.lite.primitive.modules.router import SigmoidTopKRouter, TopKRouter
 
 
@@ -60,7 +59,9 @@ def counting_scaler(monkeypatch):
 @pytest.mark.gpus(1)
 @pytest.mark.env(CUDA_DEVICE_MAX_CONNECTIONS="1")
 @pytest.mark.parametrize("coef,expected_calls", [(0.0, 0), (0.001, 1)])
-def test_topk_router_skips_aux_loss_when_coef_zero(counting_scaler, coef, expected_calls):
+def test_topk_router_skips_aux_loss_when_coef_zero(
+    counting_scaler, coef, expected_calls
+):
     if not torch.cuda.is_available():
         pytest.skip("TopKRouter gating GEMM requires CUDA")
     router = TopKRouter(_config(coef), _ps()).cuda()
@@ -73,7 +74,9 @@ def test_topk_router_skips_aux_loss_when_coef_zero(counting_scaler, coef, expect
 
 
 @pytest.mark.parametrize("coef,expected_calls", [(0.0, 0), (0.001, 1)])
-def test_sigmoid_router_skips_aux_loss_when_coef_zero(counting_scaler, coef, expected_calls):
+def test_sigmoid_router_skips_aux_loss_when_coef_zero(
+    counting_scaler, coef, expected_calls
+):
     router = SigmoidTopKRouter(_config(coef), _ps())
     router.train()
     x = torch.randn(6, 8, requires_grad=True)

--- a/experimental/lite/tests/unit/primitive/modules/test_router_replay_unit.py
+++ b/experimental/lite/tests/unit/primitive/modules/test_router_replay_unit.py
@@ -9,13 +9,14 @@ import torch.nn as nn
 
 
 def test_replay_mask_uses_live_scores_and_keeps_native_unmasked_row():
-    from megatron.lite.primitive.modules.router_replay import RouterReplay, RouterReplayAction
+    from megatron.lite.primitive.modules.router_replay import (
+        RouterReplay,
+        RouterReplayAction,
+    )
 
     RouterReplay.clear_global_router_replay_instances()
     replay = RouterReplay()
-    dense = torch.tensor(
-        [[0.1, 0.2, 0.7], [0.6, 0.3, 0.1]], requires_grad=True
-    )
+    dense = torch.tensor([[0.1, 0.2, 0.7], [0.6, 0.3, 0.1]], requires_grad=True)
     native_indices = torch.tensor([[2, 1], [0, 1]])
     native_scores = dense.gather(1, native_indices)
     target = torch.tensor([[0, 1], [2, 1]])
@@ -41,10 +42,7 @@ def test_replayed_sqrtsoftplus_scores_are_live_normalized_and_nonzero():
     # tensor would contain zeros here, which was the PR49 half-finished bug.
     indices = torch.tensor([[1, 3]])
     scores = gather_replayed_router_scores(
-        logits,
-        indices,
-        score_function="sqrtsoftplus",
-        scaling_factor=2.5,
+        logits, indices, score_function="sqrtsoftplus", scaling_factor=2.5
     )
     assert torch.all(scores > 0)
     torch.testing.assert_close(scores.sum(dim=-1), torch.tensor([2.5]))
@@ -55,7 +53,10 @@ def test_replayed_sqrtsoftplus_scores_are_live_normalized_and_nonzero():
 
 
 def test_backward_replay_keeps_fifo_across_pipeline_warmup_forwards():
-    from megatron.lite.primitive.modules.router_replay import RouterReplay, RouterReplayAction
+    from megatron.lite.primitive.modules.router_replay import (
+        RouterReplay,
+        RouterReplayAction,
+    )
 
     RouterReplay.clear_global_router_replay_instances()
     replay = RouterReplay()
@@ -77,7 +78,10 @@ def test_ds4_hash_router_records_and_replays_its_layer_column():
 
     pytest.importorskip("transformer_engine")
     from megatron.lite.model.deepseek_v4.lite.moe import DeepseekV4MoE
-    from megatron.lite.primitive.modules.router_replay import RouterReplay, RouterReplayAction
+    from megatron.lite.primitive.modules.router_replay import (
+        RouterReplay,
+        RouterReplayAction,
+    )
 
     RouterReplay.clear_global_router_replay_instances()
     module = DeepseekV4MoE.__new__(DeepseekV4MoE)
@@ -179,8 +183,7 @@ def test_replay_roots_exclude_mtp_layers():
 
 
 @pytest.mark.parametrize(
-    "protocol_name",
-    ["qwen3_moe", "qwen3_5", "deepseek_v4", "glm5", "kimi_k2"],
+    "protocol_name", ["qwen3_moe", "qwen3_5", "deepseek_v4", "glm5", "kimi_k2"]
 )
 def test_supported_moe_protocols_expose_mtp_safe_replay_roots(protocol_name):
     from pathlib import Path
@@ -205,8 +208,7 @@ def test_r3_driver_begin_fails_loudly_when_model_has_no_moe_router():
 
     chunk = nn.Sequential(nn.Linear(2, 2), nn.ReLU())
     handle = SimpleNamespace(
-        _model=chunk,
-        _extras={"model_chunks": [chunk], "protocol": None},
+        _model=chunk, _extras={"model_chunks": [chunk], "protocol": None}
     )
     driver = RouterReplayDriver.maybe_create(handle, {"action": "replay"})
     assert driver is not None
@@ -236,8 +238,7 @@ def test_r3_driver_replays_layer_order_and_causal_rows_end_to_end():
 
     model = FakeModel()
     handle = SimpleNamespace(
-        _model=model,
-        _extras={"model_chunks": [model], "protocol": None},
+        _model=model, _extras={"model_chunks": [model], "protocol": None}
     )
     batch = PackedBatch(
         input_ids=torch.arange(5),
@@ -248,18 +249,9 @@ def test_r3_driver_replays_layer_order_and_causal_rows_end_to_end():
         routed_experts=torch.nested.as_nested_tensor(
             [
                 torch.tensor(
-                    [
-                        [[10, 11], [20, 21]],
-                        [[12, 13], [22, 23]],
-                        [[14, 15], [24, 25]],
-                    ]
+                    [[[10, 11], [20, 21]], [[12, 13], [22, 23]], [[14, 15], [24, 25]]]
                 ),
-                torch.tensor(
-                    [
-                        [[16, 17], [26, 27]],
-                        [[18, 19], [28, 29]],
-                    ]
-                ),
+                torch.tensor([[[16, 17], [26, 27]], [[18, 19], [28, 29]]]),
             ],
             layout=torch.jagged,
         ),
@@ -271,7 +263,9 @@ def test_r3_driver_replays_layer_order_and_causal_rows_end_to_end():
     driver.begin()
     try:
         stepped = driver.wrap(
-            lambda active_model, _batch: [router(native) for router in active_model.routers]
+            lambda active_model, _batch: [
+                router(native) for router in active_model.routers
+            ]
         )
         layer0, layer1 = stepped(model, batch)
     finally:
@@ -280,12 +274,10 @@ def test_r3_driver_replays_layer_order_and_causal_rows_end_to_end():
     # Every row that can causally affect a response token uses rollout routes.
     # The final row of each sequence stays native because it predicts no token.
     assert torch.equal(
-        layer0,
-        torch.tensor([[10, 11], [12, 13], [4, 5], [16, 17], [8, 9]]),
+        layer0, torch.tensor([[10, 11], [12, 13], [4, 5], [16, 17], [8, 9]])
     )
     assert torch.equal(
-        layer1,
-        torch.tensor([[20, 21], [22, 23], [4, 5], [26, 27], [8, 9]]),
+        layer1, torch.tensor([[20, 21], [22, 23], [4, 5], [26, 27], [8, 9]])
     )
     assert all(router.router_replay is None for router in model.routers)
 
@@ -311,8 +303,7 @@ def test_r3_driver_accepts_next_token_routes_without_final_input_row():
 
     model = FakeModel()
     handle = SimpleNamespace(
-        _model=model,
-        _extras={"model_chunks": [model], "protocol": None},
+        _model=model, _extras={"model_chunks": [model], "protocol": None}
     )
     batch = PackedBatch(
         input_ids=torch.arange(5),
@@ -321,10 +312,7 @@ def test_r3_driver_accepts_next_token_routes_without_final_input_row():
         loss_mask=torch.tensor([0, 1, 1, 0, 1], dtype=torch.float32),
         r3_replay_mask=torch.tensor([True, True, False, True, False]),
         routed_experts=torch.nested.as_nested_tensor(
-            [
-                torch.tensor([[[10, 11]], [[12, 13]]]),
-                torch.tensor([[[20, 21]]]),
-            ],
+            [torch.tensor([[[10, 11]], [[12, 13]]]), torch.tensor([[[20, 21]]])],
             layout=torch.jagged,
         ),
     )
@@ -334,7 +322,9 @@ def test_r3_driver_accepts_next_token_routes_without_final_input_row():
     assert driver is not None
     driver.begin()
     try:
-        stepped = driver.wrap(lambda active_model, _batch: active_model.routers[0](native))
+        stepped = driver.wrap(
+            lambda active_model, _batch: active_model.routers[0](native)
+        )
         actual = stepped(model, batch)
     finally:
         driver.end()
@@ -342,8 +332,7 @@ def test_r3_driver_accepts_next_token_routes_without_final_input_row():
     # vLLM supplies routes for causal rows only.  The absent final row of each
     # input sequence remains native and therefore needs no synthetic route.
     assert torch.equal(
-        actual,
-        torch.tensor([[10, 11], [12, 13], [4, 5], [20, 21], [8, 9]]),
+        actual, torch.tensor([[10, 11], [12, 13], [4, 5], [20, 21], [8, 9]])
     )
 
 
@@ -351,8 +340,7 @@ def test_r3_driver_slices_global_layer_axis_for_pipeline_stage():
     from megatron.lite.runtime.backends.mlite.router_replay import RouterReplayDriver
 
     driver = RouterReplayDriver(
-        SimpleNamespace(_model=nn.Module(), _extras={}),
-        "replay",
+        SimpleNamespace(_model=nn.Module(), _extras={}), "replay"
     )
     driver._ps = SimpleNamespace(pp_size=2)
     driver._num_routers = 2

--- a/experimental/lite/tests/unit/primitive/optimizers/fsdp2/test_fsdp2_offload_gpu.py
+++ b/experimental/lite/tests/unit/primitive/optimizers/fsdp2/test_fsdp2_offload_gpu.py
@@ -8,7 +8,6 @@ import pytest
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-
 from megatron.lite.primitive.optimizers.fsdp2 import (
     FSDP2Config,
     build_fsdp2_adamw,
@@ -17,7 +16,10 @@ from megatron.lite.primitive.optimizers.fsdp2 import (
     fsdp2_available,
     wrap_fsdp2,
 )
-from megatron.lite.primitive.optimizers.fsdp2.adamw import iter_torch_optimizers, to_local_tensor
+from megatron.lite.primitive.optimizers.fsdp2.adamw import (
+    iter_torch_optimizers,
+    to_local_tensor,
+)
 from megatron.lite.primitive.parallel import init_parallel
 from megatron.lite.primitive.parallel.state import ParallelState
 from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
@@ -150,7 +152,9 @@ def _parallel_state() -> ParallelState:
     )
 
 
-def _build_fsdp2_model(dtype: torch.dtype = torch.bfloat16) -> tuple[nn.Module, ParallelState]:
+def _build_fsdp2_model(
+    dtype: torch.dtype = torch.bfloat16,
+) -> tuple[nn.Module, ParallelState]:
     torch.manual_seed(1234)
     model = TinyModel().cuda().to(dtype=dtype)
     ps = _parallel_state()
@@ -197,7 +201,10 @@ def test_fsdp2_runtime_model_and_optimizer_offload_roundtrip_single_gpu():
     model, ps = _build_fsdp2_model()
     optimizer = _build_optimizer(model, ps, offload_fraction=0.0)
     handle = ModelHandle(
-        model=model, optimizer=optimizer, parallel_state=ps, _extras={"model_chunks": [model]}
+        model=model,
+        optimizer=optimizer,
+        parallel_state=ps,
+        _extras={"model_chunks": [model]},
     )
     runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
 
@@ -281,9 +288,9 @@ def test_fsdp2_pp_edp_reshard_and_offload_roundtrip_eight_gpus():
     def assert_grad_devices(device: str) -> None:
         grads = [param.grad for param in model.parameters()]
         assert all(grad is not None for grad in grads)
-        assert {to_local_tensor(grad).device.type for grad in grads if grad is not None} == {
-            device
-        }
+        assert {
+            to_local_tensor(grad).device.type for grad in grads if grad is not None
+        } == {device}
 
     def check_expert_shard_after_forward(_module, _inputs, _output) -> None:
         assert_experts_are_local_shards("cuda")
@@ -306,7 +313,10 @@ def test_fsdp2_pp_edp_reshard_and_offload_roundtrip_eight_gpus():
     train_backward(4321)
 
     handle = ModelHandle(
-        model=model, optimizer=optimizer, parallel_state=ps, _extras={"model_chunks": [model]}
+        model=model,
+        optimizer=optimizer,
+        parallel_state=ps,
+        _extras={"model_chunks": [model]},
     )
     runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
     runtime.to(handle, "cpu", model=True, optimizer=True, grad=True)
@@ -366,7 +376,9 @@ def test_fsdp2_pp_edp_reshard_and_offload_roundtrip_eight_gpus():
         unit.experts.register_forward_hook(check_stress_expert_shard)
         for unit in stress_model.units
     ]
-    device_bytes = torch.cuda.get_device_properties(torch.cuda.current_device()).total_memory
+    device_bytes = torch.cuda.get_device_properties(
+        torch.cuda.current_device()
+    ).total_memory
     memory_limit_bytes = resident_bytes + 3 * expert_bytes
     memory_fraction = min(0.9, memory_limit_bytes / device_bytes)
     torch.cuda.set_per_process_memory_fraction(memory_fraction)
@@ -398,8 +410,10 @@ def test_fsdp2_pp_edp_reshard_and_offload_roundtrip_eight_gpus():
     # barrier: parameters are intentionally left materialized after forward,
     # then runtime.to(..., "cpu") must reshard them before Module.to() sees
     # their DTensor state.
-    materialized_model = TinyPipelineMoEModel(hidden_size=512, num_units=1).cuda().to(
-        dtype=torch.bfloat16
+    materialized_model = (
+        TinyPipelineMoEModel(hidden_size=512, num_units=1)
+        .cuda()
+        .to(dtype=torch.bfloat16)
     )
     materialized_expert_numels = {
         name: param.numel()
@@ -444,7 +458,9 @@ def test_fsdp2_pp_edp_reshard_and_offload_roundtrip_eight_gpus():
         local = to_local_tensor(param.detach())
         assert local.device.type == "cpu"
         if name in materialized_expert_numels:
-            assert local.numel() == materialized_expert_numels[name] // ps.expert_dp_size
+            assert (
+                local.numel() == materialized_expert_numels[name] // ps.expert_dp_size
+            )
 
     runtime.to(materialized_handle, "cuda", model=True, optimizer=False, grad=False)
     assert _local_param_devices(materialized_model) == {"cuda"}

--- a/experimental/lite/tests/unit/primitive/optimizers/fsdp2/test_fsdp2_unit.py
+++ b/experimental/lite/tests/unit/primitive/optimizers/fsdp2/test_fsdp2_unit.py
@@ -9,7 +9,6 @@ import pytest
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-
 from megatron.lite.primitive.optimizers.fsdp2 import (
     FSDP2Config,
     FSDP2Optimizer,
@@ -26,8 +25,12 @@ from megatron.lite.primitive.optimizers.fsdp2.wrap import build_fsdp2_shard_plac
 from megatron.lite.primitive.parallel.state import ParallelState
 
 fsdp2_wrap = importlib.import_module("megatron.lite.primitive.optimizers.fsdp2.wrap")
-fsdp2_optimizer = importlib.import_module("megatron.lite.primitive.optimizers.fsdp2.optimizer")
-fsdp2_grad_clip = importlib.import_module("megatron.lite.primitive.optimizers.fsdp2.grad_clip")
+fsdp2_optimizer = importlib.import_module(
+    "megatron.lite.primitive.optimizers.fsdp2.optimizer"
+)
+fsdp2_grad_clip = importlib.import_module(
+    "megatron.lite.primitive.optimizers.fsdp2.grad_clip"
+)
 fsdp2_adamw = importlib.import_module("megatron.lite.primitive.optimizers.fsdp2.adamw")
 
 
@@ -109,11 +112,7 @@ def test_fsdp2_pipeline_wraps_dense_and_experts_with_reshard(monkeypatch):
     expert_mesh = SimpleNamespace(name="expert_dp")
     optimizer = object()
     ps = ParallelState(
-        pp_size=2,
-        ep_size=2,
-        dp_cp_size=4,
-        expert_dp_size=2,
-        ep_dp_group=object(),
+        pp_size=2, ep_size=2, dp_cp_size=4, expert_dp_size=2, ep_dp_group=object()
     )
 
     def fake_wrap_expert(module, _ps, config, **kwargs):
@@ -132,9 +131,7 @@ def test_fsdp2_pipeline_wraps_dense_and_experts_with_reshard(monkeypatch):
     monkeypatch.setattr(fsdp2_optimizer, "wrap_fsdp2_module", fake_wrap_expert)
     monkeypatch.setattr(fsdp2_optimizer, "wrap_fsdp2", fake_wrap_dense)
     monkeypatch.setattr(
-        fsdp2_optimizer,
-        "build_fsdp2_adamw",
-        lambda *args, **kwargs: optimizer,
+        fsdp2_optimizer, "build_fsdp2_adamw", lambda *args, **kwargs: optimizer
     )
 
     result = fsdp2_optimizer.build_fsdp2_training_optimizer(
@@ -191,7 +188,9 @@ def test_fsdp2_optimizer_offloads_dtensor_state_without_extra_knob(monkeypatch):
     optimizer = FSDP2Optimizer(torch_optimizer, model.parameters())
     calls: list[bool] = []
 
-    def fake_move_optimizer_state_to_cpu(_optimizer, _offloaded_state, *, include_dtensor_state):
+    def fake_move_optimizer_state_to_cpu(
+        _optimizer, _offloaded_state, *, include_dtensor_state
+    ):
         calls.append(include_dtensor_state)
 
     monkeypatch.setattr(
@@ -228,7 +227,9 @@ def test_fsdp2_rejects_non_module_unit_path():
 
 
 def test_wrap_fsdp2_requires_distributed_when_mesh_is_not_provided(monkeypatch):
-    monkeypatch.setattr(fsdp2_wrap, "_load_fully_shard", lambda: lambda module, **kwargs: module)
+    monkeypatch.setattr(
+        fsdp2_wrap, "_load_fully_shard", lambda: lambda module, **kwargs: module
+    )
 
     with pytest.raises(RuntimeError, match="torch.distributed"):
         fsdp2_wrap.wrap_fsdp2(ToyModel(), ParallelState(), FSDP2Config())
@@ -284,7 +285,9 @@ def test_wrap_fsdp2_accepts_unit_module_import_paths(monkeypatch):
 
 def test_wrap_fsdp2_uses_container_order_without_nested_unit_duplicates(monkeypatch):
     model = nn.Module()
-    model.layers = nn.ModuleDict({"10": NestedToyBlock(), "2": ToyBlock(), "11": ToyBlock()})
+    model.layers = nn.ModuleDict(
+        {"10": NestedToyBlock(), "2": ToyBlock(), "11": ToyBlock()}
+    )
     calls: list[nn.Module] = []
 
     def fake_fully_shard(module, **kwargs):
@@ -395,7 +398,9 @@ def test_clip_grads_with_sharded_norm_scales_cpu_grads_once():
 
 
 @pytest.mark.gpus(1)
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for NCCL scalar test.")
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA is required for NCCL scalar test."
+)
 def test_all_reduce_scalar_moves_cpu_value_to_nccl_device(monkeypatch):
     group = object()
     reduced_devices: list[str] = []
@@ -420,11 +425,7 @@ def test_all_reduce_scalar_moves_cpu_value_to_nccl_device(monkeypatch):
 
 def test_fsdp2_optimizer_uses_scalar_all_reduce_for_all_norm_groups(monkeypatch):
     groups = SimpleNamespace(
-        dp_cp=object(),
-        tp=object(),
-        replicated=object(),
-        expert=object(),
-        pp=object(),
+        dp_cp=object(), tp=object(), replicated=object(), expert=object(), pp=object()
     )
     reduced_groups: list[object] = []
 
@@ -449,11 +450,7 @@ def test_fsdp2_optimizer_uses_scalar_all_reduce_for_all_norm_groups(monkeypatch)
     optimizer = FSDP2Optimizer(
         torch.optim.SGD([sharded, replicated, expert, tp_replicated], lr=0.0),
         [sharded, replicated, expert, tp_replicated],
-        ParallelState(
-            dp_cp_group=groups.dp_cp,
-            tp_group=groups.tp,
-            pp_group=groups.pp,
-        ),
+        ParallelState(dp_cp_group=groups.dp_cp, tp_group=groups.tp, pp_group=groups.pp),
         clip_grad=100.0,
         replicated_grad_params=[replicated],
         replicated_grad_norm_group=groups.replicated,
@@ -492,7 +489,10 @@ def test_fp32_adamw_state_dict_roundtrip_cpu():
     param.grad = torch.tensor([0.5, -0.25], dtype=torch.bfloat16)
     optimizer.step()
     state = optimizer.state_dict()
-    expected = {key: state[key][0].clone() for key in ("master_params", "exp_avgs", "exp_avg_sqs")}
+    expected = {
+        key: state[key][0].clone()
+        for key in ("master_params", "exp_avgs", "exp_avg_sqs")
+    }
     for key, value in expected.items():
         state[key][0] = SimpleNamespace(_local_tensor=value)
 
@@ -514,7 +514,9 @@ def test_fp32_adamw_state_dict_roundtrip_cpu():
     loaded_state = loaded_optimizer.state_dict()
 
     assert loaded_state["step_count"] == state["step_count"]
-    torch.testing.assert_close(loaded_param, expected["master_params"].to(torch.bfloat16))
+    torch.testing.assert_close(
+        loaded_param, expected["master_params"].to(torch.bfloat16)
+    )
     for key, value in expected.items():
         torch.testing.assert_close(loaded_state[key][0], value)
     assert loaded_state["steps"] == state["steps"]
@@ -613,7 +615,9 @@ def test_fp32_adamw_load_matches_uninterrupted_next_step_cpu(cpu_update: bool):
     loaded_state = loaded_optimizer.state_dict()
     assert loaded_state["step_count"] == direct_state["step_count"]
     for key in ("master_params", "exp_avgs", "exp_avg_sqs"):
-        torch.testing.assert_close(loaded_state[key][0], direct_state[key][0], atol=0.0, rtol=0.0)
+        torch.testing.assert_close(
+            loaded_state[key][0], direct_state[key][0], atol=0.0, rtol=0.0
+        )
     assert loaded_state["steps"] == direct_state["steps"]
 
 
@@ -629,7 +633,9 @@ def test_fused_sq_sum_matches_reference():
         torch.randn(64, 64)[:, ::2],
         torch.randn(0),
     ]
-    total = fsdp2_grad_clip.fused_sq_sum(tensors, dtype=torch.float32, device=torch.device("cpu"))
+    total = fsdp2_grad_clip.fused_sq_sum(
+        tensors, dtype=torch.float32, device=torch.device("cpu")
+    )
     assert total.ndim == 0 and total.dtype is torch.float32
     assert float(total) == pytest.approx(_reference_sq_sum(tensors), rel=1e-5)
 
@@ -645,11 +651,16 @@ def test_fused_sq_sum_launches_one_kernel_per_dtype(monkeypatch):
         assert len({t.dtype for t in bucket}) == 1
         assert all(t.is_contiguous() for t in bucket)
         launches.append((len(bucket), bucket[0].dtype))
-        return torch.tensor([_reference_sq_sum(bucket) ** 0.5], dtype=torch.float32), None
+        return (
+            torch.tensor([_reference_sq_sum(bucket) ** 0.5], dtype=torch.float32),
+            None,
+        )
 
     # CPU-only test env: force the CUDA-eligibility check so the bucket path runs.
     monkeypatch.setattr(fsdp2_grad_clip, "multi_tensor_applier", fake_applier)
-    monkeypatch.setattr(fsdp2_grad_clip, "_is_fused_eligible", lambda t: t.is_contiguous())
+    monkeypatch.setattr(
+        fsdp2_grad_clip, "_is_fused_eligible", lambda t: t.is_contiguous()
+    )
 
     torch.manual_seed(0)
     tensors = [
@@ -658,7 +669,9 @@ def test_fused_sq_sum_launches_one_kernel_per_dtype(monkeypatch):
         torch.randn(128),
         torch.randn(64, 64)[:, ::2],
     ]
-    total = fsdp2_grad_clip.fused_sq_sum(tensors, dtype=torch.float32, device=torch.device("cpu"))
+    total = fsdp2_grad_clip.fused_sq_sum(
+        tensors, dtype=torch.float32, device=torch.device("cpu")
+    )
     assert sorted(launches) == [(1, torch.float32), (2, torch.bfloat16)]
     assert float(total) == pytest.approx(_reference_sq_sum(tensors), rel=1e-5)
 
@@ -677,17 +690,23 @@ def test_grad_norm_paths_accumulate_bf16_in_fp32():
     ):
         assert actual.dtype is torch.float32
         assert float(actual) == pytest.approx(expected, rel=1e-5)
-    assert float(fsdp2_grad_clip.sharded_grad_abs_max([param, plain])) == pytest.approx(7.0)
+    assert float(fsdp2_grad_clip.sharded_grad_abs_max([param, plain])) == pytest.approx(
+        7.0
+    )
 
 
 @pytest.mark.gpus(1)
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="TE multi_tensor_l2norm is CUDA-only.")
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="TE multi_tensor_l2norm is CUDA-only."
+)
 def test_fused_sq_sum_allocates_no_full_size_temporary():
     grad = torch.randn(64 * 1024 * 1024, dtype=torch.bfloat16, device="cuda")
     torch.cuda.synchronize()
     torch.cuda.reset_peak_memory_stats()
     before = torch.cuda.memory_allocated()
-    total = fsdp2_grad_clip.fused_sq_sum([grad], dtype=torch.float32, device=grad.device)
+    total = fsdp2_grad_clip.fused_sq_sum(
+        [grad], dtype=torch.float32, device=grad.device
+    )
     torch.cuda.synchronize()
     # to(float32).pow(2) would add 4x the grad here.
     assert torch.cuda.max_memory_allocated() - before < 1 << 20
@@ -698,7 +717,11 @@ def test_fused_sq_sum_allocates_no_full_size_temporary():
 def test_fp32_adamw_bf16_grad_matches_legacy_fp32_grad_copy(monkeypatch, cpu_update):
     def legacy_prepare_grad(self, grad, master):
         if self.cpu_update:
-            return to_local_tensor(grad).detach().to(device=master.device, dtype=torch.float32)
+            return (
+                to_local_tensor(grad)
+                .detach()
+                .to(device=master.device, dtype=torch.float32)
+            )
         return grad.detach().to(dtype=torch.float32)
 
     torch.manual_seed(0)
@@ -721,7 +744,9 @@ def test_fp32_adamw_bf16_grad_matches_legacy_fp32_grad_copy(monkeypatch, cpu_upd
             opt=SimpleNamespace(),
         )
         assert isinstance(optimizer, fsdp2_adamw.FP32AdamW)
-        for _ in range(4):  # several steps so bias correction and state carry-over count
+        for _ in range(
+            4
+        ):  # several steps so bias correction and state carry-over count
             param.grad = grad.clone()
             optimizer.step()
         state = optimizer.state_dict()

--- a/experimental/lite/tests/unit/primitive/optimizers/test_dist_opt_validation.py
+++ b/experimental/lite/tests/unit/primitive/optimizers/test_dist_opt_validation.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import pytest
-
 from megatron.lite.primitive.optimizers.megatron_wrap import (
     validate_dist_opt_config,
     validate_dist_opt_session,
@@ -12,18 +11,26 @@ from megatron.lite.runtime.contracts.config import ParallelConfig
 
 
 def _engine_cfg(*, model_name: str, pp: int = 1, vpp: int = 1) -> MegatronLiteConfig:
-    return MegatronLiteConfig(model_name=model_name, parallel=ParallelConfig(pp=pp, vpp=vpp))
+    return MegatronLiteConfig(
+        model_name=model_name, parallel=ParallelConfig(pp=pp, vpp=vpp)
+    )
 
 
 def test_dist_opt_validation_accepts_model_agnostic_config():
-    validate_dist_opt_config(_engine_cfg(model_name="synthetic_custom_model", pp=1, vpp=1))
+    validate_dist_opt_config(
+        _engine_cfg(model_name="synthetic_custom_model", pp=1, vpp=1)
+    )
 
 
 def test_dist_opt_validation_keeps_vpp_parallel_constraint():
     with pytest.raises(ValueError, match="dist_opt requires pp>1 when vpp>1"):
-        validate_dist_opt_config(_engine_cfg(model_name="synthetic_custom_model", pp=1, vpp=2))
+        validate_dist_opt_config(
+            _engine_cfg(model_name="synthetic_custom_model", pp=1, vpp=2)
+        )
 
 
 def test_validate_dist_opt_session_alias_matches_config_validator():
     assert validate_dist_opt_session is validate_dist_opt_config
-    validate_dist_opt_session(_engine_cfg(model_name="another_synthetic_model", pp=2, vpp=2))
+    validate_dist_opt_session(
+        _engine_cfg(model_name="another_synthetic_model", pp=2, vpp=2)
+    )

--- a/experimental/lite/tests/unit/primitive/parallel/test_gdn_chunkwise_thd_reshuffle.py
+++ b/experimental/lite/tests/unit/primitive/parallel/test_gdn_chunkwise_thd_reshuffle.py
@@ -22,9 +22,7 @@ import os
 
 import pytest
 import torch
-
 from megatron.lite.primitive.parallel.cp import get_thd_context_parallel_rank_indices
-
 
 # Hand-computed indices for the anchor case (cp=2, cu=[0,8,12]): seq0 len8 splits into
 # 4 chunks [0,1|2,3|4,5|6,7] with zigzag owners r0,r1,r1,r0; seq1 len4 -> [8|9|10|11]
@@ -44,12 +42,7 @@ def test_thd_rank_indices_match_hand_computed_anchor():
 
 
 @pytest.mark.parametrize(
-    "cp, cu",
-    [
-        (2, [0, 8, 12]),
-        (4, [0, 16, 24, 32]),
-        (2, [0, 16, 24]),
-    ],
+    "cp, cu", [(2, [0, 8, 12]), (4, [0, 16, 24, 32]), (2, [0, 16, 24])]
 )
 def test_thd_rank_indices_partition_invariants(cp, cu):
     """Each layout partitions the global tokens exactly once; contiguous is a plain slice."""
@@ -58,7 +51,8 @@ def test_thd_rank_indices_partition_invariants(cp, cu):
     part = total // cp
     for layout in ("zigzag", "contiguous"):
         owned = [
-            get_thd_context_parallel_rank_indices(cu_t, cp, r, layout).tolist() for r in range(cp)
+            get_thd_context_parallel_rank_indices(cu_t, cp, r, layout).tolist()
+            for r in range(cp)
         ]
         flat = sorted(idx for span in owned for idx in span)
         assert flat == list(range(total)), f"{layout} not a clean partition: {flat}"
@@ -78,10 +72,12 @@ def test_thd_rank_indices_rejects_indivisible_length():
 # --------------------------------------------------------------------- gloo round-trip
 def _reshuffle_worker(rank, world, cu_list, port, results):
     os.environ.update(
-        MASTER_ADDR="127.0.0.1", MASTER_PORT=str(port), RANK=str(rank), WORLD_SIZE=str(world)
+        MASTER_ADDR="127.0.0.1",
+        MASTER_PORT=str(port),
+        RANK=str(rank),
+        WORLD_SIZE=str(world),
     )
     import torch.distributed as dist
-
     from megatron.lite.primitive.parallel.cp import (
         contiguous_to_zigzag_chunks,
         zigzag_to_contiguous_chunks,
@@ -99,7 +95,9 @@ def _reshuffle_worker(rank, world, cu_list, port, results):
         zz_idx = get_thd_context_parallel_rank_indices(cu, world, rank, "zigzag")
         local_zigzag = full.index_select(0, zz_idx).contiguous()
 
-        got_contig = zigzag_to_contiguous_chunks(local_zigzag, group, seq_dim=0, cu_seqlens=cu)
+        got_contig = zigzag_to_contiguous_chunks(
+            local_zigzag, group, seq_dim=0, cu_seqlens=cu
+        )
         expect_contig = full[rank * part : (rank + 1) * part].contiguous()
         fwd = (got_contig - expect_contig).abs().max().item()
 
@@ -112,11 +110,7 @@ def _reshuffle_worker(rank, world, cu_list, port, results):
 
 @pytest.mark.parametrize(
     "cp, cu, port",
-    [
-        (2, [0, 8, 12], 29630),
-        (4, [0, 16, 24, 32], 29631),
-        (2, [0, 16, 24], 29632),
-    ],
+    [(2, [0, 8, 12], 29630), (4, [0, 16, 24, 32], 29631), (2, [0, 16, 24], 29632)],
 )
 def test_thd_reshuffle_roundtrip_gloo(cp, cu, port):
     import torch.multiprocessing as mp

--- a/experimental/lite/tests/unit/primitive/parallel/test_parallel_dimensions_independent_unit.py
+++ b/experimental/lite/tests/unit/primitive/parallel/test_parallel_dimensions_independent_unit.py
@@ -5,7 +5,6 @@ from types import SimpleNamespace
 
 import pytest
 import torch
-
 from megatron.lite.primitive.parallel.cp import split_packed_for_cp
 from megatron.lite.primitive.parallel.pipeline import _num_microbatches_from_config
 from megatron.lite.primitive.parallel.pp import build_pipeline_chunk_layout
@@ -17,7 +16,9 @@ from megatron.lite.primitive.parallel.sp import (
 from megatron.lite.primitive.parallel.state import ParallelState
 
 
-def test_tp_vocab_embedding_and_output_single_rank_contract(transformer_engine_import_stub):
+def test_tp_vocab_embedding_and_output_single_rank_contract(
+    transformer_engine_import_stub,
+):
     transformer_engine_import_stub()
     from megatron.lite.primitive.parallel.linear import (
         VocabParallelEmbedding,
@@ -73,12 +74,16 @@ def test_cp_packed_split_handles_each_sample_independently():
     )
 
     torch.testing.assert_close(rank0[0], torch.tensor([0, 1, 6, 7, 8, 9, 14, 15]))
-    torch.testing.assert_close(rank0[1], torch.tensor([100, 101, 106, 107, 108, 109, 114, 115]))
+    torch.testing.assert_close(
+        rank0[1], torch.tensor([100, 101, 106, 107, 108, 109, 114, 115])
+    )
     torch.testing.assert_close(rank0[2], torch.tensor([0, 4, 8], dtype=torch.int32))
     assert rank0[3] == 4
 
     torch.testing.assert_close(rank1[0], torch.tensor([2, 3, 4, 5, 10, 11, 12, 13]))
-    torch.testing.assert_close(rank1[1], torch.tensor([102, 103, 104, 105, 110, 111, 112, 113]))
+    torch.testing.assert_close(
+        rank1[1], torch.tensor([102, 103, 104, 105, 110, 111, 112, 113])
+    )
     torch.testing.assert_close(rank1[2], torch.tensor([0, 4, 8], dtype=torch.int32))
     assert rank1[3] == 4
 
@@ -115,7 +120,9 @@ def test_ep_token_dispatcher_local_roundtrip_is_independent_of_deepep(
 
     ps = ParallelState(ep_size=1, ep_rank=0)
     dispatcher = TokenDispatcher(num_experts=3, hidden_size=2, ps=ps, use_deepep=False)
-    hidden = torch.tensor([[1.0, 10.0], [2.0, 20.0], [3.0, 30.0], [4.0, 40.0]], requires_grad=True)
+    hidden = torch.tensor(
+        [[1.0, 10.0], [2.0, 20.0], [3.0, 30.0], [4.0, 40.0]], requires_grad=True
+    )
     topk_indices = torch.tensor([[0], [2], [1], [2]])
     topk_scores = torch.ones(4, 1)
 
@@ -155,8 +162,7 @@ def test_ep_token_dispatcher_sums_scores_for_duplicate_experts(
 
 
 def test_alltoall_dispatch_sums_scores_for_duplicate_experts(
-    monkeypatch,
-    transformer_engine_import_stub,
+    monkeypatch, transformer_engine_import_stub
 ):
     transformer_engine_import_stub()
     from megatron.lite.primitive.modules import dispatcher as dispatcher_module
@@ -166,7 +172,9 @@ def test_alltoall_dispatch_sums_scores_for_duplicate_experts(
         output.zero_()
         output[: local_counts.numel()].copy_(local_counts)
 
-    monkeypatch.setattr(dispatcher_module.dist, "all_gather_into_tensor", fake_all_gather)
+    monkeypatch.setattr(
+        dispatcher_module.dist, "all_gather_into_tensor", fake_all_gather
+    )
     monkeypatch.setattr(dispatcher_module.dist, "get_rank", lambda group: 0)
     monkeypatch.setattr(
         dispatcher_module._AllToAll,

--- a/experimental/lite/tests/unit/primitive/parallel/test_parallel_unit.py
+++ b/experimental/lite/tests/unit/primitive/parallel/test_parallel_unit.py
@@ -21,7 +21,9 @@ from megatron.lite.primitive.parallel import (
 
 def test_cp_zigzag_split_slice_and_reconstruct_match():
     tensor = torch.arange(16).reshape(1, 8, 2)
-    parts = [zigzag_split_for_cp(tensor, rank, cp_size=2, seq_dim=1) for rank in range(2)]
+    parts = [
+        zigzag_split_for_cp(tensor, rank, cp_size=2, seq_dim=1) for rank in range(2)
+    ]
 
     assert torch.equal(parts[0], tensor[:, [0, 1, 6, 7], :])
     assert torch.equal(parts[1], tensor[:, [2, 3, 4, 5], :])
@@ -61,7 +63,9 @@ def _ranks(pp_size: int, pp_layout=None) -> list[ParallelState]:
     ]
 
 
-def _layout_indices(num_layers: int, pp_size: int, *, pp_layout=None, **kw) -> list[list[int]]:
+def _layout_indices(
+    num_layers: int, pp_size: int, *, pp_layout=None, **kw
+) -> list[list[int]]:
     return [
         build_pipeline_chunk_layout(num_layers, ps, **kw).layer_indices
         for ps in _ranks(pp_size, pp_layout)
@@ -119,7 +123,9 @@ def test_pp_layout_accounts_for_head_tail_even_when_divisible():
 
 # --- Correctness matrix: real delivery counts x MTP{off,on} x PP{2,4,8} ---
 _REAL_LAYERS = {"deepseek_v4": 43, "kimi_k2": 61, "glm5": 78}
-_CORRECTNESS_CASES = [(m, pp, mtp) for m in _REAL_LAYERS for pp in (2, 4, 8) for mtp in (0, 1)]
+_CORRECTNESS_CASES = [
+    (m, pp, mtp) for m in _REAL_LAYERS for pp in (2, 4, 8) for mtp in (0, 1)
+]
 
 
 def _mcore_reference_decoder_ids(num_layers: int, pp: int, mtp: int) -> list[list[int]]:
@@ -137,7 +143,10 @@ def _mcore_reference_decoder_ids(num_layers: int, pp: int, mtp: int) -> list[lis
         rows.append(units[pos : pos + size])
         pos += size
     ref = PipelineParallelLayerLayout(rows, pipeline_model_parallel_size=pp)
-    return [ref.get_layer_id_list(LayerType.decoder, vp_stage=0, pp_rank=r) for r in range(pp)]
+    return [
+        ref.get_layer_id_list(LayerType.decoder, vp_stage=0, pp_rank=r)
+        for r in range(pp)
+    ]
 
 
 @pytest.mark.parametrize("model, pp, mtp", _CORRECTNESS_CASES)
@@ -145,13 +154,17 @@ def test_auto_layout_is_bit_equal_to_mcore(model, pp, mtp):
     # Faithful reuse: the glue's per-stage decoder ids are exactly mcore's for the same
     # canonical layout, so correctness is inherited from mcore (not re-derived).
     n = _REAL_LAYERS[model]
-    assert _layout_indices(n, pp, num_mtp_layers=mtp) == _mcore_reference_decoder_ids(n, pp, mtp)
+    assert _layout_indices(n, pp, num_mtp_layers=mtp) == _mcore_reference_decoder_ids(
+        n, pp, mtp
+    )
 
 
 @pytest.mark.parametrize("model, pp, mtp", _CORRECTNESS_CASES)
 def test_auto_layout_is_legal_and_balanced(model, pp, mtp):
     n = _REAL_LAYERS[model]
-    chunks = [build_pipeline_chunk_layout(n, ps, num_mtp_layers=mtp) for ps in _ranks(pp)]
+    chunks = [
+        build_pipeline_chunk_layout(n, ps, num_mtp_layers=mtp) for ps in _ranks(pp)
+    ]
     # complete + ordered, no missing/dup decoder -> sum == num_layers
     assert [i for c in chunks for i in c.layer_indices] == list(range(n))
     # embedding only on stage 0; loss/head only on the last stage
@@ -160,7 +173,10 @@ def test_auto_layout_is_legal_and_balanced(model, pp, mtp):
     # MTP placed exactly `mtp` times, on the final (head) stage
     assert sum(c.has_mtp for c in chunks) == mtp and chunks[-1].has_mtp == bool(mtp)
     # balanced: per-stage unit cells (decoders + embedding/loss/mtp slots) differ by <=1
-    cells = [len(c.layer_indices) + c.has_embed + c.has_head + (mtp if c.has_mtp else 0) for c in chunks]
+    cells = [
+        len(c.layer_indices) + c.has_embed + c.has_head + (mtp if c.has_mtp else 0)
+        for c in chunks
+    ]
     assert max(cells) - min(cells) <= 1
 
 
@@ -175,8 +191,14 @@ def _glm52_index_share_groups(num_layers: int = 78) -> list[list[int]]:
     current_source: int | None = None
     for layer_idx in range(num_layers):
         layer_number = layer_idx + 1
-        if dsa_indexer_type_for_layer(layer_number, skip_topk_offset=3, topk_freq=4) == "shared":
-            source_idx = source_dsa_compute_layer(layer_number, skip_topk_offset=3, topk_freq=4) - 1
+        if (
+            dsa_indexer_type_for_layer(layer_number, skip_topk_offset=3, topk_freq=4)
+            == "shared"
+        ):
+            source_idx = (
+                source_dsa_compute_layer(layer_number, skip_topk_offset=3, topk_freq=4)
+                - 1
+            )
         else:
             source_idx = layer_idx
         if current and source_idx != current_source:
@@ -196,10 +218,7 @@ def test_grouped_pp_layout_keeps_glm52_indexshare_groups_inside_stage():
 
     chunks = [
         build_pipeline_chunk_layout(
-            78,
-            ps,
-            num_mtp_layers=1,
-            decoder_layer_groups=_glm52_index_share_groups(),
+            78, ps, num_mtp_layers=1, decoder_layer_groups=_glm52_index_share_groups()
         )
         for ps in _ranks(8)
     ]
@@ -210,10 +229,7 @@ def test_grouped_pp_layout_keeps_glm52_indexshare_groups_inside_stage():
     assert [chunk.has_mtp for chunk in chunks[:-1]] == [False] * 7
     for stage_indices in indices:
         validate_dsa_index_share_pipeline_split(
-            stage_indices,
-            topk_freq=4,
-            skip_topk_offset=3,
-            indexer_types=None,
+            stage_indices, topk_freq=4, skip_topk_offset=3, indexer_types=None
         )
 
 
@@ -226,10 +242,7 @@ def test_ungrouped_glm52_auto_layout_would_trip_indexshare_guard():
     with pytest.raises(ValueError, match="DSA IndexShare cannot cross pipeline stages"):
         for stage_indices in bad_indices:
             validate_dsa_index_share_pipeline_split(
-                stage_indices,
-                topk_freq=4,
-                skip_topk_offset=3,
-                indexer_types=None,
+                stage_indices, topk_freq=4, skip_topk_offset=3, indexer_types=None
             )
 
 
@@ -262,9 +275,14 @@ def test_pp_layout_marks_mtp_stage_from_the_layout_not_a_fixed_rank():
     # no MTP requested -> no stage owns MTP.
     assert _mtp_flags(6, 4) == [False, False, False, False]
     # single stage owns the MTP too.
-    assert build_pipeline_chunk_layout(
-        5, ParallelState(pp_size=1, pp_rank=0, pp_is_first=True, pp_is_last=True), num_mtp_layers=1
-    ).has_mtp is True
+    assert (
+        build_pipeline_chunk_layout(
+            5,
+            ParallelState(pp_size=1, pp_rank=0, pp_is_first=True, pp_is_last=True),
+            num_mtp_layers=1,
+        ).has_mtp
+        is True
+    )
 
 
 def test_pp_layout_custom_string_mtp_lands_on_the_designated_stage():
@@ -273,7 +291,10 @@ def test_pp_layout_custom_string_mtp_lands_on_the_designated_stage():
     flags = _mtp_flags(6, 4, pp_layout="Ett|tt|t|tmL", num_mtp_layers=1)
     assert flags == [False, False, False, True]
     assert _layout_indices(6, 4, pp_layout="Ett|tt|t|tmL", num_mtp_layers=1) == [
-        [0, 1], [2, 3], [4], [5]
+        [0, 1],
+        [2, 3],
+        [4],
+        [5],
     ]
 
 
@@ -288,7 +309,11 @@ def test_pp_layout_custom_string_mtp_lands_on_the_designated_stage():
 def test_pp_layout_custom_string_standalone_mtp_builds_on_designated_stage():
     # DESIRED (follow-up): `m` on a non-final stage builds MTP on that stage.
     # "E|ttttttm|L" over pp3 -> [E], [t*6, m], [L]; MTP belongs on the middle stage.
-    assert _mtp_flags(6, 3, pp_layout="E|ttttttm|L", num_mtp_layers=1) == [False, True, False]
+    assert _mtp_flags(6, 3, pp_layout="E|ttttttm|L", num_mtp_layers=1) == [
+        False,
+        True,
+        False,
+    ]
 
 
 def test_pp_layout_single_stage_owns_all_layers():
@@ -316,7 +341,9 @@ def test_virtual_pipeline_rank_is_tracked_on_lite_parallel_state():
 
 def test_thd_roll_keeps_sequence_boundaries():
     cu_seqlens = torch.tensor([0, 4, 8], dtype=torch.int32)
-    rolled, token_sum = roll_packed_thd_left(torch.arange(8), cu_seqlens_padded=cu_seqlens, dims=0)
+    rolled, token_sum = roll_packed_thd_left(
+        torch.arange(8), cu_seqlens_padded=cu_seqlens, dims=0
+    )
 
     assert torch.equal(rolled, torch.tensor([1, 2, 3, 0, 5, 6, 7, 0]))
     assert token_sum.item() == 24
@@ -335,30 +362,25 @@ def test_thd_cp_split_and_reconstruct_roundtrip():
     assert torch.equal(parts[0], torch.tensor([0, 1, 6, 7]))
     assert torch.equal(parts[1], torch.tensor([2, 3, 4, 5]))
     assert torch.equal(
-        reconstruct_packed_from_cp_parts(parts, cu_seqlens_padded=cu_seqlens, cp_size=2, dim=0),
+        reconstruct_packed_from_cp_parts(
+            parts, cu_seqlens_padded=cu_seqlens, cp_size=2, dim=0
+        ),
         tensor,
     )
 
 
 def test_plain_thd_batch_is_split_by_protocol_context_parallel_helper():
     ids = torch.nested.as_nested_tensor(
-        [torch.arange(1, 6), torch.arange(11, 18)],
-        layout=torch.jagged,
+        [torch.arange(1, 6), torch.arange(11, 18)], layout=torch.jagged
     )
     labels = torch.nested.as_nested_tensor(
-        [torch.arange(101, 106), torch.arange(111, 118)],
-        layout=torch.jagged,
+        [torch.arange(101, 106), torch.arange(111, 118)], layout=torch.jagged
     )
     loss_mask = torch.nested.as_nested_tensor(
-        [torch.ones(5), torch.ones(7)],
-        layout=torch.jagged,
+        [torch.ones(5), torch.ones(7)], layout=torch.jagged
     )
     packed = pack_nested_thd(
-        ids,
-        cp_size=2,
-        split_cp=False,
-        labels=labels,
-        loss_mask=loss_mask,
+        ids, cp_size=2, split_cp=False, labels=labels, loss_mask=loss_mask
     )
 
     assert packed.input_ids.shape == (1, 16)
@@ -425,10 +447,7 @@ def test_protocol_context_parallel_helper_is_noop_without_packed_thd_params():
     tensor = torch.arange(8)
 
     local_params, local_tensors = prepare_packed_thd_for_context_parallel(
-        None,
-        (tensor,),
-        cp_size=2,
-        cp_rank=0,
+        None, (tensor,), cp_size=2, cp_rank=0
     )
 
     assert local_params is None

--- a/experimental/lite/tests/unit/primitive/parallel/test_pipeline_thd_shape_unit.py
+++ b/experimental/lite/tests/unit/primitive/parallel/test_pipeline_thd_shape_unit.py
@@ -17,16 +17,19 @@ from types import SimpleNamespace
 import pytest
 import torch
 import torch.distributed as dist
-
 from megatron.lite.primitive.ckpt.hf_weights import unwrap_model
 from megatron.lite.primitive.parallel import pipeline as pl
 
 
 def _make_ps(pp_size: int, pp_rank: int) -> SimpleNamespace:
     return SimpleNamespace(
-        pp_size=pp_size, pp_rank=pp_rank,
-        pp_is_first=(pp_rank == 0), pp_is_last=(pp_rank == pp_size - 1),
-        pp_prev_rank=pp_rank - 1, pp_next_rank=pp_rank + 1, pp_group=None,
+        pp_size=pp_size,
+        pp_rank=pp_rank,
+        pp_is_first=(pp_rank == 0),
+        pp_is_last=(pp_rank == pp_size - 1),
+        pp_prev_rank=pp_rank - 1,
+        pp_next_rank=pp_rank + 1,
+        pp_group=None,
     )
 
 
@@ -53,17 +56,32 @@ def _run_schedule(pp_size, pp_rank, seq_lens, hidden=8):
     recorded_fwd, recorded_bwd = [], []
     fwd_q, bwd_q = list(fwd_shapes), list(fwd_shapes)  # both arrive in mb order
 
-    def fake_srp(send_fwd, send_bwd, recv_fwd, recv_bwd, ps_, tensor_shape,
-                 *, fwd_recv_buf=None, bwd_recv_buf=None, batch_p2p=True,
-                 clone_recv=False, dynamic_shape=False):
+    def fake_srp(
+        send_fwd,
+        send_bwd,
+        recv_fwd,
+        recv_bwd,
+        ps_,
+        tensor_shape,
+        *,
+        fwd_recv_buf=None,
+        bwd_recv_buf=None,
+        batch_p2p=True,
+        clone_recv=False,
+        dynamic_shape=False,
+    ):
         assert dynamic_shape, "1F1B schedule must use dynamic shape exchange"
-        assert fwd_recv_buf is None and bwd_recv_buf is None, "dynamic recv must not pre-size"
+        assert (
+            fwd_recv_buf is None and bwd_recv_buf is None
+        ), "dynamic recv must not pre-size"
         fwd_out = bwd_out = None
         if recv_fwd:
-            shp = fwd_q.pop(0); recorded_fwd.append(shp)
+            shp = fwd_q.pop(0)
+            recorded_fwd.append(shp)
             fwd_out = torch.ones(shp, requires_grad=True)
         if recv_bwd:
-            shp = bwd_q.pop(0); recorded_bwd.append(shp)
+            shp = bwd_q.pop(0)
+            recorded_bwd.append(shp)
             bwd_out = torch.ones(shp)
         return fwd_out, bwd_out
 
@@ -74,8 +92,11 @@ def _run_schedule(pp_size, pp_rank, seq_lens, hidden=8):
         else:
             inp = unwrap_model(m)._input_tensor
             assert inp is not None, "middle/last stage forwarded with a None input"
-            assert tuple(inp.shape) == (s, 1, hidden), (
-                f"input shape {tuple(inp.shape)} != {(s, 1, hidden)} for mb S={s}")
+            assert tuple(inp.shape) == (
+                s,
+                1,
+                hidden,
+            ), f"input shape {tuple(inp.shape)} != {(s, 1, hidden)} for mb S={s}"
             base = inp
         hidden_t = base * m.weight.sum()
         out = {"hidden_states": hidden_t}
@@ -87,8 +108,14 @@ def _run_schedule(pp_size, pp_rank, seq_lens, hidden=8):
     orig_srp, pl._send_recv_pipeline = pl._send_recv_pipeline, fake_srp
     try:
         pl._1f1b_schedule(
-            forward_step_fn, model, iter([(b, None) for b in batches]),
-            num_mb, SimpleNamespace(num_microbatches=num_mb), ps, fwd_shapes[0])
+            forward_step_fn,
+            model,
+            iter([(b, None) for b in batches]),
+            num_mb,
+            SimpleNamespace(num_microbatches=num_mb),
+            ps,
+            fwd_shapes[0],
+        )
     finally:
         pl._send_recv_pipeline = orig_srp
     return recorded_fwd, recorded_bwd, fwd_shapes
@@ -135,8 +162,12 @@ def _pp_hidden(mb_idx: int, seqlen: int) -> torch.Tensor:  # deterministic [S,1,
 
 
 def _dynamic_shape_worker(rank, world, port, results):
-    os.environ.update(MASTER_ADDR="127.0.0.1", MASTER_PORT=str(port),
-                      RANK=str(rank), WORLD_SIZE=str(world))
+    os.environ.update(
+        MASTER_ADDR="127.0.0.1",
+        MASTER_PORT=str(port),
+        RANK=str(rank),
+        WORLD_SIZE=str(world),
+    )
     pl._PIPELINE_TENSOR_DTYPE = torch.float32  # gloo-safe; sizing is dtype-agnostic
     dist.init_process_group("gloo", rank=rank, world_size=world)
     try:
@@ -144,34 +175,78 @@ def _dynamic_shape_worker(rank, world, port, results):
         detail = []
         for i, s in enumerate(_PP_VARLEN):
             if rank == 0:
-                pl._send_recv_pipeline(_pp_hidden(i, s), None, False, False, ps,
-                                       (1, 1, _PP_H), batch_p2p=False, dynamic_shape=True)
+                pl._send_recv_pipeline(
+                    _pp_hidden(i, s),
+                    None,
+                    False,
+                    False,
+                    ps,
+                    (1, 1, _PP_H),
+                    batch_p2p=False,
+                    dynamic_shape=True,
+                )
             else:
-                fwd_buf, _ = pl._send_recv_pipeline(None, None, True, False, ps,
-                                                    (1, 1, _PP_H), batch_p2p=False, dynamic_shape=True)
+                fwd_buf, _ = pl._send_recv_pipeline(
+                    None,
+                    None,
+                    True,
+                    False,
+                    ps,
+                    (1, 1, _PP_H),
+                    batch_p2p=False,
+                    dynamic_shape=True,
+                )
                 expect = _pp_hidden(i, s)
-                detail.append((s, tuple(fwd_buf.shape) == (s, 1, _PP_H),
-                               bool(torch.equal(fwd_buf.detach().float(), expect.float()))))
+                detail.append(
+                    (
+                        s,
+                        tuple(fwd_buf.shape) == (s, 1, _PP_H),
+                        bool(torch.equal(fwd_buf.detach().float(), expect.float())),
+                    )
+                )
         results.put((rank, detail))
     finally:
         dist.destroy_process_group()
 
 
 def _fixed_buffer_worker(rank, world, port, results):
-    os.environ.update(MASTER_ADDR="127.0.0.1", MASTER_PORT=str(port),
-                      RANK=str(rank), WORLD_SIZE=str(world))
+    os.environ.update(
+        MASTER_ADDR="127.0.0.1",
+        MASTER_PORT=str(port),
+        RANK=str(rank),
+        WORLD_SIZE=str(world),
+    )
     pl._PIPELINE_TENSOR_DTYPE = torch.float32
     dist.init_process_group("gloo", rank=rank, world_size=world)
     try:
         ps = _make_ps(2, rank)
         first_len = _PP_VARLEN[0]  # fixed recv buffer sized from the FIRST mb (S=5)
         if rank == 0:
-            pl._send_recv_pipeline(_pp_hidden(2, _PP_VARLEN[2]), None, False, False, ps,
-                                   (first_len, 1, _PP_H), batch_p2p=False, dynamic_shape=False)
+            pl._send_recv_pipeline(
+                _pp_hidden(2, _PP_VARLEN[2]),
+                None,
+                False,
+                False,
+                ps,
+                (first_len, 1, _PP_H),
+                batch_p2p=False,
+                dynamic_shape=False,
+            )
         else:
-            fixed_buf = torch.empty(first_len, 1, _PP_H, dtype=torch.float32)  # only fits S=5
-            pl._send_recv_pipeline(None, None, True, False, ps, (first_len, 1, _PP_H),
-                                   fwd_recv_buf=fixed_buf, batch_p2p=False, dynamic_shape=False)
+            fixed_buf = torch.empty(
+                first_len, 1, _PP_H, dtype=torch.float32
+            )  # only fits S=5
+            pl._send_recv_pipeline(
+                None,
+                None,
+                True,
+                False,
+                ps,
+                (first_len, 1, _PP_H),
+                fwd_recv_buf=fixed_buf,
+                batch_p2p=False,
+                dynamic_shape=False,
+            )
         results.put((rank, "no_abort"))  # reaching here without abort is the bug
     finally:
         dist.destroy_process_group()
@@ -197,6 +272,7 @@ def test_dynamic_shape_variable_len_recv_gloo():  # NEW: recv sized from wire, 0
 
 def test_fixed_buffer_truncates_variable_len_gloo():  # OLD: fixed buffer overflows -> abort
     import torch.multiprocessing as mp
+
     results = mp.get_context("spawn").SimpleQueue()
     with pytest.raises(Exception):  # gloo aborts the receiver -> spawn failure
         mp.spawn(_fixed_buffer_worker, args=(2, 29664, results), nprocs=2, join=True)

--- a/experimental/lite/tests/unit/primitive/quantization/test_block_fp8_roundtrip.py
+++ b/experimental/lite/tests/unit/primitive/quantization/test_block_fp8_roundtrip.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import pytest
 import torch
-
 from megatron.lite.primitive.quantization.block_fp8 import (
     dequantize_block_fp8,
     quantize_block_fp8,
@@ -49,9 +48,9 @@ def test_roundtrip_extreme_negative_and_near_zero_values() -> None:
     source[:128, 128:] = torch.full((128, 128), 1e-4)
     source[128:, :128] = torch.randn(128, 128) * 0.02
     block = torch.randn(128, 128) * 0.02
-    block[0, 0] = fp8_max          # one large outlier in the block sets the scale
+    block[0, 0] = fp8_max  # one large outlier in the block sets the scale
     block[1, 1] = -fp8_max
-    block[2, 2] = 0.0              # exact zero must round-trip back to zero
+    block[2, 2] = 0.0  # exact zero must round-trip back to zero
     source[128:, 128:] = block
 
     weight, scale, restored = _roundtrip(source)
@@ -69,8 +68,8 @@ def test_roundtrip_extreme_negative_and_near_zero_values() -> None:
 @pytest.mark.parametrize(
     "shape,label",
     [
-        ((512, 1024), "w1_gate_up_I_by_H"),   # expert gate/up: [I, H]
-        ((1024, 512), "w2_down_H_by_I"),      # expert down:    [H, I]
+        ((512, 1024), "w1_gate_up_I_by_H"),  # expert gate/up: [I, H]
+        ((1024, 512), "w2_down_H_by_I"),  # expert down:    [H, I]
     ],
 )
 def test_roundtrip_ds4_expert_shapes(shape: tuple[int, int], label: str) -> None:
@@ -83,11 +82,15 @@ def test_roundtrip_ds4_expert_shapes(shape: tuple[int, int], label: str) -> None
 
     weight, scale, restored = _roundtrip(source)
 
-    assert weight.shape == source.shape, f"{label}: quantization changed the shape (suspect axis/layout error)"
+    assert (
+        weight.shape == source.shape
+    ), f"{label}: quantization changed the shape (suspect axis/layout error)"
     assert scale.shape == (shape[0] // 128, shape[1] // 128)
     assert torch.isfinite(restored).all()
     rel = _frobenius_rel_err(restored, source)
-    assert rel < FROBENIUS_TOL, f"{label}: Frobenius rel err {rel:.4f} >= {FROBENIUS_TOL}"
+    assert (
+        rel < FROBENIUS_TOL
+    ), f"{label}: Frobenius rel err {rel:.4f} >= {FROBENIUS_TOL}"
 
 
 def test_roundtrip_is_deterministic() -> None:

--- a/experimental/lite/tests/unit/primitive/test_checkpoint_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_checkpoint_unit.py
@@ -6,7 +6,6 @@ import copy
 import pytest
 import torch
 import torch.nn as nn
-
 from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
 from megatron.lite.runtime.contracts.handle import ModelHandle
 
@@ -20,7 +19,9 @@ class TinyMLP(nn.Module):
         return self.layers(x)
 
 
-def _step(model: nn.Module, optimizer: torch.optim.Optimizer, x: torch.Tensor, y: torch.Tensor):
+def _step(
+    model: nn.Module, optimizer: torch.optim.Optimizer, x: torch.Tensor, y: torch.Tensor
+):
     optimizer.zero_grad(set_to_none=True)
     loss = torch.nn.functional.mse_loss(model(x), y)
     loss.backward()
@@ -56,12 +57,16 @@ def test_runtime_checkpoint_load_matches_uninterrupted_training(tmp_path):
 
     runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
     ckpt_handle = ModelHandle(
-        model=ckpt_model, optimizer=ckpt_optimizer, _extras={"model_chunks": [ckpt_model]}
+        model=ckpt_model,
+        optimizer=ckpt_optimizer,
+        _extras={"model_chunks": [ckpt_model]},
     )
     runtime.save_checkpoint(ckpt_handle, str(tmp_path), step=1, use_dcp=False)
 
     loaded_handle = ModelHandle(
-        model=loaded_model, optimizer=loaded_optimizer, _extras={"model_chunks": [loaded_model]}
+        model=loaded_model,
+        optimizer=loaded_optimizer,
+        _extras={"model_chunks": [loaded_model]},
     )
     assert runtime.load_checkpoint(loaded_handle, str(tmp_path), use_dcp=False) == 1
 
@@ -101,7 +106,9 @@ class DistOptLike:
         self.parameter_save_calls += 1
         torch.save({"parameter_save_calls": self.parameter_save_calls}, filename)
 
-    def load_parameter_state(self, filename: str, *, update_legacy_format: bool = False):
+    def load_parameter_state(
+        self, filename: str, *, update_legacy_format: bool = False
+    ):
         state = torch.load(filename)
         self.parameter_load_calls = int(state["parameter_save_calls"])
 
@@ -117,16 +124,22 @@ def test_runtime_checkpoint_uses_optimizer_state_dict_contract(tmp_path):
 
     runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
     runtime.save_checkpoint(
-        ModelHandle(model=model, optimizer=optimizer, _extras={"model_chunks": [model]}),
+        ModelHandle(
+            model=model, optimizer=optimizer, _extras={"model_chunks": [model]}
+        ),
         str(tmp_path),
         step=7,
         use_dcp=False,
     )
 
     loaded_model = TinyMLP()
-    loaded_optimizer = DistOptLike(torch.optim.AdamW(loaded_model.parameters(), lr=1.0e-3))
+    loaded_optimizer = DistOptLike(
+        torch.optim.AdamW(loaded_model.parameters(), lr=1.0e-3)
+    )
     loaded_handle = ModelHandle(
-        model=loaded_model, optimizer=loaded_optimizer, _extras={"model_chunks": [loaded_model]}
+        model=loaded_model,
+        optimizer=loaded_optimizer,
+        _extras={"model_chunks": [loaded_model]},
     )
 
     assert runtime.load_checkpoint(loaded_handle, str(tmp_path), use_dcp=False) == 7

--- a/experimental/lite/tests/unit/primitive/test_dsa_cp_native_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_dsa_cp_native_unit.py
@@ -20,10 +20,7 @@ def test_dense_cp_layout_keeps_local_queries_and_restores_global_kv_order():
     from megatron.lite.primitive.modules.attention.dsa import _dense_cp_layout
 
     query_positions, kv_reorder = _dense_cp_layout(
-        local_seq=4,
-        cp_size=2,
-        cp_rank=0,
-        device=torch.device("cpu"),
+        local_seq=4, cp_size=2, cp_rank=0, device=torch.device("cpu")
     )
 
     assert query_positions.tolist() == [0, 1, 2, 3]
@@ -36,10 +33,7 @@ def test_packed_cp_layout_uses_contiguous_global_coordinates():
 
     cu_seqlens = torch.tensor([0, 8, 16], dtype=torch.int32)
     query_positions, kv_reorder = _packed_cp_layout(
-        cu_seqlens,
-        cp_size=2,
-        cp_rank=0,
-        device=torch.device("cpu"),
+        cu_seqlens, cp_size=2, cp_rank=0, device=torch.device("cpu")
     )
 
     assert query_positions.tolist() == list(range(8))
@@ -48,9 +42,7 @@ def test_packed_cp_layout_uses_contiguous_global_coordinates():
 
 
 def test_cp_projected_kv_is_physically_aligned_for_cudnn_topk():
-    from megatron.lite.primitive.modules.attention.dsa import (
-        _pad_cp_projected_kv,
-    )
+    from megatron.lite.primitive.modules.attention.dsa import _pad_cp_projected_kv
 
     kv = torch.arange(520 * 3, dtype=torch.float32).view(520, 1, 3)
     index_k = torch.arange(520 * 2, dtype=torch.float32).view(520, 1, 2)
@@ -73,11 +65,7 @@ def test_cp_causal_mask_blocks_future_and_cross_packed_sequence_keys():
     key_positions = torch.arange(20, dtype=torch.long)
     cu_seqlens = torch.tensor([0, 8, 16], dtype=torch.int32)
 
-    mask = _build_cp_causal_mask(
-        query_positions,
-        key_positions,
-        cu_seqlens=cu_seqlens,
-    )
+    mask = _build_cp_causal_mask(query_positions, key_positions, cu_seqlens=cu_seqlens)
     valid = mask == 0
 
     assert valid[0].nonzero().flatten().tolist() == [0, 1]
@@ -159,12 +147,7 @@ def test_dense_cp_native_collective_only_receives_projected_kv_and_indexer_k():
     )
     x = torch.randn(1, 4, 64)
     result = DynamicSparseAttention._forward_dense_cp_native(
-        fake,
-        x,
-        torch.empty(0),
-        torch.empty(0),
-        torch.empty(0),
-        index_share_state=None,
+        fake, x, torch.empty(0), torch.empty(0), torch.empty(0), index_share_state=None
     )
 
     assert result is sentinel
@@ -210,8 +193,7 @@ def test_packed_cp_native_explicitly_selects_contiguous_projected_gather():
         _project_cp_output=lambda out, weight: sentinel,
     )
     params = SimpleNamespace(
-        cp_layout="contiguous",
-        cu_seqlens_q=torch.tensor([0, 8], dtype=torch.int32),
+        cp_layout="contiguous", cu_seqlens_q=torch.tensor([0, 8], dtype=torch.int32)
     )
     result = DynamicSparseAttention._forward_packed_cp_native(
         fake,
@@ -240,10 +222,14 @@ def test_cp_indexer_topk_respects_explicit_global_position_mask():
 
     _scores, actual = indexer_topk_with_mask(q, k, weights, 4, mask, 4**-0.5)
     reference = torch.einsum("qbhd,kbd->bqhk", q.float(), k.float())
-    reference = torch.relu(reference).mul(weights.permute(1, 0, 2).unsqueeze(-1)).sum(dim=2)
+    reference = (
+        torch.relu(reference).mul(weights.permute(1, 0, 2).unsqueeze(-1)).sum(dim=2)
+    )
     reference = reference * (4**-0.5) + mask.unsqueeze(0)
     values, expected = torch.topk(reference, k=4, dim=-1)
-    expected = torch.where(torch.isfinite(values), expected, torch.full_like(expected, -1))
+    expected = torch.where(
+        torch.isfinite(values), expected, torch.full_like(expected, -1)
+    )
 
     assert torch.equal(actual, expected.int())
     assert (actual[0, 0][actual[0, 0] >= 0] < 2).all()
@@ -283,7 +269,9 @@ def test_cp_dense_indexer_loss_matches_full_score_reference_and_backpropagates()
     )
 
     index_logits = torch.einsum("qbhd,kbd->bqhk", q.float(), k.float())
-    index_logits = torch.relu(index_logits).mul(weights.permute(1, 0, 2).unsqueeze(-1)).sum(dim=2)
+    index_logits = (
+        torch.relu(index_logits).mul(weights.permute(1, 0, 2).unsqueeze(-1)).sum(dim=2)
+    )
     index_logits = index_logits * (4**-0.5) + mask.unsqueeze(0)
     predict = torch.softmax(index_logits, dim=-1)
     attn_logits = torch.einsum("qbhd,kbd->bqhk", query.float(), kv.float())

--- a/experimental/lite/tests/unit/primitive/test_init_device.py
+++ b/experimental/lite/tests/unit/primitive/test_init_device.py
@@ -24,7 +24,9 @@ def _build_fsdp2(monkeypatch, transformer_engine_import_stub):
 
     monkeypatch.setattr(protocol, "Qwen3MoEModel", Model)
     monkeypatch.setattr(protocol, "init_parallel", lambda _p: SimpleNamespace())
-    monkeypatch.setattr(protocol, "normalize_lora_config", lambda _cfg: SimpleNamespace(enabled=False))
+    monkeypatch.setattr(
+        protocol, "normalize_lora_config", lambda _cfg: SimpleNamespace(enabled=False)
+    )
     monkeypatch.setattr(protocol, "parse_recompute_spec", lambda _cfg: [])
     monkeypatch.setattr(protocol, "set_cross_entropy_fusion", lambda *_args: None)
     monkeypatch.setattr(protocol, "apply_qat_to_chunks", lambda *_args: None)
@@ -34,7 +36,9 @@ def _build_fsdp2(monkeypatch, transformer_engine_import_stub):
     return seen, [param.device.type for param in bundle.chunks[0].parameters()]
 
 
-def test_fsdp2_always_builds_on_meta(monkeypatch, transformer_engine_import_stub) -> None:
+def test_fsdp2_always_builds_on_meta(
+    monkeypatch, transformer_engine_import_stub
+) -> None:
     assert _build_fsdp2(monkeypatch, transformer_engine_import_stub) == (
         ["meta"],
         ["meta"],
@@ -51,9 +55,7 @@ def test_meta_parameter_check_reports_explicit_cuda_module(
         def named_parameters(self, *args, **kwargs):
             del args, kwargs
             parameter = SimpleNamespace(
-                device=torch.device("cuda"),
-                numel=lambda: 8,
-                element_size=lambda: 2,
+                device=torch.device("cuda"), numel=lambda: 8, element_size=lambda: 2
             )
             return iter((("weight", parameter),))
 
@@ -101,18 +103,20 @@ def test_future_te_parameter_module_uses_central_device_policy(
         def __init__(self, *, device):
             super().__init__()
             seen.append(device.type)
-            self.weight = nn.Parameter(torch.empty(3, dtype=torch.bfloat16, device="cpu"))
+            self.weight = nn.Parameter(
+                torch.empty(3, dtype=torch.bfloat16, device="cpu")
+            )
 
     monkeypatch.setattr(central_te._TE, "FutureLinear", FutureLinear, raising=False)
     with torch.device("meta"):
         module = central_te.FutureLinear()
 
     assert seen == ["meta"]
-    assert (module.weight.device.type, module.weight.dtype, tuple(module.weight.shape)) == (
-        "meta",
-        torch.bfloat16,
-        (3,),
-    )
+    assert (
+        module.weight.device.type,
+        module.weight.dtype,
+        tuple(module.weight.shape),
+    ) == ("meta", torch.bfloat16, (3,))
 
 
 def test_fully_sharded_meta_model_supports_to_empty(tmp_path) -> None:
@@ -160,7 +164,10 @@ def test_custom_parameter_initializers_are_repeatable(
             for param in module.parameters(recurse=False):
                 param.fill_(float("nan"))
             module.reset_parameters()
-            assert all(torch.isfinite(param).all() for param in module.parameters(recurse=False))
+            assert all(
+                torch.isfinite(param).all()
+                for param in module.parameters(recurse=False)
+            )
 
     assert torch.equal(hca.base, torch.zeros_like(hca.base))
     assert torch.equal(hca.scale, torch.ones_like(hca.scale))
@@ -193,32 +200,20 @@ def test_expert_grouped_linears_follow_meta_context(
 
     monkeypatch.setattr(central_te._TE, "GroupedLinear", GroupedLinear, raising=False)
     monkeypatch.setattr(
-        experts,
-        "normalize_lora_config",
-        lambda _cfg: SimpleNamespace(enabled=False),
+        experts, "normalize_lora_config", lambda _cfg: SimpleNamespace(enabled=False)
     )
     ps = SimpleNamespace(
-        ep_size=1,
-        etp_size=1,
-        etp_group=None,
-        tp_size=1,
-        tp_group=None,
+        ep_size=1, etp_size=1, etp_group=None, tp_size=1, tp_group=None
     )
-    config = SimpleNamespace(
-        num_experts=8,
-        hidden_size=16,
-        moe_intermediate_size=8,
-    )
+    config = SimpleNamespace(num_experts=8, hidden_size=16, moe_intermediate_size=8)
 
     with torch.device("meta"):
         module = experts.Experts(config, ps)
 
     assert {
-        (param.device.type, param.dtype, tuple(param.shape)) for param in module.parameters()
-    } == {
-        ("meta", torch.bfloat16, (8, 16, 16)),
-        ("meta", torch.bfloat16, (8, 16, 8)),
-    }
+        (param.device.type, param.dtype, tuple(param.shape))
+        for param in module.parameters()
+    } == {("meta", torch.bfloat16, (8, 16, 16)), ("meta", torch.bfloat16, (8, 16, 8))}
 
 
 def test_te_parallel_linears_follow_meta_context(
@@ -235,7 +230,9 @@ def test_te_parallel_linears_follow_meta_context(
             super().__init__()
             seen.append(device.type)
             self.weight = nn.Parameter(
-                torch.empty(out_features, in_features, dtype=torch.bfloat16, device="cpu")
+                torch.empty(
+                    out_features, in_features, dtype=torch.bfloat16, device="cpu"
+                )
             )
 
         def forward(self, x):

--- a/experimental/lite/tests/unit/primitive/test_ops_data_trainstep_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_ops_data_trainstep_unit.py
@@ -5,15 +5,20 @@ import pytest
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-
 from megatron.lite.primitive.data import _resolve_thd_padding, fixed_batches
 from megatron.lite.primitive.deterministic import deterministic_requested
 from megatron.lite.primitive.ops.cross_entropy import vocab_parallel_cross_entropy
-from megatron.lite.primitive.ops.gated_delta_rule import l2norm, torch_chunk_gated_delta_rule
+from megatron.lite.primitive.ops.gated_delta_rule import (
+    l2norm,
+    torch_chunk_gated_delta_rule,
+)
 from megatron.lite.primitive.ops.linear_cross_entropy import linear_cross_entropy
 from megatron.lite.primitive.ops.logprob import vocab_parallel_log_probs_from_logits
 from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec
-from megatron.lite.primitive.train_step import compute_and_clip_grad_norm, run_microbatch_loop
+from megatron.lite.primitive.train_step import (
+    compute_and_clip_grad_norm,
+    run_microbatch_loop,
+)
 from megatron.lite.primitive.utils import ensure_divisible
 
 
@@ -47,7 +52,9 @@ def test_logprob_selects_labels_in_batch_sequence_or_sequence_batch_layout():
 
     torch.testing.assert_close(selected, expected)
     with pytest.raises(ValueError, match="Could not align"):
-        vocab_parallel_log_probs_from_logits(logits, torch.zeros(4, 2, dtype=torch.long))
+        vocab_parallel_log_probs_from_logits(
+            logits, torch.zeros(4, 2, dtype=torch.long)
+        )
 
 
 def test_linear_cross_entropy_fallback_matches_explicit_matmul():
@@ -108,8 +115,12 @@ def test_data_padding_env_and_fixed_batches_are_deterministic(monkeypatch):
     with pytest.raises(ValueError, match="PAD_MULTIPLE"):
         _resolve_thd_padding(seq_len=7, cp_size=2)
 
-    batches_a = fixed_batches(11, seq_len=4, num_steps=2, batch_size=2, device="cpu", seed=123)
-    batches_b = fixed_batches(11, seq_len=4, num_steps=2, batch_size=2, device="cpu", seed=123)
+    batches_a = fixed_batches(
+        11, seq_len=4, num_steps=2, batch_size=2, device="cpu", seed=123
+    )
+    batches_b = fixed_batches(
+        11, seq_len=4, num_steps=2, batch_size=2, device="cpu", seed=123
+    )
     for (ids_a, labels_a), (ids_b, labels_b) in zip(batches_a, batches_b, strict=True):
         torch.testing.assert_close(ids_a, ids_b)
         torch.testing.assert_close(labels_a, labels_b)
@@ -179,7 +190,9 @@ def test_train_step_microbatch_loop_and_grad_clip_cpu_contract():
     assert model.weight.grad is not None
     assert torch.isfinite(model.weight.grad).all()
 
-    grad_norm = compute_and_clip_grad_norm(model, optimizer=None, max_norm=0.25, use_dist_opt=False)
+    grad_norm = compute_and_clip_grad_norm(
+        model, optimizer=None, max_norm=0.25, use_dist_opt=False
+    )
 
     assert torch.isfinite(grad_norm)
     assert model.weight.grad.norm() <= 0.25 + 1.0e-6

--- a/experimental/lite/tests/unit/primitive/test_qat_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_qat_unit.py
@@ -330,8 +330,7 @@ def test_export_roundtrip_matches_fake_quant(fmt, group_size):
 
 
 @pytest.mark.parametrize(
-    "fmt,group_size",
-    [("fp8", 0), ("fp8", -1), ("fp8", 32), ("mxfp4", 32)],
+    "fmt,group_size", [("fp8", 0), ("fp8", -1), ("fp8", 32), ("mxfp4", 32)]
 )
 def test_float_export_roundtrip_matches_fake_quant(fmt, group_size):
     torch.manual_seed(13)
@@ -475,8 +474,7 @@ def _copy_via_checkpoint_primitive(
 
 
 @pytest.mark.parametrize(
-    "fmt,group_size",
-    [("int8", -1), ("int4", -1), ("fp8_e4m3", -1), ("mxfp4", 32)],
+    "fmt,group_size", [("int8", -1), ("int4", -1), ("fp8_e4m3", -1), ("mxfp4", 32)]
 )
 def test_apply_before_load_still_loads_master_weight(fmt, group_size):
     torch.manual_seed(7)
@@ -491,8 +489,7 @@ def test_apply_before_load_still_loads_master_weight(fmt, group_size):
     real_qkv = torch.randn(12, 64, dtype=torch.bfloat16)
     real_proj = torch.randn(12, 64, dtype=torch.bfloat16)
     _copy_via_checkpoint_primitive(
-        chunk,
-        {"qkv.linear.weight": real_qkv, "proj.linear.weight": real_proj},
+        chunk, {"qkv.linear.weight": real_qkv, "proj.linear.weight": real_proj}
     )
 
     # 3) the BF16 master (.original) must hold the real weights — not random init.

--- a/experimental/lite/tests/unit/primitive/test_sigmoid_router_unification_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_sigmoid_router_unification_unit.py
@@ -51,8 +51,7 @@ def _legacy_custom_router_output(config, weight, expert_bias, x):
 
 
 @pytest.mark.parametrize(
-    ("model_name", "aux_loss_alpha"),
-    [("glm5", None), ("kimi_k2", 0.0)],
+    ("model_name", "aux_loss_alpha"), [("glm5", None), ("kimi_k2", 0.0)]
 )
 def test_shared_router_is_bitwise_equal_to_legacy_custom_router(
     model_name, aux_loss_alpha, transformer_engine_import_stub
@@ -122,10 +121,7 @@ def test_qwen_topk_router_output_is_bitwise_unchanged(
     from megatron.lite.primitive.utils.moe import topk_routing_with_score_function
 
     config = SimpleNamespace(
-        hidden_size=8,
-        num_experts=8,
-        num_experts_per_tok=2,
-        router_aux_loss_coef=0.0,
+        hidden_size=8, num_experts=8, num_experts_per_tok=2, router_aux_loss_coef=0.0
     )
     router = TopKRouter(config, _ps(), compute_aux_loss=False)
     weight = torch.arange(64, dtype=torch.float32).view(8, 8) / 23
@@ -134,9 +130,7 @@ def test_qwen_topk_router_output_is_bitwise_unchanged(
         router.gate.weight.copy_(weight)
     logits = F.linear(x, weight)
     probs_dense, routing_map = topk_routing_with_score_function(
-        logits,
-        2,
-        score_function="softmax",
+        logits, 2, score_function="softmax"
     )
     expert_ids = torch.arange(8).expand_as(routing_map)
     masked_ids = torch.where(routing_map, expert_ids, torch.full_like(expert_ids, 8))
@@ -181,9 +175,7 @@ def test_router_buffers_remain_float32_after_dtype_apply(
     from megatron.lite.primitive.modules.router import SigmoidTopKRouter
 
     router = SigmoidTopKRouter(
-        _config(grouped=True, aux_loss_alpha=0.0),
-        _ps(),
-        compute_aux_loss=False,
+        _config(grouped=True, aux_loss_alpha=0.0), _ps(), compute_aux_loss=False
     ).to(torch.bfloat16)
 
     assert router.expert_bias.dtype == torch.float32

--- a/experimental/lite/tests/unit/runtime/backends/bridge/test_bridge_backend.py
+++ b/experimental/lite/tests/unit/runtime/backends/bridge/test_bridge_backend.py
@@ -96,7 +96,9 @@ def test_bridge_builds_mcore_ddp_config_object(monkeypatch):
     )
 
     ddp_config = _build_ddp_config(
-        BridgeConfig(override_ddp_config={"overlap_grad_reduce": True, "bucket_size": 1024})
+        BridgeConfig(
+            override_ddp_config={"overlap_grad_reduce": True, "bucket_size": 1024}
+        )
     )
 
     assert isinstance(ddp_config, _FakeDDPConfig)
@@ -122,7 +124,9 @@ def test_bridge_deterministic_provider_sets_te_env(monkeypatch):
 
 
 def test_bridge_registers_qwen35_moe_compat_aliases(monkeypatch):
-    from megatron.lite.runtime.backends.bridge.runtime import _register_bridge_compat_aliases
+    from megatron.lite.runtime.backends.bridge.runtime import (
+        _register_bridge_compat_aliases,
+    )
 
     registered = []
 
@@ -146,7 +150,9 @@ def test_bridge_registers_qwen35_moe_compat_aliases(monkeypatch):
         get_model_bridge=_FakeDispatcher(),
         register_bridge_implementation=lambda **kwargs: registered.append(kwargs),
     )
-    mapping_registry_mod = types.SimpleNamespace(MegatronMappingRegistry=lambda *items: list(items))
+    mapping_registry_mod = types.SimpleNamespace(
+        MegatronMappingRegistry=lambda *items: list(items)
+    )
     param_mapping_mod = types.SimpleNamespace(
         AutoMapping=_FakeMapping,
         GDNConv1dMapping=_FakeMapping,
@@ -158,7 +164,9 @@ def test_bridge_registers_qwen35_moe_compat_aliases(monkeypatch):
         split_gdn_linear_weights=lambda *args, **kwargs: (None, None),
     )
     qwen_bridge_mod = types.SimpleNamespace(Qwen3NextBridge=_FakeQwen3NextBridge)
-    common_utils_mod = types.SimpleNamespace(extract_expert_number_from_param=lambda name: 0)
+    common_utils_mod = types.SimpleNamespace(
+        extract_expert_number_from_param=lambda name: 0
+    )
     gpt_mod = types.SimpleNamespace(GPTModel=object)
 
     monkeypatch.setitem(
@@ -167,15 +175,21 @@ def test_bridge_registers_qwen35_moe_compat_aliases(monkeypatch):
         types.SimpleNamespace(model_bridge=model_bridge),
     )
     monkeypatch.setitem(
-        sys.modules, "megatron.bridge.models.conversion.mapping_registry", mapping_registry_mod
+        sys.modules,
+        "megatron.bridge.models.conversion.mapping_registry",
+        mapping_registry_mod,
     )
     monkeypatch.setitem(
-        sys.modules, "megatron.bridge.models.conversion.param_mapping", param_mapping_mod
+        sys.modules,
+        "megatron.bridge.models.conversion.param_mapping",
+        param_mapping_mod,
     )
     monkeypatch.setitem(
         sys.modules, "megatron.bridge.models.qwen.qwen3_next_bridge", qwen_bridge_mod
     )
-    monkeypatch.setitem(sys.modules, "megatron.bridge.utils.common_utils", common_utils_mod)
+    monkeypatch.setitem(
+        sys.modules, "megatron.bridge.utils.common_utils", common_utils_mod
+    )
     monkeypatch.setitem(sys.modules, "megatron.core.models.gpt.gpt_model", gpt_mod)
 
     _register_bridge_compat_aliases()
@@ -184,7 +198,13 @@ def test_bridge_registers_qwen35_moe_compat_aliases(monkeypatch):
         "Qwen3_5MoeForConditionalGeneration",
         "Qwen3_5MoeForCausalLM",
     ]
-    assert all(issubclass(item["bridge_class"], _FakeQwen3NextBridge) for item in registered)
+    assert all(
+        issubclass(item["bridge_class"], _FakeQwen3NextBridge) for item in registered
+    )
     assert all(item["bridge_class"] is not _FakeQwen3NextBridge for item in registered)
-    assert all("provider_bridge" in item["bridge_class"].__dict__ for item in registered)
-    assert all("mapping_registry" in item["bridge_class"].__dict__ for item in registered)
+    assert all(
+        "provider_bridge" in item["bridge_class"].__dict__ for item in registered
+    )
+    assert all(
+        "mapping_registry" in item["bridge_class"].__dict__ for item in registered
+    )

--- a/experimental/lite/tests/unit/runtime/backends/bridge/test_packed_batch_bridge.py
+++ b/experimental/lite/tests/unit/runtime/backends/bridge/test_packed_batch_bridge.py
@@ -61,12 +61,10 @@ def test_bridge_forward_kwargs_are_transient_bridge_metadata() -> None:
     # like the native pack_thd_forward_kwargs path, so both backends train on the
     # same shifted targets.
     assert torch.equal(
-        out["labels"].reshape(-1),
-        torch.tensor([101, 102, 0, 104, 105, 106, 107, 0]),
+        out["labels"].reshape(-1), torch.tensor([101, 102, 0, 104, 105, 106, 107, 0])
     )
     assert torch.equal(
-        out["position_ids"].reshape(-1),
-        torch.tensor([0, 1, 2, 0, 1, 2, 3, 4]),
+        out["position_ids"].reshape(-1), torch.tensor([0, 1, 2, 0, 1, 2, 3, 4])
     )
 
     psp = out["packed_seq_params"]
@@ -82,8 +80,7 @@ def test_bridge_forward_kwargs_carry_loss_mask_only_inside_bridge() -> None:
     assert "loss_mask" in out
     # loss_mask is rolled with the labels so it masks the shifted targets.
     assert torch.equal(
-        out["loss_mask"].reshape(-1),
-        torch.tensor([1, 0, 0, 1, 1, 0, 1, 0]),
+        out["loss_mask"].reshape(-1), torch.tensor([1, 0, 0, 1, 1, 0, 1, 0])
     )
 
 

--- a/experimental/lite/tests/unit/runtime/backends/mlite/test_runtime_backend_unit.py
+++ b/experimental/lite/tests/unit/runtime/backends/mlite/test_runtime_backend_unit.py
@@ -10,7 +10,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 import torch.nn as nn
-
 from megatron.lite.runtime import create_runtime
 from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig
 from megatron.lite.runtime.backends.mlite.runtime import (
@@ -20,9 +19,17 @@ from megatron.lite.runtime.backends.mlite.runtime import (
     _pipeline_callbacks,
     _reset_parameters,
 )
-from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig, RuntimeConfig
+from megatron.lite.runtime.contracts.config import (
+    OptimizerConfig,
+    ParallelConfig,
+    RuntimeConfig,
+)
 from megatron.lite.runtime.contracts.handle import ModelHandle
-from megatron.lite.runtime.contracts.loss import LossContext, get_loss_context, use_loss_context
+from megatron.lite.runtime.contracts.loss import (
+    LossContext,
+    get_loss_context,
+    use_loss_context,
+)
 
 
 def test_runtime_returns_loss_separately_from_microbatch_metrics():
@@ -50,7 +57,10 @@ def test_pipeline_callbacks_accept_wrapped_and_presplit_context():
     forward, loss = _pipeline_callbacks(
         lambda _model, batch: seen.append((batch, get_loss_context()))
         or {"loss": torch.tensor(1.0)},
-        lambda out, batch, ctx: (out["loss"], {"batch": batch, "source": ctx.source_batch}),
+        lambda out, batch, ctx: (
+            out["loss"],
+            {"batch": batch, "source": ctx.source_batch},
+        ),
     )
 
     output = forward(None, ("wrapped", context))
@@ -84,7 +94,8 @@ def test_runtime_config_accepts_mlite_backend_cfg():
 
 def test_mlite_config_defaults_and_parallel_fields():
     cfg = MegatronLiteConfig(
-        model_name="qwen3_moe", parallel=ParallelConfig(tp=4, etp=1, ep=8, pp=2, vpp=2, cp=2)
+        model_name="qwen3_moe",
+        parallel=ParallelConfig(tp=4, etp=1, ep=8, pp=2, vpp=2, cp=2),
     )
 
     assert cfg.model_name == "qwen3_moe"
@@ -353,7 +364,9 @@ class HookedOptimizer:
 
 def test_runtime_to_prefers_optimizer_specific_offload_hooks():
     optimizer = HookedOptimizer()
-    handle = ModelHandle(model=nn.Linear(2, 2), optimizer=optimizer, _extras={"model_chunks": []})
+    handle = ModelHandle(
+        model=nn.Linear(2, 2), optimizer=optimizer, _extras={"model_chunks": []}
+    )
     runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
 
     runtime.to(handle, "cpu", model=False, optimizer=True, grad=False)
@@ -397,9 +410,7 @@ def test_training_transfer_parks_optimizer_and_releases_scratch(monkeypatch):
     monkeypatch.setattr(torch.cuda, "empty_cache", lambda: events.append("empty-cache"))
     chunk = Chunk()
     handle = ModelHandle(
-        model=chunk,
-        optimizer=Optimizer(),
-        _extras={"model_chunks": [chunk]},
+        model=chunk, optimizer=Optimizer(), _extras={"model_chunks": [chunk]}
     )
     runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
 
@@ -434,9 +445,7 @@ def test_export_transfer_does_not_move_optimizer_or_release_scratch(monkeypatch)
     )
     chunk = Chunk()
     handle = ModelHandle(
-        model=chunk,
-        optimizer=HookedOptimizer(),
-        _extras={"model_chunks": [chunk]},
+        model=chunk, optimizer=HookedOptimizer(), _extras={"model_chunks": [chunk]}
     )
 
     MegatronLiteRuntime.__new__(MegatronLiteRuntime).to(
@@ -552,7 +561,10 @@ def test_megatron_ddp_detection_accepts_ddp_and_subclasses(monkeypatch):
 
 @pytest.mark.parametrize("model_cls", [_FakeMegatronDDP, _FakeMegatronDDPSubclass])
 def test_megatron_ddp_model_move_helpers_use_buffer_path(monkeypatch, model_cls):
-    from megatron.lite.runtime.megatron_utils import load_model_to_gpu, offload_model_to_cpu
+    from megatron.lite.runtime.megatron_utils import (
+        load_model_to_gpu,
+        offload_model_to_cpu,
+    )
 
     _install_fake_megatron_ddp(monkeypatch)
     model = model_cls()
@@ -579,7 +591,10 @@ def test_megatron_ddp_model_move_helpers_use_buffer_path(monkeypatch, model_cls)
 
 
 def test_native_model_move_helpers_do_not_require_megatron_core(monkeypatch):
-    from megatron.lite.runtime.megatron_utils import load_model_to_gpu, offload_model_to_cpu
+    from megatron.lite.runtime.megatron_utils import (
+        load_model_to_gpu,
+        offload_model_to_cpu,
+    )
 
     monkeypatch.setitem(sys.modules, "megatron.core", None)
     monkeypatch.setitem(sys.modules, "megatron.core.distributed", None)
@@ -638,7 +653,9 @@ def test_model_handle_dp_from_parallel_state():
 def test_model_handle_cp_range_and_config_properties():
     cfg = {"tp": 8, "ep": 4}
     default_handle = ModelHandle(model=MagicMock())
-    configured_handle = ModelHandle(model=MagicMock(), config=cfg, _extras={"cp_range": (1, 8)})
+    configured_handle = ModelHandle(
+        model=MagicMock(), config=cfg, _extras={"cp_range": (1, 8)}
+    )
 
     assert default_handle.cp_range == (1, 1)
     assert configured_handle.cp_range == (1, 8)
@@ -652,7 +669,9 @@ def test_runtime_dispatch_creates_mlite_backend():
 
         runtime = create_runtime(
             RuntimeConfig(
-                backend="mlite", hf_path="/models/test", backend_cfg={"model_name": "qwen3"}
+                backend="mlite",
+                hf_path="/models/test",
+                backend_cfg={"model_name": "qwen3"},
             )
         )
 

--- a/experimental/lite/tests/unit/runtime/backends/mlite/test_runtime_config_unit.py
+++ b/experimental/lite/tests/unit/runtime/backends/mlite/test_runtime_config_unit.py
@@ -2,10 +2,10 @@
 from __future__ import annotations
 
 import pytest
-
 from megatron.lite.runtime import RuntimeConfig, create_runtime
 from megatron.lite.runtime.backends.mlite.config import DebugConfig, MegatronLiteConfig
 from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
+
 
 def test_mlite_config_defaults_are_stable():
     cfg = MegatronLiteConfig(model_name="qwen3_moe")

--- a/experimental/lite/tests/unit/runtime/checkpoint/test_checkpoint_runtime.py
+++ b/experimental/lite/tests/unit/runtime/checkpoint/test_checkpoint_runtime.py
@@ -9,7 +9,6 @@ from unittest.mock import patch
 import numpy as np
 import torch
 import torch.nn as nn
-
 from megatron.lite.primitive.ckpt import save_training_checkpoint
 from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
 from megatron.lite.runtime.contracts.config import ParallelConfig
@@ -25,7 +24,9 @@ class TinyMLP(nn.Module):
         return self.layers(x)
 
 
-def _step(model: nn.Module, optimizer: torch.optim.Optimizer, x: torch.Tensor, y: torch.Tensor):
+def _step(
+    model: nn.Module, optimizer: torch.optim.Optimizer, x: torch.Tensor, y: torch.Tensor
+):
     optimizer.zero_grad(set_to_none=True)
     loss = torch.nn.functional.mse_loss(model(x), y)
     loss.backward()
@@ -113,7 +114,9 @@ class DistOptLike:
         self.parameter_save_calls += 1
         torch.save({"parameter_save_calls": self.parameter_save_calls}, filename)
 
-    def load_parameter_state(self, filename: str, *, update_legacy_format: bool = False):
+    def load_parameter_state(
+        self, filename: str, *, update_legacy_format: bool = False
+    ):
         state = torch.load(filename, weights_only=False)
         self.parameter_load_calls = int(state["parameter_save_calls"])
         self.update_legacy_format = update_legacy_format
@@ -130,11 +133,16 @@ def test_runtime_local_checkpoint_uses_optimizer_parameter_state_contract(tmp_pa
 
     runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
     runtime.save_checkpoint(
-        ModelHandle(model=model, optimizer=optimizer), str(tmp_path), step=7, use_dcp=False
+        ModelHandle(model=model, optimizer=optimizer),
+        str(tmp_path),
+        step=7,
+        use_dcp=False,
     )
 
     loaded_model = TinyMLP()
-    loaded_optimizer = DistOptLike(torch.optim.AdamW(loaded_model.parameters(), lr=1.0e-3))
+    loaded_optimizer = DistOptLike(
+        torch.optim.AdamW(loaded_model.parameters(), lr=1.0e-3)
+    )
 
     assert (
         runtime.load_checkpoint(
@@ -189,11 +197,16 @@ def test_runtime_local_checkpoint_uses_rank_specific_files_when_distributed(tmp_
 
     with (
         patch("megatron.lite.primitive.ckpt.dcp.dist.is_available", return_value=True),
-        patch("megatron.lite.primitive.ckpt.dcp.dist.is_initialized", return_value=True),
+        patch(
+            "megatron.lite.primitive.ckpt.dcp.dist.is_initialized", return_value=True
+        ),
         patch("megatron.lite.primitive.ckpt.dcp.dist.get_rank", return_value=3),
     ):
         runtime.save_checkpoint(
-            ModelHandle(model=model, optimizer=None), str(tmp_path), step=11, use_dcp=False
+            ModelHandle(model=model, optimizer=None),
+            str(tmp_path),
+            step=11,
+            use_dcp=False,
         )
         assert (tmp_path / "training_state_rank_00003.pt").exists()
         assert not (tmp_path / "training_state.pt").exists()
@@ -223,7 +236,9 @@ def test_primitive_explicit_dcp_saves_optimizer_rank_sidecar(tmp_path):
     parallel_state = SimpleNamespace(pp_size=1, pp_rank=0)
 
     with (
-        patch("megatron.lite.primitive.ckpt.dcp._build_meshes", return_value=(None, None)),
+        patch(
+            "megatron.lite.primitive.ckpt.dcp._build_meshes", return_value=(None, None)
+        ),
         patch(
             "megatron.lite.primitive.ckpt.dcp.DTensor.from_local",
             side_effect=lambda tensor, *args, **kwargs: tensor,
@@ -249,7 +264,9 @@ def test_runtime_dcp_checkpoint_threads_parallel_config_and_protocol_hooks(tmp_p
     def expert_classifier(name: str):
         return name.endswith("expert")
 
-    proto = SimpleNamespace(PLACEMENT_FN=placement_fn, EXPERT_CLASSIFIER=expert_classifier)
+    proto = SimpleNamespace(
+        PLACEMENT_FN=placement_fn, EXPERT_CLASSIFIER=expert_classifier
+    )
     handle = ModelHandle(
         model=[model],
         optimizer=None,

--- a/experimental/lite/tests/unit/runtime/checkpoint/test_training_checkpoint.py
+++ b/experimental/lite/tests/unit/runtime/checkpoint/test_training_checkpoint.py
@@ -23,12 +23,18 @@ from megatron.lite.primitive.ckpt.distckpt import (
     attach_model_sharded_state_dict,
 )
 from megatron.lite.primitive.parallel import ParallelState
-from megatron.lite.primitive.protocols import default_expert_classifier, default_placement_fn
+from megatron.lite.primitive.protocols import (
+    default_expert_classifier,
+    default_placement_fn,
+)
 from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
 from megatron.lite.runtime.contracts.handle import ModelHandle
 
 
-@pytest.mark.parametrize("groups, expected", [([], False), ([object(), object()], True), ([object(), None], False)])
+@pytest.mark.parametrize(
+    "groups, expected",
+    [([], False), ([object(), object()], True), ([object(), None], False)],
+)
 def test_dist_opt_checkpoint_memory_efficient_metadata(groups, expected) -> None:
     opts = [
         SimpleNamespace(
@@ -120,7 +126,9 @@ DISTOPT_METADATA = {
 }
 
 
-def test_dist_opt_checkpoint_dispatches_to_mcore_distckpt(monkeypatch, tmp_path) -> None:
+def test_dist_opt_checkpoint_dispatches_to_mcore_distckpt(
+    monkeypatch, tmp_path
+) -> None:
     model = torch.nn.Linear(4, 2)
     optimizer = FakeDistOpt()
     ps = ParallelState(pp_rank=1, tp_rank=2, dp_cp_rank=3)
@@ -132,7 +140,9 @@ def test_dist_opt_checkpoint_dispatches_to_mcore_distckpt(monkeypatch, tmp_path)
         saved["checkpoint_dir"] = checkpoint_dir
         saved["kwargs"] = kwargs
 
-    monkeypatch.setattr("megatron.lite.primitive.ckpt.distckpt.dist_checkpointing.save", fake_save)
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.distckpt.dist_checkpointing.save", fake_save
+    )
 
     dcp.save_training_checkpoint(model, optimizer, 5, str(tmp_path), use_dcp=True)
 
@@ -222,14 +232,18 @@ def test_dist_opt_replica_id_does_not_treat_pp_as_a_replica_axis() -> None:
     assert replica_id == (0, 0, 0)
 
 
-def test_dist_opt_pp_rank_one_model_keys_survive_torch_dist_main_replica_filter() -> None:
+def test_dist_opt_pp_rank_one_model_keys_survive_torch_dist_main_replica_filter() -> (
+    None
+):
     ps = ParallelState(pp_size=2, pp_rank=1, pp_is_first=False, pp_is_last=True)
     model = torch.nn.Linear(4, 2)
     attach_model_sharded_state_dict([model], ps)
 
     model_sd = _model_sharded_state_dict(model)
-    filtered_sd, _flat_mapping, _rename_mapping = _replace_state_dict_keys_with_sharded_keys(
-        model_sd, keep_only_main_replica=True
+    filtered_sd, _flat_mapping, _rename_mapping = (
+        _replace_state_dict_keys_with_sharded_keys(
+            model_sd, keep_only_main_replica=True
+        )
     )
 
     assert set(filtered_sd) == {"model_pp1.weight", "model_pp1.bias"}
@@ -280,9 +294,13 @@ def test_dist_opt_checkpoint_loads_from_mcore_distckpt(monkeypatch, tmp_path) ->
             "optimizer": {"loaded": True},
         }
 
-    monkeypatch.setattr("megatron.lite.primitive.ckpt.distckpt.dist_checkpointing.load", fake_load)
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.distckpt.dist_checkpointing.load", fake_load
+    )
 
-    step = dcp.load_training_checkpoint(model, optimizer, str(tmp_path / "step_5"), use_dcp=True)
+    step = dcp.load_training_checkpoint(
+        model, optimizer, str(tmp_path / "step_5"), use_dcp=True
+    )
 
     assert step == 5
     assert not model.wrapper_load_called
@@ -291,11 +309,14 @@ def test_dist_opt_checkpoint_loads_from_mcore_distckpt(monkeypatch, tmp_path) ->
     assert optimizer.loaded_state == {"loaded": True}
 
 
-def test_dist_opt_step_sync_traverses_multi_optimizer_chain_without_optimizer_property() -> None:
+def test_dist_opt_step_sync_traverses_multi_optimizer_chain_without_optimizer_property() -> (
+    None
+):
     class FakeTorchOptimizer:
         def __init__(self, steps):
             self.state = {
-                object(): {"step": torch.tensor(step, dtype=torch.int64)} for step in steps
+                object(): {"step": torch.tensor(step, dtype=torch.int64)}
+                for step in steps
             }
 
     class FakeDistOpt:
@@ -333,8 +354,12 @@ def test_runtime_checkpoint_api_passes_current_training_checkpoint_signature(
         calls["load"] = (model, optimizer, path, config, ps, kwargs)
         return 7
 
-    monkeypatch.setattr("megatron.lite.primitive.ckpt.save_training_checkpoint", fake_save)
-    monkeypatch.setattr("megatron.lite.primitive.ckpt.load_training_checkpoint", fake_load)
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.save_training_checkpoint", fake_save
+    )
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.load_training_checkpoint", fake_load
+    )
 
     runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
     model = torch.nn.Linear(1, 1)

--- a/experimental/lite/tests/unit/runtime/contracts/test_weight_contracts.py
+++ b/experimental/lite/tests/unit/runtime/contracts/test_weight_contracts.py
@@ -1,13 +1,11 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import pytest
-
 from megatron.lite.runtime.contracts.weights import ResyncFormat
 
 
 @pytest.mark.parametrize(
-    "expected",
-    [ResyncFormat.BF16, ResyncFormat.BLOCK_FP8, ResyncFormat.MXFP4],
+    "expected", [ResyncFormat.BF16, ResyncFormat.BLOCK_FP8, ResyncFormat.MXFP4]
 )
 def test_resync_format_round_trip(expected: ResyncFormat) -> None:
     assert ResyncFormat.parse(expected.value) is expected

--- a/experimental/lite/tests/unit/runtime/test_dynamic_cp_plugin_unit.py
+++ b/experimental/lite/tests/unit/runtime/test_dynamic_cp_plugin_unit.py
@@ -431,12 +431,7 @@ def test_dynamic_cp_enables_transformer_engine_batched_p2p(monkeypatch):
     monkeypatch.setenv("NVTE_BATCH_MHA_P2P_COMM", "0")
     pool, singleton, cp2 = _Group(4), _Group(1), _Group(2)
     ps = SimpleNamespace(
-        dp_size=4,
-        dp_rank=0,
-        dp_group=pool,
-        dp_cp_group=pool,
-        cp_size=1,
-        pp_size=1,
+        dp_size=4, dp_rank=0, dp_group=pool, dp_cp_group=pool, cp_size=1, pp_size=1
     )
     handle = ModelHandle(
         model=object(),
@@ -449,11 +444,7 @@ def test_dynamic_cp_enables_transformer_engine_batched_p2p(monkeypatch):
     )
     plugin = DynamicCPPlugin(
         {"max_seqlen_per_dp_cp_rank": 8},
-        create_groups=lambda _ps, _minimum, _parallel: {
-            1: singleton,
-            2: cp2,
-            4: pool,
-        },
+        create_groups=lambda _ps, _minimum, _parallel: {1: singleton, 2: cp2, 4: pool},
     )
 
     plugin.initialize(handle)

--- a/experimental/lite/tests/unit/runtime/test_layering_contracts.py
+++ b/experimental/lite/tests/unit/runtime/test_layering_contracts.py
@@ -59,7 +59,7 @@ DENIED_IMPORT_PREFIXES = {
 IMPORT_ALLOWLIST: dict[str, tuple[str, ...]] = {
     "megatron/lite/primitive/ops/linear_cross_entropy.py": (
         "verl.utils.kernel.linear_cross_entropy",
-    ),
+    )
 }
 
 
@@ -128,7 +128,9 @@ def _allow_ranges(path: Path) -> list[range]:
 
     ranges: list[range] = []
     start: int | None = None
-    for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+    for lineno, line in enumerate(
+        path.read_text(encoding="utf-8").splitlines(), start=1
+    ):
         if ALLOW_BEGIN in line:
             if start is not None:
                 raise AssertionError(f"nested allow range in {path}")

--- a/experimental/lite/tests/unit/verl/test_mlite_engine_loss_mask_packing.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_engine_loss_mask_packing.py
@@ -4,7 +4,6 @@
 import pytest
 import torch
 from tensordict import TensorDict
-
 from verl_mlite.engine.mlite_engine import MegatronLiteEngine
 
 pytestmark = pytest.mark.mlite
@@ -15,8 +14,7 @@ def test_response_mask_is_used_when_loss_mask_is_absent():
         [torch.arange(12), torch.arange(9)], layout=torch.jagged
     )
     response_mask = torch.nested.as_nested_tensor(
-        [torch.tensor([1.0, 1.0, 0.0, 1.0, 1.0]), torch.ones(3)],
-        layout=torch.jagged,
+        [torch.tensor([1.0, 1.0, 0.0, 1.0, 1.0]), torch.ones(3)], layout=torch.jagged
     )
     micro_batch = TensorDict(
         {"input_ids": input_ids, "response_mask": response_mask}, batch_size=[2]
@@ -27,5 +25,7 @@ def test_response_mask_is_used_when_loss_mask_is_absent():
     assert packed is not None
     assert packed.offsets().diff().tolist() == [12, 9]
     rows = packed.unbind(0)
-    torch.testing.assert_close(rows[0], torch.tensor([0.0] * 7 + [1.0, 1.0, 0.0, 1.0, 1.0]))
+    torch.testing.assert_close(
+        rows[0], torch.tensor([0.0] * 7 + [1.0, 1.0, 0.0, 1.0, 1.0])
+    )
     torch.testing.assert_close(rows[1], torch.tensor([0.0] * 6 + [1.0, 1.0, 1.0]))

--- a/experimental/lite/tests/unit/verl/test_mlite_engine_metrics.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_engine_metrics.py
@@ -7,7 +7,6 @@ from types import SimpleNamespace
 
 import pytest
 import torch
-
 from verl_mlite.engine.mlite_engine import MegatronLiteEngine
 
 pytestmark = pytest.mark.mlite
@@ -18,8 +17,7 @@ def test_mtp_metric_averages_over_physical_pool_not_logical_singleton(monkeypatc
     logical_singleton = object()
     engine = object.__new__(MegatronLiteEngine)
     engine.handle = SimpleNamespace(
-        dp_group=logical_singleton,
-        metric_group=physical_pool,
+        dp_group=logical_singleton, metric_group=physical_pool
     )
     calls = []
 

--- a/experimental/lite/tests/unit/verl/test_mlite_qat_export.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_qat_export.py
@@ -113,8 +113,7 @@ def test_qat_export_real_mxfp4_matches_modelopt_reference_encoding() -> None:
     assert torch.equal(
         packed,
         torch.tensor(
-            [[0x00, 0x21, 0x43, 0x65, 0x98, 0xBA, 0xDC, 0xFE] * 2],
-            dtype=torch.uint8,
+            [[0x00, 0x21, 0x43, 0x65, 0x98, 0xBA, 0xDC, 0xFE] * 2], dtype=torch.uint8
         ),
     )
     assert torch.equal(scale, torch.tensor([[127]], dtype=torch.uint8))

--- a/experimental/lite/tests/unit/verl/test_mlite_qat_yaml_unit.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_qat_yaml_unit.py
@@ -5,8 +5,8 @@ from pathlib import Path
 
 from hydra import compose, initialize_config_module
 from megatron.lite.primitive.quantization.qat import (
-    QATSpec,
     _DEFAULT_IGNORE_PATTERNS,
+    QATSpec,
     normalize_qat_spec,
 )
 from omegaconf import OmegaConf
@@ -15,28 +15,19 @@ from omegaconf import OmegaConf
 def _compose_engine(*overrides: str) -> dict:
     config_root = Path(__file__).parents[3] / "examples" / "verl"
     assert (config_root / "verl_mlite" / "config" / "engine" / "mlite.yaml").is_file()
-    with initialize_config_module(
-        config_module="verl_mlite.config",
-        version_base=None,
-    ):
+    with initialize_config_module(config_module="verl_mlite.config", version_base=None):
         config = compose(
             config_name=None,
             overrides=["+engine@actor_rollout_ref.actor.engine=mlite", *overrides],
         )
-    return OmegaConf.to_container(
-        config.actor_rollout_ref.actor.engine,
-        resolve=True,
-    )
+    return OmegaConf.to_container(config.actor_rollout_ref.actor.engine, resolve=True)
 
 
 def test_default_yaml_keeps_export_and_training_qat_disabled() -> None:
     engine = _compose_engine()
 
     assert engine["qat"] == {}
-    assert engine["impl_cfg"]["qat"] == {
-        "enabled": False,
-        "format": "mxfp4",
-    }
+    assert engine["impl_cfg"]["qat"] == {"enabled": False, "format": "mxfp4"}
 
     spec = normalize_qat_spec(engine["impl_cfg"]["qat"])
     assert spec == QATSpec(enabled=False, format="mxfp4")
@@ -52,10 +43,7 @@ def test_colocated_ref_follows_actor_runtime_plugins() -> None:
         config_root / "verl_mlite" / "config" / "ref" / "mlite_ref.yaml"
     )
     actor_plugins = {
-        "dynamic_context_parallel": {
-            "enabled": True,
-            "max_seqlen_per_dp_cp_rank": 4096,
-        }
+        "dynamic_context_parallel": {"enabled": True, "max_seqlen_per_dp_cp_rank": 4096}
     }
     root = OmegaConf.create(
         {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.isort]
+profile = "black"
+line_length = 88
+
+[tool.black]
+line-length = 88
+skip-magic-trailing-comma = true
+skip-string-normalization = true


### PR DESCRIPTION
Align pinned isort 5.13.2 with Black 24.4.2 at 88 columns, retaining Black's existing string and trailing-comma settings. Serialize the hooks and limit Black to one worker. Refresh 177 tracked Lite Python files from main `d8e010069`.

The configuration and formatting changes are separate commits. A third corrective commit, [`0c5ae22ee`](https://github.com/ISEEKYAN/Megatron-LM/commit/0c5ae22eebf74c19b7752c929137051c7d527ee2), preserves five initialization-order boundaries: CSA TE/Core, compat private API/checkpoint probe, DSv4 TE/MoE, Kimi attention-experts/SwiGLU JIT, and runtime DTensor/loss context. Seventeen existing `isort: skip` annotations remain. Narrow `isort: off/on` regions protect only the identified boundaries.

**Evidence correction and semantic review**

The reviewed head `bf66a3bd3` has **147/177 raw ASTs identical to base, 30 different, zero parse failures**. The differences are 28 import changes and two docstring-whitespace changes. The earlier normalized-AST result is withdrawn as evidence of semantic safety. The corrected head has **151/177 raw ASTs identical, 26 different**; this does not erase the original result or establish universal semantic equivalence.

All 30 differing files were individually checked for circular imports, import-time side effects, deferred imports, and try/except fallback behavior. Twelve injected import-control-flow scenarios match base after the order correction, with the old head as negative control. Nine real CPU import probes (three source revisions × three groups) succeed with matching outputs on PyTorch 2.12.1+cpu, with CUDA uninitialized. These are bounded source/CPU checks, not TE/Core/GPU training validation. The full matrix and limitations follow below.

**Formatter idempotence — separate evidence**

On corrected head `0c5ae22ee`, two consecutive per-file pre-commit passes cover all 246 tracked Lite Python files: **492 invocations, 984 passing hooks, zero skips, zero changes in either pass**. Both passes preserve content SHA-256 `a29833d855a24044bf7080cc9fc862252383fdc44136936024ee18c3a9f1aa84`.

All 246 Python files compile; pre-commit configuration validation and `git diff --check` pass. No Python/test files were added. Run each tracked Lite Python file separately through `pre-commit run -c experimental/lite/.pre-commit-config.yaml --files <file>` twice to reproduce the formatter check. Single-file calls avoid the observed Black multi-file process-pool hang even with one worker. Passing this check is not evidence of import-order safety.

<details>
<summary>Full 30-file import-order audit and bounded evidence</summary>

# Import-order audit for PR #147

Reviewed comparison: `d8e010069` → `bf66a3bd3`. Raw `ast.dump(..., include_attributes=False)` gives **147 identical, 30 different, 0 parse failures** among 177 changed Python files. Of the 30, 28 involve imports and two involve docstring string values. The earlier normalized-AST result is withdrawn as proof of semantic safety.

This is a source audit plus bounded CPU checks, not a proof about arbitrary Python import hooks or untested Core/TE builds. Local graph backpaths include package partial-initialization cycles; they are reported, not silently erased. The graph excludes unresolved external imports, dynamic imports and function bodies. Region analysis checks the latter separately: import bindings remain within the same function/try/guard region and do not cross an executable statement. None of these structural checks alone proves safe initialization order.

Idempotence is a separate claim with its own two-pass hook logs; a clean formatter run does not validate import semantics. The corrective patch restores five initialization-order boundaries and retains the remaining independently reviewed changes.

## Per-file review

Paths below are relative to `experimental/lite/`. C = circular imports, S = initialization side effects, L = lazy imports, F = fallback/exception flow.

| File | C | S | L | F | Decision |
|---|---|---|---|---|---|
| [examples/bench/correctness.py](https://github.com/ISEEKYAN/Megatron-LM/blob/bf66a3bd3/experimental/lite/examples/bench/correctness.py) | No local eager backpath to correctness; runtime resolves backends lazily. | set_deterministic only defines flags/functions at import; env/RNG changes occur on its explicit call, still before create_runtime. bench path insertions repeat the same roots already inserted by correctness. CPU light probe matches. | Imports remain after both sys.path guards; no create_runtime call moved. | No reordered import is in a handler. | Retain; initialization functions are not called by the moved import statements. |
| [examples/miles/miles_mlite/weight_update.py](https://github.com/ISEEKYAN/Megatron-LM/blob/bf66a3bd3/experimental/lite/examples/miles/miles_mlite/weight_update.py) | No local backpath; only stdlib imports changed order. | importlib/logging/Sequence/replace precede the unchanged ray/torch imports; logging.getLogger still follows all imports. | No dynamic miles import or worker initialization moved out of methods. | No handler changed. | Retain stdlib ordering; no crossed logger setup or ray initialization. |
| [examples/verl/verl_mlite/compat.py](https://github.com/ISEEKYAN/Megatron-LM/blob/bf66a3bd3/experimental/lite/examples/verl/verl_mlite/compat.py) | Changed region is function-local; checkpoint dependencies have no source import back to compat. | weight_sync_probe creates _PROBE/ContextVar and ckpt.__init__ eagerly imports dcp/hf_weights. Old head did this before checking TorchDispatchMode. | Keep both imports inside _instrument_bucketed_weight_sender, after the already-patched guard. | No new handler; missing private API must fail before checkpoint state is initialized. | Restore private API before checkpoint via a narrow isort off/on region; 3 injected paths match base. |
| [examples/verl/verl_mlite/rollout/layer_cluster.py](https://github.com/ISEEKYAN/Megatron-LM/blob/bf66a3bd3/experimental/lite/examples/verl/verl_mlite/rollout/layer_cluster.py) | Import sequences unchanged; no import-order cycle delta. | Only resync_layer_cluster_key docstring indentation differs; __doc__ text is observably changed. | No import or executable node moved. | No handler changed. | Retain Black docstring whitespace; do not call this raw AST identity. |
| [megatron/lite/model/deepseek_v4/lite/model.py](https://github.com/ISEEKYAN/Megatron-LM/blob/bf66a3bd3/experimental/lite/megatron/lite/model/deepseek_v4/lite/model.py) | Existing lite.__init__ -> model and moe -> lite-package partial-initialization backpaths; do not dismiss these as no cycles. | MoE imports dispatcher, which attempts DeepEP; isort moved that initialization ahead of TE. Config itself is loaded by the family package. | All imports stay module-level; no model construction moved. | Dispatcher optional DeepEP handler is a transitive dependency, not a changed handler in this file. | Restore TE -> config -> MoE; injected TE-failure and success traces match base. |
| [megatron/lite/model/deepseek_v4/lite/protocol.py](https://github.com/ISEEKYAN/Megatron-LM/blob/bf66a3bd3/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py) | No eager backpath to protocol; checkpoint and protocol_utils export normal attributes, not dynamic __getattr__ hooks. | Aliased imports split into repeated requests to the same cached module. quantization/recompute have no mutual imports; QAT has constants/dataclass and recompute defers its C++ build to _get_share_storage. | Model and MTPLossAutoScaler imports remain in their original function regions. | No handler boundary crossed. | Retain; classify split statements and quantization/recompute ordering as AST changes, not identity. |
| [megatron/lite/model/glm5/lite/model.py](https://github.com/ISEEKYAN/Megatron-LM/blob/bf66a3bd3/experimental/lite/megatron/lite/model/glm5/lite/model.py) | Existing glm5.lite package -> model backpath; glm5.__init__ has already imported Glm5Config before entering lite.model. | Only Config retrieval moves before TE; it is a normal cached class attribute under package import. | No deferred compute import becomes eager. | No changed import in handlers. | Retain cache lookup reorder; no module initialization moved for Config. |
| [megatron/lite/model/glm5/lite/protocol.py](https://github.com/ISEEKYAN/Megatron-LM/blob/bf66a3bd3/experimental/lite/megatron/lite/model/glm5/lite/protocol.py) | No eager backpath to protocol; protocol_utils contains function exports and no module __getattr__. | Alias grouping and quantization/recompute as in DSv4 protocol; no initialization callback between the statements. | Checkpoint, model and MTP imports remain function-local. | No handler boundary crossed. | Retain with source-based dependency assessment; not a runtime TE smoke. |
| [megatron/lite/model/kimi_k2/lite/model.py](https://github.com/ISEEKYAN/Megatron-LM/blob/bf66a3bd3/experimental/lite/megatron/lite/model/kimi_k2/lite/model.py) | No local eager backpath to model; Kimi config imports stdlib and primitive.config only. | Config dataclass does not depend on TE; moving SwiGLU is different: @jit_fuser executes at import and reads JIT policy. Experts already imports SwiGLU later in the original chain. | No function imports hoisted. | No local handler changed; preserve existing attention/extension initialization sequence. | Restore SwiGLU after attention/experts; retain independent config/TE lookup order. |
| [megatron/lite/model/kimi_k2/lite/protocol.py](https://github.com/ISEEKYAN/Megatron-LM/blob/bf66a3bd3/experimental/lite/megatron/lite/model/kimi_k2/lite/protocol.py) | No eager backpath to protocol; direct exports from protocol_utils are ordinary functions. | Alias splitting and QAT/recompute swap; neither module imports the other or initializes the C++ extension at import. | All deferred model/checkpoint operations remain deferred. | No handler crossed. | Retain with the same bounded QAT/recompute source argument. |
| [megatron/lite/model/qwen3_5/lite/model.py](https://github.com/ISEEKYAN/Megatron-LM/blob/bf66a3bd3/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py) | No backpath; config depends on primitive.config and stdlib only, not on model or TE. | Config dataclass/field metadata is independent of TE; no I/O occurs until from_hf/load_hf_config_dict is called. | No lazy gated-delta or checkpoint import hoisted. | No handler crossed. | Retain independent config import reorder; config CPU probe matches. |
| [megatron/lite/model/qwen3_5/lite/protocol.py](https://github.com/ISEEKYAN/Megatron-LM/blob/bf66a3bd3/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py) | No eager backpath to protocol; protocol_utils has normal function attributes. | Only ImportFrom statement splitting: flattened module/name/alias order is identical. No __getattr__ hook or intervening statement. | All import regions are unchanged. | Handler ASTs unchanged. | Retain; repeated same-module cache requests are explicitly distinguished from raw AST equality. |
| [megatron/lite/model/qwen3_moe/lite/model.py](https://github.com/ISEEKYAN/Megatron-LM/blob/bf66a3bd3/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py) | No backpath; config uses stdlib and primitive.config with no import of model/TE. | Only Config/TE order; Config defines dataclass defaults, with HF file access confined to explicit methods. | No import hoisted. | No handler crossed. | Retain; config CPU probe matches. |
| [megatron/lite/model/qwen3_moe/lite/protocol.py](https://github.com/ISEEKYAN/Megatron-LM/blob/bf66a3bd3/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py) | No eager backpath to protocol; protocol_utils normal function exports. | Only aliased ImportFrom splitting; flattened access order and barriers identical. | Model/checkpoint lazy imports unchanged. | Handler ASTs unchanged. | Retain; AST statement grouping is still different. |
| [megatron/lite/primitive/ckpt/dcp.py](https://github.com/ISEEKYAN/Megatron-LM/blob/bf66a3bd3/experimental/lite/megatron/lite/primitive/ckpt/dcp.py) | Existing ckpt.__init__ -> dcp partial-init backpath; parallel/protocols do not access dcp exports while it initializes. | DeviceMesh/DTensor retrieval moved after local imports. Earlier torch.distributed.checkpoint already loads both modules (real CPU probe confirms); protocols also imports Replicate. | distckpt and megatron.core imports stay in save/load methods. | No handler boundary crossed. | Retain cached public-type retrieval; paired checkpoint CPU imports succeed. Other torch builds remain outside this CPU probe. |
| [megatron/lite/primitive/modules/attention/csa.py](https://github.com/ISEEKYAN/Megatron-LM/blob/bf66a3bd3/experimental/lite/megatron/lite/primitive/modules/attention/csa.py) | No local eager backpath to csa; external Core/TE graph is not certified by the local graph. | Old head moved TE initialization after Core imports. Preserve original TE-first order and original Core from-import grouping. | Fused primary/fallback remain eager at module import, not moved into/out of functions. | Primary csa_kernels -> except ImportError -> legacy fused_sparse_attention tree is unchanged; injected missing module, missing symbol and both-missing paths are checked. | Restore narrow prefix order; 5 injected traces/bindings match base. No claim of real TE/Core execution. |
| [megatron/lite/primitive/modules/attention/mla.py](https://github.com/ISEEKYAN/Megatron-LM/blob/bf66a3bd3/experimental/lite/megatron/lite/primitive/modules/attention/mla.py) | Existing attention.__init__ -> mla backpath. attention imports dsa first, which imports parallel.cp; parallel package initialization precedes mla in normal package loading. | Parallel exports have a lazy __getattr__ for linear types; that implementation imports TE/utils, not rotary. rope is torch plus definitions; rotary adds lru_cache definitions but no model registration. | Two torch.distributed.nn.functional all_gather imports remain in their functions. | No handler crossed. | Retain; no local dependency on relative rope/parallel order found, with external extension behavior not runtime-certified. |
| [megatron/lite/primitive/parallel/pp.py](https://github.com/ISEEKYAN/Megatron-LM/blob/bf66a3bd3/experimental/lite/megatron/lite/primitive/parallel/pp.py) | Existing parallel package -> pp backpath, but no import AST or order changed. | Only trailing whitespace/newline in build_pipeline_chunk_layout docstring differs. | Import locations identical. | Handlers identical. | Retain docstring formatting; acknowledge changed __doc__ constant. |
| [megatron/lite/primitive/utils/rotary.py](https://github.com/ISEEKYAN/Megatron-LM/blob/bf66a3bd3/experimental/lite/megatron/lite/primitive/utils/rotary.py) | No backpath: rope does not import rotary; parent utils imports torch and defines helpers. | rope already imports torch.Tensor; importing Tensor/nn afterward retrieves normal torch attributes. No cross-module global state consumption. | No import hoisted. | No handler crossed. | Retain; rotary is covered by the paired CPU light import probe. |
| [megatron/lite/runtime/backends/mlite/runtime.py](https://github.com/ISEEKYAN/Megatron-LM/blob/bf66a3bd3/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py) | Existing mlite.__init__ -> runtime/config partial-init backpaths; config remains defined before runtime is exported. | contracts.loss creates _CURRENT_LOSS_CONTEXT. Moving DTensor after it changes side effects on a failed DTensor import. | Runtime implementation lookup and model/core imports remain in methods. | No new catch; DTensor failure must precede contract state allocation. | Restore DTensor before local contract imports; 2 injected prefix traces match base and real CPU light probes match. |
| [tests/smoke/model/glm5/lite/test_glm5_lite_cp_smoke.py](https://github.com/ISEEKYAN/Megatron-LM/blob/bf66a3bd3/experimental/lite/tests/smoke/model/glm5/lite/test_glm5_lite_cp_smoke.py) | No local backpath to test; local modules do not import the test. | HF model import and local checkpoint/config imports swap within test entry. PyTorch is imported first; imported objects are used only after the group. External HF initialization is not certified by static AST. | Remains inside test_glm5_tiny_model_cp2_matches_hf_reference_logits; no collection-time hoist. | No exception or skip guard crossed. | Retain under installed test-dependency contract; GPU/HF execution is not claimed by this audit. |
| [tests/smoke/workflows/checkpoint/test_distopt_checkpoint_smoke.py](https://github.com/ISEEKYAN/Megatron-LM/blob/bf66a3bd3/experimental/lite/tests/smoke/workflows/checkpoint/test_distopt_checkpoint_smoke.py) | No local backpath to smoke test; external Core dependencies are outside the graph. | Only public Replicate/Shard retrieval moves. Earlier Core/checkpoint imports themselves use torch distributed tensor types; no test statement executes within the group. | Main imports remain module-level; later parallel_state import unchanged. | No handler crossed. | Retain; imported test bindings unchanged. No claim of running the distributed smoke. |
| [tests/unit/examples/test_verl_mlite_engine_cp_smoke.py](https://github.com/ISEEKYAN/Megatron-LM/blob/bf66a3bd3/experimental/lite/tests/unit/examples/test_verl_mlite_engine_cp_smoke.py) | No local backpath to test; contracts.data has torch/dataclass dependencies and does not import the engine. | PackedBatch retrieval moves before engine imports, but apply_runtime_patches() remains before BOTH. Engine imports the same contracts; no binding is used mid-group. | Function-local group stays after the first four executable statements, including runtime patching. | No GPU/skip or exception barrier crossed. | Retain; preserve the important patch-before-engine dependency explicitly verified by region analysis. |
| [tests/unit/model/test_all_model_qat_r3_contracts.py](https://github.com/ISEEKYAN/Megatron-LM/blob/bf66a3bd3/experimental/lite/tests/unit/model/test_all_model_qat_r3_contracts.py) | No local backpaths to tests; hf_weights imports safetensors.torch at module scope. | Three function-local safetensors/save_file vs hf_weights swaps: loading hf_weights already loads safetensors, no operation occurs until both names are bound. | All three remain within their test functions. | No monkeypatch, handler or skip statement crossed. | Retain dependency/cache lookup order; no checkpoint numerical test is claimed. |
| [tests/unit/model/test_glm5_lite_static.py](https://github.com/ISEEKYAN/Megatron-LM/blob/bf66a3bd3/experimental/lite/tests/unit/model/test_glm5_lite_static.py) | No local backpath to tests; attention package exports ordinary functions/classes and the dsa submodule. | Two groups merge dsa with function/class exports; another swaps safe_open and checkpoint imports. hf_weights already imports safetensors. All patch/call statements remain after imports. | Three changed groups remain in their original tests. | No exception or skip guard crossed. | Retain; classify merged __import__ calls as AST changes, not identity. |
| [tests/unit/primitive/ckpt/test_hf_weights_gpu.py](https://github.com/ISEEKYAN/Megatron-LM/blob/bf66a3bd3/experimental/lite/tests/unit/primitive/ckpt/test_hf_weights_gpu.py) | No local backpath to GPU test; weight specs do not import tests. | safetensors save_file moves after checkpoint imports, which already load safetensors.torch; required dependencies and symbols unchanged. | Still module-level; no CUDA allocation statement moved. | No handler crossed. | Retain; this is source assessment, not a GPU pass. |
| [tests/unit/primitive/ckpt/test_hf_weights_streaming.py](https://github.com/ISEEKYAN/Megatron-LM/blob/bf66a3bd3/experimental/lite/tests/unit/primitive/ckpt/test_hf_weights_streaming.py) | No local backpath to tests; only pytest moves before torch/torch.nn. | No fixture or monkeypatch installation occurs between these imports; pytest is already present when pytest collects this module. | Collection-time imports remain collection-time. | No importorskip/handler crossed. | Retain within the pytest runner contract; arbitrary custom import hooks are not certified. |
| [tests/unit/primitive/ckpt/test_weight_sync_probe.py](https://github.com/ISEEKYAN/Megatron-LM/blob/bf66a3bd3/experimental/lite/tests/unit/primitive/ckpt/test_weight_sync_probe.py) | No backpath; only importlib.util/json order changes. | Both stdlib imports precede sys/types/torch and every stub/module-loading operation in the test. | No spec loader or sys.modules manipulation moved. | No handler crossed. | Retain stdlib ordering; no test setup executes between the imports. |
| [tests/unit/primitive/modules/test_router_aux_loss_gate.py](https://github.com/ISEEKYAN/Megatron-LM/blob/bf66a3bd3/experimental/lite/tests/unit/primitive/modules/test_router_aux_loss_gate.py) | No local backpath from router to test; router depends on torch/moe/utils but does not reference pytest. | router_module now precedes explicit pytest/torch imports. Under pytest collection pytest is already imported; router itself imports torch first. Fixture monkeypatching still happens after collection. | Imports stay module-level; no GPU fixture executes at import. | No handler/skip crossed. | Retain within pytest collection; do not alter the router implementation or its pre-existing behavior. |
| [tests/unit/verl/test_mlite_qat_yaml_unit.py](https://github.com/ISEEKYAN/Megatron-LM/blob/bf66a3bd3/experimental/lite/tests/unit/verl/test_mlite_qat_yaml_unit.py) | No local backpath; qat exports ordinary constants and a dataclass, with no module __getattr__. | Only names within one from-import reorder: _DEFAULT_IGNORE_PATTERNS/QATSpec. Module initialization still occurs once before any attribute binding. | No Hydra composition moved. | No handler crossed. | Retain normal attribute lookup reorder; no quantization function is invoked during import. |

## CSA and compat control-flow evidence

`fault_paths.py` executes extracted source prefixes with an injected importer. It checks order, chosen fallback bindings and failure timing; it does not import real CUDA extensions. For CSA, primary success, primary-module failure, primary-symbol failure, both layouts missing and TE failure all reproduce base behavior after correction. The original reviewed head is a negative control. For compat, available API, missing private API, and already-patched early return are checked. The missing-API negative control loads checkpoint/probe first in the old head but not in base or the correction. DSv4 TE failure and runtime DTensor failure are covered by four additional prefix scenarios. Total: 12 corrected cases match base.

## Corrected-head structural result

Corrective head `0c5ae22ee` has **151/177 identical raw ASTs, 26 different** (24 import changes, two docstring changes), zero parse failures. The complete CSA, compat, DSv4 model and runtime ASTs now match base. This does not replace or erase the original reviewed-head count of 147/177. `final-structure/regions.json` separately records the remaining import regions and unchanged non-import executable ASTs.

## Real CPU probe scope

Nine fresh-process imports (base/reviewed head/corrected head × light runtime/benchmark/quantization, five model configs, checkpoint) succeed with identical per-case outputs on local PyTorch 2.12.1+cpu. CUDA remains uninitialized. The checkpoint probe confirms distributed tensor/device-mesh modules are already cached after importing torch.distributed.checkpoint. The light probe checks that deterministic mode remains disabled and the recompute C++ extension remains unbuilt. These probes do not run training, HF GPU forwards, TE or Core extension initialization.

## Previously removed Qwen3.5 skip annotation

The save_hf_weights import remains inside save_hf_weights, after exactly the same preceding nodes and before the same kwargs handling. The entire Qwen3.5 checkpoint file has raw AST identity with base: the removed annotation did not guard a changed import order. The other 17 existing `isort: skip` annotations are retained. New order-sensitive regions use narrow `isort: off/on` boundaries because a skipped line alone still allowed neighboring sorted imports to move across it in pinned isort 5.13.2.

No router/results implementation fix is included.

</details>
