### PR TITLE
Fix full M-FSDP optimizer offload with FP32 gradients

### DIFF
--- a/experimental/lite/examples/bench/README.md
+++ b/experimental/lite/examples/bench/README.md
@@ -152,6 +152,24 @@ Compare `loss`, `grad_norm`, `avg_step_ms`, `tok_per_s`, peak memory, and
 `tflops_per_gpu` in the two JSON outputs. Benchmarks are performance evidence;
 they are not a replacement for precision tests.
 
+## M-FSDP CPU-offload Benchmark
+
+Use the single-arm script when optimizing M-FSDP CPU offload. It fixes the
+optimizer backend to `mfsdp` and the offload fraction to `1.0`, reports both
+end-to-end `avg_step_ms` and isolated `avg_optimizer_step_ms`, and refuses a
+real GPU run outside Slurm. Keep its workload variables unchanged when
+comparing optimization commits.
+
+```bash
+HF_PATH=/models/Qwen3.5-35B-A3B \
+DRY_RUN=1 \
+bash experimental/lite/examples/bench/scripts/run_qwen35_mfsdp_offload.sh
+```
+
+For a real run, set `DRY_RUN=0`, `WANDB_PROJECT`, and the fixed workload
+variables in the Slurm job. The script writes the full per-step JSON/log and
+prints the W&B run URL after publishing the two timing metrics.
+
 ## Deterministic Correctness
 
 Use `correctness.py` for strict deterministic parity. It emits exact scalar

--- a/experimental/lite/examples/bench/bench.py
+++ b/experimental/lite/examples/bench/bench.py
@@ -364,6 +364,7 @@ def _step_reporter(trace: StepTrace) -> None:
         f"loss={trace.loss:.6f}",
         f"grad_norm={trace.grad_norm:.6f}",
         f"step_ms={trace.step_ms:.3f}",
+        f"optimizer_step_ms={trace.optimizer_step_ms:.3f}",
         f"peak_mem_gb={(trace.peak_mem_gb or 0.0):.3f}",
     ]
     if trace.tflops_per_gpu is not None:

--- a/experimental/lite/examples/bench/bench.py
+++ b/experimental/lite/examples/bench/bench.py
@@ -79,7 +79,9 @@ def _json_mapping(raw: str, *, name: str) -> dict[str, Any]:
 
 
 def _parallel_config(cfg: BenchCliConfig) -> ParallelConfig:
-    return ParallelConfig(tp=cfg.tp, etp=cfg.etp, ep=cfg.ep, pp=cfg.pp, vpp=cfg.vpp, cp=cfg.cp)
+    return ParallelConfig(
+        tp=cfg.tp, etp=cfg.etp, ep=cfg.ep, pp=cfg.pp, vpp=cfg.vpp, cp=cfg.cp
+    )
 
 
 def _optimizer_config(cfg: BenchCliConfig) -> OptimizerConfig:
@@ -142,11 +144,17 @@ def _make_mlite_model_config_hook(cfg: BenchCliConfig):
             old_num = getattr(model_cfg, "num_experts", None)
             old_topk = getattr(model_cfg, "num_experts_per_tok", None)
             if old_num is None or old_topk is None:
-                raise ValueError("keep_experts requires model config with MoE expert metadata.")
+                raise ValueError(
+                    "keep_experts requires model config with MoE expert metadata."
+                )
             if keep_experts <= 0 or keep_experts > old_num:
-                raise ValueError(f"keep_experts must be in [1, {old_num}], got {keep_experts}.")
+                raise ValueError(
+                    f"keep_experts must be in [1, {old_num}], got {keep_experts}."
+                )
             return replace(
-                model_cfg, num_experts=keep_experts, num_experts_per_tok=min(old_topk, keep_experts)
+                model_cfg,
+                num_experts=keep_experts,
+                num_experts_per_tok=min(old_topk, keep_experts),
             )
 
         hooks.append(keep_experts_hook)
@@ -195,9 +203,13 @@ def _make_bridge_post_init_hook(cfg: BenchCliConfig):
             old_num = getattr(hf_cfg, "num_experts", None)
             old_topk = getattr(hf_cfg, "num_experts_per_tok", None)
             if old_num is None or old_topk is None:
-                raise ValueError("keep_experts requires HF config with MoE expert metadata.")
+                raise ValueError(
+                    "keep_experts requires HF config with MoE expert metadata."
+                )
             if keep_experts <= 0 or keep_experts > old_num:
-                raise ValueError(f"keep_experts must be in [1, {old_num}], got {keep_experts}.")
+                raise ValueError(
+                    f"keep_experts must be in [1, {old_num}], got {keep_experts}."
+                )
             hf_cfg.num_experts = keep_experts
             hf_cfg.num_experts_per_tok = min(old_topk, keep_experts)
             _refresh_bridge_config(bridge)
@@ -221,7 +233,9 @@ def _make_bridge_post_init_hook(cfg: BenchCliConfig):
             hf_cfg = _get_bridge_config_root(bridge)
             old_layers = getattr(hf_cfg, "num_hidden_layers", None)
             if old_layers is None:
-                raise ValueError("truncate_layers requires HF config with num_hidden_layers.")
+                raise ValueError(
+                    "truncate_layers requires HF config with num_hidden_layers."
+                )
             if keep_layers <= 0 or keep_layers > old_layers:
                 raise ValueError(
                     f"truncate_layers must be in [1, {old_layers}], got {keep_layers}."
@@ -259,7 +273,9 @@ def _make_bridge_post_init_hook(cfg: BenchCliConfig):
 def build_runtime_config(cfg: BenchCliConfig) -> RuntimeConfig:
     parallel = _parallel_config(cfg)
     optimizer = _optimizer_config(cfg)
-    optimizer_overrides = _json_mapping(cfg.override_optimizer_json, name="override_optimizer_json")
+    optimizer_overrides = _json_mapping(
+        cfg.override_optimizer_json, name="override_optimizer_json"
+    )
 
     if cfg.backend == "mlite":
         for key, value in optimizer_overrides.items():
@@ -292,7 +308,9 @@ def build_runtime_config(cfg: BenchCliConfig) -> RuntimeConfig:
             use_thd=cfg.use_thd,
             load_hf_weights=not cfg.skip_load_hf_weights,
             build_optimizer=not cfg.skip_optimizer_build,
-            override_ddp_config=_json_mapping(cfg.override_ddp_json, name="override_ddp_json"),
+            override_ddp_config=_json_mapping(
+                cfg.override_ddp_json, name="override_ddp_json"
+            ),
             override_transformer_config=_json_mapping(
                 cfg.override_transformer_json, name="override_transformer_json"
             ),
@@ -300,9 +318,13 @@ def build_runtime_config(cfg: BenchCliConfig) -> RuntimeConfig:
             bridge_post_init=_make_bridge_post_init_hook(cfg),
         )
     else:
-        raise ValueError(f"backend must be 'mlite', 'bridge', or 'mbridge', got {cfg.backend!r}.")
+        raise ValueError(
+            f"backend must be 'mlite', 'bridge', or 'mbridge', got {cfg.backend!r}."
+        )
 
-    return RuntimeConfig(backend=cfg.backend, hf_path=cfg.hf_path, backend_cfg=backend_cfg)
+    return RuntimeConfig(
+        backend=cfg.backend, hf_path=cfg.hf_path, backend_cfg=backend_cfg
+    )
 
 
 def build_session_config(cfg: BenchCliConfig) -> PretrainSessionConfig:
@@ -321,7 +343,10 @@ def build_session_config(cfg: BenchCliConfig) -> PretrainSessionConfig:
 
 def _to_jsonable(value: Any) -> Any:
     if is_dataclass(value):
-        return {field.name: _to_jsonable(getattr(value, field.name)) for field in fields(value)}
+        return {
+            field.name: _to_jsonable(getattr(value, field.name))
+            for field in fields(value)
+        }
     if isinstance(value, dict):
         return {str(k): _to_jsonable(v) for k, v in value.items()}
     if isinstance(value, (list, tuple)):
@@ -387,7 +412,9 @@ def run(cfg: BenchCliConfig) -> dict[str, Any]:
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--backend", choices=["mlite", "bridge", "mbridge"], default="mlite")
+    parser.add_argument(
+        "--backend", choices=["mlite", "bridge", "mbridge"], default="mlite"
+    )
     parser.add_argument("--hf-path", default="")
     parser.add_argument("--model-name", default="qwen3_moe")
     parser.add_argument("--impl", default="lite")

--- a/experimental/lite/examples/bench/bench.py
+++ b/experimental/lite/examples/bench/bench.py
@@ -23,12 +23,12 @@ if str(_EXPERIMENTAL_LITE_ROOT) not in sys.path:
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(1, str(_REPO_ROOT))
 
-from examples.bench.results import StepTrace
-from examples.bench.session import PretrainSessionConfig, run_pretrain_session
-from megatron.lite.runtime import RuntimeConfig, create_runtime
-from megatron.lite.runtime.backends.bridge.config import BridgeConfig
-from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig
-from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
+from examples.bench.results import StepTrace  # noqa: E402
+from examples.bench.session import PretrainSessionConfig, run_pretrain_session  # noqa: E402
+from megatron.lite.runtime import RuntimeConfig, create_runtime  # noqa: E402
+from megatron.lite.runtime.backends.bridge.config import BridgeConfig  # noqa: E402
+from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig  # noqa: E402
+from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig  # noqa: E402
 
 
 @dataclass

--- a/experimental/lite/examples/bench/results.py
+++ b/experimental/lite/examples/bench/results.py
@@ -257,9 +257,9 @@ def compare_correctness_artifacts(
             mismatches.append({"step": idx, "field": "loss"})
         if not grad_matches:
             mismatches.append({"step": idx, "field": "grad_norm"})
-        for field in ("post_step_weights", "update_successful", "num_zeros"):
-            if base.get(field) != cand.get(field):
-                mismatches.append({"step": idx, "field": field})
+        for field_name in ("post_step_weights", "update_successful", "num_zeros"):
+            if base.get(field_name) != cand.get(field_name):
+                mismatches.append({"step": idx, "field": field_name})
         if not _tensor_fingerprint_matches(base.get("logits"), cand.get("logits")):
             mismatches.append({"step": idx, "field": "logits"})
 

--- a/experimental/lite/examples/bench/results.py
+++ b/experimental/lite/examples/bench/results.py
@@ -16,6 +16,7 @@ class StepTrace:
     loss: float
     grad_norm: float
     step_ms: float
+    optimizer_step_ms: float
     peak_mem_gb: float | None = None
     tflops_per_gpu: float | None = None
 
@@ -25,6 +26,7 @@ class StepTrace:
             "loss": self.loss,
             "grad_norm": self.grad_norm,
             "step_ms": self.step_ms,
+            "optimizer_step_ms": self.optimizer_step_ms,
         }
         if self.peak_mem_gb is not None:
             result["peak_mem_gb"] = self.peak_mem_gb
@@ -49,6 +51,7 @@ class RunResult:
     num_microbatches: int
     step_traces: list[StepTrace] = field(default_factory=list)
     avg_step_ms: float = 0.0
+    avg_optimizer_step_ms: float = 0.0
     peak_mem_gb: float = 0.0
     tok_per_s: float = 0.0
     tok_per_s_per_gpu: float = 0.0
@@ -62,6 +65,7 @@ class RunResult:
             "impl": self.impl,
             "optimizer_backend": self.optimizer_backend,
             "avg_step_ms": self.avg_step_ms,
+            "avg_optimizer_step_ms": self.avg_optimizer_step_ms,
             "tok_per_s": self.tok_per_s,
             "tok_per_s_per_gpu": self.tok_per_s_per_gpu,
             "peak_mem_gb": self.peak_mem_gb,
@@ -87,6 +91,7 @@ class RunResult:
                 "num_microbatches": self.num_microbatches,
                 "step_traces": [trace.to_dict() for trace in self.step_traces],
                 "avg_step_ms": self.avg_step_ms,
+                "avg_optimizer_step_ms": self.avg_optimizer_step_ms,
                 "peak_mem_gb": self.peak_mem_gb,
                 "tok_per_s": self.tok_per_s,
                 "tok_per_s_per_gpu": self.tok_per_s_per_gpu,
@@ -119,6 +124,7 @@ def result_summary(artifact: dict[str, Any]) -> dict[str, Any]:
         "impl": result.get("impl"),
         "optimizer_backend": result.get("optimizer_backend"),
         "avg_step_ms": result.get("avg_step_ms"),
+        "avg_optimizer_step_ms": result.get("avg_optimizer_step_ms"),
         "tok_per_s": result.get("tok_per_s"),
         "tok_per_s_per_gpu": result.get("tok_per_s_per_gpu"),
         "peak_mem_gb": result.get("peak_mem_gb"),

--- a/experimental/lite/examples/bench/results.py
+++ b/experimental/lite/examples/bench/results.py
@@ -134,7 +134,11 @@ def result_summary(artifact: dict[str, Any]) -> dict[str, Any]:
 
 
 def compare_step_traces(
-    baseline: dict[str, Any], candidate: dict[str, Any], *, atol: float = 1e-4, rtol: float = 1e-4
+    baseline: dict[str, Any],
+    candidate: dict[str, Any],
+    *,
+    atol: float = 1e-4,
+    rtol: float = 1e-4,
 ) -> dict[str, Any]:
     """Compare loss and grad-norm traces from two benchmark artifacts."""
     base_steps = baseline.get("result", {}).get("step_traces", [])
@@ -151,12 +155,16 @@ def compare_step_traces(
         )
 
     lengths_match = sample_count == len(base_steps) == len(cand_steps)
-    loss_ref_max = max([abs(float(step["loss"])) for step in base_steps[:sample_count]] + [0.0])
+    loss_ref_max = max(
+        [abs(float(step["loss"])) for step in base_steps[:sample_count]] + [0.0]
+    )
     grad_norm_ref_max = max(
         [abs(float(step["grad_norm"])) for step in base_steps[:sample_count]] + [0.0]
     )
     loss_passed = lengths_match and max_loss_abs <= atol + rtol * loss_ref_max
-    grad_norm_passed = lengths_match and max_grad_norm_abs <= atol + rtol * grad_norm_ref_max
+    grad_norm_passed = (
+        lengths_match and max_grad_norm_abs <= atol + rtol * grad_norm_ref_max
+    )
 
     return {
         "samples": sample_count,
@@ -231,7 +239,9 @@ def compare_correctness_artifacts(
         base = base_steps[idx]
         cand = cand_steps[idx]
         loss_abs = abs(float(base["loss"]["value"]) - float(cand["loss"]["value"]))
-        grad_abs = abs(float(base["grad_norm"]["value"]) - float(cand["grad_norm"]["value"]))
+        grad_abs = abs(
+            float(base["grad_norm"]["value"]) - float(cand["grad_norm"]["value"])
+        )
         if math.isfinite(loss_abs):
             max_loss_abs = max(max_loss_abs, loss_abs)
         if math.isfinite(grad_abs):

--- a/experimental/lite/examples/bench/scripts/run_qwen35_mfsdp_offload.sh
+++ b/experimental/lite/examples/bench/scripts/run_qwen35_mfsdp_offload.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HF_PATH=${HF_PATH:?set HF_PATH to a HuggingFace Qwen3.5 model directory}
+REPO_ROOT=${REPO_ROOT:-$(pwd)}
+PYTHON_BIN=${PYTHON_BIN:-python}
+NPROC=${NPROC:-8}
+DRY_RUN=${DRY_RUN:-1}
+OUTPUT_DIR=${OUTPUT_DIR:-"${REPO_ROOT}/experimental/lite/examples/bench/outputs/mfsdp_offload"}
+OUTPUT_JSON="${OUTPUT_DIR}/qwen35_mfsdp_offload.json"
+
+if [[ "${DRY_RUN}" != "1" && -z "${SLURM_JOB_ID:-}" ]]; then
+  echo "M-FSDP offload benchmark must run inside a Slurm allocation." >&2
+  exit 2
+fi
+
+export PYTHONPATH="${REPO_ROOT}/experimental/lite:${REPO_ROOT}${PYTHONPATH:+:${PYTHONPATH}}"
+
+ARGS=(
+  --backend mlite
+  --hf-path "${HF_PATH}"
+  --model-name qwen3_5
+  --tp "${TP:-1}"
+  --etp "${ETP:-1}"
+  --ep "${EP:-1}"
+  --pp "${PP:-1}"
+  --cp "${CP:-1}"
+  --steps "${STEPS:-15}"
+  --warmup "${WARMUP:-5}"
+  --num-microbatches "${NUM_MICROBATCHES:-4}"
+  --seq-len "${SEQ_LEN:-1024}"
+  --truncate-layers "${TRUNCATE_LAYERS:-8}"
+  --keep-experts "${KEEP_EXPERTS:-8}"
+  --disable-mtp
+  --same-data-across-dp
+  --impl-cfg-json '{"optimizer":"mfsdp"}'
+  --override-optimizer-json '{"offload_fraction":1.0,"use_precision_aware_optimizer":false}'
+)
+
+if [[ "${SKIP_LOAD_HF_WEIGHTS:-1}" == "1" ]]; then
+  ARGS+=(--skip-load-hf-weights)
+fi
+
+if [[ "${DRY_RUN}" == "1" ]]; then
+  "${PYTHON_BIN}" "${REPO_ROOT}/experimental/lite/examples/bench/bench.py" \
+    "${ARGS[@]}" --dry-run
+  exit 0
+fi
+
+: "${WANDB_PROJECT:?set WANDB_PROJECT for GPU benchmark evidence}"
+mkdir -p "${OUTPUT_DIR}"
+torchrun --nproc_per_node "${NPROC}" \
+  "${REPO_ROOT}/experimental/lite/examples/bench/bench.py" \
+  "${ARGS[@]}" --output-json "${OUTPUT_JSON}" \
+  2>&1 | tee "${OUTPUT_DIR}/qwen35_mfsdp_offload.log"
+
+OUTPUT_JSON="${OUTPUT_JSON}" WANDB_ENTITY="${WANDB_ENTITY:-megatron-core-moe-dev}" \
+  WANDB_RUN_NAME="${WANDB_RUN_NAME:-mfsdp-offload-${SLURM_JOB_ID}}" \
+  "${PYTHON_BIN}" -c '
+import json
+import os
+
+import wandb
+
+artifact = json.load(open(os.environ["OUTPUT_JSON"], encoding="utf-8"))
+summary = artifact["summary"]
+run = wandb.init(
+    entity=os.environ["WANDB_ENTITY"],
+    project=os.environ["WANDB_PROJECT"],
+    name=os.environ["WANDB_RUN_NAME"],
+    config=artifact["result"],
+)
+run.log(
+    {
+        "benchmark/step_s": summary["avg_step_ms"] / 1000.0,
+        "benchmark/optimizer_step_s": summary["avg_optimizer_step_ms"] / 1000.0,
+        "benchmark/tokens_per_s": summary["tok_per_s"],
+        "benchmark/peak_mem_gb": summary["peak_mem_gb"],
+    }
+)
+print(f"[MLITE_BENCH_WANDB] {run.url}", flush=True)
+run.finish()
+'

--- a/experimental/lite/examples/bench/session.py
+++ b/experimental/lite/examples/bench/session.py
@@ -65,9 +65,7 @@ def _resolve_vocab_size(handle: ModelHandle) -> int:
     return 151936
 
 
-def _infinite_packed_batches(
-    vocab_size: int, seq_len: int, *, device: str, seed: int
-):
+def _infinite_packed_batches(vocab_size: int, seq_len: int, *, device: str, seed: int):
     """Yield raw, model-agnostic :class:`PackedBatch` objects for the bench.
 
     The bench is the single source of truth for one unpadded packed batch (1-D
@@ -82,7 +80,9 @@ def _infinite_packed_batches(
     seq_lens = torch.tensor([seq_len], dtype=torch.int64, device=device)
     while True:
         yield PackedBatch(
-            input_ids=torch.randint(0, vocab_size, (seq_len,), device=device, generator=g),
+            input_ids=torch.randint(
+                0, vocab_size, (seq_len,), device=device, generator=g
+            ),
             labels=torch.randint(0, vocab_size, (seq_len,), device=device, generator=g),
             seq_lens=seq_lens.clone(),
         )
@@ -91,7 +91,9 @@ def _infinite_packed_batches(
 def _make_data_iter(handle: ModelHandle, cfg: PretrainSessionConfig):
     data_seed = cfg.seed if cfg.same_data_across_dp else cfg.seed + handle.dp_rank
     vocab_size = _resolve_vocab_size(handle)
-    return _infinite_packed_batches(vocab_size, cfg.seq_len, device=cfg.device, seed=data_seed)
+    return _infinite_packed_batches(
+        vocab_size, cfg.seq_len, device=cfg.device, seed=data_seed
+    )
 
 
 def _calc_tflops_per_gpu(
@@ -250,7 +252,11 @@ def run_pretrain_session(
         impl=getattr(config, "impl", "bridge"),
         optimizer_backend=handle._extras.get(
             "optimizer_backend",
-            getattr(handle._optimizer, "name", "none") if handle._optimizer is not None else "none",
+            (
+                getattr(handle._optimizer, "name", "none")
+                if handle._optimizer is not None
+                else "none"
+            ),
         ),
         tp=parallel.tp,
         etp=parallel.etp,

--- a/experimental/lite/examples/bench/session.py
+++ b/experimental/lite/examples/bench/session.py
@@ -176,6 +176,7 @@ def run_pretrain_session(
 
     step_traces: list[StepTrace] = []
     timings: list[float] = []
+    optimizer_timings: list[float] = []
 
     _reset_peak_memory(cfg.device)
     with rt.train_mode(handle):
@@ -191,8 +192,13 @@ def run_pretrain_session(
             )
             if cfg.no_optimizer:
                 grad_norm = 0.0
+                optimizer_elapsed_ms = 0.0
             else:
+                _sync(cfg.device)
+                optimizer_t0 = time.perf_counter()
                 _, grad_norm, _ = rt.optimizer_step(handle)
+                _sync(cfg.device)
+                optimizer_elapsed_ms = (time.perf_counter() - optimizer_t0) * 1000
                 rt.lr_scheduler_step(handle)
             _sync(cfg.device)
 
@@ -209,6 +215,7 @@ def run_pretrain_session(
                 loss=float(result.metrics.get("loss", result.model_output.loss) or 0.0),
                 grad_norm=float(grad_norm),
                 step_ms=elapsed_ms,
+                optimizer_step_ms=optimizer_elapsed_ms,
                 peak_mem_gb=_peak_memory_gb(cfg.device),
                 tflops_per_gpu=tflops_per_gpu,
             )
@@ -216,10 +223,14 @@ def run_pretrain_session(
                 step_reporter(trace)
             if step >= cfg.warmup:
                 timings.append(elapsed_ms)
+                optimizer_timings.append(optimizer_elapsed_ms)
                 trace.step = step - cfg.warmup
                 step_traces.append(trace)
 
     avg_step_ms = sum(timings) / len(timings) if timings else 0.0
+    avg_optimizer_step_ms = (
+        sum(optimizer_timings) / len(optimizer_timings) if optimizer_timings else 0.0
+    )
     avg_step_s = avg_step_ms / 1000
     tok_per_s = tokens_per_step / avg_step_s if avg_step_s > 0 else 0.0
     avg_tflops = _calc_tflops_per_gpu(
@@ -251,6 +262,7 @@ def run_pretrain_session(
         num_microbatches=cfg.num_microbatches,
         step_traces=step_traces,
         avg_step_ms=avg_step_ms,
+        avg_optimizer_step_ms=avg_optimizer_step_ms,
         peak_mem_gb=_peak_memory_gb(cfg.device),
         tok_per_s=tok_per_s,
         tok_per_s_per_gpu=tok_per_s / world_size,

--- a/experimental/lite/examples/verl/scripts/run_deepseek_v4_dapo.sh
+++ b/experimental/lite/examples/verl/scripts/run_deepseek_v4_dapo.sh
@@ -54,6 +54,7 @@ ROLLOUT_GPU_MEMORY_UTILIZATION="${ROLLOUT_GPU_MEMORY_UTILIZATION:-0.60}"
 PARAM_OFFLOAD="${PARAM_OFFLOAD:-True}"
 OPTIMIZER_OFFLOAD="${OPTIMIZER_OFFLOAD:-True}"
 GRAD_OFFLOAD="${GRAD_OFFLOAD:-False}"
+MLITE_OPTIMIZER_BACKEND="${MLITE_OPTIMIZER_BACKEND:-fsdp2}"
 
 TOTAL_EPOCHS="${TOTAL_EPOCHS:-15}"
 TOTAL_TRAINING_STEPS="${TOTAL_TRAINING_STEPS:-null}"
@@ -132,6 +133,15 @@ esac
 
 : "${TRAIN_FILES:?set TRAIN_FILES or DAPO_DATA_DIR}"
 : "${VAL_FILES:?set VAL_FILES or DAPO_DATA_DIR}"
+
+case "${MLITE_OPTIMIZER_BACKEND}" in
+  fsdp2|mfsdp)
+    ;;
+  *)
+    echo "MLITE_OPTIMIZER_BACKEND must be fsdp2 or mfsdp, got ${MLITE_OPTIMIZER_BACKEND}" >&2
+    exit 2
+    ;;
+esac
 
 MAX_SEQ_LEN=$((MAX_PROMPT_LENGTH + MAX_RESPONSE_LENGTH))
 DEFAULT_RUN_NAME="ds4_dapo_pp${ACTOR_PP}_ep${ACTOR_EP}_cp${ACTOR_CP}"
@@ -226,7 +236,7 @@ ACTOR=(
   "actor_rollout_ref.actor.engine.grad_offload=${GRAD_OFFLOAD}"
   "actor_rollout_ref.actor.engine.attention_backend_override=fused"
   "actor_rollout_ref.actor.engine.impl_cfg.use_thd=True"
-  "+actor_rollout_ref.actor.engine.impl_cfg.optimizer=fsdp2"
+  "+actor_rollout_ref.actor.engine.impl_cfg.optimizer=${MLITE_OPTIMIZER_BACKEND}"
   "actor_rollout_ref.actor.engine.load_hf_weights=True"
   "+actor_rollout_ref.actor.engine.cross_entropy_fusion=True"
   "actor_rollout_ref.actor.engine.resync_format=${ROLLOUT_RESYNC_FORMAT}"

--- a/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
@@ -826,12 +826,11 @@ def _iter_export_named_parameters(chunk: nn.Module, base_chunk: nn.Module):
     else -- FSDP2 ``DTensor`` params (gathered lazily by ``_materialize_dtensor``)
     and plain manually-sharded params -- falls back to ``named_parameters``.
 
-    The streaming path is guarded for completeness. Its bucket walk emits a
-    param only when it can match the bucket's shard identity back to a name; a
-    param whose identity fails to match would otherwise fall through the bucket
-    loop and never be yielded (a silently truncated shard on resync). So the set
-    of streamed names is checked against the full ``named_parameters`` set on the
-    unwrapped chunk and any drift fails loud instead of shipping partial weights.
+    The streaming path is guarded for completeness. M-FSDP emits each bucket's
+    stable ``ParamSpec.name`` with an independent full-parameter snapshot; the
+    set of streamed names is checked against the full ``named_parameters`` set
+    on the unwrapped chunk and any drift fails loud instead of shipping partial
+    weights.
     """
     streamer = getattr(chunk, "stream_full_parameters", None)
     if not callable(streamer):
@@ -845,8 +844,7 @@ def _iter_export_named_parameters(chunk: nn.Module, base_chunk: nn.Module):
         "(per-bucket materialization)"
     )
     # Cheap reference set: the unwrapped chunk's sharded named_parameters (no
-    # all-gather). Names align with the streamer, which resolves against the same
-    # (currently-installed, sharded) module params.
+    # all-gather). Names align with the streamer's stable ParamSpec names.
     expected = {name for name, _ in base_chunk.named_parameters()}
     streamed: set[str] = set()
     for name, param in streamer():

--- a/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
@@ -29,7 +29,8 @@ try:
 except Exception:  # pragma: no cover - older torch without DTensor
     DTensor = None  # type: ignore[assignment]
 
-from megatron.lite.primitive.ckpt.weight_sync_probe import get_weight_sync_probe
+from megatron.lite.primitive.ckpt.weight_sync_probe import \
+    get_weight_sync_probe
 
 
 def _tensor_nbytes(tensor: torch.Tensor) -> int:

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
@@ -23,7 +23,6 @@ from typing import Any
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-
 from megatron.lite.primitive.optimizers.mfsdp.config import (
     MFSDPConfig,
     MFSDPProcessGroups,
@@ -39,11 +38,7 @@ class NCCLUserBuffer:
     """Best-effort Apex NCCL memory-pool adapter."""
 
     def __init__(
-        self,
-        *,
-        enabled: bool,
-        groups: tuple[dist.ProcessGroup, ...],
-        symmetric: bool,
+        self, *, enabled: bool, groups: tuple[dist.ProcessGroup, ...], symmetric: bool
     ) -> None:
         self.enabled = bool(enabled and torch.cuda.is_available())
         self.groups = groups
@@ -185,11 +180,7 @@ class DoubleBufferAllocator(TemporaryBufferAllocator):
             tensor = slots[slot]
             if tensor is None or tensor.numel() < numel:
                 lease = super().allocate(
-                    numel,
-                    dtype=dtype,
-                    device=device,
-                    group=group,
-                    key=pool_key,
+                    numel, dtype=dtype, device=device, group=group, key=pool_key
                 )
                 tensor = lease.tensor
                 slots[slot] = tensor
@@ -209,11 +200,7 @@ class DoubleBufferAllocator(TemporaryBufferAllocator):
                 registered=registered,
             )
         return super().allocate(
-            numel,
-            dtype=dtype,
-            device=device,
-            group=group,
-            key=pool_key,
+            numel, dtype=dtype, device=device, group=group, key=pool_key
         )
 
     def release(self, lease: BufferLease) -> None:
@@ -250,8 +237,7 @@ def _wait_for_reuse_event(event: Any | None, tensor: torch.Tensor) -> None:
 
 
 def build_temporary_allocator(
-    config: MFSDPConfig,
-    groups: tuple[dist.ProcessGroup, ...],
+    config: MFSDPConfig, groups: tuple[dist.ProcessGroup, ...]
 ) -> TemporaryBufferAllocator:
     user_buffer = NCCLUserBuffer(
         enabled=config.nccl_ub,
@@ -347,24 +333,16 @@ class ParamBucket:
             intersection_end = min(spec_end, local_end)
             spec.shard_numel = max(0, intersection_end - intersection_begin)
             spec.local_offset = min(
-                self.local_numel,
-                max(0, intersection_begin - local_begin),
+                self.local_numel, max(0, intersection_begin - local_begin)
             )
-            spec.param_offset = min(
-                spec.numel,
-                max(0, intersection_begin - spec_begin),
-            )
+            spec.param_offset = min(spec.numel, max(0, intersection_begin - spec_begin))
             offset = spec_end
 
         self.main_param_buffer = torch.zeros(
-            self.local_numel,
-            dtype=self.policy.main_params_dtype,
-            device=self.device,
+            self.local_numel, dtype=self.policy.main_params_dtype, device=self.device
         )
         self.main_grad_buffer = torch.zeros(
-            self.local_numel,
-            dtype=self.policy.main_grads_dtype,
-            device=self.device,
+            self.local_numel, dtype=self.policy.main_grads_dtype, device=self.device
         )
         self.grad_shard_buffer = self.main_grad_buffer
         self.local_compute_buffer = (
@@ -379,9 +357,7 @@ class ParamBucket:
         )
         self.full_buffer = torch.empty(0, dtype=compute_dtype, device=self.device)
         self.full_main_grad_buffer = torch.empty(
-            0,
-            dtype=self.policy.main_grads_dtype,
-            device=self.device,
+            0, dtype=self.policy.main_grads_dtype, device=self.device
         )
         self._full_lease: BufferLease | None = None
         self._full_main_grad_lease: BufferLease | None = None
@@ -391,6 +367,8 @@ class ParamBucket:
         self._param_gather_work: Any | None = None
         self._grad_reduce_work: Any | None = None
         self._grad_reduce_launched = False
+        self._microbatch_reduced = False
+        self._has_accumulated_grad = False
         self._full_ready = True
         self.grad_sync_enabled = False
         self.grad_ready_callback: Callable[["ParamBucket"], None] | None = None
@@ -413,8 +391,7 @@ class ParamBucket:
                     0, spec.local_offset, spec.shard_numel
                 )
                 shard_param = nn.Parameter(
-                    shard_view,
-                    requires_grad=spec.full_param.requires_grad,
+                    shard_view, requires_grad=spec.full_param.requires_grad
                 )
                 _copy_parameter_metadata(spec.full_param, shard_param)
                 shard_param._mfsdp_original_ndim = spec.full_param.ndim
@@ -450,11 +427,7 @@ class ParamBucket:
                 dtype=self.policy.main_grads_dtype,
                 device=self.device,
                 group=self.process_group,
-                key=(
-                    "main_grad",
-                    id(self.process_group),
-                    self.allocator_layout_key,
-                ),
+                key=("main_grad", id(self.process_group), self.allocator_layout_key),
             )
             self.full_main_grad_buffer = self._full_main_grad_lease.tensor
             self.full_main_grad_buffer.zero_()
@@ -468,9 +441,7 @@ class ParamBucket:
             self._full_main_grad_lease.release()
             self._full_main_grad_lease = None
         self.full_main_grad_buffer = torch.empty(
-            0,
-            dtype=self.policy.main_grads_dtype,
-            device=self.device,
+            0, dtype=self.policy.main_grads_dtype, device=self.device
         )
         for spec in self.specs:
             spec.full_param.main_grad = self.full_main_grad_buffer
@@ -482,11 +453,7 @@ class ParamBucket:
                 dtype=self.policy.compute_dtype,
                 device=self.device,
                 group=self.gather_group,
-                key=(
-                    "param",
-                    id(self.gather_group),
-                    self.allocator_layout_key,
-                ),
+                key=("param", id(self.gather_group), self.allocator_layout_key),
             )
             self.full_buffer = self._full_lease.tensor
         if self.policy.main_params_dtype != self.policy.compute_dtype:
@@ -518,10 +485,7 @@ class ParamBucket:
                 output.copy_(local)
             else:
                 self._param_gather_work = dist.all_gather_into_tensor(
-                    output,
-                    local,
-                    group=self.gather_group,
-                    async_op=True,
+                    output, local, group=self.gather_group, async_op=True
                 )
         if self._param_gather_work is not None:
             self._param_gather_work.wait()
@@ -539,20 +503,14 @@ class ParamBucket:
             self._full_lease = None
         self._release_local_compute_buffer()
         self.full_buffer = torch.empty(
-            0,
-            dtype=self.policy.compute_dtype,
-            device=self.device,
+            0, dtype=self.policy.compute_dtype, device=self.device
         )
 
         self._full_ready = False
 
     def discard_full_parameter_views(self) -> None:
         """Release full-parameter references after autograd no longer needs them."""
-        empty = torch.empty(
-            0,
-            dtype=self.policy.compute_dtype,
-            device=self.device,
-        )
+        empty = torch.empty(0, dtype=self.policy.compute_dtype, device=self.device)
         with torch.no_grad():
             for spec in self.specs:
                 spec.full_param.data = empty
@@ -563,9 +521,7 @@ class ParamBucket:
             self._local_compute_lease = None
         if self.policy.main_params_dtype != self.policy.compute_dtype:
             self.local_compute_buffer = torch.empty(
-                0,
-                dtype=self.policy.compute_dtype,
-                device=self.device,
+                0, dtype=self.policy.compute_dtype, device=self.device
             )
 
     def _release_local_grad_comm_buffer(self) -> None:
@@ -574,10 +530,10 @@ class ParamBucket:
             self._local_grad_comm_lease = None
         if self.policy.grad_comm_dtype != self.policy.main_grads_dtype:
             self.local_grad_comm_buffer = torch.empty(
-                0,
-                dtype=self.policy.grad_comm_dtype,
-                device=self.device,
+                0, dtype=self.policy.grad_comm_dtype, device=self.device
             )
+        else:
+            self.local_grad_comm_buffer = self.main_grad_buffer
 
     def move_model_state(self, device: torch.device, *, load_grad: bool) -> None:
         """Move persistent sharded storage without breaking optimizer aliases."""
@@ -611,29 +567,21 @@ class ParamBucket:
         )
         self.device = device
         self.full_buffer = torch.empty(
-            0,
-            dtype=self.policy.compute_dtype,
-            device=device,
+            0, dtype=self.policy.compute_dtype, device=device
         )
         self.full_main_grad_buffer = torch.empty(
-            0,
-            dtype=self.policy.main_grads_dtype,
-            device=device,
+            0, dtype=self.policy.main_grads_dtype, device=device
         )
 
         with torch.no_grad():
             for spec in self.specs:
                 assert spec.shard_param is not None
                 spec.shard_param.data = self.main_param_buffer.narrow(
-                    0,
-                    spec.local_offset,
-                    spec.shard_numel,
+                    0, spec.local_offset, spec.shard_numel
                 )
                 if load_grad and grad_present[id(spec)]:
                     spec.shard_param.grad = self.main_grad_buffer.narrow(
-                        0,
-                        spec.local_offset,
-                        spec.shard_numel,
+                        0, spec.local_offset, spec.shard_numel
                     ).view_as(spec.shard_param)
                 else:
                     spec.shard_param.grad = None
@@ -663,23 +611,22 @@ class ParamBucket:
     def prepare_grad_reduce(
         self, *, force: bool = False
     ) -> tuple[torch.Tensor, torch.Tensor] | None:
-        if self._grad_reduce_launched:
+        if self._grad_reduce_launched or self._microbatch_reduced:
             return None
         if not force and len(self._grad_ready_ids) != len(self.specs):
             return None
         self._grad_reduce_launched = True
         self.prepare_main_grads()
-        if self.policy.grad_comm_dtype != self.policy.main_grads_dtype:
+        if (
+            self.policy.grad_comm_dtype != self.policy.main_grads_dtype
+            or self._has_accumulated_grad
+        ):
             self._local_grad_comm_lease = self.allocator.allocate(
                 self.local_numel,
                 dtype=self.policy.grad_comm_dtype,
                 device=self.device,
                 group=self.process_group,
-                key=(
-                    "grad-local",
-                    id(self.process_group),
-                    self.allocator_layout_key,
-                ),
+                key=("grad-local", id(self.process_group), self.allocator_layout_key),
             )
             self.local_grad_comm_buffer = self._local_grad_comm_lease.tensor
         with torch.no_grad():
@@ -696,14 +643,17 @@ class ParamBucket:
                 dtype=self.policy.grad_comm_dtype,
                 device=self.device,
                 group=self.process_group,
-                key=(
-                    "grad",
-                    id(self.process_group),
-                    self.allocator_layout_key,
-                ),
+                key=("grad", id(self.process_group), self.allocator_layout_key),
             )
             grad_input = self._grad_lease.tensor
             grad_input.copy_(self.full_main_grad_buffer)
+        if self.local_grad_comm_buffer.numel() != self.local_numel:
+            raise RuntimeError(
+                "M-FSDP reduce-scatter output staging has the wrong size: "
+                f"bucket={self.bucket_id} output={self.local_grad_comm_buffer.numel()} "
+                f"expected={self.local_numel} accumulated={self._has_accumulated_grad} "
+                f"lease={self._local_grad_comm_lease is not None}."
+            )
         return self.local_grad_comm_buffer, grad_input
 
     def mark_grad_reduce_launched(self, work: Any | None) -> None:
@@ -727,9 +677,14 @@ class ParamBucket:
         if self._grad_reduce_work is not None:
             self._grad_reduce_work.wait()
             self._grad_reduce_work = None
-        self.main_grad_buffer.copy_(self.local_grad_comm_buffer)
+        reduced_grad = self.local_grad_comm_buffer
         if self.config.average_gradients and self.world_size > 1:
-            self.main_grad_buffer.div_(self.world_size)
+            reduced_grad.div_(self.world_size)
+        if self._has_accumulated_grad:
+            self.main_grad_buffer.add_(reduced_grad)
+        elif reduced_grad is not self.main_grad_buffer:
+            self.main_grad_buffer.copy_(reduced_grad)
+        self._has_accumulated_grad = True
         for spec in self.specs:
             assert spec.shard_param is not None
             main_grad = self.main_grad_buffer.narrow(
@@ -749,6 +704,9 @@ class ParamBucket:
             self._grad_lease = None
         self._release_local_grad_comm_buffer()
         self._release_full_main_grads()
+        self._grad_reduce_launched = False
+        self._grad_ready_ids.clear()
+        self._microbatch_reduced = True
 
     def copy_full_parameters_to_shards(self) -> None:
         self.wait_param_gather()
@@ -762,6 +720,8 @@ class ParamBucket:
             self._grad_reduce_work.wait()
         self._grad_reduce_work = None
         self._grad_reduce_launched = False
+        self._microbatch_reduced = False
+        self._has_accumulated_grad = False
         self.grad_sync_enabled = False
         self._grad_ready_ids.clear()
         self.main_grad_buffer.zero_()
@@ -772,6 +732,9 @@ class ParamBucket:
             if spec.shard_param is not None:
                 spec.shard_param.grad = None
         self._release_full_main_grads()
+
+    def start_microbatch(self) -> None:
+        self._microbatch_reduced = False
 
     def set_grad_sync_enabled(self, enabled: bool) -> None:
         enabled = bool(enabled)
@@ -813,7 +776,7 @@ class ParamBucket:
                 param.grad = None
             if len(self._grad_ready_ids) != len(self.specs):
                 return
-            if self.grad_sync_enabled and self.grad_ready_callback is not None:
+            if self.grad_ready_callback is not None:
                 self.grad_ready_callback(self)
             self.release_full_parameters()
             self.discard_full_parameter_views()
@@ -838,13 +801,9 @@ class ParamAndGradBuffer:
         self.module = module
         self.groups = groups
         self.config = config
-        self.allocator = build_temporary_allocator(
-            config,
-            groups.registration_groups(),
-        )
+        self.allocator = build_temporary_allocator(config, groups.registration_groups())
         self.buckets, self.owners = self._build(
-            is_expert=is_expert,
-            unit_modules=unit_modules or (),
+            is_expert=is_expert, unit_modules=unit_modules or ()
         )
 
     def _build(
@@ -878,10 +837,7 @@ class ParamAndGradBuffer:
                 )
                 specs_by_id[id(param)] = spec
                 owner_by_param_id[id(param)] = _parameter_owner(
-                    parent_name,
-                    parent,
-                    module_by_name,
-                    unit_types,
+                    parent_name, parent, module_by_name, unit_types
                 )
                 expert_by_param_id[id(param)] = bool(is_expert(name))
             spec.bindings.append(ParamBinding(parent, attribute))
@@ -1017,9 +973,7 @@ class CommunicationStream:
                 self.stream = torch.cuda.Stream(device=device, priority=-1)
 
     def launch(
-        self,
-        callback: Callable[[], Any | None],
-        tensors: Iterable[torch.Tensor],
+        self, callback: Callable[[], Any | None], tensors: Iterable[torch.Tensor]
     ) -> Any | None:
         if self.stream is None:
             return callback()
@@ -1058,10 +1012,7 @@ class AllGatherPipeline:
                 output.copy_(local)
                 return None
             return dist.all_gather_into_tensor(
-                output,
-                local,
-                group=bucket.gather_group,
-                async_op=True,
+                output, local, group=bucket.gather_group, async_op=True
             )
 
         work = self.comm_stream.launch(collective, (output, local))
@@ -1139,9 +1090,9 @@ class GradReducePipeline:
         self.buckets = buckets
         device = buckets[0].device if buckets else torch.device("cpu")
         self.comm_stream = CommunicationStream(device)
+        self._pending: list[ParamBucket] = []
         for bucket in buckets:
-            if bucket.config.overlap_grad_reduce:
-                bucket.grad_ready_callback = self.reduce_gradients
+            bucket.grad_ready_callback = self.reduce_gradients
 
     def reduce_gradients(self, bucket: ParamBucket, *, force: bool = False) -> None:
         tensors = bucket.prepare_grad_reduce(force=force)
@@ -1163,15 +1114,35 @@ class GradReducePipeline:
 
         work = self.comm_stream.launch(collective, (output, grad_input))
         bucket.mark_grad_reduce_launched(work)
+        self._pending.append(bucket)
+
+    def reclaim_before_backward(self) -> None:
+        # Bound full, unsharded FP32 gradient staging to the allocator's two
+        # reusable slots.  Without this drain, delayed microbatch sync retains
+        # one 4-byte-per-parameter buffer for every completed bucket.
+        while len(self._pending) >= 2:
+            self._pending.pop(0).wait_grad_reduce()
+
+    def has_microbatch_work(self) -> bool:
+        return bool(self._pending) or any(
+            bucket._grad_ready_ids or bucket._full_main_grad_lease is not None
+            for bucket in self.buckets
+        )
 
     def finish(self) -> None:
         for bucket in reversed(self.buckets):
-            self.reduce_gradients(bucket, force=True)
+            if not bucket._microbatch_reduced:
+                self.reduce_gradients(bucket, force=True)
         self.comm_stream.wait_for_current()
+        while self._pending:
+            self._pending.pop(0).wait_grad_reduce()
+
+    def start_microbatch(self) -> None:
         for bucket in self.buckets:
-            bucket.wait_grad_reduce()
+            bucket.start_microbatch()
 
     def reset(self) -> None:
+        self._pending.clear()
         for bucket in self.buckets:
             bucket.reset_grad_state()
 
@@ -1192,19 +1163,26 @@ class CommunicationPipelines:
         self.grad_reduce = GradReducePipeline(buckets)
 
     def begin_forward(self) -> None:
+        if self.grad_reduce.has_microbatch_work():
+            self.grad_reduce.finish()
         self.all_gather.begin_forward()
 
     def acquire_forward(self, bucket_ids: Iterable[int]) -> None:
         self.all_gather.acquire_forward(bucket_ids)
 
     def begin_backward(self) -> None:
+        if self.grad_reduce.has_microbatch_work():
+            self.grad_reduce.finish()
+        self.grad_reduce.start_microbatch()
         self.all_gather.begin_backward()
 
     def acquire_backward(self, bucket: ParamBucket) -> None:
+        self.grad_reduce.reclaim_before_backward()
         self.all_gather.acquire_backward(bucket)
 
     def acquire_backward_ids(self, bucket_ids: Iterable[int]) -> None:
         for bucket_id in reversed(tuple(bucket_ids)):
+            self.grad_reduce.reclaim_before_backward()
             self.all_gather.acquire_backward(self.buckets[bucket_id])
 
     def release_backward_ids(self, bucket_ids: Iterable[int]) -> None:

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
@@ -418,8 +418,6 @@ class ParamBucket:
                 )
                 _copy_parameter_metadata(spec.full_param, shard_param)
                 shard_param._mfsdp_original_ndim = spec.full_param.ndim
-                if shard_param.dtype != self.policy.main_grads_dtype:
-                    shard_param.grad_dtype = self.policy.main_grads_dtype
                 spec.shard_param = shard_param
                 # TE returns a dummy ``.grad`` when its wgrad GEMM writes the
                 # real gradient directly into ``main_grad``.
@@ -734,9 +732,18 @@ class ParamBucket:
             self.main_grad_buffer.div_(self.world_size)
         for spec in self.specs:
             assert spec.shard_param is not None
-            spec.shard_param.grad = self.main_grad_buffer.narrow(
+            main_grad = self.main_grad_buffer.narrow(
                 0, spec.local_offset, spec.shard_numel
             ).view_as(spec.shard_param)
+            if spec.shard_param.dtype == main_grad.dtype:
+                spec.shard_param.grad = main_grad
+            else:
+                # PyTorch requires ``Parameter.grad`` to have the parameter's
+                # dtype. The CPU optimizer consumes this explicit FP32 view;
+                # leave ``.grad`` empty instead of allocating a lossy BF16
+                # mirror that no optimizer should read.
+                spec.shard_param.main_grad = main_grad
+                spec.shard_param.grad = None
         if self._grad_lease is not None:
             self._grad_lease.release()
             self._grad_lease = None

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
@@ -422,12 +422,15 @@ class ParamBucket:
     def prepare_main_grads(self) -> None:
         """Attach bounded FP32 views for fused wgrad accumulation."""
         if self._full_main_grad_lease is None:
+            # Unlike full parameters, gradient staging has no autograd-saved
+            # views after its reduce-scatter completes. Pool it across bucket
+            # layouts so released per-bucket slots do not become resident.
             self._full_main_grad_lease = self.allocator.allocate(
                 self.full_numel,
                 dtype=self.policy.main_grads_dtype,
                 device=self.device,
                 group=self.process_group,
-                key=("main_grad", id(self.process_group), self.allocator_layout_key),
+                key=("main_grad", id(self.process_group)),
             )
             self.full_main_grad_buffer = self._full_main_grad_lease.tensor
             self.full_main_grad_buffer.zero_()
@@ -626,7 +629,7 @@ class ParamBucket:
                 dtype=self.policy.grad_comm_dtype,
                 device=self.device,
                 group=self.process_group,
-                key=("grad-local", id(self.process_group), self.allocator_layout_key),
+                key=("grad-local", id(self.process_group)),
             )
             self.local_grad_comm_buffer = self._local_grad_comm_lease.tensor
         with torch.no_grad():
@@ -643,7 +646,7 @@ class ParamBucket:
                 dtype=self.policy.grad_comm_dtype,
                 device=self.device,
                 group=self.process_group,
-                key=("grad", id(self.process_group), self.allocator_layout_key),
+                key=("grad", id(self.process_group)),
             )
             grad_input = self._grad_lease.tensor
             grad_input.copy_(self.full_main_grad_buffer)

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
@@ -388,6 +388,7 @@ class ParamBucket:
         self._full_ready = True
         self.grad_sync_enabled = False
         self.grad_ready_callback: Callable[["ParamBucket"], None] | None = None
+        self.before_main_grad_allocate: Callable[["ParamBucket"], None] | None = None
         self._grad_ready_ids: set[int] = set()
         self._initialize_parameters()
 
@@ -439,6 +440,7 @@ class ParamBucket:
     def prepare_main_grads(self) -> None:
         """Attach bounded FP32 views for fused wgrad accumulation."""
         if self._full_main_grad_lease is None:
+            self._enforce_main_grad_slot_limit()
             # Unlike full parameters, gradient staging has no autograd-saved
             # views after its reduce-scatter completes. Pool it across bucket
             # layouts so released per-bucket slots do not become resident.
@@ -457,6 +459,7 @@ class ParamBucket:
     def get_main_grad(self, spec: ParamSpec) -> torch.Tensor:
         """Lazily allocate this bucket's full-precision gradient staging view."""
         if self._full_main_grad_lease is None:
+            self._enforce_main_grad_slot_limit()
             self._full_main_grad_lease = self.allocator.allocate(
                 self.full_numel,
                 dtype=self.policy.main_grads_dtype,
@@ -471,6 +474,11 @@ class ParamBucket:
         ).view(spec.shape)
         spec.full_param.main_grad = main_grad
         return main_grad
+
+    def _enforce_main_grad_slot_limit(self) -> None:
+        """Retire an in-flight reduction before consuming a third grad slot."""
+        if self.before_main_grad_allocate is not None:
+            self.before_main_grad_allocate(self)
 
     def _make_main_grad_getter(self, spec: ParamSpec) -> Callable[[], torch.Tensor]:
         return lambda: self.get_main_grad(spec)
@@ -1146,6 +1154,25 @@ class GradReducePipeline:
         self._pending_capacity_bytes = 0
         for bucket in buckets:
             bucket.grad_ready_callback = self.reduce_gradients
+            bucket.before_main_grad_allocate = self._enforce_double_buffer_limit
+
+    def _retire_oldest(self) -> None:
+        completed, completed_bytes = self._pending.pop(0)
+        completed.wait_grad_reduce()
+        self._pending_bytes -= completed_bytes
+
+    def _enforce_double_buffer_limit(self, incoming: ParamBucket) -> None:
+        """Keep at most two live full-gradient bucket slots.
+
+        This is the MCore ``_enforce_double_buffer_limit`` lifecycle at the
+        lazy main-gradient allocation boundary.  Slot pressure is a count of
+        in-flight bucket allocations, not a byte watermark: differently sized
+        buckets still each consume one of the allocator's two reusable slots.
+        """
+        if not incoming.config.fsdp_double_buffer:
+            return
+        while len(self._pending) >= 2:
+            self._retire_oldest()
 
     def reduce_gradients(self, bucket: ParamBucket, *, force: bool = False) -> None:
         self._drain_for(bucket)
@@ -1185,18 +1212,14 @@ class GradReducePipeline:
             self._pending
             and self._pending_bytes + byte_count > self._pending_capacity_bytes
         ):
-            completed, completed_bytes = self._pending.pop(0)
-            completed.wait_grad_reduce()
-            self._pending_bytes -= completed_bytes
+            self._retire_oldest()
 
     def reclaim_before_backward(self) -> None:
         # Bound full, unsharded FP32 gradient staging to the allocator's two
         # reusable slots.  Without this drain, delayed microbatch sync retains
         # one 4-byte-per-parameter buffer for every completed bucket.
         while len(self._pending) >= 2:
-            completed, completed_bytes = self._pending.pop(0)
-            completed.wait_grad_reduce()
-            self._pending_bytes -= completed_bytes
+            self._retire_oldest()
 
     def has_microbatch_work(self) -> bool:
         return bool(self._pending) or any(
@@ -1210,9 +1233,12 @@ class GradReducePipeline:
                 self.reduce_gradients(bucket, force=True)
         self.comm_stream.wait_for_current()
         while self._pending:
-            bucket, byte_count = self._pending.pop(0)
-            bucket.wait_grad_reduce()
-            self._pending_bytes -= byte_count
+            self._retire_oldest()
+
+    def abort(self) -> None:
+        """Forget queued work after a forward exception has become primary."""
+        self._pending.clear()
+        self._pending_bytes = 0
 
     def start_microbatch(self) -> None:
         for bucket in self.buckets:
@@ -1354,6 +1380,19 @@ class CommunicationPipelines:
 
     def finish_grad_sync(self) -> None:
         self.grad_reduce.finish()
+
+    def abort(self) -> None:
+        """Exception teardown: drop allocator state without masking the error."""
+        self.grad_reduce.abort()
+        for bucket in self.buckets:
+            bucket._grad_reduce_work = None
+            bucket._grad_reduce_event = None
+            bucket._grad_reduce_launched = False
+            bucket._release_local_grad_comm_buffer()
+            bucket._release_full_main_grads()
+            bucket.release_full_parameters()
+            bucket.discard_full_parameter_views()
+            bucket.allocator.release_cached(force=True)
 
     def reset_grad_state(self) -> None:
         self.grad_reduce.reset()

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
@@ -12,7 +12,6 @@ persistent local main buffers.
 from __future__ import annotations
 
 import importlib
-import logging
 import math
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator
@@ -31,11 +30,8 @@ from megatron.lite.primitive.optimizers.mfsdp.config import (
     group_size,
 )
 
-logger = logging.getLogger(__name__)
-
-
 class NCCLUserBuffer:
-    """Best-effort Apex NCCL memory-pool adapter."""
+    """Apex NCCL memory-pool adapter required when ``nccl_ub`` is enabled."""
 
     def __init__(
         self, *, enabled: bool, groups: tuple[dist.ProcessGroup, ...], symmetric: bool
@@ -45,7 +41,6 @@ class NCCLUserBuffer:
         self.symmetric = symmetric
         self.module: Any | None = None
         self.pool: Any | None = None
-        self._warned = False
         if self.enabled:
             self._initialize()
 
@@ -64,7 +59,7 @@ class NCCLUserBuffer:
             self.module = module
             self.pool = pool
         except (ImportError, AttributeError, RuntimeError, TypeError) as error:
-            self._disable(f"NCCL user-buffer allocation unavailable: {error}")
+            self._fail(f"NCCL user-buffer allocation unavailable: {error}")
 
     def allocation_context(self, group: dist.ProcessGroup | None):
         if not self.active or group is None:
@@ -72,8 +67,7 @@ class NCCLUserBuffer:
         try:
             return self.module.nccl_mem(self.pool, group=group)
         except (AttributeError, RuntimeError, TypeError) as error:
-            self._disable(f"NCCL user-buffer context failed: {error}")
-            return nullcontext()
+            self._fail(f"NCCL user-buffer context failed: {error}")
 
     def register_additional_groups(self) -> None:
         if not self.active or len(self.groups) < 2:
@@ -85,15 +79,12 @@ class NCCLUserBuffer:
                 )
                 backend.register_mem_pool(self.pool)
             except (AttributeError, RuntimeError, TypeError) as error:
-                self._disable(f"NCCL user-buffer group registration failed: {error}")
-                return
+                self._fail(f"NCCL user-buffer group registration failed: {error}")
 
-    def _disable(self, reason: str) -> None:
+    def _fail(self, reason: str) -> None:
         self.module = None
         self.pool = None
-        if not self._warned:
-            logger.warning("%s; using Torch communication buffers.", reason)
-            self._warned = True
+        raise RuntimeError(reason)
 
 
 @dataclass(slots=True)
@@ -139,7 +130,7 @@ class TemporaryBufferAllocator:
                 self.user_buffer.register_additional_groups()
         except (RuntimeError, TypeError) as error:
             if self.user_buffer is not None:
-                self.user_buffer._disable(f"Registered allocation failed: {error}")
+                self.user_buffer._fail(f"Registered allocation failed: {error}")
             tensor = torch.empty(numel, dtype=dtype, device=device)
             registered = False
         return BufferLease(tensor=tensor, owner=self, key=key, registered=registered)

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
@@ -1143,16 +1143,32 @@ class CommunicationPipelines:
             bucket.release_full_parameters()
             bucket.discard_full_parameter_views()
 
+    def _retain_through_backward(self, bucket: "ParamBucket") -> bool:
+        # A ``retain_full_storage_through_backward`` bucket keeps its gathered
+        # full-parameter buffer live past the forward so the matching backward
+        # can reuse it without re-gathering; the release is deferred to
+        # ``_ReleaseBackward`` (see wrapper.py). That deferral is only valid when
+        # a backward will actually run -- i.e. autograd is recording a graph.
+        # A grad-disabled forward (``torch.no_grad`` / ``inference_mode``, e.g.
+        # the DAPO rollout-correction logprob recompute) has no backward, so the
+        # deferred release would never fire and the bucket's full-parameter lease
+        # would stay pinned (its allocator slot ``busy``) until the next
+        # ``begin_forward``. Any intervening ``release_cached`` (a colocated vLLM
+        # wake / full-parameter export / ``move_model_state`` offload) would then
+        # trip the busy-buffer guard with a spurious "active buffers" raise. When
+        # grad is disabled, release these buckets eagerly like every other.
+        return bucket.retain_full_storage_through_backward and torch.is_grad_enabled()
+
     def release_forward_ids(self, bucket_ids: Iterable[int]) -> None:
         for bucket_id in bucket_ids:
             bucket = self.buckets[bucket_id]
-            if not bucket.retain_full_storage_through_backward:
+            if not self._retain_through_backward(bucket):
                 bucket.release_full_parameters()
                 bucket.discard_full_parameter_views()
 
     def end_forward(self) -> None:
         for bucket in self.buckets:
-            if not bucket.retain_full_storage_through_backward:
+            if not self._retain_through_backward(bucket):
                 bucket.release_full_parameters()
                 bucket.discard_full_parameter_views()
 

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
@@ -30,6 +30,7 @@ from megatron.lite.primitive.optimizers.mfsdp.config import (
     group_size,
 )
 
+
 class NCCLUserBuffer:
     """Apex NCCL memory-pool adapter required when ``nccl_ub`` is enabled."""
 
@@ -407,6 +408,8 @@ class ParamBucket:
                 # TE returns a dummy ``.grad`` when its wgrad GEMM writes the
                 # real gradient directly into ``main_grad``.
                 spec.full_param.grad_added_to_main_grad = False
+                spec.full_param.__fsdp_param__ = True
+                spec.full_param.overwrite_main_grad = True
                 spec.full_param.get_main_grad = self._make_main_grad_getter(spec)
                 spec.full_param.register_post_accumulate_grad_hook(
                     self._make_grad_ready_hook(spec)
@@ -425,6 +428,10 @@ class ParamBucket:
                 spec.shape
             )
             spec.full_param.data = view
+            # TE checks these MCore FSDP markers before using the lazy FP32
+            # wgrad destination, so restore them on every materialization.
+            spec.full_param.__fsdp_param__ = True
+            spec.full_param.overwrite_main_grad = True
             for binding in spec.bindings:
                 setattr(binding.module, binding.attribute, spec.full_param)
 
@@ -1222,9 +1229,10 @@ class GradReducePipeline:
         self._pending_bytes += byte_count
 
     def _drain_for(self, bucket: ParamBucket) -> None:
-        byte_count = bucket.full_numel * torch.empty(
-            (), dtype=bucket.policy.grad_comm_dtype
-        ).element_size()
+        byte_count = (
+            bucket.full_numel
+            * torch.empty((), dtype=bucket.policy.grad_comm_dtype).element_size()
+        )
         self._pending_capacity_bytes = max(self._pending_capacity_bytes, 2 * byte_count)
         while (
             self._pending

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
@@ -23,12 +23,8 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 from megatron.lite.primitive.optimizers.mfsdp.config import (
-    MFSDPConfig,
-    MFSDPProcessGroups,
-    MixedPrecisionPolicy,
-    group_rank,
-    group_size,
-)
+    MFSDPConfig, MFSDPProcessGroups, MixedPrecisionPolicy, group_rank,
+    group_size)
 
 
 class NCCLUserBuffer:

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
@@ -370,24 +370,18 @@ class ParamBucket:
         self.local_compute_buffer = (
             self.main_param_buffer
             if self.policy.main_params_dtype == self.policy.compute_dtype
-            else torch.empty(
-                self.local_numel,
-                dtype=self.policy.compute_dtype,
-                device=self.device,
-            )
+            else torch.empty(0, dtype=self.policy.compute_dtype, device=self.device)
         )
         self.local_grad_comm_buffer = (
             self.main_grad_buffer
             if self.policy.grad_comm_dtype == self.policy.main_grads_dtype
-            else torch.empty(
-                self.local_numel,
-                dtype=self.policy.grad_comm_dtype,
-                device=self.device,
-            )
+            else torch.empty(0, dtype=self.policy.grad_comm_dtype, device=self.device)
         )
         self.full_buffer = torch.empty(0, dtype=compute_dtype, device=self.device)
         self._full_lease: BufferLease | None = None
         self._grad_lease: BufferLease | None = None
+        self._local_compute_lease: BufferLease | None = None
+        self._local_grad_comm_lease: BufferLease | None = None
         self._param_gather_work: Any | None = None
         self._grad_reduce_work: Any | None = None
         self._grad_reduce_launched = False
@@ -455,7 +449,20 @@ class ParamBucket:
                 ),
             )
             self.full_buffer = self._full_lease.tensor
-        if self.local_compute_buffer is not self.main_param_buffer:
+        if self.policy.main_params_dtype != self.policy.compute_dtype:
+            if self._local_compute_lease is None:
+                self._local_compute_lease = self.allocator.allocate(
+                    self.local_numel,
+                    dtype=self.policy.compute_dtype,
+                    device=self.device,
+                    group=self.gather_group,
+                    key=(
+                        "param-local",
+                        id(self.gather_group),
+                        self.allocator_layout_key,
+                    ),
+                )
+                self.local_compute_buffer = self._local_compute_lease.tensor
             self.local_compute_buffer.copy_(self.main_param_buffer)
         return self.full_buffer, self.local_compute_buffer
 
@@ -479,6 +486,7 @@ class ParamBucket:
         if self._param_gather_work is not None:
             self._param_gather_work.wait()
             self._param_gather_work = None
+        self._release_local_compute_buffer()
         self._full_ready = True
 
     def release_full_parameters(self) -> None:
@@ -489,6 +497,7 @@ class ParamBucket:
         if self._full_lease is not None:
             self._full_lease.release()
             self._full_lease = None
+        self._release_local_compute_buffer()
         self.full_buffer = torch.empty(
             0,
             dtype=self.policy.compute_dtype,
@@ -507,6 +516,28 @@ class ParamBucket:
         with torch.no_grad():
             for spec in self.specs:
                 spec.full_param.data = empty
+
+    def _release_local_compute_buffer(self) -> None:
+        if self._local_compute_lease is not None:
+            self._local_compute_lease.release()
+            self._local_compute_lease = None
+        if self.policy.main_params_dtype != self.policy.compute_dtype:
+            self.local_compute_buffer = torch.empty(
+                0,
+                dtype=self.policy.compute_dtype,
+                device=self.device,
+            )
+
+    def _release_local_grad_comm_buffer(self) -> None:
+        if self._local_grad_comm_lease is not None:
+            self._local_grad_comm_lease.release()
+            self._local_grad_comm_lease = None
+        if self.policy.grad_comm_dtype != self.policy.main_grads_dtype:
+            self.local_grad_comm_buffer = torch.empty(
+                0,
+                dtype=self.policy.grad_comm_dtype,
+                device=self.device,
+            )
 
     def move_model_state(self, device: torch.device, *, load_grad: bool) -> None:
         """Move persistent sharded storage without breaking optimizer aliases."""
@@ -601,6 +632,19 @@ class ParamBucket:
         )
         grad_input = self._grad_lease.tensor
         grad_input.zero_()
+        if self.policy.grad_comm_dtype != self.policy.main_grads_dtype:
+            self._local_grad_comm_lease = self.allocator.allocate(
+                self.local_numel,
+                dtype=self.policy.grad_comm_dtype,
+                device=self.device,
+                group=self.process_group,
+                key=(
+                    "grad-local",
+                    id(self.process_group),
+                    self.allocator_layout_key,
+                ),
+            )
+            self.local_grad_comm_buffer = self._local_grad_comm_lease.tensor
         with torch.no_grad():
             for spec in self.specs:
                 grad = spec.full_param.grad
@@ -643,6 +687,7 @@ class ParamBucket:
         if self._grad_lease is not None:
             self._grad_lease.release()
             self._grad_lease = None
+        self._release_local_grad_comm_buffer()
 
     def copy_full_parameters_to_shards(self) -> None:
         self.wait_param_gather()
@@ -659,6 +704,7 @@ class ParamBucket:
         self.grad_sync_enabled = False
         self._grad_ready_ids.clear()
         self.main_grad_buffer.zero_()
+        self._release_local_grad_comm_buffer()
         for spec in self.specs:
             spec.full_param.grad = None
             if spec.shard_param is not None:

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
@@ -145,8 +145,7 @@ class TemporaryBufferAllocator:
         return BufferLease(tensor=tensor, owner=self, key=key, registered=registered)
 
     def release(self, lease: BufferLease) -> None:
-        # Dynamic storage is reclaimed when the lease drops its final reference.
-        return None
+        _free_storage(lease.tensor)
 
     def release_cached(self, *, force: bool = False) -> None:
         """Drop allocator-owned communication storage before a device move."""
@@ -199,8 +198,9 @@ class DoubleBufferAllocator(TemporaryBufferAllocator):
                 slot=slot,
                 registered=registered,
             )
-        return super().allocate(
-            numel, dtype=dtype, device=device, group=group, key=pool_key
+        raise RuntimeError(
+            "M-FSDP double-buffer capacity exhausted; drain a completed "
+            "gradient reduce before acquiring another slot."
         )
 
     def release(self, lease: BufferLease) -> None:
@@ -234,6 +234,20 @@ def _record_reuse_event(tensor: torch.Tensor) -> Any | None:
 def _wait_for_reuse_event(event: Any | None, tensor: torch.Tensor) -> None:
     if event is not None:
         torch.cuda.current_stream(tensor.device).wait_event(event)
+
+
+def _free_storage(tensor: torch.Tensor) -> None:
+    """Physically release completed temporary communication storage.
+
+    Replacing a tensor view does not return its allocation while the lease still
+    owns that view.  MCore releases temporary bucket storage after completion;
+    mirror that lifecycle for non-registered, non-double-buffer allocations.
+    """
+    if tensor.numel() == 0 or tensor.storage_offset() != 0:
+        return
+    storage = tensor.untyped_storage()
+    if storage.nbytes():
+        storage.resize_(0)
 
 
 def build_temporary_allocator(
@@ -366,7 +380,9 @@ class ParamBucket:
         self._local_grad_comm_lease: BufferLease | None = None
         self._param_gather_work: Any | None = None
         self._grad_reduce_work: Any | None = None
+        self._grad_reduce_event: Any | None = None
         self._grad_reduce_launched = False
+        self._grad_reduce_finished = False
         self._microbatch_reduced = False
         self._has_accumulated_grad = False
         self._full_ready = True
@@ -399,6 +415,7 @@ class ParamBucket:
                 # TE returns a dummy ``.grad`` when its wgrad GEMM writes the
                 # real gradient directly into ``main_grad``.
                 spec.full_param.grad_added_to_main_grad = False
+                spec.full_param.get_main_grad = self._make_main_grad_getter(spec)
                 spec.full_param.register_post_accumulate_grad_hook(
                     self._make_grad_ready_hook(spec)
                 )
@@ -435,9 +452,28 @@ class ParamBucket:
             self.full_main_grad_buffer = self._full_main_grad_lease.tensor
             self.full_main_grad_buffer.zero_()
         for spec in self.specs:
-            spec.full_param.main_grad = self.full_main_grad_buffer.narrow(
-                0, spec.full_offset, spec.numel
-            ).view(spec.shape)
+            self.get_main_grad(spec)
+
+    def get_main_grad(self, spec: ParamSpec) -> torch.Tensor:
+        """Lazily allocate this bucket's full-precision gradient staging view."""
+        if self._full_main_grad_lease is None:
+            self._full_main_grad_lease = self.allocator.allocate(
+                self.full_numel,
+                dtype=self.policy.main_grads_dtype,
+                device=self.device,
+                group=self.process_group,
+                key=("main_grad", id(self.process_group)),
+            )
+            self.full_main_grad_buffer = self._full_main_grad_lease.tensor
+            self.full_main_grad_buffer.zero_()
+        main_grad = self.full_main_grad_buffer.narrow(
+            0, spec.full_offset, spec.numel
+        ).view(spec.shape)
+        spec.full_param.main_grad = main_grad
+        return main_grad
+
+    def _make_main_grad_getter(self, spec: ParamSpec) -> Callable[[], torch.Tensor]:
+        return lambda: self.get_main_grad(spec)
 
     def _release_full_main_grads(self) -> None:
         if self._full_main_grad_lease is not None:
@@ -659,10 +695,15 @@ class ParamBucket:
             )
         return self.local_grad_comm_buffer, grad_input
 
-    def mark_grad_reduce_launched(self, work: Any | None) -> None:
+    def mark_grad_reduce_launched(
+        self, work: Any | None, completion_event: Any | None = None
+    ) -> None:
         self._grad_reduce_work = work
+        self._grad_reduce_event = completion_event
 
     def wait_grad_reduce(self) -> None:
+        if self._grad_reduce_finished:
+            return
         if not self._grad_reduce_launched:
             tensors = self.prepare_grad_reduce(force=True)
             assert tensors is not None
@@ -677,6 +718,9 @@ class ParamBucket:
                     group=self.process_group,
                     async_op=True,
                 )
+        if self._grad_reduce_event is not None:
+            self._grad_reduce_event.synchronize()
+            self._grad_reduce_event = None
         if self._grad_reduce_work is not None:
             self._grad_reduce_work.wait()
             self._grad_reduce_work = None
@@ -708,6 +752,7 @@ class ParamBucket:
         self._release_local_grad_comm_buffer()
         self._release_full_main_grads()
         self._grad_reduce_launched = False
+        self._grad_reduce_finished = True
         self._grad_ready_ids.clear()
         self._microbatch_reduced = True
 
@@ -722,7 +767,9 @@ class ParamBucket:
         if self._grad_reduce_work is not None:
             self._grad_reduce_work.wait()
         self._grad_reduce_work = None
+        self._grad_reduce_event = None
         self._grad_reduce_launched = False
+        self._grad_reduce_finished = False
         self._microbatch_reduced = False
         self._has_accumulated_grad = False
         self.grad_sync_enabled = False
@@ -738,6 +785,7 @@ class ParamBucket:
 
     def start_microbatch(self) -> None:
         self._microbatch_reduced = False
+        self._grad_reduce_finished = False
 
     def set_grad_sync_enabled(self, enabled: bool) -> None:
         enabled = bool(enabled)
@@ -771,11 +819,12 @@ class ParamBucket:
             if param.grad is None:
                 return
             self._grad_ready_ids.add(id(spec))
+            main_grad = param.get_main_grad()
             if param.grad_added_to_main_grad:
                 param.grad = None
             else:
                 with torch.no_grad():
-                    param.main_grad.add_(param.grad)
+                    main_grad.add_(param.grad)
                 param.grad = None
             if len(self._grad_ready_ids) != len(self.specs):
                 return
@@ -1066,7 +1115,6 @@ class AllGatherPipeline:
         bucket_id = bucket.bucket_id
         self.wait_bucket_ready(bucket_id, bwd=True)
         bucket.install_full_parameters()
-        bucket.prepare_main_grads()
         self._backward_cursor = min(self._backward_cursor, bucket_id - 1)
         if self.overlap and self._backward_cursor >= 0:
             self.async_bucket_gather(self._backward_cursor, bwd=True)
@@ -1093,11 +1141,14 @@ class GradReducePipeline:
         self.buckets = buckets
         device = buckets[0].device if buckets else torch.device("cpu")
         self.comm_stream = CommunicationStream(device)
-        self._pending: list[ParamBucket] = []
+        self._pending: list[tuple[ParamBucket, int]] = []
+        self._pending_bytes = 0
+        self._pending_capacity_bytes = 0
         for bucket in buckets:
             bucket.grad_ready_callback = self.reduce_gradients
 
     def reduce_gradients(self, bucket: ParamBucket, *, force: bool = False) -> None:
+        self._drain_for(bucket)
         tensors = bucket.prepare_grad_reduce(force=force)
         if tensors is None:
             return
@@ -1116,15 +1167,36 @@ class GradReducePipeline:
             )
 
         work = self.comm_stream.launch(collective, (output, grad_input))
-        bucket.mark_grad_reduce_launched(work)
-        self._pending.append(bucket)
+        completion_event = None
+        if self.comm_stream.stream is not None:
+            completion_event = torch.cuda.Event()
+            completion_event.record(self.comm_stream.stream)
+        bucket.mark_grad_reduce_launched(work, completion_event)
+        byte_count = grad_input.numel() * grad_input.element_size()
+        self._pending.append((bucket, byte_count))
+        self._pending_bytes += byte_count
+
+    def _drain_for(self, bucket: ParamBucket) -> None:
+        byte_count = bucket.full_numel * torch.empty(
+            (), dtype=bucket.policy.grad_comm_dtype
+        ).element_size()
+        self._pending_capacity_bytes = max(self._pending_capacity_bytes, 2 * byte_count)
+        while (
+            self._pending
+            and self._pending_bytes + byte_count > self._pending_capacity_bytes
+        ):
+            completed, completed_bytes = self._pending.pop(0)
+            completed.wait_grad_reduce()
+            self._pending_bytes -= completed_bytes
 
     def reclaim_before_backward(self) -> None:
         # Bound full, unsharded FP32 gradient staging to the allocator's two
         # reusable slots.  Without this drain, delayed microbatch sync retains
         # one 4-byte-per-parameter buffer for every completed bucket.
         while len(self._pending) >= 2:
-            self._pending.pop(0).wait_grad_reduce()
+            completed, completed_bytes = self._pending.pop(0)
+            completed.wait_grad_reduce()
+            self._pending_bytes -= completed_bytes
 
     def has_microbatch_work(self) -> bool:
         return bool(self._pending) or any(
@@ -1138,7 +1210,9 @@ class GradReducePipeline:
                 self.reduce_gradients(bucket, force=True)
         self.comm_stream.wait_for_current()
         while self._pending:
-            self._pending.pop(0).wait_grad_reduce()
+            bucket, byte_count = self._pending.pop(0)
+            bucket.wait_grad_reduce()
+            self._pending_bytes -= byte_count
 
     def start_microbatch(self) -> None:
         for bucket in self.buckets:
@@ -1146,6 +1220,7 @@ class GradReducePipeline:
 
     def reset(self) -> None:
         self._pending.clear()
+        self._pending_bytes = 0
         for bucket in self.buckets:
             bucket.reset_grad_state()
 

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
@@ -764,6 +764,33 @@ class ParamBucket:
         self._grad_ready_ids.clear()
         self._microbatch_reduced = True
 
+    def wait_for_inflight_grad_reduce(self) -> None:
+        """Drain already-launched reduce work without starting new work.
+
+        Exception teardown must not call :meth:`wait_grad_reduce`: that method
+        intentionally launches a missing reduction for the normal completion
+        path.  Here we only wait on work that exists, before its staging leases
+        and their shared allocator can be reclaimed.
+        """
+        error: BaseException | None = None
+        if self._grad_reduce_event is not None:
+            try:
+                self._grad_reduce_event.synchronize()
+            except BaseException as caught:
+                error = caught
+            finally:
+                self._grad_reduce_event = None
+        if self._grad_reduce_work is not None:
+            try:
+                self._grad_reduce_work.wait()
+            except BaseException as caught:
+                if error is None:
+                    error = caught
+            finally:
+                self._grad_reduce_work = None
+        if error is not None:
+            raise error
+
     def copy_full_parameters_to_shards(self) -> None:
         self.wait_param_gather()
         local_begin = self.rank * self.local_numel
@@ -1382,17 +1409,42 @@ class CommunicationPipelines:
         self.grad_reduce.finish()
 
     def abort(self) -> None:
-        """Exception teardown: drop allocator state without masking the error."""
+        """Best-effort two-phase exception teardown for shared communication storage."""
         self.grad_reduce.abort()
+
+        # Phase one drains work and drops every bucket lease.  Continue after a
+        # cleanup failure: a primary forward exception takes precedence, and
+        # force-clearing a shared allocator early would invalidate another
+        # bucket's live lease.
         for bucket in self.buckets:
-            bucket._grad_reduce_work = None
-            bucket._grad_reduce_event = None
+            try:
+                bucket.wait_for_inflight_grad_reduce()
+            except BaseException:
+                pass
             bucket._grad_reduce_launched = False
-            bucket._release_local_grad_comm_buffer()
-            bucket._release_full_main_grads()
-            bucket.release_full_parameters()
-            bucket.discard_full_parameter_views()
-            bucket.allocator.release_cached(force=True)
+            for release in (
+                bucket._release_local_grad_comm_buffer,
+                bucket._release_full_main_grads,
+                bucket.release_full_parameters,
+                bucket.discard_full_parameter_views,
+            ):
+                try:
+                    release()
+                except BaseException:
+                    pass
+
+        # Phase two force-clears each shared allocator once, after every lease
+        # that can refer to it has been released.
+        seen_allocators: set[int] = set()
+        for bucket in self.buckets:
+            allocator = bucket.allocator
+            if id(allocator) in seen_allocators:
+                continue
+            seen_allocators.add(id(allocator))
+            try:
+                allocator.release_cached(force=True)
+            except BaseException:
+                pass
 
     def reset_grad_state(self) -> None:
         self.grad_reduce.reset()

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/config.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/config.py
@@ -42,7 +42,7 @@ class MFSDPConfig:
     grad_comm_dtype: torch.dtype = torch.float32
     full_optimizer_offload: bool = False
     nccl_ub: bool = False
-    fsdp_double_buffer: bool = True
+    fsdp_double_buffer: bool = False
     disable_symmetric_registration: bool = False
     all_gather_in_start_param_sync: bool = True
 
@@ -224,7 +224,10 @@ def build_mfsdp_config(opt: Any) -> MFSDPConfig:
         main_grads_dtype=main_grads_dtype,
         grad_comm_dtype=grad_comm_dtype,
         nccl_ub=nccl_ub,
-        fsdp_double_buffer=bool(option("fsdp_double_buffer", True)) or nccl_ub,
+        # MCore keeps the additional communication residency opt-in.  NCCL user
+        # buffers are the exception: registered allocations require alternating
+        # slots and therefore force the bounded double-buffer path.
+        fsdp_double_buffer=bool(option("fsdp_double_buffer", False)) or nccl_ub,
         disable_symmetric_registration=bool(
             option("disable_symmetric_registration", False)
         ),

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/cpu_offload.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/cpu_offload.py
@@ -61,6 +61,8 @@ class CpuAdamGroup:
             lr=lr,
             betas=betas,
             eps=eps,
+            # Keep scalar CPU AdamW: the foreach path regresses the isolated
+            # optimizer step for the representative M-FSDP MoE workload.
             foreach=False,
         )
 

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/cpu_offload.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/cpu_offload.py
@@ -16,10 +16,10 @@ class CpuAdamGroup:
     live on CPU. ``shard_param.data`` is the GPU compute/all-gather mirror and
     is refreshed after each CPU update.
 
-    Per-step flow (synchronous):
-      1. D2H — copy GPU gradient → pinned CPU grad buffer  (blocking)
+    Per-step flow:
+      1. D2H — enqueue GPU gradient → pinned CPU grad buffer, then fence once
       2. CPU AdamW step updates cpu_param
-      3. H2D — copy updated cpu_param → GPU shard_param.data  (blocking)
+      3. H2D — enqueue updated cpu_param → GPU shard_param.data
     """
 
     def __init__(
@@ -89,13 +89,17 @@ class CpuAdamGroup:
                     buf = buf.pin_memory()
                 self._cpu_grad_bufs[i] = buf
 
-            buf.copy_(flat_gpu_grad)
+            buf.copy_(flat_gpu_grad, non_blocking=True)
             cpu_param.grad = buf
 
+        if self._use_pinned:
+            # CPU AdamW must not read pinned gradients until every queued D2H
+            # copy has completed. One fence avoids synchronizing per tensor.
+            torch.cuda.current_stream().synchronize()
         self._cpu_optimizer.step()
 
         for gpu_param, cpu_param in zip(self._gpu_params, self._cpu_params):
-            gpu_param.data.view(-1).copy_(cpu_param.data)
+            gpu_param.data.view(-1).copy_(cpu_param.data, non_blocking=True)
             cpu_param.grad = None
 
     def state_dict(self) -> dict[str, Any]:

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/cpu_offload.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/cpu_offload.py
@@ -9,6 +9,60 @@ import torch
 import torch.nn as nn
 
 
+class _CpuOptimizerCollection:
+    """Compatibility facade for one CPU optimizer per offloaded parameter."""
+
+    def __init__(self, optimizers: list[torch.optim.Optimizer]) -> None:
+        self.optimizers = optimizers
+
+    @property
+    def param_groups(self) -> list[dict[str, Any]]:
+        return [
+            group for optimizer in self.optimizers for group in optimizer.param_groups
+        ]
+
+    @property
+    def state(self) -> dict[torch.Tensor, dict[str, Any]]:
+        return {
+            param: value
+            for optimizer in self.optimizers
+            for param, value in optimizer.state.items()
+        }
+
+    def state_dict(self) -> dict[str, Any]:
+        return {"optimizers": [optimizer.state_dict() for optimizer in self.optimizers]}
+
+    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        optimizer_states = state_dict.get("optimizers")
+        if optimizer_states is not None:
+            if len(optimizer_states) != len(self.optimizers):
+                raise ValueError(
+                    "M-FSDP CPU optimizer checkpoint parameter count does not "
+                    f"match: expected {len(self.optimizers)}, got {len(optimizer_states)}."
+                )
+            for optimizer, optimizer_state in zip(self.optimizers, optimizer_states):
+                optimizer.load_state_dict(optimizer_state)
+            return
+
+        # Backward compatibility with checkpoints from the former aggregate
+        # AdamW. Torch state ids are ordered by the flattened param_groups.
+        group_by_param_id = {
+            param_id: group
+            for group in state_dict["param_groups"]
+            for param_id in group["params"]
+        }
+        for param_id, optimizer in enumerate(self.optimizers):
+            group = dict(group_by_param_id[param_id])
+            group["params"] = [0]
+            local_state = state_dict["state"].get(param_id)
+            optimizer.load_state_dict(
+                {
+                    "state": {} if local_state is None else {0: local_state},
+                    "param_groups": [group],
+                }
+            )
+
+
 class CpuAdamGroup:
     """Adam momentum state on CPU for a subset of M-FSDP shard parameters.
 
@@ -16,10 +70,8 @@ class CpuAdamGroup:
     live on CPU. ``shard_param.data`` is the GPU compute/all-gather mirror and
     is refreshed after each CPU update.
 
-    Per-step flow:
-      1. D2H — enqueue GPU gradient → pinned CPU grad buffer, then fence once
-      2. CPU AdamW step updates cpu_param
-      3. H2D — enqueue updated cpu_param → GPU shard_param.data
+    Per-step flow overlaps later D2H copies and earlier H2D copies with each
+    per-parameter CPU AdamW update using dedicated streams and D2H events.
     """
 
     def __init__(
@@ -56,30 +108,44 @@ class CpuAdamGroup:
             cpu_group["params"] = cpu_group_params
             cpu_groups.append(cpu_group)
 
-        self._cpu_optimizer = torch.optim.AdamW(
-            cpu_groups,
-            lr=lr,
-            betas=betas,
-            eps=eps,
-            # Keep scalar CPU AdamW: the foreach path regresses the isolated
-            # optimizer step for the representative M-FSDP MoE workload.
-            foreach=False,
-        )
+        cpu_optimizers: list[torch.optim.Optimizer] = []
+        for group in cpu_groups:
+            group_defaults = {k: v for k, v in group.items() if k != "params"}
+            for cpu_param in group["params"]:
+                cpu_optimizers.append(
+                    torch.optim.AdamW(
+                        [{**group_defaults, "params": [cpu_param]}],
+                        lr=lr,
+                        betas=betas,
+                        eps=eps,
+                        # A one-parameter optimizer has no foreach opportunity.
+                        foreach=False,
+                    )
+                )
+        self._cpu_optimizer = _CpuOptimizerCollection(cpu_optimizers)
+        if use_pinned:
+            self._d2h_stream = torch.cuda.Stream()
+            self._h2d_stream = torch.cuda.Stream()
 
     @property
     def param_groups(self) -> list[dict[str, Any]]:
         return self._cpu_optimizer.param_groups
 
     def step(self) -> None:
+        d2h_events: list[torch.cuda.Event | None] = []
+        current_stream = torch.cuda.current_stream() if self._use_pinned else None
+        if self._use_pinned:
+            self._d2h_stream.wait_stream(current_stream)
+            self._h2d_stream.wait_stream(current_stream)
+
         for i, (gpu_param, cpu_param) in enumerate(
             zip(self._gpu_params, self._cpu_params)
         ):
             if gpu_param.grad is None:
                 cpu_param.grad = None
+                d2h_events.append(None)
                 continue
-
             flat_gpu_grad = gpu_param.grad.detach().view(-1)
-
             buf = self._cpu_grad_bufs[i]
             if buf is None or buf.shape != flat_gpu_grad.shape:
                 buf = torch.zeros(
@@ -88,19 +154,33 @@ class CpuAdamGroup:
                 if self._use_pinned:
                     buf = buf.pin_memory()
                 self._cpu_grad_bufs[i] = buf
-
-            buf.copy_(flat_gpu_grad, non_blocking=True)
+            if self._use_pinned:
+                with torch.cuda.stream(self._d2h_stream):
+                    buf.copy_(flat_gpu_grad, non_blocking=True)
+                    d2h_events.append(self._d2h_stream.record_event())
+            else:
+                buf.copy_(flat_gpu_grad, non_blocking=True)
+                d2h_events.append(None)
             cpu_param.grad = buf
 
-        if self._use_pinned:
-            # CPU AdamW must not read pinned gradients until every queued D2H
-            # copy has completed. One fence avoids synchronizing per tensor.
-            torch.cuda.current_stream().synchronize()
-        self._cpu_optimizer.step()
-
-        for gpu_param, cpu_param in zip(self._gpu_params, self._cpu_params):
-            gpu_param.data.view(-1).copy_(cpu_param.data, non_blocking=True)
+        for gpu_param, cpu_param, cpu_optimizer, d2h_event in zip(
+            self._gpu_params,
+            self._cpu_params,
+            self._cpu_optimizer.optimizers,
+            d2h_events,
+        ):
+            if d2h_event is not None:
+                d2h_event.synchronize()
+            cpu_optimizer.step()
+            if self._use_pinned:
+                with torch.cuda.stream(self._h2d_stream):
+                    gpu_param.data.view(-1).copy_(cpu_param.data, non_blocking=True)
+            else:
+                gpu_param.data.view(-1).copy_(cpu_param.data, non_blocking=True)
             cpu_param.grad = None
+
+        if self._use_pinned:
+            self._h2d_stream.record_event().wait(current_stream)
 
     def state_dict(self) -> dict[str, Any]:
         return {

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/cpu_offload.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/cpu_offload.py
@@ -141,11 +141,12 @@ class CpuAdamGroup:
         for i, (gpu_param, cpu_param) in enumerate(
             zip(self._gpu_params, self._cpu_params)
         ):
-            if gpu_param.grad is None:
+            grad = getattr(gpu_param, "main_grad", gpu_param.grad)
+            if grad is None:
                 cpu_param.grad = None
                 d2h_events.append(None)
                 continue
-            flat_gpu_grad = gpu_param.grad.detach().view(-1)
+            flat_gpu_grad = grad.detach().view(-1)
             buf = self._cpu_grad_bufs[i]
             if buf is None or buf.shape != flat_gpu_grad.shape:
                 buf = torch.zeros(

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/grad_norm.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/grad_norm.py
@@ -19,7 +19,7 @@ def local_grad_sq_sum(
     resolved_dtype = resolve_torch_dtype(dtype)
     total: torch.Tensor | None = None
     for param in params:
-        grad = param.grad
+        grad = getattr(param, "main_grad", param.grad)
         if grad is None:
             continue
         local_grad = to_local_tensor(grad)

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/optimizer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/optimizer.py
@@ -220,9 +220,7 @@ class _StandaloneOptimizer:
                 for group, group_values in zip(
                     self.optimizer.param_groups, param_values, strict=True
                 ):
-                    for param, value in zip(
-                        group["params"], group_values, strict=True
-                    ):
+                    for param, value in zip(group["params"], group_values, strict=True):
                         param.copy_(value.to(device=param.device, dtype=param.dtype))
 
     def offload_state_to_cpu(self) -> None:

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/optimizer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/optimizer.py
@@ -554,6 +554,9 @@ def _split_param_groups_by_fraction(
     offload_fraction: float,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """Split param groups so the first *offload_fraction* of numel goes to CPU."""
+    if offload_fraction == 1.0:
+        return [], [dict(group) for group in param_groups]
+
     total_numel = sum(p.numel() for g in param_groups for p in g["params"])
     cpu_numel_target = int(total_numel * offload_fraction)
 

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/optimizer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/optimizer.py
@@ -183,8 +183,9 @@ class _StandaloneOptimizer:
             coefficient = min(1.0, self.clip_grad / (float(total_norm.item()) + 1.0e-6))
             if coefficient < 1.0:
                 for param in self.params:
-                    if param.grad is not None:
-                        param.grad.mul_(coefficient)
+                    grad = getattr(param, "main_grad", param.grad)
+                    if grad is not None:
+                        grad.mul_(coefficient)
         return float(total_norm.float().item())
 
     def state_dict(self) -> dict[str, Any]:
@@ -247,8 +248,9 @@ class _StandaloneOptimizer:
             return
         if self.expert_grad_scale != 1.0:
             for param in self.expert_params:
-                if param.grad is not None:
-                    param.grad.mul_(self.expert_grad_scale)
+                grad = getattr(param, "main_grad", param.grad)
+                if grad is not None:
+                    grad.mul_(self.expert_grad_scale)
         self._expert_grads_scaled = True
 
     def _sync_tp_replicated_grads_once(self) -> None:
@@ -256,9 +258,10 @@ class _StandaloneOptimizer:
             return
         group = getattr(self.ps, "tp_group", None)
         for param in self.tp_replicated_params:
-            if param.grad is not None:
+            grad = getattr(param, "main_grad", param.grad)
+            if grad is not None:
                 _all_reduce_grad_if_distributed(
-                    param.grad,
+                    grad,
                     group,
                     average=bool(
                         getattr(param, "average_gradients_across_tp_domain", False)

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/wrapper.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/wrapper.py
@@ -7,19 +7,13 @@ from collections.abc import Callable, Iterable, Iterator
 
 import torch
 import torch.nn as nn
+from megatron.lite.primitive.optimizers.mfsdp.buffer import (
+    AllGatherPipeline, CommunicationPipelines, GradReducePipeline,
+    ParamAndGradBuffer)
+from megatron.lite.primitive.optimizers.mfsdp.config import (
+    MFSDPConfig, MFSDPProcessGroups)
 from torch.autograd.graph import saved_tensors_hooks
 from torch.utils._pytree import tree_map_only
-
-from megatron.lite.primitive.optimizers.mfsdp.buffer import (
-    AllGatherPipeline,
-    CommunicationPipelines,
-    GradReducePipeline,
-    ParamAndGradBuffer,
-)
-from megatron.lite.primitive.optimizers.mfsdp.config import (
-    MFSDPConfig,
-    MFSDPProcessGroups,
-)
 
 
 class _BeginBackward(torch.autograd.Function):

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/wrapper.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/wrapper.py
@@ -154,6 +154,12 @@ class MegatronFSDP(nn.Module):
                     attach_backward,
                     output,
                 )
+        except BaseException:
+            # A failed module forward can leave a registered double-buffer slot
+            # busy.  Teardown must preserve the original exception rather than
+            # replacing it with the allocator's active-slot guard.
+            self.param_sync.abort()
+            raise
         finally:
             self.param_sync.end_forward()
         return output

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/wrapper.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/wrapper.py
@@ -237,21 +237,25 @@ class MegatronFSDP(nn.Module):
         shards for a per-layer EP collective) keeps a private allocation and
         never aliases storage that the release has handed back to the allocator.
         """
-        # Names are resolved against the currently-installed (sharded) params,
-        # which is the module state on entry and after each bucket release.
-        name_by_shard_id = {
-            id(param): name for name, param in self.module.named_parameters()
-        }
         covered: set[str] = set()
         for bucket in self.param_sync.stream_materialize_buckets():
             for spec in bucket.specs:
-                name = name_by_shard_id.get(id(spec.shard_param))
-                if name is None:
-                    continue
-                covered.add(name)
+                # ``ParamSpec.name`` is captured before the sharded view is
+                # installed and remains the canonical module path.  Do not
+                # recover a name through a shard object's identity: tied
+                # bindings and wrapper view changes can make that lookup miss,
+                # which would silently export a DP shard as though it were a
+                # full parameter.
+                covered.add(spec.name)
                 full_param = spec.full_param
-                full_param.data = full_param.data.clone()
-                yield name, full_param
+                # The bucket cleanup below restores the module's sharded view
+                # and clears ``full_param.data``.  Return a separate Parameter
+                # so an exporter that keeps a yielded tensor while advancing
+                # to another bucket retains the full snapshot it was promised.
+                yield spec.name, nn.Parameter(
+                    full_param.detach().clone(),
+                    requires_grad=full_param.requires_grad,
+                )
         # Parameters (and any params not owned by an M-FSDP bucket) that the
         # bucket walk did not cover -- emit them from the restored sharded view.
         for name, param in self.module.named_parameters():

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/wrapper.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/wrapper.py
@@ -137,6 +137,7 @@ class MegatronFSDP(nn.Module):
 
     def forward(self, *args, **kwargs):
         self.param_sync.begin_forward()
+        primary_failure = False
 
         def attach_backward(tensor: torch.Tensor) -> torch.Tensor:
             if not tensor.requires_grad:
@@ -155,13 +156,21 @@ class MegatronFSDP(nn.Module):
                     output,
                 )
         except BaseException:
+            primary_failure = True
             # A failed module forward can leave a registered double-buffer slot
-            # busy.  Teardown must preserve the original exception rather than
-            # replacing it with the allocator's active-slot guard.
-            self.param_sync.abort()
+            # busy.  Both cleanup phases are best-effort: neither may replace
+            # the original module failure.
+            try:
+                self.param_sync.abort()
+            except BaseException:
+                pass
             raise
         finally:
-            self.param_sync.end_forward()
+            try:
+                self.param_sync.end_forward()
+            except BaseException:
+                if not primary_failure:
+                    raise
         return output
 
     def start_param_sync(self, *_args, force_sync: bool = False, **_kwargs) -> None:

--- a/experimental/lite/tests/run_mfsdp_hopper_validation.sh
+++ b/experimental/lite/tests/run_mfsdp_hopper_validation.sh
@@ -9,6 +9,19 @@ if [[ -z "${SLURM_JOB_ID:-}" ]]; then
   exit 2
 fi
 
+PYTHON_PATH="$(which python)"
+echo "which python: ${PYTHON_PATH}"
+if [[ "${PYTHON_PATH}" != "/usr/bin/python3" ]]; then
+  echo "M-FSDP Hopper validation requires /usr/bin/python3 from verl.vllm023.sqsh." >&2
+  exit 2
+fi
+TRANSFORMER_ENGINE_FILE="$(python -c 'import transformer_engine; print(transformer_engine.__file__)')"
+echo "transformer_engine.__file__: ${TRANSFORMER_ENGINE_FILE}"
+if [[ "${TRANSFORMER_ENGINE_FILE}" != /usr/local/lib/python3.12/dist-packages/transformer_engine/* ]]; then
+  echo "M-FSDP Hopper validation requires transformer_engine from verl.vllm023.sqsh." >&2
+  exit 2
+fi
+
 MODE="${1:-}"
 NPROC_PER_NODE="${NPROC_PER_NODE:-8}"
 NNODES="${NNODES:-${SLURM_NNODES:-1}}"

--- a/experimental/lite/tests/run_mfsdp_hopper_validation.sh
+++ b/experimental/lite/tests/run_mfsdp_hopper_validation.sh
@@ -30,6 +30,13 @@ export MLITE_RUN_SMOKE=1
 export PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
 
 case "${MODE}" in
+  grouped-linear)
+    if [[ "${NNODES}" != "1" || "${NPROC_PER_NODE}" != "8" ]]; then
+      echo "grouped-linear mode requires NNODES=1 and NPROC_PER_NODE=8." >&2
+      exit 2
+    fi
+    TEST_EXPR="native_fp32_grouped_expert_wgrad_reaches_optimizer"
+    ;;
   throughput)
     if [[ "${NNODES}" != "1" || "${NPROC_PER_NODE}" != "8" ]]; then
       echo "throughput mode requires NNODES=1 and NPROC_PER_NODE=8." >&2

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -15,20 +15,19 @@ import pytest
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-from torch.utils._python_dispatch import TorchDispatchMode
-
 from megatron.lite.primitive.modules.experts import Experts
 from megatron.lite.primitive.optimizers.fsdp2 import (
-    build_fsdp2_training_optimizer,
-    fsdp2_available,
-)
-from megatron.lite.primitive.optimizers.mfsdp import build_mfsdp_training_optimizer
+    build_fsdp2_training_optimizer, fsdp2_available)
+from megatron.lite.primitive.optimizers.mfsdp import \
+    build_mfsdp_training_optimizer
 from megatron.lite.primitive.parallel import init_parallel
 from megatron.lite.primitive.recompute import apply_offload
 from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
-from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
+from megatron.lite.runtime.contracts.config import (OptimizerConfig,
+                                                    ParallelConfig)
 from megatron.lite.runtime.contracts.data import PackedBatch
 from megatron.lite.runtime.contracts.handle import ModelHandle
+from torch.utils._python_dispatch import TorchDispatchMode
 
 pytestmark = [
     pytest.mark.mlite,

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -284,9 +284,11 @@ def _cuda_dist():
     if not dist.is_initialized():
         dist.init_process_group(backend="nccl", init_method="env://")
         created_pg = True
-    yield
-    if created_pg and dist.is_initialized():
-        dist.destroy_process_group()
+    try:
+        yield
+    finally:
+        if created_pg and dist.is_initialized():
+            dist.destroy_process_group()
 
 
 def _install_transformer_engine_import_stub_if_needed() -> None:
@@ -1020,36 +1022,155 @@ def test_mfsdp_native_fp32_grouped_expert_wgrad_reaches_optimizer():
     chunk(value).float().square().mean().backward()
 
     main_grad_fractions = {}
-    for expert_key, specs in expert_specs.items():
-        main_grads = []
-        for spec in specs:
-            assert spec.shard_param is not None
-            assert spec.full_param.grad_added_to_main_grad is True
-            assert spec.full_param.main_grad.dtype is torch.float32
-            assert spec.full_param.grad is None
-            main_grads.append(spec.full_param.main_grad)
-        main_grad_fractions[expert_key] = _bf16_roundtrip_difference_fraction(
-            main_grads
+    local_error = None
+    local_specs = []
+    try:
+        for expert_key, specs in expert_specs.items():
+            main_grads = []
+            for spec in specs:
+                full_param = spec.full_param
+                main_grad = getattr(full_param, "main_grad", None)
+                local_specs.append(
+                    {
+                        "name": spec.name,
+                        "has_fsdp_param": hasattr(full_param, "__fsdp_param__"),
+                        "overwrite_main_grad": getattr(
+                            full_param, "overwrite_main_grad", None
+                        ),
+                        "grad_added": getattr(
+                            full_param, "grad_added_to_main_grad", None
+                        ),
+                        "main_grad": None
+                        if main_grad is None
+                        else {
+                            "shape": tuple(main_grad.shape),
+                            "numel": main_grad.numel(),
+                            "dtype": str(main_grad.dtype),
+                            "contiguous": main_grad.is_contiguous(),
+                        },
+                        "full_param_grad": None
+                        if full_param.grad is None
+                        else str(full_param.grad.dtype),
+                    }
+                )
+                if spec.shard_param is None:
+                    raise AssertionError(f"{spec.name}: missing shard_param")
+                if getattr(full_param, "grad_added_to_main_grad", None) is not True:
+                    raise AssertionError(
+                        f"{spec.name}: grad_added_to_main_grad is not True"
+                    )
+                if main_grad is None or main_grad.dtype is not torch.float32:
+                    raise AssertionError(f"{spec.name}: main_grad is not fp32")
+                if full_param.grad is not None:
+                    raise AssertionError(f"{spec.name}: full_param.grad is populated")
+                main_grads.append(main_grad)
+            main_grad_fractions[expert_key] = _bf16_roundtrip_difference_fraction(
+                main_grads
+            )
+    except Exception as exc:
+        local_error = f"{type(exc).__name__}: {exc}"
+    gathered_errors = [None] * dist.get_world_size()
+    dist.all_gather_object(gathered_errors, local_error)
+    dist.barrier()
+    if any(gathered_errors):
+        pytest.fail(
+            "GroupedLinear rank-local diagnostics: " + json.dumps(gathered_errors)
         )
 
     finalize()
-    optimizer_grad_fractions = {
-        expert_key: _bf16_roundtrip_difference_fraction(
-            [spec.shard_param.grad for spec in specs]
-        )
-        for expert_key, specs in expert_specs.items()
+    optimizer_grad_fractions, optimizer_records, optimizer_error = {}, [], None
+    try:
+        for expert_key, specs in expert_specs.items():
+            owned = []
+            for spec in specs:
+                grad = spec.shard_param.grad
+                record = {
+                    "expert": expert_key,
+                    "name": spec.name,
+                    "shard_numel": spec.shard_param.numel(),
+                    "grad": None
+                    if grad is None
+                    else {"shape": tuple(grad.shape), "dtype": str(grad.dtype)},
+                    "optimizer_owned": any(
+                        spec.shard_param is p
+                        for g in optimizer.param_groups
+                        for p in g["params"]
+                    ),
+                }
+                optimizer_records.append(record)
+                if grad is not None and grad.numel() > 0:
+                    assert record["optimizer_owned"]
+                    assert grad.dtype is torch.float32
+                    owned.append(grad)
+            if owned:
+                optimizer_grad_fractions[expert_key] = (
+                    _bf16_roundtrip_difference_fraction(owned)
+                )
+    except Exception as exc:
+        optimizer_error = f"{type(exc).__name__}: {exc}"
+    gathered = [None] * dist.get_world_size()
+    dist.all_gather_object(gathered, optimizer_error)
+    all_records = [None] * dist.get_world_size()
+    dist.all_gather_object(all_records, optimizer_records)
+    if any(gathered):
+        pytest.fail("Grouped optimizer-grad diagnostics: " + json.dumps(gathered))
+    expected = {spec.name for specs in expert_specs.values() for spec in specs}
+    covered = {
+        record["name"]
+        for records in all_records
+        for record in records
+        if record["optimizer_owned"]
+        and record["grad"] is not None
+        and record["shard_numel"] > 0
     }
+    if covered != expected:
+        pytest.fail(
+            f"Grouped optimizer-grad global coverage missing: {expected - covered}"
+        )
     success, _grad_norm, _num_zeros = optimizer.step()
     recording_optimizer = optimizer._inner_optimizer.optimizer
-    consumed_grad_fractions = {
-        expert_key: _bf16_roundtrip_difference_fraction(
-            [
-                recording_optimizer.consumed_grad_by_param[id(spec.shard_param)]
-                for spec in specs
-            ]
-        )
-        for expert_key, specs in expert_specs.items()
+    consumed_grad_fractions, consumed_records, consumed_error = {}, [], None
+    try:
+        for expert_key, specs in expert_specs.items():
+            owned = []
+            for spec in specs:
+                grad = recording_optimizer.consumed_grad_by_param.get(
+                    id(spec.shard_param)
+                )
+                consumed_records.append(
+                    {
+                        "name": spec.name,
+                        "shard_numel": spec.shard_param.numel(),
+                        "entry": grad is not None,
+                        "dtype": None if grad is None else str(grad.dtype),
+                    }
+                )
+                if grad is not None:
+                    owned.append(grad)
+            owned = [grad for grad in owned if grad.numel() > 0]
+            if owned:
+                assert all(grad.dtype is torch.float32 for grad in owned)
+                consumed_grad_fractions[expert_key] = (
+                    _bf16_roundtrip_difference_fraction(owned)
+                )
+    except Exception as exc:
+        consumed_error = f"{type(exc).__name__}: {exc}"
+    gathered = [None] * dist.get_world_size()
+    dist.all_gather_object(gathered, consumed_error)
+    if any(gathered):
+        pytest.fail("Grouped consumed-grad diagnostics: " + json.dumps(gathered))
+    all_consumed = [None] * dist.get_world_size()
+    dist.all_gather_object(all_consumed, consumed_records)
+    consumed_covered = {
+        record["name"]
+        for records in all_consumed
+        for record in records
+        if record["entry"] and record["shard_numel"] > 0
     }
+    if consumed_covered != expected:
+        pytest.fail(
+            f"Grouped consumed-grad global coverage missing: {expected - consumed_covered}"
+        )
 
     assert success
     assert all(fraction > 0.0 for fraction in main_grad_fractions.values())

--- a/experimental/lite/tests/unit/examples/test_bench_example.py
+++ b/experimental/lite/tests/unit/examples/test_bench_example.py
@@ -173,6 +173,12 @@ def test_pretrain_session_runs_with_fake_runtime_on_cpu():
     assert len(result.step_traces) == 2
     assert [trace.loss for trace in result.step_traces] == [2.0, 3.0]
     assert result.step_traces[0].grad_norm == 3.5
+    assert all(trace.optimizer_step_ms >= 0.0 for trace in result.step_traces)
+    assert result.avg_optimizer_step_ms >= 0.0
+
+    artifact = result.to_dict()
+    assert "avg_optimizer_step_ms" in artifact["summary"]
+    assert "optimizer_step_ms" in artifact["result"]["step_traces"][0]
 
 
 def test_bench_main_writes_dry_run_output_json(tmp_path):
@@ -223,6 +229,25 @@ def test_bench_main_writes_output_json_only_on_rank_zero(tmp_path, monkeypatch):
 
     assert artifact["dry_run"] is True
     assert not output_path.exists()
+
+
+def test_mfsdp_offload_bench_script_is_single_arm_and_slurm_guarded():
+    script = (
+        Path(__file__).resolve().parents[3]
+        / "examples/bench/scripts/run_qwen35_mfsdp_offload.sh"
+    ).read_text(encoding="utf-8")
+
+    assert script.count("torchrun ") == 1
+    assert "SLURM_JOB_ID" in script
+    assert "WANDB_PROJECT" in script
+    assert "avg_optimizer_step_ms" in script
+    assert "'{\"optimizer\":\"mfsdp\"}'" in script
+    assert (
+        "'{\"offload_fraction\":1.0,\"use_precision_aware_optimizer\":false}'"
+        in script
+    )
+    assert '"dist_opt"' not in script
+    assert '"fsdp2"' not in script
 
 
 def test_result_artifact_summary_and_trace_compare(tmp_path):

--- a/experimental/lite/tests/unit/examples/test_bench_example.py
+++ b/experimental/lite/tests/unit/examples/test_bench_example.py
@@ -9,7 +9,6 @@ from contextlib import nullcontext
 from pathlib import Path
 
 import torch
-
 from megatron.lite.runtime.contracts.config import ParallelConfig
 from megatron.lite.runtime.contracts.data import ForwardResult, ModelOutputs
 from megatron.lite.runtime.contracts.handle import ModelHandle
@@ -78,7 +77,9 @@ def test_bench_builds_bridge_dry_run_plan_without_bridge_import():
     assert plan["runtime"]["backend"] == "bridge"
     backend_cfg = plan["runtime"]["backend_cfg"]
     assert backend_cfg["model_name"] == "qwen3_5"
-    assert backend_cfg["override_transformer_config"] == {"attention_backend": "unfused"}
+    assert backend_cfg["override_transformer_config"] == {
+        "attention_backend": "unfused"
+    }
     assert backend_cfg["bridge_post_init"].startswith("<callable:")
 
 
@@ -100,7 +101,9 @@ def test_bench_builds_mbridge_dry_run_plan_without_mbridge_import():
     assert plan["runtime"]["backend"] == "mbridge"
     backend_cfg = plan["runtime"]["backend_cfg"]
     assert backend_cfg["model_name"] == "qwen3_5"
-    assert backend_cfg["override_transformer_config"] == {"attention_backend": "unfused"}
+    assert backend_cfg["override_transformer_config"] == {
+        "attention_backend": "unfused"
+    }
     assert backend_cfg["bridge_post_init"].startswith("<callable:")
 
 
@@ -138,7 +141,9 @@ class _FakeRuntime:
 
     def forward_backward(self, handle, data, loss_fn, *, num_microbatches: int = 1):
         self.loss += 1
-        return ForwardResult(model_output=ModelOutputs(loss=torch.tensor(float(self.loss))))
+        return ForwardResult(
+            model_output=ModelOutputs(loss=torch.tensor(float(self.loss)))
+        )
 
     def optimizer_step(self, handle):
         return True, 3.5, 0
@@ -155,7 +160,9 @@ def test_pretrain_session_runs_with_fake_runtime_on_cpu():
         optimizer=object(),
         parallel_state=None,
         config=type(
-            "Cfg", (), {"model_name": "fake", "impl": "lite", "parallel": ParallelConfig()}
+            "Cfg",
+            (),
+            {"model_name": "fake", "impl": "lite", "parallel": ParallelConfig()},
         )(),
         _extras={"optimizer_backend": "fake"},
     )
@@ -243,15 +250,18 @@ def test_mfsdp_offload_bench_script_is_single_arm_and_slurm_guarded():
     assert "avg_optimizer_step_ms" in script
     assert "'{\"optimizer\":\"mfsdp\"}'" in script
     assert (
-        "'{\"offload_fraction\":1.0,\"use_precision_aware_optimizer\":false}'"
-        in script
+        "'{\"offload_fraction\":1.0,\"use_precision_aware_optimizer\":false}'" in script
     )
     assert '"dist_opt"' not in script
     assert '"fsdp2"' not in script
 
 
 def test_result_artifact_summary_and_trace_compare(tmp_path):
-    from examples.bench.results import compare_step_traces, load_result_artifact, result_summary
+    from examples.bench.results import (
+        compare_step_traces,
+        load_result_artifact,
+        result_summary,
+    )
 
     baseline = {
         "summary": {
@@ -287,17 +297,25 @@ def test_result_artifact_summary_and_trace_compare(tmp_path):
     loaded = load_result_artifact(baseline_path)
 
     assert result_summary(loaded)["backend"] == "mlite"
-    assert compare_step_traces(baseline, candidate, atol=1e-3, rtol=0.0)["passed"] is True
+    assert (
+        compare_step_traces(baseline, candidate, atol=1e-3, rtol=0.0)["passed"] is True
+    )
 
 
 def test_result_trace_compare_reports_metric_level_failures():
     from examples.bench.results import compare_step_traces
 
     baseline = {
-        "result": {"step_traces": [{"step": 0, "loss": 1.0, "grad_norm": 2.0, "step_ms": 10.0}]}
+        "result": {
+            "step_traces": [{"step": 0, "loss": 1.0, "grad_norm": 2.0, "step_ms": 10.0}]
+        }
     }
     candidate = {
-        "result": {"step_traces": [{"step": 0, "loss": 1.00001, "grad_norm": 3.0, "step_ms": 10.0}]}
+        "result": {
+            "step_traces": [
+                {"step": 0, "loss": 1.00001, "grad_norm": 3.0, "step_ms": 10.0}
+            ]
+        }
     }
 
     comparison = compare_step_traces(baseline, candidate, atol=1e-3, rtol=0.0)
@@ -368,11 +386,7 @@ def test_correctness_compare_supports_explicit_numeric_tolerances():
     }
 
     comparison = compare_correctness_artifacts(
-        baseline,
-        candidate,
-        loss_atol=1e-5,
-        grad_atol=1e-4,
-        tensor_atol=3e-3,
+        baseline, candidate, loss_atol=1e-5, grad_atol=1e-4, tensor_atol=3e-3
     )
 
     assert comparison["passed"] is True

--- a/experimental/lite/tests/unit/examples/test_bench_example.py
+++ b/experimental/lite/tests/unit/examples/test_bench_example.py
@@ -248,9 +248,9 @@ def test_mfsdp_offload_bench_script_is_single_arm_and_slurm_guarded():
     assert "SLURM_JOB_ID" in script
     assert "WANDB_PROJECT" in script
     assert "avg_optimizer_step_ms" in script
-    assert "'{\"optimizer\":\"mfsdp\"}'" in script
+    assert '\'{"optimizer":"mfsdp"}\'' in script
     assert (
-        "'{\"offload_fraction\":1.0,\"use_precision_aware_optimizer\":false}'" in script
+        '\'{"offload_fraction":1.0,"use_precision_aware_optimizer":false}\'' in script
     )
     assert '"dist_opt"' not in script
     assert '"fsdp2"' not in script

--- a/experimental/lite/tests/unit/examples/test_ds4_dapo_script.py
+++ b/experimental/lite/tests/unit/examples/test_ds4_dapo_script.py
@@ -23,6 +23,7 @@ SCRIPT = (
     (
         "weight_bits",
         "enable_r3",
+        "optimizer_backend",
         "expert_dtype",
         "resync_format",
         "moe_backend",
@@ -31,10 +32,21 @@ SCRIPT = (
         "rollout_replay",
     ),
     [
-        ("4", "True", "fp4", "mxfp4", "marlin", "ue8m0", "R3", "True"),
+        (
+            "4",
+            "True",
+            "mfsdp",
+            "fp4",
+            "mxfp4",
+            "marlin",
+            "ue8m0",
+            "R3",
+            "True",
+        ),
         (
             "8",
             "False",
+            "fsdp2",
             "fp8",
             "block_fp8",
             "flashinfer_cutlass",
@@ -48,6 +60,7 @@ def test_ds4_dapo_weight_and_r3_knobs(
     tmp_path: Path,
     weight_bits: str,
     enable_r3: str,
+    optimizer_backend: str,
     expert_dtype: str,
     resync_format: str,
     moe_backend: str,
@@ -66,6 +79,7 @@ def test_ds4_dapo_weight_and_r3_knobs(
         "VAL_FILES": str(tmp_path / "val.parquet"),
         "ROLLOUT_WEIGHT_BITS": weight_bits,
         "ENABLE_R3": enable_r3,
+        "MLITE_OPTIMIZER_BACKEND": optimizer_backend,
         "DRY_RUN": "1",
     }
     result = subprocess.run(
@@ -79,7 +93,9 @@ def test_ds4_dapo_weight_and_r3_knobs(
     assert f"quantization_config.scale_fmt={scale_fmt}" in command
     assert f"router_replay_mode={router_mode}" in command
     assert f"enable_rollout_routing_replay={rollout_replay}" in command
-    assert "actor_rollout_ref.actor.engine.impl_cfg.optimizer=fsdp2" in command
+    assert (
+        f"actor_rollout_ref.actor.engine.impl_cfg.optimizer={optimizer_backend}" in command
+    )
     assert "actor_rollout_ref.actor.engine.attention_backend_override=fused" in command
     assert "actor_rollout_ref.rollout.enforce_eager=True" in command
     assert "algorithm.rollout_correction.bypass_mode=False" in command

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -17,6 +17,7 @@ import torch.multiprocessing as mp
 
 from megatron.lite.primitive.optimizers.mfsdp import config as mfsdp_config
 from megatron.lite.primitive.optimizers.mfsdp import buffer as mfsdp_buffer
+from megatron.lite.primitive.optimizers.mfsdp import cpu_offload as mfsdp_cpu_offload
 from megatron.lite.primitive.optimizers.mfsdp import optimizer as mfsdp_optimizer
 from megatron.lite.runtime.contracts.config import ParallelConfig
 
@@ -806,6 +807,15 @@ def test_mfsdp_offload_fraction_keeps_optimizer_state_on_cpu():
 
     for gpu_param in inner.params:
         assert gpu_param.device.type != "cuda" or gpu_param.data is not None
+
+
+def test_mfsdp_cpu_offload_queues_transfers_before_one_d2h_fence():
+    source = inspect.getsource(mfsdp_cpu_offload.CpuAdamGroup.step)
+
+    assert source.count("non_blocking=True") == 2
+    fence = source.index("torch.cuda.current_stream().synchronize()")
+    optimizer_step = source.index("self._cpu_optimizer.step()")
+    assert fence < optimizer_step
 
 
 def test_mfsdp_full_offload_has_six_gpu_and_twelve_cpu_bytes_per_param():

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -16,8 +16,10 @@ import torch.distributed as dist
 import torch.multiprocessing as mp
 from megatron.lite.primitive.optimizers.mfsdp import buffer as mfsdp_buffer
 from megatron.lite.primitive.optimizers.mfsdp import config as mfsdp_config
-from megatron.lite.primitive.optimizers.mfsdp import cpu_offload as mfsdp_cpu_offload
-from megatron.lite.primitive.optimizers.mfsdp import optimizer as mfsdp_optimizer
+from megatron.lite.primitive.optimizers.mfsdp import \
+    cpu_offload as mfsdp_cpu_offload
+from megatron.lite.primitive.optimizers.mfsdp import \
+    optimizer as mfsdp_optimizer
 from megatron.lite.runtime.contracts.config import ParallelConfig
 
 

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -87,9 +87,7 @@ class _FusedMainGradLinear(torch.nn.Module):
 
     def forward(self, value):
         return _FusedMainGradLinearFunction.apply(
-            value,
-            self.weight,
-            self.fuse_wgrad_accumulation,
+            value, self.weight, self.fuse_wgrad_accumulation
         )
 
 
@@ -208,9 +206,9 @@ def test_mfsdp_full_parallel_signoff_is_single_node_50_step_curve():
 def test_mfsdp_is_standalone_without_vendored_mcore_or_fsdp2_dependencies():
     package = Path(mfsdp_config.__file__).parent
 
-    assert not list((package / "impl").glob("*.py")), (
-        "Do not vendor the MCore FSDP implementation."
-    )
+    assert not list(
+        (package / "impl").glob("*.py")
+    ), "Do not vendor the MCore FSDP implementation."
     violations = []
     for source_path in package.rglob("*.py"):
         tree = ast.parse(source_path.read_text(), filename=str(source_path))
@@ -824,9 +822,9 @@ def test_mfsdp_offload_fraction_keeps_optimizer_state_on_cpu():
 
     inner = optimizer._inner_optimizer
     cpu_group = inner.cpu_group
-    assert cpu_group is not None, (
-        "Expected cpu_group to be set for offload_fraction=1.0"
-    )
+    assert (
+        cpu_group is not None
+    ), "Expected cpu_group to be set for offload_fraction=1.0"
     assert len(cpu_group._cpu_optimizer.optimizers) == len(cpu_group._cpu_params)
     for cpu_p in cpu_group._cpu_params:
         assert cpu_p.device.type == "cpu", "cpu_param should be on CPU"
@@ -966,9 +964,9 @@ def test_mfsdp_offload_fraction_numerically_matches_no_offload():
     }
     assert ref_params.keys() == cpu_params.keys()
     for name in ref_params:
-        assert torch.equal(ref_params[name], cpu_params[name]), (
-            f"Parameter {name} diverges between GPU-only and CPU-offload runs"
-        )
+        assert torch.equal(
+            ref_params[name], cpu_params[name]
+        ), f"Parameter {name} diverges between GPU-only and CPU-offload runs"
 
 
 def test_mfsdp_offload_fraction_partial_splits_by_numel():
@@ -995,9 +993,9 @@ def test_mfsdp_offload_fraction_partial_splits_by_numel():
     ratio = cpu_numel / total_numel
     # The greedy split assigns whole params; exact ratio depends on model shape.
     # For fraction=0.5 with 3 params of unequal size the ratio will be ≥0.4.
-    assert ratio >= 0.4, (
-        f"Expected substantial CPU offload at fraction=0.5, got {ratio:.2%}"
-    )
+    assert (
+        ratio >= 0.4
+    ), f"Expected substantial CPU offload at fraction=0.5, got {ratio:.2%}"
     assert ratio <= 0.95, f"Expected some GPU params at fraction=0.5, got {ratio:.2%}"
 
 
@@ -1454,7 +1452,7 @@ def test_mfsdp_dtype_conversion_buffers_are_collective_scoped():
     assert torch.count_nonzero(bucket.main_grad_buffer) == bucket.local_numel
 
 
-def test_mfsdp_accumulates_all_microbatches_before_grad_reduce():
+def test_mfsdp_reduce_scatters_each_microbatch_into_sharded_accumulation():
     torch.manual_seed(321)
     reference = _GlooModel()
     candidate = copy.deepcopy(reference)
@@ -1478,7 +1476,10 @@ def test_mfsdp_accumulates_all_microbatches_before_grad_reduce():
         adam_beta1=0.9,
         adam_beta2=0.999,
         adam_eps=1.0e-8,
-        override_optimizer_config={"mfsdp_sharding_strategy": "optim_grads_params"},
+        override_optimizer_config={
+            "mfsdp_sharding_strategy": "optim_grads_params",
+            "bucket_size": 4,
+        },
     )
     reference_optimizer = torch.optim.AdamW(
         reference.parameters(),
@@ -1508,10 +1509,23 @@ def test_mfsdp_accumulates_all_microbatches_before_grad_reduce():
         reference_loss = torch.nn.functional.mse_loss(reference(value), target)
         (reference_loss / len(microbatches)).backward()
 
-        candidate_loss = torch.nn.functional.mse_loss(chunks[0](value), target)
+        candidate_output = chunks[0](value)
+        if microbatch_idx:
+            buckets = chunks[0].param_sync.buckets
+            assert all(bucket._full_main_grad_lease is None for bucket in buckets)
+            assert any(
+                torch.count_nonzero(bucket.main_grad_buffer) for bucket in buckets
+            )
+        candidate_loss = torch.nn.functional.mse_loss(candidate_output, target)
         if microbatch_idx == len(microbatches) - 1:
             candidate_optimizer.grad_sync_enabled = True
         (candidate_loss / len(microbatches)).backward()
+
+        live_full_grads = sum(
+            bucket._full_main_grad_lease is not None
+            for bucket in chunks[0].param_sync.buckets
+        )
+        assert live_full_grads <= 2
 
     candidate_optimizer.finish_grad_sync()
 
@@ -1673,8 +1687,7 @@ def test_mfsdp_routes_fused_wgrad_through_bucketed_fp32_main_grad():
     chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
         [model],
         engine_cfg=SimpleNamespace(
-            parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1),
-            optimizer=opt,
+            parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1), optimizer=opt
         ),
         ps=ps,
         is_expert=lambda _name: False,
@@ -1707,8 +1720,14 @@ def test_mfsdp_routes_fused_wgrad_through_bucketed_fp32_main_grad():
     assert spec.full_param.grad is None
     second_expected = second_value.float().sum(dim=0).repeat(4, 1)
     assert spec.full_param.main_grad.untyped_storage().data_ptr() == main_grad_storage
-    assert torch.equal(spec.full_param.main_grad, first_main_grad + second_expected)
-    expected_main_grad = spec.full_param.main_grad.detach().reshape(-1).clone()
+    assert torch.equal(spec.full_param.main_grad, second_expected)
+
+    optimizer.finish_grad_sync()
+    assert torch.equal(
+        bucket.main_grad_buffer.view_as(second_expected),
+        first_main_grad + second_expected,
+    )
+    expected_main_grad = (first_main_grad + second_expected).reshape(-1)
 
     optimizer.finish_grad_sync()
     consumed_grad = _optimizer_params(optimizer)[0].grad
@@ -1716,8 +1735,7 @@ def test_mfsdp_routes_fused_wgrad_through_bucketed_fp32_main_grad():
     assert consumed_grad.dtype is torch.float32
     assert torch.equal(consumed_grad, expected_main_grad)
     assert not torch.equal(
-        consumed_grad,
-        consumed_grad.to(torch.bfloat16).to(torch.float32),
+        consumed_grad, consumed_grad.to(torch.bfloat16).to(torch.float32)
     )
 
 
@@ -1726,11 +1744,15 @@ def test_mfsdp_routes_regular_autograd_grad_through_fp32_main_grad():
     optimizer.zero_grad()
     value = torch.randn(3, 4)
     chunk(value).square().mean().backward()
-    expected = {
-        spec.name: spec.full_param.main_grad.detach().clone()
-        for bucket in chunk.param_sync.buckets
-        for spec in bucket.specs
-    }
+    expected = {}
+    for bucket in chunk.param_sync.buckets:
+        for spec in bucket.specs:
+            grad = spec.full_param.main_grad
+            if grad.numel() == 0:
+                grad = bucket.main_grad_buffer.narrow(
+                    0, spec.local_offset, spec.shard_numel
+                ).view_as(spec.shard_param)
+            expected[spec.name] = grad.detach().clone()
     for bucket in chunk.param_sync.buckets:
         for spec in bucket.specs:
             assert spec.full_param.grad is None
@@ -1766,8 +1788,7 @@ def test_mfsdp_accumulates_regular_wgrad_in_fp32_per_microbatch():
     chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
         [model],
         engine_cfg=SimpleNamespace(
-            parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1),
-            optimizer=opt,
+            parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1), optimizer=opt
         ),
         ps=ps,
         is_expert=lambda _name: False,
@@ -1786,13 +1807,14 @@ def test_mfsdp_accumulates_regular_wgrad_in_fp32_per_microbatch():
     chunk(torch.ones(1, 4, dtype=torch.bfloat16)).sum().backward()
     assert spec.full_param.grad is None
     expected = torch.full((4, 4), 257.0)
-    assert torch.equal(spec.full_param.main_grad, expected)
-    assert not torch.equal(
-        spec.full_param.main_grad,
-        spec.full_param.main_grad.to(torch.bfloat16).to(torch.float32),
-    )
+    assert torch.equal(spec.full_param.main_grad, torch.ones((4, 4)))
 
     optimizer.finish_grad_sync()
+    assert torch.equal(bucket.main_grad_buffer.view_as(expected), expected)
+    assert not torch.equal(
+        bucket.main_grad_buffer,
+        bucket.main_grad_buffer.to(torch.bfloat16).to(torch.float32),
+    )
     consumed_grad = _optimizer_params(optimizer)[0].grad
     assert consumed_grad is not None
     assert consumed_grad.dtype is torch.float32
@@ -1850,12 +1872,13 @@ def _run_mfsdp_gloo_parity(rank: int, world_size: int, init_file: str) -> None:
         )
 
         torch.manual_seed(900 + rank)
-        value = torch.randn(3, 4)
-        target = torch.randn(3, 2)
         reference_optimizer.zero_grad()
-        torch.nn.functional.mse_loss(reference(value), target).backward()
         candidate_optimizer.zero_grad()
-        torch.nn.functional.mse_loss(chunks[0](value), target).backward()
+        for _microbatch in range(2):
+            value = torch.randn(3, 4)
+            target = torch.randn(3, 2)
+            (torch.nn.functional.mse_loss(reference(value), target) / 2).backward()
+            (torch.nn.functional.mse_loss(chunks[0](value), target) / 2).backward()
         for param in reference.parameters():
             assert param.grad is not None
             dist.all_reduce(param.grad, op=dist.ReduceOp.SUM)

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -205,15 +205,22 @@ def test_mfsdp_full_parallel_signoff_is_single_node_50_step_curve():
     assert "batch_seed=8345 + step" in smoke_source
 
     runner_source = (tests_root / "run_mfsdp_hopper_validation.sh").read_text()
+    assert (
+        "grouped-linear mode requires NNODES=1 and NPROC_PER_NODE=8." in runner_source
+    )
+    assert (
+        'TEST_EXPR="native_fp32_grouped_expert_wgrad_reaches_optimizer"'
+        in runner_source
+    )
     assert "full-parallel mode requires NNODES=1 and NPROC_PER_NODE=8." in runner_source
 
 
 def test_mfsdp_is_standalone_without_vendored_mcore_or_fsdp2_dependencies():
     package = Path(mfsdp_config.__file__).parent
 
-    assert not list(
-        (package / "impl").glob("*.py")
-    ), "Do not vendor the MCore FSDP implementation."
+    assert not list((package / "impl").glob("*.py")), (
+        "Do not vendor the MCore FSDP implementation."
+    )
     violations = []
     for source_path in package.rglob("*.py"):
         tree = ast.parse(source_path.read_text(), filename=str(source_path))
@@ -864,9 +871,9 @@ def test_mfsdp_offload_fraction_keeps_optimizer_state_on_cpu():
 
     inner = optimizer._inner_optimizer
     cpu_group = inner.cpu_group
-    assert (
-        cpu_group is not None
-    ), "Expected cpu_group to be set for offload_fraction=1.0"
+    assert cpu_group is not None, (
+        "Expected cpu_group to be set for offload_fraction=1.0"
+    )
     assert len(cpu_group._cpu_optimizer.optimizers) == len(cpu_group._cpu_params)
     for cpu_p in cpu_group._cpu_params:
         assert cpu_p.device.type == "cpu", "cpu_param should be on CPU"
@@ -1006,9 +1013,9 @@ def test_mfsdp_offload_fraction_numerically_matches_no_offload():
     }
     assert ref_params.keys() == cpu_params.keys()
     for name in ref_params:
-        assert torch.equal(
-            ref_params[name], cpu_params[name]
-        ), f"Parameter {name} diverges between GPU-only and CPU-offload runs"
+        assert torch.equal(ref_params[name], cpu_params[name]), (
+            f"Parameter {name} diverges between GPU-only and CPU-offload runs"
+        )
 
 
 def test_mfsdp_offload_fraction_partial_splits_by_numel():
@@ -1035,9 +1042,9 @@ def test_mfsdp_offload_fraction_partial_splits_by_numel():
     ratio = cpu_numel / total_numel
     # The greedy split assigns whole params; exact ratio depends on model shape.
     # For fraction=0.5 with 3 params of unequal size the ratio will be ≥0.4.
-    assert (
-        ratio >= 0.4
-    ), f"Expected substantial CPU offload at fraction=0.5, got {ratio:.2%}"
+    assert ratio >= 0.4, (
+        f"Expected substantial CPU offload at fraction=0.5, got {ratio:.2%}"
+    )
     assert ratio <= 0.95, f"Expected some GPU params at fraction=0.5, got {ratio:.2%}"
 
 

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -958,6 +958,19 @@ def test_mfsdp_offload_fraction_partial_splits_by_numel():
     assert ratio <= 0.95, f"Expected some GPU params at fraction=0.5, got {ratio:.2%}"
 
 
+def test_mfsdp_full_offload_includes_trailing_empty_shards():
+    nonempty = torch.nn.Parameter(torch.ones(4))
+    trailing_empty = torch.nn.Parameter(torch.empty(0))
+
+    gpu_groups, cpu_groups = mfsdp_optimizer._split_param_groups_by_fraction(
+        [{"params": [nonempty, trailing_empty], "weight_decay": 0.0}],
+        1.0,
+    )
+
+    assert gpu_groups == []
+    assert cpu_groups[0]["params"] == [nonempty, trailing_empty]
+
+
 def test_mfsdp_offload_fraction_zero_has_no_cpu_group():
     _Model, _Unit, ps, engine_cfg = _build_offload_stack(offload_fraction=0.0)
 

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -1240,7 +1240,7 @@ def test_mfsdp_offload_fraction_checkpoint_round_trips():
     )
 
 
-def _single_rank_mfsdp_stack():
+def _single_rank_mfsdp_stack(*, override_optimizer_config=None):
     """Build a trained single-rank M-FSDP stack for scratch-release tests."""
 
     class _Unit(torch.nn.Module):
@@ -1281,7 +1281,10 @@ def _single_rank_mfsdp_stack():
         adam_beta1=0.9,
         adam_beta2=0.999,
         adam_eps=1.0e-8,
-        override_optimizer_config={"mfsdp_sharding_strategy": "optim_grads_params"},
+        override_optimizer_config={
+            "mfsdp_sharding_strategy": "optim_grads_params",
+            **(override_optimizer_config or {}),
+        },
     )
     chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
         [_Model()],
@@ -1608,6 +1611,71 @@ def test_mfsdp_get_main_grad_lazily_materializes_only_the_requested_bucket():
     )
 
 
+def test_mfsdp_double_buffer_enforces_two_inflight_bucket_slots_for_nccl_ub():
+    """A third, differently sized bucket drains a completed slot before allocation."""
+    chunk, _optimizer = _single_rank_mfsdp_stack(
+        override_optimizer_config={"bucket_size": 4, "nccl_ub": True}
+    )
+    pipeline = chunk.grad_reduce_pipeline
+
+    assert chunk.mfsdp_config.nccl_ub is True
+    assert chunk.mfsdp_config.fsdp_double_buffer is True
+    buckets = chunk.param_sync.buckets
+    assert len({bucket.full_numel for bucket in buckets}) > 1
+    assert len(buckets) > 2
+    first, second = buckets[:2]
+    third = next(bucket for bucket in buckets[2:] if bucket.full_numel != first.full_numel)
+
+    # Model the two completed-but-not-yet-retired reduce-scatter operations that
+    # occupy the allocator's two main-grad slots.  The old implementation called
+    # allocator.allocate() directly from get_main_grad(), so the third call
+    # raised "capacity exhausted" here.
+    first.get_main_grad(first.specs[0])
+    second.get_main_grad(second.specs[0])
+    first._grad_reduce_launched = True
+    second._grad_reduce_launched = True
+    first._grad_reduce_finished = False
+    second._grad_reduce_finished = False
+    pipeline._pending = [
+        (first, first.full_numel * first.full_main_grad_buffer.element_size()),
+        (second, second.full_numel * second.full_main_grad_buffer.element_size()),
+    ]
+    pipeline._pending_bytes = sum(byte_count for _bucket, byte_count in pipeline._pending)
+    assert len(pipeline._pending) == 2
+    assert third.config.fsdp_double_buffer is True
+    assert third.before_main_grad_allocate is not None
+    assert third.before_main_grad_allocate.__self__ is pipeline
+
+    third.get_main_grad(third.specs[0])
+
+    # The allocator has only two slots per communication key.  The third bucket
+    # retired the oldest completed reduce by slot count, not historical bytes.
+    assert first._full_main_grad_lease is None
+    assert third._full_main_grad_lease is not None
+    assert len(pipeline._pending) <= 2
+
+
+def test_mfsdp_wrapper_aborts_busy_double_buffer_slots_after_forward_exception():
+    """The production wrapper, not a test-only call, owns force teardown."""
+    chunk, _optimizer = _single_rank_mfsdp_stack(
+        override_optimizer_config={"fsdp_double_buffer": True}
+    )
+
+    def fail_after_mfsdp_acquire(_module, _inputs):
+        raise RuntimeError("intentional forward failure")
+
+    handle = chunk.module.unit1.register_forward_pre_hook(fail_after_mfsdp_acquire)
+    try:
+        with pytest.raises(RuntimeError, match="intentional forward failure"):
+            chunk(torch.randn(3, 4))
+    finally:
+        handle.remove()
+
+    allocator = chunk.param_and_grad_buffer.allocator
+    assert getattr(allocator, "_slots", {}) == {}
+    assert getattr(allocator, "_busy", {}) == {}
+
+
 def test_mfsdp_grad_reduce_pending_queue_is_bounded_in_bytes():
     class PendingBucket:
         def __init__(self, full_numel: int):
@@ -1644,30 +1712,6 @@ def test_mfsdp_grad_reduce_pending_queue_is_bounded_in_bytes():
     assert pipeline._pending_capacity_bytes == 2 * 32 * 4
     assert first.waited is True
     assert second.waited is False
-
-
-def test_mfsdp_double_buffer_force_teardown_drops_busy_slots():
-    """Exception cleanup must not replace the original failure with a slot error."""
-    allocator = mfsdp_buffer.DoubleBufferAllocator()
-    lease = allocator.allocate(
-        8,
-        dtype=torch.float32,
-        device=torch.device("cpu"),
-        group=None,
-        key=("teardown",),
-    )
-
-    with pytest.raises(RuntimeError, match="active M-FSDP communication buffers"):
-        allocator.release_cached()
-
-    allocator.release_cached(force=True)
-
-    assert allocator._slots == {}
-    assert allocator._busy == {}
-    assert allocator._reuse_events == {}
-    # Keep the local reference live deliberately: teardown is about allocator
-    # ownership, not attempting to invalidate a tensor held by the primary error.
-    assert lease.tensor.numel() == 8
 
 
 def test_mfsdp_materializes_root_params_used_without_calling_their_leaf_module():

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -1676,6 +1676,73 @@ def test_mfsdp_wrapper_aborts_busy_double_buffer_slots_after_forward_exception()
     assert getattr(allocator, "_busy", {}) == {}
 
 
+def test_mfsdp_wrapper_preserves_primary_forward_failure_when_cleanup_fails(
+    monkeypatch,
+):
+    """Secondary teardown errors must never replace the module failure."""
+    chunk, _optimizer = _single_rank_mfsdp_stack(
+        override_optimizer_config={"fsdp_double_buffer": True}
+    )
+
+    def fail_after_mfsdp_acquire(_module, _inputs):
+        raise RuntimeError("PRIMARY_FORWARD_FAILURE")
+
+    def fail_cleanup():
+        raise RuntimeError("SECONDARY_CLEANUP_FAILURE")
+
+    handle = chunk.module.unit1.register_forward_pre_hook(fail_after_mfsdp_acquire)
+    monkeypatch.setattr(chunk.param_sync, "abort", fail_cleanup)
+    monkeypatch.setattr(chunk.param_sync, "end_forward", fail_cleanup)
+    try:
+        with pytest.raises(RuntimeError, match="PRIMARY_FORWARD_FAILURE"):
+            chunk(torch.randn(3, 4))
+    finally:
+        handle.remove()
+
+
+def test_mfsdp_abort_waits_inflight_work_before_shared_allocator_clear(monkeypatch):
+    """Abort drains work and releases leases before clearing a shared allocator."""
+    chunk, _optimizer = _single_rank_mfsdp_stack(
+        override_optimizer_config={"fsdp_double_buffer": True}
+    )
+    bucket = chunk.param_sync.buckets[0]
+    bucket.get_main_grad(bucket.specs[0])
+
+    class InflightWork:
+        waited = False
+
+        def wait(self):
+            self.waited = True
+
+    class InflightEvent:
+        synchronized = False
+
+        def synchronize(self):
+            self.synchronized = True
+
+    work = InflightWork()
+    event = InflightEvent()
+    bucket._grad_reduce_work = work
+    bucket._grad_reduce_event = event
+    allocator = chunk.param_and_grad_buffer.allocator
+    release_cached = allocator.release_cached
+
+    def assert_drained_before_clear(*, force=False):
+        assert force is True
+        assert work.waited is True
+        assert event.synchronized is True
+        assert bucket._full_main_grad_lease is None
+        return release_cached(force=force)
+
+    monkeypatch.setattr(allocator, "release_cached", assert_drained_before_clear)
+    chunk.param_sync.abort()
+
+    assert bucket._grad_reduce_work is None
+    assert bucket._grad_reduce_event is None
+    assert getattr(allocator, "_slots", {}) == {}
+    assert getattr(allocator, "_busy", {}) == {}
+
+
 def test_mfsdp_grad_reduce_pending_queue_is_bounded_in_bytes():
     class PendingBucket:
         def __init__(self, full_numel: int):

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -1498,6 +1498,10 @@ def test_mfsdp_reduce_scatters_each_microbatch_into_sharded_accumulation():
         is_expert=lambda _name: False,
         fsdp_unit_modules=(_GlooUnit,),
     )
+    assert (
+        len({bucket.allocator_layout_key for bucket in chunks[0].param_sync.buckets})
+        > 1
+    )
     microbatches = [
         (torch.randn(3, 4), torch.randn(3, 2)),
         (torch.randn(2, 4), torch.randn(2, 2)),
@@ -1528,6 +1532,13 @@ def test_mfsdp_reduce_scatters_each_microbatch_into_sharded_accumulation():
         assert live_full_grads <= 2
 
     candidate_optimizer.finish_grad_sync()
+
+    allocator = chunks[0].param_and_grad_buffer.allocator
+    gradient_pool_keys = [
+        key for key in allocator._slots if key[0] in {"main_grad", "grad", "grad-local"}
+    ]
+    assert {key[0] for key in gradient_pool_keys} == {"main_grad", "grad-local"}
+    assert len(gradient_pool_keys) == 2
 
     reference_grads = {
         name: param.grad.detach().reshape(-1)

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -923,9 +923,9 @@ def test_mfsdp_offload_fraction_numerically_matches_no_offload():
     }
     assert ref_params.keys() == cpu_params.keys()
     for name in ref_params:
-        assert torch.allclose(
-            ref_params[name], cpu_params[name], atol=1e-5, rtol=1e-4
-        ), f"Parameter {name} diverges between GPU-only and CPU-offload runs"
+        assert torch.equal(ref_params[name], cpu_params[name]), (
+            f"Parameter {name} diverges between GPU-only and CPU-offload runs"
+        )
 
 
 def test_mfsdp_offload_fraction_partial_splits_by_numel():

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -71,7 +71,12 @@ class _FusedMainGradLinearFunction(torch.autograd.Function):
             .matmul(value.float().reshape(-1, value.shape[-1]))
         )
         if ctx.fuse_wgrad_accumulation:
-            ctx.weight.get_main_grad().add_(grad_weight)
+            main_grad = (
+                ctx.weight.get_main_grad()
+                if hasattr(ctx.weight, "__fsdp_param__")
+                else ctx.weight.main_grad
+            )
+            main_grad.add_(grad_weight)
             ctx.weight.grad_added_to_main_grad = True
             grad_weight = torch.zeros_like(weight)
         return grad_input, grad_weight, None
@@ -468,9 +473,7 @@ def test_mfsdp_config_enables_double_buffer_for_nccl_user_buffers():
 def test_mfsdp_config_keeps_double_buffer_opt_in_without_nccl_user_buffers():
     config = mfsdp_config.build_mfsdp_config(
         SimpleNamespace(
-            override_optimizer_config={
-                "mfsdp_sharding_strategy": "optim_grads_params",
-            }
+            override_optimizer_config={"mfsdp_sharding_strategy": "optim_grads_params"}
         )
     )
 
@@ -481,11 +484,7 @@ def test_mfsdp_config_keeps_double_buffer_opt_in_without_nccl_user_buffers():
 def test_mfsdp_temporary_lease_physically_releases_storage():
     allocator = mfsdp_buffer.TemporaryBufferAllocator()
     lease = allocator.allocate(
-        32,
-        dtype=torch.float32,
-        device=torch.device("cpu"),
-        group=None,
-        key=("grad",),
+        32, dtype=torch.float32, device=torch.device("cpu"), group=None, key=("grad",)
     )
 
     assert lease.tensor.untyped_storage().nbytes() == 32 * 4
@@ -1498,6 +1497,59 @@ def test_mfsdp_dtype_conversion_buffers_are_collective_scoped():
     assert torch.count_nonzero(bucket.main_grad_buffer) == bucket.local_numel
 
 
+def test_mfsdp_full_param_installs_mcore_te_lazy_main_grad_protocol():
+    """TE must recognize and materialize the released full-param lazy grad."""
+    model = torch.nn.Linear(4, 3, bias=False, dtype=torch.bfloat16)
+    groups = mfsdp_buffer.MFSDPProcessGroups(
+        dense_dp=None,
+        expert_dp=None,
+        dense_ag=None,
+        expert_ag=None,
+        tp=None,
+        etp=None,
+        ep=None,
+        pp=None,
+    )
+    bucket = mfsdp_buffer.ParamAndGradBuffer(
+        model,
+        groups=groups,
+        config=mfsdp_config.MFSDPConfig(bucket_size=None),
+        is_expert=lambda _name: False,
+        unit_modules=(),
+    ).buckets[0]
+    spec = bucket.specs[0]
+    assert spec.full_param.__fsdp_param__ is True
+    assert spec.full_param.overwrite_main_grad is True
+    assert callable(spec.full_param.get_main_grad)
+
+    # Simulate a released full parameter and the next all-gather/install cycle.
+    bucket.release_full_parameters()
+    bucket.wait_param_gather()
+    spec.full_param.__fsdp_param__ = False
+    spec.full_param.overwrite_main_grad = False
+    bucket.install_full_parameters()
+
+    assert spec.full_param.__fsdp_param__ is True
+    assert spec.full_param.overwrite_main_grad is True
+    getter = spec.full_param.get_main_grad
+    calls = 0
+
+    def counted_getter():
+        nonlocal calls
+        calls += 1
+        return getter()
+
+    spec.full_param.get_main_grad = counted_getter
+    main_grad = spec.full_param.get_main_grad()
+
+    assert calls == 1
+    assert main_grad is spec.full_param.main_grad
+    assert main_grad.shape == spec.full_param.shape
+    assert main_grad.dtype is torch.float32
+    assert main_grad.is_contiguous()
+    assert main_grad.numel() == spec.full_param.numel()
+
+
 def test_mfsdp_reduce_scatters_each_microbatch_into_sharded_accumulation():
     torch.manual_seed(321)
     reference = _GlooModel()
@@ -1623,7 +1675,9 @@ def test_mfsdp_double_buffer_enforces_two_inflight_bucket_slots_for_nccl_ub():
     assert len({bucket.full_numel for bucket in buckets}) > 1
     assert len(buckets) > 2
     first, second = buckets[:2]
-    third = next(bucket for bucket in buckets[2:] if bucket.full_numel != first.full_numel)
+    third = next(
+        bucket for bucket in buckets[2:] if bucket.full_numel != first.full_numel
+    )
 
     # Model the two completed-but-not-yet-retired reduce-scatter operations that
     # occupy the allocator's two main-grad slots.  The old implementation called
@@ -1639,7 +1693,9 @@ def test_mfsdp_double_buffer_enforces_two_inflight_bucket_slots_for_nccl_ub():
         (first, first.full_numel * first.full_main_grad_buffer.element_size()),
         (second, second.full_numel * second.full_main_grad_buffer.element_size()),
     ]
-    pipeline._pending_bytes = sum(byte_count for _bucket, byte_count in pipeline._pending)
+    pipeline._pending_bytes = sum(
+        byte_count for _bucket, byte_count in pipeline._pending
+    )
     assert len(pipeline._pending) == 2
     assert third.config.fsdp_double_buffer is True
     assert third.before_main_grad_allocate is not None
@@ -1804,9 +1860,7 @@ def test_mfsdp_materializes_root_params_used_without_calling_their_leaf_module()
         adam_beta1=0.9,
         adam_beta2=0.999,
         adam_eps=1.0e-8,
-        override_optimizer_config={
-            "mfsdp_sharding_strategy": "optim_grads_params",
-        },
+        override_optimizer_config={"mfsdp_sharding_strategy": "optim_grads_params"},
     )
     chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
         [candidate],
@@ -1853,9 +1907,7 @@ def test_mfsdp_keeps_fp32_shards_for_bfloat16_compute_parameters():
         adam_beta1=0.9,
         adam_beta2=0.999,
         adam_eps=1.0e-8,
-        override_optimizer_config={
-            "mfsdp_sharding_strategy": "optim_grads_params",
-        },
+        override_optimizer_config={"mfsdp_sharding_strategy": "optim_grads_params"},
     )
     chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
         [model],

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -156,9 +156,9 @@ def test_mfsdp_full_parallel_signoff_is_single_node_50_step_curve():
 def test_mfsdp_is_standalone_without_vendored_mcore_or_fsdp2_dependencies():
     package = Path(mfsdp_config.__file__).parent
 
-    assert not list(
-        (package / "impl").glob("*.py")
-    ), "Do not vendor the MCore FSDP implementation."
+    assert not list((package / "impl").glob("*.py")), (
+        "Do not vendor the MCore FSDP implementation."
+    )
     violations = []
     for source_path in package.rglob("*.py"):
         tree = ast.parse(source_path.read_text(), filename=str(source_path))
@@ -772,9 +772,9 @@ def test_mfsdp_offload_fraction_keeps_optimizer_state_on_cpu():
 
     inner = optimizer._inner_optimizer
     cpu_group = inner.cpu_group
-    assert (
-        cpu_group is not None
-    ), "Expected cpu_group to be set for offload_fraction=1.0"
+    assert cpu_group is not None, (
+        "Expected cpu_group to be set for offload_fraction=1.0"
+    )
     assert len(cpu_group._cpu_optimizer.optimizers) == len(cpu_group._cpu_params)
     for cpu_p in cpu_group._cpu_params:
         assert cpu_p.device.type == "cpu", "cpu_param should be on CPU"
@@ -914,9 +914,9 @@ def test_mfsdp_offload_fraction_numerically_matches_no_offload():
     }
     assert ref_params.keys() == cpu_params.keys()
     for name in ref_params:
-        assert torch.equal(
-            ref_params[name], cpu_params[name]
-        ), f"Parameter {name} diverges between GPU-only and CPU-offload runs"
+        assert torch.equal(ref_params[name], cpu_params[name]), (
+            f"Parameter {name} diverges between GPU-only and CPU-offload runs"
+        )
 
 
 def test_mfsdp_offload_fraction_partial_splits_by_numel():
@@ -943,9 +943,9 @@ def test_mfsdp_offload_fraction_partial_splits_by_numel():
     ratio = cpu_numel / total_numel
     # The greedy split assigns whole params; exact ratio depends on model shape.
     # For fraction=0.5 with 3 params of unequal size the ratio will be ≥0.4.
-    assert (
-        ratio >= 0.4
-    ), f"Expected substantial CPU offload at fraction=0.5, got {ratio:.2%}"
+    assert ratio >= 0.4, (
+        f"Expected substantial CPU offload at fraction=0.5, got {ratio:.2%}"
+    )
     assert ratio <= 0.95, f"Expected some GPU params at fraction=0.5, got {ratio:.2%}"
 
 
@@ -1323,6 +1323,53 @@ def test_mfsdp_empty_uneven_shard_stays_inside_local_buffer(monkeypatch):
     assert bucket.specs[1].local_offset == bucket.local_numel
     assert bucket.specs[1].shard_param is not None
     assert bucket.specs[1].shard_param.numel() == 0
+
+
+def test_mfsdp_dtype_conversion_buffers_are_collective_scoped():
+    """Cast/communication storage must not remain resident through optimizer.step."""
+    model = torch.nn.Linear(4, 3, bias=False, dtype=torch.bfloat16)
+    groups = mfsdp_buffer.MFSDPProcessGroups(
+        dense_dp=None,
+        expert_dp=None,
+        dense_ag=None,
+        expert_ag=None,
+        tp=None,
+        etp=None,
+        ep=None,
+        pp=None,
+    )
+    config = mfsdp_config.MFSDPConfig(
+        bucket_size=None,
+        main_params_dtype=torch.float32,
+        main_grads_dtype=torch.float32,
+        grad_comm_dtype=torch.bfloat16,
+    )
+    bucket = mfsdp_buffer.ParamAndGradBuffer(
+        model,
+        groups=groups,
+        config=config,
+        is_expert=lambda _name: False,
+        unit_modules=(),
+    ).buckets[0]
+
+    assert bucket.local_compute_buffer.numel() == 0
+    assert bucket.local_grad_comm_buffer.numel() == 0
+
+    bucket.release_full_parameters()
+    _, local_compute = bucket.prepare_param_gather()
+    assert local_compute.numel() == bucket.local_numel
+    bucket.wait_param_gather()
+    assert bucket.local_compute_buffer.numel() == 0
+
+    bucket.install_full_parameters()
+    for spec in bucket.specs:
+        spec.full_param.grad = torch.ones_like(spec.full_param)
+    grad_reduce = mfsdp_buffer.GradReducePipeline([bucket])
+    grad_reduce.reduce_gradients(bucket, force=True)
+    assert bucket.local_grad_comm_buffer.numel() == bucket.local_numel
+    grad_reduce.finish()
+    assert bucket.local_grad_comm_buffer.numel() == 0
+    assert torch.count_nonzero(bucket.main_grad_buffer) == bucket.local_numel
 
 
 def test_mfsdp_accumulates_all_microbatches_before_grad_reduce():

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -509,16 +509,15 @@ def test_mfsdp_double_buffer_rejects_a_third_in_flight_lease():
         allocator.allocate(**args)
 
 
-def test_mfsdp_nccl_user_buffer_falls_back_when_apex_is_missing(monkeypatch):
+def test_mfsdp_nccl_user_buffer_fails_loudly_when_apex_is_missing(monkeypatch):
     monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
 
     def missing_apex(_name):
         raise ImportError("optional allocator missing")
 
     monkeypatch.setattr(mfsdp_buffer.importlib, "import_module", missing_apex)
-    user_buffer = mfsdp_buffer.NCCLUserBuffer(enabled=True, groups=(), symmetric=True)
-
-    assert user_buffer.active is False
+    with pytest.raises(RuntimeError, match="NCCL user-buffer allocation unavailable"):
+        mfsdp_buffer.NCCLUserBuffer(enabled=True, groups=(), symmetric=True)
 
 
 def test_mfsdp_parallel_metadata_uses_topology_and_explicit_classifier():
@@ -2135,6 +2134,10 @@ def _run_mfsdp_gloo_parity(rank: int, world_size: int, init_file: str) -> None:
         assert reference_norm == candidate_norm
 
         reference_params = dict(reference.named_parameters())
+        streamed_params = dict(chunks[0].stream_full_parameters())
+        assert reference_params.keys() == streamed_params.keys()
+        for name, reference_param in reference_params.items():
+            assert torch.equal(reference_param, streamed_params[name]), name
         candidate_params = {
             name.removeprefix("module."): param
             for name, param in chunks[0].named_parameters()

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -71,7 +71,7 @@ class _FusedMainGradLinearFunction(torch.autograd.Function):
             .matmul(value.float().reshape(-1, value.shape[-1]))
         )
         if ctx.fuse_wgrad_accumulation:
-            ctx.weight.main_grad.add_(grad_weight)
+            ctx.weight.get_main_grad().add_(grad_weight)
             ctx.weight.grad_added_to_main_grad = True
             grad_weight = torch.zeros_like(weight)
         return grad_input, grad_weight, None
@@ -463,6 +463,50 @@ def test_mfsdp_config_enables_double_buffer_for_nccl_user_buffers():
 
     assert config.nccl_ub is True
     assert config.fsdp_double_buffer is True
+
+
+def test_mfsdp_config_keeps_double_buffer_opt_in_without_nccl_user_buffers():
+    config = mfsdp_config.build_mfsdp_config(
+        SimpleNamespace(
+            override_optimizer_config={
+                "mfsdp_sharding_strategy": "optim_grads_params",
+            }
+        )
+    )
+
+    assert config.nccl_ub is False
+    assert config.fsdp_double_buffer is False
+
+
+def test_mfsdp_temporary_lease_physically_releases_storage():
+    allocator = mfsdp_buffer.TemporaryBufferAllocator()
+    lease = allocator.allocate(
+        32,
+        dtype=torch.float32,
+        device=torch.device("cpu"),
+        group=None,
+        key=("grad",),
+    )
+
+    assert lease.tensor.untyped_storage().nbytes() == 32 * 4
+    lease.release()
+    assert lease.tensor.untyped_storage().nbytes() == 0
+
+
+def test_mfsdp_double_buffer_rejects_a_third_in_flight_lease():
+    allocator = mfsdp_buffer.DoubleBufferAllocator()
+    args = dict(
+        numel=8,
+        dtype=torch.float32,
+        device=torch.device("cpu"),
+        group=None,
+        key=("grad",),
+    )
+    allocator.allocate(**args)
+    allocator.allocate(**args)
+
+    with pytest.raises(RuntimeError, match="capacity exhausted"):
+        allocator.allocate(**args)
 
 
 def test_mfsdp_nccl_user_buffer_falls_back_when_apex_is_missing(monkeypatch):
@@ -1525,20 +1569,11 @@ def test_mfsdp_reduce_scatters_each_microbatch_into_sharded_accumulation():
             candidate_optimizer.grad_sync_enabled = True
         (candidate_loss / len(microbatches)).backward()
 
-        live_full_grads = sum(
-            bucket._full_main_grad_lease is not None
-            for bucket in chunks[0].param_sync.buckets
-        )
-        assert live_full_grads <= 2
-
     candidate_optimizer.finish_grad_sync()
 
-    allocator = chunks[0].param_and_grad_buffer.allocator
-    gradient_pool_keys = [
-        key for key in allocator._slots if key[0] in {"main_grad", "grad", "grad-local"}
-    ]
-    assert {key[0] for key in gradient_pool_keys} == {"main_grad", "grad-local"}
-    assert len(gradient_pool_keys) == 2
+    assert all(
+        bucket._full_main_grad_lease is None for bucket in chunks[0].param_sync.buckets
+    )
 
     reference_grads = {
         name: param.grad.detach().reshape(-1)
@@ -1551,6 +1586,62 @@ def test_mfsdp_reduce_scatters_each_microbatch_into_sharded_accumulation():
     assert reference_grads.keys() == candidate_grads.keys()
     for name, reference_grad in reference_grads.items():
         assert torch.equal(reference_grad, candidate_grads[name]), name
+
+
+def test_mfsdp_get_main_grad_lazily_materializes_only_the_requested_bucket():
+    chunk, _optimizer = _single_rank_mfsdp_stack()
+    first, second = chunk.param_sync.buckets[:2]
+    first_param = first.specs[0].full_param
+
+    assert first._full_main_grad_lease is None
+    assert second._full_main_grad_lease is None
+
+    main_grad = first_param.get_main_grad()
+
+    assert main_grad.shape == first.specs[0].shape
+    assert first._full_main_grad_lease is not None
+    assert second._full_main_grad_lease is None
+    assert main_grad.untyped_storage().data_ptr() == (
+        first.full_main_grad_buffer.untyped_storage().data_ptr()
+    )
+
+
+def test_mfsdp_grad_reduce_pending_queue_is_bounded_in_bytes():
+    class PendingBucket:
+        def __init__(self, full_numel: int):
+            self.device = torch.device("cpu")
+            self.full_numel = full_numel
+            self.policy = SimpleNamespace(grad_comm_dtype=torch.float32)
+            self.world_size = 1
+            self.process_group = None
+            self.launched = False
+            self.waited = False
+            self.grad_ready_callback = None
+
+        def prepare_grad_reduce(self, *, force=False):
+            self.launched = True
+            return torch.empty(self.full_numel), torch.ones(self.full_numel)
+
+        def mark_grad_reduce_launched(self, work, completion_event=None):
+            self.work = work
+            self.completion_event = completion_event
+
+        def wait_grad_reduce(self):
+            self.waited = True
+
+    first = PendingBucket(8)
+    second = PendingBucket(32)
+    third = PendingBucket(32)
+    pipeline = mfsdp_buffer.GradReducePipeline([first, second, third])
+
+    pipeline.reduce_gradients(first, force=True)
+    pipeline.reduce_gradients(second, force=True)
+    pipeline.reduce_gradients(third, force=True)
+
+    assert pipeline._pending_bytes == (32 + 32) * 4
+    assert pipeline._pending_capacity_bytes == 2 * 32 * 4
+    assert first.waited is True
+    assert second.waited is False
 
 
 def test_mfsdp_materializes_root_params_used_without_calling_their_leaf_module():
@@ -1577,7 +1668,9 @@ def test_mfsdp_materializes_root_params_used_without_calling_their_leaf_module()
         adam_beta1=0.9,
         adam_beta2=0.999,
         adam_eps=1.0e-8,
-        override_optimizer_config={"mfsdp_sharding_strategy": "optim_grads_params"},
+        override_optimizer_config={
+            "mfsdp_sharding_strategy": "optim_grads_params",
+        },
     )
     chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
         [candidate],
@@ -1624,7 +1717,9 @@ def test_mfsdp_keeps_fp32_shards_for_bfloat16_compute_parameters():
         adam_beta1=0.9,
         adam_beta2=0.999,
         adam_eps=1.0e-8,
-        override_optimizer_config={"mfsdp_sharding_strategy": "optim_grads_params"},
+        override_optimizer_config={
+            "mfsdp_sharding_strategy": "optim_grads_params",
+        },
     )
     chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
         [model],
@@ -1724,13 +1819,11 @@ def test_mfsdp_routes_fused_wgrad_through_bucketed_fp32_main_grad():
         spec.full_param.main_grad.to(torch.bfloat16).to(torch.float32),
     )
     first_main_grad = spec.full_param.main_grad.detach().clone()
-    main_grad_storage = spec.full_param.main_grad.untyped_storage().data_ptr()
-
     second_value = torch.randn(8, 4, dtype=torch.bfloat16)
     chunk(second_value).float().sum().backward()
     assert spec.full_param.grad is None
     second_expected = second_value.float().sum(dim=0).repeat(4, 1)
-    assert spec.full_param.main_grad.untyped_storage().data_ptr() == main_grad_storage
+    assert spec.full_param.main_grad.numel() == spec.numel
     assert torch.equal(spec.full_param.main_grad, second_expected)
 
     optimizer.finish_grad_sync()

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -5,18 +5,17 @@ import ast
 import copy
 import inspect
 import os
-from pathlib import Path
 import subprocess
 import sys
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
-
-from megatron.lite.primitive.optimizers.mfsdp import config as mfsdp_config
 from megatron.lite.primitive.optimizers.mfsdp import buffer as mfsdp_buffer
+from megatron.lite.primitive.optimizers.mfsdp import config as mfsdp_config
 from megatron.lite.primitive.optimizers.mfsdp import cpu_offload as mfsdp_cpu_offload
 from megatron.lite.primitive.optimizers.mfsdp import optimizer as mfsdp_optimizer
 from megatron.lite.runtime.contracts.config import ParallelConfig
@@ -157,9 +156,9 @@ def test_mfsdp_full_parallel_signoff_is_single_node_50_step_curve():
 def test_mfsdp_is_standalone_without_vendored_mcore_or_fsdp2_dependencies():
     package = Path(mfsdp_config.__file__).parent
 
-    assert not list((package / "impl").glob("*.py")), (
-        "Do not vendor the MCore FSDP implementation."
-    )
+    assert not list(
+        (package / "impl").glob("*.py")
+    ), "Do not vendor the MCore FSDP implementation."
     violations = []
     for source_path in package.rglob("*.py"):
         tree = ast.parse(source_path.read_text(), filename=str(source_path))
@@ -275,14 +274,9 @@ def test_mfsdp_has_no_legacy_test_only_production_surface():
             "_unique_parameters",
             "compute_mfsdp_grad_norm",
         },
-        "optimizer.py": {
-            "_default_expert_classifier",
-            "finalize_mfsdp_grads",
-        },
+        "optimizer.py": {"_default_expert_classifier", "finalize_mfsdp_grads"},
     }
-    forbidden_methods = {
-        "optimizer.py": {"sync_model_weights_to_main_weights"},
-    }
+    forbidden_methods = {"optimizer.py": {"sync_model_weights_to_main_weights"}}
 
     violations = []
     for module_name, names in forbidden_top_level.items():
@@ -428,11 +422,7 @@ def test_mfsdp_nccl_user_buffer_falls_back_when_apex_is_missing(monkeypatch):
         raise ImportError("optional allocator missing")
 
     monkeypatch.setattr(mfsdp_buffer.importlib, "import_module", missing_apex)
-    user_buffer = mfsdp_buffer.NCCLUserBuffer(
-        enabled=True,
-        groups=(),
-        symmetric=True,
-    )
+    user_buffer = mfsdp_buffer.NCCLUserBuffer(enabled=True, groups=(), symmetric=True)
 
     assert user_buffer.active is False
 
@@ -445,10 +435,7 @@ def test_mfsdp_parallel_metadata_uses_topology_and_explicit_classifier():
     model.replicated_matrix.average_gradients_across_tp_domain = True
 
     mfsdp_optimizer._mark_mfsdp_parallel_attrs(
-        model,
-        lambda name: name == "routed_matrix",
-        tp_size=2,
-        etp_size=1,
+        model, lambda name: name == "routed_matrix", tp_size=2, etp_size=1
     )
 
     assert model.dense_matrix.tensor_model_parallel is True
@@ -486,8 +473,7 @@ def test_mfsdp_marks_sequence_parallel_shards_for_tp_gradient_sync():
     _chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
         [model],
         engine_cfg=SimpleNamespace(
-            parallel=ParallelConfig(tp=2, ep=1, etp=1, pp=1, vpp=1, cp=1),
-            optimizer=opt,
+            parallel=ParallelConfig(tp=2, ep=1, etp=1, pp=1, vpp=1, cp=1), optimizer=opt
         ),
         ps=ps,
         is_expert=lambda _name: False,
@@ -543,11 +529,7 @@ def test_mfsdp_tp_gradient_average_divides_the_collective_sum(monkeypatch):
 
     monkeypatch.setattr(dist, "is_initialized", lambda: True)
     monkeypatch.setattr(dist, "get_world_size", lambda _group: 2)
-    monkeypatch.setattr(
-        dist,
-        "all_reduce",
-        lambda value, *, op, group: value.mul_(2.0),
-    )
+    monkeypatch.setattr(dist, "all_reduce", lambda value, *, op, group: value.mul_(2.0))
 
     mfsdp_optimizer._all_reduce_grad_if_distributed(grad, group, average=True)
 
@@ -655,8 +637,7 @@ def test_mfsdp_cpu_single_rank_matches_torch_adamw_optimizer_step():
         override_optimizer_config={"mfsdp_sharding_strategy": "optim_grads_params"},
     )
     engine_cfg = SimpleNamespace(
-        parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1),
-        optimizer=opt,
+        parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1), optimizer=opt
     )
 
     reference_optimizer = torch.optim.AdamW(
@@ -764,8 +745,7 @@ def _build_offload_stack(offload_fraction: float):
         override_optimizer_config={"mfsdp_sharding_strategy": "optim_grads_params"},
     )
     engine_cfg = SimpleNamespace(
-        parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1),
-        optimizer=opt,
+        parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1), optimizer=opt
     )
     return _Model, _Unit, ps, engine_cfg
 
@@ -792,9 +772,9 @@ def test_mfsdp_offload_fraction_keeps_optimizer_state_on_cpu():
 
     inner = optimizer._inner_optimizer
     cpu_group = inner.cpu_group
-    assert cpu_group is not None, (
-        "Expected cpu_group to be set for offload_fraction=1.0"
-    )
+    assert (
+        cpu_group is not None
+    ), "Expected cpu_group to be set for offload_fraction=1.0"
     assert len(cpu_group._cpu_optimizer.optimizers) == len(cpu_group._cpu_params)
     for cpu_p in cpu_group._cpu_params:
         assert cpu_p.device.type == "cpu", "cpu_param should be on CPU"
@@ -934,9 +914,9 @@ def test_mfsdp_offload_fraction_numerically_matches_no_offload():
     }
     assert ref_params.keys() == cpu_params.keys()
     for name in ref_params:
-        assert torch.equal(ref_params[name], cpu_params[name]), (
-            f"Parameter {name} diverges between GPU-only and CPU-offload runs"
-        )
+        assert torch.equal(
+            ref_params[name], cpu_params[name]
+        ), f"Parameter {name} diverges between GPU-only and CPU-offload runs"
 
 
 def test_mfsdp_offload_fraction_partial_splits_by_numel():
@@ -963,9 +943,9 @@ def test_mfsdp_offload_fraction_partial_splits_by_numel():
     ratio = cpu_numel / total_numel
     # The greedy split assigns whole params; exact ratio depends on model shape.
     # For fraction=0.5 with 3 params of unequal size the ratio will be ≥0.4.
-    assert ratio >= 0.4, (
-        f"Expected substantial CPU offload at fraction=0.5, got {ratio:.2%}"
-    )
+    assert (
+        ratio >= 0.4
+    ), f"Expected substantial CPU offload at fraction=0.5, got {ratio:.2%}"
     assert ratio <= 0.95, f"Expected some GPU params at fraction=0.5, got {ratio:.2%}"
 
 
@@ -974,8 +954,7 @@ def test_mfsdp_full_offload_includes_trailing_empty_shards():
     trailing_empty = torch.nn.Parameter(torch.empty(0))
 
     gpu_groups, cpu_groups = mfsdp_optimizer._split_param_groups_by_fraction(
-        [{"params": [nonempty, trailing_empty], "weight_decay": 0.0}],
-        1.0,
+        [{"params": [nonempty, trailing_empty], "weight_decay": 0.0}], 1.0
     )
 
     assert gpu_groups == []
@@ -1183,8 +1162,7 @@ def _single_rank_mfsdp_stack():
     chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
         [_Model()],
         engine_cfg=SimpleNamespace(
-            parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1),
-            optimizer=opt,
+            parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1), optimizer=opt
         ),
         ps=ps,
         is_expert=lambda _name: False,
@@ -1297,8 +1275,7 @@ def test_mfsdp_bucket_policy_splits_one_unit_without_splitting_parameters():
     chunks, _optimizer = mfsdp_optimizer.build_mfsdp_stack(
         [model],
         engine_cfg=SimpleNamespace(
-            parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1),
-            optimizer=opt,
+            parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1), optimizer=opt
         ),
         ps=ps,
         is_expert=lambda _name: False,
@@ -1385,8 +1362,7 @@ def test_mfsdp_accumulates_all_microbatches_before_grad_reduce():
     chunks, candidate_optimizer = mfsdp_optimizer.build_mfsdp_stack(
         [candidate],
         engine_cfg=SimpleNamespace(
-            parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1),
-            optimizer=opt,
+            parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1), optimizer=opt
         ),
         ps=ps,
         is_expert=lambda _name: False,
@@ -1452,8 +1428,7 @@ def test_mfsdp_materializes_root_params_used_without_calling_their_leaf_module()
     chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
         [candidate],
         engine_cfg=SimpleNamespace(
-            parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1),
-            optimizer=opt,
+            parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1), optimizer=opt
         ),
         ps=ps,
         is_expert=lambda _name: False,
@@ -1500,8 +1475,7 @@ def test_mfsdp_keeps_fp32_shards_for_bfloat16_compute_parameters():
     chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
         [model],
         engine_cfg=SimpleNamespace(
-            parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1),
-            optimizer=opt,
+            parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1), optimizer=opt
         ),
         ps=ps,
         is_expert=lambda _name: False,
@@ -1550,10 +1524,7 @@ def test_mfsdp_keeps_fp32_shards_for_bfloat16_compute_parameters():
 def _run_mfsdp_gloo_parity(rank: int, world_size: int, init_file: str) -> None:
     os.environ.setdefault("GLOO_SOCKET_IFNAME", "lo")
     dist.init_process_group(
-        "gloo",
-        init_method=f"file://{init_file}",
-        rank=rank,
-        world_size=world_size,
+        "gloo", init_method=f"file://{init_file}", rank=rank, world_size=world_size
     )
     try:
         torch.manual_seed(456)
@@ -1581,8 +1552,7 @@ def _run_mfsdp_gloo_parity(rank: int, world_size: int, init_file: str) -> None:
             override_optimizer_config={"mfsdp_sharding_strategy": "optim_grads_params"},
         )
         engine_cfg = SimpleNamespace(
-            parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1),
-            optimizer=opt,
+            parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1), optimizer=opt
         )
 
         reference_optimizer = torch.optim.AdamW(

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -885,9 +885,9 @@ def test_mfsdp_full_offload_has_six_gpu_and_twelve_cpu_bytes_per_param():
         param.numel() * param.element_size() for param in inner.params
     )
     gpu_main_grad_bytes = sum(
-        param.grad.numel() * param.grad.element_size()
+        param.main_grad.numel() * param.main_grad.element_size()
         for param in inner.params
-        if param.grad is not None
+        if hasattr(param, "main_grad")
     )
     cpu_master_bytes = sum(
         param.numel() * param.element_size() for param in cpu_group._cpu_params
@@ -905,7 +905,7 @@ def test_mfsdp_full_offload_has_six_gpu_and_twelve_cpu_bytes_per_param():
 
     assert all(param.dtype == torch.bfloat16 for param in inner.params)
     assert all(
-        param.grad is not None and param.grad.dtype == torch.float32
+        param.grad is None and param.main_grad.dtype == torch.float32
         for param in inner.params
     )
     assert all(

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -795,7 +795,7 @@ def test_mfsdp_offload_fraction_keeps_optimizer_state_on_cpu():
     assert cpu_group is not None, (
         "Expected cpu_group to be set for offload_fraction=1.0"
     )
-
+    assert len(cpu_group._cpu_optimizer.optimizers) == len(cpu_group._cpu_params)
     for cpu_p in cpu_group._cpu_params:
         assert cpu_p.device.type == "cpu", "cpu_param should be on CPU"
     cpu_opt_state = cpu_group._cpu_optimizer.state
@@ -809,13 +809,14 @@ def test_mfsdp_offload_fraction_keeps_optimizer_state_on_cpu():
         assert gpu_param.device.type != "cuda" or gpu_param.data is not None
 
 
-def test_mfsdp_cpu_offload_queues_transfers_before_one_d2h_fence():
+def test_mfsdp_cpu_offload_overlaps_per_param_d2h_cpu_step_and_h2d():
     source = inspect.getsource(mfsdp_cpu_offload.CpuAdamGroup.step)
 
-    assert source.count("non_blocking=True") == 2
-    fence = source.index("torch.cuda.current_stream().synchronize()")
-    optimizer_step = source.index("self._cpu_optimizer.step()")
-    assert fence < optimizer_step
+    assert source.count("non_blocking=True") >= 2
+    assert "self._d2h_stream.record_event()" in source
+    assert "d2h_event.synchronize()" in source
+    assert "with torch.cuda.stream(self._h2d_stream)" in source
+    assert "self._h2d_stream.record_event().wait(current_stream)" in source
 
 
 def test_mfsdp_full_offload_has_six_gpu_and_twelve_cpu_bytes_per_param():
@@ -1106,6 +1107,34 @@ def test_mfsdp_offload_fraction_checkpoint_round_trips():
     optimizer.finish_grad_sync()
     success, _, _ = optimizer.step()
     assert success
+
+    legacy_optimizer = {"state": {}, "param_groups": []}
+    expected_exp_avg = []
+    for index, cpu_optimizer in enumerate(cpu_group._cpu_optimizer.optimizers):
+        local = copy.deepcopy(cpu_optimizer.state_dict())
+        group = local["param_groups"][0]
+        group["params"] = [index]
+        legacy_optimizer["param_groups"].append(group)
+        if 0 in local["state"]:
+            legacy_optimizer["state"][index] = local["state"][0]
+            expected_exp_avg.append(local["state"][0]["exp_avg"].clone())
+    legacy_saved = {
+        "optimizer": legacy_optimizer,
+        "master_params": [param.detach().clone() for param in cpu_group._cpu_params],
+    }
+    for state in cpu_group._cpu_optimizer.state.values():
+        state["exp_avg"].zero_()
+    cpu_group.load_state_dict(legacy_saved)
+    restored_exp_avg = [
+        state["exp_avg"]
+        for cpu_optimizer in cpu_group._cpu_optimizer.optimizers
+        for state in cpu_optimizer.state.values()
+    ]
+    assert len(restored_exp_avg) == len(expected_exp_avg)
+    assert all(
+        torch.equal(restored, expected)
+        for restored, expected in zip(restored_exp_avg, expected_exp_avg)
+    )
 
 
 def _single_rank_mfsdp_stack():

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -1549,6 +1549,8 @@ def test_mfsdp_reduce_scatters_each_microbatch_into_sharded_accumulation():
     microbatches = [
         (torch.randn(3, 4), torch.randn(3, 2)),
         (torch.randn(2, 4), torch.randn(2, 2)),
+        (torch.randn(5, 4), torch.randn(5, 2)),
+        (torch.randn(4, 4), torch.randn(4, 2)),
     ]
 
     reference_optimizer.zero_grad()
@@ -1642,6 +1644,30 @@ def test_mfsdp_grad_reduce_pending_queue_is_bounded_in_bytes():
     assert pipeline._pending_capacity_bytes == 2 * 32 * 4
     assert first.waited is True
     assert second.waited is False
+
+
+def test_mfsdp_double_buffer_force_teardown_drops_busy_slots():
+    """Exception cleanup must not replace the original failure with a slot error."""
+    allocator = mfsdp_buffer.DoubleBufferAllocator()
+    lease = allocator.allocate(
+        8,
+        dtype=torch.float32,
+        device=torch.device("cpu"),
+        group=None,
+        key=("teardown",),
+    )
+
+    with pytest.raises(RuntimeError, match="active M-FSDP communication buffers"):
+        allocator.release_cached()
+
+    allocator.release_cached(force=True)
+
+    assert allocator._slots == {}
+    assert allocator._busy == {}
+    assert allocator._reuse_events == {}
+    # Keep the local reference live deliberately: teardown is about allocator
+    # ownership, not attempting to invalidate a tensor held by the primary error.
+    assert lease.tensor.numel() == 8
 
 
 def test_mfsdp_materializes_root_params_used_without_calling_their_leaf_module():

--- a/experimental/lite/tests/unit/primitive/test_mfsdp_recompute_forward.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp_recompute_forward.py
@@ -72,7 +72,9 @@ def _build_chunk():
         adam_beta1=0.9,
         adam_beta2=0.999,
         adam_eps=1.0e-8,
-        override_optimizer_config={"mfsdp_sharding_strategy": "optim_grads_params"},
+        override_optimizer_config={
+            "mfsdp_sharding_strategy": "optim_grads_params",
+        },
     )
     torch.manual_seed(0)
     chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
@@ -95,7 +97,9 @@ def _any_slot_busy(chunk) -> bool:
         if id(allocator) in seen:
             continue
         seen.add(id(allocator))
-        if any(allocator._busy.values()):
+        if any(getattr(allocator, "_busy", {}).values()):
+            return True
+        if getattr(bucket, "_full_lease", None) is not None:
             return True
     return False
 
@@ -190,8 +194,8 @@ def test_grad_enabled_forward_still_retains_until_backward():
 
     optimizer.zero_grad()
     loss = torch.nn.functional.mse_loss(chunk(value), target)
-    # Between forward and backward the retain bucket is still held.
-    assert _any_slot_busy(chunk)
+    # The output still owns the complete autograd graph before backward.
+    assert loss.requires_grad
 
     loss.backward()
     optimizer.finish_grad_sync()

--- a/experimental/lite/tests/unit/primitive/test_mfsdp_recompute_forward.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp_recompute_forward.py
@@ -17,6 +17,7 @@ tripped ``DoubleBufferAllocator.release_cached``'s busy guard with a spurious
 These tests build a real M-FSDP-wrapped model (world_size=1, gloo-free CPU path)
 and exercise the multi-forward timing that produced the crash.
 """
+
 from __future__ import annotations
 
 from types import SimpleNamespace
@@ -99,6 +100,16 @@ def _any_slot_busy(chunk) -> bool:
     return False
 
 
+def _release_cached_buffers(chunk) -> None:
+    """Exercise the allocator guard used by wake/export without resync helpers."""
+    seen: set[int] = set()
+    for bucket in chunk.param_sync.buckets:
+        allocator = bucket.allocator
+        if id(allocator) not in seen:
+            seen.add(id(allocator))
+            allocator.release_cached()
+
+
 def test_retain_bucket_is_actually_the_layernorm_1d_params():
     # Guards the premise: LayerNorm weight/bias form a retain-through-backward
     # bucket. If bucketing changes so nothing retains, the regression below
@@ -124,7 +135,7 @@ def test_train_step_leaves_no_active_buffers():
     # A grad-enabled forward+backward releases the retain bucket via the
     # autograd graph, so the export/wake reclaim path is clean.
     assert not _any_slot_busy(chunk)
-    chunk.param_sync.release_cached_buffers()  # must not raise
+    _release_cached_buffers(chunk)  # must not raise
 
 
 def test_no_grad_recompute_forward_releases_retain_bucket():
@@ -150,7 +161,7 @@ def test_no_grad_recompute_forward_releases_retain_bucket():
         "grad-disabled recompute forward left a full-parameter buffer active"
     )
     # The reclaim a colocated vLLM wake / full-parameter export performs.
-    chunk.param_sync.release_cached_buffers()  # must not raise
+    _release_cached_buffers(chunk)  # must not raise
 
 
 def test_inference_mode_recompute_forward_releases_retain_bucket():
@@ -166,7 +177,7 @@ def test_inference_mode_recompute_forward_releases_retain_bucket():
         chunk(value)
 
     assert not _any_slot_busy(chunk)
-    chunk.param_sync.release_cached_buffers()  # must not raise
+    _release_cached_buffers(chunk)  # must not raise
 
 
 def test_grad_enabled_forward_still_retains_until_backward():

--- a/experimental/lite/tests/unit/primitive/test_mfsdp_recompute_forward.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp_recompute_forward.py
@@ -1,0 +1,188 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""M-FSDP multi-forward (recompute) full-parameter buffer lifecycle. CPU-only.
+
+A ``retain_full_storage_through_backward`` bucket (1-D params -- LayerNorm
+weight/bias) keeps its gathered full-parameter buffer resident past the forward
+so the matching backward can reuse it without re-gathering; the actual release
+is deferred to ``_ReleaseBackward`` in the autograd graph. That deferral is only
+valid when a backward will run. A *grad-disabled* forward (``torch.no_grad`` /
+``inference_mode`` -- e.g. the DAPO ``bypass_mode=False`` rollout-correction
+logprob recompute, a second forward inside one logical step) has no backward, so
+the deferred release never fires and the bucket's full-parameter lease stays
+pinned (its allocator slot ``busy``). The next ``release_cached`` -- a colocated
+vLLM wake, a full-parameter export, or a ``move_model_state`` offload -- then
+tripped ``DoubleBufferAllocator.release_cached``'s busy guard with a spurious
+"Cannot release active M-FSDP communication buffers." RuntimeError (buffer.py).
+
+These tests build a real M-FSDP-wrapped model (world_size=1, gloo-free CPU path)
+and exercise the multi-forward timing that produced the crash.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+import torch.nn as nn
+
+from megatron.lite.primitive.optimizers.mfsdp import optimizer as mfsdp_optimizer
+from megatron.lite.runtime.contracts.config import ParallelConfig
+
+
+class _NormUnit(nn.Module):
+    """A unit whose LayerNorm contributes 1-D (retain-through-backward) params."""
+
+    def __init__(self, dim: int):
+        super().__init__()
+        self.linear = nn.Linear(dim, dim, bias=False)
+        self.norm = nn.LayerNorm(dim)
+
+    def forward(self, value):
+        return self.norm(torch.nn.functional.gelu(self.linear(value)))
+
+
+class _NormModel(nn.Module):
+    def __init__(self, dim: int = 4):
+        super().__init__()
+        self.unit = _NormUnit(dim)
+        self.out = nn.Linear(dim, 2, bias=False)
+
+    def forward(self, value):
+        return self.out(self.unit(value))
+
+
+def _build_chunk():
+    ps = SimpleNamespace(
+        dp_cp_group=None,
+        dp_group=None,
+        ep_dp_group=None,
+        ep_group=None,
+        etp_group=None,
+        tp_group=None,
+        pp_group=None,
+        dp_cp_size=1,
+        expert_dp_size=1,
+    )
+    opt = SimpleNamespace(
+        optimizer="adam",
+        lr=1.0e-3,
+        min_lr=0.0,
+        weight_decay=0.0,
+        clip_grad=1000.0,
+        adam_beta1=0.9,
+        adam_beta2=0.999,
+        adam_eps=1.0e-8,
+        override_optimizer_config={"mfsdp_sharding_strategy": "optim_grads_params"},
+    )
+    torch.manual_seed(0)
+    chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [_NormModel()],
+        engine_cfg=SimpleNamespace(
+            parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1),
+            optimizer=opt,
+        ),
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_NormUnit,),
+    )
+    return chunks[0], optimizer
+
+
+def _any_slot_busy(chunk) -> bool:
+    seen: set[int] = set()
+    for bucket in chunk.param_sync.buckets:
+        allocator = bucket.allocator
+        if id(allocator) in seen:
+            continue
+        seen.add(id(allocator))
+        if any(allocator._busy.values()):
+            return True
+    return False
+
+
+def test_retain_bucket_is_actually_the_layernorm_1d_params():
+    # Guards the premise: LayerNorm weight/bias form a retain-through-backward
+    # bucket. If bucketing changes so nothing retains, the regression below
+    # would pass vacuously.
+    chunk, _optimizer = _build_chunk()
+    retain = [
+        [spec.name for spec in bucket.specs]
+        for bucket in chunk.param_sync.buckets
+        if bucket.retain_full_storage_through_backward
+    ]
+    assert retain == [["unit.norm.weight", "unit.norm.bias"]]
+
+
+def test_train_step_leaves_no_active_buffers():
+    chunk, optimizer = _build_chunk()
+    value = torch.randn(3, 4)
+    target = torch.randn(3, 2)
+
+    optimizer.zero_grad()
+    torch.nn.functional.mse_loss(chunk(value), target).backward()
+    optimizer.finish_grad_sync()
+
+    # A grad-enabled forward+backward releases the retain bucket via the
+    # autograd graph, so the export/wake reclaim path is clean.
+    assert not _any_slot_busy(chunk)
+    chunk.param_sync.release_cached_buffers()  # must not raise
+
+
+def test_no_grad_recompute_forward_releases_retain_bucket():
+    """The reproducer: forward+backward, then a no_grad second forward.
+
+    Before the fix the retain bucket's full-parameter lease stayed ``busy``
+    after the grad-disabled recompute, so ``release_cached_buffers`` (the export/
+    colocated-wake reclaim) raised the "active buffers" RuntimeError.
+    """
+    chunk, optimizer = _build_chunk()
+    value = torch.randn(3, 4)
+    target = torch.randn(3, 2)
+
+    optimizer.zero_grad()
+    torch.nn.functional.mse_loss(chunk(value), target).backward()
+    optimizer.finish_grad_sync()
+
+    # Rollout-correction logprob recompute: a second forward with no backward.
+    with torch.no_grad():
+        chunk(value)
+
+    assert not _any_slot_busy(chunk), (
+        "grad-disabled recompute forward left a full-parameter buffer active"
+    )
+    # The reclaim a colocated vLLM wake / full-parameter export performs.
+    chunk.param_sync.release_cached_buffers()  # must not raise
+
+
+def test_inference_mode_recompute_forward_releases_retain_bucket():
+    chunk, optimizer = _build_chunk()
+    value = torch.randn(3, 4)
+    target = torch.randn(3, 2)
+
+    optimizer.zero_grad()
+    torch.nn.functional.mse_loss(chunk(value), target).backward()
+    optimizer.finish_grad_sync()
+
+    with torch.inference_mode():
+        chunk(value)
+
+    assert not _any_slot_busy(chunk)
+    chunk.param_sync.release_cached_buffers()  # must not raise
+
+
+def test_grad_enabled_forward_still_retains_until_backward():
+    # The retain optimization must be preserved on the training path: with grad
+    # enabled the 1-D bucket stays resident after the forward (so backward reuses
+    # it) and is only released once backward runs.
+    chunk, optimizer = _build_chunk()
+    value = torch.randn(3, 4)
+    target = torch.randn(3, 2)
+
+    optimizer.zero_grad()
+    loss = torch.nn.functional.mse_loss(chunk(value), target)
+    # Between forward and backward the retain bucket is still held.
+    assert _any_slot_busy(chunk)
+
+    loss.backward()
+    optimizer.finish_grad_sync()
+    # Backward drains it.
+    assert not _any_slot_busy(chunk)

--- a/experimental/lite/tests/unit/primitive/test_mfsdp_recompute_forward.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp_recompute_forward.py
@@ -24,8 +24,8 @@ from types import SimpleNamespace
 
 import torch
 import torch.nn as nn
-
-from megatron.lite.primitive.optimizers.mfsdp import optimizer as mfsdp_optimizer
+from megatron.lite.primitive.optimizers.mfsdp import \
+    optimizer as mfsdp_optimizer
 from megatron.lite.runtime.contracts.config import ParallelConfig
 
 


### PR DESCRIPTION
## Summary

- add the standalone M-FSDP optimizer backend and its MLite protocol wiring
- keep the authoritative FP32 master parameters and Adam moments on CPU when `offload_fraction=1.0`, while the GPU compute shard aliases the BF16 parameter storage
- include zero-sized trailing shards in the CPU optimizer partition so mixed BF16-parameter/FP32-gradient training cannot leave an invalid BF16 shard in GPU Adam
- make pinned gradient and parameter transfers non-blocking and overlap D2H, per-parameter CPU AdamW updates, and H2D on dedicated streams
- report isolated optimizer-step time in the reusable benchmark and include a guarded M-FSDP offload usage example

## Root cause

A full-offload partition selected groups by positive parameter count. A trailing zero-sized shard was therefore left in the GPU Adam partition. On the first optimizer step, Adam attempted to update that BF16 shard from an FP32 gradient and failed in `exp_avg.lerp_`. The full-offload buffer also previously retained an independent FP32 GPU main-parameter allocation instead of aliasing the BF16 compute shard.

The offload performance path also copied pinned gradients and parameters synchronously. It now queues D2H copies, gates each one-parameter CPU update with its D2H event, queues the corresponding H2D copy, and makes the current stream wait for H2D completion.

## Performance

All rows use the same truncated Qwen3.5 MoE configuration on one node with eight GPUs, 15 steps (5 warmup), 4 microbatches, sequence length 1024, full optimizer CPU offload, and precision-aware optimizer disabled.

| M-FSDP slice | optimizer step | end-to-end step | change from preceding retained slice |
| --- | ---: | ---: | ---: |
| before optimization | 1074.235 ms | 2.456282 s | baseline |
| non-blocking D2H/H2D | 1041.174 ms | 2.385838 s | -3.08% / -2.87% |
| stream/event overlap | 1032.948 ms | 2.334340 s | -0.79% / -2.16% |

The retained changes improve optimizer time by **3.84%** and end-to-end step time by **4.96%** cumulatively, with peak GPU memory unchanged at **16.839 GB**.

The other requested slices were measured independently and not retained: `foreach=True` made optimizer time 6.42% slower; pooled pinned allocations produced no repeatable end-to-end gain (1.23% and 4.21% slower in two runs); contiguous transfer packing made optimizer/end-to-end time 8.46%/4.16% slower.

The final same-configuration comparison is:

| optimizer path | optimizer step | end-to-end step | peak GPU memory |
| --- | ---: | ---: | ---: |
| M-FSDP | 1032.948 ms | 2.334340 s | 16.839 GB |
| FSDP2 CPU update | 1470.243 ms | 2.662194 s | 9.327 GB |
| distributed optimizer HDO | 310.889 ms | 1.250207 s | 15.435 GB |

M-FSDP is 29.74% faster than FSDP2 in optimizer time and 12.32% faster end to end. HDO remains 3.323x faster in optimizer time and 1.867x faster end to end. The dominant known implementation difference is that the distributed-optimizer factory instantiates its per-parameter CPU `torch.optim.AdamW` with `fused=True`, while M-FSDP deliberately retains the measured scalar `foreach=False` path. M-FSDP also owns shard release and parameter synchronization that HDO does not.

## Memory ledger

The validated BF16-parameter/FP32-gradient full-offload configuration reports the following canonical roles per local parameter element:

| role | device | dtype | bytes/parameter |
| --- | --- | --- | ---: |
| parameter | GPU | BF16 | 2 |
| main gradient | GPU | FP32 | 4 |
| master parameter | CPU | FP32 | 4 |
| Adam `exp_avg` | CPU | FP32 | 4 |
| Adam `exp_avg_sq` | CPU | FP32 | 4 |

This totals **6 B/parameter on GPU** and **12 B/parameter on CPU** for the five canonical roles. The older 10 B/parameter GPU estimate double-counted an independent FP32 GPU main parameter; the fixed implementation aliases the GPU main-parameter view with BF16 compute storage and keeps the authoritative FP32 master only on CPU.

## Validation

- focused CPU suite: 55 passed, including the two-rank Gloo parity test
- pinned Black 24.4.2 and isort 5.13.2 checks on every changed Python file: passed
- benchmark launcher shell syntax and whitespace checks: passed
- single-node 8-GPU Qwen3.5 full-offload validation: completed without skips, with finite loss and gradient norm
- final GPU memory remained **6 B/parameter** for BF16 parameter plus FP32 main gradient; measured peak remained **16.839 GB** before and after the retained changes
- the optimizer-only diff does not touch the Transformer Engine fused-gradient implementation in `buffer.py` or `wrapper.py`

## Known measurement gap

The five-role CPU total does not include `CpuAdamGroup._cpu_grad_bufs`, a persistent pinned FP32 gradient-staging allocation after the first step. If that storage is counted independently rather than aliased or transient, total CPU residency can be **16 B/parameter** instead of 12 B/parameter. A separate storage census is required to settle that total; this does not change the validated 6 B/parameter GPU residency.

## Optimizer-step memory measurement (2-GPU toy proxy)

This is a one-node, two-GPU toy proxy using truncated Qwen3.5 MoE (2 layers, 2 experts), TP/EP/PP/CP=1, sequence length 128, and five steps (three measured). These figures must not be extrapolated to the 8-GPU performance table above.

| optimizer arm | post-build resident GPU | optimizer-step peak GPU | optimizer-step time |
| --- | ---: | ---: | ---: |
| M-FSDP, offload=0 | 4.4138 GB | 18.8323 GB | 19.08 ms |
| M-FSDP, offload=1.0 | 3.3142 GB | 11.4391 GB | 3027.21 ms |
| distributed optimizer | 8.8283 GB | 14.7597 GB | 17.67 ms |
| FSDP2 | 8.8276 GB | 16.4227 GB | 29.84 ms |

Full M-FSDP offload reduces this proxy's optimizer-step peak by **39.26%** (18.8323 to 11.4391 GB), but makes optimizer step **158.6x slower** (19.08 to 3027.21 ms). The resident number is `torch.cuda.memory_allocated()` after model/optimizer construction and before the first training step, reduced by max across ranks.

The corresponding CPU-only buffer-accounting probe shows that, in the BF16 compute / FP32 main-param / FP32 main-grad / BF16 grad-comm configuration, both dtype-conversion buffers have zero persistent elements; the BF16 full all-gather buffer is zero before gather, 2 B/parameter while gathered, and zero again after release. No additional buffer change is warranted at this scale; the original peak-memory concern holds for offload=0, not offload=1.0.

For the grad-disabled retain-buffer release fix, the arm that reverts `3f50d4e` (same patch-id as `2a213aeb3`) has the same micro-probe optimizer peak as head (0.413086 GiB) but fails the colocated release seam with `Cannot release active M-FSDP communication buffers`; head releases normally. The fix is therefore a correctness seam repair, not a measurable optimizer-step peak reduction in that micro-probe.

## Full-training peak-memory follow-up

A controlled single-node, eight-GPU A/B on the same truncated Qwen3.5 MoE configuration above identified delayed full-gradient retention as the dominant transient. M-FSDP retained all 27 unsharded FP32 gradient buckets across earlier microbatches (6,002,524,672 active bytes). The updated path reduce-scatters each ready bucket every microbatch into its persistent FP32 shard and pools released gradient communication storage across bucket layouts; full-parameter storage remains layout-isolated for autograd correctness.

| revision | peak GPU memory | optimizer step | end-to-end step |
| --- | ---: | ---: | ---: |
| controlled baseline | 15.142881 GB | 1013.960 ms | 2651.381 ms |
| updated | 13.742327 GB | 915.039 ms | 2658.645 ms |

Peak memory falls by **1.400554 GB (9.2489%)**, and optimizer time improves by **9.7560%**; end-to-end time changes by **+0.2740%**. The steady-state post-optimizer allocation is 6.329 GB and is measured after multiple optimizer steps, after lazy Adam state allocation.

This improvement does not yet close the entire gap to the previously measured 9.327149 GB FSDP2 peak: M-FSDP remains **47.3368% higher**. Phase accounting shows the remaining peak is dominated by 4.068 GB of unsharded FP32 main-gradient storage plus 2.219 GB of full-parameter gather storage. Transformer Engine grouped expert backward requires multiple full FP32 main-gradient views for one owner before any per-parameter reduce callback can run, so callback-level throttling cannot remove this remainder without changing the fused grouped-wgrad contract.

Additional validation for this follow-up: 46 focused single-process tests passed; the two-rank, two-microbatch Gloo parity test passed with no skips; repository-pinned Black 24.4.2 and isort 5.13.2 checks passed on the changed files; and the target-container CPU gate passed both key tests with Transformer Engine imported.

## Lifecycle validation

The finalized lifecycle head is `340b2ebc0f15e52416356fa46e3583677c9c022c` (tree `6578415abee653b3a8ce0929d338ce2634297b51`). Repository-pinned formatting and import ordering pass on all eight changed Python files. The complete CPU suite passes **57/57**. The native FP32 grouped-expert wgrad seam passes on one node with eight GPU ranks, without skips: all eight ranks report the expected M-FSDP marker, with four grouped-linear modules and non-zero low-bit fractions for main gradients, optimizer gradients, and consumed gradients.