### PR TITLE
Fix MXFP4 actor export for K3 resync

### DIFF
--- a/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
@@ -390,6 +390,13 @@ class MegatronLiteEngine(BaseEngine):
             export_kwargs["target"] = self.engine_config.resync_format
             if self.engine_config.resync_config:
                 export_kwargs["resync_config"] = dict(self.engine_config.resync_config)
+        elif (
+            self.engine_config.qat.get("enable", False)
+            and self.engine_config.qat.get("mode") == "mxfp4"
+        ):
+            # MXFP4 is a checkpoint representation, not a post-export tensor
+            # cast. Ask the model protocol for its native packed/E8M0 stream.
+            export_kwargs["target"] = "mxfp4"
         elif self._resolve_model_name() == "qwen3_5":
             # Qwen3.5 selects its vLLM checkpoint layout through target=.
             # Qwen3-MoE's HF exporter has no target parameter, so forwarding
@@ -398,7 +405,10 @@ class MegatronLiteEngine(BaseEngine):
         if self.engine_config.export_dtype:
             export_kwargs["export_dtype"] = self.engine_config.export_dtype
         weights = self.runtime.export_weights(self.handle, **export_kwargs)
-        if self.engine_config.qat.get("enable", False):
+        if (
+            self.engine_config.qat.get("enable", False)
+            and self.engine_config.qat.get("mode") != "mxfp4"
+        ):
             from verl.utils.modelopt import export_qat_weights
 
             qat_config = SimpleNamespace(**self.engine_config.qat)

--- a/experimental/lite/tests/unit/verl/test_mlite_engine_config.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_engine_config.py
@@ -255,7 +255,7 @@ def test_online_qat_export_wraps_mlite_hf_weight_stream(monkeypatch) -> None:
             qat={
                 "enable": True,
                 "apply_modelopt_fake_quant": False,
-                "mode": "mxfp4",
+                "mode": "nvfp4",
                 "group_size": 32,
                 "ignore_patterns": ["lm_head"],
             }
@@ -295,9 +295,102 @@ def test_online_qat_export_wraps_mlite_hf_weight_stream(monkeypatch) -> None:
     assert captured["weights"] is source_weights
     assert captured["modules"] == [engine.module]
     assert captured["bridge"] is None
-    assert captured["qat_config"].mode == "mxfp4"
+    assert captured["qat_config"].mode == "nvfp4"
     assert captured["qat_config"].group_size == 32
     assert captured["qat_config"].apply_modelopt_fake_quant is False
+
+
+def test_online_mxfp4_qat_uses_native_packed_scale_export_for_k3(monkeypatch) -> None:
+    """K3 must send checkpoint-format MXFP4, never BF16 into a scale loader."""
+    engine = _engine(
+        engine_config=_engine_config(
+            qat={
+                "enable": True,
+                "apply_modelopt_fake_quant": False,
+                "mode": "mxfp4",
+                "group_size": 32,
+            }
+        )
+    )
+    engine.model_config.hf_config = {"model_type": "kimi_k3"}
+    captured = {}
+
+    class Runtime:
+        @staticmethod
+        def export_weights(handle, **kwargs):
+            captured.update(kwargs)
+            return iter(
+                [
+                    (
+                        "language_model.model.layers.0.block_sparse_moe."
+                        "experts.0.w1.weight_packed",
+                        torch.empty((3072, 1792), dtype=torch.uint8),
+                    ),
+                    (
+                        "language_model.model.layers.0.block_sparse_moe."
+                        "experts.0.w1.weight_scale",
+                        torch.empty((3072, 112), dtype=torch.uint8),
+                    ),
+                    (
+                        "language_model.model.layers.0.block_sparse_moe."
+                        "experts.0.w3.weight_packed",
+                        torch.empty((3072, 1792), dtype=torch.uint8),
+                    ),
+                    (
+                        "language_model.model.layers.0.block_sparse_moe."
+                        "experts.0.w3.weight_scale",
+                        torch.empty((3072, 112), dtype=torch.uint8),
+                    ),
+                    (
+                        "language_model.model.layers.0.block_sparse_moe."
+                        "experts.0.w2.weight_packed",
+                        torch.empty((3584, 1536), dtype=torch.uint8),
+                    ),
+                    (
+                        "language_model.model.layers.0.block_sparse_moe."
+                        "experts.0.w2.weight_scale",
+                        torch.empty((3584, 96), dtype=torch.uint8),
+                    ),
+                ]
+            )
+
+    forbidden_exporter = types.ModuleType("verl.utils.modelopt")
+
+    def fail_if_called(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError("MXFP4 must use the model protocol export, not ModelOpt")
+
+    forbidden_exporter.export_qat_weights = fail_if_called
+    monkeypatch.setitem(sys.modules, "verl.utils.modelopt", forbidden_exporter)
+    engine.runtime = Runtime()
+    engine.handle = object()
+    engine.module = object()
+    engine._initial_sync_cache_cleared = True
+
+    weights, metadata = engine.get_per_tensor_param()
+
+    exported = dict(weights)
+    assert metadata is None
+    assert captured["target"] == "mxfp4"
+    assert all(tensor.dtype == torch.uint8 for tensor in exported.values())
+    assert exported[
+        "language_model.model.layers.0.block_sparse_moe.experts.0.w1.weight_packed"
+    ].shape == (3072, 1792)
+    assert exported[
+        "language_model.model.layers.0.block_sparse_moe.experts.0.w1.weight_scale"
+    ].shape == (3072, 112)
+    assert exported[
+        "language_model.model.layers.0.block_sparse_moe.experts.0.w3.weight_packed"
+    ].shape == (3072, 1792)
+    assert exported[
+        "language_model.model.layers.0.block_sparse_moe.experts.0.w3.weight_scale"
+    ].shape == (3072, 112)
+    assert exported[
+        "language_model.model.layers.0.block_sparse_moe.experts.0.w2.weight_packed"
+    ].shape == (3584, 1536)
+    assert exported[
+        "language_model.model.layers.0.block_sparse_moe.experts.0.w2.weight_scale"
+    ].shape == (3584, 96)
 
 
 def test_qat_export_rejects_native_resync_format_double_quantization() -> None:


### PR DESCRIPTION
## Summary

- Route MXFP4 QAT resynchronization through the model protocol native checkpoint export.
- Send routed-expert packed weights and E8M0 scales instead of applying a post-export generic quantizer.
- Cover the K3 stream contract: w1/w3 packed `(3072, 1792)`, scale `(3072, 112)`; w2 packed `(3584, 1536)`, scale `(3584, 96)`.

## Validation

- Python source compilation and `git diff --check` completed successfully.
- The focused integration test requires optional VERL dependencies unavailable in this CPU environment; it is not claimed as passed.
- The available Ruff 0.15 requires unrelated full-file reformatting and does not match the repository-pinned formatter; pinned pre-commit remains to be run in the target environment.
- A K3 validation carrier using MLite `main` plus this single commit completed full import closure, runtime package-path validation, and Ray startup. No dependency on #142 remains.
- Actor-to-vLLM synchronization and a training step are still being validated; no runtime metric is claimed.