### PR TITLE
Allow dist-opt gradient reduction in parameter dtype

### DIFF
--- a/experimental/lite/megatron/lite/primitive/optimizers/megatron_wrap.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/megatron_wrap.py
@@ -23,6 +23,11 @@ def validate_dist_opt_config(engine_cfg) -> None:
 validate_dist_opt_session = validate_dist_opt_config
 
 
+def _resolve_grad_reduce_in_fp32(engine_cfg) -> bool:
+    """Keep the historical FP32 default while allowing memory-bounded callers to opt out."""
+    return bool(getattr(engine_cfg, "grad_reduce_in_fp32", True))
+
+
 def _effective_etp(parallel) -> int:
     return int(parallel.etp if parallel.etp is not None else 1)
 
@@ -153,7 +158,9 @@ def build_dist_opt_stack(
         wrapped_chunks = list(model_chunks)
     else:
         ddp_config = DistributedDataParallelConfig(
-            use_distributed_optimizer=True, overlap_grad_reduce=False, grad_reduce_in_fp32=True
+            use_distributed_optimizer=True,
+            overlap_grad_reduce=False,
+            grad_reduce_in_fp32=_resolve_grad_reduce_in_fp32(engine_cfg),
         )
         wrapped_chunks = []
         for chunk_idx, chunk in enumerate(model_chunks):
@@ -205,6 +212,7 @@ def build_dist_opt_training_optimizer(
     is_expert: ExpertClassifierFn | None = None,
     skip_ddp_wrap: bool = False,
     deterministic: bool | None = None,
+    grad_reduce_in_fp32: bool = True,
 ):
     """Build the dist_opt DDP+optimizer stack from a Megatron Lite model ImplConfig."""
 
@@ -230,6 +238,7 @@ def build_dist_opt_training_optimizer(
         parallel=impl_cfg.parallel,
         optimizer=opt,
         deterministic=bool(deterministic),
+        grad_reduce_in_fp32=bool(grad_reduce_in_fp32),
     )
     model_chunks[:], optimizer = build_dist_opt_stack(
         model_chunks,

--- a/experimental/lite/tests/unit/primitive/test_dist_opt_validation.py
+++ b/experimental/lite/tests/unit/primitive/test_dist_opt_validation.py
@@ -1,9 +1,13 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from __future__ import annotations
 
+import inspect
+
 import pytest
 
 from megatron.lite.primitive.optimizers.megatron_wrap import (
+    _resolve_grad_reduce_in_fp32,
+    build_dist_opt_training_optimizer,
     validate_dist_opt_config,
     validate_dist_opt_session,
 )
@@ -27,3 +31,22 @@ def test_dist_opt_validation_keeps_vpp_parallel_constraint():
 def test_validate_dist_opt_session_alias_matches_config_validator():
     assert validate_dist_opt_session is validate_dist_opt_config
     validate_dist_opt_session(_engine_cfg(model_name="another_synthetic_model", pp=2, vpp=2))
+
+
+def test_dist_opt_grad_reduction_defaults_to_fp32():
+    assert _resolve_grad_reduce_in_fp32(_engine_cfg(model_name="default_model")) is True
+
+
+def test_dist_opt_grad_reduction_can_use_parameter_dtype():
+    engine_cfg = _engine_cfg(model_name="memory_bounded_model")
+    engine_cfg.grad_reduce_in_fp32 = False
+
+    assert _resolve_grad_reduce_in_fp32(engine_cfg) is False
+
+
+def test_training_optimizer_exposes_grad_reduction_precision():
+    parameter = inspect.signature(build_dist_opt_training_optimizer).parameters[
+        "grad_reduce_in_fp32"
+    ]
+
+    assert parameter.default is True


### PR DESCRIPTION
## Summary

Allow callers of the shared dist-opt optimizer primitive to select parameter-dtype gradient reduction while retaining the existing FP32 default.

## Validation

- `PYTHONPATH=experimental/lite pytest -q experimental/lite/tests/unit/primitive/test_dist_opt_validation.py` — 6 passed.
- `git diff --check` — clean.