### PR TITLE
Add M-FSDP full-parallel SFT precision curve

### DIFF
--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
@@ -379,7 +379,13 @@ class ParamBucket:
             )
         )
         self.full_buffer = torch.empty(0, dtype=compute_dtype, device=self.device)
+        self.full_main_grad_buffer = torch.empty(
+            0,
+            dtype=self.policy.main_grads_dtype,
+            device=self.device,
+        )
         self._full_lease: BufferLease | None = None
+        self._full_main_grad_lease: BufferLease | None = None
         self._grad_lease: BufferLease | None = None
         self._param_gather_work: Any | None = None
         self._grad_reduce_work: Any | None = None
@@ -412,6 +418,9 @@ class ParamBucket:
                 _copy_parameter_metadata(spec.full_param, shard_param)
                 shard_param._mfsdp_original_ndim = spec.full_param.ndim
                 spec.shard_param = shard_param
+                # TE returns a dummy ``.grad`` when its wgrad GEMM writes the
+                # real gradient directly into ``main_grad``.
+                spec.full_param.grad_added_to_main_grad = False
                 spec.full_param.register_post_accumulate_grad_hook(
                     self._make_grad_ready_hook(spec)
                 )
@@ -431,6 +440,39 @@ class ParamBucket:
             spec.full_param.data = view
             for binding in spec.bindings:
                 setattr(binding.module, binding.attribute, spec.full_param)
+
+    def prepare_main_grads(self) -> None:
+        """Attach bounded FP32 views for fused wgrad accumulation."""
+        if self._full_main_grad_lease is None:
+            self._full_main_grad_lease = self.allocator.allocate(
+                self.full_numel,
+                dtype=self.policy.main_grads_dtype,
+                device=self.device,
+                group=self.process_group,
+                key=(
+                    "main_grad",
+                    id(self.process_group),
+                    self.allocator_layout_key,
+                ),
+            )
+            self.full_main_grad_buffer = self._full_main_grad_lease.tensor
+            self.full_main_grad_buffer.zero_()
+        for spec in self.specs:
+            spec.full_param.main_grad = self.full_main_grad_buffer.narrow(
+                0, spec.full_offset, spec.numel
+            ).view(spec.shape)
+
+    def _release_full_main_grads(self) -> None:
+        if self._full_main_grad_lease is not None:
+            self._full_main_grad_lease.release()
+            self._full_main_grad_lease = None
+        self.full_main_grad_buffer = torch.empty(
+            0,
+            dtype=self.policy.main_grads_dtype,
+            device=self.device,
+        )
+        for spec in self.specs:
+            spec.full_param.main_grad = self.full_main_grad_buffer
 
     def prepare_param_gather(self) -> tuple[torch.Tensor, torch.Tensor]:
         if self._full_lease is None:
@@ -505,6 +547,8 @@ class ParamBucket:
         self.discard_full_parameter_views()
         if self._grad_reduce_launched:
             self.wait_grad_reduce()
+        else:
+            self._release_full_main_grads()
         self.allocator.release_cached()
 
         grad_present = {
@@ -525,6 +569,11 @@ class ParamBucket:
         self.full_buffer = torch.empty(
             0,
             dtype=self.policy.compute_dtype,
+            device=device,
+        )
+        self.full_main_grad_buffer = torch.empty(
+            0,
+            dtype=self.policy.main_grads_dtype,
             device=device,
         )
 
@@ -563,6 +612,8 @@ class ParamBucket:
         self.discard_full_parameter_views()
         if self._grad_reduce_launched:
             self.wait_grad_reduce()
+        else:
+            self._release_full_main_grads()
         self.allocator.release_cached()
 
     def prepare_grad_reduce(
@@ -573,23 +624,27 @@ class ParamBucket:
         if not force and len(self._grad_ready_ids) != len(self.specs):
             return None
         self._grad_reduce_launched = True
-        self._grad_lease = self.allocator.allocate(
-            self.full_numel,
-            dtype=self.policy.grad_comm_dtype,
-            device=self.device,
-            group=self.process_group,
-            key=(
-                "grad",
-                id(self.process_group),
-                self.allocator_layout_key,
-            ),
-        )
-        grad_input = self._grad_lease.tensor
-        grad_input.zero_()
+        self.prepare_main_grads()
+        if self.policy.grad_comm_dtype == self.policy.main_grads_dtype:
+            grad_input = self.full_main_grad_buffer
+        else:
+            self._grad_lease = self.allocator.allocate(
+                self.full_numel,
+                dtype=self.policy.grad_comm_dtype,
+                device=self.device,
+                group=self.process_group,
+                key=(
+                    "grad",
+                    id(self.process_group),
+                    self.allocator_layout_key,
+                ),
+            )
+            grad_input = self._grad_lease.tensor
+            grad_input.copy_(self.full_main_grad_buffer)
         with torch.no_grad():
             for spec in self.specs:
                 grad = spec.full_param.grad
-                if grad is not None:
+                if grad is not None and not spec.full_param.grad_added_to_main_grad:
                     grad_input.narrow(0, spec.full_offset, spec.numel).copy_(
                         grad.reshape(-1)
                     )
@@ -628,6 +683,7 @@ class ParamBucket:
         if self._grad_lease is not None:
             self._grad_lease.release()
             self._grad_lease = None
+        self._release_full_main_grads()
 
     def copy_full_parameters_to_shards(self) -> None:
         self.wait_param_gather()
@@ -646,8 +702,10 @@ class ParamBucket:
         self.main_grad_buffer.zero_()
         for spec in self.specs:
             spec.full_param.grad = None
+            spec.full_param.grad_added_to_main_grad = False
             if spec.shard_param is not None:
                 spec.shard_param.grad = None
+        self._release_full_main_grads()
 
     def set_grad_sync_enabled(self, enabled: bool) -> None:
         enabled = bool(enabled)
@@ -982,6 +1040,7 @@ class AllGatherPipeline:
         bucket_id = bucket.bucket_id
         self.wait_bucket_ready(bucket_id, bwd=True)
         bucket.install_full_parameters()
+        bucket.prepare_main_grads()
         self._backward_cursor = min(self._backward_cursor, bucket_id - 1)
         if self.overlap and self._backward_cursor >= 0:
             self.async_bucket_gather(self._backward_cursor, bwd=True)

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
@@ -625,6 +625,12 @@ class ParamBucket:
             return None
         self._grad_reduce_launched = True
         self.prepare_main_grads()
+        with torch.no_grad():
+            for spec in self.specs:
+                grad = spec.full_param.grad
+                if grad is not None and not spec.full_param.grad_added_to_main_grad:
+                    spec.full_param.main_grad.add_(grad)
+                spec.full_param.grad = None
         if self.policy.grad_comm_dtype == self.policy.main_grads_dtype:
             grad_input = self.full_main_grad_buffer
         else:
@@ -641,14 +647,6 @@ class ParamBucket:
             )
             grad_input = self._grad_lease.tensor
             grad_input.copy_(self.full_main_grad_buffer)
-        with torch.no_grad():
-            for spec in self.specs:
-                grad = spec.full_param.grad
-                if grad is not None and not spec.full_param.grad_added_to_main_grad:
-                    grad_input.narrow(0, spec.full_offset, spec.numel).copy_(
-                        grad.reshape(-1)
-                    )
-                spec.full_param.grad = None
         return self.local_grad_comm_buffer, grad_input
 
     def mark_grad_reduce_launched(self, work: Any | None) -> None:
@@ -740,6 +738,10 @@ class ParamBucket:
                 return
             self._grad_ready_ids.add(id(spec))
             if param.grad_added_to_main_grad:
+                param.grad = None
+            else:
+                with torch.no_grad():
+                    param.main_grad.add_(param.grad)
                 param.grad = None
             if len(self._grad_ready_ids) != len(self.specs):
                 return

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
@@ -739,6 +739,8 @@ class ParamBucket:
             if param.grad is None:
                 return
             self._grad_ready_ids.add(id(spec))
+            if param.grad_added_to_main_grad:
+                param.grad = None
             if len(self._grad_ready_ids) != len(self.specs):
                 return
             if self.grad_sync_enabled and self.grad_ready_callback is not None:

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/wrapper.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/wrapper.py
@@ -97,6 +97,7 @@ class MegatronFSDP(nn.Module):
             is_expert=is_expert,
             unit_modules=unit_modules,
         )
+        _enable_fused_wgrad_accumulation(module)
         self.param_sync = CommunicationPipelines(self.param_and_grad_buffer.buckets)
         self.all_gather_pipeline: AllGatherPipeline = self.param_sync.all_gather
         self.grad_reduce_pipeline: GradReducePipeline = self.param_sync.grad_reduce
@@ -270,6 +271,13 @@ def _module_by_id(root: nn.Module, module_id: int) -> nn.Module:
         if id(module) == module_id:
             return module
     raise RuntimeError("M-FSDP bucket owner is no longer part of the wrapped module.")
+
+
+def _enable_fused_wgrad_accumulation(module: nn.Module) -> None:
+    """Enable TE-style fused wgrad only inside the M-FSDP ownership boundary."""
+    for child in module.modules():
+        if hasattr(child, "fuse_wgrad_accumulation"):
+            child.fuse_wgrad_accumulation = True
 
 
 __all__ = ["MFSdpModule", "MegatronFSDP", "mark_optimizer_built"]

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -1024,6 +1024,7 @@ def test_mfsdp_non_fused_wgrad_accumulates_in_fp32_per_microbatch():
     assert not hasattr(model.linear, "fuse_wgrad_accumulation")
     chunks = [model]
     optimizer_config = _optimizer_cfg(use_fused_optimizer=False)
+    optimizer_config.clip_grad = 10000.0
     impl_cfg = SimpleNamespace(
         parallel=parallel,
         optimizer_config=optimizer_config,

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -100,6 +100,63 @@ class TinyParallelModel(nn.Module):
         return self.out(self.experts(hidden))
 
 
+class TinyTELinear(nn.Module):
+    def __init__(self, in_features: int, out_features: int):
+        super().__init__()
+        import transformer_engine.pytorch as te
+
+        self.linear = te.Linear(
+            in_features,
+            out_features,
+            bias=False,
+            params_dtype=torch.bfloat16,
+        )
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+class TinyTETransformerLayer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.dense = TinyTELinear(8, 8)
+        self.expert = TinyTELinear(8, 8)
+
+    def forward(self, x):
+        return torch.tanh(self.dense(x) + self.expert(x))
+
+
+class TinyTEQwen3MoE(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layers = nn.ModuleList(
+            [TinyTETransformerLayer(), TinyTETransformerLayer()]
+        )
+        self.out = TinyTELinear(8, 4)
+
+    def forward(self, x):
+        for layer in self.layers:
+            x = layer(x)
+        return self.out(x)
+
+
+class RecordingSGD(torch.optim.SGD):
+    def __init__(self, param_groups):
+        super().__init__(param_groups, lr=0.0)
+        self.consumed_grad_groups: list[list[torch.Tensor]] = []
+
+    def step(self, closure=None):
+        self.consumed_grad_groups = [
+            [
+                param.grad.detach().clone()
+                for param in group["params"]
+                if param.grad is not None
+            ]
+            for group in self.param_groups
+        ]
+        return super().step(closure)
+
+
 class BenchmarkUnit(nn.Module):
     def __init__(self, hidden_size: int):
         super().__init__()
@@ -309,6 +366,14 @@ def _memory_triple() -> dict[str, float]:
             strict=True,
         )
     )
+
+
+def _bf16_roundtrip_difference_fraction(tensors: list[torch.Tensor]) -> float:
+    values = torch.cat([tensor.detach().float().reshape(-1) for tensor in tensors])
+    assert values.numel() > 0
+    rounded = values.to(torch.bfloat16).to(torch.float32)
+    assert not torch.equal(values, rounded)
+    return float((values != rounded).float().mean().item())
 
 
 def _memory_delta(
@@ -674,6 +739,102 @@ def _tp_ep_parallel_config() -> ParallelConfig:
 
 def _is_tiny_expert(name: str) -> bool:
     return name.startswith("experts.")
+
+
+def test_mfsdp_native_fp32_fused_wgrad_reaches_optimizer_groups():
+    parallel = _dense_parallel_config()
+    ps = _parallel_state(parallel)
+    chunks = [_new_model(7319, TinyTEQwen3MoE)]
+    optimizer_config = _optimizer_cfg(use_fused_optimizer=False)
+    impl_cfg = SimpleNamespace(
+        parallel=parallel,
+        optimizer_config=optimizer_config,
+    )
+
+    def build_recording_optimizer(param_groups, _optimizer_config):
+        params = [param for group in param_groups for param in group["params"]]
+        assert len(params) == 5
+        return RecordingSGD(
+            [
+                {"params": params[::2], "weight_decay": 0.0},
+                {"params": params[1::2], "weight_decay": 0.0},
+            ]
+        )
+
+    optimizer, finalize = build_mfsdp_training_optimizer(
+        chunks,
+        impl_cfg=impl_cfg,
+        ps=ps,
+        is_expert=lambda name: ".expert." in name,
+        fsdp_unit_modules=(TinyTETransformerLayer,),
+        optimizer_factory=build_recording_optimizer,
+    )
+    chunk = chunks[0]
+    assert len(chunk.param_sync.buckets) == 5
+    assert len(optimizer.param_groups) == 2
+
+    optimizer.zero_grad()
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(8107 + dist.get_rank())
+    value = torch.randn(
+        64,
+        8,
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    chunk(value).float().square().mean().backward()
+
+    main_grad_by_shard = {}
+    for bucket in chunk.param_sync.buckets:
+        for spec in bucket.specs:
+            assert spec.shard_param is not None
+            assert spec.full_param.grad_added_to_main_grad is True
+            assert spec.full_param.main_grad.dtype is torch.float32
+            main_grad_by_shard[id(spec.shard_param)] = (
+                spec.full_param.main_grad.detach().clone()
+            )
+    main_grad_fractions = [
+        _bf16_roundtrip_difference_fraction(
+            [main_grad_by_shard[id(param)] for param in group["params"]]
+        )
+        for group in optimizer.param_groups
+    ]
+
+    finalize()
+    optimizer_grad_fractions = [
+        _bf16_roundtrip_difference_fraction(
+            [param.grad for param in group["params"] if param.grad is not None]
+        )
+        for group in optimizer.param_groups
+    ]
+    success, _grad_norm, _num_zeros = optimizer.step()
+    recording_optimizer = optimizer._inner_optimizer.optimizer
+    consumed_grad_fractions = [
+        _bf16_roundtrip_difference_fraction(group)
+        for group in recording_optimizer.consumed_grad_groups
+    ]
+
+    assert success
+    assert all(fraction > 0.0 for fraction in main_grad_fractions)
+    assert all(fraction > 0.0 for fraction in optimizer_grad_fractions)
+    assert all(fraction > 0.0 for fraction in consumed_grad_fractions)
+    if dist.get_rank() == 0:
+        print(
+            "[MFSDP_NATIVE_FP32_WGRAD] "
+            + json.dumps(
+                {
+                    "world_size": dist.get_world_size(),
+                    "bucket_count": len(chunk.param_sync.buckets),
+                    "optimizer_group_count": len(optimizer.param_groups),
+                    "main_grad_low_bit_fractions": main_grad_fractions,
+                    "optimizer_grad_low_bit_fractions": optimizer_grad_fractions,
+                    "consumed_grad_low_bit_fractions": consumed_grad_fractions,
+                },
+                sort_keys=True,
+            ),
+            flush=True,
+        )
 
 
 def test_mfsdp_precision_curve_matches_fsdp2():

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -176,6 +176,17 @@ class TinyTEGroupedMoE(nn.Module):
         return self.out(x)
 
 
+class TinyNonFusedLinear(nn.Module):
+    """Regular autograd linear covering M-FSDP's non-TE gradient path."""
+
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(4, 4, bias=False, dtype=torch.bfloat16)
+
+    def forward(self, x):
+        return self.linear(x)
+
+
 class RecordingSGD(torch.optim.SGD):
     def __init__(self, param_groups):
         super().__init__(param_groups, lr=0.0)
@@ -417,6 +428,11 @@ def _bf16_roundtrip_difference_fraction(tensors: list[torch.Tensor]) -> float:
     rounded = values.to(torch.bfloat16).to(torch.float32)
     assert not torch.equal(values, rounded)
     return float((values != rounded).float().mean().item())
+
+
+def _is_bf16_roundtrip_exact(tensor: torch.Tensor) -> bool:
+    values = tensor.detach().float()
+    return torch.equal(values, values.to(torch.bfloat16).to(torch.float32))
 
 
 def _memory_delta(
@@ -843,6 +859,7 @@ def test_mfsdp_native_fp32_fused_wgrad_reaches_optimizer_groups():
         for spec in bucket.specs:
             assert spec.shard_param is not None
             assert spec.full_param.grad_added_to_main_grad is True
+            assert spec.full_param.grad is None
             assert spec.full_param.main_grad.dtype is torch.float32
             main_grad_by_shard[id(spec.shard_param)] = (
                 spec.full_param.main_grad.detach().clone()
@@ -991,6 +1008,87 @@ def test_mfsdp_native_fp32_grouped_expert_wgrad_reaches_optimizer():
                     "main_grad_low_bit_fractions": main_grad_fractions,
                     "optimizer_grad_low_bit_fractions": optimizer_grad_fractions,
                     "consumed_grad_low_bit_fractions": consumed_grad_fractions,
+                },
+                sort_keys=True,
+            ),
+            flush=True,
+        )
+
+
+def test_mfsdp_non_fused_wgrad_accumulates_in_fp32_per_microbatch():
+    parallel = _dense_parallel_config()
+    ps = _parallel_state(parallel)
+    torch.manual_seed(10103)
+    torch.cuda.manual_seed_all(10103)
+    chunks = [TinyNonFusedLinear().cuda()]
+    optimizer_config = _optimizer_cfg(use_fused_optimizer=False)
+    impl_cfg = SimpleNamespace(
+        parallel=parallel,
+        optimizer_config=optimizer_config,
+    )
+
+    def build_recording_optimizer(param_groups, _optimizer_config):
+        return RecordingSGD(param_groups)
+
+    optimizer, finalize = build_mfsdp_training_optimizer(
+        chunks,
+        impl_cfg=impl_cfg,
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(TinyNonFusedLinear,),
+        optimizer_factory=build_recording_optimizer,
+    )
+    chunk = chunks[0]
+    assert not hasattr(chunk.linear, "fuse_wgrad_accumulation")
+    assert len(chunk.param_sync.buckets) == 1
+    spec = chunk.param_sync.buckets[0].specs[0]
+    assert spec.shard_param is not None
+    assert spec.full_param.grad_added_to_main_grad is False
+
+    optimizer.zero_grad()
+    chunk(torch.ones(1, 4, device="cuda", dtype=torch.bfloat16)).sum().backward()
+    single_backward_grad = spec.full_param.main_grad.detach().clone()
+    assert spec.full_param.grad is None
+    assert spec.full_param.main_grad.dtype is torch.float32
+    assert torch.equal(single_backward_grad, torch.ones(4, 4, device="cuda"))
+    assert _is_bf16_roundtrip_exact(single_backward_grad)
+
+    optimizer.zero_grad()
+    chunk(
+        torch.full((1, 4), 256.0, device="cuda", dtype=torch.bfloat16)
+    ).sum().backward()
+    assert spec.full_param.grad is None
+    assert torch.equal(
+        spec.full_param.main_grad,
+        torch.full((4, 4), 256.0, device="cuda"),
+    )
+    assert _is_bf16_roundtrip_exact(spec.full_param.main_grad)
+
+    chunk(torch.ones(1, 4, device="cuda", dtype=torch.bfloat16)).sum().backward()
+    expected = torch.full((4, 4), 257.0, device="cuda")
+    assert spec.full_param.grad is None
+    assert torch.equal(spec.full_param.main_grad, expected)
+    assert not _is_bf16_roundtrip_exact(spec.full_param.main_grad)
+
+    finalize()
+    expected_shard = expected.reshape(-1).chunk(dist.get_world_size())[dist.get_rank()]
+    assert spec.shard_param.grad is not None
+    assert spec.shard_param.grad.dtype is torch.float32
+    assert torch.equal(spec.shard_param.grad, expected_shard)
+    success, _grad_norm, _num_zeros = optimizer.step()
+    recording_optimizer = optimizer._inner_optimizer.optimizer
+    consumed_grad = recording_optimizer.consumed_grad_by_param[id(spec.shard_param)]
+    assert success
+    assert torch.equal(consumed_grad, expected_shard)
+    if dist.get_rank() == 0:
+        print(
+            "[MFSDP_NON_FUSED_FP32_ACCUMULATION] "
+            + json.dumps(
+                {
+                    "world_size": dist.get_world_size(),
+                    "single_backward_bf16_roundtrip_exact": True,
+                    "multi_microbatch_value": float(consumed_grad[0]),
+                    "multi_microbatch_bf16_roundtrip_exact": False,
                 },
                 sort_keys=True,
             ),

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -17,6 +17,7 @@ import torch.distributed as dist
 import torch.nn as nn
 from torch.utils._python_dispatch import TorchDispatchMode
 
+from megatron.lite.primitive.modules.experts import Experts
 from megatron.lite.primitive.optimizers.fsdp2 import (
     build_fsdp2_training_optimizer,
     fsdp2_available,
@@ -140,10 +141,46 @@ class TinyTEQwen3MoE(nn.Module):
         return self.out(x)
 
 
+class TinyTEGroupedExpertLayer(nn.Module):
+    def __init__(self, ps):
+        super().__init__()
+        config = SimpleNamespace(
+            num_experts=2,
+            hidden_size=8,
+            moe_intermediate_size=16,
+            swiglu_limit=0.0,
+        )
+        self.experts = Experts(config, ps)
+
+    def forward(self, x):
+        first_expert_tokens = x.shape[0] // 2
+        tokens_per_expert = torch.tensor(
+            [first_expert_tokens, x.shape[0] - first_expert_tokens],
+            device=x.device,
+            dtype=torch.int64,
+        )
+        return torch.tanh(self.experts(x, tokens_per_expert))
+
+
+class TinyTEGroupedMoE(nn.Module):
+    def __init__(self, ps):
+        super().__init__()
+        self.layers = nn.ModuleList(
+            [TinyTEGroupedExpertLayer(ps), TinyTEGroupedExpertLayer(ps)]
+        )
+        self.out = TinyTELinear(8, 4)
+
+    def forward(self, x):
+        for layer in self.layers:
+            x = layer(x)
+        return self.out(x)
+
+
 class RecordingSGD(torch.optim.SGD):
     def __init__(self, param_groups):
         super().__init__(param_groups, lr=0.0)
         self.consumed_grad_groups: list[list[torch.Tensor]] = []
+        self.consumed_grad_by_param: dict[int, torch.Tensor] = {}
 
     def step(self, closure=None):
         self.consumed_grad_groups = [
@@ -154,6 +191,12 @@ class RecordingSGD(torch.optim.SGD):
             ]
             for group in self.param_groups
         ]
+        self.consumed_grad_by_param = {
+            id(param): param.grad.detach().clone()
+            for group in self.param_groups
+            for param in group["params"]
+            if param.grad is not None
+        }
         return super().step(closure)
 
 
@@ -741,6 +784,16 @@ def _is_tiny_expert(name: str) -> bool:
     return name.startswith("experts.")
 
 
+def _grouped_expert_key(name: str) -> str | None:
+    layer_name, marker, parameter_name = name.partition("experts.")
+    if not marker:
+        return None
+    weight_name = parameter_name.rsplit(".", 1)[-1]
+    if not weight_name.startswith("weight") or not weight_name[6:].isdigit():
+        return None
+    return f"{layer_name}expert{weight_name[6:]}"
+
+
 def test_mfsdp_native_fp32_fused_wgrad_reaches_optimizer_groups():
     parallel = _dense_parallel_config()
     ps = _parallel_state(parallel)
@@ -827,6 +880,114 @@ def test_mfsdp_native_fp32_fused_wgrad_reaches_optimizer_groups():
                     "world_size": dist.get_world_size(),
                     "bucket_count": len(chunk.param_sync.buckets),
                     "optimizer_group_count": len(optimizer.param_groups),
+                    "main_grad_low_bit_fractions": main_grad_fractions,
+                    "optimizer_grad_low_bit_fractions": optimizer_grad_fractions,
+                    "consumed_grad_low_bit_fractions": consumed_grad_fractions,
+                },
+                sort_keys=True,
+            ),
+            flush=True,
+        )
+
+
+def test_mfsdp_native_fp32_grouped_expert_wgrad_reaches_optimizer():
+    parallel = _dense_parallel_config()
+    ps = _parallel_state(parallel)
+    torch.manual_seed(9127)
+    torch.cuda.manual_seed_all(9127)
+    chunks = [TinyTEGroupedMoE(ps).cuda().to(torch.bfloat16)]
+    optimizer_config = _optimizer_cfg(use_fused_optimizer=False)
+    impl_cfg = SimpleNamespace(
+        parallel=parallel,
+        optimizer_config=optimizer_config,
+    )
+
+    def build_recording_optimizer(param_groups, _optimizer_config):
+        params = [param for group in param_groups for param in group["params"]]
+        return RecordingSGD(
+            [{"params": [param], "weight_decay": 0.0} for param in params]
+        )
+
+    optimizer, finalize = build_mfsdp_training_optimizer(
+        chunks,
+        impl_cfg=impl_cfg,
+        ps=ps,
+        is_expert=lambda name: "experts." in name,
+        fsdp_unit_modules=(TinyTEGroupedExpertLayer,),
+        optimizer_factory=build_recording_optimizer,
+    )
+    chunk = chunks[0]
+    grouped_linear_modules = [
+        module for module in chunk.modules() if type(module).__name__ == "GroupedLinear"
+    ]
+    assert len(grouped_linear_modules) == 4
+    assert all(module.fuse_wgrad_accumulation for module in grouped_linear_modules)
+
+    expert_specs = {}
+    for bucket in chunk.param_sync.buckets:
+        for spec in bucket.specs:
+            expert_key = _grouped_expert_key(spec.name)
+            if expert_key is not None:
+                expert_specs.setdefault(expert_key, []).append(spec)
+    assert len(expert_specs) == 4
+    assert all(len(specs) == 2 for specs in expert_specs.values())
+
+    optimizer.zero_grad()
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(9131 + dist.get_rank())
+    value = torch.randn(
+        64,
+        8,
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    chunk(value).float().square().mean().backward()
+
+    main_grad_fractions = {}
+    for expert_key, specs in expert_specs.items():
+        main_grads = []
+        for spec in specs:
+            assert spec.shard_param is not None
+            assert spec.full_param.grad_added_to_main_grad is True
+            assert spec.full_param.main_grad.dtype is torch.float32
+            assert spec.full_param.grad is None
+            main_grads.append(spec.full_param.main_grad)
+        main_grad_fractions[expert_key] = _bf16_roundtrip_difference_fraction(
+            main_grads
+        )
+
+    finalize()
+    optimizer_grad_fractions = {
+        expert_key: _bf16_roundtrip_difference_fraction(
+            [spec.shard_param.grad for spec in specs]
+        )
+        for expert_key, specs in expert_specs.items()
+    }
+    success, _grad_norm, _num_zeros = optimizer.step()
+    recording_optimizer = optimizer._inner_optimizer.optimizer
+    consumed_grad_fractions = {
+        expert_key: _bf16_roundtrip_difference_fraction(
+            [
+                recording_optimizer.consumed_grad_by_param[id(spec.shard_param)]
+                for spec in specs
+            ]
+        )
+        for expert_key, specs in expert_specs.items()
+    }
+
+    assert success
+    assert all(fraction > 0.0 for fraction in main_grad_fractions.values())
+    assert all(fraction > 0.0 for fraction in optimizer_grad_fractions.values())
+    assert all(fraction > 0.0 for fraction in consumed_grad_fractions.values())
+    if dist.get_rank() == 0:
+        print(
+            "[MFSDP_NATIVE_FP32_GROUPED_EXPERT_WGRAD] "
+            + json.dumps(
+                {
+                    "world_size": dist.get_world_size(),
+                    "expert_group_count": len(expert_specs),
+                    "grouped_linear_count": len(grouped_linear_modules),
                     "main_grad_low_bit_fractions": main_grad_fractions,
                     "optimizer_grad_low_bit_fractions": optimizer_grad_fractions,
                     "consumed_grad_low_bit_fractions": consumed_grad_fractions,

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -40,6 +40,7 @@ pytestmark = [
 _MFSDP_SHARDING_STRATEGY = "optim_grads_params"
 _PRECISION_STEPS = 50
 _LOSS_REL_TOL = 1.0e-2
+_E2E_SFT_LOSS_REL_TOL = 5.09e-3
 _TENSOR_RTOL = 1.0e-2
 _TENSOR_ATOL = 1.0e-5
 _BENCH_WARMUP_STEPS = 5
@@ -1754,7 +1755,10 @@ def _max_snapshot_abs_diff(
     return max(float((lhs[name] - rhs[name]).abs().max()) for name in lhs)
 
 
-def test_mfsdp_matches_fsdp2_full_parallel_precision_curve(monkeypatch):
+@pytest.mark.parametrize("reference_backend", ("dist_opt", "fsdp2"))
+def test_mfsdp_matches_reference_full_parallel_precision_curve(
+    monkeypatch, reference_backend
+):
     if dist.get_world_size() != _FULL_PARALLEL_WORLD_SIZE:
         pytest.skip("M-FSDP TP2/EP2/ETP1/PP2/CP2 signoff requires exactly 8 ranks.")
 
@@ -1787,13 +1791,15 @@ def test_mfsdp_matches_fsdp2_full_parallel_precision_curve(monkeypatch):
         record_cp_split,
     )
 
-    fsdp2_handle, fsdp2_initial = _build_full_parallel_handle("fsdp2", seed=7345)
+    reference_handle, reference_initial = _build_full_parallel_handle(
+        reference_backend, seed=7345
+    )
     mfsdp_handle, mfsdp_initial = _build_full_parallel_handle("mfsdp", seed=7345)
     _assert_distinct_backend_identities(
-        fsdp2_handle._optimizer, mfsdp_handle._optimizer
+        reference_handle._optimizer, mfsdp_handle._optimizer
     )
 
-    for handle in (fsdp2_handle, mfsdp_handle):
+    for handle in (reference_handle, mfsdp_handle):
         ps = handle._parallel_state
         assert (ps.tp_size, ps.ep_size, ps.etp_size, ps.pp_size, ps.cp_size) == (
             2,
@@ -1804,16 +1810,37 @@ def test_mfsdp_matches_fsdp2_full_parallel_precision_curve(monkeypatch):
         )
 
     initial_max_abs = torch.tensor(
-        _max_snapshot_abs_diff(fsdp2_initial, mfsdp_initial), device="cuda"
+        _max_snapshot_abs_diff(reference_initial, mfsdp_initial), device="cuda"
     )
     dist.all_reduce(initial_max_abs, op=dist.ReduceOp.MAX)
     assert float(initial_max_abs) == 0.0
 
-    losses = {"fsdp2": [], "mfsdp": []}
-    grad_norms = {"fsdp2": [], "mfsdp": []}
+    losses = {reference_backend: [], "mfsdp": []}
+    grad_norms = {reference_backend: [], "mfsdp": []}
+    wandb_run = None
+    if dist.get_rank() == 0:
+        import wandb
+
+        wandb_run = wandb.init(
+            project=os.environ.get("WANDB_PROJECT", "mlite-mfsdp-precision"),
+            entity=os.environ.get("WANDB_ENTITY", "megatron-core-moe-dev"),
+            name=os.environ.get("WANDB_NAME", f"mfsdp-sft-curve-{reference_backend}"),
+            config={
+                "reference_backend": reference_backend,
+                "target_backend": "mfsdp",
+                "seed": 7345,
+                "steps": _FULL_PARALLEL_STEPS,
+                "microbatches": _FULL_PARALLEL_MICROBATCHES,
+                "same_input_sft": True,
+            },
+        )
+        print(f"[MFSDP_WANDB] url={wandb_run.url}", flush=True)
     traces = {}
     for step in range(_FULL_PARALLEL_STEPS):
-        for backend, handle in (("fsdp2", fsdp2_handle), ("mfsdp", mfsdp_handle)):
+        for backend, handle in (
+            (reference_backend, reference_handle),
+            ("mfsdp", mfsdp_handle),
+        ):
             dist.barrier()
             loss, grad_norm, trace = _run_full_parallel_step(
                 handle,
@@ -1824,8 +1851,19 @@ def test_mfsdp_matches_fsdp2_full_parallel_precision_curve(monkeypatch):
             grad_norms[backend].append(grad_norm)
             if trace:
                 traces[backend] = trace
+        if wandb_run is not None:
+            wandb_run.log(
+                {
+                    "step": step + 1,
+                    f"{reference_backend}/sft_loss": losses[reference_backend][-1],
+                    "mfsdp/sft_loss": losses["mfsdp"][-1],
+                    f"{reference_backend}/grad_norm": grad_norms[reference_backend][-1],
+                    "mfsdp/grad_norm": grad_norms["mfsdp"][-1],
+                },
+                step=step + 1,
+            )
 
-    for backend in ("fsdp2", "mfsdp"):
+    for backend in (reference_backend, "mfsdp"):
         trace = traces.get(backend, ())
         assert trace, f"{backend} tap recorded no distributed collectives."
         assert _contains_collective(trace, "all_gather", "allgather")
@@ -1837,11 +1875,11 @@ def test_mfsdp_matches_fsdp2_full_parallel_precision_curve(monkeypatch):
     )
 
     loss_rel_curve = torch.tensor(
-        _relative_difference_curve(losses["fsdp2"], losses["mfsdp"]),
+        _relative_difference_curve(losses[reference_backend], losses["mfsdp"]),
         device="cuda",
     )
     grad_norm_rel_curve = torch.tensor(
-        _relative_difference_curve(grad_norms["fsdp2"], grad_norms["mfsdp"]),
+        _relative_difference_curve(grad_norms[reference_backend], grad_norms["mfsdp"]),
         device="cuda",
     )
     dist.all_reduce(loss_rel_curve, op=dist.ReduceOp.MAX)
@@ -1850,7 +1888,7 @@ def test_mfsdp_matches_fsdp2_full_parallel_precision_curve(monkeypatch):
     max_grad_norm_rel_diff = grad_norm_rel_curve.max()
 
     if dist.get_rank() == 0:
-        ps = fsdp2_handle._parallel_state
+        ps = reference_handle._parallel_state
         print(
             "[MFSDP_FULL_PARALLEL] "
             "topology=tp2_ep2_etp1_pp2_cp2 "
@@ -1858,10 +1896,12 @@ def test_mfsdp_matches_fsdp2_full_parallel_precision_curve(monkeypatch):
             f"dp_cp_size={ps.dp_cp_size} "
             f"microbatches={_FULL_PARALLEL_MICROBATCHES} "
             f"steps={_FULL_PARALLEL_STEPS} "
+            f"reference={reference_backend} "
+            f"sft_loss_rel_tol={_E2E_SFT_LOSS_REL_TOL:.3e} "
             f"initial_max_abs_diff={float(initial_max_abs):.8e} "
             f"max_loss_rel_diff={float(max_loss_rel_diff):.8e} "
             f"max_grad_norm_rel_diff={float(max_grad_norm_rel_diff):.8e} "
-            f"fsdp2_losses={','.join(f'{value:.8f}' for value in losses['fsdp2'])} "
+            f"{reference_backend}_losses={','.join(f'{value:.8f}' for value in losses[reference_backend])} "
             f"mfsdp_losses={','.join(f'{value:.8f}' for value in losses['mfsdp'])} "
             f"cp_split={cp_splits[0][0]}->{cp_splits[0][1]} "
             f"cp_split_calls={len(cp_splits)}",
@@ -1877,13 +1917,13 @@ def test_mfsdp_matches_fsdp2_full_parallel_precision_curve(monkeypatch):
                 f"step={curve_index + 1} "
                 f"loss_rel_diff={float(loss_rel_curve[curve_index]):.8e} "
                 f"grad_norm_rel_diff={float(grad_norm_rel_curve[curve_index]):.8e} "
-                f"loss_fsdp2={losses['fsdp2'][curve_index]:.8f} "
+                f"loss_{reference_backend}={losses[reference_backend][curve_index]:.8f} "
                 f"loss_mfsdp={losses['mfsdp'][curve_index]:.8f} "
-                f"grad_norm_fsdp2={grad_norms['fsdp2'][curve_index]:.8f} "
+                f"grad_norm_{reference_backend}={grad_norms[reference_backend][curve_index]:.8f} "
                 f"grad_norm_mfsdp={grad_norms['mfsdp'][curve_index]:.8f}",
                 flush=True,
             )
-        for backend in ("fsdp2", "mfsdp"):
+        for backend in (reference_backend, "mfsdp"):
             trace = traces[backend]
             print(
                 "[MFSDP_COMM_TRACE] "
@@ -1894,7 +1934,9 @@ def test_mfsdp_matches_fsdp2_full_parallel_precision_curve(monkeypatch):
 
     assert torch.isfinite(loss_rel_curve).all()
     assert torch.isfinite(grad_norm_rel_curve).all()
-    assert float(max_loss_rel_diff) <= _LOSS_REL_TOL
+    assert float(max_loss_rel_diff) <= _E2E_SFT_LOSS_REL_TOL
     assert float(max_grad_norm_rel_diff) <= _LOSS_REL_TOL
-    assert losses["fsdp2"][-1] < losses["fsdp2"][0]
+    assert losses[reference_backend][-1] < losses[reference_backend][0]
     assert losses["mfsdp"][-1] < losses["mfsdp"][0]
+    if wandb_run is not None:
+        wandb_run.finish()

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -1592,13 +1592,13 @@ def _build_full_parallel_handle(backend: str, *, seed: int):
     initial_params = _named_model_tensors(bundle.chunks)
     assert bundle.extras.get("optimizer_backend") == backend
     post_load_hook = bundle.extras.get("post_model_load_hook")
-    assert callable(post_load_hook), (
-        f"{backend} did not expose its production post-load hook."
-    )
-    updates = post_load_hook()
-    assert isinstance(updates, dict)
-    optimizer = updates.get("optimizer", bundle.optimizer)
-    finalize_grads = updates.get("finalize_grads", bundle.finalize_grads)
+    optimizer = bundle.optimizer
+    finalize_grads = bundle.finalize_grads
+    if callable(post_load_hook):
+        updates = post_load_hook()
+        assert isinstance(updates, dict)
+        optimizer = updates.get("optimizer", optimizer)
+        finalize_grads = updates.get("finalize_grads", finalize_grads)
     assert optimizer is not None
 
     extras = dict(bundle.extras)

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -1795,9 +1795,25 @@ def test_mfsdp_matches_reference_full_parallel_precision_curve(
         reference_backend, seed=7345
     )
     mfsdp_handle, mfsdp_initial = _build_full_parallel_handle("mfsdp", seed=7345)
-    _assert_distinct_backend_identities(
-        reference_handle._optimizer, mfsdp_handle._optimizer
-    )
+    if reference_backend == "fsdp2":
+        _assert_distinct_backend_identities(
+            reference_handle._optimizer, mfsdp_handle._optimizer
+        )
+    else:
+        assert reference_handle._optimizer is not mfsdp_handle._optimizer
+        assert _qualified_type(reference_handle._optimizer).startswith(
+            "megatron.core.optimizer."
+        )
+        assert _qualified_type(mfsdp_handle._optimizer).startswith(
+            "megatron.lite.primitive.optimizers.mfsdp."
+        )
+        if dist.get_rank() == 0:
+            print(
+                "[MFSDP_BACKEND] "
+                f"configured={reference_backend} optimizer_type="
+                f"{_qualified_type(reference_handle._optimizer)}",
+                flush=True,
+            )
 
     for handle in (reference_handle, mfsdp_handle):
         ps = handle._parallel_state

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -1020,7 +1020,9 @@ def test_mfsdp_non_fused_wgrad_accumulates_in_fp32_per_microbatch():
     ps = _parallel_state(parallel)
     torch.manual_seed(10103)
     torch.cuda.manual_seed_all(10103)
-    chunks = [TinyNonFusedLinear().cuda()]
+    model = TinyNonFusedLinear().cuda()
+    assert not hasattr(model.linear, "fuse_wgrad_accumulation")
+    chunks = [model]
     optimizer_config = _optimizer_cfg(use_fused_optimizer=False)
     impl_cfg = SimpleNamespace(
         parallel=parallel,
@@ -1039,7 +1041,6 @@ def test_mfsdp_non_fused_wgrad_accumulates_in_fp32_per_microbatch():
         optimizer_factory=build_recording_optimizer,
     )
     chunk = chunks[0]
-    assert not hasattr(chunk.linear, "fuse_wgrad_accumulation")
     assert len(chunk.param_sync.buckets) == 1
     spec = chunk.param_sync.buckets[0].specs[0]
     assert spec.shard_param is not None

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -64,8 +64,11 @@ class _FusedMainGradLinearFunction(torch.autograd.Function):
     def backward(ctx, grad_output):
         value, weight = ctx.saved_tensors
         grad_input = grad_output.matmul(weight)
-        grad_weight = grad_output.float().reshape(-1, grad_output.shape[-1]).t().matmul(
-            value.float().reshape(-1, value.shape[-1])
+        grad_weight = (
+            grad_output.float()
+            .reshape(-1, grad_output.shape[-1])
+            .t()
+            .matmul(value.float().reshape(-1, value.shape[-1]))
         )
         if ctx.fuse_wgrad_accumulation:
             ctx.weight.main_grad.add_(grad_weight)
@@ -1490,6 +1493,7 @@ def test_mfsdp_routes_fused_wgrad_through_bucketed_fp32_main_grad():
     spec = bucket.specs[0]
     assert model.fuse_wgrad_accumulation is True
     assert spec.full_param.grad_added_to_main_grad is True
+    assert spec.full_param.grad is None
     assert spec.full_param.main_grad.dtype is torch.float32
     assert spec.full_param.main_grad.untyped_storage().data_ptr() == (
         bucket.full_main_grad_buffer.untyped_storage().data_ptr()
@@ -1503,6 +1507,7 @@ def test_mfsdp_routes_fused_wgrad_through_bucketed_fp32_main_grad():
 
     second_value = torch.randn(8, 4, dtype=torch.bfloat16)
     chunk(second_value).float().sum().backward()
+    assert spec.full_param.grad is None
     second_expected = second_value.float().sum(dim=0).repeat(4, 1)
     assert spec.full_param.main_grad.untyped_storage().data_ptr() == main_grad_storage
     assert torch.equal(spec.full_param.main_grad, first_main_grad + second_expected)

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -52,6 +52,44 @@ class _DirectParamModel(torch.nn.Module):
         return torch.nn.functional.linear(hidden, self.projection.weight)
 
 
+class _FusedMainGradLinearFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, value, weight, fuse_wgrad_accumulation):
+        ctx.save_for_backward(value, weight)
+        ctx.weight = weight
+        ctx.fuse_wgrad_accumulation = fuse_wgrad_accumulation
+        return torch.nn.functional.linear(value, weight)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        value, weight = ctx.saved_tensors
+        grad_input = grad_output.matmul(weight)
+        grad_weight = grad_output.float().reshape(-1, grad_output.shape[-1]).t().matmul(
+            value.float().reshape(-1, value.shape[-1])
+        )
+        if ctx.fuse_wgrad_accumulation:
+            ctx.weight.main_grad.add_(grad_weight)
+            ctx.weight.grad_added_to_main_grad = True
+            grad_weight = torch.zeros_like(weight)
+        return grad_input, grad_weight, None
+
+
+class _FusedMainGradLinear(torch.nn.Module):
+    """CPU stand-in for TE's dynamic ``weight.main_grad`` backward contract."""
+
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.randn(4, 4, dtype=torch.bfloat16))
+        self.fuse_wgrad_accumulation = False
+
+    def forward(self, value):
+        return _FusedMainGradLinearFunction.apply(
+            value,
+            self.weight,
+            self.fuse_wgrad_accumulation,
+        )
+
+
 def _optimizer_params(optimizer) -> list[torch.nn.Parameter]:
     return optimizer._inner_optimizer.params
 
@@ -1410,6 +1448,93 @@ def test_mfsdp_keeps_fp32_shards_for_bfloat16_compute_parameters():
     assert all(param.dtype is torch.float32 for param in optimizer_params)
     assert any(not torch.equal(old, new) for old, new in zip(before, optimizer_params))
     assert torch.isfinite(chunks[0](value).float()).all()
+
+
+def test_mfsdp_routes_fused_wgrad_through_bucketed_fp32_main_grad():
+    model = _FusedMainGradLinear()
+    ps = SimpleNamespace(
+        dp_cp_group=None,
+        dp_group=None,
+        ep_dp_group=None,
+        ep_group=None,
+        etp_group=None,
+        tp_group=None,
+        pp_group=None,
+        dp_cp_size=1,
+        expert_dp_size=1,
+    )
+    opt = SimpleNamespace(
+        optimizer="sgd",
+        lr=0.0,
+        weight_decay=0.0,
+        clip_grad=0.0,
+        override_optimizer_config={"mfsdp_sharding_strategy": "optim_grads_params"},
+    )
+    chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [model],
+        engine_cfg=SimpleNamespace(
+            parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1),
+            optimizer=opt,
+        ),
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_FusedMainGradLinear,),
+    )
+
+    chunk = chunks[0]
+    bucket = chunk.param_sync.buckets[0]
+    optimizer.zero_grad()
+    value = torch.randn(8, 4, dtype=torch.bfloat16)
+    chunk(value).float().sum().backward()
+
+    spec = bucket.specs[0]
+    assert model.fuse_wgrad_accumulation is True
+    assert spec.full_param.grad_added_to_main_grad is True
+    assert spec.full_param.main_grad.dtype is torch.float32
+    assert spec.full_param.main_grad.untyped_storage().data_ptr() == (
+        bucket.full_main_grad_buffer.untyped_storage().data_ptr()
+    )
+    assert not torch.equal(
+        spec.full_param.main_grad,
+        spec.full_param.main_grad.to(torch.bfloat16).to(torch.float32),
+    )
+    first_main_grad = spec.full_param.main_grad.detach().clone()
+    main_grad_storage = spec.full_param.main_grad.untyped_storage().data_ptr()
+
+    second_value = torch.randn(8, 4, dtype=torch.bfloat16)
+    chunk(second_value).float().sum().backward()
+    second_expected = second_value.float().sum(dim=0).repeat(4, 1)
+    assert spec.full_param.main_grad.untyped_storage().data_ptr() == main_grad_storage
+    assert torch.equal(spec.full_param.main_grad, first_main_grad + second_expected)
+    expected_main_grad = spec.full_param.main_grad.detach().reshape(-1).clone()
+
+    optimizer.finish_grad_sync()
+    consumed_grad = _optimizer_params(optimizer)[0].grad
+    assert consumed_grad is not None
+    assert consumed_grad.dtype is torch.float32
+    assert torch.equal(consumed_grad, expected_main_grad)
+    assert not torch.equal(
+        consumed_grad,
+        consumed_grad.to(torch.bfloat16).to(torch.float32),
+    )
+
+
+def test_mfsdp_keeps_regular_autograd_grad_as_main_grad_fallback():
+    chunk, optimizer = _single_rank_mfsdp_stack()
+    optimizer.zero_grad()
+    value = torch.randn(3, 4)
+    chunk(value).square().mean().backward()
+    expected = {
+        spec.name: spec.full_param.grad.detach().float().clone()
+        for bucket in chunk.param_sync.buckets
+        for spec in bucket.specs
+    }
+
+    optimizer.finish_grad_sync()
+
+    for name, shard in _optimizer_named_shards(optimizer).items():
+        assert shard.grad is not None
+        assert torch.equal(shard.grad.reshape(-1), expected[name].reshape(-1))
 
 
 def _run_mfsdp_gloo_parity(rank: int, world_size: int, init_file: str) -> None:

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -93,6 +93,17 @@ class _FusedMainGradLinear(torch.nn.Module):
         )
 
 
+class _RegularMainGradLinear(torch.nn.Module):
+    """Non-TE linear used to exercise the autograd gradient fallback."""
+
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.ones(4, 4, dtype=torch.bfloat16))
+
+    def forward(self, value):
+        return torch.nn.functional.linear(value, self.weight)
+
+
 def _optimizer_params(optimizer) -> list[torch.nn.Parameter]:
     return optimizer._inner_optimizer.params
 
@@ -1524,22 +1535,82 @@ def test_mfsdp_routes_fused_wgrad_through_bucketed_fp32_main_grad():
     )
 
 
-def test_mfsdp_keeps_regular_autograd_grad_as_main_grad_fallback():
+def test_mfsdp_routes_regular_autograd_grad_through_fp32_main_grad():
     chunk, optimizer = _single_rank_mfsdp_stack()
     optimizer.zero_grad()
     value = torch.randn(3, 4)
     chunk(value).square().mean().backward()
     expected = {
-        spec.name: spec.full_param.grad.detach().float().clone()
+        spec.name: spec.full_param.main_grad.detach().clone()
         for bucket in chunk.param_sync.buckets
         for spec in bucket.specs
     }
+    for bucket in chunk.param_sync.buckets:
+        for spec in bucket.specs:
+            assert spec.full_param.grad is None
+            assert spec.full_param.main_grad.dtype is torch.float32
 
     optimizer.finish_grad_sync()
 
     for name, shard in _optimizer_named_shards(optimizer).items():
         assert shard.grad is not None
         assert torch.equal(shard.grad.reshape(-1), expected[name].reshape(-1))
+
+
+def test_mfsdp_accumulates_regular_wgrad_in_fp32_per_microbatch():
+    model = _RegularMainGradLinear()
+    ps = SimpleNamespace(
+        dp_cp_group=None,
+        dp_group=None,
+        ep_dp_group=None,
+        ep_group=None,
+        etp_group=None,
+        tp_group=None,
+        pp_group=None,
+        dp_cp_size=1,
+        expert_dp_size=1,
+    )
+    opt = SimpleNamespace(
+        optimizer="sgd",
+        lr=0.0,
+        weight_decay=0.0,
+        clip_grad=0.0,
+        override_optimizer_config={"mfsdp_sharding_strategy": "optim_grads_params"},
+    )
+    chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [model],
+        engine_cfg=SimpleNamespace(
+            parallel=ParallelConfig(tp=1, ep=1, etp=1, pp=1, vpp=1, cp=1),
+            optimizer=opt,
+        ),
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_RegularMainGradLinear,),
+    )
+
+    chunk = chunks[0]
+    bucket = chunk.param_sync.buckets[0]
+    spec = bucket.specs[0]
+    optimizer.zero_grad()
+
+    chunk(torch.full((1, 4), 256.0, dtype=torch.bfloat16)).sum().backward()
+    assert spec.full_param.grad is None
+    assert torch.equal(spec.full_param.main_grad, torch.full((4, 4), 256.0))
+
+    chunk(torch.ones(1, 4, dtype=torch.bfloat16)).sum().backward()
+    assert spec.full_param.grad is None
+    expected = torch.full((4, 4), 257.0)
+    assert torch.equal(spec.full_param.main_grad, expected)
+    assert not torch.equal(
+        spec.full_param.main_grad,
+        spec.full_param.main_grad.to(torch.bfloat16).to(torch.float32),
+    )
+
+    optimizer.finish_grad_sync()
+    consumed_grad = _optimizer_params(optimizer)[0].grad
+    assert consumed_grad is not None
+    assert consumed_grad.dtype is torch.float32
+    assert torch.equal(consumed_grad, expected.reshape(-1))
 
 
 def _run_mfsdp_gloo_parity(rank: int, world_size: int, init_file: str) -> None:


### PR DESCRIPTION
## Summary

Adds a 50-step fixed-seed TP2/EP2/PP2/CP2 SFT precision curve for M-FSDP against both distributed optimizer and FSDP2. The test records W&B loss and grad-norm series for each comparison.

## Validation

CW Slurm job 15164201 completed with 8 H100 GPUs (1 node), 2 passed.

- M-FSDP vs distributed optimizer: max loss relative difference 0.2763% (threshold 0.509%), max grad-norm relative difference 0.1606%.
- M-FSDP vs FSDP2: max loss relative difference 0.3224% (threshold 0.509%), max grad-norm relative difference 0.1460%.
- At step 50: distributed optimizer / M-FSDP loss = 4.38452339 / 4.37993813; FSDP2 / M-FSDP loss = 4.38345957 / 4.37993813.

W&B runs: dist-opt `fxjvy6nx`; FSDP2 `f0q04fc1`.