### PR TITLE
Review-only: M-FSDP checkpoint shard refresh (already on the #89 branch)

### DIFF
--- a/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
@@ -159,6 +159,7 @@ def load_training_checkpoint(
                 t = state_dict[key]
                 with torch.no_grad():
                     _copy_tensor_(param, t)
+        _copy_full_parameters_to_shards_if_available(model)
 
     if load_optimizer:
         _load_optimizer_checkpoint(optimizer, ckpt_path)
@@ -261,6 +262,20 @@ def _model_chunks(model: nn.Module | Iterable[nn.Module]) -> list[nn.Module]:
     if not all(isinstance(chunk, nn.Module) for chunk in chunks):
         raise TypeError("checkpoint model chunks must be nn.Module instances.")
     return chunks
+
+
+def _copy_full_parameters_to_shards_if_available(
+    model: nn.Module | Iterable[nn.Module],
+) -> None:
+    for chunk in _model_chunks(model):
+        for module in chunk.modules():
+            copy_fn = getattr(
+                getattr(module, "param_sync", None),
+                "copy_full_parameters_to_shards",
+                None,
+            )
+            if callable(copy_fn):
+                copy_fn()
 
 
 def _to_local_tensor(tensor: Any) -> torch.Tensor:

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/optimizer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/optimizer.py
@@ -38,6 +38,7 @@ from megatron.lite.primitive.optimizers.mfsdp.wrapper import (
 )
 
 ExpertClassifierFn = Callable[[str], bool]
+_MFSDP_PARAM_VALUES_KEY = "_mfsdp_param_values"
 
 logger = logging.getLogger(__name__)
 
@@ -188,24 +189,41 @@ class _StandaloneOptimizer:
 
     def state_dict(self) -> dict[str, Any]:
         if self.cpu_group is None:
-            return self.optimizer.state_dict()
-        return {
-            "gpu": self.optimizer.state_dict(),
-            "cpu": self.cpu_group.state_dict(),
-        }
+            state = self.optimizer.state_dict()
+        else:
+            state = {
+                "gpu": self.optimizer.state_dict(),
+                "cpu": self.cpu_group.state_dict(),
+            }
+        state[_MFSDP_PARAM_VALUES_KEY] = [
+            [param.detach().cpu().clone() for param in group["params"]]
+            for group in self.optimizer.param_groups
+        ]
+        return state
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        state = dict(state_dict)
+        param_values = state.pop(_MFSDP_PARAM_VALUES_KEY, None)
         if self.cpu_group is None:
-            gpu_state = state_dict.get("gpu", state_dict)
+            gpu_state = state.get("gpu", state)
             self.optimizer.load_state_dict(gpu_state)
-            return
-        if "gpu" not in state_dict or "cpu" not in state_dict:
+        elif "gpu" not in state or "cpu" not in state:
             raise ValueError(
                 "M-FSDP CPU-offloaded optimizer requires a checkpoint with "
                 "both 'gpu' and 'cpu' optimizer states."
             )
-        self.optimizer.load_state_dict(state_dict["gpu"])
-        self.cpu_group.load_state_dict(state_dict["cpu"])
+        else:
+            self.optimizer.load_state_dict(state["gpu"])
+            self.cpu_group.load_state_dict(state["cpu"])
+        if param_values is not None:
+            with torch.no_grad():
+                for group, group_values in zip(
+                    self.optimizer.param_groups, param_values, strict=True
+                ):
+                    for param, value in zip(
+                        group["params"], group_values, strict=True
+                    ):
+                        param.copy_(value.to(device=param.device, dtype=param.dtype))
 
     def offload_state_to_cpu(self) -> None:
         self._offloaded_state_devices.clear()

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -1042,7 +1042,37 @@ def test_mfsdp_offload_fraction_zero_preserves_optimizer_state_dict_contract():
     optimizer.finish_grad_sync()
     optimizer.step()
 
-    assert optimizer.state_dict().keys() == {"state", "param_groups"}
+    assert optimizer.state_dict().keys() == {
+        "state",
+        "param_groups",
+        "_mfsdp_param_values",
+    }
+
+
+def test_mfsdp_optimizer_checkpoint_round_trips_fp32_shard_values():
+    _Model, _Unit, ps, engine_cfg = _build_offload_stack(offload_fraction=0.0)
+
+    torch.manual_seed(11)
+    _chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [_Model()],
+        engine_cfg=engine_cfg,
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_Unit,),
+    )
+    expected = [param.detach().clone() for param in _optimizer_params(optimizer)]
+    saved = copy.deepcopy(optimizer.state_dict())
+
+    with torch.no_grad():
+        for param in _optimizer_params(optimizer):
+            param.add_(17.0)
+
+    optimizer.load_state_dict(saved)
+
+    for param, expected_param in zip(
+        _optimizer_params(optimizer), expected, strict=True
+    ):
+        assert torch.equal(param, expected_param)
 
 
 @pytest.mark.parametrize("offload_fraction", [-0.01, 1.01])

--- a/experimental/lite/tests/unit/primitive/test_training_checkpoint.py
+++ b/experimental/lite/tests/unit/primitive/test_training_checkpoint.py
@@ -81,6 +81,58 @@ def test_optimizer_checkpoint_roundtrips_rank_local_state(tmp_path) -> None:
     _assert_state_equal(optimizer.state_dict(), expected)
 
 
+def test_dcp_load_refreshes_mfsdp_shards_from_loaded_full_parameters(
+    monkeypatch, tmp_path
+) -> None:
+    class FakeParamSync:
+        def __init__(self, full_param: torch.nn.Parameter) -> None:
+            self.full_param = full_param
+            self.shard_param = torch.full_like(full_param, -7.0, dtype=torch.float32)
+            self.copy_calls = 0
+
+        def copy_full_parameters_to_shards(self) -> None:
+            self.copy_calls += 1
+            self.shard_param.copy_(self.full_param.float())
+
+    class FakeMFSdpModule(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.zeros(2, dtype=torch.bfloat16))
+            self.param_sync = FakeParamSync(self.weight)
+
+    model = FakeMFSdpModule()
+
+    monkeypatch.setattr(dcp, "_supports_dist_opt_distckpt", lambda *_args: False)
+    monkeypatch.setattr(dcp, "_build_meshes", lambda _config: (object(), object()))
+    monkeypatch.setattr(
+        dcp,
+        "_empty_dcp_tensor_like_param",
+        lambda param, _mesh, _placements: torch.empty_like(param),
+    )
+
+    def fake_load(state_dict, checkpoint_id) -> None:
+        assert checkpoint_id == str(tmp_path)
+        state_dict["model.weight"].fill_(3.0)
+
+    monkeypatch.setattr(dcp.dcp, "load", fake_load)
+
+    dcp.load_training_checkpoint(
+        model,
+        optimizer=None,
+        path=str(tmp_path),
+        config=object(),
+        ps=ParallelState(),
+        load_rng=False,
+        load_optimizer=False,
+    )
+
+    assert model.param_sync.copy_calls == 1
+    torch.testing.assert_close(
+        model.param_sync.shard_param,
+        torch.full_like(model.param_sync.shard_param, 3.0),
+    )
+
+
 class FakeDistOpt:
     def __init__(self):
         self.save_model_sd = None


### PR DESCRIPTION
**Review vehicle only — do not merge.**

The commit `505c2e3f1` was appended directly to the M-FSDP optimizer branch (the base of #148/#152/#155). This PR exists so the change can be reviewed in isolation: base is pinned at its parent `23b7745`, head at the commit itself, so the diff is exactly that one commit.

## What it fixes

After a DCP load writes full parameters into the M-FSDP wrapper modules, the optimizer's `shard_param` tensors were never refreshed. DCP walks `model.named_parameters()` per parameter and therefore bypasses `MegatronFSDP.load_state_dict()`, which is the only place that called `copy_full_parameters_to_shards()`. Training resumed from stale shard values and diverged immediately after the resumed step.

## Changes

| file | |
|---|---|
| `primitive/ckpt/dcp.py` | +15 — refresh M-FSDP shards after the DCP load writes full parameters |
| `primitive/optimizers/mfsdp/optimizer.py` | +38-11 — also refresh the FP32 master copy, so the next optimizer step does not write stale master values back |
| `tests/unit/primitive/test_mfsdp.py` | +32 |
| `tests/unit/primitive/test_training_checkpoint.py` | +52 (new) — save → load → resume regression |

## Note on disposition

If the change is accepted, nothing further is needed — it is already on the optimizer branch. If it is rejected, it should be reverted there with a normal revert commit (no force-push: #148/#152/#155 are stacked on that branch).
