### PR TITLE
fix(mlite): avoid loss hook reference cycle

### DIFF
--- a/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import math
 import os
+import weakref
 from enum import Enum
 from types import SimpleNamespace
 from typing import Any
@@ -923,6 +924,8 @@ class MegatronLiteEngine(BaseEngine):
         return output
 
     def _make_runtime_loss_fn(self, loss_function, num_microbatches: int, output_lst=None):
+        loss_fn_ref = None
+
         def _loss_fn(
             raw_output: dict[str, torch.Tensor],
             runtime_batch: PackedBatch,
@@ -951,8 +954,9 @@ class MegatronLiteEngine(BaseEngine):
                 )
 
             raw_output["_verl_metrics"] = metrics
+            assert loss_fn_ref is not None
             if output_lst is not None and not getattr(
-                _loss_fn, "runtime_collects_outputs", False
+                loss_fn_ref(), "runtime_collects_outputs", False
             ):
                 output_lst.append(
                     {
@@ -963,6 +967,8 @@ class MegatronLiteEngine(BaseEngine):
                 )
             return (loss * num_microbatches if loss_function is not None else loss), metrics
 
+        # Avoid a strong self-reference while preserving the runtime hook attributes.
+        loss_fn_ref = weakref.ref(_loss_fn)
         _loss_fn.runtime_output_collector = output_lst
         _loss_fn.runtime_output_extractor = lambda output: output["_verl_model_output"]
         # The static collector records ``loss`` before this hook applies the

--- a/experimental/lite/tests/unit/verl/test_mlite_engine_config.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_engine_config.py
@@ -73,6 +73,25 @@ def test_verl_loss_hook_preserves_gradient_and_micro_outputs(num_microbatches):
     assert [output["loss"] for output in outputs] == [3.0 / num_microbatches] * num_microbatches
 
 
+def test_verl_loss_hook_has_no_strong_self_reference():
+    engine = _engine(engine_config=_engine_config())
+    hook = engine._make_runtime_loss_fn(None, num_microbatches=1)
+
+    assert all(cell.cell_contents is not hook for cell in (hook.__closure__ or ()))
+
+
+def test_verl_loss_hook_honors_runtime_output_collector():
+    engine = _engine(engine_config=_engine_config())
+    outputs = []
+    engine._build_verl_model_output = lambda **_kwargs: {"log_probs": torch.tensor(1.0)}
+    hook = engine._make_runtime_loss_fn(None, num_microbatches=1, output_lst=outputs)
+
+    hook.runtime_collects_outputs = True
+    hook({}, object(), LossContext(source_batch=object()))
+
+    assert outputs == []
+
+
 def test_optimizer_offload_enables_full_optimizer_state_offload_by_default() -> None:
     engine = _engine(
         engine_config=_engine_config(optimizer_offload=True),


### PR DESCRIPTION
## Summary

- Port verl-project/Megatron-LM#24 into the fork.
- Replace the loss hook's strong self-reference with a weak reference.
- Preserve the `runtime_collects_outputs` protocol used by dynamic context parallelism.

## Source

- Upstream PR: https://github.com/verl-project/Megatron-LM/pull/24
- Upstream commit: `b7f135539d19dcbdf4fcb573f1437221d6039f2e`

## Validation

- `python -m pytest -q experimental/lite/tests/unit/runtime/test_dynamic_cp_plugin_unit.py -k 'output or collector or loss_scale'`: `4 passed, 26 deselected`
- `python -m py_compile experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py experimental/lite/tests/unit/verl/test_mlite_engine_config.py`: passed
- Loss-hook pytest collection requires the downstream `verl` package, which is not installed in the current environment.
- The repository-pinned isort/black pre-commit hooks rewrite unrelated pre-existing formatting in both touched files; those unrelated rewrites are intentionally excluded.
