### PR TITLE
Add TP/SP attention multi-LoRA support

### DIFF
--- a/experimental/lite/.pre-commit-config.yaml
+++ b/experimental/lite/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
     language: python
     additional_dependencies: ["isort==5.13.2"]
     files: ^experimental/lite/.*\.py$
+    args: ["--profile", "black"]
   - id: black
     name: black
     entry: black

--- a/experimental/lite/.pre-commit-config.yaml
+++ b/experimental/lite/.pre-commit-config.yaml
@@ -7,7 +7,6 @@ repos:
     language: python
     additional_dependencies: ["isort==5.13.2"]
     files: ^experimental/lite/.*\.py$
-    args: ["--profile", "black"]
   - id: black
     name: black
     entry: black

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/checkpoint.py
@@ -365,6 +365,22 @@ def EXPERT_CLASSIFIER(name: str) -> bool:
 
 
 def PLACEMENT_FN(param_name: str) -> list:
+    if ".bank_" in param_name or param_name.startswith("bank_"):
+        encoded = param_name.rsplit("_", 1)[0].split("bank_", 1)[1]
+        try:
+            surface = bytes.fromhex(encoded).decode("utf-8")
+        except ValueError:
+            surface = ""
+        factor = param_name.rsplit("_", 1)[-1]
+        if ".attn.qkv." in surface:
+            return [Replicate(), Replicate(), Replicate(), Shard(1)]
+        if ".attn.proj." in surface:
+            return [
+                Replicate(),
+                Replicate(),
+                Replicate(),
+                Shard(2 if factor == "a" else 1),
+            ]
     if "experts" in param_name and "router" not in param_name:
         if "fc1" in param_name:
             return [Replicate(), Replicate(), Shard(0), Shard(0)]

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
@@ -37,6 +37,20 @@ from megatron.lite.primitive.parallel import (
     roll_packed_thd_left,
     scatter_to_sequence_parallel,
 )
+
+
+def _local_moe_lora_indices(
+    lora_indices: torch.Tensor, *, local_rows: int, tp_size: int, tp_rank: int
+) -> torch.Tensor:
+    """Normalize logical SP slots to the local MoE row order."""
+    if lora_indices.numel() == local_rows:
+        return lora_indices
+    if tp_size > 1 and lora_indices.numel() == local_rows * tp_size:
+        # SP scatter uses contiguous TP chunks; MoE must slice that same axis.
+        return lora_indices.chunk(tp_size)[tp_rank]
+    raise ValueError("MoE multi-LoRA indices must describe local or TP-global rows.")
+
+
 from megatron.lite.primitive.utils import build_fp8_recipe
 
 # isort: on
@@ -92,10 +106,16 @@ class MoELayer(nn.Module):
                 raise RuntimeError("multi-LoRA MoE sidecars do not support ETP.")
             if self._use_deepep_requested:
                 raise RuntimeError("multi-LoRA MoE sidecars do not support DeepEP.")
+            lora_indices = _local_moe_lora_indices(
+                multi_lora_sidecar.lora_indices,
+                local_rows=x_2d.shape[0],
+                tp_size=self.ps.tp_size,
+                tp_rank=self.ps.tp_rank,
+            )
             fc1_delta = apply_dense_lora_delta(
                 multi_lora_sidecar.fc1,
                 x_2d,
-                multi_lora_sidecar.lora_indices,
+                lora_indices,
                 scale=multi_lora_sidecar.scale,
                 gradient_sync_group=_sidecar_ep_sync_group(self.ps, multi_lora_sidecar),
             )
@@ -110,9 +130,7 @@ class MoELayer(nn.Module):
         if multi_lora_sidecar is not None:
             assert fc1_delta is not None
             routed_fc1_delta = self.dispatcher.dispatch_sidecar(fc1_delta)
-            routed_lora_indices = self.dispatcher.dispatch_sidecar(
-                multi_lora_sidecar.lora_indices
-            )
+            routed_lora_indices = self.dispatcher.dispatch_sidecar(lora_indices)
         self.dispatcher.wait_dispatch_event()
 
         def _fc2_delta(h: torch.Tensor) -> torch.Tensor:

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
@@ -37,6 +37,7 @@ from megatron.lite.primitive.parallel import (
     roll_packed_thd_left,
     scatter_to_sequence_parallel,
 )
+from megatron.lite.primitive.utils import build_fp8_recipe
 
 
 def _local_moe_lora_indices(
@@ -50,8 +51,6 @@ def _local_moe_lora_indices(
         return lora_indices.chunk(tp_size)[tp_rank]
     raise ValueError("MoE multi-LoRA indices must describe local or TP-global rows.")
 
-
-from megatron.lite.primitive.utils import build_fp8_recipe
 
 # isort: on
 

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
@@ -215,7 +215,12 @@ class TransformerLayer(nn.Module):
         multi_lora_sidecar: MoELoraSidecar | None = None,
     ) -> torch.Tensor:
         residual = x
-        h = self.attn(x, position_ids=position_ids, packed_seq_params=packed_seq_params)
+        h = self.attn(
+            x,
+            position_ids=position_ids,
+            packed_seq_params=packed_seq_params,
+            multi_lora_sidecar=multi_lora_sidecar,
+        )
         x = residual + h
 
         residual = x

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/multi_lora.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/multi_lora.py
@@ -81,6 +81,8 @@ class MoELoraSidecar:
     # builder sets this False for model-owned banks; dist-opt then owns their
     # single dense-DP/finalize reduction.
     requires_explicit_ep_sync: bool = True
+    qkv: DenseLoraBank | None = None
+    proj: DenseLoraBank | None = None
 
 
 __all__ = ["MoELoraSidecar", "apply_dense_lora_delta"]

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
@@ -178,13 +178,20 @@ def _inject_multi_lora_sidecars(kwargs, batch: PackedBatch, multi_lora_state) ->
             "multi_lora_slots is missing local pipeline layers: "
             f"{sorted(missing_local_layers)}"
         )
-    kwargs["multi_lora_sidecars"] = {
-        layer_idx: MoELoraSidecar(
+
+    def _sidecar(layer_idx, layer_slots):
+        attention_banks = multi_lora_state.attention_banks_for_layer(layer_idx)
+        return MoELoraSidecar(
             *multi_lora_state.banks_for_layer(layer_idx),
             lora_indices=layer_slots,
             scale=multi_lora_state.scale,
             requires_explicit_ep_sync=False,
+            qkv=None if attention_banks is None else attention_banks[0],
+            proj=None if attention_banks is None else attention_banks[1],
         )
+
+    kwargs["multi_lora_sidecars"] = {
+        layer_idx: _sidecar(layer_idx, layer_slots)
         for layer_idx, layer_slots in slots.items()
         if layer_idx in local_layers
     }
@@ -227,6 +234,7 @@ def _build_multi_lora_training_state(
     dtype = next(chunks[0].parameters()).dtype
     banks: dict[str, DenseLoraBank] = {}
     layer_surfaces: dict[int, tuple[str, str]] = {}
+    attention_surfaces: dict[int, tuple[str, str]] = {}
     for chunk in chunks:
         for layer in chunk.layers:
             layer_idx = layer.layer_idx
@@ -270,19 +278,73 @@ def _build_multi_lora_training_state(
                     )
                 ),
             )
+            attn = layer.attn
+            # Preserve TE's fused LayerNorm+QKV GEMM and request the exact
+            # normalized activation it already produces for the sidecar delta.
+            attn.qkv.linear.return_layernorm_output = True
+            attn.qkv.linear.return_layernorm_output_gathered = False
+            qkv = DenseLoraBank(
+                nn.Parameter(
+                    torch.empty(
+                        len(spec.names),
+                        spec.rank,
+                        model_cfg.hidden_size,
+                        device=device,
+                        dtype=dtype,
+                    )
+                ),
+                nn.Parameter(
+                    torch.empty(
+                        len(spec.names),
+                        attn.qkv.local_out,
+                        spec.rank,
+                        device=device,
+                        dtype=dtype,
+                    )
+                ),
+            )
+            proj = DenseLoraBank(
+                nn.Parameter(
+                    torch.empty(
+                        len(spec.names),
+                        spec.rank,
+                        attn.proj.local_in,
+                        device=device,
+                        dtype=dtype,
+                    )
+                ),
+                nn.Parameter(
+                    torch.empty(
+                        len(spec.names),
+                        model_cfg.hidden_size,
+                        spec.rank,
+                        device=device,
+                        dtype=dtype,
+                    )
+                ),
+            )
             nn.init.kaiming_uniform_(fc1.a_bank, a=5**0.5)
             nn.init.zeros_(fc1.b_bank)
             nn.init.kaiming_uniform_(fc2.a_bank, a=5**0.5)
             nn.init.zeros_(fc2.b_bank)
+            nn.init.kaiming_uniform_(qkv.a_bank, a=5**0.5)
+            nn.init.zeros_(qkv.b_bank)
+            nn.init.kaiming_uniform_(proj.a_bank, a=5**0.5)
+            nn.init.zeros_(proj.b_bank)
             fc1_surface = f"layers.{layer_idx}.moe.experts._fc1_weight_0"
             fc2_surface = f"layers.{layer_idx}.moe.experts._fc2_weight_0"
+            qkv_surface = f"layers.{layer_idx}.attn.qkv.linear.weight"
+            proj_surface = f"layers.{layer_idx}.attn.proj.linear.weight"
             layer_surfaces[layer_idx] = (fc1_surface, fc2_surface)
+            attention_surfaces[layer_idx] = (qkv_surface, proj_surface)
             # One canonical grouped native surface per layer.  The HF exporter
             # expands this shared bank across experts exactly once; registering
             # every expert here would make that exporter expand an E-sized map E
             # times and overwrite the same output keys.
             banks[fc1_surface] = fc1
             banks[fc2_surface] = fc2
+            banks[qkv_surface] = qkv
+            banks[proj_surface] = proj
     registry = NamedLoraBankRegistry(
         banks=banks,
         names={name: slot for slot, name in enumerate(spec.names)},
@@ -296,7 +358,7 @@ def _build_multi_lora_training_state(
             use_rslora=spec.use_rslora,
         ),
     )
-    state = MultiLoraTrainingState(registry, layer_surfaces)
+    state = MultiLoraTrainingState(registry, layer_surfaces, attention_surfaces)
     chunks[0].add_module("multi_lora_training_state", state)
     return state
 

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
@@ -343,15 +343,16 @@ def _build_multi_lora_training_state(
             nn.init.zeros_(qkv.b_bank)
             nn.init.kaiming_uniform_(proj.a_bank, a=5**0.5)
             nn.init.zeros_(proj.b_bank)
-            for bank, tensor_model_parallel in (
-                (fc1, False),
-                (fc2, False),
-                (qkv, True),
-                (proj, True),
-            ):
+            for bank in (fc1, fc2, qkv, proj):
+                tensor_model_parallel = (
+                    bank.partition.rank_partitioned_a
+                    or bank.partition.output_partitioned_b
+                )
                 for parameter in (bank.a_bank, bank.b_bank):
                     parameter.tensor_model_parallel = tensor_model_parallel
-                    parameter.allreduce = not tensor_model_parallel
+                    # These model-owned banks are non-expert parameters.  Keep
+                    # them in regular DP buffers independent of TP ownership.
+                    parameter.allreduce = True
             fc1_surface = f"layers.{layer_idx}.moe.experts._fc1_weight_0"
             fc2_surface = f"layers.{layer_idx}.moe.experts._fc2_weight_0"
             qkv_surface = f"layers.{layer_idx}.attn.qkv.linear.weight"

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
@@ -280,6 +280,8 @@ def _build_multi_lora_training_state(
                 ),
             )
             attn = layer.attn
+            # TP1 test doubles and the TP1 base module need no distributed
+            # attribute; real TP modules provide their authoritative size.
             tp_size = int(getattr(attn.qkv, "tp_size", 1))
             if spec.rank % tp_size:
                 raise ValueError("multi-LoRA rank must be divisible by TP size.")
@@ -341,6 +343,15 @@ def _build_multi_lora_training_state(
             nn.init.zeros_(qkv.b_bank)
             nn.init.kaiming_uniform_(proj.a_bank, a=5**0.5)
             nn.init.zeros_(proj.b_bank)
+            for bank, tensor_model_parallel in (
+                (fc1, False),
+                (fc2, False),
+                (qkv, True),
+                (proj, True),
+            ):
+                for parameter in (bank.a_bank, bank.b_bank):
+                    parameter.tensor_model_parallel = tensor_model_parallel
+                    parameter.allreduce = not tensor_model_parallel
             fc1_surface = f"layers.{layer_idx}.moe.experts._fc1_weight_0"
             fc2_surface = f"layers.{layer_idx}.moe.experts._fc2_weight_0"
             qkv_surface = f"layers.{layer_idx}.attn.qkv.linear.weight"
@@ -362,10 +373,7 @@ def _build_multi_lora_training_state(
         alpha=spec.alpha,
         base_model_identity={},
         lora_spec=LoraSpec(
-            enabled=True,
-            rank=spec.rank,
-            alpha=spec.alpha,
-            use_rslora=spec.use_rslora,
+            enabled=True, rank=spec.rank, alpha=spec.alpha, use_rslora=spec.use_rslora
         ),
     )
     state = MultiLoraTrainingState(registry, layer_surfaces, attention_surfaces)

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
@@ -169,6 +169,10 @@ def _inject_multi_lora_sidecars(kwargs, batch: PackedBatch, multi_lora_state) ->
         )
     slots = batch.extras.get("multi_lora_slots")
     if slots is None:
+        if multi_lora_state is not None:
+            raise ValueError(
+                "enabled impl_cfg.multi_lora requires multi_lora_slots in batch.extras"
+            )
         return
     if multi_lora_state is None:
         raise ValueError("multi_lora_slots requires enabled impl_cfg.multi_lora.")

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
@@ -60,6 +60,7 @@ from megatron.lite.primitive.modules.lora import (
 )
 from megatron.lite.primitive.modules.multi_lora_bank import (
     DenseLoraBank,
+    LoraBankPartition,
     MultiLoraSpec,
     MultiLoraTrainingState,
     NamedLoraBankRegistry,
@@ -279,21 +280,24 @@ def _build_multi_lora_training_state(
                 ),
             )
             attn = layer.attn
+            tp_size = int(getattr(attn.qkv, "tp_size", 1))
+            if spec.rank % tp_size:
+                raise ValueError("multi-LoRA rank must be divisible by TP size.")
             # Preserve TE's fused LayerNorm+QKV GEMM and request the exact
             # normalized activation it already produces for the sidecar delta.
             attn.qkv.linear.return_layernorm_output = True
             attn.qkv.linear.return_layernorm_output_gathered = False
             qkv = DenseLoraBank(
-                nn.Parameter(
+                a_bank=nn.Parameter(
                     torch.empty(
                         len(spec.names),
-                        spec.rank,
+                        spec.rank // tp_size,
                         model_cfg.hidden_size,
                         device=device,
                         dtype=dtype,
                     )
                 ),
-                nn.Parameter(
+                b_bank=nn.Parameter(
                     torch.empty(
                         len(spec.names),
                         attn.qkv.local_out,
@@ -302,9 +306,12 @@ def _build_multi_lora_training_state(
                         dtype=dtype,
                     )
                 ),
+                partition=LoraBankPartition(
+                    tp_size=tp_size, rank_partitioned_a=tp_size > 1
+                ),
             )
             proj = DenseLoraBank(
-                nn.Parameter(
+                a_bank=nn.Parameter(
                     torch.empty(
                         len(spec.names),
                         spec.rank,
@@ -313,14 +320,17 @@ def _build_multi_lora_training_state(
                         dtype=dtype,
                     )
                 ),
-                nn.Parameter(
+                b_bank=nn.Parameter(
                     torch.empty(
                         len(spec.names),
-                        model_cfg.hidden_size,
+                        model_cfg.hidden_size // tp_size,
                         spec.rank,
                         device=device,
                         dtype=dtype,
                     )
+                ),
+                partition=LoraBankPartition(
+                    tp_size=tp_size, output_partitioned_b=tp_size > 1
                 ),
             )
             nn.init.kaiming_uniform_(fc1.a_bank, a=5**0.5)

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
@@ -186,7 +186,9 @@ def _inject_multi_lora_sidecars(kwargs, batch: PackedBatch, multi_lora_state) ->
             *multi_lora_state.banks_for_layer(layer_idx),
             lora_indices=layer_slots,
             scale=multi_lora_state.scale,
-            requires_explicit_ep_sync=False,
+            # FC banks are EP-replicated while attention banks stay on their
+            # TP carrier; this flag is consumed only by MoE FC sidecar calls.
+            requires_explicit_ep_sync=True,
             qkv=None if attention_banks is None else attention_banks[0],
             proj=None if attention_banks is None else attention_banks[1],
         )
@@ -343,16 +345,21 @@ def _build_multi_lora_training_state(
             nn.init.zeros_(qkv.b_bank)
             nn.init.kaiming_uniform_(proj.a_bank, a=5**0.5)
             nn.init.zeros_(proj.b_bank)
-            for bank in (fc1, fc2, qkv, proj):
+            for bank, is_expert_bank in (
+                (fc1, True),
+                (fc2, True),
+                (qkv, False),
+                (proj, False),
+            ):
                 tensor_model_parallel = (
                     bank.partition.rank_partitioned_a
                     or bank.partition.output_partitioned_b
                 )
                 for parameter in (bank.a_bank, bank.b_bank):
                     parameter.tensor_model_parallel = tensor_model_parallel
-                    # These model-owned banks are non-expert parameters.  Keep
-                    # them in regular DP buffers independent of TP ownership.
-                    parameter.allreduce = True
+                    # FC banks follow expert-DP ownership plus the MoE EP
+                    # reduction; attention banks stay in regular dense-DP.
+                    parameter.allreduce = not is_expert_bank
             fc1_surface = f"layers.{layer_idx}.moe.experts._fc1_weight_0"
             fc2_surface = f"layers.{layer_idx}.moe.experts._fc2_weight_0"
             qkv_surface = f"layers.{layer_idx}.attn.qkv.linear.weight"

--- a/experimental/lite/megatron/lite/primitive/distributed_test_utils.py
+++ b/experimental/lite/megatron/lite/primitive/distributed_test_utils.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Shared distributed-test helpers for Megatron Lite primitive contracts."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+import torch.distributed as dist
+
+
+def select_lora_bank_owner_group(parallel_state, *, is_expert_bank: bool):
+    """Return the dist-opt replica group for an FC or attention LoRA bank."""
+    return parallel_state.ep_dp_group if is_expert_bank else parallel_state.dp_group
+
+
+def gather_owner_factor_records_or_raise(
+    owner_group,
+    build_record: Callable[[], Any],
+    validate_records: Callable[[list[Any]], None],
+) -> list[Any]:
+    """Validate factor records without allowing lane-local errors to strand WORLD.
+
+    The owner lane always exchanges an envelope first.  Every rank then enters
+    one WORLD error bridge, so a malformed local shard makes all ranks raise
+    the same error before the next world collective can begin.
+    """
+    envelope: dict[str, Any] = {"error": None, "record": None}
+    try:
+        envelope["record"] = build_record()
+    except Exception as error:
+        envelope["error"] = f"{type(error).__name__}: {error}"
+    envelopes: list[dict[str, Any] | None] = [None] * dist.get_world_size(owner_group)
+    dist.all_gather_object(envelopes, envelope, group=owner_group)
+
+    lane_error: str | None = None
+    records: list[Any] = []
+    try:
+        errors = [
+            item["error"] for item in envelopes if item is not None and item["error"]
+        ]
+        if errors:
+            raise RuntimeError(errors[0])
+        records = [
+            item["record"]
+            for item in envelopes
+            if item is not None and item["record"] is not None
+        ]
+        validate_records(records)
+    except Exception as error:
+        lane_error = f"{type(error).__name__}: {error}"
+
+    world_errors: list[str | None] = [None] * dist.get_world_size()
+    dist.all_gather_object(world_errors, lane_error)
+    errors = [error for error in world_errors if error is not None]
+    if errors:
+        raise RuntimeError(f"owner-group factor validation failed: {errors[0]}")
+    return records

--- a/experimental/lite/megatron/lite/primitive/distributed_test_utils.py
+++ b/experimental/lite/megatron/lite/primitive/distributed_test_utils.py
@@ -18,9 +18,9 @@ def build_lora_collective_descriptor(
     kind: str, reduction_tensor: torch.Tensor, bank_dtype: torch.dtype
 ) -> tuple[str, tuple[int, ...], str]:
     """Describe the actual tensor dtype and shape consumed by a bank collective."""
-    assert (
-        reduction_tensor.dtype is torch.float32
-    ), "LoRA reduction tensor dtype must be torch.float32"
+    assert reduction_tensor.dtype is torch.float32, (
+        "LoRA reduction tensor dtype must be torch.float32"
+    )
     if kind == "fc":
         assert bank_dtype is torch.bfloat16, "FC LoRA bank dtype must be torch.bfloat16"
         collective_dtype = bank_dtype

--- a/experimental/lite/megatron/lite/primitive/distributed_test_utils.py
+++ b/experimental/lite/megatron/lite/primitive/distributed_test_utils.py
@@ -5,7 +5,64 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
+import torch
 import torch.distributed as dist
+
+
+def canonical_lora_bank_names(banks) -> tuple[str, ...]:
+    """Return a rank-independent order for mixed LoRA bank collectives."""
+    return tuple(sorted(banks))
+
+
+def build_lora_collective_descriptor(
+    kind: str, reduction_tensor: torch.Tensor, bank_dtype: torch.dtype
+) -> tuple[str, tuple[int, ...], str]:
+    """Describe the actual tensor dtype and shape consumed by a bank collective."""
+    assert (
+        reduction_tensor.dtype is torch.float32
+    ), "LoRA reduction tensor dtype must be torch.float32"
+    if kind == "fc":
+        assert bank_dtype is torch.bfloat16, "FC LoRA bank dtype must be torch.bfloat16"
+        collective_dtype = bank_dtype
+    else:
+        assert kind == "attention", f"invalid LoRA bank kind: {kind}"
+        collective_dtype = reduction_tensor.dtype
+    return kind, tuple(reduction_tensor.shape), str(collective_dtype)
+
+
+def preflight_lora_bank_collective_order(
+    banks, build_descriptor: Callable[[str], tuple[str, tuple[int, ...], str]]
+) -> tuple[tuple[str, str, tuple[int, ...], str], ...]:
+    """Validate WORLD-wide `(name, kind, shape, dtype)` before collectives."""
+    envelope: dict[str, Any] = {"error": None, "record": None}
+    try:
+        records = []
+        for name in canonical_lora_bank_names(banks):
+            descriptor = build_descriptor(name)
+            assert type(descriptor) is tuple and len(descriptor) == 3
+            kind, shape, dtype = descriptor
+            assert kind in {"fc", "attention"}, f"invalid LoRA bank kind: {kind}"
+            assert type(shape) is tuple and all(type(dim) is int for dim in shape)
+            assert type(dtype) is str
+            records.append((name, kind, shape, dtype))
+        envelope["record"] = tuple(
+            sorted(records, key=lambda record: (record[1] != "fc", record[0]))
+        )
+    except Exception as error:
+        envelope["error"] = f"{type(error).__name__}: {error}"
+    envelopes: list[dict[str, Any] | None] = [None] * dist.get_world_size()
+    dist.all_gather_object(envelopes, envelope, group=dist.group.WORLD)
+    errors = [item["error"] for item in envelopes if item is not None and item["error"]]
+    if errors:
+        raise RuntimeError(
+            f"mixed LoRA bank collective preflight failed: local record error: {errors[0]}"
+        )
+    records = [item["record"] for item in envelopes if item is not None]
+    if not records or any(record != records[0] for record in records):
+        raise RuntimeError(
+            "mixed LoRA bank collective preflight failed: records differ across WORLD"
+        )
+    return records[0]
 
 
 def select_lora_bank_owner_group(parallel_state, *, is_expert_bank: bool):
@@ -50,7 +107,7 @@ def gather_owner_factor_records_or_raise(
         lane_error = f"{type(error).__name__}: {error}"
 
     world_errors: list[str | None] = [None] * dist.get_world_size()
-    dist.all_gather_object(world_errors, lane_error)
+    dist.all_gather_object(world_errors, lane_error, group=dist.group.WORLD)
     errors = [error for error in world_errors if error is not None]
     if errors:
         raise RuntimeError(f"owner-group factor validation failed: {errors[0]}")

--- a/experimental/lite/megatron/lite/primitive/modules/gqa.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gqa.py
@@ -10,13 +10,12 @@ from __future__ import annotations
 import torch
 import torch.nn as nn
 import transformer_engine.pytorch as te
-
 from megatron.lite.primitive.modules.gqa_utils import (
     split_grouped_qkvg,
     split_grouped_qkvg_for_tp,
 )
-from megatron.lite.primitive.modules.multi_lora_bank import apply_batched_lora_delta
 from megatron.lite.primitive.modules.mrope import MultimodalRotaryEmbedding
+from megatron.lite.primitive.modules.multi_lora_bank import apply_batched_lora_delta
 from megatron.lite.primitive.parallel import (
     ColumnParallelLinear,
     ParallelState,

--- a/experimental/lite/megatron/lite/primitive/modules/gqa.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gqa.py
@@ -15,6 +15,7 @@ from megatron.lite.primitive.modules.gqa_utils import (
     split_grouped_qkvg,
     split_grouped_qkvg_for_tp,
 )
+from megatron.lite.primitive.modules.multi_lora_bank import apply_batched_lora_delta
 from megatron.lite.primitive.modules.mrope import MultimodalRotaryEmbedding
 from megatron.lite.primitive.parallel import (
     ColumnParallelLinear,
@@ -23,7 +24,10 @@ from megatron.lite.primitive.parallel import (
     all_gather_last_dim_with_grad_reduce,
 )
 from megatron.lite.primitive.utils import ensure_divisible
-from megatron.lite.primitive.utils.rope import _apply_rotary_pos_emb_bshd, _apply_rotary_pos_emb_thd
+from megatron.lite.primitive.utils.rope import (
+    _apply_rotary_pos_emb_bshd,
+    _apply_rotary_pos_emb_thd,
+)
 from megatron.lite.primitive.utils.rotary import RotaryEmbedding
 
 # Whitelist of MC PackedSeqParams fields accepted by TE DotProductAttention.forward().
@@ -94,7 +98,9 @@ class GQAttention(nn.Module):
         # Mismatched order would put bucket boundaries in different places,
         # producing different per-rank fp32 master shard layouts and
         # non-bitwise step-1 divergence.
-        self.proj = RowParallelLinear(num_attention_heads * head_dim, hidden_size, ps, bias=False)
+        self.proj = RowParallelLinear(
+            num_attention_heads * head_dim, hidden_size, ps, bias=False
+        )
         q_cols = num_attention_heads * (2 if output_gate else 1)
         qkv_size = (q_cols + 2 * num_key_value_heads) * head_dim
         self.qkv = ColumnParallelLinear(
@@ -150,9 +156,27 @@ class GQAttention(nn.Module):
         )
 
     def forward(
-        self, x: torch.Tensor, position_ids: torch.Tensor | None = None, packed_seq_params=None
+        self,
+        x: torch.Tensor,
+        position_ids: torch.Tensor | None = None,
+        packed_seq_params=None,
+        multi_lora_sidecar=None,
     ) -> torch.Tensor:
-        qkv = self.qkv(x)
+        if multi_lora_sidecar is not None and multi_lora_sidecar.qkv is not None:
+            qkv, normalized_input = self.qkv.forward_with_normalized_input(x)
+            qkv = qkv + apply_batched_lora_delta(
+                multi_lora_sidecar.qkv,
+                normalized_input,
+                multi_lora_sidecar.lora_indices,
+                scale=multi_lora_sidecar.scale,
+                tp_group=self.ps.tp_group,
+                tp_rank=self.ps.tp_rank,
+                sequence_parallel_input=self.qkv.use_sp,
+            )
+        elif getattr(self.qkv.linear, "return_layernorm_output", False):
+            qkv, _normalized_input = self.qkv.forward_with_normalized_input(x)
+        else:
+            qkv = self.qkv(x)
         if self._replicate_kv:
             qkv = all_gather_last_dim_with_grad_reduce(qkv, self.ps.tp_group)
         q, gate, k, v = self._split_qkv(qkv)
@@ -212,8 +236,12 @@ class GQAttention(nn.Module):
             local_seq_len = q.size(0)
             seq_len_for_rope = local_seq_len * self.ps.cp_size
             freqs = self.rotary(seq_len_for_rope)
-            q = _apply_rotary_pos_emb_bshd(q, freqs, rotary_interleaved=False, mscale=1.0)
-            k = _apply_rotary_pos_emb_bshd(k, freqs, rotary_interleaved=False, mscale=1.0)
+            q = _apply_rotary_pos_emb_bshd(
+                q, freqs, rotary_interleaved=False, mscale=1.0
+            )
+            k = _apply_rotary_pos_emb_bshd(
+                k, freqs, rotary_interleaved=False, mscale=1.0
+            )
         if self._use_fp32_rope:
             q, k = q.to(orig_dtype), k.to(orig_dtype)
 
@@ -236,12 +264,25 @@ class GQAttention(nn.Module):
             attn_out = self.core_attn(q, k, v, core_attention_bias_type="no_bias")
             if attn_out.dim() > x.dim():
                 shape = attn_out.shape
-                attn_out = attn_out.reshape(*shape[:-2], self.num_heads_local * self.head_dim)
+                attn_out = attn_out.reshape(
+                    *shape[:-2], self.num_heads_local * self.head_dim
+                )
 
         if gate is not None:
             gate_fp32 = gate.reshape(attn_out.shape).float().sigmoid()
             attn_out = (attn_out.float() * gate_fp32).to(attn_out.dtype)
         output = self.proj(attn_out)
+        if multi_lora_sidecar is not None and multi_lora_sidecar.proj is not None:
+            output = output + apply_batched_lora_delta(
+                multi_lora_sidecar.proj,
+                attn_out,
+                multi_lora_sidecar.lora_indices,
+                scale=multi_lora_sidecar.scale,
+                tp_group=self.ps.tp_group,
+                tp_rank=self.ps.tp_rank,
+                input_parallel_reduce=self.ps.tp_size > 1,
+                sequence_parallel_scatter_output=self.proj.use_sp,
+            )
         return output
 
     def _split_qkv(self, qkv: torch.Tensor):
@@ -275,7 +316,9 @@ class GQAttention(nn.Module):
 
             q_per_group = ensure_divisible(nq, nkv)
             if self._output_gate:
-                return split_grouped_qkvg(qkv, num_heads=nq, num_kv_heads=nkv, head_dim=hd)
+                return split_grouped_qkvg(
+                    qkv, num_heads=nq, num_kv_heads=nkv, head_dim=hd
+                )
 
             qkv = qkv.view(*lead, nkv, (q_per_group + 2) * hd)
             q = qkv[..., : q_per_group * hd].reshape(*lead, nq, hd)

--- a/experimental/lite/megatron/lite/primitive/modules/lora.py
+++ b/experimental/lite/megatron/lite/primitive/modules/lora.py
@@ -19,12 +19,7 @@ import torch.nn.functional as F
 LORA_DEFAULT_RANK = 0
 LORA_DEFAULT_ALPHA = None
 LORA_DEFAULT_DROPOUT = 0.0
-LORA_DEFAULT_TARGET_MODULES = (
-    "linear_qkv",
-    "linear_proj",
-    "linear_fc1",
-    "linear_fc2",
-)
+LORA_DEFAULT_TARGET_MODULES = ("linear_qkv", "linear_proj", "linear_fc1", "linear_fc2")
 LORA_DEFAULT_USE_RSLORA = False
 _DEFAULT_IGNORE_PATTERNS = (
     "lm_head",
@@ -135,10 +130,7 @@ def normalize_lora_spec(config: LoraSpec | dict[str, Any] | None) -> LoraSpec:
             f"LoRA spec must be LoraSpec, dict, or None, got {type(config)!r}."
         )
     values = dict(config)
-    if (
-        "enabled" not in values
-        and int(values.get("rank", LORA_DEFAULT_RANK) or 0) > 0
-    ):
+    if "enabled" not in values and int(values.get("rank", LORA_DEFAULT_RANK) or 0) > 0:
         warnings.warn(
             "LoRA rank alone is inert; LoRA requires enabled=True.",
             UserWarning,
@@ -347,10 +339,16 @@ class _AllGatherLastDim(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad: torch.Tensor):
         flat = grad.movedim(-1, 0).contiguous().view(grad.shape[-1], -1)
-        start = ctx.group_rank * ctx.local_width
-        out = flat.narrow(0, start, ctx.local_width).contiguous()
         if ctx.reduce_backward:
-            dist.all_reduce(out, op=dist.ReduceOp.SUM, group=ctx.group)
+            # Forward concatenates rank-local *last-dimension* chunks.  Move
+            # that dimension to dim0, sum the complete gradient plane across
+            # output shards, then take this rank's local-width chunk.
+            dist.all_reduce(flat, op=dist.ReduceOp.SUM, group=ctx.group)
+            start = ctx.group_rank * ctx.local_width
+            out = flat.narrow(0, start, ctx.local_width).contiguous()
+        else:
+            start = ctx.group_rank * ctx.local_width
+            out = flat.narrow(0, start, ctx.local_width).contiguous()
         return (
             out.view(ctx.local_width, *grad.shape[:-1]).movedim(0, -1).contiguous(),
             None,

--- a/experimental/lite/megatron/lite/primitive/modules/multi_lora_bank.py
+++ b/experimental/lite/megatron/lite/primitive/modules/multi_lora_bank.py
@@ -16,14 +16,15 @@ import torch
 import torch.nn as nn
 from megatron.lite.primitive.ckpt import hf_weights
 from megatron.lite.primitive.ckpt.hf_weights import export_hf_lora_bank_adapter
-from megatron.lite.primitive.modules.lora import LoraSpec, resolve_lora_alpha
+from megatron.lite.primitive.modules import multi_lora_kernel
 from megatron.lite.primitive.modules.lora import (
-    _all_reduce_sum,
+    LoraSpec,
     _all_gather_last_dim,
+    _all_reduce_sum,
     _gather_sequence_parallel,
     _scatter_sequence_parallel,
+    resolve_lora_alpha,
 )
-from megatron.lite.primitive.modules import multi_lora_kernel
 from megatron.lite.primitive.modules.multi_lora import BatchedLoraDelta
 
 
@@ -98,7 +99,7 @@ def apply_batched_lora_delta(
         width = bank.b_bank.shape[1] * (
             partition.tp_size if partition.output_partitioned_b else 1
         )
-        return rows.new_zeros((*x.shape[:-1], width))
+        return rows.new_zeros((rows.shape[0], width)).reshape(-1, *x.shape[1:-1], width)
     if not partition.rank_partitioned_a and not partition.output_partitioned_b:
         if slots.numel() < 2 or bool(torch.all(slots[1:] >= slots[:-1])):
             delta = bank.delta(rows, slots, scale=scale)
@@ -138,7 +139,9 @@ def apply_batched_lora_delta(
         delta = delta.index_select(0, restore)
     if sequence_parallel_scatter_output:
         delta = _scatter_sequence_parallel(delta, tp_group, tp_rank)
-    return delta.reshape(*x.shape[:-1], delta.shape[-1])
+    # SP collectives may change the number of token rows.  The output layout
+    # must follow the post-collective delta, not the caller's pre-gather input.
+    return delta.reshape(-1, *x.shape[1:-1], delta.shape[-1])
 
 
 @dataclass(frozen=True)
@@ -156,7 +159,7 @@ class MultiLoraSpec:
 
 
 def normalize_multi_lora_spec(
-    config: MultiLoraSpec | Mapping[str, Any] | None,
+    config: MultiLoraSpec | Mapping[str, Any] | None
 ) -> MultiLoraSpec:
     """Normalize runtime config without allowing an unowned registry injection."""
     if config is None:
@@ -398,6 +401,11 @@ class NamedLoraBankRegistry:
                     "multi-LoRA bank TP metadata does not match export parallel state."
                 )
             a, b = selected[surface]
+            # DTensor must become its local tensor before the LoRA-internal
+            # gather.  The normal exporter then performs only the base-weight
+            # gather for this same surface.
+            a = hf_weights._materialize_dtensor(a)
+            b = hf_weights._materialize_dtensor(b)
             if ps.tp_size > 1 and bank.partition.rank_partitioned_a:
                 a = hf_weights.allgather_concat(a, ps.tp_size, ps.tp_group, dim=0)
             if ps.tp_size > 1 and bank.partition.output_partitioned_b:

--- a/experimental/lite/megatron/lite/primitive/modules/multi_lora_bank.py
+++ b/experimental/lite/megatron/lite/primitive/modules/multi_lora_bank.py
@@ -16,6 +16,11 @@ import torch
 import torch.nn as nn
 from megatron.lite.primitive.ckpt.hf_weights import export_hf_lora_bank_adapter
 from megatron.lite.primitive.modules.lora import LoraSpec, resolve_lora_alpha
+from megatron.lite.primitive.modules.lora import (
+    _all_reduce_sum,
+    _gather_sequence_parallel,
+    _scatter_sequence_parallel,
+)
 from megatron.lite.primitive.modules.multi_lora import BatchedLoraDelta
 
 
@@ -47,6 +52,44 @@ class DenseLoraBank:
         self, x: torch.Tensor, lora_indices: torch.Tensor, *, scale: float
     ) -> torch.Tensor:
         return BatchedLoraDelta.apply(x, self.a_bank, self.b_bank, lora_indices, scale)
+
+
+def apply_batched_lora_delta(
+    bank: DenseLoraBank,
+    x: torch.Tensor,
+    lora_indices: torch.Tensor,
+    *,
+    scale: float,
+    tp_group=None,
+    tp_rank: int = 0,
+    sequence_parallel_input: bool = False,
+    input_parallel_reduce: bool = False,
+    sequence_parallel_scatter_output: bool = False,
+) -> torch.Tensor:
+    """Apply a selected bank with the established LinearLoRA TP/SP collectives."""
+    if x.ndim < 2:
+        raise ValueError("batched LoRA input must have a feature dimension.")
+    rows = x.reshape(-1, x.shape[-1])
+    slots = lora_indices.reshape(-1)
+    if slots.numel() != rows.shape[0]:
+        raise ValueError("batched LoRA indices must have one entry per token.")
+    if sequence_parallel_input:
+        rows = _gather_sequence_parallel(rows, tp_group)
+        slots = _gather_sequence_parallel(slots[:, None], tp_group).squeeze(-1)
+    if slots.numel() < 2 or bool(torch.all(slots[1:] >= slots[:-1])):
+        delta = bank.delta(rows, slots, scale=scale)
+    else:
+        order = torch.argsort(slots, stable=True)
+        restore = torch.empty_like(order)
+        restore[order] = torch.arange(order.numel(), device=order.device)
+        delta = bank.delta(
+            rows.index_select(0, order), slots.index_select(0, order), scale=scale
+        ).index_select(0, restore)
+    if input_parallel_reduce:
+        delta = _all_reduce_sum(delta, tp_group)
+    if sequence_parallel_scatter_output:
+        delta = _scatter_sequence_parallel(delta, tp_group, tp_rank)
+    return delta.reshape(*x.shape[:-1], bank.b_bank.shape[1])
 
 
 @dataclass(frozen=True)
@@ -99,8 +142,6 @@ def validate_multi_lora_parallel_support(
         return
     if etp_size is not None and etp_size > 1:
         raise ValueError("multi-LoRA model-owned sidecars do not support ETP.")
-    if tp_size > 1:
-        raise ValueError("multi-LoRA model-owned sidecars do not support TP.")
     if use_deepep:
         raise ValueError("multi-LoRA model-owned sidecars do not support DeepEP.")
 
@@ -112,10 +153,12 @@ class MultiLoraTrainingState(nn.Module):
         self,
         registry: "NamedLoraBankRegistry",
         layer_surfaces: Mapping[int, tuple[str, str]],
+        attention_surfaces: Mapping[int, tuple[str, str]] | None = None,
     ) -> None:
         super().__init__()
         self.registry = registry
         self._layer_surfaces = dict(layer_surfaces)
+        self._attention_surfaces = dict(attention_surfaces or {})
         registered_tensor_names: dict[int, str] = {}
         for surface, bank in registry.banks.items():
             for factor, tensor in (("a", bank.a_bank), ("b", bank.b_bank)):
@@ -147,6 +190,16 @@ class MultiLoraTrainingState(nn.Module):
         except KeyError as exc:
             raise KeyError(f"multi-LoRA slots name unknown layer: {layer_idx}") from exc
         return self.registry.banks[fc1_surface], self.registry.banks[fc2_surface]
+
+    def attention_banks_for_layer(
+        self, layer_idx: int
+    ) -> tuple[DenseLoraBank, DenseLoraBank] | None:
+        """Return the QKV and output-projection banks for one model layer."""
+        surfaces = self._attention_surfaces.get(layer_idx)
+        if surfaces is None:
+            return None
+        qkv_surface, proj_surface = surfaces
+        return self.registry.banks[qkv_surface], self.registry.banks[proj_surface]
 
     @property
     def local_layer_indices(self) -> tuple[int, ...]:
@@ -299,6 +352,7 @@ class NamedLoraBankRegistry:
 
 __all__ = [
     "DenseLoraBank",
+    "apply_batched_lora_delta",
     "MultiLoraSpec",
     "MultiLoraTrainingState",
     "NamedLoraBankRegistry",

--- a/experimental/lite/megatron/lite/primitive/modules/multi_lora_bank.py
+++ b/experimental/lite/megatron/lite/primitive/modules/multi_lora_bank.py
@@ -166,7 +166,7 @@ class MultiLoraSpec:
 
 
 def normalize_multi_lora_spec(
-    config: MultiLoraSpec | Mapping[str, Any] | None
+    config: MultiLoraSpec | Mapping[str, Any] | None,
 ) -> MultiLoraSpec:
     """Normalize runtime config without allowing an unowned registry injection."""
     if config is None:

--- a/experimental/lite/megatron/lite/primitive/modules/multi_lora_bank.py
+++ b/experimental/lite/megatron/lite/primitive/modules/multi_lora_bank.py
@@ -89,11 +89,18 @@ def apply_batched_lora_delta(
         raise ValueError("batched LoRA input must have a feature dimension.")
     rows = x.reshape(-1, x.shape[-1])
     slots = lora_indices.reshape(-1)
-    if slots.numel() != rows.shape[0]:
-        raise ValueError("batched LoRA indices must have one entry per token.")
     if sequence_parallel_input:
+        local_rows = rows.shape[0]
         rows = _gather_sequence_parallel(rows, tp_group)
-        slots = _gather_sequence_parallel(slots[:, None], tp_group).squeeze(-1)
+        # Sidecars receive the logical batch slots.  The normalized QKV input
+        # is SP-local, so accept either logical-global slots (production) or
+        # local slots (the primitive contract) and gather only the latter.
+        if slots.numel() == local_rows:
+            slots = _gather_sequence_parallel(slots[:, None], tp_group).squeeze(-1)
+        elif slots.numel() != rows.shape[0]:
+            raise ValueError("SP LoRA indices must describe local or gathered tokens.")
+    elif slots.numel() != rows.shape[0]:
+        raise ValueError("batched LoRA indices must have one entry per token.")
     partition = bank.partition
     if rows.shape[0] == 0:
         width = bank.b_bank.shape[1] * (

--- a/experimental/lite/megatron/lite/primitive/modules/multi_lora_bank.py
+++ b/experimental/lite/megatron/lite/primitive/modules/multi_lora_bank.py
@@ -14,14 +14,24 @@ from typing import Any, Mapping
 
 import torch
 import torch.nn as nn
+from megatron.lite.primitive.ckpt import hf_weights
 from megatron.lite.primitive.ckpt.hf_weights import export_hf_lora_bank_adapter
 from megatron.lite.primitive.modules.lora import LoraSpec, resolve_lora_alpha
 from megatron.lite.primitive.modules.lora import (
     _all_reduce_sum,
+    _all_gather_last_dim,
     _gather_sequence_parallel,
     _scatter_sequence_parallel,
 )
+from megatron.lite.primitive.modules import multi_lora_kernel
 from megatron.lite.primitive.modules.multi_lora import BatchedLoraDelta
+
+
+@dataclass(frozen=True)
+class LoraBankPartition:
+    tp_size: int = 1
+    rank_partitioned_a: bool = False
+    output_partitioned_b: bool = False
 
 
 @dataclass(frozen=True)
@@ -30,16 +40,23 @@ class DenseLoraBank:
 
     a_bank: torch.Tensor
     b_bank: torch.Tensor
+    partition: LoraBankPartition = LoraBankPartition()
 
     def __post_init__(self) -> None:
         if self.a_bank.ndim != 3 or self.b_bank.ndim != 3:
             raise ValueError(
                 "DenseLoraBank requires three-dimensional A_bank and B_bank."
             )
-        if (
-            self.a_bank.shape[0] != self.b_bank.shape[0]
-            or self.a_bank.shape[1] != self.b_bank.shape[2]
+        if self.partition.tp_size < 1 or (
+            self.partition.rank_partitioned_a and self.partition.output_partitioned_b
         ):
+            raise ValueError("invalid multi-LoRA TP partition metadata.")
+        ranks_match = self.a_bank.shape[1] == self.b_bank.shape[2]
+        if self.partition.rank_partitioned_a:
+            ranks_match = (
+                self.a_bank.shape[1] * self.partition.tp_size == self.b_bank.shape[2]
+            )
+        if self.a_bank.shape[0] != self.b_bank.shape[0] or not ranks_match:
             raise ValueError(
                 "DenseLoraBank A_bank and B_bank must agree on slots and rank."
             )
@@ -76,20 +93,52 @@ def apply_batched_lora_delta(
     if sequence_parallel_input:
         rows = _gather_sequence_parallel(rows, tp_group)
         slots = _gather_sequence_parallel(slots[:, None], tp_group).squeeze(-1)
-    if slots.numel() < 2 or bool(torch.all(slots[1:] >= slots[:-1])):
-        delta = bank.delta(rows, slots, scale=scale)
+    partition = bank.partition
+    if rows.shape[0] == 0:
+        width = bank.b_bank.shape[1] * (
+            partition.tp_size if partition.output_partitioned_b else 1
+        )
+        return rows.new_zeros((*x.shape[:-1], width))
+    if not partition.rank_partitioned_a and not partition.output_partitioned_b:
+        if slots.numel() < 2 or bool(torch.all(slots[1:] >= slots[:-1])):
+            delta = bank.delta(rows, slots, scale=scale)
+        else:
+            order = torch.argsort(slots, stable=True)
+            restore = torch.empty_like(order)
+            restore[order] = torch.arange(order.numel(), device=order.device)
+            delta = bank.delta(
+                rows.index_select(0, order), slots.index_select(0, order), scale=scale
+            ).index_select(0, restore)
     else:
         order = torch.argsort(slots, stable=True)
         restore = torch.empty_like(order)
         restore[order] = torch.arange(order.numel(), device=order.device)
-        delta = bank.delta(
-            rows.index_select(0, order), slots.index_select(0, order), scale=scale
-        ).index_select(0, restore)
-    if input_parallel_reduce:
-        delta = _all_reduce_sum(delta, tp_group)
+        rows, slots = rows.index_select(0, order), slots.index_select(0, order)
+        hidden = multi_lora_kernel.batched_lora_linear_stage(
+            rows,
+            bank.a_bank,
+            slots,
+            output_dtype=torch.float32,
+            max_g_size_hint=rows.shape[0],
+        )
+        if partition.rank_partitioned_a:
+            hidden = _all_gather_last_dim(hidden, tp_group, reduce_backward=True)
+        if input_parallel_reduce:
+            hidden = _all_reduce_sum(hidden, tp_group)
+        delta = multi_lora_kernel.batched_lora_linear_stage(
+            hidden,
+            bank.b_bank,
+            slots,
+            scale=scale,
+            output_dtype=rows.dtype,
+            max_g_size_hint=rows.shape[0],
+        )
+        if partition.output_partitioned_b:
+            delta = _all_gather_last_dim(delta, tp_group, reduce_backward=False)
+        delta = delta.index_select(0, restore)
     if sequence_parallel_scatter_output:
         delta = _scatter_sequence_parallel(delta, tp_group, tp_rank)
-    return delta.reshape(*x.shape[:-1], bank.b_bank.shape[1])
+    return delta.reshape(*x.shape[:-1], delta.shape[-1])
 
 
 @dataclass(frozen=True)
@@ -142,6 +191,8 @@ def validate_multi_lora_parallel_support(
         return
     if etp_size is not None and etp_size > 1:
         raise ValueError("multi-LoRA model-owned sidecars do not support ETP.")
+    if tp_size > 1 and spec.rank % tp_size:
+        raise ValueError("multi-LoRA rank must be divisible by TP size.")
     if use_deepep:
         raise ValueError("multi-LoRA model-owned sidecars do not support DeepEP.")
 
@@ -300,7 +351,12 @@ class NamedLoraBankRegistry:
                 raise ValueError(
                     f"surface {surface!r} has {bank.slots} slots; expected {slot_count}."
                 )
-            if bank.a_bank.shape[1] != self.rank or bank.b_bank.shape[2] != self.rank:
+            a_rank = (
+                bank.a_bank.shape[1] * bank.partition.tp_size
+                if bank.partition.rank_partitioned_a
+                else bank.a_bank.shape[1]
+            )
+            if a_rank != self.rank or bank.b_bank.shape[2] != self.rank:
                 raise ValueError(
                     f"surface {surface!r} rank does not match registry rank {self.rank}."
                 )
@@ -329,18 +385,35 @@ class NamedLoraBankRegistry:
         lora_spec = self.lora_spec or LoraSpec(
             enabled=True, rank=self.rank, alpha=self.alpha
         )
-        items = list(
-            export_hf_lora_bank_adapter(
-                self.select(name),
-                spec=spec,
-                ps=ps,
-                train_scale=lora_spec.scale,
-                rank=self.rank,
-                alpha=self.alpha,
-                use_rslora=lora_spec.use_rslora,
-                export_dtype=export_dtype,
+        selected = self.select(name)
+        items = []
+        for surface, bank in self.banks.items():
+            active_partition = (
+                bank.partition.rank_partitioned_a or bank.partition.output_partitioned_b
             )
-        )
+            if (active_partition and bank.partition.tp_size != ps.tp_size) or (
+                not active_partition and bank.partition.tp_size not in (1, ps.tp_size)
+            ):
+                raise ValueError(
+                    "multi-LoRA bank TP metadata does not match export parallel state."
+                )
+            a, b = selected[surface]
+            if ps.tp_size > 1 and bank.partition.rank_partitioned_a:
+                a = hf_weights.allgather_concat(a, ps.tp_size, ps.tp_group, dim=0)
+            if ps.tp_size > 1 and bank.partition.output_partitioned_b:
+                b = hf_weights.allgather_concat(b, ps.tp_size, ps.tp_group, dim=0)
+            items.extend(
+                export_hf_lora_bank_adapter(
+                    {surface: (a, b)},
+                    spec=spec,
+                    ps=ps,
+                    train_scale=lora_spec.scale,
+                    rank=self.rank,
+                    alpha=self.alpha,
+                    use_rslora=lora_spec.use_rslora,
+                    export_dtype=export_dtype,
+                )
+            )
         state = dict(items)
         if len(state) != len(items):
             raise RuntimeError(

--- a/experimental/lite/megatron/lite/primitive/modules/multi_lora_bgmv.py
+++ b/experimental/lite/megatron/lite/primitive/modules/multi_lora_bgmv.py
@@ -394,6 +394,93 @@ def bgmv_fwd(x, lora_a, lora_b, lora_indices, scale, max_g_size_hint=None):
     return delta, hidden
 
 
+def bgmv_stage_fwd(
+    x, weight, lora_indices, *, scale=1.0, output_dtype=None, max_g_size_hint=None
+):
+    """Run selected-bank ``y=x@W.T`` with the existing shrink kernel."""
+    tokens = x.shape[0]
+    groups, out_features, in_features = weight.shape
+    offsets, sizes, groups = compute_group_offsets(lora_indices, num_loras=groups)
+    max_group = max_g_size_hint if max_g_size_hint is not None else tokens
+    out = torch.empty(
+        tokens, out_features, device=x.device, dtype=output_dtype or x.dtype
+    )
+
+    def grid(meta):
+        return (
+            triton.cdiv(max_group, meta["BLOCK_M"]),
+            triton.cdiv(out_features, meta["BLOCK_N"]),
+            groups,
+        )
+
+    _bgmv_shrink_kernel[grid](
+        x,
+        weight,
+        out,
+        offsets,
+        sizes,
+        tokens,
+        K=in_features,
+        N=out_features,
+        G=groups,
+        scale=scale,
+    )
+    return out
+
+
+def bgmv_stage_bwd(
+    x, grad_out, weight, lora_indices, *, scale=1.0, max_g_size_hint=None
+):
+    """Backward for one ``y=x@W.T`` stage: expand for x, transpose-shrink for W."""
+    tokens = x.shape[0]
+    groups, out_features, in_features = weight.shape
+    offsets, sizes, groups = compute_group_offsets(lora_indices, num_loras=groups)
+    max_group = max_g_size_hint if max_g_size_hint is not None else tokens
+    grad_x = torch.empty_like(x)
+
+    def grid_x(meta):
+        return (
+            triton.cdiv(max_group, meta["BLOCK_M"]),
+            triton.cdiv(in_features, meta["BLOCK_N"]),
+            groups,
+        )
+
+    _bgmv_expand_kernel[grid_x](
+        grad_out.contiguous(),
+        weight,
+        grad_x,
+        offsets,
+        sizes,
+        tokens,
+        K=out_features,
+        N=in_features,
+        G=groups,
+        scale=scale,
+    )
+    grad_w = torch.zeros_like(weight)
+
+    def grid_w(meta):
+        return (
+            triton.cdiv(out_features, meta["BLOCK_N"]),
+            triton.cdiv(in_features, meta["BLOCK_N"]),
+            groups,
+        )
+
+    _bgmv_shrink_transpose_kernel[grid_w](
+        grad_out.contiguous(),
+        x,
+        grad_w,
+        offsets,
+        sizes,
+        tokens,
+        M=out_features,
+        N=in_features,
+        G=groups,
+        scale=scale,
+    )
+    return grad_x, grad_w
+
+
 def bgmv_bwd(
     x, grad_out, lora_a, lora_b, lora_indices, scale, hidden=None, max_g_size_hint=None
 ):

--- a/experimental/lite/megatron/lite/primitive/modules/multi_lora_kernel.py
+++ b/experimental/lite/megatron/lite/primitive/modules/multi_lora_kernel.py
@@ -40,6 +40,69 @@ def dense_batched_lora_forward(
     return delta * scale, hidden
 
 
+def dense_batched_lora_stage_forward(
+    x, weight, slots, *, scale=1.0, output_dtype=None, max_g_size_hint=None
+):
+    """Selected-bank shrink/expand stage; CUDA dispatch stays in Mint Triton."""
+    if _TRITON_AVAILABLE and x.is_cuda and x.is_contiguous() and weight.is_contiguous():
+        return multi_lora_bgmv.bgmv_stage_fwd(
+            x,
+            weight,
+            slots,
+            scale=scale,
+            output_dtype=output_dtype,
+            max_g_size_hint=max_g_size_hint,
+        )
+    selected = weight.index_select(0, slots)
+    return (torch.bmm(selected, x.unsqueeze(-1)).squeeze(-1) * scale).to(
+        output_dtype or x.dtype
+    )
+
+
+class BatchedLoraLinearStage(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, weight, slots, scale, output_dtype, max_g_size_hint):
+        ctx.save_for_backward(x, weight, slots)
+        ctx.scale, ctx.max_g_size_hint = scale, max_g_size_hint
+        return dense_batched_lora_stage_forward(
+            x,
+            weight,
+            slots,
+            scale=scale,
+            output_dtype=output_dtype,
+            max_g_size_hint=max_g_size_hint,
+        )
+
+    @staticmethod
+    def backward(ctx, grad_out):
+        x, weight, slots = ctx.saved_tensors
+        if _can_use_triton(x, weight, weight):
+            grad_x, grad_w = multi_lora_bgmv.bgmv_stage_bwd(
+                x,
+                grad_out,
+                weight,
+                slots,
+                scale=ctx.scale,
+                max_g_size_hint=ctx.max_g_size_hint,
+            )
+        else:
+            selected = weight.index_select(0, slots)
+            grad_x = torch.bmm(grad_out.unsqueeze(1), selected).squeeze(1) * ctx.scale
+            grad_w = torch.zeros_like(weight)
+            grad_w.index_add_(
+                0, slots, grad_out.unsqueeze(-1) * x.unsqueeze(1) * ctx.scale
+            )
+        return grad_x, grad_w, None, None, None, None
+
+
+def batched_lora_linear_stage(
+    x, weight, slots, *, scale=1.0, output_dtype=None, max_g_size_hint=None
+):
+    return BatchedLoraLinearStage.apply(
+        x, weight, slots, scale, output_dtype, max_g_size_hint
+    )
+
+
 def dense_batched_lora_backward(x, grad_output, a_bank, b_bank, slots, scale, hidden):
     """Return Triton gradients, or ``None`` to select the eager fallback."""
     if not _can_use_triton(x, a_bank, b_bank):
@@ -61,4 +124,7 @@ __all__ = [
     "use_fused_bgmv",
     "dense_batched_lora_backward",
     "dense_batched_lora_forward",
+    "dense_batched_lora_stage_forward",
+    "BatchedLoraLinearStage",
+    "batched_lora_linear_stage",
 ]

--- a/experimental/lite/megatron/lite/primitive/modules/multi_lora_kernel.py
+++ b/experimental/lite/megatron/lite/primitive/modules/multi_lora_kernel.py
@@ -44,7 +44,7 @@ def dense_batched_lora_stage_forward(
     x, weight, slots, *, scale=1.0, output_dtype=None, max_g_size_hint=None
 ):
     """Selected-bank shrink/expand stage; CUDA dispatch stays in Mint Triton."""
-    if _TRITON_AVAILABLE and x.is_cuda and x.is_contiguous() and weight.is_contiguous():
+    if _can_use_triton(x, weight, weight):
         return multi_lora_bgmv.bgmv_stage_fwd(
             x,
             weight,
@@ -54,14 +54,24 @@ def dense_batched_lora_stage_forward(
             max_g_size_hint=max_g_size_hint,
         )
     selected = weight.index_select(0, slots)
-    return (torch.bmm(selected, x.unsqueeze(-1)).squeeze(-1) * scale).to(
-        output_dtype or x.dtype
-    )
+    compute_dtype = torch.promote_types(x.dtype, weight.dtype)
+    output = torch.bmm(
+        selected.to(compute_dtype), x.to(compute_dtype).unsqueeze(-1)
+    ).squeeze(-1)
+    return (output * scale).to(output_dtype or x.dtype)
 
 
 class BatchedLoraLinearStage(torch.autograd.Function):
     @staticmethod
     def forward(ctx, x, weight, slots, scale, output_dtype, max_g_size_hint):
+        if slots.ndim != 1 or slots.shape[0] != x.shape[0]:
+            raise ValueError(
+                "stage slots must be one-dimensional and match input rows."
+            )
+        if slots.numel() > 1 and bool(torch.any(slots[1:] < slots[:-1])):
+            raise ValueError(
+                "batched LoRA linear stage requires slots sorted ascending."
+            )
         ctx.save_for_backward(x, weight, slots)
         ctx.scale, ctx.max_g_size_hint = scale, max_g_size_hint
         return dense_batched_lora_stage_forward(
@@ -87,10 +97,22 @@ class BatchedLoraLinearStage(torch.autograd.Function):
             )
         else:
             selected = weight.index_select(0, slots)
-            grad_x = torch.bmm(grad_out.unsqueeze(1), selected).squeeze(1) * ctx.scale
+            compute_dtype = torch.promote_types(grad_out.dtype, weight.dtype)
+            grad_x = (
+                torch.bmm(
+                    grad_out.to(compute_dtype).unsqueeze(1), selected.to(compute_dtype)
+                ).squeeze(1)
+                * ctx.scale
+            ).to(x.dtype)
             grad_w = torch.zeros_like(weight)
             grad_w.index_add_(
-                0, slots, grad_out.unsqueeze(-1) * x.unsqueeze(1) * ctx.scale
+                0,
+                slots,
+                (
+                    grad_out.to(compute_dtype).unsqueeze(-1)
+                    * x.to(compute_dtype).unsqueeze(1)
+                    * ctx.scale
+                ).to(weight.dtype),
             )
         return grad_x, grad_w, None, None, None, None
 

--- a/experimental/lite/tests/smoke/primitive/test_multi_lora_ep2_production_gpu.py
+++ b/experimental/lite/tests/smoke/primitive/test_multi_lora_ep2_production_gpu.py
@@ -7,12 +7,13 @@ import hashlib
 import json
 import os
 import re
+import traceback
 from pathlib import Path
+from typing import Callable
 
 import pytest
 import torch
 import torch.distributed as dist
-
 from megatron.lite.primitive.ckpt import dcp
 from megatron.lite.primitive.distributed_test_utils import (
     build_lora_collective_descriptor,
@@ -30,6 +31,8 @@ pytestmark = [
     pytest.mark.gpu,
     pytest.mark.distributed,
 ]
+
+_TINY_QWEN_EXPERTS = 4
 
 
 def _qwen_symbols():
@@ -68,7 +71,7 @@ def _config():
         num_key_value_heads=2,
         head_dim=4,
         vocab_size=64,
-        num_experts=4,
+        num_experts=_TINY_QWEN_EXPERTS,
         num_experts_per_tok=1,
         moe_intermediate_size=8,
         max_position_embeddings=16,
@@ -138,6 +141,19 @@ def _tensor_record(tensor: torch.Tensor) -> dict[str, object]:
         "shape": list(cpu.shape),
         "dtype": str(cpu.dtype),
     }
+
+
+def _write_phase_a_flight_record(
+    artifact_dir: Path, **updates: object
+) -> dict[str, object]:
+    """Atomically persist rank-local Phase A progress without a collective."""
+    path = artifact_dir / f"phase_a_rank_{dist.get_rank():05d}.json"
+    record = json.loads(path.read_text()) if path.exists() else {}
+    record.update(updates)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.write_text(json.dumps(record, sort_keys=True))
+    os.replace(temporary, path)
+    return record
 
 
 def _named_parameters(bundle) -> dict[str, torch.Tensor]:
@@ -297,10 +313,18 @@ def _impl_contract(*, tp: int = 1, ep: int) -> dict[str, object]:
 
 
 def _fixed_local_router(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-    """Route every token to expert zero, available in both EP1 and EP2."""
+    """Route every token to expert zero for production empty-rank coverage."""
     return (
         torch.ones((x.shape[0], 1), device=x.device, dtype=x.dtype),
         torch.zeros((x.shape[0], 1), device=x.device, dtype=torch.long),
+    )
+
+
+def _phase_a_balanced_router(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Cycle tiny-Qwen experts so Phase A reaches both EP partitions."""
+    return (
+        torch.ones((x.shape[0], 1), device=x.device, dtype=x.dtype),
+        (torch.arange(x.shape[0], device=x.device) % _TINY_QWEN_EXPERTS).view(-1, 1),
     )
 
 
@@ -542,7 +566,10 @@ def _local_owner_factor_record(bundle, name: str) -> dict[str, object] | None:
 
 
 def _bank_sync_absolute_oracle(
-    bundle, local_contributions: dict[str, torch.Tensor]
+    bundle,
+    local_contributions: dict[str, torch.Tensor],
+    *,
+    preflight_done: Callable[[], None] | None = None,
 ) -> tuple[dict[str, torch.Tensor], dict[str, float]]:
     """Reference FC and attention gradients over their respective owner groups."""
     expected: dict[str, torch.Tensor] = {}
@@ -558,6 +585,8 @@ def _bank_sync_absolute_oracle(
         "MULTI_LORA_COLLECTIVE_PREFLIGHT " f"rank={dist.get_rank()} records={records}",
         flush=True,
     )
+    if preflight_done is not None:
+        preflight_done()
     for name, _kind, _shape, _dtype in records:
         contribution = local_contributions[name]
         if _bank_surface_kind(bundle, _bank_parameters(bundle)[name]) == "fc":
@@ -700,6 +729,9 @@ def _run_unsynchronized_reference(
         return original_dispatch(*args, **kwargs)
 
     dispatcher.dispatch = capture_dispatch
+    router = qwen.layers[0].moe.router
+    original_router = router.forward
+    router.forward = _phase_a_balanced_router
     _Qwen3MoEConfig, _model, protocol = _qwen_symbols()
     original_sidecar = protocol.MoELoraSidecar
 
@@ -716,6 +748,7 @@ def _run_unsynchronized_reference(
         assert dispatch_calls == [True]
     finally:
         dispatcher.dispatch = original_dispatch
+        router.forward = original_router
         protocol.MoELoraSidecar = original_sidecar
     return float(output["loss"].detach().cpu()), _local_full_bank_contributions(bundle)
 
@@ -867,15 +900,31 @@ def test_production_builder_distopt_finalize_and_identity_roundtrip(tmp_path):
         export_path = artifact_dir / f"adapter_exports_rank_{dist.get_rank():05d}.pt"
         torch.save(adapter_exports, export_path)
         dist.barrier()
+        _write_phase_a_flight_record(artifact_dir, export_complete=True)
         parameter_semantics = _checkpoint_semantics(bundle)
-        loss, local_contributions = _run_unsynchronized_reference(bundle, batch)
+        _write_phase_a_flight_record(artifact_dir, reference_enter=True)
+        try:
+            loss, local_contributions = _run_unsynchronized_reference(bundle, batch)
+        except Exception as error:
+            _write_phase_a_flight_record(
+                artifact_dir,
+                reference_error=f"{type(error).__name__}: {error}",
+                traceback=traceback.format_exc(),
+            )
+            raise
+        _write_phase_a_flight_record(artifact_dir, reference_done=True)
         expected_keys = _expected_semantic_bank_keys(
             bundle.extras["multi_lora_training_state"]
         )
         assert set(local_contributions) == expected_keys
         oracle_grads, normalization_by_key = _bank_sync_absolute_oracle(
-            bundle, local_contributions
+            bundle,
+            local_contributions,
+            preflight_done=lambda: _write_phase_a_flight_record(
+                artifact_dir, preflight_done=True
+            ),
         )
+        _write_phase_a_flight_record(artifact_dir, oracle_done=True)
         assert set(oracle_grads) == expected_keys
         assert all(gradient.abs().max() > 0 for gradient in oracle_grads.values())
         gathered_contributions = [None] * dist.get_world_size(
@@ -996,6 +1045,7 @@ def test_production_builder_distopt_finalize_and_identity_roundtrip(tmp_path):
             temporary_complete.write_text(json.dumps(complete_payload, sort_keys=True))
             os.replace(temporary_complete, complete_path)
         dist.barrier()
+        _write_phase_a_flight_record(artifact_dir, phase_a_complete=True)
         return
 
     complete = json.loads(complete_path.read_text())

--- a/experimental/lite/tests/smoke/primitive/test_multi_lora_ep2_production_gpu.py
+++ b/experimental/lite/tests/smoke/primitive/test_multi_lora_ep2_production_gpu.py
@@ -41,8 +41,8 @@ def _qwen_symbols():
 def _ep2_cuda_group():
     if not torch.cuda.is_available():
         pytest.skip("CUDA is required for the production multi-LoRA EP2 smoke.")
-    if int(os.environ.get("WORLD_SIZE", "1")) != 2:
-        pytest.skip("run this smoke through torchrun with exactly two ranks")
+    if int(os.environ.get("WORLD_SIZE", "1")) not in (2, 4):
+        pytest.skip("run this smoke through torchrun with 2 or 4 ranks")
     torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
     created = False
     if not dist.is_initialized():
@@ -70,14 +70,14 @@ def _config():
     )
 
 
-def _build_bundle(*, ep: int, model_seed: int):
+def _build_bundle(*, tp: int = 1, ep: int, model_seed: int):
     _Qwen3MoEConfig, _model, protocol = _qwen_symbols()
     torch.manual_seed(model_seed)
     torch.cuda.manual_seed_all(model_seed)
     return protocol.build_model(
         _config(),
         impl_cfg=protocol.ImplConfig(
-            parallel=ParallelConfig(tp=1, ep=ep, etp=1, pp=1, cp=1),
+            parallel=ParallelConfig(tp=tp, ep=ep, etp=1, pp=1, cp=1),
             optimizer="dist_opt",
             optimizer_config=OptimizerConfig(
                 optimizer="adam", lr=1.0e-3, weight_decay=0.0, clip_grad=1.0
@@ -109,6 +109,16 @@ def _phase() -> str:
     if phase not in {"ep2_oracle", "ep2_verify"}:
         pytest.skip("set MLITE_MULTI_LORA_PHASE to ep2_oracle or ep2_verify")
     return phase
+
+
+def _phase_parallel_config() -> dict[str, int]:
+    """Select checkpoint topology from the launcher, not an EP-only name."""
+    world = dist.get_world_size()
+    if world == 2:
+        return {"world": 2, "tp": 1, "ep": 2}
+    if world == 4:
+        return {"world": 4, "tp": 2, "ep": 2}
+    raise AssertionError(f"unsupported phase world size {world}; expected 2 or 4")
 
 
 def _sha256(path: Path) -> str:
@@ -191,7 +201,7 @@ def _poison_parameters(bundle) -> None:
             parameter.add_(0.125)
 
 
-def _actual_topology(bundle) -> dict[str, int]:
+def _actual_topology(bundle) -> dict[str, object]:
     """Record dense/expert decomposition from live state and process groups."""
     ps = bundle.parallel_state
     dense_dp_group_size = (
@@ -213,13 +223,55 @@ def _actual_topology(bundle) -> dict[str, int]:
         "dp_rank": ps.dp_rank,
         "expert_dp": expert_dp_group_size,
         "expert_dp_rank": ps.expert_dp_rank,
+        "tp_group_ranks": sorted(dist.get_process_group_ranks(ps.tp_group)),
+        "ep_group_ranks": sorted(dist.get_process_group_ranks(ps.ep_group)),
+        "dp_group_ranks": sorted(dist.get_process_group_ranks(ps.dp_group)),
+        "expert_dp_group_ranks": sorted(dist.get_process_group_ranks(ps.ep_dp_group)),
     }
 
 
-def _impl_contract(*, ep: int) -> dict[str, object]:
+def _assert_tp_ep_membership(bundle, *, tp: int, ep: int) -> None:
+    topology = _actual_topology(bundle)
+    assert topology["tp"] == tp and topology["ep"] == ep
+    assert len(topology["tp_group_ranks"]) == tp
+    assert len(topology["ep_group_ranks"]) == ep
+    assert dist.get_rank() in topology["tp_group_ranks"]
+    assert dist.get_rank() in topology["ep_group_ranks"]
+
+
+@pytest.mark.timeout(120)
+def test_tp2_ep1_attention_multi_lora_production_groups():
+    """GPU production builder must expose a real TP2 attention-bank path."""
+    if dist.get_world_size() != 2:
+        pytest.skip("TP2/EP1 production smoke requires exactly two ranks")
+    bundle = _build_bundle(tp=2, ep=1, model_seed=3201)
+    _assert_tp_ep_membership(bundle, tp=2, ep=1)
+    state = bundle.extras["multi_lora_training_state"]
+    qkv, proj = state.attention_banks_for_layer(0)
+    assert qkv.partition.rank_partitioned_a and proj.partition.output_partitioned_b
+    assert qkv.a_bank.requires_grad and proj.b_bank.requires_grad
+    _run_bank_gradient_contract(bundle)
+
+
+@pytest.mark.timeout(120)
+def test_tp2_ep2_attention_and_expert_multi_lora_production_groups():
+    """Four-rank production construction keeps TP attention orthogonal to EP experts."""
+    if dist.get_world_size() != 4:
+        pytest.skip("TP2/EP2 production smoke requires exactly four ranks")
+    bundle = _build_bundle(tp=2, ep=2, model_seed=3202)
+    _assert_tp_ep_membership(bundle, tp=2, ep=2)
+    state = bundle.extras["multi_lora_training_state"]
+    fc1, fc2 = state.banks_for_layer(0)
+    qkv, proj = state.attention_banks_for_layer(0)
+    assert fc1.partition.tp_size == fc2.partition.tp_size == 1
+    assert qkv.partition.rank_partitioned_a and proj.partition.output_partitioned_b
+    _run_bank_gradient_contract(bundle)
+
+
+def _impl_contract(*, tp: int = 1, ep: int) -> dict[str, object]:
     """All implementation knobs that define this production evidence."""
     return {
-        "parallel": {"tp": 1, "ep": ep, "etp": 1, "pp": 1, "cp": 1},
+        "parallel": {"tp": tp, "ep": ep, "etp": 1, "pp": 1, "cp": 1},
         "optimizer": "dist_opt",
         "optimizer_config": {
             "optimizer": "adam",
@@ -271,6 +323,31 @@ def _bank_parameters(bundle) -> dict[str, torch.Tensor]:
     return parameters
 
 
+def _run_bank_gradient_contract(bundle) -> None:
+    """Exercise mixed token routing and inspect each semantic A/B slot axis."""
+    state = bundle.extras["multi_lora_training_state"]
+    with torch.no_grad():
+        for bank in state.registry.banks.values():
+            bank.a_bank[0].fill_(0.125)
+            bank.b_bank[0].fill_(0.125)
+            bank.a_bank[1].fill_(0.25)
+            bank.b_bank[1].fill_(0.25)
+    _configure_fixed_router(bundle)
+    batch = _production_batch(bundle)
+    batch.extras["multi_lora_slots"][0].copy_(
+        torch.tensor([0, 1, 0, 1], device="cuda", dtype=torch.long)
+    )
+    loss, gradients = _run_production_forward_and_finalize(bundle, batch)
+    assert loss == loss
+    assert set(gradients) == _expected_semantic_bank_keys(state)
+    parameters = _bank_parameters(bundle)
+    for name, gradient in gradients.items():
+        assert gradient.shape == parameters[name].shape
+        assert name.rsplit("_", 1)[-1] in {"a", "b"}
+        assert gradient[0].abs().max() > 0, name
+        assert gradient[1].abs().max() > 0, name
+
+
 def _distributed_optimizer_leaves(optimizer) -> tuple[object, ...]:
     """Return dist-opt leaves without assuming a Qwen dense/expert chain shape."""
     chained = getattr(optimizer, "chained_optimizers", None)
@@ -289,7 +366,7 @@ def _group_ranks(group) -> tuple[int, ...]:
 
 
 def _optimizer_param_range(
-    bundle, parameter: torch.Tensor
+    bundle, parameter: torch.Tensor, *, is_fc: bool
 ) -> tuple[int, object, object, object, object] | None:
     """Resolve this rank's optional dist-opt shard for one dense bank.
 
@@ -306,17 +383,18 @@ def _optimizer_param_range(
     if not owners:
         return None
     leaf_index, optimizer = owners[0]
-    assert getattr(parameter, "allreduce", None) is True
+    assert getattr(parameter, "allreduce", None) is (not is_fc)
     gbuf_index, dtype, bucket_index = optimizer.model_param_gbuf_map[parameter]
     range_map = optimizer.gbuf_ranges[gbuf_index][dtype][bucket_index]
     param_range = range_map["param_map"][parameter]
     buffer = optimizer.buffers[gbuf_index]
     bucket = buffer.buckets[bucket_index]
-    dense_dp_ranks = _group_ranks(bundle.parallel_state.dp_group)
-    assert _group_ranks(optimizer.data_parallel_group) == dense_dp_ranks
-    assert _group_ranks(buffer.data_parallel_group) == dense_dp_ranks
-    if bundle.parallel_state.ep_size > 1:
-        assert dense_dp_ranks != _group_ranks(bundle.parallel_state.ep_dp_group)
+    expected_group = (
+        bundle.parallel_state.ep_dp_group if is_fc else bundle.parallel_state.dp_group
+    )
+    expected_ranks = _group_ranks(expected_group)
+    assert _group_ranks(optimizer.data_parallel_group) == expected_ranks
+    assert _group_ranks(buffer.data_parallel_group) == expected_ranks
     return leaf_index, optimizer, param_range, buffer, bucket
 
 
@@ -336,16 +414,13 @@ def _assert_dense_owner_contract(
 ) -> None:
     """Prove every local shard maps to one dense leaf, never the EP child."""
     assert records, f"no distributed-optimizer shard found for semantic bank {name}"
-    dense_dp_ranks = _group_ranks(bundle.parallel_state.dp_group)
+    is_fc = ".moe.experts._fc" in name
+    expected_ranks = _group_ranks(
+        bundle.parallel_state.ep_dp_group if is_fc else bundle.parallel_state.dp_group
+    )
     assert len({record["leaf_index"] for record in records}) == 1
-    assert all(record["owner_group_ranks"] == dense_dp_ranks for record in records)
-    assert all(record["buffer_group_ranks"] == dense_dp_ranks for record in records)
-    if bundle.parallel_state.ep_size > 1:
-        expert_dp_ranks = _group_ranks(bundle.parallel_state.ep_dp_group)
-        assert all(record["owner_group_ranks"] != expert_dp_ranks for record in records)
-        assert all(
-            record["buffer_group_ranks"] != expert_dp_ranks for record in records
-        )
+    assert all(record["owner_group_ranks"] == expected_ranks for record in records)
+    assert all(record["buffer_group_ranks"] == expected_ranks for record in records)
 
 
 def _local_full_bank_contributions(bundle) -> dict[str, torch.Tensor]:
@@ -356,19 +431,28 @@ def _local_full_bank_contributions(bundle) -> dict[str, torch.Tensor]:
     }
 
 
-def _dense_dp_absolute_oracle(
+def _bank_sync_absolute_oracle(
     bundle, local_contributions: dict[str, torch.Tensor]
 ) -> tuple[dict[str, torch.Tensor], dict[str, float]]:
-    """Independently average rank-local full grads and audit live normalization."""
-    gathered = [None] * dist.get_world_size(bundle.parallel_state.dp_group)
-    dist.all_gather_object(
-        gathered, local_contributions, group=bundle.parallel_state.dp_group
-    )
+    """Reference FC as EP→expert-DP; attention as dense-DP only."""
+    expected: dict[str, torch.Tensor] = {}
+    for name, contribution in local_contributions.items():
+        value = contribution.to("cuda")
+        if ".moe.experts._fc" in name:
+            dist.all_reduce(value, group=bundle.parallel_state.ep_group)
+            dist.all_reduce(value, group=bundle.parallel_state.ep_dp_group)
+            value.div_(bundle.parallel_state.expert_dp_size)
+        else:
+            assert ".attn." in name
+            dist.all_reduce(value, group=bundle.parallel_state.dp_group)
+            value.div_(bundle.parallel_state.dp_size)
+        expected[name] = value.cpu()
     expected_keys = set(local_contributions)
-    assert all(set(contribution) == expected_keys for contribution in gathered)
     local_factors: dict[str, dict[str, object]] = {}
     for name, parameter in _bank_parameters(bundle).items():
-        owned = _optimizer_param_range(bundle, parameter)
+        owned = _optimizer_param_range(
+            bundle, parameter, is_fc=".moe.experts._fc" in name
+        )
         if owned is None:
             continue
         leaf_index, owner, _param_range, buffer, bucket = owned
@@ -376,14 +460,17 @@ def _dense_dp_absolute_oracle(
             **_dense_owner_record(bundle, leaf_index, owner, buffer),
             "factor": float(bucket.gradient_scaling_factor),
         }
-    gathered_factors = [None] * len(gathered)
-    dist.all_gather_object(
-        gathered_factors, local_factors, group=bundle.parallel_state.dp_group
-    )
-    expected: dict[str, torch.Tensor] = {}
+    gathered_factors = [None] * dist.get_world_size()
+    dist.all_gather_object(gathered_factors, local_factors)
+    optimizer_expected: dict[str, torch.Tensor] = {}
     factors: dict[str, float] = {}
-    expected_factor = 1.0 / len(gathered)
     for name in sorted(expected_keys):
+        is_fc = ".moe.experts._fc" in name
+        expected_factor = 1.0 / (
+            bundle.parallel_state.expert_dp_size
+            if is_fc
+            else bundle.parallel_state.dp_size
+        )
         records = [
             factor_map[name] for factor_map in gathered_factors if name in factor_map
         ]
@@ -391,30 +478,30 @@ def _dense_dp_absolute_oracle(
         seen = {record["factor"] for record in records}
         assert len(seen) == 1, f"missing or inconsistent dense-DP factor for {name}"
         factor = seen.pop()
-        assert factor == expected_factor, (
-            f"dense-DP bucket factor for {name} is {factor}, expected {expected_factor}"
-        )
+        assert (
+            factor == expected_factor
+        ), f"owner bucket factor for {name} is {factor}, expected {expected_factor}"
         factors[name] = factor
-        expected[name] = torch.stack(
-            [contribution[name] for contribution in gathered]
-        ).mean(0)
-    return expected, factors
+        optimizer_expected[name] = expected[name]
+    return optimizer_expected, factors
 
 
 def _reconstruct_optimizer_owned_bank_grads(bundle) -> dict[str, torch.Tensor]:
     """Rebuild each logical bank grad from dist-opt's owned reduce-scatter shards."""
     local_shards: dict[str, dict[str, object]] = {}
     for name, parameter in _bank_parameters(bundle).items():
-        owned = _optimizer_param_range(bundle, parameter)
+        owned = _optimizer_param_range(
+            bundle, parameter, is_fc=".moe.experts._fc" in name
+        )
         if owned is None:
             continue
         leaf_index, owner, param_range, buffer, bucket = owned
         # ``gbuf_world_in_bucket`` identifies the reduce-scatter output view;
         # ``param`` maps that view back to the logical bank tensor's offsets.
         reduced = bucket.grad_data.view(-1)[
-            param_range["gbuf_world_in_bucket"].start : param_range[
-                "gbuf_world_in_bucket"
-            ].end
+            param_range["gbuf_world_in_bucket"]
+            .start : param_range["gbuf_world_in_bucket"]
+            .end
         ].detach()
         local_shards[name] = {
             **_dense_owner_record(bundle, leaf_index, owner, buffer),
@@ -425,8 +512,8 @@ def _reconstruct_optimizer_owned_bank_grads(bundle) -> dict[str, torch.Tensor]:
             "values": reduced.float().cpu().clone(),
         }
 
-    gathered = [None] * dist.get_world_size(bundle.parallel_state.dp_group)
-    dist.all_gather_object(gathered, local_shards, group=bundle.parallel_state.dp_group)
+    gathered = [None] * dist.get_world_size()
+    dist.all_gather_object(gathered, local_shards)
     expected_keys = set(_bank_parameters(bundle))
     assert set().union(*(set(shards) for shards in gathered)) == expected_keys
     reconstructed: dict[str, torch.Tensor] = {}
@@ -523,14 +610,26 @@ def _clear_gradients(bundle) -> None:
     bundle.optimizer.zero_grad()
 
 
-def _batch() -> PackedBatch:
-    torch.manual_seed(4100 + dist.get_rank())
+def _batch(*, dense_dp_rank: int) -> PackedBatch:
+    # TP ranks share one dense-DP replica batch; replicas differ by dp rank.
+    torch.manual_seed(4100 + dense_dp_rank)
     return PackedBatch(
         input_ids=torch.randint(0, 64, (4,), device="cuda"),
         labels=torch.randint(0, 64, (4,), device="cuda"),
         seq_lens=torch.tensor([4], device="cuda", dtype=torch.int64),
         extras={"multi_lora_slots": {0: torch.tensor([0, 0, 1, 1], device="cuda")}},
     )
+
+
+def _production_batch(bundle) -> PackedBatch:
+    batch = _batch(dense_dp_rank=bundle.parallel_state.dp_rank)
+    record = _batch_record(batch)
+    if bundle.parallel_state.tp_size == 1:
+        return batch
+    gathered = [None] * dist.get_world_size(bundle.parallel_state.tp_group)
+    dist.all_gather_object(gathered, record, group=bundle.parallel_state.tp_group)
+    assert all(item == gathered[0] for item in gathered)
+    return batch
 
 
 def _batch_record(batch: PackedBatch) -> dict[str, dict[str, object]]:
@@ -548,6 +647,8 @@ def _expected_semantic_bank_keys(state) -> set[str]:
     surfaces = (
         "layers.0.moe.experts._fc1_weight_0",
         "layers.0.moe.experts._fc2_weight_0",
+        "layers.0.attn.qkv.linear.weight",
+        "layers.0.attn.proj.linear.weight",
     )
     assert set(state.registry.banks) == set(surfaces)
     return {
@@ -558,10 +659,11 @@ def _expected_semantic_bank_keys(state) -> set[str]:
 
 
 @pytest.mark.timeout(120)
-def test_ep2_production_builder_distopt_finalize_and_identity_roundtrip(tmp_path):
-    """Same-topology EP2 oracle and DCP prove exactly one EP2 reduction."""
+def test_production_builder_distopt_finalize_and_identity_roundtrip(tmp_path):
+    """Same-topology TP/EP oracle and DCP prove each bank's one reduction."""
     _Qwen3MoEConfig, model, protocol = _qwen_symbols()
     phase = _phase()
+    phase_config = _phase_parallel_config()
     artifact_dir = _phase_artifact_dir()
     checkpoint_dir = artifact_dir / "production_checkpoint"
     manifest_path = artifact_dir / "manifest.json"
@@ -570,43 +672,52 @@ def test_ep2_production_builder_distopt_finalize_and_identity_roundtrip(tmp_path
     candidate_sha = os.environ.get("MLITE_CANDIDATE_SHA")
     candidate_tree = os.environ.get("MLITE_CANDIDATE_TREE_SHA")
     candidate_diff = os.environ.get("MLITE_CANDIDATE_DIFF_SHA")
-    assert candidate_sha and candidate_tree and candidate_diff, (
-        "candidate commit, tree, and diff hashes must bind the phase artifact"
-    )
+    assert (
+        candidate_sha and candidate_tree and candidate_diff
+    ), "candidate commit, tree, and diff hashes must bind the phase artifact"
 
     if phase == "ep2_oracle":
         if dist.get_rank() == 0:
-            assert not artifact_dir.exists(), (
-                "phase artifact directory already exists; refuse stale COMPLETE/checkpoint reuse"
-            )
+            assert (
+                not artifact_dir.exists()
+            ), "phase artifact directory already exists; refuse stale COMPLETE/checkpoint reuse"
             artifact_dir.mkdir(parents=True)
         dist.barrier()
-        bundle = _build_bundle(ep=2, model_seed=3100)
-        ep2_topology = _actual_topology(bundle)
-        assert ep2_topology == {
-            "world": 2,
-            "tp": 1,
-            "ep": 2,
-            "etp": 1,
-            "pp": 1,
-            "cp": 1,
-            "dp": 2,
-            "dp_rank": dist.get_rank(),
-            "expert_dp": 1,
-            "expert_dp_rank": 0,
+        bundle = _build_bundle(
+            tp=phase_config["tp"], ep=phase_config["ep"], model_seed=3100
+        )
+        oracle_topology = _actual_topology(bundle)
+        assert {
+            key: oracle_topology[key] for key in ("world", "tp", "ep")
+        } == phase_config
+        assert set(oracle_topology) == {
+            "world",
+            "tp",
+            "ep",
+            "etp",
+            "pp",
+            "cp",
+            "dp",
+            "dp_rank",
+            "expert_dp",
+            "expert_dp_rank",
+            "tp_group_ranks",
+            "ep_group_ranks",
+            "dp_group_ranks",
+            "expert_dp_group_ranks",
         }
-        ep2_topologies = [None, None]
-        dist.all_gather_object(ep2_topologies, ep2_topology)
+        oracle_topologies = [None] * phase_config["world"]
+        dist.all_gather_object(oracle_topologies, oracle_topology)
         _initialize_nonzero_banks(bundle)
         _configure_fixed_router(bundle)
-        batch = _batch()
+        batch = _production_batch(bundle)
         parameter_semantics = _checkpoint_semantics(bundle)
         loss, local_contributions = _run_unsynchronized_reference(bundle, batch)
         expected_keys = _expected_semantic_bank_keys(
             bundle.extras["multi_lora_training_state"]
         )
         assert set(local_contributions) == expected_keys
-        oracle_grads, normalization_by_key = _dense_dp_absolute_oracle(
+        oracle_grads, normalization_by_key = _bank_sync_absolute_oracle(
             bundle, local_contributions
         )
         assert set(oracle_grads) == expected_keys
@@ -632,11 +743,11 @@ def test_ep2_production_builder_distopt_finalize_and_identity_roundtrip(tmp_path
             )
             for name in expected_keys
         ), "rank-specific DP batches must produce distinct local contributions"
-        losses = [None, None]
-        batches = [None, None]
-        oracle_tensors_by_rank = [None, None]
-        local_contribution_tensors_by_rank = [None, None]
-        parameter_semantics_by_rank = [None, None]
+        losses = [None] * phase_config["world"]
+        batches = [None] * phase_config["world"]
+        oracle_tensors_by_rank = [None] * phase_config["world"]
+        local_contribution_tensors_by_rank = [None] * phase_config["world"]
+        parameter_semantics_by_rank = [None] * phase_config["world"]
         dist.all_gather_object(losses, loss)
         dist.all_gather_object(batches, _batch_record(batch))
         dist.all_gather_object(
@@ -669,10 +780,14 @@ def test_ep2_production_builder_distopt_finalize_and_identity_roundtrip(tmp_path
                 },
                 "test_sha256": _sha256(Path(__file__)),
                 "model_config": _config().to_dict(),
-                "topology": {"ep2_oracle": ep2_topologies, "ep2_verify": None},
+                "topology": {"oracle": oracle_topologies, "verify": None},
                 "impl_config": {
-                    "ep2_oracle": _impl_contract(ep=2),
-                    "ep2_verify": _impl_contract(ep=2),
+                    "oracle": _impl_contract(
+                        tp=phase_config["tp"], ep=phase_config["ep"]
+                    ),
+                    "verify": _impl_contract(
+                        tp=phase_config["tp"], ep=phase_config["ep"]
+                    ),
                 },
                 "seeds": {"model": 3100, "batch_base": 4100},
                 "batch_by_rank": batches,
@@ -687,13 +802,13 @@ def test_ep2_production_builder_distopt_finalize_and_identity_roundtrip(tmp_path
                     f"rank_{rank:05d}": _sha256(
                         artifact_dir / f"ep2_bank_grads_rank_{rank:05d}.pt"
                     )
-                    for rank in range(2)
+                    for rank in range(phase_config["world"])
                 },
                 "local_contribution_files": {
                     f"rank_{rank:05d}": _sha256(
                         artifact_dir / f"ep2_local_bank_grads_rank_{rank:05d}.pt"
                     )
-                    for rank in range(2)
+                    for rank in range(phase_config["world"])
                 },
             }
             temporary_manifest = manifest_path.with_name(f".manifest.{os.getpid()}.tmp")
@@ -726,36 +841,25 @@ def test_ep2_production_builder_distopt_finalize_and_identity_roundtrip(tmp_path
     }
     assert manifest["test_sha256"] == _sha256(Path(__file__))
     assert manifest["schema_version"] == 3
-    assert manifest["seeds"] == {
-        "model": 3100,
-        "batch_base": 4100,
-    }
+    assert manifest["seeds"] == {"model": 3100, "batch_base": 4100}
     assert manifest["loss_normalization"] == "model token-loss mean"
     assert set(manifest["dense_dp_gradient_scaling_by_key"]) == set(
         manifest["semantic_bank_keys"]
     )
     assert manifest["model_config"] == _config().to_dict()
-    assert manifest["impl_config"] == {
-        "ep2_oracle": _impl_contract(ep=2),
-        "ep2_verify": _impl_contract(ep=2),
-    }
-    assert manifest["topology"]["ep2_oracle"][dist.get_rank()] == {
-        "world": 2,
-        "tp": 1,
-        "ep": 2,
-        "etp": 1,
-        "pp": 1,
-        "cp": 1,
-        "dp": 2,
-        "dp_rank": dist.get_rank(),
-        "expert_dp": 1,
-        "expert_dp_rank": 0,
-    }
-    assert manifest["topology"]["ep2_verify"] is None
-    batch = _batch()
+    expected_impl = _impl_contract(tp=phase_config["tp"], ep=phase_config["ep"])
+    assert manifest["impl_config"] == {"oracle": expected_impl, "verify": expected_impl}
+    assert (
+        manifest["topology"]["oracle"][dist.get_rank()]["world"]
+        == phase_config["world"]
+    )
+    assert manifest["topology"]["oracle"][dist.get_rank()]["tp"] == phase_config["tp"]
+    assert manifest["topology"]["oracle"][dist.get_rank()]["ep"] == phase_config["ep"]
+    assert manifest["topology"]["verify"] is None
+    batch = _production_batch(bundle)
     expected_batch = manifest["batch_by_rank"][dist.get_rank()]
     assert _batch_record(batch) == expected_batch
-    for rank in range(2):
+    for rank in range(phase_config["world"]):
         path = artifact_dir / f"ep2_bank_grads_rank_{rank:05d}.pt"
         assert _sha256(path) == manifest["oracle_files"][f"rank_{rank:05d}"]
         local_path = artifact_dir / f"ep2_local_bank_grads_rank_{rank:05d}.pt"
@@ -769,7 +873,7 @@ def test_ep2_production_builder_distopt_finalize_and_identity_roundtrip(tmp_path
         name: _tensor_record(value) for name, value in oracle_grads.items()
     } == manifest["semantic_bank_tensors_by_rank"][dist.get_rank()]
     local_contributions_by_rank = []
-    for rank in range(2):
+    for rank in range(phase_config["world"]):
         local_path = artifact_dir / f"ep2_local_bank_grads_rank_{rank:05d}.pt"
         local_contributions = torch.load(
             local_path, map_location="cpu", weights_only=True
@@ -780,28 +884,18 @@ def test_ep2_production_builder_distopt_finalize_and_identity_roundtrip(tmp_path
         } == manifest["local_contribution_tensors_by_rank"][rank]
         local_contributions_by_rank.append(local_contributions)
 
-    bundle = _build_bundle(ep=2, model_seed=3100)
-    ep2_topology = _actual_topology(bundle)
-    assert ep2_topology == {
-        "world": 2,
-        "tp": 1,
-        "ep": 2,
-        "etp": 1,
-        "pp": 1,
-        "cp": 1,
-        "dp": 2,
-        "dp_rank": dist.get_rank(),
-        "expert_dp": 1,
-        "expert_dp_rank": 0,
-    }
+    bundle = _build_bundle(
+        tp=phase_config["tp"], ep=phase_config["ep"], model_seed=3100
+    )
+    verify_topology = _actual_topology(bundle)
+    assert verify_topology == manifest["topology"]["oracle"][dist.get_rank()]
     state = bundle.extras["multi_lora_training_state"]
     assert state is not None
     assert bundle.extras["optimizer_backend"] == "dist_opt"
     assert callable(bundle.finalize_grads)
-    assert all(
-        getattr(parameter, "allreduce", None) is True
-        for parameter in state.parameters()
-    )
+    for name, parameter in state.named_parameters():
+        is_fc = ".moe.experts._fc" in name
+        assert getattr(parameter, "allreduce", None) is (not is_fc)
     expected_keys = _expected_semantic_bank_keys(state)
     assert set(oracle_grads) == expected_keys == set(manifest["semantic_bank_keys"])
     _initialize_nonzero_banks(bundle)
@@ -810,9 +904,8 @@ def test_ep2_production_builder_distopt_finalize_and_identity_roundtrip(tmp_path
         == manifest["parameter_semantics_by_rank"][dist.get_rank()]
     )
 
-    # The real production injection creates model-owned sidecars.  They must
-    # never request the legacy explicit EP all-reduce; dense dist-opt finalize
-    # owns the one reduction for these registered parameters.
+    # FC sidecars are EP-replicated expert parameters; attention remains on
+    # its TP carrier and is dense-DP owned independently of this flag.
     kwargs = {}
     probe_batch = type(
         "Batch",
@@ -825,8 +918,8 @@ def test_ep2_production_builder_distopt_finalize_and_identity_roundtrip(tmp_path
     )()
     protocol._inject_multi_lora_sidecars(kwargs, probe_batch, state)
     sidecar = kwargs["multi_lora_sidecars"][0]
-    assert sidecar.requires_explicit_ep_sync is False
-    assert model._sidecar_ep_sync_group(bundle.parallel_state, sidecar) is None
+    assert sidecar.requires_explicit_ep_sync is True
+    assert model._sidecar_ep_sync_group(bundle.parallel_state, sidecar) is not None
 
     # This is intentionally an EP2-to-EP2 DCP round trip.  Do not turn this
     # smoke back into a cross-EP reshard test: that is a known production DCP
@@ -888,16 +981,16 @@ def test_ep2_production_builder_distopt_finalize_and_identity_roundtrip(tmp_path
     )
     assert _batch_record(batch) == expected_batch
     assert _config().to_dict() == manifest["model_config"]
-    assert _impl_contract(ep=2) == manifest["impl_config"]["ep2_verify"]
+    assert expected_impl == manifest["impl_config"]["verify"]
     _configure_fixed_router(bundle)
-    _loss, ep2_grads = _run_production_forward_and_finalize(bundle, batch)
-    assert set(ep2_grads) == expected_keys
+    _loss, production_grads = _run_production_forward_and_finalize(bundle, batch)
+    assert set(production_grads) == expected_keys
     for name, oracle in oracle_grads.items():
         assert (
             _tensor_record(oracle)
             == manifest["semantic_bank_tensors_by_rank"][dist.get_rank()][name]
         )
-        torch.testing.assert_close(ep2_grads[name].cpu(), oracle, rtol=0, atol=0)
+        torch.testing.assert_close(production_grads[name].cpu(), oracle, rtol=0, atol=0)
 
     # This actual production-forward negative control restores explicit EP
     # sync after clearing the correct arm's gradients.  It must double EP2.
@@ -922,28 +1015,35 @@ def test_ep2_production_builder_distopt_finalize_and_identity_roundtrip(tmp_path
         # operation order rather than using the FP32 mean oracle twice.
         dtype = live_bank_parameters[name].dtype
         assert dtype is torch.bfloat16
-        explicit_expected = (
-            local_contributions_by_rank[0][name].to(dtype)
-            + local_contributions_by_rank[1][name].to(dtype)
-        ).float()
-        assert not torch.equal(explicit_expected, oracle)
-        observed_bf16_rounding |= bool(
-            torch.any(explicit_expected != oracle * 2).item()
-        )
-        torch.testing.assert_close(
-            doubled_grads[name].cpu(), explicit_expected, rtol=0, atol=0
-        )
+        if ".moe.experts._fc" in name:
+            explicit_expected = sum(
+                (
+                    contribution[name].to(dtype)
+                    for contribution in local_contributions_by_rank
+                )
+            ).float()
+            assert not torch.equal(explicit_expected, oracle)
+            observed_bf16_rounding |= bool(
+                torch.any(explicit_expected != oracle * 2).item()
+            )
+            torch.testing.assert_close(
+                doubled_grads[name].cpu(), explicit_expected, rtol=0, atol=0
+            )
+        else:
+            torch.testing.assert_close(
+                doubled_grads[name].cpu(), oracle, rtol=0, atol=0
+            )
     assert observed_bf16_rounding
     for name, param in state.named_parameters():
         assert name.startswith("bank_") and "." not in name
-    ep2_topologies = [None, None]
-    dist.all_gather_object(ep2_topologies, ep2_topology)
+    verify_topologies = [None] * phase_config["world"]
+    dist.all_gather_object(verify_topologies, verify_topology)
     if dist.get_rank() == 0:
         receipt = {
             "commit": candidate_sha,
             "manifest_sha256": _sha256(manifest_path),
             "phase": "ep2_verify",
-            "topology_by_rank": ep2_topologies,
+            "topology_by_rank": verify_topologies,
             "checkpoint_files": checkpoint_files,
         }
         temporary_receipt = phase_b_receipt_path.with_name(

--- a/experimental/lite/tests/smoke/primitive/test_multi_lora_ep2_production_gpu.py
+++ b/experimental/lite/tests/smoke/primitive/test_multi_lora_ep2_production_gpu.py
@@ -14,6 +14,10 @@ import torch
 import torch.distributed as dist
 
 from megatron.lite.primitive.ckpt import dcp
+from megatron.lite.primitive.distributed_test_utils import (
+    gather_owner_factor_records_or_raise,
+    select_lora_bank_owner_group,
+)
 from megatron.lite.primitive.train_step import run_microbatch_loop
 from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
 from megatron.lite.runtime.contracts.data import PackedBatch
@@ -453,8 +457,8 @@ def _optimizer_param_range(
     """Resolve this rank's optional dist-opt shard for one dense bank.
 
     ``model_param_gbuf_map`` describes locally owned reduce-scatter ranges, so
-    a valid rank may own none of a small bank.  Global ownership is checked
-    only after gathering the local records below.
+    a valid rank may own none of a small bank.  Owner-group membership is
+    checked only after gathering that group's local records below.
     """
     is_fc = _bank_surface_kind(bundle, parameter) == "fc"
     owners = [
@@ -472,8 +476,8 @@ def _optimizer_param_range(
     param_range = range_map["param_map"][parameter]
     buffer = optimizer.buffers[gbuf_index]
     bucket = buffer.buckets[bucket_index]
-    expected_group = (
-        bundle.parallel_state.ep_dp_group if is_fc else bundle.parallel_state.dp_group
+    expected_group = select_lora_bank_owner_group(
+        bundle.parallel_state, is_expert_bank=is_fc
     )
     expected_ranks = _group_ranks(expected_group)
     assert _group_ranks(optimizer.data_parallel_group) == expected_ranks
@@ -489,10 +493,10 @@ def _assert_model_owned_bank_allreduce(parameter: torch.Tensor, *, is_fc: bool) 
     assert bool(value) == (not is_fc)
 
 
-def _dense_owner_record(
+def _owner_group_record(
     bundle, leaf_index: int, optimizer, buffer
 ) -> dict[str, object]:
-    """Serialize the leaf/group contract for cross-rank ownership validation."""
+    """Serialize one optimizer leaf's owner-group contract."""
     return {
         "leaf_index": leaf_index,
         "owner_group_ranks": _group_ranks(optimizer.data_parallel_group),
@@ -500,14 +504,14 @@ def _dense_owner_record(
     }
 
 
-def _assert_dense_owner_contract(
+def _assert_owner_group_contract(
     bundle, name: str, records: list[dict[str, object]]
 ) -> None:
-    """Prove every local shard maps to one dense leaf, never the EP child."""
+    """Prove every local shard maps to the intended owner-group leaf."""
     assert records, f"no distributed-optimizer shard found for semantic bank {name}"
     is_fc = _bank_surface_kind(bundle, _bank_parameters(bundle)[name]) == "fc"
     expected_ranks = _group_ranks(
-        bundle.parallel_state.ep_dp_group if is_fc else bundle.parallel_state.dp_group
+        select_lora_bank_owner_group(bundle.parallel_state, is_expert_bank=is_fc)
     )
     assert len({record["leaf_index"] for record in records}) == 1
     assert all(record["owner_group_ranks"] == expected_ranks for record in records)
@@ -522,10 +526,23 @@ def _local_full_bank_contributions(bundle) -> dict[str, torch.Tensor]:
     }
 
 
+def _local_owner_factor_record(bundle, name: str) -> dict[str, object] | None:
+    """Inspect one local factor only inside its owner-lane error envelope."""
+    parameter = _bank_parameters(bundle)[name]
+    owned = _optimizer_param_range(bundle, parameter)
+    if owned is None:
+        return None
+    leaf_index, owner, _param_range, buffer, bucket = owned
+    return {
+        **_owner_group_record(bundle, leaf_index, owner, buffer),
+        "factor": float(bucket.gradient_scaling_factor),
+    }
+
+
 def _bank_sync_absolute_oracle(
     bundle, local_contributions: dict[str, torch.Tensor]
 ) -> tuple[dict[str, torch.Tensor], dict[str, float]]:
-    """Reference FC as EP→expert-DP; attention as dense-DP only."""
+    """Reference FC and attention gradients over their respective owner groups."""
     expected: dict[str, torch.Tensor] = {}
     for name, contribution in local_contributions.items():
         if _bank_surface_kind(bundle, _bank_parameters(bundle)[name]) == "fc":
@@ -549,37 +566,36 @@ def _bank_sync_absolute_oracle(
             value.div_(bundle.parallel_state.dp_size)
         expected[name] = value.cpu()
     expected_keys = set(local_contributions)
-    local_factors: dict[str, dict[str, object]] = {}
-    for name, parameter in _bank_parameters(bundle).items():
-        owned = _optimizer_param_range(bundle, parameter)
-        if owned is None:
-            continue
-        leaf_index, owner, _param_range, buffer, bucket = owned
-        local_factors[name] = {
-            **_dense_owner_record(bundle, leaf_index, owner, buffer),
-            "factor": float(bucket.gradient_scaling_factor),
-        }
-    gathered_factors = [None] * dist.get_world_size()
-    dist.all_gather_object(gathered_factors, local_factors)
     optimizer_expected: dict[str, torch.Tensor] = {}
     factors: dict[str, float] = {}
     for name in sorted(expected_keys):
         is_fc = _bank_surface_kind(bundle, _bank_parameters(bundle)[name]) == "fc"
+        owner_group = select_lora_bank_owner_group(
+            bundle.parallel_state, is_expert_bank=is_fc
+        )
         expected_factor = 1.0 / (
             bundle.parallel_state.expert_dp_size
             if is_fc
             else bundle.parallel_state.dp_size
         )
-        records = [
-            factor_map[name] for factor_map in gathered_factors if name in factor_map
-        ]
-        _assert_dense_owner_contract(bundle, name, records)
-        seen = {record["factor"] for record in records}
-        assert len(seen) == 1, f"missing or inconsistent dense-DP factor for {name}"
-        factor = seen.pop()
-        assert (
-            factor == expected_factor
-        ), f"owner bucket factor for {name} is {factor}, expected {expected_factor}"
+
+        def validate_records(records) -> None:
+            _assert_owner_group_contract(bundle, name, records)
+            seen = {record["factor"] for record in records}
+            assert (
+                len(seen) == 1
+            ), f"missing or inconsistent owner-group factor for {name}"
+            factor = seen.pop()
+            assert (
+                factor == expected_factor
+            ), f"owner-group factor for {name} is {factor}, expected {expected_factor}"
+
+        records = gather_owner_factor_records_or_raise(
+            owner_group,
+            lambda: _local_owner_factor_record(bundle, name),
+            validate_records,
+        )
+        factor = records[0]["factor"]
         factors[name] = factor
         optimizer_expected[name] = expected[name]
     return optimizer_expected, factors
@@ -610,7 +626,7 @@ def _reconstruct_optimizer_owned_bank_grads(bundle) -> dict[str, torch.Tensor]:
                     .end
                 ].detach()
                 local["shard"] = {
-                    **_dense_owner_record(bundle, leaf_index, owner, buffer),
+                    **_owner_group_record(bundle, leaf_index, owner, buffer),
                     "start": param_range["param"].start,
                     "end": param_range["param"].end,
                     "shape": tuple(parameter.shape),
@@ -634,7 +650,7 @@ def _reconstruct_optimizer_owned_bank_grads(bundle) -> dict[str, torch.Tensor]:
             assert end - start == values.numel()
             ranges.append((start, end))
             flat[start:end].copy_(values)
-        _assert_dense_owner_contract(bundle, name, records)
+        _assert_owner_group_contract(bundle, name, records)
         offset = 0
         for start, end in sorted(ranges):
             assert start == offset, f"non-contiguous dist-opt shard coverage for {name}"

--- a/experimental/lite/tests/smoke/primitive/test_multi_lora_ep2_production_gpu.py
+++ b/experimental/lite/tests/smoke/primitive/test_multi_lora_ep2_production_gpu.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Two-GPU production lifecycle proof for model-owned Qwen3-MoE multi-LoRA."""
 
-
 from __future__ import annotations
 
 import hashlib
@@ -384,9 +383,9 @@ def _bank_surface_kind(bundle, parameter: torch.Tensor) -> str:
     for surface, bank in state.registry.banks.items():
         if parameter is bank.a_bank or parameter is bank.b_bank:
             matches.append(surface)
-    assert (
-        len(matches) == 1
-    ), f"bank parameter has ambiguous/missing registry surface: {matches}"
+    assert len(matches) == 1, (
+        f"bank parameter has ambiguous/missing registry surface: {matches}"
+    )
     surface = matches[0]
     if ".moe.experts._fc" in surface:
         return "fc"
@@ -608,7 +607,7 @@ def _bank_sync_absolute_oracle(
         ),
     )
     print(
-        "MULTI_LORA_COLLECTIVE_PREFLIGHT " f"rank={dist.get_rank()} records={records}",
+        f"MULTI_LORA_COLLECTIVE_PREFLIGHT rank={dist.get_rank()} records={records}",
         flush=True,
     )
     if preflight_done is not None:
@@ -652,13 +651,13 @@ def _bank_sync_absolute_oracle(
         def validate_records(records) -> None:
             _assert_owner_group_contract(bundle, name, records)
             seen = {record["factor"] for record in records}
-            assert (
-                len(seen) == 1
-            ), f"missing or inconsistent owner-group factor for {name}"
+            assert len(seen) == 1, (
+                f"missing or inconsistent owner-group factor for {name}"
+            )
             factor = seen.pop()
-            assert (
-                factor == expected_factor
-            ), f"owner-group factor for {name} is {factor}, expected {expected_factor}"
+            assert factor == expected_factor, (
+                f"owner-group factor for {name} is {factor}, expected {expected_factor}"
+            )
 
         records = lora_dist_utils.gather_owner_factor_records_or_raise(
             owner_group,
@@ -691,9 +690,9 @@ def _reconstruct_optimizer_owned_bank_grads(bundle) -> dict[str, torch.Tensor]:
             if owned is not None:
                 leaf_index, owner, param_range, buffer, bucket = owned
                 reduced = bucket.grad_data.view(-1)[
-                    param_range["gbuf_world_in_bucket"]
-                    .start : param_range["gbuf_world_in_bucket"]
-                    .end
+                    param_range["gbuf_world_in_bucket"].start : param_range[
+                        "gbuf_world_in_bucket"
+                    ].end
                 ].detach()
                 local["shard"] = {
                     **_owner_group_record(bundle, leaf_index, owner, buffer),
@@ -883,15 +882,15 @@ def test_production_builder_distopt_finalize_and_identity_roundtrip(tmp_path):
     candidate_sha = os.environ.get("MLITE_CANDIDATE_SHA")
     candidate_tree = os.environ.get("MLITE_CANDIDATE_TREE_SHA")
     candidate_diff = os.environ.get("MLITE_CANDIDATE_DIFF_SHA")
-    assert (
-        candidate_sha and candidate_tree and candidate_diff
-    ), "candidate commit, tree, and diff hashes must bind the phase artifact"
+    assert candidate_sha and candidate_tree and candidate_diff, (
+        "candidate commit, tree, and diff hashes must bind the phase artifact"
+    )
 
     if phase == "ep2_oracle":
         if dist.get_rank() == 0:
-            assert (
-                not artifact_dir.exists()
-            ), "phase artifact directory already exists; refuse stale COMPLETE/checkpoint reuse"
+            assert not artifact_dir.exists(), (
+                "phase artifact directory already exists; refuse stale COMPLETE/checkpoint reuse"
+            )
             artifact_dir.mkdir(parents=True)
         dist.barrier()
         bundle = _build_bundle(

--- a/experimental/lite/tests/smoke/primitive/test_multi_lora_ep2_production_gpu.py
+++ b/experimental/lite/tests/smoke/primitive/test_multi_lora_ep2_production_gpu.py
@@ -447,7 +447,7 @@ def _optimizer_param_range(
     if not owners:
         return None
     leaf_index, optimizer = owners[0]
-    assert getattr(parameter, "allreduce", None) is (not is_fc)
+    _assert_model_owned_bank_allreduce(parameter, is_fc=is_fc)
     gbuf_index, dtype, bucket_index = optimizer.model_param_gbuf_map[parameter]
     range_map = optimizer.gbuf_ranges[gbuf_index][dtype][bucket_index]
     param_range = range_map["param_map"][parameter]
@@ -460,6 +460,14 @@ def _optimizer_param_range(
     assert _group_ranks(optimizer.data_parallel_group) == expected_ranks
     assert _group_ranks(buffer.data_parallel_group) == expected_ranks
     return leaf_index, optimizer, param_range, buffer, bucket
+
+
+def _assert_model_owned_bank_allreduce(parameter: torch.Tensor, *, is_fc: bool) -> None:
+    """Check explicit optimizer ownership without relying on bool identity."""
+    value = getattr(parameter, "allreduce", None)
+    assert value is not None, "model-owned LoRA bank is missing allreduce ownership"
+    # Megatron may attach a bool-like scalar rather than Python's singleton.
+    assert bool(value) == (not is_fc)
 
 
 def _dense_owner_record(

--- a/experimental/lite/tests/smoke/primitive/test_multi_lora_ep2_production_gpu.py
+++ b/experimental/lite/tests/smoke/primitive/test_multi_lora_ep2_production_gpu.py
@@ -15,7 +15,9 @@ import torch.distributed as dist
 
 from megatron.lite.primitive.ckpt import dcp
 from megatron.lite.primitive.distributed_test_utils import (
+    build_lora_collective_descriptor,
     gather_owner_factor_records_or_raise,
+    preflight_lora_bank_collective_order,
     select_lora_bank_owner_group,
 )
 from megatron.lite.primitive.train_step import run_microbatch_loop
@@ -544,7 +546,20 @@ def _bank_sync_absolute_oracle(
 ) -> tuple[dict[str, torch.Tensor], dict[str, float]]:
     """Reference FC and attention gradients over their respective owner groups."""
     expected: dict[str, torch.Tensor] = {}
-    for name, contribution in local_contributions.items():
+    records = preflight_lora_bank_collective_order(
+        local_contributions,
+        lambda name: build_lora_collective_descriptor(
+            _bank_surface_kind(bundle, _bank_parameters(bundle)[name]),
+            local_contributions[name],
+            _bank_parameters(bundle)[name].dtype,
+        ),
+    )
+    print(
+        "MULTI_LORA_COLLECTIVE_PREFLIGHT " f"rank={dist.get_rank()} records={records}",
+        flush=True,
+    )
+    for name, _kind, _shape, _dtype in records:
+        contribution = local_contributions[name]
         if _bank_surface_kind(bundle, _bank_parameters(bundle)[name]) == "fc":
             bank_dtype = _bank_parameters(bundle)[name].dtype
             assert bank_dtype is torch.bfloat16

--- a/experimental/lite/tests/smoke/primitive/test_multi_lora_ep2_production_gpu.py
+++ b/experimental/lite/tests/smoke/primitive/test_multi_lora_ep2_production_gpu.py
@@ -334,18 +334,82 @@ def _run_bank_gradient_contract(bundle) -> None:
             bank.b_bank[1].fill_(0.25)
     _configure_fixed_router(bundle)
     batch = _production_batch(bundle)
+    parameters = _bank_parameters(bundle)
+
+    def assert_slots(gradients, *, active: tuple[int, ...]) -> None:
+        assert set(gradients) == _expected_semantic_bank_keys(state)
+        for name, gradient in gradients.items():
+            assert gradient.shape == parameters[name].shape
+            assert name.rsplit("_", 1)[-1] in {"a", "b"}
+            for slot in range(gradient.shape[0]):
+                if slot in active:
+                    assert gradient[slot].abs().max() > 0, (name, slot)
+                else:
+                    assert gradient[slot].eq(0).all(), (name, slot)
+
+    # Independent miss arm: all factors are nonzero but every token selects
+    # alpha.  Its bravo gradients must be exactly zero before the mixed arm.
+    batch.extras["multi_lora_slots"][0].zero_()
+    loss, gradients = _run_production_forward_and_finalize(bundle, batch)
+    assert loss == loss
+    assert_slots(gradients, active=(0,))
+    _clear_gradients(bundle)
+
+    # A separate lifecycle establishes that the same semantic A/B slot axis
+    # receives gradients for both adapters under mixed token routing.
     batch.extras["multi_lora_slots"][0].copy_(
         torch.tensor([0, 1, 0, 1], device="cuda", dtype=torch.long)
     )
     loss, gradients = _run_production_forward_and_finalize(bundle, batch)
     assert loss == loss
-    assert set(gradients) == _expected_semantic_bank_keys(state)
-    parameters = _bank_parameters(bundle)
-    for name, gradient in gradients.items():
-        assert gradient.shape == parameters[name].shape
-        assert name.rsplit("_", 1)[-1] in {"a", "b"}
-        assert gradient[0].abs().max() > 0, name
-        assert gradient[1].abs().max() > 0, name
+    assert_slots(gradients, active=(0, 1))
+
+
+def _adapter_export_oracle(bundle) -> dict[str, dict[str, torch.Tensor]]:
+    """Export both slots through the real TP materialization + native mapper."""
+    from megatron.lite.model.qwen3_moe.lite.checkpoint import Qwen3MoEWeightSpec
+    from megatron.lite.primitive.ckpt.hf_weights import VLLM_LORA_NAME_PREFIX
+
+    state = bundle.extras["multi_lora_training_state"]
+    expected_modules = {
+        f"model.layers.0.mlp.experts.{expert}.{projection}"
+        for expert in range(_config().num_experts)
+        for projection in ("gate_proj", "up_proj", "down_proj")
+    } | {
+        f"model.layers.0.self_attn.{projection}"
+        for projection in ("q_proj", "k_proj", "v_proj", "o_proj")
+    }
+    expected_keys = {
+        f"{VLLM_LORA_NAME_PREFIX}{module}.lora_{factor}.weight"
+        for module in expected_modules
+        for factor in ("A", "B")
+    }
+    exported = {
+        name: state.registry.export_hf_state(
+            name, Qwen3MoEWeightSpec(_config()), bundle.parallel_state
+        )
+        for name in ("alpha", "bravo")
+    }
+    for name, tensors in exported.items():
+        assert set(tensors) == expected_keys, name
+        assert all(tensor.ndim == 2 for tensor in tensors.values())
+        assert all(
+            tensor.shape[0 if key.endswith("lora_A.weight") else 1]
+            == state.registry.rank
+            for key, tensor in tensors.items()
+        )
+    assert any(
+        not torch.equal(exported["alpha"][key], exported["bravo"][key])
+        for key in expected_keys
+    )
+    records = {
+        name: {key: _tensor_record(value) for key, value in tensors.items()}
+        for name, tensors in exported.items()
+    }
+    gathered = [None] * bundle.parallel_state.dp_size
+    dist.all_gather_object(gathered, records, group=bundle.parallel_state.dp_group)
+    assert all(record == gathered[0] for record in gathered)
+    return exported
 
 
 def _distributed_optimizer_leaves(optimizer) -> tuple[object, ...]:
@@ -711,6 +775,10 @@ def test_production_builder_distopt_finalize_and_identity_roundtrip(tmp_path):
         _initialize_nonzero_banks(bundle)
         _configure_fixed_router(bundle)
         batch = _production_batch(bundle)
+        adapter_exports = _adapter_export_oracle(bundle)
+        export_path = artifact_dir / f"adapter_exports_rank_{dist.get_rank():05d}.pt"
+        torch.save(adapter_exports, export_path)
+        dist.barrier()
         parameter_semantics = _checkpoint_semantics(bundle)
         loss, local_contributions = _run_unsynchronized_reference(bundle, batch)
         expected_keys = _expected_semantic_bank_keys(
@@ -748,6 +816,7 @@ def test_production_builder_distopt_finalize_and_identity_roundtrip(tmp_path):
         oracle_tensors_by_rank = [None] * phase_config["world"]
         local_contribution_tensors_by_rank = [None] * phase_config["world"]
         parameter_semantics_by_rank = [None] * phase_config["world"]
+        adapter_export_records_by_rank = [None] * phase_config["world"]
         dist.all_gather_object(losses, loss)
         dist.all_gather_object(batches, _batch_record(batch))
         dist.all_gather_object(
@@ -762,6 +831,13 @@ def test_production_builder_distopt_finalize_and_identity_roundtrip(tmp_path):
             },
         )
         dist.all_gather_object(parameter_semantics_by_rank, parameter_semantics)
+        dist.all_gather_object(
+            adapter_export_records_by_rank,
+            {
+                adapter: {key: _tensor_record(value) for key, value in tensors.items()}
+                for adapter, tensors in adapter_exports.items()
+            },
+        )
         dist.barrier()
         oracle_path = artifact_dir / f"ep2_bank_grads_rank_{dist.get_rank():05d}.pt"
         local_path = (
@@ -798,6 +874,13 @@ def test_production_builder_distopt_finalize_and_identity_roundtrip(tmp_path):
                 "semantic_bank_tensors_by_rank": oracle_tensors_by_rank,
                 "local_contribution_tensors_by_rank": local_contribution_tensors_by_rank,
                 "parameter_semantics_by_rank": parameter_semantics_by_rank,
+                "adapter_export_tensors_by_rank": adapter_export_records_by_rank,
+                "adapter_export_files": {
+                    f"rank_{rank:05d}": _sha256(
+                        artifact_dir / f"adapter_exports_rank_{rank:05d}.pt"
+                    )
+                    for rank in range(phase_config["world"])
+                },
                 "oracle_files": {
                     f"rank_{rank:05d}": _sha256(
                         artifact_dir / f"ep2_bank_grads_rank_{rank:05d}.pt"
@@ -883,6 +966,20 @@ def test_production_builder_distopt_finalize_and_identity_roundtrip(tmp_path):
             name: _tensor_record(value) for name, value in local_contributions.items()
         } == manifest["local_contribution_tensors_by_rank"][rank]
         local_contributions_by_rank.append(local_contributions)
+    adapter_export_path = (
+        artifact_dir / f"adapter_exports_rank_{dist.get_rank():05d}.pt"
+    )
+    assert (
+        _sha256(adapter_export_path)
+        == manifest["adapter_export_files"][f"rank_{dist.get_rank():05d}"]
+    )
+    adapter_export_oracle = torch.load(
+        adapter_export_path, map_location="cpu", weights_only=True
+    )
+    assert {
+        adapter: {key: _tensor_record(value) for key, value in tensors.items()}
+        for adapter, tensors in adapter_export_oracle.items()
+    } == manifest["adapter_export_tensors_by_rank"][dist.get_rank()]
 
     bundle = _build_bundle(
         tp=phase_config["tp"], ep=phase_config["ep"], model_seed=3100
@@ -980,6 +1077,11 @@ def test_production_builder_distopt_finalize_and_identity_roundtrip(tmp_path):
         post_load_semantics == manifest["parameter_semantics_by_rank"][dist.get_rank()]
     )
     assert _batch_record(batch) == expected_batch
+    restored_exports = _adapter_export_oracle(bundle)
+    for adapter, tensors in restored_exports.items():
+        assert set(tensors) == set(adapter_export_oracle[adapter])
+        for key, value in tensors.items():
+            assert torch.equal(value.cpu(), adapter_export_oracle[adapter][key])
     assert _config().to_dict() == manifest["model_config"]
     assert expected_impl == manifest["impl_config"]["verify"]
     _configure_fixed_router(bundle)

--- a/experimental/lite/tests/smoke/primitive/test_multi_lora_ep2_production_gpu.py
+++ b/experimental/lite/tests/smoke/primitive/test_multi_lora_ep2_production_gpu.py
@@ -552,45 +552,48 @@ def _bank_sync_absolute_oracle(
 
 def _reconstruct_optimizer_owned_bank_grads(bundle) -> dict[str, torch.Tensor]:
     """Rebuild each logical bank grad from dist-opt's owned reduce-scatter shards."""
-    local_shards: dict[str, dict[str, object]] = {}
-    for name, parameter in _bank_parameters(bundle).items():
-        owned = _optimizer_param_range(
-            bundle, parameter, is_fc=".moe.experts._fc" in name
-        )
-        if owned is None:
-            continue
-        leaf_index, owner, param_range, buffer, bucket = owned
-        # ``gbuf_world_in_bucket`` identifies the reduce-scatter output view;
-        # ``param`` maps that view back to the logical bank tensor's offsets.
-        reduced = bucket.grad_data.view(-1)[
-            param_range["gbuf_world_in_bucket"]
-            .start : param_range["gbuf_world_in_bucket"]
-            .end
-        ].detach()
-        local_shards[name] = {
-            **_dense_owner_record(bundle, leaf_index, owner, buffer),
-            "start": param_range["param"].start,
-            "end": param_range["param"].end,
-            "shape": tuple(parameter.shape),
-            "dtype": str(reduced.dtype),
-            "values": reduced.float().cpu().clone(),
-        }
-
-    gathered = [None] * dist.get_world_size()
-    dist.all_gather_object(gathered, local_shards)
-    expected_keys = set(_bank_parameters(bundle))
-    assert set().union(*(set(shards) for shards in gathered)) == expected_keys
+    parameters = _bank_parameters(bundle)
     reconstructed: dict[str, torch.Tensor] = {}
-    for name in sorted(expected_keys):
-        shape = tuple(_bank_parameters(bundle)[name].shape)
+    for name in sorted(parameters):
+        parameter = parameters[name]
+        is_fc = ".moe.experts._fc" in name
+        group = (
+            bundle.parallel_state.ep_dp_group
+            if is_fc
+            else bundle.parallel_state.dp_group
+        )
+        local: dict[str, object] = {"error": None, "shard": None}
+        # Ownership metadata is local and may be absent.  Never raise before
+        # the owner group has collectively observed every rank's result.
+        try:
+            owned = _optimizer_param_range(bundle, parameter, is_fc=is_fc)
+            if owned is not None:
+                leaf_index, owner, param_range, buffer, bucket = owned
+                reduced = bucket.grad_data.view(-1)[
+                    param_range["gbuf_world_in_bucket"]
+                    .start : param_range["gbuf_world_in_bucket"]
+                    .end
+                ].detach()
+                local["shard"] = {
+                    **_dense_owner_record(bundle, leaf_index, owner, buffer),
+                    "start": param_range["param"].start,
+                    "end": param_range["param"].end,
+                    "shape": tuple(parameter.shape),
+                    "dtype": str(reduced.dtype),
+                    "values": reduced.float().cpu().clone(),
+                }
+        except Exception as error:  # reported symmetrically below
+            local["error"] = f"{type(error).__name__}: {error}"
+        gathered = _gather_optimizer_owned_bank_shards(local, group=group)
+        errors = [record["error"] for record in gathered if record["error"]]
+        assert not errors, f"owner metadata error for {name}: {errors}"
+        records = [
+            record["shard"] for record in gathered if record["shard"] is not None
+        ]
+        shape = tuple(parameter.shape)
         flat = torch.empty(int(torch.tensor(shape).prod()), dtype=torch.float32)
         ranges = []
-        records = []
-        for shards in gathered:
-            if name not in shards:
-                continue
-            shard = shards[name]
-            records.append(shard)
+        for shard in records:
             start, end = int(shard["start"]), int(shard["end"])
             values = shard["values"]
             assert end - start == values.numel()
@@ -604,6 +607,16 @@ def _reconstruct_optimizer_owned_bank_grads(bundle) -> dict[str, torch.Tensor]:
         assert offset == flat.numel(), f"incomplete dist-opt shard coverage for {name}"
         reconstructed[name] = flat.reshape(shape)
     return reconstructed
+
+
+def _gather_optimizer_owned_bank_shards(
+    local_shard: dict[str, object], *, group
+) -> list[dict[str, object]]:
+    """Gather one semantic bank on its dist-opt owner group, non-owners included."""
+    gathered: list[dict[str, object] | None] = [None] * dist.get_world_size(group)
+    dist.all_gather_object(gathered, local_shard, group=group)
+    assert all(shards is not None for shards in gathered)
+    return [shards for shards in gathered if shards is not None]
 
 
 def _run_unsynchronized_reference(
@@ -939,9 +952,6 @@ def test_production_builder_distopt_finalize_and_identity_roundtrip(tmp_path):
     assert manifest["topology"]["oracle"][dist.get_rank()]["tp"] == phase_config["tp"]
     assert manifest["topology"]["oracle"][dist.get_rank()]["ep"] == phase_config["ep"]
     assert manifest["topology"]["verify"] is None
-    batch = _production_batch(bundle)
-    expected_batch = manifest["batch_by_rank"][dist.get_rank()]
-    assert _batch_record(batch) == expected_batch
     for rank in range(phase_config["world"]):
         path = artifact_dir / f"ep2_bank_grads_rank_{rank:05d}.pt"
         assert _sha256(path) == manifest["oracle_files"][f"rank_{rank:05d}"]
@@ -990,6 +1000,9 @@ def test_production_builder_distopt_finalize_and_identity_roundtrip(tmp_path):
     assert state is not None
     assert bundle.extras["optimizer_backend"] == "dist_opt"
     assert callable(bundle.finalize_grads)
+    batch = _production_batch(bundle)
+    expected_batch = manifest["batch_by_rank"][dist.get_rank()]
+    assert _batch_record(batch) == expected_batch
     for name, parameter in state.named_parameters():
         is_fc = ".moe.experts._fc" in name
         assert getattr(parameter, "allreduce", None) is (not is_fc)

--- a/experimental/lite/tests/smoke/primitive/test_multi_lora_ep2_production_gpu.py
+++ b/experimental/lite/tests/smoke/primitive/test_multi_lora_ep2_production_gpu.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Two-GPU production lifecycle proof for model-owned Qwen3-MoE multi-LoRA."""
 
+
 from __future__ import annotations
 
 import hashlib
@@ -11,18 +12,13 @@ import traceback
 from pathlib import Path
 from typing import Callable
 
+import megatron.lite.primitive.distributed_test_utils as lora_dist_utils
+import megatron.lite.runtime.contracts.config as runtime_config
 import pytest
 import torch
 import torch.distributed as dist
 from megatron.lite.primitive.ckpt import dcp
-from megatron.lite.primitive.distributed_test_utils import (
-    build_lora_collective_descriptor,
-    gather_owner_factor_records_or_raise,
-    preflight_lora_bank_collective_order,
-    select_lora_bank_owner_group,
-)
 from megatron.lite.primitive.train_step import run_microbatch_loop
-from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
 from megatron.lite.runtime.contracts.data import PackedBatch
 
 pytestmark = [
@@ -86,9 +82,9 @@ def _build_bundle(*, tp: int = 1, ep: int, model_seed: int):
     return protocol.build_model(
         _config(),
         impl_cfg=protocol.ImplConfig(
-            parallel=ParallelConfig(tp=tp, ep=ep, etp=1, pp=1, cp=1),
+            parallel=runtime_config.ParallelConfig(tp=tp, ep=ep, etp=1, pp=1, cp=1),
             optimizer="dist_opt",
-            optimizer_config=OptimizerConfig(
+            optimizer_config=runtime_config.OptimizerConfig(
                 optimizer="adam", lr=1.0e-3, weight_decay=0.0, clip_grad=1.0
             ),
             multi_lora={"names": ("alpha", "bravo"), "rank": 2, "alpha": 4},
@@ -144,16 +140,36 @@ def _tensor_record(tensor: torch.Tensor) -> dict[str, object]:
 
 
 def _write_phase_a_flight_record(
-    artifact_dir: Path, **updates: object
+    artifact_dir: Path, *, remove: tuple[str, ...] = (), **updates: object
 ) -> dict[str, object]:
     """Atomically persist rank-local Phase A progress without a collective."""
     path = artifact_dir / f"phase_a_rank_{dist.get_rank():05d}.json"
     record = json.loads(path.read_text()) if path.exists() else {}
+    for key in remove:
+        record.pop(key, None)
     record.update(updates)
     temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
     temporary.write_text(json.dumps(record, sort_keys=True))
     os.replace(temporary, path)
     return record
+
+
+def _run_phase_a_stage(artifact_dir: Path, stage: str, action):
+    """Record any rank-local Phase A failure before a later collective."""
+    _write_phase_a_flight_record(artifact_dir, current_stage=stage)
+    try:
+        value = action()
+    except Exception as error:
+        _write_phase_a_flight_record(
+            artifact_dir,
+            stage_error=f"{type(error).__name__}: {error}",
+            traceback=traceback.format_exc(),
+        )
+        raise
+    _write_phase_a_flight_record(
+        artifact_dir, remove=("stage_error", "traceback"), **{f"{stage}_done": True}
+    )
+    return value
 
 
 def _named_parameters(bundle) -> dict[str, torch.Tensor]:
@@ -321,10 +337,11 @@ def _fixed_local_router(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
 
 
 def _phase_a_balanced_router(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-    """Cycle tiny-Qwen experts so Phase A reaches both EP partitions."""
+    """Route TP-local rows across both EP partitions in Phase A."""
+    experts_per_ep = _TINY_QWEN_EXPERTS // 2
     return (
         torch.ones((x.shape[0], 1), device=x.device, dtype=x.dtype),
-        (torch.arange(x.shape[0], device=x.device) % _TINY_QWEN_EXPERTS).view(-1, 1),
+        ((torch.arange(x.shape[0], device=x.device) % 2) * experts_per_ep).view(-1, 1),
     )
 
 
@@ -344,6 +361,13 @@ def _configure_fixed_router(bundle) -> None:
     for chunk in bundle.chunks:
         qwen = getattr(chunk, "module", chunk)
         qwen.layers[0].moe.router.forward = _fixed_local_router
+
+
+def _configure_phase_a_balanced_router(bundle) -> None:
+    """Bind Phase A oracle and Phase B parity runs to the same route graph."""
+    for chunk in bundle.chunks:
+        qwen = getattr(chunk, "module", chunk)
+        qwen.layers[0].moe.router.forward = _phase_a_balanced_router
 
 
 def _bank_parameters(bundle) -> dict[str, torch.Tensor]:
@@ -415,7 +439,7 @@ def _run_bank_gradient_contract(bundle) -> None:
 
 def _adapter_export_oracle(bundle) -> dict[str, dict[str, torch.Tensor]]:
     """Export both slots through the real TP materialization + native mapper."""
-    from megatron.lite.model.qwen3_moe.lite.checkpoint import Qwen3MoEWeightSpec
+    import megatron.lite.model.qwen3_moe.lite.checkpoint as qwen_checkpoint
     from megatron.lite.primitive.ckpt.hf_weights import VLLM_LORA_NAME_PREFIX
 
     state = bundle.extras["multi_lora_training_state"]
@@ -434,7 +458,7 @@ def _adapter_export_oracle(bundle) -> dict[str, dict[str, torch.Tensor]]:
     }
     exported = {
         name: state.registry.export_hf_state(
-            name, Qwen3MoEWeightSpec(_config()), bundle.parallel_state
+            name, qwen_checkpoint.Qwen3MoEWeightSpec(_config()), bundle.parallel_state
         )
         for name in ("alpha", "bravo")
     }
@@ -502,7 +526,7 @@ def _optimizer_param_range(
     param_range = range_map["param_map"][parameter]
     buffer = optimizer.buffers[gbuf_index]
     bucket = buffer.buckets[bucket_index]
-    expected_group = select_lora_bank_owner_group(
+    expected_group = lora_dist_utils.select_lora_bank_owner_group(
         bundle.parallel_state, is_expert_bank=is_fc
     )
     expected_ranks = _group_ranks(expected_group)
@@ -537,7 +561,9 @@ def _assert_owner_group_contract(
     assert records, f"no distributed-optimizer shard found for semantic bank {name}"
     is_fc = _bank_surface_kind(bundle, _bank_parameters(bundle)[name]) == "fc"
     expected_ranks = _group_ranks(
-        select_lora_bank_owner_group(bundle.parallel_state, is_expert_bank=is_fc)
+        lora_dist_utils.select_lora_bank_owner_group(
+            bundle.parallel_state, is_expert_bank=is_fc
+        )
     )
     assert len({record["leaf_index"] for record in records}) == 1
     assert all(record["owner_group_ranks"] == expected_ranks for record in records)
@@ -573,9 +599,9 @@ def _bank_sync_absolute_oracle(
 ) -> tuple[dict[str, torch.Tensor], dict[str, float]]:
     """Reference FC and attention gradients over their respective owner groups."""
     expected: dict[str, torch.Tensor] = {}
-    records = preflight_lora_bank_collective_order(
+    records = lora_dist_utils.preflight_lora_bank_collective_order(
         local_contributions,
-        lambda name: build_lora_collective_descriptor(
+        lambda name: lora_dist_utils.build_lora_collective_descriptor(
             _bank_surface_kind(bundle, _bank_parameters(bundle)[name]),
             local_contributions[name],
             _bank_parameters(bundle)[name].dtype,
@@ -614,7 +640,7 @@ def _bank_sync_absolute_oracle(
     factors: dict[str, float] = {}
     for name in sorted(expected_keys):
         is_fc = _bank_surface_kind(bundle, _bank_parameters(bundle)[name]) == "fc"
-        owner_group = select_lora_bank_owner_group(
+        owner_group = lora_dist_utils.select_lora_bank_owner_group(
             bundle.parallel_state, is_expert_bank=is_fc
         )
         expected_factor = 1.0 / (
@@ -634,7 +660,7 @@ def _bank_sync_absolute_oracle(
                 factor == expected_factor
             ), f"owner-group factor for {name} is {factor}, expected {expected_factor}"
 
-        records = gather_owner_factor_records_or_raise(
+        records = lora_dist_utils.gather_owner_factor_records_or_raise(
             owner_group,
             lambda: _local_owner_factor_record(bundle, name),
             validate_records,
@@ -901,32 +927,44 @@ def test_production_builder_distopt_finalize_and_identity_roundtrip(tmp_path):
         torch.save(adapter_exports, export_path)
         dist.barrier()
         _write_phase_a_flight_record(artifact_dir, export_complete=True)
-        parameter_semantics = _checkpoint_semantics(bundle)
-        _write_phase_a_flight_record(artifact_dir, reference_enter=True)
-        try:
-            loss, local_contributions = _run_unsynchronized_reference(bundle, batch)
-        except Exception as error:
-            _write_phase_a_flight_record(
-                artifact_dir,
-                reference_error=f"{type(error).__name__}: {error}",
-                traceback=traceback.format_exc(),
-            )
-            raise
-        _write_phase_a_flight_record(artifact_dir, reference_done=True)
-        expected_keys = _expected_semantic_bank_keys(
-            bundle.extras["multi_lora_training_state"]
+        parameter_semantics = _run_phase_a_stage(
+            artifact_dir, "checkpoint_semantics", lambda: _checkpoint_semantics(bundle)
         )
-        assert set(local_contributions) == expected_keys
-        oracle_grads, normalization_by_key = _bank_sync_absolute_oracle(
-            bundle,
-            local_contributions,
-            preflight_done=lambda: _write_phase_a_flight_record(
-                artifact_dir, preflight_done=True
+        loss, local_contributions = _run_phase_a_stage(
+            artifact_dir,
+            "reference",
+            lambda: _run_unsynchronized_reference(bundle, batch),
+        )
+        expected_keys = _run_phase_a_stage(
+            artifact_dir,
+            "key_validation",
+            lambda: _expected_semantic_bank_keys(
+                bundle.extras["multi_lora_training_state"]
             ),
         )
+
+        def validate_local_keys() -> None:
+            assert set(local_contributions) == expected_keys
+
+        _run_phase_a_stage(artifact_dir, "key_validation", validate_local_keys)
+        oracle_grads, normalization_by_key = _run_phase_a_stage(
+            artifact_dir,
+            "oracle_collective",
+            lambda: _bank_sync_absolute_oracle(
+                bundle,
+                local_contributions,
+                preflight_done=lambda: _write_phase_a_flight_record(
+                    artifact_dir, preflight_done=True
+                ),
+            ),
+        )
+
+        def validate_oracle() -> None:
+            assert set(oracle_grads) == expected_keys
+            assert all(gradient.abs().max() > 0 for gradient in oracle_grads.values())
+
+        _run_phase_a_stage(artifact_dir, "oracle_validation", validate_oracle)
         _write_phase_a_flight_record(artifact_dir, oracle_done=True)
-        assert set(oracle_grads) == expected_keys
-        assert all(gradient.abs().max() > 0 for gradient in oracle_grads.values())
         gathered_contributions = [None] * dist.get_world_size(
             bundle.parallel_state.dp_group
         )
@@ -1006,6 +1044,10 @@ def test_production_builder_distopt_finalize_and_identity_roundtrip(tmp_path):
                 "batch_by_rank": batches,
                 "loss_by_rank": losses,
                 "loss_normalization": "model token-loss mean",
+                "router_contract": {
+                    "oracle_and_verify": "balanced_global_experts_0_2",
+                    "production_smoke": "expert0_only",
+                },
                 "dense_dp_gradient_scaling_by_key": normalization_by_key,
                 "semantic_bank_keys": sorted(expected_keys),
                 "semantic_bank_tensors_by_rank": oracle_tensors_by_rank,
@@ -1064,6 +1106,10 @@ def test_production_builder_distopt_finalize_and_identity_roundtrip(tmp_path):
     assert manifest["schema_version"] == 3
     assert manifest["seeds"] == {"model": 3100, "batch_base": 4100}
     assert manifest["loss_normalization"] == "model token-loss mean"
+    assert manifest["router_contract"] == {
+        "oracle_and_verify": "balanced_global_experts_0_2",
+        "production_smoke": "expert0_only",
+    }
     assert set(manifest["dense_dp_gradient_scaling_by_key"]) == set(
         manifest["semantic_bank_keys"]
     )
@@ -1223,7 +1269,11 @@ def test_production_builder_distopt_finalize_and_identity_roundtrip(tmp_path):
             assert torch.equal(value.cpu(), adapter_export_oracle[adapter][key])
     assert _config().to_dict() == manifest["model_config"]
     assert expected_impl == manifest["impl_config"]["verify"]
-    _configure_fixed_router(bundle)
+    assert (
+        manifest["router_contract"]["oracle_and_verify"]
+        == "balanced_global_experts_0_2"
+    )
+    _configure_phase_a_balanced_router(bundle)
     _loss, production_grads = _run_production_forward_and_finalize(bundle, batch)
     assert set(production_grads) == expected_keys
     for name, oracle in oracle_grads.items():

--- a/experimental/lite/tests/smoke/primitive/test_multi_lora_ep2_production_gpu.py
+++ b/experimental/lite/tests/smoke/primitive/test_multi_lora_ep2_production_gpu.py
@@ -498,7 +498,7 @@ def _assert_dense_owner_contract(
 def _local_full_bank_contributions(bundle) -> dict[str, torch.Tensor]:
     """Read unsynchronized full gradients for the independent DP oracle arm."""
     return {
-        name: _main_grad(parameter).detach().float().cpu().clone()
+        name: _main_grad(parameter).detach().cpu().clone()
         for name, parameter in _bank_parameters(bundle).items()
     }
 
@@ -509,13 +509,20 @@ def _bank_sync_absolute_oracle(
     """Reference FC as EP→expert-DP; attention as dense-DP only."""
     expected: dict[str, torch.Tensor] = {}
     for name, contribution in local_contributions.items():
-        value = contribution.to("cuda")
         if ".moe.experts._fc" in name:
+            bank_dtype = _bank_parameters(bundle)[name].dtype
+            assert bank_dtype is torch.bfloat16
+            assert contribution.dtype is torch.float32
+            value = contribution.to("cuda", dtype=bank_dtype)
             dist.all_reduce(value, group=bundle.parallel_state.ep_group)
+            value = value.float()
             dist.all_reduce(value, group=bundle.parallel_state.ep_dp_group)
             value.div_(bundle.parallel_state.expert_dp_size)
         else:
             assert ".attn." in name
+            assert contribution.dtype is torch.float32
+            value = contribution.to("cuda")
+            value = value.float()
             dist.all_reduce(value, group=bundle.parallel_state.dp_group)
             value.div_(bundle.parallel_state.dp_size)
         expected[name] = value.cpu()
@@ -642,6 +649,14 @@ def _run_unsynchronized_reference(
         return original_dispatch(*args, **kwargs)
 
     dispatcher.dispatch = capture_dispatch
+    _Qwen3MoEConfig, _model, protocol = _qwen_symbols()
+    original_sidecar = protocol.MoELoraSidecar
+
+    def disable_explicit_sync(*args, **kwargs):
+        kwargs["requires_explicit_ep_sync"] = False
+        return original_sidecar(*args, **kwargs)
+
+    protocol.MoELoraSidecar = disable_explicit_sync
     try:
         output = bundle.forward_step(chunk, batch)
         assert output["loss"].isfinite()
@@ -650,6 +665,7 @@ def _run_unsynchronized_reference(
         assert dispatch_calls == [True]
     finally:
         dispatcher.dispatch = original_dispatch
+        protocol.MoELoraSidecar = original_sidecar
     return float(output["loss"].detach().cpu()), _local_full_bank_contributions(bundle)
 
 
@@ -960,6 +976,7 @@ def test_production_builder_distopt_finalize_and_identity_roundtrip(tmp_path):
     assert manifest["topology"]["oracle"][dist.get_rank()]["tp"] == phase_config["tp"]
     assert manifest["topology"]["oracle"][dist.get_rank()]["ep"] == phase_config["ep"]
     assert manifest["topology"]["verify"] is None
+    local_contributions_by_rank = []
     for rank in range(phase_config["world"]):
         path = artifact_dir / f"ep2_bank_grads_rank_{rank:05d}.pt"
         assert _sha256(path) == manifest["oracle_files"][f"rank_{rank:05d}"]
@@ -973,7 +990,6 @@ def test_production_builder_distopt_finalize_and_identity_roundtrip(tmp_path):
     assert {
         name: _tensor_record(value) for name, value in oracle_grads.items()
     } == manifest["semantic_bank_tensors_by_rank"][dist.get_rank()]
-    local_contributions_by_rank = []
     for rank in range(phase_config["world"]):
         local_path = artifact_dir / f"ep2_local_bank_grads_rank_{rank:05d}.pt"
         local_contributions = torch.load(
@@ -1012,8 +1028,7 @@ def test_production_builder_distopt_finalize_and_identity_roundtrip(tmp_path):
     expected_batch = manifest["batch_by_rank"][dist.get_rank()]
     assert _batch_record(batch) == expected_batch
     for name, parameter in state.named_parameters():
-        is_fc = ".moe.experts._fc" in name
-        assert getattr(parameter, "allreduce", None) is (not is_fc)
+        _assert_model_owned_bank_allreduce(parameter, is_fc=".moe.experts._fc" in name)
     expected_keys = _expected_semantic_bank_keys(state)
     assert set(oracle_grads) == expected_keys == set(manifest["semantic_bank_keys"])
     _initialize_nonzero_banks(bundle)
@@ -1115,48 +1130,43 @@ def test_production_builder_distopt_finalize_and_identity_roundtrip(tmp_path):
         )
         torch.testing.assert_close(production_grads[name].cpu(), oracle, rtol=0, atol=0)
 
-    # This actual production-forward negative control restores explicit EP
-    # sync after clearing the correct arm's gradients.  It must double EP2.
+    # Production owns FC synchronization explicitly.  Disabling it is the
+    # negative control: FC must diverge while TP attention remains unchanged.
     _clear_gradients(bundle)
     original_sidecar = protocol.MoELoraSidecar
 
-    def force_explicit_sync(*args, **kwargs):
-        kwargs["requires_explicit_ep_sync"] = True
+    def disable_explicit_sync(*args, **kwargs):
+        kwargs["requires_explicit_ep_sync"] = False
         return original_sidecar(*args, **kwargs)
 
-    protocol.MoELoraSidecar = force_explicit_sync
+    protocol.MoELoraSidecar = disable_explicit_sync
     try:
-        _loss, doubled_grads = _run_production_forward_and_finalize(bundle, batch)
+        _loss, unsynced_grads = _run_production_forward_and_finalize(bundle, batch)
     finally:
         protocol.MoELoraSidecar = original_sidecar
-    assert set(doubled_grads) == expected_keys
-    live_bank_parameters = _bank_parameters(bundle)
-    observed_bf16_rounding = False
+    assert set(unsynced_grads) == expected_keys
     for name, oracle in oracle_grads.items():
-        # The legacy explicit all-reduce sums in the live BF16 bank dtype before
-        # the dist-opt reconstruction returns FP32 shards.  Preserve that exact
-        # operation order rather than using the FP32 mean oracle twice.
-        dtype = live_bank_parameters[name].dtype
-        assert dtype is torch.bfloat16
         if ".moe.experts._fc" in name:
-            explicit_expected = sum(
-                (
-                    contribution[name].to(dtype)
-                    for contribution in local_contributions_by_rank
-                )
-            ).float()
-            assert not torch.equal(explicit_expected, oracle)
-            observed_bf16_rounding |= bool(
-                torch.any(explicit_expected != oracle * 2).item()
+            group_ranks = tuple(
+                dist.get_process_group_ranks(bundle.parallel_state.ep_dp_group)
+            )
+            expected = (
+                sum(
+                    (
+                        local_contributions_by_rank[rank][name].float()
+                        for rank in group_ranks
+                    )
+                ).float()
+                / bundle.parallel_state.expert_dp_size
             )
             torch.testing.assert_close(
-                doubled_grads[name].cpu(), explicit_expected, rtol=0, atol=0
+                unsynced_grads[name].cpu(), expected, rtol=0, atol=0
             )
+            assert not torch.equal(expected, oracle), name
         else:
             torch.testing.assert_close(
-                doubled_grads[name].cpu(), oracle, rtol=0, atol=0
+                unsynced_grads[name].cpu(), oracle, rtol=0, atol=0
             )
-    assert observed_bf16_rounding
     for name, param in state.named_parameters():
         assert name.startswith("bank_") and "." not in name
     verify_topologies = [None] * phase_config["world"]

--- a/experimental/lite/tests/smoke/primitive/test_multi_lora_ep2_production_gpu.py
+++ b/experimental/lite/tests/smoke/primitive/test_multi_lora_ep2_production_gpu.py
@@ -323,6 +323,24 @@ def _bank_parameters(bundle) -> dict[str, torch.Tensor]:
     return parameters
 
 
+def _bank_surface_kind(bundle, parameter: torch.Tensor) -> str:
+    """Classify encoded bank parameters through the registry's native surface."""
+    state = bundle.extras["multi_lora_training_state"]
+    matches = []
+    for surface, bank in state.registry.banks.items():
+        if parameter is bank.a_bank or parameter is bank.b_bank:
+            matches.append(surface)
+    assert (
+        len(matches) == 1
+    ), f"bank parameter has ambiguous/missing registry surface: {matches}"
+    surface = matches[0]
+    if ".moe.experts._fc" in surface:
+        return "fc"
+    if ".attn." in surface:
+        return "attention"
+    raise AssertionError(f"unsupported model-owned bank surface: {surface}")
+
+
 def _run_bank_gradient_contract(bundle) -> None:
     """Exercise mixed token routing and inspect each semantic A/B slot axis."""
     state = bundle.extras["multi_lora_training_state"]
@@ -430,7 +448,7 @@ def _group_ranks(group) -> tuple[int, ...]:
 
 
 def _optimizer_param_range(
-    bundle, parameter: torch.Tensor, *, is_fc: bool
+    bundle, parameter: torch.Tensor
 ) -> tuple[int, object, object, object, object] | None:
     """Resolve this rank's optional dist-opt shard for one dense bank.
 
@@ -438,6 +456,7 @@ def _optimizer_param_range(
     a valid rank may own none of a small bank.  Global ownership is checked
     only after gathering the local records below.
     """
+    is_fc = _bank_surface_kind(bundle, parameter) == "fc"
     owners = [
         (index, child)
         for index, child in enumerate(_distributed_optimizer_leaves(bundle.optimizer))
@@ -486,7 +505,7 @@ def _assert_dense_owner_contract(
 ) -> None:
     """Prove every local shard maps to one dense leaf, never the EP child."""
     assert records, f"no distributed-optimizer shard found for semantic bank {name}"
-    is_fc = ".moe.experts._fc" in name
+    is_fc = _bank_surface_kind(bundle, _bank_parameters(bundle)[name]) == "fc"
     expected_ranks = _group_ranks(
         bundle.parallel_state.ep_dp_group if is_fc else bundle.parallel_state.dp_group
     )
@@ -509,7 +528,7 @@ def _bank_sync_absolute_oracle(
     """Reference FC as EP→expert-DP; attention as dense-DP only."""
     expected: dict[str, torch.Tensor] = {}
     for name, contribution in local_contributions.items():
-        if ".moe.experts._fc" in name:
+        if _bank_surface_kind(bundle, _bank_parameters(bundle)[name]) == "fc":
             bank_dtype = _bank_parameters(bundle)[name].dtype
             assert bank_dtype is torch.bfloat16
             assert contribution.dtype is torch.float32
@@ -519,7 +538,10 @@ def _bank_sync_absolute_oracle(
             dist.all_reduce(value, group=bundle.parallel_state.ep_dp_group)
             value.div_(bundle.parallel_state.expert_dp_size)
         else:
-            assert ".attn." in name
+            assert (
+                _bank_surface_kind(bundle, _bank_parameters(bundle)[name])
+                == "attention"
+            )
             assert contribution.dtype is torch.float32
             value = contribution.to("cuda")
             value = value.float()
@@ -529,9 +551,7 @@ def _bank_sync_absolute_oracle(
     expected_keys = set(local_contributions)
     local_factors: dict[str, dict[str, object]] = {}
     for name, parameter in _bank_parameters(bundle).items():
-        owned = _optimizer_param_range(
-            bundle, parameter, is_fc=".moe.experts._fc" in name
-        )
+        owned = _optimizer_param_range(bundle, parameter)
         if owned is None:
             continue
         leaf_index, owner, _param_range, buffer, bucket = owned
@@ -544,7 +564,7 @@ def _bank_sync_absolute_oracle(
     optimizer_expected: dict[str, torch.Tensor] = {}
     factors: dict[str, float] = {}
     for name in sorted(expected_keys):
-        is_fc = ".moe.experts._fc" in name
+        is_fc = _bank_surface_kind(bundle, _bank_parameters(bundle)[name]) == "fc"
         expected_factor = 1.0 / (
             bundle.parallel_state.expert_dp_size
             if is_fc
@@ -571,7 +591,7 @@ def _reconstruct_optimizer_owned_bank_grads(bundle) -> dict[str, torch.Tensor]:
     reconstructed: dict[str, torch.Tensor] = {}
     for name in sorted(parameters):
         parameter = parameters[name]
-        is_fc = ".moe.experts._fc" in name
+        is_fc = _bank_surface_kind(bundle, parameter) == "fc"
         group = (
             bundle.parallel_state.ep_dp_group
             if is_fc
@@ -581,7 +601,7 @@ def _reconstruct_optimizer_owned_bank_grads(bundle) -> dict[str, torch.Tensor]:
         # Ownership metadata is local and may be absent.  Never raise before
         # the owner group has collectively observed every rank's result.
         try:
-            owned = _optimizer_param_range(bundle, parameter, is_fc=is_fc)
+            owned = _optimizer_param_range(bundle, parameter)
             if owned is not None:
                 leaf_index, owner, param_range, buffer, bucket = owned
                 reduced = bucket.grad_data.view(-1)[
@@ -1028,7 +1048,9 @@ def test_production_builder_distopt_finalize_and_identity_roundtrip(tmp_path):
     expected_batch = manifest["batch_by_rank"][dist.get_rank()]
     assert _batch_record(batch) == expected_batch
     for name, parameter in state.named_parameters():
-        _assert_model_owned_bank_allreduce(parameter, is_fc=".moe.experts._fc" in name)
+        _assert_model_owned_bank_allreduce(
+            parameter, is_fc=_bank_surface_kind(bundle, parameter) == "fc"
+        )
     expected_keys = _expected_semantic_bank_keys(state)
     assert set(oracle_grads) == expected_keys == set(manifest["semantic_bank_keys"])
     _initialize_nonzero_banks(bundle)
@@ -1146,7 +1168,7 @@ def test_production_builder_distopt_finalize_and_identity_roundtrip(tmp_path):
         protocol.MoELoraSidecar = original_sidecar
     assert set(unsynced_grads) == expected_keys
     for name, oracle in oracle_grads.items():
-        if ".moe.experts._fc" in name:
+        if _bank_surface_kind(bundle, _bank_parameters(bundle)[name]) == "fc":
             group_ranks = tuple(
                 dist.get_process_group_ranks(bundle.parallel_state.ep_dp_group)
             )

--- a/experimental/lite/tests/unit/primitive/test_lora_tp_gradients.py
+++ b/experimental/lite/tests/unit/primitive/test_lora_tp_gradients.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -784,3 +785,14 @@ def test_optimizer_owned_bank_owner_error_is_visible_to_every_rank_gloo(tmp_path
     ]
     if init_file.exists():
         os.unlink(init_file)
+
+
+def test_model_owned_bank_allreduce_is_explicit_and_bool_like():
+    from experimental.lite.tests.smoke.primitive.test_multi_lora_ep2_production_gpu import (
+        _assert_model_owned_bank_allreduce,
+    )
+
+    _assert_model_owned_bank_allreduce(SimpleNamespace(allreduce=1), is_fc=False)
+    _assert_model_owned_bank_allreduce(SimpleNamespace(allreduce=0), is_fc=True)
+    with pytest.raises(AssertionError, match="missing allreduce"):
+        _assert_model_owned_bank_allreduce(SimpleNamespace(), is_fc=False)

--- a/experimental/lite/tests/unit/primitive/test_lora_tp_gradients.py
+++ b/experimental/lite/tests/unit/primitive/test_lora_tp_gradients.py
@@ -22,6 +22,7 @@ from megatron.lite.primitive.modules.multi_lora_bank import (
     LoraBankPartition,
     apply_batched_lora_delta,
 )
+from megatron.lite.model.qwen3_moe.lite.multi_lora import _AllReduceGradient
 
 pytestmark = [pytest.mark.mlite, pytest.mark.distributed]
 
@@ -582,5 +583,64 @@ def test_multi_lora_proj_tp2_sp_matches_tp1_forward_and_gradients(tmp_path):
     for result in results:
         for key in ("forward", "x", "a", "b"):
             assert result[key] <= 3e-6, results
+    if init_file.exists():
+        os.unlink(init_file)
+
+
+def _tp2_ep2_bank_ownership_worker(rank, world_size, init_file, queue):
+    dist.init_process_group(
+        "gloo", init_method=f"file://{init_file}", rank=rank, world_size=world_size
+    )
+    try:
+        # Create every group in identical global order, then select ownership.
+        group01 = dist.new_group([0, 1])
+        group23 = dist.new_group([2, 3])
+        group02 = dist.new_group([0, 2])
+        group13 = dist.new_group([1, 3])
+        ep = group01 if rank < 2 else group23
+        dp = group02 if rank in (0, 2) else group13
+        fc = torch.tensor(float(rank + 1), requires_grad=True)
+        attn = torch.tensor(float(rank + 1), requires_grad=True)
+        (_AllReduceGradient.apply(fc, ep) * (rank + 1)).backward()
+        (attn * (rank + 1)).backward()
+        fc_grad, attn_grad = fc.grad.clone(), attn.grad.clone()
+        old_fc = torch.tensor(float(rank + 1))
+        dist.all_reduce(old_fc, group=dp)
+        old_fc.div_(2)
+        dist.all_reduce(fc_grad, group=dp)
+        fc_grad.div_(2)
+        dist.all_reduce(attn_grad, group=dp)
+        attn_grad.div_(2)
+        queue.put(
+            (
+                rank,
+                fc_grad.item(),
+                attn_grad.item(),
+                old_fc.item(),
+                tuple(dist.get_process_group_ranks(ep)),
+                tuple(dist.get_process_group_ranks(dp)),
+            )
+        )
+    finally:
+        dist.destroy_process_group()
+
+
+def test_tp2_ep2_bank_ownership_uses_ep_then_expert_dp_for_fc_only(tmp_path):
+    init_file = tmp_path / "tp2-ep2-bank-ownership"
+    queue = mp.get_context("spawn").SimpleQueue()
+    mp.spawn(
+        _tp2_ep2_bank_ownership_worker,
+        args=(4, str(init_file), queue),
+        nprocs=4,
+        join=True,
+    )
+    results = sorted((queue.get() for _ in range(4)))
+    assert [row[1:4] for row in results] == [
+        (5.0, 2.0, 2.0),
+        (5.0, 3.0, 3.0),
+        (5.0, 2.0, 2.0),
+        (5.0, 3.0, 3.0),
+    ]
+    assert all(row[1] != row[3] for row in results)
     if init_file.exists():
         os.unlink(init_file)

--- a/experimental/lite/tests/unit/primitive/test_lora_tp_gradients.py
+++ b/experimental/lite/tests/unit/primitive/test_lora_tp_gradients.py
@@ -10,6 +10,7 @@ import pytest
 import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
+from megatron.lite.model.qwen3_moe.lite.multi_lora import _AllReduceGradient
 from megatron.lite.primitive.modules import multi_lora_kernel
 from megatron.lite.primitive.modules.lora import (
     LinearLoRA,
@@ -23,7 +24,6 @@ from megatron.lite.primitive.modules.multi_lora_bank import (
     LoraBankPartition,
     apply_batched_lora_delta,
 )
-from megatron.lite.model.qwen3_moe.lite.multi_lora import _AllReduceGradient
 
 pytestmark = [pytest.mark.mlite, pytest.mark.distributed]
 
@@ -562,6 +562,9 @@ def _multi_lora_proj_tp_worker(rank, world_size, init_file, queue):
         queue.put(
             {
                 "rank": rank,
+                "input_rows": x_local.shape[0],
+                "slot_rows": slots.numel(),
+                "output_rows": actual.shape[0],
                 "forward": (actual - y_ref[token_slice]).abs().max().item(),
                 "x": (x_local.grad - x_ref.grad[:, input_slice]).abs().max().item(),
                 "a": (a_local.grad - a_ref.grad[:, :, input_slice]).abs().max().item(),
@@ -584,6 +587,22 @@ def test_multi_lora_proj_tp2_sp_matches_tp1_forward_and_gradients(tmp_path):
     for result in results:
         for key in ("forward", "x", "a", "b"):
             assert result[key] <= 3e-6, results
+    if init_file.exists():
+        os.unlink(init_file)
+
+
+def test_attention_proj_tp2_sp_keeps_logical_slots_until_scatter(tmp_path):
+    """Row-parallel attention O-proj consumes global rows then SP-scatters output."""
+    init_file = tmp_path / "attention-proj-tp2-sp-slots"
+    queue = mp.get_context("spawn").SimpleQueue()
+    mp.spawn(
+        _multi_lora_proj_tp_worker, args=(2, str(init_file), queue), nprocs=2, join=True
+    )
+    results = sorted((queue.get() for _ in range(2)), key=lambda result: result["rank"])
+    for result in results:
+        assert result["input_rows"] == result["slot_rows"] == 4
+        assert result["output_rows"] == 2
+        assert result["forward"] <= 3e-6
     if init_file.exists():
         os.unlink(init_file)
 

--- a/experimental/lite/tests/unit/primitive/test_lora_tp_gradients.py
+++ b/experimental/lite/tests/unit/primitive/test_lora_tp_gradients.py
@@ -9,8 +9,19 @@ import pytest
 import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
-from megatron.lite.primitive.modules.lora import LinearLoRA, SharedGroupedLinearLoRA
+from megatron.lite.primitive.modules import multi_lora_kernel
+from megatron.lite.primitive.modules.lora import (
+    LinearLoRA,
+    SharedGroupedLinearLoRA,
+    _all_gather_last_dim,
+    _gather_sequence_parallel,
+)
 from megatron.lite.primitive.modules.lora_apply import LoRAWrappedLinear
+from megatron.lite.primitive.modules.multi_lora_bank import (
+    DenseLoraBank,
+    LoraBankPartition,
+    apply_batched_lora_delta,
+)
 
 pytestmark = [pytest.mark.mlite, pytest.mark.distributed]
 
@@ -317,5 +328,189 @@ def test_qkv_tp2_sp_uses_base_normalized_input_and_matches_merged_export(tmp_pat
         assert result["merged_forward"] < 1e-12
         assert result["materialized_delta"] < 1e-12
 
+    if init_file.exists():
+        os.unlink(init_file)
+
+
+def _multi_lora_qkv_tp_worker(
+    rank: int, world_size: int, init_file: str, queue
+) -> None:
+    dist.init_process_group(
+        "gloo", init_method=f"file://{init_file}", rank=rank, world_size=world_size
+    )
+    try:
+        torch.manual_seed(20260809)
+        tokens, hidden, out_features, lora_rank = 4, 4, 6, 4
+        slots = torch.tensor([0, 0, 1, 1], dtype=torch.int64)
+        x_full = torch.randn(tokens, hidden, dtype=torch.float32)
+        a_full = torch.randn(2, lora_rank, hidden, dtype=torch.float32)
+        b_full = torch.randn(2, out_features, lora_rank, dtype=torch.float32)
+        grad_full = torch.randn(tokens, out_features, dtype=torch.float32)
+
+        x_ref = x_full.clone().requires_grad_(True)
+        a_ref = a_full.clone().requires_grad_(True)
+        b_ref = b_full.clone().requires_grad_(True)
+        # The production carrier retains the established BGMV FP32 A-stage
+        # scratch before the rank gather, including when its inputs are FP64
+        # in this CPU oracle.
+        y_ref = apply_batched_lora_delta(
+            DenseLoraBank(a_ref, b_ref), x_ref, slots, scale=1.0
+        )
+        (y_ref * grad_full).sum().backward()
+
+        local_rank = lora_rank // world_size
+        local_out = out_features // world_size
+        token_slice = slice(
+            rank * (tokens // world_size), (rank + 1) * (tokens // world_size)
+        )
+        rank_slice = slice(rank * local_rank, (rank + 1) * local_rank)
+        out_slice = slice(rank * local_out, (rank + 1) * local_out)
+        a_local = a_full[:, rank_slice].clone().requires_grad_(True)
+        b_local = b_full[:, out_slice].clone().requires_grad_(True)
+        x_local = x_full[token_slice].clone().requires_grad_(True)
+        bank = DenseLoraBank(
+            a_local,
+            b_local,
+            LoraBankPartition(tp_size=world_size, rank_partitioned_a=True),
+        )
+        actual = apply_batched_lora_delta(
+            bank,
+            x_local,
+            slots[token_slice],
+            scale=1.0,
+            tp_group=dist.group.WORLD,
+            sequence_parallel_input=True,
+        )
+        (actual * grad_full[:, out_slice]).sum().backward()
+        queue.put(
+            {
+                "rank": rank,
+                "forward": (actual - y_ref[:, out_slice]).abs().max().item(),
+                "x_grad": (x_local.grad - x_ref.grad[token_slice]).abs().max().item(),
+                "a_grad": (a_local.grad - a_ref.grad[:, rank_slice]).abs().max().item(),
+                "b_grad": (b_local.grad - b_ref.grad[:, out_slice]).abs().max().item(),
+            }
+        )
+    finally:
+        dist.destroy_process_group()
+
+
+def _multi_lora_qkv_tp_backward_probe_worker(
+    rank: int, world_size: int, init_file: str, queue
+) -> None:
+    """Isolate the hidden all-gather backward before changing production."""
+    dist.init_process_group(
+        "gloo", init_method=f"file://{init_file}", rank=rank, world_size=world_size
+    )
+    try:
+        torch.manual_seed(20260810)
+        slots = torch.tensor([0, 0, 1, 1], dtype=torch.int64)
+        x_full = torch.randn(4, 4)
+        a_full = torch.randn(2, 4, 4)
+        b_full = torch.randn(2, 6, 4)
+        grad_full = torch.randn(4, 6)
+        token_slice = slice(rank * 2, (rank + 1) * 2)
+        rank_slice = slice(rank * 2, (rank + 1) * 2)
+        out_slice = slice(rank * 3, (rank + 1) * 3)
+        rows = _gather_sequence_parallel(
+            x_full[token_slice].clone().requires_grad_(), dist.group.WORLD
+        )
+        hidden = multi_lora_kernel.batched_lora_linear_stage(
+            rows,
+            a_full[:, rank_slice].clone().requires_grad_(),
+            slots,
+            output_dtype=torch.float32,
+            max_g_size_hint=4,
+        )
+        hidden.retain_grad()
+        hidden_full = _all_gather_last_dim(
+            hidden, dist.group.WORLD, reduce_backward=True
+        )
+        out = multi_lora_kernel.batched_lora_linear_stage(
+            hidden_full,
+            b_full[:, out_slice].clone().requires_grad_(),
+            slots,
+            max_g_size_hint=4,
+        )
+        (out * grad_full[:, out_slice]).sum().backward()
+        expected = torch.stack(
+            [b_full[slot].t() @ grad for slot, grad in zip(slots, grad_full)]
+        )[:, rank_slice]
+        queue.put({"rank": rank, "hidden": (hidden.grad - expected).abs().max().item()})
+    finally:
+        dist.destroy_process_group()
+
+
+def test_multi_lora_qkv_tp2_probe_hidden_gather_backward(tmp_path):
+    world_size = 2
+    init_file = tmp_path / "multi-lora-qkv-tp-probe-init"
+    queue = mp.get_context("spawn").SimpleQueue()
+    mp.spawn(
+        _multi_lora_qkv_tp_backward_probe_worker,
+        args=(world_size, str(init_file), queue),
+        nprocs=world_size,
+        join=True,
+    )
+    results = sorted(
+        (queue.get() for _ in range(world_size)), key=lambda item: item["rank"]
+    )
+    assert [item["hidden"] for item in results] == pytest.approx([0.0, 0.0], abs=1e-6)
+    if init_file.exists():
+        os.unlink(init_file)
+
+
+def _all_gather_last_dim_no_reduce_worker(rank, world_size, init_file, queue):
+    dist.init_process_group(
+        "gloo", init_method=f"file://{init_file}", rank=rank, world_size=world_size
+    )
+    try:
+        local = (
+            torch.arange(4, dtype=torch.float32)
+            .reshape(2, 2)
+            .add_(rank * 10)
+            .requires_grad_()
+        )
+        gathered = _all_gather_last_dim(local, dist.group.WORLD, reduce_backward=False)
+        grad = torch.arange(gathered.numel(), dtype=torch.float32).reshape_as(gathered)
+        (gathered * grad).sum().backward()
+        expected = grad[:, rank * 2 : (rank + 1) * 2]
+        queue.put((rank, (local.grad - expected).abs().max().item()))
+    finally:
+        dist.destroy_process_group()
+
+
+def test_all_gather_last_dim_tp2_without_reduce_backward_returns_local_chunk(tmp_path):
+    init_file = tmp_path / "all-gather-last-dim-no-reduce-init"
+    queue = mp.get_context("spawn").SimpleQueue()
+    mp.spawn(
+        _all_gather_last_dim_no_reduce_worker,
+        args=(2, str(init_file), queue),
+        nprocs=2,
+        join=True,
+    )
+    assert [
+        error for _, error in sorted(queue.get() for _ in range(2))
+    ] == pytest.approx([0.0, 0.0])
+    if init_file.exists():
+        os.unlink(init_file)
+
+
+def test_multi_lora_qkv_tp2_sp_matches_tp1_forward_and_gradients(tmp_path):
+    """The bank carrier must retain the single-LoRA QKV TP/SP contract."""
+    world_size = 2
+    init_file = tmp_path / "multi-lora-qkv-tp-init"
+    queue = mp.get_context("spawn").SimpleQueue()
+    mp.spawn(
+        _multi_lora_qkv_tp_worker,
+        args=(world_size, str(init_file), queue),
+        nprocs=world_size,
+        join=True,
+    )
+    results = sorted(
+        (queue.get() for _ in range(world_size)), key=lambda result: result["rank"]
+    )
+    for result in results:
+        for key in ("forward", "x_grad", "a_grad", "b_grad"):
+            assert result[key] < 1e-6, results
     if init_file.exists():
         os.unlink(init_file)

--- a/experimental/lite/tests/unit/primitive/test_lora_tp_gradients.py
+++ b/experimental/lite/tests/unit/primitive/test_lora_tp_gradients.py
@@ -796,3 +796,67 @@ def test_model_owned_bank_allreduce_is_explicit_and_bool_like():
     _assert_model_owned_bank_allreduce(SimpleNamespace(allreduce=0), is_fc=True)
     with pytest.raises(AssertionError, match="missing allreduce"):
         _assert_model_owned_bank_allreduce(SimpleNamespace(), is_fc=False)
+
+
+def test_encoded_bank_parameter_uses_registry_surface_metadata():
+    from experimental.lite.tests.smoke.primitive.test_multi_lora_ep2_production_gpu import (
+        _bank_surface_kind,
+    )
+
+    fc_a, fc_b, attn_a, attn_b = (torch.tensor(float(index)) for index in range(4))
+    state = SimpleNamespace(
+        registry=SimpleNamespace(
+            banks={
+                "layers.0.moe.experts._fc1_weight_0": SimpleNamespace(
+                    a_bank=fc_a, b_bank=fc_b
+                ),
+                "layers.0.attn.qkv.linear.weight": SimpleNamespace(
+                    a_bank=attn_a, b_bank=attn_b
+                ),
+            }
+        )
+    )
+    bundle = SimpleNamespace(extras={"multi_lora_training_state": state})
+    encoded = {
+        "bank_66635f615f5f_a": fc_a,
+        "bank_66635f625f5f_b": fc_b,
+        "bank_6174746e5f615f_a": attn_a,
+        "bank_6174746e5f625f_b": attn_b,
+    }
+    assert all(
+        ".moe.experts._fc" not in name and ".attn." not in name for name in encoded
+    )
+    assert [
+        _bank_surface_kind(bundle, parameter) for parameter in encoded.values()
+    ] == ["fc", "fc", "attention", "attention"]
+
+
+@pytest.mark.parametrize(
+    "surfaces, message",
+    [
+        ({}, "ambiguous/missing"),
+        ({"x": None, "y": None}, "ambiguous/missing"),
+        ({"layers.0.other": None}, "unsupported"),
+    ],
+)
+def test_bank_surface_metadata_fails_loud_for_missing_ambiguous_or_unsupported(
+    surfaces, message
+):
+    from experimental.lite.tests.smoke.primitive.test_multi_lora_ep2_production_gpu import (
+        _bank_surface_kind,
+    )
+
+    parameter = torch.tensor(1.0)
+    banks = {
+        surface: SimpleNamespace(a_bank=parameter, b_bank=torch.tensor(2.0))
+        for surface in surfaces
+    }
+    bundle = SimpleNamespace(
+        extras={
+            "multi_lora_training_state": SimpleNamespace(
+                registry=SimpleNamespace(banks=banks)
+            )
+        }
+    )
+    with pytest.raises(AssertionError, match=message):
+        _bank_surface_kind(bundle, parameter)

--- a/experimental/lite/tests/unit/primitive/test_lora_tp_gradients.py
+++ b/experimental/lite/tests/unit/primitive/test_lora_tp_gradients.py
@@ -514,3 +514,73 @@ def test_multi_lora_qkv_tp2_sp_matches_tp1_forward_and_gradients(tmp_path):
             assert result[key] < 1e-6, results
     if init_file.exists():
         os.unlink(init_file)
+
+
+def _multi_lora_proj_tp_worker(rank, world_size, init_file, queue):
+    dist.init_process_group(
+        "gloo", init_method=f"file://{init_file}", rank=rank, world_size=world_size
+    )
+    try:
+        torch.manual_seed(20260811)
+        tokens, hidden, local_in, lora_rank = 4, 4, 2, 4
+        slots = torch.tensor([0, 0, 1, 1], dtype=torch.long)
+        x_full = torch.randn(tokens, hidden)
+        a_full = torch.randn(2, lora_rank, hidden)
+        b_full = torch.randn(2, hidden, lora_rank)
+        grad_full = torch.randn(tokens, hidden)
+        x_ref, a_ref, b_ref = (
+            value.clone().requires_grad_() for value in (x_full, a_full, b_full)
+        )
+        y_ref = apply_batched_lora_delta(
+            DenseLoraBank(a_ref, b_ref), x_ref, slots, scale=1.0
+        )
+        (y_ref * grad_full).sum().backward()
+        token_slice, input_slice, output_slice = (
+            slice(rank * 2, (rank + 1) * 2),
+            slice(rank * local_in, (rank + 1) * local_in),
+            slice(rank * local_in, (rank + 1) * local_in),
+        )
+        x_local = x_full[:, input_slice].clone().requires_grad_()
+        a_local = a_full[:, :, input_slice].clone().requires_grad_()
+        b_local = b_full[:, output_slice].clone().requires_grad_()
+        bank = DenseLoraBank(
+            a_local, b_local, LoraBankPartition(tp_size=2, output_partitioned_b=True)
+        )
+        actual = apply_batched_lora_delta(
+            bank,
+            x_local,
+            slots,
+            scale=1.0,
+            tp_group=dist.group.WORLD,
+            tp_rank=rank,
+            input_parallel_reduce=True,
+            sequence_parallel_scatter_output=True,
+        )
+        (actual * grad_full[token_slice]).sum().backward()
+        queue.put(
+            {
+                "rank": rank,
+                "forward": (actual - y_ref[token_slice]).abs().max().item(),
+                "x": (x_local.grad - x_ref.grad[:, input_slice]).abs().max().item(),
+                "a": (a_local.grad - a_ref.grad[:, :, input_slice]).abs().max().item(),
+                "b": (b_local.grad - b_ref.grad[:, output_slice]).abs().max().item(),
+            }
+        )
+    finally:
+        dist.destroy_process_group()
+
+
+def test_multi_lora_proj_tp2_sp_matches_tp1_forward_and_gradients(tmp_path):
+    init_file = tmp_path / "multi-lora-proj-tp-init"
+    queue = mp.get_context("spawn").SimpleQueue()
+    mp.spawn(
+        _multi_lora_proj_tp_worker, args=(2, str(init_file), queue), nprocs=2, join=True
+    )
+    results = sorted((queue.get() for _ in range(2)), key=lambda result: result["rank"])
+    # TP and TP1 sum FP32 contractions in a different legal order.  This
+    # permits a few ULP on x/A while forward and B remain exact.
+    for result in results:
+        for key in ("forward", "x", "a", "b"):
+            assert result[key] <= 3e-6, results
+    if init_file.exists():
+        os.unlink(init_file)

--- a/experimental/lite/tests/unit/primitive/test_lora_tp_gradients.py
+++ b/experimental/lite/tests/unit/primitive/test_lora_tp_gradients.py
@@ -644,3 +644,143 @@ def test_tp2_ep2_bank_ownership_uses_ep_then_expert_dp_for_fc_only(tmp_path):
     assert all(row[1] != row[3] for row in results)
     if init_file.exists():
         os.unlink(init_file)
+
+
+def _optimizer_owned_bank_gather_worker(rank, world_size, init_file, queue):
+    dist.init_process_group(
+        "gloo", init_method=f"file://{init_file}", rank=rank, world_size=world_size
+    )
+    try:
+        from experimental.lite.tests.smoke.primitive.test_multi_lora_ep2_production_gpu import (
+            _gather_optimizer_owned_bank_shards,
+        )
+
+        # Rank one owns no reduce-scatter range; it must nevertheless issue
+        # the same world all_gather_object as rank zero.
+        local = (
+            {"error": None, "shard": {"bank_a": {"rank": rank}}}
+            if rank == 0
+            else {"error": None, "shard": None}
+        )
+        gathered = _gather_optimizer_owned_bank_shards(local, group=dist.group.WORLD)
+        queue.put((rank, gathered))
+    finally:
+        dist.destroy_process_group()
+
+
+def test_optimizer_owned_bank_reconstruction_gathers_non_owner_gloo(tmp_path):
+    init_file = tmp_path / "optimizer-owned-bank-gather"
+    queue = mp.get_context("spawn").SimpleQueue()
+    mp.spawn(
+        _optimizer_owned_bank_gather_worker,
+        args=(2, str(init_file), queue),
+        nprocs=2,
+        join=True,
+    )
+    results = sorted((queue.get() for _ in range(2)))
+    assert results == [
+        (
+            0,
+            [
+                {"error": None, "shard": {"bank_a": {"rank": 0}}},
+                {"error": None, "shard": None},
+            ],
+        ),
+        (
+            1,
+            [
+                {"error": None, "shard": {"bank_a": {"rank": 0}}},
+                {"error": None, "shard": None},
+            ],
+        ),
+    ]
+    if init_file.exists():
+        os.unlink(init_file)
+
+
+def _owner_group_gather_worker(rank, world_size, init_file, queue):
+    dist.init_process_group(
+        "gloo", init_method=f"file://{init_file}", rank=rank, world_size=world_size
+    )
+    try:
+        from experimental.lite.tests.smoke.primitive.test_multi_lora_ep2_production_gpu import (
+            _gather_optimizer_owned_bank_shards,
+        )
+
+        group02 = dist.new_group([0, 2])
+        group13 = dist.new_group([1, 3])
+        lane = group02 if rank in (0, 2) else group13
+        # Same semantic name has a distinct owner/value in each EDP lane.
+        owner = rank in (0, 1)
+        local = (
+            {
+                "error": None,
+                "shard": {"bank": "fc1_a", "lane": 0 if rank in (0, 2) else 1},
+            }
+            if owner
+            else {"error": None, "shard": None}
+        )
+        gathered = _gather_optimizer_owned_bank_shards(local, group=lane)
+        queue.put((rank, gathered))
+    finally:
+        dist.destroy_process_group()
+
+
+def test_optimizer_owned_bank_gather_isolates_ep_dp_lanes_gloo(tmp_path):
+    init_file = tmp_path / "owner-group-lanes"
+    queue = mp.get_context("spawn").SimpleQueue()
+    mp.spawn(
+        _owner_group_gather_worker, args=(4, str(init_file), queue), nprocs=4, join=True
+    )
+    results = dict(queue.get() for _ in range(4))
+    assert (
+        results[0]
+        == results[2]
+        == [
+            {"error": None, "shard": {"bank": "fc1_a", "lane": 0}},
+            {"error": None, "shard": None},
+        ]
+    )
+    assert (
+        results[1]
+        == results[3]
+        == [
+            {"error": None, "shard": {"bank": "fc1_a", "lane": 1}},
+            {"error": None, "shard": None},
+        ]
+    )
+    if init_file.exists():
+        os.unlink(init_file)
+
+
+def _owner_group_error_worker(rank, world_size, init_file, queue):
+    dist.init_process_group(
+        "gloo", init_method=f"file://{init_file}", rank=rank, world_size=world_size
+    )
+    try:
+        from experimental.lite.tests.smoke.primitive.test_multi_lora_ep2_production_gpu import (
+            _gather_optimizer_owned_bank_shards,
+        )
+
+        record = {
+            "error": "AssertionError: malformed owner" if rank == 0 else None,
+            "shard": None,
+        }
+        gathered = _gather_optimizer_owned_bank_shards(record, group=dist.group.WORLD)
+        queue.put((rank, [item["error"] for item in gathered]))
+    finally:
+        dist.destroy_process_group()
+
+
+def test_optimizer_owned_bank_owner_error_is_visible_to_every_rank_gloo(tmp_path):
+    init_file = tmp_path / "owner-group-error"
+    queue = mp.get_context("spawn").SimpleQueue()
+    mp.spawn(
+        _owner_group_error_worker, args=(2, str(init_file), queue), nprocs=2, join=True
+    )
+    assert sorted(queue.get() for _ in range(2)) == [
+        (0, ["AssertionError: malformed owner", None]),
+        (1, ["AssertionError: malformed owner", None]),
+    ]
+    if init_file.exists():
+        os.unlink(init_file)

--- a/experimental/lite/tests/unit/primitive/test_multi_lora_owner_groups_gloo_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_multi_lora_owner_groups_gloo_unit.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""CPU Gloo contracts for multi-LoRA dist-opt bank owner groups."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from megatron.lite.primitive.distributed_test_utils import (
+    gather_owner_factor_records_or_raise,
+    select_lora_bank_owner_group,
+)
+from megatron.lite.primitive.parallel import init_parallel
+
+
+def _init_gloo(rank: int, world: int, init_file: str) -> None:
+    dist.init_process_group(
+        "gloo", init_method=f"file://{init_file}", rank=rank, world_size=world
+    )
+
+
+def _tp2_ep2_factor_lane_worker(rank: int, world: int, init_file: str) -> None:
+    _init_gloo(rank, world, init_file)
+    try:
+        ps = init_parallel(SimpleNamespace(tp=2, ep=2, etp=1, cp=1, pp=1))
+        # Attention and FC banks select their distinct owner groups.
+        expected_dp = (0, 2) if rank % 2 == 0 else (1, 3)
+        expected_ep = (0, 1) if rank < 2 else (2, 3)
+        attention_group = select_lora_bank_owner_group(ps, is_expert_bank=False)
+        fc_group = select_lora_bank_owner_group(ps, is_expert_bank=True)
+        assert attention_group is ps.dp_group
+        assert fc_group is ps.ep_dp_group
+        assert tuple(dist.get_process_group_ranks(attention_group)) == expected_dp
+        assert tuple(dist.get_process_group_ranks(fc_group)) == expected_dp
+        assert tuple(dist.get_process_group_ranks(ps.ep_group)) == expected_ep
+
+        # This mirrors the oracle's fixed collection: gather factor records
+        # within the bank's owner lane, never over WORLD then cross-checking
+        # records from the other legal TP lane.  Each lane has one optimizer
+        # owner and one legal no-shard member.
+        def validate_records(values) -> None:
+            assert len(values) == 1
+            assert values[0]["factor"] == 0.5
+
+        records = gather_owner_factor_records_or_raise(
+            attention_group,
+            lambda: {"rank": rank, "factor": 0.5} if rank < 2 else None,
+            validate_records,
+        )
+        assert records == [{"rank": min(expected_dp), "factor": 0.5}]
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.distributed
+def test_tp2_ep2_factor_records_do_not_mix_dp_lanes_gloo(tmp_path):
+    torch.multiprocessing.spawn(
+        _tp2_ep2_factor_lane_worker,
+        args=(4, str(tmp_path / "tp2_ep2_factor_lanes")),
+        nprocs=4,
+        join=True,
+    )
+
+
+def _malformed_factor_worker(rank: int, world: int, init_file: str) -> None:
+    _init_gloo(rank, world, init_file)
+    try:
+        ps = init_parallel(SimpleNamespace(tp=2, ep=2, etp=1, cp=1, pp=1))
+        owner_group = select_lora_bank_owner_group(ps, is_expert_bank=False)
+
+        def build_record():
+            if rank == 0:
+                raise AssertionError("malformed local factor metadata")
+            return {"rank": rank, "factor": 0.5}
+
+        try:
+            gather_owner_factor_records_or_raise(
+                owner_group, build_record, lambda values: None
+            )
+        except RuntimeError as error:
+            result = str(error)
+        else:
+            result = None
+        expected = (
+            "owner-group factor validation failed: RuntimeError: AssertionError: "
+            "malformed local factor metadata"
+        )
+        assert result == expected
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.distributed
+def test_malformed_owner_factor_record_fails_the_whole_world_without_hanging_gloo(
+    tmp_path,
+):
+    torch.multiprocessing.spawn(
+        _malformed_factor_worker,
+        args=(4, str(tmp_path / "malformed_factor_lane")),
+        nprocs=4,
+        join=True,
+    )
+
+
+def _owner_boundary_worker(
+    rank: int, world: int, init_file: str, tp: int, ep: int
+) -> None:
+    _init_gloo(rank, world, init_file)
+    try:
+        ps = init_parallel(SimpleNamespace(tp=tp, ep=ep, etp=1, cp=1, pp=1))
+        attention_group = select_lora_bank_owner_group(ps, is_expert_bank=False)
+        fc_group = select_lora_bank_owner_group(ps, is_expert_bank=True)
+        assert attention_group is ps.dp_group
+        assert fc_group is ps.ep_dp_group
+        expected_attention = 1 if (tp, ep) == (2, 1) else 2
+        expected_fc = 2 if (tp, ep) == (2, 1) else 1
+        assert dist.get_world_size(attention_group) == expected_attention
+        assert dist.get_world_size(fc_group) == expected_fc
+
+        def validate_attention(values) -> None:
+            assert len(values) == expected_attention
+
+        def validate_fc(values) -> None:
+            assert len(values) == expected_fc
+
+        attention_records = gather_owner_factor_records_or_raise(
+            attention_group, lambda: {"rank": rank, "factor": 0.5}, validate_attention
+        )
+        fc_records = gather_owner_factor_records_or_raise(
+            fc_group, lambda: {"rank": rank, "factor": 0.5}, validate_fc
+        )
+        assert all(record["factor"] == 0.5 for record in attention_records)
+        assert all(record["factor"] == 0.5 for record in fc_records)
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.distributed
+@pytest.mark.parametrize(("tp", "ep"), [(2, 1), (1, 2)])
+def test_attention_and_fc_owner_groups_cover_tp_ep_boundaries_gloo(tmp_path, tp, ep):
+    torch.multiprocessing.spawn(
+        _owner_boundary_worker,
+        args=(2, str(tmp_path / f"tp{tp}_ep{ep}_owner_boundary"), tp, ep),
+        nprocs=2,
+        join=True,
+    )

--- a/experimental/lite/tests/unit/primitive/test_multi_lora_owner_groups_gloo_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_multi_lora_owner_groups_gloo_unit.py
@@ -10,7 +10,10 @@ import torch
 import torch.distributed as dist
 
 from megatron.lite.primitive.distributed_test_utils import (
+    build_lora_collective_descriptor,
+    canonical_lora_bank_names,
     gather_owner_factor_records_or_raise,
+    preflight_lora_bank_collective_order,
     select_lora_bank_owner_group,
 )
 from megatron.lite.primitive.parallel import init_parallel
@@ -145,5 +148,283 @@ def test_attention_and_fc_owner_groups_cover_tp_ep_boundaries_gloo(tmp_path, tp,
         _owner_boundary_worker,
         args=(2, str(tmp_path / f"tp{tp}_ep{ep}_owner_boundary"), tp, ep),
         nprocs=2,
+        join=True,
+    )
+
+
+def test_canonical_lora_bank_names_stabilize_rank_local_insertion_order():
+    """Every rank must enter mixed FC/attention collectives in one order."""
+    rank_zero_order = {
+        "layers.0.attn.qkv.linear.weight": object(),
+        "layers.0.mlp.experts.linear_fc1.weight": object(),
+        "layers.0.attn.proj.linear.weight": object(),
+    }
+    rank_two_order = {
+        "layers.0.mlp.experts.linear_fc1.weight": object(),
+        "layers.0.attn.proj.linear.weight": object(),
+        "layers.0.attn.qkv.linear.weight": object(),
+    }
+    expected = (
+        "layers.0.attn.proj.linear.weight",
+        "layers.0.attn.qkv.linear.weight",
+        "layers.0.mlp.experts.linear_fc1.weight",
+    )
+    assert canonical_lora_bank_names(rank_zero_order) == expected
+    assert canonical_lora_bank_names(rank_two_order) == expected
+
+
+def _assert_two_owner_records(values) -> None:
+    assert len(values) == 2
+    assert all(value["factor"] == 0.5 for value in values)
+
+
+def _mixed_bank_collective_order_worker(rank: int, world: int, init_file: str) -> None:
+    _init_gloo(rank, world, init_file)
+    try:
+        ps = init_parallel(SimpleNamespace(tp=2, ep=2, etp=1, cp=1, pp=1))
+        ordered = (
+            "layers.0.mlp.experts.linear_fc1.weight",
+            "layers.0.attn.qkv.linear.weight",
+        )
+        local_banks = {
+            name: torch.tensor(float(rank + 1))
+            for name in (ordered if rank % 2 == 0 else tuple(reversed(ordered)))
+        }
+        kinds = {ordered[0]: "fc", ordered[1]: "attention"}
+        records = preflight_lora_bank_collective_order(
+            local_banks,
+            lambda name: (
+                kinds[name],
+                tuple(local_banks[name].shape),
+                str(local_banks[name].dtype),
+            ),
+        )
+        assert records == (
+            (ordered[0], "fc", (), "torch.float32"),
+            (ordered[1], "attention", (), "torch.float32"),
+        )
+
+        actual = {}
+        for name, _kind, _shape, _dtype in records:
+            value = local_banks[name].clone()
+            if kinds[name] == "fc":
+                dist.all_reduce(value, group=ps.ep_group)
+                dist.all_reduce(value, group=ps.ep_dp_group)
+                assert value.item() == 10.0
+            else:
+                dist.all_reduce(value, group=ps.dp_group)
+                assert value.item() == (4.0 if rank % 2 == 0 else 6.0)
+            actual[name] = value.item()
+        gathered = [None] * world
+        dist.all_gather_object(gathered, actual, group=dist.group.WORLD)
+        assert all(record[ordered[0]] == 10.0 for record in gathered)
+        assert [record[ordered[1]] for record in gathered] == [4.0, 6.0, 4.0, 6.0]
+        gather_owner_factor_records_or_raise(
+            ps.dp_group,
+            lambda: {"rank": rank, "factor": 0.5},
+            _assert_two_owner_records,
+        )
+        dist.barrier(group=dist.group.WORLD)
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.distributed
+def test_mixed_fc_attention_collectives_have_canonical_world4_order_gloo(tmp_path):
+    torch.multiprocessing.spawn(
+        _mixed_bank_collective_order_worker,
+        args=(4, str(tmp_path / "mixed_fc_attention_collective_order")),
+        nprocs=4,
+        join=True,
+    )
+
+
+def _mixed_bank_preflight_mismatch_worker(
+    rank: int, world: int, init_file: str
+) -> None:
+    _init_gloo(rank, world, init_file)
+    try:
+        banks = {"layers.0.mlp.experts.linear_fc1.weight": torch.ones(2, 3)}
+
+        def describe_bank(name):
+            assert name in banks
+            return (
+                "attention" if rank == 0 else "fc",
+                tuple(banks[name].shape),
+                str(banks[name].dtype),
+            )
+
+        try:
+            preflight_lora_bank_collective_order(banks, describe_bank)
+        except RuntimeError as error:
+            result = str(error)
+        else:
+            result = None
+        results = [None] * world
+        dist.all_gather_object(results, result, group=dist.group.WORLD)
+        assert (
+            result
+            == "mixed LoRA bank collective preflight failed: records differ across WORLD"
+        )
+        assert results == [result] * world
+        dist.barrier(group=dist.group.WORLD)
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.distributed
+def test_mixed_bank_preflight_mismatch_fails_whole_world_without_hanging_gloo(tmp_path):
+    torch.multiprocessing.spawn(
+        _mixed_bank_preflight_mismatch_worker,
+        args=(4, str(tmp_path / "mixed_bank_preflight_mismatch")),
+        nprocs=4,
+        join=True,
+    )
+
+
+def _invalid_descriptor_worker(rank: int, world: int, init_file: str) -> None:
+    _init_gloo(rank, world, init_file)
+    try:
+        banks = {"layers.0.attn.qkv.linear.weight": torch.ones(2, 3)}
+        try:
+            preflight_lora_bank_collective_order(
+                banks, lambda _name: ("invalid", (2, 3), "torch.float32")
+            )
+        except RuntimeError as error:
+            result = str(error)
+        else:
+            result = None
+        results = [None] * world
+        dist.all_gather_object(results, result, group=dist.group.WORLD)
+        expected = (
+            "mixed LoRA bank collective preflight failed: local record error: "
+            "AssertionError: invalid LoRA bank kind: invalid"
+        )
+        assert results == [expected] * world
+        dist.barrier(group=dist.group.WORLD)
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.distributed
+def test_invalid_preflight_descriptor_fails_whole_world_without_hanging_gloo(tmp_path):
+    torch.multiprocessing.spawn(
+        _invalid_descriptor_worker,
+        args=(4, str(tmp_path / "invalid_preflight_descriptor")),
+        nprocs=4,
+        join=True,
+    )
+
+
+def _descriptor_builder_error_worker(rank: int, world: int, init_file: str) -> None:
+    _init_gloo(rank, world, init_file)
+    try:
+        banks = {"layers.0.attn.qkv.linear.weight": torch.ones(2, 3)}
+
+        def build_descriptor(_name):
+            if rank == 0:
+                raise AssertionError("malformed descriptor")
+            return ("attention", (2, 3), "torch.float32")
+
+        try:
+            preflight_lora_bank_collective_order(banks, build_descriptor)
+        except RuntimeError as error:
+            result = str(error)
+        else:
+            result = None
+        results = [None] * world
+        dist.all_gather_object(results, result, group=dist.group.WORLD)
+        expected = (
+            "mixed LoRA bank collective preflight failed: local record error: "
+            "AssertionError: malformed descriptor"
+        )
+        assert results == [expected] * world
+        dist.barrier(group=dist.group.WORLD)
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.distributed
+def test_descriptor_builder_error_fails_whole_world_without_hanging_gloo(tmp_path):
+    torch.multiprocessing.spawn(
+        _descriptor_builder_error_worker,
+        args=(4, str(tmp_path / "descriptor_builder_error")),
+        nprocs=4,
+        join=True,
+    )
+
+
+def _fc_bank_dtype_drift_worker(rank: int, world: int, init_file: str) -> None:
+    _init_gloo(rank, world, init_file)
+    try:
+        banks = {"layers.0.mlp.experts.linear_fc1.weight": torch.ones(2, 3)}
+
+        def build_descriptor(_name):
+            bank_dtype = torch.float32 if rank == 0 else torch.bfloat16
+            return build_lora_collective_descriptor("fc", banks[_name], bank_dtype)
+
+        try:
+            preflight_lora_bank_collective_order(banks, build_descriptor)
+        except RuntimeError as error:
+            result = str(error)
+        else:
+            result = None
+        results = [None] * world
+        dist.all_gather_object(results, result, group=dist.group.WORLD)
+        expected = (
+            "mixed LoRA bank collective preflight failed: local record error: "
+            "AssertionError: FC LoRA bank dtype must be torch.bfloat16"
+        )
+        assert results == [expected] * world
+        dist.barrier(group=dist.group.WORLD)
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.distributed
+def test_fc_bank_dtype_drift_fails_whole_world_in_preflight_gloo(tmp_path):
+    torch.multiprocessing.spawn(
+        _fc_bank_dtype_drift_worker,
+        args=(4, str(tmp_path / "fc_bank_dtype_drift")),
+        nprocs=4,
+        join=True,
+    )
+
+
+def _fc_contribution_dtype_drift_worker(rank: int, world: int, init_file: str) -> None:
+    _init_gloo(rank, world, init_file)
+    try:
+        banks = {"layers.0.mlp.experts.linear_fc1.weight": torch.ones(2, 3)}
+
+        def build_descriptor(_name):
+            reduction_tensor = banks[_name].double() if rank == 0 else banks[_name]
+            return build_lora_collective_descriptor(
+                "fc", reduction_tensor, torch.bfloat16
+            )
+
+        try:
+            preflight_lora_bank_collective_order(banks, build_descriptor)
+        except RuntimeError as error:
+            result = str(error)
+        else:
+            result = None
+        results = [None] * world
+        dist.all_gather_object(results, result, group=dist.group.WORLD)
+        expected = (
+            "mixed LoRA bank collective preflight failed: local record error: "
+            "AssertionError: LoRA reduction tensor dtype must be torch.float32"
+        )
+        assert results == [expected] * world
+        dist.barrier(group=dist.group.WORLD)
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.distributed
+def test_fc_contribution_dtype_drift_fails_whole_world_in_preflight_gloo(tmp_path):
+    torch.multiprocessing.spawn(
+        _fc_contribution_dtype_drift_worker,
+        args=(4, str(tmp_path / "fc_contribution_dtype_drift")),
+        nprocs=4,
         join=True,
     )

--- a/experimental/lite/tests/unit/primitive/test_multi_lora_owner_groups_gloo_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_multi_lora_owner_groups_gloo_unit.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """CPU Gloo contracts for multi-LoRA dist-opt bank owner groups."""
 
-
 from __future__ import annotations
 
 import importlib.util

--- a/experimental/lite/tests/unit/primitive/test_multi_lora_owner_groups_gloo_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_multi_lora_owner_groups_gloo_unit.py
@@ -3,12 +3,13 @@
 
 from __future__ import annotations
 
+import importlib.util
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 import torch
 import torch.distributed as dist
-
 from megatron.lite.primitive.distributed_test_utils import (
     build_lora_collective_descriptor,
     canonical_lora_bank_names,
@@ -171,6 +172,81 @@ def test_canonical_lora_bank_names_stabilize_rank_local_insertion_order():
     )
     assert canonical_lora_bank_names(rank_zero_order) == expected
     assert canonical_lora_bank_names(rank_two_order) == expected
+
+
+def _fixed_router_ep_coverage_worker(rank: int, world: int, init_file: str) -> None:
+    _init_gloo(rank, world, init_file)
+    try:
+        smoke_path = (
+            Path(__file__).parents[2]
+            / "smoke/primitive/test_multi_lora_ep2_production_gpu.py"
+        )
+        spec = importlib.util.spec_from_file_location(
+            "multi_lora_ep2_smoke", smoke_path
+        )
+        assert spec is not None and spec.loader is not None
+        smoke = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(smoke)
+        flight_dir = Path(init_file).parent / "phase_a_flight_records"
+        flight_dir.mkdir(exist_ok=True)
+        smoke._write_phase_a_flight_record(flight_dir, export_complete=True)
+        smoke._write_phase_a_flight_record(flight_dir, reference_enter=True)
+        smoke._write_phase_a_flight_record(flight_dir, reference_done=True)
+        smoke._write_phase_a_flight_record(flight_dir, preflight_done=True)
+        smoke._write_phase_a_flight_record(flight_dir, oracle_done=True)
+        flight_record = smoke._write_phase_a_flight_record(
+            flight_dir, phase_a_complete=True
+        )
+        assert flight_record == {
+            "export_complete": True,
+            "oracle_done": True,
+            "phase_a_complete": True,
+            "preflight_done": True,
+            "reference_done": True,
+            "reference_enter": True,
+        }
+        assert (flight_dir / f"phase_a_rank_{rank:05d}.json").is_file()
+        rows = torch.zeros(4, 8)
+        _scores, production_experts = smoke._fixed_local_router(rows)
+        _scores, phase_a_experts = smoke._phase_a_balanced_router(rows)
+        production_routes = tuple(int(value) for value in production_experts.flatten())
+        phase_a_routes = tuple(int(value) for value in phase_a_experts.flatten())
+        local_experts = (0, 1) if rank % 2 == 0 else (2, 3)
+        record = {
+            "rank": rank,
+            "production_routes": production_routes,
+            "production_receives_tokens": any(
+                expert in local_experts for expert in production_routes
+            ),
+            "phase_a_routes": phase_a_routes,
+            "phase_a_receives_tokens": any(
+                expert in local_experts for expert in phase_a_routes
+            ),
+        }
+        records = [None] * world
+        dist.all_gather_object(records, record, group=dist.group.WORLD)
+        assert all(item["production_routes"] == (0, 0, 0, 0) for item in records)
+        assert [item["production_receives_tokens"] for item in records] == [
+            True,
+            False,
+            True,
+            False,
+        ]
+        assert all(item["phase_a_routes"] == (0, 1, 2, 3) for item in records)
+        assert all(item["phase_a_receives_tokens"] for item in records)
+        dist.barrier(group=dist.group.WORLD)
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.distributed
+def test_production_and_phase_a_routers_cover_their_tp2_ep2_contracts_gloo(tmp_path):
+    torch.multiprocessing.spawn(
+        _fixed_router_ep_coverage_worker,
+        args=(4, str(tmp_path / "fixed_router_ep_coverage")),
+        nprocs=4,
+        join=True,
+    )
 
 
 def _assert_two_owner_records(values) -> None:

--- a/experimental/lite/tests/unit/primitive/test_multi_lora_owner_groups_gloo_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_multi_lora_owner_groups_gloo_unit.py
@@ -1,22 +1,18 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """CPU Gloo contracts for multi-LoRA dist-opt bank owner groups."""
 
+
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
+import megatron.lite.primitive.distributed_test_utils as lora_dist_utils
 import pytest
 import torch
 import torch.distributed as dist
-from megatron.lite.primitive.distributed_test_utils import (
-    build_lora_collective_descriptor,
-    canonical_lora_bank_names,
-    gather_owner_factor_records_or_raise,
-    preflight_lora_bank_collective_order,
-    select_lora_bank_owner_group,
-)
 from megatron.lite.primitive.parallel import init_parallel
 
 
@@ -33,8 +29,10 @@ def _tp2_ep2_factor_lane_worker(rank: int, world: int, init_file: str) -> None:
         # Attention and FC banks select their distinct owner groups.
         expected_dp = (0, 2) if rank % 2 == 0 else (1, 3)
         expected_ep = (0, 1) if rank < 2 else (2, 3)
-        attention_group = select_lora_bank_owner_group(ps, is_expert_bank=False)
-        fc_group = select_lora_bank_owner_group(ps, is_expert_bank=True)
+        attention_group = lora_dist_utils.select_lora_bank_owner_group(
+            ps, is_expert_bank=False
+        )
+        fc_group = lora_dist_utils.select_lora_bank_owner_group(ps, is_expert_bank=True)
         assert attention_group is ps.dp_group
         assert fc_group is ps.ep_dp_group
         assert tuple(dist.get_process_group_ranks(attention_group)) == expected_dp
@@ -49,7 +47,7 @@ def _tp2_ep2_factor_lane_worker(rank: int, world: int, init_file: str) -> None:
             assert len(values) == 1
             assert values[0]["factor"] == 0.5
 
-        records = gather_owner_factor_records_or_raise(
+        records = lora_dist_utils.gather_owner_factor_records_or_raise(
             attention_group,
             lambda: {"rank": rank, "factor": 0.5} if rank < 2 else None,
             validate_records,
@@ -73,7 +71,9 @@ def _malformed_factor_worker(rank: int, world: int, init_file: str) -> None:
     _init_gloo(rank, world, init_file)
     try:
         ps = init_parallel(SimpleNamespace(tp=2, ep=2, etp=1, cp=1, pp=1))
-        owner_group = select_lora_bank_owner_group(ps, is_expert_bank=False)
+        owner_group = lora_dist_utils.select_lora_bank_owner_group(
+            ps, is_expert_bank=False
+        )
 
         def build_record():
             if rank == 0:
@@ -81,7 +81,7 @@ def _malformed_factor_worker(rank: int, world: int, init_file: str) -> None:
             return {"rank": rank, "factor": 0.5}
 
         try:
-            gather_owner_factor_records_or_raise(
+            lora_dist_utils.gather_owner_factor_records_or_raise(
                 owner_group, build_record, lambda values: None
             )
         except RuntimeError as error:
@@ -115,8 +115,10 @@ def _owner_boundary_worker(
     _init_gloo(rank, world, init_file)
     try:
         ps = init_parallel(SimpleNamespace(tp=tp, ep=ep, etp=1, cp=1, pp=1))
-        attention_group = select_lora_bank_owner_group(ps, is_expert_bank=False)
-        fc_group = select_lora_bank_owner_group(ps, is_expert_bank=True)
+        attention_group = lora_dist_utils.select_lora_bank_owner_group(
+            ps, is_expert_bank=False
+        )
+        fc_group = lora_dist_utils.select_lora_bank_owner_group(ps, is_expert_bank=True)
         assert attention_group is ps.dp_group
         assert fc_group is ps.ep_dp_group
         expected_attention = 1 if (tp, ep) == (2, 1) else 2
@@ -130,10 +132,10 @@ def _owner_boundary_worker(
         def validate_fc(values) -> None:
             assert len(values) == expected_fc
 
-        attention_records = gather_owner_factor_records_or_raise(
+        attention_records = lora_dist_utils.gather_owner_factor_records_or_raise(
             attention_group, lambda: {"rank": rank, "factor": 0.5}, validate_attention
         )
-        fc_records = gather_owner_factor_records_or_raise(
+        fc_records = lora_dist_utils.gather_owner_factor_records_or_raise(
             fc_group, lambda: {"rank": rank, "factor": 0.5}, validate_fc
         )
         assert all(record["factor"] == 0.5 for record in attention_records)
@@ -170,8 +172,8 @@ def test_canonical_lora_bank_names_stabilize_rank_local_insertion_order():
         "layers.0.attn.qkv.linear.weight",
         "layers.0.mlp.experts.linear_fc1.weight",
     )
-    assert canonical_lora_bank_names(rank_zero_order) == expected
-    assert canonical_lora_bank_names(rank_two_order) == expected
+    assert lora_dist_utils.canonical_lora_bank_names(rank_zero_order) == expected
+    assert lora_dist_utils.canonical_lora_bank_names(rank_two_order) == expected
 
 
 def _fixed_router_ep_coverage_worker(rank: int, world: int, init_file: str) -> None:
@@ -206,7 +208,30 @@ def _fixed_router_ep_coverage_worker(rank: int, world: int, init_file: str) -> N
             "reference_enter": True,
         }
         assert (flight_dir / f"phase_a_rank_{rank:05d}.json").is_file()
-        rows = torch.zeros(4, 8)
+        try:
+            smoke._run_phase_a_stage(
+                flight_dir,
+                "reference",
+                lambda: (_ for _ in ()).throw(AssertionError("reference failure")),
+            )
+        except AssertionError:
+            pass
+        failed_record = json.loads(
+            (flight_dir / f"phase_a_rank_{rank:05d}.json").read_text()
+        )
+        assert failed_record["current_stage"] == "reference"
+        assert failed_record["stage_error"] == "AssertionError: reference failure"
+        assert "reference failure" in failed_record["traceback"]
+        smoke._run_phase_a_stage(flight_dir, "reference", lambda: None)
+        repaired_record = json.loads(
+            (flight_dir / f"phase_a_rank_{rank:05d}.json").read_text()
+        )
+        assert "stage_error" not in repaired_record
+        assert "traceback" not in repaired_record
+        assert repaired_record["reference_done"] is True
+        dist.barrier(group=dist.group.WORLD)
+        assert not list(flight_dir.glob(".phase_a_rank_*.tmp"))
+        rows = torch.zeros(2, 8)
         _scores, production_experts = smoke._fixed_local_router(rows)
         _scores, phase_a_experts = smoke._phase_a_balanced_router(rows)
         production_routes = tuple(int(value) for value in production_experts.flatten())
@@ -225,14 +250,14 @@ def _fixed_router_ep_coverage_worker(rank: int, world: int, init_file: str) -> N
         }
         records = [None] * world
         dist.all_gather_object(records, record, group=dist.group.WORLD)
-        assert all(item["production_routes"] == (0, 0, 0, 0) for item in records)
+        assert all(item["production_routes"] == (0, 0) for item in records)
         assert [item["production_receives_tokens"] for item in records] == [
             True,
             False,
             True,
             False,
         ]
-        assert all(item["phase_a_routes"] == (0, 1, 2, 3) for item in records)
+        assert all(item["phase_a_routes"] == (0, 2) for item in records)
         assert all(item["phase_a_receives_tokens"] for item in records)
         dist.barrier(group=dist.group.WORLD)
     finally:
@@ -267,7 +292,7 @@ def _mixed_bank_collective_order_worker(rank: int, world: int, init_file: str) -
             for name in (ordered if rank % 2 == 0 else tuple(reversed(ordered)))
         }
         kinds = {ordered[0]: "fc", ordered[1]: "attention"}
-        records = preflight_lora_bank_collective_order(
+        records = lora_dist_utils.preflight_lora_bank_collective_order(
             local_banks,
             lambda name: (
                 kinds[name],
@@ -295,7 +320,7 @@ def _mixed_bank_collective_order_worker(rank: int, world: int, init_file: str) -
         dist.all_gather_object(gathered, actual, group=dist.group.WORLD)
         assert all(record[ordered[0]] == 10.0 for record in gathered)
         assert [record[ordered[1]] for record in gathered] == [4.0, 6.0, 4.0, 6.0]
-        gather_owner_factor_records_or_raise(
+        lora_dist_utils.gather_owner_factor_records_or_raise(
             ps.dp_group,
             lambda: {"rank": rank, "factor": 0.5},
             _assert_two_owner_records,
@@ -331,7 +356,7 @@ def _mixed_bank_preflight_mismatch_worker(
             )
 
         try:
-            preflight_lora_bank_collective_order(banks, describe_bank)
+            lora_dist_utils.preflight_lora_bank_collective_order(banks, describe_bank)
         except RuntimeError as error:
             result = str(error)
         else:
@@ -363,7 +388,7 @@ def _invalid_descriptor_worker(rank: int, world: int, init_file: str) -> None:
     try:
         banks = {"layers.0.attn.qkv.linear.weight": torch.ones(2, 3)}
         try:
-            preflight_lora_bank_collective_order(
+            lora_dist_utils.preflight_lora_bank_collective_order(
                 banks, lambda _name: ("invalid", (2, 3), "torch.float32")
             )
         except RuntimeError as error:
@@ -403,7 +428,9 @@ def _descriptor_builder_error_worker(rank: int, world: int, init_file: str) -> N
             return ("attention", (2, 3), "torch.float32")
 
         try:
-            preflight_lora_bank_collective_order(banks, build_descriptor)
+            lora_dist_utils.preflight_lora_bank_collective_order(
+                banks, build_descriptor
+            )
         except RuntimeError as error:
             result = str(error)
         else:
@@ -437,10 +464,14 @@ def _fc_bank_dtype_drift_worker(rank: int, world: int, init_file: str) -> None:
 
         def build_descriptor(_name):
             bank_dtype = torch.float32 if rank == 0 else torch.bfloat16
-            return build_lora_collective_descriptor("fc", banks[_name], bank_dtype)
+            return lora_dist_utils.build_lora_collective_descriptor(
+                "fc", banks[_name], bank_dtype
+            )
 
         try:
-            preflight_lora_bank_collective_order(banks, build_descriptor)
+            lora_dist_utils.preflight_lora_bank_collective_order(
+                banks, build_descriptor
+            )
         except RuntimeError as error:
             result = str(error)
         else:
@@ -474,12 +505,14 @@ def _fc_contribution_dtype_drift_worker(rank: int, world: int, init_file: str) -
 
         def build_descriptor(_name):
             reduction_tensor = banks[_name].double() if rank == 0 else banks[_name]
-            return build_lora_collective_descriptor(
+            return lora_dist_utils.build_lora_collective_descriptor(
                 "fc", reduction_tensor, torch.bfloat16
             )
 
         try:
-            preflight_lora_bank_collective_order(banks, build_descriptor)
+            lora_dist_utils.preflight_lora_bank_collective_order(
+                banks, build_descriptor
+            )
         except RuntimeError as error:
             result = str(error)
         else:

--- a/experimental/lite/tests/unit/primitive/test_multi_lora_protocol_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_multi_lora_protocol_unit.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Protocol-level contracts for model-owned multi-LoRA activation."""
+
+import importlib
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+import torch.nn as nn
+
+
+def _protocol(monkeypatch):
+    fake_model = types.ModuleType("megatron.lite.model.qwen3_moe.lite.model")
+    fake_model.MTPLossAutoScaler = type("MTPLossAutoScaler", (), {})
+    fake_model.Qwen3MoEModel = nn.Module
+    monkeypatch.setitem(
+        sys.modules, "megatron.lite.model.qwen3_moe.lite.model", fake_model
+    )
+    return importlib.import_module("megatron.lite.model.qwen3_moe.lite.protocol")
+
+
+def test_model_owned_multi_lora_requires_slots_but_no_adapter_remains_a_noop(
+    monkeypatch,
+):
+    protocol = _protocol(monkeypatch)
+
+    class MissingSlotsBatch:
+        extras = {}
+
+    with pytest.raises(
+        ValueError, match=r"enabled impl_cfg\.multi_lora requires multi_lora_slots"
+    ):
+        protocol._inject_multi_lora_sidecars(
+            {}, MissingSlotsBatch(), SimpleNamespace(local_layer_indices=())
+        )
+
+    no_adapter_kwargs = {}
+    protocol._inject_multi_lora_sidecars(no_adapter_kwargs, MissingSlotsBatch(), None)
+    assert no_adapter_kwargs == {}
+
+    class ValidSlotsBatch:
+        extras = {"multi_lora_slots": {}}
+
+    enabled_kwargs = {}
+    protocol._inject_multi_lora_sidecars(
+        enabled_kwargs, ValidSlotsBatch(), SimpleNamespace(local_layer_indices=())
+    )
+    assert enabled_kwargs == {"multi_lora_sidecars": {}}

--- a/experimental/lite/tests/unit/primitive/test_multi_lora_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_multi_lora_unit.py
@@ -152,7 +152,7 @@ def test_batched_lora_linear_stage_cpu_oracle_forward_backward_and_empty():
     torch.manual_seed(9)
     x = torch.randn(4, 3, dtype=torch.float64, requires_grad=True)
     weight = torch.randn(3, 2, 3, dtype=torch.float64, requires_grad=True)
-    slots = torch.tensor([2, 0, 2, 0], dtype=torch.int64)
+    slots = torch.tensor([0, 0, 2, 2], dtype=torch.int64)
     actual = multi_lora_kernel.batched_lora_linear_stage(x, weight, slots, scale=0.75)
     actual.square().sum().backward()
     actual_grads = (x.grad.detach().clone(), weight.grad.detach().clone())
@@ -166,6 +166,10 @@ def test_batched_lora_linear_stage_cpu_oracle_forward_backward_and_empty():
     torch.testing.assert_close(actual_grads[0], ref_x.grad)
     torch.testing.assert_close(actual_grads[1], ref_w.grad)
     assert actual_grads[1][1].eq(0).all()
+    with pytest.raises(ValueError, match="slots sorted"):
+        multi_lora_kernel.batched_lora_linear_stage(
+            x.detach(), weight.detach(), torch.tensor([2, 0, 2, 0]), scale=0.75
+        )
     empty = multi_lora_kernel.batched_lora_linear_stage(
         torch.empty(0, 3, dtype=torch.bfloat16),
         torch.ones(3, 2, 3, dtype=torch.bfloat16),
@@ -255,6 +259,18 @@ def test_tp_attention_builder_uses_linear_lora_partition_shapes(monkeypatch):
     # materialization; no second names/slot authority is allowed.
     assert qkv.partition.rank_partitioned_a is True
     assert proj.partition.output_partitioned_b is True
+    # Optimizer metadata follows the explicit bank partition, not parameter
+    # dimensionality: attention factors are TP shards, dense expert banks are
+    # replicas and therefore need the data-parallel all-reduce hook.
+    fc1, fc2 = state.banks_for_layer(0)
+    for bank in (qkv, proj):
+        for parameter in (bank.a_bank, bank.b_bank):
+            assert parameter.tensor_model_parallel is True
+            assert parameter.allreduce is False
+    for bank in (fc1, fc2):
+        for parameter in (bank.a_bank, bank.b_bank):
+            assert parameter.tensor_model_parallel is False
+            assert parameter.allreduce is True
 
 
 def test_tp_attention_builder_rejects_rank_not_divisible_by_tp():
@@ -292,7 +308,8 @@ def test_qkv_tp_carrier_collective_trace_has_hidden_rank_gather(monkeypatch):
     monkeypatch.setattr(
         multi_lora_bank,
         "_gather_sequence_parallel",
-        lambda value, group: calls.append(("sp_gather", value.shape)) or value,
+        lambda value, group: calls.append(("sp_gather", value.shape))
+        or torch.cat((value, value), dim=0),
     )
     monkeypatch.setattr(
         multi_lora_bank,
@@ -317,7 +334,7 @@ def test_qkv_tp_carrier_collective_trace_has_hidden_rank_gather(monkeypatch):
         torch.ones(2, 4, 4),
         LoraBankPartition(tp_size=2, rank_partitioned_a=True),
     )
-    apply_batched_lora_delta(
+    result = apply_batched_lora_delta(
         bank,
         torch.ones(2, 1, 4),
         torch.tensor([0, 1], dtype=torch.int64),
@@ -328,10 +345,13 @@ def test_qkv_tp_carrier_collective_trace_has_hidden_rank_gather(monkeypatch):
     assert calls == [
         ("sp_gather", (2, 4)),
         ("sp_gather", (2, 1)),
-        ("A", (2, 4)),
-        ("rank_gather", (2, 2), True),
-        ("B", (2, 4)),
+        ("A", (4, 4)),
+        ("rank_gather", (4, 2), True),
+        ("B", (4, 4)),
     ]
+    # The mocked SP all-gather doubles token rows at TP2, so the post-
+    # collective output must not be reshaped with the pre-gather row count.
+    assert result.shape == (4, 1, 4)
 
 
 def test_proj_tp_carrier_collective_trace_has_local_b_then_output_gather(monkeypatch):
@@ -354,7 +374,7 @@ def test_proj_tp_carrier_collective_trace_has_local_b_then_output_gather(monkeyp
         multi_lora_bank,
         "_scatter_sequence_parallel",
         lambda value, group, rank: (
-            calls.append(("sp_scatter", value.shape, rank)) or value
+            calls.append(("sp_scatter", value.shape, rank)) or value[rank::2]
         ),
     )
 
@@ -371,7 +391,7 @@ def test_proj_tp_carrier_collective_trace_has_local_b_then_output_gather(monkeyp
         torch.ones(2, 2, 4),
         LoraBankPartition(tp_size=2, output_partitioned_b=True),
     )
-    apply_batched_lora_delta(
+    result = apply_batched_lora_delta(
         bank,
         torch.ones(2, 1, 2),
         torch.tensor([0, 1], dtype=torch.int64),
@@ -390,6 +410,9 @@ def test_proj_tp_carrier_collective_trace_has_local_b_then_output_gather(monkeyp
         ("output_gather", (2, 2), False),
         ("sp_scatter", (2, 4), 1),
     ]
+    # The SP scatter returns one rank's half of the rows; reshape follows its
+    # actual result rather than the two input rows.
+    assert result.shape == (1, 1, 4)
 
 
 def test_tp_named_export_materializes_internal_partitions_before_base_gathers(
@@ -434,12 +457,21 @@ def test_tp_named_export_materializes_internal_partitions_before_base_gathers(
         base_model_identity={},
     )
     calls = []
+    materialized = []
+    events = []
+
+    def _materialize(value):
+        materialized.append(tuple(value.shape))
+        events.append(("materialize", tuple(value.shape)))
+        return value
 
     def _gather(value, world_size, group, *, dim):
         calls.append((tuple(value.shape), dim, value.flatten()[0].item()))
+        events.append(("gather", tuple(value.shape), dim))
         return torch.cat((value, value + 100), dim=dim)
 
     monkeypatch.setattr(hf_weights, "allgather_concat", _gather)
+    monkeypatch.setattr(hf_weights, "_materialize_dtensor", _materialize)
     config = Qwen3MoEConfig(
         num_hidden_layers=1,
         hidden_size=4,
@@ -463,6 +495,21 @@ def test_tp_named_export_materializes_internal_partitions_before_base_gathers(
         ((2, 4), 0, 0.0),  # O-proj output-partitioned B
         ((4, 2), 1, 0.0),  # O-proj row-parallel A
     ]
+    # The selected pair is materialized before the metadata-directed gather.
+    # The legacy exporter may materialize its plain inputs again, but it must
+    # not introduce a second partition gather.
+    assert events[:3] == [
+        ("materialize", (2, 4)),
+        ("materialize", (4, 4)),
+        ("gather", (2, 4), 0),
+    ]
+    proj_internal = events.index(("gather", (2, 4), 0), 3)
+    assert events[proj_internal - 2 : proj_internal + 1] == [
+        ("materialize", (4, 2)),
+        ("materialize", (2, 4)),
+        ("gather", (2, 4), 0),
+    ]
+    assert materialized
     q_prefix = f"{VLLM_LORA_NAME_PREFIX}model.layers.0.self_attn"
     assert exported[f"{q_prefix}.q_proj.lora_A.weight"].shape == (4, 4)
     assert exported[f"{q_prefix}.k_proj.lora_B.weight"].shape == (2, 4)
@@ -947,10 +994,7 @@ def test_model_owned_checkpoint_identity_is_pp_global_and_rejects_contract_chang
             alpha=alpha,
             base_model_identity={},
         )
-        return MultiLoraTrainingState(
-            registry,
-            {layer_idx: (fc1_surface, fc2_surface)},
-        )
+        return MultiLoraTrainingState(registry, {layer_idx: (fc1_surface, fc2_surface)})
 
     source = nn.Module()
     source.add_module("multi_lora_training_state", build_state(("alpha", "bravo")))
@@ -1003,11 +1047,7 @@ def test_semantic_bank_parameter_names_survive_reordered_registry_and_pp_stages(
             banks=banks, names={"alpha": 0}, rank=1, alpha=1, base_model_identity={}
         )
         return MultiLoraTrainingState(
-            registry,
-            {
-                0: (surfaces[0], surfaces[1]),
-                1: (surfaces[2], surfaces[3]),
-            },
+            registry, {0: (surfaces[0], surfaces[1]), 1: (surfaces[2], surfaces[3])}
         )
 
     source = nn.Module()
@@ -1195,10 +1235,7 @@ def test_production_builder_owns_native_banks_and_injects_sidecars(monkeypatch):
     class FakeLayer:
         layer_idx = 0
         attn = SimpleNamespace(
-            qkv=SimpleNamespace(
-                local_out=8,
-                linear=SimpleNamespace(),
-            ),
+            qkv=SimpleNamespace(local_out=8, linear=SimpleNamespace()),
             proj=SimpleNamespace(local_in=4),
         )
 

--- a/experimental/lite/tests/unit/primitive/test_multi_lora_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_multi_lora_unit.py
@@ -14,7 +14,10 @@ import pytest
 import torch
 import torch.nn as nn
 from megatron.lite.model.qwen3_moe.lite import multi_lora
-from megatron.lite.model.qwen3_moe.lite.checkpoint import Qwen3MoEWeightSpec
+from megatron.lite.model.qwen3_moe.lite.checkpoint import (
+    PLACEMENT_FN,
+    Qwen3MoEWeightSpec,
+)
 from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
 from megatron.lite.primitive.bundle import ModelBundle
 from megatron.lite.primitive.ckpt.hf_weights import (
@@ -26,18 +29,21 @@ from megatron.lite.primitive.ckpt.identity import (
     require_checkpoint_identity_match,
 )
 from megatron.lite.primitive.ckpt import dcp
+from megatron.lite.primitive.ckpt import hf_weights
 from megatron.lite.primitive.modules import multi_lora_kernel
 from megatron.lite.primitive.modules import multi_lora_bank
 from megatron.lite.primitive.modules.lora import LoraSpec
 from megatron.lite.primitive.modules.multi_lora import BatchedLoraDelta
 from megatron.lite.primitive.modules.multi_lora_bank import (
     DenseLoraBank,
+    LoraBankPartition,
     MultiLoraSpec,
     MultiLoraTrainingState,
     NamedLoraBankRegistry,
     apply_batched_lora_delta,
     validate_multi_lora_parallel_support,
 )
+from torch.distributed.tensor import Shard
 
 # isort: on
 
@@ -142,6 +148,34 @@ def test_batched_lora_delta_matches_dense_reference_for_sorted_slots():
     torch.testing.assert_close(actual, expected)
 
 
+def test_batched_lora_linear_stage_cpu_oracle_forward_backward_and_empty():
+    torch.manual_seed(9)
+    x = torch.randn(4, 3, dtype=torch.float64, requires_grad=True)
+    weight = torch.randn(3, 2, 3, dtype=torch.float64, requires_grad=True)
+    slots = torch.tensor([2, 0, 2, 0], dtype=torch.int64)
+    actual = multi_lora_kernel.batched_lora_linear_stage(x, weight, slots, scale=0.75)
+    actual.square().sum().backward()
+    actual_grads = (x.grad.detach().clone(), weight.grad.detach().clone())
+    ref_x = x.detach().clone().requires_grad_()
+    ref_w = weight.detach().clone().requires_grad_()
+    reference = (
+        torch.stack([ref_w[slot] @ row for row, slot in zip(ref_x, slots)]) * 0.75
+    )
+    reference.square().sum().backward()
+    torch.testing.assert_close(actual, reference)
+    torch.testing.assert_close(actual_grads[0], ref_x.grad)
+    torch.testing.assert_close(actual_grads[1], ref_w.grad)
+    assert actual_grads[1][1].eq(0).all()
+    empty = multi_lora_kernel.batched_lora_linear_stage(
+        torch.empty(0, 3, dtype=torch.bfloat16),
+        torch.ones(3, 2, 3, dtype=torch.bfloat16),
+        torch.empty(0, dtype=torch.int64),
+        output_dtype=torch.bfloat16,
+        max_g_size_hint=4,
+    )
+    assert empty.shape == (0, 2) and empty.dtype is torch.bfloat16
+
+
 def test_attention_bank_delta_matches_dense_oracle_and_only_updates_selected_slots():
     """The generic attention carrier keeps per-token slots and zero banks inert."""
     x = torch.tensor([[1.0, 2.0], [3.0, -1.0], [2.0, 4.0]], requires_grad=True)
@@ -170,51 +204,314 @@ def test_attention_bank_delta_matches_dense_oracle_and_only_updates_selected_slo
     )
 
 
-def test_attention_bank_tp_sp_contract_reuses_linear_lora_collective_order(monkeypatch):
-    """QKV gathers SP input; O-proj reduces TP-local contributions then scatters."""
+def test_tp_attention_builder_uses_linear_lora_partition_shapes(monkeypatch):
+    """TP2 attention banks must have the same local A/B layouts as LinearLoRA."""
+    fake_model = types.ModuleType("megatron.lite.model.qwen3_moe.lite.model")
+    fake_model.MTPLossAutoScaler = type("MTPLossAutoScaler", (), {})
+    fake_model.Qwen3MoEModel = nn.Module
+    monkeypatch.setitem(
+        sys.modules, "megatron.lite.model.qwen3_moe.lite.model", fake_model
+    )
+    protocol = importlib.import_module("megatron.lite.model.qwen3_moe.lite.protocol")
+
+    class FakeLayer:
+        layer_idx = 0
+        attn = SimpleNamespace(
+            qkv=SimpleNamespace(
+                local_out=4, linear=SimpleNamespace(), use_sp=True, tp_size=2
+            ),
+            proj=SimpleNamespace(local_in=2, use_sp=True),
+        )
+
+    class FakeChunk(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.anchor = nn.Parameter(torch.zeros(1))
+            self.layers = [FakeLayer()]
+
+    config = Qwen3MoEConfig(
+        num_hidden_layers=1,
+        hidden_size=4,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=2,
+        vocab_size=8,
+        num_experts=1,
+        num_experts_per_tok=1,
+        moe_intermediate_size=4,
+        layer_types=["full_attention"],
+    )
+    state = protocol._build_multi_lora_training_state(
+        [FakeChunk()], config, MultiLoraSpec(names=("alpha", "bravo"), rank=4)
+    )
+    qkv, proj = state.attention_banks_for_layer(0)
+    # QKV: A rank is TP-local, B keeps the local column-parallel output.
+    assert qkv.a_bank.shape == (2, 2, 4)
+    assert qkv.b_bank.shape == (2, 4, 4)
+    # O-proj: A sees row-parallel local input, B is output-partitioned.
+    assert proj.a_bank.shape == (2, 4, 2)
+    assert proj.b_bank.shape == (2, 2, 4)
+    # Registry-owned metadata must drive both optimizer placement and export
+    # materialization; no second names/slot authority is allowed.
+    assert qkv.partition.rank_partitioned_a is True
+    assert proj.partition.output_partitioned_b is True
+
+
+def test_tp_attention_builder_rejects_rank_not_divisible_by_tp():
+    with pytest.raises(ValueError, match="rank.*divisible.*TP"):
+        validate_multi_lora_parallel_support(
+            MultiLoraSpec(names=("alpha",), rank=3),
+            tp_size=2,
+            etp_size=1,
+            use_deepep=False,
+        )
+
+
+def test_attention_bank_checkpoint_placement_never_shards_slot_dimension():
+    qkv_a = MultiLoraTrainingState.parameter_name(
+        "layers.0.attn.qkv.linear.weight", "a"
+    )
+    qkv_b = MultiLoraTrainingState.parameter_name(
+        "layers.0.attn.qkv.linear.weight", "b"
+    )
+    proj_a = MultiLoraTrainingState.parameter_name(
+        "layers.0.attn.proj.linear.weight", "a"
+    )
+    proj_b = MultiLoraTrainingState.parameter_name(
+        "layers.0.attn.proj.linear.weight", "b"
+    )
+    # [slot, rank, input/output]: TP must use rank/output/input axes only.
+    assert PLACEMENT_FN(qkv_a)[-1] == Shard(1)
+    assert PLACEMENT_FN(qkv_b)[-1] == Shard(1)
+    assert PLACEMENT_FN(proj_a)[-1] == Shard(2)
+    assert PLACEMENT_FN(proj_b)[-1] == Shard(1)
+
+
+def test_qkv_tp_carrier_collective_trace_has_hidden_rank_gather(monkeypatch):
     calls = []
     monkeypatch.setattr(
         multi_lora_bank,
         "_gather_sequence_parallel",
-        lambda value, group: calls.append(("gather", value.shape)) or value,
+        lambda value, group: calls.append(("sp_gather", value.shape)) or value,
     )
     monkeypatch.setattr(
         multi_lora_bank,
+        "_all_gather_last_dim",
+        lambda value, group, reduce_backward: (
+            calls.append(("rank_gather", value.shape, reduce_backward))
+            or torch.cat((value, value), dim=-1)
+        ),
+        raising=False,
+    )
+
+    monkeypatch.setattr(
+        multi_lora_kernel,
+        "batched_lora_linear_stage",
+        lambda value, weight, slots, **kwargs: (
+            calls.append(("A" if weight.shape[1] == 2 else "B", value.shape))
+            or value.new_zeros((value.shape[0], weight.shape[1]))
+        ),
+    )
+    bank = DenseLoraBank(
+        torch.ones(2, 2, 4),
+        torch.ones(2, 4, 4),
+        LoraBankPartition(tp_size=2, rank_partitioned_a=True),
+    )
+    apply_batched_lora_delta(
+        bank,
+        torch.ones(2, 1, 4),
+        torch.tensor([0, 1], dtype=torch.int64),
+        scale=1.0,
+        tp_group=object(),
+        sequence_parallel_input=True,
+    )
+    assert calls == [
+        ("sp_gather", (2, 4)),
+        ("sp_gather", (2, 1)),
+        ("A", (2, 4)),
+        ("rank_gather", (2, 2), True),
+        ("B", (2, 4)),
+    ]
+
+
+def test_proj_tp_carrier_collective_trace_has_local_b_then_output_gather(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        multi_lora_bank,
         "_all_reduce_sum",
-        lambda value, group: calls.append(("reduce", value.shape)) or value,
+        lambda value, group: calls.append(("rank_reduce", value.shape)) or value,
+    )
+    monkeypatch.setattr(
+        multi_lora_bank,
+        "_all_gather_last_dim",
+        lambda value, group, reduce_backward: (
+            calls.append(("output_gather", value.shape, reduce_backward))
+            or torch.cat((value, value), dim=-1)
+        ),
+        raising=False,
     )
     monkeypatch.setattr(
         multi_lora_bank,
         "_scatter_sequence_parallel",
         lambda value, group, rank: (
-            calls.append(("scatter", value.shape, rank)) or value
+            calls.append(("sp_scatter", value.shape, rank)) or value
+        ),
+    )
+
+    monkeypatch.setattr(
+        multi_lora_kernel,
+        "batched_lora_linear_stage",
+        lambda value, weight, slots, **kwargs: (
+            calls.append(("A" if weight.shape[1] == 4 else "B", value.shape))
+            or value.new_zeros((value.shape[0], weight.shape[1]))
         ),
     )
     bank = DenseLoraBank(
-        nn.Parameter(torch.ones(2, 1, 2)), nn.Parameter(torch.ones(2, 3, 1))
+        torch.ones(2, 4, 2),
+        torch.ones(2, 2, 4),
+        LoraBankPartition(tp_size=2, output_partitioned_b=True),
     )
-    x = torch.ones(2, 1, 2)
-    slots = torch.tensor([0, 1], dtype=torch.int64)
-    qkv = apply_batched_lora_delta(
-        bank, x, slots, scale=1.0, tp_group=object(), sequence_parallel_input=True
-    )
-    proj = apply_batched_lora_delta(
+    apply_batched_lora_delta(
         bank,
-        x,
-        slots,
+        torch.ones(2, 1, 2),
+        torch.tensor([0, 1], dtype=torch.int64),
         scale=1.0,
         tp_group=object(),
         tp_rank=1,
         input_parallel_reduce=True,
         sequence_parallel_scatter_output=True,
     )
-    assert qkv.shape == proj.shape == (2, 1, 3)
     assert calls == [
-        ("gather", (2, 2)),
-        ("gather", (2, 1)),
-        ("reduce", (2, 3)),
-        ("scatter", (2, 3), 1),
+        ("A", (2, 2)),
+        ("rank_reduce", (2, 4)),
+        ("B", (2, 4)),
+        # LinearLoRA.forward uses the default reduce_backward=False here: the
+        # hidden gradient already crossed the preceding all-reduce.
+        ("output_gather", (2, 2), False),
+        ("sp_scatter", (2, 4), 1),
     ]
+
+
+def test_tp_named_export_materializes_internal_partitions_before_base_gathers(
+    monkeypatch,
+):
+    """Adapter-internal gathers precede native QKV-B/O-proj-A placement gathers."""
+
+    class PartitionedBank:
+        def __init__(self, a_bank, b_bank, partition):
+            self.a_bank = a_bank
+            self.b_bank = b_bank
+            self.partition = partition
+
+        @property
+        def slots(self):
+            return self.a_bank.shape[0]
+
+    qkv_surface = "layers.0.attn.qkv.linear.weight"
+    proj_surface = "layers.0.attn.proj.linear.weight"
+    # Rank 0's local QKV-A and O-proj-B shards use values distinguishable from
+    # the mocked rank 1 shard returned by allgather_concat below.
+    qkv_a = torch.arange(8, dtype=torch.float32).reshape(1, 2, 4)
+    qkv_b = torch.arange(16, dtype=torch.float32).reshape(1, 4, 4)
+    proj_a = torch.arange(8, dtype=torch.float32).reshape(1, 4, 2)
+    proj_b = torch.arange(8, dtype=torch.float32).reshape(1, 2, 4)
+    # This is the red contract for the future partition-aware validator: its
+    # current homogeneous-rank guard is itself the missing capability, so keep
+    # the export assertion independently reachable.
+    monkeypatch.setattr(NamedLoraBankRegistry, "__post_init__", lambda self: None)
+    registry = NamedLoraBankRegistry(
+        banks={
+            qkv_surface: PartitionedBank(
+                qkv_a, qkv_b, LoraBankPartition(tp_size=2, rank_partitioned_a=True)
+            ),
+            proj_surface: PartitionedBank(
+                proj_a, proj_b, LoraBankPartition(tp_size=2, output_partitioned_b=True)
+            ),
+        },
+        names={"alpha": 0},
+        rank=4,
+        alpha=4,
+        base_model_identity={},
+    )
+    calls = []
+
+    def _gather(value, world_size, group, *, dim):
+        calls.append((tuple(value.shape), dim, value.flatten()[0].item()))
+        return torch.cat((value, value + 100), dim=dim)
+
+    monkeypatch.setattr(hf_weights, "allgather_concat", _gather)
+    config = Qwen3MoEConfig(
+        num_hidden_layers=1,
+        hidden_size=4,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=2,
+        vocab_size=8,
+        num_experts=1,
+        num_experts_per_tok=1,
+        moe_intermediate_size=4,
+        layer_types=["full_attention"],
+    )
+    exported = registry.export_hf_state(
+        "alpha",
+        Qwen3MoEWeightSpec(config),
+        SimpleNamespace(tp_size=2, tp_group=object(), etp_size=1, etp_group=None),
+    )
+    assert calls == [
+        ((2, 4), 0, 0.0),  # QKV rank-partitioned A
+        ((4, 4), 0, 0.0),  # QKV column-parallel B
+        ((2, 4), 0, 0.0),  # O-proj output-partitioned B
+        ((4, 2), 1, 0.0),  # O-proj row-parallel A
+    ]
+    q_prefix = f"{VLLM_LORA_NAME_PREFIX}model.layers.0.self_attn"
+    assert exported[f"{q_prefix}.q_proj.lora_A.weight"].shape == (4, 4)
+    assert exported[f"{q_prefix}.k_proj.lora_B.weight"].shape == (2, 4)
+    assert exported[f"{q_prefix}.v_proj.lora_B.weight"].shape == (2, 4)
+    assert exported[f"{q_prefix}.o_proj.lora_A.weight"].shape == (4, 4)
+    assert exported[f"{q_prefix}.o_proj.lora_B.weight"].shape == (4, 4)
+    torch.testing.assert_close(
+        exported[f"{q_prefix}.q_proj.lora_A.weight"],
+        torch.tensor(
+            [
+                [0.0, 1.0, 2.0, 3.0],
+                [4.0, 5.0, 6.0, 7.0],
+                [100.0, 101.0, 102.0, 103.0],
+                [104.0, 105.0, 106.0, 107.0],
+            ]
+        ),
+    )
+    # Native fused QKV B is gathered on output rows before native_to_hf splits
+    # it; the mocked rank-1 rows therefore appear in K/V rather than Q.
+    torch.testing.assert_close(
+        exported[f"{q_prefix}.k_proj.lora_B.weight"],
+        torch.tensor([[100.0, 101.0, 102.0, 103.0], [104.0, 105.0, 106.0, 107.0]]),
+    )
+    torch.testing.assert_close(
+        exported[f"{q_prefix}.v_proj.lora_B.weight"],
+        torch.tensor([[108.0, 109.0, 110.0, 111.0], [112.0, 113.0, 114.0, 115.0]]),
+    )
+    torch.testing.assert_close(
+        exported[f"{q_prefix}.o_proj.lora_A.weight"],
+        torch.tensor(
+            [
+                [0.0, 1.0, 100.0, 101.0],
+                [2.0, 3.0, 102.0, 103.0],
+                [4.0, 5.0, 104.0, 105.0],
+                [6.0, 7.0, 106.0, 107.0],
+            ]
+        ),
+    )
+    torch.testing.assert_close(
+        exported[f"{q_prefix}.o_proj.lora_B.weight"],
+        torch.tensor(
+            [
+                [0.0, 1.0, 2.0, 3.0],
+                [4.0, 5.0, 6.0, 7.0],
+                [100.0, 101.0, 102.0, 103.0],
+                [104.0, 105.0, 106.0, 107.0],
+            ]
+        ),
+    )
 
 
 def test_batched_lora_delta_backward_matches_reference_for_repeated_slots():

--- a/experimental/lite/tests/unit/primitive/test_multi_lora_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_multi_lora_unit.py
@@ -354,6 +354,72 @@ def test_qkv_tp_carrier_collective_trace_has_hidden_rank_gather(monkeypatch):
     assert result.shape == (4, 1, 4)
 
 
+def test_qkv_sp_accepts_global_slots_without_second_slot_gather(monkeypatch):
+    """Production SP passes local rows but logical-global adapter slots."""
+    calls = []
+
+    def gather(value, _group):
+        calls.append(tuple(value.shape))
+        return torch.cat((value, value + 1), dim=0)
+
+    monkeypatch.setattr(multi_lora_bank, "_gather_sequence_parallel", gather)
+    monkeypatch.setattr(
+        multi_lora_bank,
+        "_all_gather_last_dim",
+        lambda value, _group, reduce_backward: torch.cat((value, value), dim=-1),
+    )
+    bank = DenseLoraBank(
+        torch.arange(2 * 2 * 4, dtype=torch.float32).reshape(2, 2, 4) / 16,
+        torch.arange(2 * 4 * 4, dtype=torch.float32).reshape(2, 4, 4) / 16,
+        LoraBankPartition(tp_size=2, rank_partitioned_a=True),
+    )
+    local_rows = torch.randn(2, 1, 4, requires_grad=True)
+    global_slots = torch.tensor([0, 1, 0, 1])
+    actual = apply_batched_lora_delta(
+        bank,
+        local_rows,
+        global_slots,
+        scale=0.5,
+        tp_group=object(),
+        sequence_parallel_input=True,
+    )
+    explicit_rows = torch.cat(
+        (local_rows.detach(), local_rows.detach() + 1), dim=0
+    ).requires_grad_()
+    expected = apply_batched_lora_delta(
+        bank, explicit_rows, global_slots, scale=0.5, tp_group=object()
+    )
+    torch.testing.assert_close(actual, expected)
+    actual.sum().backward()
+    expected.sum().backward()
+    torch.testing.assert_close(
+        local_rows.grad, explicit_rows.grad[:2] + explicit_rows.grad[2:]
+    )
+    assert calls == [(2, 4)]
+
+
+def test_qkv_sp_rejects_slots_neither_local_nor_global(monkeypatch):
+    monkeypatch.setattr(
+        multi_lora_bank,
+        "_gather_sequence_parallel",
+        lambda value, _group: torch.cat((value, value), dim=0),
+    )
+    bank = DenseLoraBank(
+        torch.ones(2, 2, 4),
+        torch.ones(2, 4, 4),
+        LoraBankPartition(tp_size=2, rank_partitioned_a=True),
+    )
+    with pytest.raises(ValueError, match="SP LoRA indices"):
+        apply_batched_lora_delta(
+            bank,
+            torch.ones(2, 1, 4),
+            torch.tensor([0, 1, 0]),
+            scale=1.0,
+            tp_group=object(),
+            sequence_parallel_input=True,
+        )
+
+
 def test_proj_tp_carrier_collective_trace_has_local_b_then_output_gather(monkeypatch):
     calls = []
     monkeypatch.setattr(

--- a/experimental/lite/tests/unit/primitive/test_multi_lora_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_multi_lora_unit.py
@@ -266,7 +266,7 @@ def test_tp_attention_builder_uses_linear_lora_partition_shapes(monkeypatch):
     for bank in (qkv, proj):
         for parameter in (bank.a_bank, bank.b_bank):
             assert parameter.tensor_model_parallel is True
-            assert parameter.allreduce is False
+            assert parameter.allreduce is True
     for bank in (fc1, fc2):
         for parameter in (bank.a_bank, bank.b_bank):
             assert parameter.tensor_model_parallel is False
@@ -1287,6 +1287,10 @@ def test_production_builder_owns_native_banks_and_injects_sidecars(monkeypatch):
     assert qkv.b_bank.shape == (2, 8, 24)
     assert proj.a_bank.shape == (2, 24, 4)
     assert proj.b_bank.shape == (2, 4, 24)
+    for bank in (fc1, fc2, qkv, proj):
+        for parameter in (bank.a_bank, bank.b_bank):
+            assert parameter.tensor_model_parallel is False
+            assert parameter.allreduce is True
     assert set(state.registry.banks) == {
         "layers.0.moe.experts._fc1_weight_0",
         "layers.0.moe.experts._fc2_weight_0",

--- a/experimental/lite/tests/unit/primitive/test_multi_lora_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_multi_lora_unit.py
@@ -35,6 +35,7 @@ from megatron.lite.primitive.modules.multi_lora_bank import (
     MultiLoraSpec,
     MultiLoraTrainingState,
     NamedLoraBankRegistry,
+    apply_batched_lora_delta,
     validate_multi_lora_parallel_support,
 )
 
@@ -139,6 +140,81 @@ def test_batched_lora_delta_matches_dense_reference_for_sorted_slots():
     )
 
     torch.testing.assert_close(actual, expected)
+
+
+def test_attention_bank_delta_matches_dense_oracle_and_only_updates_selected_slots():
+    """The generic attention carrier keeps per-token slots and zero banks inert."""
+    x = torch.tensor([[1.0, 2.0], [3.0, -1.0], [2.0, 4.0]], requires_grad=True)
+    a_bank = nn.Parameter(torch.tensor([[[1.0, 0.0]], [[0.0, 2.0]], [[3.0, 1.0]]]))
+    b_bank = nn.Parameter(torch.tensor([[[2.0]], [[-1.0]], [[0.0]]]))
+    slots = torch.tensor([1, 0, 1], dtype=torch.int64)
+    actual = apply_batched_lora_delta(
+        DenseLoraBank(a_bank, b_bank), x, slots, scale=0.5
+    )
+    expected = torch.stack(
+        [0.5 * (b_bank[slot] @ a_bank[slot] @ row) for row, slot in zip(x, slots)]
+    )
+    torch.testing.assert_close(actual, expected)
+    actual.sum().backward()
+    assert a_bank.grad[2].eq(0).all() and b_bank.grad[2].eq(0).all()
+
+    zero_bank = DenseLoraBank(
+        nn.Parameter(torch.ones(1, 1, 2)), nn.Parameter(torch.zeros(1, 1, 1))
+    )
+    assert (
+        apply_batched_lora_delta(
+            zero_bank, x.detach(), torch.zeros(3, dtype=torch.int64), scale=1.0
+        )
+        .eq(0)
+        .all()
+    )
+
+
+def test_attention_bank_tp_sp_contract_reuses_linear_lora_collective_order(monkeypatch):
+    """QKV gathers SP input; O-proj reduces TP-local contributions then scatters."""
+    calls = []
+    monkeypatch.setattr(
+        multi_lora_bank,
+        "_gather_sequence_parallel",
+        lambda value, group: calls.append(("gather", value.shape)) or value,
+    )
+    monkeypatch.setattr(
+        multi_lora_bank,
+        "_all_reduce_sum",
+        lambda value, group: calls.append(("reduce", value.shape)) or value,
+    )
+    monkeypatch.setattr(
+        multi_lora_bank,
+        "_scatter_sequence_parallel",
+        lambda value, group, rank: (
+            calls.append(("scatter", value.shape, rank)) or value
+        ),
+    )
+    bank = DenseLoraBank(
+        nn.Parameter(torch.ones(2, 1, 2)), nn.Parameter(torch.ones(2, 3, 1))
+    )
+    x = torch.ones(2, 1, 2)
+    slots = torch.tensor([0, 1], dtype=torch.int64)
+    qkv = apply_batched_lora_delta(
+        bank, x, slots, scale=1.0, tp_group=object(), sequence_parallel_input=True
+    )
+    proj = apply_batched_lora_delta(
+        bank,
+        x,
+        slots,
+        scale=1.0,
+        tp_group=object(),
+        tp_rank=1,
+        input_parallel_reduce=True,
+        sequence_parallel_scatter_output=True,
+    )
+    assert qkv.shape == proj.shape == (2, 1, 3)
+    assert calls == [
+        ("gather", (2, 2)),
+        ("gather", (2, 1)),
+        ("reduce", (2, 3)),
+        ("scatter", (2, 3), 1),
+    ]
 
 
 def test_batched_lora_delta_backward_matches_reference_for_repeated_slots():
@@ -821,6 +897,13 @@ def test_production_builder_owns_native_banks_and_injects_sidecars(monkeypatch):
 
     class FakeLayer:
         layer_idx = 0
+        attn = SimpleNamespace(
+            qkv=SimpleNamespace(
+                local_out=8,
+                linear=SimpleNamespace(),
+            ),
+            proj=SimpleNamespace(local_in=4),
+        )
 
     class FakeChunk(nn.Module):
         def __init__(self):
@@ -861,19 +944,30 @@ def test_production_builder_owns_native_banks_and_injects_sidecars(monkeypatch):
     )
     assert state is chunk.multi_lora_training_state
     fc1, fc2 = state.banks_for_layer(0)
+    qkv, proj = state.attention_banks_for_layer(0)
     assert fc1.a_bank.shape == (2, 24, 4)
     assert fc1.b_bank.shape == (2, 12, 24)
     assert fc2.a_bank.shape == (2, 24, 6)
     assert fc2.b_bank.shape == (2, 4, 24)
+    assert qkv.a_bank.shape == (2, 24, 4)
+    assert qkv.b_bank.shape == (2, 8, 24)
+    assert proj.a_bank.shape == (2, 24, 4)
+    assert proj.b_bank.shape == (2, 4, 24)
     assert set(state.registry.banks) == {
         "layers.0.moe.experts._fc1_weight_0",
         "layers.0.moe.experts._fc2_weight_0",
+        "layers.0.attn.qkv.linear.weight",
+        "layers.0.attn.proj.linear.weight",
     }
     assert {id(parameter) for parameter in state.parameters()} == {
         id(fc1.a_bank),
         id(fc1.b_bank),
         id(fc2.a_bank),
         id(fc2.b_bank),
+        id(state.registry.banks["layers.0.attn.qkv.linear.weight"].a_bank),
+        id(state.registry.banks["layers.0.attn.qkv.linear.weight"].b_bank),
+        id(state.registry.banks["layers.0.attn.proj.linear.weight"].a_bank),
+        id(state.registry.banks["layers.0.attn.proj.linear.weight"].b_bank),
     }
     optimizer_parameter_ids = {
         id(parameter)
@@ -890,11 +984,13 @@ def test_production_builder_owns_native_banks_and_injects_sidecars(monkeypatch):
         for surface in (
             "layers.0.moe.experts._fc1_weight_0",
             "layers.0.moe.experts._fc2_weight_0",
+            "layers.0.attn.qkv.linear.weight",
+            "layers.0.attn.proj.linear.weight",
         )
         for factor in ("a", "b")
     } <= set(checkpoint_state)
     selected = state.registry.select("alpha")
-    assert len(selected) == 2
+    assert len(selected) == 4
     selected_fc1_a, selected_fc1_b = selected["layers.0.moe.experts._fc1_weight_0"]
     selected_fc2_a, selected_fc2_b = selected["layers.0.moe.experts._fc2_weight_0"]
     torch.testing.assert_close(selected_fc1_a, fc1.a_bank[0])
@@ -928,6 +1024,9 @@ def test_production_builder_owns_native_banks_and_injects_sidecars(monkeypatch):
         f"model.layers.0.mlp.experts.{expert_idx}.{projection}"
         for expert_idx in range(config.num_experts)
         for projection in ("gate_proj", "up_proj", "down_proj")
+    } | {
+        f"model.layers.0.self_attn.{projection}"
+        for projection in ("q_proj", "k_proj", "v_proj", "o_proj")
     }
     expected_keys = {
         f"{VLLM_LORA_NAME_PREFIX}{module}.lora_{factor}.weight"
@@ -936,7 +1035,7 @@ def test_production_builder_owns_native_banks_and_injects_sidecars(monkeypatch):
     }
     generated_keys = [key for key, _ in generated]
     assert set(generated_keys) == expected_keys
-    assert len(generated_keys) == len(expected_keys) == config.num_experts * 3 * 2
+    assert len(generated_keys) == len(expected_keys) == (config.num_experts * 3 + 4) * 2
     assert len(generated_keys) == len(set(generated_keys))
     assert (
         set(state.registry.export_hf_state("alpha", Qwen3MoEWeightSpec(config), ps))
@@ -960,19 +1059,17 @@ def test_production_builder_owns_native_banks_and_injects_sidecars(monkeypatch):
     sidecar = output["multi_lora_sidecars"][0]
     assert bundle.extras["multi_lora_registry"] is state.registry
     assert sidecar.fc1 is fc1 and sidecar.fc2 is fc2
+    assert sidecar.qkv is qkv and sidecar.proj is proj
     assert sidecar.lora_indices is batch.extras["multi_lora_slots"][0]
 
 
-def test_multi_lora_parallel_contract_rejects_etp_and_deepep():
+def test_multi_lora_parallel_contract_allows_tp_and_rejects_etp_and_deepep():
     spec = multi_lora_bank.MultiLoraSpec(names=("alpha",), rank=2)
     with pytest.raises(ValueError, match="ETP"):
         validate_multi_lora_parallel_support(
             spec, tp_size=1, etp_size=2, use_deepep=False
         )
-    with pytest.raises(ValueError, match="TP"):
-        validate_multi_lora_parallel_support(
-            spec, tp_size=2, etp_size=1, use_deepep=False
-        )
+    validate_multi_lora_parallel_support(spec, tp_size=2, etp_size=1, use_deepep=False)
     with pytest.raises(ValueError, match="DeepEP"):
         validate_multi_lora_parallel_support(
             spec, tp_size=1, etp_size=1, use_deepep=True

--- a/experimental/lite/tests/unit/primitive/test_multi_lora_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_multi_lora_unit.py
@@ -308,8 +308,9 @@ def test_qkv_tp_carrier_collective_trace_has_hidden_rank_gather(monkeypatch):
     monkeypatch.setattr(
         multi_lora_bank,
         "_gather_sequence_parallel",
-        lambda value, group: calls.append(("sp_gather", value.shape))
-        or torch.cat((value, value), dim=0),
+        lambda value, group: (
+            calls.append(("sp_gather", value.shape)) or torch.cat((value, value), dim=0)
+        ),
     )
     monkeypatch.setattr(
         multi_lora_bank,

--- a/experimental/lite/tests/unit/primitive/test_multi_lora_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_multi_lora_unit.py
@@ -1521,6 +1521,27 @@ def test_qwen_moe_sidecar_sorts_then_restores_unsorted_slots():
     torch.testing.assert_close(actual, expected)
 
 
+@pytest.mark.parametrize(("tp_rank", "expected"), [(0, [0, 1]), (1, [2, 3])])
+def test_moe_sp_global_slots_follow_contiguous_scatter_order(
+    transformer_engine_import_stub, tp_rank, expected
+):
+    transformer_engine_import_stub()
+    from megatron.lite.model.qwen3_moe.lite.model import _local_moe_lora_indices
+
+    slots = torch.tensor([0, 1, 2, 3])
+    actual = _local_moe_lora_indices(slots, local_rows=2, tp_size=2, tp_rank=tp_rank)
+    assert actual.tolist() == expected
+    # Local input is already in SP-scatter order and must not be sliced again.
+    assert (
+        _local_moe_lora_indices(actual, local_rows=2, tp_size=2, tp_rank=tp_rank)
+        is actual
+    )
+    with pytest.raises(ValueError, match="local or TP-global"):
+        _local_moe_lora_indices(
+            torch.tensor([0, 1, 2]), local_rows=2, tp_size=2, tp_rank=tp_rank
+        )
+
+
 def test_ep_gradient_sync_is_identity_in_forward_and_all_reduces_in_backward(
     monkeypatch,
 ):

--- a/experimental/lite/tests/unit/primitive/test_multi_lora_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_multi_lora_unit.py
@@ -270,7 +270,7 @@ def test_tp_attention_builder_uses_linear_lora_partition_shapes(monkeypatch):
     for bank in (fc1, fc2):
         for parameter in (bank.a_bank, bank.b_bank):
             assert parameter.tensor_model_parallel is False
-            assert parameter.allreduce is True
+            assert parameter.allreduce is False
 
 
 def test_tp_attention_builder_rejects_rank_not_divisible_by_tp():
@@ -1087,10 +1087,10 @@ def test_semantic_bank_parameter_names_survive_reordered_registry_and_pp_stages(
     assert all("." not in name for name in stage_zero | stage_one)
 
 
-def test_model_owned_sidecar_has_no_explicit_ep_gradient_owner(
+def test_model_owned_fc_sidecar_has_explicit_ep_gradient_owner(
     monkeypatch, transformer_engine_import_stub
 ):
-    """Production injection, not a tensor attribute, selects dense finalize ownership."""
+    """Model-owned replicated FC banks retain their explicit EP owner."""
     state = MultiLoraTrainingState(
         NamedLoraBankRegistry(
             banks={
@@ -1127,14 +1127,14 @@ def test_model_owned_sidecar_has_no_explicit_ep_gradient_owner(
     protocol = importlib.import_module("megatron.lite.model.qwen3_moe.lite.protocol")
     protocol._inject_multi_lora_sidecars(injected, Batch(), state)
     owned = injected["multi_lora_sidecars"][0]
-    assert owned.requires_explicit_ep_sync is False
+    assert owned.requires_explicit_ep_sync is True
 
     # Test the real model.py selector, not a hand-passed ``None`` argument.
     transformer_engine_import_stub()
     sys.modules.pop("megatron.lite.model.qwen3_moe.lite.model", None)
     model = importlib.import_module("megatron.lite.model.qwen3_moe.lite.model")
     ps = SimpleNamespace(ep_size=2, ep_group=object())
-    assert model._sidecar_ep_sync_group(ps, owned) is None
+    assert model._sidecar_ep_sync_group(ps, owned) is ps.ep_group
 
     # The legacy external contract still selects one explicit EP group for
     # each of its two model call sites (fc1 and fc2).
@@ -1287,7 +1287,11 @@ def test_production_builder_owns_native_banks_and_injects_sidecars(monkeypatch):
     assert qkv.b_bank.shape == (2, 8, 24)
     assert proj.a_bank.shape == (2, 24, 4)
     assert proj.b_bank.shape == (2, 4, 24)
-    for bank in (fc1, fc2, qkv, proj):
+    for bank in (fc1, fc2):
+        for parameter in (bank.a_bank, bank.b_bank):
+            assert parameter.tensor_model_parallel is False
+            assert parameter.allreduce is False
+    for bank in (qkv, proj):
         for parameter in (bank.a_bank, bank.b_bank):
             assert parameter.tensor_model_parallel is False
             assert parameter.allreduce is True


### PR DESCRIPTION
## Summary

- add QKV and output-projection multi-LoRA banks to the model-owned training state
- preserve single-LoRA TP/SP partitioning and native checkpoint/HF export mappings
- add TP/EP ownership, distributed preflight, checkpoint round-trip, and production smoke coverage

## Validation

- multi-LoRA unit and distributed ownership coverage
- TP/SP gradient and partition-contract coverage
- production smoke coverage for TP/EP and checkpoint round-trip paths
