### PR TITLE
fix DS4 QAT HF checkpoint loading

### DIFF
--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
@@ -272,7 +272,7 @@ class DeepseekV4WeightSpec:
         )
         weight_map: dict[str, list[str]] = {}
         for name in logical_state_keys:
-            if _is_native_metadata_key(name):
+            if ".parametrizations." in name or _is_native_metadata_key(name):
                 continue
             global_name = to_global_layer_name(name, layer_map)
             mapped_name = _to_global_expert_name(global_name, self.config, ps)

--- a/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
@@ -875,7 +875,11 @@ def _load_weight_map_for_model(
     state: dict[str, torch.Tensor],
 ) -> dict[str, list[str]]:
     """Build the one native-to-HF plan shared by load and export."""
-    logical_state_keys = tuple(canonical_state_key(name) for name in state)
+    logical_state_keys = tuple(
+        canonical_state_key(name)
+        for name in state
+        if ".parametrizations." not in name or name.endswith(".original")
+    )
     load_weight_map = getattr(spec, "load_weight_map", None)
     return (
         load_weight_map(base_model, ps, logical_state_keys)


### PR DESCRIPTION
## Summary

Fix DeepSeek-V4 HF checkpoint loading when QAT is enabled.

- Exclude parametrization-owned auxiliary state, such as `amax`, when building the dynamic HF load map.
- Preserve `.parametrizations.weight.original` as the logical HF `weight`.
- Add a DS4-side defensive filter for parametrization state.
- Keep ordinary persistent buffers unchanged.

## Root cause

QAT adds auxiliary buffers such as:

`...parametrizations.weight.0.amax`

to the model `state_dict`. DS4 dynamically derives its HF load map from those
state keys, so the auxiliary buffer was incorrectly treated as a required HF
checkpoint tensor. Initial HF checkpoints do not contain QAT statistics, causing
the load to fail.

## Behavior after the fix

- QAT master weights continue to load from their normal HF tensor names.
- QAT auxiliary statistics are not required from the initial HF checkpoint.
- Non-QAT loading and ordinary persistent-buffer handling are unchanged.

## Validation

- Focused DS4/QAT/HF loading checks passed locally.
- `git diff --check` passed.
- Final diff: 2 files, +6/-2.