### PR TITLE
feat(mlite): add training and rollout offload for standalone M-FSDP

### DIFF
--- a/experimental/lite/examples/bench/README.md
+++ b/experimental/lite/examples/bench/README.md
@@ -155,13 +155,17 @@ they are not a replacement for precision tests.
 ## Standalone M-FSDP
 
 The native Qwen3 MoE and Qwen3.5 implementations accept `mfsdp` as the
-optimizer selected through `impl_cfg_json`. For the no-offload path, keep
-optimizer state and parameter shards on GPU (`offload_fraction=0.0`). The
-communication-unit budget follows MCore's automatic rule unless an application
-explicitly overrides and revalidates it.
+optimizer selected through `impl_cfg_json`. With `offload_fraction=0.0`, model
+and optimizer shards remain on GPU. With full training offload
+(`offload_fraction=1.0`), the local BF16 parameter shard and FP32 Adam master,
+first moment, and second moment remain on pinned CPU memory. M-FSDP stages one
+bounded local parameter shard on GPU for each forward/backward all-gather and
+keeps the sharded FP32 main gradient on GPU until the CPU optimizer consumes it.
 
-This standalone delivery rejects nonzero `offload_fraction`; optimizer offload
-is a separate implementation and validation path.
+Full training offload selects the memory-first MCore communication policy: one
+bucket-sized communication budget and no parameter-gather prefetch. Explicit
+communication overrides are preserved and must be revalidated for the target
+workload.
 
 ```bash
 unset CUDA_DEVICE_MAX_CONNECTIONS
@@ -185,6 +189,28 @@ torchrun --standalone --nproc_per_node 8 \
     '{"offload_fraction":0.0,"use_precision_aware_optimizer":false,"gradient_accumulation_fusion":false,"megatron_fsdp_main_params_dtype":"fp32","megatron_fsdp_main_grads_dtype":"fp32","megatron_fsdp_grad_comm_dtype":"fp32"}' \
   --output-json /tmp/qwen35_mfsdp_bench.json
 ```
+
+To run the full training-offload path, keep the command unchanged except for:
+
+```bash
+--override-optimizer-json \
+  '{"offload_fraction":1.0,"gradient_accumulation_fusion":false,"megatron_fsdp_main_grads_dtype":"fp32","megatron_fsdp_grad_comm_dtype":"fp32"}'
+```
+
+Colocated train/rollout runtimes reclaim the complete training allocation via
+the existing runtime transfer boundary:
+
+```python
+runtime.to(handle, "cpu", model=True, optimizer=True, grad=True)
+# Run rollout while M-FSDP training state is offloaded.
+runtime.to(handle, "cuda", model=True, optimizer=True, grad=True)
+```
+
+The first call atomically releases communication scratch, retains the parameter
+and Adam shards on CPU, and drops the GPU main-gradient shard instead of making
+a persistent CPU gradient copy. The second call recreates an empty GPU gradient
+shard and restores training. Both calls must occur at an optimizer-step
+boundary.
 
 The storage-resize path allocates each communication bucket only while its
 lifetime is active. NCCL user buffers and fixed communication pools are not part

--- a/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
@@ -403,11 +403,15 @@ def _mfsdp_replicated_dtensor(bucket, tensor: torch.Tensor) -> DTensor:
     )
 
 
-def _mfsdp_param_optimizer_state(inner, param) -> dict[str, Any]:
+def _mfsdp_param_optimizer_state(
+    inner, param, *, create: bool = False
+) -> dict[str, Any]:
     cpu_group = getattr(inner, "cpu_group", None)
     if cpu_group is not None and cpu_group.owns_param(param):
         return cpu_group.checkpoint_state(param)
     torch_optimizer = getattr(inner, "optimizer", inner)
+    if create:
+        return torch_optimizer.state.setdefault(param, {})
     return torch_optimizer.state.get(param, {})
 
 
@@ -684,7 +688,7 @@ def _mfsdp_unpack_optimizer_tensor(
             ):
                 inner.optimizer.state.pop(spec.shard_param, None)
             continue
-        state = _mfsdp_param_optimizer_state(inner, spec.shard_param)
+        state = _mfsdp_param_optimizer_state(inner, spec.shard_param, create=True)
         value = (
             local.narrow(0, spec.local_offset, spec.shard_numel)
             .view_as(spec.shard_param)

--- a/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
@@ -345,7 +345,7 @@ def _mfsdp_bucket_mesh(bucket) -> DeviceMesh:
     if not dist.is_initialized():
         raise RuntimeError("M-FSDP DCP requires torch.distributed initialization.")
     group = bucket.process_group or dist.group.WORLD
-    return DeviceMesh.from_group(group, bucket.main_param_buffer.device.type)
+    return DeviceMesh.from_group(group, bucket.device.type)
 
 
 def _mfsdp_standard_shard_range(logical_numel: int, world_size: int, rank: int):
@@ -361,10 +361,17 @@ def _mfsdp_gather_padded_bucket(bucket, local: torch.Tensor) -> torch.Tensor:
             f"M-FSDP bucket {bucket.bucket_id} local tensor has {local.numel()} "
             f"elements, expected {bucket.local_numel}."
         )
+    communication_local = local.detach().to(bucket.device)
     if bucket.world_size == 1:
-        return local.detach().clone()
-    full = torch.empty(bucket.full_numel, dtype=local.dtype, device=local.device)
-    dist.all_gather_into_tensor(full, local.contiguous(), group=bucket.process_group)
+        return communication_local.clone()
+    full = torch.empty(
+        bucket.full_numel,
+        dtype=communication_local.dtype,
+        device=bucket.device,
+    )
+    dist.all_gather_into_tensor(
+        full, communication_local.contiguous(), group=bucket.process_group
+    )
     return full
 
 
@@ -385,6 +392,7 @@ def _mfsdp_logical_dtensor(bucket, local_padded: torch.Tensor) -> DTensor:
 
 
 def _mfsdp_replicated_dtensor(bucket, tensor: torch.Tensor) -> DTensor:
+    tensor = tensor.to(bucket.device)
     return DTensor.from_local(
         tensor,
         _mfsdp_bucket_mesh(bucket),
@@ -395,16 +403,24 @@ def _mfsdp_replicated_dtensor(bucket, tensor: torch.Tensor) -> DTensor:
     )
 
 
-def _mfsdp_pack_optimizer_tensor(bucket, torch_optimizer, state_name: str):
+def _mfsdp_param_optimizer_state(inner, param) -> dict[str, Any]:
+    cpu_group = getattr(inner, "cpu_group", None)
+    if cpu_group is not None and cpu_group.owns_param(param):
+        return cpu_group.checkpoint_state(param)
+    torch_optimizer = getattr(inner, "optimizer", inner)
+    return torch_optimizer.state.get(param, {})
+
+
+def _mfsdp_pack_optimizer_tensor(bucket, inner, state_name: str):
     packed = torch.zeros(
         bucket.local_numel,
-        dtype=bucket.main_param_buffer.dtype,
-        device=bucket.main_param_buffer.device,
+        dtype=torch.float32,
+        device=bucket.device,
     )
     for spec in bucket.specs:
         if spec.shard_param is None or not spec.full_param.requires_grad:
             continue
-        value = torch_optimizer.state.get(spec.shard_param, {}).get(state_name)
+        value = _mfsdp_param_optimizer_state(inner, spec.shard_param).get(state_name)
         if value is None:
             continue
         if not torch.is_tensor(value) or value.numel() != spec.shard_numel:
@@ -418,18 +434,18 @@ def _mfsdp_pack_optimizer_tensor(bucket, torch_optimizer, state_name: str):
     return packed
 
 
-def _mfsdp_optimizer_metadata(bucket, torch_optimizer):
+def _mfsdp_optimizer_metadata(bucket, inner):
     initialized = torch.zeros(
-        len(bucket.specs), dtype=torch.uint8, device=bucket.main_param_buffer.device
+        len(bucket.specs), dtype=torch.uint8, device=bucket.device
     )
     step_present = torch.zeros_like(initialized)
     steps = torch.zeros(
-        len(bucket.specs), dtype=torch.float64, device=bucket.main_param_buffer.device
+        len(bucket.specs), dtype=torch.float64, device=bucket.device
     )
     for index, spec in enumerate(bucket.specs):
         if spec.shard_param is None or not spec.full_param.requires_grad:
             continue
-        state = torch_optimizer.state.get(spec.shard_param, {})
+        state = _mfsdp_param_optimizer_state(inner, spec.shard_param)
         if not state:
             continue
         initialized[index] = 1
@@ -495,6 +511,32 @@ def _mfsdp_restore_optimizer_param_groups(
         group["params"] = params
 
 
+def _mfsdp_optimizer_group_state(inner) -> list[dict[str, Any]] | dict[str, Any]:
+    gpu = _mfsdp_optimizer_param_groups(inner.optimizer)
+    if inner.cpu_group is None:
+        return gpu
+    return {"gpu": gpu, "cpu": inner.cpu_group.checkpoint_metadata()}
+
+
+def _mfsdp_restore_optimizer_group_state(
+    inner, saved: list[dict[str, Any]] | dict[str, Any]
+) -> None:
+    if inner.cpu_group is None:
+        if not isinstance(saved, list):
+            raise RuntimeError(
+                "M-FSDP checkpoint contains CPU optimizer metadata but the "
+                "target optimizer has no CPU-offloaded group."
+            )
+        _mfsdp_restore_optimizer_param_groups(inner.optimizer, saved)
+        return
+    if not isinstance(saved, dict) or "gpu" not in saved or "cpu" not in saved:
+        raise RuntimeError(
+            "M-FSDP CPU-offloaded DCP requires both GPU and CPU optimizer metadata."
+        )
+    _mfsdp_restore_optimizer_param_groups(inner.optimizer, saved["gpu"])
+    inner.cpu_group.load_checkpoint_metadata(saved["cpu"])
+
+
 def _mfsdp_domain_key(bucket, ps) -> str:
     if ps is None:
         if dist.get_world_size() != bucket.world_size:
@@ -524,9 +566,9 @@ def _mfsdp_checkpoint_template(
     include_model: bool,
     include_optimizer: bool,
 ):
-    torch_optimizer = None
+    inner = None
     if include_optimizer:
-        _inner, torch_optimizer = _mfsdp_optimizer_parts(optimizer)
+        inner, _torch_optimizer = _mfsdp_optimizer_parts(optimizer)
     domains: dict[str, dict[str, dict[str, Any]]] = {}
     for chunk_index, chunk in enumerate(chunks):
         for bucket in chunk.param_and_grad_buffer.buckets:
@@ -543,9 +585,9 @@ def _mfsdp_checkpoint_template(
                     bucket, bucket.main_param_buffer
                 )
             if include_optimizer and bucket.requires_grad:
-                assert torch_optimizer is not None
+                assert inner is not None
                 initialized, step_present, steps = _mfsdp_optimizer_metadata(
-                    bucket, torch_optimizer
+                    bucket, inner
                 )
                 bucket_state["state_initialized"] = _mfsdp_replicated_dtensor(
                     bucket, initialized
@@ -556,12 +598,19 @@ def _mfsdp_checkpoint_template(
                 bucket_state["step"] = _mfsdp_replicated_dtensor(bucket, steps)
                 bucket_state["exp_avg"] = _mfsdp_logical_dtensor(
                     bucket,
-                    _mfsdp_pack_optimizer_tensor(bucket, torch_optimizer, "exp_avg"),
+                    _mfsdp_pack_optimizer_tensor(bucket, inner, "exp_avg"),
                 )
                 bucket_state["exp_avg_sq"] = _mfsdp_logical_dtensor(
                     bucket,
-                    _mfsdp_pack_optimizer_tensor(bucket, torch_optimizer, "exp_avg_sq"),
+                    _mfsdp_pack_optimizer_tensor(bucket, inner, "exp_avg_sq"),
                 )
+                if inner.cpu_group is not None:
+                    bucket_state["master_param"] = _mfsdp_logical_dtensor(
+                        bucket,
+                        _mfsdp_pack_optimizer_tensor(
+                            bucket, inner, "master_param"
+                        ),
+                    )
             domain = domains.setdefault(_mfsdp_domain_key(bucket, ps), {})
             chunk_state = domain.setdefault(str(chunk_index), {})
             chunk_state[str(bucket.bucket_id)] = bucket_state
@@ -590,10 +639,8 @@ def _save_mfsdp_checkpoint(
             include_optimizer=save_optimizer,
         )
     if save_optimizer:
-        _inner, torch_optimizer = _mfsdp_optimizer_parts(optimizer)
-        state_dict["optimizer_param_groups"] = _mfsdp_optimizer_param_groups(
-            torch_optimizer
-        )
+        inner, _torch_optimizer = _mfsdp_optimizer_parts(optimizer)
+        state_dict["optimizer_param_groups"] = _mfsdp_optimizer_group_state(inner)
     dcp.save(state_dict, checkpoint_id=path)
 
 
@@ -602,40 +649,73 @@ def _mfsdp_copy_logical_to_bucket(bucket, logical: torch.Tensor, target: torch.T
     local_start = bucket.rank * bucket.local_numel
     local_end = min(local_start + bucket.local_numel, bucket.logical_numel)
     if local_end > local_start:
+        source = logical.narrow(0, local_start, local_end - local_start)
         target.narrow(0, 0, local_end - local_start).copy_(
-            logical.narrow(0, local_start, local_end - local_start)
+            source.to(device=target.device, dtype=target.dtype)
         )
 
 
 def _mfsdp_unpack_optimizer_tensor(
     bucket,
-    torch_optimizer,
+    inner,
     logical: torch.Tensor,
     state_name: str,
     initialized: torch.Tensor,
     step_present: torch.Tensor,
     steps: torch.Tensor,
 ) -> None:
-    local = torch.zeros_like(bucket.main_param_buffer)
+    local = torch.zeros(
+        bucket.local_numel,
+        dtype=logical.dtype,
+        device=logical.device,
+    )
     _mfsdp_copy_logical_to_bucket(bucket, logical, local)
     for index, spec in enumerate(bucket.specs):
         if spec.shard_param is None or not spec.full_param.requires_grad:
             continue
-        if not bool(initialized[index].item()):
-            torch_optimizer.state.pop(spec.shard_param, None)
+        if state_name == "master_param" and (
+            inner.cpu_group is None
+            or not inner.cpu_group.owns_param(spec.shard_param)
+        ):
             continue
-        state = torch_optimizer.state.setdefault(spec.shard_param, {})
-        state[state_name] = (
+        if not bool(initialized[index].item()):
+            if inner.cpu_group is None or not inner.cpu_group.owns_param(
+                spec.shard_param
+            ):
+                inner.optimizer.state.pop(spec.shard_param, None)
+            continue
+        state = _mfsdp_param_optimizer_state(inner, spec.shard_param)
+        value = (
             local.narrow(0, spec.local_offset, spec.shard_numel)
             .view_as(spec.shard_param)
-            .clone()
         )
+        current = state.get(state_name)
+        if torch.is_tensor(current):
+            current.copy_(value.to(device=current.device, dtype=current.dtype))
+        else:
+            state[state_name] = value.to(spec.shard_param.device).clone()
+        if state_name == "master_param":
+            master = state[state_name]
+            with torch.no_grad():
+                spec.shard_param.copy_(
+                    master.to(
+                        device=spec.shard_param.device,
+                        dtype=spec.shard_param.dtype,
+                    )
+                )
         if bool(step_present[index].item()):
-            state["step"] = torch.tensor(
-                float(steps[index].item()),
-                dtype=torch.float32,
-                device=spec.shard_param.device,
-            )
+            step_value = float(steps[index].item())
+            current_step = state.get("step")
+            if torch.is_tensor(current_step):
+                current_step.fill_(step_value)
+            elif current_step is not None:
+                state["step"] = int(step_value)
+            else:
+                state["step"] = torch.tensor(
+                    step_value,
+                    dtype=torch.float32,
+                    device=spec.shard_param.device,
+                )
         else:
             state.pop("step", None)
 
@@ -659,17 +739,15 @@ def _load_mfsdp_checkpoint(
             include_optimizer=load_optimizer,
         ),
     }
-    torch_optimizer = None
+    inner = None
     if load_optimizer:
-        _inner, torch_optimizer = _mfsdp_optimizer_parts(optimizer)
-        state_dict["optimizer_param_groups"] = _mfsdp_optimizer_param_groups(
-            torch_optimizer
-        )
+        inner, _torch_optimizer = _mfsdp_optimizer_parts(optimizer)
+        state_dict["optimizer_param_groups"] = _mfsdp_optimizer_group_state(inner)
     dcp.load(state_dict, checkpoint_id=path)
     if load_optimizer:
-        assert torch_optimizer is not None
-        _mfsdp_restore_optimizer_param_groups(
-            torch_optimizer, state_dict["optimizer_param_groups"]
+        assert inner is not None
+        _mfsdp_restore_optimizer_group_state(
+            inner, state_dict["optimizer_param_groups"]
         )
     loaded_domains = state_dict["mfsdp"]["domains"]
     for chunk_index, chunk in enumerate(chunks):
@@ -692,7 +770,7 @@ def _load_mfsdp_checkpoint(
                 bucket.copy_main_weights_to_model_weights()
                 bucket.invalidate_full_parameters()
             if load_optimizer and bucket.requires_grad:
-                assert torch_optimizer is not None
+                assert inner is not None
                 initialized = loaded_bucket["state_initialized"].to_local()
                 step_present = loaded_bucket["step_present"].to_local()
                 steps = loaded_bucket["step"].to_local()
@@ -700,9 +778,20 @@ def _load_mfsdp_checkpoint(
                     logical_state = loaded_bucket[state_name].full_tensor()
                     _mfsdp_unpack_optimizer_tensor(
                         bucket,
-                        torch_optimizer,
+                        inner,
                         logical_state,
                         state_name,
+                        initialized,
+                        step_present,
+                        steps,
+                    )
+                if "master_param" in loaded_bucket:
+                    logical_master = loaded_bucket["master_param"].full_tensor()
+                    _mfsdp_unpack_optimizer_tensor(
+                        bucket,
+                        inner,
+                        logical_master,
+                        "master_param",
                         initialized,
                         step_present,
                         steps,

--- a/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
@@ -425,6 +425,12 @@ def _mfsdp_pack_optimizer_tensor(bucket, inner, state_name: str):
         if spec.shard_param is None or not spec.full_param.requires_grad:
             continue
         value = _mfsdp_param_optimizer_state(inner, spec.shard_param).get(state_name)
+        if value is None and state_name == "master_param":
+            # A partial-offload checkpoint may be restored with another DP
+            # size, moving the deterministic CPU/GPU split boundary.  GPU-owned
+            # shards already are the FP32 master, so save them in the common
+            # master field as well instead of leaving an unrecoverable zero.
+            value = spec.shard_param.detach()
         if value is None:
             continue
         if not torch.is_tensor(value) or value.numel() != spec.shard_numel:

--- a/experimental/lite/megatron/lite/primitive/optimizers/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 import importlib
 
+from megatron.lite.primitive.optimizers.runtime_adapter import DEFAULT_RUNTIME_ADAPTER
+
 BACKENDS = {
     "dist_opt": "megatron.lite.primitive.optimizers.megatron_wrap",
     "fsdp2": "megatron.lite.primitive.optimizers.fsdp2",
@@ -12,7 +14,9 @@ BACKENDS = {
 }
 
 
-def get_optimizer_backend(name: str):
+def get_optimizer_backend(name: str | None):
+    if name in (None, "none"):
+        return DEFAULT_RUNTIME_ADAPTER
     if name not in BACKENDS:
         raise ValueError(f"Unknown Megatron Lite optimizer backend: {name!r}.")
     return importlib.import_module(BACKENDS[name]).BACKEND

--- a/experimental/lite/megatron/lite/primitive/optimizers/fp32_adamw.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fp32_adamw.py
@@ -1,0 +1,354 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Backend-neutral FP32 AdamW update kernel for local parameter shards."""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Callable, Iterable
+from typing import Any, Protocol
+
+import torch
+import torch.nn as nn
+
+LocalTensorFn = Callable[[nn.Parameter], torch.Tensor]
+LocalGradFn = Callable[[nn.Parameter], torch.Tensor | None]
+CopyMasterSliceFn = Callable[[nn.Parameter, torch.Tensor, int, int], None]
+
+
+class GradTransferPolicy(Protocol):
+    """Scratch-transfer contract used by the sliced update pipeline."""
+
+    depth: int
+
+    def copy_grad_slice(self, grad: torch.Tensor, start: int, length: int) -> Any: ...
+
+    def wait_grad_slice(self, ticket: Any) -> torch.Tensor: ...
+
+    def release_grad_slice(self, ticket: Any) -> None: ...
+
+    def drain(self) -> None: ...
+
+
+class SynchronousGradTransfer:
+    """Default transfer policy for gradients already on the update device."""
+
+    depth = 1
+
+    def __init__(self, device: torch.device | str | None = None) -> None:
+        self.device = None if device is None else torch.device(device)
+
+    def copy_grad_slice(
+        self, grad: torch.Tensor, start: int, length: int
+    ) -> torch.Tensor:
+        value = grad.detach().reshape(-1).narrow(0, start, length)
+        return value.to(device=self.device or value.device, dtype=torch.float32)
+
+    def wait_grad_slice(self, ticket: torch.Tensor) -> torch.Tensor:
+        return ticket
+
+    def release_grad_slice(self, ticket: torch.Tensor) -> None:
+        del ticket
+
+    def drain(self) -> None:
+        pass
+
+
+def normalize_param_groups(
+    params: Iterable[nn.Parameter] | Iterable[dict[str, Any]],
+    *,
+    default_weight_decay: float,
+) -> list[dict[str, Any]]:
+    """Normalize torch-style parameters without introducing backend knowledge."""
+    items = list(params)
+    if not items:
+        return []
+    if all(isinstance(item, dict) for item in items):
+        groups: list[dict[str, Any]] = []
+        for item in items:
+            group = dict(item)
+            group_params = list(group.get("params", ()))
+            if not group_params:
+                continue
+            group["params"] = group_params
+            group.setdefault("weight_decay", default_weight_decay)
+            groups.append(group)
+        return groups
+    return [{"params": items, "weight_decay": default_weight_decay}]
+
+
+class FP32AdamW:
+    """Scalar AdamW over ordinary local tensors with optional bounded slicing.
+
+    Sharding, collectives, model residency, and checkpoint envelopes remain the
+    responsibility of backend adapters. This class owns only FP32 master/moment
+    state and the elementwise update.
+    """
+
+    def __init__(
+        self,
+        params: Iterable[nn.Parameter] | Iterable[dict[str, Any]],
+        *,
+        lr: float,
+        weight_decay: float,
+        betas: tuple[float, float],
+        eps: float,
+        local_param: LocalTensorFn | None = None,
+        local_grad: LocalGradFn | None = None,
+        copy_master_slice_to_param: CopyMasterSliceFn | None = None,
+        master_device: torch.device | str | None = None,
+        pin_master: bool = False,
+        transfer_policy: GradTransferPolicy | None = None,
+        slice_capacity: int | None = None,
+    ) -> None:
+        if slice_capacity is not None and slice_capacity <= 0:
+            raise ValueError("slice_capacity must be a positive element count or None.")
+        self.param_groups = normalize_param_groups(
+            params, default_weight_decay=weight_decay
+        )
+        self.params: list[nn.Parameter] = []
+        self.lr = float(lr)
+        self.weight_decay = float(weight_decay)
+        self.betas = (float(betas[0]), float(betas[1]))
+        self.eps = float(eps)
+        self.step_count = 0
+        self.slice_capacity = slice_capacity
+        self._local_param = local_param or (lambda param: param.detach())
+        self._local_grad = local_grad or (lambda param: param.grad)
+        self._copy_master_slice = (
+            copy_master_slice_to_param or self._default_copy_master_slice
+        )
+        self._master_device = (
+            None if master_device is None else torch.device(master_device)
+        )
+        if pin_master and self._master_device != torch.device("cpu"):
+            raise ValueError("pin_master requires master_device='cpu'.")
+        self._pin_master = bool(pin_master)
+        self._transfer_policy = transfer_policy or SynchronousGradTransfer(
+            self._master_device
+        )
+        if int(self._transfer_policy.depth) <= 0:
+            raise ValueError("gradient transfer depth must be positive.")
+
+        self.state: dict[nn.Parameter, dict[str, Any]] = {}
+        for group in self.param_groups:
+            group.setdefault("lr", self.lr)
+            group.setdefault("wd_mult", 1.0)
+            group["weight_decay"] = float(group.get("weight_decay", self.weight_decay))
+            for param in group["params"]:
+                self.params.append(param)
+                local = self._local_param(param).detach()
+                if self._pin_master:
+                    master = torch.empty(
+                        local.shape, dtype=torch.float32, device="cpu", pin_memory=True
+                    )
+                    master.copy_(local)
+                elif self._master_device is None and local.dtype is torch.float32:
+                    master = local
+                else:
+                    master = local.to(
+                        device=self._master_device or local.device, dtype=torch.float32
+                    ).clone()
+                self.state[param] = {
+                    "master_param": master,
+                    "exp_avg": torch.zeros_like(master, dtype=torch.float32),
+                    "exp_avg_sq": torch.zeros_like(master, dtype=torch.float32),
+                    "step": 0,
+                }
+
+    def zero_grad(self, *args, **kwargs) -> None:
+        set_to_none = bool(args[0]) if args else bool(kwargs.get("set_to_none", False))
+        for param in self.params:
+            if set_to_none:
+                param.grad = None
+            elif param.grad is not None:
+                param.grad.detach_()
+                param.grad.zero_()
+
+    def step(self) -> None:
+        self.step_count += 1
+        beta1, beta2 = self.betas
+        for group in self.param_groups:
+            group_lr = float(group.get("lr", self.lr))
+            group_weight_decay = float(group.get("weight_decay", self.weight_decay))
+            for param in group["params"]:
+                grad = self._local_grad(param)
+                if grad is None or grad.numel() == 0:
+                    continue
+                state = self.state[param]
+                state["step"] = int(state["step"]) + 1
+                param_step = int(state["step"])
+                step_size = group_lr / (1.0 - beta1**param_step)
+                bias_correction2_sqrt = (1.0 - beta2**param_step) ** 0.5
+                self._step_one_param(
+                    param,
+                    grad,
+                    state,
+                    group_lr=group_lr,
+                    group_weight_decay=group_weight_decay,
+                    beta1=beta1,
+                    beta2=beta2,
+                    step_size=step_size,
+                    bias_correction2_sqrt=bias_correction2_sqrt,
+                )
+        self._transfer_policy.drain()
+
+    def _step_one_param(
+        self,
+        param: nn.Parameter,
+        grad: torch.Tensor,
+        state: dict[str, Any],
+        *,
+        group_lr: float,
+        group_weight_decay: float,
+        beta1: float,
+        beta2: float,
+        step_size: float,
+        bias_correction2_sqrt: float,
+    ) -> None:
+        master = state["master_param"].reshape(-1)
+        exp_avg = state["exp_avg"].reshape(-1)
+        exp_avg_sq = state["exp_avg_sq"].reshape(-1)
+        capacity = self.slice_capacity or master.numel()
+        slices = iter(
+            (start, min(capacity, master.numel() - start))
+            for start in range(0, master.numel(), capacity)
+        )
+        pending: deque[tuple[int, int, Any]] = deque()
+        for _ in range(min(int(self._transfer_policy.depth), master.numel())):
+            try:
+                start, length = next(slices)
+            except StopIteration:
+                break
+            pending.append(
+                (
+                    start,
+                    length,
+                    self._transfer_policy.copy_grad_slice(grad, start, length),
+                )
+            )
+
+        while pending:
+            start, length, ticket = pending.popleft()
+            grad_slice = self._transfer_policy.wait_grad_slice(ticket)
+            master_slice = master.narrow(0, start, length)
+            exp_avg_slice = exp_avg.narrow(0, start, length)
+            exp_avg_sq_slice = exp_avg_sq.narrow(0, start, length)
+            if group_weight_decay != 0.0:
+                master_slice.mul_(1.0 - group_lr * group_weight_decay)
+            exp_avg_slice.mul_(beta1).add_(grad_slice, alpha=1.0 - beta1)
+            exp_avg_sq_slice.mul_(beta2).addcmul_(
+                grad_slice, grad_slice, value=1.0 - beta2
+            )
+            denom = exp_avg_sq_slice.sqrt().div_(bias_correction2_sqrt).add_(self.eps)
+            master_slice.addcdiv_(exp_avg_slice, denom, value=-step_size)
+            self._copy_master_slice(param, state["master_param"], start, length)
+            self._transfer_policy.release_grad_slice(ticket)
+            try:
+                next_start, next_length = next(slices)
+            except StopIteration:
+                continue
+            pending.append(
+                (
+                    next_start,
+                    next_length,
+                    self._transfer_policy.copy_grad_slice(
+                        grad, next_start, next_length
+                    ),
+                )
+            )
+
+    def _default_copy_master_slice(
+        self, param: nn.Parameter, master: torch.Tensor, start: int, length: int
+    ) -> None:
+        target = self._local_param(param).detach().reshape(-1).narrow(0, start, length)
+        source = master.reshape(-1).narrow(0, start, length)
+        target.copy_(source.to(device=target.device, dtype=target.dtype))
+
+    def state_dict(self) -> dict[str, Any]:
+        return {
+            "type": "fp32_adamw",
+            "step_count": self.step_count,
+            "master_params": [
+                self.state[param]["master_param"] for param in self.params
+            ],
+            "exp_avgs": [self.state[param]["exp_avg"] for param in self.params],
+            "exp_avg_sqs": [self.state[param]["exp_avg_sq"] for param in self.params],
+            "steps": [int(self.state[param]["step"]) for param in self.params],
+            "lrs": [
+                float(group.get("lr", self.lr))
+                for group in self.param_groups
+                for _param in group["params"]
+            ],
+            "weight_decays": [
+                float(group.get("weight_decay", self.weight_decay))
+                for group in self.param_groups
+                for _param in group["params"]
+            ],
+            "betas": self.betas,
+            "eps": self.eps,
+        }
+
+    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        if state_dict.get("type") != "fp32_adamw":
+            raise ValueError("Invalid FP32 AdamW state_dict.")
+        self.step_count = int(state_dict.get("step_count", 0))
+        for source_name, target_name in (
+            ("master_params", "master_param"),
+            ("exp_avgs", "exp_avg"),
+            ("exp_avg_sqs", "exp_avg_sq"),
+        ):
+            loaded = state_dict.get(source_name)
+            if not isinstance(loaded, list) or len(loaded) != len(self.params):
+                raise ValueError(f"Invalid FP32 AdamW {source_name} state.")
+            for param, source in zip(self.params, loaded, strict=True):
+                target = self.state[param][target_name]
+                local_source = getattr(source, "_local_tensor", source)
+                if (
+                    not isinstance(local_source, torch.Tensor)
+                    or local_source.shape != target.shape
+                ):
+                    raise ValueError(f"Invalid FP32 AdamW {source_name} tensor.")
+                target.copy_(local_source.to(device=target.device, dtype=target.dtype))
+        steps = state_dict.get("steps")
+        if steps is not None:
+            if not isinstance(steps, list) or len(steps) != len(self.params):
+                raise ValueError("Invalid FP32 AdamW steps state.")
+            for param, step in zip(self.params, steps, strict=True):
+                self.state[param]["step"] = int(step)
+        else:
+            for param in self.params:
+                self.state[param]["step"] = self.step_count
+        loaded_lrs = state_dict.get("lrs")
+        if loaded_lrs is not None:
+            if not isinstance(loaded_lrs, list) or len(loaded_lrs) != len(self.params):
+                raise ValueError("Invalid FP32 AdamW lr state.")
+            index = 0
+            for group in self.param_groups:
+                group["lr"] = float(loaded_lrs[index])
+                index += len(group["params"])
+        weight_decays = state_dict.get("weight_decays")
+        if weight_decays is not None:
+            if not isinstance(weight_decays, list) or len(weight_decays) != len(
+                self.params
+            ):
+                raise ValueError("Invalid FP32 AdamW weight_decay state.")
+            index = 0
+            for group in self.param_groups:
+                group["weight_decay"] = float(weight_decays[index])
+                index += len(group["params"])
+        loaded_betas = state_dict.get("betas")
+        if loaded_betas is not None:
+            self.betas = (float(loaded_betas[0]), float(loaded_betas[1]))
+        if "eps" in state_dict:
+            self.eps = float(state_dict["eps"])
+        for param in self.params:
+            master = self.state[param]["master_param"]
+            self._copy_master_slice(param, master, 0, master.numel())
+
+
+__all__ = [
+    "FP32AdamW",
+    "GradTransferPolicy",
+    "SynchronousGradTransfer",
+    "normalize_param_groups",
+]

--- a/experimental/lite/megatron/lite/primitive/optimizers/fp32_adamw.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fp32_adamw.py
@@ -13,6 +13,7 @@ import torch.nn as nn
 LocalTensorFn = Callable[[nn.Parameter], torch.Tensor]
 LocalGradFn = Callable[[nn.Parameter], torch.Tensor | None]
 CopyMasterSliceFn = Callable[[nn.Parameter, torch.Tensor, int, int], None]
+STATE_DICT_TYPE = "mlite_fp32_adamw_v1"
 
 
 class GradTransferPolicy(Protocol):
@@ -266,7 +267,7 @@ class FP32AdamW:
 
     def state_dict(self) -> dict[str, Any]:
         return {
-            "type": "fp32_adamw",
+            "type": STATE_DICT_TYPE,
             "step_count": self.step_count,
             "master_params": [
                 self.state[param]["master_param"] for param in self.params
@@ -289,7 +290,7 @@ class FP32AdamW:
         }
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
-        if state_dict.get("type") != "fp32_adamw":
+        if state_dict.get("type") != STATE_DICT_TYPE:
             raise ValueError("Invalid FP32 AdamW state_dict.")
         self.step_count = int(state_dict.get("step_count", 0))
         for source_name, target_name in (

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/optimizer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/optimizer.py
@@ -40,6 +40,7 @@ from megatron.lite.primitive.optimizers.fsdp2.wrap import (
     wrap_fsdp2,
     wrap_fsdp2_module,
 )
+from megatron.lite.primitive.optimizers.runtime_adapter import DefaultOptimizerRuntimeAdapter
 from megatron.lite.primitive.parallel.state import ParallelState
 
 _DEFAULT_RESHARD_AFTER_FORWARD: bool | int | None = True
@@ -645,7 +646,7 @@ def _matches_megatron_no_weight_decay(
 
 
 @dataclass(frozen=True, slots=True)
-class FSDP2OptimizerBackend:
+class FSDP2OptimizerBackend(DefaultOptimizerRuntimeAdapter):
     name: str = "fsdp2"
     runtime_backend: str = "fsdp2"
 

--- a/experimental/lite/megatron/lite/primitive/optimizers/megatron_wrap.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/megatron_wrap.py
@@ -11,6 +11,7 @@ import torch  # pyright: ignore[reportMissingImports]
 import torch.nn as nn  # pyright: ignore[reportMissingImports]
 
 from megatron.lite.primitive.protocols import ExpertClassifierFn, default_expert_classifier
+from megatron.lite.primitive.optimizers.runtime_adapter import DefaultOptimizerRuntimeAdapter
 
 
 def validate_dist_opt_config(engine_cfg) -> None:
@@ -409,7 +410,7 @@ def _build_pg_collection(ps, engine_cfg):
 
 
 @dataclass(frozen=True, slots=True)
-class DistOptBackend:
+class DistOptBackend(DefaultOptimizerRuntimeAdapter):
     name: str = "dist_opt"
     runtime_backend: str = "dist_opt"
 

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/backend.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/backend.py
@@ -3,10 +3,12 @@
 
 from __future__ import annotations
 
+import gc
 from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any
 
+import torch
 import torch.distributed as dist
 from torch.distributed.checkpoint.metadata import (
     ChunkStorageMetadata,
@@ -20,6 +22,8 @@ from torch.distributed.checkpoint.planner import (
 )
 from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.placement_types import Replicate, Shard, _StridedShard
+
+from megatron.lite.primitive.optimizers.runtime_adapter import DefaultOptimizerRuntimeAdapter
 
 
 def gather_chunk_metadata(dtensor: DTensor) -> ChunkStorageMetadata:
@@ -110,13 +114,43 @@ def _walk_state(
 
 
 @dataclass(frozen=True, slots=True)
-class MegatronFSDPBackend:
+class MegatronFSDPBackend(DefaultOptimizerRuntimeAdapter):
     name: str = "mfsdp"
     runtime_backend: str = "megatron_fsdp"
 
     def pipeline_model_chunks(self, model_chunks: list[Any]) -> list[Any]:
         """The sharding wrappers own M-FSDP's forward/backward lifecycle."""
         return list(model_chunks)
+
+    def transfer_training_state(
+        self,
+        optimizer: Any | None,
+        model_chunks: list[Any],
+        device: str,
+        *,
+        model: bool,
+        optimizer_state: bool,
+        grad: bool,
+    ) -> None:
+        if not (model and grad):
+            return super().transfer_training_state(
+                optimizer,
+                model_chunks,
+                device,
+                model=model,
+                optimizer_state=optimizer_state,
+                grad=grad,
+            )
+        if optimizer is None:
+            raise RuntimeError("M-FSDP training transfer requires an optimizer.")
+        if device == "cpu":
+            optimizer.offload_for_rollout()
+            if torch.cuda.is_available():
+                torch.cuda.synchronize()
+                gc.collect()
+                torch.cuda.empty_cache()
+        elif device == "cuda":
+            optimizer.load_from_rollout()
 
     def zero_grad(self, optimizer: Any) -> None:
         optimizer.zero_grad()

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
@@ -670,7 +670,10 @@ class ParamBucket:
                     main_grad = self.main_grad_buffer.narrow(
                         0, spec.local_offset, spec.shard_numel
                     ).view_as(spec.shard_param)
-                    if spec.shard_param.dtype == main_grad.dtype:
+                    if (
+                        spec.shard_param.dtype == main_grad.dtype
+                        and not self.config.use_decoupled_grad
+                    ):
                         spec.shard_param.grad = main_grad
                         if hasattr(spec.shard_param, "main_grad"):
                             delattr(spec.shard_param, "main_grad")
@@ -813,7 +816,10 @@ class ParamBucket:
                 spec.shard_param.grad = None
                 spec.shard_param.main_grad = None
                 continue
-            if spec.shard_param.dtype == main_grad.dtype:
+            if (
+                spec.shard_param.dtype == main_grad.dtype
+                and not self.config.use_decoupled_grad
+            ):
                 spec.shard_param.grad = main_grad
                 if hasattr(spec.shard_param, "main_grad"):
                     delattr(spec.shard_param, "main_grad")

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
@@ -399,6 +399,11 @@ class ParamBucket:
                 )
                 _copy_parameter_metadata(spec.full_param, shard_param)
                 shard_param._mfsdp_original_ndim = spec.full_param.ndim
+                # Optimizer-offload placement must be identical on every DP
+                # rank and remain stable when a checkpoint is resharded.  A
+                # local shard can be smaller (or empty) on boundary ranks, so
+                # retain the logical parameter size for placement accounting.
+                shard_param._mfsdp_global_numel = spec.numel
                 shard_param._mfsdp_compute_device = self._training_compute_device
                 spec.shard_param = shard_param
                 # TE returns a dummy ``.grad`` when its wgrad GEMM writes the

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
@@ -149,7 +149,7 @@ class MCoreBufferAllocators:
     ) -> BufferLease:
         allocator = (
             self.weight_allocator
-            if key and key[0] == "param"
+            if key and key[0] in {"param", "param_local"}
             else self.grad_allocator
         )
         return allocator.allocate(
@@ -257,6 +257,10 @@ class ParamBucket:
         if any(spec.full_param.requires_grad != self.requires_grad for spec in specs):
             raise ValueError("M-FSDP bucket mixes trainable and frozen parameters.")
         self.device = specs[0].full_param.device
+        self._training_compute_device = self.device
+        self._training_param_offload = bool(
+            config.full_optimizer_offload and self.device.type == "cuda"
+        )
         compute_dtype = specs[0].full_param.dtype
         main_params_dtype = (
             compute_dtype
@@ -289,10 +293,14 @@ class ParamBucket:
             )
             spec.param_offset = min(spec.numel, max(0, intersection_begin - spec_begin))
 
+        param_storage_device = (
+            torch.device("cpu") if self._training_param_offload else self.device
+        )
         self.main_param_buffer = torch.zeros(
             self.local_numel,
             dtype=self.policy.main_params_dtype,
-            device=self.device,
+            device=param_storage_device,
+            pin_memory=self._training_param_offload,
         )
         # Match MCore's two persistent sharded weight buffers: optimizer state
         # updates the high-precision main shard, while parameter all-gathers
@@ -329,6 +337,7 @@ class ParamBucket:
             0, dtype=self.policy.main_grads_dtype, device=self.device
         )
         self._full_lease: BufferLease | None = None
+        self._local_compute_lease: BufferLease | None = None
         self._full_main_grad_lease: BufferLease | None = None
         self._grad_lease: BufferLease | None = None
         self._param_gather_work: Any | None = None
@@ -390,6 +399,7 @@ class ParamBucket:
                 )
                 _copy_parameter_metadata(spec.full_param, shard_param)
                 shard_param._mfsdp_original_ndim = spec.full_param.ndim
+                shard_param._mfsdp_compute_device = self._training_compute_device
                 spec.shard_param = shard_param
                 # TE returns a dummy ``.grad`` when its wgrad GEMM writes the
                 # real gradient directly into ``main_grad``.
@@ -518,6 +528,23 @@ class ParamBucket:
                 ),
             )
             self.full_buffer = self._full_lease.tensor
+        if self._training_param_offload and self._local_compute_lease is None:
+            self._local_compute_lease = self.allocator.allocate(
+                self.local_numel,
+                dtype=self.policy.compute_dtype,
+                device=self.device,
+                group=self.gather_group,
+                key=("param_local", self.bucket_id),
+                pool_key=(
+                    "param_local",
+                    id(self.gather_group),
+                    self.allocator_layout_key,
+                ),
+            )
+            self.local_compute_buffer = self._local_compute_lease.tensor
+            self.local_compute_buffer.copy_(
+                self.model_param_buffer, non_blocking=self.model_param_buffer.is_pinned()
+            )
         return self.full_buffer, self.local_compute_buffer
 
     def mark_param_gather_launched(
@@ -584,8 +611,9 @@ class ParamBucket:
             self._full_ready = False
 
     def _release_local_compute_buffer(self) -> None:
-        # MCore retains the compute-precision model-weight shard for the whole
-        # training lifetime.  Only the unsharded all-gather output is scratch.
+        if self._local_compute_lease is not None:
+            self._local_compute_lease.release()
+            self._local_compute_lease = None
         self.local_compute_buffer = self.model_param_buffer
 
     def _release_local_grad_comm_buffer(self) -> None:
@@ -617,12 +645,15 @@ class ParamBucket:
             for spec in self.specs
         }
         compute_shares_main = self.model_param_buffer is self.main_param_buffer
-        self.main_param_buffer = self.main_param_buffer.to(device)
-        self.model_param_buffer = (
-            self.main_param_buffer
-            if compute_shares_main
-            else self.model_param_buffer.to(device)
-        )
+        if not self._training_param_offload:
+            self.main_param_buffer = self.main_param_buffer.to(device)
+            self.model_param_buffer = (
+                self.main_param_buffer
+                if compute_shares_main
+                else self.model_param_buffer.to(device)
+            )
+        elif self.main_param_buffer.device.type != "cpu":
+            raise RuntimeError("M-FSDP training-offload parameter shard left CPU.")
         grad_comm_shares_main = self.local_grad_comm_buffer is self.main_grad_buffer
         grad_numel = self.local_numel if self.requires_grad else 0
         if load_grad:
@@ -651,6 +682,9 @@ class ParamBucket:
             else self.local_grad_comm_buffer.to(device)
         )
         self.device = device
+        for spec in self.specs:
+            if spec.shard_param is not None:
+                spec.shard_param._mfsdp_compute_device = device
         self.full_buffer = (
             torch.empty(0, dtype=self.policy.compute_dtype, device=device)
             if persistent_full is None

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/buffer.py
@@ -259,7 +259,9 @@ class ParamBucket:
         self.device = specs[0].full_param.device
         compute_dtype = specs[0].full_param.dtype
         main_params_dtype = (
-            compute_dtype if not self.requires_grad else config.main_params_dtype
+            compute_dtype
+            if not self.requires_grad or config.full_optimizer_offload
+            else config.main_params_dtype
         )
         self.policy = MixedPrecisionPolicy(
             compute_dtype=compute_dtype,
@@ -597,6 +599,7 @@ class ParamBucket:
     def move_model_state(self, device: torch.device, *, load_grad: bool) -> None:
         """Move persistent sharded storage without breaking optimizer aliases."""
         device = torch.device(device)
+        persistent_full = None if self.is_fsdp_unit else self.full_buffer
         self.release_full_parameters()
         self.discard_full_parameter_views()
         if self._grad_reduce_launched:
@@ -621,7 +624,25 @@ class ParamBucket:
             else self.model_param_buffer.to(device)
         )
         grad_comm_shares_main = self.local_grad_comm_buffer is self.main_grad_buffer
-        self.main_grad_buffer = self.main_grad_buffer.to(device)
+        grad_numel = self.local_numel if self.requires_grad else 0
+        if load_grad:
+            if self.main_grad_buffer.numel() == grad_numel:
+                self.main_grad_buffer = self.main_grad_buffer.to(device)
+            else:
+                # Rollout offload deliberately drops gradients.  Re-entering
+                # training creates a fresh zeroed shard instead of retaining a
+                # useless 4 B/parameter CPU copy.
+                self.main_grad_buffer = torch.zeros(
+                    grad_numel,
+                    dtype=self.policy.main_grads_dtype,
+                    device=device,
+                )
+        else:
+            self.main_grad_buffer = torch.empty(
+                0,
+                dtype=self.policy.main_grads_dtype,
+                device=device,
+            )
         self.grad_shard_buffer = self.main_grad_buffer
         self.local_compute_buffer = self.model_param_buffer
         self.local_grad_comm_buffer = (
@@ -630,8 +651,10 @@ class ParamBucket:
             else self.local_grad_comm_buffer.to(device)
         )
         self.device = device
-        self.full_buffer = torch.empty(
-            0, dtype=self.policy.compute_dtype, device=device
+        self.full_buffer = (
+            torch.empty(0, dtype=self.policy.compute_dtype, device=device)
+            if persistent_full is None
+            else persistent_full.to(device)
         )
         self.full_main_grad_buffer = torch.empty(
             0, dtype=self.policy.main_grads_dtype, device=device
@@ -657,7 +680,13 @@ class ParamBucket:
                 else:
                     spec.shard_param.grad = None
                     spec.shard_param.main_grad = None
-                spec.full_param.data = self.full_buffer
+                spec.full_param.data = (
+                    self.full_buffer
+                    if self.is_fsdp_unit
+                    else self.full_buffer.narrow(
+                        0, spec.full_offset, spec.numel
+                    ).view(spec.shape)
+                )
 
     def release_scratch_keep_weights(self) -> None:
         """Drop the all-gather scratch while leaving the sharded weights resident.

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/config.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/config.py
@@ -299,7 +299,7 @@ def validate_mfsdp_topology(parallel_cfg) -> None:
     vpp = int(getattr(parallel_cfg, "vpp", 1) or 1)
 
     if vpp > 1 and pp <= 1:
-        raise ValueError("optimizer_impl='megatron_fsdp' requires pp>1 when vpp>1.")
+        raise ValueError("optimizer='mfsdp' requires pp>1 when vpp>1.")
 
 
 def validate_optimizer_name(
@@ -307,7 +307,7 @@ def validate_optimizer_name(
 ) -> None:
     if optimizer_name not in _SUPPORTED_OPTIMIZERS and not has_optimizer_factory:
         raise ValueError(
-            "optimizer_impl='megatron_fsdp' supports only adam/sgd, "
+            "optimizer='mfsdp' supports only adam/sgd, "
             f"got {optimizer_name!r}; provide optimizer_factory for an optional "
             "algorithm such as Muon."
         )

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/config.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/config.py
@@ -50,6 +50,10 @@ class MFSDPConfig:
     use_decoupled_grad: bool = False
     gradient_accumulation_fusion: bool = False
     all_gather_in_start_param_sync: bool = True
+    # Full training-time optimizer offload keeps the authoritative FP32
+    # master in the CPU optimizer.  The persistent device shard is therefore
+    # the compute-dtype mirror, not a second FP32 master.
+    full_optimizer_offload: bool = False
 
 
 @dataclass(frozen=True, slots=True)

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/config.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/config.py
@@ -51,8 +51,8 @@ class MFSDPConfig:
     gradient_accumulation_fusion: bool = False
     all_gather_in_start_param_sync: bool = True
     # Full training-time optimizer offload keeps the authoritative FP32
-    # master in the CPU optimizer.  The persistent device shard is therefore
-    # the compute-dtype mirror, not a second FP32 master.
+    # master and the compute-dtype local shard on CPU. Only the current unit's
+    # bounded all-gather input is staged on device during forward/backward.
     full_optimizer_offload: bool = False
 
 

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/cpu_offload.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/cpu_offload.py
@@ -1,0 +1,357 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Bounded CPU AdamW adapter for M-FSDP shard parameters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.nn as nn
+from megatron.lite.primitive.optimizers.fp32_adamw import FP32AdamW
+
+
+@dataclass(slots=True)
+class _RingTicket:
+    slot: int
+    length: int
+    event: torch.cuda.Event | None
+
+
+class _PinnedGradRing:
+    """Two reusable gradient slots plus the M-FSDP transfer streams."""
+
+    depth = 2
+
+    def __init__(self, *, capacity: int, total_numel: int, use_cuda: bool) -> None:
+        if capacity <= 0:
+            raise ValueError("M-FSDP CPU AdamW bucket_size must be positive.")
+        self.capacity = int(capacity)
+        self.total_numel = int(total_numel)
+        self.use_cuda = bool(use_cuda)
+        self._slots: list[torch.Tensor | None] = [None, None]
+        self._in_use = [False, False]
+        self._next_slot = 0
+        self._d2h_stream: torch.cuda.Stream | None = None
+        self._h2d_stream: torch.cuda.Stream | None = None
+        self._last_h2d_event: torch.cuda.Event | None = None
+        self.high_water_elements = 0
+        self.d2h_bytes = 0
+        self.h2d_bytes = 0
+
+    @property
+    def allocated_elements(self) -> int:
+        return sum(slot.numel() for slot in self._slots if slot is not None)
+
+    @property
+    def live_leases(self) -> int:
+        return sum(self._in_use)
+
+    def _ensure_runtime(self) -> None:
+        if not self.use_cuda or self._d2h_stream is not None:
+            return
+        self._d2h_stream = torch.cuda.Stream()
+        self._h2d_stream = torch.cuda.Stream()
+        current = torch.cuda.current_stream()
+        self._d2h_stream.wait_stream(current)
+        self._h2d_stream.wait_stream(current)
+
+    def _ensure_slot(self, index: int, length: int) -> torch.Tensor:
+        if length > self.capacity:
+            raise RuntimeError(
+                f"gradient slice length {length} exceeds ring capacity {self.capacity}."
+            )
+        slot = self._slots[index]
+        if slot is None or slot.numel() < length:
+            old_numel = 0 if slot is None else slot.numel()
+            proposed = self.allocated_elements - old_numel + length
+            hard_bound = min(self.total_numel, self.depth * self.capacity)
+            if proposed > hard_bound:
+                raise RuntimeError(
+                    "M-FSDP pinned gradient ring exceeded its hard bound: "
+                    f"requested {proposed} elements, bound {hard_bound}."
+                )
+            slot = torch.empty(
+                length, dtype=torch.float32, device="cpu", pin_memory=self.use_cuda
+            )
+            self._slots[index] = slot
+            self.high_water_elements = max(self.high_water_elements, proposed)
+        return slot
+
+    def copy_grad_slice(
+        self, grad: torch.Tensor, start: int, length: int
+    ) -> _RingTicket:
+        self._ensure_runtime()
+        slot_index = self._next_slot
+        self._next_slot = (self._next_slot + 1) % self.depth
+        if self._in_use[slot_index]:
+            raise RuntimeError("M-FSDP gradient ring slot was reused before release.")
+        slot = self._ensure_slot(slot_index, length)
+        source = grad.detach().reshape(-1).narrow(0, start, length)
+        target = slot.narrow(0, 0, length)
+        event = None
+        if self.use_cuda:
+            assert self._d2h_stream is not None
+            # The persistent transfer stream must depend on this step's
+            # reduce-scatter result, not only on the stream state that existed
+            # when the ring was first constructed.
+            self._d2h_stream.wait_stream(torch.cuda.current_stream(source.device))
+            with torch.cuda.stream(self._d2h_stream):
+                target.copy_(source, non_blocking=True)
+                event = self._d2h_stream.record_event()
+        else:
+            target.copy_(source)
+        self._in_use[slot_index] = True
+        self.d2h_bytes += length * torch.float32.itemsize
+        return _RingTicket(slot=slot_index, length=length, event=event)
+
+    def wait_grad_slice(self, ticket: _RingTicket) -> torch.Tensor:
+        if ticket.event is not None:
+            ticket.event.synchronize()
+        slot = self._slots[ticket.slot]
+        if slot is None:
+            raise RuntimeError("M-FSDP gradient ring ticket references no slot.")
+        return slot.narrow(0, 0, ticket.length)
+
+    def release_grad_slice(self, ticket: _RingTicket) -> None:
+        if not self._in_use[ticket.slot]:
+            raise RuntimeError("M-FSDP gradient ring ticket was released twice.")
+        self._in_use[ticket.slot] = False
+
+    def copy_master_slice_to_param(
+        self, param: nn.Parameter, master: torch.Tensor, start: int, length: int
+    ) -> None:
+        target = param.detach().reshape(-1).narrow(0, start, length)
+        source = master.reshape(-1).narrow(0, start, length)
+        if self.use_cuda:
+            self._ensure_runtime()
+            assert self._h2d_stream is not None
+            with torch.cuda.stream(self._h2d_stream):
+                target.copy_(source, non_blocking=True)
+                self._last_h2d_event = self._h2d_stream.record_event()
+        else:
+            target.copy_(source.to(dtype=target.dtype))
+        self.h2d_bytes += length * target.element_size()
+
+    def drain(self) -> None:
+        if self._last_h2d_event is not None:
+            self._last_h2d_event.synchronize()
+            self._last_h2d_event = None
+        if self.live_leases:
+            raise RuntimeError(
+                f"M-FSDP optimizer returned with {self.live_leases} live transfer leases."
+            )
+
+    def release_runtime(self) -> None:
+        self.drain()
+        self._slots = [None, None]
+        self._d2h_stream = None
+        self._h2d_stream = None
+
+
+class CpuAdamGroup:
+    """M-FSDP adapter around the shared FP32 AdamW local-shard kernel."""
+
+    _FORMAT_VERSION = 2
+
+    def __init__(
+        self,
+        gpu_param_groups: list[dict[str, Any]],
+        *,
+        lr: float,
+        betas: tuple[float, float],
+        eps: float,
+        bucket_size: int,
+    ) -> None:
+        self._gpu_params = [
+            param for group in gpu_param_groups for param in group["params"]
+        ]
+        total_numel = sum(param.numel() for param in self._gpu_params)
+        use_cuda = bool(
+            torch.cuda.is_available()
+            and any(param.device.type == "cuda" for param in self._gpu_params)
+        )
+        self._ring = _PinnedGradRing(
+            capacity=int(bucket_size), total_numel=total_numel, use_cuda=use_cuda
+        )
+        default_weight_decay = float(
+            gpu_param_groups[0].get("weight_decay", 0.0) if gpu_param_groups else 0.0
+        )
+        self._optimizer = FP32AdamW(
+            gpu_param_groups,
+            lr=lr,
+            weight_decay=default_weight_decay,
+            betas=betas,
+            eps=eps,
+            local_param=lambda param: param.detach(),
+            local_grad=_mfsdp_optimizer_grad,
+            copy_master_slice_to_param=self._ring.copy_master_slice_to_param,
+            master_device="cpu",
+            pin_master=use_cuda,
+            transfer_policy=self._ring,
+            slice_capacity=int(bucket_size),
+        )
+
+    @property
+    def param_groups(self) -> list[dict[str, Any]]:
+        return self._optimizer.param_groups
+
+    @property
+    def gpu_params(self) -> tuple[nn.Parameter, ...]:
+        """Stable original shard parameters used for membership checks."""
+        return tuple(self._gpu_params)
+
+    @property
+    def _cpu_params(self) -> list[torch.Tensor]:
+        return [
+            self._optimizer.state[param]["master_param"]
+            for param in self._optimizer.params
+        ]
+
+    @property
+    def ring_depth(self) -> int:
+        return self._ring.depth
+
+    @property
+    def ring_allocated_elements(self) -> int:
+        return self._ring.allocated_elements
+
+    @property
+    def ring_high_water_elements(self) -> int:
+        return self._ring.high_water_elements
+
+    @property
+    def live_transfer_leases(self) -> int:
+        return self._ring.live_leases
+
+    @property
+    def d2h_bytes(self) -> int:
+        return self._ring.d2h_bytes
+
+    @property
+    def h2d_bytes(self) -> int:
+        return self._ring.h2d_bytes
+
+    def step(self) -> None:
+        self._optimizer.step()
+
+    def release_transfer_state(self) -> None:
+        self._ring.release_runtime()
+
+    def state_dict(self) -> dict[str, Any]:
+        self._ring.drain()
+        return {
+            "format_version": self._FORMAT_VERSION,
+            "optimizer": self._optimizer.state_dict(),
+        }
+
+    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        self._ring.drain()
+        optimizer_state = state_dict.get("optimizer", state_dict)
+        if optimizer_state.get("type") == "fp32_adamw":
+            self._optimizer.load_state_dict(optimizer_state)
+        else:
+            self._optimizer.load_state_dict(self._convert_legacy_state(state_dict))
+        self._ring.drain()
+
+    def _convert_legacy_state(self, state_dict: dict[str, Any]) -> dict[str, Any]:
+        optimizer_state = state_dict.get("optimizer", state_dict)
+        master_params = state_dict.get("master_params")
+        if master_params is not None and len(master_params) != len(self._gpu_params):
+            raise ValueError(
+                "M-FSDP CPU optimizer checkpoint master parameter count does not "
+                f"match: expected {len(self._gpu_params)}, got {len(master_params)}."
+            )
+        current = self._optimizer.state_dict()
+        exp_avgs = [torch.zeros_like(value) for value in current["exp_avgs"]]
+        exp_avg_sqs = [torch.zeros_like(value) for value in current["exp_avg_sqs"]]
+        steps = [0 for _ in self._gpu_params]
+        lrs = list(current["lrs"])
+        weight_decays = list(current["weight_decays"])
+        loaded_betas = self._optimizer.betas
+        loaded_eps = self._optimizer.eps
+
+        per_param = optimizer_state.get("optimizers")
+        if per_param is not None:
+            if len(per_param) != len(self._gpu_params):
+                raise ValueError(
+                    "M-FSDP CPU optimizer checkpoint parameter count does not "
+                    f"match: expected {len(self._gpu_params)}, got {len(per_param)}."
+                )
+            entries = []
+            for local in per_param:
+                groups = local.get("param_groups", [])
+                local_state = next(iter(local.get("state", {}).values()), None)
+                entries.append((groups[0] if groups else {}, local_state))
+        else:
+            group_by_param_id = {
+                param_id: group
+                for group in optimizer_state.get("param_groups", [])
+                for param_id in group.get("params", [])
+            }
+            raw_state = optimizer_state.get("state", {})
+            entries = [
+                (group_by_param_id.get(index, {}), raw_state.get(index))
+                for index in range(len(self._gpu_params))
+            ]
+
+        for index, (group, local_state) in enumerate(entries):
+            if group:
+                lrs[index] = float(group.get("lr", lrs[index]))
+                weight_decays[index] = float(
+                    group.get("weight_decay", weight_decays[index])
+                )
+                group_betas = tuple(group.get("betas", loaded_betas))
+                group_eps = float(group.get("eps", loaded_eps))
+                if tuple(float(value) for value in group_betas) != tuple(loaded_betas):
+                    if index != 0:
+                        raise ValueError(
+                            "M-FSDP legacy CPU AdamW checkpoint has per-parameter betas."
+                        )
+                    loaded_betas = tuple(float(value) for value in group_betas)
+                if group_eps != loaded_eps:
+                    if index != 0:
+                        raise ValueError(
+                            "M-FSDP legacy CPU AdamW checkpoint has per-parameter eps."
+                        )
+                    loaded_eps = group_eps
+            if not local_state:
+                continue
+            exp_avgs[index].copy_(local_state["exp_avg"])
+            exp_avg_sqs[index].copy_(local_state["exp_avg_sq"])
+            raw_step = local_state.get("step", 0)
+            steps[index] = int(
+                raw_step.item() if isinstance(raw_step, torch.Tensor) else raw_step
+            )
+
+        masters = (
+            [
+                param.detach().to(device="cpu", dtype=torch.float32).clone()
+                for param in self._gpu_params
+            ]
+            if master_params is None
+            else list(master_params)
+        )
+        return {
+            "type": "fp32_adamw",
+            "step_count": max(steps, default=0),
+            "master_params": masters,
+            "exp_avgs": exp_avgs,
+            "exp_avg_sqs": exp_avg_sqs,
+            "steps": steps,
+            "lrs": lrs,
+            "weight_decays": weight_decays,
+            "betas": loaded_betas,
+            "eps": loaded_eps,
+        }
+
+
+def _mfsdp_optimizer_grad(param: nn.Parameter) -> torch.Tensor | None:
+    decoupled = getattr(param, "decoupled_grad", None)
+    if decoupled is not None:
+        return decoupled
+    main_grad = getattr(param, "main_grad", None)
+    return main_grad if main_grad is not None else param.grad
+
+
+__all__ = ["CpuAdamGroup"]

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/cpu_offload.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/cpu_offload.py
@@ -166,6 +166,7 @@ class CpuAdamGroup:
         self._gpu_params = [
             param for group in gpu_param_groups for param in group["params"]
         ]
+        self._gpu_param_ids = {id(param) for param in self._gpu_params}
         total_numel = sum(param.numel() for param in self._gpu_params)
         use_cuda = bool(
             torch.cuda.is_available()
@@ -238,6 +239,54 @@ class CpuAdamGroup:
 
     def step(self) -> None:
         self._optimizer.step()
+
+    def owns_param(self, param: nn.Parameter) -> bool:
+        """Return whether this CPU group owns ``param``'s AdamW state."""
+        return id(param) in self._gpu_param_ids
+
+    def checkpoint_state(self, param: nn.Parameter) -> dict[str, Any]:
+        """Expose one shard's canonical FP32 state to the DCP adapter."""
+        if not self.owns_param(param):
+            raise KeyError("Parameter is not owned by this M-FSDP CPU Adam group.")
+        return self._optimizer.state[param]
+
+    def checkpoint_metadata(self) -> dict[str, Any]:
+        """Return non-tensor optimizer metadata independent of DP sharding."""
+        self._ring.drain()
+        return {
+            "format_version": self._FORMAT_VERSION,
+            "step_count": int(self._optimizer.step_count),
+            "param_groups": [
+                {
+                    key: value
+                    for key, value in group.items()
+                    if key != "params"
+                }
+                for group in self._optimizer.param_groups
+            ],
+            "betas": tuple(float(value) for value in self._optimizer.betas),
+            "eps": float(self._optimizer.eps),
+        }
+
+    def load_checkpoint_metadata(self, metadata: dict[str, Any]) -> None:
+        """Restore DCP metadata while preserving live parameter identities."""
+        self._ring.drain()
+        saved_groups = metadata.get("param_groups")
+        if not isinstance(saved_groups, list) or len(saved_groups) != len(
+            self._optimizer.param_groups
+        ):
+            raise ValueError("Invalid M-FSDP CPU AdamW parameter-group metadata.")
+        for group, saved in zip(
+            self._optimizer.param_groups, saved_groups, strict=True
+        ):
+            params = group["params"]
+            group.clear()
+            group.update(saved)
+            group["params"] = params
+        self._optimizer.step_count = int(metadata.get("step_count", 0))
+        loaded_betas = metadata.get("betas", self._optimizer.betas)
+        self._optimizer.betas = tuple(float(value) for value in loaded_betas)
+        self._optimizer.eps = float(metadata.get("eps", self._optimizer.eps))
 
     def release_transfer_state(self) -> None:
         self._ring.release_runtime()

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/cpu_offload.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/cpu_offload.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import torch
 import torch.nn as nn
-from megatron.lite.primitive.optimizers.fp32_adamw import FP32AdamW
+from megatron.lite.primitive.optimizers.fp32_adamw import FP32AdamW, STATE_DICT_TYPE
 
 
 @dataclass(slots=True)
@@ -248,8 +248,13 @@ class CpuAdamGroup:
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
         self._ring.drain()
         optimizer_state = state_dict.get("optimizer", state_dict)
-        if optimizer_state.get("type") == "fp32_adamw":
+        if optimizer_state.get("type") == STATE_DICT_TYPE:
             self._optimizer.load_state_dict(optimizer_state)
+        elif optimizer_state.get("type") is not None:
+            raise ValueError(
+                "Invalid M-FSDP CPU optimizer state_dict type: "
+                f"{optimizer_state.get('type')!r}."
+            )
         else:
             self._optimizer.load_state_dict(self._convert_legacy_state(state_dict))
         self._ring.drain()
@@ -333,7 +338,7 @@ class CpuAdamGroup:
             else list(master_params)
         )
         return {
-            "type": "fp32_adamw",
+            "type": STATE_DICT_TYPE,
             "step_count": max(steps, default=0),
             "master_params": masters,
             "exp_avgs": exp_avgs,

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/cpu_offload.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/cpu_offload.py
@@ -123,15 +123,15 @@ class _PinnedGradRing:
     ) -> None:
         target = param.detach().reshape(-1).narrow(0, start, length)
         source = master.reshape(-1).narrow(0, start, length)
-        if self.use_cuda:
+        if target.device.type == "cuda":
             self._ensure_runtime()
             assert self._h2d_stream is not None
             with torch.cuda.stream(self._h2d_stream):
                 target.copy_(source, non_blocking=True)
                 self._last_h2d_event = self._h2d_stream.record_event()
+            self.h2d_bytes += length * target.element_size()
         else:
             target.copy_(source.to(dtype=target.dtype))
-        self.h2d_bytes += length * target.element_size()
 
     def drain(self) -> None:
         if self._last_h2d_event is not None:
@@ -150,7 +150,7 @@ class _PinnedGradRing:
 
 
 class CpuAdamGroup:
-    """M-FSDP adapter around the shared FP32 AdamW local-shard kernel."""
+    """CPU AdamW plus bounded GPU-gradient transfers for M-FSDP shards."""
 
     _FORMAT_VERSION = 2
 
@@ -169,7 +169,11 @@ class CpuAdamGroup:
         total_numel = sum(param.numel() for param in self._gpu_params)
         use_cuda = bool(
             torch.cuda.is_available()
-            and any(param.device.type == "cuda" for param in self._gpu_params)
+            and any(
+                torch.device(getattr(param, "_mfsdp_compute_device", param.device)).type
+                == "cuda"
+                for param in self._gpu_params
+            )
         )
         self._ring = _PinnedGradRing(
             capacity=int(bucket_size), total_numel=total_numel, use_cuda=use_cuda

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/optimizer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/optimizer.py
@@ -20,6 +20,7 @@ from megatron.lite.primitive.optimizers.mfsdp.config import (
     build_mfsdp_process_groups,
     validate_mfsdp_config,
 )
+from megatron.lite.primitive.optimizers.mfsdp.cpu_offload import CpuAdamGroup
 from megatron.lite.primitive.optimizers.mfsdp.fully_shard import fully_shard_model
 from megatron.lite.primitive.optimizers.mfsdp.fused_ops import (
     OptimizerFactory,
@@ -36,6 +37,26 @@ logger = logging.getLogger(__name__)
 
 ExpertClassifierFn = Callable[[str], bool]
 _MFSDP_PARAM_VALUES_KEY = "_mfsdp_param_values"
+
+
+class _NullOptimizer:
+    """Torch-optimizer surface for the all-CPU-update case."""
+
+    param_groups: list[dict[str, Any]] = []
+    state: dict[Any, Any] = {}
+
+    def step(self) -> None:
+        pass
+
+    def zero_grad(self, *args, **kwargs) -> None:
+        pass
+
+    def state_dict(self) -> dict[str, Any]:
+        return {"state": {}, "param_groups": []}
+
+    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        if state_dict not in ({}, {"state": {}, "param_groups": []}):
+            raise ValueError("Invalid empty GPU optimizer state.")
 
 def _override(opt: Any, name: str, default: Any) -> Any:
     values = dict(getattr(opt, "override_optimizer_config", None) or {})
@@ -56,6 +77,7 @@ class _StandaloneOptimizer:
         expert_params: Iterable[nn.Parameter],
         expert_grad_scale: float,
         use_decoupled_grad: bool = False,
+        cpu_group: CpuAdamGroup | None = None,
     ) -> None:
         self.optimizer = optimizer
         self.params = params
@@ -82,10 +104,17 @@ class _StandaloneOptimizer:
         self._expert_grads_scaled = False
         self._tp_replicated_grads_synced = False
         self._offloaded_state_devices: dict[tuple[int, str], torch.device] = {}
+        self.cpu_group = cpu_group
+        self._cpu_param_ids = (
+            set() if cpu_group is None else {id(param) for param in cpu_group.gpu_params}
+        )
 
     @property
     def param_groups(self) -> list[dict[str, Any]]:
-        return list(self.optimizer.param_groups)
+        groups = list(self.optimizer.param_groups)
+        if self.cpu_group is not None:
+            groups.extend(self.cpu_group.param_groups)
+        return groups
 
     def zero_grad(self) -> None:
         self.optimizer.zero_grad()
@@ -99,6 +128,8 @@ class _StandaloneOptimizer:
         if not math.isfinite(grad_norm):
             return False, grad_norm, 0
         self.optimizer.step()
+        if self.cpu_group is not None:
+            self.cpu_group.step()
         return True, grad_norm, 0
 
     @torch.no_grad()
@@ -106,6 +137,13 @@ class _StandaloneOptimizer:
         """Install reduced shards using MCore's standard or decoupled grad path."""
         for group in self.optimizer.param_groups:
             for param in group["params"]:
+                if id(param) in self._cpu_param_ids:
+                    # CPU AdamW consumes the FP32 M-FSDP main-grad directly;
+                    # installing it as a BF16 .grad would discard precision.
+                    param.grad = None
+                    if hasattr(param, "decoupled_grad"):
+                        param.decoupled_grad = None
+                    continue
                 main_grad = getattr(param, "main_grad", None)
                 if main_grad is None or main_grad.numel() == 0:
                     continue
@@ -169,7 +207,14 @@ class _StandaloneOptimizer:
         return float(total_norm.float().item())
 
     def state_dict(self) -> dict[str, Any]:
-        state = self.optimizer.state_dict()
+        state = (
+            self.optimizer.state_dict()
+            if self.cpu_group is None
+            else {
+                "gpu": self.optimizer.state_dict(),
+                "cpu": self.cpu_group.state_dict(),
+            }
+        )
         state[_MFSDP_PARAM_VALUES_KEY] = [
             [param.detach().cpu().clone() for param in group["params"]]
             for group in self.optimizer.param_groups
@@ -179,7 +224,16 @@ class _StandaloneOptimizer:
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
         state = dict(state_dict)
         param_values = state.pop(_MFSDP_PARAM_VALUES_KEY, None)
-        self.optimizer.load_state_dict(state)
+        if self.cpu_group is None:
+            self.optimizer.load_state_dict(state.get("gpu", state))
+        elif "gpu" not in state or "cpu" not in state:
+            raise ValueError(
+                "M-FSDP CPU-offloaded optimizer checkpoint requires both "
+                "'gpu' and 'cpu' states."
+            )
+        else:
+            self.optimizer.load_state_dict(state["gpu"])
+            self.cpu_group.load_state_dict(state["cpu"])
         if param_values is not None:
             with torch.no_grad():
                 for group, group_values in zip(
@@ -189,6 +243,8 @@ class _StandaloneOptimizer:
                         param.copy_(value.to(device=param.device, dtype=param.dtype))
 
     def offload_state_to_cpu(self) -> None:
+        if self.cpu_group is not None:
+            self.cpu_group.release_transfer_state()
         self._offloaded_state_devices.clear()
         for param, state in self.optimizer.state.items():
             for key, value in tuple(state.items()):
@@ -279,6 +335,8 @@ class MFSdpOptimizer:
         self._inner_optimizer = optimizer
         self._model_chunks = model_chunks
         self._grad_sync_enabled = False
+        self._rollout_offloaded = False
+        self._pre_rollout_devices: list[torch.device] = []
 
     @property
     def grad_sync_enabled(self) -> bool:
@@ -295,12 +353,14 @@ class MFSdpOptimizer:
         return self._inner_optimizer.param_groups
 
     def zero_grad(self) -> None:
+        self._require_training_resident("zero_grad")
         self.grad_sync_enabled = False
         self._inner_optimizer.zero_grad()
         for chunk in self._model_chunks:
             chunk.zero_grad_buffer()
 
     def finish_grad_sync(self, *, update_optimizer_grads: bool = True) -> None:
+        self._require_training_resident("finish_grad_sync")
         for chunk in self._model_chunks:
             chunk.finish_grad_sync()
         if update_optimizer_grads:
@@ -313,6 +373,7 @@ class MFSdpOptimizer:
         return self._inner_optimizer.clip_grad_norm()
 
     def step(self) -> tuple[bool, float, int]:
+        self._require_training_resident("step")
         result = self._inner_optimizer.step()
         for chunk in self._model_chunks:
             chunk.param_sync.copy_main_weights_to_model_weights()
@@ -334,6 +395,46 @@ class MFSdpOptimizer:
 
     def load_state_to_device(self) -> None:
         self._inner_optimizer.load_state_to_device()
+
+    def offload_for_rollout(self) -> None:
+        """Move the complete training state out of GPU at an optimizer boundary."""
+        if self._rollout_offloaded:
+            return
+        if self.grad_sync_enabled:
+            raise RuntimeError(
+                "M-FSDP train-to-rollout offload requires an optimizer-step boundary; "
+                "gradient synchronization is still enabled."
+            )
+        self._pre_rollout_devices = [
+            (
+                chunk.param_sync.buckets[0].device
+                if chunk.param_sync.buckets
+                else torch.device("cpu")
+            )
+            for chunk in self._model_chunks
+        ]
+        for chunk in self._model_chunks:
+            chunk.move_model_state("cpu", load_grad=False)
+        self._inner_optimizer.offload_state_to_cpu()
+        self._rollout_offloaded = True
+
+    def load_from_rollout(self) -> None:
+        """Restore training shards and state after colocated rollout sleeps."""
+        if not self._rollout_offloaded:
+            return
+        for chunk, device in zip(
+            self._model_chunks, self._pre_rollout_devices, strict=True
+        ):
+            chunk.move_model_state(device, load_grad=True)
+        self._inner_optimizer.load_state_to_device()
+        self._pre_rollout_devices = []
+        self._rollout_offloaded = False
+
+    def _require_training_resident(self, operation: str) -> None:
+        if self._rollout_offloaded:
+            raise RuntimeError(
+                f"M-FSDP cannot {operation} while training state is offloaded for rollout."
+            )
 
 
 def build_mfsdp_stack(
@@ -357,14 +458,15 @@ def build_mfsdp_stack(
     opt = engine_cfg.optimizer
     classifier = is_expert or (lambda _name: False)
     offload_fraction = float(getattr(opt, "offload_fraction", 0.0) or 0.0)
-    if not math.isfinite(offload_fraction) or offload_fraction != 0.0:
+    if not math.isfinite(offload_fraction) or not 0.0 <= offload_fraction <= 1.0:
         raise ValueError(
-            "M-FSDP optimizer offload is not part of the offload=0 standalone "
-            f"implementation; expected offload_fraction=0.0, got {offload_fraction}."
+            f"M-FSDP offload_fraction must be in [0, 1], got {offload_fraction}."
         )
     config = build_mfsdp_config(
         opt, calculate_per_token_loss=calculate_per_token_loss
     )
+    if offload_fraction == 1.0:
+        config = replace(config, full_optimizer_offload=True)
     if (
         config.suggested_communication_unit_size is None
         and suggested_communication_unit_size is not None
@@ -409,12 +511,42 @@ def build_mfsdp_stack(
         weight_decay=float(getattr(opt, "weight_decay", 0.01)),
         apply_wd_to_qk_layernorm=bool(getattr(opt, "apply_wd_to_qk_layernorm", False)),
     )
-    torch_optimizer = _build_optimizer_algorithm(
-        param_groups,
-        opt,
-        optimizer_factory=optimizer_factory,
-        use_decoupled_grad=config.use_decoupled_grad,
-    )
+    cpu_group = None
+    if offload_fraction > 0.0:
+        optimizer_name = str(getattr(opt, "optimizer", "adam")).lower()
+        if optimizer_name not in {"adam", "adamw"}:
+            raise ValueError(
+                "M-FSDP CPU optimizer offload supports AdamW only; "
+                f"got {optimizer_name!r}."
+            )
+        if optimizer_factory is not None:
+            raise ValueError(
+                "M-FSDP CPU optimizer offload cannot preserve an injected "
+                "optimizer_factory algorithm."
+            )
+        gpu_param_groups, cpu_param_groups = _split_param_groups_by_fraction(
+            param_groups, offload_fraction
+        )
+        torch_optimizer = (
+            _build_optimizer_algorithm(
+                gpu_param_groups,
+                opt,
+                optimizer_factory=None,
+                use_decoupled_grad=config.use_decoupled_grad,
+            )
+            if gpu_param_groups
+            else _NullOptimizer()
+        )
+        cpu_group = _build_cpu_adam_group(
+            cpu_param_groups, opt, bucket_size=config.bucket_size
+        )
+    else:
+        torch_optimizer = _build_optimizer_algorithm(
+            param_groups,
+            opt,
+            optimizer_factory=optimizer_factory,
+            use_decoupled_grad=config.use_decoupled_grad,
+        )
 
     standalone_optimizer = _StandaloneOptimizer(
         torch_optimizer,
@@ -434,6 +566,7 @@ def build_mfsdp_stack(
             )
         ),
         use_decoupled_grad=config.use_decoupled_grad,
+        cpu_group=cpu_group,
     )
     optimizer = MFSdpOptimizer(standalone_optimizer, wrapped_chunks)
     return wrapped_chunks, optimizer
@@ -471,6 +604,55 @@ def _order_param_gathers_for_parallel_collectives(
             "and model-parallel collectives span intersecting process groups."
         )
     return replace(config, overlap_param_gather=False)
+
+
+def _split_param_groups_by_fraction(
+    param_groups: list[dict[str, Any]], offload_fraction: float
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Match HDO's deterministic leading-numel split without splitting a tensor."""
+    total_numel = sum(param.numel() for group in param_groups for param in group["params"])
+    cpu_target = int(total_numel * offload_fraction)
+    cpu_numel = 0
+    gpu_groups: list[dict[str, Any]] = []
+    cpu_groups: list[dict[str, Any]] = []
+    for group in param_groups:
+        gpu_params: list[nn.Parameter] = []
+        cpu_params: list[nn.Parameter] = []
+        for param in group["params"]:
+            if cpu_numel < cpu_target:
+                cpu_params.append(param)
+                cpu_numel += param.numel()
+            else:
+                gpu_params.append(param)
+        for params, target in ((gpu_params, gpu_groups), (cpu_params, cpu_groups)):
+            if params:
+                copied = dict(group)
+                copied["params"] = params
+                target.append(copied)
+    return gpu_groups, cpu_groups
+
+
+def _build_cpu_adam_group(
+    cpu_param_groups: list[dict[str, Any]], opt: Any, *, bucket_size: int | None
+) -> CpuAdamGroup:
+    beta1 = getattr(opt, "adam_beta1", None)
+    beta2 = getattr(opt, "adam_beta2", None)
+    eps = getattr(opt, "adam_eps", None)
+    capacity = bucket_size or max(
+        1,
+        max(
+            param.numel()
+            for group in cpu_param_groups
+            for param in group["params"]
+        ),
+    )
+    return CpuAdamGroup(
+        cpu_param_groups,
+        lr=float(getattr(opt, "lr", 1.0e-4)),
+        betas=(0.9 if beta1 is None else beta1, 0.999 if beta2 is None else beta2),
+        eps=1.0e-8 if eps is None else eps,
+        bucket_size=capacity,
+    )
 
 
 def _mark_mfsdp_parallel_attrs(

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/optimizer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/optimizer.py
@@ -645,8 +645,16 @@ def _order_param_gathers_for_parallel_collectives(
 def _split_param_groups_by_fraction(
     param_groups: list[dict[str, Any]], offload_fraction: float
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
-    """Match HDO's deterministic leading-numel split without splitting a tensor."""
-    total_numel = sum(param.numel() for group in param_groups for param in group["params"])
+    """Choose whole logical parameters identically on every DP rank."""
+
+    def placement_numel(param: nn.Parameter) -> int:
+        return int(getattr(param, "_mfsdp_global_numel", param.numel()))
+
+    total_numel = sum(
+        placement_numel(param)
+        for group in param_groups
+        for param in group["params"]
+    )
     cpu_target = int(total_numel * offload_fraction)
     cpu_numel = 0
     gpu_groups: list[dict[str, Any]] = []
@@ -657,7 +665,7 @@ def _split_param_groups_by_fraction(
         for param in group["params"]:
             if cpu_numel < cpu_target:
                 cpu_params.append(param)
-                cpu_numel += param.numel()
+                cpu_numel += placement_numel(param)
             else:
                 gpu_params.append(param)
         for params, target in ((gpu_params, gpu_groups), (cpu_params, cpu_groups)):

--- a/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/optimizer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/mfsdp/optimizer.py
@@ -63,6 +63,22 @@ def _override(opt: Any, name: str, default: Any) -> Any:
     return values.get(name, getattr(opt, name, default))
 
 
+def _resolve_offload_fraction(opt: Any) -> float:
+    """Resolve the stable field and MCore-compatible raw override aliases."""
+    values = dict(getattr(opt, "override_optimizer_config", None) or {})
+    value = getattr(opt, "offload_fraction", None)
+    if value is None:
+        value = values.get("offload_fraction", values.get("optimizer_offload_fraction"))
+    if value is None and values.get("optimizer_cpu_offload"):
+        value = 1.0
+    return float(value or 0.0)
+
+
+def _has_explicit_option(opt: Any, name: str) -> bool:
+    values = dict(getattr(opt, "override_optimizer_config", None) or {})
+    return name in values or (hasattr(opt, name) and getattr(opt, name) is not None)
+
+
 class _StandaloneOptimizer:
     """Torch optimizer adapter with M-FSDP-aware norm and state movement."""
 
@@ -457,7 +473,7 @@ def build_mfsdp_stack(
     )
     opt = engine_cfg.optimizer
     classifier = is_expert or (lambda _name: False)
-    offload_fraction = float(getattr(opt, "offload_fraction", 0.0) or 0.0)
+    offload_fraction = _resolve_offload_fraction(opt)
     if not math.isfinite(offload_fraction) or not 0.0 <= offload_fraction <= 1.0:
         raise ValueError(
             f"M-FSDP offload_fraction must be in [0, 1], got {offload_fraction}."
@@ -465,8 +481,6 @@ def build_mfsdp_stack(
     config = build_mfsdp_config(
         opt, calculate_per_token_loss=calculate_per_token_loss
     )
-    if offload_fraction == 1.0:
-        config = replace(config, full_optimizer_offload=True)
     if (
         config.suggested_communication_unit_size is None
         and suggested_communication_unit_size is not None
@@ -476,6 +490,28 @@ def build_mfsdp_stack(
         config = replace(
             config,
             suggested_communication_unit_size=int(suggested_communication_unit_size),
+        )
+    if offload_fraction == 1.0:
+        # These are MCore's native communication controls. Full optimizer
+        # offload is memory-first: bound the communication queue to one bucket
+        # and avoid retaining a prefetched full-parameter bucket. Explicit user
+        # choices remain authoritative.
+        config = replace(
+            config,
+            full_optimizer_offload=True,
+            suggested_communication_unit_size=(
+                config.suggested_communication_unit_size
+                if (
+                    suggested_communication_unit_size is not None
+                    or _has_explicit_option(opt, "suggested_communication_unit_size")
+                )
+                else config.bucket_size
+            ),
+            overlap_param_gather=(
+                config.overlap_param_gather
+                if _has_explicit_option(opt, "overlap_param_gather")
+                else False
+            ),
         )
     config = _order_param_gathers_for_parallel_collectives(config, ps)
     groups = build_mfsdp_process_groups(ps)

--- a/experimental/lite/megatron/lite/primitive/optimizers/runtime_adapter.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/runtime_adapter.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Runtime-facing optimizer lifecycle adapters.
+
+The runtime delegates execution-wrapper ownership and device transitions through
+this contract. Optimizer implementations may override either operation without
+teaching the runtime about a concrete sharding backend.
+"""
+
+from __future__ import annotations
+
+import gc
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+
+@dataclass(frozen=True, slots=True)
+class DefaultOptimizerRuntimeAdapter:
+    name: str = "none"
+    runtime_backend: str = "none"
+
+    def pipeline_model_chunks(self, model_chunks: list[Any]) -> list[Any]:
+        from megatron.lite.primitive.ckpt.hf_weights import unwrap_model
+
+        return [unwrap_model(chunk) for chunk in model_chunks]
+
+    def release_export_scratch(self, model_chunks: list[Any]) -> None:
+        for chunk in model_chunks:
+            release = getattr(chunk, "release_export_scratch", None)
+            if callable(release):
+                release()
+
+    def transfer_training_state(
+        self,
+        optimizer: Any | None,
+        model_chunks: list[Any],
+        device: str,
+        *,
+        model: bool,
+        optimizer_state: bool,
+        grad: bool,
+    ) -> None:
+        from megatron.lite.runtime.megatron_utils import (
+            load_model_to_gpu,
+            load_optimizer,
+            offload_model_to_cpu,
+            offload_optimizer,
+        )
+
+        training_transfer = model and grad
+        if device == "cpu":
+            if model:
+                offload_model_to_cpu(model_chunks)
+            if (optimizer_state or training_transfer) and optimizer is not None:
+                offload_state = getattr(optimizer, "offload_state_to_cpu", None)
+                if callable(offload_state):
+                    offload_state()
+                else:
+                    offload_optimizer(optimizer)
+            if training_transfer:
+                self.release_export_scratch(model_chunks)
+                if torch.cuda.is_available():
+                    torch.cuda.synchronize()
+                    gc.collect()
+                    torch.cuda.empty_cache()
+        elif device == "cuda":
+            if model:
+                load_model_to_gpu(model_chunks, load_grad=grad)
+            if (optimizer_state or training_transfer) and optimizer is not None:
+                load_state = getattr(optimizer, "load_state_to_device", None)
+                if callable(load_state):
+                    load_state()
+                else:
+                    load_optimizer(optimizer)
+
+
+DEFAULT_RUNTIME_ADAPTER = DefaultOptimizerRuntimeAdapter()
+
+
+__all__ = ["DEFAULT_RUNTIME_ADAPTER", "DefaultOptimizerRuntimeAdapter"]

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -434,6 +434,10 @@ class MegatronLiteRuntime(RuntimeBase):
                     gc.collect()
                     torch.cuda.empty_cache()
                 return
+            if training_transfer and handle._extras.get("optimizer_backend") == "mfsdp":
+                raise RuntimeError(
+                    "M-FSDP training transfer requires atomic offload_for_rollout()."
+                )
             if model:
                 offload_model_to_cpu(model_chunks)
             if (optimizer or training_transfer) and handle._optimizer is not None:
@@ -462,6 +466,10 @@ class MegatronLiteRuntime(RuntimeBase):
             if callable(rollout_load):
                 rollout_load()
                 return
+            if training_transfer and handle._extras.get("optimizer_backend") == "mfsdp":
+                raise RuntimeError(
+                    "M-FSDP training transfer requires atomic load_from_rollout()."
+                )
             if model:
                 load_model_to_gpu(model_chunks, load_grad=grad)
             if (optimizer or training_transfer) and handle._optimizer is not None:

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -422,6 +422,18 @@ class MegatronLiteRuntime(RuntimeBase):
         # scratch buffers or optimizer residency.
         training_transfer = model and grad
         if device == "cpu":
+            rollout_offload = (
+                getattr(handle._optimizer, "offload_for_rollout", None)
+                if training_transfer and handle._optimizer is not None
+                else None
+            )
+            if callable(rollout_offload):
+                rollout_offload()
+                if torch.cuda.is_available():
+                    torch.cuda.synchronize()
+                    gc.collect()
+                    torch.cuda.empty_cache()
+                return
             if model:
                 offload_model_to_cpu(model_chunks)
             if (optimizer or training_transfer) and handle._optimizer is not None:
@@ -442,6 +454,14 @@ class MegatronLiteRuntime(RuntimeBase):
                     gc.collect()
                     torch.cuda.empty_cache()
         elif device == "cuda":
+            rollout_load = (
+                getattr(handle._optimizer, "load_from_rollout", None)
+                if training_transfer and handle._optimizer is not None
+                else None
+            )
+            if callable(rollout_load):
+                rollout_load()
+                return
             if model:
                 load_model_to_gpu(model_chunks, load_grad=grad)
             if (optimizer or training_transfer) and handle._optimizer is not None:

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import gc
 import os
 from collections.abc import Callable, Iterator, Mapping
 from dataclasses import fields as dc_fields
@@ -263,12 +262,11 @@ class MegatronLiteRuntime(RuntimeBase):
         if bundle.forward_step is None:
             raise ValueError("Megatron Lite model bundles must provide a typed forward_step.")
 
-        optimizer_backend_name = bundle.extras.get("optimizer_backend")
-        optimizer_runtime_backend = None
-        if optimizer_backend_name not in (None, "none"):
-            from megatron.lite.primitive.optimizers import get_optimizer_backend
+        from megatron.lite.primitive.optimizers import get_optimizer_backend
 
-            optimizer_runtime_backend = get_optimizer_backend(optimizer_backend_name)
+        optimizer_runtime_backend = get_optimizer_backend(
+            bundle.extras.get("optimizer_backend")
+        )
 
         p = rt_cfg.parallel
         model = bundle.chunks[0] if len(bundle.chunks) == 1 else bundle.chunks
@@ -391,10 +389,10 @@ class MegatronLiteRuntime(RuntimeBase):
     def release_export_scratch(self, handle: ModelHandle) -> None:
         """Release retained full-parameter scratch before colocated rollout wake."""
         model_chunks = handle._extras.get("model_chunks", [handle._model])
-        for chunk in model_chunks:
-            release = getattr(chunk, "release_export_scratch", None)
-            if callable(release):
-                release()
+        from megatron.lite.primitive.optimizers import get_optimizer_backend
+
+        backend = handle._extras.get("optimizer_runtime_backend")
+        (backend or get_optimizer_backend(None)).release_export_scratch(model_chunks)
 
     # ── Memory ──
 
@@ -408,76 +406,17 @@ class MegatronLiteRuntime(RuntimeBase):
         grad: bool = True,
     ) -> None:
         model_chunks = handle._extras.get("model_chunks", [handle._model])
-        from megatron.lite.runtime.megatron_utils import (
-            load_model_to_gpu,
-            load_optimizer,
-            offload_model_to_cpu,
-            offload_optimizer,
-        )
+        from megatron.lite.primitive.optimizers import get_optimizer_backend
 
-        # A model+gradient transfer is the training context boundary.  On its
-        # CPU side the colocated rollout is about to map its sleeping weights;
-        # on its CUDA side training is taking the device back.  Keep the whole
-        # release/restore contract here rather than teaching VERL about backend
-        # scratch buffers or optimizer residency.
-        training_transfer = model and grad
-        if device == "cpu":
-            rollout_offload = (
-                getattr(handle._optimizer, "offload_for_rollout", None)
-                if training_transfer and handle._optimizer is not None
-                else None
-            )
-            if callable(rollout_offload):
-                rollout_offload()
-                if torch.cuda.is_available():
-                    torch.cuda.synchronize()
-                    gc.collect()
-                    torch.cuda.empty_cache()
-                return
-            if training_transfer and handle._extras.get("optimizer_backend") == "mfsdp":
-                raise RuntimeError(
-                    "M-FSDP training transfer requires atomic offload_for_rollout()."
-                )
-            if model:
-                offload_model_to_cpu(model_chunks)
-            if (optimizer or training_transfer) and handle._optimizer is not None:
-                offload_state = getattr(handle._optimizer, "offload_state_to_cpu", None)
-                if callable(offload_state):
-                    offload_state()
-                else:
-                    offload_optimizer(handle._optimizer)
-            if training_transfer:
-                self.release_export_scratch(handle)
-                if torch.cuda.is_available():
-                    torch.cuda.synchronize()
-                    # R3/full-recompute may leave CUDA tensors reachable only
-                    # through dead Python cycles until the next periodic GC.
-                    # vLLM remaps its sleeping weights immediately after this
-                    # boundary, so collect those cycles before asking the CUDA
-                    # allocator to return their now-unused blocks.
-                    gc.collect()
-                    torch.cuda.empty_cache()
-        elif device == "cuda":
-            rollout_load = (
-                getattr(handle._optimizer, "load_from_rollout", None)
-                if training_transfer and handle._optimizer is not None
-                else None
-            )
-            if callable(rollout_load):
-                rollout_load()
-                return
-            if training_transfer and handle._extras.get("optimizer_backend") == "mfsdp":
-                raise RuntimeError(
-                    "M-FSDP training transfer requires atomic load_from_rollout()."
-                )
-            if model:
-                load_model_to_gpu(model_chunks, load_grad=grad)
-            if (optimizer or training_transfer) and handle._optimizer is not None:
-                load_state = getattr(handle._optimizer, "load_state_to_device", None)
-                if callable(load_state):
-                    load_state()
-                else:
-                    load_optimizer(handle._optimizer)
+        backend = handle._extras.get("optimizer_runtime_backend")
+        (backend or get_optimizer_backend(None)).transfer_training_state(
+            handle._optimizer,
+            model_chunks,
+            device,
+            model=model,
+            optimizer_state=optimizer,
+            grad=grad,
+        )
 
     # ── Mode switching ──
 

--- a/experimental/lite/skills/README.md
+++ b/experimental/lite/skills/README.md
@@ -76,7 +76,9 @@ validation commands instead of copying long design background.
 - `primitive.parallel.pp`
 - `primitive.parallel.cp`
 - `primitive.optimizer.fsdp`
+- `primitive.optimizer.mfsdp`
 - `primitive.optimizer.distopt`
+- `primitive.checkpoint.mfsdp`
 - `primitive.module.moe`
 - `primitive.module.gqa`
 - `primitive.module.thd`

--- a/experimental/lite/skills/primitive/checkpoint/mfsdp.md
+++ b/experimental/lite/skills/primitive/checkpoint/mfsdp.md
@@ -1,0 +1,64 @@
+# M-FSDP Distributed Checkpoint Skill
+
+Define and validate distributed checkpoint continuity for standalone M-FSDP,
+including CPU-offloaded AdamW state.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "primitive.checkpoint.mfsdp", kind="primitive", purpose="checkpoint standalone M-FSDP state",
+    imports=["basic.constitution"], calls=["primitive.contract", "primitive.validate", "primitive.optimizer.mfsdp"],
+    inputs=["task", "implementation", "config", "reference", "budget"],
+    outputs=["principle", "implementation_contract", "usage_contract", "validation", "risks"],
+    exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def mfsdp(task, implementation, config, reference, budget):
+    optimizer = primitive.optimizer.mfsdp(task, implementation, config, reference, budget)
+    if not optimizer.done:
+        return blocked("M-FSDP optimizer contract not satisfied", evidence=optimizer)
+    contract = primitive.contract(implementation.checkpoint, scope=task.scope, reference=reference)
+    if not contract.done:
+        return blocked("M-FSDP checkpoint contract not satisfied", evidence=contract)
+
+    principle = {
+        "semantics": "save-load-continue matches uninterrupted M-FSDP training",
+        "state": [
+            "model parameter shards",
+            "GPU and CPU optimizer parameter-group metadata",
+            "FP32 master parameters, exp_avg, exp_avg_sq, and step",
+        ],
+        "reference": reference or "uninterrupted next optimizer step",
+    }
+    implementation_contract = {
+        "owned_files": ["primitive.ckpt.dcp", "primitive.optimizers.mfsdp"],
+        "placement": [
+            "CPU-resident shards stage through the process-group compute device",
+            "restored pinned tensors preserve their allocated storage and parameter identities",
+        ],
+        "failure_modes": [
+            "missing GPU or CPU optimizer metadata fails loudly",
+            "bucket identity or parameter-group count mismatch fails loudly",
+        ],
+    }
+    usage_contract = {
+        "choose_when": ["optimizer backend is mfsdp", "runtime use_dcp is true"],
+        "valid": ["model-only", "optimizer-only", "combined", "same or changed DP size"],
+        "avoid_when": ["loading CPU-offloaded state into a target without the matching offload contract"],
+    }
+    validation = primitive.validate(task, primitive=implementation.checkpoint, implementation=implementation, budget=budget)
+    if not validation.done:
+        return blocked("M-FSDP checkpoint validation failed", evidence=validation)
+    return done(
+        principle=principle,
+        implementation_contract=implementation_contract,
+        usage_contract=usage_contract,
+        validation=validation,
+        risks=["silent optimizer-state omission", "DP-reshard metadata drift", "checkpoint-time staging peak"],
+    )
+```

--- a/experimental/lite/skills/primitive/optimizer/mfsdp.md
+++ b/experimental/lite/skills/primitive/optimizer/mfsdp.md
@@ -1,0 +1,69 @@
+# Standalone Megatron FSDP Skill
+
+Define, compose, and validate the standalone M-FSDP optimizer and its two
+offload lifecycles.
+
+## Schema
+
+<!-- MLITE_SKILL_SCHEMA_BEGIN -->
+```python
+schema = Skill(
+    "primitive.optimizer.mfsdp", kind="primitive", purpose="define and validate standalone M-FSDP",
+    imports=["basic.constitution"], calls=["primitive.contract", "primitive.validate"],
+    inputs=["task", "implementation", "config", "reference", "budget"],
+    outputs=["principle", "implementation_contract", "usage_contract", "validation", "risks"],
+    exits=["done", "blocked", "out_of_scope"],
+)
+```
+<!-- MLITE_SKILL_SCHEMA_END -->
+
+```python
+def mfsdp(task, implementation, config, reference, budget):
+    contract = primitive.contract(implementation.mfsdp, scope=task.scope, reference=reference)
+    if not contract.done:
+        return blocked("M-FSDP contract not satisfied", evidence=contract)
+
+    principle = {
+        "semantics": "match MCore M-FSDP parameter, gradient, and optimizer-shard ownership",
+        "invariants": [
+            "gather materializes reference weights before compute",
+            "reduce-scatter lands in the owned sharded main gradient",
+            "optimizer update matches the independent unsharded reference",
+            "temporary communication storage has a bounded owner and lifetime",
+        ],
+        "reference": reference or "MCore M-FSDP lifecycle plus unsharded AdamW update",
+    }
+    implementation_contract = {
+        "owned_files": ["primitive.optimizers.mfsdp", "primitive.optimizers.fp32_adamw"],
+        "training_offload": [
+            "CPU-resident local parameter shard and FP32 Adam master/moments",
+            "bounded CPU-to-GPU parameter lease before each gather",
+            "bounded GPU-to-CPU gradient staging during optimizer step",
+        ],
+        "rollout_offload": [
+            "drain communication before transition",
+            "release model, optimizer, and gradient GPU storage atomically",
+            "restore fresh training gradients without retaining a CPU gradient copy",
+        ],
+        "boundaries": [
+            "model code classifies ownership; optimizer primitive owns sharding and offload",
+            "unsupported optimizer algorithms fail loudly instead of silently changing algorithm",
+        ],
+    }
+    usage_contract = {
+        "config": require_config_keys(config, ["optimizer", "offload_fraction"]),
+        "choose_when": ["standalone M-FSDP is selected", "training or rollout GPU reclaim is required"],
+        "valid": ["offload_fraction in [0, 1]", "AdamW for CPU update"],
+        "avoid_when": ["the requested optimizer lacks an explicit CPU implementation"],
+    }
+    validation = primitive.validate(task, primitive=implementation.mfsdp, implementation=implementation, budget=budget)
+    if not validation.done:
+        return blocked("M-FSDP validation failed", evidence=validation)
+    return done(
+        principle=principle,
+        implementation_contract=implementation_contract,
+        usage_contract=usage_contract,
+        validation=validation,
+        risks=["state drift after DCP resume", "unbounded transfer staging", "stale rollout state"],
+    )
+```

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 import sys
 from types import SimpleNamespace
@@ -705,6 +706,80 @@ def test_mfsdp_non_fused_wgrad_accumulates_in_fp32_per_microbatch():
                     "single_backward_bf16_roundtrip_exact": True,
                     "multi_microbatch_value": float(consumed_grad[0]),
                     "multi_microbatch_bf16_roundtrip_exact": False,
+                },
+                sort_keys=True,
+            ),
+            flush=True,
+        )
+
+
+def test_mfsdp_training_and_rollout_offload_distributed_smoke():
+    """Exercise both offload contracts with real NCCL sharding on every rank."""
+    parallel = _dense_parallel_config()
+    ps = _parallel_state(parallel)
+    chunks = [_new_model(17321, TinyTEQwen3MoE)]
+    optimizer_config = _optimizer_cfg(use_fused_optimizer=False)
+    optimizer_config.offload_fraction = 1.0
+    optimizer_config.override_optimizer_config.update(
+        {"gradient_accumulation_fusion": True, "bucket_size": 17}
+    )
+    impl_cfg = SimpleNamespace(parallel=parallel, optimizer_config=optimizer_config)
+    optimizer, finalize = build_mfsdp_training_optimizer(
+        chunks,
+        impl_cfg=impl_cfg,
+        ps=ps,
+        is_expert=lambda name: ".expert." in name,
+        fsdp_unit_modules=(TinyTETransformerLayer,),
+    )
+    chunk = chunks[0]
+    cpu_group = optimizer._inner_optimizer.cpu_group
+    assert cpu_group is not None
+
+    def run_step(seed: int) -> float:
+        optimizer.zero_grad()
+        generator = torch.Generator(device="cuda")
+        generator.manual_seed(seed + dist.get_rank())
+        value = torch.randn(
+            64, 8, device="cuda", dtype=torch.bfloat16, generator=generator
+        )
+        loss = chunk(value).float().square().mean()
+        loss.backward()
+        finalize()
+        success, grad_norm, _num_zeros = optimizer.step()
+        assert success and math.isfinite(grad_norm)
+        return float(loss.item())
+
+    first_loss = run_step(17331)
+    assert cpu_group.d2h_bytes > 0 and cpu_group.h2d_bytes > 0
+    assert cpu_group.live_transfer_leases == 0
+    assert cpu_group.ring_high_water_elements <= min(
+        sum(param.numel() for param in cpu_group.gpu_params), 2 * 17
+    )
+    assert all(
+        state["master_param"].device.type == "cpu"
+        and state["exp_avg"].device.type == "cpu"
+        and state["exp_avg_sq"].device.type == "cpu"
+        for state in cpu_group._optimizer.state.values()
+    )
+
+    optimizer.offload_for_rollout()
+    assert all(bucket.device.type == "cpu" for bucket in chunk.param_sync.buckets)
+    assert all(bucket.main_grad_buffer.numel() == 0 for bucket in chunk.param_sync.buckets)
+    optimizer.load_from_rollout()
+    assert all(bucket.device.type == "cuda" for bucket in chunk.param_sync.buckets)
+    second_loss = run_step(17341)
+
+    if dist.get_rank() == 0:
+        print(
+            "[MFSDP_TWO_OFFLOADS] "
+            + json.dumps(
+                {
+                    "world_size": dist.get_world_size(),
+                    "first_loss": first_loss,
+                    "second_loss": second_loss,
+                    "d2h_bytes": cpu_group.d2h_bytes,
+                    "h2d_bytes": cpu_group.h2d_bytes,
+                    "ring_high_water_elements": cpu_group.ring_high_water_elements,
                 },
                 sort_keys=True,
             ),

--- a/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_mfsdp_parity_smoke.py
@@ -750,7 +750,12 @@ def test_mfsdp_training_and_rollout_offload_distributed_smoke():
         return float(loss.item())
 
     first_loss = run_step(17331)
-    assert cpu_group.d2h_bytes > 0 and cpu_group.h2d_bytes > 0
+    assert cpu_group.d2h_bytes > 0 and cpu_group.h2d_bytes == 0
+    assert all(
+        bucket.main_param_buffer.device.type == "cpu"
+        and bucket.main_param_buffer.is_pinned()
+        for bucket in chunk.param_sync.buckets
+    )
     assert cpu_group.live_transfer_leases == 0
     assert cpu_group.ring_high_water_elements <= min(
         sum(param.numel() for param in cpu_group.gpu_params), 2 * 17
@@ -767,6 +772,10 @@ def test_mfsdp_training_and_rollout_offload_distributed_smoke():
     assert all(bucket.main_grad_buffer.numel() == 0 for bucket in chunk.param_sync.buckets)
     optimizer.load_from_rollout()
     assert all(bucket.device.type == "cuda" for bucket in chunk.param_sync.buckets)
+    assert all(
+        bucket.main_param_buffer.device.type == "cpu"
+        for bucket in chunk.param_sync.buckets
+    )
     second_loss = run_step(17341)
 
     if dist.get_rank() == 0:

--- a/experimental/lite/tests/smoke/workflows/checkpoint/test_save_load_export_smoke.py
+++ b/experimental/lite/tests/smoke/workflows/checkpoint/test_save_load_export_smoke.py
@@ -413,8 +413,12 @@ def _build_handle(
             "protocol": protocol,
         }
     )
+    # Match MegatronLiteRuntime.build_model(): the non-pipeline runtime calls
+    # forward_step with the sole chunk, while pipeline schedules receive the
+    # complete chunk list through ``model_chunks``.
+    model = chunks[0] if len(chunks) == 1 else chunks
     handle = ModelHandle(
-        model=chunks,
+        model=model,
         optimizer=optimizer,
         parallel_state=bundle.parallel_state,
         config=SimpleNamespace(parallel=parallel),

--- a/experimental/lite/tests/smoke/workflows/checkpoint/test_save_load_export_smoke.py
+++ b/experimental/lite/tests/smoke/workflows/checkpoint/test_save_load_export_smoke.py
@@ -618,6 +618,34 @@ def test_qwen3_5_mfsdp_save_load_roundtrip(tmp_path):
     _assert_params_bitwise_equal(saved, loaded)
 
 
+def test_qwen3_5_mfsdp_full_offload_dcp_continues_next_step(tmp_path):
+    """Full-offload DCP restores CPU master/moments for the next update."""
+    if dist.get_world_size() != 8:
+        pytest.skip("M-FSDP full-offload DCP smoke requires exactly 8 GPUs.")
+
+    set_deterministic(2026)
+    uninterrupted, cfg, _protocol = _build_handle(
+        "qwen3_5", "mfsdp", seed=4242, offload_fraction=1.0
+    )
+    _train_step(uninterrupted, "mfsdp", cfg)
+
+    ckpt_dir = _shared_tmp_path(tmp_path, "mfsdp_full_offload_ckpt")
+    runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
+    runtime.save_checkpoint(uninterrupted, ckpt_dir, step=1)
+
+    resumed, _cfg2, _proto2 = _build_handle(
+        "qwen3_5", "mfsdp", seed=9999, offload_fraction=1.0
+    )
+    assert runtime.load_checkpoint(resumed, ckpt_dir) == 1
+    _assert_params_bitwise_equal(uninterrupted, resumed)
+
+    set_deterministic(3031)
+    _train_step(uninterrupted, "mfsdp", cfg)
+    set_deterministic(3031)
+    _train_step(resumed, "mfsdp", cfg)
+    _assert_params_bitwise_equal(uninterrupted, resumed)
+
+
 @pytest.mark.env(CUDA_DEVICE_MAX_CONNECTIONS="1")
 @pytest.mark.parametrize("model_name", list(MODELS))
 def test_export_hf_bf16_reload(model_name, tmp_path):

--- a/experimental/lite/tests/unit/primitive/test_fp32_adamw.py
+++ b/experimental/lite/tests/unit/primitive/test_fp32_adamw.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+import torch
+from megatron.lite.primitive.optimizers.fp32_adamw import FP32AdamW
+
+
+@pytest.mark.parametrize("slice_capacity", [None, 3])
+def test_fp32_adamw_matches_scalar_torch_adamw(slice_capacity: int | None):
+    initial = [
+        torch.tensor([1.0, -2.0, 3.0, -4.0, 5.0]),
+        torch.tensor([0.25, -0.75]),
+        torch.empty(0),
+    ]
+    candidate = [torch.nn.Parameter(value.clone()) for value in initial]
+    reference = [torch.nn.Parameter(value.clone()) for value in initial]
+    candidate_optimizer = FP32AdamW(
+        [
+            {"params": [candidate[0], candidate[2]], "weight_decay": 0.1},
+            {"params": [candidate[1]], "weight_decay": 0.0},
+        ],
+        lr=0.03,
+        weight_decay=0.1,
+        betas=(0.8, 0.95),
+        eps=1.0e-6,
+        slice_capacity=slice_capacity,
+    )
+    reference_optimizer = torch.optim.AdamW(
+        [
+            {"params": [reference[0]], "weight_decay": 0.1},
+            {"params": [reference[1]], "weight_decay": 0.0},
+        ],
+        lr=0.03,
+        betas=(0.8, 0.95),
+        eps=1.0e-6,
+        foreach=False,
+    )
+
+    grads = [
+        (torch.tensor([0.5, -0.25, 0.0, 1.0, -0.5]), None),
+        (None, torch.tensor([0.125, -0.375])),
+        (torch.tensor([-0.2, 0.4, -0.6, 0.8, -1.0]), torch.tensor([0.3, 0.1])),
+    ]
+    for grad0, grad1 in grads:
+        candidate[0].grad = None if grad0 is None else grad0.clone()
+        candidate[1].grad = None if grad1 is None else grad1.clone()
+        candidate[2].grad = torch.empty(0)
+        reference[0].grad = None if grad0 is None else grad0.clone()
+        reference[1].grad = None if grad1 is None else grad1.clone()
+        candidate_optimizer.step()
+        reference_optimizer.step()
+
+    for actual, expected in zip(candidate[:2], reference[:2], strict=True):
+        torch.testing.assert_close(actual, expected, atol=0.0, rtol=0.0)
+    assert candidate_optimizer.state[candidate[0]]["step"] == 2
+    assert candidate_optimizer.state[candidate[1]]["step"] == 2
+    assert candidate_optimizer.state[candidate[2]]["step"] == 0
+
+
+def test_sliced_update_advances_step_once_and_matches_unsliced():
+    initial = torch.linspace(-1.0, 1.0, 11)
+    sliced_param = torch.nn.Parameter(initial.clone())
+    whole_param = torch.nn.Parameter(initial.clone())
+    sliced = FP32AdamW(
+        [sliced_param],
+        lr=0.01,
+        weight_decay=0.2,
+        betas=(0.9, 0.99),
+        eps=1.0e-8,
+        slice_capacity=4,
+    )
+    whole = FP32AdamW(
+        [whole_param], lr=0.01, weight_decay=0.2, betas=(0.9, 0.99), eps=1.0e-8
+    )
+
+    grad = torch.linspace(0.3, -0.4, 11)
+    sliced_param.grad = grad.clone()
+    whole_param.grad = grad.clone()
+    sliced.step()
+    whole.step()
+
+    torch.testing.assert_close(sliced_param, whole_param, atol=0.0, rtol=0.0)
+    for key in ("master_param", "exp_avg", "exp_avg_sq"):
+        torch.testing.assert_close(
+            sliced.state[sliced_param][key],
+            whole.state[whole_param][key],
+            atol=0.0,
+            rtol=0.0,
+        )
+    assert sliced.state[sliced_param]["step"] == 1
+
+
+def test_shared_fp32_adamw_has_no_backend_imports():
+    source = Path(
+        "experimental/lite/megatron/lite/primitive/optimizers/fp32_adamw.py"
+    ).read_text()
+    imports = [
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+    ]
+    rendered = "\n".join(ast.unparse(node) for node in imports)
+
+    for forbidden in (
+        "fsdp2",
+        "mfsdp",
+        "DTensor",
+        "torch.distributed",
+        "megatron.lite.model",
+    ):
+        assert forbidden not in rendered

--- a/experimental/lite/tests/unit/primitive/test_fp32_adamw.py
+++ b/experimental/lite/tests/unit/primitive/test_fp32_adamw.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 import torch
-from megatron.lite.primitive.optimizers.fp32_adamw import FP32AdamW
+from megatron.lite.primitive.optimizers.fp32_adamw import FP32AdamW, STATE_DICT_TYPE
 
 
 @pytest.mark.parametrize("slice_capacity", [None, 3])
@@ -113,3 +113,19 @@ def test_shared_fp32_adamw_has_no_backend_imports():
         "megatron.lite.model",
     ):
         assert forbidden not in rendered
+
+
+def test_shared_fp32_adamw_state_tag_does_not_collide_with_fsdp2():
+    param = torch.nn.Parameter(torch.ones(2))
+    optimizer = FP32AdamW(
+        [param],
+        lr=1.0e-3,
+        weight_decay=0.0,
+        betas=(0.9, 0.999),
+        eps=1.0e-8,
+    )
+
+    assert STATE_DICT_TYPE == "mlite_fp32_adamw_v1"
+    assert optimizer.state_dict()["type"] == STATE_DICT_TYPE
+    with pytest.raises(ValueError, match="Invalid FP32 AdamW"):
+        optimizer.load_state_dict({"type": "fp32_adamw"})

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -1033,6 +1033,30 @@ def test_mfsdp_accepts_raw_override_only_offload_fraction():
     assert optimizer._inner_optimizer.optimizer.param_groups == []
 
 
+def test_mfsdp_offload_split_uses_dp_invariant_logical_parameter_sizes():
+    def rank_params(local_sizes):
+        params = [nn.Parameter(torch.empty(size)) for size in local_sizes]
+        params[0]._mfsdp_global_numel = 8
+        params[1]._mfsdp_global_numel = 4
+        return params
+
+    placements = []
+    for local_sizes in ((0, 4), (8, 0)):
+        params = rank_params(local_sizes)
+        indices = {id(param): index for index, param in enumerate(params)}
+        gpu, cpu = mfsdp_optimizer._split_param_groups_by_fraction(
+            [{"params": params, "weight_decay": 0.0}], 0.5
+        )
+        placements.append(
+            (
+                [indices[id(param)] for group in gpu for param in group["params"]],
+                [indices[id(param)] for group in cpu for param in group["params"]],
+            )
+        )
+
+    assert placements == [([1], [0]), ([1], [0])]
+
+
 def test_mfsdp_full_optimizer_offload_uses_bounded_cpu_state_and_fp32_main_grad():
     _Model, _Unit, ps, engine_cfg = _build_optimizer_stack(1.0)
     engine_cfg.optimizer.override_optimizer_config["bucket_size"] = 5

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -1100,6 +1100,79 @@ def test_mfsdp_offload_zero_does_not_construct_cpu_optimizer(monkeypatch):
     assert optimizer._inner_optimizer.cpu_group is None
 
 
+def test_mfsdp_partial_optimizer_offload_updates_cpu_and_gpu_groups():
+    _Model, _Unit, ps, engine_cfg = _build_optimizer_stack(0.5)
+    chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [_Model()],
+        engine_cfg=engine_cfg,
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_Unit,),
+    )
+    inner = optimizer._inner_optimizer
+    assert inner.cpu_group is not None
+    assert inner.optimizer.param_groups
+    cpu_ids = {id(param) for param in inner.cpu_group.gpu_params}
+    gpu_ids = {
+        id(param)
+        for group in inner.optimizer.param_groups
+        for param in group["params"]
+    }
+    assert cpu_ids and gpu_ids and cpu_ids.isdisjoint(gpu_ids)
+
+    optimizer.zero_grad()
+    value = torch.randn(3, 4)
+    target = torch.randn(3, 2)
+    torch.nn.functional.mse_loss(chunks[0](value), target).backward()
+    optimizer.finish_grad_sync()
+    assert optimizer.step()[0]
+
+
+def test_mfsdp_offloaded_checkpoint_matches_loaded_next_step():
+    _Model, _Unit, ps, engine_cfg = _build_optimizer_stack(1.0)
+    torch.manual_seed(55)
+    model_a = _Model()
+    model_b = copy.deepcopy(model_a)
+    chunks_a, optimizer_a = mfsdp_optimizer.build_mfsdp_stack(
+        [model_a],
+        engine_cfg=engine_cfg,
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_Unit,),
+    )
+    chunks_b, optimizer_b = mfsdp_optimizer.build_mfsdp_stack(
+        [model_b],
+        engine_cfg=engine_cfg,
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_Unit,),
+    )
+    first_value = torch.randn(3, 4)
+    first_target = torch.randn(3, 2)
+    optimizer_a.zero_grad()
+    torch.nn.functional.mse_loss(chunks_a[0](first_value), first_target).backward()
+    optimizer_a.finish_grad_sync()
+    assert optimizer_a.step()[0]
+
+    saved = copy.deepcopy(optimizer_a.state_dict())
+    assert saved["cpu"]["format_version"] == 2
+    optimizer_b.load_state_dict(saved)
+
+    next_value = torch.randn(3, 4)
+    next_target = torch.randn(3, 2)
+    for chunks, optimizer in ((chunks_a, optimizer_a), (chunks_b, optimizer_b)):
+        optimizer.zero_grad()
+        torch.nn.functional.mse_loss(chunks[0](next_value), next_target).backward()
+        optimizer.finish_grad_sync()
+        assert optimizer.step()[0]
+
+    params_a = dict(chunks_a[0].stream_full_parameters())
+    params_b = dict(chunks_b[0].stream_full_parameters())
+    assert params_a.keys() == params_b.keys()
+    for name in params_a:
+        assert torch.equal(params_a[name], params_b[name]), name
+
+
 def test_mfsdp_rollout_offload_drops_grad_storage_and_restores_next_step():
     _Model, _Unit, ps, engine_cfg = _build_optimizer_stack(1.0)
     chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -1016,6 +1016,23 @@ def test_mfsdp_rejects_invalid_optimizer_offload_fraction(offload_fraction):
         )
 
 
+def test_mfsdp_accepts_raw_override_only_offload_fraction():
+    _Model, _Unit, ps, engine_cfg = _build_optimizer_stack()
+    del engine_cfg.optimizer.offload_fraction
+    engine_cfg.optimizer.override_optimizer_config["offload_fraction"] = 1.0
+
+    _chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [_Model()],
+        engine_cfg=engine_cfg,
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_Unit,),
+    )
+
+    assert optimizer._inner_optimizer.cpu_group is not None
+    assert optimizer._inner_optimizer.optimizer.param_groups == []
+
+
 def test_mfsdp_full_optimizer_offload_uses_bounded_cpu_state_and_fp32_main_grad():
     _Model, _Unit, ps, engine_cfg = _build_optimizer_stack(1.0)
     engine_cfg.optimizer.override_optimizer_config["bucket_size"] = 5
@@ -1056,6 +1073,138 @@ def test_mfsdp_full_optimizer_offload_uses_bounded_cpu_state_and_fp32_main_grad(
         assert state["master_param"].device.type == "cpu"
         assert state["exp_avg"].device.type == "cpu"
         assert state["exp_avg_sq"].device.type == "cpu"
+
+
+def test_mfsdp_cpu_adam_group_matches_torch_adamw_across_steps():
+    initial = torch.tensor([1.0, -2.0, 3.0, -4.0, 5.0])
+    candidate = torch.nn.Parameter(initial.clone())
+    reference = torch.nn.Parameter(initial.clone())
+    candidate_group = mfsdp_optimizer.CpuAdamGroup(
+        [{"params": [candidate], "weight_decay": 0.2}],
+        lr=0.03,
+        betas=(0.8, 0.95),
+        eps=1.0e-6,
+        bucket_size=2,
+    )
+    reference_optimizer = torch.optim.AdamW(
+        [{"params": [reference], "weight_decay": 0.2}],
+        lr=0.03,
+        betas=(0.8, 0.95),
+        eps=1.0e-6,
+        foreach=False,
+    )
+
+    for grad in (
+        torch.tensor([0.5, -0.25, 0.0, 1.0, -0.5]),
+        torch.tensor([-0.2, 0.4, -0.6, 0.8, -1.0]),
+        torch.tensor([0.3, 0.1, -0.1, -0.3, 0.7]),
+    ):
+        candidate.main_grad = grad.clone()
+        reference.grad = grad.clone()
+        candidate_group.step()
+        reference_optimizer.step()
+
+    torch.testing.assert_close(candidate, reference, atol=0.0, rtol=0.0)
+    state = candidate_group._optimizer.state[candidate]
+    reference_state = reference_optimizer.state[reference]
+    assert state["step"] == 3
+    torch.testing.assert_close(
+        state["exp_avg"], reference_state["exp_avg"], atol=2.0e-8, rtol=2.0e-7
+    )
+    torch.testing.assert_close(
+        state["exp_avg_sq"], reference_state["exp_avg_sq"], atol=2.0e-8, rtol=2.0e-7
+    )
+
+
+def test_mfsdp_same_dtype_reduced_grad_uses_decoupled_optimizer_contract(monkeypatch):
+    _Model, _Unit, ps, engine_cfg = _build_optimizer_stack()
+    engine_cfg.optimizer.override_optimizer_config["use_precision_aware_optimizer"] = True
+
+    class _DecoupledOptimizer:
+        def __init__(self, groups):
+            self.param_groups = groups
+            self.state = {}
+
+        def zero_grad(self):
+            for group in self.param_groups:
+                for param in group["params"]:
+                    param.grad = None
+                    param.decoupled_grad = None
+
+        def step(self):
+            assert all(
+                param.grad is None and getattr(param, "decoupled_grad", None) is not None
+                for group in self.param_groups
+                for param in group["params"]
+                if param.numel()
+            )
+
+        def state_dict(self):
+            return {"state": {}, "param_groups": []}
+
+    monkeypatch.setattr(
+        mfsdp_optimizer,
+        "_build_optimizer_algorithm",
+        lambda groups, *_args, **_kwargs: _DecoupledOptimizer(groups),
+    )
+    chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [_Model()],
+        engine_cfg=engine_cfg,
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_Unit,),
+    )
+
+    optimizer.zero_grad()
+    torch.nn.functional.mse_loss(
+        chunks[0](torch.randn(3, 4)), torch.randn(3, 2)
+    ).backward()
+    optimizer.finish_grad_sync()
+
+    params = [param for param in _optimizer_params(optimizer) if param.numel()]
+    assert all(param.grad is None for param in params)
+    assert all(getattr(param, "decoupled_grad", None) is param.main_grad for param in params)
+    assert optimizer.step()[0]
+
+
+def test_mfsdp_full_offload_defaults_to_mcore_memory_first_communication_policy():
+    _Model, _Unit, ps, engine_cfg = _build_optimizer_stack(1.0)
+    engine_cfg.optimizer.override_optimizer_config["bucket_size"] = 5
+
+    chunks, _optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [_Model()],
+        engine_cfg=engine_cfg,
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_Unit,),
+    )
+
+    config = chunks[0].mfsdp_config
+    assert config.suggested_communication_unit_size == 5
+    assert config.overlap_param_gather is False
+
+
+def test_mfsdp_full_offload_preserves_explicit_mcore_communication_policy():
+    _Model, _Unit, ps, engine_cfg = _build_optimizer_stack(1.0)
+    engine_cfg.optimizer.override_optimizer_config.update(
+        {
+            "bucket_size": 5,
+            "suggested_communication_unit_size": 9,
+            "overlap_param_gather": True,
+        }
+    )
+
+    chunks, _optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [_Model()],
+        engine_cfg=engine_cfg,
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_Unit,),
+    )
+
+    config = chunks[0].mfsdp_config
+    assert config.suggested_communication_unit_size == 9
+    assert config.overlap_param_gather is True
 
 
 def test_mfsdp_full_optimizer_offload_has_six_device_bytes_per_bf16_param():

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -1002,8 +1002,8 @@ def test_mfsdp_optimizer_checkpoint_round_trips_fp32_shard_values():
         assert torch.equal(param, expected_param)
 
 
-@pytest.mark.parametrize("offload_fraction", [-0.01, 0.5, 1.0, 1.01])
-def test_mfsdp_rejects_optimizer_offload(offload_fraction):
+@pytest.mark.parametrize("offload_fraction", [-0.01, 1.01, float("nan")])
+def test_mfsdp_rejects_invalid_optimizer_offload_fraction(offload_fraction):
     _Model, _Unit, ps, engine_cfg = _build_optimizer_stack(offload_fraction)
 
     with pytest.raises(ValueError, match="offload_fraction"):
@@ -1014,6 +1014,172 @@ def test_mfsdp_rejects_optimizer_offload(offload_fraction):
             is_expert=lambda _name: False,
             fsdp_unit_modules=(_Unit,),
         )
+
+
+def test_mfsdp_full_optimizer_offload_uses_bounded_cpu_state_and_fp32_main_grad():
+    _Model, _Unit, ps, engine_cfg = _build_optimizer_stack(1.0)
+    engine_cfg.optimizer.override_optimizer_config["bucket_size"] = 5
+    chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [_Model()],
+        engine_cfg=engine_cfg,
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_Unit,),
+    )
+
+    cpu_group = optimizer._inner_optimizer.cpu_group
+    assert cpu_group is not None
+    assert optimizer._inner_optimizer.optimizer.param_groups == []
+    for bucket in chunks[0].param_sync.buckets:
+        assert bucket.main_param_buffer.dtype == bucket.policy.compute_dtype
+        assert bucket.main_grad_buffer.dtype == torch.float32
+
+    value = torch.randn(3, 4)
+    target = torch.randn(3, 2)
+    optimizer.zero_grad()
+    torch.nn.functional.mse_loss(chunks[0](value), target).backward()
+    optimizer.finish_grad_sync()
+    assert all(
+        mfsdp_optimizer._optimizer_grad(param) is not None
+        and mfsdp_optimizer._optimizer_grad(param).dtype == torch.float32
+        for param in cpu_group.gpu_params
+        if param.numel()
+    )
+    assert optimizer.step()[0]
+
+    assert cpu_group.live_transfer_leases == 0
+    assert cpu_group.ring_allocated_elements <= min(
+        sum(param.numel() for param in cpu_group.gpu_params),
+        2 * 5,
+    )
+    for state in cpu_group._optimizer.state.values():
+        assert state["master_param"].device.type == "cpu"
+        assert state["exp_avg"].device.type == "cpu"
+        assert state["exp_avg_sq"].device.type == "cpu"
+
+
+def test_mfsdp_full_optimizer_offload_has_six_device_bytes_per_bf16_param():
+    _Model, _Unit, ps, engine_cfg = _build_optimizer_stack(1.0)
+    model = _Model().to(dtype=torch.bfloat16)
+    chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [model],
+        engine_cfg=engine_cfg,
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_Unit,),
+    )
+    inner = optimizer._inner_optimizer
+    cpu_group = inner.cpu_group
+    assert cpu_group is not None
+    total_numel = sum(param.numel() for param in inner.params)
+    device_param_bytes = sum(param.numel() * param.element_size() for param in inner.params)
+    device_grad_bytes = sum(
+        bucket.main_grad_buffer.numel() * bucket.main_grad_buffer.element_size()
+        for bucket in chunks[0].param_sync.buckets
+    )
+    assert device_param_bytes + device_grad_bytes == 6 * total_numel
+    assert sum(param.numel() * param.element_size() for param in cpu_group._cpu_params) == (
+        4 * total_numel
+    )
+
+
+def test_mfsdp_offload_zero_does_not_construct_cpu_optimizer(monkeypatch):
+    _Model, _Unit, ps, engine_cfg = _build_optimizer_stack(0.0)
+
+    def reject_cpu_optimizer(*args, **kwargs):
+        raise AssertionError("offload=0 constructed CPU offload state")
+
+    monkeypatch.setattr(mfsdp_optimizer, "CpuAdamGroup", reject_cpu_optimizer)
+    _chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [_Model()],
+        engine_cfg=engine_cfg,
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_Unit,),
+    )
+    assert optimizer._inner_optimizer.cpu_group is None
+
+
+def test_mfsdp_rollout_offload_drops_grad_storage_and_restores_next_step():
+    _Model, _Unit, ps, engine_cfg = _build_optimizer_stack(1.0)
+    chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [_Model()],
+        engine_cfg=engine_cfg,
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_Unit,),
+    )
+    before = {
+        name: param.detach().clone()
+        for name, param in chunks[0].stream_full_parameters()
+    }
+
+    optimizer.offload_for_rollout()
+    assert all(bucket.main_grad_buffer.numel() == 0 for bucket in chunks[0].param_sync.buckets)
+    with pytest.raises(RuntimeError, match="offloaded for rollout"):
+        optimizer.zero_grad()
+
+    optimizer.load_from_rollout()
+    assert all(
+        bucket.main_grad_buffer.numel()
+        == (bucket.local_numel if bucket.requires_grad else 0)
+        for bucket in chunks[0].param_sync.buckets
+    )
+    after = {
+        name: param.detach().clone()
+        for name, param in chunks[0].stream_full_parameters()
+    }
+    assert before.keys() == after.keys()
+    for name in before:
+        assert torch.equal(before[name], after[name]), name
+
+    optimizer.zero_grad()
+    value = torch.randn(3, 4)
+    target = torch.randn(3, 2)
+    torch.nn.functional.mse_loss(chunks[0](value), target).backward()
+    optimizer.finish_grad_sync()
+    assert optimizer.step()[0]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_mfsdp_cuda_training_and_rollout_offloads_round_trip():
+    _Model, _Unit, ps, engine_cfg = _build_optimizer_stack(1.0)
+    engine_cfg.optimizer.override_optimizer_config["bucket_size"] = 7
+    chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
+        [_Model().to(device="cuda", dtype=torch.bfloat16)],
+        engine_cfg=engine_cfg,
+        ps=ps,
+        is_expert=lambda _name: False,
+        fsdp_unit_modules=(_Unit,),
+    )
+    cpu_group = optimizer._inner_optimizer.cpu_group
+    assert cpu_group is not None
+    masters_before = [param.clone() for param in cpu_group._cpu_params]
+
+    value = torch.randn(3, 4, device="cuda", dtype=torch.bfloat16)
+    target = torch.randn(3, 2, device="cuda", dtype=torch.bfloat16)
+    optimizer.zero_grad()
+    torch.nn.functional.mse_loss(chunks[0](value), target).backward()
+    optimizer.finish_grad_sync()
+    assert optimizer.step()[0]
+    assert cpu_group.d2h_bytes > 0
+    assert cpu_group.h2d_bytes > 0
+    assert any(
+        not torch.equal(before, after)
+        for before, after in zip(masters_before, cpu_group._cpu_params, strict=True)
+    )
+    assert all(bucket.device.type == "cuda" for bucket in chunks[0].param_sync.buckets)
+
+    optimizer.offload_for_rollout()
+    assert all(bucket.device.type == "cpu" for bucket in chunks[0].param_sync.buckets)
+    assert all(bucket.main_grad_buffer.numel() == 0 for bucket in chunks[0].param_sync.buckets)
+    optimizer.load_from_rollout()
+    assert all(bucket.device.type == "cuda" for bucket in chunks[0].param_sync.buckets)
+
+    optimizer.zero_grad()
+    torch.nn.functional.mse_loss(chunks[0](value), target).backward()
+    optimizer.finish_grad_sync()
+    assert optimizer.step()[0]
 
 
 def _single_rank_mfsdp_stack(*, override_optimizer_config=None):

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -3156,13 +3156,21 @@ def test_mfsdp_dcp_optimizer_only_template_omits_model_weights(
         dist.destroy_process_group()
 
 
-def _run_mfsdp_dcp_source(rank: int, world_size: int, init_file: str, root: str):
+def _run_mfsdp_dcp_source(
+    rank: int,
+    world_size: int,
+    init_file: str,
+    root: str,
+    offload_fraction: float,
+):
     os.environ.setdefault("GLOO_SOCKET_IFNAME", "lo")
     dist.init_process_group(
         "gloo", init_method=f"file://{init_file}", rank=rank, world_size=world_size
     )
     try:
-        _model, chunk, optimizer, ps, _opt = _dcp_test_stack(world_size, rank)
+        _model, chunk, optimizer, ps, _opt = _dcp_test_stack(
+            world_size, rank, offload_fraction=offload_fraction
+        )
         torch.manual_seed(3000 + rank)
         value = torch.randn(3, 4)
         target = torch.randn(3, 2)
@@ -3171,7 +3179,7 @@ def _run_mfsdp_dcp_source(rank: int, world_size: int, init_file: str, root: str)
         optimizer.finish_grad_sync()
         assert optimizer.step()[0]
 
-        torch_optimizer = optimizer._inner_optimizer.optimizer
+        inner_optimizer = optimizer._inner_optimizer
         expected = {
             "params": {
                 name: param.detach().cpu().clone()
@@ -3183,20 +3191,20 @@ def _run_mfsdp_dcp_source(rank: int, world_size: int, init_file: str, root: str)
             exp_avg = checkpoint_dcp._mfsdp_gather_padded_bucket(
                 bucket,
                 checkpoint_dcp._mfsdp_pack_optimizer_tensor(
-                    bucket, torch_optimizer, "exp_avg"
+                    bucket, inner_optimizer, "exp_avg"
                 ),
             )
             exp_avg_sq = checkpoint_dcp._mfsdp_gather_padded_bucket(
                 bucket,
                 checkpoint_dcp._mfsdp_pack_optimizer_tensor(
-                    bucket, torch_optimizer, "exp_avg_sq"
+                    bucket, inner_optimizer, "exp_avg_sq"
                 ),
             )
             (
                 _initialized,
                 _step_present,
                 steps,
-            ) = checkpoint_dcp._mfsdp_optimizer_metadata(bucket, torch_optimizer)
+            ) = checkpoint_dcp._mfsdp_optimizer_metadata(bucket, inner_optimizer)
             for index, spec in enumerate(bucket.specs):
                 expected["optimizer"][spec.name] = {
                     "step": steps[index].cpu().clone(),
@@ -3224,15 +3232,23 @@ def _run_mfsdp_dcp_source(rank: int, world_size: int, init_file: str, root: str)
         dist.destroy_process_group()
 
 
-def _run_mfsdp_dcp_target(rank: int, world_size: int, init_file: str, root: str):
+def _run_mfsdp_dcp_target(
+    rank: int,
+    world_size: int,
+    init_file: str,
+    root: str,
+    offload_fraction: float,
+):
     os.environ.setdefault("GLOO_SOCKET_IFNAME", "lo")
     dist.init_process_group(
         "gloo", init_method=f"file://{init_file}", rank=rank, world_size=world_size
     )
     try:
-        _model, chunk, optimizer, ps, opt = _dcp_test_stack(world_size, rank)
-        torch_optimizer = optimizer._inner_optimizer.optimizer
-        for group in torch_optimizer.param_groups:
+        _model, chunk, optimizer, ps, opt = _dcp_test_stack(
+            world_size, rank, offload_fraction=offload_fraction
+        )
+        inner_optimizer = optimizer._inner_optimizer
+        for group in inner_optimizer.param_groups:
             group["lr"] = 0.25
         step = checkpoint_dcp.load_training_checkpoint(
             chunk,
@@ -3243,7 +3259,8 @@ def _run_mfsdp_dcp_target(rank: int, world_size: int, init_file: str, root: str)
             load_rng=False,
         )
         assert step == 13
-        assert all(group["lr"] == opt.lr for group in torch_optimizer.param_groups)
+        assert inner_optimizer.param_groups
+        assert all(group["lr"] == opt.lr for group in inner_optimizer.param_groups)
         expected = torch.load(
             os.path.join(root, "expected.pt"), map_location="cpu", weights_only=False
         )
@@ -3291,20 +3308,31 @@ def _run_mfsdp_dcp_target(rank: int, world_size: int, init_file: str, root: str)
         dist.destroy_process_group()
 
 
+@pytest.mark.parametrize("offload_fraction", [0.0, 0.5, 1.0])
 @pytest.mark.parametrize(("source_world", "target_world"), [(2, 4), (4, 2)])
 def test_mfsdp_dcp_cross_dp_reshard_matches_next_step(
-    tmp_path, source_world, target_world
+    tmp_path, source_world, target_world, offload_fraction
 ):
     root = str(tmp_path)
     mp.spawn(
         _run_mfsdp_dcp_source,
-        args=(source_world, str(tmp_path / "source-init"), root),
+        args=(
+            source_world,
+            str(tmp_path / "source-init"),
+            root,
+            offload_fraction,
+        ),
         nprocs=source_world,
         join=True,
     )
     mp.spawn(
         _run_mfsdp_dcp_target,
-        args=(target_world, str(tmp_path / "target-init"), root),
+        args=(
+            target_world,
+            str(tmp_path / "target-init"),
+            root,
+            offload_fraction,
+        ),
         nprocs=target_world,
         join=True,
     )

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -1035,7 +1035,7 @@ def test_mfsdp_accepts_raw_override_only_offload_fraction():
 
 def test_mfsdp_offload_split_uses_dp_invariant_logical_parameter_sizes():
     def rank_params(local_sizes):
-        params = [nn.Parameter(torch.empty(size)) for size in local_sizes]
+        params = [torch.nn.Parameter(torch.empty(size)) for size in local_sizes]
         params[0]._mfsdp_global_numel = 8
         params[1]._mfsdp_global_numel = 4
         return params

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -2932,7 +2932,9 @@ def test_mfsdp_dcp_same_topology_restores_flat_master_and_adam_state(tmp_path):
         dist.destroy_process_group()
 
 
-def _dcp_test_stack(world_size: int, rank: int):
+def _dcp_test_stack(
+    world_size: int, rank: int, *, offload_fraction: float = 0.0
+):
     torch.manual_seed(2468)
     model = _GlooModel()
     ps = SimpleNamespace(
@@ -2954,6 +2956,7 @@ def _dcp_test_stack(world_size: int, rank: int):
     )
     opt = SimpleNamespace(
         optimizer="adam",
+        offload_fraction=offload_fraction,
         lr=1.0e-3,
         min_lr=0.0,
         weight_decay=0.0,
@@ -2973,6 +2976,90 @@ def _dcp_test_stack(world_size: int, rank: int):
         fsdp_unit_modules=(_GlooUnit,),
     )
     return model, chunks[0], optimizer, ps, opt
+
+
+def test_mfsdp_dcp_full_offload_restores_cpu_adam_and_next_step(tmp_path):
+    init_file = str(tmp_path / "mfsdp-dcp-full-offload-init")
+    dist.init_process_group(
+        "gloo", init_method=f"file://{init_file}", rank=0, world_size=1
+    )
+    try:
+        torch.manual_seed(97531)
+        _model, uninterrupted, uninterrupted_optimizer, ps, _opt = _dcp_test_stack(
+            1, 0, offload_fraction=1.0
+        )
+        first_value = torch.randn(3, 4)
+        first_target = torch.randn(3, 2)
+        next_value = torch.randn(4, 4)
+        next_target = torch.randn(4, 2)
+
+        uninterrupted_optimizer.zero_grad()
+        torch.nn.functional.mse_loss(
+            uninterrupted(first_value), first_target
+        ).backward()
+        uninterrupted_optimizer.finish_grad_sync()
+        assert uninterrupted_optimizer.step()[0]
+
+        expected_cpu_state = copy.deepcopy(
+            uninterrupted_optimizer._inner_optimizer.cpu_group.state_dict()
+        )
+        checkpoint_dcp.save_training_checkpoint(
+            uninterrupted,
+            uninterrupted_optimizer,
+            31,
+            str(tmp_path / "full-offload-checkpoint"),
+            ps=ps,
+            use_dcp=True,
+            save_rng=False,
+        )
+
+        uninterrupted_optimizer.zero_grad()
+        torch.nn.functional.mse_loss(
+            uninterrupted(next_value), next_target
+        ).backward()
+        uninterrupted_optimizer.finish_grad_sync()
+        uninterrupted_result = uninterrupted_optimizer.step()
+        expected_params = {
+            name: param.detach().clone()
+            for name, param in uninterrupted.stream_full_parameters()
+        }
+
+        _model, resumed, resumed_optimizer, resumed_ps, _opt = _dcp_test_stack(
+            1, 0, offload_fraction=1.0
+        )
+        step = checkpoint_dcp.load_training_checkpoint(
+            resumed,
+            resumed_optimizer,
+            str(tmp_path / "full-offload-checkpoint"),
+            ps=resumed_ps,
+            use_dcp=True,
+            load_rng=False,
+        )
+        assert step == 31
+        actual_cpu_state = resumed_optimizer._inner_optimizer.cpu_group.state_dict()
+        for key in ("master_params", "exp_avgs", "exp_avg_sqs"):
+            for actual, expected in zip(
+                actual_cpu_state["optimizer"][key],
+                expected_cpu_state["optimizer"][key],
+                strict=True,
+            ):
+                assert torch.equal(actual, expected), key
+        assert actual_cpu_state["optimizer"]["steps"] == expected_cpu_state[
+            "optimizer"
+        ]["steps"]
+
+        resumed_optimizer.zero_grad()
+        torch.nn.functional.mse_loss(resumed(next_value), next_target).backward()
+        resumed_optimizer.finish_grad_sync()
+        resumed_result = resumed_optimizer.step()
+        actual_params = dict(resumed.stream_full_parameters())
+
+        assert resumed_result == uninterrupted_result
+        assert actual_params.keys() == expected_params.keys()
+        for name, tensor in actual_params.items():
+            assert torch.equal(tensor, expected_params[name]), name
+    finally:
+        dist.destroy_process_group()
 
 
 def test_mfsdp_dcp_model_only_round_trip_does_not_require_optimizer(tmp_path):

--- a/experimental/lite/tests/unit/primitive/test_mfsdp.py
+++ b/experimental/lite/tests/unit/primitive/test_mfsdp.py
@@ -1207,9 +1207,10 @@ def test_mfsdp_full_offload_preserves_explicit_mcore_communication_policy():
     assert config.overlap_param_gather is True
 
 
-def test_mfsdp_full_optimizer_offload_has_six_device_bytes_per_bf16_param():
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_mfsdp_full_optimizer_offload_keeps_only_grad_shards_on_device():
     _Model, _Unit, ps, engine_cfg = _build_optimizer_stack(1.0)
-    model = _Model().to(dtype=torch.bfloat16)
+    model = _Model().to(device="cuda", dtype=torch.bfloat16)
     chunks, optimizer = mfsdp_optimizer.build_mfsdp_stack(
         [model],
         engine_cfg=engine_cfg,
@@ -1221,12 +1222,13 @@ def test_mfsdp_full_optimizer_offload_has_six_device_bytes_per_bf16_param():
     cpu_group = inner.cpu_group
     assert cpu_group is not None
     total_numel = sum(param.numel() for param in inner.params)
-    device_param_bytes = sum(param.numel() * param.element_size() for param in inner.params)
+    assert all(param.device.type == "cpu" and param.is_pinned() for param in inner.params)
     device_grad_bytes = sum(
         bucket.main_grad_buffer.numel() * bucket.main_grad_buffer.element_size()
         for bucket in chunks[0].param_sync.buckets
     )
-    assert device_param_bytes + device_grad_bytes == 6 * total_numel
+    assert device_grad_bytes == 4 * total_numel
+    assert all(bucket.main_grad_buffer.device.type == "cuda" for bucket in chunks[0].param_sync.buckets)
     assert sum(param.numel() * param.element_size() for param in cpu_group._cpu_params) == (
         4 * total_numel
     )
@@ -1385,18 +1387,27 @@ def test_mfsdp_cuda_training_and_rollout_offloads_round_trip():
     optimizer.finish_grad_sync()
     assert optimizer.step()[0]
     assert cpu_group.d2h_bytes > 0
-    assert cpu_group.h2d_bytes > 0
+    assert cpu_group.h2d_bytes == 0
     assert any(
         not torch.equal(before, after)
         for before, after in zip(masters_before, cpu_group._cpu_params, strict=True)
     )
     assert all(bucket.device.type == "cuda" for bucket in chunks[0].param_sync.buckets)
+    assert all(
+        bucket.main_param_buffer.device.type == "cpu"
+        and bucket.main_param_buffer.is_pinned()
+        for bucket in chunks[0].param_sync.buckets
+    )
 
     optimizer.offload_for_rollout()
     assert all(bucket.device.type == "cpu" for bucket in chunks[0].param_sync.buckets)
     assert all(bucket.main_grad_buffer.numel() == 0 for bucket in chunks[0].param_sync.buckets)
     optimizer.load_from_rollout()
     assert all(bucket.device.type == "cuda" for bucket in chunks[0].param_sync.buckets)
+    assert all(
+        bucket.main_param_buffer.device.type == "cpu"
+        for bucket in chunks[0].param_sync.buckets
+    )
 
     optimizer.zero_grad()
     torch.nn.functional.mse_loss(chunks[0](value), target).backward()

--- a/experimental/lite/tests/unit/runtime/backends/mlite/test_runtime_backend_unit.py
+++ b/experimental/lite/tests/unit/runtime/backends/mlite/test_runtime_backend_unit.py
@@ -87,6 +87,8 @@ def test_runtime_source_does_not_branch_on_mfsdp():
     source = open(runtime.__file__, encoding="utf-8").read()
     assert '== "mfsdp"' not in source
     assert "M-FSDP" not in source
+    assert "offload_for_rollout" not in source
+    assert "load_from_rollout" not in source
 
 
 def test_runtime_config_defaults_to_mlite_backend():
@@ -278,7 +280,7 @@ def test_training_transfer_parks_optimizer_and_releases_scratch(monkeypatch):
     monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
     monkeypatch.setattr(torch.cuda, "synchronize", lambda: events.append("synchronize"))
     monkeypatch.setattr(
-        "megatron.lite.runtime.backends.mlite.runtime.gc.collect",
+        "megatron.lite.primitive.optimizers.runtime_adapter.gc.collect",
         lambda: events.append("collect"),
     )
     monkeypatch.setattr(torch.cuda, "empty_cache", lambda: events.append("empty-cache"))
@@ -315,6 +317,8 @@ def test_training_transfer_prefers_atomic_mfsdp_rollout_transition(monkeypatch):
         def load_from_rollout(self):
             events.append("mfsdp-load")
 
+    from megatron.lite.primitive.optimizers.mfsdp.backend import MegatronFSDPBackend
+
     import megatron.lite.runtime.megatron_utils as megatron_utils
 
     monkeypatch.setattr(
@@ -331,7 +335,10 @@ def test_training_transfer_prefers_atomic_mfsdp_rollout_transition(monkeypatch):
     handle = ModelHandle(
         model=nn.Linear(2, 2),
         optimizer=Optimizer(),
-        _extras={"model_chunks": []},
+        _extras={
+            "model_chunks": [],
+            "optimizer_runtime_backend": MegatronFSDPBackend(),
+        },
     )
     runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
 
@@ -343,15 +350,20 @@ def test_training_transfer_prefers_atomic_mfsdp_rollout_transition(monkeypatch):
 
 @pytest.mark.parametrize("device", ["cpu", "cuda"])
 def test_mfsdp_training_transfer_without_atomic_hook_fails_loud(device, monkeypatch):
+    from megatron.lite.primitive.optimizers.mfsdp.backend import MegatronFSDPBackend
+
     monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
     handle = ModelHandle(
         model=nn.Linear(2, 2),
-        optimizer=object(),
-        _extras={"model_chunks": [], "optimizer_backend": "mfsdp"},
+        optimizer=None,
+        _extras={
+            "model_chunks": [],
+            "optimizer_runtime_backend": MegatronFSDPBackend(),
+        },
     )
     runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
 
-    with pytest.raises(RuntimeError, match="requires atomic"):
+    with pytest.raises(RuntimeError, match="requires an optimizer"):
         runtime.to(handle, device, model=True, optimizer=False, grad=True)
 
 

--- a/experimental/lite/tests/unit/runtime/backends/mlite/test_runtime_backend_unit.py
+++ b/experimental/lite/tests/unit/runtime/backends/mlite/test_runtime_backend_unit.py
@@ -305,6 +305,42 @@ def test_training_transfer_parks_optimizer_and_releases_scratch(monkeypatch):
     ]
 
 
+def test_training_transfer_prefers_atomic_mfsdp_rollout_transition(monkeypatch):
+    events = []
+
+    class Optimizer:
+        def offload_for_rollout(self):
+            events.append("mfsdp-offload")
+
+        def load_from_rollout(self):
+            events.append("mfsdp-load")
+
+    import megatron.lite.runtime.megatron_utils as megatron_utils
+
+    monkeypatch.setattr(
+        megatron_utils,
+        "offload_model_to_cpu",
+        lambda chunks: pytest.fail("generic model offload must not run"),
+    )
+    monkeypatch.setattr(
+        megatron_utils,
+        "load_model_to_gpu",
+        lambda chunks, load_grad: pytest.fail("generic model load must not run"),
+    )
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    handle = ModelHandle(
+        model=nn.Linear(2, 2),
+        optimizer=Optimizer(),
+        _extras={"model_chunks": []},
+    )
+    runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
+
+    runtime.to(handle, "cpu", model=True, optimizer=False, grad=True)
+    runtime.to(handle, "cuda", model=True, optimizer=False, grad=True)
+
+    assert events == ["mfsdp-offload", "mfsdp-load"]
+
+
 def test_export_transfer_does_not_move_optimizer_or_release_scratch(monkeypatch):
     events = []
 

--- a/experimental/lite/tests/unit/runtime/backends/mlite/test_runtime_backend_unit.py
+++ b/experimental/lite/tests/unit/runtime/backends/mlite/test_runtime_backend_unit.py
@@ -341,6 +341,20 @@ def test_training_transfer_prefers_atomic_mfsdp_rollout_transition(monkeypatch):
     assert events == ["mfsdp-offload", "mfsdp-load"]
 
 
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_mfsdp_training_transfer_without_atomic_hook_fails_loud(device, monkeypatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    handle = ModelHandle(
+        model=nn.Linear(2, 2),
+        optimizer=object(),
+        _extras={"model_chunks": [], "optimizer_backend": "mfsdp"},
+    )
+    runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
+
+    with pytest.raises(RuntimeError, match="requires atomic"):
+        runtime.to(handle, device, model=True, optimizer=False, grad=True)
+
+
 def test_export_transfer_does_not_move_optimizer_or_release_scratch(monkeypatch):
     events = []
 


### PR DESCRIPTION
## Summary

- add bounded training-time parameter and optimizer offload for standalone M-FSDP
- keep the MLite runtime backend-agnostic by delegating train/rollout state transfer through the optimizer adapter contract; concrete M-FSDP ordering remains in the primitive optimizer backend
- add atomic train-to-rollout offload and restore without retaining a CPU gradient copy
- preserve CPU FP32 master parameters, Adam moments, steps, and parameter-group metadata through distributed checkpoints
- keep partial-offload placement invariant across DP ranks and DP-size resharding
- add unit, cross-DP reshard, DP8 NCCL continuity, and stable MLite skill contracts

This is a stacked PR based on the standalone M-FSDP PR.

## Validation

The production acceptance configuration is Qwen3.5 truncated to 8 layers and 8 experts, DP8 on one 8-GPU node, sequence length 1024, four microbatches, and full optimizer offload.

- Performance: 2377.386 ms average step time and 9.001975 GB peak allocated memory over 15 measured steps after five warmup steps. All ranks were finite.
- FSDP2 comparison on the same frozen configuration: 2554.363 ms and 9.350398 GB. M-FSDP is 6.93% faster and uses 3.73% less peak allocated memory.
- HDO comparison on the same frozen configuration: 1434.972 ms and 14.710745 GB. M-FSDP is 65.67% slower and uses 38.81% less peak allocated memory; this tradeoff is intentionally reported rather than described as parity.
- Precision: 50-step no-offload versus full-offload training has 0.125059% maximum relative loss difference, below the 0.509% threshold. Maximum relative grad-norm difference is 0.841246%; all ranks remain finite. This is tolerance parity, not bitwise parity.
- DCP continuity: all eight ranks pass full-offload save at step 1, load into a fresh model, and the next resumed optimizer step versus uninterrupted training.
- Cross-DP DCP: offload fractions 0.0, 0.5, and 1.0 pass both DP2-to-DP4 and DP4-to-DP2 resharding, including the next optimizer step.
- RSS: training, rollout transition, export/resync, and the combined path each pass 30 cycles. Maximum per-rank steady VmRSS slopes are 0.03364, 0.00632, 0.05197, and 0.01674 MiB/cycle respectively; reachable CPU tensor, pinned tensor, CUDA allocated, and CUDA reserved slopes are zero in every scenario.
- CPU regression suite after the runtime-boundary refactor: 141 passed and 2 conditionally skipped.

Validation used the repository's supported runtime environment and the system Python/Transformer Engine installation.
