### PR TITLE
lite: own QAT rollout weight export

### DIFF
--- a/experimental/lite/examples/verl/verl_mlite/config/engine/mlite.yaml
+++ b/experimental/lite/examples/verl/verl_mlite/config/engine/mlite.yaml
@@ -8,8 +8,7 @@ grad_offload: false
 forward_only: false
 dtype: bfloat16
 export_dtype: bfloat16
-# Optional verl-owned export_qat_weights passthrough. It is not used by the
-# vLLM compressed-tensors MXFP4 rollout path; see ../../../../QAT.md.
+# Optional MLite-owned QAT rollout export configuration.
 qat: {}
 resync_format: null
 resync_config: {}

--- a/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
@@ -28,6 +28,7 @@ from verl.utils import tensordict_utils as tu
 from verl.utils.device import get_device_id, get_device_name
 from verl.utils.memory_utils import aggressive_empty_cache
 from verl.workers.config import HFModelConfig, OptimizerConfig
+from verl_mlite import qat_export
 from verl_mlite.compat import _patch_bucketed_weight_sender, load_verl_engine_api
 
 try:
@@ -401,12 +402,7 @@ class MegatronLiteEngine(BaseEngine):
             export_kwargs["export_dtype"] = self.engine_config.export_dtype
         weights = self.runtime.export_weights(self.handle, **export_kwargs)
         if self.engine_config.qat.get("enable", False):
-            from verl.utils.modelopt import export_qat_weights
-
-            qat_config = SimpleNamespace(**self.engine_config.qat)
-            weights = export_qat_weights(
-                weights, [self.module], qat_config, bridge=None
-            )
+            weights = qat_export.export_qat_weights(weights, self.engine_config.qat)
         return weights, None
 
     def get_data_parallel_size(self):

--- a/experimental/lite/examples/verl/verl_mlite/qat_export.py
+++ b/experimental/lite/examples/verl/verl_mlite/qat_export.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""MLite-owned QAT weight export for rollout synchronization.
+
+This module intentionally depends only on MLite primitives.  VERL's ModelOpt
+helpers are a private integration surface and have moved between releases.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator, Mapping
+from fnmatch import fnmatch
+from typing import Any
+
+import torch
+from megatron.lite.primitive.quantization.mxfp4 import MXFP4_BLOCK_SIZE, quantize_mxfp4
+
+
+def _get_field(config: Any, name: str, default: Any) -> Any:
+    if isinstance(config, Mapping):
+        return config.get(name, default)
+    return getattr(config, name, default)
+
+
+def _is_ignored(name: str, patterns: list[str]) -> bool:
+    module_name = name.removesuffix(".weight")
+    for pattern in patterns:
+        if pattern.startswith("re:"):
+            if re.search(pattern[3:], module_name):
+                return True
+        elif pattern in module_name or fnmatch(module_name, pattern):
+            return True
+    return False
+
+
+def _process_weights(
+    weights: Iterator[tuple[str, torch.Tensor]], ignore_patterns: list[str]
+) -> Iterator[tuple[str, torch.Tensor]]:
+    for name, weight in weights:
+        if "_quantizer." in name:
+            continue
+        if (
+            not name.endswith(".weight")
+            or "norm" in name
+            or _is_ignored(name, ignore_patterns)
+        ):
+            yield name, weight
+            continue
+
+        packed, scale = quantize_mxfp4(weight)
+        yield name, packed.view(torch.uint8)
+        yield name.removesuffix(".weight") + ".weight_scale", scale.view(torch.uint8)
+
+
+def export_qat_weights(
+    weights: Iterator[tuple[str, torch.Tensor]], qat_config: Any
+) -> Iterator[tuple[str, torch.Tensor]]:
+    """Wrap an HF-named BF16 stream with MLite's MXFP4 serializer.
+
+    MLite owns fake quantization during training, so ModelOpt module metadata is
+    neither available nor needed at this boundary.
+    """
+    if _get_field(qat_config, "apply_modelopt_fake_quant", True):
+        raise ValueError(
+            "MLite QAT export requires apply_modelopt_fake_quant=False; "
+            "MLite owns training fake quantization"
+        )
+    mode = str(_get_field(qat_config, "mode", "w4a16")).lower()
+    if mode != "mxfp4":
+        raise ValueError(f"MLite QAT export only supports mode='mxfp4', got {mode!r}")
+    group_size = int(_get_field(qat_config, "group_size", MXFP4_BLOCK_SIZE))
+    if group_size != MXFP4_BLOCK_SIZE:
+        raise ValueError(
+            f"MXFP4 QAT export requires group_size={MXFP4_BLOCK_SIZE}, got {group_size}"
+        )
+    patterns = [
+        str(pattern) for pattern in _get_field(qat_config, "ignore_patterns", [])
+    ]
+    return _process_weights(weights, patterns)
+
+
+__all__ = ["export_qat_weights"]

--- a/experimental/lite/tests/unit/examples/test_verl_mlite_engine_config.py
+++ b/experimental/lite/tests/unit/examples/test_verl_mlite_engine_config.py
@@ -224,7 +224,7 @@ def test_qwen3_moe_online_weight_export_does_not_pass_unsupported_target() -> No
     assert "target" not in captured["kwargs"]
 
 
-def test_online_qat_export_wraps_mlite_hf_weight_stream(monkeypatch) -> None:
+def test_online_qat_export_uses_mlite_owned_exporter(monkeypatch) -> None:
     engine = _engine(
         engine_config=_engine_config(
             qat={
@@ -246,21 +246,13 @@ def test_online_qat_export_wraps_mlite_hf_weight_stream(monkeypatch) -> None:
         def export_weights(handle, **kwargs):
             return source_weights
 
-    def fake_export(weights, modules, qat_config, bridge):
-        captured.update(
-            weights=weights,
-            modules=modules,
-            qat_config=qat_config,
-            bridge=bridge,
-        )
+    def fake_export(weights, qat_config):
+        captured.update(weights=weights, qat_config=qat_config)
         return iter([("packed.weight", torch.ones(2, 16, dtype=torch.uint8))])
 
-    fake_modelopt = types.ModuleType("verl.utils.modelopt")
-    fake_modelopt.export_qat_weights = fake_export
-    monkeypatch.setitem(sys.modules, "verl.utils.modelopt", fake_modelopt)
+    monkeypatch.setattr("verl_mlite.qat_export.export_qat_weights", fake_export)
     engine.runtime = Runtime()
     engine.handle = object()
-    engine.module = object()
     engine._initial_sync_cache_cleared = True
 
     weights, metadata = engine.get_per_tensor_param()
@@ -268,11 +260,7 @@ def test_online_qat_export_wraps_mlite_hf_weight_stream(monkeypatch) -> None:
     assert [name for name, _ in weights] == ["packed.weight"]
     assert metadata is None
     assert captured["weights"] is source_weights
-    assert captured["modules"] == [engine.module]
-    assert captured["bridge"] is None
-    assert captured["qat_config"].mode == "mxfp4"
-    assert captured["qat_config"].group_size == 32
-    assert captured["qat_config"].apply_modelopt_fake_quant is False
+    assert captured["qat_config"] == engine.engine_config.qat
 
 
 def test_qat_export_rejects_native_resync_format_double_quantization() -> None:

--- a/experimental/lite/tests/unit/verl/test_mlite_qat_export.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_qat_export.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Contracts for the MLite-owned QAT rollout exporter."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from megatron.lite.primitive.quantization.mxfp4 import MXFP4_BLOCK_SIZE
+
+
+def _qat_config(**overrides):
+    config = {
+        "enable": True,
+        "apply_modelopt_fake_quant": False,
+        "mode": "mxfp4",
+        "group_size": MXFP4_BLOCK_SIZE,
+        "ignore_patterns": ["lm_head", "embed_tokens", "re:.*mlp.gate$"],
+    }
+    config.update(overrides)
+    return config
+
+
+def test_qat_export_stays_lazy() -> None:
+    from verl_mlite.qat_export import export_qat_weights
+
+    consumed = []
+
+    def source():
+        consumed.append(True)
+        yield "model.layers.0.mlp.down_proj.weight", torch.ones(2, MXFP4_BLOCK_SIZE)
+
+    exported = export_qat_weights(source(), _qat_config())
+
+    assert consumed == []
+    next(exported)
+    assert consumed == [True]
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"apply_modelopt_fake_quant": True}, "apply_modelopt_fake_quant=False"),
+        ({"mode": "w4a16", "group_size": 16}, "only supports mode='mxfp4'"),
+        ({"group_size": 16}, "group_size=32"),
+    ],
+)
+def test_qat_export_rejects_unsupported_contract(overrides, message) -> None:
+    from verl_mlite.qat_export import export_qat_weights
+
+    with pytest.raises(ValueError, match=message):
+        export_qat_weights(iter(()), _qat_config(**overrides))


### PR DESCRIPTION
## What changed

- Add an MLite-owned lazy MXFP4 QAT rollout exporter backed by the in-repository quantization primitive.
- Route the engine's QAT online weight stream through that exporter.
- Preserve uint8 packed weights and scales, ignore-pattern handling, and fail-loud validation for unsupported QAT contracts.
- Keep QAT online export mutually exclusive with the native resync format.

## Why

The previous engine path imported `export_qat_weights` directly from the private `verl.utils.modelopt` integration surface. A VERL rename or module move therefore broke MLite rollout export at import time. The engine now depends only on MLite-owned code and repository primitives at this boundary.

## Impact

MXFP4 QAT rollout synchronization no longer depends on the location or naming of VERL's ModelOpt helpers. Non-QAT online export behavior is unchanged.

## Validation

- Targeted QAT and online-export tests against VERL `9356c26c`: 8 passed, 9 deselected.
- Independent MXFP4 packed-weight and scale parity check: passed.
- Python compilation, import-order check, Black formatting check, dependency grep, and `git diff --check`: passed.