### PR TITLE
lite: accept response_mask when packing VERL micro-batches

### DIFF
--- a/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
@@ -845,10 +845,14 @@ class MegatronLiteEngine(BaseEngine):
     def _loss_mask_for_packing(
         micro_batch: TensorDict, input_ids: torch.Tensor
     ) -> torch.Tensor | None:
-        if "loss_mask" not in micro_batch.keys():
+        if "loss_mask" in micro_batch.keys():
+            mask_key = "loss_mask"
+        elif "response_mask" in micro_batch.keys():
+            mask_key = "response_mask"
+        else:
             return None
 
-        loss_mask = micro_batch["loss_mask"]
+        loss_mask = micro_batch[mask_key]
         input_lengths = input_ids.offsets().diff().tolist()
         if getattr(loss_mask, "is_nested", False):
             # VERL delivers ``response_mask`` / ``loss_mask`` as a *response-only*

--- a/experimental/lite/tests/unit/verl/test_mlite_engine_loss_mask_packing.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_engine_loss_mask_packing.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Regression coverage for loss-mask selection in MLite VERL packing."""
+
+import pytest
+import torch
+from tensordict import TensorDict
+
+from verl_mlite.engine.mlite_engine import MegatronLiteEngine
+
+pytestmark = pytest.mark.mlite
+
+
+def test_response_mask_is_used_when_loss_mask_is_absent():
+    input_ids = torch.nested.as_nested_tensor(
+        [torch.arange(12), torch.arange(9)], layout=torch.jagged
+    )
+    response_mask = torch.nested.as_nested_tensor(
+        [torch.tensor([1.0, 1.0, 0.0, 1.0, 1.0]), torch.ones(3)],
+        layout=torch.jagged,
+    )
+    micro_batch = TensorDict(
+        {"input_ids": input_ids, "response_mask": response_mask}, batch_size=[2]
+    )
+
+    packed = MegatronLiteEngine._loss_mask_for_packing(micro_batch, input_ids)
+
+    assert packed is not None
+    assert packed.offsets().diff().tolist() == [12, 9]
+    rows = packed.unbind(0)
+    torch.testing.assert_close(rows[0], torch.tensor([0.0] * 7 + [1.0, 1.0, 0.0, 1.0, 1.0]))
+    torch.testing.assert_close(rows[1], torch.tensor([0.0] * 6 + [1.0, 1.0, 1.0]))


### PR DESCRIPTION
`_loss_mask_for_packing` looked only for a `loss_mask` key and returned `None` otherwise, while the engine entry point treats `response_mask` as the same thing. A micro-batch carrying only `response_mask` therefore packed with no loss mask at all, which drops the mask for MTP and the packed path.

- `_loss_mask_for_packing` now follows the same contract as the entry point: `loss_mask` first, `response_mask` as fallback.
- Adds a `response_mask`-only jagged packed regression test, covering prompt left-padding zeros and preservation of zeros inside the response.

Found by review of #174; the defect predates it and is unrelated to that change, so it lands separately.