### PR TITLE
lite: detach model_output tensors before stashing per-microbatch on cp=0

### DIFF
--- a/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
@@ -958,9 +958,13 @@ class MegatronLiteEngine(BaseEngine):
             if output_lst is not None and not getattr(
                 loss_fn_ref(), "runtime_collects_outputs", False
             ):
+                detached_model_output = {
+                    k: (v.detach() if isinstance(v, torch.Tensor) else v)
+                    for k, v in model_output.items()
+                }
                 output_lst.append(
                     {
-                        "model_output": model_output,
+                        "model_output": detached_model_output,
                         "loss": float(loss.detach().item()),
                         "metrics": metrics,
                     }


### PR DESCRIPTION
Port of **verl-project/Megatron-LM#32** by @shyoshyo (leikaixiang.shyoshyo@bytedance.com). Original commit cherry-picked as-is; authorship and commit message preserved, no squash, no rewrite.

## What it fixes

On the last PP stage, only `is_mp_src_rank_with_outputs()` (tp==0 && cp==0 && pp==last) allocates the runtime `output_lst`, and the loss hook appends one `{"model_output": ..., "loss": ..., "metrics": ...}` per microbatch. `model_output["log_probs"]` comes from the protocol's `unpack_forward_output`, which on CP>1 chains through the differentiable `torch.distributed.nn.functional.all_gather` -> `torch.cat` -> slice -> `torch.nested.as_nested_tensor`. Those tensors keep `requires_grad=True` and are *not* on the path `loss.mean().backward()` traverses, so their saved-for-backward buffers stay pinned for the whole step.

Upstream reproduced this on DS-V4-Flash (PP=4 EP=2 CP=2, MAX_LENGTH=16384, 128 microbatches/step): rank=6 (cp=0) grows ~0.5 GB per microbatch to ~60 GB while rank=7 (cp=1) stays flat at 4.45 GB; also reproduced at PP=4 EP=8 CP=8, 32768. Fits in HBM at 16k, OOMs deterministically at 128k.

The fix detaches every tensor in `model_output` before stashing the per-microbatch copy. The live `model_output` handed to `loss_function` is untouched, so gradients are unchanged.

## Review notes (checked against this repo's `main`)

- **Detach is semantics-preserving here.** `_build_verl_model_output` only ever returns `log_probs` and (optionally) `entropy`, both plain tensors, so the dict comprehension covers the whole payload -- no list/tuple/nested container escapes it.
- **No consumer needs the graph.** `output_lst` is handed to `postprocess_batch_func` only *after* `runtime.forward_backward(...)` returns, i.e. after backward has already run; differentiating through those tensors was never possible. `forward_only` paths need no grad at all.
- **Consistent with the dynamic-CP path**, whose `_record_output` in `dynamic_cp.py` already does the equivalent `.detach().cpu()`. This brings the static path in line.
- Diff is byte-identical to the upstream PR head (`3282f104`) and applies cleanly on `main`.
- Changed lines are clean under the repo's `experimental/lite/.pre-commit-config.yaml` toolchain (isort + black 24.4.2 with `--skip-magic-trailing-comma --skip-string-normalization`); the only formatting/lint noise in this file is pre-existing on `main` and untouched here.

## Not covered

No regression test is included -- reproducing the leak needs a multi-GPU CP>1 run. A cheap follow-up would be a unit assertion that every tensor collected into `output_lst` has `requires_grad=False`. Upstream's evidence is an end-to-end training run (memory curves + loss/metric parity spot check), not an in-tree test.

Upstream PR: https://github.com/verl-project/Megatron-LM/pull/32