### PR TITLE
lite: mark test_hf_weights_gpu with its real GPU requirements

### DIFF
--- a/experimental/lite/tests/unit/primitive/ckpt/test_hf_weights_gpu.py
+++ b/experimental/lite/tests/unit/primitive/ckpt/test_hf_weights_gpu.py
@@ -25,7 +25,7 @@ from megatron.lite.primitive.ckpt.hf_weights import (
 from megatron.lite.primitive.quantization.qat import QATSpec, apply_qat_to_chunks
 
 
-pytestmark = pytest.mark.mlite
+pytestmark = [pytest.mark.mlite, pytest.mark.gpus(1)]
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -126,6 +126,7 @@ def _expert_tensor(global_expert_id: int) -> torch.Tensor:
     return base + global_expert_id * 1000
 
 
+@pytest.mark.gpus(2)
 def test_ep2_export_gather_matches_single_rank_reference_bitwise() -> None:
     _require_two_ranks()
     config = _qwen35_config()
@@ -164,6 +165,7 @@ def test_ep2_export_gather_matches_single_rank_reference_bitwise() -> None:
     assert torch.equal(exported[key], expected)
 
 
+@pytest.mark.gpus(2)
 def test_tp2_fused_gate_up_load_and_export_match_full_tensor_bitwise() -> None:
     _require_two_ranks()
     config = _qwen35_config()


### PR DESCRIPTION
## What is broken

`_test_harness/markers.py` documents that **an absent `gpus` marker means a CPU test**. `tests/unit/primitive/ckpt/test_hf_weights_gpu.py` carried only `pytest.mark.mlite`, so the runner scheduled all five of its CUDA tests into the `gpus=0` cpu suite, where `torch.cuda.is_available()` is false and each of them skips.

That is not a harmless miss, because of two other harness rules:

1. `_test_harness/pytest_worker.py` counts any skip as a failure unless `MLITE_TEST_ALLOW_SKIPS=1`. So the cpu suite reported `status=FAIL` while pytest itself said `701 passed, 0 failed, 5 skipped`.
2. `runner.py` stops at the first non-PASS suite.

Net effect: **every GPU suite after the cpu suite had never run**, on any invocation, on any machine. The two EP2/TP2 bitwise export comparisons in this very file had therefore never executed either -- which is exactly the kind of coverage you want for sharded HF export.

## The fix

Two of the five tests call `_require_two_ranks()` and assert `dist.get_world_size() == 2`, so a blanket module-level `gpus(1)` makes them fail the assertion instead of skipping. `_gpus_marker` reads `next(item.iter_markers("gpus"))` (closest-first), so a per-test marker overrides the module-level one:

```python
pytestmark = [pytest.mark.mlite, pytest.mark.gpus(1)]

@pytest.mark.gpus(2)
def test_ep2_export_gather_matches_single_rank_reference_bitwise() -> None: ...

@pytest.mark.gpus(2)
def test_tp2_fused_gate_up_load_and_export_match_full_tensor_bitwise() -> None: ...
```

## Evidence

One 8xH100 node, standard profile (`bash tests/run_tests.sh`, no arguments), Slurm jobs `16028083` / `16028711` / `16029014`.

Before:

```
suite=cpu gpus=0 status=FAIL  passed=701 failed=0 skipped=5 xfailed=1
overall=FAIL exit_code=1          <- run aborts here, nothing else executes
SKIPPED unit/primitive/ckpt/test_hf_weights_gpu.py:129/167/214/268/300  CUDA is required
```

After:

```
suite=cpu                            PASS  701 passed / 0 skipped
suite=1gpu-csa-thd-cp                PASS  3
suite=1gpu-fsdp2-offload-gpu         PASS  2
suite=1gpu-fsdp2-unit                PASS  1
suite=1gpu-glm5-lite-static          PASS  3 + 4
suite=1gpu-hf-weights-gpu            PASS  3
suite=1gpu-hf-weights-streaming      PASS  1
suite=1gpu-qwen-lite-forward-smoke   PASS  2
suite=1gpu-router-aux-loss-gate      PASS  2
suite=2gpu-distopt-checkpoint-smoke  PASS  1
suite=2gpu-fsdp2-offload-checkpoint  PASS  3
suite=2gpu-glm5-lite-cp-smoke        FAIL  2 passed / 3 failed
```

Intermediate step worth recording: with a blanket `gpus(1)` the two two-rank tests failed their `world_size == 2` assertion; adding the per-test `gpus(2)` markers turned `1gpu-hf-weights-gpu` green and let both of them run for the first time.

## Not fixed here

`2gpu-glm5-lite-cp-smoke` (`test_glm5_dsa_cp2_*`, `test_glm5_tiny_model_cp2_*`) is red on `main` independently of this change, and it is now the suite that blocks the run. Until it is addressed, the 8-GPU suite `smoke/workflows/checkpoint/test_save_load_export_smoke.py` (21 cases) still never executes. Tracked separately.

Note on formatting: this file does not currently satisfy the repo's `isort`/`black` hooks as invoked standalone (import wrapping, unrelated to this change), both before and after. This PR deliberately does not reformat those lines.