### PR TITLE
fix(verl): consume lazy weight exports on actor thread

### DIFF
--- a/experimental/lite/examples/verl/verl_mlite/compat.py
+++ b/experimental/lite/examples/verl/verl_mlite/compat.py
@@ -8,12 +8,8 @@ import importlib.abc
 import importlib.machinery
 import importlib.util
 import os
-import queue
 import sys
-import threading
 from collections.abc import Iterable
-from concurrent.futures import ThreadPoolExecutor
-from contextvars import copy_context
 from functools import wraps
 from pathlib import Path
 from typing import Any
@@ -1052,7 +1048,13 @@ class _SyncBucketProducer:
 
 
 def _install_bucketed_sender_prefetch(sender_cls: type) -> bool:
-    """Overlap synchronous weight production with the receiver's bucket ACK."""
+    """Install the MLite-aware bucket packer without moving model work off-thread.
+
+    ``weights`` is not an ordinary host iterator: advancing it can enter FSDP
+    parameter materialization and PP/EP collectives.  Those operations must run
+    on the actor thread which owns the rank's CUDA device and model lifecycle.
+    Only the produced tensors may be copied into the IPC staging buffer here.
+    """
     if getattr(sender_cls, "_mlite_weight_prefetch_patch", False):
         return False
 
@@ -1064,11 +1066,6 @@ def _install_bucketed_sender_prefetch(sender_cls: type) -> bool:
         if not isinstance(weights, Iterable) or hasattr(weights, "__aiter__") or self.use_shm:
             return await original_async_send_weights(self, weights)
 
-        executor = None
-        stop = threading.Event()
-        free_slots = None
-        ready_results = None
-        held_slot = None
         try:
             self._init_socket()
             self._init_buffer()
@@ -1077,77 +1074,25 @@ def _install_bucketed_sender_prefetch(sender_cls: type) -> bool:
             ):
                 raise RuntimeError("MLite sender prefetch requires a CUDA IPC buffer")
 
-            staging_slots = [torch.empty_like(self.buffer) for _ in range(2)]
+            staging = torch.empty_like(self.buffer)
             producer = _SyncBucketProducer(weights, self.bucket_size)
-            free_slots = queue.Queue(maxsize=2)
-            ready_results = queue.Queue(maxsize=2)
-            for slot_index in range(2):
-                free_slots.put_nowait(slot_index)
-            executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="mlite-weight-prefetch")
-
-            def put_ready(result):
-                while not stop.is_set():
-                    try:
-                        ready_results.put(result, timeout=0.05)
-                        return True
-                    except queue.Full:
-                        continue
-                return False
-
-            def produce():
-                slot_index = None
-                try:
-                    while not stop.is_set():
-                        try:
-                            slot_index = free_slots.get(timeout=0.05)
-                        except queue.Empty:
-                            continue
-                        result = producer.next_bucket(staging_slots[slot_index])
-                        if not put_ready((*result, slot_index)):
-                            return
-                        slot_index = None
-                        kind, *_, is_last = result
-                        if kind == "eof" or is_last:
-                            return
-                except BaseException as exc:
-                    put_ready(("error", exc, None, 0, None, True, slot_index))
-
-            context = copy_context()
-            worker_future = executor.submit(context.run, produce)
             while True:
-                try:
-                    result = ready_results.get(timeout=0.1)
-                except queue.Empty:
-                    if worker_future.done():
-                        worker_future.result()
-                        raise RuntimeError("MLite weight prefetch stopped without a terminal result")
-                    continue
-
-                kind, metadata_or_name, direct_weight, used_bytes, ready, is_last, held_slot = (
-                    result
+                kind, metadata_or_name, direct_weight, used_bytes, ready, is_last = (
+                    producer.next_bucket(staging)
                 )
-                if kind == "error":
-                    raise metadata_or_name
                 if kind == "eof":
-                    free_slots.put_nowait(held_slot)
-                    held_slot = None
                     self.socket.send_pyobj({"bucket_meta": {}, "is_last": True})
                     self.socket.recv()
                     break
                 if kind == "direct":
-                    free_slots.put_nowait(held_slot)
-                    held_slot = None
                     self._direct_send_large_weight(metadata_or_name, direct_weight)
                     continue
 
                 if ready is not None:
                     ready.synchronize()
-                staging = staging_slots[held_slot]
                 self.buffer[:used_bytes].copy_(staging[:used_bytes], non_blocking=True)
                 if self.buffer.device.type == "cuda":
                     torch.cuda.synchronize(self.buffer.device)
-                free_slots.put_nowait(held_slot)
-                held_slot = None
 
                 self.socket.send_pyobj(
                     {"bucket_meta": metadata_or_name, "is_last": is_last}
@@ -1156,14 +1101,6 @@ def _install_bucketed_sender_prefetch(sender_cls: type) -> bool:
                 if is_last:
                     break
         finally:
-            stop.set()
-            if held_slot is not None and free_slots is not None:
-                try:
-                    free_slots.put_nowait(held_slot)
-                except queue.Full:
-                    pass
-            if executor is not None:
-                executor.shutdown(wait=True, cancel_futures=True)
             self._cleanup()
 
     sender_cls.async_send_weights = prefetched_async_send_weights

--- a/experimental/lite/tests/unit/examples/test_verl_compat_weight_sender.py
+++ b/experimental/lite/tests/unit/examples/test_verl_compat_weight_sender.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import asyncio
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+import torch
+
+VERL_EXAMPLE_ROOT = Path(__file__).resolve().parents[3] / "examples" / "verl"
+if str(VERL_EXAMPLE_ROOT) not in sys.path:
+    sys.path.insert(0, str(VERL_EXAMPLE_ROOT))
+
+from verl_mlite import compat
+
+pytestmark = pytest.mark.optional
+
+
+class _Socket:
+    def __init__(self) -> None:
+        self.messages = []
+
+    def send_pyobj(self, value) -> None:
+        self.messages.append(value)
+
+    def recv(self):
+        return b"ack"
+
+
+class _Sender:
+    use_shm = False
+    bucket_size = 64
+    _mlite_prefetch_allow_cpu = True
+
+    def __init__(self) -> None:
+        self.socket = _Socket()
+        self.buffer = None
+        self.cleaned = False
+
+    async def async_send_weights(self, _weights):
+        raise AssertionError("the MLite bucket packer should handle a sync generator")
+
+    def _init_socket(self) -> None:
+        pass
+
+    def _init_buffer(self) -> None:
+        self.buffer = torch.empty(self.bucket_size, dtype=torch.uint8)
+
+    def _direct_send_large_weight(self, _name, _weight) -> None:
+        raise AssertionError("test weight unexpectedly exceeded the bucket")
+
+    def _cleanup(self) -> None:
+        self.cleaned = True
+
+
+def test_lazy_weight_generator_is_not_submitted_to_an_executor(monkeypatch) -> None:
+    consumed = []
+
+    def forbidden_submit(*_args, **_kwargs):
+        raise AssertionError("lazy model-weight production must not enter an executor")
+
+    monkeypatch.setattr(ThreadPoolExecutor, "submit", forbidden_submit)
+
+    def weights():
+        consumed.append(True)
+        yield "model.layers.0.weight", torch.arange(8, dtype=torch.bfloat16)
+
+    assert compat._install_bucketed_sender_prefetch(_Sender)
+    sender = _Sender()
+    asyncio.run(sender.async_send_weights(weights()))
+
+    assert consumed == [True]
+    assert sender.cleaned
+    assert sender.socket.messages[0]["is_last"] is True
+    assert "model.layers.0.weight" in sender.socket.messages[0]["bucket_meta"]


### PR DESCRIPTION
## Summary

- consume lazy weight-export iterators on the actor/coroutine thread
- remove executor-backed prefetch of generator iteration and redundant queue staging
- add a regression test that fails if lazy export is submitted to ThreadPoolExecutor

## Why

Layerwise/FSDP-backed weight exporters are lazy: generator iteration reads live parameter storage and must remain on the actor-owned thread. Executor iteration can race offload/reload and violates exporter ownership.

## Validation

- scripts_rl/215.unit_prefetched_async_send_weights_pr.sh
- 1 passed
- separate 8-GPU real DAPO one-step: 65,536/65,536 selected-token logprobs bitwise; all optimizer ranks present

This PR is intentionally isolated from DS4 model changes and experiment scaffolding.