### PR TITLE
lite: replace use_deepep with moe_token_dispatcher_type and add a HybridEP backend

### DIFF
--- a/experimental/lite/examples/moe_token_dispatcher.py
+++ b/experimental/lite/examples/moe_token_dispatcher.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Select a MoE token-dispatch backend with ``moe_token_dispatcher_type``.
+
+The option takes one of ``alltoall``, ``deepep`` or ``hybridep``. ``alltoall`` needs no
+optional dependency; ``deepep`` and ``hybridep`` both come from DeepEP, with ``hybridep``
+requiring the branch that exports ``HybridEPBuffer``. A backend that is asked for but not
+installed raises rather than falling back, so a missing dependency cannot be mistaken for
+a backend that was simply not enabled.
+
+Run under torchrun, one rank per expert-parallel rank::
+
+    torchrun --nproc_per_node=8 examples/moe_token_dispatcher.py --dispatcher-type hybridep
+
+Pass ``--compare-with alltoall`` to additionally check the chosen backend against the
+AllToAll reference on identical inputs -- the check this example is derived from produces
+bitwise-equal forward and backward results on 8 ranks.
+
+Two HybridEP-specific notes, both learned the hard way on H100:
+
+* ``hidden_size`` must be a multiple of 512. HybridEP JIT-specialises its kernel on the
+  hidden dimension and static-asserts that a token's scaling-factor row is a multiple of
+  16B (one fp32 scale per 128 elements). Production widths clear this -- DeepSeek-V4 7168,
+  Qwen3-MoE 4096, GLM 5120 -- but small toy widths do not, and the failure surfaces as an
+  nvcc static assertion rather than a Python error.
+* ``CUDA_HOME`` must be set in the environment; HybridEP's C++ runtime resolves against it
+  and raises if it is missing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+import torch.distributed as dist
+
+_EXPERIMENTAL_LITE_ROOT = Path(__file__).resolve().parents[1]
+if str(_EXPERIMENTAL_LITE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_EXPERIMENTAL_LITE_ROOT))
+
+from megatron.lite.primitive.modules.dispatcher import TokenDispatcher  # noqa: E402
+from megatron.lite.primitive.parallel import init_parallel  # noqa: E402
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--dispatcher-type", default="alltoall", choices=["alltoall", "deepep", "hybridep"]
+    )
+    p.add_argument("--compare-with", default=None, choices=["alltoall", "deepep", "hybridep"])
+    p.add_argument("--num-experts", type=int, default=16)
+    p.add_argument("--hidden-size", type=int, default=1024, help="multiple of 512 for hybridep")
+    p.add_argument("--topk", type=int, default=2)
+    p.add_argument("--num-tokens", type=int, default=256)
+    return p.parse_args()
+
+
+def apply_experts(dispatched, tokens_per_expert, probs, num_local_experts, ep_rank):
+    """Stand in for the expert MLPs with a permutation-equivariant op.
+
+    Each row's result depends only on its expert and its routing probability, never on
+    where the backend placed it, so two backends' combined outputs are comparable even
+    though their permuted layouts differ.
+    """
+    local_ids = torch.repeat_interleave(
+        torch.arange(num_local_experts, device=dispatched.device), tokens_per_expert
+    )
+    global_ids = ep_rank * num_local_experts + local_ids
+    weight = (global_ids.to(dispatched.dtype) + 1.0).unsqueeze(1) * 0.01
+    return dispatched * weight * probs.to(dispatched.dtype).unsqueeze(1)
+
+
+def run(dispatcher_type, args, ps, hidden, topk_scores, topk_indices, ep_rank):
+    dispatcher = TokenDispatcher(
+        num_experts=args.num_experts,
+        hidden_size=args.hidden_size,
+        ps=ps,
+        moe_token_dispatcher_type=dispatcher_type,
+    )
+    x = hidden.clone().detach().requires_grad_(True)
+    dispatched, tokens_per_expert, probs = dispatcher.dispatch(x, topk_scores, topk_indices)
+    expert_out = apply_experts(
+        dispatched, tokens_per_expert, probs, dispatcher.num_local_experts, ep_rank
+    )
+    combined = dispatcher.combine(expert_out)
+    combined.sum().backward()
+    return combined.detach(), x.grad.detach()
+
+
+def main() -> int:
+    args = parse_args()
+    rank = int(os.environ["RANK"])
+    torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
+    dist.init_process_group("nccl")
+
+    ep_size = dist.get_world_size()
+    ps = init_parallel(SimpleNamespace(tp=1, ep=ep_size, cp=1, pp=1, etp=None))
+    ep_rank = dist.get_rank(group=ps.ep_group)
+
+    torch.manual_seed(1234 + rank)
+    hidden = torch.randn(args.num_tokens, args.hidden_size, device="cuda", dtype=torch.bfloat16)
+    logits = torch.randn(args.num_tokens, args.num_experts, device="cuda", dtype=torch.float32)
+    topk_scores, topk_indices = torch.topk(logits.softmax(dim=-1), args.topk, dim=-1)
+
+    out, grad = run(args.dispatcher_type, args, ps, hidden, topk_scores, topk_indices, ep_rank)
+    if rank == 0:
+        print(f"{args.dispatcher_type}: combined={tuple(out.shape)} ep_size={ep_size}", flush=True)
+
+    status = 0
+    if args.compare_with:
+        ref, ref_grad = run(args.compare_with, args, ps, hidden, topk_scores, topk_indices, ep_rank)
+        fwd = (out.float() - ref.float()).abs().max().item()
+        bwd = (grad.float() - ref_grad.float()).abs().max().item()
+        agreed = torch.tensor([1 if fwd == 0.0 and bwd == 0.0 else 0], device="cuda")
+        dist.all_reduce(agreed, op=dist.ReduceOp.MIN)
+        print(f"[rank{rank}] vs {args.compare_with}: fwd={fwd:.3e} bwd={bwd:.3e}", flush=True)
+        dist.barrier()
+        if rank == 0:
+            print("bitwise-equal" if int(agreed.item()) else "MISMATCH", flush=True)
+        status = 0 if int(agreed.item()) else 1
+
+    dist.destroy_process_group()
+    return status
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/model.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/model.py
@@ -43,6 +43,7 @@ from megatron.lite.model.deepseek_v4.lite.moe import DeepseekV4MoE
 from megatron.lite.primitive.modules.attention.csa import CompressedSparseAttention
 from megatron.lite.primitive.modules.attention.hca import HyperConnection
 from megatron.lite.primitive.modules.attention.mhc import MultiHeadHyperConnectionHead
+from megatron.lite.primitive.modules.dispatcher import TokenDispatcherType
 from megatron.lite.primitive.modules.mtp import MTPLossAutoScaler
 from megatron.lite.primitive.ops.cross_entropy import vocab_parallel_cross_entropy
 from megatron.lite.primitive.ops.linear_cross_entropy import linear_cross_entropy
@@ -146,7 +147,7 @@ class DeepseekV4Layer(nn.Module):
         ps: ParallelState,
         layer_idx: int,
         *,
-        use_deepep: bool = False,
+        moe_token_dispatcher_type: TokenDispatcherType = "alltoall",
     ):
         super().__init__()
         self.layer_idx = layer_idx
@@ -156,7 +157,7 @@ class DeepseekV4Layer(nn.Module):
         # DS4 ONLY: CSA attention behind the SBHD shim (Kimi builds MLA here).
         self.self_attn = DeepseekV4CSAAttention(config, layer_idx=layer_idx, ps=ps)
         # DS4 ONLY: hash-routed MoE family (shared Experts/Router/dispatcher).
-        self.mlp = DeepseekV4MoE(config, ps, layer_idx=layer_idx, use_deepep=use_deepep)
+        self.mlp = DeepseekV4MoE(config, ps, layer_idx=layer_idx, moe_token_dispatcher_type=moe_token_dispatcher_type)
         # DS4 ONLY: per-layer multi-head hyper-connections wrapping attn + ffn.
         self.attn_hc = HyperConnection(
             config.hidden_size, config.hc_mult, config.hc_sinkhorn_iters, config.hc_eps
@@ -214,10 +215,10 @@ class DeepseekV4MTPLayer(DeepseekV4Layer):
         layer_idx: int,
         *,
         embedding: VocabParallelEmbedding,
-        use_deepep: bool,
+        moe_token_dispatcher_type: TokenDispatcherType,
         detach_encoder: bool,
     ):
-        super().__init__(config, ps, layer_idx, use_deepep=use_deepep)
+        super().__init__(config, ps, layer_idx, moe_token_dispatcher_type=moe_token_dispatcher_type)
         self.config = config
         object.__setattr__(self, "embedding", embedding)
         self.detach_encoder = detach_encoder
@@ -310,7 +311,7 @@ class DeepseekV4Model(nn.Module):
         mtp_enable: bool = False,
         mtp_enable_train: bool = False,
         mtp_detach_encoder: bool = False,
-        use_deepep: bool = False,
+        moe_token_dispatcher_type: TokenDispatcherType = "alltoall",
     ):
         super().__init__()
         del hf_path, use_thd  # DS4 CSA derives its own masking from position_ids.
@@ -352,7 +353,7 @@ class DeepseekV4Model(nn.Module):
         # for its dense-vs-MoE / per-layer logic.
         self.layers = nn.ModuleDict(
             {
-                str(local): DeepseekV4Layer(config, ps, global_idx, use_deepep=use_deepep)
+                str(local): DeepseekV4Layer(config, ps, global_idx, moe_token_dispatcher_type=moe_token_dispatcher_type)
                 for local, global_idx in enumerate(self.layer_indices)
             }
         )
@@ -381,7 +382,7 @@ class DeepseekV4Model(nn.Module):
                         ps,
                         config.num_hidden_layers + idx,
                         embedding=mtp_embedding,
-                        use_deepep=use_deepep,
+                        moe_token_dispatcher_type=moe_token_dispatcher_type,
                         detach_encoder=mtp_detach_encoder,
                     )
                     for idx in range(config.num_nextn_predict_layers)

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/moe.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/moe.py
@@ -4,7 +4,10 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
-from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
+from megatron.lite.primitive.modules.dispatcher import (
+    TokenDispatcher,
+    TokenDispatcherType,
+)
 from megatron.lite.primitive.modules.experts import Experts
 from megatron.lite.primitive.modules.mlp import SwiGLUMLP
 from megatron.lite.primitive.modules.router import SigmoidTopKRouter
@@ -23,7 +26,7 @@ class DeepseekV4MoE(nn.Module):
         ps: ParallelState,
         *,
         layer_idx: int,
-        use_deepep: bool = False,
+        moe_token_dispatcher_type: TokenDispatcherType = "alltoall",
     ):
         super().__init__()
         self.hidden_size = config.hidden_size
@@ -54,7 +57,7 @@ class DeepseekV4MoE(nn.Module):
             config.n_routed_experts,
             config.hidden_size,
             ps,
-            use_deepep=use_deepep,
+            moe_token_dispatcher_type=moe_token_dispatcher_type,
         )
 
     def _hash_route(

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
@@ -23,6 +23,7 @@ from megatron.lite.model.protocol_utils import (
     router_replay_roots as router_replay_roots,
 )
 from megatron.lite.primitive.bundle import ModelBundle
+from megatron.lite.primitive.modules.dispatcher import TokenDispatcherType
 from megatron.lite.primitive.parallel import ParallelState, init_parallel
 from megatron.lite.primitive.parallel.cp import (
     contiguous_position_ids_for_cp,
@@ -58,7 +59,7 @@ class ImplConfig:
     recompute: list[str] = field(default_factory=list)
     offload: list[str] = field(default_factory=list)
     use_thd: bool = False
-    use_deepep: bool = False
+    moe_token_dispatcher_type: TokenDispatcherType = "alltoall"
     attention_backend_override: str | None = None
     deterministic: bool = True
     mtp_enable: bool = True
@@ -385,7 +386,7 @@ def build_model(model_cfg: DeepseekV4Config, *, impl_cfg: ImplConfig) -> ModelBu
         cp=ps.cp_size,
         vpp=vpp,
         fp8=False,
-        use_deepep=impl_cfg.use_deepep,
+        moe_token_dispatcher_type=impl_cfg.moe_token_dispatcher_type,
     )
 
     def _chunk(i: int | None = None):
@@ -395,7 +396,7 @@ def build_model(model_cfg: DeepseekV4Config, *, impl_cfg: ImplConfig) -> ModelBu
                 train_cfg,
                 ps,
                 vpp_chunk_id=i,
-                use_deepep=impl_cfg.use_deepep,
+                moe_token_dispatcher_type=impl_cfg.moe_token_dispatcher_type,
                 use_thd=impl_cfg.use_thd,
                 hf_path=impl_cfg.hf_path,
                 attention_backend_override=impl_cfg.attention_backend_override,

--- a/experimental/lite/megatron/lite/model/glm5/lite/model.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/model.py
@@ -40,7 +40,10 @@ from megatron.lite.primitive.modules.attention import (
     build_rotary_embeddings,
     dsa,
 )
-from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
+from megatron.lite.primitive.modules.dispatcher import (
+    TokenDispatcher,
+    TokenDispatcherType,
+)
 from megatron.lite.primitive.modules.experts import Experts
 from megatron.lite.primitive.modules.mtp import MTPLossAutoScaler
 from megatron.lite.primitive.modules.router import SigmoidTopKRouter
@@ -286,7 +289,7 @@ class MoELayer(nn.Module):
         config: Glm5Config,
         ps: ParallelState,
         *,
-        use_deepep: bool,
+        moe_token_dispatcher_type: TokenDispatcherType,
         router_bias_rate: float,
         fp8: bool,
         moe_act_recompute: bool,
@@ -313,7 +316,7 @@ class MoELayer(nn.Module):
             config.num_experts,
             config.hidden_size,
             ps,
-            use_deepep=use_deepep,
+            moe_token_dispatcher_type=moe_token_dispatcher_type,
         )
         self.shared_expert = SharedExpert(config, ps)
 
@@ -345,7 +348,7 @@ class Glm5Layer(nn.Module):
         ps: ParallelState,
         layer_idx: int,
         *,
-        use_deepep: bool = False,
+        moe_token_dispatcher_type: TokenDispatcherType = "alltoall",
         router_bias_rate: float = 0.0,
         fp8: bool = False,
         moe_act_recompute: bool = False,
@@ -378,7 +381,7 @@ class Glm5Layer(nn.Module):
             self.moe: MoELayer | None = MoELayer(
                 config,
                 ps,
-                use_deepep=use_deepep,
+                moe_token_dispatcher_type=moe_token_dispatcher_type,
                 router_bias_rate=router_bias_rate,
                 fp8=fp8,
                 moe_act_recompute=moe_act_recompute,
@@ -432,7 +435,7 @@ class Glm5MTPLayer(nn.Module):
         layer_idx: int,
         *,
         embedding: VocabParallelEmbedding,
-        use_deepep: bool,
+        moe_token_dispatcher_type: TokenDispatcherType,
         router_bias_rate: float,
         fp8: bool,
         moe_act_recompute: bool,
@@ -460,7 +463,7 @@ class Glm5MTPLayer(nn.Module):
             config,
             ps,
             config.num_hidden_layers + layer_idx,
-            use_deepep=use_deepep,
+            moe_token_dispatcher_type=moe_token_dispatcher_type,
             router_bias_rate=router_bias_rate,
             fp8=fp8,
             moe_act_recompute=moe_act_recompute,
@@ -519,7 +522,7 @@ class Glm5MTPBlock(nn.Module):
         ps: ParallelState,
         *,
         embedding: VocabParallelEmbedding,
-        use_deepep: bool,
+        moe_token_dispatcher_type: TokenDispatcherType,
         router_bias_rate: float,
         fp8: bool,
         moe_act_recompute: bool,
@@ -542,7 +545,7 @@ class Glm5MTPBlock(nn.Module):
                     ps,
                     idx,
                     embedding=embedding,
-                    use_deepep=use_deepep,
+                    moe_token_dispatcher_type=moe_token_dispatcher_type,
                     router_bias_rate=router_bias_rate,
                     fp8=fp8,
                     moe_act_recompute=moe_act_recompute,
@@ -716,7 +719,7 @@ class Glm5Model(nn.Module):
                     config,
                     ps,
                     idx,
-                    use_deepep=train_config.use_deepep,
+                    moe_token_dispatcher_type=train_config.moe_token_dispatcher_type,
                     router_bias_rate=router_bias_rate,
                     fp8=train_config.fp8,
                     moe_act_recompute=moe_act_recompute,
@@ -747,7 +750,7 @@ class Glm5Model(nn.Module):
                 config,
                 ps,
                 embedding=mtp_embedding,
-                use_deepep=train_config.use_deepep,
+                moe_token_dispatcher_type=train_config.moe_token_dispatcher_type,
                 router_bias_rate=router_bias_rate,
                 fp8=train_config.fp8,
                 moe_act_recompute=moe_act_recompute,

--- a/experimental/lite/megatron/lite/model/glm5/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/protocol.py
@@ -34,6 +34,7 @@ from megatron.lite.model.protocol_utils import (
     set_cross_entropy_fusion,
 )
 from megatron.lite.primitive.bundle import ModelBundle
+from megatron.lite.primitive.modules.dispatcher import TokenDispatcherType
 from megatron.lite.primitive.parallel import ParallelState, init_parallel
 from megatron.lite.primitive.parallel.cp import contiguous_slice_for_cp
 from megatron.lite.primitive.parallel.thd import (
@@ -103,7 +104,7 @@ class ImplConfig:
     optimizer: str | None = "dist_opt"
     recompute: list[str] = field(default_factory=list)
     offload: list[str] = field(default_factory=list)
-    use_deepep: bool = False
+    moe_token_dispatcher_type: TokenDispatcherType = "alltoall"
     use_thd: bool = False
     cross_entropy_fusion: bool = False
     hf_path: str = ""
@@ -266,8 +267,10 @@ def _build_dist_opt_optimizer(
 def build_model(model_cfg: Glm5Config, *, impl_cfg: ImplConfig) -> ModelBundle:
     p = impl_cfg.parallel
     _validate_parallel_scope(p)
-    if impl_cfg.use_deepep and (p.etp is not None and p.etp > 1):
-        raise ValueError("use_deepep and etp>1 are mutually exclusive")
+    if impl_cfg.moe_token_dispatcher_type == "deepep" and (p.etp is not None and p.etp > 1):
+        raise ValueError(
+            "moe_token_dispatcher_type='deepep' and etp>1 are mutually exclusive"
+        )
     if impl_cfg.router_aux_loss_coef is not None:
         # GLM-5 has no aux_loss_alpha HF field; honour an explicit override only.
         model_cfg.aux_loss_alpha = impl_cfg.router_aux_loss_coef
@@ -296,7 +299,7 @@ def build_model(model_cfg: Glm5Config, *, impl_cfg: ImplConfig) -> ModelBundle:
         pp=ps.pp_size,
         cp=ps.cp_size,
         vpp=vpp,
-        use_deepep=impl_cfg.use_deepep,
+        moe_token_dispatcher_type=impl_cfg.moe_token_dispatcher_type,
         fp8=False,
         recompute_modules=recompute_spec,
         offload_modules=list(impl_cfg.offload),

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/model.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/model.py
@@ -13,7 +13,10 @@ import torch.nn.functional as F
 from megatron.lite.primitive import transformer_engine as te
 from megatron.lite.model.kimi_k2.config import KimiK2Config
 from megatron.lite.primitive.modules.attention import MultiLatentAttention
-from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
+from megatron.lite.primitive.modules.dispatcher import (
+    TokenDispatcher,
+    TokenDispatcherType,
+)
 from megatron.lite.primitive.modules.experts import Experts
 from megatron.lite.primitive.modules.mtp import MTPLossAutoScaler
 from megatron.lite.primitive.modules.router import SigmoidTopKRouter
@@ -127,7 +130,7 @@ class MoELayer(nn.Module):
         config: KimiK2Config,
         ps: ParallelState,
         *,
-        use_deepep: bool,
+        moe_token_dispatcher_type: TokenDispatcherType,
         router_bias_rate: float,
         fp8: bool,
         moe_act_recompute: bool,
@@ -154,7 +157,7 @@ class MoELayer(nn.Module):
             config.num_experts,
             config.hidden_size,
             ps,
-            use_deepep=use_deepep,
+            moe_token_dispatcher_type=moe_token_dispatcher_type,
         )
         self.shared_expert = SharedExpert(config, ps)
 
@@ -186,7 +189,7 @@ class KimiK2Layer(nn.Module):
         ps: ParallelState,
         layer_idx: int,
         *,
-        use_deepep: bool = False,
+        moe_token_dispatcher_type: TokenDispatcherType = "alltoall",
         router_bias_rate: float = 0.0,
         fp8: bool = False,
         moe_act_recompute: bool = False,
@@ -216,7 +219,7 @@ class KimiK2Layer(nn.Module):
             self.moe: MoELayer | None = MoELayer(
                 config,
                 ps,
-                use_deepep=use_deepep,
+                moe_token_dispatcher_type=moe_token_dispatcher_type,
                 router_bias_rate=router_bias_rate,
                 fp8=fp8,
                 moe_act_recompute=moe_act_recompute,
@@ -259,7 +262,7 @@ class KimiK2MTPLayer(nn.Module):
         layer_idx: int,
         *,
         embedding: VocabParallelEmbedding,
-        use_deepep: bool,
+        moe_token_dispatcher_type: TokenDispatcherType,
         router_bias_rate: float,
         fp8: bool,
         moe_act_recompute: bool,
@@ -283,7 +286,7 @@ class KimiK2MTPLayer(nn.Module):
             config,
             ps,
             config.num_hidden_layers + layer_idx,
-            use_deepep=use_deepep,
+            moe_token_dispatcher_type=moe_token_dispatcher_type,
             router_bias_rate=router_bias_rate,
             fp8=fp8,
             moe_act_recompute=moe_act_recompute,
@@ -330,7 +333,7 @@ class KimiK2MTPBlock(nn.Module):
         ps: ParallelState,
         *,
         embedding: VocabParallelEmbedding,
-        use_deepep: bool,
+        moe_token_dispatcher_type: TokenDispatcherType,
         router_bias_rate: float,
         fp8: bool,
         moe_act_recompute: bool,
@@ -349,7 +352,7 @@ class KimiK2MTPBlock(nn.Module):
                     ps,
                     idx,
                     embedding=embedding,
-                    use_deepep=use_deepep,
+                    moe_token_dispatcher_type=moe_token_dispatcher_type,
                     router_bias_rate=router_bias_rate,
                     fp8=fp8,
                     moe_act_recompute=moe_act_recompute,
@@ -464,7 +467,7 @@ class KimiK2Model(nn.Module):
                     config,
                     ps,
                     idx,
-                    use_deepep=train_config.use_deepep,
+                    moe_token_dispatcher_type=train_config.moe_token_dispatcher_type,
                     router_bias_rate=router_bias_rate,
                     fp8=train_config.fp8,
                     moe_act_recompute=moe_act_recompute,
@@ -491,7 +494,7 @@ class KimiK2Model(nn.Module):
                 config,
                 ps,
                 embedding=mtp_embedding,
-                use_deepep=train_config.use_deepep,
+                moe_token_dispatcher_type=train_config.moe_token_dispatcher_type,
                 router_bias_rate=router_bias_rate,
                 fp8=train_config.fp8,
                 moe_act_recompute=moe_act_recompute,

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/protocol.py
@@ -20,6 +20,7 @@ from megatron.lite.model.protocol_utils import (
     unpack_thd_forward_output,
 )
 from megatron.lite.primitive.bundle import ModelBundle
+from megatron.lite.primitive.modules.dispatcher import TokenDispatcherType
 from megatron.lite.primitive.parallel import ParallelState, init_parallel
 from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec
 from megatron.lite.primitive.quantization import (
@@ -79,7 +80,7 @@ class ImplConfig:
     optimizer: str | None = "dist_opt"
     recompute: list[str] = field(default_factory=list)
     offload: list[str] = field(default_factory=list)
-    use_deepep: bool = False
+    moe_token_dispatcher_type: TokenDispatcherType = "alltoall"
     use_thd: bool = False
     cross_entropy_fusion: bool = False
     hf_path: str = ""
@@ -147,8 +148,10 @@ def _build_dist_opt_optimizer(
 
 def build_model(model_cfg: KimiK2Config, *, impl_cfg: ImplConfig) -> ModelBundle:
     p = impl_cfg.parallel
-    if impl_cfg.use_deepep and (p.etp is not None and p.etp > 1):
-        raise ValueError("use_deepep and etp>1 are mutually exclusive")
+    if impl_cfg.moe_token_dispatcher_type == "deepep" and (p.etp is not None and p.etp > 1):
+        raise ValueError(
+            "moe_token_dispatcher_type='deepep' and etp>1 are mutually exclusive"
+        )
     if impl_cfg.router_aux_loss_coef is not None:
         model_cfg.aux_loss_alpha = impl_cfg.router_aux_loss_coef
     mtp_enable = bool(impl_cfg.mtp_enable)
@@ -174,7 +177,7 @@ def build_model(model_cfg: KimiK2Config, *, impl_cfg: ImplConfig) -> ModelBundle
         pp=ps.pp_size,
         cp=ps.cp_size,
         vpp=vpp,
-        use_deepep=impl_cfg.use_deepep,
+        moe_token_dispatcher_type=impl_cfg.moe_token_dispatcher_type,
         fp8=False,
         recompute_modules=recompute_spec,
         deterministic=impl_cfg.deterministic,

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
@@ -13,13 +13,9 @@ from contextlib import nullcontext
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-
-from megatron.lite.primitive import transformer_engine as te
 from megatron.lite.model.qwen3_5.config import Qwen35Config
-from megatron.lite.primitive.modules.dispatcher import (
-    TokenDispatcher,
-    TokenDispatcherType,
-)
+from megatron.lite.primitive import transformer_engine as te
+from megatron.lite.primitive.modules.dispatcher import TokenDispatcher, TokenDispatcherType
 from megatron.lite.primitive.modules.experts import Experts, swiglu_with_probs
 from megatron.lite.primitive.modules.gated_delta_net import GatedDeltaNet
 from megatron.lite.primitive.modules.gqa import GQAttention as FullAttention

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
@@ -16,7 +16,10 @@ import torch.nn as nn
 
 from megatron.lite.primitive import transformer_engine as te
 from megatron.lite.model.qwen3_5.config import Qwen35Config
-from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
+from megatron.lite.primitive.modules.dispatcher import (
+    TokenDispatcher,
+    TokenDispatcherType,
+)
 from megatron.lite.primitive.modules.experts import Experts, swiglu_with_probs
 from megatron.lite.primitive.modules.gated_delta_net import GatedDeltaNet
 from megatron.lite.primitive.modules.gqa import GQAttention as FullAttention
@@ -158,7 +161,7 @@ class MoELayer(nn.Module):
         config: Qwen35Config,
         ps: ParallelState,
         *,
-        use_deepep: bool,
+        moe_token_dispatcher_type: TokenDispatcherType,
         router_bias_rate: float,
         fp8: bool,
         moe_act_recompute: bool,
@@ -182,7 +185,7 @@ class MoELayer(nn.Module):
             config.num_experts,
             config.hidden_size,
             ps,
-            use_deepep=use_deepep,
+            moe_token_dispatcher_type=moe_token_dispatcher_type,
             moe_permute_fusion=moe_permute_fusion,
         )
         self.shared_expert = SharedExpert(config, ps, use_plain_te_linear=shared_expert_plain_te)
@@ -232,7 +235,7 @@ class Qwen35Layer(nn.Module):
         ps: ParallelState,
         layer_idx: int,
         *,
-        use_deepep: bool = False,
+        moe_token_dispatcher_type: TokenDispatcherType = "alltoall",
         router_bias_rate: float = 0.0,
         fp8: bool = False,
         moe_act_recompute: bool = False,
@@ -280,7 +283,7 @@ class Qwen35Layer(nn.Module):
         self.moe = MoELayer(
             config,
             ps,
-            use_deepep=use_deepep,
+            moe_token_dispatcher_type=moe_token_dispatcher_type,
             router_bias_rate=router_bias_rate,
             fp8=fp8,
             moe_act_recompute=moe_act_recompute,
@@ -403,7 +406,7 @@ class Qwen35Model(nn.Module):
                     config,
                     ps,
                     idx,
-                    use_deepep=train_config.use_deepep,
+                    moe_token_dispatcher_type=train_config.moe_token_dispatcher_type,
                     router_bias_rate=router_bias_rate,
                     fp8=train_config.fp8,
                     moe_act_recompute=moe_act_recompute,
@@ -441,7 +444,7 @@ class Qwen35Model(nn.Module):
                         config,
                         ps,
                         config.num_hidden_layers + layer_idx,
-                        use_deepep=train_config.use_deepep,
+                        moe_token_dispatcher_type=train_config.moe_token_dispatcher_type,
                         router_bias_rate=router_bias_rate,
                         fp8=train_config.fp8,
                         moe_act_recompute=moe_act_recompute,

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
@@ -24,6 +24,7 @@ from megatron.lite.model.qwen3_5.lite.checkpoint import export_hf_weights as _ex
 from megatron.lite.model.qwen3_5.lite.checkpoint import load_hf_weights as _load_hf_weights_impl
 from megatron.lite.model.qwen3_5.lite.checkpoint import save_hf_weights as _save_hf_weights_impl
 from megatron.lite.primitive.bundle import ModelBundle
+from megatron.lite.primitive.modules.dispatcher import TokenDispatcherType
 from megatron.lite.primitive.parallel import ParallelState, init_parallel
 from megatron.lite.primitive.quantization import (
     QATSpec,
@@ -57,7 +58,7 @@ class ImplConfig:
     optimizer: str | None = "dist_opt"
     recompute: list[str] = field(default_factory=list)
     offload: list[str] = field(default_factory=list)
-    use_deepep: bool = False
+    moe_token_dispatcher_type: TokenDispatcherType = "alltoall"
     use_thd: bool = False
     cross_entropy_fusion: bool = False
     hf_path: str = ""
@@ -169,8 +170,10 @@ def build_model(model_cfg: Qwen35Config, *, impl_cfg: ImplConfig) -> ModelBundle
 
     p = impl_cfg.parallel
 
-    if impl_cfg.use_deepep and (p.etp is not None and p.etp > 1):
-        raise ValueError("use_deepep and etp>1 are mutually exclusive")
+    if impl_cfg.moe_token_dispatcher_type == "deepep" and (p.etp is not None and p.etp > 1):
+        raise ValueError(
+            "moe_token_dispatcher_type='deepep' and etp>1 are mutually exclusive"
+        )
 
     if impl_cfg.router_aux_loss_coef is not None:
         model_cfg.router_aux_loss_coef = impl_cfg.router_aux_loss_coef
@@ -198,7 +201,7 @@ def build_model(model_cfg: Qwen35Config, *, impl_cfg: ImplConfig) -> ModelBundle
         pp=ps.pp_size,
         cp=ps.cp_size,
         vpp=vpp,
-        use_deepep=impl_cfg.use_deepep,
+        moe_token_dispatcher_type=impl_cfg.moe_token_dispatcher_type,
         fp8=False,
         recompute_modules=recompute_spec,
         deterministic=deterministic,

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
@@ -15,7 +15,10 @@ import torch.nn as nn
 
 from megatron.lite.primitive import transformer_engine as te
 from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
-from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
+from megatron.lite.primitive.modules.dispatcher import (
+    TokenDispatcher,
+    TokenDispatcherType,
+)
 from megatron.lite.primitive.modules.experts import Experts
 from megatron.lite.primitive.modules.gqa import GQAttention
 from megatron.lite.primitive.modules.lora import LoraConfig
@@ -46,7 +49,7 @@ class MoELayer(nn.Module):
         config: Qwen3MoEConfig,
         ps: ParallelState,
         *,
-        use_deepep: bool = True,
+        moe_token_dispatcher_type: TokenDispatcherType = "deepep",
         router_bias_rate: float = 0.0,
         fp8: bool = False,
         moe_act_recompute: bool = False,
@@ -61,7 +64,7 @@ class MoELayer(nn.Module):
             config, ps, fp8=fp8, moe_act_recompute=moe_act_recompute, lora_config=lora_config
         )
         self.dispatcher = TokenDispatcher(
-            config.num_experts, config.hidden_size, ps, use_deepep=use_deepep
+            config.num_experts, config.hidden_size, ps, moe_token_dispatcher_type=moe_token_dispatcher_type
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -120,7 +123,7 @@ class TransformerLayer(nn.Module):
         ps: ParallelState,
         layer_idx: int,
         *,
-        use_deepep: bool = True,
+        moe_token_dispatcher_type: TokenDispatcherType = "deepep",
         router_bias_rate: float = 0.0,
         fp8: bool = False,
         moe_act_recompute: bool = False,
@@ -151,7 +154,7 @@ class TransformerLayer(nn.Module):
         self.moe = MoELayer(
             config,
             ps,
-            use_deepep=use_deepep,
+            moe_token_dispatcher_type=moe_token_dispatcher_type,
             router_bias_rate=router_bias_rate,
             fp8=fp8,
             moe_act_recompute=moe_act_recompute,
@@ -206,7 +209,7 @@ class MultiTokenPredictionLayer(nn.Module):
         layer_idx: int,
         *,
         embedding: VocabParallelEmbedding,
-        use_deepep: bool,
+        moe_token_dispatcher_type: TokenDispatcherType,
         router_bias_rate: float,
         fp8: bool,
         moe_act_recompute: bool,
@@ -227,7 +230,7 @@ class MultiTokenPredictionLayer(nn.Module):
             config,
             ps,
             config.num_hidden_layers + layer_idx,
-            use_deepep=use_deepep,
+            moe_token_dispatcher_type=moe_token_dispatcher_type,
             router_bias_rate=router_bias_rate,
             fp8=fp8,
             moe_act_recompute=moe_act_recompute,
@@ -279,7 +282,7 @@ class MultiTokenPredictionBlock(nn.Module):
         ps: ParallelState,
         *,
         embedding: VocabParallelEmbedding,
-        use_deepep: bool,
+        moe_token_dispatcher_type: TokenDispatcherType,
         router_bias_rate: float,
         fp8: bool,
         moe_act_recompute: bool,
@@ -299,7 +302,7 @@ class MultiTokenPredictionBlock(nn.Module):
                     ps,
                     idx,
                     embedding=embedding,
-                    use_deepep=use_deepep,
+                    moe_token_dispatcher_type=moe_token_dispatcher_type,
                     router_bias_rate=router_bias_rate,
                     fp8=fp8,
                     moe_act_recompute=moe_act_recompute,
@@ -352,7 +355,7 @@ class Qwen3MoEModel(nn.Module):
         vpp: int | None = None,
         vpp_chunk_id: int | None = None,
         *,
-        use_deepep: bool = False,
+        moe_token_dispatcher_type: TokenDispatcherType = "alltoall",
         fp8: bool = False,
         recompute_modules: list[str] | None = None,
         router_bias_rate: float = 0.0,
@@ -389,7 +392,7 @@ class Qwen3MoEModel(nn.Module):
                     config,
                     ps,
                     idx,
-                    use_deepep=use_deepep,
+                    moe_token_dispatcher_type=moe_token_dispatcher_type,
                     router_bias_rate=router_bias_rate,
                     fp8=fp8,
                     moe_act_recompute=moe_act_recompute,
@@ -417,7 +420,7 @@ class Qwen3MoEModel(nn.Module):
                 config,
                 ps,
                 embedding=mtp_embedding,
-                use_deepep=use_deepep,
+                moe_token_dispatcher_type=moe_token_dispatcher_type,
                 router_bias_rate=router_bias_rate,
                 fp8=fp8,
                 moe_act_recompute=moe_act_recompute,

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
@@ -12,13 +12,9 @@ from contextlib import nullcontext
 
 import torch
 import torch.nn as nn
-
-from megatron.lite.primitive import transformer_engine as te
 from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
-from megatron.lite.primitive.modules.dispatcher import (
-    TokenDispatcher,
-    TokenDispatcherType,
-)
+from megatron.lite.primitive import transformer_engine as te
+from megatron.lite.primitive.modules.dispatcher import TokenDispatcher, TokenDispatcherType
 from megatron.lite.primitive.modules.experts import Experts
 from megatron.lite.primitive.modules.gqa import GQAttention
 from megatron.lite.primitive.modules.lora import LoraConfig
@@ -64,7 +60,10 @@ class MoELayer(nn.Module):
             config, ps, fp8=fp8, moe_act_recompute=moe_act_recompute, lora_config=lora_config
         )
         self.dispatcher = TokenDispatcher(
-            config.num_experts, config.hidden_size, ps, moe_token_dispatcher_type=moe_token_dispatcher_type
+            config.num_experts,
+            config.hidden_size,
+            ps,
+            moe_token_dispatcher_type=moe_token_dispatcher_type,
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
@@ -41,6 +41,7 @@ from megatron.lite.model.qwen3_moe.lite.checkpoint import EXPERT_CLASSIFIER, PLA
 from megatron.lite.model.qwen3_moe.lite.checkpoint import load_hf_weights as _load_hf_weights_impl
 from megatron.lite.model.qwen3_moe.lite.model import MTPLossAutoScaler, Qwen3MoEModel
 from megatron.lite.primitive.bundle import ModelBundle
+from megatron.lite.primitive.modules.dispatcher import TokenDispatcherType
 from megatron.lite.primitive.modules.lora import (
     LoraConfig,
     freeze_non_lora_params,
@@ -82,7 +83,7 @@ class ImplConfig:
     optimizer: str | None = "dist_opt"  # None = no optimizer (inference)
     recompute: list[str] = field(default_factory=list)
     offload: list[str] = field(default_factory=list)
-    use_deepep: bool = False
+    moe_token_dispatcher_type: TokenDispatcherType = "alltoall"
     use_thd: bool = False
     cross_entropy_fusion: bool = False
     router_aux_loss_coef: float | None = None
@@ -177,8 +178,10 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
     lora_config = normalize_lora_config(impl_cfg.lora)
 
     # ── validation ──
-    if impl_cfg.use_deepep and (p.etp is not None and p.etp > 1):
-        raise ValueError("use_deepep and etp>1 are mutually exclusive")
+    if impl_cfg.moe_token_dispatcher_type == "deepep" and (p.etp is not None and p.etp > 1):
+        raise ValueError(
+            "moe_token_dispatcher_type='deepep' and etp>1 are mutually exclusive"
+        )
 
     # ── override model config from impl_cfg ──
     if impl_cfg.router_aux_loss_coef is not None:
@@ -201,7 +204,7 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
     # ── build chunks ──
     recompute_spec = parse_recompute_spec(impl_cfg.recompute)
     model_kwargs: dict[str, Any] = dict(
-        use_deepep=impl_cfg.use_deepep,
+        moe_token_dispatcher_type=impl_cfg.moe_token_dispatcher_type,
         fp8=False,
         recompute_modules=recompute_spec,
         router_bias_rate=impl_cfg.router_bias_rate,

--- a/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
+++ b/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-"""Token dispatcher: AllToAll and DeepEP dispatch/combine."""
+"""Token dispatcher: AllToAll, DeepEP and HybridEP dispatch/combine."""
 
 from __future__ import annotations
 
 import os
+from typing import Literal, get_args
 
 import torch  # pyright: ignore[reportMissingImports]
 import torch.distributed as dist  # pyright: ignore[reportMissingImports]
@@ -20,6 +21,36 @@ except ImportError:
     deep_ep = None  # type: ignore
     EventHandle = None  # type: ignore
     EventOverlap = None  # type: ignore
+
+try:
+    from deep_ep import HybridEPBuffer  # pyright: ignore[reportMissingImports]
+except ImportError:
+    HybridEPBuffer = None  # type: ignore
+
+#: The token dispatch backend. ``alltoall`` needs no extra dependency; ``deepep`` and
+#: ``hybridep`` both come from DeepEP (``hybridep`` needs the ``hybrid-ep`` branch, which
+#: is what exports ``HybridEPBuffer``).
+TokenDispatcherType = Literal["alltoall", "deepep", "hybridep"]
+
+#: HybridEP dispatch/combine kernels use 64-token chunks for their public APIs.
+HYBRIDEP_TOKEN_ALIGNMENT = 64
+
+_INSTALL_HINTS = {
+    "deepep": "Install DeepEP from https://github.com/deepseek-ai/DeepEP.",
+    "hybridep": (
+        "Install DeepEP's hybrid-ep branch from "
+        "https://github.com/deepseek-ai/DeepEP/tree/hybrid-ep "
+        "(it is what exports deep_ep.HybridEPBuffer)."
+    ),
+}
+
+
+def _missing_backend_message(backend: str, ep_size: int) -> str:
+    return (
+        f"moe_token_dispatcher_type={backend!r} was requested with expert_parallel_size="
+        f"{ep_size}, but {backend} is not installed. {_INSTALL_HINTS[backend]} "
+        "Set moe_token_dispatcher_type='alltoall' to run without it."
+    )
 
 
 def _hidden_bytes(hidden_size: int) -> int:
@@ -186,6 +217,92 @@ class _DeepEPCombine(torch.autograd.Function):
         return None, grad_rank_grouped, None, None, None
 
 
+_hybrid_ep_buffer = None
+
+
+def init_hybrid_ep_buffer(
+    group: dist.ProcessGroup, hidden_dim: int, num_tokens: int, num_local_experts: int
+) -> None:
+    """Allocate the process-wide HybridEP buffer.
+
+    A dispatch that needs a larger buffer than the one allocated here reallocates at
+    runtime, at extra cost. The buffer is shared by every layer, as in mcore.
+    """
+    global _hybrid_ep_buffer
+    _hybrid_ep_buffer = HybridEPBuffer(
+        group=group,
+        hidden_dim=hidden_dim,
+        max_num_of_tokens_per_rank=num_tokens,
+        num_local_experts=num_local_experts,
+        use_fp8=False,
+    )
+
+
+def reset_hybrid_ep_buffer() -> None:
+    """Drop the process-wide HybridEP buffer."""
+    global _hybrid_ep_buffer
+    _hybrid_ep_buffer = None
+
+
+class _HybridEPDispatch(torch.autograd.Function):
+    """Fused permute + dispatch all-to-all + permute, via the HybridEP backend."""
+
+    @staticmethod
+    def forward(ctx, hidden_states, routing_map, probs, group, num_local_experts):
+        if _hybrid_ep_buffer is None:
+            num_tokens, hidden_dim = hidden_states.shape[-2:]
+            init_hybrid_ep_buffer(group, hidden_dim, num_tokens, num_local_experts)
+        # num_permuted_tokens is left unset: MLite is dropless, so there is no static
+        # budget to size the buffers with, and HybridEP resolves the size itself (at the
+        # cost of a D2H sync).
+        dispatched_hidden, dispatched_probs, _, tokens_per_expert, handle = (
+            _hybrid_ep_buffer.dispatch_with_permute(
+                hidden=hidden_states,
+                routing_map=routing_map,
+                probs=probs,
+                scaling_factor=None,
+                num_of_experts_per_rank=num_local_experts,
+                pad_multiple=None,
+                num_permuted_tokens=None,
+                non_blocking=False,
+            )
+        )
+        ctx.handle = handle
+        return dispatched_hidden, dispatched_probs, tokens_per_expert, handle
+
+    @staticmethod
+    def backward(ctx, grad_dispatched, grad_probs, grad_tokens_per_expert, grad_handle):
+        del grad_tokens_per_expert, grad_handle
+        combined_hidden, combined_probs = _hybrid_ep_buffer.combine_with_unpermute(
+            hidden=grad_dispatched, probs=grad_probs, handle=ctx.handle, pad_multiple=None
+        )
+        return combined_hidden, None, combined_probs, None, None
+
+
+class _HybridEPCombine(torch.autograd.Function):
+    """Fused unpermute + combine all-to-all + unpermute, via the HybridEP backend."""
+
+    @staticmethod
+    def forward(ctx, expert_output, handle, num_permuted_tokens):
+        combined_hidden, _ = _hybrid_ep_buffer.combine_with_unpermute(
+            hidden=expert_output, handle=handle, pad_multiple=None
+        )
+        ctx.handle = handle
+        ctx.num_permuted_tokens = num_permuted_tokens
+        return combined_hidden
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        dispatched_hidden, _, _, _, _ = _hybrid_ep_buffer.dispatch_with_permute(
+            hidden=grad_output,
+            scaling_factor=None,
+            handle=ctx.handle,
+            pad_multiple=None,
+            num_permuted_tokens=ctx.num_permuted_tokens,
+        )
+        return dispatched_hidden, None, None
+
+
 class TokenDispatcher:
 
     def __init__(
@@ -194,7 +311,7 @@ class TokenDispatcher:
         hidden_size: int,
         ps: ParallelState,
         *,
-        use_deepep: bool = True,
+        moe_token_dispatcher_type: TokenDispatcherType = "deepep",
         moe_permute_fusion: bool | None = None,
     ):
         self.ps = ps
@@ -205,10 +322,31 @@ class TokenDispatcher:
             _use_moe_permute_fusion() if moe_permute_fusion is None else bool(moe_permute_fusion)
         )
 
-        self.use_deepep = use_deepep and deep_ep is not None and ps.ep_size > 1
-        if self.use_deepep:
+        if moe_token_dispatcher_type not in get_args(TokenDispatcherType):
+            raise ValueError(
+                f"Unknown moe_token_dispatcher_type {moe_token_dispatcher_type!r}; "
+                f"expected one of {list(get_args(TokenDispatcherType))}."
+            )
+        self.moe_token_dispatcher_type: TokenDispatcherType = moe_token_dispatcher_type
+        # With a single expert-parallel rank there is nothing to dispatch, so every
+        # backend degenerates to the local permute and none of them is required to be
+        # installed. Above that, an explicitly requested backend must be available:
+        # falling back would make "dependency missing" and "backend off" look alike.
+        self.backend = "local" if ps.ep_size <= 1 else moe_token_dispatcher_type
+        if self.backend == "deepep" and deep_ep is None:
+            raise RuntimeError(_missing_backend_message("deepep", ps.ep_size))
+        if self.backend == "hybridep" and HybridEPBuffer is None:
+            raise RuntimeError(_missing_backend_message("hybridep", ps.ep_size))
+
+        if self.backend == "deepep":
             assert ps.tp_ep_group is not None
             self.buffer = _build_deepep_buffer(ps.tp_ep_group, hidden_size)
+        if self.backend == "hybridep":
+            assert ps.tp_ep_group is not None
+
+        self._hybridep_handle = None
+        self._hybridep_num_permuted_tokens: int | None = None
+        self._hybridep_num_tokens: int | None = None
 
         self._row_id_map: torch.Tensor | None = None
         self._restore_shape: tuple | None = None
@@ -229,26 +367,30 @@ class TokenDispatcher:
     def dispatch(
         self, hidden_states: torch.Tensor, topk_scores: torch.Tensor, topk_indices: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
-        if self.ep_size <= 1:
+        if self.backend == "local":
             return self._dispatch_local(hidden_states, topk_scores, topk_indices)
-        if self.use_deepep:
+        if self.backend == "deepep":
             return self._dispatch_deepep(hidden_states, topk_scores, topk_indices)
+        if self.backend == "hybridep":
+            return self._dispatch_hybridep(hidden_states, topk_scores, topk_indices)
         dispatched, tpe, sorted_scores = self._dispatch_alltoall(
             hidden_states, topk_scores, topk_indices
         )
         return dispatched, tpe, sorted_scores
 
     def combine(self, expert_output: torch.Tensor) -> torch.Tensor:
-        if self.ep_size <= 1:
+        if self.backend == "local":
             return self._combine_local(expert_output)
-        if self.use_deepep:
+        if self.backend == "deepep":
             return self._combine_deepep(expert_output)
+        if self.backend == "hybridep":
+            return self._combine_hybridep(expert_output)
         return self._combine_alltoall(expert_output)
 
     def submit_deepep_combine(
         self, expert_output: torch.Tensor, *, allocate_on_comm_stream: bool = False
     ):
-        if not self.use_deepep:
+        if self.backend != "deepep":
             raise RuntimeError("submit_deepep_combine requires DeepEP combine.")
         rank_grouped = unpermute(
             expert_output,
@@ -276,7 +418,7 @@ class TokenDispatcher:
         return {"combined": combined, "event": event}
 
     def finish_deepep_combine(self, state):
-        if not self.use_deepep:
+        if self.backend != "deepep":
             raise RuntimeError("finish_deepep_combine requires DeepEP combine.")
         event = state.get("event")
         if event is not None:
@@ -421,7 +563,7 @@ class TokenDispatcher:
     def submit_deepep_dispatch(
         self, hidden_states, topk_scores, topk_indices, *, allocate_on_comm_stream: bool = False
     ):
-        if not self.use_deepep:
+        if self.backend != "deepep":
             raise RuntimeError("submit_deepep_dispatch requires DeepEP dispatch.")
         previous_event = (
             EventOverlap(EventHandle())
@@ -467,7 +609,7 @@ class TokenDispatcher:
         }
 
     def finish_deepep_dispatch(self, state):
-        if not self.use_deepep:
+        if self.backend != "deepep":
             raise RuntimeError("finish_deepep_dispatch requires DeepEP dispatch.")
         self._handle = state["handle"]
         self._deepep_event = state["event"]
@@ -585,5 +727,58 @@ class TokenDispatcher:
         self._local_tpe_list = None
         return combined
 
+    def _dispatch_hybridep(self, hidden_states, topk_scores, topk_indices):
+        t, h = hidden_states.shape
+        e = self.num_experts
 
-__all__ = ["TokenDispatcher"]
+        routing_map = torch.zeros(t, e, dtype=torch.bool, device=hidden_states.device)
+        routing_map.scatter_(1, topk_indices, True)
+        probs_2d = torch.zeros(t, e, dtype=topk_scores.dtype, device=hidden_states.device)
+        probs_2d.scatter_(1, topk_indices, topk_scores)
+
+        # HybridEP dispatch requires every rank in the group to hand it the same token
+        # count, so pad up to the group-wide max (and to the kernels' 64-token chunk).
+        # THD packing makes uneven counts routine, so this is unconditional rather than a
+        # knob; combine() trims back down. Costs one 1-element all-reduce per dispatch.
+        max_num_tokens = torch.tensor([t], device=hidden_states.device, dtype=torch.long)
+        dist.all_reduce(max_num_tokens, op=dist.ReduceOp.MAX, group=self.ps.tp_ep_group)
+        padded_t = int(max_num_tokens.item())
+        padded_t += -padded_t % HYBRIDEP_TOKEN_ALIGNMENT
+
+        if padded_t > t:
+            pad_rows = padded_t - t
+            routing_map = torch.cat([routing_map, routing_map.new_zeros((pad_rows, e))], dim=0)
+            probs_2d = torch.cat([probs_2d, probs_2d.new_zeros((pad_rows, e))], dim=0)
+            hidden_states = torch.cat(
+                [hidden_states, hidden_states.new_zeros((pad_rows, h))], dim=0
+            )
+        self._hybridep_num_tokens = t
+
+        # HybridEP only supports float32 probs.
+        dispatched, dispatched_probs, tokens_per_expert, handle = _HybridEPDispatch.apply(
+            hidden_states,
+            routing_map,
+            probs_2d.float(),
+            self.ps.tp_ep_group,
+            self.num_local_experts,
+        )
+        self._hybridep_handle = handle
+        tokens_per_expert = tokens_per_expert.to(torch.int64)
+        # combine() needs the permuted size to allocate its output; without a static
+        # budget it is only knowable after dispatch (this .sum() is the D2H sync).
+        self._hybridep_num_permuted_tokens = tokens_per_expert.sum()
+        return dispatched, tokens_per_expert, dispatched_probs
+
+    def _combine_hybridep(self, expert_output):
+        combined = _HybridEPCombine.apply(
+            expert_output, self._hybridep_handle, self._hybridep_num_permuted_tokens
+        )
+        if self._hybridep_num_tokens is not None:
+            combined = combined[: self._hybridep_num_tokens]
+        self._hybridep_handle = None
+        self._hybridep_num_permuted_tokens = None
+        self._hybridep_num_tokens = None
+        return combined
+
+
+__all__ = ["TokenDispatcher", "TokenDispatcherType", "reset_hybrid_ep_buffer"]

--- a/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
+++ b/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
@@ -733,7 +733,10 @@ class TokenDispatcher:
         routing_map = torch.zeros(t, e, dtype=torch.bool, device=hidden_states.device)
         routing_map.scatter_(1, topk_indices, True)
         probs_2d = torch.zeros(t, e, dtype=topk_scores.dtype, device=hidden_states.device)
-        probs_2d.scatter_(1, topk_indices, topk_scores)
+        # scatter_add_, not scatter_: hash routing (ds4) can send a token to the same
+        # expert twice, and the duplicate slots' probabilities have to accumulate. Same
+        # reasoning as the alltoall and local paths above.
+        probs_2d.scatter_add_(1, topk_indices, topk_scores)
 
         # HybridEP dispatch requires every rank in the group to hand it the same token
         # count, so pad up to the group-wide max (and to the kernels' 64-token chunk).

--- a/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
+++ b/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
@@ -769,10 +769,13 @@ class TokenDispatcher:
             self.num_local_experts,
         )
         self._hybridep_handle = handle
-        tokens_per_expert = tokens_per_expert.to(torch.int64)
         # combine() needs the permuted size to allocate its output; without a static
-        # budget it is only knowable after dispatch (this .sum() is the D2H sync).
-        self._hybridep_num_permuted_tokens = tokens_per_expert.sum()
+        # budget it is only knowable after dispatch. HybridEP hands tokens_per_expert
+        # back on the host, so read the total here while it is free.
+        self._hybridep_num_permuted_tokens = int(tokens_per_expert.sum())
+        # ...but every other backend returns tokens_per_expert on the compute device,
+        # and the expert grouping downstream indexes with it. Match them.
+        tokens_per_expert = tokens_per_expert.to(device=dispatched.device, dtype=torch.int64)
         return dispatched, tokens_per_expert, dispatched_probs
 
     def _combine_hybridep(self, expert_output):

--- a/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
+++ b/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
@@ -253,8 +253,8 @@ class _HybridEPDispatch(torch.autograd.Function):
             num_tokens, hidden_dim = hidden_states.shape[-2:]
             init_hybrid_ep_buffer(group, hidden_dim, num_tokens, num_local_experts)
         # num_permuted_tokens is left unset: MLite is dropless, so there is no static
-        # budget to size the buffers with, and HybridEP resolves the size itself (at the
-        # cost of a D2H sync).
+        # budget to size the buffers with. HybridEP then resolves the size itself off
+        # host-side metadata, which costs a D2H sync (its use_host_meta default).
         dispatched_hidden, dispatched_probs, _, tokens_per_expert, handle = (
             _hybrid_ep_buffer.dispatch_with_permute(
                 hidden=hidden_states,
@@ -264,7 +264,6 @@ class _HybridEPDispatch(torch.autograd.Function):
                 num_of_experts_per_rank=num_local_experts,
                 pad_multiple=None,
                 num_permuted_tokens=None,
-                non_blocking=False,
             )
         )
         ctx.handle = handle

--- a/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
+++ b/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
@@ -337,11 +337,15 @@ class TokenDispatcher:
         if self.backend == "hybridep" and HybridEPBuffer is None:
             raise RuntimeError(_missing_backend_message("hybridep", ps.ep_size))
 
+        if self.backend in ("deepep", "hybridep") and ps.tp_ep_group is None:
+            raise RuntimeError(
+                f"moe_token_dispatcher_type={self.backend!r} dispatches over the ETPxEP "
+                "group, but ParallelState.tp_ep_group is unset. Build the dispatcher from "
+                "an initialised ParallelState (init_parallel), or use "
+                "moe_token_dispatcher_type='alltoall'."
+            )
         if self.backend == "deepep":
-            assert ps.tp_ep_group is not None
             self.buffer = _build_deepep_buffer(ps.tp_ep_group, hidden_size)
-        if self.backend == "hybridep":
-            assert ps.tp_ep_group is not None
 
         self._hybridep_handle = None
         self._hybridep_num_permuted_tokens: int | None = None

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/config.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/config.py
@@ -79,7 +79,7 @@ class MegatronLiteConfig:
         for k in list(impl_cfg):
             if k in cfg:
                 impl_cfg[k] = cfg[k]
-        for k in ("recompute", "use_thd", "use_deepep", "precision_aware_opt"):
+        for k in ("recompute", "use_thd", "moe_token_dispatcher_type", "precision_aware_opt"):
             if k in cfg and k not in impl_cfg:
                 impl_cfg[k] = cfg[k]
 

--- a/experimental/lite/skills/primitive/module/moe.md
+++ b/experimental/lite/skills/primitive/module/moe.md
@@ -33,7 +33,7 @@ def moe(task, implementation, config, reference, budget):
         "boundaries": ["module owns routing math; EP owns distributed expert placement; DeepEP owns dispatch/combine transport"],
     }
     usage_contract = {
-        "config": require_config_keys(config, ["num_experts", "top_k", "expert_parallel_size", "use_deepep"]),
+        "config": require_config_keys(config, ["num_experts", "top_k", "expert_parallel_size", "moe_token_dispatcher_type"]),
         "choose_when": ["model architecture has sparse experts", "expert count justifies EP or grouped GEMM"],
         "avoid_when": ["router tie behavior cannot be stabilized", "DeepEP metadata cannot be validated against all-to-all"],
         "compose_with": ["primitive.parallel.ep", "DeepEP dispatcher when EP>1", "primitive.parallel.tp for expert MLP if explicit"],

--- a/experimental/lite/tests/smoke/model/glm5/lite/test_glm5_lite_cp_smoke.py
+++ b/experimental/lite/tests/smoke/model/glm5/lite/test_glm5_lite_cp_smoke.py
@@ -20,7 +20,7 @@ def _make_train_config(ps):
         pp=ps.pp_size,
         cp=ps.cp_size,
         vpp=None,
-        use_deepep=False,
+        moe_token_dispatcher_type="alltoall",
         fp8=False,
         recompute_modules=[],
         deterministic=True,

--- a/experimental/lite/tests/smoke/model/kimi_k2/lite/test_kimi_k2_lite_cp_smoke.py
+++ b/experimental/lite/tests/smoke/model/kimi_k2/lite/test_kimi_k2_lite_cp_smoke.py
@@ -111,7 +111,7 @@ def _train_cfg(cp: int):
         pp=1,
         cp=cp,
         vpp=None,
-        use_deepep=False,
+        moe_token_dispatcher_type="alltoall",
         fp8=False,
         recompute_modules={},
         deterministic=False,

--- a/experimental/lite/tests/smoke/model/test_qwen_lite_forward_smoke.py
+++ b/experimental/lite/tests/smoke/model/test_qwen_lite_forward_smoke.py
@@ -129,7 +129,7 @@ def test_qwen3_moe_lite_tiny_forward_backward_smoke():
     _Qwen3MoEConfig, Qwen3MoEModel = _qwen3_symbols()
     config = _tiny_qwen3_config()
     model = (
-        Qwen3MoEModel(config, _parallel_state(), use_deepep=False)
+        Qwen3MoEModel(config, _parallel_state(), moe_token_dispatcher_type="alltoall")
         .cuda()
         .to(torch.bfloat16)
     )
@@ -152,7 +152,7 @@ def test_qwen35_lite_tiny_forward_backward_smoke():
         pp=1,
         cp=1,
         vpp=None,
-        use_deepep=False,
+        moe_token_dispatcher_type="alltoall",
         fp8=False,
         recompute_modules=[],
         deterministic=True,
@@ -222,7 +222,7 @@ def test_qwen35_tp2_tp4_mixed_attention_parity_and_backward():
             pp=1,
             cp=1,
             vpp=None,
-            use_deepep=False,
+            moe_token_dispatcher_type="alltoall",
             fp8=False,
             recompute_modules=[],
             deterministic=True,

--- a/experimental/lite/tests/smoke/workflows/checkpoint/test_qwen3_moe_distopt_checkpoint_smoke.py
+++ b/experimental/lite/tests/smoke/workflows/checkpoint/test_qwen3_moe_distopt_checkpoint_smoke.py
@@ -98,7 +98,7 @@ def _build_handle(model_seed: int) -> ModelHandle:
         optimizer_config=OptimizerConfig(
             optimizer="adam", lr=1.0e-3, weight_decay=0.0, clip_grad=1.0
         ),
-        use_deepep=False,
+        moe_token_dispatcher_type="alltoall",
         deterministic=True,
     )
     bundle = protocol.build_model(model_cfg, impl_cfg=impl_cfg)

--- a/experimental/lite/tests/smoke/workflows/checkpoint/test_save_load_export_smoke.py
+++ b/experimental/lite/tests/smoke/workflows/checkpoint/test_save_load_export_smoke.py
@@ -381,7 +381,7 @@ def _build_handle(
         parallel=parallel,
         optimizer=backend,
         optimizer_config=_optimizer_config(offload_fraction),
-        use_deepep=False,
+        moe_token_dispatcher_type="alltoall",
         deterministic=True,
     )
     bundle = protocol.build_model(cfg, impl_cfg=impl_cfg)

--- a/experimental/lite/tests/smoke/workflows/train_export/test_auto_pipeline_layout_smoke.py
+++ b/experimental/lite/tests/smoke/workflows/train_export/test_auto_pipeline_layout_smoke.py
@@ -411,7 +411,7 @@ def _build_handle_from_config(
         parallel=parallel,
         optimizer="dist_opt",
         optimizer_config=_optimizer_config(),
-        use_deepep=False,
+        moe_token_dispatcher_type="alltoall",
         deterministic=True,
     )
     if impl_overrides:

--- a/experimental/lite/tests/unit/model/test_all_model_qat_r3_contracts.py
+++ b/experimental/lite/tests/unit/model/test_all_model_qat_r3_contracts.py
@@ -294,7 +294,7 @@ def _train_config():
         pp=1,
         cp=1,
         vpp=None,
-        use_deepep=False,
+        moe_token_dispatcher_type="alltoall",
         fp8=False,
         recompute_modules=[],
         offload_modules=[],
@@ -323,7 +323,7 @@ def _real_tiny_model(model_name: str, monkeypatch):
             max_position_embeddings=16,
             layer_types=["full_attention", "full_attention"],
         )
-        return Qwen3MoEModel(config, ps, use_deepep=False)
+        return Qwen3MoEModel(config, ps, moe_token_dispatcher_type="alltoall")
     if model_name == "qwen3_5":
         from megatron.lite.model.qwen3_5.config import Qwen35Config
         from megatron.lite.model.qwen3_5.lite.model import Qwen35Model

--- a/experimental/lite/tests/unit/model/test_glm5_lite_static.py
+++ b/experimental/lite/tests/unit/model/test_glm5_lite_static.py
@@ -19,7 +19,7 @@ def _make_train_config(ps):
         pp=ps.pp_size,
         cp=ps.cp_size,
         vpp=None,
-        use_deepep=False,
+        moe_token_dispatcher_type="alltoall",
         fp8=False,
         recompute_modules=[],
         deterministic=True,

--- a/experimental/lite/tests/unit/primitive/parallel/test_parallel_dimensions_independent_unit.py
+++ b/experimental/lite/tests/unit/primitive/parallel/test_parallel_dimensions_independent_unit.py
@@ -139,7 +139,7 @@ def test_ep_token_dispatcher_sums_scores_for_duplicate_experts(
     from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
 
     ps = ParallelState(ep_size=1, ep_rank=0)
-    dispatcher = TokenDispatcher(num_experts=3, hidden_size=2, ps=ps, use_deepep=False)
+    dispatcher = TokenDispatcher(num_experts=3, hidden_size=2, ps=ps, moe_token_dispatcher_type="alltoall")
     hidden = torch.tensor([[1.0, 10.0], [2.0, 20.0]])
     topk_indices = torch.tensor([[1, 1, 2], [0, 2, 0]])
     topk_scores = torch.tensor([[0.2, 0.3, 0.5], [0.1, 0.4, 0.5]], requires_grad=True)
@@ -178,7 +178,7 @@ def test_alltoall_dispatch_sums_scores_for_duplicate_experts(
         num_experts=4,
         hidden_size=2,
         ps=ParallelState(ep_size=2, ep_rank=0, ep_group=object()),
-        use_deepep=False,
+        moe_token_dispatcher_type="alltoall",
     )
     hidden = torch.tensor([[1.0, 10.0], [2.0, 20.0]])
     topk_indices = torch.tensor([[1, 1, 0], [0, 1, 0]])
@@ -202,7 +202,7 @@ def test_deepep_dispatch_finish_sums_scores_for_duplicate_experts(
         num_experts=3,
         hidden_size=2,
         ps=ParallelState(ep_size=1, ep_rank=0),
-        use_deepep=False,
+        moe_token_dispatcher_type="alltoall",
     )
     recv_hidden = torch.tensor([[1.0, 10.0], [2.0, 20.0]])
     recv_indices = torch.tensor([[1, 1, 2], [0, 2, 0]])

--- a/experimental/lite/tests/unit/primitive/parallel/test_parallel_dimensions_independent_unit.py
+++ b/experimental/lite/tests/unit/primitive/parallel/test_parallel_dimensions_independent_unit.py
@@ -114,7 +114,7 @@ def test_ep_token_dispatcher_local_roundtrip_is_independent_of_deepep(
     from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
 
     ps = ParallelState(ep_size=1, ep_rank=0)
-    dispatcher = TokenDispatcher(num_experts=3, hidden_size=2, ps=ps, use_deepep=False)
+    dispatcher = TokenDispatcher(num_experts=3, hidden_size=2, ps=ps, moe_token_dispatcher_type="alltoall")
     hidden = torch.tensor([[1.0, 10.0], [2.0, 20.0], [3.0, 30.0], [4.0, 40.0]], requires_grad=True)
     topk_indices = torch.tensor([[0], [2], [1], [2]])
     topk_scores = torch.ones(4, 1)

--- a/experimental/lite/tests/unit/primitive/test_init_device.py
+++ b/experimental/lite/tests/unit/primitive/test_init_device.py
@@ -267,7 +267,7 @@ def test_dispatcher_metadata_stays_materialized_in_meta_context() -> None:
             num_experts=4,
             hidden_size=8,
             ps=SimpleNamespace(ep_size=2),
-            use_deepep=False,
+            moe_token_dispatcher_type="alltoall",
         )
 
     assert dispatcher._sort_by_experts == [0, 2, 1, 3]

--- a/experimental/lite/tests/unit/primitive/test_moe_token_dispatcher_type_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_moe_token_dispatcher_type_unit.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Backend selection for moe_token_dispatcher_type.
+
+These run on CPU with neither DeepEP nor HybridEP installed, which is exactly the state
+that used to be indistinguishable from "the backend is off": the old `use_deepep` flag
+was ANDed with `deep_ep is not None`, so a requested DeepEP run silently became an
+AllToAll run. The typed option is required to say so instead.
+"""
+
+import pytest
+import torch
+
+from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
+from megatron.lite.primitive.parallel import ParallelState
+
+
+def _ps(ep_size: int) -> ParallelState:
+    return ParallelState(ep_size=ep_size, ep_rank=0)
+
+
+def _build(ep_size: int, dispatcher_type: str) -> TokenDispatcher:
+    return TokenDispatcher(
+        num_experts=4,
+        hidden_size=2,
+        ps=_ps(ep_size),
+        moe_token_dispatcher_type=dispatcher_type,
+    )
+
+
+@pytest.mark.parametrize(
+    "dispatcher_type, hint",
+    [("deepep", "github.com/deepseek-ai/DeepEP"), ("hybridep", "hybrid-ep")],
+)
+def test_requesting_an_uninstalled_backend_fails_loud(dispatcher_type, hint):
+    # Neither package is importable here, so this is the "dependency missing" case.
+    with pytest.raises(RuntimeError) as excinfo:
+        _build(ep_size=2, dispatcher_type=dispatcher_type)
+
+    message = str(excinfo.value)
+    assert dispatcher_type in message
+    assert "not installed" in message
+    # The error has to be actionable: where to get it, and how to run without it.
+    assert hint in message
+    assert "alltoall" in message
+
+
+@pytest.mark.parametrize("dispatcher_type", ["deepep", "hybridep"])
+def test_uninstalled_backend_does_not_silently_become_alltoall(dispatcher_type):
+    # The regression guard proper. Under the old `use_deepep` flag this construction
+    # succeeded and quietly ran AllToAll; nothing downstream could tell.
+    with pytest.raises(RuntimeError):
+        _build(ep_size=2, dispatcher_type=dispatcher_type)
+
+
+def test_alltoall_needs_no_optional_dependency():
+    dispatcher = _build(ep_size=2, dispatcher_type="alltoall")
+    assert dispatcher.backend == "alltoall"
+
+
+@pytest.mark.parametrize("dispatcher_type", ["alltoall", "deepep", "hybridep"])
+def test_single_ep_rank_degenerates_to_local_for_every_backend(dispatcher_type):
+    # With one expert-parallel rank there is no dispatch to perform, so no backend is
+    # required to be installed -- including the ones that are missing here.
+    dispatcher = _build(ep_size=1, dispatcher_type=dispatcher_type)
+    assert dispatcher.backend == "local"
+    assert dispatcher.moe_token_dispatcher_type == dispatcher_type
+
+
+@pytest.mark.parametrize("dispatcher_type", ["allgather", "flex", "DeepEP", "", None, True])
+def test_unknown_dispatcher_type_is_rejected(dispatcher_type):
+    with pytest.raises(ValueError, match="Unknown moe_token_dispatcher_type"):
+        _build(ep_size=2, dispatcher_type=dispatcher_type)
+
+
+def test_alltoall_and_deepep_share_the_local_roundtrip_at_ep1():
+    # Guards the AC-3 claim that the rename left the data path alone: the two types are
+    # bit-identical wherever they run the same code.
+    hidden = torch.tensor([[1.0, 10.0], [2.0, 20.0], [3.0, 30.0], [4.0, 40.0]])
+    topk_indices = torch.tensor([[0], [2], [1], [2]])
+    topk_scores = torch.ones(4, 1)
+
+    outputs = []
+    for dispatcher_type in ("alltoall", "deepep"):
+        dispatcher = _build(ep_size=1, dispatcher_type=dispatcher_type)
+        dispatched, tokens_per_expert, probs = dispatcher.dispatch(
+            hidden, topk_scores, topk_indices
+        )
+        outputs.append((dispatched, tokens_per_expert, probs, dispatcher.combine(dispatched)))
+
+    for left, right in zip(outputs[0], outputs[1]):
+        torch.testing.assert_close(left, right, rtol=0, atol=0)

--- a/experimental/lite/tests/unit/primitive/test_moe_token_dispatcher_type_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_moe_token_dispatcher_type_unit.py
@@ -27,10 +27,7 @@ def _ps(ep_size: int) -> ParallelState:
 
 def _build(ep_size: int, dispatcher_type: str) -> TokenDispatcher:
     return TokenDispatcher(
-        num_experts=4,
-        hidden_size=2,
-        ps=_ps(ep_size),
-        moe_token_dispatcher_type=dispatcher_type,
+        num_experts=4, hidden_size=2, ps=_ps(ep_size), moe_token_dispatcher_type=dispatcher_type
     )
 
 

--- a/experimental/lite/tests/unit/primitive/test_moe_token_dispatcher_type_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_moe_token_dispatcher_type_unit.py
@@ -1,17 +1,24 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Backend selection for moe_token_dispatcher_type.
 
-These run on CPU with neither DeepEP nor HybridEP installed, which is exactly the state
-that used to be indistinguishable from "the backend is off": the old `use_deepep` flag
-was ANDed with `deep_ep is not None`, so a requested DeepEP run silently became an
-AllToAll run. The typed option is required to say so instead.
+The case worth pinning is a missing optional dependency, which used to be
+indistinguishable from "the backend is off": the old `use_deepep` flag was ANDed with
+`deep_ep is not None`, so a requested DeepEP run silently became an AllToAll run. The
+typed option has to say so instead.
+
+Absence is simulated rather than assumed -- DeepEP is installed in the validation
+container and absent on a laptop, and this suite has to mean the same thing in both.
 """
 
 import pytest
 import torch
 
+from megatron.lite.primitive.modules import dispatcher as dispatcher_mod
 from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
 from megatron.lite.primitive.parallel import ParallelState
+
+#: Module global that each backend's availability is read from.
+_BACKEND_SYMBOL = {"deepep": "deep_ep", "hybridep": "HybridEPBuffer"}
 
 
 def _ps(ep_size: int) -> ParallelState:
@@ -27,12 +34,21 @@ def _build(ep_size: int, dispatcher_type: str) -> TokenDispatcher:
     )
 
 
+@pytest.fixture
+def without_backend(monkeypatch):
+    def _uninstall(dispatcher_type):
+        monkeypatch.setattr(dispatcher_mod, _BACKEND_SYMBOL[dispatcher_type], None)
+
+    return _uninstall
+
+
 @pytest.mark.parametrize(
     "dispatcher_type, hint",
     [("deepep", "github.com/deepseek-ai/DeepEP"), ("hybridep", "hybrid-ep")],
 )
-def test_requesting_an_uninstalled_backend_fails_loud(dispatcher_type, hint):
-    # Neither package is importable here, so this is the "dependency missing" case.
+def test_requesting_an_uninstalled_backend_fails_loud(dispatcher_type, hint, without_backend):
+    without_backend(dispatcher_type)
+
     with pytest.raises(RuntimeError) as excinfo:
         _build(ep_size=2, dispatcher_type=dispatcher_type)
 
@@ -45,10 +61,25 @@ def test_requesting_an_uninstalled_backend_fails_loud(dispatcher_type, hint):
 
 
 @pytest.mark.parametrize("dispatcher_type", ["deepep", "hybridep"])
-def test_uninstalled_backend_does_not_silently_become_alltoall(dispatcher_type):
+def test_uninstalled_backend_does_not_silently_become_alltoall(dispatcher_type, without_backend):
     # The regression guard proper. Under the old `use_deepep` flag this construction
     # succeeded and quietly ran AllToAll; nothing downstream could tell.
+    without_backend(dispatcher_type)
+
     with pytest.raises(RuntimeError):
+        _build(ep_size=2, dispatcher_type=dispatcher_type)
+
+
+@pytest.mark.parametrize("dispatcher_type", ["deepep", "hybridep"])
+def test_installed_backend_without_a_process_group_fails_loud(dispatcher_type, monkeypatch):
+    # Both backends dispatch over the ETPxEP group. Reaching this point with an
+    # uninitialised ParallelState used to trip a bare `assert`, which says nothing about
+    # what to do next -- and disappears entirely under `python -O`.
+    # Presence is simulated so this runs the same way with or without DeepEP installed;
+    # the group check comes first, so the stand-in is never called.
+    monkeypatch.setattr(dispatcher_mod, _BACKEND_SYMBOL[dispatcher_type], object())
+
+    with pytest.raises(RuntimeError, match="tp_ep_group"):
         _build(ep_size=2, dispatcher_type=dispatcher_type)
 
 

--- a/experimental/lite/tests/unit/runtime/backends/mlite/test_runtime_backend_unit.py
+++ b/experimental/lite/tests/unit/runtime/backends/mlite/test_runtime_backend_unit.py
@@ -99,14 +99,14 @@ def test_mlite_config_impl_cfg_optimizer_and_load_gate():
     hook = lambda cfg: cfg  # noqa: E731
     cfg = MegatronLiteConfig(
         model_name="qwen3_moe",
-        impl_cfg={"recompute": "full", "use_deepep": True},
+        impl_cfg={"recompute": "full", "moe_token_dispatcher_type": "deepep"},
         optimizer=OptimizerConfig(lr=1e-4, weight_decay=0.1, adam_beta1=0.9),
         load_hf_weights=False,
         model_config_hook=hook,
     )
 
     assert cfg.impl_cfg["recompute"] == "full"
-    assert cfg.impl_cfg["use_deepep"] is True
+    assert cfg.impl_cfg["moe_token_dispatcher_type"] == "deepep"
     assert cfg.optimizer.lr == 1e-4
     assert cfg.optimizer.adam_beta1 == 0.9
     assert cfg.load_hf_weights is False


### PR DESCRIPTION
## What

Replaces the boolean `use_deepep` with a typed `moe_token_dispatcher_type: Literal['alltoall', 'deepep', 'hybridep']`, and wires up HybridEP as a third dispatch backend. The old flag is removed outright -- no compatibility alias -- with `False -> 'alltoall'` and `True -> 'deepep'` preserving every call site's default. `use_deepep` has 0 occurrences left under `experimental/lite`.

This mirrors a move mcore already made: it folded its own `moe_enable_deepep` boolean into a typed dispatcher selection. mcore spells it in two levels (`moe_token_dispatcher_type='flex'` plus `moe_flex_dispatcher_backend='deepep'|'hybridep'|'ncclep'`); MLite deliberately flattens that to a single three-valued option, while the backend implementation is ported faithfully.

## A requested backend that is missing now fails loudly

The old selection was `use_deepep and deep_ep is not None`, so a DeepEP run on a machine without DeepEP silently became an AllToAll run -- "dependency missing" and "backend switched off" were the same observable state. An explicitly requested backend now raises with an actionable message instead. This is the one intentional behaviour change; `ep_size <= 1` still degenerates to the local permute for every backend, since there is no dispatch to perform.

A bare `assert ps.tp_ep_group is not None` on the same path became a real error too -- it said nothing about what to do next, and vanishes under `python -O`.

## The AllToAll and DeepEP data paths are untouched

Comparing `TokenDispatcher` methods against `main` at the AST level:

| method | verdict |
| --- | --- |
| `_dispatch_alltoall`, `_combine_alltoall` | byte-identical |
| `_dispatch_deepep`, `_combine_deepep`, `_finish_deepep_dispatch` | byte-identical |
| `_dispatch_local`, `_combine_local`, `wait_dispatch_event` | byte-identical |
| `submit_deepep_*`, `finish_deepep_*` (4) | identical except the `use_deepep` guard rename |
| `__init__`, `dispatch`, `combine` | backend selection only |
| `_dispatch_hybridep`, `_combine_hybridep` | new |

Only 14 lines are removed from `dispatcher.py`, all of them the docstring, the flag declaration, the selection expression, or a renamed guard. Dispatch/combine call order, collective order and autograd boundaries are unchanged. The four `submit_deepep_*`/`finish_deepep_*` APIs keep their names: they are genuinely DeepEP-specific and HybridEP does not share them.

## HybridEP

Ported from `_HybridEPManager` and the `hybrid_ep_*` helpers in `fused_a2a.py`. Two deliberate departures from a literal copy:

- **Called against the installed DeepEP, not the newest one.** mcore passes `non_blocking=` to `dispatch_with_permute`; DeepEP 1.2.1 has no such parameter (it has `use_host_meta` instead), so a verbatim copy raises `TypeError`. The dropless path wants host-side metadata anyway, which is that parameter's default.
- **No knobs.** The SM/block-count tuning knobs are left at HybridEP's defaults, and kernel-level permute fusion is left off -- mcore guards it with a version sniff that silently downgrades, and the installed version does not support it, so the branch can never be taken. Uneven per-rank token counts are padded unconditionally rather than behind a flag: THD packing makes them routine, and this is correctness, not tuning.

HybridEP also returns `tokens_per_expert` on the host, while every other backend returns it on the compute device and downstream expert grouping indexes with it; it is moved back to match.

Two HybridEP constraints worth knowing, both documented in the example: `hidden_size` must be a multiple of 512 (its kernel static-asserts a 16B scaling-factor row; DeepSeek-V4 7168, Qwen3-MoE 4096 and GLM 5120 all clear it), and `CUDA_HOME` must be set.

## Validation

Run in the pinned container on 8x H100.

**No regression.** Both arms in one allocation, `main` vs this branch, `tests/run_tests.sh` at `profile=standard`:

| arm | passed | failed | skipped | xfailed | errors |
| --- | --- | --- | --- | --- | --- |
| `main` | 701 | 0 | 5 | 1 | 0 |
| this branch | 718 | 0 | 5 | 1 | 0 |

Identical failure profile; `+17` is exactly the new tests. Both arms report `status=FAIL` from the same 5 pre-existing skips under the repo's skip-is-not-pass rule.

**HybridEP on 8 ranks.** `ep=8`, 2 local experts of 16, hidden 1024, bf16, with deliberately ragged per-rank token counts (256..480) to exercise the padding path. Against the AllToAll reference on identical inputs, every rank agrees **bitwise** in both directions -- `fwd_absmax=0.000e+00`, `bwd_absmax=0.000e+00`, matching row counts (694/741/739/708/793/758/715/740). The expert stand-in is permutation-equivariant, so the two backends' differing internal layouts are compared fairly.

The new unit tests carry a negative control: reverting the fail-loud check to the old silent fallback turns exactly the 4 dependency tests red and leaves the other 13 green.

## Usage

```
torchrun --nproc_per_node=8 examples/moe_token_dispatcher.py \\
    --dispatcher-type hybridep --compare-with alltoall
```

Copied from `NVIDIA/Megatron-LM@19deef67f` (fetched 2026-08-19); `token_dispatcher.py` and `fused_a2a.py` are unchanged there since `d262dbed3`.