### PR TITLE
feat(lite): add deterministic DeepEP and FP8 primitives

### DIFF
--- a/experimental/lite/megatron/lite/model/deepseek_v4/quantization.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/quantization.py
@@ -1,0 +1,18 @@
+"""DeepSeek-V4 checkpoint quantization policy shared by load and resync."""
+
+
+def is_release_unquantized_weight(name: str) -> bool:
+    """Return whether the official V4 release stores ``name`` unscaled."""
+
+    if name in {"embed.weight", "head.weight", "norm.weight"}:
+        return True
+    if name.endswith("norm.weight") or name.endswith(".ffn.gate.weight"):
+        return True
+    if ".attn.compressor." in name:
+        return True
+    return ".attn.indexer." in name and not name.endswith(
+        ".attn.indexer.wq_b.weight"
+    )
+
+
+__all__ = ["is_release_unquantized_weight"]

--- a/experimental/lite/megatron/lite/primitive/alignment/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/alignment/__init__.py
@@ -1,0 +1,6 @@
+"""Numerical-alignment primitives ported from THUDM/slime.
+
+The DeepEP route and DeepGEMM MoE implementation is kept structurally aligned
+with slime commit a74ae3a0 (Apache-2.0) and adapted only at import boundaries.
+"""
+

--- a/experimental/lite/megatron/lite/primitive/alignment/deepep_route.py
+++ b/experimental/lite/megatron/lite/primitive/alignment/deepep_route.py
@@ -1,0 +1,715 @@
+"""Normal-DeepEP route alignment for the vLLM low-latency MoE layout.
+
+Route ordering follows THUDM/slime a74ae3a0; execution uses vLLM primitives.
+"""
+
+from __future__ import annotations
+
+import torch
+
+_BACKWARD_CHUNK_ROWS = 1024
+
+def _ordered_route_backward(
+    *,
+    route_values: torch.Tensor,
+    topk_weights: torch.Tensor,
+    output_index: torch.Tensor,
+    grad_output: torch.Tensor,
+    grad_routes: torch.Tensor | None,
+    grad_weights: torch.Tensor | None,
+    static_mapping_valid: bool | None = None,
+) -> None:
+    """Differentiate the ordered top-k gather with an optional static fast path."""
+    routes_alias_values = (
+        grad_routes is not None
+        and grad_routes.untyped_storage().data_ptr() == route_values.untyped_storage().data_ptr()
+    )
+    use_static_mapping = static_mapping_valid is not None
+    if use_static_mapping and static_mapping_valid is None:
+        # The hot DeepEP caller passes this bit from its forward scatter,
+        # where torch.nonzero has already exposed the route count to Python.
+        # Other internal callers retain a safe fallback instead of assuming
+        # that padded token slots own an expert-output row.
+        static_mapping_valid = bool(torch.all(output_index >= 0).item())
+    if use_static_mapping and static_mapping_valid:
+        # Dropless fixed-top-k routing produces exactly one valid route row for
+        # every flattened [token, top-k] slot.  Express that static mapping
+        # directly instead of materializing torch.nonzero's data-dependent
+        # output and synchronizing once per MoE layer.
+        num_routes = output_index.numel()
+        topk = output_index.shape[1]
+        flat_output_index = output_index.reshape(-1)
+        flat_weights = topk_weights.reshape(-1)
+        flat_grad_weights = grad_weights.reshape(-1) if grad_weights is not None else None
+        chunk_rows = _BACKWARD_CHUNK_ROWS
+        # When the forward combine input is dead after this operation, its
+        # route-sized storage can hold the route gradient.  Complete every
+        # probability gradient first because it still reads the original
+        # route values; only then overwrite that storage with route gradients.
+        if routes_alias_values and flat_grad_weights is not None:
+            for start in range(0, num_routes, chunk_rows):
+                end = min(start + chunk_rows, num_routes)
+                flat_positions = torch.arange(
+                    start,
+                    end,
+                    device=output_index.device,
+                    dtype=torch.long,
+                )
+                token_rows = torch.div(flat_positions, topk, rounding_mode="floor")
+                route_rows = flat_output_index[start:end].to(dtype=torch.long)
+                token_grads = grad_output.index_select(0, token_rows)
+                selected_route_values = route_values.index_select(0, route_rows)
+                weight_grads = (token_grads.float() * selected_route_values.float()).sum(dim=-1)
+                flat_grad_weights[start:end].copy_(weight_grads)
+
+        fused_route_grad = False
+        if grad_routes is not None and grad_output.is_cuda:
+            from megatron.lite.primitive.alignment.deterministic_route_kernels import ordered_route_grad
+
+            ordered_route_grad(
+                grad_output.contiguous(),
+                topk_weights.contiguous(),
+                output_index.contiguous(),
+                grad_routes,
+            )
+            fused_route_grad = True
+
+        if (grad_routes is not None and not fused_route_grad) or (
+            flat_grad_weights is not None and not routes_alias_values
+        ):
+            for start in range(0, num_routes, chunk_rows):
+                end = min(start + chunk_rows, num_routes)
+                flat_positions = torch.arange(
+                    start,
+                    end,
+                    device=output_index.device,
+                    dtype=torch.long,
+                )
+                token_rows = torch.div(flat_positions, topk, rounding_mode="floor")
+                route_rows = flat_output_index[start:end].to(dtype=torch.long)
+                token_grads = grad_output.index_select(0, token_rows)
+                weights = flat_weights[start:end]
+
+                if grad_routes is not None and not fused_route_grad:
+                    route_grads = (token_grads.float() * weights.float().unsqueeze(1)).to(dtype=grad_routes.dtype)
+                    # Every static top-k slot maps to one distinct route row.
+                    grad_routes.index_copy_(0, route_rows, route_grads)
+                if flat_grad_weights is not None and not routes_alias_values:
+                    selected_route_values = route_values.index_select(0, route_rows)
+                    weight_grads = (token_grads.float() * selected_route_values.float()).sum(dim=-1)
+                    flat_grad_weights[start:end].copy_(weight_grads)
+        return
+
+    if use_static_mapping:
+        # Padding-aware fixed-shape path.  Mapping every masked slot to row 0
+        # keeps all intermediates bounded by chunk_rows and avoids allocating
+        # torch.nonzero's data-dependent route table.  Masked slots write an
+        # exact zero; row 0 is restored in a final ordered kernel, so duplicate
+        # sentinel writes cannot affect the visible gradient.
+        num_slots = output_index.numel()
+        num_route_rows = route_values.shape[0]
+        flat_output_index = output_index.reshape(-1)
+        flat_weights = topk_weights.reshape(-1)
+        flat_grad_weights = grad_weights.reshape(-1) if grad_weights is not None else None
+        chunk_rows = _BACKWARD_CHUNK_ROWS
+
+        if num_route_rows == 0:
+            if grad_routes is not None:
+                grad_routes.zero_()
+            if flat_grad_weights is not None:
+                flat_grad_weights.zero_()
+            return
+
+        def probability_grad_chunk(start: int, end: int) -> None:
+            flat_positions = torch.arange(
+                start,
+                end,
+                device=output_index.device,
+                dtype=torch.long,
+            )
+            token_rows = torch.div(
+                flat_positions,
+                output_index.shape[1],
+                rounding_mode="floor",
+            )
+            route_rows = flat_output_index[start:end].to(dtype=torch.long)
+            valid_rows = route_rows >= 0
+            safe_route_rows = route_rows.clamp(min=0, max=num_route_rows - 1)
+            token_grads = grad_output.index_select(0, token_rows)
+            selected_route_values = route_values.index_select(0, safe_route_rows)
+            weight_grads = (token_grads.float() * selected_route_values.float()).sum(dim=-1)
+            weight_grads.masked_fill_(~valid_rows, 0)
+            flat_grad_weights[start:end].copy_(weight_grads)
+
+        if routes_alias_values and flat_grad_weights is not None:
+            for start in range(0, num_slots, chunk_rows):
+                probability_grad_chunk(start, min(start + chunk_rows, num_slots))
+
+        if grad_routes is not None and routes_alias_values:
+            grad_routes.zero_()
+
+        for start in range(0, num_slots, chunk_rows):
+            end = min(start + chunk_rows, num_slots)
+            flat_positions = torch.arange(
+                start,
+                end,
+                device=output_index.device,
+                dtype=torch.long,
+            )
+            token_rows = torch.div(
+                flat_positions,
+                output_index.shape[1],
+                rounding_mode="floor",
+            )
+            route_rows = flat_output_index[start:end].to(dtype=torch.long)
+            valid_rows = route_rows >= 0
+            safe_route_rows = route_rows.clamp(min=0, max=num_route_rows - 1)
+            token_grads = grad_output.index_select(0, token_rows)
+
+            if grad_routes is not None:
+                weights = flat_weights[start:end].float().masked_fill(~valid_rows, 0)
+                route_grads = (token_grads.float() * weights.unsqueeze(1)).to(dtype=grad_routes.dtype)
+                grad_routes.index_copy_(0, safe_route_rows, route_grads)
+            if flat_grad_weights is not None and not routes_alias_values:
+                selected_route_values = route_values.index_select(0, safe_route_rows)
+                weight_grads = (token_grads.float() * selected_route_values.float()).sum(dim=-1)
+                weight_grads.masked_fill_(~valid_rows, 0)
+                flat_grad_weights[start:end].copy_(weight_grads)
+
+        if grad_routes is not None:
+            route_zero_matches = flat_output_index == 0
+            torch._assert_async(
+                torch.any(route_zero_matches),
+                "non-empty expert output has no route mapped to row zero",
+            )
+            route_zero_position = torch.argmax(route_zero_matches.to(dtype=torch.int32)).reshape(1)
+            route_zero_token = torch.div(
+                route_zero_position,
+                output_index.shape[1],
+                rounding_mode="floor",
+            )
+            route_zero_weight = flat_weights.index_select(0, route_zero_position).float()
+            route_zero_grad = (
+                grad_output.index_select(0, route_zero_token).float() * route_zero_weight.unsqueeze(1)
+            ).to(dtype=grad_routes.dtype)
+            grad_routes.narrow(0, 0, 1).copy_(route_zero_grad)
+        return
+
+    valid_positions = torch.nonzero(output_index >= 0, as_tuple=False)
+    # If the returned input gradient aliases route_values, finish every
+    # probability gradient before clearing or overwriting that storage.
+    # Padded DeepEP batches contain -1 output indices, and aligned expert rows
+    # not referenced by a real token must receive a zero gradient.
+    if routes_alias_values and grad_weights is not None:
+        for start in range(0, valid_positions.shape[0], _BACKWARD_CHUNK_ROWS):
+            end = min(start + _BACKWARD_CHUNK_ROWS, valid_positions.shape[0])
+            positions = valid_positions[start:end]
+            token_rows = positions[:, 0]
+            topk_columns = positions[:, 1]
+            route_rows = output_index[token_rows, topk_columns].to(dtype=torch.long)
+            token_grads = grad_output.index_select(0, token_rows)
+            selected_route_values = route_values.index_select(0, route_rows)
+            weight_grads = (token_grads.float() * selected_route_values.float()).sum(dim=-1)
+            grad_weights[token_rows, topk_columns] = weight_grads
+
+    if grad_routes is not None and routes_alias_values:
+        grad_routes.zero_()
+
+    for start in range(0, valid_positions.shape[0], _BACKWARD_CHUNK_ROWS):
+        end = min(start + _BACKWARD_CHUNK_ROWS, valid_positions.shape[0])
+        positions = valid_positions[start:end]
+class _DeepEPScatterWithDeterministicBackward(torch.autograd.Function):
+    """Scatter routes with a deterministic backward."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        hidden_states: torch.Tensor,
+        output_index: torch.Tensor,
+        total_rows: int,
+    ) -> torch.Tensor:
+        output = hidden_states.new_zeros((int(total_rows), hidden_states.shape[1]))
+        if hidden_states.is_cuda:
+            from megatron.lite.primitive.alignment.deterministic_route_kernels import scatter_routes_forward
+
+            scatter_routes_forward(
+                hidden_states.contiguous(),
+                output_index.contiguous(),
+                output,
+            )
+        else:
+            valid_positions = torch.nonzero(output_index >= 0, as_tuple=False)
+            for start in range(0, valid_positions.shape[0], _BACKWARD_CHUNK_ROWS):
+                positions = valid_positions[start : start + _BACKWARD_CHUNK_ROWS]
+                token_rows = positions[:, 0]
+                topk_columns = positions[:, 1]
+                destination_rows = output_index[token_rows, topk_columns].to(dtype=torch.long)
+                output.index_copy_(
+                    0,
+                    destination_rows,
+                    hidden_states.index_select(0, token_rows),
+                )
+
+        ctx.input_shape = tuple(hidden_states.shape)
+        ctx.input_dtype = hidden_states.dtype
+        ctx.input_device = hidden_states.device
+        ctx.save_for_backward(output_index)
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        if not ctx.needs_input_grad[0]:
+            return None, None, None
+
+        (output_index,) = ctx.saved_tensors
+        grad_input = torch.zeros(
+            ctx.input_shape,
+            dtype=ctx.input_dtype,
+            device=ctx.input_device,
+        )
+        if grad_output.is_cuda:
+            from megatron.lite.primitive.alignment.deterministic_route_kernels import scatter_routes_backward
+
+            scatter_routes_backward(
+                grad_output.contiguous(),
+                output_index.contiguous(),
+                grad_input,
+            )
+        else:
+            # Accumulate top-k slots in their original order.  Each token row
+            # is owned by one thread here, avoiding the nondeterministic
+            # atomics that an index_add over expert-major occurrences would
+            # require.
+            for start in range(0, output_index.shape[0], _BACKWARD_CHUNK_ROWS):
+                end = min(start + _BACKWARD_CHUNK_ROWS, output_index.shape[0])
+                grad_chunk = grad_input[start:end]
+                for column in range(output_index.shape[1]):
+                    route_rows = output_index[start:end, column].to(dtype=torch.long)
+                    valid_rows = route_rows >= 0
+                    safe_route_rows = route_rows.clamp(min=0, max=max(grad_output.shape[0] - 1, 0))
+                    if grad_output.shape[0] == 0:
+                        continue
+                    selected = grad_output.index_select(0, safe_route_rows)
+                    selected.masked_fill_(~valid_rows.unsqueeze(1), 0)
+                    grad_chunk.add_(selected)
+        return grad_input, None, None
+
+
+def _scatter_deepep_routes_with_padding(
+    hidden_states: torch.Tensor,
+    topk_indices: torch.Tensor,
+    topk_weights: torch.Tensor,
+    tokens_per_expert: torch.Tensor,
+    *,
+    return_route_positions: bool = False,
+    expected_route_count: int | None = None,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    bool,
+    torch.Tensor,
+]:
+    """Build vLLM LL's expert-major DeepEP layout deterministically."""
+    if hidden_states.ndim != 2 or topk_indices.ndim != 2:
+        raise ValueError("DeepEP scatter expects [tokens, hidden] and [tokens, topk]")
+    if topk_indices.shape != topk_weights.shape:
+        raise ValueError("DeepEP top-k indices and weights must have identical shapes")
+    if hidden_states.shape[0] != topk_indices.shape[0]:
+        raise ValueError("DeepEP hidden-state and top-k token dimensions differ")
+    if topk_indices.dtype not in (torch.int32, torch.int64):
+        raise TypeError(f"DeepEP top-k indices must be integer, got {topk_indices.dtype}")
+    if topk_weights.dtype != torch.float32:
+        raise TypeError(f"DeepEP top-k weights must be FP32, got {topk_weights.dtype}")
+
+    if tokens_per_expert.device.type == "cpu":
+        # Normal DeepEP returns this metadata as a CPU tensor constructed from
+        # its receive-count list.  The output row count is consequently
+        # already known to Python; do not upload the counts only to block on a
+        # device sum immediately afterwards.
+        count_values = tuple(int(value) for value in tokens_per_expert.reshape(-1).tolist())
+        total_rows = sum(count_values)
+    else:
+        count_values = None
+
+    num_experts = tokens_per_expert.numel()
+    valid = (topk_indices >= 0) & (topk_indices < num_experts)
+    sanitized_indices = topk_indices.masked_fill(~valid, -1)
+    real_counts = torch.bincount(
+        sanitized_indices.masked_select(valid).to(dtype=torch.long),
+        minlength=num_experts,
+    )
+
+    # The route-preserving metadata handle gives Python the exact number of
+    # received routes.  Normal DeepEP's CPU count list is unpadded in this
+    # case, so ``real_counts`` is the same per-expert metadata already resident
+    # on CUDA.  Reusing it avoids a blocking pageable-CPU-to-CUDA upload once
+    # per MoE layer (and again during checkpoint recomputation).  Retain the
+    # original upload for aligned/padded layouts and callers without the exact
+    # route count.
+    counts_are_exact_unpadded = (
+        count_values is not None and expected_route_count is not None and total_rows == expected_route_count
+    )
+    if counts_are_exact_unpadded:
+        counts = real_counts
+        torch._assert_async(
+            real_counts.sum() == expected_route_count,
+            "DeepEP received route count differs from its route-preserving metadata",
+        )
+    else:
+        counts = tokens_per_expert.to(
+            device=topk_indices.device,
+            dtype=torch.long,
+        ).reshape(-1)
+    torch._assert_async(
+        torch.all(real_counts <= counts),
+        "DeepEP real route count exceeds its aligned expert count",
+    )
+
+    if count_values is None:
+        total_rows = int(counts.sum().item())
+    permuted_probs = topk_weights.new_zeros((total_rows,))
+    output_index = torch.full_like(topk_indices, -1)
+    routing_map = torch.zeros(
+        (topk_indices.shape[0], num_experts),
+        device=topk_indices.device,
+        dtype=torch.bool,
+    )
+    expert_offsets = torch.cumsum(counts, dim=0) - counts
+
+    if expected_route_count is not None and valid.is_cuda:
+        from megatron.lite.primitive.alignment.deterministic_route_kernels import compact_route_positions
+
+        occurrences = compact_route_positions(valid.contiguous(), expected_route_count)
+    else:
+        occurrences = torch.nonzero(valid, as_tuple=False)
+    # The metadata handle exposes the compact route count as tensor shape.  If
+    # it is available, use that static value instead of forcing nonzero to
+    # report its data-dependent output size to Python.
+    route_count = occurrences.shape[0] if expected_route_count is None else expected_route_count
+    all_routes_valid = route_count == topk_indices.numel()
+    if occurrences.numel():
+        token_rows = occurrences[:, 0]
+        topk_columns = occurrences[:, 1]
+        route_experts = sanitized_indices[token_rows, topk_columns].to(dtype=torch.long)
+        expert_order = torch.argsort(route_experts, stable=True)
+        token_rows = token_rows.index_select(0, expert_order)
+        topk_columns = topk_columns.index_select(0, expert_order)
+        route_experts = route_experts.index_select(0, expert_order)
+
+        real_offsets = torch.cumsum(real_counts, dim=0) - real_counts
+        within_expert = torch.arange(
+            route_experts.numel(),
+            device=hidden_states.device,
+            dtype=torch.long,
+        ) - real_offsets.index_select(0, route_experts)
+        destination_rows = expert_offsets.index_select(0, route_experts) + within_expert
+        permuted_probs.index_copy_(
+            0,
+            destination_rows,
+            topk_weights[token_rows, topk_columns],
+        )
+        output_index[token_rows, topk_columns] = destination_rows.to(dtype=output_index.dtype)
+        routing_map[token_rows, route_experts] = True
+
+    torch._assert_async(
+        torch.all(~valid | (output_index >= 0)),
+        "A valid DeepEP route has no expert-major output row",
+    )
+    permuted_hidden = _DeepEPScatterWithDeterministicBackward.apply(
+        hidden_states,
+        output_index,
+        total_rows,
+    )
+    result = (
+        permuted_hidden,
+        permuted_probs,
+        output_index,
+        sanitized_indices,
+        routing_map,
+        all_routes_valid,
+        real_counts,
+    )
+    if return_route_positions:
+        return (*result, occurrences)
+    return result
+
+
+class _VLLMEPGatherWithBF16Backward(torch.autograd.Function):
+    """vLLM rollout's ordered FP32 gather with a deterministic BF16 backward."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        hidden_states: torch.Tensor,
+        topk_indices: torch.Tensor,
+        topk_weights: torch.Tensor,
+        output_index: torch.Tensor,
+        reuse_input_for_grad: bool,
+        static_mapping_valid: bool | None,
+    ) -> torch.Tensor:
+        if hidden_states.ndim != 2 or hidden_states.dtype != torch.bfloat16:
+            raise TypeError(
+                "vLLM ep_gather requires BF16 [expert_rows, hidden], got "
+                f"{hidden_states.dtype} {tuple(hidden_states.shape)}"
+            )
+        if topk_indices.shape != topk_weights.shape or topk_indices.shape != output_index.shape:
+            raise ValueError("DeepEP gather IDs, weights, and output indices must align")
+        from vllm.model_executor.layers.fused_moe.deep_gemm_utils import ep_gather
+
+        output_shape = (topk_indices.shape[0], hidden_states.shape[1])
+        output = torch.empty(
+            output_shape,
+            device=hidden_states.device,
+            dtype=hidden_states.dtype,
+        )
+        ep_gather(
+            hidden_states,
+            topk_indices,
+            topk_weights,
+            output_index,
+            None,
+            output,
+        )
+        ctx.reuse_input_for_grad = bool(reuse_input_for_grad)
+        ctx.static_mapping_valid = static_mapping_valid
+        ctx.save_for_backward(hidden_states, topk_weights, output_index)
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        hidden_states, topk_weights, output_index = ctx.saved_tensors
+        needs_hidden = ctx.needs_input_grad[0]
+        needs_weights = ctx.needs_input_grad[2]
+        if needs_hidden and ctx.reuse_input_for_grad:
+            # The caller guarantees this combine input has no forward consumer
+            # after ep_gather.  Returning its detached storage as the input
+            # gradient avoids a second route-sized BF16 allocation.
+            grad_hidden = hidden_states.detach()
+        else:
+            grad_hidden = torch.zeros_like(hidden_states) if needs_hidden else None
+        grad_weights = torch.zeros_like(topk_weights) if needs_weights else None
+
+        _ordered_route_backward(
+            route_values=hidden_states,
+            topk_weights=topk_weights,
+            output_index=output_index,
+            grad_output=grad_output,
+            grad_routes=grad_hidden,
+            grad_weights=grad_weights,
+            static_mapping_valid=ctx.static_mapping_valid,
+        )
+
+        return grad_hidden, None, grad_weights, None, None, None
+
+
+def _compact_route_preserving_metadata_inputs(
+    hidden_states: torch.Tensor,
+    topk_indices: torch.Tensor,
+    topk_weights: torch.Tensor,
+    *,
+    assume_all_routes_valid: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, bool]:
+    """Build the small route-level dispatch used by the normal-mode prototype.
+
+    The real hidden state remains rank-deduplicated in the primary DeepEP
+    dispatch.  This second dispatch only carries a sixteen-BF16 fingerprint and
+    creates a normal DeepEP handle whose logical tokens are ``(token, slot)``.
+    The handle can consequently transport the real route outputs during
+    combine without multiplying dispatch hidden traffic by top-k.
+
+    Sixteen BF16 values are the smallest payload accepted by DeepEP's normal
+    intranode dispatch: its TMA path requires the hidden payload to be a
+    multiple of 32 bytes.  Keeping that constraint explicit here prevents a
+    device-side assertion for otherwise-valid route metadata.
+    """
+    if hidden_states.ndim != 2 or hidden_states.dtype != torch.bfloat16:
+        raise TypeError(
+            "Route-preserving DeepEP metadata requires BF16 [tokens, hidden], "
+            f"got {hidden_states.dtype} {tuple(hidden_states.shape)}"
+        )
+    if hidden_states.shape[1] < 16:
+        raise ValueError("Route-preserving DeepEP fingerprints require hidden >= 16")
+    if topk_indices.ndim != 2 or topk_weights.shape != topk_indices.shape:
+        raise ValueError("Route-preserving DeepEP top-k IDs and weights must align")
+    if topk_indices.shape[0] != hidden_states.shape[0]:
+        raise ValueError("Route-preserving DeepEP token counts do not align")
+    if topk_indices.dtype not in (torch.int32, torch.int64):
+        raise TypeError(f"Route-preserving DeepEP IDs must be integer, got {topk_indices.dtype}")
+    if topk_weights.dtype != torch.float32:
+        raise TypeError(f"Route-preserving DeepEP weights must be FP32, got {topk_weights.dtype}")
+
+    flat_indices = topk_indices.reshape(-1)
+    if assume_all_routes_valid:
+        # With no capacity factor and no router token mask, the router emits a
+        # fixed valid top-k for every source token.  Keep this fast path tied
+        # to that structural guarantee instead of synchronizing on nonzero's
+        # data-dependent output once per MoE layer.
+        torch._assert_async(
+            torch.all(flat_indices >= 0),
+            "Route-preserving DeepEP expected a valid fixed top-k",
+        )
+        compact_indices = flat_indices.reshape(-1, 1).contiguous()
+        compact_weights = topk_weights.detach().reshape(-1, 1).contiguous()
+        fingerprints = (
+            hidden_states.detach()
+            .narrow(1, 0, 16)
+            .unsqueeze(1)
+            .expand(-1, topk_indices.shape[1], -1)
+            .reshape(-1, 16)
+            .contiguous()
+        )
+        output_index = torch.arange(
+            flat_indices.numel(),
+            device=flat_indices.device,
+            dtype=torch.long,
+        ).reshape_as(topk_indices)
+        return compact_indices, compact_weights, fingerprints, output_index, True
+
+    valid_positions = torch.nonzero(flat_indices >= 0, as_tuple=False).reshape(-1)
+    if valid_positions.numel() == 0:
+        raise RuntimeError("Route-preserving DeepEP received no valid expert routes")
+    compact_indices = flat_indices.index_select(0, valid_positions).reshape(-1, 1).contiguous()
+    compact_weights = topk_weights.detach().reshape(-1).index_select(0, valid_positions).reshape(-1, 1).contiguous()
+    token_rows = torch.div(valid_positions, topk_indices.shape[1], rounding_mode="floor")
+    fingerprints = hidden_states.detach().narrow(1, 0, 16).index_select(0, token_rows).contiguous()
+    output_index = torch.full_like(topk_indices, -1, dtype=torch.long)
+    output_index.reshape(-1).index_copy_(
+        0,
+        valid_positions,
+        torch.arange(valid_positions.numel(), device=valid_positions.device, dtype=torch.long),
+    )
+    all_routes_valid = valid_positions.numel() == topk_indices.numel()
+    return compact_indices, compact_weights, fingerprints, output_index, all_routes_valid
+
+
+def _deepep_route_handle_received_rows(handle: tuple) -> int:
+    """Return the received route count encoded by a normal DeepEP handle."""
+    if not isinstance(handle, tuple):
+        raise TypeError(f"DeepEP route handle must be a tuple, got {type(handle).__name__}")
+    if len(handle) == 6:
+        # Intranode: (..., recv_src_idx, ...).
+        received_metadata = handle[3]
+    elif len(handle) == 10:
+        # Internode: (..., recv_src_meta, ...).
+        received_metadata = handle[7]
+    else:
+        raise ValueError(f"Unsupported normal DeepEP route handle length: {len(handle)}")
+    if not isinstance(received_metadata, torch.Tensor) or received_metadata.ndim < 1:
+        raise TypeError("DeepEP route handle has invalid received-source metadata")
+    return received_metadata.shape[0]
+
+
+def _validate_and_order_route_preserving_outputs(
+    expert_outputs: torch.Tensor,
+    received_tokens: torch.Tensor,
+    received_topk_indices: torch.Tensor,
+    received_topk_weights: torch.Tensor,
+    output_index: torch.Tensor,
+    route_fingerprints: torch.Tensor,
+    route_indices: torch.Tensor,
+    route_weights: torch.Tensor,
+    *,
+    order_outputs: bool = True,
+    route_positions: torch.Tensor | None = None,
+    return_route_rows: bool = False,
+) -> torch.Tensor:
+    """Return expert outputs in the route handle's receive order.
+
+    Normal DeepEP's primary dispatch is rank-deduplicated: its received route
+    probabilities are not a reliable per-(token, slot) identity when one token
+    reaches multiple experts on the same rank.  Pair the primary hidden rows
+    with the route-preserving metadata by expert ID and a sixteen-BF16 source
+    fingerprint.  The metadata dispatch and the caller-owned source weights
+    remain authoritative for exact route probabilities.
+    """
+    if expert_outputs.ndim != 2 or received_tokens.ndim != 2:
+        raise ValueError("Route-preserving DeepEP expects 2D hidden tensors")
+    if received_topk_indices.shape != received_topk_weights.shape:
+        raise ValueError("Received DeepEP IDs and weights do not align")
+    if output_index.shape != received_topk_indices.shape:
+        raise ValueError("Received DeepEP route mapping does not align")
+
+    positions = torch.nonzero(output_index >= 0, as_tuple=False) if route_positions is None else route_positions
+    if positions.shape[0] != route_indices.numel():
+        raise RuntimeError(
+            "Route-preserving DeepEP route count mismatch: "
+            f"primary={positions.shape[0]} metadata={route_indices.numel()}"
+        )
+    token_rows = positions[:, 0]
+    topk_slots = positions[:, 1]
+    expected_indices = received_topk_indices[token_rows, topk_slots].reshape(-1)
+    expected_fingerprints = received_tokens.narrow(1, 0, 16).index_select(0, token_rows)
+    if route_fingerprints.shape != expected_fingerprints.shape:
+        raise RuntimeError(
+            "Route-preserving DeepEP fingerprint shape mismatch: "
+            f"{tuple(route_fingerprints.shape)} != {tuple(expected_fingerprints.shape)}"
+        )
+
+    def stable_key_order(
+        fingerprints: torch.Tensor,
+        indices: torch.Tensor,
+    ) -> torch.Tensor:
+        """Lexicographically order exact route identity without hashing."""
+        order = torch.arange(
+            indices.numel(), device=indices.device, dtype=torch.long
+        )
+        fingerprint_bits = fingerprints.contiguous().view(torch.int16)
+        columns = [
+            *(fingerprint_bits[:, column] for column in range(fingerprint_bits.shape[1])),
+            indices.to(dtype=torch.long),
+        ]
+        # Stable least-significant-to-most-significant sorts implement a
+        # deterministic lexicographic order and retain duplicate multiplicity.
+        for column in reversed(columns):
+            permutation = torch.argsort(
+                column.index_select(0, order), stable=True
+            )
+            order = order.index_select(0, permutation)
+        return order
+
+    primary_order = stable_key_order(expected_fingerprints, expected_indices)
+    metadata_order = stable_key_order(
+        route_fingerprints,
+        route_indices.to(dtype=expected_indices.dtype),
+    )
+    torch._assert_async(
+        torch.all(
+            expected_indices.index_select(0, primary_order)
+            == route_indices.to(dtype=expected_indices.dtype).index_select(
+                0, metadata_order
+            )
+        ),
+        "Route-preserving DeepEP metadata changed expert identities",
+    )
+    torch._assert_async(
+        torch.all(torch.isfinite(route_weights)),
+        "Route-preserving DeepEP metadata contains nonfinite route probabilities",
+    )
+    torch._assert_async(
+        torch.all(
+            expected_fingerprints.contiguous()
+            .view(torch.int16)
+            .index_select(0, primary_order)
+            == route_fingerprints.contiguous()
+            .view(torch.int16)
+            .index_select(0, metadata_order)
+        ),
+        "Route-preserving DeepEP metadata changed source fingerprints",
+    )
+
+    # metadata_to_primary[m] is the corresponding route occurrence in the
+    # primary hidden dispatch.  Stable ordering gives duplicate identities a
+    # deterministic one-to-one pairing; identical duplicates are semantically
+    # interchangeable.
+    metadata_to_primary = torch.empty_like(metadata_order)
+    metadata_to_primary.scatter_(0, metadata_order, primary_order)
+    primary_route_rows = output_index[token_rows, topk_slots].to(dtype=torch.long)
+    route_rows = primary_route_rows.index_select(0, metadata_to_primary)
+    if return_route_rows:
+        return route_rows
+    if not order_outputs:
+        return expert_outputs
+    return expert_outputs.index_select(0, route_rows)

--- a/experimental/lite/megatron/lite/primitive/alignment/deterministic_route_kernels.py
+++ b/experimental/lite/megatron/lite/primitive/alignment/deterministic_route_kernels.py
@@ -1,0 +1,296 @@
+"""Deterministic Triton kernels for route permutation gradients.
+
+These kernels only replace launch-heavy tensor indexing with equivalent
+pointwise copies or one-program-per-token ordered reductions.  They do not use
+atomics, and every visible output element has exactly one writer.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _scatter_routes_forward_kernel(
+    hidden_states,
+    output_index,
+    output,
+    num_slots,
+    hidden_size: tl.constexpr,
+    topk: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    hidden_block = tl.program_id(0)
+    first_slot = tl.program_id(1)
+    num_slot_programs = tl.num_programs(1)
+    hidden_offsets = hidden_block * BLOCK_D + tl.arange(0, BLOCK_D)
+    hidden_mask = hidden_offsets < hidden_size
+
+    for slot_i32 in range(first_slot, num_slots, num_slot_programs):
+        slot = slot_i32.to(tl.int64)
+        destination_i32 = tl.load(output_index + slot)
+        destination = destination_i32.to(tl.int64)
+        token = slot // topk
+        valid = destination_i32 >= 0
+        values = tl.load(
+            hidden_states + token * hidden_size + hidden_offsets,
+            mask=hidden_mask & valid,
+            other=0.0,
+        )
+        tl.store(
+            output + destination * hidden_size + hidden_offsets,
+            values,
+            mask=hidden_mask & valid,
+        )
+
+
+@triton.jit
+def _scatter_routes_backward_kernel(
+    grad_output,
+    output_index,
+    grad_input,
+    num_tokens,
+    grad_output_rows,
+    hidden_size: tl.constexpr,
+    topk: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    hidden_block = tl.program_id(0)
+    first_token = tl.program_id(1)
+    num_token_programs = tl.num_programs(1)
+    hidden_offsets = hidden_block * BLOCK_D + tl.arange(0, BLOCK_D)
+    hidden_mask = hidden_offsets < hidden_size
+
+    for token_i32 in range(first_token, num_tokens, num_token_programs):
+        token = token_i32.to(tl.int64)
+        accumulator = tl.zeros([BLOCK_D], dtype=tl.float32)
+        for route_slot in range(topk):
+            route_i32 = tl.load(output_index + token * topk + route_slot)
+            valid = (route_i32 >= 0) & (route_i32 < grad_output_rows)
+            safe_route = tl.maximum(route_i32, 0).to(tl.int64)
+            route_grad = tl.load(
+                grad_output + safe_route * hidden_size + hidden_offsets,
+                mask=hidden_mask & valid,
+                other=0.0,
+            ).to(tl.float32)
+            # The reference performs one BF16 in-place add per top-k slot.
+            # Keep that observable rounding boundary instead of accumulating
+            # all slots in FP32 and casting only once.
+            accumulator = (accumulator + route_grad).to(tl.bfloat16).to(tl.float32)
+        tl.store(
+            grad_input + token * hidden_size + hidden_offsets,
+            accumulator,
+            mask=hidden_mask,
+        )
+
+
+@triton.jit
+def _ordered_route_grad_kernel(
+    grad_output,
+    topk_weights,
+    output_index,
+    grad_routes,
+    num_slots,
+    hidden_size: tl.constexpr,
+    topk: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    hidden_block = tl.program_id(0)
+    first_slot = tl.program_id(1)
+    num_slot_programs = tl.num_programs(1)
+    hidden_offsets = hidden_block * BLOCK_D + tl.arange(0, BLOCK_D)
+    hidden_mask = hidden_offsets < hidden_size
+
+    for slot_i32 in range(first_slot, num_slots, num_slot_programs):
+        slot = slot_i32.to(tl.int64)
+        route_i32 = tl.load(output_index + slot)
+        route = route_i32.to(tl.int64)
+        token = slot // topk
+        valid = route_i32 >= 0
+        weight = tl.load(topk_weights + slot).to(tl.float32)
+        token_grad = tl.load(
+            grad_output + token * hidden_size + hidden_offsets,
+            mask=hidden_mask & valid,
+            other=0.0,
+        ).to(tl.float32)
+        tl.store(
+            grad_routes + route * hidden_size + hidden_offsets,
+            token_grad * weight,
+            mask=hidden_mask & valid,
+        )
+
+
+@triton.jit
+def _compact_route_positions_kernel(
+    valid,
+    prefix,
+    positions,
+    num_slots,
+    topk: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    flat_slot = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    in_bounds = flat_slot < num_slots
+    is_valid = tl.load(valid + flat_slot, mask=in_bounds, other=0).to(tl.int1)
+    compact_row = tl.load(prefix + flat_slot, mask=in_bounds, other=0).to(tl.int64) - 1
+    write_mask = in_bounds & is_valid
+    tl.store(
+        positions + compact_row * 2,
+        flat_slot // topk,
+        mask=write_mask,
+    )
+    tl.store(
+        positions + compact_row * 2 + 1,
+        flat_slot % topk,
+        mask=write_mask,
+    )
+
+
+def _validate_common(
+    value: torch.Tensor,
+    output_index: torch.Tensor,
+) -> None:
+    if not value.is_cuda or not output_index.is_cuda:
+        raise RuntimeError("deterministic route kernels require CUDA tensors")
+    if value.ndim != 2 or value.dtype != torch.bfloat16:
+        raise TypeError(
+            "deterministic route kernels require BF16 [rows, hidden], got " f"{value.dtype} {tuple(value.shape)}"
+        )
+    if output_index.ndim != 2 or output_index.dtype not in (torch.int32, torch.int64):
+        raise TypeError(
+            "deterministic route kernels require an integer [tokens, topk] mapping, got "
+            f"{output_index.dtype} {tuple(output_index.shape)}"
+        )
+    if not value.is_contiguous() or not output_index.is_contiguous():
+        raise RuntimeError("deterministic route kernel inputs must be contiguous")
+
+
+def scatter_routes_forward(
+    hidden_states: torch.Tensor,
+    output_index: torch.Tensor,
+    output: torch.Tensor,
+) -> None:
+    """Copy token rows into their unique expert-major route rows."""
+    _validate_common(hidden_states, output_index)
+    if output.ndim != 2 or output.dtype != hidden_states.dtype or not output.is_contiguous():
+        raise TypeError("deterministic route-scatter output must be contiguous BF16 [rows, hidden]")
+    hidden_size = hidden_states.shape[1]
+    block_d = 1024 if hidden_size >= 1024 else triton.next_power_of_2(hidden_size)
+    num_slot_programs = min(output_index.numel(), 8192)
+    grid = (triton.cdiv(hidden_size, block_d), num_slot_programs)
+    _scatter_routes_forward_kernel[grid](
+        hidden_states,
+        output_index,
+        output,
+        output_index.numel(),
+        hidden_size=hidden_size,
+        topk=output_index.shape[1],
+        BLOCK_D=block_d,
+        num_warps=4,
+    )
+
+
+def scatter_routes_backward(
+    grad_output: torch.Tensor,
+    output_index: torch.Tensor,
+    grad_input: torch.Tensor,
+) -> None:
+    """Sum route gradients in fixed top-k order into token rows."""
+    _validate_common(grad_output, output_index)
+    if (
+        grad_input.shape != (output_index.shape[0], grad_output.shape[1])
+        or grad_input.dtype != grad_output.dtype
+        or not grad_input.is_contiguous()
+    ):
+        raise TypeError("deterministic route-scatter input gradient has an invalid layout")
+    hidden_size = grad_output.shape[1]
+    block_d = 1024 if hidden_size >= 1024 else triton.next_power_of_2(hidden_size)
+    num_token_programs = min(output_index.shape[0], 2048)
+    grid = (triton.cdiv(hidden_size, block_d), num_token_programs)
+    _scatter_routes_backward_kernel[grid](
+        grad_output,
+        output_index,
+        grad_input,
+        output_index.shape[0],
+        grad_output.shape[0],
+        hidden_size=hidden_size,
+        topk=output_index.shape[1],
+        BLOCK_D=block_d,
+        num_warps=4,
+    )
+
+
+def ordered_route_grad(
+    grad_output: torch.Tensor,
+    topk_weights: torch.Tensor,
+    output_index: torch.Tensor,
+    grad_routes: torch.Tensor,
+) -> None:
+    """Write each token/slot gradient to its unique route row."""
+    _validate_common(grad_output, output_index)
+    if topk_weights.shape != output_index.shape or topk_weights.dtype != torch.float32:
+        raise TypeError("ordered route gradients require FP32 [tokens, topk] weights")
+    if not topk_weights.is_cuda or not topk_weights.is_contiguous():
+        raise RuntimeError("ordered route-gradient weights must be contiguous CUDA tensors")
+    if (
+        grad_routes.ndim != 2
+        or grad_routes.shape[1] != grad_output.shape[1]
+        or grad_routes.dtype != grad_output.dtype
+        or not grad_routes.is_cuda
+        or not grad_routes.is_contiguous()
+    ):
+        raise TypeError("ordered route-gradient output has an invalid layout")
+    hidden_size = grad_output.shape[1]
+    block_d = 1024 if hidden_size >= 1024 else triton.next_power_of_2(hidden_size)
+    num_slot_programs = min(output_index.numel(), 8192)
+    grid = (triton.cdiv(hidden_size, block_d), num_slot_programs)
+    _ordered_route_grad_kernel[grid](
+        grad_output,
+        topk_weights,
+        output_index,
+        grad_routes,
+        output_index.numel(),
+        hidden_size=hidden_size,
+        topk=output_index.shape[1],
+        BLOCK_D=block_d,
+        num_warps=4,
+    )
+
+
+def compact_route_positions(
+    valid: torch.Tensor,
+    num_routes: int,
+) -> torch.Tensor:
+    """Compact a row-major fixed-top-k validity mask without a host sync."""
+    if valid.ndim != 2 or valid.dtype != torch.bool or not valid.is_cuda:
+        raise ValueError("route-position compaction requires a CUDA bool [tokens, topk] mask")
+    if num_routes < 0 or num_routes > valid.numel():
+        raise ValueError(f"invalid compact route count {num_routes} for {valid.numel()} slots")
+
+    flat_valid = valid.reshape(-1).contiguous()
+    prefix = torch.cumsum(flat_valid, dim=0, dtype=torch.int32)
+    positions = torch.empty(
+        (num_routes, 2),
+        device=valid.device,
+        dtype=torch.long,
+    )
+    if flat_valid.numel():
+        torch._assert_async(
+            prefix[-1] == num_routes,
+            "DeepEP compact route count differs from its metadata handle",
+        )
+    if num_routes:
+        block_size = 256
+        grid = (triton.cdiv(flat_valid.numel(), block_size),)
+        _compact_route_positions_kernel[grid](
+            flat_valid,
+            prefix,
+            positions,
+            flat_valid.numel(),
+            topk=valid.shape[1],
+            BLOCK_SIZE=block_size,
+        )
+    return positions
+

--- a/experimental/lite/megatron/lite/primitive/alignment/vllm_grouped_moe.py
+++ b/experimental/lite/megatron/lite/primitive/alignment/vllm_grouped_moe.py
@@ -1,0 +1,282 @@
+"""vLLM grouped-DeepGEMM forward with a BF16-master training backward."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+from megatron.lite.primitive.modules.experts import swiglu_with_probs
+from megatron.lite.primitive.quantization.deployment_block_fp8 import (
+    pack_grouped_block_fp8_weight,
+)
+
+_M_ALIGNMENT = 128
+_EXPERTS_PER_FORWARD_GROUP = 4
+_BACKWARD_CHUNK_ROWS = 1024
+
+
+def _pad_expert_rows(
+    value: torch.Tensor, counts: tuple[int, ...]
+) -> tuple[torch.Tensor, tuple[int, ...], torch.Tensor | None]:
+    padded_counts = tuple(
+        ((count + _M_ALIGNMENT - 1) // _M_ALIGNMENT) * _M_ALIGNMENT if count else 0
+        for count in counts
+    )
+    if padded_counts == counts:
+        return value, padded_counts, None
+    valid_ranges = []
+    padded_start = 0
+    for count, padded_count in zip(counts, padded_counts, strict=True):
+        if count:
+            valid_ranges.append(
+                torch.arange(
+                    padded_start,
+                    padded_start + count,
+                    device=value.device,
+                    dtype=torch.long,
+                )
+            )
+        padded_start += padded_count
+    valid_rows = torch.cat(valid_ranges) if valid_ranges else torch.empty(0, device=value.device, dtype=torch.long)
+    padded = value.new_zeros((sum(padded_counts), value.shape[1]))
+    if valid_rows.numel():
+        padded.index_copy_(0, valid_rows, value)
+    return padded, padded_counts, valid_rows
+
+
+def _build_m_indices(counts: tuple[int, ...], device: torch.device) -> torch.Tensor:
+    output = torch.empty(sum(counts), dtype=torch.int32, device=device)
+    offset = 0
+    for expert, count in enumerate(counts):
+        if count:
+            output.narrow(0, offset, count).fill_(expert)
+            offset += count
+    return output
+
+
+def _vllm_quantize_contiguous_input(
+    value: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Match the vLLM LL dispatch quant contract in contiguous layout."""
+    import vllm.envs as envs
+    from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+        per_token_group_quant_fp8,
+        per_token_group_quant_fp8_packed_for_deepgemm,
+    )
+    from vllm.utils.deep_gemm import DeepGemmQuantScaleFMT
+
+    scale_format = DeepGemmQuantScaleFMT.from_oracle()
+    if scale_format == DeepGemmQuantScaleFMT.UE8M0:
+        return per_token_group_quant_fp8_packed_for_deepgemm(
+            value,
+            128,
+            use_ue8m0=True,
+        )
+    if scale_format not in (
+        DeepGemmQuantScaleFMT.FLOAT32,
+        DeepGemmQuantScaleFMT.FLOAT32_CEIL_UE8M0,
+    ):
+        raise RuntimeError(
+            "contiguous DS4 input requires FLOAT32 or packed UE8M0 scales, "
+            f"got {scale_format}"
+        )
+    return per_token_group_quant_fp8(
+        value,
+        128,
+        eps=1e-10,
+        dtype=torch.float8_e4m3fn,
+        column_major_scales=True,
+        tma_aligned_scales=bool(envs.VLLM_USE_DEEP_GEMM_TMA_ALIGNED_SCALES),
+        use_ue8m0=False,
+    )
+
+
+def _vllm_silu_mul_quant(
+    gate_up: torch.Tensor,
+    *,
+    output: torch.Tensor,
+    swiglu_limit: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+        ds4_silu_mul_quant_fp8,
+        is_ds4_alignment_quant_enabled,
+        per_token_group_quant_fp8_packed_for_deepgemm,
+        silu_mul_per_token_group_quant_fp8_colmajor,
+        silu_mul_quant_fp8_packed_triton,
+    )
+    from vllm.utils.deep_gemm import DeepGemmQuantScaleFMT
+
+    scale_format = DeepGemmQuantScaleFMT.from_oracle()
+    if is_ds4_alignment_quant_enabled():
+        if swiglu_limit > 0:
+            # BatchedDeepGemmExperts, which is the rollout reference for this
+            # DS4 path, exposes plain SiLU*up at this fused quant boundary.
+            # Keep the argument for the BF16 fallback/VJP contract, but do not
+            # introduce a training-only clamp into the visible forward.
+            pass
+        return ds4_silu_mul_quant_fp8(
+            gate_up,
+            output_q=output,
+            use_ue8m0=(scale_format == DeepGemmQuantScaleFMT.UE8M0),
+            round_scale=(scale_format != DeepGemmQuantScaleFMT.FLOAT32),
+            masked_m=None,
+            group_size=128,
+        )
+    if scale_format == DeepGemmQuantScaleFMT.UE8M0:
+        return silu_mul_quant_fp8_packed_triton(
+            input=gate_up,
+            output_q=output,
+            group_size=128,
+            clamp_limit=swiglu_limit,
+            alpha=1.0,
+            beta=0.0,
+        )
+    if gate_up.shape[0] == 0:
+        return per_token_group_quant_fp8_packed_for_deepgemm(
+            gate_up[:, : gate_up.shape[1] // 2], 128, out_q=output
+        )
+    return silu_mul_per_token_group_quant_fp8_colmajor(
+        input=gate_up,
+        output=output,
+        use_ue8m0=(scale_format == DeepGemmQuantScaleFMT.FLOAT32_CEIL_UE8M0),
+        clamp_limit=swiglu_limit,
+        group_size=128,
+        alpha=1.0,
+        beta=0.0,
+    )
+
+
+def _vllm_grouped_forward(
+    hidden_states: torch.Tensor,
+    counts: tuple[int, ...],
+    swiglu_limit: float,
+    w13: tuple[torch.Tensor, ...],
+    w2: tuple[torch.Tensor, ...],
+) -> torch.Tensor:
+    from vllm.utils.deep_gemm import m_grouped_fp8_gemm_nt_contiguous
+
+    if hidden_states.shape[0] == 0:
+        return hidden_states.new_empty((0, hidden_states.shape[1]))
+    # Slime's BI path deliberately launches contiguous DeepGEMM over at most
+    # four adjacent experts at a time.  Apart from bounding transient packed
+    # weights and activation workspaces, that is the production scheduling
+    # contract under which normal DeepEP is composed with the next layer's
+    # communication.  Keep the same grouping instead of issuing one oversized
+    # launch over every EP-local expert.
+    compact_output = hidden_states.new_empty(
+        (hidden_states.shape[0], w2[0].shape[0])
+    )
+    token_offset = 0
+    for expert_start in range(0, len(counts), _EXPERTS_PER_FORWARD_GROUP):
+        expert_end = min(
+            expert_start + _EXPERTS_PER_FORWARD_GROUP,
+            len(counts),
+        )
+        group_counts = counts[expert_start:expert_end]
+        group_tokens = sum(group_counts)
+        if group_tokens == 0:
+            continue
+        group_hidden = hidden_states.narrow(0, token_offset, group_tokens)
+        padded, padded_counts, valid_rows = _pad_expert_rows(
+            group_hidden, group_counts
+        )
+        m_indices = _build_m_indices(padded_counts, hidden_states.device)
+        packed_input = _vllm_quantize_contiguous_input(padded)
+        packed_w13 = pack_grouped_block_fp8_weight(w13[expert_start:expert_end])
+        gate_up = hidden_states.new_empty((padded.shape[0], w13[0].shape[0]))
+        m_grouped_fp8_gemm_nt_contiguous(
+            packed_input,
+            (packed_w13.qweight, packed_w13.scales),
+            gate_up,
+            m_indices,
+        )
+        activated_q = torch.empty(
+            (padded.shape[0], w2[0].shape[1]),
+            device=hidden_states.device,
+            dtype=torch.float8_e4m3fn,
+        )
+        activated_q, activated_scale = _vllm_silu_mul_quant(
+            gate_up,
+            output=activated_q,
+            swiglu_limit=swiglu_limit,
+        )
+        packed_w2 = pack_grouped_block_fp8_weight(w2[expert_start:expert_end])
+        group_output = hidden_states.new_empty(
+            (padded.shape[0], w2[0].shape[0])
+        )
+        m_grouped_fp8_gemm_nt_contiguous(
+            (activated_q, activated_scale),
+            (packed_w2.qweight, packed_w2.scales),
+            group_output,
+            m_indices,
+        )
+        if valid_rows is not None:
+            group_output = group_output.index_select(0, valid_rows)
+        compact_output.narrow(0, token_offset, group_tokens).copy_(group_output)
+        token_offset += group_tokens
+    if token_offset != hidden_states.shape[0]:
+        raise RuntimeError(
+            "grouped MoE expert counts do not cover all expert-major rows: "
+            f"{token_offset} != {hidden_states.shape[0]}"
+        )
+    return compact_output
+
+
+class VLLMGroupedMoEWithBF16Backward(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        hidden_states: torch.Tensor,
+        tokens_per_expert: torch.Tensor,
+        permuted_probs: torch.Tensor,
+        swiglu_limit: float,
+        *weights: torch.Tensor,
+    ) -> torch.Tensor:
+        num_experts = tokens_per_expert.numel()
+        if len(weights) != 2 * num_experts:
+            raise ValueError("grouped MoE weight count does not match local experts")
+        counts = tuple(int(value) for value in tokens_per_expert.detach().cpu().tolist())
+        if sum(counts) != hidden_states.shape[0]:
+            raise ValueError("tokens_per_expert does not match expert-major rows")
+        w13 = tuple(weights[:num_experts])
+        w2 = tuple(weights[num_experts:])
+        output = _vllm_grouped_forward(hidden_states, counts, float(swiglu_limit), w13, w2)
+        ctx.counts = counts
+        ctx.swiglu_limit = float(swiglu_limit)
+        ctx.save_for_backward(hidden_states, *weights)
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        hidden_states, *weights = ctx.saved_tensors
+        num_experts = len(ctx.counts)
+        w13 = weights[:num_experts]
+        w2 = weights[num_experts:]
+        grad_hidden = torch.empty_like(hidden_states) if ctx.needs_input_grad[0] else None
+        grad_w13 = [torch.zeros_like(weight) if ctx.needs_input_grad[4 + i] else None for i, weight in enumerate(w13)]
+        grad_w2 = [torch.zeros_like(weight) if ctx.needs_input_grad[4 + num_experts + i] else None for i, weight in enumerate(w2)]
+        offset = 0
+        for expert, count in enumerate(ctx.counts):
+            for start in range(0, count, _BACKWARD_CHUNK_ROWS):
+                end = min(start + _BACKWARD_CHUNK_ROWS, count)
+                row_slice = slice(offset + start, offset + end)
+                with torch.enable_grad():
+                    hidden = hidden_states[row_slice].detach().requires_grad_(True)
+                    fc1 = w13[expert].detach().requires_grad_(True)
+                    fc2 = w2[expert].detach().requires_grad_(True)
+                    gate_up = F.linear(hidden, fc1)
+                    activated = swiglu_with_probs(gate_up, None, ctx.swiglu_limit)
+                    recomputed = F.linear(activated, fc2)
+                    grad_h, grad_fc1, grad_fc2 = torch.autograd.grad(
+                        recomputed,
+                        (hidden, fc1, fc2),
+                        grad_output[row_slice],
+                    )
+                if grad_hidden is not None:
+                    grad_hidden[row_slice].copy_(grad_h)
+                if grad_w13[expert] is not None:
+                    grad_w13[expert].add_(grad_fc1)
+                if grad_w2[expert] is not None:
+                    grad_w2[expert].add_(grad_fc2)
+            offset += count
+        return grad_hidden, None, None, None, *grad_w13, *grad_w2

--- a/experimental/lite/megatron/lite/primitive/kernels/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/kernels/__init__.py
@@ -3,4 +3,22 @@
 
 from __future__ import annotations
 
-__all__: list[str] = []
+from .vllm_ds4 import (
+    DS4KVInsertAdapter,
+    FlashMLAAdapter,
+    FusedQKVRMSNormAdapter,
+    KVCacheLayout,
+    MHCKernel,
+    MHCTileLangAdapter,
+    OProjectionAdapter,
+)
+
+__all__ = [
+    "DS4KVInsertAdapter",
+    "FlashMLAAdapter",
+    "FusedQKVRMSNormAdapter",
+    "KVCacheLayout",
+    "MHCKernel",
+    "MHCTileLangAdapter",
+    "OProjectionAdapter",
+]

--- a/experimental/lite/megatron/lite/primitive/kernels/vllm_ds4.py
+++ b/experimental/lite/megatron/lite/primitive/kernels/vllm_ds4.py
@@ -1,0 +1,250 @@
+"""Thin calls into the vLLM DeepSeek-V4 kernels used by mLite training."""
+
+from __future__ import annotations
+
+import importlib
+from enum import Enum
+from typing import Any
+
+import torch
+from torch import Tensor, nn
+
+from megatron.lite.primitive.quantization.deployment_block_fp8 import (
+    quantize_block_fp8_weight,
+)
+
+
+def _symbol(module: str, name: str) -> Any:
+    try:
+        return getattr(importlib.import_module(module), name)
+    except (ImportError, AttributeError) as exc:
+        raise NotImplementedError(f"missing vLLM kernel {module}.{name}") from exc
+
+
+def _op(namespace: str, name: str):
+    try:
+        return getattr(getattr(torch.ops, namespace), name)
+    except AttributeError as exc:
+        raise NotImplementedError(f"missing torch.ops.{namespace}.{name}") from exc
+
+
+class MHCKernel(str, Enum):
+    PRE = "pre"
+    PRE_BROADCAST = "pre_broadcast"
+    POST = "post"
+    POST_PRE = "post_pre"
+    HEAD = "head"
+
+
+_MHC_ENTRIES = {
+    MHCKernel.PRE: "mhc_pre_tilelang",
+    MHCKernel.PRE_BROADCAST: "mhc_pre_broadcast_tilelang",
+    MHCKernel.POST: "mhc_post_tilelang",
+    MHCKernel.POST_PRE: "mhc_fused_post_pre_tilelang",
+    MHCKernel.HEAD: "hc_head_fused_kernel_tilelang",
+}
+
+
+class MHCTileLangAdapter(nn.Module):
+    def __init__(self, kernel: MHCKernel | str) -> None:
+        super().__init__()
+        self.kernel = MHCKernel(kernel)
+
+    def forward(self, *args, **kwargs):
+        return _symbol(
+            "vllm.model_executor.kernels.mhc.tilelang",
+            _MHC_ENTRIES[self.kernel],
+        )(*args, **kwargs)
+
+
+class FusedQKVRMSNormAdapter(nn.Module):
+    def forward(self, q, kv, q_weight, kv_weight, eps):
+        return _symbol("vllm.models.common.ops", "fused_q_kv_rmsnorm")(
+            q, kv, q_weight, kv_weight, eps
+        )
+
+
+class KVCacheLayout(str, Enum):
+    FP8_DS_MLA = "fp8_ds_mla"
+
+
+class DS4KVInsertAdapter(nn.Module):
+    """Invoke vLLM's fused QNorm/RoPE/fresh-KV quantization boundary."""
+
+    def __init__(self, layout: KVCacheLayout | str) -> None:
+        super().__init__()
+        if KVCacheLayout(layout) is not KVCacheLayout.FP8_DS_MLA:
+            raise ValueError("mLite.vllm supports only the fp8_ds_mla prefill layout")
+
+    def forward(
+        self,
+        q: Tensor,
+        kv: Tensor,
+        cache: Tensor,
+        slot_mapping: Tensor,
+        positions: Tensor,
+        cos_sin_cache: Tensor,
+        *,
+        eps: float,
+        block_size: int,
+        padded_heads: int | None = None,
+        q_out: Tensor | None = None,
+        **_unused,
+    ) -> Tensor:
+        if padded_heads is None:
+            raise ValueError("padded_heads is required")
+        if q_out is not None:
+            _op("_C", "fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert_out")(
+                q,
+                kv,
+                q_out,
+                cache,
+                slot_mapping,
+                positions,
+                cos_sin_cache,
+                padded_heads,
+                eps,
+                block_size,
+            )
+            return q_out
+        return _op("_C", "fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert")(
+            q,
+            kv,
+            cache,
+            slot_mapping,
+            positions,
+            cos_sin_cache,
+            padded_heads,
+            eps,
+            block_size,
+        )
+
+
+class FlashMLAAdapter(nn.Module):
+    def sparse(
+        self,
+        q: Tensor,
+        kv: Tensor,
+        indices: Tensor,
+        *,
+        sm_scale: float,
+        attn_sink: Tensor | None = None,
+        topk_length: Tensor | None = None,
+        out: Tensor | None = None,
+    ):
+        return _symbol("vllm.v1.attention.ops.flashmla", "flash_mla_sparse_fwd")(
+            q=q,
+            kv=kv,
+            indices=indices,
+            sm_scale=sm_scale,
+            attn_sink=attn_sink,
+            topk_length=topk_length,
+            out=out,
+        )
+
+
+class OProjectionAdapter(nn.Module):
+    """Pack mLite masters and invoke vLLM's official grouped FP8 O projection."""
+
+    def forward(
+        self,
+        o: Tensor,
+        positions: Tensor,
+        cos_sin_cache: Tensor,
+        wo_a: Tensor,
+        wo_b: Tensor,
+        *,
+        n_groups: int,
+        heads_per_group: int,
+        nope_dim: int,
+        rope_dim: int,
+        o_lora_rank: int,
+    ) -> Tensor:
+        post_process = _symbol(
+            "vllm.model_executor.layers.quantization.utils.fp8_utils",
+            "deepgemm_post_process_fp8_weight_block",
+        )
+        official = _symbol(
+            "vllm.models.deepseek_v4.nvidia.ops.o_proj", "deep_gemm_fp8_o_proj"
+        )
+        recipe_fn = _symbol(
+            "vllm.models.deepseek_v4.nvidia.ops.o_proj", "compute_fp8_einsum_recipe"
+        )
+
+        with torch.inference_mode():
+            canonical_wa = quantize_block_fp8_weight(wo_a)
+            wa_q, wa_s = post_process(
+                wq=canonical_wa.qweight,
+                ws=canonical_wa.scales,
+                quant_block_shape=(128, 128),
+                use_e8m0=True,
+                is_bmm=True,
+                bmm_batch_size=n_groups,
+            )
+            packed_wa = type("_PackedGroupedWeight", (), {})()
+            packed_wa.weight = wa_q
+            packed_wa.weight_scale = wa_s
+
+            canonical_wb = quantize_block_fp8_weight(wo_b)
+            wb_q, wb_s = post_process(
+                wq=canonical_wb.qweight,
+                ws=canonical_wb.scales,
+                quant_block_shape=(128, 128),
+                use_e8m0=True,
+            )
+
+            def packed_wb(value: Tensor) -> Tensor:
+                activation_quant = _symbol(
+                    "vllm.model_executor.layers.quantization.utils.fp8_utils",
+                    "per_token_group_quant_fp8",
+                )
+                aligned = bool(
+                    _symbol("vllm.envs", "VLLM_USE_DEEP_GEMM_TMA_ALIGNED_SCALES")
+                )
+                aq, a_s = activation_quant(
+                    value,
+                    128,
+                    use_ue8m0=True,
+                    column_major_scales=True,
+                    tma_aligned_scales=aligned,
+                )
+                output = torch.empty(
+                    value.shape[0],
+                    wb_q.shape[0],
+                    dtype=torch.bfloat16,
+                    device=value.device,
+                )
+                _symbol("vllm.utils.deep_gemm", "fp8_gemm_nt")(
+                    (aq, a_s),
+                    (wb_q, wb_s),
+                    output,
+                    is_deep_gemm_e8m0_used=True,
+                )
+                return output
+
+            recipe, aligned = recipe_fn()
+            return official(
+                o,
+                positions,
+                cos_sin_cache,
+                packed_wa,
+                packed_wb,
+                n_groups=n_groups,
+                heads_per_group=heads_per_group,
+                nope_dim=nope_dim,
+                rope_dim=rope_dim,
+                o_lora_rank=o_lora_rank,
+                einsum_recipe=recipe,
+                tma_aligned_scales=aligned,
+            )
+
+
+__all__ = [
+    "DS4KVInsertAdapter",
+    "FlashMLAAdapter",
+    "FusedQKVRMSNormAdapter",
+    "KVCacheLayout",
+    "MHCKernel",
+    "MHCTileLangAdapter",
+    "OProjectionAdapter",
+]

--- a/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
+++ b/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
@@ -12,6 +12,13 @@ from megatron.lite.primitive.modules.moe import _AllToAll
 from megatron.lite.primitive.parallel import ParallelState
 from megatron.lite.primitive.utils import ensure_divisible
 from megatron.lite.primitive.utils.moe import permute, unpermute
+from megatron.lite.primitive.alignment.deepep_route import (
+    _VLLMEPGatherWithBF16Backward,
+    _compact_route_preserving_metadata_inputs,
+    _deepep_route_handle_received_rows,
+    _scatter_deepep_routes_with_padding,
+    _validate_and_order_route_preserving_outputs,
+)
 
 try:
     import deep_ep  # pyright: ignore[reportMissingImports]
@@ -22,16 +29,48 @@ except ImportError:
     EventOverlap = None  # type: ignore
 
 
+_deepep_buffer = None
+def _configure_deepep_deterministic_allocator() -> None:
+    """Avoid DeepEP's known deterministic ``torch.empty`` stream race.
+
+    Legacy normal DeepEP waits its communication stream before allocating
+    output tensors.  PyTorch's deterministic debug fill is consequently
+    enqueued after that wait on the compute stream and can race DeepEP's
+    communication-stream writers.  ``fill_uninitialized_memory`` is only an
+    uninitialized-memory debugging aid; disabling it does not relax PyTorch's
+    deterministic algorithm selection.
+
+    See https://github.com/deepseek-ai/DeepEP/issues/589.
+    """
+
+    if (
+        torch.are_deterministic_algorithms_enabled()
+        and torch.utils.deterministic.fill_uninitialized_memory
+    ):
+        torch.utils.deterministic.fill_uninitialized_memory = False
+
+
 def _hidden_bytes(hidden_size: int) -> int:
     return hidden_size * 2
 
 
-def _build_deepep_buffer(group: dist.ProcessGroup, hidden_size: int):
+def _get_deepep_buffer(group: dist.ProcessGroup, hidden_bytes: int):
+    """Return MCore's process-wide normal-DeepEP communication buffer.
+
+    This deliberately mirrors ``megatron.core.transformer.moe.fused_a2a``:
+    dispatch and combine look the buffer up from their process group and the
+    payload width on every forward/backward entry.  In particular, the tiny
+    route-fingerprint dispatch reuses the full-width primary buffer instead of
+    creating a second per-layer DeepEP runtime.
+    """
+
     if deep_ep is None:
         raise RuntimeError("DeepEP buffer requested but deep_ep is not installed.")
 
+    _configure_deepep_deterministic_allocator()
+
+    global _deepep_buffer
     group_size = dist.get_world_size(group=group)
-    hidden_bytes = _hidden_bytes(hidden_size)
     num_nvl_bytes = 0
     num_rdma_bytes = 0
 
@@ -42,11 +81,34 @@ def _build_deepep_buffer(group: dist.ProcessGroup, hidden_size: int):
         num_nvl_bytes = max(
             config.get_nvl_buffer_size_hint(hidden_bytes, group_size), num_nvl_bytes
         )
-        num_rdma_bytes = max(
-            config.get_rdma_buffer_size_hint(hidden_bytes, group_size), num_rdma_bytes
-        )
+        # Match MCore: a node-local EP group neither needs an RDMA heap nor can
+        # assume that a DeepEP build exposes internode size hints.
+        if group_size > torch.cuda.device_count():
+            num_rdma_bytes = max(
+                config.get_rdma_buffer_size_hint(hidden_bytes, group_size),
+                num_rdma_bytes,
+            )
 
-    return deep_ep.Buffer(group=group, num_nvl_bytes=num_nvl_bytes, num_rdma_bytes=num_rdma_bytes)
+    if (
+        _deepep_buffer is None
+        or getattr(_deepep_buffer, "runtime", None) is None
+        or _deepep_buffer.group != group
+        or _deepep_buffer.num_nvl_bytes < num_nvl_bytes
+        or _deepep_buffer.num_rdma_bytes < num_rdma_bytes
+    ):
+        _deepep_buffer = deep_ep.Buffer(
+            group=group,
+            num_nvl_bytes=num_nvl_bytes,
+            num_rdma_bytes=num_rdma_bytes,
+            explicitly_destroy=True,
+        )
+    return _deepep_buffer
+
+
+def _build_deepep_buffer(group: dist.ProcessGroup, hidden_size: int):
+    """Compatibility wrapper for callers that specify a BF16 hidden width."""
+
+    return _get_deepep_buffer(group, _hidden_bytes(hidden_size))
 
 
 def _use_moe_permute_fusion() -> bool:
@@ -57,11 +119,61 @@ def _tensor_hidden_bytes(x: torch.Tensor) -> int:
     return x.size(1) * max(x.element_size(), 2)
 
 
+def _dispatch_deepep_raw(
+    group,
+    hidden_states: torch.Tensor,
+    topk_indices: torch.Tensor,
+    topk_scores: torch.Tensor,
+    num_experts: int,
+    *,
+    async_finish: bool,
+    allocate_on_comm_stream: bool,
+):
+    """Run the shared normal-DeepEP dispatch without owning autograd state."""
+    buffer = _get_deepep_buffer(group, _tensor_hidden_bytes(hidden_states))
+    hidden_states = hidden_states.contiguous()
+    topk_indices = topk_indices.contiguous()
+    topk_scores = topk_scores.float().contiguous()
+    previous_event = (
+        EventOverlap(EventHandle())
+        if async_finish and EventHandle is not None and EventOverlap is not None
+        else None
+    )
+    (
+        num_tokens_per_rank,
+        num_tokens_per_rdma_rank,
+        num_tokens_per_expert,
+        is_token_in_rank,
+        event,
+    ) = buffer.get_dispatch_layout(
+        topk_indices,
+        num_experts=num_experts,
+        previous_event=previous_event,
+        async_finish=async_finish,
+        allocate_on_comm_stream=allocate_on_comm_stream,
+    )
+    result = buffer.dispatch(
+        hidden_states,
+        topk_idx=topk_indices,
+        topk_weights=topk_scores,
+        num_tokens_per_rank=num_tokens_per_rank,
+        num_tokens_per_rdma_rank=num_tokens_per_rdma_rank,
+        is_token_in_rank=is_token_in_rank,
+        num_tokens_per_expert=num_tokens_per_expert,
+        previous_event=event,
+        async_finish=async_finish,
+        allocate_on_comm_stream=allocate_on_comm_stream,
+    )
+    if async_finish:
+        result[-1].current_stream_wait()
+    return result
+
+
 class _DeepEPDispatch(torch.autograd.Function):
     @staticmethod
     def forward(
         ctx,
-        buffer,
+        group,
         hidden_states: torch.Tensor,
         topk_indices: torch.Tensor,
         topk_scores: torch.Tensor,
@@ -69,48 +181,34 @@ class _DeepEPDispatch(torch.autograd.Function):
         async_finish: bool,
         allocate_on_comm_stream: bool,
     ):
-        previous_event = (
-            EventOverlap(EventHandle())
-            if async_finish and EventHandle is not None and EventOverlap is not None
-            else None
-        )
         (
-            num_tokens_per_rank,
-            num_tokens_per_rdma_rank,
-            num_tokens_per_expert,
-            is_token_in_rank,
-            event,
-        ) = buffer.get_dispatch_layout(
+            recv_hidden,
+            recv_indices,
+            recv_probs,
+            recv_per_expert,
+            handle,
+            _,
+        ) = _dispatch_deepep_raw(
+            group,
+            hidden_states,
             topk_indices,
-            num_experts=num_experts,
-            previous_event=previous_event,
+            topk_scores,
+            num_experts,
             async_finish=async_finish,
             allocate_on_comm_stream=allocate_on_comm_stream,
         )
-        (recv_hidden, recv_indices, recv_probs, recv_per_expert, handle, after_event) = (
-            buffer.dispatch(
-                hidden_states.contiguous(),
-                topk_idx=topk_indices,
-                topk_weights=topk_scores.float(),
-                num_tokens_per_rank=num_tokens_per_rank,
-                num_tokens_per_rdma_rank=num_tokens_per_rdma_rank,
-                is_token_in_rank=is_token_in_rank,
-                num_tokens_per_expert=num_tokens_per_expert,
-                previous_event=event,
-                async_finish=async_finish,
-                allocate_on_comm_stream=allocate_on_comm_stream,
-            )
-        )
-        if async_finish:
-            after_event.current_stream_wait()
 
-        ctx.buffer = buffer
+        ctx.group = group
         ctx.handle = handle
         ctx.async_finish = async_finish
         ctx.allocate_on_comm_stream = allocate_on_comm_stream
-        recv_per_expert_tensor = torch.tensor(
-            recv_per_expert, dtype=torch.int64, device=recv_hidden.device
-        )
+        # Match MCore/Slime's normal-DeepEP contract: the public API returns
+        # receive counts as a Python list and the dispatcher materializes that
+        # metadata on CPU.  Do not enqueue an unrelated CUDA allocation while
+        # DeepEP's communication result is becoming visible.  The aligned
+        # scatter consumes CPU counts directly and derives its CUDA counts from
+        # the received route metadata when needed.
+        recv_per_expert_tensor = torch.tensor(recv_per_expert, dtype=torch.int64)
         return recv_hidden, recv_indices, recv_probs, recv_per_expert_tensor, handle
 
     @staticmethod
@@ -123,8 +221,9 @@ class _DeepEPDispatch(torch.autograd.Function):
             if ctx.async_finish and EventHandle is not None and EventOverlap is not None
             else None
         )
+        buffer = _get_deepep_buffer(ctx.group, _tensor_hidden_bytes(grad_recv_hidden))
         grad_scores = None if grad_recv_probs is None else grad_recv_probs.float()
-        grad_hidden, grad_topk_scores, after_event = ctx.buffer.combine(
+        grad_hidden, grad_topk_scores, after_event = buffer.combine(
             grad_recv_hidden.contiguous(),
             ctx.handle,
             topk_weights=grad_scores,
@@ -141,12 +240,13 @@ class _DeepEPCombine(torch.autograd.Function):
     @staticmethod
     def forward(
         ctx,
-        buffer,
+        group,
         rank_grouped: torch.Tensor,
         handle,
         async_finish: bool,
         allocate_on_comm_stream: bool,
     ):
+        buffer = _get_deepep_buffer(group, _tensor_hidden_bytes(rank_grouped))
         previous_event = (
             EventOverlap(EventHandle())
             if async_finish and EventHandle is not None and EventOverlap is not None
@@ -161,7 +261,7 @@ class _DeepEPCombine(torch.autograd.Function):
         )
         if async_finish:
             after_event.current_stream_wait()
-        ctx.buffer = buffer
+        ctx.group = group
         ctx.handle = handle
         ctx.async_finish = async_finish
         ctx.allocate_on_comm_stream = allocate_on_comm_stream
@@ -174,7 +274,8 @@ class _DeepEPCombine(torch.autograd.Function):
             if ctx.async_finish and EventHandle is not None and EventOverlap is not None
             else None
         )
-        grad_rank_grouped, _, _, _, _, after_event = ctx.buffer.dispatch(
+        buffer = _get_deepep_buffer(ctx.group, _tensor_hidden_bytes(grad_output))
+        grad_rank_grouped, _, _, _, _, after_event = buffer.dispatch(
             grad_output.contiguous(),
             handle=ctx.handle,
             previous_event=previous_event,
@@ -195,7 +296,9 @@ class TokenDispatcher:
         ps: ParallelState,
         *,
         use_deepep: bool = True,
+        deepep_align_to_low_latency: bool = False,
         moe_permute_fusion: bool | None = None,
+        capacity_factor: float | None = None,
     ):
         self.ps = ps
         self.num_experts = num_experts
@@ -206,9 +309,27 @@ class TokenDispatcher:
         )
 
         self.use_deepep = use_deepep and deep_ep is not None and ps.ep_size > 1
+        self.deepep_align_to_low_latency = bool(deepep_align_to_low_latency)
+        self.capacity_factor = capacity_factor
+        if self.deepep_align_to_low_latency and ps.ep_size > 1 and not self.use_deepep:
+            raise RuntimeError(
+                "low-latency semantic alignment at EP>1 requires normal DeepEP"
+            )
         if self.use_deepep:
             assert ps.tp_ep_group is not None
-            self.buffer = _build_deepep_buffer(ps.tp_ep_group, hidden_size)
+            self._deepep_group = ps.tp_ep_group
+            # Match MCore's _DeepepManager initialization exactly.  DeepEP's
+            # SM allocation is process-global; leaving it at the package
+            # default makes this shared dispatcher differ from both mLite.lite
+            # through MCore and Slime, and can starve later collectives while
+            # grouped expert kernels are active.
+            deep_ep.Buffer.set_num_sms(20)
+            # Match MCore/Slime: get_buffer() is entered by the first dispatch,
+            # after a colocated trainer has woken and restored its CUDA state.
+            # Eager construction here makes the DeepEP runtime span VERL's
+            # initial model offload/empty-cache boundary, a lifecycle that the
+            # mature fused_a2a manager deliberately avoids.
+            self.buffer = None
 
         self._row_id_map: torch.Tensor | None = None
         self._restore_shape: tuple | None = None
@@ -216,7 +337,6 @@ class TokenDispatcher:
         self._output_splits: list[int] | None = None
         self._handle = None
         self._deepep_event = None
-
         if self.ep_size > 1 and self.num_local_experts > 1:
             chunk_idxs = torch.arange(self.ep_size * self.num_local_experts, device="cpu")
             self._sort_by_experts = (
@@ -226,9 +346,43 @@ class TokenDispatcher:
                 chunk_idxs.reshape(self.num_local_experts, self.ep_size).T.ravel().tolist()
             )
 
+    def _ensure_deepep_buffer(self, hidden_states: torch.Tensor):
+        """Lazily enter MCore/Slime's process-wide normal DeepEP runtime."""
+
+        if not self.use_deepep:
+            raise RuntimeError("DeepEP buffer requested while DeepEP is disabled")
+        self.buffer = _get_deepep_buffer(
+            self._deepep_group, _tensor_hidden_bytes(hidden_states)
+        )
+        return self.buffer
+
     def dispatch(
-        self, hidden_states: torch.Tensor, topk_scores: torch.Tensor, topk_indices: torch.Tensor
+        self,
+        hidden_states: torch.Tensor,
+        topk_scores: torch.Tensor,
+        topk_indices: torch.Tensor,
+        *,
+        router_token_masks: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        # Match slime's _DeepepManager.setup_metadata contract.  The fixed-topk
+        # route path is valid only when neither expert-capacity dropping nor a
+        # router token mask can introduce -1 sentinels.
+        source_fixed_topk_valid = (
+            self.capacity_factor is None and router_token_masks is None
+        )
+        if self.capacity_factor is not None:
+            topk_indices = topk_indices.masked_fill(topk_scores == 0, -1)
+        if router_token_masks is not None:
+            topk_indices = topk_indices.masked_fill(
+                router_token_masks.view(-1, 1), -1
+            )
+        if self.deepep_align_to_low_latency:
+            return self._dispatch_low_latency_aligned(
+                hidden_states,
+                topk_scores,
+                topk_indices,
+                source_fixed_topk_valid=source_fixed_topk_valid,
+            )
         if self.ep_size <= 1:
             return self._dispatch_local(hidden_states, topk_scores, topk_indices)
         if self.use_deepep:
@@ -239,11 +393,195 @@ class TokenDispatcher:
         return dispatched, tpe, sorted_scores
 
     def combine(self, expert_output: torch.Tensor) -> torch.Tensor:
+        if self.deepep_align_to_low_latency:
+            return self._combine_low_latency_aligned(expert_output)
         if self.ep_size <= 1:
             return self._combine_local(expert_output)
         if self.use_deepep:
             return self._combine_deepep(expert_output)
         return self._combine_alltoall(expert_output)
+
+    def _dispatch_low_latency_aligned(
+        self,
+        hidden_states: torch.Tensor,
+        topk_scores: torch.Tensor,
+        topk_indices: torch.Tensor,
+        *,
+        source_fixed_topk_valid: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Normal DeepEP transport with vLLM LL route/layout semantics."""
+
+        if self.use_deepep:
+            self._ensure_deepep_buffer(hidden_states)
+
+        if hidden_states.ndim != 2 or hidden_states.dtype != torch.bfloat16:
+            raise TypeError("aligned DeepEP requires BF16 [tokens, hidden]")
+        if hidden_states.shape[1] < 16:
+            raise ValueError("aligned DeepEP requires hidden size >= 16")
+        if topk_indices.shape != topk_scores.shape:
+            raise ValueError("top-k IDs and scores must have identical shapes")
+        topk_indices = topk_indices.long().contiguous()
+        topk_scores = topk_scores.float().contiguous()
+
+        if self.ep_size > 1:
+            (
+                received_hidden,
+                received_indices,
+                received_weights,
+                received_per_expert,
+                _,
+            ) = _DeepEPDispatch.apply(
+                self._deepep_group,
+                hidden_states,
+                topk_indices,
+                topk_scores,
+                self.num_experts,
+                False,
+                False,
+            )
+            (
+                route_indices,
+                route_weights,
+                route_fingerprints,
+                source_output_index,
+                source_all_routes_valid,
+            ) = _compact_route_preserving_metadata_inputs(
+                hidden_states,
+                topk_indices,
+                topk_scores,
+                assume_all_routes_valid=source_fixed_topk_valid,
+            )
+            (
+                received_fingerprints,
+                received_route_indices,
+                received_route_weights,
+                _,
+                route_handle,
+                _,
+            ) = _dispatch_deepep_raw(
+                self._deepep_group,
+                route_fingerprints,
+                route_indices,
+                route_weights,
+                self.num_experts,
+                async_finish=False,
+                allocate_on_comm_stream=False,
+            )
+        else:
+            received_hidden = hidden_states
+            received_indices = topk_indices
+            received_weights = topk_scores
+            positions = torch.nonzero(topk_indices >= 0, as_tuple=False)
+            token_rows = positions[:, 0]
+            topk_slots = positions[:, 1]
+            received_fingerprints = hidden_states.detach().narrow(
+                1, 0, 16
+            ).index_select(0, token_rows)
+            received_route_indices = topk_indices[token_rows, topk_slots]
+            received_route_weights = topk_scores[token_rows, topk_slots]
+            route_handle = None
+            source_output_index = torch.arange(
+                topk_indices.numel(), device=topk_indices.device, dtype=torch.long
+            ).reshape_as(topk_indices)
+            source_all_routes_valid = True
+            received_per_expert = torch.bincount(
+                received_route_indices.reshape(-1).long(),
+                minlength=self.num_local_experts,
+            )
+
+        expected_route_count = (
+            _deepep_route_handle_received_rows(route_handle)
+            if route_handle is not None
+            else int((received_indices >= 0).sum().item())
+        )
+        (
+            expert_hidden,
+            expert_probs,
+            output_index,
+            sanitized_indices,
+            _,
+            all_routes_valid,
+            device_tokens_per_expert,
+            positions,
+        ) = _scatter_deepep_routes_with_padding(
+            received_hidden,
+            received_indices,
+            received_weights,
+            received_per_expert,
+            return_route_positions=True,
+            expected_route_count=expected_route_count,
+        )
+        metadata_route_rows = _validate_and_order_route_preserving_outputs(
+            expert_hidden,
+            received_hidden,
+            sanitized_indices,
+            received_weights,
+            output_index,
+            received_fingerprints,
+            received_route_indices.reshape(-1),
+            received_route_weights.reshape(-1),
+            order_outputs=False,
+            route_positions=positions,
+            return_route_rows=True,
+        )
+        self._aligned_received_output_index = output_index
+        self._aligned_received_positions = positions
+        self._aligned_metadata_route_rows = metadata_route_rows
+        self._aligned_route_handle = route_handle
+        self._aligned_source_indices = topk_indices
+        self._aligned_source_weights = topk_scores
+        self._aligned_source_shape = hidden_states.shape
+        self._aligned_source_output_index = source_output_index
+        self._aligned_source_all_routes_valid = source_all_routes_valid
+        self._aligned_device_tokens_per_expert = device_tokens_per_expert
+        self._local_tpe_list = received_per_expert.tolist()
+        return expert_hidden, received_per_expert, expert_probs
+
+    def _combine_low_latency_aligned(
+        self, expert_output: torch.Tensor
+    ) -> torch.Tensor:
+        route_outputs = expert_output.index_select(
+            0, self._aligned_metadata_route_rows
+        )
+        if self.ep_size > 1:
+            # Match Slime's route-preserving DeepEP lifecycle in both training
+            # and forward-only execution: submit combine asynchronously through
+            # the autograd wrapper, then make the current stream wait for the
+            # returned event.  Calling Buffer.combine synchronously only in
+            # no-grad mode leaves a different channel/handle completion order
+            # across pipeline microbatches.
+            source_routes = _DeepEPCombine.apply(
+                self._deepep_group,
+                route_outputs,
+                self._aligned_route_handle,
+                True,
+                False,
+            )
+        else:
+            source_routes = route_outputs
+        output = _VLLMEPGatherWithBF16Backward.apply(
+            source_routes,
+            self._aligned_source_indices,
+            self._aligned_source_weights,
+            self._aligned_source_output_index,
+            True,
+            self._aligned_source_all_routes_valid,
+        )
+        for name in (
+            "_aligned_received_output_index",
+            "_aligned_received_positions",
+            "_aligned_metadata_route_rows",
+            "_aligned_route_handle",
+            "_aligned_source_indices",
+            "_aligned_source_weights",
+            "_aligned_source_shape",
+            "_aligned_source_output_index",
+            "_aligned_source_all_routes_valid",
+            "_aligned_device_tokens_per_expert",
+        ):
+            delattr(self, name)
+        self._local_tpe_list = None
+        return output
 
     def submit_deepep_combine(
         self, expert_output: torch.Tensor, *, allocate_on_comm_stream: bool = False
@@ -261,7 +599,10 @@ class TokenDispatcher:
             if EventHandle is not None and EventOverlap is not None
             else None
         )
-        combined = self.buffer.combine(
+        buffer = _get_deepep_buffer(
+            self._deepep_group, _tensor_hidden_bytes(rank_grouped)
+        )
+        combined = buffer.combine(
             rank_grouped,
             self._handle,
             previous_event=previous_event,
@@ -423,18 +764,22 @@ class TokenDispatcher:
     ):
         if not self.use_deepep:
             raise RuntimeError("submit_deepep_dispatch requires DeepEP dispatch.")
+        hidden_states = hidden_states.contiguous()
+        topk_indices = topk_indices.contiguous()
+        topk_scores = topk_scores.float().contiguous()
         previous_event = (
             EventOverlap(EventHandle())
             if EventHandle is not None and EventOverlap is not None
             else None
         )
+        buffer = self._ensure_deepep_buffer(hidden_states)
         (
             num_tokens_per_rank,
             num_tokens_per_rdma_rank,
             num_tokens_per_expert,
             is_token_in_rank,
             event,
-        ) = self.buffer.get_dispatch_layout(
+        ) = buffer.get_dispatch_layout(
             topk_indices,
             num_experts=self.num_experts,
             previous_event=previous_event,
@@ -442,9 +787,8 @@ class TokenDispatcher:
             allocate_on_comm_stream=allocate_on_comm_stream,
         )
 
-        topk_scores = topk_scores.float()
         recv_hidden, recv_indices, recv_probs, recv_per_expert, handle, event = (
-            self.buffer.dispatch(
+            buffer.dispatch(
                 hidden_states,
                 topk_idx=topk_indices,
                 topk_weights=topk_scores,
@@ -488,10 +832,6 @@ class TokenDispatcher:
     ):
         if isinstance(recv_per_expert, torch.Tensor):
             recv_per_expert = [int(x) for x in recv_per_expert.detach().cpu().tolist()]
-        local_tpe = torch.tensor(
-            recv_per_expert[: self.num_local_experts], dtype=torch.int64, device=recv_hidden.device
-        )
-        self._local_tpe_list = [int(x) for x in recv_per_expert[: self.num_local_experts]]
         rows = recv_hidden.size(0)
         recv_indices = recv_indices.to(torch.long)
         routing_map = torch.zeros(
@@ -505,8 +845,20 @@ class TokenDispatcher:
         row_ids = row_ids.expand_as(recv_indices)[valid]
         expert_ids = recv_indices[valid]
         routing_map[row_ids, expert_ids] = True
-        probs_2d.index_put_((row_ids, expert_ids), recv_probs[valid], accumulate=True)
-        num_out = sum(int(x) for x in recv_per_expert)
+        # DS4 hash routing can map multiple top-k slots of one token to the
+        # same expert. The boolean routing map intentionally deduplicates those
+        # routes, so their weights must be accumulated and expert counts must
+        # be derived from that same deduplicated map. Using DeepEP's raw slot
+        # counts here over-allocates permute rows and feeds uninitialized
+        # expert outputs into combine.
+        probs_2d.index_put_(
+            (row_ids, expert_ids),
+            recv_probs[valid],
+            accumulate=True,
+        )
+        local_tpe = routing_map.sum(dim=0).to(torch.int64)
+        self._local_tpe_list = [int(x) for x in local_tpe.detach().cpu().tolist()]
+        num_out = int(local_tpe.sum().item())
         dispatched, permuted_probs, sorted_indices = permute(
             recv_hidden,
             routing_map,
@@ -541,9 +893,10 @@ class TokenDispatcher:
         return dispatched, local_tpe, permuted_probs
 
     def _dispatch_deepep(self, hidden_states, topk_scores, topk_indices):
+        self._ensure_deepep_buffer(hidden_states)
         if torch.is_grad_enabled():
             recv_hidden, recv_indices, recv_probs, recv_per_expert, handle = _DeepEPDispatch.apply(
-                self.buffer,
+                self._deepep_group,
                 hidden_states,
                 topk_indices,
                 topk_scores.float(),
@@ -574,9 +927,14 @@ class TokenDispatcher:
             fused=self.moe_permute_fusion,
         )
         if torch.is_grad_enabled():
-            combined = _DeepEPCombine.apply(self.buffer, rank_grouped, self._handle, False, False)
+            combined = _DeepEPCombine.apply(
+                self._deepep_group, rank_grouped, self._handle, False, False
+            )
         else:
-            combined = self.buffer.combine(rank_grouped, self._handle)
+            buffer = _get_deepep_buffer(
+                self._deepep_group, _tensor_hidden_bytes(rank_grouped)
+            )
+            combined = buffer.combine(rank_grouped, self._handle)
         if isinstance(combined, tuple):
             combined = combined[0]
         self._row_id_map = None

--- a/experimental/lite/megatron/lite/primitive/quantization/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/quantization/__init__.py
@@ -3,6 +3,21 @@
 
 from __future__ import annotations
 
+from megatron.lite.primitive.quantization.deployment_block_fp8 import (
+    BLOCK_SHAPE,
+    CanonicalBlockFP8Weight,
+    DeploymentBlockFP8Adapter,
+    DeploymentFusedBlockFP8Adapter,
+    PackedBlockFP8Activation,
+    PackedBlockFP8Weight,
+    PackedGroupedBlockFP8Weight,
+    fp8_gemm_nt,
+    pack_block_fp8_activation,
+    pack_block_fp8_weight,
+    pack_grouped_block_fp8_weight,
+    quantize_block_fp8_weight,
+    requantize_block_fp8_weight,
+)
 from megatron.lite.primitive.quantization.qat import (
     QATSpec,
     WeightFakeQuant,
@@ -19,6 +34,13 @@ from megatron.lite.primitive.quantization.qat import (
 )
 
 __all__ = [
+    "BLOCK_SHAPE",
+    "CanonicalBlockFP8Weight",
+    "DeploymentBlockFP8Adapter",
+    "DeploymentFusedBlockFP8Adapter",
+    "PackedBlockFP8Activation",
+    "PackedBlockFP8Weight",
+    "PackedGroupedBlockFP8Weight",
     "QATSpec",
     "WeightFakeQuant",
     "apply_qat_to_chunks",
@@ -26,8 +48,14 @@ __all__ = [
     "compute_amax",
     "dequantize_weight",
     "fake_quantize_weight",
+    "fp8_gemm_nt",
     "normalize_qat_spec",
     "pack_int4",
+    "pack_block_fp8_activation",
+    "pack_block_fp8_weight",
+    "pack_grouped_block_fp8_weight",
+    "quantize_block_fp8_weight",
+    "requantize_block_fp8_weight",
     "qat_state_dict",
     "quantize_weight",
     "unpack_int4",

--- a/experimental/lite/megatron/lite/primitive/quantization/checkpoint_block_fp8.py
+++ b/experimental/lite/megatron/lite/primitive/quantization/checkpoint_block_fp8.py
@@ -1,0 +1,105 @@
+"""Dequantize release block-FP8 tensors into BF16 master weights."""
+
+from __future__ import annotations
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+except ImportError:  # CPU-only contract environments do not require Triton.
+    triton = None
+    tl = None
+
+
+BLOCK_SHAPE = (128, 128)
+
+
+if triton is not None:
+
+    @triton.jit
+    def _block_fp8_to_bf16_kernel(
+        qweight,
+        scales,
+        output,
+        columns,
+        scale_columns,
+        elements,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < elements
+        rows = offsets // columns
+        columns_in_row = offsets - rows * columns
+        scale_offsets = (rows // 128) * scale_columns + columns_in_row // 128
+        values = tl.load(qweight + offsets, mask=mask).to(tl.float32)
+        block_scales = tl.load(scales + scale_offsets, mask=mask)
+        tl.store(output + offsets, values * block_scales, mask=mask)
+
+else:
+    _block_fp8_to_bf16_kernel = None
+
+
+class BlockFP8CheckpointDequantAdapter:
+    """Strict checkpoint-only block dequantization.
+
+    Release weights use one scale per ``128 x 128`` block.  The resulting BF16
+    tensor becomes model state; deployment FP8 packing remains a separate
+    forward-time operation.
+    """
+
+    def __call__(
+        self,
+        qweight: torch.Tensor,
+        scales: torch.Tensor,
+    ) -> torch.Tensor:
+        if qweight.ndim != 2:
+            raise ValueError("checkpoint block-FP8 weight must be 2-D")
+        if qweight.dtype != torch.float8_e4m3fn:
+            raise TypeError(
+                "checkpoint block-FP8 weight must use torch.float8_e4m3fn"
+            )
+        expected = tuple(
+            (size + block - 1) // block
+            for size, block in zip(qweight.shape, BLOCK_SHAPE, strict=True)
+        )
+        if scales.ndim != 2 or tuple(scales.shape) != expected:
+            raise ValueError(
+                f"checkpoint scales must have shape {expected}, got "
+                f"{tuple(scales.shape)}"
+            )
+        if scales.device != qweight.device:
+            raise ValueError("checkpoint weight and scales must share a device")
+        if scales.dtype == torch.uint8:
+            scale_fp32 = (scales.to(torch.int32) << 23).view(torch.float32)
+        elif scales.dtype == torch.float8_e8m0fnu:
+            scale_fp32 = (scales.view(torch.uint8).to(torch.int32) << 23).view(
+                torch.float32
+            )
+        elif scales.dtype == torch.float32:
+            scale_fp32 = scales
+        else:
+            raise TypeError(
+                "checkpoint block scales must be float32, float8_e8m0fnu, or uint8"
+            )
+        if qweight.is_cuda and _block_fp8_to_bf16_kernel is not None:
+            output = torch.empty_like(qweight, dtype=torch.bfloat16)
+            block_size = 256
+            grid = (triton.cdiv(qweight.numel(), block_size),)
+            _block_fp8_to_bf16_kernel[grid](
+                qweight,
+                scale_fp32.contiguous(),
+                output,
+                qweight.shape[1],
+                scale_fp32.shape[1],
+                qweight.numel(),
+                BLOCK_SIZE=block_size,
+            )
+            return output
+        expanded = scale_fp32.repeat_interleave(BLOCK_SHAPE[0], dim=0)
+        expanded = expanded.repeat_interleave(BLOCK_SHAPE[1], dim=1)
+        expanded = expanded[: qweight.shape[0], : qweight.shape[1]]
+        return (qweight.float() * expanded).to(torch.bfloat16)
+
+
+__all__ = ["BLOCK_SHAPE", "BlockFP8CheckpointDequantAdapter"]

--- a/experimental/lite/megatron/lite/primitive/quantization/deployment_block_fp8.py
+++ b/experimental/lite/megatron/lite/primitive/quantization/deployment_block_fp8.py
@@ -1,0 +1,216 @@
+"""Thin BF16-master adapters over vLLM's block-FP8 deployment path."""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from typing import Iterable
+
+import torch
+from torch import nn
+
+try:
+    import triton
+    import triton.language as tl
+except ImportError:  # CPU-only import/test environments
+    triton = tl = None
+
+BLOCK_SHAPE = (128, 128)
+
+
+@dataclass(frozen=True)
+class CanonicalBlockFP8Weight:
+    qweight: torch.Tensor
+    scales: torch.Tensor
+    block_shape: tuple[int, int] = BLOCK_SHAPE
+
+
+@dataclass(frozen=True)
+class PackedBlockFP8Weight:
+    qweight: torch.Tensor
+    scales: torch.Tensor
+    cache_key: object | None = None
+
+
+@dataclass(frozen=True)
+class PackedBlockFP8Activation:
+    qactivation: torch.Tensor
+    scales: torch.Tensor
+
+
+PackedGroupedBlockFP8Weight = PackedBlockFP8Weight
+
+
+def _entry(module: str, name: str):
+    try:
+        return getattr(importlib.import_module(module), name)
+    except (ImportError, AttributeError) as error:
+        raise RuntimeError(f"vLLM deployment entry point {module}.{name} is unavailable") from error
+
+
+def _key(weight: nn.Parameter):
+    return (id(weight), weight._version, weight.device, weight.dtype, tuple(weight.shape))
+
+
+def _validate_weight(weight: torch.Tensor) -> None:
+    if weight.dtype != torch.bfloat16 or weight.ndim != 2:
+        raise TypeError("block-FP8 master weight must be a 2-D BF16 tensor")
+    if any(size % block for size, block in zip(weight.shape, BLOCK_SHAPE, strict=True)):
+        raise ValueError(f"weight shape {tuple(weight.shape)} must be divisible by {BLOCK_SHAPE}")
+
+
+if triton is not None:
+
+    @triton.jit
+    def _requantize(master, scales, output, columns, scale_columns, elements, BLOCK: tl.constexpr):
+        offsets = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+        mask = offsets < elements
+        rows = offsets // columns
+        columns_in_row = offsets - rows * columns
+        scale_offsets = (rows // 128) * scale_columns + columns_in_row // 128
+        values = tl.load(master + offsets, mask=mask).to(tl.float32)
+        tl.store(output + offsets, values / tl.load(scales + scale_offsets, mask=mask), mask=mask)
+
+
+def requantize_block_fp8_weight(weight: torch.Tensor, scales: torch.Tensor):
+    """Recover release FP8 bytes using the release scales, without rescaling."""
+    _validate_weight(weight)
+    expected = (weight.shape[0] // 128, weight.shape[1] // 128)
+    if scales.dtype != torch.float32 or tuple(scales.shape) != expected or scales.device != weight.device:
+        raise ValueError(f"fixed scales must be float32 {expected} on the weight device")
+    if not bool(torch.all(torch.isfinite(scales) & (scales > 0))):
+        raise ValueError("fixed scales must be finite and positive")
+    with torch.inference_mode():
+        if weight.is_cuda and triton is not None:
+            qweight = torch.empty_like(weight, dtype=torch.float8_e4m3fn)
+            _requantize[(triton.cdiv(weight.numel(), 256),)](
+                weight, scales.contiguous(), qweight, weight.shape[1], scales.shape[1], weight.numel(), BLOCK=256
+            )
+        else:
+            expanded = scales.repeat_interleave(128, 0).repeat_interleave(128, 1)
+            qweight = (weight.float() / expanded).to(torch.float8_e4m3fn)
+    return CanonicalBlockFP8Weight(qweight, scales)
+
+
+def quantize_block_fp8_weight(weight: torch.Tensor):
+    _validate_weight(weight)
+    scales = getattr(weight, "_fp8_source_scales", None)
+    if scales is not None and getattr(weight, "_fp8_source_scale_version", None) == weight._version:
+        return requantize_block_fp8_weight(weight, scales)
+    with torch.inference_mode():
+        qweight, scales = _entry("vllm.utils.deep_gemm", "per_block_cast_to_fp8")(
+            weight.detach(), block_size=list(BLOCK_SHAPE), use_ue8m0=False
+        )
+    return CanonicalBlockFP8Weight(qweight, scales)
+
+
+def _post_process(qweight, scales):
+    with torch.inference_mode():
+        return _entry(
+            "vllm.model_executor.layers.quantization.utils.fp8_utils",
+            "deepgemm_post_process_fp8_weight_block",
+        )(wq=qweight, ws=scales, quant_block_shape=BLOCK_SHAPE, use_e8m0=True)
+
+
+def pack_block_fp8_weight(weight: nn.Parameter):
+    canonical = quantize_block_fp8_weight(weight)
+    qweight, scales = _post_process(canonical.qweight, canonical.scales)
+    return PackedBlockFP8Weight(qweight, scales, _key(weight))
+
+
+def pack_grouped_block_fp8_weight(weights: Iterable[nn.Parameter]):
+    weights = tuple(weights)
+    if not weights:
+        raise ValueError("grouped block-FP8 packing requires at least one expert")
+    canonical = tuple(quantize_block_fp8_weight(weight) for weight in weights)
+    qweight, scales = _post_process(
+        torch.stack([item.qweight for item in canonical]),
+        torch.stack([item.scales for item in canonical]),
+    )
+    return PackedBlockFP8Weight(qweight, scales, tuple(_key(weight) for weight in weights))
+
+
+def pack_block_fp8_activation(x: torch.Tensor):
+    if x.dtype != torch.bfloat16 or x.ndim != 2 or x.shape[1] % 128 or x.stride(-1) != 1:
+        raise ValueError("block-FP8 activation must be contiguous 2-D BF16 with K divisible by 128")
+    oracle = _entry("vllm.utils.deep_gemm", "DeepGemmQuantScaleFMT").from_oracle()
+    packed = getattr(oracle, "name", "") == "UE8M0"
+    quantize = _entry(
+        "vllm.model_executor.layers.quantization.utils.fp8_utils",
+        "per_token_group_quant_fp8_packed_for_deepgemm" if packed else "per_token_group_quant_fp8",
+    )
+    with torch.inference_mode():
+        if packed:
+            qactivation, scales = quantize(x, 128, use_ue8m0=True)
+        else:
+            tma = bool(_entry("vllm.envs", "VLLM_USE_DEEP_GEMM_TMA_ALIGNED_SCALES"))
+            qactivation, scales = quantize(
+                x, 128, use_ue8m0=True, column_major_scales=True, tma_aligned_scales=tma
+            )
+    return PackedBlockFP8Activation(qactivation, scales)
+
+
+def fp8_gemm_nt(x: torch.Tensor, weight: PackedBlockFP8Weight):
+    if x.ndim != 2 or x.shape[1] != weight.qweight.shape[-1]:
+        raise ValueError("activation K does not match packed weight K")
+    activation = pack_block_fp8_activation(x)
+    output = torch.empty((x.shape[0], weight.qweight.shape[-2]), dtype=torch.bfloat16, device=x.device)
+    with torch.inference_mode():
+        _entry("vllm.utils.deep_gemm", "fp8_gemm_nt")(
+            (activation.qactivation, activation.scales),
+            (weight.qweight, weight.scales),
+            output,
+            is_deep_gemm_e8m0_used=True,
+        )
+    return output
+
+
+class DeploymentBlockFP8Adapter:
+    def __init__(self, *, cache_weight: bool = False):
+        self.cache_weight = cache_weight
+        self._cached_weight = None
+
+    def clear_cache(self):
+        self._cached_weight = None
+
+    def pack_weight(self, weight: nn.Parameter):
+        key = _key(weight)
+        if self.cache_weight and self._cached_weight is not None and self._cached_weight.cache_key == key:
+            return self._cached_weight
+        packed = pack_block_fp8_weight(weight)
+        if self.cache_weight:
+            self._cached_weight = packed
+        return packed
+
+    def __call__(self, x, weight):
+        return fp8_gemm_nt(x, self.pack_weight(weight))
+
+
+class DeploymentFusedBlockFP8Adapter(DeploymentBlockFP8Adapter):
+    def pack_weight(self, weights):
+        weights = tuple(weights)
+        key = tuple(_key(weight) for weight in weights)
+        if self.cache_weight and self._cached_weight is not None and self._cached_weight.cache_key == key:
+            return self._cached_weight
+        canonical = tuple(quantize_block_fp8_weight(weight) for weight in weights)
+        qweight, scales = _post_process(
+            torch.cat([item.qweight for item in canonical]),
+            torch.cat([item.scales for item in canonical]),
+        )
+        packed = PackedBlockFP8Weight(qweight, scales, key)
+        if self.cache_weight:
+            self._cached_weight = packed
+        return packed
+
+    def __call__(self, x, *weights):
+        return fp8_gemm_nt(x, self.pack_weight(weights))
+
+
+__all__ = [
+    "BLOCK_SHAPE", "CanonicalBlockFP8Weight", "DeploymentBlockFP8Adapter",
+    "DeploymentFusedBlockFP8Adapter", "PackedBlockFP8Activation",
+    "PackedBlockFP8Weight", "PackedGroupedBlockFP8Weight", "fp8_gemm_nt",
+    "pack_block_fp8_activation", "pack_block_fp8_weight",
+    "pack_grouped_block_fp8_weight", "quantize_block_fp8_weight",
+    "requantize_block_fp8_weight",
+]

--- a/experimental/lite/tests/unit/primitive/modules/test_dispatcher_ll_alignment.py
+++ b/experimental/lite/tests/unit/primitive/modules/test_dispatcher_ll_alignment.py
@@ -1,0 +1,305 @@
+import types
+
+import torch
+
+import megatron.lite.primitive.modules.dispatcher as dispatcher_module
+from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
+from megatron.lite.primitive.parallel import ParallelState
+
+
+def test_deepep_disables_unsafe_deterministic_empty_fill(monkeypatch) -> None:
+    monkeypatch.setattr(
+        dispatcher_module.torch,
+        "are_deterministic_algorithms_enabled",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        dispatcher_module.torch.utils.deterministic,
+        "fill_uninitialized_memory",
+        True,
+    )
+
+    dispatcher_module._configure_deepep_deterministic_allocator()
+
+    assert not dispatcher_module.torch.utils.deterministic.fill_uninitialized_memory
+
+
+def test_deepep_initialization_matches_mcore_num_sms(monkeypatch) -> None:
+    calls = []
+
+    class FakeBuffer:
+        @staticmethod
+        def set_num_sms(value):
+            calls.append(value)
+
+    group = object()
+    monkeypatch.setattr(
+        dispatcher_module,
+        "deep_ep",
+        type("FakeDeepEP", (), {"Buffer": FakeBuffer}),
+    )
+    ps = types.SimpleNamespace(ep_size=2, tp_ep_group=group)
+
+    dispatcher = TokenDispatcher(4, 16, ps, use_deepep=True)
+
+    assert calls == [20]
+    assert dispatcher.buffer is None
+
+
+def test_deepep_buffer_is_created_lazily_at_dispatch(monkeypatch) -> None:
+    import megatron.lite.primitive.modules.dispatcher as dispatcher_module
+
+    class FakeBuffer:
+        @staticmethod
+        def set_num_sms(_value):
+            pass
+
+    group = object()
+    sentinel = object()
+    monkeypatch.setattr(
+        dispatcher_module,
+        "deep_ep",
+        type("FakeDeepEP", (), {"Buffer": FakeBuffer}),
+    )
+    monkeypatch.setattr(
+        dispatcher_module,
+        "_get_deepep_buffer",
+        lambda actual_group, _hidden_bytes: (
+            sentinel if actual_group is group else None
+        ),
+    )
+    dispatcher = TokenDispatcher(
+        4,
+        16,
+        types.SimpleNamespace(ep_size=2, tp_ep_group=group),
+        use_deepep=True,
+        deepep_align_to_low_latency=True,
+    )
+    dispatcher._ensure_deepep_buffer(
+        torch.zeros(2, 16, dtype=torch.bfloat16)
+    )
+
+    assert dispatcher.buffer is sentinel
+
+
+def _capture_aligned_dispatch_contract(dispatcher, monkeypatch):
+    captured = {}
+
+    def fake_aligned(self, hidden, scores, indices, *, source_fixed_topk_valid):
+        captured["indices"] = indices
+        captured["source_fixed_topk_valid"] = source_fixed_topk_valid
+        return hidden, torch.empty(0, dtype=torch.int64), scores
+
+    monkeypatch.setattr(
+        dispatcher,
+        "_dispatch_low_latency_aligned",
+        types.MethodType(fake_aligned, dispatcher),
+    )
+    return captured
+
+
+def test_aligned_dispatch_fixed_topk_contract_matches_slime(monkeypatch) -> None:
+    dispatcher = TokenDispatcher.__new__(TokenDispatcher)
+    dispatcher.capacity_factor = None
+    dispatcher.deepep_align_to_low_latency = True
+    captured = _capture_aligned_dispatch_contract(dispatcher, monkeypatch)
+    hidden = torch.zeros(2, 16, dtype=torch.bfloat16)
+    scores = torch.ones(2, 2, dtype=torch.float32)
+    indices = torch.tensor([[0, 1], [1, 0]], dtype=torch.int64)
+
+    dispatcher.dispatch(hidden, scores, indices)
+
+    assert captured["source_fixed_topk_valid"] is True
+    assert captured["indices"] is indices
+
+
+def test_aligned_dispatch_masks_routes_like_slime(monkeypatch) -> None:
+    dispatcher = TokenDispatcher.__new__(TokenDispatcher)
+    dispatcher.capacity_factor = 1.0
+    dispatcher.deepep_align_to_low_latency = True
+    captured = _capture_aligned_dispatch_contract(dispatcher, monkeypatch)
+    hidden = torch.zeros(2, 16, dtype=torch.bfloat16)
+    scores = torch.tensor([[1.0, 0.0], [0.5, 0.5]], dtype=torch.float32)
+    indices = torch.tensor([[0, 1], [1, 0]], dtype=torch.int64)
+    token_mask = torch.tensor([False, True])
+
+    dispatcher.dispatch(
+        hidden,
+        scores,
+        indices,
+        router_token_masks=token_mask,
+    )
+
+    assert captured["source_fixed_topk_valid"] is False
+    assert torch.equal(
+        captured["indices"],
+        torch.tensor([[0, -1], [-1, -1]], dtype=torch.int64),
+    )
+
+
+def test_aligned_deepep_buffer_matches_mcore_process_wide_reuse(monkeypatch) -> None:
+    import megatron.lite.primitive.modules.dispatcher as dispatcher_module
+
+    class FakeConfig:
+        def get_nvl_buffer_size_hint(self, hidden_bytes, group_size):
+            return hidden_bytes * group_size
+
+        def get_rdma_buffer_size_hint(self, hidden_bytes, group_size):
+            return hidden_bytes * group_size * 2
+
+    class FakeBuffer:
+        created = 0
+
+        @staticmethod
+        def get_dispatch_config(group_size):
+            return FakeConfig()
+
+        @staticmethod
+        def get_combine_config(group_size):
+            return FakeConfig()
+
+        def __init__(self, *, group, num_nvl_bytes, num_rdma_bytes, explicitly_destroy):
+            type(self).created += 1
+            self.group = group
+            self.num_nvl_bytes = num_nvl_bytes
+            self.num_rdma_bytes = num_rdma_bytes
+            self.explicitly_destroy = explicitly_destroy
+            self.runtime = object()
+
+    group = object()
+    monkeypatch.setattr(dispatcher_module, "deep_ep", type("FakeDeepEP", (), {"Buffer": FakeBuffer}))
+    monkeypatch.setattr(dispatcher_module.dist, "get_world_size", lambda *, group: 4)
+    monkeypatch.setattr(dispatcher_module.torch.cuda, "device_count", lambda: 4)
+    monkeypatch.setattr(dispatcher_module, "_deepep_buffer", None)
+    layer0_primary = dispatcher_module._build_deepep_buffer(group, 4096)
+    layer0_metadata = dispatcher_module._build_deepep_buffer(group, 4096)
+    layer1_primary = dispatcher_module._build_deepep_buffer(group, 4096)
+
+    assert layer0_primary is layer0_metadata is layer1_primary
+    assert FakeBuffer.created == 1
+    assert layer0_primary.num_rdma_bytes == 0
+
+    grown = dispatcher_module._build_deepep_buffer(group, 8192)
+    assert grown is not layer0_primary
+    assert FakeBuffer.created == 2
+
+
+def test_deepep_receive_counts_keep_mcore_cpu_contract(monkeypatch) -> None:
+    import megatron.lite.primitive.modules.dispatcher as dispatcher_module
+
+    class FakeBuffer:
+        def get_dispatch_layout(self, *_args, **_kwargs):
+            return None, None, None, None, None
+
+        def dispatch(self, hidden, **_kwargs):
+            return hidden, None, None, [3, 5], (), None
+
+    monkeypatch.setattr(dispatcher_module, "_get_deepep_buffer", lambda *_args: FakeBuffer())
+    ctx = types.SimpleNamespace()
+    hidden = torch.zeros(2, 16, dtype=torch.bfloat16)
+    indices = torch.zeros(2, 1, dtype=torch.int64)
+    scores = torch.ones(2, 1, dtype=torch.float32)
+
+    result = dispatcher_module._DeepEPDispatch.forward(
+        ctx, object(), hidden, indices, scores, 2, False, False
+    )
+
+    counts = result[3]
+    assert counts.device.type == "cpu"
+    assert counts.dtype == torch.int64
+    assert counts.tolist() == [3, 5]
+
+
+def test_ll_alignment_preserves_duplicate_slots_and_fp32_gather(monkeypatch) -> None:
+    import vllm.model_executor.layers.fused_moe.deep_gemm_utils as deep_gemm_utils
+
+    def fake_ep_gather(
+        input_tensor, recv_ids, recv_weights, input_index, expert_map, output
+    ):
+        assert expert_map is None
+        output.zero_()
+        for token in range(recv_ids.shape[0]):
+            accumulator = torch.zeros(input_tensor.shape[1], dtype=torch.float32)
+            for slot in range(recv_ids.shape[1]):
+                row = int(input_index[token, slot])
+                if row >= 0:
+                    accumulator += input_tensor[row].float() * recv_weights[token, slot]
+            output[token].copy_(accumulator.to(output.dtype))
+
+    monkeypatch.setattr(deep_gemm_utils, "ep_gather", fake_ep_gather)
+    dispatcher = TokenDispatcher(
+        num_experts=2,
+        hidden_size=16,
+        ps=ParallelState(ep_size=1, ep_rank=0),
+        use_deepep=False,
+        deepep_align_to_low_latency=True,
+    )
+    hidden = torch.stack(
+        (
+            torch.ones(16, dtype=torch.bfloat16),
+            torch.full((16,), 2, dtype=torch.bfloat16),
+        )
+    )
+    # Token 0 deliberately selects expert 0 twice.  Ordinary boolean routing
+    # maps collapse these two slots; LL semantics must retain both.
+    indices = torch.tensor([[0, 0], [1, 0]], dtype=torch.int64)
+    weights = torch.tensor([[0.25, 0.75], [0.4, 0.6]], dtype=torch.float32)
+
+    dispatched, tokens_per_expert, _ = dispatcher.dispatch(
+        hidden, weights, indices
+    )
+
+    assert tokens_per_expert.tolist() == [3, 1]
+    torch.testing.assert_close(dispatched[0], hidden[0])
+    torch.testing.assert_close(dispatched[1], hidden[0])
+    torch.testing.assert_close(dispatched[2], hidden[1])
+    torch.testing.assert_close(dispatched[3], hidden[1])
+
+    expert_output = dispatched.clone()
+    expert_output[:3].mul_(2)  # expert 0
+    expert_output[3:].mul_(3)  # expert 1
+    actual = dispatcher.combine(expert_output)
+    expected = torch.stack(
+        (
+            torch.full((16,), 2.0, dtype=torch.bfloat16),
+            torch.full((16,), 4.8, dtype=torch.bfloat16),
+        )
+    )
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_normal_deepep_finish_deduplicates_hash_routes() -> None:
+    dispatcher = TokenDispatcher.__new__(TokenDispatcher)
+    dispatcher.num_local_experts = 2
+    dispatcher.moe_permute_fusion = False
+    dispatcher._local_tpe_list = None
+    dispatcher._row_id_map = None
+    dispatcher._restore_shape = None
+
+    hidden = torch.stack(
+        (
+            torch.ones(16, dtype=torch.bfloat16),
+            torch.full((16,), 2, dtype=torch.bfloat16),
+        )
+    )
+    indices = torch.tensor([[0, 0], [1, 0]], dtype=torch.int64)
+    weights = torch.tensor([[0.25, 0.75], [0.4, 0.6]], dtype=torch.float32)
+
+    dispatched, tokens_per_expert, routed_weights = (
+        dispatcher._finish_deepep_dispatch(
+            hidden,
+            indices,
+            weights,
+            # DeepEP counts top-k slots before duplicate expert IDs are folded.
+            [3, 1],
+        )
+    )
+
+    assert tokens_per_expert.tolist() == [2, 1]
+    assert dispatched.shape == (3, 16)
+    torch.testing.assert_close(
+        routed_weights,
+        torch.tensor([1.0, 0.6, 0.4], dtype=torch.float32),
+        rtol=0,
+        atol=0,
+    )

--- a/experimental/lite/tests/unit/primitive/quantization/test_checkpoint_block_fp8.py
+++ b/experimental/lite/tests/unit/primitive/quantization/test_checkpoint_block_fp8.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from megatron.lite.primitive.quantization.checkpoint_block_fp8 import (
+    BlockFP8CheckpointDequantAdapter,
+)
+
+
+def test_dequantizes_partial_128_blocks_to_bf16() -> None:
+    qweight = torch.ones(130, 129, dtype=torch.float8_e4m3fn)
+    scales = torch.tensor([[1.0, 2.0], [4.0, 8.0]], dtype=torch.float32)
+
+    actual = BlockFP8CheckpointDequantAdapter()(qweight, scales)
+
+    assert actual.dtype == torch.bfloat16
+    assert actual.shape == qweight.shape
+    assert torch.all(actual[:128, :128] == 1)
+    assert torch.all(actual[:128, 128:] == 2)
+    assert torch.all(actual[128:, :128] == 4)
+    assert torch.all(actual[128:, 128:] == 8)
+
+
+def test_rejects_missing_or_misaligned_scale_contract() -> None:
+    adapter = BlockFP8CheckpointDequantAdapter()
+    with pytest.raises(TypeError, match="float8_e4m3fn"):
+        adapter(torch.ones(128, 128, dtype=torch.bfloat16), torch.ones(1, 1))
+    with pytest.raises(ValueError, match="shape"):
+        adapter(
+            torch.ones(129, 128, dtype=torch.float8_e4m3fn),
+            torch.ones(1, 1),
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_cuda_fused_dequant_matches_cpu_reference_bitwise() -> None:
+    torch.manual_seed(7)
+    qweight = (
+        torch.randn(257, 259)
+        .clamp(-448, 448)
+        .to(torch.float8_e4m3fn)
+    )
+    scales = torch.rand(3, 3, dtype=torch.float32)
+    adapter = BlockFP8CheckpointDequantAdapter()
+
+    expected = adapter(qweight, scales)
+    actual = adapter(qweight.cuda(), scales.cuda()).cpu()
+
+    assert torch.equal(actual, expected)

--- a/experimental/lite/tests/unit/primitive/quantization/test_deployment_block_fp8.py
+++ b/experimental/lite/tests/unit/primitive/quantization/test_deployment_block_fp8.py
@@ -1,0 +1,332 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""CPU contracts for the lazy vLLM deployment block-FP8 adapter."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+import megatron.lite.primitive.quantization.deployment_block_fp8 as deployment_fp8
+from megatron.lite.primitive.quantization.deployment_block_fp8 import (
+    BLOCK_SHAPE,
+    DeploymentBlockFP8Adapter,
+    DeploymentFusedBlockFP8Adapter,
+    PackedBlockFP8Weight,
+    fp8_gemm_nt,
+    pack_block_fp8_activation,
+    pack_block_fp8_weight,
+    pack_grouped_block_fp8_weight,
+)
+
+
+@pytest.fixture
+def fake_vllm(monkeypatch):
+    calls: list[tuple] = []
+
+    deep_gemm = ModuleType("vllm.utils.deep_gemm")
+
+    def per_block_cast_to_fp8(x, block_size, use_ue8m0):
+        calls.append(("weight_quant", x, block_size, use_ue8m0))
+        qweight = x.float().clamp(-1, 1).to(torch.float8_e4m3fn)
+        scales = torch.ones(
+            x.shape[0] // 128,
+            x.shape[1] // 128,
+            dtype=torch.float32,
+            device=x.device,
+        )
+        return qweight, scales
+
+    deep_gemm.per_block_cast_to_fp8 = per_block_cast_to_fp8
+    class FakeScaleFormat:
+        @classmethod
+        def from_oracle(cls):
+            return SimpleNamespace(name="UE8M0")
+
+    deep_gemm.DeepGemmQuantScaleFMT = FakeScaleFormat
+
+    def gemm_op(
+        activation,
+        weight,
+        output,
+        *,
+        is_deep_gemm_e8m0_used,
+    ):
+        qinput, input_scale = activation
+        qweight, weight_scale = weight
+        calls.append(
+            (
+                "gemm",
+                qinput,
+                input_scale,
+                qweight,
+                weight_scale,
+                output,
+                is_deep_gemm_e8m0_used,
+            )
+        )
+        output.fill_(3)
+
+    deep_gemm.fp8_gemm_nt = gemm_op
+
+    fp8_utils = ModuleType(
+        "vllm.model_executor.layers.quantization.utils.fp8_utils"
+    )
+
+    def post_process(*, wq, ws, quant_block_shape, use_e8m0):
+        calls.append(
+            ("weight_postprocess", wq, ws, quant_block_shape, use_e8m0)
+        )
+        return wq, ws.to(torch.int32)
+
+    def activation_quant(x, group_size, use_ue8m0):
+        calls.append(("activation_quant", x, group_size, use_ue8m0))
+        qactivation = x.float().clamp(-1, 1).to(torch.float8_e4m3fn)
+        packed_k = (x.shape[1] // group_size + 3) // 4
+        scales = torch.ones(
+            x.shape[0], packed_k, dtype=torch.int32, device=x.device
+        )
+        return qactivation, scales
+
+    fp8_utils.deepgemm_post_process_fp8_weight_block = post_process
+    fp8_utils.per_token_group_quant_fp8_packed_for_deepgemm = activation_quant
+
+    monkeypatch.setitem(sys.modules, "vllm.utils.deep_gemm", deep_gemm)
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm.model_executor.layers.quantization.utils.fp8_utils",
+        fp8_utils,
+    )
+
+    return calls
+
+
+def _weight() -> nn.Parameter:
+    return nn.Parameter(torch.randn(128, 256, dtype=torch.bfloat16))
+
+
+def test_vllm_import_is_lazy_and_missing_entry_point_fails_closed(
+    monkeypatch,
+) -> None:
+    real_import = importlib.import_module
+    imported: list[str] = []
+
+    def tracked_import(name: str, package=None):
+        imported.append(name)
+        return real_import(name, package)
+
+    monkeypatch.setattr(deployment_fp8.importlib, "import_module", tracked_import)
+    adapter = DeploymentBlockFP8Adapter()
+    assert imported == []
+    assert adapter.cache_weight is False
+
+    def missing_import(name: str, package=None):
+        raise ImportError(name)
+
+    monkeypatch.setattr(deployment_fp8.importlib, "import_module", missing_import)
+    with pytest.raises(RuntimeError, match="vLLM deployment entry point"):
+        adapter.pack_weight(_weight())
+
+
+def test_weight_path_calls_vllm_and_packs_official_layout(fake_vllm) -> None:
+    master = _weight()
+    packed = pack_block_fp8_weight(master)
+
+    assert [call[0] for call in fake_vllm] == [
+        "weight_quant",
+        "weight_postprocess",
+    ]
+    quant_call, post_call = fake_vllm
+    assert quant_call[1] is not master
+    assert quant_call[1].data_ptr() == master.data_ptr()
+    assert quant_call[2:] == ([128, 128], False)
+    assert post_call[3:] == (BLOCK_SHAPE, True)
+    assert packed.qweight.dtype == torch.float8_e4m3fn
+    assert packed.qweight.shape == master.shape
+    assert packed.scales.dtype == torch.int32
+    assert packed.cache_key == (
+        id(master), master._version, master.device, master.dtype, tuple(master.shape)
+    )
+
+
+def test_fixed_scale_requantization_reconstructs_fp8_bitwise() -> None:
+    qweight = torch.randn(128, 256).clamp(-4, 4).to(torch.float8_e4m3fn)
+    scales = torch.tensor([[0.125, 0.25]], dtype=torch.float32)
+    expanded = scales.repeat_interleave(128, 0).repeat_interleave(128, 1)
+    master = (qweight.float() * expanded).to(torch.bfloat16)
+
+    reconstructed = deployment_fp8.requantize_block_fp8_weight(master, scales)
+
+    assert torch.equal(reconstructed.qweight, qweight)
+    assert reconstructed.scales is scales
+
+
+def test_grouped_weight_scales_are_transformed_jointly(fake_vllm) -> None:
+    masters = [_weight(), _weight()]
+    packed = pack_grouped_block_fp8_weight(masters)
+
+    assert [call[0] for call in fake_vllm] == [
+        "weight_quant",
+        "weight_quant",
+        "weight_postprocess",
+    ]
+    post_call = fake_vllm[-1]
+    assert post_call[1].shape == (2, 128, 256)
+    assert post_call[2].shape == (2, 1, 2)
+    assert packed.qweight.shape == (2, 128, 256)
+    assert packed.scales.shape == (2, 1, 2)
+    assert tuple(key[0] for key in packed.cache_key) == tuple(id(master) for master in masters)
+
+
+def test_fused_release_parameters_preserve_bytes_scales_and_cache(fake_vllm) -> None:
+    qweights = [
+        torch.randn(128, 256).clamp(-4, 4).to(torch.float8_e4m3fn)
+        for _ in range(2)
+    ]
+    scales = [
+        torch.tensor([[0.125, 0.25]], dtype=torch.float32),
+        torch.tensor([[0.5, 1.0]], dtype=torch.float32),
+    ]
+    masters = []
+    for qweight, scale in zip(qweights, scales, strict=True):
+        expanded = scale.repeat_interleave(128, 0).repeat_interleave(128, 1)
+        master = nn.Parameter((qweight.float() * expanded).to(torch.bfloat16))
+        master._fp8_source_scales = scale
+        master._fp8_source_scale_version = master._version
+        masters.append(master)
+
+    adapter = DeploymentFusedBlockFP8Adapter(cache_weight=True)
+    packed = adapter.pack_weight(masters)
+
+    assert [call[0] for call in fake_vllm] == ["weight_postprocess"]
+    post = fake_vllm[0]
+    assert torch.equal(post[1], torch.cat(qweights))
+    assert torch.equal(post[2], torch.cat(scales))
+    assert adapter.pack_weight(masters) is packed
+    assert tuple(key[0] for key in packed.cache_key) == tuple(id(master) for master in masters)
+
+    with torch.no_grad():
+        masters[1].add_(1)
+    assert adapter.pack_weight(masters) is not packed
+
+
+def test_activation_and_gemm_call_use_packed_vllm_contract(fake_vllm) -> None:
+    x = torch.randn(4, 256, dtype=torch.bfloat16)
+    packed_weight = pack_block_fp8_weight(_weight())
+    packed_activation = pack_block_fp8_activation(x)
+
+    assert packed_activation.qactivation.shape == x.shape
+    assert packed_activation.scales.shape == (4, 1)
+    activation_call = fake_vllm[-1]
+    assert activation_call[0] == "activation_quant"
+    assert activation_call[1:] == (x, 128, True)
+
+    output = fp8_gemm_nt(x, packed_weight)
+    assert output.dtype == torch.bfloat16
+    assert output.shape == (4, 128)
+    assert torch.equal(output, torch.full_like(output, 3))
+    gemm_call = fake_vllm[-1]
+    assert gemm_call[0] == "gemm"
+    assert gemm_call[-1] is True
+    assert gemm_call[1].dtype == torch.float8_e4m3fn
+    assert gemm_call[3] is packed_weight.qweight
+    assert gemm_call[4] is packed_weight.scales
+
+
+def test_master_and_state_dict_remain_bf16_and_fp8_is_not_registered(
+    fake_vllm,
+) -> None:
+    owner = nn.Linear(256, 128, bias=False, dtype=torch.bfloat16)
+    before = {name: value.clone() for name, value in owner.state_dict().items()}
+    adapter = DeploymentBlockFP8Adapter()
+
+    packed = adapter.pack_weight(owner.weight)
+
+    assert owner.weight.dtype == torch.bfloat16
+    assert isinstance(owner.weight, nn.Parameter)
+    assert owner.state_dict().keys() == before.keys()
+    torch.testing.assert_close(owner.state_dict()["weight"], before["weight"])
+    assert not isinstance(packed.qweight, nn.Parameter)
+    assert not isinstance(packed.scales, nn.Parameter)
+    assert vars(adapter).keys() == {"cache_weight", "_cached_weight"}
+    assert adapter._cached_weight is None
+
+
+def test_opt_in_cache_uses_parameter_version_and_invalidates(fake_vllm) -> None:
+    master = _weight()
+    adapter = DeploymentBlockFP8Adapter(cache_weight=True)
+
+    first = adapter.pack_weight(master)
+    second = adapter.pack_weight(master)
+    assert second is first
+    assert [call[0] for call in fake_vllm].count("weight_quant") == 1
+
+    with torch.no_grad():
+        master.add_(1)
+    third = adapter.pack_weight(master)
+    assert third is not first
+    assert third.cache_key[1] > first.cache_key[1]
+    assert [call[0] for call in fake_vllm].count("weight_quant") == 2
+
+    adapter.clear_cache()
+    assert adapter._cached_weight is None
+
+
+@pytest.mark.parametrize(
+    ("value", "error", "message"),
+    [
+        (
+            torch.randn(128, 128),
+            TypeError,
+            "must be a 2-D BF16 tensor",
+        ),
+        (
+            nn.Parameter(torch.randn(128, 128)),
+            TypeError,
+            "must be a 2-D BF16 tensor",
+        ),
+        (
+            nn.Parameter(torch.randn(2, 128, 128, dtype=torch.bfloat16)),
+            TypeError,
+            "must be a 2-D BF16 tensor",
+        ),
+        (
+            nn.Parameter(torch.randn(128, 129, dtype=torch.bfloat16)),
+            ValueError,
+            "must be divisible",
+        ),
+    ],
+)
+def test_invalid_master_weight_fails_before_vllm_import(
+    value, error, message
+) -> None:
+    with pytest.raises(error, match=message):
+        pack_block_fp8_weight(value)
+
+
+def test_invalid_activation_and_gemm_contracts_fail_closed(fake_vllm) -> None:
+    with pytest.raises(ValueError, match="contiguous 2-D BF16"):
+        pack_block_fp8_activation(torch.randn(2, 128))
+    with pytest.raises(ValueError, match="contiguous 2-D BF16"):
+        pack_block_fp8_activation(
+            torch.randn(2, 2, 128, dtype=torch.bfloat16)
+        )
+    with pytest.raises(ValueError, match="contiguous 2-D BF16"):
+        pack_block_fp8_activation(
+            torch.randn(2, 129, dtype=torch.bfloat16)
+        )
+    noncontiguous = torch.randn(2, 256, dtype=torch.bfloat16)[:, ::2]
+    with pytest.raises(ValueError, match="contiguous 2-D BF16"):
+        pack_block_fp8_activation(noncontiguous)
+
+def test_missing_deep_gemm_entry_fails_closed(fake_vllm, monkeypatch) -> None:
+    packed = pack_block_fp8_weight(_weight())
+    del sys.modules["vllm.utils.deep_gemm"].fp8_gemm_nt
+
+    with pytest.raises(RuntimeError, match="fp8_gemm_nt is unavailable"):
+        fp8_gemm_nt(torch.randn(2, 256, dtype=torch.bfloat16), packed)
+

--- a/experimental/lite/tests/unit/primitive/test_deepep_route_alignment.py
+++ b/experimental/lite/tests/unit/primitive/test_deepep_route_alignment.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import torch
+
+from megatron.lite.primitive.alignment.deepep_route import (
+    _validate_and_order_route_preserving_outputs,
+)
+
+
+def test_route_metadata_preserves_primary_receive_order() -> None:
+    received_tokens = torch.arange(4 * 16, dtype=torch.bfloat16).reshape(4, 16)
+    received_indices = torch.tensor([[0], [1], [0], [1]], dtype=torch.int64)
+    received_weights = torch.tensor([[0.1], [0.2], [0.3], [0.4]])
+    output_index = torch.tensor([[0], [2], [1], [3]], dtype=torch.int64)
+    expert_outputs = torch.tensor([[10.0], [30.0], [20.0], [40.0]])
+
+    route_fingerprints = received_tokens.clone()
+    route_indices = received_indices.reshape(-1).clone()
+    route_weights = received_weights.reshape(-1).clone()
+
+    route_rows = _validate_and_order_route_preserving_outputs(
+        expert_outputs,
+        received_tokens,
+        received_indices,
+        received_weights,
+        output_index,
+        route_fingerprints,
+        route_indices,
+        route_weights,
+        return_route_rows=True,
+    )
+    assert torch.equal(route_rows, torch.tensor([0, 2, 1, 3]))
+    ordered = _validate_and_order_route_preserving_outputs(
+        expert_outputs,
+        received_tokens,
+        received_indices,
+        received_weights,
+        output_index,
+        route_fingerprints,
+        route_indices,
+        route_weights,
+    )
+    assert torch.equal(ordered, torch.tensor([[10.0], [20.0], [30.0], [40.0]]))
+
+
+def test_route_metadata_rejects_changed_receive_order() -> None:
+    received_tokens = torch.arange(4 * 16, dtype=torch.bfloat16).reshape(4, 16)
+    received_indices = torch.tensor([[0], [1], [0], [1]], dtype=torch.int64)
+    received_weights = torch.tensor([[0.1], [0.2], [0.3], [0.4]])
+    output_index = torch.tensor([[0], [2], [1], [3]], dtype=torch.int64)
+    expert_outputs = torch.tensor([[10.0], [30.0], [20.0], [40.0]])
+
+    metadata_to_primary = torch.tensor([2, 0, 3, 1])
+    route_fingerprints = received_tokens.index_select(0, metadata_to_primary)
+    route_indices = received_indices.reshape(-1).index_select(0, metadata_to_primary)
+    route_weights = received_weights.reshape(-1).index_select(0, metadata_to_primary)
+
+    try:
+        _validate_and_order_route_preserving_outputs(
+            expert_outputs,
+            received_tokens,
+            received_indices,
+            received_weights,
+            output_index,
+            route_fingerprints,
+            route_indices,
+            route_weights,
+        )
+    except RuntimeError as error:
+        assert "changed local expert order" in str(error)
+    else:
+        raise AssertionError("changed metadata receive order was accepted")

--- a/experimental/lite/tests/unit/primitive/test_vllm_grouped_moe.py
+++ b/experimental/lite/tests/unit/primitive/test_vllm_grouped_moe.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from megatron.lite.primitive.alignment import vllm_grouped_moe
+from megatron.lite.primitive.modules.experts import swiglu_with_probs
+
+
+def _reference(
+    hidden: torch.Tensor,
+    counts: tuple[int, ...],
+    limit: float,
+    w13: tuple[torch.Tensor, ...],
+    w2: tuple[torch.Tensor, ...],
+) -> torch.Tensor:
+    outputs = []
+    offset = 0
+    for count, fc1, fc2 in zip(counts, w13, w2, strict=True):
+        selected = hidden[offset : offset + count]
+        gate_up = F.linear(selected, fc1)
+        outputs.append(F.linear(swiglu_with_probs(gate_up, None, limit), fc2))
+        offset += count
+    return torch.cat(outputs)
+
+
+def test_grouped_moe_preserves_clamped_forward_and_bf16_master_vjp(
+    monkeypatch,
+) -> None:
+    torch.manual_seed(7)
+    counts = (2, 1)
+    limit = 10.0
+    hidden = (torch.randn(3, 4) * 8).requires_grad_(True)
+    w13 = tuple((torch.randn(6, 4) * 3).requires_grad_(True) for _ in counts)
+    w2 = tuple(torch.randn(4, 3).requires_grad_(True) for _ in counts)
+    tokens_per_expert = torch.tensor(counts, dtype=torch.int32)
+    probabilities = torch.ones(sum(counts), 1)
+
+    monkeypatch.setattr(vllm_grouped_moe, "_vllm_grouped_forward", _reference)
+    output = vllm_grouped_moe.VLLMGroupedMoEWithBF16Backward.apply(
+        hidden,
+        tokens_per_expert,
+        probabilities,
+        limit,
+        *w13,
+        *w2,
+    )
+    expected = _reference(hidden, counts, limit, w13, w2)
+    unclamped = _reference(hidden, counts, 0.0, w13, w2)
+    assert torch.equal(output, expected)
+    assert not torch.allclose(output, unclamped)
+
+    grad_output = torch.randn_like(output)
+    output.backward(grad_output)
+    actual_grads = (hidden.grad, *(weight.grad for weight in w13 + w2))
+
+    ref_hidden = hidden.detach().requires_grad_(True)
+    ref_w13 = tuple(weight.detach().requires_grad_(True) for weight in w13)
+    ref_w2 = tuple(weight.detach().requires_grad_(True) for weight in w2)
+    ref_output = _reference(ref_hidden, counts, limit, ref_w13, ref_w2)
+    expected_grads = torch.autograd.grad(
+        ref_output,
+        (ref_hidden, *ref_w13, *ref_w2),
+        grad_output,
+    )
+    for actual, expected_grad in zip(actual_grads, expected_grads, strict=True):
+        torch.testing.assert_close(actual, expected_grad)
+
+
+@pytest.mark.gpus(1)
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or importlib.util.find_spec("vllm") is None,
+    reason="requires CUDA and vLLM grouped DeepGEMM",
+)
+def test_real_grouped_deepgemm_forward_has_bf16_master_vjp() -> None:
+    from vllm.utils.deep_gemm import DeepGemmQuantScaleFMT
+
+    DeepGemmQuantScaleFMT.init_oracle_cache()
+    torch.manual_seed(11)
+    counts = (2, 1)
+    limit = 10.0
+    hidden = ((torch.randn(3, 128, device="cuda", dtype=torch.bfloat16) * 8)).requires_grad_(True)
+    w13 = tuple(
+        torch.nn.Parameter(
+            torch.randn(256, 128, device="cuda", dtype=torch.bfloat16) * 3
+        )
+        for _ in counts
+    )
+    w2 = tuple(
+        torch.nn.Parameter(
+            torch.randn(128, 128, device="cuda", dtype=torch.bfloat16)
+        )
+        for _ in counts
+    )
+    tokens_per_expert = torch.tensor(counts, device="cuda", dtype=torch.int32)
+    probabilities = torch.ones(sum(counts), 1, device="cuda", dtype=torch.float32)
+    output = vllm_grouped_moe.VLLMGroupedMoEWithBF16Backward.apply(
+        hidden,
+        tokens_per_expert,
+        probabilities,
+        limit,
+        *w13,
+        *w2,
+    )
+    assert torch.isfinite(output).all()
+
+    grad_output = torch.randn_like(output)
+    output.backward(grad_output)
+    actual_grads = (hidden.grad, *(weight.grad for weight in w13 + w2))
+
+    ref_hidden = hidden.detach().requires_grad_(True)
+    ref_w13 = tuple(weight.detach().requires_grad_(True) for weight in w13)
+    ref_w2 = tuple(weight.detach().requires_grad_(True) for weight in w2)
+    ref_output = _reference(ref_hidden, counts, limit, ref_w13, ref_w2)
+    expected_grads = torch.autograd.grad(
+        ref_output,
+        (ref_hidden, *ref_w13, *ref_w2),
+        grad_output,
+    )
+    for actual, expected_grad in zip(actual_grads, expected_grads, strict=True):
+        torch.testing.assert_close(actual, expected_grad, rtol=0, atol=0)


### PR DESCRIPTION
## What changed

- adds the Slime-style normal-DeepEP route identity/ordering bridge
- adds contiguous batch-invariant DeepGEMM expert execution with actual expert counts and pad-128
- adds the shared FP8 checkpoint/deployment adapters used by DS4 training
- includes focused DeepEP, grouped-MoE, dispatcher, and FP8 unit gates

## Why

This isolates the model-independent transport and quantization contract required to align normal training DeepEP with vLLM low-latency rollout semantics.

## Validation

- fixed CUDA 13 DS4 image gate
- focused reduced suite: 49 passed, 3 skipped
- final stacked tree is byte-identical to validated commit `6945aeb4e565d2147c1244b1c6815dac3fde2325`

Stack base: `main`.
