### PR TITLE
[Lite] Remove full-size FP32 temporaries from the FSDP2 optimizer step

### DIFF
--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/adamw.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/adamw.py
@@ -11,6 +11,8 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 
+from megatron.lite.primitive.optimizers.fsdp2.grad_clip import fused_sq_sum
+
 
 def local_grad_sq_sum(
     params: Iterable[nn.Parameter],
@@ -18,18 +20,19 @@ def local_grad_sq_sum(
     dtype: torch.dtype,
     default_device: torch.device | None = None,
 ) -> torch.Tensor:
-    total: torch.Tensor | None = None
+    grads: list[torch.Tensor] = []
+    device: torch.device | None = None
     for param in params:
         grad = param.grad
         if grad is None:
             continue
-        grad = to_local_tensor(grad)
-        if total is None:
-            total = torch.zeros((), device=grad.device, dtype=dtype)
-        total += grad.detach().to(dtype).pow(2).sum()
-    if total is None:
+        grad = to_local_tensor(grad).detach()
+        if device is None:
+            device = grad.device
+        grads.append(grad)
+    if device is None:
         return torch.zeros((), device=default_device or torch.device("cpu"), dtype=dtype)
-    return total
+    return fused_sq_sum(grads, dtype=dtype, device=device)
 
 
 def to_local_tensor(tensor):

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/adamw.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/adamw.py
@@ -230,10 +230,11 @@ class FP32AdamW:
                 self._copy_master_to_param(param, master)
 
     def _prepare_grad(self, grad: torch.Tensor, master: torch.Tensor) -> torch.Tensor:
+        # No .to(float32): add_()/addcmul_() promote into the FP32 accumulators, so a
+        # full-size cast here would only cost peak memory.
         if self.cpu_update:
-            grad = to_local_tensor(grad)
-            return grad.detach().to(device=master.device, dtype=torch.float32)
-        return grad.detach().to(dtype=torch.float32)
+            return to_local_tensor(grad).detach().to(device=master.device)
+        return grad.detach()
 
     def _copy_master_to_param(self, param: nn.Parameter, master: torch.Tensor) -> None:
         model_dtype = self._model_param_dtype(param)

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/grad_clip.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/grad_clip.py
@@ -12,6 +12,11 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 
+from transformer_engine.pytorch.optimizers import (  # pyright: ignore[reportMissingImports]
+    multi_tensor_applier,
+    multi_tensor_l2norm,
+)
+
 try:  # pragma: no cover - import availability is PyTorch-version dependent.
     from torch.distributed.tensor import DTensor, Partial, Replicate
 except ImportError:  # pragma: no cover
@@ -23,7 +28,6 @@ def sharded_grad_sq_sum(
     *,
     accum_dtype: str | torch.dtype = torch.float32,
     default_device: torch.device | None = None,
-    chunk_size_numel: int = 0,
     scalar_all_reduce: (
         Callable[[torch.Tensor, dist.ProcessGroup, dist.ReduceOp], None] | None
     ) = None,
@@ -40,7 +44,7 @@ def sharded_grad_sq_sum(
     groups = _group_grads(params)
     total: torch.Tensor | None = None
     for group in groups.values():
-        local_sq = _group_local_sq_sum(group, dtype=dtype, chunk_size_numel=chunk_size_numel)
+        local_sq = _group_local_sq_sum(group, dtype=dtype)
         meta = group[0][2]
         if meta is not None and not _has_partial_placement(meta) and dist.is_initialized():
             _reduce_dtensor_scalar_(
@@ -184,34 +188,48 @@ def _group_grads(
     return groups
 
 
-def _group_local_sq_sum(
-    group: list[tuple[nn.Parameter, torch.Tensor, Any | None]],
-    *,
-    dtype: torch.dtype,
-    chunk_size_numel: int = 0,
+def fused_sq_sum(
+    tensors: Iterable[torch.Tensor], *, dtype: torch.dtype, device: torch.device
 ) -> torch.Tensor:
-    device = _local_grad(group[0][1], group[0][2]).device
+    """Sum of squares accumulated in ``dtype``, without a full-size cast of any input."""
+
     total = torch.zeros((), device=device, dtype=dtype)
-    for _param, grad, meta in group:
-        local_grad = _local_grad(grad, meta)
-        total += _tensor_sq_sum(local_grad.detach(), dtype=dtype, chunk_size_numel=chunk_size_numel)
+    # multi_tensor_applier dispatches on the list's scalar type, so bucket by dtype.
+    buckets: dict[tuple[torch.dtype, torch.device], list[torch.Tensor]] = defaultdict(list)
+    for tensor in tensors:
+        if tensor.numel() == 0:
+            continue
+        if _is_fused_eligible(tensor):
+            buckets[(tensor.dtype, tensor.device)].append(tensor)
+        else:
+            total += torch.linalg.vector_norm(tensor, 2.0, dtype=dtype).pow_(2).to(device)
+    for (_bucket_dtype, bucket_device), bucket in buckets.items():
+        noop_flag = torch.zeros(1, dtype=torch.int, device=bucket_device)
+        norm, _ = multi_tensor_applier(multi_tensor_l2norm, noop_flag, [bucket], False)
+        total += norm.reshape(()).to(device=device, dtype=dtype).pow(2)
     return total
 
 
-def _tensor_sq_sum(
-    tensor: torch.Tensor, *, dtype: torch.dtype, chunk_size_numel: int = 0
+def _is_fused_eligible(tensor: torch.Tensor) -> bool:
+    # The kernel needs contiguous CUDA input, and a contiguous() copy here would cost
+    # the allocation we are avoiding. Tests patch this to reach the bucket path on CPU.
+    return tensor.is_cuda and tensor.is_contiguous()
+
+
+def _group_local_sq_sum(
+    group: list[tuple[nn.Parameter, torch.Tensor, Any | None]], *, dtype: torch.dtype
 ) -> torch.Tensor:
-    if chunk_size_numel <= 0 or tensor.numel() <= chunk_size_numel:
-        return tensor.to(dtype).pow(2).sum()
-    try:
-        flat = tensor.view(-1)
-    except RuntimeError:
-        flat = tensor.reshape(-1)
-    total = torch.zeros((), device=tensor.device, dtype=dtype)
-    for start in range(0, flat.numel(), chunk_size_numel):
-        chunk = flat.narrow(0, start, min(chunk_size_numel, flat.numel() - start))
-        total += chunk.to(dtype).pow(2).sum()
-    return total
+    meta = group[0][2]
+    device = _local_grad(group[0][1], meta).device
+    if meta is not None and _has_partial_placement(meta):
+        # _local_grad() materializes the global-shaped grad here; keep one alive at a time.
+        total = torch.zeros((), device=device, dtype=dtype)
+        for _param, grad, grad_meta in group:
+            local = _local_grad(grad, grad_meta).detach()
+            total += fused_sq_sum([local], dtype=dtype, device=device)
+        return total
+    locals_ = [_local_grad(grad, grad_meta).detach() for _param, grad, grad_meta in group]
+    return fused_sq_sum(locals_, dtype=dtype, device=device)
 
 
 def _group_local_abs_max(
@@ -222,7 +240,9 @@ def _group_local_abs_max(
     for _param, grad, meta in group:
         local_grad = _local_grad(grad, meta)
         if local_grad.numel() > 0:
-            total = torch.maximum(total, local_grad.detach().to(dtype).abs().max())
+            # vector_norm(inf) is abs().max() without the intermediate tensors.
+            local_max = torch.linalg.vector_norm(local_grad.detach(), float("inf"), dtype=dtype)
+            total = torch.maximum(total, local_max.to(device))
     return total
 
 
@@ -320,6 +340,7 @@ def _process_group_backend(group: dist.ProcessGroup) -> str:
 __all__ = [
     "all_reduce_scalar_",
     "clip_grads_with_sharded_norm_",
+    "fused_sq_sum",
     "resolve_torch_dtype",
     "sharded_grad_abs_max",
     "sharded_grad_norm",

--- a/experimental/lite/tests/unit/primitive/optimizers/fsdp2/test_fsdp2_unit.py
+++ b/experimental/lite/tests/unit/primitive/optimizers/fsdp2/test_fsdp2_unit.py
@@ -20,6 +20,7 @@ from megatron.lite.primitive.optimizers.fsdp2 import (
 from megatron.lite.primitive.optimizers.fsdp2.adamw import (
     build_adamw_optimizer,
     local_grad_sq_sum,
+    to_local_tensor,
 )
 from megatron.lite.primitive.optimizers.fsdp2.wrap import build_fsdp2_shard_placement_fn
 from megatron.lite.primitive.parallel.state import ParallelState
@@ -27,6 +28,7 @@ from megatron.lite.primitive.parallel.state import ParallelState
 fsdp2_wrap = importlib.import_module("megatron.lite.primitive.optimizers.fsdp2.wrap")
 fsdp2_optimizer = importlib.import_module("megatron.lite.primitive.optimizers.fsdp2.optimizer")
 fsdp2_grad_clip = importlib.import_module("megatron.lite.primitive.optimizers.fsdp2.grad_clip")
+fsdp2_adamw = importlib.import_module("megatron.lite.primitive.optimizers.fsdp2.adamw")
 
 
 class ToyBlock(nn.Module):
@@ -689,3 +691,43 @@ def test_fused_sq_sum_allocates_no_full_size_temporary():
     # to(float32).pow(2) would add 4x the grad here.
     assert torch.cuda.max_memory_allocated() - before < 1 << 20
     assert float(total) == pytest.approx(_reference_sq_sum([grad.cpu()]), rel=1e-3)
+
+
+@pytest.mark.parametrize("cpu_update", [False, True])
+def test_fp32_adamw_bf16_grad_matches_legacy_fp32_grad_copy(monkeypatch, cpu_update):
+    def legacy_prepare_grad(self, grad, master):
+        if self.cpu_update:
+            return to_local_tensor(grad).detach().to(device=master.device, dtype=torch.float32)
+        return grad.detach().to(dtype=torch.float32)
+
+    torch.manual_seed(0)
+    grad = torch.randn(512, dtype=torch.bfloat16)
+
+    def run():
+        torch.manual_seed(1)
+        param = nn.Parameter(torch.randn(512, dtype=torch.bfloat16))
+        optimizer = build_adamw_optimizer(
+            [{"params": [param], "weight_decay": 0.01}],
+            all_params=[param],
+            lr=0.1,
+            weight_decay=0.01,
+            betas=(0.9, 0.99),
+            eps=1.0e-8,
+            foreach=False,
+            use_fp32_master=True,
+            cpu_update=cpu_update,
+            model_param_dtypes={id(param): torch.bfloat16},
+            opt=SimpleNamespace(),
+        )
+        assert isinstance(optimizer, fsdp2_adamw.FP32AdamW)
+        for _ in range(4):  # several steps so bias correction and state carry-over count
+            param.grad = grad.clone()
+            optimizer.step()
+        state = optimizer.state_dict()
+        keys = ("exp_avgs", "exp_avg_sqs", "master_params")
+        return (param.detach().clone(), *(state[key][0].clone() for key in keys))
+
+    current = run()
+    monkeypatch.setattr(fsdp2_adamw.FP32AdamW, "_prepare_grad", legacy_prepare_grad)
+    for from_current, from_legacy in zip(current, run()):
+        assert torch.equal(from_current, from_legacy)

--- a/experimental/lite/tests/unit/primitive/optimizers/fsdp2/test_fsdp2_unit.py
+++ b/experimental/lite/tests/unit/primitive/optimizers/fsdp2/test_fsdp2_unit.py
@@ -680,6 +680,7 @@ def test_grad_norm_paths_accumulate_bf16_in_fp32():
     assert float(fsdp2_grad_clip.sharded_grad_abs_max([param, plain])) == pytest.approx(7.0)
 
 
+@pytest.mark.gpus(1)
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="TE multi_tensor_l2norm is CUDA-only.")
 def test_fused_sq_sum_allocates_no_full_size_temporary():
     grad = torch.randn(64 * 1024 * 1024, dtype=torch.bfloat16, device="cuda")

--- a/experimental/lite/tests/unit/primitive/optimizers/fsdp2/test_fsdp2_unit.py
+++ b/experimental/lite/tests/unit/primitive/optimizers/fsdp2/test_fsdp2_unit.py
@@ -17,7 +17,10 @@ from megatron.lite.primitive.optimizers.fsdp2 import (
     clip_grads_with_sharded_norm_,
     fsdp2_available,
 )
-from megatron.lite.primitive.optimizers.fsdp2.adamw import build_adamw_optimizer
+from megatron.lite.primitive.optimizers.fsdp2.adamw import (
+    build_adamw_optimizer,
+    local_grad_sq_sum,
+)
 from megatron.lite.primitive.optimizers.fsdp2.wrap import build_fsdp2_shard_placement_fn
 from megatron.lite.primitive.parallel.state import ParallelState
 
@@ -610,3 +613,79 @@ def test_fp32_adamw_load_matches_uninterrupted_next_step_cpu(cpu_update: bool):
     for key in ("master_params", "exp_avgs", "exp_avg_sqs"):
         torch.testing.assert_close(loaded_state[key][0], direct_state[key][0], atol=0.0, rtol=0.0)
     assert loaded_state["steps"] == direct_state["steps"]
+
+
+def _reference_sq_sum(tensors) -> float:
+    return float(sum(t.double().pow(2).sum() for t in tensors))
+
+
+def test_fused_sq_sum_matches_reference():
+    torch.manual_seed(0)
+    tensors = [
+        torch.randn(1024, dtype=torch.bfloat16),
+        torch.randn(37, 41),
+        torch.randn(64, 64)[:, ::2],
+        torch.randn(0),
+    ]
+    total = fsdp2_grad_clip.fused_sq_sum(tensors, dtype=torch.float32, device=torch.device("cpu"))
+    assert total.ndim == 0 and total.dtype is torch.float32
+    assert float(total) == pytest.approx(_reference_sq_sum(tensors), rel=1e-5)
+
+
+def test_fused_sq_sum_launches_one_kernel_per_dtype(monkeypatch):
+    """Mixed-dtype lists must not reach the kernel, non-contiguous tensors must not
+    either, and contiguous grads must not be launched one at a time."""
+    launches: list[tuple[int, torch.dtype]] = []
+
+    def fake_applier(op, noop_flag, tensor_lists, *args):
+        bucket = tensor_lists[0]
+        assert op is fsdp2_grad_clip.multi_tensor_l2norm
+        assert len({t.dtype for t in bucket}) == 1
+        assert all(t.is_contiguous() for t in bucket)
+        launches.append((len(bucket), bucket[0].dtype))
+        return torch.tensor([_reference_sq_sum(bucket) ** 0.5], dtype=torch.float32), None
+
+    # CPU-only test env: force the CUDA-eligibility check so the bucket path runs.
+    monkeypatch.setattr(fsdp2_grad_clip, "multi_tensor_applier", fake_applier)
+    monkeypatch.setattr(fsdp2_grad_clip, "_is_fused_eligible", lambda t: t.is_contiguous())
+
+    torch.manual_seed(0)
+    tensors = [
+        torch.randn(512, dtype=torch.bfloat16),
+        torch.randn(256, dtype=torch.bfloat16),
+        torch.randn(128),
+        torch.randn(64, 64)[:, ::2],
+    ]
+    total = fsdp2_grad_clip.fused_sq_sum(tensors, dtype=torch.float32, device=torch.device("cpu"))
+    assert sorted(launches) == [(1, torch.float32), (2, torch.bfloat16)]
+    assert float(total) == pytest.approx(_reference_sq_sum(tensors), rel=1e-5)
+
+
+def test_grad_norm_paths_accumulate_bf16_in_fp32():
+    torch.manual_seed(0)
+    param = nn.Parameter(torch.randn(4096, dtype=torch.bfloat16))
+    param.grad = torch.full((4096,), 0.01, dtype=torch.bfloat16)
+    plain = nn.Parameter(torch.randn(8))
+    plain.grad = torch.arange(8, dtype=torch.float32)
+    expected = _reference_sq_sum([param.grad, plain.grad])
+
+    for actual in (
+        fsdp2_grad_clip.sharded_grad_sq_sum([param, plain]),
+        local_grad_sq_sum([param, plain], dtype=torch.float32),
+    ):
+        assert actual.dtype is torch.float32
+        assert float(actual) == pytest.approx(expected, rel=1e-5)
+    assert float(fsdp2_grad_clip.sharded_grad_abs_max([param, plain])) == pytest.approx(7.0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="TE multi_tensor_l2norm is CUDA-only.")
+def test_fused_sq_sum_allocates_no_full_size_temporary():
+    grad = torch.randn(64 * 1024 * 1024, dtype=torch.bfloat16, device="cuda")
+    torch.cuda.synchronize()
+    torch.cuda.reset_peak_memory_stats()
+    before = torch.cuda.memory_allocated()
+    total = fsdp2_grad_clip.fused_sq_sum([grad], dtype=torch.float32, device=grad.device)
+    torch.cuda.synchronize()
+    # to(float32).pow(2) would add 4x the grad here.
+    assert torch.cuda.max_memory_allocated() - before < 1 << 20
+    assert float(total) == pytest.approx(_reference_sq_sum([grad.cpu()]), rel=1e-3)


### PR DESCRIPTION
# [Lite] Remove full-size FP32 temporaries from the FSDP2 optimizer step

## Motivation

FSDP2 OOMs more easily than it should. Two places in the optimizer step allocate
transient FP32 buffers proportional to the *largest* gradient, at exactly the
point where memory is already at its high-water mark.

**1. Grad norm.** `grad_clip.py` computed `t.to(float32).pow(2).sum()` per grad.
This keeps **two** full-size FP32 temporaries alive at once — the cast result is
still referenced while `pow()` allocates its own output — i.e. **4x the bytes of
a BF16 grad**. On a large fused expert weight that is hundreds of MB of pure
transient. It also launches 3 kernels per parameter in a Python loop.

**2. AdamW step.** `FP32AdamW._prepare_grad()` did `grad.detach().to(float32)`
for every parameter — another 2x the BF16 grad, in the *same* phase. Fixing only
the grad norm would leave the end-to-end peak unchanged.

mcore does not have either problem: `get_grad_norm_fp32` uses TE/apex's fused
`multi_tensor_l2norm`, and its grads are already FP32 `main_grad` buffers by the
time they reach the optimizer, so no cast is needed at all.

## Changes

**Grad norm → TE fused `multi_tensor_l2norm`** (same kernel as mcore
`megatron/core/optimizer/clip_grads.py`): FP32 accumulation inside the kernel,
zero temporaries, one launch per bucket instead of one per parameter.

- `grad_clip.py`: new `fused_sq_sum()`, bucketed by `(dtype, device)` —
  `multi_tensor_applier` dispatches on the tensor list's scalar type, so
  mixed-dtype lists are not safe to pass. mcore never hit this because its grads
  are uniformly FP32; lite mixes BF16 and FP32.
- Non-contiguous tensors deliberately stay off the multi-tensor path (they would
  need a full `contiguous()` copy — exactly the allocation being removed) and use
  `torch.linalg.vector_norm`, which is likewise temporary-free. CPU tensors use
  the same path, which keeps the CPU-only unit tests working.
- `Partial`-placement groups still process one grad at a time: `_local_grad()`
  calls `full_tensor()` there, and collecting the group into a list first would
  keep several global-shaped tensors alive simultaneously.
- `_group_local_abs_max()` had the identical double-temporary defect in
  `.to(dtype).abs().max()`; now `vector_norm(inf)`. This also fixes the
  comparison silently being done in BF16 for BF16 grads.
- `adamw.py`: `local_grad_sq_sum()` shares the fused path, so plain-tensor grads
  do not fall back to a full-size allocation.
- Removed the unused `chunk_size_numel` plumbing (no callers in tree).

**AdamW step:** `_prepare_grad()` no longer materializes an FP32 copy.
`exp_avg`/`exp_avg_sq` are already FP32 and `add_()`/`addcmul_()` promote a BF16
operand to the accumulator dtype inside the kernel, so the copy bought nothing.
For `cpu_update`, the D2H transfer now moves the grad in its own dtype, halving
it as well.

## Numerics

Grad norm: `norm` then square instead of a direct squared sum. Relative error is
~1e-7 (and it is *less* prone to FP32 overflow, not more). All new tests assert
against a float64 reference.

AdamW: **bitwise identical**. Verified over 4 steps across `param`, `exp_avg`,
`exp_avg_sq` and `master_param`, for both the GPU path and `cpu_update`.

## Tests

Added to `test_fsdp2_unit.py`:

- `fused_sq_sum` vs a float64 reference on mixed BF16/FP32/empty inputs
- one multi-tensor launch **per dtype**, not per parameter (guards the bucketing)
- non-contiguous tensors never reach the multi-tensor kernel
- BF16 grads accumulate in FP32 on both the sq-sum and inf-norm paths
- `FP32AdamW` bitwise equivalence vs the old FP32-copy path, parametrized over
  `cpu_update`
- **CUDA-only**: peak allocation during the norm must stay under 1 MB for a
  64M-element BF16 grad (the old code allocated 512 MB there). Numerical tests
  cannot catch a memory regression — this is the one that guards the actual point
  of the change.

`_is_fused_eligible()` exists as a monkeypatch seam so the CPU-only unit tests can
exercise the bucket path without a GPU.

## Not in this PR

`denom = exp_avg_sq.sqrt()` in the AdamW step is still a full-size FP32
temporary. Removing it needs a fused Adam kernel. `maybe_build_te_fused_adam_optimizer()`
already wires up TE `FusedAdam(master_weights=True)` behind
`fsdp2_use_te_fused_adam` (default off) — flipping that default is the better
lever, but it changes optimizer state format and needs convergence validation, so
it belongs in its own PR.
