### PR TITLE
sync(lite): adopt the verl-project lite tree

### DIFF
--- a/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
@@ -518,7 +518,14 @@ class MegatronLiteEngine(BaseEngine):
         if dist.is_initialized():
             dist.barrier()
 
-        proto.save_hf_weights(model_chunks, hf_local_path, model_cfg, ps)
+        save_kwargs: dict[str, Any] = {}
+        if self.engine_config.resync_format is not None:
+            save_kwargs["target"] = self.engine_config.resync_format
+            if self.engine_config.resync_config:
+                save_kwargs["resync_config"] = dict(self.engine_config.resync_config)
+        if self.engine_config.export_dtype:
+            save_kwargs["export_dtype"] = self.engine_config.export_dtype
+        proto.save_hf_weights(model_chunks, hf_local_path, model_cfg, ps, **save_kwargs)
 
         if self._rank == 0:
             hf_config = getattr(self.model_config, "hf_config", None)

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
@@ -240,8 +240,30 @@ class DeepseekV4WeightSpec:
     ``weight<local>`` ids to global before calling ``native_to_hf``.
     """
 
+    # HF names whose released dtype is fp32.  These tensors are declared fp32
+    # at construction (see ``mhc.py`` / attention sinks / compressor.ape) but
+    # the protocol's module-wide ``.to(bfloat16)`` downcasts them; the export
+    # path re-materializes them as fp32 so the saved checkpoint matches the
+    # DeepSeek-V4-Flash release byte-for-byte in dtype.
+    _FP32_HF_SUFFIXES: tuple[str, ...] = (
+        ".attn_sink",
+        ".compressor.ape",
+        ".indexer.compressor.ape",
+        ".ffn.gate.bias",
+    )
+    _FP32_HF_INFIXES: tuple[str, ...] = ("hc_head_", ".hc_attn_", ".hc_ffn_")
+
     def __init__(self, config: DeepseekV4Config):
         self.config = config
+
+    def hf_export_dtype_override(self, hf_name: str) -> torch.dtype | None:
+        """Return an explicit export dtype for ``hf_name``, or ``None`` when
+        the shared exporter's default (usually the training dtype) is fine."""
+        if hf_name.endswith(self._FP32_HF_SUFFIXES):
+            return torch.float32
+        if any(marker in hf_name for marker in self._FP32_HF_INFIXES):
+            return torch.float32
+        return None
 
     @property
     def num_experts(self) -> int:
@@ -382,7 +404,14 @@ def _export_unquantized_weights(
     )
 
     spec = DeepseekV4WeightSpec(config)
-    yield from _export(model, spec, ps, vocab_size=config.vocab_size, **kwargs)
+    for name, tensor in _export(
+        model, spec, ps, vocab_size=config.vocab_size, **kwargs
+    ):
+        if tensor.is_floating_point():
+            override = spec.hf_export_dtype_override(name)
+            if override is not None and tensor.dtype != override:
+                tensor = tensor.to(override)
+        yield name, tensor
 
 
 def export_hf_weights(model, config: DeepseekV4Config, ps: ParallelState, **kwargs):

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/resync.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/resync.py
@@ -86,6 +86,11 @@ def export_resync_weights(
     # representation; serializing them as UE8M0 causes a large online-reload
     # regression even though W4/MXFP4 legitimately uses UE8M0 scales.
     fp8_scale_format = "e8m0" if expert_dtype == "fp4" else "float32"
+    # Run MXFP4 / block-FP8 on the GPU when it is available: SFT save
+    # gathers on CPU (rank0_only, cpu=True) and CPU quantization is
+    # Python/torch-op bound (~30x slower than the write). RL online resync
+    # already runs on GPU tensors, so the H2D/D2H copies are skipped.
+    quant_on_gpu = torch.cuda.is_available()
 
     for name, tensor in weights:
         if (
@@ -98,12 +103,17 @@ def export_resync_weights(
             yield name, tensor
             continue
 
+        needs_move_to_gpu = quant_on_gpu and tensor.device.type != "cuda"
+        source = tensor.cuda(non_blocking=True) if needs_move_to_gpu else tensor
         if is_routed_expert(name) and expert_dtype == "fp4":
-            quantized, scale = quantize_mxfp4(tensor)
+            quantized, scale = quantize_mxfp4(source)
         else:
             quantized, scale = quantize_block_fp8(
-                tensor, block_shape, scale_format=fp8_scale_format
+                source, block_shape, scale_format=fp8_scale_format
             )
+        if needs_move_to_gpu:
+            quantized = quantized.to(tensor.device)
+            scale = scale.to(tensor.device)
         yield name, quantized
         yield _scale_name(name), scale
 

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/protocol.py
@@ -288,10 +288,10 @@ def export_hf_weights(chunks, model_cfg: KimiK2Config, ps: ParallelState, **kwar
     yield from export_impl(chunks, model_cfg, ps, **kwargs)
 
 
-def save_hf_weights(chunks, path: str, model_cfg: KimiK2Config, ps: ParallelState) -> None:
+def save_hf_weights(chunks, path: str, model_cfg: KimiK2Config, ps: ParallelState, **kwargs) -> None:
     from megatron.lite.model.kimi_k2.lite.checkpoint import save_hf_weights as save_impl
 
-    save_impl(chunks, path, model_cfg, ps)
+    save_impl(chunks, path, model_cfg, ps, **kwargs)
 
 
 def vocab_size(model_cfg) -> int | None:

--- a/experimental/lite/megatron/lite/model/qwen3_5/config.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/config.py
@@ -15,6 +15,7 @@ _HF_FIELDS = frozenset(
         "num_key_value_heads",
         "head_dim",
         "vocab_size",
+        "intermediate_size",
         "rms_norm_eps",
         "max_position_embeddings",
         "router_aux_loss_coef",
@@ -42,14 +43,16 @@ _HF_FIELDS = frozenset(
 
 @dataclass
 class Qwen35Config:
-    """Pure Qwen3.5-35B-A3B architecture parameters."""
+    """Qwen3.5 architecture parameters."""
 
+    model_type: str = "qwen3_5_moe"
     num_hidden_layers: int = 40
     hidden_size: int = 2048
     num_attention_heads: int = 16
     num_key_value_heads: int = 2
     head_dim: int = 256
     vocab_size: int = 248320
+    intermediate_size: int | None = None
     rms_norm_eps: float = 1e-6
     max_position_embeddings: int = 262144
     router_aux_loss_coef: float = 0.001
@@ -70,6 +73,7 @@ class Qwen35Config:
     partial_rotary_factor: float = 0.25
     rope_theta: float = 10_000_000.0
     mrope_section: list[int] | None = None
+    hf_text_prefix: str = "model.language_model"
     num_nextn_predict_layers: int = 0
     mtp_loss_scaling_factor: float = 0.1
     mtp_use_dedicated_embeddings: bool = False
@@ -83,6 +87,10 @@ class Qwen35Config:
     @property
     def rotary_dim(self) -> int:
         return int(self.head_dim * self.partial_rotary_factor)
+
+    @property
+    def is_moe(self) -> bool:
+        return self.model_type == "qwen3_5_moe"
 
     @property
     def full_attn_qkv_size(self) -> int:
@@ -145,6 +153,15 @@ class Qwen35Config:
         _check(self.head_dim > 0, f"head_dim must be > 0, got {self.head_dim}")
         _check(self.vocab_size > 0, f"vocab_size must be > 0, got {self.vocab_size}")
         _check(
+            self.hf_text_prefix in {"model", "model.language_model"},
+            "hf_text_prefix must be 'model' or 'model.language_model', "
+            f"got {self.hf_text_prefix!r}",
+        )
+        _check(
+            self.model_type in {"qwen3_5", "qwen3_5_moe"},
+            f"model_type must be qwen3_5 or qwen3_5_moe, got {self.model_type!r}",
+        )
+        _check(
             self.num_attention_heads >= 1,
             f"num_attention_heads must be >= 1, got {self.num_attention_heads}",
         )
@@ -153,20 +170,28 @@ class Qwen35Config:
             f"num_attention_heads({self.num_attention_heads}) must be divisible by "
             f"num_key_value_heads({self.num_key_value_heads})",
         )
-        _check(self.num_experts >= 1, f"num_experts must be >= 1, got {self.num_experts}")
-        _check(
-            1 <= self.num_experts_per_tok <= self.num_experts,
-            f"num_experts_per_tok({self.num_experts_per_tok}) must be in "
-            f"[1, num_experts({self.num_experts})]",
-        )
-        _check(
-            self.moe_intermediate_size > 0,
-            f"moe_intermediate_size must be > 0, got {self.moe_intermediate_size}",
-        )
-        _check(
-            self.shared_expert_intermediate_size > 0,
-            f"shared_expert_intermediate_size must be > 0, got {self.shared_expert_intermediate_size}",
-        )
+        if self.is_moe:
+            _check(self.num_experts >= 1, f"num_experts must be >= 1, got {self.num_experts}")
+            _check(
+                1 <= self.num_experts_per_tok <= self.num_experts,
+                f"num_experts_per_tok({self.num_experts_per_tok}) must be in "
+                f"[1, num_experts({self.num_experts})]",
+            )
+            _check(
+                self.moe_intermediate_size > 0,
+                f"moe_intermediate_size must be > 0, got {self.moe_intermediate_size}",
+            )
+            _check(
+                self.shared_expert_intermediate_size > 0,
+                f"shared_expert_intermediate_size must be > 0, "
+                f"got {self.shared_expert_intermediate_size}",
+            )
+        else:
+            _check(
+                self.intermediate_size is not None and self.intermediate_size > 0,
+                f"intermediate_size must be > 0 for dense Qwen3.5, "
+                f"got {self.intermediate_size}",
+            )
         _check(
             self.linear_num_key_heads >= 1,
             f"linear_num_key_heads must be >= 1, got {self.linear_num_key_heads}",
@@ -230,9 +255,17 @@ class Qwen35Config:
 
     @classmethod
     def _from_hf_dict(cls, hf: dict, **overrides) -> Qwen35Config:
-        if "text_config" in hf and isinstance(hf["text_config"], dict):
-            hf = hf["text_config"]
+        model_type = hf.get("model_type")
+        if model_type not in {"qwen3_5", "qwen3_5_moe"}:
+            raise ValueError(f"Unsupported Qwen3.5 model_type: {model_type!r}")
+
+        text_hf = hf.get("text_config")
+        is_composite = isinstance(text_hf, dict)
+        if is_composite:
+            hf = text_hf
         kwargs = {k: v for k, v in hf.items() if k in _HF_FIELDS}
+        kwargs["model_type"] = model_type
+        kwargs["hf_text_prefix"] = "model.language_model" if is_composite else "model"
         mtp_num_hidden_layers = kwargs.pop("mtp_num_hidden_layers", None)
         if kwargs.get("num_nextn_predict_layers") is None and mtp_num_hidden_layers is not None:
             kwargs["num_nextn_predict_layers"] = int(mtp_num_hidden_layers)

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/checkpoint.py
@@ -7,6 +7,7 @@ It intentionally does not require wrapper-specific state on the model.
 
 from __future__ import annotations
 
+import logging
 import re
 
 import torch
@@ -18,6 +19,9 @@ from megatron.lite.primitive.quantization.mxfp4 import MXFP4_BLOCK_SIZE, quantiz
 from megatron.lite.primitive.utils import ensure_divisible
 from megatron.lite.runtime.contracts.weights import ResyncFormat
 from torch.distributed.tensor import Replicate, Shard
+
+
+logger = logging.getLogger(__name__)
 
 
 def EXPERT_CLASSIFIER(name: str) -> bool:
@@ -50,6 +54,10 @@ def PLACEMENT_FN(param_name: str) -> list:
     if "gate_up" in param_name and "shared" in param_name:
         return [Replicate(), Replicate(), Replicate(), Shard(0)]
     if "down" in param_name and "shared" in param_name:
+        return [Replicate(), Replicate(), Replicate(), Shard(1)]
+    if ".mlp.gate_up.linear.weight" in param_name:
+        return [Replicate(), Replicate(), Replicate(), Shard(0)]
+    if ".mlp.down.linear.weight" in param_name:
         return [Replicate(), Replicate(), Replicate(), Shard(1)]
     if "embed" in param_name or "head" in param_name:
         return [Replicate(), Replicate(), Replicate(), Shard(0)]
@@ -280,14 +288,15 @@ class Qwen35WeightSpec:
 
     def weight_map(self) -> dict[str, list[str]]:
         c = self.config
+        text_prefix = c.hf_text_prefix
         weight_map: dict[str, list[str]] = {
-            "embed.embedding.weight": ["model.language_model.embed_tokens.weight"],
-            "norm.weight": ["model.language_model.norm.weight"],
+            "embed.embedding.weight": [f"{text_prefix}.embed_tokens.weight"],
+            "norm.weight": [f"{text_prefix}.norm.weight"],
             "head.col.linear.weight": ["lm_head.weight"],
         }
         for layer_idx in range(c.num_hidden_layers):
             local_prefix = f"layers.{layer_idx}"
-            hf_prefix = f"model.language_model.layers.{layer_idx}"
+            hf_prefix = f"{text_prefix}.layers.{layer_idx}"
             mlp = f"{hf_prefix}.mlp"
             if c.layer_type_at(layer_idx) == "full_attention":
                 attention = f"{hf_prefix}.self_attn"
@@ -338,33 +347,49 @@ class Qwen35WeightSpec:
                         ],
                     }
                 )
-            weight_map.update(
-                {
-                    f"{local_prefix}.mlp_norm.weight": [
-                        f"{hf_prefix}.post_attention_layernorm.weight"
-                    ],
-                    f"{local_prefix}.moe.router.gate.weight": [f"{mlp}.gate.weight"],
-                    f"{local_prefix}.moe.shared_expert.gate_up.linear.weight": [
-                        f"{mlp}.shared_expert.gate_proj.weight",
-                        f"{mlp}.shared_expert.up_proj.weight",
-                    ],
-                    f"{local_prefix}.moe.shared_expert.down.linear.weight": [
-                        f"{mlp}.shared_expert.down_proj.weight"
-                    ],
-                    f"{local_prefix}.moe.shared_expert.shared_gate.weight": [
-                        f"{mlp}.shared_expert_gate.weight"
-                    ],
-                }
-            )
-            for expert_idx in range(c.num_experts):
-                weight_map[f"{local_prefix}.moe.experts.fc1.weight{expert_idx}"] = [
-                    f"{mlp}.experts.{expert_idx}.gate_proj.weight",
-                    f"{mlp}.experts.{expert_idx}.up_proj.weight",
-                ]
-            for expert_idx in range(c.num_experts):
-                weight_map[f"{local_prefix}.moe.experts.fc2.weight{expert_idx}"] = [
-                    f"{mlp}.experts.{expert_idx}.down_proj.weight"
-                ]
+            if c.is_moe:
+                weight_map.update(
+                    {
+                        f"{local_prefix}.mlp_norm.weight": [
+                            f"{hf_prefix}.post_attention_layernorm.weight"
+                        ],
+                        f"{local_prefix}.moe.router.gate.weight": [f"{mlp}.gate.weight"],
+                        f"{local_prefix}.moe.shared_expert.gate_up.linear.weight": [
+                            f"{mlp}.shared_expert.gate_proj.weight",
+                            f"{mlp}.shared_expert.up_proj.weight",
+                        ],
+                        f"{local_prefix}.moe.shared_expert.down.linear.weight": [
+                            f"{mlp}.shared_expert.down_proj.weight"
+                        ],
+                        f"{local_prefix}.moe.shared_expert.shared_gate.weight": [
+                            f"{mlp}.shared_expert_gate.weight"
+                        ],
+                    }
+                )
+                for expert_idx in range(c.num_experts):
+                    weight_map[f"{local_prefix}.moe.experts.fc1.weight{expert_idx}"] = [
+                        f"{mlp}.experts.{expert_idx}.gate_proj.weight",
+                        f"{mlp}.experts.{expert_idx}.up_proj.weight",
+                    ]
+                for expert_idx in range(c.num_experts):
+                    weight_map[f"{local_prefix}.moe.experts.fc2.weight{expert_idx}"] = [
+                        f"{mlp}.experts.{expert_idx}.down_proj.weight"
+                    ]
+            else:
+                weight_map.update(
+                    {
+                        f"{local_prefix}.mlp.gate_up.linear.layer_norm_weight": [
+                            f"{hf_prefix}.post_attention_layernorm.weight"
+                        ],
+                        f"{local_prefix}.mlp.gate_up.linear.weight": [
+                            f"{mlp}.gate_proj.weight",
+                            f"{mlp}.up_proj.weight",
+                        ],
+                        f"{local_prefix}.mlp.down.linear.weight": [
+                            f"{mlp}.down_proj.weight"
+                        ],
+                    }
+                )
         return weight_map
 
     def hf_to_native(
@@ -450,7 +475,12 @@ class Qwen35WeightSpec:
             if _linear_attn_head_replication(self.config, ps.tp_size):
                 return shards[0]
             return torch.cat(shards, dim=0).contiguous()
-        if native_name.endswith(".moe.shared_expert.gate_up.linear.weight"):
+        if native_name.endswith(
+            (
+                ".mlp.gate_up.linear.weight",
+                ".moe.shared_expert.gate_up.linear.weight",
+            )
+        ):
             return _merge_gate_up_tp_shards(_allgather_tp_shards(tensor, ps))
         return None
 
@@ -465,7 +495,12 @@ class Qwen35WeightSpec:
             if _linear_attn_head_replication(self.config, len(shards)):
                 return shards[0]
             return torch.cat(shards, dim=0).contiguous()
-        if native_name.endswith(".moe.shared_expert.gate_up.linear.weight"):
+        if native_name.endswith(
+            (
+                ".mlp.gate_up.linear.weight",
+                ".moe.shared_expert.gate_up.linear.weight",
+            )
+        ):
             return _merge_gate_up_tp_shards(shards)
         return None
 
@@ -484,9 +519,9 @@ class Qwen35WeightSpec:
             return self._native_to_vllm(native_name, tensor)
 
         if native_name == "embed.embedding.weight":
-            return [("model.language_model.embed_tokens.weight", tensor)]
+            return [(f"{self.config.hf_text_prefix}.embed_tokens.weight", tensor)]
         if native_name == "norm.weight":
-            return [("model.language_model.norm.weight", tensor)]
+            return [(f"{self.config.hf_text_prefix}.norm.weight", tensor)]
         if native_name == "head.col.linear.weight":
             return [("lm_head.weight", tensor)]
         if native_name == "mtp_embed.embedding.weight" or native_name.startswith(
@@ -500,7 +535,7 @@ class Qwen35WeightSpec:
 
         layer_idx = int(match.group(1))
         suffix = match.group(2)
-        prefix = f"model.language_model.layers.{layer_idx}"
+        prefix = f"{self.config.hf_text_prefix}.layers.{layer_idx}"
 
         if suffix == "full_attn.qkv.linear.layer_norm_weight":
             return [(f"{prefix}.input_layernorm.weight", tensor)]
@@ -544,6 +579,16 @@ class Qwen35WeightSpec:
 
         if suffix == "mlp_norm.weight":
             return [(f"{prefix}.post_attention_layernorm.weight", tensor)]
+        if suffix == "mlp.gate_up.linear.layer_norm_weight":
+            return [(f"{prefix}.post_attention_layernorm.weight", tensor)]
+        if suffix == "mlp.gate_up.linear.weight":
+            gate, up = tensor.chunk(2, dim=0)
+            return [
+                (f"{prefix}.mlp.gate_proj.weight", gate.contiguous()),
+                (f"{prefix}.mlp.up_proj.weight", up.contiguous()),
+            ]
+        if suffix == "mlp.down.linear.weight":
+            return [(f"{prefix}.mlp.down_proj.weight", tensor)]
         if suffix == "moe.router.gate.weight":
             return [(f"{prefix}.mlp.gate.weight", tensor)]
         if suffix == "moe.shared_expert.gate_up.linear.weight":
@@ -646,6 +691,16 @@ class Qwen35WeightSpec:
 
         if suffix == "mlp_norm.weight":
             return [(f"{prefix}.post_attention_layernorm.weight", tensor)]
+        if suffix == "mlp.gate_up.linear.layer_norm_weight":
+            return [(f"{prefix}.post_attention_layernorm.weight", tensor)]
+        if suffix == "mlp.gate_up.linear.weight":
+            gate, up = tensor.chunk(2, dim=0)
+            return [
+                (f"{prefix}.mlp.gate_proj.weight", gate.contiguous()),
+                (f"{prefix}.mlp.up_proj.weight", up.contiguous()),
+            ]
+        if suffix == "mlp.down.linear.weight":
+            return [(f"{prefix}.mlp.down_proj.weight", tensor)]
         if suffix == "moe.router.gate.weight":
             return [(f"{prefix}.mlp.gate.weight", tensor)]
         if suffix == "moe.shared_expert.gate_up.linear.weight":
@@ -704,6 +759,10 @@ class Qwen35WeightSpec:
         if native_name.endswith(".linear_attn.in_proj.linear.weight"):
             return (0, 0)
         if native_name.endswith(".linear_attn.o_proj.linear.weight"):
+            return (1, 0)
+        if native_name.endswith(".mlp.gate_up.linear.weight"):
+            return (0, 0)
+        if native_name.endswith(".mlp.down.linear.weight"):
             return (1, 0)
         if native_name.endswith(".moe.shared_expert.gate_up.linear.weight"):
             return (0, 0)
@@ -814,11 +873,18 @@ def save_hf_weights(
     path: str,
     config: Qwen35Config,
     ps: ParallelState,
+    **kwargs,
 ) -> None:
     from megatron.lite.primitive.ckpt.hf_weights import (  # isort: skip
         save_hf_weights as _save,
     )
 
+    # Qwen3.5 has no MXFP4/block-FP8 save-time resync path, so the engine-level
+    # export kwargs are accepted for signature-compatibility but not consumed.
+    if kwargs:
+        logger.warning(
+            "Qwen3.5 save_hf_weights ignoring unsupported kwargs: %s", kwargs
+        )
     _save(model, path, Qwen35WeightSpec(config), ps, vocab_size=config.vocab_size)
 
 

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
@@ -50,6 +50,7 @@ _SP_GRAD_SUFFIXES: tuple[str, ...] = (
     ".full_attn.k_norm.weight",
     ".linear_attn.in_proj.linear.layer_norm_weight",
     ".linear_attn.norm.weight",
+    ".mlp.gate_up.linear.layer_norm_weight",
     ".mlp_norm.weight",
     ".moe.router.gate.weight",
     ".moe.shared_expert.shared_gate.weight",
@@ -78,6 +79,27 @@ def _qwen_mrope_section(config: Qwen35Config) -> list[int]:
     rotary_half = max(int(config.rotary_dim // 2), 1)
     base = rotary_half // 3
     return [base, base, rotary_half - 2 * base]
+
+
+class DenseMLP(nn.Module):
+    def __init__(self, config: Qwen35Config, ps: ParallelState):
+        super().__init__()
+        assert config.intermediate_size is not None
+        self.gate_up = ColumnParallelLinear(
+            config.hidden_size,
+            config.intermediate_size * 2,
+            ps,
+            bias=False,
+            normalization="RMSNorm",
+            eps=config.rms_norm_eps,
+            zero_centered_gamma=True,
+        )
+        self.down = RowParallelLinear(
+            config.intermediate_size, config.hidden_size, ps, bias=False
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.down(_swiglu(self.gate_up(x)))
 
 
 class SharedExpert(nn.Module):
@@ -274,21 +296,27 @@ class Qwen35Layer(nn.Module):
                 deterministic=deterministic,
                 cp_mode=gdn_cp_mode,
             )
-        self.mlp_norm = te.RMSNorm(
-            config.hidden_size, eps=config.rms_norm_eps, zero_centered_gamma=True
-        )
-        self.moe = MoELayer(
-            config,
-            ps,
-            use_deepep=use_deepep,
-            router_bias_rate=router_bias_rate,
-            fp8=fp8,
-            moe_act_recompute=moe_act_recompute,
-            router_dtype=torch.float32,
-            preserve_3d_graph=deterministic,
-            shared_expert_plain_te=deterministic,
-            moe_permute_fusion=True,
-        )
+        if config.is_moe:
+            self.mlp_norm: nn.Module | None = te.RMSNorm(
+                config.hidden_size, eps=config.rms_norm_eps, zero_centered_gamma=True
+            )
+            self.moe: MoELayer | None = MoELayer(
+                config,
+                ps,
+                use_deepep=use_deepep,
+                router_bias_rate=router_bias_rate,
+                fp8=fp8,
+                moe_act_recompute=moe_act_recompute,
+                router_dtype=torch.float32,
+                preserve_3d_graph=deterministic,
+                shared_expert_plain_te=deterministic,
+                moe_permute_fusion=True,
+            )
+            self.mlp: DenseMLP | None = None
+        else:
+            self.mlp_norm = None
+            self.moe = None
+            self.mlp = DenseMLP(config, ps)
 
     def forward(
         self, x: torch.Tensor, position_ids: torch.Tensor | None = None, packed_seq_params=None
@@ -301,8 +329,11 @@ class Qwen35Layer(nn.Module):
             h = self.linear_attn(x, position_ids=position_ids, packed_seq_params=packed_seq_params)
         x = residual + h
         residual = x
-        x = residual + self.moe(self.mlp_norm(x))
-        return x
+        if self.moe is not None:
+            assert self.mlp_norm is not None
+            return residual + self.moe(self.mlp_norm(x))
+        assert self.mlp is not None
+        return residual + self.mlp(x)
 
 
 def _temperature_to_float(temperature: float | torch.Tensor) -> float:
@@ -729,6 +760,7 @@ def _build_native_vision_model(hf_path: str) -> nn.Module | None:
 
 
 __all__ = [
+    "DenseMLP",
     "FullAttention",
     "GatedDeltaNet",
     "MoELayer",

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from types import SimpleNamespace
@@ -86,14 +87,30 @@ def _full_attn_module(layer, name: str):
     return getattr(full_attn, name, None) if full_attn is not None else None
 
 
+def _maybe(module_name: str) -> Callable[[nn.Module], nn.Module | None]:
+    def getter(layer: nn.Module) -> nn.Module | None:
+        return getattr(layer, module_name, None)
+
+    return getter
+
+
+def _moe_module(name: str) -> Callable[[nn.Module], nn.Module | None]:
+    def getter(layer: nn.Module) -> nn.Module | None:
+        moe = getattr(layer, "moe", None)
+        return getattr(moe, name, None) if moe is not None else None
+
+    return getter
+
+
 MODULE_MAP = {
     "core_attn": lambda layer: _full_attn_module(layer, "core_attn"),
-    "experts": lambda layer: layer.moe.experts,
-    "moe": lambda layer: layer.moe,
-    "router": lambda layer: layer.moe.router,
-    "mlp_norm": lambda layer: layer.mlp_norm,
+    "experts": _moe_module("experts"),
+    "moe": _maybe("moe"),
+    "router": _moe_module("router"),
+    "mlp": _maybe("mlp"),
+    "mlp_norm": _maybe("mlp_norm"),
     "attn_proj": lambda layer: _full_attn_module(layer, "proj"),
-    "linear_attn": lambda layer: layer.linear_attn,
+    "linear_attn": _maybe("linear_attn"),
 }
 
 
@@ -315,9 +332,9 @@ def export_hf_weights(
 
 
 def save_hf_weights(
-    chunks: list[nn.Module], path: str, model_cfg: Qwen35Config, ps: ParallelState
+    chunks: list[nn.Module], path: str, model_cfg: Qwen35Config, ps: ParallelState, **kwargs
 ) -> None:
-    _save_hf_weights_impl(chunks, path, model_cfg, ps)
+    _save_hf_weights_impl(chunks, path, model_cfg, ps, **kwargs)
 
 
 def vocab_size(model_cfg) -> int | None:

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/checkpoint.py
@@ -8,6 +8,8 @@ model-specific: the weight map and tensor conversions.
 
 from __future__ import annotations
 
+import logging
+
 import torch
 from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
 from megatron.lite.primitive.ckpt.dcp import (  # noqa: F401 — re-export
@@ -20,6 +22,9 @@ from megatron.lite.primitive.ckpt.hf_weights import extract_layer_idx, parse_exp
 from megatron.lite.primitive.quantization.mxfp4 import MXFP4_BLOCK_SIZE, quantize_mxfp4
 from megatron.lite.runtime.contracts.weights import ResyncFormat
 from torch.distributed.tensor import Replicate, Shard
+
+
+logger = logging.getLogger(__name__)
 
 
 def _pack_mcore_qkv(
@@ -319,9 +324,15 @@ def _export_mxfp4_weights(weights):
         yield f"{name[:-7]}.weight_scale", scale.view(torch.uint8)
 
 
-def save_hf_weights(model, path: str, config: Qwen3MoEConfig, ps) -> None:
+def save_hf_weights(model, path: str, config: Qwen3MoEConfig, ps, **kwargs) -> None:
     from megatron.lite.primitive.ckpt.hf_weights import save_hf_weights as _save
 
+    # Qwen3-MoE has no MXFP4/block-FP8 save-time resync path, so the engine-level
+    # export kwargs are accepted for signature-compatibility but not consumed.
+    if kwargs:
+        logger.warning(
+            "Qwen3-MoE save_hf_weights ignoring unsupported kwargs: %s", kwargs
+        )
     _save(model, path, Qwen3MoEWeightSpec(config), ps, vocab_size=config.vocab_size)
 
 

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
@@ -361,10 +361,11 @@ def save_hf_weights(
     path: str,
     model_cfg: Qwen3MoEConfig,
     ps: ParallelState,
+    **kwargs,
 ) -> None:
     from megatron.lite.model.qwen3_moe.lite.checkpoint import save_hf_weights as _save
 
-    _save(chunks, path, model_cfg, ps)
+    _save(chunks, path, model_cfg, ps, **kwargs)
 
 
 # ---------------------------------------------------------------------------

--- a/experimental/lite/megatron/lite/model/registry.py
+++ b/experimental/lite/megatron/lite/model/registry.py
@@ -88,7 +88,7 @@ register_model(
 register_model(
     "qwen3_5",
     package="megatron.lite.model.qwen3_5",
-    hf_model_types=["qwen3_5_moe"],
+    hf_model_types=["qwen3_5", "qwen3_5_moe"],
     impls={"lite": "megatron.lite.model.qwen3_5.lite.protocol"},
 )
 

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/adamw.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/adamw.py
@@ -11,6 +11,8 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 
+from megatron.lite.primitive.optimizers.fsdp2.grad_clip import fused_sq_sum
+
 
 def local_grad_sq_sum(
     params: Iterable[nn.Parameter],
@@ -18,18 +20,19 @@ def local_grad_sq_sum(
     dtype: torch.dtype,
     default_device: torch.device | None = None,
 ) -> torch.Tensor:
-    total: torch.Tensor | None = None
+    grads: list[torch.Tensor] = []
+    device: torch.device | None = None
     for param in params:
         grad = param.grad
         if grad is None:
             continue
-        grad = to_local_tensor(grad)
-        if total is None:
-            total = torch.zeros((), device=grad.device, dtype=dtype)
-        total += grad.detach().to(dtype).pow(2).sum()
-    if total is None:
+        grad = to_local_tensor(grad).detach()
+        if device is None:
+            device = grad.device
+        grads.append(grad)
+    if device is None:
         return torch.zeros((), device=default_device or torch.device("cpu"), dtype=dtype)
-    return total
+    return fused_sq_sum(grads, dtype=dtype, device=device)
 
 
 def to_local_tensor(tensor):
@@ -227,10 +230,11 @@ class FP32AdamW:
                 self._copy_master_to_param(param, master)
 
     def _prepare_grad(self, grad: torch.Tensor, master: torch.Tensor) -> torch.Tensor:
+        # No .to(float32): add_()/addcmul_() promote into the FP32 accumulators, so a
+        # full-size cast here would only cost peak memory.
         if self.cpu_update:
-            grad = to_local_tensor(grad)
-            return grad.detach().to(device=master.device, dtype=torch.float32)
-        return grad.detach().to(dtype=torch.float32)
+            return to_local_tensor(grad).detach().to(device=master.device)
+        return grad.detach()
 
     def _copy_master_to_param(self, param: nn.Parameter, master: torch.Tensor) -> None:
         model_dtype = self._model_param_dtype(param)

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/grad_clip.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/grad_clip.py
@@ -12,6 +12,11 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 
+from transformer_engine.pytorch.optimizers import (  # pyright: ignore[reportMissingImports]
+    multi_tensor_applier,
+    multi_tensor_l2norm,
+)
+
 try:  # pragma: no cover - import availability is PyTorch-version dependent.
     from torch.distributed.tensor import DTensor, Partial, Replicate
 except ImportError:  # pragma: no cover
@@ -23,7 +28,6 @@ def sharded_grad_sq_sum(
     *,
     accum_dtype: str | torch.dtype = torch.float32,
     default_device: torch.device | None = None,
-    chunk_size_numel: int = 0,
     scalar_all_reduce: (
         Callable[[torch.Tensor, dist.ProcessGroup, dist.ReduceOp], None] | None
     ) = None,
@@ -40,7 +44,7 @@ def sharded_grad_sq_sum(
     groups = _group_grads(params)
     total: torch.Tensor | None = None
     for group in groups.values():
-        local_sq = _group_local_sq_sum(group, dtype=dtype, chunk_size_numel=chunk_size_numel)
+        local_sq = _group_local_sq_sum(group, dtype=dtype)
         meta = group[0][2]
         if meta is not None and not _has_partial_placement(meta) and dist.is_initialized():
             _reduce_dtensor_scalar_(
@@ -184,34 +188,48 @@ def _group_grads(
     return groups
 
 
-def _group_local_sq_sum(
-    group: list[tuple[nn.Parameter, torch.Tensor, Any | None]],
-    *,
-    dtype: torch.dtype,
-    chunk_size_numel: int = 0,
+def fused_sq_sum(
+    tensors: Iterable[torch.Tensor], *, dtype: torch.dtype, device: torch.device
 ) -> torch.Tensor:
-    device = _local_grad(group[0][1], group[0][2]).device
+    """Sum of squares accumulated in ``dtype``, without a full-size cast of any input."""
+
     total = torch.zeros((), device=device, dtype=dtype)
-    for _param, grad, meta in group:
-        local_grad = _local_grad(grad, meta)
-        total += _tensor_sq_sum(local_grad.detach(), dtype=dtype, chunk_size_numel=chunk_size_numel)
+    # multi_tensor_applier dispatches on the list's scalar type, so bucket by dtype.
+    buckets: dict[tuple[torch.dtype, torch.device], list[torch.Tensor]] = defaultdict(list)
+    for tensor in tensors:
+        if tensor.numel() == 0:
+            continue
+        if _is_fused_eligible(tensor):
+            buckets[(tensor.dtype, tensor.device)].append(tensor)
+        else:
+            total += torch.linalg.vector_norm(tensor, 2.0, dtype=dtype).pow_(2).to(device)
+    for (_bucket_dtype, bucket_device), bucket in buckets.items():
+        noop_flag = torch.zeros(1, dtype=torch.int, device=bucket_device)
+        norm, _ = multi_tensor_applier(multi_tensor_l2norm, noop_flag, [bucket], False)
+        total += norm.reshape(()).to(device=device, dtype=dtype).pow(2)
     return total
 
 
-def _tensor_sq_sum(
-    tensor: torch.Tensor, *, dtype: torch.dtype, chunk_size_numel: int = 0
+def _is_fused_eligible(tensor: torch.Tensor) -> bool:
+    # The kernel needs contiguous CUDA input, and a contiguous() copy here would cost
+    # the allocation we are avoiding. Tests patch this to reach the bucket path on CPU.
+    return tensor.is_cuda and tensor.is_contiguous()
+
+
+def _group_local_sq_sum(
+    group: list[tuple[nn.Parameter, torch.Tensor, Any | None]], *, dtype: torch.dtype
 ) -> torch.Tensor:
-    if chunk_size_numel <= 0 or tensor.numel() <= chunk_size_numel:
-        return tensor.to(dtype).pow(2).sum()
-    try:
-        flat = tensor.view(-1)
-    except RuntimeError:
-        flat = tensor.reshape(-1)
-    total = torch.zeros((), device=tensor.device, dtype=dtype)
-    for start in range(0, flat.numel(), chunk_size_numel):
-        chunk = flat.narrow(0, start, min(chunk_size_numel, flat.numel() - start))
-        total += chunk.to(dtype).pow(2).sum()
-    return total
+    meta = group[0][2]
+    device = _local_grad(group[0][1], meta).device
+    if meta is not None and _has_partial_placement(meta):
+        # _local_grad() materializes the global-shaped grad here; keep one alive at a time.
+        total = torch.zeros((), device=device, dtype=dtype)
+        for _param, grad, grad_meta in group:
+            local = _local_grad(grad, grad_meta).detach()
+            total += fused_sq_sum([local], dtype=dtype, device=device)
+        return total
+    locals_ = [_local_grad(grad, grad_meta).detach() for _param, grad, grad_meta in group]
+    return fused_sq_sum(locals_, dtype=dtype, device=device)
 
 
 def _group_local_abs_max(
@@ -222,7 +240,9 @@ def _group_local_abs_max(
     for _param, grad, meta in group:
         local_grad = _local_grad(grad, meta)
         if local_grad.numel() > 0:
-            total = torch.maximum(total, local_grad.detach().to(dtype).abs().max())
+            # vector_norm(inf) is abs().max() without the intermediate tensors.
+            local_max = torch.linalg.vector_norm(local_grad.detach(), float("inf"), dtype=dtype)
+            total = torch.maximum(total, local_max.to(device))
     return total
 
 
@@ -320,6 +340,7 @@ def _process_group_backend(group: dist.ProcessGroup) -> str:
 __all__ = [
     "all_reduce_scalar_",
     "clip_grads_with_sharded_norm_",
+    "fused_sq_sum",
     "resolve_torch_dtype",
     "sharded_grad_abs_max",
     "sharded_grad_norm",

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -13,6 +13,7 @@ from typing import Any
 
 import torch
 import torch.distributed as dist
+from torch.distributed.tensor import DTensor  # pyright: ignore[reportMissingImports]
 from megatron.lite.runtime.backends import Runtime as RuntimeBase
 from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig
 from megatron.lite.runtime.contracts.data import ForwardResult, ModelOutputs, PackedBatch
@@ -53,8 +54,35 @@ def _build_impl_cfg(proto, rt_cfg: MegatronLiteConfig):
 
 def _reset_parameters(module: torch.nn.Module) -> None:
     reset = getattr(module, "reset_parameters", None)
-    if callable(reset):
-        reset()
+    if not callable(reset):
+        return
+
+    original_parameters = dict(module.named_parameters(recurse=False))
+    reset()
+    with torch.no_grad():
+        for name, original in original_parameters.items():
+            replacement = module._parameters.get(name)
+            if replacement is None:
+                raise RuntimeError(f"{type(module).__name__}.reset_parameters() removed {name!r}.")
+            if replacement is original:
+                continue
+            original_local = original.to_local() if isinstance(original, DTensor) else original
+            replacement_local = (
+                replacement.to_local() if isinstance(replacement, DTensor) else replacement
+            )
+            if original_local.shape != replacement_local.shape:
+                raise RuntimeError(
+                    f"{type(module).__name__}.reset_parameters() changed {name!r} shape "
+                    f"from {tuple(original_local.shape)} to {tuple(replacement_local.shape)}."
+                )
+            if original_local.data_ptr() != replacement_local.data_ptr():
+                original_local.copy_(
+                    replacement_local.to(
+                        device=original_local.device,
+                        dtype=original_local.dtype,
+                    )
+                )
+            module._parameters[name] = original
 
 
 def _apply_attention_backend_env(backend: str | None, *, tag: str) -> None:

--- a/experimental/lite/tests/unit/model/qwen3_5/lite/test_qwen35_export.py
+++ b/experimental/lite/tests/unit/model/qwen3_5/lite/test_qwen35_export.py
@@ -44,6 +44,14 @@ def _tiny_config() -> Qwen35Config:
     )
 
 
+def _tiny_dense_config() -> Qwen35Config:
+    return replace(
+        _tiny_config(),
+        model_type="qwen3_5",
+        intermediate_size=12,
+    )
+
+
 def _single_rank_parallel_state() -> SimpleNamespace:
     return SimpleNamespace(
         pp_size=1, tp_size=1, tp_group=None, ep_size=1, ep_group=None, etp_size=1, etp_group=None
@@ -348,6 +356,91 @@ def test_qwen35_export_maps_top_level_and_layer_norm_names() -> None:
         exported = dict(spec.native_to_hf(native_name, tensor))
         assert set(exported) == {hf_name}
         assert torch.equal(exported[hf_name], tensor)
+
+
+def test_qwen35_dense_load_and_export_map_gated_mlp_weights() -> None:
+    cfg = _tiny_dense_config()
+    spec = Qwen35WeightSpec(cfg)
+    weight_map = spec.weight_map()
+    gate = torch.arange(cfg.intermediate_size * cfg.hidden_size).reshape(
+        cfg.intermediate_size, cfg.hidden_size
+    )
+    up = gate + 1000
+    down = torch.arange(cfg.hidden_size * cfg.intermediate_size).reshape(
+        cfg.hidden_size, cfg.intermediate_size
+    )
+
+    assert weight_map["layers.0.mlp.gate_up.linear.layer_norm_weight"] == [
+        "model.language_model.layers.0.post_attention_layernorm.weight"
+    ]
+    assert weight_map["layers.0.mlp.gate_up.linear.weight"] == [
+        "model.language_model.layers.0.mlp.gate_proj.weight",
+        "model.language_model.layers.0.mlp.up_proj.weight",
+    ]
+    assert weight_map["layers.0.mlp.down.linear.weight"] == [
+        "model.language_model.layers.0.mlp.down_proj.weight"
+    ]
+    assert not any(".moe." in name for name in weight_map)
+
+    gate_up = spec.hf_to_native("layers.0.mlp.gate_up.linear.weight", [gate, up])
+    exported = dict(spec.native_to_hf("layers.0.mlp.gate_up.linear.weight", gate_up))
+    exported.update(spec.native_to_hf("layers.0.mlp.down.linear.weight", down))
+
+    assert torch.equal(
+        exported["model.language_model.layers.0.mlp.gate_proj.weight"], gate
+    )
+    assert torch.equal(
+        exported["model.language_model.layers.0.mlp.up_proj.weight"], up
+    )
+    assert torch.equal(
+        exported["model.language_model.layers.0.mlp.down_proj.weight"], down
+    )
+
+
+def test_qwen35_hf_text_prefix_selects_composite_and_standalone_names() -> None:
+    composite = Qwen35WeightSpec(
+        replace(_tiny_dense_config(), hf_text_prefix="model.language_model")
+    )
+    standalone = Qwen35WeightSpec(
+        replace(_tiny_dense_config(), hf_text_prefix="model")
+    )
+    native_name = "layers.0.mlp.down.linear.weight"
+    tensor = torch.arange(12)
+
+    assert composite.weight_map()[native_name] == [
+        "model.language_model.layers.0.mlp.down_proj.weight"
+    ]
+    assert standalone.weight_map()[native_name] == [
+        "model.layers.0.mlp.down_proj.weight"
+    ]
+    assert set(dict(composite.native_to_hf(native_name, tensor))) == {
+        "model.language_model.layers.0.mlp.down_proj.weight"
+    }
+    assert set(dict(standalone.native_to_hf(native_name, tensor))) == {
+        "model.layers.0.mlp.down_proj.weight"
+    }
+
+
+def test_qwen35_dense_mlp_tp_specs_and_placements() -> None:
+    spec = Qwen35WeightSpec(_tiny_dense_config())
+    gate_up = "layers.0.mlp.gate_up.linear.weight"
+    down = "layers.0.mlp.down.linear.weight"
+    gate = torch.arange(48).reshape(6, 8)
+    up = gate + 1000
+    shards = [
+        torch.cat([gate.chunk(2)[rank], up.chunk(2)[rank]], dim=0)
+        for rank in range(2)
+    ]
+
+    assert type(PLACEMENT_FN(gate_up)[-1]).__name__ == "Shard"
+    assert PLACEMENT_FN(gate_up)[-1].dim == 0
+    assert type(PLACEMENT_FN(down)[-1]).__name__ == "Shard"
+    assert PLACEMENT_FN(down)[-1].dim == 1
+    assert spec.tp_spec(gate_up) == (0, 0)
+    assert spec.tp_spec(down) == (1, 0)
+    assert torch.equal(
+        spec.merge_dense_shards(gate_up, shards), torch.cat([gate, up], dim=0)
+    )
 
 
 def test_qwen35_export_unpacks_full_attention_q_gate() -> None:

--- a/experimental/lite/tests/unit/model/test_deepseek_v4_hf_export_dtype.py
+++ b/experimental/lite/tests/unit/model/test_deepseek_v4_hf_export_dtype.py
@@ -1,0 +1,65 @@
+"""Pin fp32-on-export whitelist for DeepSeek-V4 HF checkpoints."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import torch
+
+
+_CHECKPOINT_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "megatron"
+    / "lite"
+    / "model"
+    / "deepseek_v4"
+    / "lite"
+    / "checkpoint.py"
+)
+_SPEC = importlib.util.spec_from_file_location(
+    "deepseek_v4_checkpoint_under_test", _CHECKPOINT_PATH
+)
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+DeepseekV4WeightSpec = _MODULE.DeepseekV4WeightSpec
+
+
+# ``hf_export_dtype_override`` inspects only the HF name; config is unused, so
+# ``None`` is enough to exercise the whitelist logic without dragging in the
+# full ``DeepseekV4Config`` (and its transitive Megatron-core deps).
+_SPEC_UNDER_TEST = DeepseekV4WeightSpec.__new__(DeepseekV4WeightSpec)
+
+
+@pytest.mark.parametrize(
+    "hf_name",
+    [
+        "model.layers.0.self_attn.attn_sink",
+        "model.layers.3.self_attn.compressor.ape",
+        "model.layers.3.self_attn.indexer.compressor.ape",
+        "model.layers.5.mlp.ffn.gate.bias",
+        "model.hc_head_q",
+        "model.layers.2.self_attn.hc_attn_k",
+        "model.layers.2.mlp.hc_ffn_gate",
+    ],
+)
+def test_fp32_whitelist_forces_float32(hf_name: str) -> None:
+    assert _SPEC_UNDER_TEST.hf_export_dtype_override(hf_name) is torch.float32
+
+
+@pytest.mark.parametrize(
+    "hf_name",
+    [
+        "model.embed_tokens.weight",
+        "model.norm.weight",
+        "lm_head.weight",
+        "model.layers.0.self_attn.q_proj.weight",
+        "model.layers.0.mlp.experts.0.up_proj.weight",
+        "model.layers.0.mlp.gate.weight",
+        "model.layers.0.mlp.shared_experts.up_proj.weight",
+    ],
+)
+def test_non_whitelisted_names_default_to_none(hf_name: str) -> None:
+    assert _SPEC_UNDER_TEST.hf_export_dtype_override(hf_name) is None

--- a/experimental/lite/tests/unit/model/test_hf_save_protocol_contract.py
+++ b/experimental/lite/tests/unit/model/test_hf_save_protocol_contract.py
@@ -69,3 +69,112 @@ def test_new_hf_save_protocols_delegate_all_arguments(
             {},
         )
     ]
+
+
+# Engine-side ``save_contents=['hf_model']`` unconditionally forwards
+# ``export_dtype`` / ``target`` / ``resync_config`` — protocols that don't
+# consume them must still accept them without raising ``TypeError``.
+_ENGINE_EXPORT_KWARGS = {
+    "export_dtype": "bfloat16",
+    "target": "mxfp4",
+    "resync_config": {"expert_dtype": "fp4"},
+}
+
+
+@pytest.mark.parametrize(
+    "model_name", ["kimi_k2", "qwen3_moe", "qwen3_5", "deepseek_v4"]
+)
+def test_hf_save_protocols_accept_engine_export_kwargs(
+    model_name: str, monkeypatch: pytest.MonkeyPatch, transformer_engine_import_stub
+) -> None:
+    transformer_engine_import_stub()
+    if model_name == "deepseek_v4":
+        # DS4 protocol drags in megatron.core via the CSA module at import time.
+        pytest.importorskip(
+            "megatron.core",
+            reason="deepseek_v4 protocol needs megatron.core in the test env",
+        )
+    protocol = importlib.import_module(
+        f"megatron.lite.model.{model_name}.lite.protocol"
+    )
+    checkpoint = importlib.import_module(
+        f"megatron.lite.model.{model_name}.lite.checkpoint"
+    )
+    calls = []
+
+    def _record(*args, **kwargs):
+        calls.append((args, kwargs))
+
+    # kimi_k2 / qwen3_moe use function-local imports of the checkpoint
+    # writer; qwen3_5 aliases it at module load as ``_save_hf_weights_impl``.
+    # Patch both surfaces so the test targets whichever the protocol uses.
+    monkeypatch.setattr(checkpoint, "save_hf_weights", _record)
+    if hasattr(protocol, "_save_hf_weights_impl"):
+        monkeypatch.setattr(protocol, "_save_hf_weights_impl", _record)
+
+    chunks, model_cfg, parallel_state = object(), object(), object()
+
+    protocol.save_hf_weights(
+        chunks,
+        "/tmp/hf-save-kwargs",
+        model_cfg,
+        parallel_state,
+        **_ENGINE_EXPORT_KWARGS,
+    )
+
+    assert calls == [
+        (
+            (chunks, "/tmp/hf-save-kwargs", model_cfg, parallel_state),
+            _ENGINE_EXPORT_KWARGS,
+        )
+    ]
+
+
+@pytest.mark.parametrize("model_name", ["qwen3_moe", "qwen3_5"])
+def test_hf_save_checkpoint_warns_on_unused_export_kwargs(
+    model_name: str,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    transformer_engine_import_stub,
+) -> None:
+    """Protocols without an MXFP4/block-FP8 save path warn (with kwargs printed)
+    when engine-level export kwargs arrive, and never forward them to the
+    shared writer.  Stays fully in-memory: the writer is monkeypatched."""
+    transformer_engine_import_stub()
+    checkpoint = importlib.import_module(
+        f"megatron.lite.model.{model_name}.lite.checkpoint"
+    )
+    calls = []
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.hf_weights.save_hf_weights",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    class _Config:
+        vocab_size = 32
+
+    model, parallel_state = object(), object()
+    with caplog.at_level("WARNING", logger=checkpoint.__name__):
+        checkpoint.save_hf_weights(
+            model,
+            "/tmp/hf-save-drop",
+            _Config(),
+            parallel_state,
+            **_ENGINE_EXPORT_KWARGS,
+        )
+
+    assert len(calls) == 1
+    forwarded_kwargs = calls[0][1]
+    for key in _ENGINE_EXPORT_KWARGS:
+        assert key not in forwarded_kwargs
+    assert forwarded_kwargs.get("vocab_size") == 32
+
+    warnings = [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelname == "WARNING"
+    ]
+    assert any("ignoring unsupported kwargs" in msg for msg in warnings)
+    joined = "\n".join(warnings)
+    for key in _ENGINE_EXPORT_KWARGS:
+        assert key in joined

--- a/experimental/lite/tests/unit/model/test_qwen_config_unit.py
+++ b/experimental/lite/tests/unit/model/test_qwen_config_unit.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 
 import pytest
+import torch.nn as nn
 
 from megatron.lite.model.qwen3_5.config import Qwen35Config
 from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
@@ -52,8 +53,29 @@ def _tiny_qwen35_text_config() -> dict:
     }
 
 
+def _tiny_dense_qwen35_text_config() -> dict:
+    config = _tiny_qwen35_text_config()
+    config.update(
+        {
+            "model_type": "qwen3_5",
+            "intermediate_size": 24,
+            "num_nextn_predict_layers": 0,
+            "layer_types": ["linear_attention", "full_attention"],
+        }
+    )
+    for field in (
+        "num_experts",
+        "num_experts_per_tok",
+        "moe_intermediate_size",
+        "shared_expert_intermediate_size",
+    ):
+        config.pop(field)
+    return config
+
+
 def test_registry_resolves_qwen_lite_model_names():
     assert resolve_model_type_from_hf({"model_type": "qwen3_moe"}) == "qwen3"
+    assert resolve_model_type_from_hf({"model_type": "qwen3_5"}) == "qwen3_5"
     assert resolve_model_type_from_hf({"model_type": "qwen3_5_moe"}) == "qwen3_5"
     assert resolve_runtime_model_name("qwen3", "lite") == "qwen3"
     assert resolve_runtime_model_name("qwen3_moe", "lite") == "qwen3_moe"
@@ -86,6 +108,103 @@ def test_qwen35_config_from_text_config_splits_mtp_layer_types():
     assert cfg.mtp_layer_types == ["full_attention"]
     assert cfg.rotary_dim == 4
     assert cfg.mrope_section == [1, 1, 0]
+    assert cfg.hf_text_prefix == "model.language_model"
+
+
+def test_qwen35_dense_config_uses_nested_text_variant_and_intermediate_size():
+    cfg = Qwen35Config._from_hf_dict(
+        {"model_type": "qwen3_5", "text_config": _tiny_dense_qwen35_text_config()}
+    )
+
+    assert cfg.model_type == "qwen3_5"
+    assert not cfg.is_moe
+    assert cfg.intermediate_size == 24
+    assert cfg.hf_text_prefix == "model.language_model"
+
+
+def test_qwen35_standalone_text_config_uses_model_hf_prefix():
+    cfg = Qwen35Config._from_hf_dict(_tiny_dense_qwen35_text_config())
+
+    assert cfg.model_type == "qwen3_5"
+    assert cfg.hf_text_prefix == "model"
+
+
+def test_qwen35_dense_config_requires_intermediate_size():
+    hf = _tiny_dense_qwen35_text_config()
+    hf.pop("intermediate_size")
+
+    with pytest.raises(ValueError, match="intermediate_size"):
+        Qwen35Config._from_hf_dict({"model_type": "qwen3_5", "text_config": hf})
+
+
+def test_qwen35_dense_and_moe_layers_select_distinct_ffn_branches(
+    transformer_engine_import_stub, monkeypatch
+):
+    transformer_engine_import_stub()
+
+    from megatron.lite.model.qwen3_5.lite import model as qwen35_model
+    from megatron.lite.model.qwen3_5.lite.protocol import MODULE_MAP
+
+    class Attention(nn.Module):
+        def __init__(self, **kwargs):
+            super().__init__()
+
+    class Linear(nn.Module):
+        def __init__(self, in_features, out_features, ps, **kwargs):
+            super().__init__()
+            del ps, kwargs
+            self.linear = nn.Linear(in_features, out_features, bias=False)
+
+        def forward(self, x):
+            return self.linear(x)
+
+    class MoE(nn.Module):
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+
+    monkeypatch.setattr(qwen35_model, "FullAttention", Attention)
+    monkeypatch.setattr(qwen35_model, "ColumnParallelLinear", Linear)
+    monkeypatch.setattr(qwen35_model, "RowParallelLinear", Linear)
+    monkeypatch.setattr(qwen35_model, "MoELayer", MoE)
+    monkeypatch.setattr(qwen35_model.te, "RMSNorm", lambda *args, **kwargs: nn.Identity())
+
+    ps = object()
+    dense = Qwen35Config(
+        model_type="qwen3_5",
+        num_hidden_layers=1,
+        hidden_size=8,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=4,
+        intermediate_size=12,
+        layer_types=["full_attention"],
+    )
+    moe = Qwen35Config(
+        num_hidden_layers=1,
+        hidden_size=8,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=4,
+        num_experts=2,
+        num_experts_per_tok=1,
+        moe_intermediate_size=4,
+        shared_expert_intermediate_size=4,
+        layer_types=["full_attention"],
+    )
+
+    dense_layer = qwen35_model.Qwen35Layer(dense, ps, 0)
+    moe_layer = qwen35_model.Qwen35Layer(moe, ps, 0)
+
+    assert isinstance(dense_layer.mlp, qwen35_model.DenseMLP)
+    assert dense_layer.moe is None
+    assert dense_layer.mlp_norm is None
+    assert moe_layer.mlp is None
+    assert isinstance(moe_layer.moe, MoE)
+    assert isinstance(moe_layer.mlp_norm, nn.Identity)
+    assert MODULE_MAP["mlp"](dense_layer) is dense_layer.mlp
+    assert MODULE_MAP["moe"](dense_layer) is None
+    assert MODULE_MAP["router"](dense_layer) is None
+    assert MODULE_MAP["experts"](dense_layer) is None
 
 
 def test_qwen_lite_protocols_build_configs_from_hf_dicts(transformer_engine_import_stub):

--- a/experimental/lite/tests/unit/primitive/optimizers/fsdp2/test_fsdp2_unit.py
+++ b/experimental/lite/tests/unit/primitive/optimizers/fsdp2/test_fsdp2_unit.py
@@ -17,13 +17,18 @@ from megatron.lite.primitive.optimizers.fsdp2 import (
     clip_grads_with_sharded_norm_,
     fsdp2_available,
 )
-from megatron.lite.primitive.optimizers.fsdp2.adamw import build_adamw_optimizer
+from megatron.lite.primitive.optimizers.fsdp2.adamw import (
+    build_adamw_optimizer,
+    local_grad_sq_sum,
+    to_local_tensor,
+)
 from megatron.lite.primitive.optimizers.fsdp2.wrap import build_fsdp2_shard_placement_fn
 from megatron.lite.primitive.parallel.state import ParallelState
 
 fsdp2_wrap = importlib.import_module("megatron.lite.primitive.optimizers.fsdp2.wrap")
 fsdp2_optimizer = importlib.import_module("megatron.lite.primitive.optimizers.fsdp2.optimizer")
 fsdp2_grad_clip = importlib.import_module("megatron.lite.primitive.optimizers.fsdp2.grad_clip")
+fsdp2_adamw = importlib.import_module("megatron.lite.primitive.optimizers.fsdp2.adamw")
 
 
 class ToyBlock(nn.Module):
@@ -610,3 +615,120 @@ def test_fp32_adamw_load_matches_uninterrupted_next_step_cpu(cpu_update: bool):
     for key in ("master_params", "exp_avgs", "exp_avg_sqs"):
         torch.testing.assert_close(loaded_state[key][0], direct_state[key][0], atol=0.0, rtol=0.0)
     assert loaded_state["steps"] == direct_state["steps"]
+
+
+def _reference_sq_sum(tensors) -> float:
+    return float(sum(t.double().pow(2).sum() for t in tensors))
+
+
+def test_fused_sq_sum_matches_reference():
+    torch.manual_seed(0)
+    tensors = [
+        torch.randn(1024, dtype=torch.bfloat16),
+        torch.randn(37, 41),
+        torch.randn(64, 64)[:, ::2],
+        torch.randn(0),
+    ]
+    total = fsdp2_grad_clip.fused_sq_sum(tensors, dtype=torch.float32, device=torch.device("cpu"))
+    assert total.ndim == 0 and total.dtype is torch.float32
+    assert float(total) == pytest.approx(_reference_sq_sum(tensors), rel=1e-5)
+
+
+def test_fused_sq_sum_launches_one_kernel_per_dtype(monkeypatch):
+    """Mixed-dtype lists must not reach the kernel, non-contiguous tensors must not
+    either, and contiguous grads must not be launched one at a time."""
+    launches: list[tuple[int, torch.dtype]] = []
+
+    def fake_applier(op, noop_flag, tensor_lists, *args):
+        bucket = tensor_lists[0]
+        assert op is fsdp2_grad_clip.multi_tensor_l2norm
+        assert len({t.dtype for t in bucket}) == 1
+        assert all(t.is_contiguous() for t in bucket)
+        launches.append((len(bucket), bucket[0].dtype))
+        return torch.tensor([_reference_sq_sum(bucket) ** 0.5], dtype=torch.float32), None
+
+    # CPU-only test env: force the CUDA-eligibility check so the bucket path runs.
+    monkeypatch.setattr(fsdp2_grad_clip, "multi_tensor_applier", fake_applier)
+    monkeypatch.setattr(fsdp2_grad_clip, "_is_fused_eligible", lambda t: t.is_contiguous())
+
+    torch.manual_seed(0)
+    tensors = [
+        torch.randn(512, dtype=torch.bfloat16),
+        torch.randn(256, dtype=torch.bfloat16),
+        torch.randn(128),
+        torch.randn(64, 64)[:, ::2],
+    ]
+    total = fsdp2_grad_clip.fused_sq_sum(tensors, dtype=torch.float32, device=torch.device("cpu"))
+    assert sorted(launches) == [(1, torch.float32), (2, torch.bfloat16)]
+    assert float(total) == pytest.approx(_reference_sq_sum(tensors), rel=1e-5)
+
+
+def test_grad_norm_paths_accumulate_bf16_in_fp32():
+    torch.manual_seed(0)
+    param = nn.Parameter(torch.randn(4096, dtype=torch.bfloat16))
+    param.grad = torch.full((4096,), 0.01, dtype=torch.bfloat16)
+    plain = nn.Parameter(torch.randn(8))
+    plain.grad = torch.arange(8, dtype=torch.float32)
+    expected = _reference_sq_sum([param.grad, plain.grad])
+
+    for actual in (
+        fsdp2_grad_clip.sharded_grad_sq_sum([param, plain]),
+        local_grad_sq_sum([param, plain], dtype=torch.float32),
+    ):
+        assert actual.dtype is torch.float32
+        assert float(actual) == pytest.approx(expected, rel=1e-5)
+    assert float(fsdp2_grad_clip.sharded_grad_abs_max([param, plain])) == pytest.approx(7.0)
+
+
+@pytest.mark.gpus(1)
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="TE multi_tensor_l2norm is CUDA-only.")
+def test_fused_sq_sum_allocates_no_full_size_temporary():
+    grad = torch.randn(64 * 1024 * 1024, dtype=torch.bfloat16, device="cuda")
+    torch.cuda.synchronize()
+    torch.cuda.reset_peak_memory_stats()
+    before = torch.cuda.memory_allocated()
+    total = fsdp2_grad_clip.fused_sq_sum([grad], dtype=torch.float32, device=grad.device)
+    torch.cuda.synchronize()
+    # to(float32).pow(2) would add 4x the grad here.
+    assert torch.cuda.max_memory_allocated() - before < 1 << 20
+    assert float(total) == pytest.approx(_reference_sq_sum([grad.cpu()]), rel=1e-3)
+
+
+@pytest.mark.parametrize("cpu_update", [False, True])
+def test_fp32_adamw_bf16_grad_matches_legacy_fp32_grad_copy(monkeypatch, cpu_update):
+    def legacy_prepare_grad(self, grad, master):
+        if self.cpu_update:
+            return to_local_tensor(grad).detach().to(device=master.device, dtype=torch.float32)
+        return grad.detach().to(dtype=torch.float32)
+
+    torch.manual_seed(0)
+    grad = torch.randn(512, dtype=torch.bfloat16)
+
+    def run():
+        torch.manual_seed(1)
+        param = nn.Parameter(torch.randn(512, dtype=torch.bfloat16))
+        optimizer = build_adamw_optimizer(
+            [{"params": [param], "weight_decay": 0.01}],
+            all_params=[param],
+            lr=0.1,
+            weight_decay=0.01,
+            betas=(0.9, 0.99),
+            eps=1.0e-8,
+            foreach=False,
+            use_fp32_master=True,
+            cpu_update=cpu_update,
+            model_param_dtypes={id(param): torch.bfloat16},
+            opt=SimpleNamespace(),
+        )
+        assert isinstance(optimizer, fsdp2_adamw.FP32AdamW)
+        for _ in range(4):  # several steps so bias correction and state carry-over count
+            param.grad = grad.clone()
+            optimizer.step()
+        state = optimizer.state_dict()
+        keys = ("exp_avgs", "exp_avg_sqs", "master_params")
+        return (param.detach().clone(), *(state[key][0].clone() for key in keys))
+
+    current = run()
+    monkeypatch.setattr(fsdp2_adamw.FP32AdamW, "_prepare_grad", legacy_prepare_grad)
+    for from_current, from_legacy in zip(current, run()):
+        assert torch.equal(from_current, from_legacy)

--- a/experimental/lite/tests/unit/runtime/backends/mlite/test_runtime_backend_unit.py
+++ b/experimental/lite/tests/unit/runtime/backends/mlite/test_runtime_backend_unit.py
@@ -181,6 +181,26 @@ def test_reset_parameters_helper_reinitializes_each_module_via_apply():
     assert calls == ["first", "second"]
 
 
+def test_reset_parameters_helper_preserves_replaced_parameter_identity():
+    class ReplacingReset(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = nn.Parameter(torch.tensor([1.0]))
+
+        def reset_parameters(self):
+            self.weight = nn.Parameter(torch.tensor([3.0]))
+
+    model = ReplacingReset()
+    original = model.weight
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+
+    model.apply(_reset_parameters)
+
+    assert optimizer.param_groups[0]["params"][0] is model.weight
+    assert model.weight is original
+    torch.testing.assert_close(model.weight, torch.tensor([3.0]))
+
+
 @pytest.mark.parametrize(
     "load_hf_weights", [True, False], ids=["checkpoint", "random-reset"]
 )


### PR DESCRIPTION
Brings `experimental/lite` here in line with `verl-project/Megatron-LM@lite` (`2a4126e78`), so the two forks stop drifting ahead of the upstream sync to NVIDIA dev (#6397).

## What arrives

- **Qwen3.5 dense model support** (verl-project#27) — merged on the verl-project fork and never ported back here. `qwen3_5/{config,lite/checkpoint,lite/model,lite/protocol}.py`, the `registry.py` entry, and two unit tests.
- **verl-project#33** — the FSDP2 optimizer-step change that removes full-size FP32 temporaries. Twin of #186 here.
- **verl-project#35** — preserves optimizer parameter identity across `reset_parameters()`.

12 files, +657/-113, all under `experimental/lite`.

## Deliberately not taken

- **`.gitignore`** — exists on the verl-project branch, not adopted here.
- **`README.md`** — the text there is specific to that branch's VERL-preview framing ("This `lite` branch provides VERL users with a preview..."), which does not describe this branch.

## Verification

After this commit, `experimental/lite` is **byte-identical** to `verl-project/Megatron-LM@lite`:

```
$ git diff --stat HEAD verl-project/lite -- experimental/lite
(empty)

$ git diff --stat HEAD verl-project/lite
 .gitignore | 3 +++
 README.md  | 9 ++++++++-
```

i.e. the only remaining differences are exactly the two files excluded above.

## Note on what is and is not validated here

verl-project#33 arrived with a moe panel verdict (approve-with-caveats, no blockers) and a double-arm standard-profile run showing zero regression. Qwen3.5 dense support and #35 have not been run through our gate. A double-arm `run_tests.sh` on this branch is in flight; I will post the numbers here when it lands, and this should not be merged on the strength of the byte-identity check alone.

Next step after this lands: refresh #6397 (currently three weeks stale, and blocked on the CSA `csa_utils/` rename — see verl-project#29).