### PR TITLE
fix(mLite): align CP compressed host boundaries

### DIFF
--- a/experimental/lite/megatron/lite/model/deepseek_v4/vllm/primitive/attention/host_geometry.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/vllm/primitive/attention/host_geometry.py
@@ -37,3 +37,42 @@ def compressed_sequence_boundaries(
             raise ValueError("sequence boundaries must be strictly increasing")
         compressed.append(compressed[-1] + (end - start) // ratio)
     return tuple(compressed)
+
+
+def local_compressed_sequence_boundaries(
+    sequence_boundaries: tuple[int, ...],
+    *,
+    global_start: int,
+    local_rows: int,
+    ratio: int,
+) -> tuple[int, ...]:
+    """Derive the compressed rows physically emitted by one contiguous CP rank.
+
+    This mirrors ``CompressorInputCompact``. In particular, a sequence that ends
+    at or before this rank's first row contributes no compressed groups, even
+    when its end is within the compressor's left-boundary window.
+    """
+    if ratio < 1:
+        raise ValueError("ratio must be positive")
+    if global_start < 0 or local_rows < 1:
+        raise ValueError("global_start must be non-negative and local_rows positive")
+
+    d_comp = 8 if ratio == 4 else ratio
+    local_end = global_start + local_rows
+    first_range_group_start = global_start - d_comp
+    compressed = [0]
+    for seq_start, seq_end in zip(sequence_boundaries, sequence_boundaries[1:]):
+        if seq_end <= seq_start:
+            raise ValueError("sequence boundaries must be strictly increasing")
+        local_seq_end = min(seq_end, local_end)
+        if seq_start >= local_seq_end or global_start >= local_seq_end:
+            compressed.append(compressed[-1])
+            continue
+
+        first_visible_numer = max(0, first_range_group_start - seq_start)
+        first_visible_group = (first_visible_numer + ratio - 1) // ratio
+        stop_visible_group = (local_seq_end - seq_start) // ratio
+        compressed.append(
+            compressed[-1] + max(0, stop_visible_group - first_visible_group)
+        )
+    return tuple(compressed)

--- a/experimental/lite/megatron/lite/model/deepseek_v4/vllm/primitive/attention/module.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/vllm/primitive/attention/module.py
@@ -34,6 +34,9 @@ from megatron.lite.model.deepseek_v4.vllm.primitive.attention.backward import (
     compressed_compact_graph,
     visible_sparse_attention,
 )
+from megatron.lite.model.deepseek_v4.vllm.primitive.attention.host_geometry import (
+    local_compressed_sequence_boundaries,
+)
 from megatron.lite.model.deepseek_v4.vllm.primitive.attention.runtime import (
     AttentionKernelMetadata,
     c128_all_visible_topk,
@@ -747,23 +750,12 @@ class VLLMAttention(CompressedSparseAttention):
                 # request-local compressed boundaries in this path.
                 local_compressed_boundaries = compressed_boundaries
             else:
-                local_boundaries = [0]
-                local_end = global_start + l_local
-                d_comp = 8 if ratio == 4 else ratio
-                for seq_start, seq_end in zip(
-                    sequence_boundaries, sequence_boundaries[1:]
-                ):
-                    owned_start = max(global_start, seq_start)
-                    owned_end = min(local_end, seq_end)
-                    first_group = max(
-                        0,
-                        (owned_start - seq_start - d_comp + ratio - 1) // ratio,
-                    )
-                    last_group = max(0, (owned_end - seq_start) // ratio)
-                    local_boundaries.append(
-                        local_boundaries[-1] + max(0, last_group - first_group)
-                    )
-                local_compressed_boundaries = tuple(local_boundaries)
+                local_compressed_boundaries = local_compressed_sequence_boundaries(
+                    sequence_boundaries,
+                    global_start=global_start,
+                    local_rows=l_local,
+                    ratio=ratio,
+                )
             if cu_seqlens_compressed.numel() != len(compressed_boundaries):
                 raise RuntimeError(
                     "DS4 host compressed boundaries do not match GPU metadata shape"

--- a/experimental/lite/tests/unit/model/deepseek_v4/vllm/test_attention_host_geometry.py
+++ b/experimental/lite/tests/unit/model/deepseek_v4/vllm/test_attention_host_geometry.py
@@ -4,6 +4,7 @@ import pytest
 
 from megatron.lite.model.deepseek_v4.vllm.primitive.attention.host_geometry import (
     compressed_sequence_boundaries,
+    local_compressed_sequence_boundaries,
     padded_sequence_boundaries,
 )
 
@@ -36,8 +37,58 @@ def test_compressed_geometry_floors_each_request(
     assert compressed_sequence_boundaries(boundaries, ratio=ratio) == expected
 
 
+@pytest.mark.parametrize("distance", range(1, 8))
+def test_local_compressed_geometry_ignores_left_boundary_only_sequences(
+    distance: int,
+) -> None:
+    global_start = 16
+    boundaries = (0, 5, global_start - distance, 48)
+
+    local = local_compressed_sequence_boundaries(
+        boundaries,
+        global_start=global_start,
+        local_rows=16,
+        ratio=4,
+    )
+
+    # CompressorInputCompact requires range_start < local_seq_end. Both packed
+    # sequences ending before this rank therefore emit zero groups, including
+    # the C4 danger window 0 < global_start - seq_end < d_comp (8).
+    assert local[:3] == (0, 0, 0)
+
+
+@pytest.mark.parametrize(
+    ("boundaries", "global_start", "local_rows", "ratio", "expected"),
+    [
+        ((0, 12, 32), 8, 8, 4, (0, 3, 4)),
+        ((0, 8, 24, 40), 16, 8, 4, (0, 0, 4, 4)),
+        ((0, 256, 512), 256, 128, 128, (0, 0, 1)),
+    ],
+)
+def test_local_compressed_geometry_matches_compactor_visible_groups(
+    boundaries: tuple[int, ...],
+    global_start: int,
+    local_rows: int,
+    ratio: int,
+    expected: tuple[int, ...],
+) -> None:
+    assert (
+        local_compressed_sequence_boundaries(
+            boundaries,
+            global_start=global_start,
+            local_rows=local_rows,
+            ratio=ratio,
+        )
+        == expected
+    )
+
+
 def test_invalid_host_geometry_fails_closed() -> None:
     with pytest.raises(ValueError, match="positive integers"):
         padded_sequence_boundaries((4, 0), cp_size=2)
     with pytest.raises(ValueError, match="strictly increasing"):
         compressed_sequence_boundaries((0, 8, 8), ratio=4)
+    with pytest.raises(ValueError, match="local_rows positive"):
+        local_compressed_sequence_boundaries(
+            (0, 8), global_start=0, local_rows=0, ratio=4
+        )


### PR DESCRIPTION
## Summary

- Match host-derived CP-local compressed boundaries to `CompressorInputCompact`.
- Exclude packed requests that end at or before the current CP rank, including requests ending inside the ratio-4 compressor's 8-token left-boundary window.
- Add focused coverage for the 1–7 token danger window and ratio-4/ratio-128 layouts.

## Root cause

The host path counted compressed groups from a packed request that had already ended to the left of the current CP rank. The device compactor correctly rejects that request with `range_start < local_seq_end`, so the host metadata and emitted compressed rows diverged. This shifted subsequent requests' compressed-row boundaries and made training old-logprob depend on packed micro-batch layout.

## Validation

- `experimental/lite/tests/run_tests.sh experimental/lite/tests/unit/model/deepseek_v4/vllm/test_attention_host_geometry.py`: **17 passed**.
- Exhaustive comparison against the full-stack-validated patch: **2,964,000 boundary configurations equivalent**.
- DeepSeek-V4-Flash-Base, 43 layers, 32 GB200 GPUs, actor CP2/EP32, rollout DP8/EP8:
  - training-only packing replay: `mu_vs_A=A_vs_C=mu_vs_C=1.0`;
  - normal training: 10/10 consecutive steps with `rollout_probs_diff_max=0`, `k3_kl=0`, and `log_ppl_diff=0`;
  - top-level Slurm job completed successfully.

## Duplicate-work check

- No open PR in `ISEEKYAN/Megatron-LM` addresses this mLite host-boundary mismatch.
- NVIDIA Megatron Core's CP compactor already contains the equivalent request/rank-intersection guard (introduced with the Core CP path), so this PR intentionally targets the mLite `ds4-v9-rc1` implementation rather than duplicating a Core fix.
- NVIDIA/Megatron-LM PR #6887 was reviewed for overlapping CP/CSA work and does not fix this mLite path.

## AI assistance

AI assistance was used for debugging, exhaustive boundary comparison, test execution, and drafting this PR. The human submitter should review every changed line and the validation evidence before marking the PR ready for review.
