### PR TITLE
refactor(mLite): restate the CP boundary fix as an empty-intersection guard

### DIFF
--- a/experimental/lite/megatron/lite/model/deepseek_v4/vllm/primitive/attention/host_geometry.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/vllm/primitive/attention/host_geometry.py
@@ -59,20 +59,16 @@ def local_compressed_sequence_boundaries(
 
     d_comp = 8 if ratio == 4 else ratio
     local_end = global_start + local_rows
-    first_range_group_start = global_start - d_comp
     compressed = [0]
     for seq_start, seq_end in zip(sequence_boundaries, sequence_boundaries[1:]):
         if seq_end <= seq_start:
             raise ValueError("sequence boundaries must be strictly increasing")
-        local_seq_end = min(seq_end, local_end)
-        if seq_start >= local_seq_end or global_start >= local_seq_end:
+        owned_start = max(global_start, seq_start)
+        owned_end = min(local_end, seq_end)
+        if owned_start >= owned_end:
             compressed.append(compressed[-1])
             continue
-
-        first_visible_numer = max(0, first_range_group_start - seq_start)
-        first_visible_group = (first_visible_numer + ratio - 1) // ratio
-        stop_visible_group = (local_seq_end - seq_start) // ratio
-        compressed.append(
-            compressed[-1] + max(0, stop_visible_group - first_visible_group)
-        )
+        first_group = max(0, (owned_start - seq_start - d_comp + ratio - 1) // ratio)
+        last_group = max(0, (owned_end - seq_start) // ratio)
+        compressed.append(compressed[-1] + max(0, last_group - first_group))
     return tuple(compressed)

--- a/experimental/lite/tests/unit/model/deepseek_v4/vllm/test_attention_host_geometry.py
+++ b/experimental/lite/tests/unit/model/deepseek_v4/vllm/test_attention_host_geometry.py
@@ -37,7 +37,7 @@ def test_compressed_geometry_floors_each_request(
     assert compressed_sequence_boundaries(boundaries, ratio=ratio) == expected
 
 
-@pytest.mark.parametrize("distance", range(1, 8))
+@pytest.mark.parametrize("distance", range(0, 8))
 def test_local_compressed_geometry_ignores_left_boundary_only_sequences(
     distance: int,
 ) -> None:


### PR DESCRIPTION
## Summary

Follow-up to #190. That PR fixed the host/device compressed-boundary mismatch, but it also rewrote the surrounding arithmetic, so the diff no longer showed that the only behavioural change was the added guard. This restores the pre-#190 expressions verbatim and reduces the fix to the one thing it actually is.

`owned_start` / `owned_end` are an **interval intersection** (this request ∩ this CP rank). The bug was that the intersection was never tested for emptiness: when a packed request ends 1–7 tokens before the rank's first row, the intersection is inverted (`owned_start > owned_end`), and the `- d_comp` lookback below turns that inverted span into a positive one, inventing rows `CompressorInputCompact` never emits.

```diff
         owned_start = max(global_start, seq_start)
         owned_end = min(local_end, seq_end)
+        if owned_start >= owned_end:
+            compressed.append(compressed[-1])
+            continue
         first_group = max(0, (owned_start - seq_start - d_comp + ratio - 1) // ratio)
```

`owned_start >= owned_end` is exactly the negation of the device kernel's two-part visibility test (`seq_start < local_seq_end and range_start < local_seq_end`), so the mirror of `CompressorInputCompact` is preserved in one line instead of two.

## What this changes

- Restores `owned_start` / `owned_end` / `first_group` / `last_group` verbatim from before #190; the guard is now the whole delta.
- Extends the danger-window parametrisation from `range(1, 8)` to `range(0, 8)`. `distance == 0` (a request ending exactly on the rank boundary) is the worst case — two phantom rows rather than one — and was the only value in the window left untested.

Public signature, raises, and behaviour are unchanged. No production code path is touched other than the body of `local_compressed_sequence_boundaries`.

## Validation

- `experimental/lite/tests/run_tests.sh experimental/lite/tests/unit/model/deepseek_v4/vllm/test_attention_host_geometry.py`: **18 passed** (17 before, +1 from `distance == 0`).
- Exhaustive equivalence over **115,818,214** configurations — ratio 4 and 128, packed layouts of 1–4 requests, total lengths 4–40, every `(global_start, local_rows)` split: this version, the #190 version, and a reference transcription of `_compressor_input_compact_fwd_kernel` all agree on every one.
- No GPU run was repeated: since behaviour is provably identical to the merged #190, the 32-GPU end-to-end validation in that PR (10/10 steps `rollout_probs_diff_max=0`) still stands.

## Why bother, given #190 is merged

The value is reviewability of the next change. In its current form, seeing that #190 is correct requires proving two arithmetic expressions equivalent; in this form, the fix reads as "an empty intersection owns nothing", which is checkable by eye. Given this loop already cost one silent training-correctness bug, that matters more than the diff size.

## Follow-ups this PR deliberately does *not* do

Kept separate so this stays a pure no-op refactor:

1. Have the kernel return the per-request group counts it actually emits, so the host stops maintaining a second implementation of the same geometry.
2. Collapse `d_comp = 8 if ratio == 4 else ratio`, currently duplicated in six places (`cp_utils.py` ×2, `runtime.py`, `csa.py`, `module.py`, `host_geometry.py`), into one shared helper. That duplication is the soil this bug grew in.
3. Add a host↔device consistency test that runs the real compactor on a small CUDA case and compares its emitted `comp_ids` against this function. The current tests — and the exhaustive comparison above — are host-to-host only.

## Duplicate-work check

- `gh pr list --repo ISEEKYAN/Megatron-LM --state open` shows no open PR touching `host_geometry.py` or the mLite CP compressed-boundary path.
- This is a follow-up to #190 (merged as 15bcb0624), not a competing fix.

## AI assistance

AI assistance was used for the root-cause analysis, the exhaustive equivalence check, and drafting this PR. The human submitter should review every changed line before merging.