### PR TITLE
fix(lite): mmap rank-local optimizer checkpoints

### DIFF
--- a/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
@@ -250,7 +250,9 @@ def _load_optimizer_checkpoint(optimizer, path: str) -> None:
     load_state_dict_fn = getattr(optimizer, "load_state_dict", None)
     if not callable(load_state_dict_fn):
         raise TypeError(f"Optimizer {type(optimizer).__name__} does not provide load_state_dict().")
-    state = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+    state = torch.load(
+        ckpt_path, map_location="cpu", weights_only=False, mmap=True
+    )
     load_state_dict_fn(state)
 
 

--- a/experimental/lite/tests/unit/runtime/checkpoint/test_training_checkpoint.py
+++ b/experimental/lite/tests/unit/runtime/checkpoint/test_training_checkpoint.py
@@ -81,6 +81,24 @@ def test_optimizer_checkpoint_roundtrips_rank_local_state(tmp_path) -> None:
     _assert_state_equal(optimizer.state_dict(), expected)
 
 
+def test_optimizer_checkpoint_load_uses_mmap(monkeypatch, tmp_path) -> None:
+    model = torch.nn.Linear(4, 2)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=0.01)
+    dcp._save_optimizer_checkpoint(optimizer, str(tmp_path))
+    original_load = dcp.torch.load
+    load_kwargs = {}
+
+    def observed_load(*args, **kwargs):
+        load_kwargs.update(kwargs)
+        return original_load(*args, **kwargs)
+
+    monkeypatch.setattr(dcp.torch, "load", observed_load)
+
+    dcp._load_optimizer_checkpoint(optimizer, str(tmp_path))
+
+    assert load_kwargs["mmap"] is True
+
+
 class FakeDistOpt:
     def __init__(self):
         self.save_model_sd = None


### PR DESCRIPTION
## What

Load rank-local optimizer checkpoint shards with torch.load mmap=True. This avoids materializing a second anonymous CPU copy before FP32AdamW copies into already allocated optimizer state.

## Why this is not a duplicate

ISEEKYAN/Megatron-LM has no open mmap or optimizer-checkpoint-resume PR. This is independent of the DCP local-staging PR: it affects resume reads, not checkpoint writes.

## Validation

- Unit: optimizer checkpoint round-trip and mmap-argument tests passed on the ds4-v9-rc1 image.
- Full 32-rank resume validation loaded model, optimizer, RNG, and extra state from a 107 GB/rank optimizer shard without cgroup OOM.
- This change does not alter model arithmetic or serving output.

## AI assistance and review

OpenAI Codex assisted with the implementation and tests. This draft requires a human reviewer to inspect every changed line and validate the production result before merge.