### PR TITLE
fix(lite): optionally stage checkpoint files locally

### DIFF
--- a/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
@@ -22,6 +22,11 @@ import torch.nn as nn  # pyright: ignore[reportMissingImports]
 from torch.distributed.device_mesh import DeviceMesh  # pyright: ignore[reportMissingImports]
 from torch.distributed.tensor import DTensor  # pyright: ignore[reportMissingImports]
 
+from megatron.lite.primitive.ckpt.local_stage import (
+    NodeLocalStagingFileSystem as _NodeLocalStagingFileSystem,
+    local_stage_root,
+    publish_staged_file as _publish_staged_file,
+)
 from megatron.lite.primitive.parallel import ParallelState
 from megatron.lite.primitive.protocols import (
     ExpertClassifierFn,
@@ -88,7 +93,12 @@ def save_training_checkpoint(
 
     ckpt_path = os.path.join(path, f"step_{step}")
     os.makedirs(ckpt_path, exist_ok=True)
-    dcp.save(state_dict, checkpoint_id=ckpt_path)
+    storage_writer = _staged_dcp_writer(ckpt_path)
+    dcp.save(
+        state_dict,
+        checkpoint_id=ckpt_path,
+        storage_writer=storage_writer,
+    )
     if save_optimizer:
         _save_optimizer_checkpoint(optimizer, ckpt_path)
     if save_rng:
@@ -205,7 +215,13 @@ def _save_dist_opt_checkpoint(
     from megatron.lite.primitive.ckpt.distckpt import save_dist_opt_checkpoint
 
     save_dist_opt_checkpoint(
-        model, optimizer, step, path, save_model=save_model, save_optimizer=save_optimizer
+        model,
+        optimizer,
+        step,
+        path,
+        save_model=save_model,
+        save_optimizer=save_optimizer,
+        local_stage_root=local_stage_root(),
     )
 
 
@@ -229,6 +245,31 @@ def _optimizer_checkpoint_path(path: str) -> str:
     return os.path.join(path, f"optimizer_rank_{rank}.pt")
 
 
+def _staged_dcp_writer(checkpoint_path: str):
+    filesystem = _local_staging_filesystem()
+    if filesystem is None:
+        return None
+    writer = dcp.FileSystemWriter(checkpoint_path)
+    writer.fs = filesystem
+    return writer
+
+
+def _local_staging_filesystem() -> _NodeLocalStagingFileSystem | None:
+    stage_root = local_stage_root()
+    return _NodeLocalStagingFileSystem(stage_root) if stage_root is not None else None
+
+
+def _torch_save_with_optional_staging(
+    state: Any, destination: str | os.PathLike[str]
+) -> None:
+    filesystem = _local_staging_filesystem()
+    if filesystem is None:
+        torch.save(state, destination)
+        return
+    with filesystem.create_stream(os.fspath(destination), "wb") as stream:
+        torch.save(state, stream)
+
+
 def _save_optimizer_checkpoint(optimizer, path: str) -> None:
     if optimizer is None:
         log_rank0("Skipping optimizer checkpoint save because optimizer is None")
@@ -236,7 +277,9 @@ def _save_optimizer_checkpoint(optimizer, path: str) -> None:
     state_dict_fn = getattr(optimizer, "state_dict", None)
     if not callable(state_dict_fn):
         raise TypeError(f"Optimizer {type(optimizer).__name__} does not provide state_dict().")
-    torch.save(state_dict_fn(), _optimizer_checkpoint_path(path))
+    _torch_save_with_optional_staging(
+        state_dict_fn(), _optimizer_checkpoint_path(path)
+    )
 
 
 def _load_optimizer_checkpoint(optimizer, path: str) -> None:
@@ -434,7 +477,7 @@ def _restore_rng_state(state: dict[str, Any] | None) -> None:
 def _save_rng_sidecar(path: str | os.PathLike[str]) -> None:
     rng_file = _rng_sidecar_file(path)
     rng_file.parent.mkdir(parents=True, exist_ok=True)
-    torch.save(_get_rng_state(), rng_file)
+    _torch_save_with_optional_staging(_get_rng_state(), rng_file)
 
 
 def _load_rng_sidecar(path: str | os.PathLike[str]) -> None:

--- a/experimental/lite/megatron/lite/primitive/ckpt/distckpt.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/distckpt.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import os
 from collections.abc import Callable, Iterable, MutableMapping
 from dataclasses import replace
+from pathlib import Path
 from types import MethodType
 from typing import Any
 
@@ -14,6 +15,12 @@ import torch.nn as nn
 
 from megatron.core import dist_checkpointing
 from megatron.core.dist_checkpointing.mapping import ShardedTensor
+from megatron.core.dist_checkpointing.strategies.torch import TorchDistSaveShardedStrategy
+from megatron.lite.primitive.ckpt.local_stage import (
+    NodeLocalStagingFileSystem,
+    allocate_stage_path,
+    publish_staged_file,
+)
 from megatron.lite.primitive.parallel import ParallelState
 from megatron.lite.primitive.protocols import (
     ExpertClassifierFn,
@@ -66,6 +73,7 @@ def save_dist_opt_checkpoint(
     *,
     save_model: bool = True,
     save_optimizer: bool = True,
+    local_stage_root: Path | None = None,
 ) -> None:
     """Save model and DistributedOptimizer state through mcore dist_checkpointing."""
 
@@ -84,12 +92,56 @@ def save_dist_opt_checkpoint(
             )
         finally:
             _restore_state_dict_patches(patches)
+    save_strategy = (
+        _NodeLocalDistSaveStrategy(local_stage_root)
+        if local_stage_root is not None
+        else None
+    )
     dist_checkpointing.save(
         state_dict,
         checkpoint_dir,
+        sharded_strategy=save_strategy,
         validate_access_integrity=False,
         content_metadata=metadata,
     )
+
+
+class _NodeLocalDistSaveStrategy(TorchDistSaveShardedStrategy):
+    def __init__(self, stage_root: Path):
+        super().__init__()
+        self._stage_root = stage_root
+
+    def _get_save_and_finalize_callbacks(
+        self, writer, save_state_dict_ret, async_strategy
+    ):
+        writer.fs = NodeLocalStagingFileSystem(self._stage_root)
+        request = super()._get_save_and_finalize_callbacks(
+            writer, save_state_dict_ret, async_strategy
+        )
+        if len(request.async_fn_args) < 2:
+            return request
+
+        staged_files: list[tuple[Path, Path]] = []
+        write_buckets = request.async_fn_args[1]
+        for index, (destination, storage_key, payload) in enumerate(write_buckets):
+            destination = Path(destination)
+            stage_path = allocate_stage_path(self._stage_root, destination.name)
+            write_buckets[index] = (str(stage_path), storage_key, payload)
+            staged_files.append((stage_path, destination))
+
+        original_finalize_fns = tuple(request.finalize_fns)
+
+        def finalize_and_publish() -> None:
+            try:
+                for finalize_fn in original_finalize_fns:
+                    finalize_fn()
+                for stage_path, destination in staged_files:
+                    publish_staged_file(stage_path, destination)
+            finally:
+                for stage_path, _ in staged_files:
+                    stage_path.unlink(missing_ok=True)
+
+        return request._replace(finalize_fns=[finalize_and_publish])
 
 
 def load_dist_opt_checkpoint(

--- a/experimental/lite/megatron/lite/primitive/ckpt/local_stage.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/local_stage.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from __future__ import annotations
+
+import contextlib
+import os
+import tempfile
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+from typing import IO
+
+import torch.distributed as dist  # pyright: ignore[reportMissingImports]
+from torch.distributed.checkpoint.filesystem import (  # pyright: ignore[reportMissingImports]
+    FileSystem,
+)
+
+
+def local_stage_root() -> Path | None:
+    stage_dir = os.environ.get("MLITE_DCP_LOCAL_STAGE_DIR")
+    return Path(stage_dir) if stage_dir else None
+
+
+def rank_stage_dir(stage_root: Path) -> Path:
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    path = stage_root / f"rank-{rank}"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def allocate_stage_path(stage_root: Path, destination_name: str) -> Path:
+    descriptor, path = tempfile.mkstemp(
+        prefix=f"{destination_name}.", suffix=".stage", dir=rank_stage_dir(stage_root)
+    )
+    os.close(descriptor)
+    return Path(path)
+
+
+class NodeLocalStagingFileSystem(FileSystem):
+    def __init__(self, stage_root: Path):
+        self._stage_root = stage_root
+
+    @contextlib.contextmanager
+    def create_stream(self, path: str, mode: str) -> Iterator[IO[bytes]]:
+        if mode != "wb":
+            with super().create_stream(path, mode) as stream:
+                yield stream
+            return
+
+        destination = Path(path)
+        stage_path = allocate_stage_path(self._stage_root, destination.name)
+        try:
+            with stage_path.open("wb", buffering=0) as stream:
+                yield stream
+                stream.flush()
+                os.fsync(stream.fileno())
+            publish_staged_file(stage_path, destination)
+        finally:
+            stage_path.unlink(missing_ok=True)
+
+
+def publish_staged_file(source: Path, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_name(
+        f".{destination.name}.publish.{os.getpid()}.{uuid.uuid4().hex}"
+    )
+    source_fd = os.open(source, os.O_RDONLY | os.O_CLOEXEC)
+    destination_fd = None
+    try:
+        size = os.fstat(source_fd).st_size
+        destination_fd = os.open(
+            temporary,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC,
+            0o600,
+        )
+        offset = 0
+        while offset < size:
+            written = os.sendfile(destination_fd, source_fd, offset, size - offset)
+            if written <= 0:
+                raise OSError(
+                    f"sendfile returned {written} after {offset}/{size} bytes"
+                )
+            offset += written
+        os.fsync(destination_fd)
+        os.close(destination_fd)
+        destination_fd = None
+        os.close(source_fd)
+        source_fd = None
+        os.replace(temporary, destination)
+        fsync_directory(destination.parent)
+    finally:
+        if destination_fd is not None:
+            os.close(destination_fd)
+        if source_fd is not None:
+            os.close(source_fd)
+        temporary.unlink(missing_ok=True)
+
+
+def fsync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)

--- a/experimental/lite/tests/unit/runtime/checkpoint/test_training_checkpoint.py
+++ b/experimental/lite/tests/unit/runtime/checkpoint/test_training_checkpoint.py
@@ -15,6 +15,7 @@ from megatron.core.dist_checkpointing.strategies.torch import (
 )
 from megatron.lite.primitive.ckpt import dcp
 from megatron.lite.primitive.ckpt.distckpt import (
+    _NodeLocalDistSaveStrategy,
     _dist_opt_checkpoint_metadata,
     _model_sharded_state_dict,
     _rank_offsets_and_replica_id,
@@ -99,6 +100,74 @@ def test_optimizer_checkpoint_load_uses_mmap(monkeypatch, tmp_path) -> None:
     assert load_kwargs["mmap"] is True
 
 
+def test_dcp_local_stage_publishes_completed_shard(tmp_path) -> None:
+    stage_root = tmp_path / "stage"
+    destination = tmp_path / "checkpoint" / "__0_0.distcp"
+    filesystem = dcp._NodeLocalStagingFileSystem(stage_root)
+
+    with filesystem.create_stream(str(destination), "wb") as stream:
+        stream.write(b"checkpoint bytes")
+
+    assert destination.read_bytes() == b"checkpoint bytes"
+    assert not list(stage_root.rglob("*.stage"))
+
+
+def test_dcp_local_stage_does_not_publish_failed_write(tmp_path) -> None:
+    stage_root = tmp_path / "stage"
+    destination = tmp_path / "checkpoint" / "__0_0.distcp"
+    filesystem = dcp._NodeLocalStagingFileSystem(stage_root)
+
+    with (
+        pytest.raises(RuntimeError, match="write failed"),
+        filesystem.create_stream(str(destination), "wb") as stream,
+    ):
+        stream.write(b"partial checkpoint bytes")
+        raise RuntimeError("write failed")
+
+    assert not destination.exists()
+    assert not list(stage_root.rglob("*.stage"))
+
+
+def test_dcp_local_stage_writer_is_opt_in(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("MLITE_DCP_LOCAL_STAGE_DIR", raising=False)
+    assert dcp._staged_dcp_writer(str(tmp_path / "checkpoint")) is None
+
+    monkeypatch.setenv("MLITE_DCP_LOCAL_STAGE_DIR", str(tmp_path / "stage"))
+    writer = dcp._staged_dcp_writer(str(tmp_path / "checkpoint"))
+
+    assert isinstance(writer.fs, dcp._NodeLocalStagingFileSystem)
+
+
+def test_dcp_local_stage_publishes_optimizer(monkeypatch, tmp_path) -> None:
+    stage_root = tmp_path / "stage"
+    monkeypatch.setenv("MLITE_DCP_LOCAL_STAGE_DIR", str(stage_root))
+    model = torch.nn.Linear(4, 2)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=0.01)
+
+    dcp._save_optimizer_checkpoint(optimizer, str(tmp_path))
+
+    checkpoint = tmp_path / "optimizer_rank_0.pt"
+    assert checkpoint.exists()
+    _assert_state_equal(
+        torch.load(checkpoint, weights_only=False), optimizer.state_dict()
+    )
+    assert not list(stage_root.rglob("*.stage"))
+
+
+def test_dcp_local_stage_publishes_rng_sidecar(monkeypatch, tmp_path) -> None:
+    stage_root = tmp_path / "stage"
+    monkeypatch.setenv("MLITE_DCP_LOCAL_STAGE_DIR", str(stage_root))
+    expected = {"torch_rng_state": torch.arange(4)}
+    monkeypatch.setattr(dcp, "_get_rng_state", lambda: expected)
+
+    dcp._save_rng_sidecar(tmp_path)
+
+    checkpoint = tmp_path / "rng_state_rank_00000.pt"
+    assert checkpoint.exists()
+    _assert_state_equal(torch.load(checkpoint, weights_only=False), expected)
+    assert not list(stage_root.rglob("*.stage"))
+
+
 class FakeDistOpt:
     def __init__(self):
         self.save_model_sd = None
@@ -163,7 +232,61 @@ def test_dist_opt_checkpoint_dispatches_to_mcore_distckpt(monkeypatch, tmp_path)
     assert saved["checkpoint_dir"] == str(tmp_path / "step_5")
     assert saved["kwargs"]["validate_access_integrity"] is False
     assert saved["kwargs"]["content_metadata"] == DISTOPT_METADATA
+    assert saved["kwargs"]["sharded_strategy"] is None
     assert not (tmp_path / "step_5" / "optimizer_rank_0.pt").exists()
+
+
+def test_dist_opt_checkpoint_uses_local_stage_strategy(monkeypatch, tmp_path) -> None:
+    model = torch.nn.Linear(4, 2)
+    optimizer = FakeDistOpt()
+    attach_model_sharded_state_dict([model], ParallelState())
+    saved = {}
+
+    def fake_save(_state_dict, _checkpoint_dir, **kwargs):
+        saved.update(kwargs)
+
+    monkeypatch.setenv("MLITE_DCP_LOCAL_STAGE_DIR", str(tmp_path / "stage"))
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.distckpt.dist_checkpointing.save", fake_save
+    )
+
+    dcp.save_training_checkpoint(model, optimizer, 5, str(tmp_path), use_dcp=True)
+
+    strategy = saved["sharded_strategy"]
+    assert isinstance(strategy, _NodeLocalDistSaveStrategy)
+    assert strategy._stage_root == tmp_path / "stage"
+
+
+def test_dist_opt_local_stage_saves_checkpoint_end_to_end(
+    monkeypatch, tmp_path
+) -> None:
+    if torch.distributed.is_initialized():
+        pytest.skip("requires ownership of the default process group")
+    torch.distributed.init_process_group(
+        "gloo",
+        init_method=f"file://{tmp_path / 'dist-init'}",
+        rank=0,
+        world_size=1,
+    )
+    try:
+        stage_root = tmp_path / "stage"
+        checkpoint_root = tmp_path / "checkpoint"
+        monkeypatch.setenv("MLITE_DCP_LOCAL_STAGE_DIR", str(stage_root))
+        monkeypatch.setattr(torch.cuda, "synchronize", lambda: None)
+        monkeypatch.setattr(torch.cuda, "current_device", lambda: torch.device("cpu"))
+        model = torch.nn.Linear(4, 2)
+        attach_model_sharded_state_dict([model], ParallelState())
+
+        dcp.save_training_checkpoint(
+            model, None, 5, str(checkpoint_root), use_dcp=True
+        )
+
+        step_path = checkpoint_root / "step_5"
+        assert (step_path / ".metadata").exists()
+        assert list(step_path.glob("*.distcp"))
+        assert not list(stage_root.rglob("*.stage"))
+    finally:
+        torch.distributed.destroy_process_group()
 
 
 def test_dist_opt_checkpoint_offsets_cover_tp_pp_ep_etp_topology() -> None:


### PR DESCRIPTION
## What

Add an opt-in MLITE_DCP_LOCAL_STAGE_DIR path for all files produced by the mLite DCP checkpoint path: DCP shards and metadata, rank-local optimizer shards, and RNG sidecars. Each file is written and fsynced on node-local storage, copied to the destination with sendfile, then atomically renamed into place. Default behavior is unchanged.

## Scope and why this is not a duplicate

ISEEKYAN/Megatron-LM has no open Lustre or local-staging checkpoint PR. This is a deployment workaround for the observed Lustre short-write and EFAULT failure, not a new checkpoint transaction protocol and not a claim to fix Lustre or PyTorch DCP globally. It is separate from optimizer mmap, which fixes resume memory pressure.

## Validation

- Current PR unit command: /opt/ds4-venv/bin/python -m pytest experimental/lite/tests/unit/runtime/checkpoint/test_training_checkpoint.py -q
- Result: 18 passed. Coverage includes DCP publish, optimizer publish, RNG publish, opt-in selection, and failure leaving no final destination file.
- Production evidence from the predecessor implementation of the same three-file staging boundary: a full 32-card checkpoint produced 99 files, about 3.2 TiB, with no temporary or empty files; save time was about 269 seconds and full resume passed.
- This change does not alter model arithmetic or serving output.

## AI assistance and review

OpenAI Codex assisted with the implementation and tests. This draft requires a human reviewer to inspect every changed line and validate the production result before merge.