### PR TITLE
fix(ds4): invalidate deployment state after model restore

### DIFF
--- a/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
@@ -685,6 +685,9 @@ class MegatronLiteEngine(BaseEngine):
                 load_model=True,
                 load_optimizer=True,
             )
+            post_update_hook = self.handle._extras.get("post_optimizer_step_hook")
+            if callable(post_update_hook):
+                post_update_hook()
             scheduler_path = os.path.join(local_path, _LR_SCHEDULER_STATE)
             if self.handle._lr_scheduler is not None and os.path.exists(scheduler_path):
                 state = torch.load(

--- a/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
@@ -121,6 +121,8 @@ def load_training_checkpoint(
             path,
             load_rng=load_rng,
             load_parameter_state_update_legacy_format=load_parameter_state_update_legacy_format,
+            load_model=load_model,
+            load_optimizer=load_optimizer,
         )
     ckpt_path = _resolve_step_checkpoint_path(path)
     if _supports_dist_opt_distckpt(model, optimizer):
@@ -485,18 +487,21 @@ def _load_local_training_checkpoint(
     *,
     load_rng: bool = True,
     load_parameter_state_update_legacy_format: bool = False,
+    load_model: bool = True,
+    load_optimizer: bool = True,
 ) -> int:
     ckpt_file = _local_checkpoint_file(path)
     state = torch.load(ckpt_file, map_location="cpu", weights_only=False)
     if state.get("format") != "megatron_lite.local_training.v1":
         raise RuntimeError(f"Unsupported local checkpoint format in {ckpt_file}")
-    chunks = _model_chunks(model)
-    chunk_states = state.get("model")
-    if not isinstance(chunk_states, list) or len(chunk_states) != len(chunks):
-        raise RuntimeError("Checkpoint model chunk count does not match target model.")
-    for chunk, chunk_state in zip(chunks, chunk_states, strict=True):
-        _load_chunk_tensor_state(chunk, chunk_state)
-    if optimizer is not None and state.get("optimizer") is not None:
+    if load_model:
+        chunks = _model_chunks(model)
+        chunk_states = state.get("model")
+        if not isinstance(chunk_states, list) or len(chunk_states) != len(chunks):
+            raise RuntimeError("Checkpoint model chunk count does not match target model.")
+        for chunk, chunk_state in zip(chunks, chunk_states, strict=True):
+            _load_chunk_tensor_state(chunk, chunk_state)
+    if load_optimizer and optimizer is not None and state.get("optimizer") is not None:
         optimizer.load_state_dict(state["optimizer"])
         parameter_state_name = state.get("optimizer_parameter_state")
         load_parameter_state = getattr(optimizer, "load_parameter_state", None)

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -369,7 +369,8 @@ class MegatronLiteRuntime(RuntimeBase):
             )
         )
         get_placements, is_expert = _checkpoint_hooks(handle)
-        return load_training_checkpoint(
+        load_model = kwargs.pop("load_model", True)
+        step = load_training_checkpoint(
             _checkpoint_model(handle, use_dcp=use_dcp),
             handle._optimizer,
             path,
@@ -380,10 +381,15 @@ class MegatronLiteRuntime(RuntimeBase):
             use_dcp=use_dcp,
             load_rng=load_rng,
             load_parameter_state_update_legacy_format=update_legacy_format,
-            load_model=kwargs.pop("load_model", True),
+            load_model=load_model,
             load_optimizer=kwargs.pop("load_optimizer", True),
             **kwargs,
         )
+        if load_model:
+            post_update_hook = handle._extras.get("post_optimizer_step_hook")
+            if callable(post_update_hook):
+                post_update_hook()
+        return step
 
     def export_weights(self, handle: ModelHandle, **kwargs) -> Iterator[tuple[str, torch.Tensor]]:
         model_chunks = handle._extras.get("model_chunks", [handle._model])

--- a/experimental/lite/tests/unit/examples/test_verl_mlite_engine_config.py
+++ b/experimental/lite/tests/unit/examples/test_verl_mlite_engine_config.py
@@ -357,6 +357,65 @@ def test_qat_export_rejects_native_resync_format_double_quantization() -> None:
         _engine_config(qat={"enable": True, "mode": "mxfp4"}, resync_format="mxfp4")
 
 
+@pytest.mark.parametrize("loaded_step", [0, 5])
+def test_checkpoint_resume_invalidates_post_update_state(
+    monkeypatch, tmp_path, loaded_step
+) -> None:
+    engine = _engine(engine_config=_engine_config())
+    calls = []
+    engine.runtime = object()
+    engine.module = torch.nn.Linear(1, 1)
+    engine.handle = SimpleNamespace(
+        _optimizer=object(),
+        _config=SimpleNamespace(parallel=object()),
+        _parallel_state=object(),
+        _lr_scheduler=None,
+        _extras={
+            "protocol": None,
+            "post_optimizer_step_hook": lambda: calls.append("post_update"),
+        },
+    )
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.load_training_checkpoint",
+        lambda *_args, **_kwargs: loaded_step,
+    )
+
+    engine.load_checkpoint(str(tmp_path))
+
+    assert calls == ["post_update"]
+
+
+def test_checkpoint_load_failure_does_not_run_post_load_hook(
+    monkeypatch, tmp_path
+) -> None:
+    engine = _engine(engine_config=_engine_config())
+    calls = []
+    engine.runtime = object()
+    engine.module = torch.nn.Linear(1, 1)
+    engine.handle = SimpleNamespace(
+        _optimizer=object(),
+        _config=SimpleNamespace(parallel=object()),
+        _parallel_state=object(),
+        _lr_scheduler=None,
+        _extras={
+            "protocol": None,
+            "post_optimizer_step_hook": lambda: calls.append("post_update"),
+        },
+    )
+
+    def fail_load(*_args, **_kwargs):
+        raise RuntimeError("checkpoint load failed")
+
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.load_training_checkpoint", fail_load
+    )
+
+    with pytest.raises(RuntimeError, match="checkpoint load failed"):
+        engine.load_checkpoint(str(tmp_path))
+
+    assert calls == []
+
+
 def test_local_lr_scheduler_warmup_decay_and_state_roundtrip() -> None:
     from verl_mlite.engine.mlite_engine import _build_lr_scheduler
 

--- a/experimental/lite/tests/unit/model/deepseek_v4/lite/test_deepseek_v4_hf_load_local_to_global.py
+++ b/experimental/lite/tests/unit/model/deepseek_v4/lite/test_deepseek_v4_hf_load_local_to_global.py
@@ -256,6 +256,54 @@ def test_ds4_optimizer_invalidation_removes_parameter_source_scale_state():
     assert model._fp8_source_scales_valid is False
 
 
+def test_ds4_resume_invalidation_requantizes_first_export_from_current_weight():
+    from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
+    from megatron.lite.primitive.parallel.state import ParallelState
+    from megatron.lite.primitive.quantization.block_fp8 import quantize_block_fp8
+
+    ckpt = _checkpoint_module()
+    model = _QATStage([0], 128)
+    parameter = model.layers["0"].self_attn.self_attn.wq_a.weight
+    native_name = "layers.0.self_attn.self_attn.wq_a.weight"
+    hf_name = "layers.0.attn.wq_a.weight"
+    stale_scale = torch.tensor([[0.25]], dtype=torch.float32)
+    model._fp8_source_scales_valid = True
+    model._fp8_source_scales_by_name = {native_name: stale_scale}
+    parameter._fp8_source_scales = stale_scale
+    parameter._fp8_source_scale_version = parameter._version
+
+    with torch.no_grad():
+        parameter.fill_(1.0)
+
+    config = DeepseekV4Config(
+        num_hidden_layers=1,
+        n_routed_experts=8,
+        expert_dtype="fp8",
+        quantization_config={"weight_block_size": [128, 128]},
+    )
+    export_kwargs = {
+        "target": "block_fp8",
+        "resync_config": {"expert_dtype": "fp8"},
+    }
+    stale_export = dict(
+        ckpt.export_hf_weights(model, config, ParallelState(), **export_kwargs)
+    )
+    assert torch.equal(stale_export["layers.0.attn.wq_a.scale"], stale_scale)
+
+    ckpt.invalidate_bound_source_scales(model)
+    current_export = dict(
+        ckpt.export_hf_weights(model, config, ParallelState(), **export_kwargs)
+    )
+    expected_weight, expected_scale = quantize_block_fp8(
+        parameter, (128, 128), scale_format="float32"
+    )
+
+    assert torch.equal(current_export[hf_name], expected_weight)
+    assert torch.equal(current_export["layers.0.attn.wq_a.scale"], expected_scale)
+    assert not torch.equal(stale_export[hf_name], current_export[hf_name])
+    assert not torch.equal(expected_scale, stale_scale)
+
+
 def test_ds4_fused_expert_preserves_w1_w3_bytes_and_scale_order():
     from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
 

--- a/experimental/lite/tests/unit/runtime/checkpoint/test_checkpoint_runtime.py
+++ b/experimental/lite/tests/unit/runtime/checkpoint/test_checkpoint_runtime.py
@@ -82,6 +82,42 @@ def test_runtime_local_checkpoint_load_matches_uninterrupted_training(tmp_path):
     _assert_model_close(direct_model, loaded_model)
 
 
+def test_runtime_local_checkpoint_honors_selective_restore(tmp_path):
+    saved_model = TinyMLP()
+    saved_optimizer = torch.optim.AdamW(saved_model.parameters(), lr=1.0e-3)
+    runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
+    runtime.save_checkpoint(
+        ModelHandle(model=saved_model, optimizer=saved_optimizer),
+        str(tmp_path),
+        step=1,
+        use_dcp=False,
+    )
+
+    loaded_model = TinyMLP()
+    loaded_optimizer = torch.optim.AdamW(loaded_model.parameters(), lr=2.0e-3)
+    model_before = copy.deepcopy(loaded_model)
+    runtime.load_checkpoint(
+        ModelHandle(model=loaded_model, optimizer=loaded_optimizer),
+        str(tmp_path),
+        use_dcp=False,
+        load_model=False,
+        load_optimizer=True,
+    )
+    _assert_model_close(loaded_model, model_before)
+    assert loaded_optimizer.param_groups[0]["lr"] == 1.0e-3
+
+    optimizer_before = copy.deepcopy(loaded_optimizer.state_dict())
+    runtime.load_checkpoint(
+        ModelHandle(model=loaded_model, optimizer=loaded_optimizer),
+        str(tmp_path),
+        use_dcp=False,
+        load_model=True,
+        load_optimizer=False,
+    )
+    _assert_model_close(loaded_model, saved_model)
+    assert loaded_optimizer.state_dict() == optimizer_before
+
+
 class DistOptLike:
     """Small optimizer wrapper with the same checkpoint contract as dist_opt."""
 

--- a/experimental/lite/tests/unit/runtime/checkpoint/test_training_checkpoint.py
+++ b/experimental/lite/tests/unit/runtime/checkpoint/test_training_checkpoint.py
@@ -406,3 +406,30 @@ def test_runtime_checkpoint_api_passes_current_training_checkpoint_signature(
         },
     )
     assert loaded_step == 7
+
+
+@pytest.mark.parametrize("load_model, expected_calls", [(True, 1), (False, 0)])
+def test_runtime_checkpoint_invalidates_state_only_after_model_load(
+    monkeypatch, tmp_path, load_model, expected_calls
+) -> None:
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.load_training_checkpoint",
+        lambda *_args, **_kwargs: 0,
+    )
+    calls = []
+    model = torch.nn.Linear(1, 1)
+    handle = ModelHandle(
+        model=model,
+        optimizer=object(),
+        parallel_state=object(),
+        config=SimpleNamespace(
+            parallel=SimpleNamespace(tp=1, etp=1, ep=1, pp=1, cp=1)
+        ),
+        _extras={"post_optimizer_step_hook": lambda: calls.append("post_update")},
+    )
+
+    MegatronLiteRuntime.__new__(MegatronLiteRuntime).load_checkpoint(
+        handle, str(tmp_path), load_model=load_model
+    )
+
+    assert calls == ["post_update"] * expected_calls


### PR DESCRIPTION
## What

Invalidate DS4 derived FP8 deployment-scale and weight-cache state after any successful model checkpoint restore, including step zero. Apply the existing post-update invalidation hook in both the generic mLite runtime and the VERL adapter. Optimizer-only restores with load_model=False do not invalidate model-derived state.

## Why this is not a duplicate

ISEEKYAN/Megatron-LM has no open PR for the DS4 source-scale registry lifecycle. NVIDIA/Megatron-LM #6666 addresses a different MXFP8 checkpoint encoding issue by regenerating quantized parameters from FP32 optimizer masters; this change invalidates a DS4 model-level deployment cache after restore.

## Validation

- Current PR unit command: /opt/ds4-venv/bin/python -m pytest experimental/lite/tests/unit/runtime/checkpoint/test_training_checkpoint.py experimental/lite/tests/unit/examples/test_verl_mlite_engine_config.py experimental/lite/tests/unit/model/deepseek_v4/lite/test_deepseek_v4_hf_load_local_to_global.py -q
- Result: 28 passed, 20 hardware-dependent tests skipped. Covered cases include step zero and nonzero VERL restores, generic runtime model restore, load_model=False, failed load, and first export using current weights.
- Full 32-GB200 production validation of the VERL resume path: first resumed step 6 had rollout_probs_diff_max=0, log_ppl_diff=0, and k3_kl=0.

## AI assistance and review

OpenAI Codex assisted with the implementation and tests. This draft requires a human reviewer to inspect every changed line and validate the production result before merge.