### PR TITLE
fix(ds4): reduce grouped SwiGLU backward memory

### DIFF
--- a/experimental/lite/megatron/lite/model/deepseek_v4/vllm/primitive/dense.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/vllm/primitive/dense.py
@@ -226,6 +226,23 @@ _compiled_clamped_swiglu_vjp = torch.compile(
     dynamic=False,
 )
 
+_compiled_dynamic_clamped_swiglu_vjp = torch.compile(
+    _clamped_swiglu_vjp,
+    fullgraph=True,
+    dynamic=True,
+)
+
+
+def dynamic_clamped_swiglu_vjp(
+    grad_output: torch.Tensor,
+    value: torch.Tensor,
+    limit: float,
+) -> torch.Tensor:
+    """Evaluate the VJP for dynamic routed-token shapes without an autograd graph."""
+    if not value.is_cuda:
+        return _clamped_swiglu_vjp(grad_output, value, limit)
+    return _compiled_dynamic_clamped_swiglu_vjp(grad_output, value, limit)
+
 
 class _ClampedSwiGLUVJP(torch.autograd.Function):
     @staticmethod

--- a/experimental/lite/megatron/lite/model/deepseek_v4/vllm/primitive/moe/grouped.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/vllm/primitive/moe/grouped.py
@@ -11,6 +11,9 @@ from megatron.lite.primitive.modules.experts import swiglu_with_probs
 from megatron.lite.model.deepseek_v4.vllm.primitive.block_fp8 import (
     DeploymentGroupedBlockFP8Adapter,
 )
+from megatron.lite.model.deepseek_v4.vllm.primitive.dense import (
+    dynamic_clamped_swiglu_vjp,
+)
 
 _M_ALIGNMENT = 128
 _PACK_DEBUG_SYNC = os.getenv("MLITE_VLLM_PACK_DEBUG_SYNC") == "1"
@@ -296,13 +299,11 @@ def _te_grouped_bf16_backward(
     hidden_mats = tuple(torch.split(hidden_states, counts))
     grad_output_mats = tuple(torch.split(grad_output.contiguous(), counts))
 
-    with torch.enable_grad():
-        gate_up_graph = gate_up.detach().requires_grad_(True)
-        activated = swiglu_with_probs(
-            gate_up_graph,
-            None,
-            swiglu_limit,
-        )
+    activated = swiglu_with_probs(
+        gate_up,
+        None,
+        swiglu_limit,
+    )
 
     grad_activated = torch.empty_like(activated)
     with _nvtx_range("moe_bwd/fc2_dgrad"):
@@ -344,10 +345,10 @@ def _te_grouped_bf16_backward(
         ]
 
     with _nvtx_range("moe_bwd/swiglu"):
-        (grad_gate_up,) = torch.autograd.grad(
-            activated,
-            gate_up_graph,
+        grad_gate_up = dynamic_clamped_swiglu_vjp(
             grad_activated,
+            gate_up,
+            swiglu_limit,
         )
     grad_gate_up_mats = tuple(torch.split(grad_gate_up.contiguous(), counts))
 

--- a/experimental/lite/tests/unit/model/deepseek_v4/vllm/test_grouped_moe.py
+++ b/experimental/lite/tests/unit/model/deepseek_v4/vllm/test_grouped_moe.py
@@ -275,7 +275,9 @@ def test_grouped_moe_preserves_clamped_forward_and_bf16_master_vjp(
 def test_te_grouped_bf16_backward_matches_reference_bitwise(monkeypatch) -> None:
     torch.manual_seed(17)
     counts = (64, 32)
-    limit = 10.0
+    # Keep the limit below the generated FC1 range so both gate and up clamp
+    # derivatives are covered by the exact-gradient comparison.
+    limit = 1.0
     hidden = (
         torch.randn(sum(counts), 128, device="cuda", dtype=torch.bfloat16) * 2
     ).requires_grad_(True)


### PR DESCRIPTION
  ## Summary

  - Replace the nested autograd graph in grouped-MoE clamped SwiGLU backward with an analytic BF16-master VJP.
  - Compile the VJP with dynamic routed-token shapes.
  - Keep grouped-MoE forward, FP8 quantization, DeepGEMM, routing, and weight export unchanged.
  - Do not enable or retain eager execution.

  ## Motivation

  The 64-GPU PP4/CP2/EP16 run OOMed in grouped-MoE backward while allocating 1.88 GiB for the SwiGLU autograd VJP, with only 1.85 GiB free.

  The analytic VJP avoids retaining the temporary FP32 autograd graph.

  ## Validation

  - H100/Transformer Engine grouped backward passes with active clamp regions.
  - Dynamic token shapes `96, 127, 257, 513` run without recompilation.
  - Maximum backward difference from the unfused analytic formula: `7.63e-06`.
  - Realistic `32768 x 4096` BF16 benchmark:
    - old peak delta: `2.125 GiB`
    - new peak delta: `0.250 GiB`
    - reduction: `1.875 GiB`
  - 4-GPU, two-step true-on-policy validation using CUDA graph `PIECEWISE`:
    - probability max diff: `0.0`
    - Pearson: `1.0`
    - `k3_kl`: `0.0`
    - W&B: https://wandb.ai/vime/verl-ds4-v4-preview/runs/1wkrc7hj

  ## Scope

  Backward computation only. Forward and rollout behavior are unchanged.