### PR TITLE
fix(lite): reduce checkpoint and optimizer host memory

### DIFF
--- a/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/dcp.py
@@ -24,9 +24,11 @@ from torch.distributed.tensor import DTensor  # pyright: ignore[reportMissingImp
 
 from megatron.lite.primitive.ckpt.local_stage import (
     NodeLocalStagingFileSystem as _NodeLocalStagingFileSystem,
-    local_stage_root,
-    publish_staged_file as _publish_staged_file,
 )
+from megatron.lite.primitive.ckpt.local_stage import (
+    local_stage_root,
+)
+from megatron.lite.primitive.ckpt.local_stage import publish_staged_file as _publish_staged_file
 from megatron.lite.primitive.parallel import ParallelState
 from megatron.lite.primitive.protocols import (
     ExpertClassifierFn,
@@ -248,10 +250,12 @@ def _optimizer_checkpoint_path(path: str) -> str:
 
 
 def _staged_dcp_writer(checkpoint_path: str):
+    # One writer bounds D2H staging to one tensor.  More writer threads trade
+    # host-memory peak for throughput, which is undesirable for colocated RL.
+    writer = dcp.FileSystemWriter(checkpoint_path, thread_count=1)
     filesystem = _local_staging_filesystem()
     if filesystem is None:
-        return None
-    writer = dcp.FileSystemWriter(checkpoint_path)
+        return writer
     writer.fs = filesystem
     return writer
 

--- a/experimental/lite/megatron/lite/primitive/ckpt/distckpt.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/distckpt.py
@@ -3,19 +3,40 @@
 
 from __future__ import annotations
 
+import inspect
 import os
 from collections.abc import Callable, Iterable, MutableMapping
 from dataclasses import replace
+from functools import partial
 from pathlib import Path
 from types import MethodType
 from typing import Any
 
 import torch
 import torch.nn as nn
+from torch.distributed.checkpoint.filesystem import (
+    DEFAULT_SUFFIX,
+    SerializationFormat,
+    _write_item,
+)
+from torch.distributed.checkpoint.planner import SavePlan, SavePlanner, WriteItemType
 
 from megatron.core import dist_checkpointing
 from megatron.core.dist_checkpointing.mapping import ShardedTensor
-from megatron.core.dist_checkpointing.strategies.torch import TorchDistSaveShardedStrategy
+from megatron.core.dist_checkpointing.strategies.filesystem_async import (
+    FileSystemWriterAsync,
+    get_write_results_queue,
+)
+from megatron.core.dist_checkpointing.strategies.state_dict_saver import (
+    save_state_dict_async_plan,
+)
+from megatron.core.dist_checkpointing.strategies.torch import (
+    MCoreSavePlanner,
+    TorchDistSaveShardedStrategy,
+    _replace_state_dict_keys_with_sharded_keys,
+    mcore_to_pyt_state_dict,
+)
+from megatron.core.msc_utils import MultiStorageClientFeature
 from megatron.lite.primitive.ckpt.local_stage import (
     NodeLocalStagingFileSystem,
     allocate_stage_path,
@@ -30,7 +51,7 @@ from megatron.lite.primitive.protocols import (
 )
 
 _DISTOPT_METADATA = {
-    "distrib_optim_sharding_type": "fully_reshardable",
+    "distrib_optim_sharding_type": "dp_reshardable",
     "distrib_optim_fully_reshardable_mem_efficient": False,
     "chained_optim_avoid_prefix": True,
 }
@@ -95,7 +116,7 @@ def save_dist_opt_checkpoint(
     save_strategy = (
         _NodeLocalDistSaveStrategy(local_stage_root)
         if local_stage_root is not None
-        else None
+        else _MemoryEfficientDistSaveStrategy()
     )
     dist_checkpointing.save(
         state_dict,
@@ -106,7 +127,138 @@ def save_dist_opt_checkpoint(
     )
 
 
-class _NodeLocalDistSaveStrategy(TorchDistSaveShardedStrategy):
+class _BoundedMemoryFileSystemWriter(FileSystemWriterAsync):
+    """Synchronous MLite writer with at most one tensor staging allocation."""
+
+    def __init__(self, path, *args, **kwargs):
+        kwargs["thread_count"] = 1
+        super().__init__(path, *args, **kwargs)
+
+    def prepare_write_data(self, plan: SavePlan, planner: SavePlanner) -> None:
+        storage_plan = plan.storage_data
+        file_name = f"{storage_plan.prefix}0{DEFAULT_SUFFIX}"
+        bytes_data = []
+        tensor_data = []
+        for item in plan.items:
+            data = planner.resolve_data(item)
+            if item.type == WriteItemType.BYTE_IO:
+                bytes_data.append((item, data))
+            else:
+                # Keep the original tensor/view here.  Cloning every view during
+                # planning retains a second full checkpoint payload until I/O ends.
+                tensor_data.append((item, data.detach()))
+        if bytes_data or tensor_data:
+            self.write_buckets = [
+                (
+                    os.path.join(self.checkpoint_dir, file_name),
+                    file_name,
+                    (bytes_data, tensor_data),
+                )
+            ]
+            self.results_queue = get_write_results_queue()
+        else:
+            self.write_buckets = []
+            self.results_queue = None
+
+    def get_save_function_and_args(self):
+        if not self.write_buckets:
+            return None, None, []
+        transforms = [self.transforms] if hasattr(self, "transforms") else []
+        return (
+            partial(self._write_bounded, transforms, self.use_msc),
+            None,
+            [torch.distributed.get_rank(), self.write_buckets, self.results_queue],
+        )
+
+    @staticmethod
+    def _write_bounded(transforms, use_msc, _rank, write_buckets, results_queue) -> None:
+        results = {}
+        serialization_kwargs = {}
+        if "serialization_format" in inspect.signature(_write_item).parameters:
+            serialization_kwargs["serialization_format"] = SerializationFormat.TORCH_SAVE
+        try:
+            for bucket_index, (file_name, storage_key, payload) in enumerate(write_buckets):
+                bytes_data, tensor_data = payload
+                local_results = []
+                open_file = open
+                if use_msc:
+                    import multistorageclient as msc
+
+                    open_file = msc.open
+                with open_file(file_name, "wb") as stream:
+                    for write_item, data in bytes_data:
+                        local_results.append(
+                            _write_item(
+                                *transforms,
+                                stream,
+                                data,
+                                write_item,
+                                storage_key,
+                                **serialization_kwargs,
+                            )
+                        )
+                    for write_item, source in tensor_data:
+                        tensor = source.detach()
+                        if tensor.device.type != "cpu":
+                            if (
+                                tensor.device.type == "cuda"
+                                and "dequantize" in type(tensor).__dict__
+                            ):
+                                tensor = tensor.dequantize()
+                            tensor = tensor.to("cpu")
+                        elif tensor.untyped_storage().nbytes() != tensor.numel() * tensor.itemsize:
+                            tensor = tensor.clone()
+                        local_results.append(
+                            _write_item(
+                                *transforms,
+                                stream,
+                                tensor,
+                                write_item,
+                                storage_key,
+                                **serialization_kwargs,
+                            )
+                        )
+                        del tensor
+                    if use_msc:
+                        stream.fsync()
+                    else:
+                        os.fsync(stream.fileno())
+                results[bucket_index] = local_results
+        except Exception as error:
+            results = error
+        results_queue.put(results)
+
+
+class _MemoryEfficientDistSaveStrategy(TorchDistSaveShardedStrategy):
+    """MCore-compatible synchronous strategy using bounded tensor staging."""
+
+    def async_save(self, sharded_state_dict, checkpoint_dir, async_strategy="mcore"):
+        if async_strategy != "mcore":
+            raise ValueError("MLite bounded-memory checkpointing supports synchronous mcore saves")
+        sharded_state_dict, _, _ = _replace_state_dict_keys_with_sharded_keys(
+            sharded_state_dict, self.keep_only_main_replica
+        )
+        pyt_state_dict = mcore_to_pyt_state_dict(sharded_state_dict, False)
+        writer = _BoundedMemoryFileSystemWriter(
+            checkpoint_dir,
+            thread_count=1,
+            use_msc=MultiStorageClientFeature.is_enabled(),
+        )
+        save_state_dict_ret = save_state_dict_async_plan(
+            pyt_state_dict,
+            writer,
+            None,
+            0,
+            planner=MCoreSavePlanner(
+                dedup_replicated_tensors=not self.keep_only_main_replica,
+                flatten_state_dict=False,
+                flatten_sharded_tensors=False,
+            ),
+        )[0]
+        return self._get_save_and_finalize_callbacks(writer, save_state_dict_ret, async_strategy)
+
+
+class _NodeLocalDistSaveStrategy(_MemoryEfficientDistSaveStrategy):
     def __init__(self, stage_root: Path):
         super().__init__()
         self._stage_root = stage_root

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/optimizer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/optimizer.py
@@ -403,16 +403,18 @@ def build_fsdp2_training_optimizer(
         from megatron.lite.primitive.deterministic import deterministic_requested
 
         deterministic = deterministic_requested()
-    effective_use_fp32_shards = (
+    fsdp2_use_fp32_shards = (
         bool(use_fp32_shards)
         if use_fp32_shards is not None
         else get_bool_opt(opt, "fsdp2_use_fp32_shards", default=_DEFAULT_USE_FP32_SHARDS)
     )
-    effective_use_fp32_master = (
+    fsdp2_use_fp32_master = (
         bool(use_fp32_master)
         if use_fp32_master is not None
         else get_bool_opt(opt, "fsdp2_use_fp32_master", default=_DEFAULT_USE_FP32_MASTER)
     )
+    if fsdp2_use_fp32_shards:
+        fsdp2_use_fp32_master = False
 
     unit_reshard_after_forward = _fsdp2_unit_reshard_after_forward(
         ps, reshard_after_forward=reshard_after_forward
@@ -430,7 +432,7 @@ def build_fsdp2_training_optimizer(
         reduce_dtype=reduce_dtype,
         cast_forward_inputs=cast_forward_inputs,
     )
-    if effective_use_fp32_shards:
+    if fsdp2_use_fp32_shards:
         model_param_dtypes = _collect_model_param_dtypes(model_chunks)
         for chunk in model_chunks:
             promote_fsdp2_trainable_params_to_fp32(chunk)
@@ -493,7 +495,7 @@ def build_fsdp2_training_optimizer(
         tp_replicated_grad_sync_group=ps.tp_group if tp_replicated_grad_params else None,
         grad_norm_accum_dtype="float32",
         adamw_foreach=False if deterministic else adamw_foreach,
-        use_fp32_master=effective_use_fp32_master,
+        use_fp32_master=fsdp2_use_fp32_master,
         model_param_dtypes=model_param_dtypes,
     )
 

--- a/experimental/lite/megatron/lite/runtime/megatron_utils.py
+++ b/experimental/lite/megatron/lite/runtime/megatron_utils.py
@@ -120,6 +120,19 @@ def _reshard_fsdp2_modules(model_chunk: Any) -> None:
             module.reshard()
 
 
+def _pinned_cpu_copy(tensor: torch.Tensor) -> torch.Tensor:
+    """Copy CUDA data directly into its final pinned CPU allocation."""
+    cpu_tensor = torch.empty(
+        tensor.size(),
+        dtype=tensor.dtype,
+        layout=tensor.layout,
+        device="cpu",
+        pin_memory=True,
+    )
+    cpu_tensor.copy_(tensor, non_blocking=False)
+    return cpu_tensor
+
+
 def offload_model_to_cpu(model_list: list) -> None:
     """Offload DDP model to CPU via buffer-resize (zero-copy on GPU side)."""
     for model_chunk in model_list:
@@ -128,8 +141,17 @@ def offload_model_to_cpu(model_list: list) -> None:
             for buffers in all_buffers:
                 for buffer in buffers:
                     if buffer.param_data.storage().size() > 0:
-                        buffer.param_data.cpu_data = buffer.param_data.data.cpu().pin_memory()
-                        buffer.param_data_size = buffer.param_data.storage().size()
+                        param_data_size = buffer.param_data.storage().size()
+                        cpu_data = getattr(buffer.param_data, "cpu_data", None)
+                        if (
+                            cpu_data is not None
+                            and cpu_data.storage().size() == param_data_size
+                        ):
+                            cpu_data.copy_(buffer.param_data.data, non_blocking=False)
+                        else:
+                            cpu_data = _pinned_cpu_copy(buffer.param_data.data)
+                            buffer.param_data.cpu_data = cpu_data
+                        buffer.param_data_size = param_data_size
                         buffer.param_data.storage().resize_(0)
 
                     if buffer.grad_data.storage().size() > 0:

--- a/experimental/lite/tests/unit/primitive/optimizers/fsdp2/test_fsdp2_unit.py
+++ b/experimental/lite/tests/unit/primitive/optimizers/fsdp2/test_fsdp2_unit.py
@@ -118,6 +118,7 @@ def test_fsdp2_pipeline_wraps_dense_and_experts_with_reshard(monkeypatch):
     expert_calls = []
     expert_mesh = SimpleNamespace(name="expert_dp")
     optimizer = object()
+    optimizer_kwargs = {}
     ps = ParallelState(
         pp_size=2,
         ep_size=2,
@@ -141,11 +142,11 @@ def test_fsdp2_pipeline_wraps_dense_and_experts_with_reshard(monkeypatch):
     )
     monkeypatch.setattr(fsdp2_optimizer, "wrap_fsdp2_module", fake_wrap_expert)
     monkeypatch.setattr(fsdp2_optimizer, "wrap_fsdp2", fake_wrap_dense)
-    monkeypatch.setattr(
-        fsdp2_optimizer,
-        "build_fsdp2_adamw",
-        lambda *args, **kwargs: optimizer,
-    )
+    def fake_build_optimizer(*_args, **kwargs):
+        optimizer_kwargs.update(kwargs)
+        return optimizer
+
+    monkeypatch.setattr(fsdp2_optimizer, "build_fsdp2_adamw", fake_build_optimizer)
 
     result = fsdp2_optimizer.build_fsdp2_training_optimizer(
         [model],
@@ -154,8 +155,8 @@ def test_fsdp2_pipeline_wraps_dense_and_experts_with_reshard(monkeypatch):
         unit_modules=(ToyMoEBlock,),
         expert_classifier=lambda name: ".experts." in f".{name}",
         reshard_after_forward=True,
-        use_fp32_shards=False,
-        use_fp32_master=False,
+        use_fp32_shards=True,
+        use_fp32_master=True,
     )
 
     assert result is optimizer
@@ -172,6 +173,7 @@ def test_fsdp2_pipeline_wraps_dense_and_experts_with_reshard(monkeypatch):
     assert dense_config.reshard_after_forward is True
     assert dense_config.last_unit_reshard_after_forward is True
     assert dense_kwargs["ignored_params"] == set(model.experts.parameters())
+    assert optimizer_kwargs["use_fp32_master"] is False
 
 
 def test_fsdp2_replicates_parameters_that_must_keep_their_compute_dtype(monkeypatch):

--- a/experimental/lite/tests/unit/runtime/backends/mlite/test_runtime_backend_unit.py
+++ b/experimental/lite/tests/unit/runtime/backends/mlite/test_runtime_backend_unit.py
@@ -600,11 +600,23 @@ def test_megatron_ddp_detection_accepts_ddp_and_subclasses(monkeypatch):
 
 @pytest.mark.parametrize("model_cls", [_FakeMegatronDDP, _FakeMegatronDDPSubclass])
 def test_megatron_ddp_model_move_helpers_use_buffer_path(monkeypatch, model_cls):
+    import megatron.lite.runtime.megatron_utils as megatron_utils
     from megatron.lite.runtime.megatron_utils import load_model_to_gpu, offload_model_to_cpu
 
     _install_fake_megatron_ddp(monkeypatch)
     model = model_cls()
     buffer = model.buffer
+    pinned_copies = []
+
+    def fake_pinned_cpu_copy(tensor):
+        pinned_copies.append(tensor)
+        return tensor.cpu().pin_memory()
+
+    monkeypatch.setattr(
+        megatron_utils,
+        "_pinned_cpu_copy",
+        fake_pinned_cpu_copy,
+    )
 
     offload_model_to_cpu([model])
 
@@ -624,6 +636,14 @@ def test_megatron_ddp_model_move_helpers_use_buffer_path(monkeypatch, model_cls)
     assert buffer.param_data.copied_from is buffer.param_data.cpu_data
     assert buffer.param_data.copy_non_blocking is True
     assert buffer.grad_data.zero_calls == 1
+
+    cpu_data = buffer.param_data.cpu_data
+    offload_model_to_cpu([model])
+
+    assert pinned_copies == [buffer.param_data]
+    assert buffer.param_data.cpu_data is cpu_data
+    assert cpu_data.copied_from is buffer.param_data
+    assert cpu_data.copy_non_blocking is False
 
 
 def test_native_model_move_helpers_do_not_require_megatron_core(monkeypatch):

--- a/experimental/lite/tests/unit/runtime/checkpoint/test_training_checkpoint.py
+++ b/experimental/lite/tests/unit/runtime/checkpoint/test_training_checkpoint.py
@@ -15,9 +15,10 @@ from megatron.core.dist_checkpointing.strategies.torch import (
 )
 from megatron.lite.primitive.ckpt import dcp
 from megatron.lite.primitive.ckpt.distckpt import (
-    _NodeLocalDistSaveStrategy,
     _dist_opt_checkpoint_metadata,
+    _MemoryEfficientDistSaveStrategy,
     _model_sharded_state_dict,
+    _NodeLocalDistSaveStrategy,
     _rank_offsets_and_replica_id,
     _single_or_all_model_state,
     _synchronize_native_optimizer_steps,
@@ -128,13 +129,18 @@ def test_dcp_local_stage_does_not_publish_failed_write(tmp_path) -> None:
     assert not list(stage_root.rglob("*.stage"))
 
 
-def test_dcp_local_stage_writer_is_opt_in(monkeypatch, tmp_path) -> None:
+def test_fsdp2_dcp_writer_is_single_threaded_and_local_stage_is_opt_in(
+    monkeypatch, tmp_path
+) -> None:
     monkeypatch.delenv("MLITE_DCP_LOCAL_STAGE_DIR", raising=False)
-    assert dcp._staged_dcp_writer(str(tmp_path / "checkpoint")) is None
+    writer = dcp._staged_dcp_writer(str(tmp_path / "checkpoint"))
+    assert writer.thread_count == 1
+    assert not isinstance(writer.fs, dcp._NodeLocalStagingFileSystem)
 
     monkeypatch.setenv("MLITE_DCP_LOCAL_STAGE_DIR", str(tmp_path / "stage"))
     writer = dcp._staged_dcp_writer(str(tmp_path / "checkpoint"))
 
+    assert writer.thread_count == 1
     assert isinstance(writer.fs, dcp._NodeLocalStagingFileSystem)
 
 
@@ -201,7 +207,7 @@ class FakeWrapper(torch.nn.Module):
 
 
 DISTOPT_METADATA = {
-    "distrib_optim_sharding_type": "fully_reshardable",
+    "distrib_optim_sharding_type": "dp_reshardable",
     "distrib_optim_fully_reshardable_mem_efficient": False,
     "chained_optim_avoid_prefix": True,
 }
@@ -232,7 +238,7 @@ def test_dist_opt_checkpoint_dispatches_to_mcore_distckpt(monkeypatch, tmp_path)
     assert saved["checkpoint_dir"] == str(tmp_path / "step_5")
     assert saved["kwargs"]["validate_access_integrity"] is False
     assert saved["kwargs"]["content_metadata"] == DISTOPT_METADATA
-    assert saved["kwargs"]["sharded_strategy"] is None
+    assert isinstance(saved["kwargs"]["sharded_strategy"], _MemoryEfficientDistSaveStrategy)
     assert not (tmp_path / "step_5" / "optimizer_rank_0.pt").exists()
 
 


### PR DESCRIPTION
# fix(lite): reduce checkpoint and optimizer host memory

## Summary

- Bound MLite distributed-checkpoint staging to one tensor and one writer thread instead of cloning the full payload during planning.
- Reuse the pinned CPU model-offload buffer across context switches.
- Use `dp_reshardable` dist-opt checkpoint metadata.
- Automatically disable the separate FSDP2 FP32 master when FSDP2 parameter shards are already FP32.
- Keep all production and test changes under `experimental/lite`.

## Motivation

The 4-layer colocated preview validation showed excessive host-memory peaks during optimizer state handling and checkpoint saves. Two avoidable contributors were full-payload checkpoint staging and retaining both FP32 parameter shards and an additional FP32 master copy in FSDP2.

## Validation

Unit tests on base `8f9d70d4d`:

- 27 focused MLite checkpoint/offload/FSDP2 tests passed.
- isort completed.
- `py_compile` and `git diff --check` passed.

4-GPU, 4-layer, 2-step preview runs on `0cb3d96c3`, saving at both steps:

| Backend | Job | Result | Step 1 / Step 2 rollout diff | KL |
| --- | --- | --- | --- | --- |
| dist_opt | 640848 | completed | 0 / 0 | 0 / 0 |
| FSDP2 | 640994 | completed | 0 / 0 | 0 / 0 |

FSDP2 memory before/after removing the redundant FP32 master:

| Metric | Before (640852) | After (640994) |
| --- | ---: | ---: |
| cgroup total peak | 851.59 GiB | 763.02 GiB |
| cgroup anon peak | 528.37 GiB | 444.59 GiB |
| step 1 checkpoint | 40.62 s | 28.55 s |
| step 2 checkpoint | 37.10 s | 26.36 s |

Backend comparison after the changes:

| Metric | dist_opt | FSDP2 |
| --- | ---: | ---: |
| Slurm elapsed | 9:47 | 10:06 |
| step 2 total | 94.22 s | 95.28 s |
| step 2 actor update | 28.55 s | 37.71 s |
| step 2 checkpoint | 36.49 s | 26.36 s |
| cgroup total peak | 789.35 GiB | 763.02 GiB |

Both backends saved step 1 and continued through step 2 with exact rollout/training probability alignment.
