### PR TITLE
lite(qwen3_5): export and DCP placements for GDN state follow shard_for_load

### DIFF
--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/checkpoint.py
@@ -64,6 +64,10 @@ def PLACEMENT_FN(param_name: str) -> list:
     if "conv1d" in param_name:
         return [Replicate(), Replicate(), Replicate(), Shard(0)]
     if "dt_bias" in param_name or "A_log" in param_name:
+        # GDN per-value-head state is Replicate only while the heads are
+        # replicated (tp_size > heads); ``shard_for_load`` otherwise chunks it
+        # across TP. This name-only fallback cannot tell the two apart, so the
+        # protocol and runtime take placements from ``make_placement_fn``.
         return [Replicate(), Replicate(), Replicate(), Replicate()]
     return [Replicate(), Replicate(), Replicate(), Replicate()]
 
@@ -128,6 +132,24 @@ def _tp_linear_attn_state(
     if _linear_attn_head_replication(cfg, ps.tp_size):
         return tensor
     return _tp(tensor, ps.tp_rank, ps.tp_size)
+
+
+def make_placement_fn(cfg: Qwen35Config, tp_size: int):
+    """Config-exact DCP placements: GDN state follows ``shard_for_load``.
+
+    ``PLACEMENT_FN`` is name-only and assumes the usual layout where every TP
+    rank owns a slice of the linear-attention heads. When ``tp_size`` exceeds
+    the head count the loader keeps ``dt_bias`` / ``A_log`` whole on every rank
+    (``_tp_linear_attn_state``), so their placement must be Replicate instead.
+    """
+    replicated = _linear_attn_head_replication(cfg, tp_size)
+
+    def placement_fn(param_name: str) -> list:
+        if not replicated and ("dt_bias" in param_name or "A_log" in param_name):
+            return [Replicate(), Replicate(), Replicate(), Shard(0)]
+        return PLACEMENT_FN(param_name)
+
+    return placement_fn
 
 
 def _merge_full_attn_qkvg(
@@ -772,6 +794,10 @@ class Qwen35WeightSpec:
             native_name.endswith(suffix) for suffix in (".linear_attn.conv1d.weight",)
         ):
             return (0, 0)
+        if native_name.endswith((".linear_attn.dt_bias", ".linear_attn.A_log")):
+            # Chunked across TP by shard_for_load; merge_dense_shards / gather_dense
+            # return the single replica when the heads are replicated instead.
+            return (0, 0)
         return None
 
     def is_expert(self, native_name: str) -> bool:
@@ -894,5 +920,6 @@ __all__ = [
     "Qwen35WeightSpec",
     "export_hf_weights",
     "load_hf_weights",
+    "make_placement_fn",
     "save_hf_weights",
 ]

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
@@ -20,7 +20,7 @@ from megatron.lite.model.protocol_utils import (
     unpack_thd_forward_output,
 )
 from megatron.lite.model.qwen3_5.config import Qwen35Config
-from megatron.lite.model.qwen3_5.lite.checkpoint import EXPERT_CLASSIFIER, PLACEMENT_FN
+from megatron.lite.model.qwen3_5.lite.checkpoint import EXPERT_CLASSIFIER, PLACEMENT_FN, make_placement_fn
 from megatron.lite.model.qwen3_5.lite.checkpoint import export_hf_weights as _export_hf_weights_impl
 from megatron.lite.model.qwen3_5.lite.checkpoint import load_hf_weights as _load_hf_weights_impl
 from megatron.lite.model.qwen3_5.lite.checkpoint import save_hf_weights as _save_hf_weights_impl
@@ -43,6 +43,7 @@ __all__ = [
     "build_model_config",
     "export_hf_weights",
     "load_hf_weights",
+    "make_placement_fn",
     "save_hf_weights",
     "vocab_size",
 ]
@@ -274,7 +275,10 @@ def build_model(model_cfg: Qwen35Config, *, impl_cfg: ImplConfig) -> ModelBundle
         from megatron.lite.runtime.megatron_utils import register_training_hooks
 
         attach_model_sharded_state_dict(
-            chunks, ps, get_placements=PLACEMENT_FN, is_expert=is_expert_param
+            chunks,
+            ps,
+            get_placements=make_placement_fn(model_cfg, ps.tp_size),
+            is_expert=is_expert_param,
         )
         register_training_hooks(chunks, optimizer)
         optimizer_backend = "dist_opt"

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -681,7 +681,12 @@ def _checkpoint_hooks(handle: ModelHandle):
     from megatron.lite.primitive.protocols import default_expert_classifier, default_placement_fn
 
     proto = handle._extras.get("protocol")
-    return (
-        getattr(proto, "PLACEMENT_FN", default_placement_fn),
-        getattr(proto, "EXPERT_CLASSIFIER", default_expert_classifier),
-    )
+    get_placements = getattr(proto, "PLACEMENT_FN", default_placement_fn)
+    make_placement_fn = getattr(proto, "make_placement_fn", None)
+    model_cfg = handle._extras.get("model_cfg")
+    if callable(make_placement_fn) and model_cfg is not None:
+        # Config-exact placements (e.g. Qwen3.5 GDN state, TP-sharded only
+        # while tp_size <= linear-attention heads) so DCP metadata matches
+        # what shard_for_load actually put on each rank.
+        get_placements = make_placement_fn(model_cfg, handle._parallel_state.tp_size)
+    return (get_placements, getattr(proto, "EXPERT_CLASSIFIER", default_expert_classifier))

--- a/experimental/lite/tests/unit/model/qwen3_5/lite/test_qwen35_export.py
+++ b/experimental/lite/tests/unit/model/qwen3_5/lite/test_qwen35_export.py
@@ -9,6 +9,7 @@ from megatron.lite.model.qwen3_5.config import Qwen35Config
 from megatron.lite.model.qwen3_5.lite.checkpoint import (
     PLACEMENT_FN,
     Qwen35WeightSpec,
+    make_placement_fn,
     _merge_full_attn_qkvg,
     _merge_gate_up_tp_shards,
     _merge_linear_attn_conv1d_tp_shards,
@@ -625,13 +626,22 @@ def test_qwen35_linear_attention_tp4_replicated_heads_roundtrip() -> None:
     )
 
 
-def test_qwen35_linear_attention_state_is_tp_replicated() -> None:
-    spec = Qwen35WeightSpec(_tiny_config())
+def test_qwen35_linear_attention_state_placement_follows_head_layout() -> None:
+    replicated_cfg = _tiny_config()  # 2 linear heads: replicated under tp_size=4
+    sharded_cfg = replace(replicated_cfg, linear_num_key_heads=8, linear_num_value_heads=8)
+    spec = Qwen35WeightSpec(replicated_cfg)
 
-    assert type(PLACEMENT_FN("layers.0.linear_attn.dt_bias")[-1]).__name__ == "Replicate"
-    assert type(PLACEMENT_FN("layers.0.linear_attn.A_log")[-1]).__name__ == "Replicate"
-    assert spec.tp_spec("layers.0.linear_attn.dt_bias") is None
-    assert spec.tp_spec("layers.0.linear_attn.A_log") is None
+    for name in ("layers.0.linear_attn.dt_bias", "layers.0.linear_attn.A_log"):
+        # name-only fallback keeps the replicated placement ...
+        assert type(PLACEMENT_FN(name)[-1]).__name__ == "Replicate"
+        assert type(make_placement_fn(replicated_cfg, tp_size=4)(name)[-1]).__name__ == "Replicate"
+        # ... the config-exact placement shards exactly like shard_for_load
+        exact = make_placement_fn(sharded_cfg, tp_size=4)(name)
+        assert type(exact[-1]).__name__ == "Shard" and exact[-1].dim == 0
+        # export always TP-gathers; the merge returns one replica when replicated
+        assert spec.tp_spec(name) == (0, 0)
+        state = torch.arange(2)
+        assert torch.equal(spec.merge_dense_shards(name, [state] * 4), state)
 
 
 def test_qwen35_linear_attention_state_load_matches_head_layout() -> None:
@@ -962,3 +972,94 @@ def test_qwen35_export_packs_base_expert_fc2_and_expert_metadata() -> None:
     assert spec.expert_global_id(native_name) == 2
     assert spec.expert_local_name(native_name, 0) == "layers.0.moe.experts.fc2.weight0"
     assert spec.tp_spec(native_name) == (1, 1)
+
+
+def _gdn_config() -> Qwen35Config:
+    return replace(
+        _tiny_dense_config(),
+        layer_types=["linear_attention"],
+        linear_num_key_heads=4,
+        linear_num_value_heads=8,
+    )
+
+
+def test_qwen35_gdn_state_export_and_placement_follow_load_sharding() -> None:
+    """dt_bias / A_log are chunked across TP at load time (one slice of the
+    value heads per rank); export merging and DCP placement must undo exactly
+    that, and fall back to a single replica only when TP exceeds the heads."""
+    cfg = _gdn_config()
+    spec = Qwen35WeightSpec(cfg)
+    full = torch.arange(cfg.linear_num_value_heads, dtype=torch.float32)
+    for name in ("layers.0.linear_attn.dt_bias", "layers.0.linear_attn.A_log"):
+        shards = [
+            spec.shard_for_load(name, full, SimpleNamespace(tp_size=4, tp_rank=rank))
+            for rank in range(4)
+        ]
+        assert [shard.numel() for shard in shards] == [2, 2, 2, 2]
+        assert spec.tp_spec(name) == (0, 0)
+        assert torch.equal(spec.merge_dense_shards(name, shards), full)
+        exact = make_placement_fn(cfg, tp_size=4)(name)
+        assert type(exact[-1]).__name__ == "Shard" and exact[-1].dim == 0
+
+        whole = spec.shard_for_load(name, full, SimpleNamespace(tp_size=16, tp_rank=3))
+        assert torch.equal(whole, full)
+        assert torch.equal(spec.merge_dense_shards(name, [full] * 16), full)
+        assert all(
+            type(p).__name__ == "Replicate" for p in make_placement_fn(cfg, tp_size=16)(name)
+        )
+    # everything else is untouched by the factory
+    assert make_placement_fn(cfg, tp_size=16)("layers.0.mlp.down.linear.weight") == PLACEMENT_FN(
+        "layers.0.mlp.down.linear.weight"
+    )
+
+
+def test_qwen35_export_gathers_gdn_state_across_tp(monkeypatch) -> None:
+    """Regression: with tp_size=4 the exporter used to emit this rank's 2-head
+    slice as the whole tensor (vLLM then fails loading a [heads/tp] A_log)."""
+    cfg = _gdn_config()
+    tp_size = 4
+
+    class TinyGDN(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.layers = nn.ModuleList([nn.Module()])
+            self.layers[0].linear_attn = nn.Module()
+            self.layers[0].linear_attn.register_parameter(
+                "dt_bias", nn.Parameter(torch.tensor([0.0, 1.0]))
+            )
+            self.layers[0].linear_attn.register_parameter(
+                "A_log", nn.Parameter(torch.tensor([10.0, 11.0]))
+            )
+
+    ps = SimpleNamespace(
+        pp_size=1,
+        tp_size=tp_size,
+        tp_group=object(),
+        ep_size=1,
+        ep_group=None,
+        etp_size=1,
+        etp_group=None,
+    )
+
+    def fake_all_gather(output, tensor, group=None):
+        del group
+        numel = tensor.numel()
+        for rank in range(tp_size):
+            output[rank * numel : (rank + 1) * numel].copy_(tensor + 100 * rank)
+
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.hf_weights.dist.all_gather_into_tensor",
+        fake_all_gather,
+    )
+
+    exported = dict(export_hf_weights(TinyGDN(), cfg, ps))
+
+    dt_bias = exported["model.language_model.layers.0.linear_attn.dt_bias"]
+    a_log = exported["model.language_model.layers.0.linear_attn.A_log"]
+    assert dt_bias.shape == (cfg.linear_num_value_heads,)
+    assert torch.equal(
+        dt_bias, torch.cat([torch.tensor([0.0, 1.0]) + 100 * rank for rank in range(tp_size)])
+    )
+    assert torch.equal(
+        a_log, torch.cat([torch.tensor([10.0, 11.0]) + 100 * rank for rank in range(tp_size)])
+    )

--- a/experimental/lite/tests/unit/runtime/backends/mlite/test_runtime_backend_unit.py
+++ b/experimental/lite/tests/unit/runtime/backends/mlite/test_runtime_backend_unit.py
@@ -17,6 +17,7 @@ from megatron.lite.runtime.backends.mlite.runtime import (
     MegatronLiteRuntime,
     _apply_attention_backend_env,
     _build_impl_cfg,
+    _checkpoint_hooks,
     _pipeline_callbacks,
     _reset_parameters,
 )
@@ -663,3 +664,35 @@ def test_runtime_dispatch_creates_mlite_backend():
 def test_runtime_dispatch_unknown_backend_raises():
     with pytest.raises(KeyError):
         create_runtime(RuntimeConfig(backend="nonexistent"))
+
+
+def test_checkpoint_hooks_prefer_config_exact_placements():
+    """Protocols that expose make_placement_fn(cfg, tp_size) get placements that
+    match what shard_for_load put on each rank (Qwen3.5 GDN state is TP-sharded
+    only while tp_size <= linear-attention heads); others keep PLACEMENT_FN."""
+    from types import SimpleNamespace
+
+    from megatron.lite.model.qwen3_5.config import Qwen35Config
+    from megatron.lite.model.qwen3_5.lite import protocol as qwen35_protocol
+
+    cfg = Qwen35Config(
+        num_hidden_layers=1,
+        layer_types=["linear_attention"],
+        linear_num_key_heads=8,
+        linear_num_value_heads=8,
+    )
+    name = "layers.0.linear_attn.A_log"
+
+    def hooks(tp_size, proto=qwen35_protocol):
+        handle = SimpleNamespace(
+            _extras={"protocol": proto, "model_cfg": cfg},
+            _parallel_state=SimpleNamespace(tp_size=tp_size),
+        )
+        return _checkpoint_hooks(handle)[0]
+
+    sharded = hooks(4)(name)
+    assert type(sharded[-1]).__name__ == "Shard" and sharded[-1].dim == 0
+    assert type(hooks(16)(name)[-1]).__name__ == "Replicate"
+
+    plain = SimpleNamespace(PLACEMENT_FN=lambda _name: ["plain"], EXPERT_CLASSIFIER=lambda _name: False)
+    assert hooks(4, proto=plain)(name) == ["plain"]


### PR DESCRIPTION
Fixes #203.

`shard_for_load` chunks `linear_attn.dt_bias` / `linear_attn.A_log` across TP whenever `tp_size <= linear-attention heads` (`_tp_linear_attn_state`), but `PLACEMENT_FN` declared them `Replicate` and `tp_spec` returned `None`. The pp=1 streaming exporter only TP-gathers params that have a `tp_spec`, so `export_weights` emitted this rank's slice as the whole tensor (Qwen3.5-27B-class config, TP4: `[12]` instead of `[48]`; vLLM: `length 24 exceeds dimension size 12`), and `save_checkpoint` wrote DCP metadata with the local shape.

Changes
- `Qwen35WeightSpec.tp_spec` -> `(0, 0)` for both names. The existing `merge_dense_shards` / `gather_dense` hooks already return a single replica when the heads are replicated, so both layouts export correctly.
- `make_placement_fn(cfg, tp_size)`: config-exact DCP placements (`Shard(0)` on the TP mesh dim unless replicated). Used by the protocol's `attach_model_sharded_state_dict` and by the runtime's `_checkpoint_hooks` (falls back to `PLACEMENT_FN` for protocols without the factory). The name-only `PLACEMENT_FN` keeps its previous answer.
- Tests: TP4 export of a GDN module yields `[heads]` (monkeypatched gather); load/merge/placement round-trip for the sharded and replicated layouts (the former `..._is_tp_replicated` test asserted the inconsistent layout and is rewritten); runtime hook selection.

Verified inside the Megatron-Core 0.16.0rc0 / TE 2.12 container: `tests/unit/model/qwen3_5 tests/unit/runtime/backends/mlite tests/unit/primitive/ckpt tests/unit/runtime/checkpoint` -> 139 passed, 6 skipped. End-to-end on Qwen3.8-27B (TP4, CP2) the exporter now yields full `[48]` GDN state vectors and vLLM loads the export.
