### PR TITLE
fix(ds4): propagate sparse attention sink gradient

### DIFF
--- a/experimental/lite/megatron/lite/model/deepseek_v4/vllm/primitive/attention/backward.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/vllm/primitive/attention/backward.py
@@ -41,7 +41,7 @@ def _default_sparse_backward(q, kv, out, grad_out, lse, sink, indices, scale, le
         softmax_scale=scale,
         topk_length=length,
     )
-    return result["dq"], result["dkv"]
+    return result["dq"], result["dkv"], result["d_sink"]
 
 
 def _compressed_sequence_graph(
@@ -271,7 +271,7 @@ class _VisibleSparseAttentionFunction(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad_out):
         q, kv, out, lse, indices, length, sink = ctx.saved_tensors
-        dq, dkv = ctx.backward_op(
+        dq, dkv, d_sink = ctx.backward_op(
             q, kv, out, grad_out, lse, sink, indices, ctx.scale, length
         )
         dkv = dkv.reshape_as(kv)
@@ -284,7 +284,7 @@ class _VisibleSparseAttentionFunction(torch.autograd.Function):
                 torch.isfinite(dkv).all(),
                 "native CP sparse attention produced non-finite dkv",
             )
-        return None, None, None, dq, dkv, None, None, None
+        return None, None, None, dq, dkv, None, None, d_sink
 
 
 def visible_sparse_attention(

--- a/experimental/lite/tests/unit/model/deepseek_v4/vllm/backward/test_flashmla_backward.py
+++ b/experimental/lite/tests/unit/model/deepseek_v4/vllm/backward/test_flashmla_backward.py
@@ -56,18 +56,22 @@ def test_real_flashmla_sparse_backward_matches_reference_direction() -> None:
         topk_length=lengths,
     )[:3]
     grad_out = torch.randn_like(out)
-    dq, dkv = _default_sparse_backward(
+    dq, dkv, d_sink = _default_sparse_backward(
         q, kv, out, grad_out, lse, sink, indices, scale, lengths
     )
-    dq_repeat, dkv_repeat = _default_sparse_backward(
+    dq_repeat, dkv_repeat, d_sink_repeat = _default_sparse_backward(
         q, kv, out, grad_out, lse, sink, indices, scale, lengths
     )
     assert torch.isfinite(dq).all()
     assert torch.isfinite(dkv).all()
+    assert torch.isfinite(d_sink).all()
     # cuDNN DSA computes DQ deterministically, while DKV uses BF16 atomic
     # accumulation when multiple queries select the same KV row. Keep the
     # vendor path, but explicitly bound that known non-deterministic surface.
     torch.testing.assert_close(dq, dq_repeat, rtol=0, atol=0)
+    # Sink gradients also use floating-point atomics in the vendor kernel;
+    # repeated launches differ only at float32 roundoff scale.
+    torch.testing.assert_close(d_sink, d_sink_repeat, rtol=2e-7, atol=1e-7)
     dkv_delta = (dkv.float() - dkv_repeat.float()).norm()
     assert dkv_delta / dkv.float().norm() < 1e-4
     assert (dkv.float() - dkv_repeat.float()).abs().max() <= 0.03125
@@ -75,6 +79,7 @@ def test_real_flashmla_sparse_backward_matches_reference_direction() -> None:
     with torch.enable_grad():
         q_ref = q.detach().float().requires_grad_(True)
         kv_ref = kv.detach().float().requires_grad_(True)
+        sink_ref = sink.detach().requires_grad_(True)
         selected = kv_ref.index_select(0, indices.clamp_min(0).long().flatten())
         selected = selected.view(sequence, topk, dim)
         ordinal = torch.arange(topk, device="cuda")
@@ -82,14 +87,14 @@ def test_real_flashmla_sparse_backward_matches_reference_direction() -> None:
         logits = torch.einsum("shd,std->sht", q_ref, selected) * scale
         logits = logits.masked_fill(~valid.unsqueeze(1), float("-inf"))
         logits = torch.cat(
-            (logits, sink.view(1, -1, 1).expand(sequence, -1, -1)), dim=-1
+            (logits, sink_ref.view(1, -1, 1).expand(sequence, -1, -1)), dim=-1
         )
         probabilities = torch.softmax(logits, dim=-1)
         reference_out = torch.einsum(
             "sht,std->shd", probabilities[..., :-1], selected[..., :512]
         )
-        reference_dq, reference_dkv = torch.autograd.grad(
-            reference_out, (q_ref, kv_ref), grad_out.float()
+        reference_dq, reference_dkv, reference_d_sink = torch.autograd.grad(
+            reference_out, (q_ref, kv_ref, sink_ref), grad_out.float()
         )
     assert F.cosine_similarity(
         dq.float().flatten(), reference_dq.flatten(), dim=0
@@ -98,4 +103,7 @@ def test_real_flashmla_sparse_backward_matches_reference_direction() -> None:
         dkv[:sequence].float().flatten(),
         reference_dkv[:sequence].flatten(),
         dim=0,
+    ) > 0.98
+    assert F.cosine_similarity(
+        d_sink.float().flatten(), reference_d_sink.flatten(), dim=0
     ) > 0.98


### PR DESCRIPTION
  ## Summary

  - Propagate the vendor FlashMLA `d_sink` result through the DS4 vLLM sparse-attention autograd bridge.
  - Add finite-value, repeatability, and FP32-reference direction checks for the sink gradient.
  - Leave the vLLM forward path unchanged.
  - Do not modify the Lite implementation.

  ## Root cause

  `_default_sparse_backward()` received `d_sink` from the cuDNN DSA backward kernel but returned only `dq` and `dkv`. `_VisibleSparseAttentionFunction.backward()` consequently returned
  `None` for the attention-sink input, so every DS4 layer silently lost its sink gradient.

  ## Validation

  - DS4 vLLM backward suite plus grouped BF16 regression: **22 passed**
  - Gradient fingerprint restores the four missing per-layer sink gradients: **598 → 602 tensors**
  - `d_sink` is finite
  - Repeated kernel launches agree within FP32 atomic roundoff (`rtol=2e-7`, `atol=1e-7`)
  - Direction cosine against the FP32 reference is **> 0.98**
  - 4-layer, 4-GPU real GSM8K SFT completed under EP4, PP4, and CP4

  ## Scope

  This PR fixes the independently verified missing sink gradient only. It does not claim to resolve the remaining Lite/vLLM loss or global grad-norm mismatch.
