### PR TITLE
fix(lite/csa): fix RoPE offset for DeepSeek-V4 contiguous CP sharding

### DIFF
--- a/experimental/lite/megatron/lite/primitive/modules/attention/csa.py
+++ b/experimental/lite/megatron/lite/primitive/modules/attention/csa.py
@@ -8,10 +8,8 @@ import torch.nn as nn
 
 # Zero-copy imports of the DSv4 THD-CP helpers that live in Megatron Core.
 # The development branch groups them under the csa_utils package.
-from megatron.core.fusions.fused_mla_yarn_rope_apply import fused_mla_rope_out_of_place
 from megatron.core.tensor_parallel.mappings import gather_from_sequence_parallel_region
 from megatron.core.transformer.experimental_attention_variant.csa import (
-    _apply_fused_rope,
     _unfused_indexer_sparse_attn_from_topk,
     unfused_compressed_sparse_attn,
 )
@@ -33,18 +31,6 @@ from megatron.lite.primitive.modules.attention.dsa import rotate_activation
 from megatron.lite.primitive.parallel.linear import AccumulatingLinear
 from megatron.lite.primitive.parallel.state import ParallelState
 from megatron.lite.primitive.utils.rotary import _yarn_find_correction_range, _yarn_linear_ramp_mask
-
-
-class _SingleRankGroup:
-    """Stand-in for a process group when CP is off."""
-
-    @staticmethod
-    def rank() -> int:
-        return 0
-
-    @staticmethod
-    def size() -> int:
-        return 1
 
 
 @jit_fuser
@@ -886,12 +872,14 @@ class CompressedSparseAttention(nn.Module):
         cos_thd = cos.squeeze(0)
         sin_thd = sin.squeeze(0)
         nope_dim = self.head_dim - self.rope_head_dim
-        rope_group = cp_group if cp_group is not None else _SingleRankGroup()
-        query_thd = _apply_fused_rope(
-            query_thd, cos_thd, sin_thd, nope_dim, self.rope_head_dim, cu_seqlens, rope_group
+        # DS4 uses contiguous CP shards. The generic Core helper interprets
+        # cp_rank/cp_size as a zigzag shard, so pass the explicit global row
+        # offset through the contiguous-THD helper instead.
+        query_thd = cp_utils.apply_thd_cp_local_rope_fused(
+            query_thd, cos_thd, sin_thd, nope_dim, self.rope_head_dim, cu_seqlens, global_start
         )
-        key_thd = _apply_fused_rope(
-            key_thd, cos_thd, sin_thd, nope_dim, self.rope_head_dim, cu_seqlens, rope_group
+        key_thd = cp_utils.apply_thd_cp_local_rope_fused(
+            key_thd, cos_thd, sin_thd, nope_dim, self.rope_head_dim, cu_seqlens, global_start
         )
         x_thd = x.transpose(0, 1).contiguous()  # (total, 1, hidden)
         qr_thd = q_low.transpose(0, 1).contiguous()  # (total, 1, q_lora_rank)
@@ -920,17 +908,15 @@ class CompressedSparseAttention(nn.Module):
         )
         # context: (total, 1, np * hn).
         context = context.squeeze(1).view(seq_len, self.num_heads, self.head_dim)
-        context = fused_mla_rope_out_of_place(
+        context = cp_utils.apply_thd_cp_local_rope_fused(
             context,
             cos_thd,
             sin_thd,
             nope_dim,
             self.rope_head_dim,
             cu_seqlens,
-            rope_group.rank(),
-            rope_group.size(),
+            global_start,
             inverse=True,
-            remove_interleaving=True,
         )
         grouped = context.view(
             1, seq_len, self.config.o_groups, self.num_heads_per_group * self.head_dim

--- a/experimental/lite/tests/unit/primitive/modules/attention/test_csa_thd_cp.py
+++ b/experimental/lite/tests/unit/primitive/modules/attention/test_csa_thd_cp.py
@@ -339,6 +339,61 @@ def test_forward_thd_packed_builds_layout_and_is_differentiable(monkeypatch):
 
 
 @pytest.mark.gpus(1)
+def test_forward_thd_uses_contiguous_rope_offsets(monkeypatch):
+    csa = _csa()
+    config = _tiny_config()
+    device = torch.device("cuda")
+    ps = _ps(cp_size=2, cp_rank=1)
+    try:
+        module = csa.CompressedSparseAttention(config, layer_idx=0, ps=ps).to(device)
+    except RuntimeError as exc:
+        pytest.skip(f"real Transformer Engine required to build CSA: {exc}")
+
+    local_rows = 8
+    global_rows = local_rows * ps.cp_size
+    x = torch.randn(1, local_rows, config.hidden_size, device=device)
+    position_ids = torch.arange(local_rows, global_rows, device=device).unsqueeze(0)
+    cu_seqlens = torch.tensor([0, global_rows], dtype=torch.int32, device=device)
+    packed = SimpleNamespace(
+        qkv_format="thd",
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_q_padded=None,
+        cu_seqlens_kv=cu_seqlens,
+        cu_seqlens_kv_padded=None,
+        max_seqlen_q=global_rows,
+        max_seqlen_kv=global_rows,
+    )
+    rope_starts = []
+
+    def fake_rope(tensor, _cos, _sin, _nope_dim, _rope_dim, _cu, global_start, **_kwargs):
+        rope_starts.append(global_start)
+        return tensor
+
+    monkeypatch.setattr(csa.cp_utils, "apply_thd_cp_local_rope_fused", fake_rope)
+    monkeypatch.setattr(
+        csa.cp_utils,
+        "exchange_cp_boundary_hidden",
+        lambda tensor, *_args: tensor.new_zeros((_d_window(config), 1, config.hidden_size)),
+    )
+    monkeypatch.setattr(
+        module,
+        "_project_boundary_kv",
+        lambda *_args: x.new_zeros((_d_window(config), 1, 1, config.head_dim)),
+    )
+    monkeypatch.setattr(
+        module,
+        "_forward_thd_cp",
+        lambda query, *_args: query.reshape(
+            local_rows, 1, config.num_attention_heads * config.head_dim
+        ),
+    )
+
+    module(x, position_ids=position_ids, packed_seq_params=packed)
+
+    assert rope_starts == [local_rows, local_rows, local_rows]
+
+
+@pytest.mark.gpus(1)
 def test_project_boundary_kv_shape(monkeypatch):
     csa = _csa()
     torch.manual_seed(0)


### PR DESCRIPTION
DeepSeek-V4 uses contiguous CP shards. However, the generic Core helper interprets `cp_rank` and `cp_size` as a zigzag shard by default. This mismatch causes incorrect positional embeddings in RoPE when Context Parallelism (CP) is enabled.

This commit updates the THD CP RoPE application in `csa.py` to use `cp_utils.apply_thd_cp_local_rope_fused` with an explicitly calculated `global_start` offset. This bypasses the zigzag assumption and ensures the correct contiguous sequence offset is applied for RoPE.

Test Validation:
- Ran full regression tests via `experimental/lite/tests/run_tests.sh`.
- Confirmed that remaining failures (GLM5 CP smoke tests and NVRx v0.6.0 version check) are baseline issues present on the parent commit (https://github.com/shyoshyo/Megatron-LM/commit/de2d42008d9d584c07f2da7914a4d3d78fb5ff5b) and are completely unrelated to this RoPE fix.

- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

## 📝 MR Description

### 🎯 Motivation & Background
In the DeepSeek-V4 path of Megatron-Lite, the model utilizes Compressed Sparse Attention (CSA). When Context Parallelism (CP) is enabled, DS-V4 employs **contiguous CP shards**. 
However, the generic RoPE helper in Megatron Core interprets `cp_rank` and `cp_size` as a **zigzag shard** by default to calculate the sequence offset. This mismatch causes incorrect positional embeddings to be applied during RoPE computation in the THD layout, which can severely impact model convergence and accuracy when training with CP.

### 🛠️ Changes
1. **Fix RoPE Offset Logic**: Updated the THD CP RoPE application in `experimental/lite/megatron/lite/primitive/modules/attention/csa.py` to utilize `cp_utils.apply_thd_cp_local_rope_fused`.
2. **Explicit `global_start` Injection**: Instead of relying on the underlying implicit `cp_rank` derivation (which assumes zigzag), we now explicitly pass the pre-calculated `global_start` (global row offset). This forces the underlying kernel to apply the correct contiguous sequence offset.
3. **Style Alignment**: Minimized comment churn and preserved the original code formatting style (avoiding unnecessary line breaks in function parameters) to keep the diff clean and focused.

### 📊 Testing & Experimental Data

#### 1. Unit Regression Tests

All Lite regression tests were executed locally via `experimental/lite/tests/run_tests.sh`.

- **Test Environment**: 8x H20 GPUs, `flash-linear-attention==0.5.1`, `tilelang==0.1.12` (to resolve Hopper GPU Triton issues).
- **Test Results**: 
  - CSA THD-CP tests passed successfully (including the newly added contiguous RoPE offset verification).
  - **Baseline Failures Noted**: Some failures were observed in `test_glm5_lite_cp_smoke.py` (assertion errors) and `nvrx.py` (requires v0.6.0 but v0.5.0 is installed). We have verified by checking out the parent commit (`de2d42008`) that **these are existing baseline issues** and are completely unrelated to this PR's RoPE modifications.

#### 2. Loss Alignment & Numerical Evidence
To validate the fix, we compared the step-by-step loss against the old stable baseline across both 43-layer and 4-layer setups.

**43-Layer Full Model (PP=4, EP=8, CP=8, 13 steps):**
Fixing the RoPE offset is sufficient to restore the expected training curve on the full model. The loss divergence is almost entirely eliminated:
- **Unfixed Version vs. Old Baseline**: Mean delta `+0.078156`, RMSE `0.081873`.
- **Fixed RoPE (This MR) vs. Old Baseline**: Mean delta `+0.002101`, RMSE `0.003353`.
- *Conclusion*: RMSE dropped by **~96%**. From step 7 onwards, the step-by-step difference is within `±5e-4`, proving the curves are basically aligned.

**4-Layer Diagnostic & The mHC Sinkhorn Note:**
During a single-step diagnostic on a 4-layer model, we observed a Step 1 loss gap:
- Old Baseline: `16.6354427`
- New Unfixed: `16.6925898`
- New + Fixed RoPE + Legacy Sinkhorn: `16.6356430` (perfectly aligned)

*Why is there a remaining gap on the 4-layer model?* 
This is coupled with an intentional semantic change in the **mHC Sinkhorn regularization**. The new version uses Megatron Core's `fused_sinkhorn`, which alters the iteration formula to align with the official DeepSeek-V4 inference logic. 

Specifically, the legacy Lite Sinkhorn was implemented as:
```python
comb = exp(logits - row_max)
for _ in range(iters):
    comb = comb / row_sum.clamp(min=eps)
    comb = comb / col_sum.clamp(min=eps)
```
The new Core fused Sinkhorn applies a mathematically different normalization and iteration step:
```python
comb = softmax(logits, dim=-1) + eps
comb = comb / (col_sum + eps)
for _ in range(iters - 1):
    comb = comb / (row_sum + eps)
    comb = comb / (col_sum + eps)
```

- **This is a feature, not a bug**, and therefore **no revert for Sinkhorn is included in this MR**.
- While the 4-layer diagnostic requires reverting *both* RoPE and Sinkhorn to achieve strict bit-exact alignment, our 43-layer data demonstrates that at scale, the Sinkhorn variance is negligible. Fixing the contiguous CP RoPE mapping alone is the key to resolving the actual loss divergence.

### 🔗 Related Issues
*(Add links to any related issues or Jira tickets here)*

### 📝 CheckList
- [x] Code changes are minimal and concise (complies with `AGENTS.md`).
- [x] All local debugging code (e.g., `raise Exception`) has been removed.
- [x] Passed local full regression tests (`run_tests.sh`).
- [x] Verified training loss curves on 43-layer setups.


:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
