### PR TITLE
Add differentiable V4.1 vision and multi-image inputs

### DIFF
--- a/experimental/lite/docs/specs/deepseek_v41_d_semantics.md
+++ b/experimental/lite/docs/specs/deepseek_v41_d_semantics.md
@@ -90,16 +90,30 @@ siblings, following C's plain-export decoder contract. Frozen Engram storage
 keeps its FP8 values/scales. Trainable tables export FP32 masters and regenerate
 resident storage on reload; callers must use `refresh_storage()` after accepted
 optimizer steps. Original nested config is retained. This is a training export,
-not a deployment quantization conversion. Saving requires the inactive MTP, vision
-and aligner bytes to be present; it cannot fabricate checkpoint data for
-unimplemented modules.
+not a deployment quantization conversion. Saving requires the inactive MTP
+bytes to be present; it cannot fabricate checkpoint data for unimplemented modules.
 
-The multimodal handoff consists of `model.vision` and `model.aligner` archival
-subtrees, image-vector archival owners, `encode_image(patches, n_vit_h, n_vit_w)`,
-and `forward(..., images=..., token_types=...)`. These execution interfaces raise
-`NotImplementedError`; the multimodal integration supplies their computation and
-trainability. `model.mtp` retains its archival subtree and `forward_spec` rejects
-DSpark execution. Neither subtree is silently dropped in text-only mode.
+The model exposes live `vision`, `aligner`, `image_start`, `image_end` and
+`image_newline` parameters through the same checkpoint binding contract.
+`encode_image(patches, n_vit_h, n_vit_w)` is differentiable. The aligner pads
+right/bottom and unfolds channel-first cells; 2D RoPE uses height then width.
+`image_data.ImageConfig` defaults to patch size 14, downsample ratio 3, 1024
+image tokens and 295936 minimum pixels. `prepare_image_inputs` consumes decoded
+PIL images and token IDs, returning expanded IDs, token types and sample-local
+`ImageInput` spans; URL loading and tokenization remain caller responsibilities.
+`forward(..., images=..., token_types=...)` replaces spans before HC expansion,
+propagates modality masks through MoE/Engram, and rejects spans crossing packed
+sample boundaries. `merge_image_embeddings(images, h)` returns a new tensor.
+The generic `PackedBatch` protocol, trainability policy, optimizer routing and
+three-stage external vision scheduling require the training integration.
+`model.mtp` remains archival and `forward_spec` rejects DSpark execution.
+
+Independent vision/processor tests read hash-checked reference files from
+`DS41_REFERENCE_DIR` (default `/tmp/ds41-fixture-reference`). No new official
+source is vendored. Reduced FP32/BF16 checks compare forward and every input/
+parameter gradient; mutation checks exercise spatial order, padding, RoPE,
+patch order, delimiters and the tower/aligner boundary. These are reduced
+numerical semantics checks, not full-size model acceptance.
 
 The protocol accepts unpadded `PackedBatch`, restarts CSA2/Engram state per sample,
 shifts labels and masks within each sample and masks terminal targets. It returns

--- a/experimental/lite/megatron/lite/model/deepseek_v41/lite/image_data.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v41/lite/image_data.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Model-local image data contract, before HC expansion and sequence packing.
+
+Inputs are decoded PIL images and already tokenized prompts. Loading URLs and
+choosing a tokenizer remain caller responsibilities. Starts are sample-local.
+"""
+
+import math
+from dataclasses import dataclass
+
+import numpy as np
+import torch
+from PIL import ImageOps
+
+TEXT = -1
+IMAGE_START, IMAGE, IMAGE_NEW_LINE, IMAGE_END = range(4)
+
+
+@dataclass(frozen=True)
+class ImageConfig:
+    patch_size: int = 14
+    downsample_ratio: int = 3
+    max_image_tokens: int = 1024
+    min_pixels: int = 295936
+    max_wh_ratio: float | None = None
+
+    def __post_init__(self):
+        if (
+            self.patch_size < 1
+            or self.downsample_ratio < 1
+            or self.max_image_tokens < 4
+            or self.min_pixels < 0
+            or (self.max_wh_ratio is not None and self.max_wh_ratio <= 0)
+        ):
+            raise ValueError('Invalid image preprocessing configuration')
+
+
+@dataclass(frozen=True)
+class ImageInput:
+    start: int
+    patches: torch.Tensor
+    n_vit_h: int
+    n_vit_w: int
+    types: torch.Tensor
+
+
+def image_token_types(height, width):
+    if min(height, width) < 1:
+        raise ValueError('Image token grid must be positive')
+    return torch.tensor(
+        [IMAGE_START] + ([IMAGE] * width + [IMAGE_NEW_LINE]) * height + [IMAGE_END],
+        dtype=torch.int64,
+    )
+
+
+def plan_image_grid(width, height, config=ImageConfig()):
+    if min(width, height) <= 0:
+        raise ValueError('Image dimensions must be positive')
+    p, r = config.patch_size, config.downsample_ratio
+    if config.max_wh_ratio is not None:
+        width = min(width, height * config.max_wh_ratio)
+    if width * height < config.min_pixels:
+        scale = math.sqrt(config.min_pixels / (width * height))
+        width, height = int(width * scale), int(height * scale)
+    best_h, best_w = math.ceil(height / p) * p, math.ceil(width / p) * p
+    grid = lambda h, w: (math.ceil((h // p) / r), math.ceil((w // p) / r))
+    gh, gw = grid(best_h, best_w)
+    budget = config.max_image_tokens
+    if gh * (gw + 1) + 2 > budget:
+        aspect = height / width
+        floating_w = math.sqrt((budget - 2) / aspect + 0.25) - 0.5
+        floating_h = floating_w * aspect
+        cell = p * r
+        if floating_w < 1:
+            best_h, best_w = (budget - 2) // 2 * cell, cell
+        elif floating_h < 1:
+            best_h, best_w = cell, (budget - 3) * cell
+        else:
+            scale = min(
+                math.floor(floating_w) * cell / width, math.floor(floating_h) * cell / height
+            )
+            best_h, best_w = (math.floor(height * scale / p) * p, math.floor(width * scale / p) * p)
+        gh, gw = grid(best_h, best_w)
+    if min(gh, gw) < 1 or gh * (gw + 1) + 2 > budget:
+        raise ValueError('Image resize cannot satisfy token budget')
+    return gh, gw, best_h, best_w
+
+
+def preprocess_image(image, config=ImageConfig()):
+    image = image.convert('RGB')
+    gh, gw, height, width = plan_image_grid(image.width, image.height, config)
+    if config.max_wh_ratio is not None and image.width >= config.max_wh_ratio * image.height:
+        image = image.resize((width, height))
+    else:
+        image = ImageOps.pad(image, (width, height), color=(127, 127, 127))
+    pixels = torch.from_numpy(np.asarray(image, dtype=np.float32)).permute(2, 0, 1) / 255
+    pixels = ((pixels - 0.5) / 0.5).to(torch.bfloat16)
+    p = config.patch_size
+    nh, nw = height // p, width // p
+    patches = pixels.reshape(3, nh, p, nw, p).permute(1, 3, 0, 2, 4).reshape(nh * nw, 3, p, p)
+    return patches, nh, nw, gh, gw
+
+
+def prepare_image_inputs(tokens, images, image_token_id, config=ImageConfig()):
+    """Expand each placeholder into its full span, preserving image order."""
+    if sum(token == image_token_id for token in tokens) != len(images):
+        raise ValueError('Image placeholder count differs from image count')
+    ids, types, spans = [], [], []
+    iterator = iter(images)
+    for token in tokens:
+        if token != image_token_id:
+            ids.append(token)
+            types.append(TEXT)
+            continue
+        patches, nh, nw, gh, gw = preprocess_image(next(iterator), config)
+        layout = image_token_types(gh, gw)
+        spans.append(ImageInput(len(ids), patches, nh, nw, layout))
+        ids.extend([image_token_id] * len(layout))
+        types.extend(layout.tolist())
+    return ids, types, spans or None
+
+
+def merge_image_embeddings(tokens, images, features, image_start, image_end, image_newline):
+    """Out-of-place differentiable replacement of validated [B,S,D] spans.
+
+    ``features[b][i]`` is the aligner output for ``images[b][i]``. Call this
+    before ``expand_hc``; gradients from every HC copy then reach the owner.
+    """
+    if tokens.ndim != 3 or len(images) != len(tokens) or len(features) != len(tokens):
+        raise ValueError('Expected matching batch lists and tokens [B,S,D]')
+    result = tokens.clone()
+    for batch, (sample, encoded) in enumerate(zip(images, features)):
+        sample, encoded = sample or (), encoded or ()
+        if len(sample) != len(encoded):
+            raise ValueError('Every image requires one feature tensor')
+        end = 0
+        for img, values in zip(sample, encoded):
+            layout = img.types.to(device=tokens.device)
+            size = layout.numel()
+            if (
+                layout.ndim != 1
+                or size < 4
+                or img.start < end
+                or img.start + size > tokens.shape[1]
+            ):
+                raise ValueError('Image spans must be ordered, disjoint and in bounds')
+            # Validate row delimiters as well as the feature count.
+            kinds = layout.tolist()
+            rows = kinds[1:-1]
+            if (
+                kinds[0] != IMAGE_START
+                or kinds[-1] != IMAGE_END
+                or not rows
+                or rows[-1] != IMAGE_NEW_LINE
+                or any(k not in (IMAGE, IMAGE_NEW_LINE) for k in rows)
+            ):
+                raise ValueError('Invalid image span delimiters')
+            widths, width = [], 0
+            for kind in rows:
+                if kind == IMAGE:
+                    width += 1
+                else:
+                    widths.append(width)
+                    width = 0
+            if not widths or min(widths) < 1 or len(set(widths)) != 1:
+                raise ValueError('Image rows must have equal positive widths')
+            if values.shape != (sum(widths), tokens.shape[-1]):
+                raise ValueError('Aligner feature shape differs from image slots')
+            span = result[batch, img.start : img.start + size]
+            for kind, value in (
+                (IMAGE_START, image_start),
+                (IMAGE_END, image_end),
+                (IMAGE_NEW_LINE, image_newline),
+                (IMAGE, values),
+            ):
+                span[layout == kind] = value.to(device=tokens.device, dtype=tokens.dtype)
+            end = img.start + size
+    return result

--- a/experimental/lite/megatron/lite/model/deepseek_v41/lite/model.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v41/lite/model.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Single-rank text assembly with explicit live tensor and archival owners.
 
-Vision/aligner and DSpark have storage owners but no execution implementation.
+Vision/aligner have live differentiable owners; DSpark remains archival.
 The floating diagnostic mode is explicit; it is not native quantized parity.
 """
 
@@ -18,6 +18,8 @@ from .checkpoint_store import validate_execution
 from .engram import Engram, EngramTable, NgramHash, hash_multipliers, prime_buckets
 from .moe import DeepseekV41MoE, ModalityRouter, SwiGLUExpert
 from .packing import packed_forward
+from .vision import ViT, Aligner
+from .image_data import merge_image_embeddings, TEXT
 
 
 @dataclass(frozen=True)
@@ -210,15 +212,33 @@ class DeepseekV41Model(nn.Module):
                 )
                 for attr in ('q_weight', 'k_weight'):
                     self._bind(prefix + '.' + attr, module, attr, 'engram_norm')
-        self.vision = DeferredModule('vision')
-        self.aligner = DeferredModule('aligner')
+        vision_args = SimpleNamespace(
+            vision_dim=v['hidden_size'],
+            vision_n_heads=v['num_attention_heads'],
+            vision_n_layers=v['num_hidden_layers'],
+            vision_inter_dim=v['intermediate_size'],
+            vision_patch_size=v['patch_size'],
+            vision_rope_theta=v['rope_theta'],
+            vision_downsample_ratio=v['downsample_ratio'],
+            dim=t['hidden_size'],
+        )
+        self.vision = ViT(vision_args)
+        self.aligner = Aligner(vision_args)
+        for root in ('vision', 'aligner'):
+            module = getattr(self, root)
+            for name, parameter in module.named_parameters():
+                path, attribute = name.rsplit('.', 1)
+                self._bind(root + '.' + name, module.get_submodule(path), attribute, root)
+        for key in ('image_start', 'image_end', 'image_newline'):
+            self.register_parameter(key, nn.Parameter(torch.zeros(t['hidden_size'])))
+            self._bind(key, self, key, 'image_delimiter')
         self.mtp = DeferredModule('DSpark')
         for root, key in self._archive_keys(t, v):
+            if root != 'mtp':
+                continue
             module = getattr(self, root)
             owner = module.leaf_owner(key[len(root) + 1 :])
             self.archival_bindings[key] = TensorBinding(key, owner, None, 'archival')
-        for key in ('image_start', 'image_end', 'image_newline'):
-            self.archival_bindings[key] = TensorBinding(key, self.vision, None, 'archival')
         self.validate_parameter_bindings()
 
     def _bind(self, key, owner, attribute, role, head_count=None, encoding=None):
@@ -355,37 +375,77 @@ class DeepseekV41Model(nn.Module):
         if len(ids) != len(set(ids)) or set(ids) != {id(p) for p in self.parameters()}:
             raise ValueError('Every parameter must have exactly one binding')
 
-    def _sequence(self, hidden, pre, *, input_ids):
+    def _sequence(self, hidden, pre, *, input_ids, image_mask=None):
         hashes = None
         if self.engram_layer_ids:
             if self.engram_hash is None:
                 raise ValueError('Engram execution requires an explicit tokenizer token_map')
-            hashes = self.engram_hash(input_ids)
+            hashes = self.engram_hash(input_ids, None if image_mask is None else ~image_mask)
         state = AttentionState()
         for index, layer in enumerate(self.layers):
             if layer.engram is not None:
-                hidden = layer.engram(hidden, hashes[:, :, self.engram_layer_ids.index(index)])
-            hidden, pre, state = layer.forward_with_state(hidden, pre, state)
+                hidden = layer.engram(
+                    hidden,
+                    hashes[:, :, self.engram_layer_ids.index(index)],
+                    None if image_mask is None else ~image_mask,
+                )
+            hidden, pre, state = layer.forward_with_state(
+                hidden, pre, state, ffn_kwargs={'image_mask': image_mask}
+            )
         return hidden, pre
 
     def forward(self, input_ids, *, cu_seqlens=None, images=None, token_types=None):
-        if images is not None or token_types is not None:
-            raise NotImplementedError('Multimodal inputs require vision/aligner integration')
         if input_ids.ndim != 2 or input_ids.dtype != torch.int64 or not input_ids.shape[1]:
             raise ValueError('Expected nonempty int64 input_ids [B,S]')
-        hidden, pre = expand_hc(self.embed(input_ids), self.hc_mult)
+        embeddings = self.embed(input_ids)
+        image_mask = None
+        if images is not None:
+            if len(images) != len(input_ids):
+                raise ValueError('Image batch size differs from input IDs')
+            expected_types = torch.full_like(input_ids, TEXT)
+            for batch, sample in enumerate(images):
+                for img in sample or ():
+                    if cu_seqlens is not None:
+                        boundaries = cu_seqlens.tolist()
+                        if not any(
+                            a <= img.start and img.start + img.types.numel() <= b
+                            for a, b in zip(boundaries, boundaries[1:])
+                        ):
+                            raise ValueError('Image span crosses a packed sequence boundary')
+                    expected_types[batch, img.start : img.start + img.types.numel()] = img.types.to(
+                        input_ids.device
+                    )
+            if token_types is not None and not torch.equal(
+                token_types.to(input_ids.device), expected_types
+            ):
+                raise ValueError('Token types disagree with image spans')
+            embeddings = self.merge_image_embeddings(images, embeddings)
+            image_mask = expected_types >= 0
+        elif token_types is not None:
+            if token_types.shape != input_ids.shape or (token_types != TEXT).any():
+                raise ValueError('Image token types require image inputs')
+        hidden, pre = expand_hc(embeddings, self.hc_mult)
         if cu_seqlens is None:
-            hidden, pre = self._sequence(hidden, pre, input_ids=input_ids)
+            hidden, pre = self._sequence(hidden, pre, input_ids=input_ids, image_mask=image_mask)
         else:
             hidden, pre = packed_forward(
-                self._sequence, hidden, pre, cu_seqlens, input_ids=input_ids
+                self._sequence, hidden, pre, cu_seqlens, input_ids=input_ids, image_mask=image_mask
             )
         hidden = self.norm(contract_hc(hidden, pre))
         return {'logits': F.linear(hidden.float(), self.head.weight.float())}
 
     def encode_image(self, patches, n_vit_h, n_vit_w):
-        raise NotImplementedError(
-            'encode_image(patches, n_vit_h, n_vit_w) requires F3 vision/aligner'
+        weight = self.vision.patch_embed.proj.weight
+        patches = patches.to(device=weight.device, dtype=weight.dtype)
+        return self.aligner(self.vision(patches, n_vit_h, n_vit_w), n_vit_h, n_vit_w)
+
+    def merge_image_embeddings(self, images, h):
+        features = [
+            [self.encode_image(img.patches, img.n_vit_h, img.n_vit_w) for img in sample or ()]
+            for sample in images
+        ]
+        return merge_image_embeddings(
+            h, images, features, self.image_start, self.image_end, self.image_newline
         )
 
     def forward_spec(self, *args, **kwargs):

--- a/experimental/lite/megatron/lite/model/deepseek_v41/lite/vision.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v41/lite/vision.py
@@ -1,0 +1,134 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Differentiable V4.1 vision tower and spatial aligner.
+
+State names follow the pinned release; no inference-mode boundary is installed.
+Trainability and distributed synchronization belong to the training protocol.
+"""
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+
+class RMSNorm(nn.Module):
+    """Keep one FP32 cast so backward accumulates before returning to BF16."""
+
+    def __init__(self, dim, eps=1e-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.eps = eps
+
+    def forward(self, x):
+        dtype = x.dtype
+        value = x.float()
+        value = value * torch.rsqrt(value.square().mean(-1, keepdim=True) + self.eps)
+        return (self.weight * value).to(dtype)
+
+
+def get_vision_cos_sin(n_h, n_w, dim, theta, device=None):
+    frequency = 1.0 / (theta ** (torch.arange(0, dim, 2, device=device).float() / dim))
+    # Height frequencies precede width frequencies in each half of the head.
+    height, width = torch.meshgrid(
+        torch.arange(n_h, device=device), torch.arange(n_w, device=device), indexing='ij'
+    )
+    phase = (
+        (torch.stack((height, width), -1).reshape(-1, 2, 1).float() * frequency)
+        .flatten(1)
+        .unsqueeze(1)
+    )
+    return phase.cos(), phase.sin()
+
+
+def apply_rotary(x, cos, sin):
+    first, second = x.float().chunk(2, -1)
+    return torch.cat((first * cos - second * sin, second * cos + first * sin), -1).to(x.dtype)
+
+
+class PatchEmbed(nn.Module):
+    def __init__(self, args):
+        super().__init__()
+        self.proj = nn.Linear(3 * args.vision_patch_size**2, args.vision_dim)
+
+    def forward(self, patches):
+        return self.proj(patches.flatten(1))
+
+
+class Attention(nn.Module):
+    def __init__(self, args):
+        super().__init__()
+        self.n_heads = args.vision_n_heads
+        self.head_dim = args.vision_dim // self.n_heads
+        if args.vision_dim % self.n_heads or self.head_dim % 4:
+            raise ValueError('Vision heads require a dimension divisible by four')
+        self.wqkv = nn.Linear(args.vision_dim, 3 * args.vision_dim)
+        self.wo = nn.Linear(args.vision_dim, args.vision_dim)
+
+    def forward(self, x, cos, sin):
+        q, k, v = [
+            part.reshape(len(x), self.n_heads, self.head_dim) for part in self.wqkv(x).chunk(3, -1)
+        ]
+        q, k = apply_rotary(q, cos, sin), apply_rotary(k, cos, sin)
+        result = F.scaled_dot_product_attention(
+            q.transpose(0, 1), k.transpose(0, 1), v.transpose(0, 1)
+        )
+        return self.wo(result.transpose(0, 1).reshape(len(x), -1))
+
+
+class MLP(nn.Module):
+    def __init__(self, args):
+        super().__init__()
+        self.w1 = nn.Linear(args.vision_dim, 2 * args.vision_inter_dim, bias=False)
+        self.w2 = nn.Linear(args.vision_inter_dim, args.vision_dim, bias=False)
+
+    def forward(self, x):
+        gate, up = self.w1(x).chunk(2, -1)
+        return self.w2(F.silu(gate) * up)
+
+
+class Block(nn.Module):
+    def __init__(self, args):
+        super().__init__()
+        self.norm1, self.norm2 = RMSNorm(args.vision_dim), RMSNorm(args.vision_dim)
+        self.attn, self.mlp = Attention(args), MLP(args)
+
+    def forward(self, x, cos, sin):
+        x = x + self.attn(self.norm1(x), cos, sin)
+        return x + self.mlp(self.norm2(x))
+
+
+class ViT(nn.Module):
+    def __init__(self, args):
+        super().__init__()
+        self.rope_dim = args.vision_dim // args.vision_n_heads // 2
+        self.rope_theta = args.vision_rope_theta
+        self.patch_embed = PatchEmbed(args)
+        self.blocks = nn.ModuleList([Block(args) for _ in range(args.vision_n_layers)])
+        self.norm = RMSNorm(args.vision_dim)
+
+    def forward(self, patches, n_h, n_w):
+        if min(n_h, n_w) < 1 or len(patches) != n_h * n_w:
+            raise ValueError('Patch count must equal the positive image grid area')
+        x = self.patch_embed(patches)
+        cos, sin = get_vision_cos_sin(n_h, n_w, self.rope_dim, self.rope_theta, x.device)
+        for block in self.blocks:
+            x = block(x, cos, sin)
+        return self.norm(x)
+
+
+class Aligner(nn.Module):
+    def __init__(self, args):
+        super().__init__()
+        self.downsample_ratio = args.vision_downsample_ratio
+        if self.downsample_ratio < 1:
+            raise ValueError('Downsample ratio must be positive')
+        self.w1 = nn.Linear(args.vision_dim * self.downsample_ratio**2, args.dim)
+        self.w2 = nn.Linear(args.dim, args.dim)
+
+    def forward(self, x, n_h, n_w):
+        if min(n_h, n_w) < 1 or x.ndim != 2 or len(x) != n_h * n_w:
+            raise ValueError('Features must match the positive image grid')
+        ratio = self.downsample_ratio
+        spatial = x.reshape(n_h, n_w, -1).permute(2, 0, 1)
+        spatial = F.pad(spatial, (0, -n_w % ratio, 0, -n_h % ratio))
+        cells = F.unfold(spatial.unsqueeze(0), ratio, stride=ratio)[0].transpose(0, 1)
+        return self.w2(F.gelu(self.w1(cells)))

--- a/experimental/lite/tests/unit/model/test_deepseek_v41_semantics.py
+++ b/experimental/lite/tests/unit/model/test_deepseek_v41_semantics.py
@@ -547,10 +547,6 @@ def test_v41_registry_assembly_forward_and_parameter_owners(moe):
     independent = torch.cat([model(ids[:3][None])['logits'], model(ids[3:][None])['logits']], 1)
     torch.testing.assert_close(model(ids[None], cu_seqlens=batch.cu_seqlens)['logits'], independent)
     for call in (
-        lambda: model.vision(None),
-        lambda: model.aligner(None),
-        lambda: model.encode_image(None, 1, 1),
-        lambda: model(ids[None], images=[]),
         lambda: model.forward_spec(ids[None]),
     ):
         with pytest.raises(NotImplementedError):
@@ -685,3 +681,305 @@ def test_v41_registry_quantized_cuda_forward_backward(moe):
     output['loss'].backward()
     gradient = model.layers[20].attn.compressor.wkv.weight.grad
     assert gradient is not None and torch.isfinite(gradient).all() and gradient.abs().sum() > 0
+
+
+def _check_vision_official(monkeypatch, dtype):
+    import hashlib
+    import importlib.util
+    from pathlib import Path
+    from megatron.lite.model.deepseek_v41.lite import vision
+
+    root = Path(__file__).resolve().parents[3]
+    monkeypatch.syspath_prepend(str(root / 'tools/deepseek_v41'))
+    from fixtures import REFERENCE_SHA256
+    import os
+
+    path = Path(os.environ.get('DS41_REFERENCE_DIR', '/tmp/ds41-fixture-reference')) / 'vision.py'
+    assert hashlib.sha256(path.read_bytes()).hexdigest() == REFERENCE_SHA256['vision.py']
+    spec = importlib.util.spec_from_file_location('official_vision', path)
+    official = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(official)
+    args = SimpleNamespace(
+        vision_patch_size=14,
+        vision_dim=64,
+        vision_n_heads=4,
+        vision_inter_dim=128,
+        vision_n_layers=2,
+        vision_rope_theta=10000.0,
+        vision_downsample_ratio=3,
+        dim=12,
+    )
+    torch.manual_seed(19)
+    actual = torch.nn.Sequential(vision.ViT(args), vision.Aligner(args)).to(dtype)
+    reference = torch.nn.Sequential(official.ViT(args), official.Aligner(args)).to(dtype)
+    reference.load_state_dict(actual.state_dict())
+    for height, width in [(3, 6), (4, 5), (1, 2)]:
+        x = torch.randn(height * width, 3, 14, 14, dtype=dtype, requires_grad=True)
+        y = actual[1](actual[0](x, height, width), height, width)
+        expected = reference[1](reference[0](x, height, width), height, width)
+        torch.testing.assert_close(y, expected, rtol=0, atol=0)
+        probe = torch.randn_like(y)
+        ga = torch.autograd.grad((y * probe).sum(), (x, *actual.parameters()))
+        gb = torch.autograd.grad(
+            (expected * probe).sum(),
+            (
+                x,
+                *[
+                    dict(reference.named_parameters())[name]
+                    for name, _ in actual.named_parameters()
+                ],
+            ),
+        )
+        for a, b in zip(ga, gb):
+            torch.testing.assert_close(a, b, rtol=0, atol=0)
+
+
+def test_v41_multimage_copy_gradient():
+    from megatron.lite.model.deepseek_v41.lite import image_data
+
+    types = image_data.image_token_types(1, 2)
+    images = [
+        [
+            image_data.ImageInput(1, torch.zeros(2, 3, 2, 2), 1, 2, types),
+            image_data.ImageInput(7, torch.zeros(2, 3, 2, 2), 1, 2, types),
+        ]
+    ]
+    text = torch.randn(1, 13, 4, requires_grad=True)
+    features = [torch.randn(2, 4, requires_grad=True) for _ in range(2)]
+    delimiters = [torch.randn(4, requires_grad=True) for _ in range(3)]
+    merged = image_data.merge_image_embeddings(text, images, [features], *delimiters)
+    expanded, _ = hc.expand_hc(merged, 3)
+    probe = torch.arange(expanded.numel()).reshape_as(expanded).float()
+    gradients = torch.autograd.grad((expanded * probe).sum(), (text, *features, *delimiters))
+    expected = text.clone()
+    for start, feature in zip((1, 7), features):
+        expected[:, start : start + 5] = torch.stack(
+            (delimiters[0], feature[0], feature[1], delimiters[2], delimiters[1])
+        )
+    for copy in range(3):
+        torch.testing.assert_close(expanded[:, :, copy], expected)
+    summed = probe.sum(2)
+    mask = torch.ones(13, dtype=torch.bool)
+    mask[1:6] = False
+    mask[7:12] = False
+    torch.testing.assert_close(gradients[0], summed * mask[None, :, None])
+    for grad, start in zip(gradients[1:3], (2, 8)):
+        torch.testing.assert_close(grad, summed[0, start : start + 2])
+    for grad, offsets in zip(gradients[3:], ((1, 7), (5, 11), (4, 10))):
+        torch.testing.assert_close(grad, summed[0, list(offsets)].sum(0))
+
+
+@pytest.mark.parametrize('size', [(17, 23), (125, 97), (2000, 7), (7, 2000), (1024, 768)])
+@pytest.mark.parametrize('max_ratio', [None, 4])
+def test_v41_image_processor_official(size, max_ratio, monkeypatch):
+    import hashlib
+    import importlib.util
+    import io
+    import os
+    import sys
+    from pathlib import Path
+    import numpy as np
+    from PIL import Image
+    from megatron.lite.model.deepseek_v41.lite import image_data as data
+
+    root = Path(__file__).resolve().parents[3]
+    monkeypatch.syspath_prepend(str(root / 'tools/deepseek_v41'))
+    from fixtures import REFERENCE_SHA256
+
+    path = (
+        Path(os.environ.get('DS41_REFERENCE_DIR', '/tmp/ds41-fixture-reference'))
+        / 'image_processor.py'
+    )
+    assert hashlib.sha256(path.read_bytes()).hexdigest() == REFERENCE_SHA256[path.name]
+    spec = importlib.util.spec_from_file_location('official_image_processor', path)
+    official = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, official)
+    spec.loader.exec_module(official)
+    config = data.ImageConfig(max_wh_ratio=max_ratio)
+    args = SimpleNamespace(
+        vision_patch_size=14,
+        vision_downsample_ratio=3,
+        vision_max_n_token=1024,
+        vision_min_pixels=295936,
+        vision_max_wh_ratio=max_ratio,
+    )
+    width, height = size
+    image = Image.fromarray(
+        np.random.default_rng(7).integers(0, 256, (height, width, 3), dtype=np.uint8)
+    )
+    buffer = io.BytesIO()
+    image.save(buffer, format='PNG')
+    expected = official.load_image({'data': buffer.getvalue()}, args)
+    actual = data.preprocess_image(image, config)
+    assert actual[1:] == expected[1:]
+    torch.testing.assert_close(actual[0], expected[0], rtol=0, atol=0)
+    ids, types, images = data.prepare_image_inputs([1, 99, 2, 99, 3], [image, image], 99, config)
+    layout = official.image_token_types(*actual[-2:])
+    assert images[0].start == 1 and images[1].start == len(layout) + 2
+    assert ids == [1] + [99] * len(layout) + [2] + [99] * len(layout) + [3]
+    assert types == [-1] + layout.tolist() + [-1] + layout.tolist() + [-1]
+    torch.testing.assert_close(images[1].patches, expected[0], rtol=0, atol=0)
+    assert data.prepare_image_inputs([1, 2], [], 99) == ([1, 2], [-1, -1], None)
+    with pytest.raises(ValueError, match='placeholder'):
+        data.prepare_image_inputs([99], [], 99)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_v41_vision_nondivisible_official(monkeypatch, dtype):
+    _check_vision_official(monkeypatch, dtype)
+
+
+@pytest.mark.gpus(1)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_v41_vision_cuda_official(monkeypatch, dtype):
+    assert torch.cuda.is_available()
+    with torch.device("cuda"):
+        _check_vision_official(monkeypatch, dtype)
+        test_v41_multimage_copy_gradient()
+
+
+@pytest.mark.parametrize('mutation', ['spatial_order', 'padding', 'rope_axes', 'seam'])
+def test_v41_vision_rejects_mutations(monkeypatch, mutation):
+    from megatron.lite.model.deepseek_v41.lite import vision
+
+    if mutation == 'seam':
+        original = vision.ViT.forward
+
+        def wrong(self, patches, h, w):
+            return original(self, patches, h, w).roll(1, 0)
+
+        monkeypatch.setattr(vision.ViT, 'forward', wrong)
+    elif mutation == 'rope_axes':
+        original = vision.get_vision_cos_sin
+
+        def wrong(h, w, dim, theta, device=None):
+            return original(w, h, dim, theta, device)
+
+        monkeypatch.setattr(vision, 'get_vision_cos_sin', wrong)
+    else:
+
+        def wrong(self, x, h, w):
+            r = self.downsample_ratio
+            spatial = x.reshape(h, w, -1).permute(2, 0, 1)
+            if mutation == 'padding':
+                spatial = torch.nn.functional.pad(spatial, (-w % r, 0, -h % r, 0))
+            else:
+                spatial = torch.nn.functional.pad(spatial, (0, -w % r, 0, -h % r))
+            cells = torch.nn.functional.unfold(spatial[None], r, stride=r)[0].T
+            if mutation == 'spatial_order':
+                cells = cells.reshape(len(cells), -1, r * r).transpose(1, 2).flatten(1)
+            return self.w2(torch.nn.functional.gelu(self.w1(cells)))
+
+        monkeypatch.setattr(vision.Aligner, 'forward', wrong)
+    with pytest.raises(AssertionError):
+        _check_vision_official(monkeypatch, torch.float32)
+
+
+@pytest.mark.parametrize('fault', ['overlap', 'bounds', 'delimiter', 'features'])
+def test_v41_image_span_rejects_invalid(fault):
+    from megatron.lite.model.deepseek_v41.lite import image_data as data
+
+    layout = data.image_token_types(1, 2)
+    start = -1 if fault == 'overlap' else 4 if fault == 'bounds' else 0
+    if fault == 'delimiter':
+        layout[0] = data.IMAGE
+    image = data.ImageInput(start, torch.zeros(2, 3, 2, 2), 1, 2, layout)
+    features = torch.ones(3 if fault == 'features' else 2, 4)
+    with pytest.raises(ValueError):
+        data.merge_image_embeddings(
+            torch.zeros(1, 5, 4), [[image]], [[features]], *[torch.ones(4) for _ in range(3)]
+        )
+
+
+def test_v41_vision_assembly_live_owners_and_reachability(moe, monkeypatch):
+    from megatron.lite.model.deepseek_v41.lite import image_data as data
+
+    _, bundle = _assembly_bundle()
+    model = bundle.chunks[0]
+    patches = torch.randn(4, 3, 14, 14, requires_grad=True)
+    result = model.encode_image(patches, 2, 2)
+    result.square().sum().backward()
+    assert patches.grad.abs().sum() > 0
+    for root in ('vision', 'aligner'):
+        for name, parameter in getattr(model, root).named_parameters():
+            binding = model.tensor_bindings[root + '.' + name]
+            assert binding.tensor is parameter and parameter.grad is not None
+
+    class Reached(Exception):
+        pass
+
+    def probe(*args, **kwargs):
+        raise Reached()
+
+    for root in ('vision', 'aligner'):
+        with monkeypatch.context() as patch:
+            patch.setattr(getattr(model, root), 'forward', probe)
+            with pytest.raises(Reached):
+                model.encode_image(patches, 2, 2)
+    layout = data.image_token_types(1, 1)
+    images = [[data.ImageInput(1, patches, 2, 2, layout)]]
+    embeddings = torch.randn(1, 6, model.embed.embedding_dim, requires_grad=True)
+    merged = model.merge_image_embeddings(images, embeddings)
+    assert merged.shape == embeddings.shape
+    torch.testing.assert_close(merged[0, 2], result.detach()[0])
+    merged.sum().backward()
+    assert model.image_start.grad is not None
+
+
+def test_v41_multimage_packed_model_forward(moe, device='cpu'):
+    from megatron.lite.model.deepseek_v41.lite import image_data as data
+
+    _, bundle = _assembly_bundle(device=device)
+    model = bundle.chunks[0]
+    first, second = [torch.randn(4, 3, 14, 14, requires_grad=True) for _ in range(2)]
+    layout = data.image_token_types(1, 1)
+    images = [[data.ImageInput(1, first, 2, 2, layout), data.ImageInput(7, second, 2, 2, layout)]]
+    ids = torch.tensor([[1, 99, 99, 99, 99, 2, 3, 99, 99, 99, 99, 4]])
+    types = torch.tensor([[-1, 0, 1, 2, 3, -1] * 2])
+    result = model(ids, cu_seqlens=torch.tensor([0, 6, 12]), images=images, token_types=types)[
+        'logits'
+    ]
+    independent = []
+    for index, patches in enumerate((first, second)):
+        local = [[data.ImageInput(1, patches, 2, 2, layout)]]
+        independent.append(model(ids[:, index * 6 : (index + 1) * 6], images=local)['logits'])
+    torch.testing.assert_close(result, torch.cat(independent, 1))
+    gradients = torch.autograd.grad(
+        result[:, 6:].square().sum(), (first, second, model.image_start)
+    )
+    assert not gradients[0].any() and gradients[1].abs().sum() > 0
+    assert torch.isfinite(gradients[2]).all() and gradients[2].abs().sum() > 0
+    with pytest.raises(ValueError, match='Token types'):
+        model(ids, images=images, token_types=torch.full_like(types, -1))
+    with pytest.raises(ValueError, match='crosses'):
+        model(ids, images=images, cu_seqlens=torch.tensor([0, 3, 12]))
+
+
+@pytest.mark.gpus(1)
+def test_v41_multimage_cuda_model_forward(moe):
+    assert torch.cuda.is_available()
+    with torch.device('cuda'):
+        test_v41_multimage_packed_model_forward(moe, device='cuda')
+
+
+@pytest.mark.parametrize('mutation', ['patch_order', 'delimiter'])
+def test_v41_image_processor_rejects_mutations(monkeypatch, mutation):
+    from megatron.lite.model.deepseek_v41.lite import image_data as data
+
+    if mutation == 'patch_order':
+        original = data.preprocess_image
+
+        def wrong(*args, **kwargs):
+            patches, *grid = original(*args, **kwargs)
+            return patches.flip(0), *grid
+
+        monkeypatch.setattr(data, 'preprocess_image', wrong)
+    else:
+        original = data.image_token_types
+
+        def wrong(*args):
+            return original(*args).roll(1)
+
+        monkeypatch.setattr(data, 'image_token_types', wrong)
+    with pytest.raises(AssertionError):
+        test_v41_image_processor_official((125, 97), None, monkeypatch)


### PR DESCRIPTION
Adds a differentiable V4.1 vision tower and aligner, replacing the assembly's deferred visual owners with live checkpoint-bound parameters. Multi-image inputs now expand placeholders into validated spans, replace embeddings before HC expansion, and preserve modality masks and gradient isolation across packed samples.

The processor follows the pinned reference's resize/padding and patch order; the aligner uses right/bottom zero padding and channel-first unfold. FP32/BF16 forward and all input/parameter gradients match the hash-checked official reference exactly. Reference vision/processor source is read from an external cache, with no additional vendored source.

Stacked on `feature/c4-v4-1-config-model-protocol-registry-own-051b6930b8` at `57d30df47`. Post-training trainability policy, generic training-protocol multimodal transport, distributed vision synchronization and three-stage scheduling remain separate integration work.

Validation:
- CPU: 55 passed; four GPU tests excluded from the CPU selection.
- Slurm 18369519 at `f5096164a`: 59 passed, no skips; single H100, PyTorch 26.04 container.
- Full unit regression, Slurm 18369394: 20 failed, 780 passed, 22 skipped, 5 errors (exit 1). The 25 failure/error cases match baseline 18354480 exactly: added=[], removed=[]. All three production files match the submitted commit; the final focused run additionally includes three mutation cases.
- Tests cover live owner/checkpoint round-trip, actual packed multimodal forward/backward, per-HC-copy gradients, entry reachability probes, and rejected mutations of patch order, delimiters, spatial order, padding, RoPE axes and the tower/aligner boundary.
- Changed Python syntax, scoped formatting, and git diff whitespace checks passed.
