### PR TITLE
Connect paired pipeline state to the real V4.1 model and text protocol

### DIFF
--- a/experimental/lite/docs/deepseek_v41_pipeline_integration.md
+++ b/experimental/lite/docs/deepseek_v41_pipeline_integration.md
@@ -1,0 +1,35 @@
+# V4.1 pipeline integration
+
+Depends on the standalone Engram distribution primitives and C4.
+
+## Real model range interface
+
+On the C4 assembly base, `DeepseekV41Model.forward_pipeline_range` executes an
+explicit `[start,end)` range of the actual layers. It carries the shifted HC
+pair, the saved Block(19) pair, latent/main KV, index keys, selection/candidate
+metadata and the canonical KV/index owners. Layer 20 consumes the saved pair;
+subsequent ranges preserve the source-20 KV while reindexing updates selection.
+`finish_pipeline` uses the actual final HC contraction, normalization and head.
+
+`protocol.pipeline_forward_step` exposes the range result and produces the same
+text logits, shifted-label loss and log-probabilities as the ordinary protocol on
+the final range. It currently requires one sequence per microbatch; multi-sequence
+packed and CP inputs fail explicitly until separate state routing is integrated.
+`build_model` now accepts PP-only topology through the existing `init_parallel`
+and constructs equal contiguous local layer intervals. Non-owner layer slots are
+`None`, preserving global indices; only the first stage allocates the embedding,
+and only the last allocates normalization/head parameters. Local actual bindings
+remain exact and unique. Standalone stage export is rejected until distributed
+checkpoint assembly is implemented. The common scheduler's single-tensor contract
+has not yet been extended to this paired payload.
+
+The four-rank integration fixture constructs the real registry/protocol model,
+compares two microbatches against monolithic execution, transfers every boundary
+through typed NCCL P2P, reverses backward order, and compares each range's actual
+parameter bindings and one owner update. Before PP construction it releases the
+monolithic reference model and retains only local reference weights/gradients
+and output values. The real parallel protocol allocates the local stage and
+strictly loads those local weights. This reduced fixture uses FP32 diagnostic
+projections, not native quantized full-scale qualification. Common scheduler,
+VPP, mixed optimizers, TP/EP/CP composition and complete restart/export gates remain
+open.

--- a/experimental/lite/megatron/lite/model/deepseek_v41/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v41/lite/checkpoint.py
@@ -23,7 +23,9 @@ def _tensor(store, name):
     if entry.byte_length == 0:
         return torch.empty(entry.shape, dtype=dtype)
     # Own the backing storage; neither the immutable entry nor a mapped file is mutated.
-    return torch.frombuffer(bytearray(store.read(name)), dtype=dtype).reshape(entry.shape)
+    return torch.frombuffer(bytearray(store.read(name)), dtype=dtype).reshape(
+        entry.shape
+    )
 
 
 def load_weight(store, name, *, output_dtype=torch.bfloat16):
@@ -61,11 +63,17 @@ def load_weight(store, name, *, output_dtype=torch.bfloat16):
             row_block = 1 if name.endswith(".engram.embed.weight") else 32
             expected = ((rows + row_block - 1) // row_block, (columns + 31) // 32)
             if tuple(scale.shape) != expected:
-                raise ValueError(f"scale shape mismatch: {tuple(scale.shape)} != {expected}")
+                raise ValueError(
+                    f"scale shape mismatch: {tuple(scale.shape)} != {expected}"
+                )
             # Reuse the aligned primitive, allowing a final partially occupied block.
-            padded = torch.zeros(expected[0] * row_block, expected[1] * 32, dtype=weight.dtype)
+            padded = torch.zeros(
+                expected[0] * row_block, expected[1] * 32, dtype=weight.dtype
+            )
             padded[:rows, :columns] = weight
-            result = dequantize_block_fp8(padded, scale, (row_block, 32))[:rows, :columns]
+            result = dequantize_block_fp8(padded, scale, (row_block, 32))[
+                :rows, :columns
+            ]
         else:
             raise TypeError(f"unsupported weight dtype: {weight.dtype}")
     result = result.to(output_dtype)
@@ -137,7 +145,9 @@ def bind_checkpoint(model, records, *, store=None, allow_missing_mtp=False):
                 elif dtype not in ('F32', 'BF16', 'F16'):
                     raise ValueError(f'unsupported dtype: {name}: {dtype}')
             if tuple(header['shape']) != shape:
-                raise ValueError(f'checkpoint shape mismatch: {name}: {header["shape"]} != {shape}')
+                raise ValueError(
+                    f'checkpoint shape mismatch: {name}: {header["shape"]} != {shape}'
+                )
         result[name] = replace(binding, header=header, store=store)
     model.validate_parameter_bindings()
     model.checkpoint_bindings = result
@@ -164,6 +174,10 @@ def export_model(model):
     """
     from .engram import EngramTable
 
+    if model.local_layer_range != (0, len(model.layers)):
+        raise NotImplementedError(
+            'Pipeline stage export requires distributed checkpoint assembly'
+        )
     model.validate_parameter_bindings()
     for name, binding in model.tensor_bindings.items():
         if binding.role == 'scale':
@@ -184,6 +198,7 @@ def save_model(model, path):
     import shutil
     import tempfile
     from pathlib import Path
+
     from .checkpoint_store import CheckpointTensorStore, TensorEntry
 
     path = Path(path)
@@ -192,7 +207,9 @@ def save_model(model, path):
     archive = model.archival_store
     required = set(model.archival_bindings)
     if archive is None or not required <= archive.entries.keys():
-        raise ValueError('Complete MTP/vision/aligner archival storage is required for export')
+        raise ValueError(
+            'Complete MTP/vision/aligner archival storage is required for export'
+        )
     if archive.entries.keys() - model.archival_bindings.keys():
         raise ValueError('Unknown archival keys')
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -217,7 +234,9 @@ def save_model(model, path):
                 stream.write(raw)
         CheckpointTensorStore(entries).save(staging / 'model.safetensors')
         spool.unlink()
-        (staging / 'config.json').write_text(json.dumps(model.config.to_hf_dict(), indent=2) + '\n')
+        (staging / 'config.json').write_text(
+            json.dumps(model.config.to_hf_dict(), indent=2) + '\n'
+        )
         os.rename(staging, path)
     except BaseException:
         shutil.rmtree(staging)
@@ -229,6 +248,7 @@ def load_model(model, path):
     """Bind every header before loading any live tensor, retaining archive bytes."""
     import json
     from pathlib import Path
+
     from .checkpoint_store import CheckpointTensorStore
     from .engram import EngramTable
 
@@ -249,7 +269,10 @@ def load_model(model, path):
             expected = list(json.loads(source.read(size)))
         expected = [name for name in expected if name != '__metadata__']
     store = CheckpointTensorStore.load(paths, expected_keys=expected)
-    records = [dict(name=name, dtype=e.dtype, shape=e.shape) for name, e in store.entries.items()]
+    records = [
+        dict(name=name, dtype=e.dtype, shape=e.shape)
+        for name, e in store.entries.items()
+    ]
     bindings = bind_checkpoint(model, records, store=store)
     for name, binding in bindings.items():
         if binding.role in ('archival', 'scale'):
@@ -263,10 +286,14 @@ def load_model(model, path):
                 if store.entries[name].dtype != 'F8_E4M3':
                     raise ValueError('Frozen Engram requires FP8 table storage')
                 table.weight.copy_(_tensor(store, name).to(table.weight.device))
-                table.scale.copy_(_tensor(store, name[:-6] + 'scale').to(table.scale.device))
+                table.scale.copy_(
+                    _tensor(store, name[:-6] + 'scale').to(table.scale.device)
+                )
             else:
                 table.master.copy_(
-                    load_weight(store, name, output_dtype=torch.float32).to(table.master.device)
+                    load_weight(store, name, output_dtype=torch.float32).to(
+                        table.master.device
+                    )
                 )
                 table.refresh_storage()
         else:
@@ -277,5 +304,9 @@ def load_model(model, path):
             )
             target.copy_(value.to(target.device))
     model.archival_store = CheckpointTensorStore(
-        {name: e for name, e in store.entries.items() if bindings[name].role == 'archival'}
+        {
+            name: e
+            for name, e in store.entries.items()
+            if bindings[name].role == 'archival'
+        }
     )

--- a/experimental/lite/megatron/lite/model/deepseek_v41/lite/model.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v41/lite/model.py
@@ -44,7 +44,9 @@ class DeferredModule(nn.Module):
         self.scope = scope
 
     def forward(self, *args, **kwargs):
-        raise NotImplementedError(f'{self.scope} execution is not implemented in text-only mode')
+        raise NotImplementedError(
+            f'{self.scope} execution is not implemented in text-only mode'
+        )
 
     def leaf_owner(self, path):
         owner = self
@@ -81,6 +83,7 @@ class DeepseekV41Model(nn.Module):
         gate_temperature=1.0,
         bias_rate=0.001,
         enable_dspark_execution=False,
+        layer_range=None,
     ):
         super().__init__()
         validate_execution(enable_dspark_execution=enable_dspark_execution)
@@ -88,22 +91,44 @@ class DeepseekV41Model(nn.Module):
         cfg = config.to_hf_dict()
         t, v = cfg['text_config'], cfg['vision_config']
         self.hc_mult = t['hc_mult']
+        count = t['num_hidden_layers']
+        start, end = (0, count) if layer_range is None else layer_range
+        if (
+            type(start) is not int
+            or type(end) is not int
+            or not 0 <= start < end <= count
+        ):
+            raise ValueError('Invalid local pipeline stage interval')
+        self.local_layer_range = (start, end)
         self.tensor_bindings = {}
         self.archival_bindings = {}
         self.archival_store = None
         self.checkpoint_bindings = None
-        self.embed = nn.Embedding(t['vocab_size'], t['hidden_size'], dtype=torch.bfloat16)
-        self.norm = RMSNorm(t['hidden_size'], t['rms_norm_eps'])
-        self.head = nn.Linear(t['hidden_size'], t['vocab_size'], bias=False, dtype=torch.float32)
-        self._bind('embed.weight', self.embed, 'weight', 'embedding')
-        self._bind('norm.weight', self.norm, 'weight', 'norm')
-        self._bind('head.weight', self.head, 'weight', 'head')
+        self.embed = self.norm = self.head = None
+        if start == 0:
+            self.embed = nn.Embedding(
+                t['vocab_size'], t['hidden_size'], dtype=torch.bfloat16
+            )
+            self._bind('embed.weight', self.embed, 'weight', 'embedding')
+        if end == count:
+            self.norm = RMSNorm(t['hidden_size'], t['rms_norm_eps'])
+            self.head = nn.Linear(
+                t['hidden_size'], t['vocab_size'], bias=False, dtype=torch.float32
+            )
+            self._bind('norm.weight', self.norm, 'weight', 'norm')
+            self._bind('head.weight', self.head, 'weight', 'head')
         self.layers = nn.ModuleList()
         flags = dict(
-            linear_fp8=quantized, main_qat=quantized, index_qat=quantized, swa_fp8=quantized
+            linear_fp8=quantized,
+            main_qat=quantized,
+            index_qat=quantized,
+            swa_fp8=quantized,
         )
         ac = config.attention_config(**flags)
         for layer_id in range(t['num_hidden_layers']):
+            if not start <= layer_id < end:
+                self.layers.append(None)  # Preserve canonical global layer indices.
+                continue
             prefix = f'layers.{layer_id}'
             attention = CSA2Attention(ac, layer_id)
             router = ModalityRouter(
@@ -113,9 +138,14 @@ class DeepseekV41Model(nn.Module):
                 bias_rate=bias_rate,
             )
             experts = [
-                self._expert(t, quantized, shared=False) for _ in range(t['n_routed_experts'])
+                self._expert(t, quantized, shared=False)
+                for _ in range(t['n_routed_experts'])
             ]
-            shared = self._expert(t, quantized, shared=True) if t['n_shared_experts'] else None
+            shared = (
+                self._expert(t, quantized, shared=True)
+                if t['n_shared_experts']
+                else None
+            )
             ffn = DeepseekV41MoE(router, experts, shared)
             block = DeepseekV41Block(
                 t['hidden_size'],
@@ -129,11 +159,15 @@ class DeepseekV41Model(nn.Module):
             block.engram = None
             self.layers.append(block)
             self._bind_attention(prefix + '.attn', attention, t)
-            self._bind(prefix + '.ffn.gate.weight', router.router.gate, 'weight', 'router')
+            self._bind(
+                prefix + '.ffn.gate.weight', router.router.gate, 'weight', 'router'
+            )
             for attr in ('bias', 'bias_vl'):
                 self._bind(prefix + '.ffn.gate.' + attr, router, attr, 'router_bias')
             for index, expert in enumerate(experts):
-                self._bind_expert(f'{prefix}.ffn.experts.{index}', expert, 'expert', 'I8')
+                self._bind_expert(
+                    f'{prefix}.ffn.experts.{index}', expert, 'expert', 'I8'
+                )
             if shared is not None:
                 self._bind_expert(
                     prefix + '.ffn.shared_experts', shared, 'shared_expert', 'F8_E4M3'
@@ -147,7 +181,9 @@ class DeepseekV41Model(nn.Module):
                 )
                 mixes = getattr(block, f'{side}_mixes')
                 for attr in ('fn', 'base', 'scale'):
-                    self._bind(prefix + f'.hc_{side}_{attr}', mixes, attr, 'hyper_connection')
+                    self._bind(
+                        prefix + f'.hc_{side}_{attr}', mixes, attr, 'hyper_connection'
+                    )
         self.engram_hash = None
         self.engram_layer_ids = tuple(t['engram_layer_ids'])
         if self.engram_layer_ids:
@@ -161,7 +197,9 @@ class DeepseekV41Model(nn.Module):
                         t['engram_vocab_size'],
                     )
                     if primes.flatten(1).sum(1).tolist() != t['engram_num_embeddings']:
-                        raise ValueError('engram_num_embeddings disagrees with prime layout')
+                        raise ValueError(
+                            'engram_num_embeddings disagrees with prime layout'
+                        )
                     if (
                         len(token_map) != t['vocab_size']
                         or min(token_map) < 0
@@ -177,6 +215,8 @@ class DeepseekV41Model(nn.Module):
                         token_map, t['engram_pad_token_id'], multipliers, primes
                     )
             for offset, layer_id in enumerate(self.engram_layer_ids):
+                if not start <= layer_id < end:
+                    continue
                 rows, width = t['engram_num_embeddings'][offset], t['engram_head_dim']
                 table = EngramTable(
                     torch.zeros(rows, width, dtype=torch.float8_e4m3fn),
@@ -189,7 +229,11 @@ class DeepseekV41Model(nn.Module):
                     fp8=quantized,
                 )
                 module = Engram(
-                    t['hidden_size'], t['hc_mult'], table, projection, eps=t['rms_norm_eps']
+                    t['hidden_size'],
+                    t['hc_mult'],
+                    table,
+                    projection,
+                    eps=t['rms_norm_eps'],
                 )
                 self.layers[layer_id].engram = module
                 prefix = f'layers.{layer_id}.engram'
@@ -200,7 +244,9 @@ class DeepseekV41Model(nn.Module):
                     'engram_table',
                     encoding='F8_E4M3',
                 )
-                self._bind(prefix + '.embed.scale', table, 'scale', 'scale', encoding='F8_E8M0')
+                self._bind(
+                    prefix + '.embed.scale', table, 'scale', 'scale', encoding='F8_E8M0'
+                )
                 self._bind(
                     prefix + '.wkv.weight',
                     projection,
@@ -218,13 +264,17 @@ class DeepseekV41Model(nn.Module):
             owner = module.leaf_owner(key[len(root) + 1 :])
             self.archival_bindings[key] = TensorBinding(key, owner, None, 'archival')
         for key in ('image_start', 'image_end', 'image_newline'):
-            self.archival_bindings[key] = TensorBinding(key, self.vision, None, 'archival')
+            self.archival_bindings[key] = TensorBinding(
+                key, self.vision, None, 'archival'
+            )
         self.validate_parameter_bindings()
 
     def _bind(self, key, owner, attribute, role, head_count=None, encoding=None):
         if key in self.tensor_bindings:
             raise ValueError(f'duplicate binding: {key}')
-        self.tensor_bindings[key] = TensorBinding(key, owner, attribute, role, head_count, encoding)
+        self.tensor_bindings[key] = TensorBinding(
+            key, owner, attribute, role, head_count, encoding
+        )
         if encoding in ('I8', 'F8_E4M3') and role != 'engram_table':
             scale = key[:-6] + 'scale'
             self.tensor_bindings[scale] = TensorBinding(
@@ -237,7 +287,11 @@ class DeepseekV41Model(nn.Module):
         width = t['moe_intermediate_size'] * (t['n_shared_experts'] if shared else 1)
 
         def projection(a, b):
-            return Linear(a, b, fp8=quantized) if shared else FP4Linear(a, b, quantized=quantized)
+            return (
+                Linear(a, b, fp8=quantized)
+                if shared
+                else FP4Linear(a, b, quantized=quantized)
+            )
 
         return SwiGLUExpert(
             projection(dim, width),
@@ -260,10 +314,17 @@ class DeepseekV41Model(nn.Module):
         for name in ('wq_a', 'wq_b', 'wkv', 'wo_a', 'wo_b'):
             heads = t['num_attention_heads'] if name == 'wq_b' else None
             self._bind(
-                prefix + '.' + name + '.weight', getattr(a, name), 'weight', name, heads, 'F8_E4M3'
+                prefix + '.' + name + '.weight',
+                getattr(a, name),
+                'weight',
+                name,
+                heads,
+                'F8_E4M3',
             )
         for name in ('q_norm', 'kv_norm'):
-            self._bind(prefix + '.' + name + '.weight', getattr(a, name), 'weight', 'norm')
+            self._bind(
+                prefix + '.' + name + '.weight', getattr(a, name), 'weight', 'norm'
+            )
         self._bind(prefix + '.attn_sink', a, 'attn_sink', 'attention_sink')
         if a.compressor is not None:
             for name in ('wkv', 'norm', 'wgate'):
@@ -300,7 +361,11 @@ class DeepseekV41Model(nn.Module):
                 'norm2.weight',
             ):
                 yield 'vision', f'vision.blocks.{index}.{suffix}'
-        for suffix in ('norm.weight', 'patch_embed.proj.bias', 'patch_embed.proj.weight'):
+        for suffix in (
+            'norm.weight',
+            'patch_embed.proj.bias',
+            'patch_embed.proj.weight',
+        ):
             yield 'vision', 'vision.' + suffix
         for name in ('w1', 'w2'):
             for suffix in ('weight', 'bias'):
@@ -332,7 +397,11 @@ class DeepseekV41Model(nn.Module):
                     for suffix in ('weight', 'scale'):
                         yield 'mtp', prefix + f'ffn.{expert}.{name}.{suffix}'
             if index == 0:
-                for suffix in ('main_norm.weight', 'main_proj.weight', 'main_proj.scale'):
+                for suffix in (
+                    'main_norm.weight',
+                    'main_proj.weight',
+                    'main_proj.scale',
+                ):
                     yield 'mtp', prefix + suffix
             if index == t['num_nextn_predict_layers'] - 1:
                 for suffix in (
@@ -359,19 +428,122 @@ class DeepseekV41Model(nn.Module):
         hashes = None
         if self.engram_layer_ids:
             if self.engram_hash is None:
-                raise ValueError('Engram execution requires an explicit tokenizer token_map')
+                raise ValueError(
+                    'Engram execution requires an explicit tokenizer token_map'
+                )
             hashes = self.engram_hash(input_ids)
         state = AttentionState()
         for index, layer in enumerate(self.layers):
             if layer.engram is not None:
-                hidden = layer.engram(hidden, hashes[:, :, self.engram_layer_ids.index(index)])
+                hidden = layer.engram(
+                    hidden, hashes[:, :, self.engram_layer_ids.index(index)]
+                )
             hidden, pre, state = layer.forward_with_state(hidden, pre, state)
         return hidden, pre
 
+    def forward_pipeline_range(
+        self, input_ids, *, start, end, payload=None, owners=(-1, -1)
+    ):
+        """Execute a contiguous real layer range with explicit, graph-bearing state.
+
+        This is the model boundary used by a PP scheduler, not a scheduler or a
+        parameter sharder. Input IDs belong to one unpacked sequence batch; the
+        caller must split packed samples before constructing each generation.
+        """
+        from .pipeline import PairedPayload
+
+        if (
+            type(start) is not int
+            or type(end) is not int
+            or not 0 <= start < end <= len(self.layers)
+        ):
+            raise ValueError('Invalid pipeline layer interval')
+        local_start, local_end = self.local_layer_range
+        if not local_start <= start < end <= local_end:
+            raise ValueError('Requested range is outside this pipeline stage')
+        if (
+            input_ids.ndim != 2
+            or input_ids.dtype != torch.int64
+            or not input_ids.shape[1]
+        ):
+            raise ValueError('Expected nonempty int64 input_ids [B,S]')
+        if start == 0:
+            if payload is not None or owners != (-1, -1):
+                raise ValueError('First pipeline range must start with fresh state')
+            hidden, pre = expand_hc(self.embed(input_ids), self.hc_mult)
+            state = AttentionState()
+            ced_h = ced_p = None
+        else:
+            if payload is None or payload.h.shape[:2] != input_ids.shape:
+                raise ValueError('Pipeline range requires matching input state')
+            if start >= 20 and (payload.ced_h is None or payload.ced_p is None):
+                raise ValueError('Decoder pipeline range requires the saved CED pair')
+            hidden, pre = payload.h, payload.p
+            ced_h, ced_p = payload.ced_h, payload.ced_p
+            state = AttentionState(
+                kv_owner=None if owners[0] == -1 else owners[0],
+                index_owner=None if owners[1] == -1 else owners[1],
+                latent=payload.latent,
+                main_kv=payload.kv,
+                index_k=payload.index_k,
+                indices=payload.topk,
+                candidates=payload.candidates,
+            )
+        hashes = None
+        if any(start <= layer < end for layer in self.engram_layer_ids):
+            if self.engram_hash is None:
+                raise ValueError(
+                    'Engram execution requires an explicit tokenizer token_map'
+                )
+            hashes = self.engram_hash(input_ids)
+        for index in range(start, end):
+            if index == 20:
+                # Block(19)'s shifted coefficients belong to h20. They cannot
+                # be reconstructed from a later block's current coefficients.
+                hidden, pre = ced_h, ced_p
+            layer = self.layers[index]
+            if layer.engram is not None:
+                hidden = layer.engram(
+                    hidden, hashes[:, :, self.engram_layer_ids.index(index)]
+                )
+            hidden, pre, state = layer.forward_with_state(hidden, pre, state)
+            if index == 19:
+                ced_h, ced_p = hidden, pre
+        return PairedPayload(
+            h=hidden,
+            p=pre,
+            ced_h=ced_h,
+            ced_p=ced_p,
+            kv=state.main_kv,
+            latent=state.latent,
+            # O12: index selection is discrete and has no indexer objective.
+            index_k=None if state.index_k is None else state.index_k.detach(),
+            topk=state.indices,
+            candidates=state.candidates,
+        ), (
+            -1 if state.kv_owner is None else state.kv_owner,
+            -1 if state.index_owner is None else state.index_owner,
+        )
+
+    def finish_pipeline(self, payload):
+        """Apply the actual final shifted HC contraction, norm and output head."""
+        if self.head is None or self.norm is None:
+            raise RuntimeError('Only the final pipeline stage owns the output head')
+        hidden = self.norm(contract_hc(payload.h, payload.p))
+        return F.linear(hidden.float(), self.head.weight.float())
+
     def forward(self, input_ids, *, cu_seqlens=None, images=None, token_types=None):
+        if self.local_layer_range != (0, len(self.layers)):
+            raise RuntimeError('A local pipeline stage requires the range protocol')
         if images is not None or token_types is not None:
-            raise NotImplementedError('Multimodal inputs require vision/aligner integration')
-        if input_ids.ndim != 2 or input_ids.dtype != torch.int64 or not input_ids.shape[1]:
+            raise NotImplementedError(
+                'Multimodal inputs require vision/aligner integration'
+            )
+        if (
+            input_ids.ndim != 2
+            or input_ids.dtype != torch.int64
+            or not input_ids.shape[1]
+        ):
             raise ValueError('Expected nonempty int64 input_ids [B,S]')
         hidden, pre = expand_hc(self.embed(input_ids), self.hc_mult)
         if cu_seqlens is None:

--- a/experimental/lite/megatron/lite/model/deepseek_v41/lite/pipeline.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v41/lite/pipeline.py
@@ -1,0 +1,205 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Paired PP payload lifetime; the C4 protocol owns scheduling and layer binding."""
+
+from dataclasses import dataclass
+
+import torch
+
+PAYLOAD_FIELDS = (
+    'h',
+    'p',
+    'ced_h',
+    'ced_p',
+    'kv',
+    'kv_values',
+    'kv_scale',
+    'index_k',
+    'index_scale',
+    'topk',
+    'positions',
+    'latent',
+    'candidates',
+)
+
+
+@dataclass(frozen=True)
+class PipelineTag:
+    step: int
+    microbatch: int
+    chunk: int
+    generation: int
+    kv_owner: int = 20
+    index_owner: int = 20
+
+    def __post_init__(self):
+        if any(type(v) is not int or v < 0 for v in self.as_tuple()[:4]):
+            raise ValueError('Require nonnegative integer pipeline tags')
+        if any(type(v) is not int or not -1 <= v < 40 for v in self.as_tuple()[4:]):
+            raise ValueError('Invalid pipeline source owner')
+
+    def as_tuple(self):
+        return (
+            self.step,
+            self.microbatch,
+            self.chunk,
+            self.generation,
+            self.kv_owner,
+            self.index_owner,
+        )
+
+
+@dataclass(frozen=True)
+class PairedPayload:
+    h: torch.Tensor
+    p: torch.Tensor
+    ced_h: torch.Tensor | None = None
+    ced_p: torch.Tensor | None = None
+    kv: torch.Tensor | None = None
+    kv_values: torch.Tensor | None = None
+    kv_scale: torch.Tensor | None = None
+    index_k: torch.Tensor | None = None
+    index_scale: torch.Tensor | None = None
+    topk: torch.Tensor | None = None
+    positions: torch.Tensor | None = None
+    latent: torch.Tensor | None = None
+    candidates: torch.Tensor | None = None
+
+    def __post_init__(self):
+        if not isinstance(self.h, torch.Tensor) or not isinstance(self.p, torch.Tensor):
+            raise ValueError('Require a current HC pair')
+        if (self.ced_h is None) != (self.ced_p is None):
+            raise ValueError('CED h/p must travel as a pair')
+        for h, p in ((self.h, self.p), (self.ced_h, self.ced_p)):
+            if h is not None and (
+                p is None
+                or h.ndim != 4
+                or p.shape != h.shape[:-1]
+                or not h.is_floating_point()
+                or not p.is_floating_point()
+            ):
+                raise ValueError(
+                    'HC pair requires h[batch,sequence,hc,hidden] and p[batch,sequence,hc]'
+                )
+        for name in (
+            'kv_values',
+            'kv_scale',
+            'index_k',
+            'index_scale',
+            'topk',
+            'positions',
+            'candidates',
+        ):
+            value = getattr(self, name)
+            if value is not None and value.requires_grad:
+                raise ValueError(
+                    'Published bytes, integer positions and frozen indexers have no gradient'
+                )
+        for name in ('topk', 'positions'):
+            value = getattr(self, name)
+            if value is not None and value.dtype not in (torch.int32, torch.int64):
+                raise ValueError(
+                    'Pipeline selection and position metadata must be integer tensors'
+                )
+
+    def tensors(self):
+        return tuple(getattr(self, name) for name in PAYLOAD_FIELDS)
+
+    def differentiable(self):
+        return {
+            name: value
+            for name, value in zip(PAYLOAD_FIELDS, self.tensors())
+            if value is not None and value.requires_grad
+        }
+
+    @classmethod
+    def from_tensors(cls, tensors):
+        if len(tensors) != len(PAYLOAD_FIELDS):
+            raise ValueError('Pipeline payload field count differs')
+        return cls(**dict(zip(PAYLOAD_FIELDS, tensors)))
+
+
+class PipelineLedger:
+    """Keep each generation live through recompute and all consumer returns.
+
+    A return names a consumer explicitly and supplies every differentiable field
+    (zero for an unused path). Indexers/Top-K never enter autograd. Backward runs
+    once after the exact expected consumer set has returned; no optimizer is
+    registered here, so C4/F2 retain canonical parameter ownership.
+    """
+
+    def __init__(self):
+        self._live = {}
+        self._latest = {}
+        self._finished_step = -1
+
+    def publish(self, tag, payload, *, consumers):
+        identity = (tag.step, tag.microbatch, tag.chunk)
+        if (
+            tag.step <= self._finished_step
+            or tag.generation <= self._latest.get(identity, -1)
+            or any(t.as_tuple()[:3] == identity for t in self._live)
+        ):
+            raise RuntimeError('Duplicate or still-live pipeline generation')
+        consumers = tuple(consumers)
+        if not consumers or len(set(consumers)) != len(consumers):
+            raise ValueError('Require distinct expected pipeline consumers')
+        self._latest[identity] = tag.generation
+        self._live[tag] = (payload, set(consumers), set(), {})
+
+    def _entry(self, tag):
+        if tag not in self._live:
+            raise RuntimeError('Unknown, stale or released pipeline generation')
+        return self._live[tag]
+
+    def read(self, tag):
+        return self._entry(tag)[0]
+
+    def return_gradients(self, tag, consumer, gradients):
+        payload, expected, returned, total = self._entry(tag)
+        if consumer not in expected or consumer in returned:
+            raise RuntimeError('Unexpected or duplicate pipeline gradient return')
+        fields = payload.differentiable()
+        if gradients.keys() != fields.keys():
+            raise ValueError('Gradient fields differ from the floating owner paths')
+        for name, tensor in fields.items():
+            gradient = gradients[name]
+            if (
+                gradient.shape != tensor.shape
+                or gradient.dtype != tensor.dtype
+                or gradient.device != tensor.device
+            ):
+                raise ValueError('Pipeline gradient shape/dtype/device differs')
+        for name, gradient in gradients.items():
+            if name not in total:
+                total[name] = gradient.detach().clone()
+            else:
+                total[name].add_(gradient.detach())
+        returned.add(consumer)
+
+    def backward(self, tag):
+        payload, expected, returned, total = self._entry(tag)
+        if returned != expected:
+            raise RuntimeError('Cannot release pipeline state with missing returns')
+        fields = payload.differentiable()
+        if fields:
+            torch.autograd.backward(
+                tuple(fields.values()), tuple(total[name] for name in fields)
+            )
+        del self._live[tag]
+
+    def assert_quiescent(self):
+        if self._live:
+            raise RuntimeError('Pipeline generations are still live')
+
+    def finish_step(self, step):
+        """Bound generation bookkeeping after the scheduler drains a step."""
+        if type(step) is not int or step <= self._finished_step:
+            raise RuntimeError('Stale pipeline step retirement')
+        if any(tag.step <= step for tag in self._live):
+            raise RuntimeError('Pipeline generations are still live')
+        self._finished_step = step
+        self._latest = {
+            identity: generation
+            for identity, generation in self._latest.items()
+            if identity[0] > step
+        }

--- a/experimental/lite/megatron/lite/model/deepseek_v41/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v41/lite/protocol.py
@@ -1,15 +1,15 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-"""Text-only single-rank protocol. Distributed and optimizer routing are separate."""
+"""Text protocol and PP-only local construction; mixed parallel routing is separate."""
 
 from dataclasses import dataclass, field
 
 import torch
-from torch.nn import functional as F
-
 from megatron.lite.model.deepseek_v41.config import DeepseekV41Config
 from megatron.lite.primitive.bundle import ModelBundle
-from megatron.lite.primitive.parallel.state import ParallelState
+from megatron.lite.primitive.parallel.state import ParallelState, init_parallel
 from megatron.lite.runtime.contracts import ParallelConfig
+from torch.nn import functional as F
+
 from .checkpoint import export_model, load_model, save_model
 
 
@@ -31,7 +31,9 @@ def build_model_config(source, **overrides):
     if overrides:
         raise ValueError('Apply overrides to the explicit nested source config')
     return (
-        DeepseekV41Config(source) if isinstance(source, dict) else DeepseekV41Config.from_hf(source)
+        DeepseekV41Config(source)
+        if isinstance(source, dict)
+        else DeepseekV41Config.from_hf(source)
     )
 
 
@@ -40,13 +42,33 @@ def build_model(model_cfg, *, impl_cfg):
 
     p = impl_cfg.parallel
     if (
-        any(getattr(p, key) != 1 for key in ('tp', 'ep', 'cp', 'pp', 'vpp'))
+        any(getattr(p, key) != 1 for key in ('tp', 'ep', 'cp', 'vpp'))
         or p.etp not in (None, 1)
         or p.pp_layout is not None
     ):
-        raise NotImplementedError('V4.1 assembly currently requires single-rank parallelism')
-    if torch.distributed.is_initialized() and torch.distributed.get_world_size() != 1:
-        raise NotImplementedError('Distributed V4.1 construction requires the parallel integration')
+        raise NotImplementedError(
+            'V4.1 stage construction supports PP only; TP/EP/CP/VPP remain pending'
+        )
+    ps = ParallelState()
+    layer_range = None
+    if p.pp > 1:
+        if (
+            not torch.distributed.is_initialized()
+            or torch.distributed.get_world_size() != p.pp
+        ):
+            raise ValueError(
+                'PP stage construction requires exactly pp initialized ranks'
+            )
+        count = model_cfg.to_hf_dict()['text_config']['num_hidden_layers']
+        if count % p.pp:
+            raise ValueError('Equal PP stages must divide the real layer count')
+        ps = init_parallel(p)
+        width = count // p.pp
+        layer_range = (ps.pp_rank * width, (ps.pp_rank + 1) * width)
+    elif torch.distributed.is_initialized() and torch.distributed.get_world_size() != 1:
+        raise NotImplementedError(
+            'Data parallel construction requires the distributed integration'
+        )
     if impl_cfg.optimizer is not None:
         raise NotImplementedError(
             'Optimizer construction requires the V4.1 object-based routing integration'
@@ -62,6 +84,7 @@ def build_model(model_cfg, *, impl_cfg):
             gate_temperature=impl_cfg.gate_temperature,
             bias_rate=impl_cfg.bias_rate,
             enable_dspark_execution=impl_cfg.enable_dspark_execution,
+            layer_range=layer_range,
         )
     # Keep HC coefficients, router and normalization tensors in their native
     # precision. Only residual projections change dtype in diagnostic mode.
@@ -79,7 +102,7 @@ def build_model(model_cfg, *, impl_cfg):
         model.engram_hash.to(device=impl_cfg.device)
     return ModelBundle(
         [model],
-        ParallelState(),
+        ps,
         forward_step=_forward_step,
         extras={
             'model_cfg': model_cfg,
@@ -89,25 +112,102 @@ def build_model(model_cfg, *, impl_cfg):
     )
 
 
-def _forward_step(model, batch):
+def _validate_text_batch(batch):
     if batch.routed_experts is not None or batch.r3_replay_mask is not None:
         raise NotImplementedError('Routing replay requires the replay integration')
     if batch.extras:
-        raise NotImplementedError('Text-only protocol does not accept extra modality fields')
+        raise NotImplementedError(
+            'Text-only protocol does not accept extra modality fields'
+        )
     if batch.input_ids.ndim != 1 or batch.total_tokens != batch.input_ids.numel():
         raise ValueError('Expected packed 1-D tokens matching seq_lens')
     if batch.position_ids is not None and not torch.equal(
         batch.position_ids,
-        torch.cat([torch.arange(int(n), device=batch.input_ids.device) for n in batch.seq_lens]),
+        torch.cat(
+            [
+                torch.arange(int(n), device=batch.input_ids.device)
+                for n in batch.seq_lens
+            ]
+        ),
     ):
         raise ValueError('Only sequence-local positions are supported')
+
+
+def _forward_step(model, batch):
+    _validate_text_batch(batch)
+    logits = model(batch.input_ids[None], cu_seqlens=batch.cu_seqlens)['logits'][0]
+    return _text_output(logits, batch)
+
+
+def pipeline_forward_step(model, batch, *, start, end, payload=None, owners=(-1, -1)):
+    """Model/protocol range boundary; a scheduler owns transport and generation.
+
+    Packed multi-sequence/CP partitioning is a separate integration. Reject it
+    explicitly until the scheduler can carry separate CSA2 state per sample.
+    """
+    _validate_text_batch(batch)
+    if batch.seq_lens.numel() != 1:
+        raise NotImplementedError(
+            'Pipeline packed sequences require per-sample state routing'
+        )
+    payload, owners = model.forward_pipeline_range(
+        batch.input_ids[None], start=start, end=end, payload=payload, owners=owners
+    )
+    result = {'pipeline_payload': payload, 'pipeline_owners': owners}
+    if end == len(model.layers):
+        result.update(_text_output(model.finish_pipeline(payload)[0], batch))
+    return result
+
+
+def packed_pipeline_forward_step(model, batch, *, start, end, state=None):
+    """CP1 packed range with an independent carrier per unpadded sequence.
+
+    State is an ordered tuple of (PairedPayload, owners) pairs. Transport must
+    preserve this sequence order and all native compressed-state shapes. This
+    entry does not partition CP or replace the distributed PP scheduler.
+    """
+    _validate_text_batch(batch)
+    lengths = batch.seq_lens.tolist()
+    if not lengths or any(length <= 0 for length in lengths):
+        raise ValueError('Packed pipeline requires positive sequence lengths')
+    if start == 0:
+        if state is not None:
+            raise ValueError('First packed range requires fresh sequence states')
+        state = tuple((None, (-1, -1)) for _ in lengths)
+    elif state is None or len(state) != len(lengths):
+        raise ValueError('Packed pipeline requires one state per sequence')
+    outputs = []
+    offset = 0
+    for length, (payload, owners) in zip(lengths, state):
+        payload, owners = model.forward_pipeline_range(
+            batch.input_ids[offset : offset + length][None],
+            start=start,
+            end=end,
+            payload=payload,
+            owners=owners,
+        )
+        outputs.append((payload, owners))
+        offset += length
+    result = {'packed_pipeline_state': tuple(outputs)}
+    if end == len(model.layers):
+        from .pipeline import PairedPayload
+
+        final = PairedPayload(
+            h=torch.cat([payload.h for payload, _ in outputs], dim=1),
+            p=torch.cat([payload.p for payload, _ in outputs], dim=1),
+        )
+        result.update(_text_output(model.finish_pipeline(final)[0], batch))
+    return result
+
+
+def _text_output(logits, batch):
     from megatron.lite.runtime.contracts.loss import get_loss_context
 
     context = get_loss_context()
     temperature = 1.0 if context is None else context.temperature
     if temperature <= 0:
         raise ValueError('Temperature must be positive')
-    logits = model(batch.input_ids[None], cu_seqlens=batch.cu_seqlens)['logits'][0] / temperature
+    logits = logits / temperature
     result = {'logits': logits}
     if batch.labels is not None:
         if batch.labels.shape != batch.input_ids.shape:
@@ -139,13 +239,18 @@ def _forward_step(model, batch):
 
 def unpack_forward_output(model, batch, output):
     if isinstance(output, dict):
-        return {key: unpack_forward_output(model, batch, value) for key, value in output.items()}
+        return {
+            key: unpack_forward_output(model, batch, value)
+            for key, value in output.items()
+        }
     if (
         isinstance(output, torch.Tensor)
         and output.ndim > 0
         and output.shape[0] == batch.total_tokens
     ):
-        return torch.nested.as_nested_tensor(list(output.split(batch.seq_lens.tolist())))
+        return torch.nested.as_nested_tensor(
+            list(output.split(batch.seq_lens.tolist()))
+        )
     return output
 
 
@@ -164,7 +269,9 @@ def export_hf_weights(chunks, model_cfg, ps, **kwargs):
     if kwargs:
         raise ValueError('Unsupported export options')
     model = _single(chunks)
-    if model.archival_store is None or set(model.archival_store.entries) != set(model.archival_bindings):
+    if model.archival_store is None or set(model.archival_store.entries) != set(
+        model.archival_bindings
+    ):
         raise ValueError('Complete archival storage is required for export')
     yield from export_model(model)
     if model.archival_store is not None:

--- a/experimental/lite/tests/unit/model/test_deepseek_v41_semantics.py
+++ b/experimental/lite/tests/unit/model/test_deepseek_v41_semantics.py
@@ -863,6 +863,37 @@ def test_v41_pipeline_constructor_allocates_only_local_owners(moe, monkeypatch):
     assert assigned == expected, 'PP local owners do not cover the monolithic model'
 
 
+def test_v41_pipeline_rejects_range_outside_local_stage(moe):
+    from megatron.lite.model.deepseek_v41.lite.model import DeepseekV41Model
+
+    stage = DeepseekV41Model(
+        _assembly_config(),
+        token_map=list(range(256)),
+        quantized=False,
+        layer_range=(0, 20),
+    )
+    with pytest.raises(
+        ValueError, match='^Requested range is outside this pipeline stage$'
+    ):
+        stage.forward_pipeline_range(torch.tensor([[3, 4]]), start=0, end=21)
+
+
+def test_v41_pipeline_rejects_output_on_nonfinal_stage(moe):
+    from megatron.lite.model.deepseek_v41.lite.model import DeepseekV41Model
+
+    stage = DeepseekV41Model(
+        _assembly_config(),
+        token_map=list(range(256)),
+        quantized=False,
+        layer_range=(0, 20),
+    )
+    payload, _ = stage.forward_pipeline_range(torch.tensor([[3, 4]]), start=0, end=20)
+    with pytest.raises(
+        RuntimeError, match='^Only the final pipeline stage owns the output head$'
+    ):
+        stage.finish_pipeline(payload)
+
+
 def test_v41_packed_pipeline_matches_monolithic(moe):
     from megatron.lite.runtime.contracts import PackedBatch
 

--- a/experimental/lite/tests/unit/model/test_deepseek_v41_semantics.py
+++ b/experimental/lite/tests/unit/model/test_deepseek_v41_semantics.py
@@ -105,7 +105,9 @@ def test_v41_modality_bias_selection_and_vjp(image, moe):
         routed_scaling_factor=1.5,
         scoring_func='sqrtsoftplus',
     )
-    router = moe.ModalityRouter(config, SimpleNamespace(tp_size=1), gate_temperature=0.7)
+    router = moe.ModalityRouter(
+        config, SimpleNamespace(tp_size=1), gate_temperature=0.7
+    )
     with torch.no_grad():
         router.router.gate.weight.copy_(torch.eye(3))
         (router.bias_vl if image else router.bias)[2] = 4
@@ -124,7 +126,9 @@ def test_v41_modality_bias_selection_and_vjp(image, moe):
     router.update_bias(stats)
     delta = torch.zeros(2, 3)
     delta[int(image)] = torch.tensor([-0.001, 0.001, -0.001])
-    torch.testing.assert_close(torch.stack([router.bias, router.bias_vl]), before + delta)
+    torch.testing.assert_close(
+        torch.stack([router.bias, router.bias_vl]), before + delta
+    )
     assert not router.router.compute_aux_loss
 
 
@@ -211,10 +215,14 @@ def test_v41_mhc_two_sublayer_shift_uses_unequal_coefficients(copies):
 
         # Independent equations across both sublayers AND the next block boundary.
         expected_attn_input = (expected_hidden * expected_pre.unsqueeze(-1)).sum(-2)
-        expected_hidden = expected_hidden + 0.25 * (expected_attn_input + 17).unsqueeze(-2)
+        expected_hidden = expected_hidden + 0.25 * (expected_attn_input + 17).unsqueeze(
+            -2
+        )
         expected_ffn_input = (expected_hidden * attn_pre.unsqueeze(-1)).sum(-2)
         wrong_ffn_input = (expected_hidden * expected_pre.unsqueeze(-1)).sum(-2)
-        expected_hidden = expected_hidden + 0.25 * (expected_ffn_input - 9).unsqueeze(-2)
+        expected_hidden = expected_hidden + 0.25 * (expected_ffn_input - 9).unsqueeze(
+            -2
+        )
         torch.testing.assert_close(attention.inputs[0], expected_attn_input)
         torch.testing.assert_close(ffn.inputs[0], expected_ffn_input)
         torch.testing.assert_close(hidden, expected_hidden)
@@ -244,7 +252,10 @@ def test_v41_ced_boundaries_match_pinned_official_oracle(dtype, length, monkeypa
 
     reference = root / "tests/fixtures/deepseek_v41/reference"
     for name in ("model.py", "config.json", "inference_config.json"):
-        assert hashlib.sha256((reference / name).read_bytes()).hexdigest() == REFERENCE_SHA256[name]
+        assert (
+            hashlib.sha256((reference / name).read_bytes()).hexdigest()
+            == REFERENCE_SHA256[name]
+        )
     source = reference / "model.py"
     classes = {
         node.name: node
@@ -268,7 +279,9 @@ def test_v41_ced_boundaries_match_pinned_official_oracle(dtype, length, monkeypa
     # Only method containers are constructed here; no official arithmetic is rewritten.
     namespace = {"torch": torch, "nn": torch.nn}
     exec(
-        compile(ast.Module(body=[classes["RMSNorm"]], type_ignores=[]), str(source), "exec"),
+        compile(
+            ast.Module(body=[classes["RMSNorm"]], type_ignores=[]), str(source), "exec"
+        ),
         namespace,
     )
     official_norm = namespace["RMSNorm"]
@@ -283,7 +296,9 @@ def test_v41_ced_boundaries_match_pinned_official_oracle(dtype, length, monkeypa
         {"forward": official_method("Indexer", "forward")},
     )()
     args = reduced_overrides()
-    rows = json.loads((root / "tests/fixtures/deepseek_v41/manifest.json").read_text())["tensors"]
+    rows = json.loads((root / "tests/fixtures/deepseek_v41/manifest.json").read_text())[
+        "tensors"
+    ]
     rows = {row["name"]: (ordinal, row) for ordinal, row in enumerate(rows)}
 
     def bind(module, name):
@@ -320,7 +335,9 @@ def test_v41_ced_boundaries_match_pinned_official_oracle(dtype, length, monkeypa
     ).to(dtype)
     official_attn_norm = official_norm(config.dim, config.eps).to(dtype)
     official_compressor.compress_ratio = 1
-    official_compressor.wkv = torch.nn.Linear(config.dim, config.head_dim, bias=False, dtype=dtype)
+    official_compressor.wkv = torch.nn.Linear(
+        config.dim, config.head_dim, bias=False, dtype=dtype
+    )
     official_compressor.norm = official_norm(config.head_dim, config.eps).to(dtype)
     official_indexer.owns_k = True
     official_indexer.compress_ratio = 1
@@ -370,14 +387,18 @@ def test_v41_ced_boundaries_match_pinned_official_oracle(dtype, length, monkeypa
 
     handle = official_indexer.k_norm.register_forward_hook(capture_index)
     try:
-        with pytest.raises(BoundaryCaptured, match="official pre-RoPE boundary reached"):
+        with pytest.raises(
+            BoundaryCaptured, match="official pre-RoPE boundary reached"
+        ):
             official_indexer(x20, None, latent20, 0, 0)
     finally:
         handle.remove()
     actual = {}
     handles = [
         attention.register_forward_pre_hook(
-            lambda module, inputs: actual.update({"ced.x20": inputs[0].detach().clone()})
+            lambda module, inputs: actual.update(
+                {"ced.x20": inputs[0].detach().clone()}
+            )
         )
     ]
     for module, stage in (
@@ -411,9 +432,12 @@ def test_v41_nested_config_drives_attention(tmp_path):
     import copy
     import json
     from pathlib import Path
+
     from megatron.lite.model.deepseek_v41.config import DeepseekV41Config
 
-    reference = Path(__file__).parents[2] / 'fixtures/deepseek_v41/reference/config.json'
+    reference = (
+        Path(__file__).parents[2] / 'fixtures/deepseek_v41/reference/config.json'
+    )
     release = json.loads(reference.read_text())
     tiny = copy.deepcopy(release)
     tiny['text_config'].update(
@@ -461,9 +485,12 @@ def test_v41_nested_config_drives_attention(tmp_path):
 def test_v41_config_rejects_unimplemented_topology(field, value):
     import json
     from pathlib import Path
+
     from megatron.lite.model.deepseek_v41.config import DeepseekV41Config
 
-    reference = Path(__file__).parents[2] / 'fixtures/deepseek_v41/reference/config.json'
+    reference = (
+        Path(__file__).parents[2] / 'fixtures/deepseek_v41/reference/config.json'
+    )
     release = json.loads(reference.read_text())
     release['text_config'][field] = value
     with pytest.raises(ValueError, match=field):
@@ -471,9 +498,10 @@ def test_v41_config_rejects_unimplemented_topology(field, value):
 
 
 def _assembly_config():
+    import importlib.util
     import json
     from pathlib import Path
-    import importlib.util
+
     from megatron.lite.model.deepseek_v41.config import DeepseekV41Config
 
     root = Path(__file__).parents[2] / 'fixtures/deepseek_v41'
@@ -523,7 +551,9 @@ def test_v41_registry_assembly_forward_and_parameter_owners(moe):
     model = bundle.chunks[0]
     assert resolve_model_type_from_hf(_assembly_config().to_hf_dict()) == 'deepseek_v41'
     assert len(model.layers) == 40
-    assert model.vision is not None and model.aligner is not None and model.mtp is not None
+    assert (
+        model.vision is not None and model.aligner is not None and model.mtp is not None
+    )
     owners = list(model.parameter_bindings())
     assert len({id(b.tensor) for b in owners}) == len(owners)
     assert {id(b.tensor) for b in owners} == {id(p) for p in model.parameters()}
@@ -536,7 +566,9 @@ def test_v41_registry_assembly_forward_and_parameter_owners(moe):
     assert output['log_probs'].shape == (6,)
     assert torch.isfinite(output['log_probs']).all()
     targets = torch.tensor([5, 6, 0, 8, 3, 0])
-    expected_loss = torch.nn.functional.cross_entropy(output['logits'], targets, reduction='none')
+    expected_loss = torch.nn.functional.cross_entropy(
+        output['logits'], targets, reduction='none'
+    )
     torch.testing.assert_close(output['log_probs'], -expected_loss)
     torch.testing.assert_close(output['loss'], expected_loss[[0, 1, 3, 4]].mean())
     output['loss'].backward()
@@ -544,8 +576,12 @@ def test_v41_registry_assembly_forward_and_parameter_owners(moe):
     assert model.layers[20].attn.compressor.wkv.weight.grad.abs().sum() > 0
     assert all(p.grad is None for p in model.layers[20].attn.indexer.parameters())
     # Each packed sample gets fresh attention/Engram state and local positions.
-    independent = torch.cat([model(ids[:3][None])['logits'], model(ids[3:][None])['logits']], 1)
-    torch.testing.assert_close(model(ids[None], cu_seqlens=batch.cu_seqlens)['logits'], independent)
+    independent = torch.cat(
+        [model(ids[:3][None])['logits'], model(ids[3:][None])['logits']], 1
+    )
+    torch.testing.assert_close(
+        model(ids[None], cu_seqlens=batch.cu_seqlens)['logits'], independent
+    )
     for call in (
         lambda: model.vision(None),
         lambda: model.aligner(None),
@@ -561,21 +597,25 @@ def test_v41_fixture_headers_and_complete_release_key_owners(moe):
     import itertools
     import json
     from pathlib import Path
-    from megatron.lite.model.deepseek_v41.lite.checkpoint import bind_checkpoint
+
     from megatron.lite.model.deepseek_v41.config import DeepseekV41Config
+    from megatron.lite.model.deepseek_v41.lite.checkpoint import bind_checkpoint
     from megatron.lite.model.deepseek_v41.lite.model import DeepseekV41Model
 
     root = Path(__file__).parents[3]
-    records = json.loads((root / 'tests/fixtures/deepseek_v41/manifest.json').read_text())[
-        'tensors'
-    ]
+    records = json.loads(
+        (root / 'tests/fixtures/deepseek_v41/manifest.json').read_text()
+    )['tensors']
     _, bundle = _assembly_bundle(device='meta')
     bindings = bind_checkpoint(bundle.chunks[0], records, allow_missing_mtp=True)
     assert len(bindings) == 3204
     with pytest.raises(ValueError, match='coverage'):
         bind_checkpoint(bundle.chunks[0], records)
     # Quantization scales are owned by the same live module as their weights.
-    assert bindings['layers.0.attn.wo_a.scale'].owner is bundle.chunks[0].layers[0].attn.wo_a
+    assert (
+        bindings['layers.0.attn.wo_a.scale'].owner
+        is bundle.chunks[0].layers[0].attn.wo_a
+    )
     bad = [dict(r) for r in records]
     next(r for r in bad if r['name'] == 'layers.0.attn.wq_a.weight')['shape'] = [1, 1]
     with pytest.raises(ValueError, match='shape'):
@@ -584,28 +624,35 @@ def test_v41_fixture_headers_and_complete_release_key_owners(moe):
         bind_checkpoint(bundle.chunks[0], records[1:], allow_missing_mtp=True)
     with pytest.raises(ValueError, match='duplicate'):
         bind_checkpoint(bundle.chunks[0], records + records[:1], allow_missing_mtp=True)
-    release = json.loads((root / 'tests/fixtures/deepseek_v41/reference/config.json').read_text())
+    release = json.loads(
+        (root / 'tests/fixtures/deepseek_v41/reference/config.json').read_text()
+    )
     with torch.device('meta'):
         model = DeepseekV41Model(DeepseekV41Config(release))
-    families = json.loads((root / 'docs/contracts/deepseek_v41/weights.json').read_text())[
-        'families'
+    families = json.loads(
+        (root / 'docs/contracts/deepseek_v41/weights.json').read_text()
+    )['families']
+    keys = [
+        f['pattern'].format(*ix)
+        for f in families
+        for ix in itertools.product(*f['indices'])
     ]
-    keys = [f['pattern'].format(*ix) for f in families for ix in itertools.product(*f['indices'])]
     all_bindings = bind_checkpoint(model, keys)
     assert len(all_bindings) == 96085
     assert sum(k.startswith('mtp.') for k in all_bindings) == 2401
     assert all(b.owner is not None for b in all_bindings.values())
-    assert {id(b.tensor) for b in model.parameter_bindings()} == {id(p) for p in model.parameters()}
+    assert {id(b.tensor) for b in model.parameter_bindings()} == {
+        id(p) for p in model.parameters()
+    }
     with pytest.raises(ValueError, match='coverage'):
         bind_checkpoint(model, keys + ['layers.3.attn.compressor.wkv.weight'])
 
 
 def test_v41_assembly_checkpoint_updates_backbone_preserves_archive(tmp_path, moe):
-    from megatron.lite.model.deepseek_v41.lite.checkpoint import (
-        save_model,
-        load_model,
+    from megatron.lite.model.deepseek_v41.lite.checkpoint import load_model, save_model
+    from megatron.lite.model.deepseek_v41.lite.checkpoint_store import (
+        CheckpointTensorStore,
     )
-    from megatron.lite.model.deepseek_v41.lite.checkpoint_store import CheckpointTensorStore
     from safetensors.torch import save_file
 
     _, bundle = _assembly_bundle(trainable_engram=True)
@@ -625,7 +672,8 @@ def test_v41_assembly_checkpoint_updates_backbone_preserves_archive(tmp_path, mo
     load_model(restored.chunks[0], output)
     torch.testing.assert_close(restored.chunks[0].embed.weight, before + 0.25)
     torch.testing.assert_close(
-        restored.chunks[0].layers[1].engram.embed.master, model.layers[1].engram.embed.master
+        restored.chunks[0].layers[1].engram.embed.master,
+        model.layers[1].engram.embed.master,
     )
     for binding in restored.chunks[0].checkpoint_bindings.values():
         assert binding.header is not None and binding.store is not None
@@ -640,7 +688,8 @@ def test_v41_assembly_final_shifted_mix_and_engram_reachability(moe, monkeypatch
     model = bundle.chunks[0]
     calls = []
     hooks = [
-        model.layers[i].engram.register_forward_hook(lambda *args: calls.append(1)) for i in (1, 14)
+        model.layers[i].engram.register_forward_hook(lambda *args: calls.append(1))
+        for i in (1, 14)
     ]
     ids = torch.tensor([[1, 3, 5]])
     model(ids)
@@ -650,7 +699,9 @@ def test_v41_assembly_final_shifted_mix_and_engram_reachability(moe, monkeypatch
     h = torch.randn(1, 3, 4, 128)
     p = torch.tensor([0.1, 0.7, 0.2, 0.4]).expand(1, 3, 4)
     monkeypatch.setattr(model, '_sequence', lambda *args, **kwargs: (h, p))
-    expected = torch.nn.functional.linear(model.norm((h * p[..., None]).sum(2)), model.head.weight)
+    expected = torch.nn.functional.linear(
+        model.norm((h * p[..., None]).sum(2)), model.head.weight
+    )
     torch.testing.assert_close(model(ids)['logits'], expected)
     # Alias injection must be rejected even when the key count stays unchanged.
     from dataclasses import replace
@@ -672,9 +723,7 @@ def test_v41_registry_quantized_cuda_forward_backward(moe):
     bundle = proto.build_model(
         _assembly_config(),
         impl_cfg=proto.ImplConfig(
-            device='cuda',
-            token_map=list(range(256)),
-            quantized=True,
+            device='cuda', token_map=list(range(256)), quantized=True
         ),
     )
     model = bundle.chunks[0]
@@ -684,4 +733,433 @@ def test_v41_registry_quantized_cuda_forward_backward(moe):
     assert torch.isfinite(output['loss'])
     output['loss'].backward()
     gradient = model.layers[20].attn.compressor.wkv.weight.grad
-    assert gradient is not None and torch.isfinite(gradient).all() and gradient.abs().sum() > 0
+    assert (
+        gradient is not None
+        and torch.isfinite(gradient).all()
+        and gradient.abs().sum() > 0
+    )
+
+
+def test_v41_real_pipeline_ranges_match_monolithic_gradients(moe):
+    _, bundle = _assembly_bundle()
+    model = bundle.chunks[0]
+    ids = torch.tensor([[3, 4, 5, 6, 7, 8, 9, 10]])
+    expected = model(ids)['logits']
+    coefficients = torch.linspace(-0.5, 1.0, expected.numel()).reshape_as(expected)
+    (expected * coefficients).sum().backward()
+    gradients = {
+        name: None if p.grad is None else p.grad.detach().clone()
+        for name, p in model.named_parameters()
+    }
+    model.zero_grad(set_to_none=True)
+    payload, owners = None, (-1, -1)
+    for start, end in ((0, 20), (20, 24), (24, 32), (32, 40)):
+        payload, owners = model.forward_pipeline_range(
+            ids, start=start, end=end, payload=payload, owners=owners
+        )
+        assert payload.ced_h is not None and payload.ced_p is not None
+        if end > 20:
+            assert owners == (20, ((end - 1 - 20) // 4) * 4 + 20)
+            assert payload.candidates is not None
+        if end == 24:
+            owner_kv = payload.kv
+        if end > 24:
+            assert payload.kv is owner_kv
+    actual = model.finish_pipeline(payload)
+    torch.testing.assert_close(
+        actual,
+        expected,
+        atol=0,
+        rtol=0,
+        msg=lambda detail: 'Real C4 pipeline logits differ from monolithic reference: '
+        + detail,
+    )
+    (actual * coefficients).sum().backward()
+    for name, parameter in model.named_parameters():
+        reference = gradients[name]
+        if reference is None:
+            assert parameter.grad is None, name
+        else:
+            torch.testing.assert_close(
+                parameter.grad,
+                reference,
+                atol=0,
+                rtol=0,
+                msg=lambda detail, name=name: "Real C4 pipeline gradient differs for "
+                + name
+                + ": "
+                + detail,
+            )
+    assert gradients['layers.20.attn.compressor.wkv.weight'].abs().sum() > 0
+
+
+def test_v41_pipeline_protocol_preserves_text_loss(moe):
+    from megatron.lite.runtime.contracts import PackedBatch
+
+    proto, bundle = _assembly_bundle()
+    model = bundle.chunks[0]
+    ids = torch.arange(3, 11)
+    batch = PackedBatch(ids, ids.roll(-1), torch.tensor([8]), torch.ones(8))
+    expected = bundle.forward_step(model, batch)
+    payload, owners = None, (-1, -1)
+    for start, end in ((0, 20), (20, 24), (24, 32), (32, 40)):
+        output = proto.pipeline_forward_step(
+            model, batch, start=start, end=end, payload=payload, owners=owners
+        )
+        payload, owners = output['pipeline_payload'], output['pipeline_owners']
+        assert ('loss' in output) == (end == 40)
+    for name in ('logits', 'log_probs', 'loss'):
+        torch.testing.assert_close(output[name], expected[name], atol=0, rtol=0)
+    packed = PackedBatch(ids, ids.roll(-1), torch.tensor([4, 4]), torch.ones(8))
+    with pytest.raises(NotImplementedError, match='packed'):
+        proto.pipeline_forward_step(model, packed, start=0, end=20)
+
+
+def test_v41_pipeline_constructor_allocates_only_local_owners(moe, monkeypatch):
+    from megatron.lite.model.deepseek_v41.lite import model as model_module
+
+    _, reference_bundle = _assembly_bundle()
+    reference = reference_bundle.chunks[0]
+    expected = {b.release_key for b in reference.parameter_bindings()}
+    original_attention = model_module.CSA2Attention
+    constructed = []
+
+    def counted(config, layer_id):
+        constructed.append(layer_id)
+        return original_attention(config, layer_id)
+
+    monkeypatch.setattr(model_module, 'CSA2Attention', counted)
+    assigned = set()
+    for start, end in ((0, 20), (20, 24), (24, 32), (32, 40)):
+        constructed.clear()
+        stage = model_module.DeepseekV41Model(
+            reference.config,
+            token_map=list(range(256)),
+            quantized=False,
+            layer_range=(start, end),
+        )
+        assert constructed == list(range(start, end)), 'Non-owner layer was allocated'
+        assert stage.local_layer_range == (start, end)
+        assert [i for i, layer in enumerate(stage.layers) if layer is not None] == list(
+            range(start, end)
+        )
+        assert (stage.embed is not None) == (start == 0)
+        assert (stage.norm is not None) == (end == 40)
+        assert (stage.head is not None) == (end == 40)
+        bindings = list(stage.parameter_bindings())
+        keys = {binding.release_key for binding in bindings}
+        assert not assigned & keys, 'A parameter owner was assigned to two PP ranks'
+        assigned.update(keys)
+        assert {id(binding.tensor) for binding in bindings} == {
+            id(p) for p in stage.parameters()
+        }
+        stage.validate_parameter_bindings()
+        from megatron.lite.model.deepseek_v41.lite.checkpoint import export_model
+
+        with pytest.raises(NotImplementedError, match='stage export'):
+            list(export_model(stage))
+        with pytest.raises(RuntimeError, match='stage'):
+            stage(torch.tensor([[3, 4]]))
+    assert assigned == expected, 'PP local owners do not cover the monolithic model'
+
+
+def test_v41_packed_pipeline_matches_monolithic(moe):
+    from megatron.lite.runtime.contracts import PackedBatch
+
+    proto, bundle = _assembly_bundle()
+    model = bundle.chunks[0]
+    ids = torch.arange(3, 19)
+    batch = PackedBatch(ids, ids.roll(-1), torch.tensor([5, 8, 3]), torch.ones(16))
+    expected = bundle.forward_step(model, batch)
+    expected['loss'].backward()
+    gradients = {
+        n: None if p.grad is None else p.grad.clone()
+        for n, p in model.named_parameters()
+    }
+    model.zero_grad(set_to_none=True)
+    state = None
+    for start, end in ((0, 20), (20, 24), (24, 32), (32, 40)):
+        output = proto.packed_pipeline_forward_step(
+            model, batch, start=start, end=end, state=state
+        )
+        state = output['packed_pipeline_state']
+        assert [payload.h.shape[1] for payload, owners in state] == [5, 8, 3]
+    for key in ('logits', 'log_probs', 'loss'):
+        torch.testing.assert_close(
+            output[key],
+            expected[key],
+            atol=0,
+            rtol=0,
+            msg=lambda detail: 'Packed PP differs from monolithic reference: ' + detail,
+        )
+    output['loss'].backward()
+    for name, parameter in model.named_parameters():
+        if gradients[name] is None:
+            assert parameter.grad is None, name
+        else:
+            torch.testing.assert_close(
+                parameter.grad,
+                gradients[name],
+                atol=1e-6,
+                rtol=1e-5,
+                msg=lambda detail, name=name: 'Packed PP gradient differs: '
+                + name
+                + ': '
+                + detail,
+            )
+
+
+def _real_model_worker(rank, rendezvous):
+    from datetime import timedelta
+
+    import torch.distributed as dist
+    from megatron.lite.model.deepseek_v41.lite import pipeline, protocol
+    from megatron.lite.primitive.parallel import tensor_payload as transport
+    from megatron.lite.runtime.contracts import PackedBatch, ParallelConfig
+
+    torch.cuda.set_device(rank)
+    device = torch.device('cuda', rank)
+    torch.manual_seed(1729)
+    # Compute an independent monolithic reference, retain only this rank's
+    # weights/gradients, then discard the full model before PP construction.
+    bundle = protocol.build_model(
+        _assembly_config(),
+        impl_cfg=protocol.ImplConfig(
+            device=str(device),
+            dtype=torch.float32,
+            quantized=False,
+            token_map=list(range(256)),
+        ),
+    )
+    model = bundle.chunks[0]
+    reference_parameter_count = sum(p.numel() for p in model.parameters())
+    boundaries = (0, 10, 20, 30, 40)
+    start, end = boundaries[rank : rank + 2]
+    owned_modules = list(model.layers[start:end])
+    if rank == 0:
+        owned_modules.append(model.embed)
+    if rank == 3:
+        owned_modules.extend((model.norm, model.head))
+    owned_ids = {id(p) for module in owned_modules for p in module.parameters()}
+    bindings = [b for b in model.parameter_bindings() if id(b.tensor) in owned_ids]
+    assert {id(b.tensor) for b in bindings} == owned_ids
+    params = [b.tensor for b in bindings if b.tensor.requires_grad]
+    inputs = [torch.arange(3 + mb, 11 + mb, device=device)[None] for mb in range(2)]
+    batches = [
+        PackedBatch(ids[0], None, torch.tensor([ids.numel()], device=device))
+        for ids in inputs
+    ]
+    reference_logits = []
+    for mb, ids in enumerate(inputs):
+        logits = bundle.forward_step(model, batches[mb])['logits']
+        reference_logits.append(logits.detach())
+        coefficients = torch.linspace(
+            -0.5, 1.0, logits.numel(), device=device
+        ).reshape_as(logits)
+        (logits * coefficients * (mb + 1)).sum().backward()
+    reference_grads = {
+        binding.release_key: (
+            None
+            if binding.tensor.grad is None
+            else binding.tensor.grad.detach().clone()
+        )
+        for binding in bindings
+        if binding.tensor.requires_grad
+    }
+    if model.engram_hash is not None:
+        owned_modules.append(model.engram_hash)
+    owned_values = {
+        id(value)
+        for module in owned_modules
+        for value in (*module.parameters(), *module.buffers())
+    }
+    local_state = {
+        name: tensor.detach().clone()
+        for name, tensor in model.state_dict(keep_vars=True).items()
+        if id(tensor) in owned_values
+    }
+    import gc
+    import weakref
+
+    reference_model = weakref.ref(model)
+    del model, bundle, owned_modules, bindings, params, logits
+    gc.collect()
+    assert (
+        reference_model() is None
+    ), 'Full reference model remained live during PP construction'
+    dist.init_process_group(
+        'nccl',
+        init_method=rendezvous,
+        rank=rank,
+        world_size=4,
+        timeout=timedelta(seconds=120),
+    )
+    bundle = protocol.build_model(
+        _assembly_config(),
+        impl_cfg=protocol.ImplConfig(
+            device=str(device),
+            dtype=torch.float32,
+            quantized=False,
+            token_map=list(range(256)),
+            parallel=ParallelConfig(pp=4),
+        ),
+    )
+    model = bundle.chunks[0]
+    assert model.local_layer_range == (start, end)
+    assert [i for i, layer in enumerate(model.layers) if layer is not None] == list(
+        range(start, end)
+    ), 'PP constructor allocated non-owner layers'
+    assert (
+        sum(p.numel() for p in model.parameters()) < reference_parameter_count
+    ), 'PP parameter allocation did not shrink to the local stage'
+    model.load_state_dict(local_state, strict=True)
+    del local_state
+    bindings = list(model.parameter_bindings())
+    owned_ids = {id(p) for p in model.parameters()}
+    assert {id(binding.tensor) for binding in bindings} == owned_ids
+    params = [binding.tensor for binding in bindings if binding.tensor.requires_grad]
+    assert bundle.parallel_state.pp_rank == rank and bundle.parallel_state.pp_size == 4
+    group = bundle.parallel_state.pp_group
+    ledger = pipeline.PipelineLedger()
+    incoming, outputs, errors = [], [], []
+    stage_results = []
+
+    def owners_at(boundary):
+        if boundary == 0:
+            return (-1, -1)
+        if boundary == 10:
+            return (8, 8)
+        if boundary == 20:
+            return (14, 14)
+        return (20, 20 + ((boundary - 1 - 20) // 4) * 4)
+
+    def tag_at(boundary, mb):
+        return pipeline.PipelineTag(11, mb, boundary, 0, *owners_at(boundary))
+
+    def compare(actual, expected, label):
+        try:
+            torch.testing.assert_close(actual, expected, atol=3e-5, rtol=3e-5)
+        except AssertionError as exc:
+            errors.append(label + ': ' + str(exc))
+
+    try:
+        for mb, ids in enumerate(inputs):
+            payload = None
+            if rank:
+                payload = pipeline.PairedPayload.from_tensors(
+                    transport.recv_tensor_payload(
+                        (*tag_at(start, mb).as_tuple(), 0),
+                        peer=rank - 1,
+                        group=group,
+                        device=device,
+                    )
+                )
+            incoming.append(payload)
+            stage_result = protocol.pipeline_forward_step(
+                model,
+                batches[mb],
+                start=start,
+                end=end,
+                payload=payload,
+                owners=owners_at(start),
+            )
+            output, owners = (
+                stage_result['pipeline_payload'],
+                stage_result['pipeline_owners'],
+            )
+            stage_results.append(stage_result)
+            assert owners == owners_at(end), 'Real C4 range changed the canonical owner'
+            outputs.append(output)
+            if rank < 3:
+                ledger.publish(tag_at(end, mb), output, consumers=(rank + 1,))
+                transport.send_tensor_payload(
+                    output.tensors(),
+                    (*tag_at(end, mb).as_tuple(), 0),
+                    peer=rank + 1,
+                    group=group,
+                    device=device,
+                )
+            else:
+                compare(stage_result['logits'], reference_logits[mb], 'real C4 logits')
+        for mb in reversed(range(2)):
+            if rank == 3:
+                logits = stage_results[mb]['logits']
+                coefficients = torch.linspace(
+                    -0.5, 1.0, logits.numel(), device=device
+                ).reshape_as(logits)
+                (logits * coefficients * (mb + 1)).sum().backward()
+            else:
+                returned = transport.recv_tensor_payload(
+                    (*tag_at(end, mb).as_tuple(), 1),
+                    peer=rank + 1,
+                    group=group,
+                    device=device,
+                )
+                ledger.return_gradients(
+                    tag_at(end, mb),
+                    rank + 1,
+                    {
+                        name: value
+                        for name, value in zip(pipeline.PAYLOAD_FIELDS, returned)
+                        if value is not None
+                    },
+                )
+                ledger.backward(tag_at(end, mb))
+            if rank:
+                fields = incoming[mb].differentiable()
+                returned = {
+                    name: torch.zeros_like(value) if value.grad is None else value.grad
+                    for name, value in fields.items()
+                }
+                transport.send_tensor_payload(
+                    tuple(returned.get(name) for name in pipeline.PAYLOAD_FIELDS),
+                    (*tag_at(start, mb).as_tuple(), 1),
+                    peer=rank - 1,
+                    group=group,
+                    device=device,
+                )
+        ledger.assert_quiescent()
+        for binding in bindings:
+            p = binding.tensor
+            if not p.requires_grad:
+                assert p.grad is None, 'Frozen indexer received a gradient'
+                continue
+            expected = reference_grads[binding.release_key]
+            if expected is None or p.grad is None:
+                if (expected is None) != (p.grad is None):
+                    errors.append(
+                        binding.release_key + ': missing or unexpected gradient'
+                    )
+            else:
+                compare(p.grad, expected, binding.release_key + ' gradient')
+        before = {id(p): p.detach().clone() for p in params}
+        torch.optim.SGD(params, lr=1e-4).step()
+        for binding in bindings:
+            p = binding.tensor
+            if p.requires_grad:
+                g = reference_grads[binding.release_key]
+                expected = before[id(p)] if g is None else before[id(p)] - 1e-4 * g
+                compare(p, expected, binding.release_key + ' single owner update')
+        all_errors = [None] * 4
+        dist.all_gather_object(all_errors, errors)
+        failures = [message for rank_errors in all_errors for message in rank_errors]
+        if failures:
+            raise AssertionError(
+                'Real C4 pipeline differs from monolithic reference: ' + failures[0]
+            )
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.gpus(4)
+def test_real_c4_pipeline_four_rank_forward_backward_update(tmp_path):
+    import os
+
+    import torch.multiprocessing as mp
+
+    assert os.getenv('SLURM_JOB_ID'), 'Real C4 pipeline validation requires Slurm'
+    if torch.cuda.device_count() < 4:
+        pytest.skip('Requires the declared four-GPU allocation')
+    mp.spawn(
+        _real_model_worker, args=(f'file://{tmp_path}/real-c4',), nprocs=4, join=True
+    )


### PR DESCRIPTION
Integrate the real C4 model with contiguous pipeline layer ranges, local PP parameter ownership and per-sequence packed state. Carry the paired HC/CED state and actual CSA2 owner state through range forward/backward; keep embedding on the first stage and norm/head on the last. Standalone stage export fails explicitly until distributed checkpoint assembly exists.

Review scope: C4 base `57d30df479d74658244baca1c05d8284ecd98f9f`; head `cb8f682e3eb55f4413c48ac8e0c0f68a027234eb`; **3 commits, 6 changed files, +1152/-93**. The integration now includes `pipeline.py`, fixing the runtime import failure on the C4 base alone. It is byte-identical to #211's copy; this is the sole shared changed file. All other standalone primitives and Sinkhorn remain in #211.

This PR is self-contained on its C4 base and does not require a #211 patch to execute. Required merge order: **main → #212 (C) → #210 (D) → #213 (C4) → #211 → #215**, followed by #218 (G1). #211 must land after C4 #213 and before #215. Optimizer routing remains owned by #216. Model/protocol/test edits may need rebasing against #214/#216, which share C4.

Validation of the assembled dependencies plus this integration: CPU 72 passed, 3 GPU cases deselected, exit 0; changed-file formatting passed. The CP1 packed range case uses unequal lengths [5,8,3], compares logits/log-probabilities/loss to the full packed model, and checks parameter gradients. This is CPU semantic evidence, not distributed packed/CP acceptance.

Earlier real four-rank evidence: 18370130 (3 passed); reachability 18370429 (`REAL C4 PIPELINE RANGE REACHABILITY PROBE`); CED mutation 18370431 (`Real C4 pipeline differs from monolithic reference: embed.weight gradient`). Local owner baseline 18371700 (1 passed, 2 deselected, no skips, 0:0); constructor probe 18372508; non-owner allocation mutation 18372509 (`PP constructor allocated non-owner layers`); CED mutation 18372510 (named monolithic gradient mismatch, maximum absolute difference 2.292509 vs 3e-5). The real C4 GPU test has since moved into the existing semantics test file; these job IDs describe the earlier tested layout, not a rerun of this final head.

Remaining work: common PP scheduler, distributed packed/THD and CP validation, TP/EP combinations, global mixed-optimizer coordination and text/vision restart/export. Dense results do not establish packed correctness. Overall submit requires a completed standard full-regression run of the final remote delivery state with added failures = 0 against mainparent 18354480. No overall completion or final-head no-regression claim is made.


Previous-head independent full regression: Slurm **18382664**, node pool0-01789, exact clean `aaecac5e94d3674865d61f9d9a819294541a4c87` tree on C4, tools present, no #211 patch. Unchanged tests7064.sbatch, full default selection, no -k or MLITE_TEST_SELECTION. Result: **20 failed, 759 passed, 23 skipped, 5 errors**, 171.04 seconds; sacct FAILED 1:0. All 25 failure/error IDs exactly match mainparent 18354480: **added = 0, removed = 0**. Existing baseline failures remain; this is not an all-green result. Earlier job 18379378 tested an assembled tree and is superseded for independent-merge evidence. Remaining distributed acceptance boundaries above still apply.


Reviewer-provided full-stack validation: the chain `main ← #212 ← #210 ← #213 ← #211 ← #215 ← #218` merged cleanly and ran as Slurm **18384558**: **12 failed, 870 passed**, with **added = 0, removed = 8** relative to mainparent 18354480. This supplements the independent PR regression evidence above. The reviewer also verified that the shared `pipeline.py` copies are identical and merge cleanly in this order.


Stage-boundary guard coverage: two tests in the existing semantics file assert the exact ValueError message for a range outside the local stage and the exact RuntimeError message for output on a nonfinal stage. Replacing each corresponding raise with pass independently makes its new test fail (1 failed each, exit 1). Restored tests: 2 passed; full CPU file: 36 passed, 2 GPU cases skipped, exit 0. Formatting passed. Final-head independent full regression **18385779** on pool0-01829 used the clean `cb8f682e3eb55f4413c48ac8e0c0f68a027234eb` tree, with tools and pipeline.py present and sinkhorn.py absent, without a #211 patch. The unchanged standard harness ran the full default selection: **20 failed, 761 passed, 23 skipped, 5 errors in 159.99s**; sacct FAILED 1:0. Against mainparent 18354480, the 25 failure/error IDs match exactly: **added = 0, removed = 0**. The two new guard tests pass in this full run; baseline failures remain.
