### PR TITLE
Add head-wise Muon and object-based V4.1 optimizer routing

### DIFF
--- a/experimental/lite/docs/specs/deepseek_v41_optimizer_routing.md
+++ b/experimental/lite/docs/specs/deepseek_v41_optimizer_routing.md
@@ -1,0 +1,108 @@
+# V4.1 logical optimizer routing
+
+The single-rank text protocol constructs an actual Muon/Sinkhorn/AdamW stack.
+It consumes module objects and validates their checkpoint bindings. Parameter
+names are audit labels only. An unknown owner, alias, active indexer, unresolved
+head count, unsupported backend, or missing NS configuration raises an error.
+Archival vision and DSpark tensors are not trainable parameters. A future active
+vision implementation must register its explicit routing and trainability mask;
+there is no matrix-shaped catch-all route.
+
+## Backend and numerical contract
+
+Muon reuses NVIDIA `emerging-optimizers==0.3.0`, tag
+[`b309e2f01cda75dc96a6dc1a2355a7b3b64b5e16`](https://github.com/NVIDIA-NeMo/Emerging-Optimizers/tree/b309e2f01cda75dc96a6dc1a2355a7b3b64b5e16).
+The consumed API is `muon_utils.newton_schulz(matrix, steps, coefficient_type)`.
+The audited `muon_utils.py` SHA256 is
+`81319fbb67d1ec0663a9d954388696f933a6b0500e1d2cc8841469e6548ea75f`.
+No NS polynomial is duplicated in MLite. NS steps and coefficient family must
+be supplied explicitly; the example below is a port recipe, not a claim about
+unpublished official NS settings. Each head uses the same unbatched backend
+call as its independent reference, with highest FP32 matmul precision.
+
+For each logical matrix, `M = .95 M + .05 G`, `N = .95 M + .05 G`.
+The NS direction is normalized to RMS .18 (zero stays zero), followed by
+decoupled decay and the group's LR. These are separate operations: the RMS
+correction does not multiply weight decay. FP32 momentum is owned by the
+original physical parameter; splitting creates no new parameter owners.
+
+| Actual owner | Algorithm / logical partition | LR | Decay |
+|---|---|---|---|
+| Text embedding and prediction head | Sinkhorn, each complete matrix | base | 0 |
+| Trainable Engram table master | Sinkhorn, complete logical table | 5x | 0 |
+| Attention `wq_b` | Muon, `[heads, head_dim, q_rank]` | base | .1 |
+| Attention `wq_a`, shared latent `wkv` | Muon, one matrix each | base | .1 |
+| `wo_a`, `wo_b`, compressor projections, each expert projection, router, HC linear | Muon, each existing physical matrix; no new `wo_a` grouping | base | .1 |
+| Engram projection | Muon, one matrix | 5x | .1 |
+| Norms, including matrix-shaped Engram gains | AdamW, elementwise | base / Engram 5x | .1 |
+| Learned HC bias/scale and attention sink | AdamW, elementwise | base | 0 |
+| Indexer and router correction buffers | No optimizer group | — | — |
+
+AdamW uses betas (.9, .95) and epsilon 1e-20. Sinkhorn reuses the shared
+Algorithm-1 primitive: K=11, tau=1e-3, epsilon=1e-20, momentum=.95, gamma=.18,
+fresh normalization on each step, no weight decay. Engram's construction-time
+switch controls its persistent FP32 table master. Frozen tables retain FP8
+storage and scales without allocating table optimizer state.
+
+## Gradient and publication contract
+
+Optimizer-enabled construction preserves FP32 parameter masters while retaining
+BF16 residual computation. Floating linear and FP4 STE weight gradients use
+an FP32 GEMM directly; the FP8 provider returns its FP32 weight GEMM to the
+master without an intervening BF16 cast. This is a numerical correctness
+provider, not a claim of TE fused accumulation. Autocast is disabled around
+weight-gradient GEMMs. The post-accumulation hook exposes the native `.grad`
+buffer as `main_grad`; it does not widen or copy a BF16 gradient.
+
+The coordinator computes one global norm and clips all active groups together.
+Muon/Sinkhorn stage weight and momentum candidates. AdamW uses the actual Torch
+backend on private candidate parameters/state. Engram candidate storage/scales
+are encoded before any backend publishes. Nonfinite inputs/candidates or a
+candidate-encoding exception leave live weights, optimizer states, and table storage
+unchanged. An accepted step publishes all three algorithms and Engram scales.
+
+This local coordinator uses extra candidate storage, including an AdamW copy.
+It is not a distributed/state-sharded performance implementation. TP/EP/CP/PP,
+offload, and logical reassembly remain explicitly unsupported by this protocol.
+Checkpoint model state together with `bundle.optimizer.state_dict()`; optimizer
+restore validates owner ordering and logical matrix layouts. HF export is not
+a substitute for restoring high-precision training masters.
+
+## Use and validation
+
+Install the pinned optional Muon dependency in the execution environment:
+
+```sh
+python -m pip install emerging-optimizers==0.3.0
+```
+
+```python
+import torch
+from megatron.lite.model.deepseek_v41.lite import protocol
+from megatron.lite.model.deepseek_v41.lite.optimizer_groups import OptimizerConfig
+
+bundle = protocol.build_model(
+    model_config,
+    impl_cfg=protocol.ImplConfig(
+        device='cuda', dtype=torch.bfloat16, quantized=True,
+        token_map=token_map, trainable_engram=True,
+        optimizer='muon',
+        optimizer_config=OptimizerConfig(
+            lr=1e-3, ns_steps=5, coefficient_type='quintic', clip_grad=1.0,
+        ),
+    ),
+)
+bundle.optimizer.zero_grad()
+bundle.forward_step(bundle.chunks[0], packed_batch)['loss'].backward()
+successful, grad_norm, _ = bundle.optimizer.step()
+```
+
+Tests are integrated in `tests/unit/model/test_deepseek_v41_semantics.py`.
+The distinct-head test compares three updates and momentum against separate
+per-head NVIDIA calls, bitwise, and confirms that a whole-matrix update differs.
+The native-gradient test checks two microbatches against direct FP32 products,
+including a BF16 autocast context, and rejects BF16-roundtrippable gradients.
+Actual-bundle tests check both Engram modes, owner coverage, live backend types,
+FP32 momentum, update reachability, atomic failure, and exact resumed updates.
+CUDA variants exercise the quantized model and require the repository's GPU
+harness; a CPU skip does not validate them.

--- a/experimental/lite/megatron/lite/model/deepseek_v41/lite/attention.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v41/lite/attention.py
@@ -94,6 +94,12 @@ class Linear(nn.Linear):
         self.fp8 = fp8
 
     def forward(self, x):
+        if getattr(self, 'native_fp32', False) and not self.fp8:
+            from megatron.lite.primitive.modules.native_fp32_linear import (
+                native_fp32_linear,
+            )
+
+            return native_fp32_linear(x, self.weight)
         return (
             ds41_fp8.dynamic_fp8_linear(x, self.weight)
             if self.fp8
@@ -275,5 +281,18 @@ class CSA2Attention(nn.Module):
         output = rotate(output, positions, c, ratio, inverse=True)
         grouped = output.reshape(b, length, c.groups, -1)
         weight = self.wo_a.weight.reshape(c.groups, c.o_rank, -1)
-        output = torch.einsum('bsgd,grd->bsgr', grouped, weight).flatten(2)
+        if getattr(self.wo_a, 'native_fp32', False):
+            from megatron.lite.primitive.modules.native_fp32_linear import (
+                native_fp32_linear,
+            )
+
+            output = torch.stack(
+                [
+                    native_fp32_linear(grouped[:, :, i], weight[i])
+                    for i in range(c.groups)
+                ],
+                dim=2,
+            ).flatten(2)
+        else:
+            output = torch.einsum('bsgd,grd->bsgr', grouped, weight).flatten(2)
         return self.wo_b(output), state

--- a/experimental/lite/megatron/lite/model/deepseek_v41/lite/model.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v41/lite/model.py
@@ -63,6 +63,16 @@ class FP4Linear(Linear):
         self.quantized = quantized
 
     def forward(self, x):
+        if getattr(self, 'native_fp32', False):
+            from megatron.lite.primitive.modules.native_fp32_linear import (
+                native_fp32_linear,
+            )
+            from megatron.lite.primitive.quantization.ds41_index import fake_quant_index
+
+            return native_fp32_linear(
+                fake_quant_index(x, enabled=self.quantized),
+                fake_quant_index(self.weight, enabled=self.quantized),
+            )
         if not self.quantized:
             return F.linear(x, self.weight)
         from megatron.lite.primitive.quantization.ds41_index import fake_quant_index
@@ -373,7 +383,10 @@ class DeepseekV41Model(nn.Module):
             raise NotImplementedError('Multimodal inputs require vision/aligner integration')
         if input_ids.ndim != 2 or input_ids.dtype != torch.int64 or not input_ids.shape[1]:
             raise ValueError('Expected nonempty int64 input_ids [B,S]')
-        hidden, pre = expand_hc(self.embed(input_ids), self.hc_mult)
+        tokens = self.embed(input_ids)
+        if hasattr(self, 'residual_dtype'):
+            tokens = tokens.to(self.residual_dtype)
+        hidden, pre = expand_hc(tokens, self.hc_mult)
         if cu_seqlens is None:
             hidden, pre = self._sequence(hidden, pre, input_ids=input_ids)
         else:

--- a/experimental/lite/megatron/lite/model/deepseek_v41/lite/optimizer_groups.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v41/lite/optimizer_groups.py
@@ -1,0 +1,295 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Object-based V4.1 routing and single-rank transactional optimizer assembly.
+
+Release keys are audit labels, never dispatch inputs. Unknown active objects
+fail closed. Vision execution/its explicit trainability mask belong to the
+multimodal assembly; archival vision/MTP owners allocate no optimizer state.
+"""
+
+import math
+from copy import deepcopy
+from dataclasses import dataclass
+
+import torch
+from megatron.lite.primitive.optimizers.headwise_muon import HeadwiseMuon
+from megatron.lite.primitive.optimizers.sinkhorn import Sinkhorn
+from megatron.lite.primitive.quantization.block_fp8 import quantize_block_fp8
+
+
+@dataclass(frozen=True)
+class OptimizerConfig:
+    lr: float
+    ns_steps: int
+    coefficient_type: str
+    clip_grad: float = 1.0
+
+
+def parameter_groups(model, *, lr):
+    if not math.isfinite(lr) or lr < 0:
+        raise ValueError('Invalid base learning rate')
+    model.validate_parameter_bindings()
+    bindings = {id(b.tensor): b for b in model.parameter_bindings()}
+    registered = list(model.named_parameters(remove_duplicate=False))
+    if len(registered) != len({id(p) for _, p in registered}):
+        raise ValueError('Unexpected parameter alias in module tree')
+    groups, seen = [], set()
+
+    def add(p, algorithm, *, role, shape=None, multiplier=1, decay=0.1, heads=None):
+        if id(p) in seen:
+            raise ValueError('Duplicate optimizer owner')
+        seen.add(id(p))
+        b = bindings.get(id(p))
+        if b is None or b.role != role:
+            raise ValueError('Unknown or mismatched parameter owner role')
+        if b.head_count != heads:
+            raise ValueError('Unresolved or incorrect logical head count')
+        if not p.requires_grad:
+            return
+        if algorithm in ('muon', 'sinkhorn') and p.ndim != 2:
+            raise ValueError(
+                'Matrix optimizer requires the declared two-dimensional owner'
+            )
+        if shape is not None and math.prod(shape) != p.numel():
+            raise ValueError('Logical matrix shape disagrees with actual owner')
+        if (
+            shape is not None
+            and len(shape) == 3
+            and tuple(p.shape) != (shape[0] * shape[1], shape[2])
+        ):
+            raise ValueError('Head layout disagrees with physical matrix axes')
+        groups.append(
+            dict(
+                params=[p],
+                algorithm=algorithm,
+                owner_key=b.release_key,
+                matrix_shape=tuple(p.shape) if shape is None else tuple(shape),
+                lr=lr * multiplier,
+                weight_decay=decay,
+            )
+        )
+
+    def norm(module, role='norm'):
+        add(module.weight, 'adamw', role=role)
+
+    add(model.embed.weight, 'sinkhorn', role='embedding', decay=0)
+    add(model.head.weight, 'sinkhorn', role='head', decay=0)
+    norm(model.norm)
+    for block in model.layers:
+        a, c = block.attn, block.attn.config
+        for module, role in (
+            (a.wq_a, 'wq_a'),
+            (a.wkv, 'wkv'),
+            (a.wo_a, 'wo_a'),
+            (a.wo_b, 'wo_b'),
+        ):
+            add(module.weight, 'muon', role=role)
+        add(
+            a.wq_b.weight,
+            'muon',
+            role='wq_b',
+            shape=(c.heads, c.head_dim, c.q_rank),
+            heads=c.heads,
+        )
+        norm(a.q_norm)
+        norm(a.kv_norm)
+        add(a.attn_sink, 'adamw', role='attention_sink', decay=0)
+        if a.compressor is not None:
+            add(a.compressor.wkv.weight, 'muon', role='compressor')
+            norm(a.compressor.norm, 'compressor')
+            if hasattr(a.compressor, 'wgate'):
+                add(a.compressor.wgate.weight, 'muon', role='compressor')
+        if a.indexer is not None:
+            for p in a.indexer.parameters():
+                if p.requires_grad:
+                    raise ValueError('Post-training indexer must remain frozen')
+                if id(p) not in bindings or bindings[id(p)].role != 'indexer':
+                    raise ValueError('Unknown indexer parameter')
+                seen.add(id(p))
+        norm(block.attn_norm)
+        norm(block.ffn_norm)
+        for mixes in (block.attn_mixes, block.ffn_mixes):
+            add(mixes.fn, 'muon', role='hyper_connection')
+            add(mixes.base, 'adamw', role='hyper_connection', decay=0)
+            add(mixes.scale, 'adamw', role='hyper_connection', decay=0)
+        add(block.ffn.gate.router.gate.weight, 'muon', role='router')
+        for expert in block.ffn.experts:
+            for module in (expert.w1, expert.w2, expert.w3):
+                add(module.weight, 'muon', role='expert')
+        shared = block.ffn.shared_experts
+        if shared is not None:
+            for module in (shared.w1, shared.w2, shared.w3):
+                add(module.weight, 'muon', role='shared_expert')
+        if block.engram is not None:
+            e = block.engram
+            if e.embed.master is not None:
+                add(
+                    e.embed.master,
+                    'sinkhorn',
+                    role='engram_table',
+                    multiplier=5,
+                    decay=0,
+                )
+            add(e.wkv.weight, 'muon', role='engram_projection', multiplier=5)
+            for p in (e.q_weight, e.k_weight):
+                add(p, 'adamw', role='engram_norm', multiplier=5)
+    if seen != set(bindings):
+        raise ValueError('Unknown parameter owner; no catch-all optimizer route')
+    return groups
+
+
+class V41Optimizer:
+    """Local correctness coordinator; every backend publishes on one commit.
+
+    AdamW staging uses the real torch backend on private candidate parameters.
+    It deliberately costs extra local storage. Distributed staging/sharding is
+    owned by the parallel integration rather than silently approximated here.
+    """
+
+    def __init__(self, model, config):
+        if not isinstance(config, OptimizerConfig):
+            raise TypeError('V4.1 requires an explicit model OptimizerConfig')
+        if not math.isfinite(config.clip_grad) or config.clip_grad < 0:
+            raise ValueError('Invalid gradient clipping threshold')
+        groups = parameter_groups(model, lr=config.lr)
+        if not groups or any(
+            p.dtype != torch.float32 for g in groups for p in g['params']
+        ):
+            raise ValueError('V4.1 optimizer requires native FP32 parameter masters')
+        self.config = config
+        self.optimizers = []
+        for algorithm in ('muon', 'sinkhorn', 'adamw'):
+            selected = [g for g in groups if g['algorithm'] == algorithm]
+            if not selected:
+                continue
+            if algorithm == 'muon':
+                backend = HeadwiseMuon(
+                    selected,
+                    lr=config.lr,
+                    ns_steps=config.ns_steps,
+                    coefficient_type=config.coefficient_type,
+                )
+            elif algorithm == 'sinkhorn':
+                backend = Sinkhorn(selected, lr=config.lr)
+            else:
+                backend = torch.optim.AdamW(
+                    selected, lr=config.lr, betas=(0.9, 0.95), eps=1e-20, foreach=False
+                )
+            self.optimizers.append(backend)
+        self.tables = [
+            b.engram.embed
+            for b in model.layers
+            if b.engram is not None and b.engram.embed.master is not None
+        ]
+
+    @property
+    def param_groups(self):
+        return [g for o in self.optimizers for g in o.param_groups]
+
+    def zero_grad(self, set_to_none=True):
+        for backend in self.optimizers:
+            backend.zero_grad(set_to_none=set_to_none)
+        for group in self.param_groups:
+            for p in group['params']:
+                p.main_grad = p.grad
+
+    @torch.no_grad()
+    def step(self):
+        parameters = [p for g in self.param_groups for p in g['params']]
+        gradients = [
+            p.main_grad if getattr(p, 'main_grad', None) is not None else p.grad
+            for p in parameters
+        ]
+        active = [g for g in gradients if g is not None]
+        if any(g.dtype != torch.float32 or g.is_sparse for g in active):
+            raise ValueError('Expected native dense FP32 main_grad')
+        norm = (
+            torch.stack([g.double().square().sum() for g in active]).sum().sqrt()
+            if active
+            else torch.tensor(0.0)
+        )
+        if not torch.isfinite(norm):
+            return False, float(norm), None
+        coefficient = (
+            min(1.0, self.config.clip_grad / (float(norm) + 1e-6))
+            if self.config.clip_grad
+            else 1.0
+        )
+        # Reversible gradient views permit retry on failed publication.
+        original = [(p, p.grad, getattr(p, 'main_grad', None)) for p in parameters]
+        staged_adam, candidates = [], {}
+        try:
+            for p, g in zip(parameters, gradients):
+                p.grad = None if g is None else g * coefficient
+                p.main_grad = p.grad
+            for backend in self.optimizers:
+                if isinstance(backend, torch.optim.AdamW):
+                    candidate = deepcopy(backend)
+                    for old, new in zip(backend.param_groups, candidate.param_groups):
+                        for p, q in zip(old['params'], new['params']):
+                            q.grad = p.grad
+                    candidate.step()
+                    for old, new in zip(backend.param_groups, candidate.param_groups):
+                        for p, q in zip(old['params'], new['params']):
+                            candidates[id(p)] = q
+                    if any(
+                        not torch.isfinite(v).all()
+                        for s in candidate.state.values()
+                        for v in s.values()
+                        if isinstance(v, torch.Tensor)
+                    ):
+                        return False, float(norm), None
+                    staged_adam.append((backend, candidate))
+                else:
+                    if not backend.prepare_step():
+                        return False, float(norm), None
+                    candidates.update(
+                        (id(p), value) for p, value in backend.candidates()
+                    )
+            if any(not torch.isfinite(p).all() for p in candidates.values()):
+                return False, float(norm), None
+            storage = []
+            for table in self.tables:
+                weight, scale = quantize_block_fp8(
+                    candidates[id(table.master)], (1, 32), scale_format='e8m0'
+                )
+                if (
+                    not torch.isfinite(weight.float()).all()
+                    or not torch.isfinite(scale.float()).all()
+                ):
+                    return False, float(norm), None
+                storage.append((table, weight, scale))
+            for backend in self.optimizers:
+                if not isinstance(backend, torch.optim.AdamW):
+                    backend.commit_step()
+            for backend, candidate in staged_adam:
+                for old, new in zip(backend.param_groups, candidate.param_groups):
+                    for p, q in zip(old['params'], new['params']):
+                        p.copy_(q)
+                backend.load_state_dict(candidate.state_dict())
+            for table, weight, scale in storage:
+                table.weight.copy_(weight)
+                table.scale.copy_(scale)
+            return True, float(norm), None
+        finally:
+            for backend in self.optimizers:
+                if not isinstance(backend, torch.optim.AdamW):
+                    backend.discard_step()
+            for p, grad, main in original:
+                p.grad, p.main_grad = grad, main
+
+    def state_dict(self):
+        return dict(
+            owners=[g['owner_key'] for g in self.param_groups],
+            clip_grad=self.config.clip_grad,
+            optimizers=[o.state_dict() for o in self.optimizers],
+        )
+
+    def load_state_dict(self, state):
+        if state.get('clip_grad') != self.config.clip_grad:
+            raise ValueError('Optimizer clipping contract differs')
+        if state.get('owners') != [g['owner_key'] for g in self.param_groups] or len(
+            state['optimizers']
+        ) != len(self.optimizers):
+            raise ValueError('Optimizer owner layout differs')
+        for backend, saved in zip(self.optimizers, state['optimizers']):
+            backend.load_state_dict(saved)

--- a/experimental/lite/megatron/lite/model/deepseek_v41/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v41/lite/protocol.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Text-only single-rank protocol. Distributed and optimizer routing are separate."""
 
+from contextlib import nullcontext
 from dataclasses import dataclass, field
 
 import torch
@@ -11,12 +12,14 @@ from megatron.lite.primitive.bundle import ModelBundle
 from megatron.lite.primitive.parallel.state import ParallelState
 from megatron.lite.runtime.contracts import ParallelConfig
 from .checkpoint import export_model, load_model, save_model
+from .optimizer_groups import OptimizerConfig, V41Optimizer
 
 
 @dataclass(frozen=True)
 class ImplConfig:
     parallel: ParallelConfig = field(default_factory=ParallelConfig)
     optimizer: str | None = None
+    optimizer_config: OptimizerConfig | None = None
     device: str = 'cuda'
     dtype: torch.dtype = torch.bfloat16
     quantized: bool = True
@@ -47,9 +50,15 @@ def build_model(model_cfg, *, impl_cfg):
         raise NotImplementedError('V4.1 assembly currently requires single-rank parallelism')
     if torch.distributed.is_initialized() and torch.distributed.get_world_size() != 1:
         raise NotImplementedError('Distributed V4.1 construction requires the parallel integration')
-    if impl_cfg.optimizer is not None:
-        raise NotImplementedError(
-            'Optimizer construction requires the V4.1 object-based routing integration'
+    if impl_cfg.optimizer not in (None, 'muon'):
+        raise ValueError('V4.1 optimizer must be explicitly selected as muon')
+    if impl_cfg.optimizer is None and impl_cfg.optimizer_config is not None:
+        raise ValueError('optimizer_config requires selecting the V4.1 optimizer')
+    if impl_cfg.optimizer == 'muon' and not isinstance(
+        impl_cfg.optimizer_config, OptimizerConfig
+    ):
+        raise ValueError(
+            'V4.1 Muon requires explicit optimizer_config including NS backend settings'
         )
     if impl_cfg.dtype not in (torch.bfloat16, torch.float32):
         raise ValueError('V4.1 residual dtype must be BF16 or FP32')
@@ -77,16 +86,44 @@ def build_model(model_cfg, *, impl_cfg):
             module.output_dtype = impl_cfg.dtype
     if model.engram_hash is not None:
         model.engram_hash.to(device=impl_cfg.device)
+    optimizer = None
+    if impl_cfg.optimizer == 'muon':
+        if impl_cfg.device == 'meta':
+            raise ValueError(
+                'Materialize V4.1 parameters before constructing optimizer state'
+            )
+        # Persistent FP32 owners receive FP32 wgrad from the numerical providers.
+        # No post-hoc BF16 gradient widening is used.
+        from .attention import Linear
+
+        for module in model.modules():
+            if isinstance(module, Linear):
+                module.native_fp32 = True
+                module.weight.data = module.weight.data.float()
+        for p in model.parameters():
+            if p.requires_grad:
+                p.data = p.data.float()
+                p.main_grad = None
+                p.register_post_accumulate_grad_hook(_publish_main_grad)
+        model.residual_dtype = impl_cfg.dtype
+        optimizer = V41Optimizer(model, impl_cfg.optimizer_config)
     return ModelBundle(
         [model],
         ParallelState(),
+        optimizer=optimizer,
         forward_step=_forward_step,
         extras={
             'model_cfg': model_cfg,
-            'optimizer_backend': 'none',
+            'optimizer_backend': 'none' if optimizer is None else 'v41',
             'parameter_bindings': model.parameter_bindings,
         },
     )
+
+
+def _publish_main_grad(parameter):
+    if parameter.grad.dtype != torch.float32:
+        raise RuntimeError('V4.1 gradient producer did not return native FP32')
+    parameter.main_grad = parameter.grad
 
 
 def _forward_step(model, batch):
@@ -107,7 +144,16 @@ def _forward_step(model, batch):
     temperature = 1.0 if context is None else context.temperature
     if temperature <= 0:
         raise ValueError('Temperature must be positive')
-    logits = model(batch.input_ids[None], cu_seqlens=batch.cu_seqlens)['logits'][0] / temperature
+    precision = (
+        torch.autocast(device_type=batch.input_ids.device.type, enabled=False)
+        if hasattr(model, 'residual_dtype')
+        else nullcontext()
+    )
+    with precision:
+        logits = (
+            model(batch.input_ids[None], cu_seqlens=batch.cu_seqlens)['logits'][0]
+            / temperature
+        )
     result = {'logits': logits}
     if batch.labels is not None:
         if batch.labels.shape != batch.input_ids.shape:

--- a/experimental/lite/megatron/lite/primitive/modules/native_fp32_linear.py
+++ b/experimental/lite/megatron/lite/primitive/modules/native_fp32_linear.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Floating linear with a persistent FP32 master and native FP32 wgrad.
+
+The forward uses the activation dtype. The backward weight GEMM multiplies
+FP32 operands and returns FP32 directly to the FP32 leaf, avoiding a BF16
+weight-gradient intermediate. This is a correctness provider, not TE fusion.
+"""
+
+import torch
+from torch.nn import functional as F
+
+
+class _NativeLinear(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, weight):
+        if weight.dtype != torch.float32:
+            raise ValueError('Native wgrad requires an FP32 master')
+        compute_weight = weight.to(x.dtype)
+        ctx.save_for_backward(x, compute_weight)
+        return F.linear(x, compute_weight)
+
+    @staticmethod
+    def backward(ctx, grad):
+        x, weight = ctx.saved_tensors
+        dx = grad @ weight
+        with torch.autocast(device_type=grad.device.type, enabled=False):
+            dw = (
+                grad.reshape(-1, weight.shape[0]).float().T
+                @ x.reshape(-1, weight.shape[1]).float()
+            )
+        return dx, dw
+
+
+def native_fp32_linear(x, weight):
+    return _NativeLinear.apply(x, weight)

--- a/experimental/lite/megatron/lite/primitive/optimizers/headwise_muon.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/headwise_muon.py
@@ -1,0 +1,200 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Muon on explicitly declared logical matrices, with FP32 owner state.
+
+The caller owns layout interpretation. ``matrix_shape`` is (rows, columns) or
+(heads, rows, columns), independent of parameter names and physical flattening.
+Newton-Schulz is supplied by NVIDIA emerging_optimizers, never reimplemented.
+This local primitive requires reassembled matrices; distributed lowering is a
+separate contract. prepare/commit permits an atomic mixed-optimizer coordinator.
+"""
+
+import math
+
+import torch
+
+
+class HeadwiseMuon(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        *,
+        lr,
+        ns_steps,
+        coefficient_type,
+        weight_decay=0.1,
+        momentum=0.95,
+        update_rms=0.18,
+    ):
+        from emerging_optimizers.orthogonalized_optimizers.muon_utils import (
+            newton_schulz,
+        )
+
+        if type(ns_steps) is not int or ns_steps < 1:
+            raise ValueError('ns_steps must be a positive integer')
+        # Validate the explicitly selected backend API/config before allocating state.
+        newton_schulz(torch.zeros(1, 1), ns_steps, coefficient_type=coefficient_type)
+        self._orthogonalize = newton_schulz
+        self._prepared = None
+        super().__init__(
+            params,
+            dict(
+                lr=lr,
+                weight_decay=weight_decay,
+                momentum=momentum,
+                update_rms=update_rms,
+                ns_steps=ns_steps,
+                coefficient_type=coefficient_type,
+            ),
+        )
+        self._validate_groups()
+
+    def _validate_groups(self):
+        seen = set()
+        for group in self.param_groups:
+            shape = group.get('matrix_shape')
+            if (
+                not isinstance(shape, (tuple, list))
+                or len(shape) not in (2, 3)
+                or any(type(d) is not int or d < 1 for d in shape)
+            ):
+                raise ValueError(
+                    'An explicit positive logical matrix shape is required'
+                )
+            for key in ('lr', 'weight_decay', 'momentum', 'update_rms'):
+                if not math.isfinite(group[key]) or group[key] < 0:
+                    raise ValueError(f'Invalid Muon {key}')
+            if group['momentum'] >= 1:
+                raise ValueError('Muon momentum must be less than one')
+            for p in group['params']:
+                if id(p) in seen:
+                    raise ValueError('Duplicate Muon parameter owner')
+                seen.add(id(p))
+                if (
+                    p.numel() != math.prod(shape)
+                    or not p.is_contiguous()
+                    or p.dtype != torch.float32
+                    or not p.requires_grad
+                ):
+                    raise ValueError(
+                        'Muon requires a contiguous FP32 master matching its logical shape'
+                    )
+
+    @torch.no_grad()
+    def prepare_step(self):
+        if self._prepared is not None:
+            raise RuntimeError('A Muon step is already prepared')
+        self._validate_groups()
+        prepared = []
+        for group in self.param_groups:
+            for p in group['params']:
+                grad = getattr(p, 'main_grad', p.grad)
+                if grad is None:
+                    continue
+                if (
+                    grad.dtype != torch.float32
+                    or grad.shape != p.shape
+                    or grad.is_sparse
+                ):
+                    raise ValueError(
+                        'Muon requires matching dense native FP32 gradients'
+                    )
+                if not torch.isfinite(grad).all():
+                    return False
+                previous = self.state.get(p, {}).get(
+                    'momentum_buffer', torch.zeros_like(p)
+                )
+                beta = group['momentum']
+                momentum = beta * previous + (1 - beta) * grad
+                nesterov = beta * momentum + (1 - beta) * grad
+                from emerging_optimizers.utils import fp32_matmul_precision
+
+                logical = nesterov.reshape(group['matrix_shape'])
+                matrices = logical.unbind(0) if logical.ndim == 3 else (logical,)
+                directions = []
+                with torch.autocast(
+                    device_type=p.device.type, enabled=False
+                ), fp32_matmul_precision('highest'):
+                    for matrix in matrices:
+                        update = self._orthogonalize(
+                            matrix,
+                            group['ns_steps'],
+                            coefficient_type=group['coefficient_type'],
+                        )
+                        rms = update.square().mean().sqrt()
+                        directions.append(
+                            update * (group['update_rms'] / rms.clamp_min(1e-30))
+                        )
+                update = torch.stack(directions) if logical.ndim == 3 else directions[0]
+                candidate = p * (1 - group['lr'] * group['weight_decay'])
+                candidate = candidate - group['lr'] * update.reshape_as(p)
+                if (
+                    not torch.isfinite(candidate).all()
+                    or not torch.isfinite(momentum).all()
+                ):
+                    return False
+                prepared.append((p, candidate, momentum))
+        self._prepared = prepared
+        return True
+
+    def candidates(self):
+        if self._prepared is None:
+            raise RuntimeError('No prepared Muon step')
+        return tuple((p, value) for p, value, _ in self._prepared)
+
+    @torch.no_grad()
+    def commit_step(self):
+        if self._prepared is None:
+            raise RuntimeError('No prepared Muon step')
+        for p, value, momentum in self._prepared:
+            p.copy_(value)
+            self.state[p]['momentum_buffer'] = momentum
+        self._prepared = None
+
+    def discard_step(self):
+        self._prepared = None
+
+    def step(self, closure=None):
+        if closure is not None:
+            raise ValueError('Muon requires explicit accumulated gradients')
+        if not self.prepare_step():
+            return False
+        self.commit_step()
+        return True
+
+    def state_dict(self):
+        if self._prepared is not None:
+            raise RuntimeError('Cannot checkpoint a prepared Muon step')
+        return super().state_dict()
+
+    def load_state_dict(self, state_dict):
+        if self._prepared is not None:
+            raise RuntimeError('Cannot restore a prepared Muon step')
+        saved = state_dict['param_groups']
+        if len(saved) != len(self.param_groups) or any(
+            tuple(a['matrix_shape']) != tuple(b['matrix_shape'])
+            for a, b in zip(saved, self.param_groups)
+        ):
+            raise ValueError('Muon logical layout changed; reshard explicitly')
+        for old, current in zip(saved, self.param_groups):
+            if len(old['params']) != len(current['params']) or any(
+                old[key] != current[key]
+                for key in ('ns_steps', 'coefficient_type', 'momentum', 'update_rms')
+            ):
+                raise ValueError('Muon backend recipe or owner count changed')
+            for pid, parameter in zip(old['params'], current['params']):
+                state = state_dict['state'].get(pid)
+                if state is None:
+                    continue
+                momentum = state.get('momentum_buffer')
+                if (
+                    set(state) != {'momentum_buffer'}
+                    or not isinstance(momentum, torch.Tensor)
+                    or momentum.dtype != torch.float32
+                    or momentum.shape != parameter.shape
+                    or not torch.isfinite(momentum).all()
+                ):
+                    raise ValueError(
+                        'Muon checkpoint requires matching finite FP32 momentum'
+                    )
+        super().load_state_dict(state_dict)
+        self._validate_groups()

--- a/experimental/lite/megatron/lite/primitive/optimizers/sinkhorn.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/sinkhorn.py
@@ -1,0 +1,338 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Fresh-N Algorithm-1 Sinkhorn direction for logical parameter matrices.
+
+Row/column process groups describe disjoint pieces of one logical matrix.
+Only norm vectors are reduced; the logical table is never gathered. Replica
+gradients are reduce-scattered before momentum and normalization.
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+import torch.distributed as dist
+
+K = 11
+TAU = 1e-3
+EPS = 1e-20
+GAMMA = 0.18
+
+
+def _reduce(tensor, group, op=dist.ReduceOp.SUM):
+    if group is not None:
+        dist.all_reduce(tensor, op=op, group=group)
+    return tensor
+
+
+def _any(flag, device, row_group, column_group):
+    value = torch.tensor(int(flag), device=device, dtype=torch.int32)
+    _reduce(value, row_group, dist.ReduceOp.MAX)
+    _reduce(value, column_group, dist.ReduceOp.MAX)
+    return bool(value.item())
+
+
+def sinkhorn_direction(nesterov, *, row_group=None, column_group=None, trace=None):
+    """Fresh current-N direction; groups partition rows and columns respectively.
+
+    A replica's optimizer-owned rows are disjoint matrix rows too, and therefore
+    belong in row_group. Padding must already be stripped. None means local,
+    never WORLD. All ranks participate, including zero-row/zero-column shards.
+    Optional trace(iteration, U) receives detached copies for A4 stage auditing.
+    """
+    if nesterov.ndim != 2 or nesterov.dtype != torch.float32:
+        raise ValueError('Sinkhorn requires an FP32 matrix [m, n]')
+    rows = _reduce(torch.tensor(nesterov.shape[0], device=nesterov.device), row_group)
+    columns = _reduce(
+        torch.tensor(nesterov.shape[1], device=nesterov.device), column_group
+    )
+    if rows.item() <= 0 or columns.item() <= 0:
+        raise ValueError('Sinkhorn requires a nonempty logical matrix')
+    if _any(
+        not torch.isfinite(nesterov).all(), nesterov.device, row_group, column_group
+    ):
+        raise ValueError('Sinkhorn requires a finite logical matrix')
+
+    def norm(matrix, axis):
+        # Scale before squaring so finite large/tiny FP32 N retains its norm.
+        group = column_group if axis == 1 else row_group
+        shape = list(matrix.shape)
+        shape[axis] = 1
+        maximum = (
+            matrix.abs().amax(dim=axis, keepdim=True)
+            if matrix.shape[axis]
+            else matrix.new_zeros(shape)
+        )
+        _reduce(maximum, group, dist.ReduceOp.MAX)
+        scale = torch.where(maximum == 0, torch.ones_like(maximum), maximum)
+        squares = (matrix / scale).square().sum(dim=axis, keepdim=True)
+        _reduce(squares, column_group if axis == 1 else row_group)
+        return squares.sqrt() * maximum
+
+    rho = norm(nesterov, 1)
+    mean = _reduce(rho.sum(), row_group) / rows
+    update = nesterov.clone()
+    update.masked_fill_(rho <= TAU * mean, 0)
+    for iteration in range(K):
+        axis = 1 if iteration % 2 == 0 else 0
+        update = update / (norm(update, axis) + EPS)
+        if trace is not None:
+            trace(iteration + 1, update.detach().clone())
+    return update * math.sqrt(columns.item())
+
+
+def algorithm1_update(
+    weight: torch.Tensor,
+    momentum: torch.Tensor,
+    gradient: torch.Tensor,
+    *,
+    lr: float,
+    beta: float = 0.95,
+    multiplier: float = 1.0,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """One exact local Algorithm-1 update, returning ``(W_next, M, N)``.
+
+    ``lr * multiplier`` is supplied by the group router; Engram uses a 5x
+    multiplier.  There is no decay and no normalized-state cache.
+    """
+    if any(
+        x.shape != weight.shape or x.dtype != torch.float32
+        for x in (momentum, gradient)
+    ):
+        raise ValueError('Algorithm 1 requires matching FP32 momentum and gradient')
+    if weight.ndim != 2 or not all(math.isfinite(x) for x in (lr, beta, multiplier)):
+        raise ValueError('Invalid Algorithm 1 inputs')
+    if not 0 <= beta < 1 or lr < 0:
+        raise ValueError('Invalid Algorithm 1 hyperparameters')
+    m = beta * momentum + (1 - beta) * gradient
+    n = beta * m + (1 - beta) * gradient
+    direction = sinkhorn_direction(n)
+    return weight - (GAMMA * lr * multiplier) * direction, m, n
+
+
+def _span(rows, parts, rank):
+    size, extra = divmod(rows, parts)
+    begin = rank * size + min(rank, extra)
+    return begin, begin + size + (rank < extra)
+
+
+class Sinkhorn(torch.optim.Optimizer):
+    """FP32 Algorithm 1 with replica-sharded momentum and staged publication.
+
+    Parameters are resident FP32 masters. A native FP32 ``main_grad`` takes
+    precedence over ``grad``; low precision gradients are rejected, never widened.
+    Replica gradients are summed (loss normalization belongs to the caller).
+    Each replica retains momentum only for its balanced contiguous row interval.
+    row_group spans all disjoint optimizer-owned row intervals; column_group
+    spans feature partitions. These caller-created groups must form a rectangle.
+    No parameter, state or gradient is offloaded.
+    """
+
+    def __init__(
+        self, params, *, lr, row_group=None, column_group=None, replica_group=None
+    ):
+        super().__init__(params, dict(lr=lr, multiplier=1.0))
+        self.row_group = row_group
+        self.column_group = column_group
+        self.replica_group = replica_group
+        self.replica_size = (
+            1 if replica_group is None else dist.get_world_size(replica_group)
+        )
+        self.replica_rank = 0 if replica_group is None else dist.get_rank(replica_group)
+        self._prepared = None
+        if self.replica_size > 1 and row_group is None:
+            raise ValueError('Replica-owned rows require a logical row group')
+        parameters = [p for group in self.param_groups for p in group['params']]
+        if len({id(p) for p in parameters}) != len(parameters):
+            raise ValueError('Each Sinkhorn parameter owner must appear once')
+        for group in self.param_groups:
+            for parameter in group['params']:
+                if (
+                    parameter.ndim != 2
+                    or parameter.dtype != torch.float32
+                    or not parameter.requires_grad
+                ):
+                    raise ValueError('Sinkhorn owns trainable FP32 matrix masters only')
+                if (
+                    any(g is not None for g in (row_group, column_group, replica_group))
+                    and not parameter.is_cuda
+                ):
+                    raise ValueError(
+                        'Distributed Sinkhorn requires resident CUDA state'
+                    )
+
+    def _gradient_shard(self, gradient):
+        if self.replica_group is None:
+            return gradient
+        rows, columns = gradient.shape
+        width = max(1, (rows + self.replica_size - 1) // self.replica_size)
+        packed = gradient.new_zeros(self.replica_size, width, columns)
+        for rank in range(self.replica_size):
+            start, end = _span(rows, self.replica_size, rank)
+            packed[rank, : end - start].copy_(gradient[start:end])
+        result = gradient.new_empty(width, columns)
+        dist.reduce_scatter_tensor(
+            result, packed.flatten(0, 1), group=self.replica_group
+        )
+        start, end = _span(rows, self.replica_size, self.replica_rank)
+        return result[: end - start]
+
+    def _replicate(self, shard, rows):
+        if self.replica_group is None:
+            return shard
+        width = max(1, (rows + self.replica_size - 1) // self.replica_size)
+        padded = shard.new_zeros(width, shard.shape[1])
+        padded[: shard.shape[0]].copy_(shard)
+        gathered = [torch.empty_like(padded) for _ in range(self.replica_size)]
+        dist.all_gather(gathered, padded, group=self.replica_group)
+        pieces = []
+        for rank, value in enumerate(gathered):
+            start, end = _span(rows, self.replica_size, rank)
+            pieces.append(value[: end - start])
+        return torch.cat(pieces)
+
+    @torch.no_grad()
+    def prepare_step(self):
+        """Stage W/M without changing live weights or state; return false on inf.
+
+        The mixed optimizer coordinator can quantize candidate tables and agree
+        on clip/skip before commit_step. No warm-start state is ever staged.
+        """
+        if self._prepared is not None:
+            raise RuntimeError('A Sinkhorn step is already prepared')
+        inputs = []
+        for group in self.param_groups:
+            lr, multiplier = group['lr'], group['multiplier']
+            if not all(math.isfinite(x) and x >= 0 for x in (lr, multiplier)):
+                raise ValueError('Invalid Sinkhorn learning rate or multiplier')
+            for parameter in group['params']:
+                gradient = getattr(parameter, 'main_grad', parameter.grad)
+                if gradient is None:
+                    gradient = torch.zeros_like(parameter)
+                invalid = (
+                    gradient.dtype != torch.float32
+                    or gradient.shape != parameter.shape
+                    or gradient.device != parameter.device
+                )
+                if _any(invalid, parameter.device, self.row_group, self.column_group):
+                    raise ValueError('Sinkhorn requires matching native FP32 gradients')
+                if _any(
+                    not torch.isfinite(gradient).all(),
+                    parameter.device,
+                    self.row_group,
+                    self.column_group,
+                ):
+                    return False
+                inputs.append((parameter, gradient, lr, multiplier))
+        prepared = []
+        for parameter, gradient, lr, multiplier in inputs:
+            start, end = _span(parameter.shape[0], self.replica_size, self.replica_rank)
+            gradient = self._gradient_shard(gradient)
+            previous = self.state.get(parameter, {}).get('momentum')
+            if previous is None:
+                previous = torch.zeros_like(gradient)
+            momentum = 0.95 * previous + 0.05 * gradient
+            nesterov = 0.95 * momentum + 0.05 * gradient
+            if _any(
+                not torch.isfinite(nesterov).all(),
+                parameter.device,
+                self.row_group,
+                self.column_group,
+            ):
+                return False
+            direction = sinkhorn_direction(
+                nesterov, row_group=self.row_group, column_group=self.column_group
+            )
+            candidate = parameter[start:end] - (GAMMA * lr * multiplier) * direction
+            if _any(
+                not torch.isfinite(candidate).all(),
+                parameter.device,
+                self.row_group,
+                self.column_group,
+            ):
+                return False
+            prepared.append(
+                (parameter, self._replicate(candidate, parameter.shape[0]), momentum)
+            )
+        self._prepared = prepared
+        return True
+
+    def agree_skip(self, skip):
+        """OR a publication/skip decision across the logical matrix grid."""
+        parameter = self.param_groups[0]['params'][0]
+        return _any(skip, parameter.device, self.row_group, self.column_group)
+
+    def candidates(self):
+        if self._prepared is None:
+            raise RuntimeError('No prepared Sinkhorn step')
+        return tuple(
+            (parameter, candidate) for parameter, candidate, _ in self._prepared
+        )
+
+    @torch.no_grad()
+    def commit_step(self):
+        if self._prepared is None:
+            raise RuntimeError('No prepared Sinkhorn step')
+        for parameter, candidate, momentum in self._prepared:
+            parameter.copy_(candidate)
+            self.state[parameter]['momentum'] = momentum
+        self._prepared = None
+
+    def discard_step(self):
+        self._prepared = None
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        if closure is not None:
+            raise ValueError('Sinkhorn requires explicit accumulated gradients')
+        if not self.prepare_step():
+            return False
+        self.commit_step()
+        return True
+
+    def state_dict(self):
+        if self._prepared is not None:
+            raise RuntimeError('Cannot checkpoint a prepared Sinkhorn step')
+        result = super().state_dict()
+        ranks = tuple(
+            None if group is None else tuple(dist.get_process_group_ranks(group))
+            for group in (self.row_group, self.column_group, self.replica_group)
+        )
+        result['sinkhorn_layout'] = [
+            (tuple(p.shape), self.replica_size, self.replica_rank, ranks)
+            for group in self.param_groups
+            for p in group['params']
+        ]
+        return result
+
+    def load_state_dict(self, state_dict):
+        if self._prepared is not None:
+            raise RuntimeError('Cannot restore a prepared Sinkhorn step')
+        current = self.state_dict()['sinkhorn_layout']
+        if state_dict.get('sinkhorn_layout') != current:
+            raise ValueError('Sinkhorn checkpoint layout differs; reshard explicitly')
+        saved_ids = [
+            pid for group in state_dict['param_groups'] for pid in group['params']
+        ]
+        parameters = [p for group in self.param_groups for p in group['params']]
+        if len(saved_ids) != len(parameters):
+            raise ValueError('Sinkhorn checkpoint parameter count differs')
+        for pid, parameter in zip(saved_ids, parameters):
+            saved = state_dict['state'].get(pid)
+            if saved is None:
+                continue
+            start, end = _span(parameter.shape[0], self.replica_size, self.replica_rank)
+            momentum = saved.get('momentum')
+            if (
+                set(saved) != {'momentum'}
+                or not isinstance(momentum, torch.Tensor)
+                or momentum.dtype != torch.float32
+                or momentum.shape != (end - start, parameter.shape[1])
+                or not torch.isfinite(momentum).all()
+            ):
+                raise ValueError(
+                    'Sinkhorn checkpoint requires matching finite FP32 momentum'
+                )
+        super().load_state_dict(
+            {k: v for k, v in state_dict.items() if k != 'sinkhorn_layout'}
+        )

--- a/experimental/lite/megatron/lite/primitive/quantization/ds41_fp8.py
+++ b/experimental/lite/megatron/lite/primitive/quantization/ds41_fp8.py
@@ -73,8 +73,9 @@ class _DynamicLinear(torch.autograd.Function):
             weight, (32, 32), scale_format="e8m0"
         )
         decoded_weight = dequantize_block_fp8(encoded_weight, scales, (32, 32)).to(
-            weight.dtype
+            x.dtype
         )
+        ctx.weight_dtype = weight.dtype
         ctx.save_for_backward(
             activation.decoded.reshape(-1, x.shape[-1]), decoded_weight
         )
@@ -91,8 +92,13 @@ class _DynamicLinear(torch.autograd.Function):
     def backward(ctx, grad):
         activation, weight = ctx.saved_tensors
         flat_grad = grad.reshape(-1, weight.shape[0]).float()
-        dx = (flat_grad @ weight.float()).reshape(ctx.input_shape).to(activation.dtype)
-        dw = (flat_grad.T @ activation.float()).to(weight.dtype)
+        with torch.autocast(device_type=grad.device.type, enabled=False):
+            dx = (
+                (flat_grad @ weight.float())
+                .reshape(ctx.input_shape)
+                .to(activation.dtype)
+            )
+            dw = (flat_grad.T @ activation.float()).to(ctx.weight_dtype)
         return dx, dw
 
 
@@ -110,6 +116,10 @@ def dynamic_fp8_linear(x, weight):
         raise ValueError(
             "Linear requires matching K and weight dimensions divisible by 32"
         )
-    if x.device != weight.device or x.dtype != weight.dtype:
-        raise ValueError("floating activation and weight must share device and dtype")
+    if x.device != weight.device or (
+        x.dtype != weight.dtype and weight.dtype != torch.float32
+    ):
+        raise ValueError(
+            "activation and weight must share device and compute dtype, or use an FP32 master"
+        )
     return _DynamicLinear.apply(x, weight)

--- a/experimental/lite/tests/unit/model/test_deepseek_v41_semantics.py
+++ b/experimental/lite/tests/unit/model/test_deepseek_v41_semantics.py
@@ -525,6 +525,8 @@ def test_v41_headwise_muon_distinct_heads_and_resume(device):
     from emerging_optimizers.orthogonalized_optimizers.muon_utils import newton_schulz
     from megatron.lite.primitive.optimizers.headwise_muon import HeadwiseMuon
 
+    from emerging_optimizers.utils import fp32_matmul_precision
+
     torch.manual_seed(712)
     weight = torch.nn.Parameter(torch.randn(6, 5, device=device))
     expected = weight.detach().clone()
@@ -542,12 +544,14 @@ def test_v41_headwise_muon_distinct_heads_and_resume(device):
         momentum = 0.95 * momentum + 0.05 * gradient
         nesterov = 0.95 * momentum + 0.05 * gradient
         directions = []
-        for head in nesterov.split(3):
-            update = newton_schulz(head, 5, coefficient_type='quintic')
-            directions.append(update * (0.18 / update.square().mean().sqrt()))
-        expected = expected * (1 - 0.03 * 0.1) - 0.03 * torch.cat(directions)
-        vanilla = newton_schulz(nesterov, 5, coefficient_type='quintic')
-        vanilla *= 0.18 / vanilla.square().mean().sqrt()
+        # Match the declared FP32 NS arithmetic, independent of ambient TF32 settings.
+        with fp32_matmul_precision('highest'):
+            for head in nesterov.split(3):
+                update = newton_schulz(head, 5, coefficient_type='quintic')
+                directions.append(update * (0.18 / update.square().mean().sqrt()))
+            expected = expected * (1 - 0.03 * 0.1) - 0.03 * torch.cat(directions)
+            vanilla = newton_schulz(nesterov, 5, coefficient_type='quintic')
+            vanilla *= 0.18 / vanilla.square().mean().sqrt()
         assert not torch.allclose(vanilla, torch.cat(directions), atol=1e-3, rtol=1e-3)
         assert opt.step()
         torch.testing.assert_close(weight, expected, atol=0, rtol=0)

--- a/experimental/lite/tests/unit/model/test_deepseek_v41_semantics.py
+++ b/experimental/lite/tests/unit/model/test_deepseek_v41_semantics.py
@@ -659,6 +659,92 @@ def test_v41_actual_optimizer_routes_and_native_gradients(moe, trainable, device
     assert a.wq_b.weight.grad is None and a.wq_b.weight.main_grad is None
 
 
+def test_v41_optimizer_routing_ignores_misleading_names(moe, monkeypatch):
+    from dataclasses import replace
+
+    from megatron.lite.model.deepseek_v41.lite.optimizer_groups import parameter_groups
+
+    _, bundle = _assembly_bundle()
+    model = bundle.chunks[0]
+    a = model.layers[0].attn
+    # Both public naming surfaces lie: the shared matrices look like per-head Q.
+    labels = {
+        id(a.wq_a.weight): "decoy.attn.wq_b.weight",
+        id(a.wkv.weight): "decoy.query_projection.weight",
+        id(a.wq_b.weight): "decoy.shared_latent.weight",
+    }
+    named = model.named_parameters
+    monkeypatch.setattr(
+        model,
+        "named_parameters",
+        lambda *args, **kwargs: (
+            (labels.get(id(p), name), p) for name, p in named(*args, **kwargs)
+        ),
+    )
+    for key, binding in list(model.tensor_bindings.items()):
+        if id(binding.tensor) in labels:
+            model.tensor_bindings[key] = replace(
+                binding, release_key=labels[id(binding.tensor)]
+            )
+    groups = parameter_groups(model, lr=1e-3)
+    by_id = {id(p): g for g in groups for p in g["params"]}
+    assert by_id[id(a.wq_a.weight)]["matrix_shape"] == tuple(a.wq_a.weight.shape)
+    assert by_id[id(a.wkv.weight)]["matrix_shape"] == tuple(a.wkv.weight.shape)
+    assert by_id[id(a.wq_b.weight)]["matrix_shape"] == (8, 64, 64)
+    indexer_ids = {
+        id(p)
+        for block in model.layers
+        if block.attn.indexer is not None
+        for p in block.attn.indexer.parameters()
+    }
+    assert indexer_ids and indexer_ids.isdisjoint(by_id)
+
+
+@pytest.mark.parametrize("trainable", [False, True])
+def test_v41_optimizer_engram_persistent_master_and_reencoding(moe, trainable):
+    from megatron.lite.model.deepseek_v41.lite.optimizer_groups import (
+        OptimizerConfig,
+        V41Optimizer,
+    )
+    from megatron.lite.primitive.quantization.block_fp8 import quantize_block_fp8
+
+    _, bundle = _assembly_bundle(trainable_engram=trainable)
+    model = bundle.chunks[0]
+    opt = V41Optimizer(
+        model, OptimizerConfig(lr=0.1, ns_steps=5, coefficient_type="quintic")
+    )
+    tables = [b.engram.embed for b in model.layers if b.engram is not None]
+    before = [(t.weight.clone(), t.scale.clone()) for t in tables]
+    masters = [t.master for t in tables]
+    for t in tables:
+        if trainable:
+            assert t.master.dtype == torch.float32
+            # Force a scale boundary crossing so stale scale publication is observable.
+            with torch.no_grad():
+                t.master.mul_(128)
+            t.master.grad = torch.randn_like(t.master)
+        else:
+            assert t.master is None and not list(t.parameters())
+    assert opt.step()[0]
+    for t, master, (weight, scale) in zip(tables, masters, before):
+        assert t.master is master
+        if trainable:
+            expected_weight, expected_scale = quantize_block_fp8(
+                master, (1, 32), scale_format="e8m0"
+            )
+            assert torch.equal(
+                t.weight.view(torch.uint8), expected_weight.view(torch.uint8)
+            )
+            assert torch.equal(
+                t.scale.view(torch.uint8), expected_scale.view(torch.uint8)
+            )
+            assert not torch.equal(t.weight.view(torch.uint8), weight.view(torch.uint8))
+            assert not torch.equal(t.scale.view(torch.uint8), scale.view(torch.uint8))
+        else:
+            assert torch.equal(t.weight.view(torch.uint8), weight.view(torch.uint8))
+            assert torch.equal(t.scale.view(torch.uint8), scale.view(torch.uint8))
+
+
 def test_v41_native_linear_accumulates_unrounded_weight_gradients():
     from megatron.lite.primitive.modules.native_fp32_linear import native_fp32_linear
 

--- a/experimental/lite/tests/unit/model/test_deepseek_v41_semantics.py
+++ b/experimental/lite/tests/unit/model/test_deepseek_v41_semantics.py
@@ -503,6 +503,7 @@ def _assembly_bundle(device='cpu', trainable_engram=False):
     proto = registry.get_train_runtime_module(
         registry.resolve_runtime_model_name('deepseek_v41', 'lite')
     )
+
     return proto, proto.build_model(
         cfg,
         impl_cfg=proto.ImplConfig(
@@ -513,6 +514,248 @@ def _assembly_bundle(device='cpu', trainable_engram=False):
             trainable_engram=trainable_engram,
         ),
     )
+
+
+@pytest.mark.parametrize(
+    'device', ['cpu', pytest.param('cuda', marks=pytest.mark.gpus(1))]
+)
+def test_v41_headwise_muon_distinct_heads_and_resume(device):
+    from copy import deepcopy
+
+    from emerging_optimizers.orthogonalized_optimizers.muon_utils import newton_schulz
+    from megatron.lite.primitive.optimizers.headwise_muon import HeadwiseMuon
+
+    torch.manual_seed(712)
+    weight = torch.nn.Parameter(torch.randn(6, 5, device=device))
+    expected = weight.detach().clone()
+    momentum = torch.zeros_like(weight)
+    opt = HeadwiseMuon(
+        [{'params': [weight], 'matrix_shape': (2, 3, 5)}],
+        lr=0.03,
+        ns_steps=5,
+        coefficient_type='quintic',
+    )
+    for step in range(3):
+        gradient = torch.randn_like(weight)
+        gradient[3:] *= 17
+        weight.grad = gradient
+        momentum = 0.95 * momentum + 0.05 * gradient
+        nesterov = 0.95 * momentum + 0.05 * gradient
+        directions = []
+        for head in nesterov.split(3):
+            update = newton_schulz(head, 5, coefficient_type='quintic')
+            directions.append(update * (0.18 / update.square().mean().sqrt()))
+        expected = expected * (1 - 0.03 * 0.1) - 0.03 * torch.cat(directions)
+        vanilla = newton_schulz(nesterov, 5, coefficient_type='quintic')
+        vanilla *= 0.18 / vanilla.square().mean().sqrt()
+        assert not torch.allclose(vanilla, torch.cat(directions), atol=1e-3, rtol=1e-3)
+        assert opt.step()
+        torch.testing.assert_close(weight, expected, atol=0, rtol=0)
+        torch.testing.assert_close(opt.state[weight]['momentum_buffer'], momentum)
+        assert opt.state[weight]['momentum_buffer'].dtype == torch.float32
+        if step == 1:
+            saved = deepcopy(opt.state_dict())
+            opt = HeadwiseMuon(
+                [{'params': [weight], 'matrix_shape': (2, 3, 5)}],
+                lr=0.03,
+                ns_steps=5,
+                coefficient_type='quintic',
+            )
+            opt.load_state_dict(saved)
+
+
+def test_v41_headwise_muon_rejects_layout_and_atomic_nonfinite():
+    from megatron.lite.primitive.optimizers.headwise_muon import HeadwiseMuon
+
+    a = torch.nn.Parameter(torch.ones(6, 5))
+    b = torch.nn.Parameter(torch.ones(6, 5))
+    settings = dict(lr=0.01, ns_steps=5, coefficient_type='quintic')
+    with pytest.raises(ValueError, match='logical'):
+        HeadwiseMuon([{'params': [a], 'matrix_shape': (4, 3, 5)}], **settings)
+    opt = HeadwiseMuon([{'params': [a, b], 'matrix_shape': (2, 3, 5)}], **settings)
+    a.grad = torch.ones_like(a)
+    b.grad = torch.full_like(b, float('nan'))
+    assert not opt.step()
+    assert not opt.state
+    assert torch.equal(a, torch.ones_like(a))
+    assert torch.equal(b, torch.ones_like(b))
+
+
+@pytest.mark.parametrize('trainable', [False, True])
+@pytest.mark.parametrize(
+    'device', ['cpu', pytest.param('cuda', marks=pytest.mark.gpus(1))]
+)
+def test_v41_actual_optimizer_routes_and_native_gradients(moe, trainable, device):
+    from megatron.lite.model.deepseek_v41.lite import protocol
+    from megatron.lite.model.deepseek_v41.lite.optimizer_groups import OptimizerConfig
+    from megatron.lite.runtime.contracts import PackedBatch
+
+    torch.manual_seed(41)
+    bundle = protocol.build_model(
+        _assembly_config(),
+        impl_cfg=protocol.ImplConfig(
+            device=device,
+            quantized=device == 'cuda',
+            dtype=torch.bfloat16,
+            token_map=list(range(256)),
+            trainable_engram=trainable,
+            optimizer='muon',
+            optimizer_config=OptimizerConfig(
+                lr=1e-3, ns_steps=5, coefficient_type='quintic'
+            ),
+        ),
+    )
+    model, opt = bundle.chunks[0], bundle.optimizer
+    groups = {g['owner_key']: g for g in opt.param_groups}
+    a = model.layers[0].attn
+    assert groups['layers.0.attn.wq_a.weight']['matrix_shape'] == tuple(
+        a.wq_a.weight.shape
+    )
+    assert groups['layers.0.attn.wkv.weight']['matrix_shape'] == tuple(
+        a.wkv.weight.shape
+    )
+    assert groups['layers.0.attn.wq_b.weight']['matrix_shape'] == (8, 64, 64)
+    assert all('indexer' not in key for key in groups)
+    assert {id(p) for g in opt.param_groups for p in g['params']} == {
+        id(p) for p in model.parameters() if p.requires_grad
+    }
+    assert len([p for g in opt.param_groups for p in g['params']]) == len(groups)
+    for block in model.layers:
+        if block.engram is not None:
+            table = block.engram.embed
+            assert (table.master is not None) == trainable
+            assert table.weight.dtype == torch.float8_e4m3fn
+    assert {type(o).__name__ for o in opt.optimizers} == {
+        'HeadwiseMuon',
+        'Sinkhorn',
+        'AdamW',
+    }
+    for key, group in groups.items():
+        if '.engram.' in key:
+            assert group['lr'] == 5e-3
+        if key.endswith(('q_weight', 'k_weight')):
+            assert group['algorithm'] == 'adamw' and group['weight_decay'] == 0.1
+    ids = torch.tensor([3, 4, 3, 5], device=device)
+    batch = PackedBatch(
+        ids, ids, torch.tensor([4], device=device), torch.ones(4, device=device)
+    )
+    bundle.forward_step(model, batch)['loss'].backward()
+    gradient = a.wq_b.weight.main_grad
+    assert gradient.dtype == torch.float32 and gradient is a.wq_b.weight.grad
+    assert not torch.equal(gradient, gradient.bfloat16().float())
+    before = a.wq_b.weight.detach().clone()
+    success, norm, _ = opt.step()
+    assert success and norm > 0 and not torch.equal(before, a.wq_b.weight)
+    for backend in opt.optimizers:
+        for state in backend.state.values():
+            for key, value in state.items():
+                if 'momentum' in key:
+                    assert value.dtype == torch.float32
+    opt.zero_grad()
+    assert a.wq_b.weight.grad is None and a.wq_b.weight.main_grad is None
+
+
+def test_v41_native_linear_accumulates_unrounded_weight_gradients():
+    from megatron.lite.primitive.modules.native_fp32_linear import native_fp32_linear
+
+    torch.manual_seed(417)
+    weight = torch.nn.Parameter(torch.randn(7, 5))
+    reference = torch.zeros_like(weight)
+    for _ in range(2):
+        x = torch.randn(11, 5).bfloat16().requires_grad_()
+        grad = torch.randn(11, 7).bfloat16()
+        output = native_fp32_linear(x, weight)
+        assert torch.equal(output, torch.nn.functional.linear(x, weight.bfloat16()))
+        with torch.autocast('cpu', dtype=torch.bfloat16):
+            output.backward(grad)
+        reference += grad.float().T @ x.float()
+    assert torch.equal(weight.grad, reference)
+    assert not torch.equal(weight.grad, weight.grad.bfloat16().float())
+
+
+def test_v41_optimizer_resume_and_atomic_skip(moe, monkeypatch):
+    from copy import deepcopy
+
+    from megatron.lite.model.deepseek_v41.lite import optimizer_groups, protocol
+    from megatron.lite.runtime.contracts import PackedBatch
+
+    config = optimizer_groups.OptimizerConfig(
+        lr=1e-3, ns_steps=5, coefficient_type='quintic'
+    )
+    impl = protocol.ImplConfig(
+        device='cpu',
+        quantized=False,
+        dtype=torch.bfloat16,
+        token_map=list(range(256)),
+        trainable_engram=True,
+        optimizer='muon',
+        optimizer_config=config,
+    )
+    bundle = protocol.build_model(_assembly_config(), impl_cfg=impl)
+    model, opt = bundle.chunks[0], bundle.optimizer
+    ids = torch.tensor([2, 3, 4])
+    batch = PackedBatch(ids, ids, torch.tensor([3]), torch.ones(3))
+    bundle.forward_step(model, batch)['loss'].backward()
+    assert opt.step()[0]
+    saved_weights, saved_opt = deepcopy(model.state_dict()), deepcopy(opt.state_dict())
+    # A nonfinite gradient in AdamW must not let Muon or Sinkhorn publish first.
+    p = model.norm.weight
+    old = p.main_grad.clone()
+    p.main_grad.fill_(float('inf'))
+    assert not opt.step()[0]
+    p.main_grad.copy_(old)
+    for key, value in model.state_dict().items():
+        assert torch.equal(
+            value.view(torch.uint8), saved_weights[key].view(torch.uint8)
+        )
+
+    def reject_publication(*args, **kwargs):
+        raise RuntimeError('publication probe')
+
+    with monkeypatch.context() as patch:
+        patch.setattr(optimizer_groups, 'quantize_block_fp8', reject_publication)
+        with pytest.raises(RuntimeError, match='publication probe'):
+            opt.step()
+    for key, value in model.state_dict().items():
+        assert torch.equal(
+            value.view(torch.uint8), saved_weights[key].view(torch.uint8)
+        )
+    restored = protocol.build_model(_assembly_config(), impl_cfg=impl)
+    restored.chunks[0].load_state_dict(saved_weights)
+    restored.optimizer.load_state_dict(saved_opt)
+    for candidate in (bundle, restored):
+        candidate.optimizer.zero_grad()
+        candidate.forward_step(candidate.chunks[0], batch)['loss'].backward()
+        assert candidate.optimizer.step()[0]
+    for p, q in zip(model.parameters(), restored.chunks[0].parameters()):
+        torch.testing.assert_close(p, q, atol=0, rtol=0)
+
+
+def test_v41_optimizer_rejects_unknown_alias_and_live_indexer(moe):
+    from dataclasses import replace
+
+    from megatron.lite.model.deepseek_v41.lite.optimizer_groups import parameter_groups
+
+    _, bundle = _assembly_bundle()
+    model = bundle.chunks[0]
+    model.extra = torch.nn.Parameter(torch.ones(2, 2))
+    with pytest.raises(ValueError):
+        parameter_groups(model, lr=1e-3)
+    del model.extra
+    binding = model.tensor_bindings['layers.0.attn.wq_b.weight']
+    model.tensor_bindings['layers.0.attn.wq_b.weight'] = replace(
+        binding, head_count=None
+    )
+    with pytest.raises(ValueError, match='head'):
+        parameter_groups(model, lr=1e-3)
+    model.tensor_bindings['layers.0.attn.wq_b.weight'] = binding
+    model.extra = model.layers[0].attn.wq_a.weight
+    with pytest.raises(ValueError, match='alias'):
+        parameter_groups(model, lr=1e-3)
+    del model.extra
+    model.layers[2].attn.indexer.requires_grad_(True)
+    with pytest.raises(ValueError, match='indexer'):
+        parameter_groups(model, lr=1e-3)
 
 
 def test_v41_registry_assembly_forward_and_parameter_owners(moe):


### PR DESCRIPTION
Wire the V4.1 protocol to actual Muon, Sinkhorn, and AdamW optimizers using concrete parameter owners. Apply independent Muon updates to wq_b heads while retaining shared-matrix updates for wq_a and wkv; reject unclassified owners and trainable indexers.

Keep FP32 master weights and native FP32 weight gradients across BF16/quantized compute. Support frozen and trainable Engram tables, stage updates before publication, and restore optimizer state with owner/layout validation. Reuse Emerging Optimizers v0.3.0 Newton–Schulz and the existing shared Sinkhorn implementation.

Validation:
- CPU suites with the additional guards in 501cf3ea6: 81 passed; 4 CUDA cases skipped on CPU.
- H100 GPU execution on a4d24d883: all 4 CUDA cases passed, zero skips; scheduler exit code 0. The follow-up only adds CPU guards; production code and those GPU cases are unchanged.
- Eight routing/entry/publication mutations rejected by focused tests, including misleading names, indexer inclusion, and stale FP8 scales.
- Misleading parameter and release labels cannot change object-based routing. Frozen tables retain FP8 bytes; trainable tables retain the FP32 master object and regenerate FP8 data/scales across a forced scale boundary.
- Independent per-head reference remains bitwise equal across three updates and state restore.

This implementation targets the existing single-rank model. Candidate staging uses additional memory; distributed optimizer integration and active vision owners remain outside this change. Newton–Schulz recipe parameters must be supplied explicitly.

External dependency: install `emerging-optimizers==0.3.0` (`pip install emerging-optimizers==0.3.0`), published from [NVIDIA-NeMo/Emerging-Optimizers](https://github.com/NVIDIA-NeMo/Emerging-Optimizers/tree/v0.3.0). Newton–Schulz is supplied by that package, not reimplemented here. The standard test overlay now provides this dependency; missing it raises an import error rather than skipping core optimizer tests.

Full-suite regression against mainparent job 18354480: recheck job 18377699 completed with **768 passed, 20 failed, 22 skipped, 5 collection errors; added=0, removed=0**. The existing baseline failures/errors leave the scheduler exit code at 1:0; the regression criterion is zero added failures. All 72 baseline test files retain identical MD5 hashes and the skip list is identical. The ten previously missing-dependency failures now execute successfully.
