### PR TITLE
Run packed V4.1 paired state through the common pipeline scheduler

### DIFF
--- a/experimental/lite/megatron/lite/model/deepseek_v41/lite/pipeline.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v41/lite/pipeline.py
@@ -203,3 +203,172 @@ class PipelineLedger:
             for identity, generation in self._latest.items()
             if identity[0] > step
         }
+
+
+class PackedPipelineAdapter:
+    """Sequence-preserving paired transport for the common PP scheduler.
+
+    Each packed sequence has its own ledger and wire tag; no sequence dimension
+    is flattened into another sample's CSA2 state. Frozen source index keys and
+    candidates are read-only shadows. Only floating owner paths return gradients.
+    """
+
+    def __init__(self, model, parallel_state, *, recompute=False):
+        self.model, self.ps = model, parallel_state
+        self.recompute = recompute
+        self.step = 0
+        self._active = False
+        self._records = {}
+        self._ledgers = {}
+
+    def begin(self, count, *, forward_only=False):
+        if self._active or self._records:
+            raise RuntimeError('Pipeline step is still live')
+        if count < 1:
+            raise ValueError('Require at least one pipeline microbatch')
+        self._active = True
+        self._count = count
+        self._forward_only = forward_only
+
+    @staticmethod
+    def owners(boundary):
+        layer = boundary - 1
+        if layer < 2:
+            return (-1, -1)
+        kv = 20 if layer >= 20 else 14 if layer >= 14 else 8 if layer >= 8 else 2
+        index = 20 + ((layer - 20) // 4) * 4 if layer >= 20 else kv
+        return kv, index
+
+    def _tag(self, boundary, microbatch):
+        return PipelineTag(self.step, microbatch, boundary, 0, *self.owners(boundary))
+
+    def _transfer(self, tensors, boundary, microbatch, sequence, phase, *, send):
+        from megatron.lite.primitive.parallel import tensor_payload
+
+        tag = (*self._tag(boundary, microbatch).as_tuple(), sequence, phase)
+        forward = phase != 1
+        peer = self.ps.pp_next_rank if send == forward else self.ps.pp_prev_rank
+        kwargs = dict(
+            peer=peer,
+            group=self.ps.pp_group,
+            device=next(self.model.parameters()).device,
+        )
+        if send:
+            return tensor_payload.send_tensor_payload(tensors, tag, **kwargs)
+        return tensor_payload.recv_tensor_payload(tag, **kwargs)
+
+    def forward(self, batch, microbatch):
+        from .protocol import packed_pipeline_forward_step
+
+        if (
+            not self._active
+            or microbatch in self._records
+            or not 0 <= microbatch < self._count
+        ):
+            raise RuntimeError('Unknown or duplicate pipeline microbatch')
+        start, end = self.model.local_layer_range
+        state = None
+        if self.ps.pp_rank:
+            (lengths,) = self._transfer(None, start, microbatch, 0, 2, send=False)
+            if not torch.equal(lengths, batch.seq_lens):
+                raise ValueError(
+                    'Packed pipeline sequence boundaries differ across stages'
+                )
+            state = tuple(
+                (
+                    PairedPayload.from_tensors(
+                        self._transfer(None, start, microbatch, sequence, 0, send=False)
+                    ),
+                    self.owners(start),
+                )
+                for sequence in range(len(batch.seq_lens))
+            )
+
+        def run():
+            return packed_pipeline_forward_step(
+                self.model, batch, start=start, end=end, state=state
+            )
+
+        if self._forward_only:
+            with torch.no_grad():
+                out = run()
+        elif self.recompute:
+            from torch.utils.checkpoint import checkpoint
+
+            out = checkpoint(run, use_reentrant=False, preserve_rng_state=True)
+        else:
+            out = run()
+        outputs = out['packed_pipeline_state']
+        self._records[microbatch] = (state, len(outputs))
+        if self.ps.pp_rank < self.ps.pp_size - 1:
+            self._transfer((batch.seq_lens,), end, microbatch, 0, 2, send=True)
+            for sequence, (payload, owners) in enumerate(outputs):
+                if owners != self.owners(end):
+                    raise ValueError('Pipeline range changed canonical source owners')
+                if not self._forward_only:
+                    ledger = self._ledgers.setdefault(sequence, PipelineLedger())
+                    ledger.publish(
+                        self._tag(end, microbatch),
+                        payload,
+                        consumers=(self.ps.pp_next_rank,),
+                    )
+                self._transfer(
+                    payload.tensors(), end, microbatch, sequence, 0, send=True
+                )
+        # Graph ownership is retained by ledger or by final-stage loss, not metrics.
+        return {
+            key: value for key, value in out.items() if key != 'packed_pipeline_state'
+        }
+
+    def backward(self, microbatch, loss):
+        if not self._active or self._forward_only or microbatch not in self._records:
+            raise RuntimeError('Unknown, stale or released pipeline microbatch')
+        state, sequences = self._records[microbatch]
+        start, end = self.model.local_layer_range
+        if self.ps.pp_rank == self.ps.pp_size - 1:
+            if loss is None:
+                raise ValueError('Final pipeline stage requires a scalar loss')
+            loss.backward()
+        else:
+            for sequence in range(sequences):
+                values = self._transfer(None, end, microbatch, sequence, 1, send=False)
+                ledger = self._ledgers[sequence]
+                tag = self._tag(end, microbatch)
+                ledger.return_gradients(
+                    tag,
+                    self.ps.pp_next_rank,
+                    {
+                        name: value
+                        for name, value in zip(PAYLOAD_FIELDS, values)
+                        if value is not None
+                    },
+                )
+                ledger.backward(tag)
+        if state is not None:
+            for sequence, (payload, _) in enumerate(state):
+                gradients = {
+                    name: torch.zeros_like(value) if value.grad is None else value.grad
+                    for name, value in payload.differentiable().items()
+                }
+                self._transfer(
+                    tuple(gradients.get(name) for name in PAYLOAD_FIELDS),
+                    start,
+                    microbatch,
+                    sequence,
+                    1,
+                    send=True,
+                )
+        del self._records[microbatch]
+
+    def finish(self):
+        if not self._active:
+            raise RuntimeError('No active pipeline step')
+        if self._forward_only:
+            self._records.clear()
+        if self._records:
+            raise RuntimeError('Pipeline microbatches are still live')
+        for ledger in self._ledgers.values():
+            ledger.assert_quiescent()
+            ledger.finish_step(self.step)
+        self._active = False
+        self.step += 1

--- a/experimental/lite/megatron/lite/model/deepseek_v41/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v41/lite/protocol.py
@@ -35,6 +35,7 @@ class ImplConfig:
     gate_temperature: float = 1.0
     bias_rate: float = 0.001
     enable_dspark_execution: bool = False
+    pipeline_recompute: bool = False
 
 
 def build_model_config(source, **overrides):
@@ -145,6 +146,8 @@ def build_model(model_cfg, *, impl_cfg):
                 p.register_post_accumulate_grad_hook(_publish_main_grad)
         model.residual_dtype = impl_cfg.dtype
         optimizer = V41Optimizer(model, impl_cfg.optimizer_config)
+    from .pipeline import PackedPipelineAdapter
+
     return ModelBundle(
         [model],
         ps,
@@ -154,6 +157,11 @@ def build_model(model_cfg, *, impl_cfg):
             'model_cfg': model_cfg,
             'optimizer_backend': 'none' if optimizer is None else 'v41',
             'parameter_bindings': model.parameter_bindings,
+            'pipeline_payload_adapter': (
+                PackedPipelineAdapter(model, ps, recompute=impl_cfg.pipeline_recompute)
+                if ps.pp_size > 1
+                else None
+            ),
         },
     )
 

--- a/experimental/lite/megatron/lite/primitive/parallel/pipeline.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/pipeline.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING
 
 import torch  # pyright: ignore[reportMissingImports]
 import torch.distributed as dist  # pyright: ignore[reportMissingImports]
-
 from megatron.lite.primitive.utils import ensure_divisible
 from megatron.lite.runtime.contracts.loss import split_loss_context, use_loss_context
 
@@ -28,6 +27,7 @@ def forward_backward_pipelining(
     pre_forward_hook: Callable[[torch.Tensor], None] | None = None,
     loss_fn: Callable | None = None,
     forward_only: bool = False,
+    payload_adapter=None,
 ) -> list[dict]:
     """
     Run forward and backward passes with pipeline parallelism.
@@ -57,6 +57,15 @@ def forward_backward_pipelining(
     Returns:
         List of output dicts from forward passes.
     """
+    if payload_adapter is not None:
+        return _payload_pipeline_schedule(
+            payload_adapter,
+            data_iter,
+            _num_microbatches_from_config(config, ps),
+            loss_fn=loss_fn,
+            forward_only=forward_only,
+        )
+
     if ps.pp_size <= 1:
         if forward_only:
             return _forward_only_no_pipeline(
@@ -127,6 +136,32 @@ def forward_backward_pipelining(
 # ══════════════════════════════════════════════════════════════════════
 # No pipeline (PP=1)
 # ══════════════════════════════════════════════════════════════════════
+def _payload_pipeline_schedule(adapter, data_iter, count, *, loss_fn, forward_only):
+    """Drain a model-owned typed carrier, retaining distinct microbatch graphs.
+
+    Model adapters own schemas, P2P and generation validation. This fill/drain
+    schedule forwards in input order and returns cotangents in reverse order;
+    it does not reinterpret paired state as a single hidden tensor.
+    """
+    outputs = []
+    adapter.begin(count, forward_only=forward_only)
+    for microbatch in range(count):
+        item = next(data_iter)
+        batch, context = split_loss_context(item)
+        with use_loss_context(context):
+            out = adapter.forward(batch, microbatch)
+            if out:
+                _apply_external_loss(out, item, loss_fn)
+        outputs.append(out)
+    if not forward_only:
+        for microbatch in reversed(range(count)):
+            out = outputs[microbatch]
+            loss = out.get('loss')
+            adapter.backward(microbatch, None if loss is None else loss / count)
+    adapter.finish()
+    return [_compact_pipeline_output(out) for out in outputs]
+
+
 def _num_microbatches_from_config(config, ps: ParallelState) -> int:
     explicit = getattr(config, "num_microbatches", None)
     if explicit is not None:
@@ -169,7 +204,9 @@ def _compact_pipeline_output(out: dict | None) -> dict:
         compact["model_output"] = out["model_output"]
     if "loss" in out and out["loss"] is not None:
         loss = out["loss"]
-        compact["loss"] = loss.detach().item() if isinstance(loss, torch.Tensor) else float(loss)
+        compact["loss"] = (
+            loss.detach().item() if isinstance(loss, torch.Tensor) else float(loss)
+        )
     if "_loss_fn_metrics" in out:
         compact["metrics"] = out["_loss_fn_metrics"]
     elif "metrics" in out:
@@ -208,7 +245,14 @@ def _no_pipeline(
 
 
 def _forward_only_no_pipeline(
-    forward_step_fn, model, data_iter, config, ps, *, pre_forward_hook=None, loss_fn=None
+    forward_step_fn,
+    model,
+    data_iter,
+    config,
+    ps,
+    *,
+    pre_forward_hook=None,
+    loss_fn=None,
 ):
     num_microbatches = _num_microbatches_from_config(config, ps)
     del ps
@@ -290,13 +334,7 @@ def _1f1b_schedule(
         # Megatron dynamic shape exchange: the recv buffer is sized from the shape
         # the sender transmits, so no per-mb shape has to be tracked here.
         return _send_recv_pipeline(
-            send_fwd,
-            send_bwd,
-            recv_fwd,
-            recv_bwd,
-            ps,
-            tensor_shape,
-            dynamic_shape=True,
+            send_fwd, send_bwd, recv_fwd, recv_bwd, ps, tensor_shape, dynamic_shape=True
         )
 
     # ── Warmup: pure forward passes ──
@@ -310,7 +348,9 @@ def _1f1b_schedule(
         current_input = fwd_input
         out = _run_forward(fwd_input, batch, loss_ctx)
         hidden = out.get("hidden_states")
-        loss_s = out["loss"] / num_microbatches if "loss" in out and ps.pp_is_last else None
+        loss_s = (
+            out["loss"] / num_microbatches if "loss" in out and ps.pp_is_last else None
+        )
 
         # Recv the next forward input for every remaining warmup mb AND — on the
         # last warmup step — for the first STEADY mb (num_steady > 0). Middle
@@ -341,7 +381,9 @@ def _1f1b_schedule(
         mb_idx += 1
         out = _run_forward(fwd_input, batch, loss_ctx)
         hidden = out.get("hidden_states")
-        loss_s = out["loss"] / num_microbatches if "loss" in out and ps.pp_is_last else None
+        loss_s = (
+            out["loss"] / num_microbatches if "loss" in out and ps.pp_is_last else None
+        )
 
         input_tensors.append(fwd_input if not ps.pp_is_first else None)
         output_hiddens.append(hidden)
@@ -431,10 +473,14 @@ def _communicate_shapes(
     """
     device = _pipeline_device()
     recv_fwd_t = (
-        torch.empty(_PIPELINE_SHAPE_NDIM, dtype=torch.int64, device=device) if recv_fwd else None
+        torch.empty(_PIPELINE_SHAPE_NDIM, dtype=torch.int64, device=device)
+        if recv_fwd
+        else None
     )
     recv_bwd_t = (
-        torch.empty(_PIPELINE_SHAPE_NDIM, dtype=torch.int64, device=device) if recv_bwd else None
+        torch.empty(_PIPELINE_SHAPE_NDIM, dtype=torch.int64, device=device)
+        if recv_bwd
+        else None
     )
     send_fwd_t = (
         torch.tensor(tuple(send_fwd.size()), dtype=torch.int64, device=device)
@@ -574,12 +620,18 @@ def _send_recv_pipeline(
         ops.append(dist.P2POp(dist.isend, t, ps.pp_next_rank, p2p_group))
     if recv_fwd:
         if dynamic_shape:
-            fwd_buf = torch.empty(recv_fwd_shape, dtype=_PIPELINE_TENSOR_DTYPE, device=_pipeline_device())
+            fwd_buf = torch.empty(
+                recv_fwd_shape, dtype=_PIPELINE_TENSOR_DTYPE, device=_pipeline_device()
+            )
         else:
             fwd_buf = (
                 fwd_recv_buf
                 if fwd_recv_buf is not None
-                else torch.empty(tensor_shape, dtype=_PIPELINE_TENSOR_DTYPE, device=_pipeline_device())
+                else torch.empty(
+                    tensor_shape,
+                    dtype=_PIPELINE_TENSOR_DTYPE,
+                    device=_pipeline_device(),
+                )
             )
         ops.append(dist.P2POp(dist.irecv, fwd_buf, ps.pp_prev_rank, p2p_group))
     if send_bwd is not None:
@@ -587,12 +639,18 @@ def _send_recv_pipeline(
         ops.append(dist.P2POp(dist.isend, t, ps.pp_prev_rank, p2p_group))
     if recv_bwd:
         if dynamic_shape:
-            bwd_buf = torch.empty(recv_bwd_shape, dtype=_PIPELINE_TENSOR_DTYPE, device=_pipeline_device())
+            bwd_buf = torch.empty(
+                recv_bwd_shape, dtype=_PIPELINE_TENSOR_DTYPE, device=_pipeline_device()
+            )
         else:
             bwd_buf = (
                 bwd_recv_buf
                 if bwd_recv_buf is not None
-                else torch.empty(tensor_shape, dtype=_PIPELINE_TENSOR_DTYPE, device=_pipeline_device())
+                else torch.empty(
+                    tensor_shape,
+                    dtype=_PIPELINE_TENSOR_DTYPE,
+                    device=_pipeline_device(),
+                )
             )
         ops.append(dist.P2POp(dist.irecv, bwd_buf, ps.pp_next_rank, p2p_group))
 
@@ -646,7 +704,9 @@ def _pipeline_stage_barrier(ps: ParallelState) -> None:
         dist.barrier(group=ps.pp_cpu_group)
 
 
-def _set_virtual_pipeline_rank(ps: ParallelState, chunk_id: int | None, num_chunks: int) -> None:
+def _set_virtual_pipeline_rank(
+    ps: ParallelState, chunk_id: int | None, num_chunks: int
+) -> None:
     if chunk_id is None or num_chunks <= 1:
         ps.virtual_pipeline_size = None
         ps.virtual_pipeline_rank = None
@@ -748,7 +808,9 @@ def _forward_only_pipeline_schedule(
                 if recv_next:
                     pending_activation = fwd_buf
 
-        outputs.append(_compact_pipeline_output(last_output) if last_output is not None else {})
+        outputs.append(
+            _compact_pipeline_output(last_output) if last_output is not None else {}
+        )
 
     _set_virtual_pipeline_rank(ps, None, num_chunks)
     return outputs
@@ -795,7 +857,8 @@ def _interleaved_1f1b_schedule(
         batch = next(data_iter)
         _set_aux_loss_scale(pre_forward_hook, num_microbatches)
         saved: dict[
-            int, tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None, dict]
+            int,
+            tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None, dict],
         ] = {}
         pending_activation: torch.Tensor | None = None
 
@@ -814,7 +877,9 @@ def _interleaved_1f1b_schedule(
                 activation = None if is_first_stage else pending_activation
                 pending_activation = None
                 if _dbg:
-                    activation_shape = None if activation is None else tuple(activation.shape)
+                    activation_shape = (
+                        None if activation is None else tuple(activation.shape)
+                    )
                     print(
                         f"[VPP r{rank}] mb={mb_id} fwd stage={stage_id} "
                         f"chunk={chunk_id} activation_shape={activation_shape}",
@@ -840,7 +905,11 @@ def _interleaved_1f1b_schedule(
                         f"chunk={chunk_id} hidden_shape={hidden_shape}",
                         flush=True,
                     )
-                loss = out["loss"] / num_microbatches if is_last_stage and "loss" in out else None
+                loss = (
+                    out["loss"] / num_microbatches
+                    if is_last_stage and "loss" in out
+                    else None
+                )
                 saved[stage_id] = (activation, hidden, loss, out)
 
                 if is_last_stage:

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -13,12 +13,20 @@ from typing import Any
 
 import torch
 import torch.distributed as dist
-from torch.distributed.tensor import DTensor  # pyright: ignore[reportMissingImports]
 from megatron.lite.runtime.backends import Runtime as RuntimeBase
 from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig
-from megatron.lite.runtime.contracts.data import ForwardResult, ModelOutputs, PackedBatch
+from megatron.lite.runtime.contracts.data import (
+    ForwardResult,
+    ModelOutputs,
+    PackedBatch,
+)
 from megatron.lite.runtime.contracts.handle import ModelHandle
-from megatron.lite.runtime.contracts.loss import get_loss_context, split_loss_context, use_loss_context
+from megatron.lite.runtime.contracts.loss import (
+    get_loss_context,
+    split_loss_context,
+    use_loss_context,
+)
+from torch.distributed.tensor import DTensor  # pyright: ignore[reportMissingImports]
 
 
 def _build_impl_cfg(proto, rt_cfg: MegatronLiteConfig):
@@ -26,20 +34,28 @@ def _build_impl_cfg(proto, rt_cfg: MegatronLiteConfig):
     init_fields = {f.name for f in dc_fields(proto.ImplConfig) if f.init}
     # Only forward impl_cfg keys this model's ImplConfig declares: the connector
     # may pass knobs (e.g. cross_entropy_fusion) that some models don't model.
-    impl_cfg_kwargs = {key: value for key, value in rt_cfg.impl_cfg.items() if key in init_fields}
+    impl_cfg_kwargs = {
+        key: value for key, value in rt_cfg.impl_cfg.items() if key in init_fields
+    }
     impl_cfg_kwargs["parallel"] = rt_cfg.parallel
     if (
         "attention_backend_override" in init_fields
         and impl_cfg_kwargs.get("attention_backend_override") is None
     ):
-        impl_cfg_kwargs["attention_backend_override"] = rt_cfg.attention_backend_override
+        impl_cfg_kwargs["attention_backend_override"] = (
+            rt_cfg.attention_backend_override
+        )
     if (
         "router_aux_loss_coef" in init_fields
         and impl_cfg_kwargs.get("router_aux_loss_coef") is None
         and rt_cfg.router_aux_loss_coef is not None
     ):
         impl_cfg_kwargs["router_aux_loss_coef"] = rt_cfg.router_aux_loss_coef
-    if "hf_path" in init_fields and impl_cfg_kwargs.get("hf_path") in (None, "") and rt_cfg.hf_path:
+    if (
+        "hf_path" in init_fields
+        and impl_cfg_kwargs.get("hf_path") in (None, "")
+        and rt_cfg.hf_path
+    ):
         impl_cfg_kwargs["hf_path"] = rt_cfg.hf_path
     # Thread the user-level OptimizerConfig so the protocol can pass it to
     # optimizer primitives without reading runtime internals.
@@ -63,12 +79,18 @@ def _reset_parameters(module: torch.nn.Module) -> None:
         for name, original in original_parameters.items():
             replacement = module._parameters.get(name)
             if replacement is None:
-                raise RuntimeError(f"{type(module).__name__}.reset_parameters() removed {name!r}.")
+                raise RuntimeError(
+                    f"{type(module).__name__}.reset_parameters() removed {name!r}."
+                )
             if replacement is original:
                 continue
-            original_local = original.to_local() if isinstance(original, DTensor) else original
+            original_local = (
+                original.to_local() if isinstance(original, DTensor) else original
+            )
             replacement_local = (
-                replacement.to_local() if isinstance(replacement, DTensor) else replacement
+                replacement.to_local()
+                if isinstance(replacement, DTensor)
+                else replacement
             )
             if original_local.shape != replacement_local.shape:
                 raise RuntimeError(
@@ -78,8 +100,7 @@ def _reset_parameters(module: torch.nn.Module) -> None:
             if original_local.data_ptr() != replacement_local.data_ptr():
                 original_local.copy_(
                     replacement_local.to(
-                        device=original_local.device,
-                        dtype=original_local.dtype,
+                        device=original_local.device, dtype=original_local.dtype
                     )
                 )
             module._parameters[name] = original
@@ -108,9 +129,13 @@ def _apply_attention_backend_env(backend: str | None, *, tag: str) -> None:
     os.environ["NVTE_UNFUSED_ATTN"] = unfused
 
 
-def _infer_pipeline_tensor_shape(batch: PackedBatch, model_cfg: Any, ps) -> tuple[int, int, int]:
+def _infer_pipeline_tensor_shape(
+    batch: PackedBatch, model_cfg: Any, ps
+) -> tuple[int, int, int]:
     if model_cfg is None or not hasattr(model_cfg, "hidden_size"):
-        raise ValueError("Megatron Lite pipeline runtime requires model_cfg.hidden_size.")
+        raise ValueError(
+            "Megatron Lite pipeline runtime requires model_cfg.hidden_size."
+        )
     if not isinstance(batch, PackedBatch):
         raise TypeError("Megatron Lite pipeline runtime requires PackedBatch inputs.")
 
@@ -122,7 +147,9 @@ def _infer_pipeline_tensor_shape(batch: PackedBatch, model_cfg: Any, ps) -> tupl
         batch_size = int(input_ids.size(0))
         local_seq_len = int(input_ids.size(1))
     else:
-        raise ValueError(f"Unsupported input_ids rank for pipeline runtime: {input_ids.dim()}.")
+        raise ValueError(
+            f"Unsupported input_ids rank for pipeline runtime: {input_ids.dim()}."
+        )
 
     if local_seq_len < 1:
         raise ValueError("Pipeline tensor shape requires non-empty sequence.")
@@ -136,7 +163,11 @@ def _infer_pipeline_tensor_shape(batch: PackedBatch, model_cfg: Any, ps) -> tupl
     # (each sequence padded to align = tp * (2*cp if cp>1 else 1)) then divide by CP*TP.
     seq_lens = getattr(batch, "seq_lens", None)
     if seq_lens is not None and cp_size * tp_size > 1:
-        sl = seq_lens if isinstance(seq_lens, torch.Tensor) else torch.as_tensor(seq_lens)
+        sl = (
+            seq_lens
+            if isinstance(seq_lens, torch.Tensor)
+            else torch.as_tensor(seq_lens)
+        )
         sl = sl.to(torch.int64).reshape(-1)
         align = tp_size * (2 * cp_size if cp_size > 1 else 1)
         padded = sl + (align - sl % align) % align
@@ -267,9 +298,15 @@ class MegatronLiteRuntime(RuntimeBase):
 
         # ── load HF weights (optional) ──
         loaded_hf_weights = False
-        if rt_cfg.load_hf_weights and rt_cfg.hf_path and hasattr(proto, "load_hf_weights"):
+        if (
+            rt_cfg.load_hf_weights
+            and rt_cfg.hf_path
+            and hasattr(proto, "load_hf_weights")
+        ):
             for chunk in bundle.chunks:
-                proto.load_hf_weights(chunk, rt_cfg.hf_path, model_cfg, bundle.parallel_state)
+                proto.load_hf_weights(
+                    chunk, rt_cfg.hf_path, model_cfg, bundle.parallel_state
+                )
             loaded_hf_weights = True
 
         post_load_hook = bundle.extras.pop("post_model_load_hook", None)
@@ -285,7 +322,9 @@ class MegatronLiteRuntime(RuntimeBase):
                 extra_updates = post_load_updates.get("extras")
                 if extra_updates:
                     if not isinstance(extra_updates, dict):
-                        raise TypeError("post_model_load_hook extras update must be a dict.")
+                        raise TypeError(
+                            "post_model_load_hook extras update must be a dict."
+                        )
                     bundle.extras.update(extra_updates)
 
         if (loaded_hf_weights or meta_initialized) and bundle.optimizer is not None:
@@ -294,7 +333,9 @@ class MegatronLiteRuntime(RuntimeBase):
                 reload_model_params()
 
         if bundle.forward_step is None:
-            raise ValueError("Megatron Lite model bundles must provide a typed forward_step.")
+            raise ValueError(
+                "Megatron Lite model bundles must provide a typed forward_step."
+            )
 
         p = rt_cfg.parallel
         model = bundle.chunks[0] if len(bundle.chunks) == 1 else bundle.chunks
@@ -318,7 +359,10 @@ class MegatronLiteRuntime(RuntimeBase):
 
     def _load_protocol(self, rt_cfg: MegatronLiteConfig):
         """Load and return the model protocol module."""
-        from megatron.lite.model.registry import TRAIN_RUNTIME_MODULES, resolve_runtime_model_name
+        from megatron.lite.model.registry import (
+            TRAIN_RUNTIME_MODULES,
+            resolve_runtime_model_name,
+        )
 
         try:
             runtime_key = resolve_runtime_model_name(rt_cfg.model_name, rt_cfg.impl)
@@ -338,7 +382,9 @@ class MegatronLiteRuntime(RuntimeBase):
 
         for fn_name in ("build_model_config", "build_model"):
             if not callable(getattr(proto, fn_name, None)):
-                raise ValueError(f"Protocol module {mod_path} missing required function: {fn_name}")
+                raise ValueError(
+                    f"Protocol module {mod_path} missing required function: {fn_name}"
+                )
         if not hasattr(proto, "ImplConfig"):
             raise ValueError(f"Protocol module {mod_path} missing ImplConfig class")
 
@@ -401,7 +447,9 @@ class MegatronLiteRuntime(RuntimeBase):
             **kwargs,
         )
 
-    def export_weights(self, handle: ModelHandle, **kwargs) -> Iterator[tuple[str, torch.Tensor]]:
+    def export_weights(
+        self, handle: ModelHandle, **kwargs
+    ) -> Iterator[tuple[str, torch.Tensor]]:
         model_chunks = handle._extras.get("model_chunks", [handle._model])
         proto = handle._extras.get("protocol")
         model_cfg = handle._extras.get("model_cfg")
@@ -497,7 +545,9 @@ class MegatronLiteRuntime(RuntimeBase):
         router_replay: Any = None,
     ) -> ForwardResult:
         from megatron.lite.primitive.train_step import run_microbatch_loop
-        from megatron.lite.runtime.backends.mlite.router_replay import RouterReplayDriver
+        from megatron.lite.runtime.backends.mlite.router_replay import (
+            RouterReplayDriver,
+        )
 
         forward_step = handle._extras["forward_step"]
         if num_microbatches < 1:
@@ -520,7 +570,9 @@ class MegatronLiteRuntime(RuntimeBase):
             from types import SimpleNamespace
 
             from megatron.lite.primitive.ckpt.hf_weights import unwrap_model
-            from megatron.lite.primitive.parallel.pipeline import forward_backward_pipelining
+            from megatron.lite.primitive.parallel.pipeline import (
+                forward_backward_pipelining,
+            )
 
             first_item = next(data_iter)
             first_batch, _loss_context = split_loss_context(first_item)
@@ -530,11 +582,18 @@ class MegatronLiteRuntime(RuntimeBase):
             # forward-only schedules ignore this and use Megatron dynamic shape
             # exchange (the sender transmits its real per-micro-batch size), so THD
             # variable-length packing no longer needs a locally-derived shape.
-            tensor_shape = _infer_pipeline_tensor_shape(first_batch, model_cfg, ps)
+            payload_adapter = handle._extras.get("pipeline_payload_adapter")
+            tensor_shape = (
+                None
+                if payload_adapter is not None
+                else _infer_pipeline_tensor_shape(first_batch, model_cfg, ps)
+            )
 
             model_chunks = handle._extras.get("model_chunks", [handle._model])
             pipeline_chunks = [unwrap_model(chunk) for chunk in model_chunks]
-            pipeline_forward_step, pipeline_loss_fn = _pipeline_callbacks(forward_step, loss_fn)
+            pipeline_forward_step, pipeline_loss_fn = _pipeline_callbacks(
+                forward_step, loss_fn
+            )
             try:
                 outputs = forward_backward_pipelining(
                     pipeline_forward_step,
@@ -546,6 +605,7 @@ class MegatronLiteRuntime(RuntimeBase):
                     pre_forward_hook=handle._extras.get("pre_forward_hook"),
                     loss_fn=pipeline_loss_fn,
                     forward_only=forward_only,
+                    payload_adapter=payload_adapter,
                 )
             finally:
                 if replay_driver is not None:
@@ -562,7 +622,9 @@ class MegatronLiteRuntime(RuntimeBase):
                 dtype=torch.float32,
             )
             if ps.pp_group is not None and ps.pp_global_ranks is not None:
-                dist.broadcast(loss_payload, src=ps.pp_global_ranks[-1], group=ps.pp_group)
+                dist.broadcast(
+                    loss_payload, src=ps.pp_global_ranks[-1], group=ps.pp_group
+                )
             out = {"loss": loss_payload[1]} if bool(loss_payload[0].item()) else {}
         else:
             try:
@@ -678,7 +740,10 @@ def _checkpoint_model(handle: ModelHandle, *, use_dcp: bool):
 
 
 def _checkpoint_hooks(handle: ModelHandle):
-    from megatron.lite.primitive.protocols import default_expert_classifier, default_placement_fn
+    from megatron.lite.primitive.protocols import (
+        default_expert_classifier,
+        default_placement_fn,
+    )
 
     proto = handle._extras.get("protocol")
     return (

--- a/experimental/lite/tests/unit/model/test_deepseek_v41_semantics.py
+++ b/experimental/lite/tests/unit/model/test_deepseek_v41_semantics.py
@@ -862,6 +862,37 @@ def test_v41_pipeline_constructor_allocates_only_local_owners(moe, monkeypatch):
     assert assigned == expected, 'PP local owners do not cover the monolithic model'
 
 
+def test_v41_pipeline_rejects_range_outside_local_stage(moe):
+    from megatron.lite.model.deepseek_v41.lite.model import DeepseekV41Model
+
+    stage = DeepseekV41Model(
+        _assembly_config(),
+        token_map=list(range(256)),
+        quantized=False,
+        layer_range=(0, 20),
+    )
+    with pytest.raises(
+        ValueError, match='^Requested range is outside this pipeline stage$'
+    ):
+        stage.forward_pipeline_range(torch.tensor([[3, 4]]), start=0, end=21)
+
+
+def test_v41_pipeline_rejects_output_on_nonfinal_stage(moe):
+    from megatron.lite.model.deepseek_v41.lite.model import DeepseekV41Model
+
+    stage = DeepseekV41Model(
+        _assembly_config(),
+        token_map=list(range(256)),
+        quantized=False,
+        layer_range=(0, 20),
+    )
+    payload, _ = stage.forward_pipeline_range(torch.tensor([[3, 4]]), start=0, end=20)
+    with pytest.raises(
+        RuntimeError, match='^Only the final pipeline stage owns the output head$'
+    ):
+        stage.finish_pipeline(payload)
+
+
 def test_v41_packed_pipeline_matches_monolithic(moe):
     from megatron.lite.runtime.contracts import PackedBatch
 

--- a/experimental/lite/tests/unit/model/test_deepseek_v41_semantics.py
+++ b/experimental/lite/tests/unit/model/test_deepseek_v41_semantics.py
@@ -939,7 +939,7 @@ def test_v41_packed_pipeline_matches_monolithic(moe):
             )
 
 
-def _real_model_worker(rank, rendezvous):
+def _real_model_worker(rank, rendezvous, scheduled=False, recompute=False):
     from datetime import timedelta
 
     import torch.distributed as dist
@@ -979,10 +979,14 @@ def _real_model_worker(rank, rendezvous):
     bindings = [b for b in model.parameter_bindings() if id(b.tensor) in owned_ids]
     assert {id(b.tensor) for b in bindings} == owned_ids
     params = [b.tensor for b in bindings if b.tensor.requires_grad]
-    inputs = [torch.arange(3 + mb, 11 + mb, device=device)[None] for mb in range(2)]
+    lengths = ((5, 8, 3), (4, 7)) if scheduled else ((8,), (8,))
+    inputs = [
+        torch.arange(3 + mb, 3 + mb + sum(ns), device=device)[None]
+        for mb, ns in enumerate(lengths)
+    ]
     batches = [
-        PackedBatch(ids[0], None, torch.tensor([ids.numel()], device=device))
-        for ids in inputs
+        PackedBatch(ids[0], None, torch.tensor(ns, device=device))
+        for ids, ns in zip(inputs, lengths)
     ]
     reference_logits = []
     for mb, ids in enumerate(inputs):
@@ -991,7 +995,7 @@ def _real_model_worker(rank, rendezvous):
         coefficients = torch.linspace(
             -0.5, 1.0, logits.numel(), device=device
         ).reshape_as(logits)
-        (logits * coefficients * (mb + 1)).sum().backward()
+        ((logits * coefficients * (mb + 1)).sum() / (2 if scheduled else 1)).backward()
     reference_grads = {
         binding.release_key: (
             None
@@ -1038,6 +1042,7 @@ def _real_model_worker(rank, rendezvous):
             quantized=False,
             token_map=list(range(256)),
             parallel=ParallelConfig(pp=4),
+            pipeline_recompute=recompute,
         ),
     )
     model = bundle.chunks[0]
@@ -1082,81 +1087,125 @@ def _real_model_worker(rank, rendezvous):
             errors.append(label + ': ' + str(exc))
 
     try:
-        for mb, ids in enumerate(inputs):
-            payload = None
-            if rank:
-                payload = pipeline.PairedPayload.from_tensors(
-                    transport.recv_tensor_payload(
-                        (*tag_at(start, mb).as_tuple(), 0),
+        if scheduled:
+            from types import SimpleNamespace
+
+            from megatron.lite.primitive.parallel.pipeline import (
+                forward_backward_pipelining,
+            )
+
+            adapter = bundle.extras['pipeline_payload_adapter']
+            seen = []
+
+            def objective(out, batch):
+                mb = next(
+                    i for i, candidate in enumerate(batches) if candidate is batch
+                )
+                logits = out['logits']
+                compare(logits, reference_logits[mb], 'packed scheduled logits')
+                seen.append(mb)
+                coefficients = torch.linspace(
+                    -0.5, 1.0, logits.numel(), device=device
+                ).reshape_as(logits)
+                return (logits * coefficients * (mb + 1)).sum(), {}
+
+            forward_backward_pipelining(
+                bundle.forward_step,
+                [model],
+                iter(batches),
+                SimpleNamespace(num_microbatches=2),
+                bundle.parallel_state,
+                loss_fn=objective,
+                payload_adapter=adapter,
+            )
+            assert seen == ([0, 1] if rank == 3 else [])
+            assert adapter.step == 1 and not adapter._records
+            with pytest.raises(RuntimeError, match='stale'):
+                adapter.backward(0, None)
+        else:
+            for mb, ids in enumerate(inputs):
+                payload = None
+                if rank:
+                    payload = pipeline.PairedPayload.from_tensors(
+                        transport.recv_tensor_payload(
+                            (*tag_at(start, mb).as_tuple(), 0),
+                            peer=rank - 1,
+                            group=group,
+                            device=device,
+                        )
+                    )
+                incoming.append(payload)
+                stage_result = protocol.pipeline_forward_step(
+                    model,
+                    batches[mb],
+                    start=start,
+                    end=end,
+                    payload=payload,
+                    owners=owners_at(start),
+                )
+                output, owners = (
+                    stage_result['pipeline_payload'],
+                    stage_result['pipeline_owners'],
+                )
+                stage_results.append(stage_result)
+                assert owners == owners_at(
+                    end
+                ), 'Real C4 range changed the canonical owner'
+                outputs.append(output)
+                if rank < 3:
+                    ledger.publish(tag_at(end, mb), output, consumers=(rank + 1,))
+                    transport.send_tensor_payload(
+                        output.tensors(),
+                        (*tag_at(end, mb).as_tuple(), 0),
+                        peer=rank + 1,
+                        group=group,
+                        device=device,
+                    )
+                else:
+                    compare(
+                        stage_result['logits'], reference_logits[mb], 'real C4 logits'
+                    )
+            for mb in reversed(range(2)):
+                if rank == 3:
+                    logits = stage_results[mb]['logits']
+                    coefficients = torch.linspace(
+                        -0.5, 1.0, logits.numel(), device=device
+                    ).reshape_as(logits)
+                    (logits * coefficients * (mb + 1)).sum().backward()
+                else:
+                    returned = transport.recv_tensor_payload(
+                        (*tag_at(end, mb).as_tuple(), 1),
+                        peer=rank + 1,
+                        group=group,
+                        device=device,
+                    )
+                    ledger.return_gradients(
+                        tag_at(end, mb),
+                        rank + 1,
+                        {
+                            name: value
+                            for name, value in zip(pipeline.PAYLOAD_FIELDS, returned)
+                            if value is not None
+                        },
+                    )
+                    ledger.backward(tag_at(end, mb))
+                if rank:
+                    fields = incoming[mb].differentiable()
+                    returned = {
+                        name: (
+                            torch.zeros_like(value)
+                            if value.grad is None
+                            else value.grad
+                        )
+                        for name, value in fields.items()
+                    }
+                    transport.send_tensor_payload(
+                        tuple(returned.get(name) for name in pipeline.PAYLOAD_FIELDS),
+                        (*tag_at(start, mb).as_tuple(), 1),
                         peer=rank - 1,
                         group=group,
                         device=device,
                     )
-                )
-            incoming.append(payload)
-            stage_result = protocol.pipeline_forward_step(
-                model,
-                batches[mb],
-                start=start,
-                end=end,
-                payload=payload,
-                owners=owners_at(start),
-            )
-            output, owners = (
-                stage_result['pipeline_payload'],
-                stage_result['pipeline_owners'],
-            )
-            stage_results.append(stage_result)
-            assert owners == owners_at(end), 'Real C4 range changed the canonical owner'
-            outputs.append(output)
-            if rank < 3:
-                ledger.publish(tag_at(end, mb), output, consumers=(rank + 1,))
-                transport.send_tensor_payload(
-                    output.tensors(),
-                    (*tag_at(end, mb).as_tuple(), 0),
-                    peer=rank + 1,
-                    group=group,
-                    device=device,
-                )
-            else:
-                compare(stage_result['logits'], reference_logits[mb], 'real C4 logits')
-        for mb in reversed(range(2)):
-            if rank == 3:
-                logits = stage_results[mb]['logits']
-                coefficients = torch.linspace(
-                    -0.5, 1.0, logits.numel(), device=device
-                ).reshape_as(logits)
-                (logits * coefficients * (mb + 1)).sum().backward()
-            else:
-                returned = transport.recv_tensor_payload(
-                    (*tag_at(end, mb).as_tuple(), 1),
-                    peer=rank + 1,
-                    group=group,
-                    device=device,
-                )
-                ledger.return_gradients(
-                    tag_at(end, mb),
-                    rank + 1,
-                    {
-                        name: value
-                        for name, value in zip(pipeline.PAYLOAD_FIELDS, returned)
-                        if value is not None
-                    },
-                )
-                ledger.backward(tag_at(end, mb))
-            if rank:
-                fields = incoming[mb].differentiable()
-                returned = {
-                    name: torch.zeros_like(value) if value.grad is None else value.grad
-                    for name, value in fields.items()
-                }
-                transport.send_tensor_payload(
-                    tuple(returned.get(name) for name in pipeline.PAYLOAD_FIELDS),
-                    (*tag_at(start, mb).as_tuple(), 1),
-                    peer=rank - 1,
-                    group=group,
-                    device=device,
-                )
         ledger.assert_quiescent()
         for binding in bindings:
             p = binding.tensor
@@ -2744,3 +2793,72 @@ def test_v41_g1_stage_export_boundary(moe):
         stage = DeepseekV41Model(_assembly_config(), layer_range=(0, 20))
     with pytest.raises(NotImplementedError, match='distributed checkpoint assembly'):
         next(export_model(stage))
+
+
+@pytest.mark.gpus(4)
+@pytest.mark.parametrize('recompute', [False, True])
+def test_real_packed_pipeline_scheduler_forward_backward_update(tmp_path, recompute):
+    import os
+
+    import torch.multiprocessing as mp
+
+    assert os.getenv('SLURM_JOB_ID'), 'Packed pipeline validation requires Slurm'
+    if torch.cuda.device_count() < 4:
+        pytest.skip('Requires the declared four-GPU allocation')
+    mp.spawn(
+        _real_model_worker,
+        args=(f'file://{tmp_path}/packed-scheduler', True, recompute),
+        nprocs=4,
+        join=True,
+    )
+
+
+@pytest.mark.parametrize('recompute', [False, True])
+def test_packed_pipeline_scheduler_local_gradients_and_lifetime(moe, recompute):
+    from types import SimpleNamespace
+
+    from megatron.lite.model.deepseek_v41.lite.pipeline import PackedPipelineAdapter
+    from megatron.lite.primitive.parallel.pipeline import forward_backward_pipelining
+    from megatron.lite.runtime.contracts import PackedBatch
+
+    _, bundle = _assembly_bundle()
+    model = bundle.chunks[0]
+    batches = [
+        PackedBatch(torch.arange(3, 3 + sum(ns)), None, torch.tensor(ns))
+        for ns in ((5, 8, 3), (4, 7))
+    ]
+    expected = [bundle.forward_step(model, batch)['logits'] for batch in batches]
+    sum(logits.float().square().sum() / 2 for logits in expected).backward()
+    gradients = {
+        name: None if p.grad is None else p.grad.clone()
+        for name, p in model.named_parameters()
+    }
+    model.zero_grad(set_to_none=True)
+    adapter = PackedPipelineAdapter(model, bundle.parallel_state, recompute=recompute)
+    seen = []
+
+    def objective(out, batch):
+        index = next(i for i, candidate in enumerate(batches) if candidate is batch)
+        torch.testing.assert_close(out['logits'], expected[index], atol=0, rtol=0)
+        seen.append(index)
+        return out['logits'].float().square().sum(), {}
+
+    forward_backward_pipelining(
+        bundle.forward_step,
+        [model],
+        iter(batches),
+        SimpleNamespace(num_microbatches=2),
+        bundle.parallel_state,
+        loss_fn=objective,
+        payload_adapter=adapter,
+    )
+    assert seen == [0, 1] and adapter.step == 1
+    for name, p in model.named_parameters():
+        if gradients[name] is None:
+            assert p.grad is None
+        else:
+            torch.testing.assert_close(p.grad, gradients[name], atol=1e-5, rtol=1e-5)
+    with pytest.raises(RuntimeError, match='stale'):
+        adapter.backward(0, None)
+    with pytest.raises(RuntimeError, match='active'):
+        adapter.finish()


### PR DESCRIPTION
Connect the V4.1 packed carrier to the common pipeline scheduler and MLite runtime. Each packed sequence retains separate HC/CED, main KV, frozen index keys/candidates and generation-scoped gradient ownership. The fill/drain schedule forwards microbatches in input order and returns gradients in reverse order. Non-reentrant recompute preserves the per-microbatch state.

This is an incremental continuation on #218 at `94ac35c3b`, including the two stage-boundary regression tests already validated in #215. Existing #211/#215 remain unchanged. Prerequisite order: main → #212 → #210 → #213 → #211 → #215 → #218 → this PR. #214/#216/#217 content is incorporated by the reviewed #218 integration tree; do not independently reapply those conflicting changes.

Interface: `ImplConfig(pipeline_recompute=...)` produces `bundle.extras['pipeline_payload_adapter']`; `forward_backward_pipelining(..., payload_adapter=...)` and the MLite runtime consume it. Payload tags include step, microbatch, boundary, generation, KV/index owners, sequence and direction. Floating owner paths return gradients; frozen source index keys and selection metadata do not. The ledger rejects stale returns and drains before the next step.

Validation at `7cc0ee28c`: Slurm **18387357**, four H100 GPUs, **4 passed in 54.55s**, all sacct steps COMPLETED 0:0, no skips. Tests compare true model packed microbatches [5,8,3] and [4,7] with monolithic logits, local owner gradients and one update, both with and without recompute. The same allocation also runs the existing distinct-consumer gradient-sum, single-owner update and stale-generation transport tests. Local schedule checks: 2 passed. Formatting passed. Local inherited optimizer tests lack emerging_optimizers; the standard cluster overlay supplies that dependency.

Final full-suite comparison: Slurm **18388135**, 12 failed, 874 passed, 37 skipped, 5 errors; against mainparent 18354480 **added=0, removed=8**. The 8 removals are the previously recorded order-sensitive checkpoint tests. This uses the existing fullstack.sbatch wrapper and external SHA-verified reference directory; initial 18387506 omitted that directory and had 27 FileNotFoundError additions, preserved as invalid environment evidence.

CED-corruption negative control **18387513** changes only the saved CED coefficients used by range execution to zeros. It fails the actual monolithic `embed.weight gradient` comparison, maximum absolute difference 1.864850 versus 3e-5 tolerance (1 failed, exit 1); no timeout sentinel. This is PP-only fill/drain integration. TP/EP/CP, virtual-pipeline interleaving, distributed mixed optimizer coordination and complete text/vision restart/export are not completed by this PR. No whole-task completion claim.
