### PR TITLE
Fail early when native EP collective participants diverge

### DIFF
--- a/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
+++ b/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
@@ -8,6 +8,7 @@ import os
 import torch  # pyright: ignore[reportMissingImports]
 import torch.distributed as dist  # pyright: ignore[reportMissingImports]
 
+from megatron.lite.primitive.modules.ep_participation import check_ep_participation
 from megatron.lite.primitive.modules.moe import _AllToAll
 from megatron.lite.primitive.parallel import ParallelState
 from megatron.lite.primitive.utils import ensure_divisible
@@ -324,6 +325,7 @@ class TokenDispatcher:
         return result
 
     def _dispatch_alltoall(self, hidden_states, topk_scores, topk_indices):
+        check_ep_participation(self.ps.ep_group, "dispatch.metadata")
         t, h = hidden_states.shape
         e = self.num_experts
 

--- a/experimental/lite/megatron/lite/primitive/modules/ep_participation.py
+++ b/experimental/lite/megatron/lite/primitive/modules/ep_participation.py
@@ -63,7 +63,7 @@ class _Participation:
                 )
                 raise RuntimeError(self.failure)
             if not missing:
-                return
+                return sequence
             time.sleep(0.001)
 
 
@@ -85,4 +85,4 @@ def check_ep_participation(group, phase):
     if state is None:
         state = _Participation(group)
         _participation[group] = state
-    state.check(phase)
+    return state.check(phase)

--- a/experimental/lite/megatron/lite/primitive/modules/ep_participation.py
+++ b/experimental/lite/megatron/lite/primitive/modules/ep_participation.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Bounded host-side rendezvous before native EP collectives."""
+
+from __future__ import annotations
+
+import json
+import time
+from weakref import WeakKeyDictionary
+
+import torch.distributed as dist
+from torch.distributed.distributed_c10d import _get_process_group_store
+
+
+class _Participation:
+    def __init__(self, group):
+        # Reuse the group's namespace; no extra collective/group creation on a
+        # rank-local dispatch path. An absent rank need not execute this code.
+        self.store = dist.PrefixStore("mlite_ep_participation", _get_process_group_store(group))
+        self.ranks = dist.get_process_group_ranks(group)
+        self.keys = [str(rank) for rank in self.ranks]
+        self.key = str(dist.get_rank())
+        self.sequence = 0
+        self.phase = ""
+        self.failure = None
+        self.ready = False
+
+    def check(self, phase):
+        if self.failure is not None:
+            raise RuntimeError(self.failure)
+        self.sequence += 1
+        sequence = self.sequence
+        self.store.set(self.key, json.dumps([sequence, phase, self.phase]))
+        self.phase = phase
+        deadline = time.monotonic() + 10.0
+        while True:
+            # Never get a nonexistent key: Store.get otherwise waits for its
+            # own (possibly 1800s) timeout. Keys remain bounded at one per rank.
+            self.ready = self.ready or self.store.check(self.keys)
+            if not self.ready and time.monotonic() < deadline:
+                time.sleep(0.001)
+                continue
+            available = (
+                self.keys if self.ready else [key for key in self.keys if self.store.check([key])]
+            )
+            records = dict(zip(available, map(json.loads, self.store.multi_get(available))))
+            missing, mismatched = [], []
+            for rank, key in zip(self.ranks, self.keys):
+                count, current, previous = records.get(key, [0, "", ""])
+                if count < sequence:
+                    missing.append(f"rank {rank} expected={sequence} actual={count}")
+                else:
+                    # A peer may already be waiting at the next rendezvous.
+                    actual_phase = current if count == sequence else previous
+                    if count > sequence + 1 or actual_phase != phase:
+                        mismatched.append(
+                            f"rank {rank} expected={sequence}:{phase} actual={count}:{actual_phase}"
+                        )
+            if mismatched or (missing and time.monotonic() >= deadline):
+                self.failure = (
+                    f"EP participation failed before {phase}: "
+                    f"expected participants={len(self.ranks)} "
+                    f"actual={len(self.ranks) - len(missing)}; " + "; ".join(missing + mismatched)
+                )
+                raise RuntimeError(self.failure)
+            if not missing:
+                return
+            time.sleep(0.001)
+
+
+_participation = WeakKeyDictionary()
+
+
+def check_ep_participation(group, phase):
+    """Require every EP peer within 10s, assuming the rendezvous Store is live.
+
+    This guards host participation, not CUDA completion or arbitrary Store
+    failure. A failed group must be torn down. Like EP collectives themselves,
+    calls on a group must be serialized and identically ordered across ranks.
+    """
+    if group is None:
+        group = dist.group.WORLD
+    if dist.get_world_size(group) <= 1:
+        return
+    state = _participation.get(group)
+    if state is None:
+        state = _Participation(group)
+        _participation[group] = state
+    state.check(phase)

--- a/experimental/lite/megatron/lite/primitive/modules/moe.py
+++ b/experimental/lite/megatron/lite/primitive/modules/moe.py
@@ -51,7 +51,7 @@ class MoEAuxLossAutoScaler(torch.autograd.Function):
 class _AllToAll(torch.autograd.Function):
     @staticmethod
     def forward(ctx, input_tensor, input_splits, output_splits, group):
-        check_ep_participation(group, "alltoall.forward")
+        ctx.ep_sequence = check_ep_participation(group, "alltoall.forward")
         ctx.input_splits = input_splits
         ctx.output_splits = output_splits
         ctx.group = group
@@ -68,7 +68,7 @@ class _AllToAll(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad_output):
-        check_ep_participation(ctx.group, "alltoall.backward")
+        check_ep_participation(ctx.group, f"alltoall.backward:{ctx.ep_sequence}")
         grad_output = grad_output.contiguous()
         grad_input = grad_output.new_empty([sum(ctx.input_splits)] + list(grad_output.shape[1:]))
         dist.all_to_all_single(

--- a/experimental/lite/megatron/lite/primitive/modules/moe.py
+++ b/experimental/lite/megatron/lite/primitive/modules/moe.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 import torch  # pyright: ignore[reportMissingImports]
 import torch.distributed as dist  # pyright: ignore[reportMissingImports]
 
+from megatron.lite.primitive.modules.ep_participation import check_ep_participation
+
 __all__ = ["MoEAuxLossAutoScaler", "_AllToAll"]
 
 
@@ -49,6 +51,7 @@ class MoEAuxLossAutoScaler(torch.autograd.Function):
 class _AllToAll(torch.autograd.Function):
     @staticmethod
     def forward(ctx, input_tensor, input_splits, output_splits, group):
+        check_ep_participation(group, "alltoall.forward")
         ctx.input_splits = input_splits
         ctx.output_splits = output_splits
         ctx.group = group
@@ -65,6 +68,7 @@ class _AllToAll(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad_output):
+        check_ep_participation(ctx.group, "alltoall.backward")
         grad_output = grad_output.contiguous()
         grad_input = grad_output.new_empty([sum(ctx.input_splits)] + list(grad_output.shape[1:]))
         dist.all_to_all_single(

--- a/experimental/lite/tests/unit/primitive/parallel/test_parallel_dimensions_independent_unit.py
+++ b/experimental/lite/tests/unit/primitive/parallel/test_parallel_dimensions_independent_unit.py
@@ -161,6 +161,10 @@ def test_alltoall_dispatch_sums_scores_for_duplicate_experts(
     transformer_engine_import_stub()
     from megatron.lite.primitive.modules import dispatcher as dispatcher_module
 
+    # This is a local routing arithmetic test; distributed participation is
+    # covered by the real eight-process EP tests.
+    monkeypatch.setattr(dispatcher_module, "check_ep_participation", lambda group, phase: None)
+
     def fake_all_gather(output, local_counts, group):
         del group
         output.zero_()

--- a/experimental/lite/tests/unit/primitive/test_ep_dispatch_participation.py
+++ b/experimental/lite/tests/unit/primitive/test_ep_dispatch_participation.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Real eight-process CPU regressions; missing ranks never enter the guard."""
+
+from __future__ import annotations
+
+import multiprocessing
+import time
+from datetime import timedelta
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.distributed as dist
+
+pytestmark = pytest.mark.mlite
+
+
+@pytest.fixture(autouse=True)
+def _te_import_stub(transformer_engine_import_stub):
+    transformer_engine_import_stub()
+
+
+def _worker(rank, rendezvous, results, release, mode):
+    torch.set_num_threads(1)
+    dist.init_process_group(
+        "gloo",
+        init_method=rendezvous,
+        rank=rank,
+        world_size=8,
+        timeout=timedelta(seconds=25),
+    )
+    from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
+    from megatron.lite.primitive.modules.moe import _AllToAll
+    from megatron.lite.primitive.parallel import ParallelState
+
+    ps = ParallelState(ep_size=8, ep_group=dist.group.WORLD)
+    dispatcher = TokenDispatcher(8, 2, ps, use_deepep=False, moe_permute_fusion=False)
+    # Rank 2 has the largest input. Missing participation is unrelated to emptiness.
+    count = 16 if rank == 2 else rank + 1
+    x = torch.full((count, 2), float(rank), requires_grad=True)
+    indices = torch.full((count, 1), (rank + 1) % 8, dtype=torch.long)
+    scores = torch.ones(count, 1, requires_grad=True)
+    dist.barrier()
+    start = time.monotonic()
+    try:
+        if mode == "dispatch_missing" and rank == 2:
+            release.wait(20)
+            return
+        if mode == "phase_mismatch":
+            if rank == 2:
+                _AllToAll.backward(
+                    SimpleNamespace(group=ps.ep_group, input_splits=[1] * 8, output_splits=[1] * 8),
+                    x[:1].expand(8, 2),
+                )
+            else:
+                _AllToAll.apply(x[:1].expand(8, 2), [1] * 8, [1] * 8, ps.ep_group)
+        elif mode == "a2a_missing":
+            if rank == 2:
+                release.wait(20)
+                return
+            _AllToAll.apply(x[:1].expand(8, 2), [1] * 8, [1] * 8, ps.ep_group)
+        elif mode == "backward_missing":
+            y = _AllToAll.apply(x[:1].expand(8, 2), [1] * 8, [1] * 8, ps.ep_group)
+            if rank == 2:
+                release.wait(20)
+                return
+            y.sum().backward()
+        else:
+            if mode == "empty" and rank == 2:
+                x = torch.empty(0, 2, requires_grad=True)
+                indices = torch.empty(0, 1, dtype=torch.long)
+                scores = torch.empty(0, 1, requires_grad=True)
+            for _ in range(3):
+                y, _, routed_scores = dispatcher.dispatch(x, scores, indices)
+                restored = dispatcher.combine(y * routed_scores.unsqueeze(-1))
+                torch.testing.assert_close(restored, x, rtol=0, atol=0)
+                restored.sum().backward()
+                torch.testing.assert_close(x.grad, torch.ones_like(x), rtol=0, atol=0)
+                x.grad = None
+                scores.grad = None
+        results.put((rank, "ok", time.monotonic() - start))
+    except Exception as exc:
+        results.put((rank, str(exc), time.monotonic() - start))
+    finally:
+        dist.destroy_process_group()
+
+
+def _run(tmp_path, mode):
+    # fork avoids eight independent TE/CUDA imports; workers only execute CPU ops.
+    ctx = multiprocessing.get_context("fork")
+    results, release = ctx.Queue(), ctx.Event()
+    processes = [
+        ctx.Process(
+            target=_worker,
+            args=(
+                rank,
+                f"file://{tmp_path / 'rendezvous'}",
+                results,
+                release,
+                mode,
+            ),
+        )
+        for rank in range(8)
+    ]
+    try:
+        for process in processes:
+            process.start()
+        expected = 7 if mode.endswith("missing") else 8
+        rows = [results.get(timeout=18) for _ in range(expected)]
+        return rows
+    finally:
+        release.set()
+        for process in processes:
+            process.join(timeout=2)
+        for process in processes:
+            if process.is_alive():
+                process.terminate()
+                process.join()
+
+
+@pytest.mark.parametrize("mode", ["dispatch_missing", "a2a_missing", "backward_missing"])
+def test_missing_rank_fails_before_collective(tmp_path, mode):
+    rows = _run(tmp_path, mode)
+    assert {rank for rank, _, _ in rows} == {0, 1, 3, 4, 5, 6, 7}
+    for _, message, elapsed in rows:
+        assert "EP participation" in message, message
+        assert "rank 2" in message, message
+        expected, actual = (2, 1) if mode == "backward_missing" else (1, 0)
+        assert f"rank 2 expected={expected} actual={actual}" in message, message
+        assert "expected participants=8 actual=7" in message, message
+        assert elapsed < 15, (message, elapsed)
+
+
+@pytest.mark.parametrize("mode", ["ragged", "empty"])
+def test_all_ranks_dispatch_and_backward(tmp_path, mode):
+    rows = _run(tmp_path, mode)
+    assert all(message == "ok" for _, message, _ in rows), rows
+
+
+def test_forward_backward_order_mismatch(tmp_path):
+    rows = _run(tmp_path, "phase_mismatch")
+    for _, message, elapsed in rows:
+        assert "EP participation" in message, message
+        assert "alltoall.forward" in message and "alltoall.backward" in message, message
+        assert elapsed < 5, (message, elapsed)

--- a/experimental/lite/tests/unit/primitive/test_ep_dispatch_participation.py
+++ b/experimental/lite/tests/unit/primitive/test_ep_dispatch_participation.py
@@ -4,8 +4,10 @@
 from __future__ import annotations
 
 import multiprocessing
+import sys
 import time
 from datetime import timedelta
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -15,13 +17,14 @@ import torch.distributed as dist
 pytestmark = pytest.mark.mlite
 
 
-@pytest.fixture(autouse=True)
-def _te_import_stub(transformer_engine_import_stub):
-    transformer_engine_import_stub()
-
-
 def _worker(rank, rendezvous, results, release, mode):
+    # Spawned interpreters reuse the shared CPU-only TE import fixture.
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+    from conftest import transformer_engine_import_stub
+
+    transformer_engine_import_stub.__wrapped__(pytest.MonkeyPatch())()
     torch.set_num_threads(1)
+    torch.set_default_device("cpu")
     dist.init_process_group(
         "gloo",
         init_method=rendezvous,
@@ -49,7 +52,12 @@ def _worker(rank, rendezvous, results, release, mode):
         if mode == "phase_mismatch":
             if rank == 2:
                 _AllToAll.backward(
-                    SimpleNamespace(group=ps.ep_group, input_splits=[1] * 8, output_splits=[1] * 8),
+                    SimpleNamespace(
+                        group=ps.ep_group,
+                        input_splits=[1] * 8,
+                        output_splits=[1] * 8,
+                        ep_sequence=0,
+                    ),
                     x[:1].expand(8, 2),
                 )
             else:
@@ -59,6 +67,10 @@ def _worker(rank, rendezvous, results, release, mode):
                 release.wait(20)
                 return
             _AllToAll.apply(x[:1].expand(8, 2), [1] * 8, [1] * 8, ps.ep_group)
+        elif mode == "backward_identity":
+            first = _AllToAll.apply(x[:1].expand(8, 2), [1] * 8, [1] * 8, ps.ep_group)
+            second = _AllToAll.apply(x[:1].expand(8, 2), [1] * 8, [1] * 8, ps.ep_group)
+            (first if rank == 2 else second).sum().backward()
         elif mode == "backward_missing":
             y = _AllToAll.apply(x[:1].expand(8, 2), [1] * 8, [1] * 8, ps.ep_group)
             if rank == 2:
@@ -86,8 +98,8 @@ def _worker(rank, rendezvous, results, release, mode):
 
 
 def _run(tmp_path, mode):
-    # fork avoids eight independent TE/CUDA imports; workers only execute CPU ops.
-    ctx = multiprocessing.get_context("fork")
+    # The full suite may already have used autograd/CUDA: never fork that state.
+    ctx = multiprocessing.get_context("spawn")
     results, release = ctx.Queue(), ctx.Event()
     processes = [
         ctx.Process(
@@ -106,7 +118,7 @@ def _run(tmp_path, mode):
         for process in processes:
             process.start()
         expected = 7 if mode.endswith("missing") else 8
-        rows = [results.get(timeout=18) for _ in range(expected)]
+        rows = [results.get(timeout=60) for _ in range(expected)]
         return rows
     finally:
         release.set()
@@ -142,4 +154,12 @@ def test_forward_backward_order_mismatch(tmp_path):
     for _, message, elapsed in rows:
         assert "EP participation" in message, message
         assert "alltoall.forward" in message and "alltoall.backward" in message, message
+        assert elapsed < 5, (message, elapsed)
+
+
+def test_skipped_backward_cannot_impersonate_another_collective(tmp_path):
+    rows = _run(tmp_path, "backward_identity")
+    for _, message, elapsed in rows:
+        assert "EP participation" in message, message
+        assert "alltoall.backward" in message, message
         assert elapsed < 5, (message, elapsed)


### PR DESCRIPTION
When one expert-parallel rank misses a native dispatch collective, peers can wait for the NCCL watchdog for 1800 seconds. Add a bounded host-side participation rendezvous before dispatch metadata exchange and native all-to-all forward/backward. With a live process-group Store, peers report missing global ranks, expected/actual invocation counts, and participant totals after 10 seconds.

The guard reuses the existing process-group Store and keeps one record per rank. It checks collective phase and ties each backward to its forward sequence, so a different same-shaped backward cannot impersonate the missing operation. Empty ranks remain valid participants. No environment variable or additional process group is introduced.

Reference source: `nv/dev@0cd11658f44350a141656751259cfe1f72398e9f`, fetched on 2026-09-10 22:16:56 -0700 (verified from the local remote-ref reflog). Reviewed `token_dispatcher.py`, `moe_layer.py`, and `fused_a2a.py`: token counts, capacity alignment, and empty-token handling still require all peers to enter the collectives; they do not supply a bounded missing-peer diagnostic to copy.

This diagnoses EP participation asymmetry; it does not establish why the rank in the original incident failed to arrive. Store/server failure, CUDA completion, and DeepEP are outside this guard's scope. The check adds host synchronization and treats more than 10 seconds of rank skew as fatal. It uses PyTorch's internal process-group Store accessor.

Validation:

- Seven real eight-process CPU/Gloo tests passed without skips. Cases cover an absent rank with the largest input, forward/backward absence, ragged and empty inputs, phase mismatch, and a skipped backward impersonating another same-shaped collective.
- Four independent mutations fail as expected: removing each of the three guard call sites, and removing only the backward identity binding.
- Eight-GPU NCCL smoke, Slurm **18393560**, all steps **COMPLETED / 0:0**: ragged/empty dispatch → combine → backward matches exactly; all seven peers diagnose missing global rank 2 in **10.000–10.001s**, reporting `expected participants=8 actual=7; rank 2 expected=43 actual=42`.
- Full regression using the existing `tests7064.sbatch`, Slurm **18393559**: **689 passed, 20 failed, 22 skipped, 5 errors** (exit 1). The requested baseline **18354480** has **682 passed, 20 failed, 22 skipped, 5 errors** (exit 1). Failure/error names match exactly: **added=0, removed=0**. This is no new regression, not an all-green suite.

The existing fully mocked duplicate-expert arithmetic test now also mocks the participation check; actual collective participation is exercised by the eight-process tests above.
