### PR TITLE
Fix isolated CSA test imports and declare the Kimi Core dependency

### DIFF
--- a/experimental/lite/tests/unit/model/test_all_model_qat_r3_contracts.py
+++ b/experimental/lite/tests/unit/model/test_all_model_qat_r3_contracts.py
@@ -213,16 +213,17 @@ def _install_cpu_te_construction_stubs(transformer_engine_import_stub, monkeypat
     for name, replacement in te_types.items():
         monkeypatch.setattr(te, name, replacement, raising=False)
     # Parameterized tests may have imported model/primitive modules under a
-    # previous fixture-owned TE stub. Patch every retained module-local ``te``
-    # reference as well as the current sys.modules entry.
+    # previous fixture-owned TE stub. Patch retained ``te`` and centralized
+    # constructor ``_TE`` references as well as the current sys.modules entry.
     for module in tuple(sys.modules.values()):
-        module_te = getattr(module, "te", None)
-        if not isinstance(module_te, types.ModuleType):
-            continue
-        if module_te.__name__ != "transformer_engine.pytorch":
-            continue
-        for name, replacement in te_types.items():
-            monkeypatch.setattr(module_te, name, replacement, raising=False)
+        for alias in ("te", "_TE"):
+            module_te = getattr(module, alias, None)
+            if not isinstance(module_te, types.ModuleType):
+                continue
+            if module_te.__name__ != "transformer_engine.pytorch":
+                continue
+            for name, replacement in te_types.items():
+                monkeypatch.setattr(module_te, name, replacement, raising=False)
 
     te_root = importlib.import_module("transformer_engine")
     monkeypatch.setattr(te_root, "__version__", "2.0.0")

--- a/experimental/lite/tests/unit/model/test_all_model_qat_r3_contracts.py
+++ b/experimental/lite/tests/unit/model/test_all_model_qat_r3_contracts.py
@@ -262,6 +262,11 @@ def _install_csa_import_stubs(monkeypatch):
     dsa_kernels = types.ModuleType(
         "megatron.core.transformer.experimental_attention_variant.dsa_kernels"
     )
+    csa_kernels = types.ModuleType(
+        "megatron.core.transformer.experimental_attention_variant.csa_kernels"
+    )
+    csa_kernels.FusedCSAIndexerSparseAttnFromTopkFunc = torch.autograd.Function
+    csa_kernels.csa_sparse_attn = unavailable
     core_csa._unfused_indexer_sparse_attn_from_topk = unavailable
     core_csa.unfused_compressed_sparse_attn = unavailable
     core_dsa.DSAIndexerLossAutoScaler = torch.autograd.Function
@@ -281,9 +286,15 @@ def _install_csa_import_stubs(monkeypatch):
         "megatron.core.transformer.experimental_attention_variant.csa": core_csa,
         "megatron.core.transformer.experimental_attention_variant.dsa": core_dsa,
         "megatron.core.transformer.experimental_attention_variant.dsa_kernels": dsa_kernels,
+        "megatron.core.transformer.experimental_attention_variant.csa_kernels": csa_kernels,
     }
+    for package in (core, tensor_parallel, transformer, variants):
+        package.__path__ = []
     for name, module in modules.items():
         monkeypatch.setitem(sys.modules, name, module)
+        parent_name, _, child_name = name.rpartition(".")
+        if parent_name in modules:
+            setattr(modules[parent_name], child_name, module)
 
 
 def _train_config():

--- a/experimental/lite/tests/unit/model/test_kimi_k2_lite_static.py
+++ b/experimental/lite/tests/unit/model/test_kimi_k2_lite_static.py
@@ -184,6 +184,7 @@ def test_kimi_k2_impl_config_accepts_runtime_mtp_fields():
 
 
 def test_kimi_k2_mtp_and_pp_layout_rules_are_explicit():
+    pytest.importorskip("megatron.core")
     from megatron.lite.primitive.parallel import (  # isort: skip
         ParallelState,
         build_pipeline_chunk_layout,


### PR DESCRIPTION
CPU QAT/replay tests retained an old Transformer Engine module through the centralized constructor’s `_TE` alias, while the helper only patched `te`. The CSA helper also omitted the fused CSA module and modeled parent packages as ordinary modules. Complete the CSA import hierarchy and patch both retained TE aliases so the existing real tiny-model tests work both individually and together.

Declare the external Core dependency of the existing Kimi pipeline layout test: it skips explicitly when Core is unavailable and executes when Core is installed.

Validation (CPU, same commands and environment for baseline and patch):
- Both affected test files at merge-base main `d8e010069`: **15 failed, 70 passed**, exit 1.
- Both affected test files after this fix: **85 passed, 0 failed, 0 skipped**, exit 0.
- Failure-set comparison: **added=0, removed=15**. This includes all three affected DeepSeek V4 cases and the Kimi layout test with real Core.
- Earlier isolated-process checks: each DeepSeek V4 target passed independently; the Kimi test passed with installed Core and explicitly skipped with Core imports blocked to simulate a missing dependency.
- `git diff --check` passes. These results cover the two affected files, not the entire repository suite or GPU CSA execution.

Formatting caveat: this checkout pins isort 5.13.2 and black 24.4.2, not Ruff. Existing formatting in the QAT test file fails those hooks on the baseline too. Unrelated formatting changes are excluded from this focused fix.

Only two existing test files change. Production code is unchanged; the synthetic CSA kernels remain import-only stand-ins for CPU construction/state-dict tests, not evidence of real CSA execution.