### PR TITLE
Fix grouped router auxiliary gradients and resync correctness gates

### DIFF
--- a/experimental/lite/examples/bench/results.py
+++ b/experimental/lite/examples/bench/results.py
@@ -241,6 +241,20 @@ def compare_correctness_artifacts(
             mismatches.append({"step": idx, "field": "loss"})
         if not grad_matches:
             mismatches.append({"step": idx, "field": "grad_norm"})
+        base_grad = base.get("grad_fingerprint")
+        cand_grad = cand.get("grad_fingerprint")
+        if base_grad is not None or cand_grad is not None:
+            # The aggregate digest already covers names, dtypes and bytes.
+            # Optional diagnostic details do not change the comparison.
+            if (
+                not isinstance(base_grad, dict)
+                or not isinstance(cand_grad, dict)
+                or not base_grad.get("sha256")
+                or base_grad.get("sha256") != cand_grad.get("sha256")
+                or base_grad.get("tensor_count") is None
+                or base_grad.get("tensor_count") != cand_grad.get("tensor_count")
+            ):
+                mismatches.append({"step": idx, "field": "grad_fingerprint"})
         for field in ("post_step_weights", "update_successful", "num_zeros"):
             if base.get(field) != cand.get(field):
                 mismatches.append({"step": idx, "field": field})

--- a/experimental/lite/examples/verl/verl_mlite/compat.py
+++ b/experimental/lite/examples/verl/verl_mlite/compat.py
@@ -785,13 +785,19 @@ def _patch_verl_dsv4_native_layerwise_reload() -> bool:
         rollout_utils = importlib.import_module(
             "verl.workers.rollout.vllm_rollout.utils"
         )
-    except Exception:
-        return False
+    except Exception as exc:
+        raise RuntimeError(
+            "Cannot install DS4 native layerwise reload: failed to import VERL "
+            "reload dependencies. Refusing unsafe legacy FP8 finalization."
+        ) from exc
     original_prepare = getattr(fp8_utils, "prepare_quanted_weights_for_loading", None)
     original_process = getattr(fp8_utils, "process_quanted_weights_after_loading", None)
     original_load = getattr(fp8_utils, "load_quanted_weights", None)
     if original_prepare is None or original_process is None or original_load is None:
-        return False
+        raise RuntimeError(
+            "Cannot install DS4 native layerwise reload: VERL FP8 reload APIs "
+            "are missing. Refusing unsafe legacy FP8 finalization."
+        )
     if getattr(original_prepare, "_verl_mlite_ds4_layerwise", False):
         return True
 

--- a/experimental/lite/megatron/lite/primitive/modules/router.py
+++ b/experimental/lite/megatron/lite/primitive/modules/router.py
@@ -267,10 +267,12 @@ class SigmoidTopKRouter(nn.Module):
         )
         if apply_aux_loss:
             _reject_aux_loss_during_replay(self.router_replay)
-            _, aux_scores = compute_routing_scores_for_aux_loss(
+            aux_routing_map, aux_scores = compute_routing_scores_for_aux_loss(
                 logits, self.topk, score_function=self.score_function, fused=self.moe_router_fusion
             )
-            tokens_per_expert = routing_map.sum(dim=0).to(torch.int64)
+            # Balance the same unbiased, unrestricted affinities used by
+            # aux_scores, independently of dispatch groups and expert bias.
+            tokens_per_expert = aux_routing_map.sum(dim=0).to(torch.int64)
             total_num_tokens = num_tokens
             if self._aux_loss_group is not None:
                 dist.all_reduce(tokens_per_expert, group=self._aux_loss_group)

--- a/experimental/lite/tests/unit/examples/test_bench_example.py
+++ b/experimental/lite/tests/unit/examples/test_bench_example.py
@@ -355,3 +355,51 @@ def test_correctness_compare_supports_explicit_numeric_tolerances():
 
     assert comparison["passed"] is True
     assert abs(comparison["max_tensor_abs"] - 2e-3) < 1e-12
+
+
+def test_correctness_gradient_fingerprint_is_a_quality_gate(tmp_path):
+    import pytest
+    from examples.bench.correctness import main
+    from examples.bench.results import compare_correctness_artifacts
+
+    baseline = {
+        "steps": [
+            {
+                "loss": {"value": 1.0},
+                "grad_norm": {"value": 2.0},
+                "grad_fingerprint": {"sha256": "a", "tensor_count": 1},
+            }
+        ]
+    }
+    candidate = json.loads(json.dumps(baseline))
+    candidate["steps"][0]["grad_fingerprint"]["sha256"] = "b"
+    base_path, cand_path = tmp_path / "base.json", tmp_path / "cand.json"
+    base_path.write_text(json.dumps(baseline))
+    cand_path.write_text(json.dumps(candidate))
+    with pytest.raises(SystemExit) as exc:
+        main(["compare", str(base_path), str(cand_path), "--fail-on-mismatch"])
+    assert exc.value.code == 1
+    comparison = compare_correctness_artifacts(baseline, candidate)
+    assert comparison["passed"] is False
+    assert {"step": 0, "field": "grad_fingerprint"} in comparison["mismatches"]
+
+
+def test_correctness_gradient_digest_contract():
+    from examples.bench.results import compare_correctness_artifacts
+
+    baseline = {
+        "steps": [
+            {
+                "loss": {"value": 1.0},
+                "grad_norm": {"value": 2.0},
+                "grad_fingerprint": {"sha256": "a", "tensor_count": 1},
+            }
+        ]
+    }
+    candidate = json.loads(json.dumps(baseline))
+    candidate["steps"][0]["grad_fingerprint"]["details"] = [{"name": "weight"}]
+    assert compare_correctness_artifacts(baseline, candidate)["passed"]
+    candidate["steps"][0]["grad_fingerprint"]["tensor_count"] = 2
+    assert not compare_correctness_artifacts(baseline, candidate)["passed"]
+    del candidate["steps"][0]["grad_fingerprint"]
+    assert not compare_correctness_artifacts(baseline, candidate)["passed"]

--- a/experimental/lite/tests/unit/examples/test_verl_compat_native_layerwise_reload.py
+++ b/experimental/lite/tests/unit/examples/test_verl_compat_native_layerwise_reload.py
@@ -131,3 +131,68 @@ def test_non_ds4_keeps_verl_reload_path(monkeypatch) -> None:
     assert loaded[0][1] is source
     fp8_utils.process_quanted_weights_after_loading(runner, state)
     assert events == ["legacy-state"]
+
+
+def test_ds4_reload_import_failure_is_loud(monkeypatch):
+    import pytest
+
+    monkeypatch.setattr(compat, "_vllm_importable", lambda: True)
+    failure = ImportError("incompatible VERL reload dependency")
+
+    def broken_import(name):
+        raise failure
+
+    monkeypatch.setattr(compat.importlib, "import_module", broken_import)
+    with pytest.raises(RuntimeError, match="DS4.*reload") as exc:
+        compat._patch_verl_dsv4_native_layerwise_reload()
+    assert exc.value.__cause__ is failure
+
+
+def test_ds4_reload_without_vllm_is_not_applicable(monkeypatch):
+    monkeypatch.setattr(compat, "_vllm_importable", lambda: False)
+    assert compat._patch_verl_dsv4_native_layerwise_reload() is False
+
+
+def test_ds4_reload_missing_api_is_loud(monkeypatch):
+    from types import SimpleNamespace
+
+    import pytest
+
+    monkeypatch.setattr(compat, "_vllm_importable", lambda: True)
+    monkeypatch.setattr(
+        compat.importlib, "import_module", lambda name: SimpleNamespace()
+    )
+    with pytest.raises(RuntimeError, match="DS4.*reload APIs"):
+        compat._patch_verl_dsv4_native_layerwise_reload()
+
+
+def test_reload_preserves_non_ds4_and_installs_once(monkeypatch):
+    from types import SimpleNamespace
+
+    events = []
+    fp8 = SimpleNamespace(
+        prepare_quanted_weights_for_loading=lambda runner: "original-state",
+        process_quanted_weights_after_loading=lambda runner, state: events.append(
+            state
+        ),
+        load_quanted_weights=lambda weights, runner: list(weights),
+    )
+    rollout = SimpleNamespace()
+    modules = {
+        "verl.utils.vllm.vllm_fp8_utils": fp8,
+        "verl.utils.vllm.vllm_dsv4_fp8_utils": SimpleNamespace(
+            is_deepseek_v4_model=lambda m: False
+        ),
+        "verl.workers.rollout.vllm_rollout.utils": rollout,
+    }
+    monkeypatch.setattr(compat, "_vllm_importable", lambda: True)
+    monkeypatch.setattr(compat.importlib, "import_module", modules.__getitem__)
+    assert compat._patch_verl_dsv4_native_layerwise_reload()
+    prepare = fp8.prepare_quanted_weights_for_loading
+    assert compat._patch_verl_dsv4_native_layerwise_reload()
+    assert fp8.prepare_quanted_weights_for_loading is prepare
+    runner = SimpleNamespace(model=object())
+    state = prepare(runner)
+    fp8.process_quanted_weights_after_loading(runner, state)
+    assert events == ["original-state"]
+    assert rollout.load_quanted_weights([("weight", 1)], runner) == [("weight", 1)]

--- a/experimental/lite/tests/unit/primitive/test_router_group_aux.py
+++ b/experimental/lite/tests/unit/primitive/test_router_group_aux.py
@@ -7,14 +7,30 @@ import pytest
 import torch
 
 
+@pytest.mark.parametrize("fused", [False, True])
 @pytest.mark.parametrize("groups,bias", [(1, False), (2, False), (2, True)])
 def test_sigmoid_aux_gradient_matches_unrestricted_reference(
-    transformer_engine_import_stub, monkeypatch, groups, bias
+    transformer_engine_import_stub, monkeypatch, groups, bias, fused
 ):
     transformer_engine_import_stub()
     from megatron.lite.primitive.modules.moe import MoEAuxLossAutoScaler
     from megatron.lite.primitive.modules.router import SigmoidTopKRouter
+    from megatron.lite.primitive.utils import moe as moe_utils
 
+    # Exercise the real fused dispatch/aux branches on CPU, replacing only
+    # their TE entrypoints. This is wiring coverage, not CUDA kernel validation.
+    fused_calls = []
+
+    def fused_topk(**kwargs):
+        fused_calls.append("dispatch")
+        return moe_utils.topk_routing_with_score_function(**kwargs, fused=False)
+
+    def fused_aux(**kwargs):
+        fused_calls.append("aux")
+        return moe_utils.compute_routing_scores_for_aux_loss(**kwargs, fused=False)
+
+    monkeypatch.setattr(moe_utils, "fused_topk_with_score_function", fused_topk)
+    monkeypatch.setattr(moe_utils, "fused_compute_score_for_moe_aux_loss", fused_aux)
     monkeypatch.setattr(MoEAuxLossAutoScaler, "main_loss_backward_scale", None)
     config = SimpleNamespace(
         hidden_size=4,
@@ -25,13 +41,16 @@ def test_sigmoid_aux_gradient_matches_unrestricted_reference(
         n_group=groups,
         topk_group=1,
     )
-    router = SigmoidTopKRouter(config, SimpleNamespace(tp_size=1))
+    router = SigmoidTopKRouter(
+        config, SimpleNamespace(tp_size=1), moe_router_fusion=fused
+    )
     with torch.no_grad():
         router.gate.weight.copy_(torch.eye(4))
         if bias:
             router.expert_bias.copy_(torch.tensor([0.0, 0.0, 2.0, 2.0]))
     x = torch.tensor([[3.0, -2.0, 2.0, 1.0], [4.0, -3.0, 1.5, 0.5]], requires_grad=True)
     scores, indices = router(x)
+    assert fused_calls == (["dispatch", "aux"] if fused else [])
     # Zero task gradient isolates the actual autoscaler-attached aux gradient.
     (scores.sum() * 0).backward()
 

--- a/experimental/lite/tests/unit/primitive/test_router_group_aux.py
+++ b/experimental/lite/tests/unit/primitive/test_router_group_aux.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""The balancing objective uses unbiased, unrestricted expert affinity."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+
+@pytest.mark.parametrize("groups,bias", [(1, False), (2, False), (2, True)])
+def test_sigmoid_aux_gradient_matches_unrestricted_reference(
+    transformer_engine_import_stub, monkeypatch, groups, bias
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.moe import MoEAuxLossAutoScaler
+    from megatron.lite.primitive.modules.router import SigmoidTopKRouter
+
+    monkeypatch.setattr(MoEAuxLossAutoScaler, "main_loss_backward_scale", None)
+    config = SimpleNamespace(
+        hidden_size=4,
+        n_routed_experts=4,
+        num_experts_per_tok=2,
+        aux_loss_alpha=0.1,
+        routed_scaling_factor=1.0,
+        n_group=groups,
+        topk_group=1,
+    )
+    router = SigmoidTopKRouter(config, SimpleNamespace(tp_size=1))
+    with torch.no_grad():
+        router.gate.weight.copy_(torch.eye(4))
+        if bias:
+            router.expert_bias.copy_(torch.tensor([0.0, 0.0, 2.0, 2.0]))
+    x = torch.tensor([[3.0, -2.0, 2.0, 1.0], [4.0, -3.0, 1.5, 0.5]], requires_grad=True)
+    scores, indices = router(x)
+    # Zero task gradient isolates the actual autoscaler-attached aux gradient.
+    (scores.sum() * 0).backward()
+
+    ref_x = x.detach().clone().requires_grad_()
+    ref_weight = router.gate.weight.detach().clone().requires_grad_()
+    affinity = (ref_x @ ref_weight.T).sigmoid()
+    probabilities = affinity / affinity.sum(-1, keepdim=True)
+    chosen = affinity.topk(2, dim=-1).indices
+    counts = torch.bincount(chosen.flatten(), minlength=4)
+    reference_loss = (probabilities.mean(0) * (counts / 4)).sum() * 4 * 0.1
+    reference_loss.backward()
+    if groups > 1:
+        assert not torch.equal(indices.sort(-1).values, chosen.sort(-1).values)
+    torch.testing.assert_close(x.grad, ref_x.grad)
+    torch.testing.assert_close(router.gate.weight.grad, ref_weight.grad)


### PR DESCRIPTION
This PR fixes three existing correctness defects, each reproducible on main at d8e010069. It has been rebuilt from freshly fetched main (still d8e010069) with only the semantic fixes and their regression tests.

- **Grouped router auxiliary gradients:** with `n_group=2`, dispatch selects different experts from unrestricted affinity top-k, but the old auxiliary loss mixes dispatch counts with unrestricted scores. The regression first asserts that routing really differs, then compares both input and gate-weight gradients against an independent sigmoid balancing formula. Both grouped cases fail on main; the input-gradient maximum absolute discrepancy is approximately 0.0109. Use the auxiliary helper's own routing map for the counts.
- **Benchmark gradient gate:** keep loss and gradient norm unchanged and change only `grad_fingerprint.sha256`. On main, comparison reports `passed: true` and `--fail-on-mismatch` does not exit with failure. Compare the digest and tensor count, retaining optional diagnostic details as non-semantic; the fixed CLI exits with status 1.
- **DS4 reload dependency failure:** make vLLM applicable and inject an import failure while installing native layerwise reload. On main, the installer silently returns False. The fixed installer raises an actionable RuntimeError with the import exception chained, and also rejects missing reload APIs. The no-vLLM and non-DS4 paths remain covered by tests.

Validation and scope:

- **6 files, +189/-5:** production fixes +27/-5 across 3 files; regression tests +181/-0 across 3 files. No formatter configuration, `pyproject.toml`, or unrelated formatting hunks. Formatting remains the separate responsibility of #147.
- AST audit against main uses `ast.dump(ast.parse(source), include_attributes=False)` and parses both sides. All **160 existing production Python files**: **157 identical / 3 different / 0 parse failures**. The only differences are `primitive/modules/router.py`, `examples/bench/results.py`, and `examples/verl/verl_mlite/compat.py`.
- Tests are counted separately: **86 existing test Python files**: **84 identical / 2 different / 0 parse failures**, because two files append regression functions. Their pre-existing bytes are unchanged. **1 new test file** parses successfully and is not counted as identical to a nonexistent baseline. Thus all **246 existing Python files** total **241 identical / 5 different / 0 parse failures**, plus 1 new file.
- Main negative control: **4 failed, 1 passed**, exit status 1. Cleaned implementation: **40 CPU tests passed, no skips**, exit status 0. `git diff --check` passes. No GPU/end-to-end rollout validation was run. Repository-wide formatting is intentionally not applied in this PR.

These are pre-existing main defects, not regressions introduced by the formatting PR.



Fused-branch coverage follow-up:

- The same auxiliary-gradient regression now runs all 3 group/bias cases with `moe_router_fusion=False` and `True` (6 cases). Grouped cases first prove dispatch differs from unrestricted top-k, then compare input and gate-weight gradients against the independent reference.
- CPU mathematical substitutes at the two TE entrypoints allow the real fused dispatch and auxiliary branches to execute. Call assertions require both entrypoints exactly once for fused mode and neither for non-fused mode. This verifies branch wiring and gradient contracts, not actual CUDA fused kernels.
- Replacing only the router with main d8e010069 gives **4 failed / 2 passed**, exit status 1: both grouped scenarios fail for each fusion setting. The fixed full suite gives **40 passed**, exit status 0, with no skips.

Known bounded gaps (documented only; unchanged in this PR):

1. Gradient fingerprints compare SHA-256 and tensor count, ignoring optional details.
2. `post_step_weights` uses whole-dictionary equality; asymmetric diagnostic details can cause a false mismatch.
3. Tensor comparison accepts matching BF16-canonical fingerprints even when raw SHA-256 differs.
4. Non-finite deltas are excluded from maximum-error metrics, so summaries may still report zero.
5. DS4 reload updates process-global `SKIP_TENSORS` without restoring it.
6. Layerwise processing has no reentrancy guard; reachability of concurrent/reentrant use was not established by review.
7. The legacy DS4 bridge is not connected to `apply_runtime_patches`.
8. Weight fingerprints sample approximately 1/16 of values and do not prove full-tensor equality.
